### PR TITLE
[FIX] event_sale: ticket price is not correctly updated

### DIFF
--- a/addons/event_sale/models/sale_order.py
+++ b/addons/event_sale/models/sale_order.py
@@ -130,13 +130,7 @@ class SaleOrderLine(models.Model):
 
     @api.depends('event_ticket_id')
     def _compute_price_unit(self):
-        """Do not update the price on qty/uom change"""
-        event_lines = self.filtered('event_ticket_id')
-        super(SaleOrderLine, self-event_lines)._compute_price_unit()
-        for line in event_lines:
-            if not line.product_id or line._origin.product_id != line.product_id:
-                # Note: this also computes the price for new lines :)
-                super(SaleOrderLine, line)._compute_price_unit()
+        super()._compute_price_unit()
 
     @api.depends('event_ticket_id')
     def _compute_name(self):

--- a/addons/event_sale/tests/test_event_sale.py
+++ b/addons/event_sale/tests/test_event_sale.py
@@ -179,6 +179,11 @@ class TestEventSale(TestEventSaleCommon):
         # ------------------------------------------------------------
 
         ticket2_line.write({'product_uom_qty': 3})
+
+        # Whenever the quantity is modified the price is recomputed in function of the ticket,
+        # so we reapply the wanted price.
+        ticket2_line.write({'price_unit': 50})
+
         editor_action = customer_so.action_confirm()
         self.assertEqual(customer_so.state, 'sale')
         self.assertEqual(customer_so.amount_untaxed, TICKET1_COUNT * 10 + (TICKET2_COUNT + 2) * 50)


### PR DESCRIPTION
When using the product configurator for event tickets the
price was not updated when picking a ticket with a different
price.
This of course is to the desired behavior.

This commit makes sure the unit price is correctly
recomputed when the ticket is modified on the SO
line.

Task - 2767301
