### PR TITLE
[FIX] signo negativo en tax report

### DIFF
--- a/addons/l10n_ec/data/account_tax_template_withhold_profit_data.xml
+++ b/addons/l10n_ec/data/account_tax_template_withhold_profit_data.xml
@@ -20,18 +20,6 @@
                 (0,0, {
                     'factor_percent': 100,
                     'repartition_type': 'base',
-                    'plus_report_line_ids': [ref('tax_report_line_103_303')],
-                }),
-                (0,0, {
-                    'factor_percent': 100,
-                    'repartition_type': 'tax',
-                    'account_id': ref('l10n_ec.ret_ir_10x100'),
-                    'plus_report_line_ids': [ref('tax_report_line_103_353')],
-                })]"/>
-            <field name="refund_repartition_line_ids" eval="[(5, 0, 0),
-                (0,0, {
-                    'factor_percent': 100,
-                    'repartition_type': 'base',
                     'minus_report_line_ids': [ref('tax_report_line_103_303')],
                 }),
                 (0,0, {
@@ -39,6 +27,18 @@
                     'repartition_type': 'tax',
                     'account_id': ref('l10n_ec.ret_ir_10x100'),
                     'minus_report_line_ids': [ref('tax_report_line_103_353')],
+                })]"/>
+            <field name="refund_repartition_line_ids" eval="[(5, 0, 0),
+                (0,0, {
+                    'factor_percent': 100,
+                    'repartition_type': 'base',
+                    'plus_report_line_ids': [ref('tax_report_line_103_303')],
+                }),
+                (0,0, {
+                    'factor_percent': 100,
+                    'repartition_type': 'tax',
+                    'account_id': ref('l10n_ec.ret_ir_10x100'),
+                    'plus_report_line_ids': [ref('tax_report_line_103_353')],
                 })]"/>
         </record>
         <record id="tax_withhold_profit_304" model="account.tax.template">
@@ -57,18 +57,6 @@
                 (0,0, {
                     'factor_percent': 100,
                     'repartition_type': 'base',
-                    'plus_report_line_ids': [ref('tax_report_line_103_304')],
-                }),
-                (0,0, {
-                    'factor_percent': 100,
-                    'repartition_type': 'tax',
-                    'account_id': ref('l10n_ec.ret_ir_8x100'),
-                    'plus_report_line_ids': [ref('tax_report_line_103_354')],
-                })]"/>
-            <field name="refund_repartition_line_ids" eval="[(5, 0, 0),
-                (0,0, {
-                    'factor_percent': 100,
-                    'repartition_type': 'base',
                     'minus_report_line_ids': [ref('tax_report_line_103_304')],
                 }),
                 (0,0, {
@@ -76,6 +64,18 @@
                     'repartition_type': 'tax',
                     'account_id': ref('l10n_ec.ret_ir_8x100'),
                     'minus_report_line_ids': [ref('tax_report_line_103_354')],
+                })]"/>
+            <field name="refund_repartition_line_ids" eval="[(5, 0, 0),
+                (0,0, {
+                    'factor_percent': 100,
+                    'repartition_type': 'base',
+                    'plus_report_line_ids': [ref('tax_report_line_103_304')],
+                }),
+                (0,0, {
+                    'factor_percent': 100,
+                    'repartition_type': 'tax',
+                    'account_id': ref('l10n_ec.ret_ir_8x100'),
+                    'plus_report_line_ids': [ref('tax_report_line_103_354')],
                 })]"/>
         </record>
         <record id="tax_withhold_profit_304A" model="account.tax.template">
@@ -94,18 +94,6 @@
                 (0,0, {
                     'factor_percent': 100,
                     'repartition_type': 'base',
-                    'plus_report_line_ids': [ref('tax_report_line_103_304')],
-                }),
-                (0,0, {
-                    'factor_percent': 100,
-                    'repartition_type': 'tax',
-                    'account_id': ref('l10n_ec.ret_ir_8x100'),
-                    'plus_report_line_ids': [ref('tax_report_line_103_354')],
-                })]"/>
-            <field name="refund_repartition_line_ids" eval="[(5, 0, 0),
-                (0,0, {
-                    'factor_percent': 100,
-                    'repartition_type': 'base',
                     'minus_report_line_ids': [ref('tax_report_line_103_304')],
                 }),
                 (0,0, {
@@ -113,6 +101,18 @@
                     'repartition_type': 'tax',
                     'account_id': ref('l10n_ec.ret_ir_8x100'),
                     'minus_report_line_ids': [ref('tax_report_line_103_354')],
+                })]"/>
+            <field name="refund_repartition_line_ids" eval="[(5, 0, 0),
+                (0,0, {
+                    'factor_percent': 100,
+                    'repartition_type': 'base',
+                    'plus_report_line_ids': [ref('tax_report_line_103_304')],
+                }),
+                (0,0, {
+                    'factor_percent': 100,
+                    'repartition_type': 'tax',
+                    'account_id': ref('l10n_ec.ret_ir_8x100'),
+                    'plus_report_line_ids': [ref('tax_report_line_103_354')],
                 })]"/>
         </record>
         <record id="tax_withhold_profit_304B" model="account.tax.template">
@@ -131,18 +131,6 @@
                 (0,0, {
                     'factor_percent': 100,
                     'repartition_type': 'base',
-                    'plus_report_line_ids': [ref('tax_report_line_103_304')],
-                }),
-                (0,0, {
-                    'factor_percent': 100,
-                    'repartition_type': 'tax',
-                    'account_id': ref('l10n_ec.ret_ir_8x100'),
-                    'plus_report_line_ids': [ref('tax_report_line_103_354')],
-                })]"/>
-            <field name="refund_repartition_line_ids" eval="[(5, 0, 0),
-                (0,0, {
-                    'factor_percent': 100,
-                    'repartition_type': 'base',
                     'minus_report_line_ids': [ref('tax_report_line_103_304')],
                 }),
                 (0,0, {
@@ -150,6 +138,18 @@
                     'repartition_type': 'tax',
                     'account_id': ref('l10n_ec.ret_ir_8x100'),
                     'minus_report_line_ids': [ref('tax_report_line_103_354')],
+                })]"/>
+            <field name="refund_repartition_line_ids" eval="[(5, 0, 0),
+                (0,0, {
+                    'factor_percent': 100,
+                    'repartition_type': 'base',
+                    'plus_report_line_ids': [ref('tax_report_line_103_304')],
+                }),
+                (0,0, {
+                    'factor_percent': 100,
+                    'repartition_type': 'tax',
+                    'account_id': ref('l10n_ec.ret_ir_8x100'),
+                    'plus_report_line_ids': [ref('tax_report_line_103_354')],
                 })]"/>
         </record>
         <record id="tax_withhold_profit_304C" model="account.tax.template">
@@ -168,18 +168,6 @@
                 (0,0, {
                     'factor_percent': 100,
                     'repartition_type': 'base',
-                    'plus_report_line_ids': [ref('tax_report_line_103_304')],
-                }),
-                (0,0, {
-                    'factor_percent': 100,
-                    'repartition_type': 'tax',
-                    'account_id': ref('l10n_ec.ret_ir_8x100'),
-                    'plus_report_line_ids': [ref('tax_report_line_103_354')],
-                })]"/>
-            <field name="refund_repartition_line_ids" eval="[(5, 0, 0),
-                (0,0, {
-                    'factor_percent': 100,
-                    'repartition_type': 'base',
                     'minus_report_line_ids': [ref('tax_report_line_103_304')],
                 }),
                 (0,0, {
@@ -187,6 +175,18 @@
                     'repartition_type': 'tax',
                     'account_id': ref('l10n_ec.ret_ir_8x100'),
                     'minus_report_line_ids': [ref('tax_report_line_103_354')],
+                })]"/>
+            <field name="refund_repartition_line_ids" eval="[(5, 0, 0),
+                (0,0, {
+                    'factor_percent': 100,
+                    'repartition_type': 'base',
+                    'plus_report_line_ids': [ref('tax_report_line_103_304')],
+                }),
+                (0,0, {
+                    'factor_percent': 100,
+                    'repartition_type': 'tax',
+                    'account_id': ref('l10n_ec.ret_ir_8x100'),
+                    'plus_report_line_ids': [ref('tax_report_line_103_354')],
                 })]"/>
         </record>
         <record id="tax_withhold_profit_304D" model="account.tax.template">
@@ -205,13 +205,13 @@
                 (0,0, {
                     'factor_percent': 100,
                     'repartition_type': 'base',
-                    'plus_report_line_ids': [ref('tax_report_line_103_304')],
+                    'minus_report_line_ids': [ref('tax_report_line_103_304')],
                 }),
                 (0,0, {
                     'factor_percent': 100,
                     'repartition_type': 'tax',
                     'account_id': ref('l10n_ec.ret_ir_8x100'),
-                    'plus_report_line_ids': [ref('tax_report_line_103_354')],
+                    'minus_report_line_ids': [ref('tax_report_line_103_354')],
                 })]"/>
             <field name="refund_repartition_line_ids" eval="[(5, 0, 0),
                 (0,0, {
@@ -242,18 +242,6 @@
                 (0,0, {
                     'factor_percent': 100,
                     'repartition_type': 'base',
-                    'plus_report_line_ids': [ref('tax_report_line_103_304')],
-                }),
-                (0,0, {
-                    'factor_percent': 100,
-                    'repartition_type': 'tax',
-                    'account_id': ref('l10n_ec.ret_ir_8x100'),
-                    'plus_report_line_ids': [ref('tax_report_line_103_354')],
-                })]"/>
-            <field name="refund_repartition_line_ids" eval="[(5, 0, 0),
-                (0,0, {
-                    'factor_percent': 100,
-                    'repartition_type': 'base',
                     'minus_report_line_ids': [ref('tax_report_line_103_304')],
                 }),
                 (0,0, {
@@ -261,6 +249,18 @@
                     'repartition_type': 'tax',
                     'account_id': ref('l10n_ec.ret_ir_8x100'),
                     'minus_report_line_ids': [ref('tax_report_line_103_354')],
+                })]"/>
+            <field name="refund_repartition_line_ids" eval="[(5, 0, 0),
+                (0,0, {
+                    'factor_percent': 100,
+                    'repartition_type': 'base',
+                    'plus_report_line_ids': [ref('tax_report_line_103_304')],
+                }),
+                (0,0, {
+                    'factor_percent': 100,
+                    'repartition_type': 'tax',
+                    'account_id': ref('l10n_ec.ret_ir_8x100'),
+                    'plus_report_line_ids': [ref('tax_report_line_103_354')],
                 })]"/>
         </record>
         <record id="tax_withhold_profit_307" model="account.tax.template">
@@ -279,18 +279,6 @@
                 (0,0, {
                     'factor_percent': 100,
                     'repartition_type': 'base',
-                    'plus_report_line_ids': [ref('tax_report_line_103_307')],
-                }),
-                (0,0, {
-                    'factor_percent': 100,
-                    'repartition_type': 'tax',
-                    'account_id': ref('l10n_ec.ret_ir_2x100'),
-                    'plus_report_line_ids': [ref('tax_report_line_103_357')],
-                })]"/>
-            <field name="refund_repartition_line_ids" eval="[(5, 0, 0),
-                (0,0, {
-                    'factor_percent': 100,
-                    'repartition_type': 'base',
                     'minus_report_line_ids': [ref('tax_report_line_103_307')],
                 }),
                 (0,0, {
@@ -298,6 +286,18 @@
                     'repartition_type': 'tax',
                     'account_id': ref('l10n_ec.ret_ir_2x100'),
                     'minus_report_line_ids': [ref('tax_report_line_103_357')],
+                })]"/>
+            <field name="refund_repartition_line_ids" eval="[(5, 0, 0),
+                (0,0, {
+                    'factor_percent': 100,
+                    'repartition_type': 'base',
+                    'plus_report_line_ids': [ref('tax_report_line_103_307')],
+                }),
+                (0,0, {
+                    'factor_percent': 100,
+                    'repartition_type': 'tax',
+                    'account_id': ref('l10n_ec.ret_ir_2x100'),
+                    'plus_report_line_ids': [ref('tax_report_line_103_357')],
                 })]"/>
         </record>
         <record id="tax_withhold_profit_308" model="account.tax.template">
@@ -316,18 +316,6 @@
                 (0,0, {
                     'factor_percent': 100,
                     'repartition_type': 'base',
-                    'plus_report_line_ids': [ref('tax_report_line_103_308')],
-                }),
-                (0,0, {
-                    'factor_percent': 100,
-                    'repartition_type': 'tax',
-                    'account_id': ref('l10n_ec.ret_ir_10x100'),
-                    'plus_report_line_ids': [ref('tax_report_line_103_358')],
-                })]"/>
-            <field name="refund_repartition_line_ids" eval="[(5, 0, 0),
-                (0,0, {
-                    'factor_percent': 100,
-                    'repartition_type': 'base',
                     'minus_report_line_ids': [ref('tax_report_line_103_308')],
                 }),
                 (0,0, {
@@ -335,6 +323,18 @@
                     'repartition_type': 'tax',
                     'account_id': ref('l10n_ec.ret_ir_10x100'),
                     'minus_report_line_ids': [ref('tax_report_line_103_358')],
+                })]"/>
+            <field name="refund_repartition_line_ids" eval="[(5, 0, 0),
+                (0,0, {
+                    'factor_percent': 100,
+                    'repartition_type': 'base',
+                    'plus_report_line_ids': [ref('tax_report_line_103_308')],
+                }),
+                (0,0, {
+                    'factor_percent': 100,
+                    'repartition_type': 'tax',
+                    'account_id': ref('l10n_ec.ret_ir_10x100'),
+                    'plus_report_line_ids': [ref('tax_report_line_103_358')],
                 })]"/>
         </record>
         <record id="tax_withhold_profit_309" model="account.tax.template">
@@ -353,25 +353,25 @@
                 (0,0, {
                     'factor_percent': 100,
                     'repartition_type': 'base',
-                    'plus_report_line_ids': [ref('tax_report_line_103_309')],
-                }),
-                (0,0, {
-                    'factor_percent': 100,
-                    'repartition_type': 'tax',
-                    'account_id': ref('l10n_ec.ret_ir_1_75x100'),
-                    'plus_report_line_ids': [ref('tax_report_line_103_359')],
-                })]"/>
-            <field name="refund_repartition_line_ids" eval="[(5, 0, 0),
-                (0,0, {
-                    'factor_percent': 100,
-                    'repartition_type': 'base',
                     'minus_report_line_ids': [ref('tax_report_line_103_309')],
                 }),
                 (0,0, {
                     'factor_percent': 100,
                     'repartition_type': 'tax',
-                    'account_id': ref('l10n_ec.ret_ir_10x100'),
+                    'account_id': ref('l10n_ec.ret_ir_1_75x100'),
                     'minus_report_line_ids': [ref('tax_report_line_103_359')],
+                })]"/>
+            <field name="refund_repartition_line_ids" eval="[(5, 0, 0),
+                (0,0, {
+                    'factor_percent': 100,
+                    'repartition_type': 'base',
+                    'plus_report_line_ids': [ref('tax_report_line_103_309')],
+                }),
+                (0,0, {
+                    'factor_percent': 100,
+                    'repartition_type': 'tax',
+                    'account_id': ref('l10n_ec.ret_ir_10x100'),
+                    'plus_report_line_ids': [ref('tax_report_line_103_359')],
                 })]"/>
         </record>
         <record id="tax_withhold_profit_310" model="account.tax.template">
@@ -390,18 +390,6 @@
                 (0,0, {
                     'factor_percent': 100,
                     'repartition_type': 'base',
-                    'plus_report_line_ids': [ref('tax_report_line_103_310')],
-                }),
-                (0,0, {
-                    'factor_percent': 100,
-                    'repartition_type': 'tax',
-                    'account_id': ref('l10n_ec.ret_ir_1x100'),
-                    'plus_report_line_ids': [ref('tax_report_line_103_360')],
-                })]"/>
-            <field name="refund_repartition_line_ids" eval="[(5, 0, 0),
-                (0,0, {
-                    'factor_percent': 100,
-                    'repartition_type': 'base',
                     'minus_report_line_ids': [ref('tax_report_line_103_310')],
                 }),
                 (0,0, {
@@ -409,6 +397,18 @@
                     'repartition_type': 'tax',
                     'account_id': ref('l10n_ec.ret_ir_1x100'),
                     'minus_report_line_ids': [ref('tax_report_line_103_360')],
+                })]"/>
+            <field name="refund_repartition_line_ids" eval="[(5, 0, 0),
+                (0,0, {
+                    'factor_percent': 100,
+                    'repartition_type': 'base',
+                    'plus_report_line_ids': [ref('tax_report_line_103_310')],
+                }),
+                (0,0, {
+                    'factor_percent': 100,
+                    'repartition_type': 'tax',
+                    'account_id': ref('l10n_ec.ret_ir_1x100'),
+                    'plus_report_line_ids': [ref('tax_report_line_103_360')],
                 })]"/>
         </record>
         <record id="tax_withhold_profit_311" model="account.tax.template">
@@ -427,18 +427,6 @@
                 (0,0, {
                     'factor_percent': 100,
                     'repartition_type': 'base',
-                    'plus_report_line_ids': [ref('tax_report_line_103_311')],
-                }),
-                (0,0, {
-                    'factor_percent': 100,
-                    'repartition_type': 'tax',
-                    'account_id': ref('l10n_ec.ret_ir_2x100'),
-                    'plus_report_line_ids': [ref('tax_report_line_103_361')],
-                })]"/>
-            <field name="refund_repartition_line_ids" eval="[(5, 0, 0),
-                (0,0, {
-                    'factor_percent': 100,
-                    'repartition_type': 'base',
                     'minus_report_line_ids': [ref('tax_report_line_103_311')],
                 }),
                 (0,0, {
@@ -446,6 +434,18 @@
                     'repartition_type': 'tax',
                     'account_id': ref('l10n_ec.ret_ir_2x100'),
                     'minus_report_line_ids': [ref('tax_report_line_103_361')],
+                })]"/>
+            <field name="refund_repartition_line_ids" eval="[(5, 0, 0),
+                (0,0, {
+                    'factor_percent': 100,
+                    'repartition_type': 'base',
+                    'plus_report_line_ids': [ref('tax_report_line_103_311')],
+                }),
+                (0,0, {
+                    'factor_percent': 100,
+                    'repartition_type': 'tax',
+                    'account_id': ref('l10n_ec.ret_ir_2x100'),
+                    'plus_report_line_ids': [ref('tax_report_line_103_361')],
                 })]"/>
         </record>
         <record id="tax_withhold_profit_312" model="account.tax.template">
@@ -464,18 +464,6 @@
                 (0,0, {
                     'factor_percent': 100,
                     'repartition_type': 'base',
-                    'plus_report_line_ids': [ref('tax_report_line_103_312')],
-                }),
-                (0,0, {
-                    'factor_percent': 100,
-                    'repartition_type': 'tax',
-                    'account_id': ref('l10n_ec.ret_ir_1_75x100'),
-                    'plus_report_line_ids': [ref('tax_report_line_103_362')],
-                })]"/>
-            <field name="refund_repartition_line_ids" eval="[(5, 0, 0),
-                (0,0, {
-                    'factor_percent': 100,
-                    'repartition_type': 'base',
                     'minus_report_line_ids': [ref('tax_report_line_103_312')],
                 }),
                 (0,0, {
@@ -483,6 +471,18 @@
                     'repartition_type': 'tax',
                     'account_id': ref('l10n_ec.ret_ir_1_75x100'),
                     'minus_report_line_ids': [ref('tax_report_line_103_362')],
+                })]"/>
+            <field name="refund_repartition_line_ids" eval="[(5, 0, 0),
+                (0,0, {
+                    'factor_percent': 100,
+                    'repartition_type': 'base',
+                    'plus_report_line_ids': [ref('tax_report_line_103_312')],
+                }),
+                (0,0, {
+                    'factor_percent': 100,
+                    'repartition_type': 'tax',
+                    'account_id': ref('l10n_ec.ret_ir_1_75x100'),
+                    'plus_report_line_ids': [ref('tax_report_line_103_362')],
                 })]"/>
         </record>
         <record id="tax_withhold_profit_312A" model="account.tax.template">
@@ -501,18 +501,6 @@
                 (0,0, {
                     'factor_percent': 100,
                     'repartition_type': 'base',
-                    'plus_report_line_ids': [ref('tax_report_line_103_312')],
-                }),
-                (0,0, {
-                    'factor_percent': 100,
-                    'repartition_type': 'tax',
-                    'account_id': ref('l10n_ec.ret_ir_1x100'),
-                    'plus_report_line_ids': [ref('tax_report_line_103_362')],
-                })]"/>
-            <field name="refund_repartition_line_ids" eval="[(5, 0, 0),
-                (0,0, {
-                    'factor_percent': 100,
-                    'repartition_type': 'base',
                     'minus_report_line_ids': [ref('tax_report_line_103_312')],
                 }),
                 (0,0, {
@@ -520,6 +508,18 @@
                     'repartition_type': 'tax',
                     'account_id': ref('l10n_ec.ret_ir_1x100'),
                     'minus_report_line_ids': [ref('tax_report_line_103_362')],
+                })]"/>
+            <field name="refund_repartition_line_ids" eval="[(5, 0, 0),
+                (0,0, {
+                    'factor_percent': 100,
+                    'repartition_type': 'base',
+                    'plus_report_line_ids': [ref('tax_report_line_103_312')],
+                }),
+                (0,0, {
+                    'factor_percent': 100,
+                    'repartition_type': 'tax',
+                    'account_id': ref('l10n_ec.ret_ir_1x100'),
+                    'plus_report_line_ids': [ref('tax_report_line_103_362')],
                 })]"/>
         </record>
         <record id="tax_withhold_profit_314A" model="account.tax.template">
@@ -538,18 +538,6 @@
                 (0,0, {
                     'factor_percent': 100,
                     'repartition_type': 'base',
-                    'plus_report_line_ids': [ref('tax_report_line_103_314')],
-                }),
-                (0,0, {
-                    'factor_percent': 100,
-                    'repartition_type': 'tax',
-                    'account_id': ref('l10n_ec.ret_ir_8x100'),
-                    'plus_report_line_ids': [ref('tax_report_line_103_364')],
-                })]"/>
-            <field name="refund_repartition_line_ids" eval="[(5, 0, 0),
-                (0,0, {
-                    'factor_percent': 100,
-                    'repartition_type': 'base',
                     'minus_report_line_ids': [ref('tax_report_line_103_314')],
                 }),
                 (0,0, {
@@ -557,6 +545,18 @@
                     'repartition_type': 'tax',
                     'account_id': ref('l10n_ec.ret_ir_8x100'),
                     'minus_report_line_ids': [ref('tax_report_line_103_364')],
+                })]"/>
+            <field name="refund_repartition_line_ids" eval="[(5, 0, 0),
+                (0,0, {
+                    'factor_percent': 100,
+                    'repartition_type': 'base',
+                    'plus_report_line_ids': [ref('tax_report_line_103_314')],
+                }),
+                (0,0, {
+                    'factor_percent': 100,
+                    'repartition_type': 'tax',
+                    'account_id': ref('l10n_ec.ret_ir_8x100'),
+                    'plus_report_line_ids': [ref('tax_report_line_103_364')],
                 })]"/>
         </record>
         <record id="tax_withhold_profit_314B" model="account.tax.template">
@@ -575,18 +575,6 @@
                 (0,0, {
                     'factor_percent': 100,
                     'repartition_type': 'base',
-                    'plus_report_line_ids': [ref('tax_report_line_103_314')],
-                }),
-                (0,0, {
-                    'factor_percent': 100,
-                    'repartition_type': 'tax',
-                    'account_id': ref('l10n_ec.ret_ir_8x100'),
-                    'plus_report_line_ids': [ref('tax_report_line_103_364')],
-                })]"/>
-            <field name="refund_repartition_line_ids" eval="[(5, 0, 0),
-                (0,0, {
-                    'factor_percent': 100,
-                    'repartition_type': 'base',
                     'minus_report_line_ids': [ref('tax_report_line_103_314')],
                 }),
                 (0,0, {
@@ -594,6 +582,18 @@
                     'repartition_type': 'tax',
                     'account_id': ref('l10n_ec.ret_ir_8x100'),
                     'minus_report_line_ids': [ref('tax_report_line_103_364')],
+                })]"/>
+            <field name="refund_repartition_line_ids" eval="[(5, 0, 0),
+                (0,0, {
+                    'factor_percent': 100,
+                    'repartition_type': 'base',
+                    'plus_report_line_ids': [ref('tax_report_line_103_314')],
+                }),
+                (0,0, {
+                    'factor_percent': 100,
+                    'repartition_type': 'tax',
+                    'account_id': ref('l10n_ec.ret_ir_8x100'),
+                    'plus_report_line_ids': [ref('tax_report_line_103_364')],
                 })]"/>
         </record>
         <record id="tax_withhold_profit_314C" model="account.tax.template">
@@ -612,18 +612,6 @@
                 (0,0, {
                     'factor_percent': 100,
                     'repartition_type': 'base',
-                    'plus_report_line_ids': [ref('tax_report_line_103_314')],
-                }),
-                (0,0, {
-                    'factor_percent': 100,
-                    'repartition_type': 'tax',
-                    'account_id': ref('l10n_ec.ret_ir_8x100'),
-                    'plus_report_line_ids': [ref('tax_report_line_103_364')],
-                })]"/>
-            <field name="refund_repartition_line_ids" eval="[(5, 0, 0),
-                (0,0, {
-                    'factor_percent': 100,
-                    'repartition_type': 'base',
                     'minus_report_line_ids': [ref('tax_report_line_103_314')],
                 }),
                 (0,0, {
@@ -631,6 +619,18 @@
                     'repartition_type': 'tax',
                     'account_id': ref('l10n_ec.ret_ir_8x100'),
                     'minus_report_line_ids': [ref('tax_report_line_103_364')],
+                })]"/>
+            <field name="refund_repartition_line_ids" eval="[(5, 0, 0),
+                (0,0, {
+                    'factor_percent': 100,
+                    'repartition_type': 'base',
+                    'plus_report_line_ids': [ref('tax_report_line_103_314')],
+                }),
+                (0,0, {
+                    'factor_percent': 100,
+                    'repartition_type': 'tax',
+                    'account_id': ref('l10n_ec.ret_ir_8x100'),
+                    'plus_report_line_ids': [ref('tax_report_line_103_364')],
                 })]"/>
         </record>
         <record id="tax_withhold_profit_314D" model="account.tax.template">
@@ -649,18 +649,6 @@
                 (0,0, {
                     'factor_percent': 100,
                     'repartition_type': 'base',
-                    'plus_report_line_ids': [ref('tax_report_line_103_314')],
-                }),
-                (0,0, {
-                    'factor_percent': 100,
-                    'repartition_type': 'tax',
-                    'account_id': ref('l10n_ec.ret_ir_8x100'),
-                    'plus_report_line_ids': [ref('tax_report_line_103_364')],
-                })]"/>
-            <field name="refund_repartition_line_ids" eval="[(5, 0, 0),
-                (0,0, {
-                    'factor_percent': 100,
-                    'repartition_type': 'base',
                     'minus_report_line_ids': [ref('tax_report_line_103_314')],
                 }),
                 (0,0, {
@@ -668,6 +656,18 @@
                     'repartition_type': 'tax',
                     'account_id': ref('l10n_ec.ret_ir_8x100'),
                     'minus_report_line_ids': [ref('tax_report_line_103_364')],
+                })]"/>
+            <field name="refund_repartition_line_ids" eval="[(5, 0, 0),
+                (0,0, {
+                    'factor_percent': 100,
+                    'repartition_type': 'base',
+                    'plus_report_line_ids': [ref('tax_report_line_103_314')],
+                }),
+                (0,0, {
+                    'factor_percent': 100,
+                    'repartition_type': 'tax',
+                    'account_id': ref('l10n_ec.ret_ir_8x100'),
+                    'plus_report_line_ids': [ref('tax_report_line_103_364')],
                 })]"/>
         </record>
         <record id="tax_withhold_profit_319" model="account.tax.template">
@@ -686,18 +686,6 @@
                 (0,0, {
                     'factor_percent': 100,
                     'repartition_type': 'base',
-                    'plus_report_line_ids': [ref('tax_report_line_103_319')],
-                }),
-                (0,0, {
-                    'factor_percent': 100,
-                    'repartition_type': 'tax',
-                    'account_id': ref('l10n_ec.ret_ir_1_75x100'),
-                    'plus_report_line_ids': [ref('tax_report_line_103_369')],
-                })]"/>
-            <field name="refund_repartition_line_ids" eval="[(5, 0, 0),
-                (0,0, {
-                    'factor_percent': 100,
-                    'repartition_type': 'base',
                     'minus_report_line_ids': [ref('tax_report_line_103_319')],
                 }),
                 (0,0, {
@@ -705,6 +693,18 @@
                     'repartition_type': 'tax',
                     'account_id': ref('l10n_ec.ret_ir_1_75x100'),
                     'minus_report_line_ids': [ref('tax_report_line_103_369')],
+                })]"/>
+            <field name="refund_repartition_line_ids" eval="[(5, 0, 0),
+                (0,0, {
+                    'factor_percent': 100,
+                    'repartition_type': 'base',
+                    'plus_report_line_ids': [ref('tax_report_line_103_319')],
+                }),
+                (0,0, {
+                    'factor_percent': 100,
+                    'repartition_type': 'tax',
+                    'account_id': ref('l10n_ec.ret_ir_1_75x100'),
+                    'plus_report_line_ids': [ref('tax_report_line_103_369')],
                 })]"/>
         </record>
         <record id="tax_withhold_profit_320" model="account.tax.template">
@@ -723,18 +723,6 @@
                 (0,0, {
                     'factor_percent': 100,
                     'repartition_type': 'base',
-                    'plus_report_line_ids': [ref('tax_report_line_103_320')],
-                }),
-                (0,0, {
-                    'factor_percent': 100,
-                    'repartition_type': 'tax',
-                    'account_id': ref('l10n_ec.ret_ir_8x100'),
-                    'plus_report_line_ids': [ref('tax_report_line_103_370')],
-                })]"/>
-            <field name="refund_repartition_line_ids" eval="[(5, 0, 0),
-                (0,0, {
-                    'factor_percent': 100,
-                    'repartition_type': 'base',
                     'minus_report_line_ids': [ref('tax_report_line_103_320')],
                 }),
                 (0,0, {
@@ -742,6 +730,18 @@
                     'repartition_type': 'tax',
                     'account_id': ref('l10n_ec.ret_ir_8x100'),
                     'minus_report_line_ids': [ref('tax_report_line_103_370')],
+                })]"/>
+            <field name="refund_repartition_line_ids" eval="[(5, 0, 0),
+                (0,0, {
+                    'factor_percent': 100,
+                    'repartition_type': 'base',
+                    'plus_report_line_ids': [ref('tax_report_line_103_320')],
+                }),
+                (0,0, {
+                    'factor_percent': 100,
+                    'repartition_type': 'tax',
+                    'account_id': ref('l10n_ec.ret_ir_8x100'),
+                    'plus_report_line_ids': [ref('tax_report_line_103_370')],
                 })]"/>
         </record>
         <record id="tax_withhold_profit_322" model="account.tax.template">
@@ -760,18 +760,6 @@
                 (0,0, {
                     'factor_percent': 100,
                     'repartition_type': 'base',
-                    'plus_report_line_ids': [ref('tax_report_line_103_322')],
-                }),
-                (0,0, {
-                    'factor_percent': 100,
-                    'repartition_type': 'tax',
-                    'account_id': ref('l10n_ec.ret_ir_1_75x100'),
-                    'plus_report_line_ids': [ref('tax_report_line_103_372')],
-                })]"/>
-            <field name="refund_repartition_line_ids" eval="[(5, 0, 0),
-                (0,0, {
-                    'factor_percent': 100,
-                    'repartition_type': 'base',
                     'minus_report_line_ids': [ref('tax_report_line_103_322')],
                 }),
                 (0,0, {
@@ -779,6 +767,18 @@
                     'repartition_type': 'tax',
                     'account_id': ref('l10n_ec.ret_ir_1_75x100'),
                     'minus_report_line_ids': [ref('tax_report_line_103_372')],
+                })]"/>
+            <field name="refund_repartition_line_ids" eval="[(5, 0, 0),
+                (0,0, {
+                    'factor_percent': 100,
+                    'repartition_type': 'base',
+                    'plus_report_line_ids': [ref('tax_report_line_103_322')],
+                }),
+                (0,0, {
+                    'factor_percent': 100,
+                    'repartition_type': 'tax',
+                    'account_id': ref('l10n_ec.ret_ir_1_75x100'),
+                    'plus_report_line_ids': [ref('tax_report_line_103_372')],
                 })]"/>
         </record>
         <record id="tax_withhold_profit_332" model="account.tax.template">
@@ -1035,18 +1035,6 @@
                 (0,0, {
                     'factor_percent': 100,
                     'repartition_type': 'base',
-                    'plus_report_line_ids': [ref('tax_report_line_103_343')],
-                }),
-                (0,0, {
-                    'factor_percent': 100,
-                    'repartition_type': 'tax',
-                    'account_id': ref('l10n_ec.ret_ir_1x100'),
-                    'plus_report_line_ids': [ref('tax_report_line_103_393')],
-                })]"/>
-            <field name="refund_repartition_line_ids" eval="[(5, 0, 0),
-                (0,0, {
-                    'factor_percent': 100,
-                    'repartition_type': 'base',
                     'minus_report_line_ids': [ref('tax_report_line_103_343')],
                 }),
                 (0,0, {
@@ -1054,6 +1042,18 @@
                     'repartition_type': 'tax',
                     'account_id': ref('l10n_ec.ret_ir_1x100'),
                     'minus_report_line_ids': [ref('tax_report_line_103_393')],
+                })]"/>
+            <field name="refund_repartition_line_ids" eval="[(5, 0, 0),
+                (0,0, {
+                    'factor_percent': 100,
+                    'repartition_type': 'base',
+                    'plus_report_line_ids': [ref('tax_report_line_103_343')],
+                }),
+                (0,0, {
+                    'factor_percent': 100,
+                    'repartition_type': 'tax',
+                    'account_id': ref('l10n_ec.ret_ir_1x100'),
+                    'plus_report_line_ids': [ref('tax_report_line_103_393')],
                 })]"/>
         </record>
         <record id="tax_withhold_profit_343B" model="account.tax.template">
@@ -1072,18 +1072,6 @@
                 (0,0, {
                     'factor_percent': 100,
                     'repartition_type': 'base',
-                    'plus_report_line_ids': [ref('tax_report_line_103_343')],
-                }),
-                (0,0, {
-                    'factor_percent': 100,
-                    'repartition_type': 'tax',
-                    'account_id': ref('l10n_ec.ret_ir_1x100'),
-                    'plus_report_line_ids': [ref('tax_report_line_103_393')],
-                })]"/>
-            <field name="refund_repartition_line_ids" eval="[(5, 0, 0),
-                (0,0, {
-                    'factor_percent': 100,
-                    'repartition_type': 'base',
                     'minus_report_line_ids': [ref('tax_report_line_103_343')],
                 }),
                 (0,0, {
@@ -1091,6 +1079,18 @@
                     'repartition_type': 'tax',
                     'account_id': ref('l10n_ec.ret_ir_1x100'),
                     'minus_report_line_ids': [ref('tax_report_line_103_393')],
+                })]"/>
+            <field name="refund_repartition_line_ids" eval="[(5, 0, 0),
+                (0,0, {
+                    'factor_percent': 100,
+                    'repartition_type': 'base',
+                    'plus_report_line_ids': [ref('tax_report_line_103_343')],
+                }),
+                (0,0, {
+                    'factor_percent': 100,
+                    'repartition_type': 'tax',
+                    'account_id': ref('l10n_ec.ret_ir_1x100'),
+                    'plus_report_line_ids': [ref('tax_report_line_103_393')],
                 })]"/>
         </record>
         <record id="tax_withhold_profit_3440" model="account.tax.template">
@@ -1109,18 +1109,6 @@
                 (0,0, {
                     'factor_percent': 100,
                     'repartition_type': 'base',
-                    'plus_report_line_ids': [ref('tax_report_line_103_3440')],
-                }),
-                (0,0, {
-                    'factor_percent': 100,
-                    'repartition_type': 'tax',
-                    'account_id': ref('l10n_ec.ret_ir_2_75x100'),
-                    'plus_report_line_ids': [ref('tax_report_line_103_394')],
-                })]"/>
-            <field name="refund_repartition_line_ids" eval="[(5, 0, 0),
-                (0,0, {
-                    'factor_percent': 100,
-                    'repartition_type': 'base',
                     'minus_report_line_ids': [ref('tax_report_line_103_3440')],
                 }),
                 (0,0, {
@@ -1128,6 +1116,18 @@
                     'repartition_type': 'tax',
                     'account_id': ref('l10n_ec.ret_ir_2_75x100'),
                     'minus_report_line_ids': [ref('tax_report_line_103_394')],
+                })]"/>
+            <field name="refund_repartition_line_ids" eval="[(5, 0, 0),
+                (0,0, {
+                    'factor_percent': 100,
+                    'repartition_type': 'base',
+                    'plus_report_line_ids': [ref('tax_report_line_103_3440')],
+                }),
+                (0,0, {
+                    'factor_percent': 100,
+                    'repartition_type': 'tax',
+                    'account_id': ref('l10n_ec.ret_ir_2_75x100'),
+                    'plus_report_line_ids': [ref('tax_report_line_103_394')],
                 })]"/>
         </record>
         <record id="tax_withhold_profit_346" model="account.tax.template">
@@ -1146,18 +1146,6 @@
                 (0,0, {
                     'factor_percent': 100,
                     'repartition_type': 'base',
-                    'plus_report_line_ids': [ref('tax_report_line_103_396')],
-                }),
-                (0,0, {
-                    'factor_percent': 100,
-                    'repartition_type': 'tax',
-                    'account_id': ref('l10n_ec.ret_ir_1_75x100'),
-                    'plus_report_line_ids': [ref('tax_report_line_103_346')],
-                })]"/>
-            <field name="refund_repartition_line_ids" eval="[(5, 0, 0),
-                (0,0, {
-                    'factor_percent': 100,
-                    'repartition_type': 'base',
                     'minus_report_line_ids': [ref('tax_report_line_103_396')],
                 }),
                 (0,0, {
@@ -1165,6 +1153,18 @@
                     'repartition_type': 'tax',
                     'account_id': ref('l10n_ec.ret_ir_1_75x100'),
                     'minus_report_line_ids': [ref('tax_report_line_103_346')],
+                })]"/>
+            <field name="refund_repartition_line_ids" eval="[(5, 0, 0),
+                (0,0, {
+                    'factor_percent': 100,
+                    'repartition_type': 'base',
+                    'plus_report_line_ids': [ref('tax_report_line_103_396')],
+                }),
+                (0,0, {
+                    'factor_percent': 100,
+                    'repartition_type': 'tax',
+                    'account_id': ref('l10n_ec.ret_ir_1_75x100'),
+                    'plus_report_line_ids': [ref('tax_report_line_103_346')],
                 })]"/>
         </record>
         <record id="tax_withhold_profit_347_346" model="account.tax.template">
@@ -1183,18 +1183,6 @@
                 (0,0, {
                     'factor_percent': 100,
                     'repartition_type': 'base',
-                    'plus_report_line_ids': [ref('tax_report_line_103_346')],
-                }),
-                (0,0, {
-                    'factor_percent': 100,
-                    'repartition_type': 'tax',
-                    'account_id': ref('l10n_ec.ret_ir_2x100'),
-                    'plus_report_line_ids': [ref('tax_report_line_103_396')],
-                })]"/>
-            <field name="refund_repartition_line_ids" eval="[(5, 0, 0),
-                (0,0, {
-                    'factor_percent': 100,
-                    'repartition_type': 'base',
                     'minus_report_line_ids': [ref('tax_report_line_103_346')],
                 }),
                 (0,0, {
@@ -1202,6 +1190,18 @@
                     'repartition_type': 'tax',
                     'account_id': ref('l10n_ec.ret_ir_2x100'),
                     'minus_report_line_ids': [ref('tax_report_line_103_396')],
+                })]"/>
+            <field name="refund_repartition_line_ids" eval="[(5, 0, 0),
+                (0,0, {
+                    'factor_percent': 100,
+                    'repartition_type': 'base',
+                    'plus_report_line_ids': [ref('tax_report_line_103_346')],
+                }),
+                (0,0, {
+                    'factor_percent': 100,
+                    'repartition_type': 'tax',
+                    'account_id': ref('l10n_ec.ret_ir_2x100'),
+                    'plus_report_line_ids': [ref('tax_report_line_103_396')],
                 })]"/>
         </record>
         <record id="tax_withhold_profit_501_411" model="account.tax.template">
@@ -1220,18 +1220,6 @@
                 (0,0, {
                     'factor_percent': 100,
                     'repartition_type': 'base',
-                    'plus_report_line_ids': [ref('tax_report_line_103_411')],
-                }),
-                (0,0, {
-                    'factor_percent': 100,
-                    'repartition_type': 'tax',
-                    'account_id': ref('l10n_ec.ret_ir_22x100'),
-                    'plus_report_line_ids': [ref('tax_report_line_103_461')],
-                })]"/>
-            <field name="refund_repartition_line_ids" eval="[(5, 0, 0),
-                (0,0, {
-                    'factor_percent': 100,
-                    'repartition_type': 'base',
                     'minus_report_line_ids': [ref('tax_report_line_103_411')],
                 }),
                 (0,0, {
@@ -1239,6 +1227,18 @@
                     'repartition_type': 'tax',
                     'account_id': ref('l10n_ec.ret_ir_22x100'),
                     'minus_report_line_ids': [ref('tax_report_line_103_461')],
+                })]"/>
+            <field name="refund_repartition_line_ids" eval="[(5, 0, 0),
+                (0,0, {
+                    'factor_percent': 100,
+                    'repartition_type': 'base',
+                    'plus_report_line_ids': [ref('tax_report_line_103_411')],
+                }),
+                (0,0, {
+                    'factor_percent': 100,
+                    'repartition_type': 'tax',
+                    'account_id': ref('l10n_ec.ret_ir_22x100'),
+                    'plus_report_line_ids': [ref('tax_report_line_103_461')],
                 })]"/>
         </record>
         <record id="tax_withhold_profit_501_422" model="account.tax.template">
@@ -1257,18 +1257,6 @@
                 (0,0, {
                     'factor_percent': 100,
                     'repartition_type': 'base',
-                    'plus_report_line_ids': [ref('tax_report_line_103_422')],
-                }),
-                (0,0, {
-                    'factor_percent': 100,
-                    'repartition_type': 'tax',
-                    'account_id': ref('l10n_ec.ret_ir_22x100'),
-                    'plus_report_line_ids': [ref('tax_report_line_103_472')],
-                })]"/>
-            <field name="refund_repartition_line_ids" eval="[(5, 0, 0),
-                (0,0, {
-                    'factor_percent': 100,
-                    'repartition_type': 'base',
                     'minus_report_line_ids': [ref('tax_report_line_103_422')],
                 }),
                 (0,0, {
@@ -1276,6 +1264,18 @@
                     'repartition_type': 'tax',
                     'account_id': ref('l10n_ec.ret_ir_22x100'),
                     'minus_report_line_ids': [ref('tax_report_line_103_472')],
+                })]"/>
+            <field name="refund_repartition_line_ids" eval="[(5, 0, 0),
+                (0,0, {
+                    'factor_percent': 100,
+                    'repartition_type': 'base',
+                    'plus_report_line_ids': [ref('tax_report_line_103_422')],
+                }),
+                (0,0, {
+                    'factor_percent': 100,
+                    'repartition_type': 'tax',
+                    'account_id': ref('l10n_ec.ret_ir_22x100'),
+                    'plus_report_line_ids': [ref('tax_report_line_103_472')],
                 })]"/>
         </record>
         <record id="tax_withhold_profit_502_411" model="account.tax.template">
@@ -1294,18 +1294,6 @@
                 (0,0, {
                     'factor_percent': 100,
                     'repartition_type': 'base',
-                    'plus_report_line_ids': [ref('tax_report_line_103_411')],
-                }),
-                (0,0, {
-                    'factor_percent': 100,
-                    'repartition_type': 'tax',
-                    'account_id': ref('l10n_ec.ret_ir_22x100'),
-                    'plus_report_line_ids': [ref('tax_report_line_103_461')],
-                })]"/>
-            <field name="refund_repartition_line_ids" eval="[(5, 0, 0),
-                (0,0, {
-                    'factor_percent': 100,
-                    'repartition_type': 'base',
                     'minus_report_line_ids': [ref('tax_report_line_103_411')],
                 }),
                 (0,0, {
@@ -1313,6 +1301,18 @@
                     'repartition_type': 'tax',
                     'account_id': ref('l10n_ec.ret_ir_22x100'),
                     'minus_report_line_ids': [ref('tax_report_line_103_461')],
+                })]"/>
+            <field name="refund_repartition_line_ids" eval="[(5, 0, 0),
+                (0,0, {
+                    'factor_percent': 100,
+                    'repartition_type': 'base',
+                    'plus_report_line_ids': [ref('tax_report_line_103_411')],
+                }),
+                (0,0, {
+                    'factor_percent': 100,
+                    'repartition_type': 'tax',
+                    'account_id': ref('l10n_ec.ret_ir_22x100'),
+                    'plus_report_line_ids': [ref('tax_report_line_103_461')],
                 })]"/>
         </record>
         <record id="tax_withhold_profit_502_422" model="account.tax.template">
@@ -1331,18 +1331,6 @@
                 (0,0, {
                     'factor_percent': 100,
                     'repartition_type': 'base',
-                    'plus_report_line_ids': [ref('tax_report_line_103_422')],
-                }),
-                (0,0, {
-                    'factor_percent': 100,
-                    'repartition_type': 'tax',
-                    'account_id': ref('l10n_ec.ret_ir_22x100'),
-                    'plus_report_line_ids': [ref('tax_report_line_103_472')],
-                })]"/>
-            <field name="refund_repartition_line_ids" eval="[(5, 0, 0),
-                (0,0, {
-                    'factor_percent': 100,
-                    'repartition_type': 'base',
                     'minus_report_line_ids': [ref('tax_report_line_103_422')],
                 }),
                 (0,0, {
@@ -1350,6 +1338,18 @@
                     'repartition_type': 'tax',
                     'account_id': ref('l10n_ec.ret_ir_22x100'),
                     'minus_report_line_ids': [ref('tax_report_line_103_472')],
+                })]"/>
+            <field name="refund_repartition_line_ids" eval="[(5, 0, 0),
+                (0,0, {
+                    'factor_percent': 100,
+                    'repartition_type': 'base',
+                    'plus_report_line_ids': [ref('tax_report_line_103_422')],
+                }),
+                (0,0, {
+                    'factor_percent': 100,
+                    'repartition_type': 'tax',
+                    'account_id': ref('l10n_ec.ret_ir_22x100'),
+                    'plus_report_line_ids': [ref('tax_report_line_103_472')],
                 })]"/>
         </record>
         <record id="tax_withhold_profit_509_411" model="account.tax.template">
@@ -1368,18 +1368,6 @@
                 (0,0, {
                     'factor_percent': 100,
                     'repartition_type': 'base',
-                    'plus_report_line_ids': [ref('tax_report_line_103_411')],
-                }),
-                (0,0, {
-                    'factor_percent': 100,
-                    'repartition_type': 'tax',
-                    'account_id': ref('l10n_ec.ret_ir_22x100'),
-                    'plus_report_line_ids': [ref('tax_report_line_103_461')],
-                })]"/>
-            <field name="refund_repartition_line_ids" eval="[(5, 0, 0),
-                (0,0, {
-                    'factor_percent': 100,
-                    'repartition_type': 'base',
                     'minus_report_line_ids': [ref('tax_report_line_103_411')],
                 }),
                 (0,0, {
@@ -1387,6 +1375,18 @@
                     'repartition_type': 'tax',
                     'account_id': ref('l10n_ec.ret_ir_22x100'),
                     'minus_report_line_ids': [ref('tax_report_line_103_461')],
+                })]"/>
+            <field name="refund_repartition_line_ids" eval="[(5, 0, 0),
+                (0,0, {
+                    'factor_percent': 100,
+                    'repartition_type': 'base',
+                    'plus_report_line_ids': [ref('tax_report_line_103_411')],
+                }),
+                (0,0, {
+                    'factor_percent': 100,
+                    'repartition_type': 'tax',
+                    'account_id': ref('l10n_ec.ret_ir_22x100'),
+                    'plus_report_line_ids': [ref('tax_report_line_103_461')],
                 })]"/>
         </record>
         <record id="tax_withhold_profit_509_422" model="account.tax.template">
@@ -1405,18 +1405,6 @@
                 (0,0, {
                     'factor_percent': 100,
                     'repartition_type': 'base',
-                    'plus_report_line_ids': [ref('tax_report_line_103_422')],
-                }),
-                (0,0, {
-                    'factor_percent': 100,
-                    'repartition_type': 'tax',
-                    'account_id': ref('l10n_ec.ret_ir_22x100'),
-                    'plus_report_line_ids': [ref('tax_report_line_103_472')],
-                })]"/>
-            <field name="refund_repartition_line_ids" eval="[(5, 0, 0),
-                (0,0, {
-                    'factor_percent': 100,
-                    'repartition_type': 'base',
                     'minus_report_line_ids': [ref('tax_report_line_103_422')],
                 }),
                 (0,0, {
@@ -1424,6 +1412,18 @@
                     'repartition_type': 'tax',
                     'account_id': ref('l10n_ec.ret_ir_22x100'),
                     'minus_report_line_ids': [ref('tax_report_line_103_472')],
+                })]"/>
+            <field name="refund_repartition_line_ids" eval="[(5, 0, 0),
+                (0,0, {
+                    'factor_percent': 100,
+                    'repartition_type': 'base',
+                    'plus_report_line_ids': [ref('tax_report_line_103_422')],
+                }),
+                (0,0, {
+                    'factor_percent': 100,
+                    'repartition_type': 'tax',
+                    'account_id': ref('l10n_ec.ret_ir_22x100'),
+                    'plus_report_line_ids': [ref('tax_report_line_103_472')],
                 })]"/>
         </record>
         <record id="tax_withhold_profit_511_411" model="account.tax.template">
@@ -1442,18 +1442,6 @@
                 (0,0, {
                     'factor_percent': 100,
                     'repartition_type': 'base',
-                    'plus_report_line_ids': [ref('tax_report_line_103_411')],
-                }),
-                (0,0, {
-                    'factor_percent': 100,
-                    'repartition_type': 'tax',
-                    'account_id': ref('l10n_ec.ret_ir_22x100'),
-                    'plus_report_line_ids': [ref('tax_report_line_103_461')],
-                })]"/>
-            <field name="refund_repartition_line_ids" eval="[(5, 0, 0),
-                (0,0, {
-                    'factor_percent': 100,
-                    'repartition_type': 'base',
                     'minus_report_line_ids': [ref('tax_report_line_103_411')],
                 }),
                 (0,0, {
@@ -1461,6 +1449,18 @@
                     'repartition_type': 'tax',
                     'account_id': ref('l10n_ec.ret_ir_22x100'),
                     'minus_report_line_ids': [ref('tax_report_line_103_461')],
+                })]"/>
+            <field name="refund_repartition_line_ids" eval="[(5, 0, 0),
+                (0,0, {
+                    'factor_percent': 100,
+                    'repartition_type': 'base',
+                    'plus_report_line_ids': [ref('tax_report_line_103_411')],
+                }),
+                (0,0, {
+                    'factor_percent': 100,
+                    'repartition_type': 'tax',
+                    'account_id': ref('l10n_ec.ret_ir_22x100'),
+                    'plus_report_line_ids': [ref('tax_report_line_103_461')],
                 })]"/>
         </record>
         <record id="tax_withhold_profit_512_411" model="account.tax.template">
@@ -1479,18 +1479,6 @@
                 (0,0, {
                     'factor_percent': 100,
                     'repartition_type': 'base',
-                    'plus_report_line_ids': [ref('tax_report_line_103_411')],
-                }),
-                (0,0, {
-                    'factor_percent': 100,
-                    'repartition_type': 'tax',
-                    'account_id': ref('l10n_ec.ret_ir_22x100'),
-                    'plus_report_line_ids': [ref('tax_report_line_103_461')],
-                })]"/>
-            <field name="refund_repartition_line_ids" eval="[(5, 0, 0),
-                (0,0, {
-                    'factor_percent': 100,
-                    'repartition_type': 'base',
                     'minus_report_line_ids': [ref('tax_report_line_103_411')],
                 }),
                 (0,0, {
@@ -1498,6 +1486,18 @@
                     'repartition_type': 'tax',
                     'account_id': ref('l10n_ec.ret_ir_22x100'),
                     'minus_report_line_ids': [ref('tax_report_line_103_461')],
+                })]"/>
+            <field name="refund_repartition_line_ids" eval="[(5, 0, 0),
+                (0,0, {
+                    'factor_percent': 100,
+                    'repartition_type': 'base',
+                    'plus_report_line_ids': [ref('tax_report_line_103_411')],
+                }),
+                (0,0, {
+                    'factor_percent': 100,
+                    'repartition_type': 'tax',
+                    'account_id': ref('l10n_ec.ret_ir_22x100'),
+                    'plus_report_line_ids': [ref('tax_report_line_103_461')],
                 })]"/>
         </record>
         <record id="tax_withhold_profit_517_411" model="account.tax.template">
@@ -1516,18 +1516,6 @@
                 (0,0, {
                     'factor_percent': 100,
                     'repartition_type': 'base',
-                    'plus_report_line_ids': [ref('tax_report_line_103_411')],
-                }),
-                (0,0, {
-                    'factor_percent': 100,
-                    'repartition_type': 'tax',
-                    'account_id': ref('l10n_ec.ret_ir_22x100'),
-                    'plus_report_line_ids': [ref('tax_report_line_103_461')],
-                })]"/>
-            <field name="refund_repartition_line_ids" eval="[(5, 0, 0),
-                (0,0, {
-                    'factor_percent': 100,
-                    'repartition_type': 'base',
                     'minus_report_line_ids': [ref('tax_report_line_103_411')],
                 }),
                 (0,0, {
@@ -1535,6 +1523,18 @@
                     'repartition_type': 'tax',
                     'account_id': ref('l10n_ec.ret_ir_22x100'),
                     'minus_report_line_ids': [ref('tax_report_line_103_461')],
+                })]"/>
+            <field name="refund_repartition_line_ids" eval="[(5, 0, 0),
+                (0,0, {
+                    'factor_percent': 100,
+                    'repartition_type': 'base',
+                    'plus_report_line_ids': [ref('tax_report_line_103_411')],
+                }),
+                (0,0, {
+                    'factor_percent': 100,
+                    'repartition_type': 'tax',
+                    'account_id': ref('l10n_ec.ret_ir_22x100'),
+                    'plus_report_line_ids': [ref('tax_report_line_103_461')],
                 })]"/>
         </record>
         <record id="tax_withhold_profit_520D_411" model="account.tax.template">
@@ -1553,18 +1553,6 @@
                 (0,0, {
                     'factor_percent': 100,
                     'repartition_type': 'base',
-                    'plus_report_line_ids': [ref('tax_report_line_103_411')],
-                }),
-                (0,0, {
-                    'factor_percent': 100,
-                    'repartition_type': 'tax',
-                    'account_id': ref('l10n_ec.ret_ir_22x100'),
-                    'plus_report_line_ids': [ref('tax_report_line_103_461')],
-                })]"/>
-            <field name="refund_repartition_line_ids" eval="[(5, 0, 0),
-                (0,0, {
-                    'factor_percent': 100,
-                    'repartition_type': 'base',
                     'minus_report_line_ids': [ref('tax_report_line_103_411')],
                 }),
                 (0,0, {
@@ -1572,6 +1560,18 @@
                     'repartition_type': 'tax',
                     'account_id': ref('l10n_ec.ret_ir_22x100'),
                     'minus_report_line_ids': [ref('tax_report_line_103_461')],
+                })]"/>
+            <field name="refund_repartition_line_ids" eval="[(5, 0, 0),
+                (0,0, {
+                    'factor_percent': 100,
+                    'repartition_type': 'base',
+                    'plus_report_line_ids': [ref('tax_report_line_103_411')],
+                }),
+                (0,0, {
+                    'factor_percent': 100,
+                    'repartition_type': 'tax',
+                    'account_id': ref('l10n_ec.ret_ir_22x100'),
+                    'plus_report_line_ids': [ref('tax_report_line_103_461')],
                 })]"/>
         </record>
         <record id="tax_withhold_profit_522A_410" model="account.tax.template">
@@ -1590,18 +1590,6 @@
                 (0,0, {
                     'factor_percent': 100,
                     'repartition_type': 'base',
-                    'plus_report_line_ids': [ref('tax_report_line_103_410')],
-                }),
-                (0,0, {
-                    'factor_percent': 100,
-                    'repartition_type': 'tax',
-                    'account_id': ref('l10n_ec.ret_ir_22x100'),
-                    'plus_report_line_ids': [ref('tax_report_line_103_460')],
-                })]"/>
-            <field name="refund_repartition_line_ids" eval="[(5, 0, 0),
-                (0,0, {
-                    'factor_percent': 100,
-                    'repartition_type': 'base',
                     'minus_report_line_ids': [ref('tax_report_line_103_410')],
                 }),
                 (0,0, {
@@ -1609,6 +1597,18 @@
                     'repartition_type': 'tax',
                     'account_id': ref('l10n_ec.ret_ir_22x100'),
                     'minus_report_line_ids': [ref('tax_report_line_103_460')],
+                })]"/>
+            <field name="refund_repartition_line_ids" eval="[(5, 0, 0),
+                (0,0, {
+                    'factor_percent': 100,
+                    'repartition_type': 'base',
+                    'plus_report_line_ids': [ref('tax_report_line_103_410')],
+                }),
+                (0,0, {
+                    'factor_percent': 100,
+                    'repartition_type': 'tax',
+                    'account_id': ref('l10n_ec.ret_ir_22x100'),
+                    'plus_report_line_ids': [ref('tax_report_line_103_460')],
                 })]"/>
         </record>
         <!-- 
@@ -1627,18 +1627,6 @@
                 (0,0, {
                     'factor_percent': 100,
                     'repartition_type': 'base',
-                    'plus_report_line_ids': [ref('tax_report_line_103_343')],
-                }),
-                (0,0, {
-                    'factor_percent': 100,
-                    'repartition_type': 'tax',
-                    'account_id': ref('l10n_ec.ec_sale_profit_withhold'),
-                    'plus_report_line_ids': [ref('tax_report_line_103_393')],
-                })]"/>
-            <field name="refund_repartition_line_ids" eval="[(5, 0, 0),
-                (0,0, {
-                    'factor_percent': 100,
-                    'repartition_type': 'base',
                     'minus_report_line_ids': [ref('tax_report_line_103_343')],
                 }),
                 (0,0, {
@@ -1646,6 +1634,18 @@
                     'repartition_type': 'tax',
                     'account_id': ref('l10n_ec.ec_sale_profit_withhold'),
                     'minus_report_line_ids': [ref('tax_report_line_103_393')],
+                })]"/>
+            <field name="refund_repartition_line_ids" eval="[(5, 0, 0),
+                (0,0, {
+                    'factor_percent': 100,
+                    'repartition_type': 'base',
+                    'plus_report_line_ids': [ref('tax_report_line_103_343')],
+                }),
+                (0,0, {
+                    'factor_percent': 100,
+                    'repartition_type': 'tax',
+                    'account_id': ref('l10n_ec.ec_sale_profit_withhold'),
+                    'plus_report_line_ids': [ref('tax_report_line_103_393')],
                 })]"/>
         </record>
         <record id="tax_withhold_profit_sale_1_75x100" model="account.tax.template">
@@ -1661,18 +1661,6 @@
                 (0,0, {
                     'factor_percent': 100,
                     'repartition_type': 'base',
-                    'plus_report_line_ids': [ref('tax_report_line_103_346')],
-                }),
-                (0,0, {
-                    'factor_percent': 100,
-                    'repartition_type': 'tax',
-                    'account_id': ref('l10n_ec.ec_sale_profit_withhold'),
-                    'plus_report_line_ids': [ref('tax_report_line_103_396')],
-                })]"/>
-            <field name="refund_repartition_line_ids" eval="[(5, 0, 0),
-                (0,0, {
-                    'factor_percent': 100,
-                    'repartition_type': 'base',
                     'minus_report_line_ids': [ref('tax_report_line_103_346')],
                 }),
                 (0,0, {
@@ -1680,6 +1668,18 @@
                     'repartition_type': 'tax',
                     'account_id': ref('l10n_ec.ec_sale_profit_withhold'),
                     'minus_report_line_ids': [ref('tax_report_line_103_396')],
+                })]"/>
+            <field name="refund_repartition_line_ids" eval="[(5, 0, 0),
+                (0,0, {
+                    'factor_percent': 100,
+                    'repartition_type': 'base',
+                    'plus_report_line_ids': [ref('tax_report_line_103_346')],
+                }),
+                (0,0, {
+                    'factor_percent': 100,
+                    'repartition_type': 'tax',
+                    'account_id': ref('l10n_ec.ec_sale_profit_withhold'),
+                    'plus_report_line_ids': [ref('tax_report_line_103_396')],
                 })]"/>
         </record>
         <record id="tax_withhold_profit_sale_2x100" model="account.tax.template">
@@ -1695,18 +1695,6 @@
                 (0,0, {
                     'factor_percent': 100,
                     'repartition_type': 'base',
-                    'plus_report_line_ids': [ref('tax_report_line_103_344')],
-                }),
-                (0,0, {
-                    'factor_percent': 100,
-                    'repartition_type': 'tax',
-                    'account_id': ref('l10n_ec.ec_sale_profit_withhold'),
-                    'plus_report_line_ids': [ref('tax_report_line_103_394')],
-                })]"/>
-            <field name="refund_repartition_line_ids" eval="[(5, 0, 0),
-                (0,0, {
-                    'factor_percent': 100,
-                    'repartition_type': 'base',
                     'minus_report_line_ids': [ref('tax_report_line_103_344')],
                 }),
                 (0,0, {
@@ -1714,6 +1702,18 @@
                     'repartition_type': 'tax',
                     'account_id': ref('l10n_ec.ec_sale_profit_withhold'),
                     'minus_report_line_ids': [ref('tax_report_line_103_394')],
+                })]"/>
+            <field name="refund_repartition_line_ids" eval="[(5, 0, 0),
+                (0,0, {
+                    'factor_percent': 100,
+                    'repartition_type': 'base',
+                    'plus_report_line_ids': [ref('tax_report_line_103_344')],
+                }),
+                (0,0, {
+                    'factor_percent': 100,
+                    'repartition_type': 'tax',
+                    'account_id': ref('l10n_ec.ec_sale_profit_withhold'),
+                    'plus_report_line_ids': [ref('tax_report_line_103_394')],
                 })]"/>
         </record>
         <record id="tax_withhold_profit_sale_2_75x100" model="account.tax.template">
@@ -1729,18 +1729,6 @@
                 (0,0, {
                     'factor_percent': 100,
                     'repartition_type': 'base',
-                    'plus_report_line_ids': [ref('tax_report_line_103_3440')],
-                }),
-                (0,0, {
-                    'factor_percent': 100,
-                    'repartition_type': 'tax',
-                    'account_id': ref('l10n_ec.ec_sale_profit_withhold'),
-                    'plus_report_line_ids': [ref('tax_report_line_103_3940')],
-                })]"/>
-            <field name="refund_repartition_line_ids" eval="[(5, 0, 0),
-                (0,0, {
-                    'factor_percent': 100,
-                    'repartition_type': 'base',
                     'minus_report_line_ids': [ref('tax_report_line_103_3440')],
                 }),
                 (0,0, {
@@ -1748,6 +1736,18 @@
                     'repartition_type': 'tax',
                     'account_id': ref('l10n_ec.ec_sale_profit_withhold'),
                     'minus_report_line_ids': [ref('tax_report_line_103_3940')],
+                })]"/>
+            <field name="refund_repartition_line_ids" eval="[(5, 0, 0),
+                (0,0, {
+                    'factor_percent': 100,
+                    'repartition_type': 'base',
+                    'plus_report_line_ids': [ref('tax_report_line_103_3440')],
+                }),
+                (0,0, {
+                    'factor_percent': 100,
+                    'repartition_type': 'tax',
+                    'account_id': ref('l10n_ec.ec_sale_profit_withhold'),
+                    'plus_report_line_ids': [ref('tax_report_line_103_3940')],
                 })]"/>
         </record>
         <record id="tax_withhold_profit_sale_5x100" model="account.tax.template">
@@ -1763,18 +1763,6 @@
                 (0,0, {
                     'factor_percent': 100,
                     'repartition_type': 'base',
-                    'plus_report_line_ids': [ref('tax_report_line_103_346')],
-                }),
-                (0,0, {
-                    'factor_percent': 100,
-                    'repartition_type': 'tax',
-                    'account_id': ref('l10n_ec.ec_sale_profit_withhold'),
-                    'plus_report_line_ids': [ref('tax_report_line_103_396')],
-                })]"/>
-            <field name="refund_repartition_line_ids" eval="[(5, 0, 0),
-                (0,0, {
-                    'factor_percent': 100,
-                    'repartition_type': 'base',
                     'minus_report_line_ids': [ref('tax_report_line_103_346')],
                 }),
                 (0,0, {
@@ -1782,6 +1770,18 @@
                     'repartition_type': 'tax',
                     'account_id': ref('l10n_ec.ec_sale_profit_withhold'),
                     'minus_report_line_ids': [ref('tax_report_line_103_396')],
+                })]"/>
+            <field name="refund_repartition_line_ids" eval="[(5, 0, 0),
+                (0,0, {
+                    'factor_percent': 100,
+                    'repartition_type': 'base',
+                    'plus_report_line_ids': [ref('tax_report_line_103_346')],
+                }),
+                (0,0, {
+                    'factor_percent': 100,
+                    'repartition_type': 'tax',
+                    'account_id': ref('l10n_ec.ec_sale_profit_withhold'),
+                    'plus_report_line_ids': [ref('tax_report_line_103_396')],
                 })]"/>
         </record>
         <record id="tax_withhold_profit_sale_8x100" model="account.tax.template">
@@ -1797,18 +1797,6 @@
                 (0,0, {
                     'factor_percent': 100,
                     'repartition_type': 'base',
-                    'plus_report_line_ids': [ref('tax_report_line_103_345')],
-                }),
-                (0,0, {
-                    'factor_percent': 100,
-                    'repartition_type': 'tax',
-                    'account_id': ref('l10n_ec.ec_sale_profit_withhold'),
-                    'plus_report_line_ids': [ref('tax_report_line_103_395')],
-                })]"/>
-            <field name="refund_repartition_line_ids" eval="[(5, 0, 0),
-                (0,0, {
-                    'factor_percent': 100,
-                    'repartition_type': 'base',
                     'minus_report_line_ids': [ref('tax_report_line_103_345')],
                 }),
                 (0,0, {
@@ -1816,6 +1804,18 @@
                     'repartition_type': 'tax',
                     'account_id': ref('l10n_ec.ec_sale_profit_withhold'),
                     'minus_report_line_ids': [ref('tax_report_line_103_395')],
+                })]"/>
+            <field name="refund_repartition_line_ids" eval="[(5, 0, 0),
+                (0,0, {
+                    'factor_percent': 100,
+                    'repartition_type': 'base',
+                    'plus_report_line_ids': [ref('tax_report_line_103_345')],
+                }),
+                (0,0, {
+                    'factor_percent': 100,
+                    'repartition_type': 'tax',
+                    'account_id': ref('l10n_ec.ec_sale_profit_withhold'),
+                    'plus_report_line_ids': [ref('tax_report_line_103_395')],
                 })]"/>
         </record>
         <record id="tax_withhold_profit_sale_10x100" model="account.tax.template">
@@ -1831,18 +1831,6 @@
                 (0,0, {
                     'factor_percent': 100,
                     'repartition_type': 'base',
-                    'plus_report_line_ids': [ref('tax_report_line_103_346')],
-                }),
-                (0,0, {
-                    'factor_percent': 100,
-                    'repartition_type': 'tax',
-                    'account_id': ref('l10n_ec.ec_sale_profit_withhold'),
-                    'plus_report_line_ids': [ref('tax_report_line_103_396')],
-                })]"/>
-            <field name="refund_repartition_line_ids" eval="[(5, 0, 0),
-                (0,0, {
-                    'factor_percent': 100,
-                    'repartition_type': 'base',
                     'minus_report_line_ids': [ref('tax_report_line_103_346')],
                 }),
                 (0,0, {
@@ -1850,6 +1838,18 @@
                     'repartition_type': 'tax',
                     'account_id': ref('l10n_ec.ec_sale_profit_withhold'),
                     'minus_report_line_ids': [ref('tax_report_line_103_396')],
+                })]"/>
+            <field name="refund_repartition_line_ids" eval="[(5, 0, 0),
+                (0,0, {
+                    'factor_percent': 100,
+                    'repartition_type': 'base',
+                    'plus_report_line_ids': [ref('tax_report_line_103_346')],
+                }),
+                (0,0, {
+                    'factor_percent': 100,
+                    'repartition_type': 'tax',
+                    'account_id': ref('l10n_ec.ec_sale_profit_withhold'),
+                    'plus_report_line_ids': [ref('tax_report_line_103_396')],
                 })]"/>
         </record>
         <record id="tax_withhold_profit_sale_15x100" model="account.tax.template">
@@ -1865,18 +1865,6 @@
                 (0,0, {
                     'factor_percent': 100,
                     'repartition_type': 'base',
-                    'plus_report_line_ids': [ref('tax_report_line_103_346')],
-                }),
-                (0,0, {
-                    'factor_percent': 100,
-                    'repartition_type': 'tax',
-                    'account_id': ref('l10n_ec.ec_sale_profit_withhold'),
-                    'plus_report_line_ids': [ref('tax_report_line_103_396')],
-                })]"/>
-            <field name="refund_repartition_line_ids" eval="[(5, 0, 0),
-                (0,0, {
-                    'factor_percent': 100,
-                    'repartition_type': 'base',
                     'minus_report_line_ids': [ref('tax_report_line_103_346')],
                 }),
                 (0,0, {
@@ -1884,6 +1872,18 @@
                     'repartition_type': 'tax',
                     'account_id': ref('l10n_ec.ec_sale_profit_withhold'),
                     'minus_report_line_ids': [ref('tax_report_line_103_396')],
+                })]"/>
+            <field name="refund_repartition_line_ids" eval="[(5, 0, 0),
+                (0,0, {
+                    'factor_percent': 100,
+                    'repartition_type': 'base',
+                    'plus_report_line_ids': [ref('tax_report_line_103_346')],
+                }),
+                (0,0, {
+                    'factor_percent': 100,
+                    'repartition_type': 'tax',
+                    'account_id': ref('l10n_ec.ec_sale_profit_withhold'),
+                    'plus_report_line_ids': [ref('tax_report_line_103_396')],
                 })]"/>
         </record>
         <record id="tax_withhold_profit_sale_22x100" model="account.tax.template">
@@ -1899,13 +1899,13 @@
                 (0,0, {
                     'factor_percent': 100,
                     'repartition_type': 'base',
-                    'plus_report_line_ids': [ref('tax_report_line_103_346')],
+                    'minus_report_line_ids': [ref('tax_report_line_103_346')],
                 }),
                 (0,0, {
                     'factor_percent': 100,
                     'repartition_type': 'tax',
                     'account_id': ref('l10n_ec.ec_sale_profit_withhold'),
-                    'plus_report_line_ids': [ref('tax_report_line_103_396')],
+                    'minus_report_line_ids': [ref('tax_report_line_103_396')],
                 })]"/>
             <field name="refund_repartition_line_ids" eval="[(5, 0, 0),
                 (0,0, {
@@ -1917,7 +1917,7 @@
                     'factor_percent': 100,
                     'repartition_type': 'tax',
                     'account_id': ref('l10n_ec.ec_sale_profit_withhold'),
-                    'minus_report_line_ids': [ref('tax_report_line_103_396')],
+                    'plus_report_line_ids': [ref('tax_report_line_103_396')],
                 })]"/>
         </record>
     </data>

--- a/addons/l10n_ec/data/account_tax_template_withhold_vat_data.xml
+++ b/addons/l10n_ec/data/account_tax_template_withhold_vat_data.xml
@@ -23,7 +23,7 @@
                     'factor_percent': 12,
                     'repartition_type': 'tax',
                     'account_id': ref('l10n_ec.ec_vat_withhold_10'),
-                    'plus_report_line_ids': [ref('tax_report_line_104_721')],
+                    'minus_report_line_ids': [ref('tax_report_line_104_721')],
                 }),]"/>
             <field name="refund_repartition_line_ids" eval="[(5, 0, 0),
                 (0,0, {
@@ -34,7 +34,7 @@
                     'factor_percent': 12,
                     'repartition_type': 'tax',
                     'account_id': ref('l10n_ec.ec_vat_withhold_10'),
-                    'minus_report_line_ids': [ref('tax_report_line_104_721')],
+                    'plus_report_line_ids': [ref('tax_report_line_104_721')],
                 }),]"/>
         </record>
         <record id="tax_withhold_vat_20" model="account.tax.template">
@@ -56,7 +56,7 @@
                     'factor_percent': 12,
                     'repartition_type': 'tax',
                     'account_id': ref('l10n_ec.ec_vat_withhold_20'),
-                    'plus_report_line_ids': [ref('tax_report_line_104_723')],
+                    'minus_report_line_ids': [ref('tax_report_line_104_723')],
                 }),]"/>
             <field name="refund_repartition_line_ids" eval="[(5, 0, 0),
                 (0,0, {
@@ -67,7 +67,7 @@
                     'factor_percent': 12,
                     'repartition_type': 'tax',
                     'account_id': ref('l10n_ec.ec_vat_withhold_20'),
-                    'minus_report_line_ids': [ref('tax_report_line_104_723')],
+                    'plus_report_line_ids': [ref('tax_report_line_104_723')],
                 }),]"/>
         </record>
         <record id="tax_withhold_vat_30" model="account.tax.template">
@@ -89,7 +89,7 @@
                     'factor_percent': 12,
                     'repartition_type': 'tax',
                     'account_id': ref('l10n_ec.ec_vat_withhold_30'),
-                    'plus_report_line_ids': [ref('tax_report_line_104_725')],
+                    'minus_report_line_ids': [ref('tax_report_line_104_725')],
                 }),]"/>
             <field name="refund_repartition_line_ids" eval="[(5, 0, 0),
                 (0,0, {
@@ -100,7 +100,7 @@
                     'factor_percent': 12,
                     'repartition_type': 'tax',
                     'account_id': ref('l10n_ec.ec_vat_withhold_30'),
-                    'minus_report_line_ids': [ref('tax_report_line_104_725')],
+                    'plus_report_line_ids': [ref('tax_report_line_104_725')],
                 }),]"/>
         </record>
         <record id="tax_withhold_vat_50" model="account.tax.template">
@@ -122,7 +122,7 @@
                     'factor_percent': 12,
                     'repartition_type': 'tax',
                     'account_id': ref('l10n_ec.ec_vat_withhold_50'),
-                    'plus_report_line_ids': [ref('tax_report_line_104_727')],
+                    'minus_report_line_ids': [ref('tax_report_line_104_727')],
                 }),]"/>
             <field name="refund_repartition_line_ids" eval="[(5, 0, 0),
                 (0,0, {
@@ -133,7 +133,7 @@
                     'factor_percent': 12,
                     'repartition_type': 'tax',
                     'account_id': ref('l10n_ec.ec_vat_withhold_50'),
-                    'minus_report_line_ids': [ref('tax_report_line_104_727')],
+                    'plus_report_line_ids': [ref('tax_report_line_104_727')],
                 }),]"/>
         </record>
         <record id="tax_withhold_vat_70" model="account.tax.template">
@@ -155,7 +155,7 @@
                     'factor_percent': 12,
                     'repartition_type': 'tax',
                     'account_id': ref('l10n_ec.ec_vat_withhold_70'),
-                    'plus_report_line_ids': [ref('tax_report_line_104_729')],
+                    'minus_report_line_ids': [ref('tax_report_line_104_729')],
                 }),]"/>
             <field name="refund_repartition_line_ids" eval="[(5, 0, 0),
                 (0,0, {
@@ -166,7 +166,7 @@
                     'factor_percent': 12,
                     'repartition_type': 'tax',
                     'account_id': ref('l10n_ec.ec_vat_withhold_70'),
-                    'minus_report_line_ids': [ref('tax_report_line_104_729')],
+                    'plus_report_line_ids': [ref('tax_report_line_104_729')],
                 }),]"/>
         </record>
         <record id="tax_withhold_vat_100" model="account.tax.template">
@@ -187,8 +187,8 @@
                 (0,0, {
                     'factor_percent': 12,
                     'repartition_type': 'tax',
-                    'account_id': ref('l10n_ec.ec_vat_withhold_70'),
-                    'plus_report_line_ids': [ref('tax_report_line_104_731')],
+                    'account_id': ref('l10n_ec.ec_vat_withhold_100'),
+                    'minus_report_line_ids': [ref('tax_report_line_104_731')],
                 }),]"/>
             <field name="refund_repartition_line_ids" eval="[(5, 0, 0),
                 (0,0, {
@@ -198,8 +198,8 @@
                 (0,0, {
                     'factor_percent': 12,
                     'repartition_type': 'tax',
-                    'account_id': ref('l10n_ec.ec_vat_withhold_70'),
-                    'minus_report_line_ids': [ref('tax_report_line_104_731')],
+                    'account_id': ref('l10n_ec.ec_vat_withhold_100'),
+                    'plus_report_line_ids': [ref('tax_report_line_104_731')],
                 }),]"/>
         </record>
         <!-- 
@@ -224,7 +224,7 @@
                     'factor_percent': 12,
                     'repartition_type': 'tax',
                     'account_id': ref('l10n_ec.ec_sale_vat_outstanding_withholds'),
-                    'plus_report_line_ids': [ref('tax_report_line_104_609')],
+                    'minus_report_line_ids': [ref('tax_report_line_104_609')],
                 }),]"/>
             <field name="refund_repartition_line_ids" eval="[(5, 0, 0),
                 (0,0, {
@@ -235,7 +235,7 @@
                     'factor_percent': 12,
                     'repartition_type': 'tax',
                     'account_id': ref('l10n_ec.ec_sale_vat_outstanding_withholds'),
-                    'minus_report_line_ids': [ref('tax_report_line_104_609')],
+                    'plus_report_line_ids': [ref('tax_report_line_104_609')],
                 }),]"/>
         </record>
         <record id="tax_sale_withhold_vat_20" model="account.tax.template">
@@ -257,7 +257,7 @@
                     'factor_percent': 12,
                     'repartition_type': 'tax',
                     'account_id': ref('l10n_ec.ec_sale_vat_outstanding_withholds'),
-                    'plus_report_line_ids': [ref('tax_report_line_104_609')],
+                    'minus_report_line_ids': [ref('tax_report_line_104_609')],
                 }),]"/>
             <field name="refund_repartition_line_ids" eval="[(5, 0, 0),
                 (0,0, {
@@ -268,7 +268,7 @@
                     'factor_percent': 12,
                     'repartition_type': 'tax',
                     'account_id': ref('l10n_ec.ec_sale_vat_outstanding_withholds'),
-                    'minus_report_line_ids': [ref('tax_report_line_104_609')],
+                    'plus_report_line_ids': [ref('tax_report_line_104_609')],
                 }),]"/>
         </record>
         <record id="tax_sale_withhold_vat_30" model="account.tax.template">
@@ -290,7 +290,7 @@
                     'factor_percent': 12,
                     'repartition_type': 'tax',
                     'account_id': ref('l10n_ec.ec_sale_vat_outstanding_withholds'),
-                    'plus_report_line_ids': [ref('tax_report_line_104_609')],
+                    'minus_report_line_ids': [ref('tax_report_line_104_609')],
                 }),]"/>
             <field name="refund_repartition_line_ids" eval="[(5, 0, 0),
                 (0,0, {
@@ -301,7 +301,7 @@
                     'factor_percent': 12,
                     'repartition_type': 'tax',
                     'account_id': ref('l10n_ec.ec_sale_vat_outstanding_withholds'),
-                    'minus_report_line_ids': [ref('tax_report_line_104_609')],
+                    'plus_report_line_ids': [ref('tax_report_line_104_609')],
                 }),]"/>
         </record>
         <record id="tax_sale_withhold_vat_50" model="account.tax.template">
@@ -323,7 +323,7 @@
                     'factor_percent': 12,
                     'repartition_type': 'tax',
                     'account_id': ref('l10n_ec.ec_sale_vat_outstanding_withholds'),
-                    'plus_report_line_ids': [ref('tax_report_line_104_609')],
+                    'minus_report_line_ids': [ref('tax_report_line_104_609')],
                 }),]"/>
             <field name="refund_repartition_line_ids" eval="[(5, 0, 0),
                 (0,0, {
@@ -334,7 +334,7 @@
                     'factor_percent': 12,
                     'repartition_type': 'tax',
                     'account_id': ref('l10n_ec.ec_sale_vat_outstanding_withholds'),
-                    'minus_report_line_ids': [ref('tax_report_line_104_609')],
+                    'plus_report_line_ids': [ref('tax_report_line_104_609')],
                 }),]"/>
         </record>
         <record id="tax_sale_withhold_vat_70" model="account.tax.template">
@@ -356,7 +356,7 @@
                     'factor_percent': 12,
                     'repartition_type': 'tax',
                     'account_id': ref('l10n_ec.ec_sale_vat_outstanding_withholds'),
-                    'plus_report_line_ids': [ref('tax_report_line_104_609')],
+                    'minus_report_line_ids': [ref('tax_report_line_104_609')],
                 }),]"/>
             <field name="refund_repartition_line_ids" eval="[(5, 0, 0),
                 (0,0, {
@@ -367,7 +367,7 @@
                     'factor_percent': 12,
                     'repartition_type': 'tax',
                     'account_id': ref('l10n_ec.ec_sale_vat_outstanding_withholds'),
-                    'minus_report_line_ids': [ref('tax_report_line_104_609')],
+                    'plus_report_line_ids': [ref('tax_report_line_104_609')],
                 }),]"/>
         </record>
         <record id="tax_sale_withhold_vat_100" model="account.tax.template">
@@ -389,7 +389,7 @@
                     'factor_percent': 12,
                     'repartition_type': 'tax',
                     'account_id': ref('l10n_ec.ec_sale_vat_outstanding_withholds'),
-                    'plus_report_line_ids': [ref('tax_report_line_104_609')],
+                    'minus_report_line_ids': [ref('tax_report_line_104_609')],
                 }),]"/>
             <field name="refund_repartition_line_ids" eval="[(5, 0, 0),
                 (0,0, {
@@ -400,7 +400,7 @@
                     'factor_percent': 12,
                     'repartition_type': 'tax',
                     'account_id': ref('l10n_ec.ec_sale_vat_outstanding_withholds'),
-                    'minus_report_line_ids': [ref('tax_report_line_104_609')],
+                    'plus_report_line_ids': [ref('tax_report_line_104_609')],
                 }),]"/>
         </record>
     </data>


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
Negative sign on 104 and 103 ecuadorian tax report

Current behavior before PR:
Tax report shows negative values

Desired behavior after PR is merged:
Tax report should only have positive values

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
