### PR TITLE
[FIX] survey: send survey invite in partner's language

### DIFF
--- a/addons/survey/wizard/survey_invite.py
+++ b/addons/survey/wizard/survey_invite.py
@@ -138,17 +138,23 @@ class SurveyInvite(models.TransientModel):
                         ', '.join(invalid_partners.mapped('name'))
                     ))
 
-    @api.depends('template_id')
+    @api.depends('template_id', 'partner_ids')
     def _compute_subject(self):
         for invite in self:
+            langs = set(invite.partner_ids.mapped('lang')) - {False}
+            if len(langs) == 1:
+                invite = invite.with_context(lang=langs.pop())
             if invite.template_id:
                 invite.subject = invite.template_id.subject
             elif not invite.subject:
                 invite.subject = False
 
-    @api.depends('template_id')
+    @api.depends('template_id', 'partner_ids')
     def _compute_body(self):
         for invite in self:
+            langs = set(invite.partner_ids.mapped('lang')) - {False}
+            if len(langs) == 1:
+                invite = invite.with_context(lang=langs.pop())
             if invite.template_id:
                 invite.body = invite.template_id.body_html
             elif not invite.body:
@@ -253,6 +259,9 @@ class SurveyInvite(models.TransientModel):
 
         # compute partners and emails, try to find partners for given emails
         valid_partners = self.partner_ids
+        langs = set(valid_partners.mapped('lang')) - {False}
+        if len(langs) == 1:
+            self = self.with_context(lang=langs.pop())
         valid_emails = []
         for email in emails_split.split(self.emails or ''):
             partner = False


### PR DESCRIPTION
Survey invites sent to contacts are in the user's language and they
should be in the partner's language

Steps to reproduce:
1. Install Surveys and Contacts
2. Install another language (eg. fr_FR) but keep English as the
application language
3. Create a contact with the different language (fr_FR)
4. Create a survey and share it with the french contact (the template
used should have translations in both language)
5. Check the mail sent (Settings > Technical > Email > Emails)
6. The email is written in English but it should be in the contact's
language

Solution:
If all the recipients of the invite use the same language, display the
invite in the recipients' language to the sender so he can modify it or
send it directly
If they use different languages, use the template in the sender's
language

opw-2760489