### PR TITLE
[IMP] base: Disable cron toggle on neutralized databases

### DIFF
--- a/odoo/addons/base/models/ir_cron.py
+++ b/odoo/addons/base/models/ir_cron.py
@@ -320,5 +320,10 @@ class ir_cron(models.Model):
 
     @api.model
     def toggle(self, model, domain):
+        # Prevent deactivated cron jobs from being re-enabled through side effects on
+        # neutralized databases.
+        if self.env['ir.config_parameter'].sudo().get_param('database.is_neutralized'):
+            return True
+
         active = bool(self.env[model].search_count(domain))
         return self.try_write({'active': active})


### PR DESCRIPTION
In some cases like `fetchmail.server` and `calendar.alarm`, modifying
the record can result in the corresponding cron job being enabled as a
side effect through `ir.cron.toggle`, even if it was archived before. In
`fetchmail.server`'s case on a neutralized database, this can result in
the cron job unintentionally affecting a production mailbox.

Since `ir.cron.toggle` is inherently risky on a neutralized database,
this PR disables it when an `ir.config_parameter` indicates we are on
one.

This parameter can be set both by the neutralization API introduced in
Odoo 15.2 and by legacy neutralization tools for older Odoo versions.