### PR TITLE
[FIX] website_slides: better compute (dis)likes

### DIFF
--- a/addons/website_slides/models/slide_slide.py
+++ b/addons/website_slides/models/slide_slide.py
@@ -133,7 +133,8 @@ class Slide(models.Model):
                                    string='Subscribers', groups='website.group_website_publisher', copy=False)
     slide_partner_ids = fields.One2many('slide.slide.partner', 'slide_id', string='Subscribers information', groups='website.group_website_publisher', copy=False)
     user_membership_id = fields.Many2one(
-        'slide.slide.partner', string="Subscriber information", compute='_compute_user_membership_id', compute_sudo=False,
+        'slide.slide.partner', string="Subscriber information",
+        compute='_compute_user_membership_id', compute_sudo=False,
         help="Subscriber information for the current logged in user")
     # Quiz related fields
     question_ids = fields.One2many("slide.question", "slide_id", string="Questions")
@@ -162,9 +163,9 @@ class Slide(models.Model):
     # website
     website_id = fields.Many2one(related='channel_id.website_id', readonly=True)
     date_published = fields.Datetime('Publish Date', readonly=True, tracking=True)
-    likes = fields.Integer('Likes', compute='_compute_user_info', store=True, compute_sudo=False)
-    dislikes = fields.Integer('Dislikes', compute='_compute_user_info', store=True, compute_sudo=False)
-    user_vote = fields.Integer('User vote', compute='_compute_user_info', compute_sudo=False)
+    likes = fields.Integer('Likes', compute='_compute_like_info', store=True, compute_sudo=False)
+    dislikes = fields.Integer('Dislikes', compute='_compute_like_info', store=True, compute_sudo=False)
+    user_vote = fields.Integer('User vote', compute='_compute_user_membership_id', compute_sudo=False)
     embed_code = fields.Text('Embed Code', readonly=True, compute='_compute_embed_code')
     # views
     embedcount_ids = fields.One2many('slide.embed', 'slide_id', string="Embed Count")
@@ -230,8 +231,38 @@ class Slide(models.Model):
             record.total_views = record.slide_views + record.public_views
 
     @api.depends('slide_partner_ids.vote')
+    def _compute_like_info(self):
+        if not self.ids:
+            self.update({'likes': 0, 'dislikes': 0})
+            return
+
+        rg_data_like = self.env['slide.slide.partner'].sudo().read_group(
+            [('slide_id', 'in', self.ids), ('vote', '=', 1)],
+            ['slide_id'], ['slide_id']
+        )
+        rg_data_dislike = self.env['slide.slide.partner'].sudo().read_group(
+            [('slide_id', 'in', self.ids), ('vote', '=', -1)],
+            ['slide_id'], ['slide_id']
+        )
+        mapped_data_like = dict(
+            (rg_data['slide_id'][0], rg_data['slide_id_count'])
+            for rg_data in rg_data_like
+        )
+        mapped_data_dislike = dict(
+            (rg_data['slide_id'][0], rg_data['slide_id_count'])
+            for rg_data in rg_data_dislike
+        )
+
+        for slide in self:
+            slide.likes = mapped_data_like.get(slide.id, 0)
+            slide.dislikes = mapped_data_dislike.get(slide.id, 0)
+
+    @api.depends('slide_partner_ids.vote')
     @api.depends_context('uid')
     def _compute_user_info(self):
+        """ Deprecated. Now computed directly by _compute_user_membership_id
+        for user_vote and _compute_like_info for likes / dislikes. Remove me in
+        master. """
         default_stats = {'likes': 0, 'dislikes': 0, 'user_vote': False}
 
         if not self.ids:
@@ -242,6 +273,7 @@ class Slide(models.Model):
         slide_partners = self.env['slide.slide.partner'].sudo().search([
             ('slide_id', 'in', self.ids)
         ])
+
         for slide_partner in slide_partners:
             if slide_partner.vote == 1:
                 slide_data[slide_partner.slide_id.id]['likes'] += 1
@@ -251,6 +283,7 @@ class Slide(models.Model):
                 slide_data[slide_partner.slide_id.id]['dislikes'] += 1
                 if slide_partner.partner_id == self.env.user.partner_id:
                     slide_data[slide_partner.slide_id.id]['user_vote'] = -1
+
         for slide in self:
             slide.update(slide_data[slide.id])
 
@@ -297,7 +330,7 @@ class Slide(models.Model):
                 result[cid]['total_slides'] += slide_type_count
         return result
 
-    @api.depends('slide_partner_ids.partner_id')
+    @api.depends('slide_partner_ids.partner_id', 'slide_partner_ids.vote')
     @api.depends('uid')
     def _compute_user_membership_id(self):
         slide_partners = self.env['slide.slide.partner'].sudo().search([
@@ -310,6 +343,7 @@ class Slide(models.Model):
                 (slide_partner for slide_partner in slide_partners if slide_partner.slide_id == record),
                 self.env['slide.slide.partner']
             )
+            record.user_vote = record.user_membership_id.vote
 
     @api.depends('document_id', 'slide_type', 'mime_type')
     def _compute_embed_code(self):


### PR DESCRIPTION
In this commit we fix computation of likes and dislikes by splitting computation
by usage. We also fix batch computation as it was sharing a dict. As frontend UI
leads to voting one slide at a time this should have few effect on stored values.
But now batch computation is correct.

Task-2607416

Co-Authored-By: Munaf Bahelim <mub@odoo.com>
Co-Authored-By: Thibault Delavallée <tde@odoo.com>
