### PR TITLE
[FIX] sale_management: confirmation mail for unregistered users

### DIFF
--- a/addons/sale_management/models/sale_order.py
+++ b/addons/sale_management/models/sale_order.py
@@ -3,7 +3,7 @@
 
 from datetime import timedelta
 
-from odoo import api, fields, models, _
+from odoo import api, fields, models, _, SUPERUSER_ID
 from odoo.exceptions import UserError, ValidationError
 
 
@@ -152,7 +152,7 @@ class SaleOrder(models.Model):
         res = super(SaleOrder, self).action_confirm()
         for order in self:
             if order.sale_order_template_id and order.sale_order_template_id.mail_template_id:
-                self.sale_order_template_id.mail_template_id.send_mail(order.id)
+                order.sale_order_template_id.mail_template_id.with_user(SUPERUSER_ID).send_mail(order.id)
         return res
 
     def get_access_action(self, access_uid=None):


### PR DESCRIPTION
Step to reproduce:
- Create a Quotation Template QT and set in in the sale settings
- In the confirmation Tab of QT add a confirmation email
- As a portal user, purchase an item in ecommerce
 The payment must be confirmed. (tested using payment_test module)

Current Behaviour:
- Traceback on confirmation email rendering, portal user do not
 have access to the full data.

Behaviour after PR:
- Email is rendered as superuser to ensure data is correctly
 fetched

opw-2749804


--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
