### PR TITLE
[FIX] point_of_sale: generate tax line for 0% tax

### DIFF
--- a/addons/point_of_sale/models/pos_session.py
+++ b/addons/point_of_sale/models/pos_session.py
@@ -842,7 +842,7 @@ class PosSession(models.Model):
         rounding_difference = data.get('rounding_difference')
         MoveLine = data.get('MoveLine')
 
-        tax_vals = [self._get_tax_vals(key, amounts['amount'], amounts['amount_converted'], amounts['base_amount_converted']) for key, amounts in taxes.items() if amounts['amount']]
+        tax_vals = [self._get_tax_vals(key, amounts['amount'], amounts['amount_converted'], amounts['base_amount_converted']) for key, amounts in taxes.items()]
         # Check if all taxes lines have account_id assigned. If not, there are repartition lines of the tax that have no account_id.
         tax_names_no_account = [line['name'] for line in tax_vals if line['account_id'] == False]
         if len(tax_names_no_account) > 0:


### PR DESCRIPTION
The generic tax report in V15 need the tax line for each tax to be computed correctly.
Currently the tax line for 0% tax will not be generated for a journal entry generated
from the point of sale and will not be taken into account in the tax report.

Now we will generate this tax line. This is basically a reverse of 0ddfbab90f68b4a7af7548471742f9a1dd20ae58
removing generation of 0% tax line because it could cause issue if no account is set on
the tax. This case is now handled by 4f7061dcb402ed56d56c51de35edf747d0684a8d.

opw-2754107
