### PR TITLE
[REM] base: Remove cron code commenting

### DIFF
--- a/odoo/addons/base/models/ir_actions.py
+++ b/odoo/addons/base/models/ir_actions.py
@@ -655,19 +655,6 @@ class IrActionsServer(models.Model):
                 )
         return res or False
 
-    def _neutralize(self):
-        # In some cases, cron neutralization is not enough as modifying records
-        # like `fetchmail.server`, `calendar.alarm` and `base.automation` will
-        # re-enable their cron jobs as a side-effect.
-        super()._neutralize()
-        self.flush()
-        self.invalidate_cache()
-        self.env.cr.execute("""
-            UPDATE ir_act_server
-            SET code = '#' || REPLACE(code, E'\n', E'\n#')
-            WHERE usage = 'ir_cron' AND state = 'code'
-        """)
-
 
 class IrServerObjectLines(models.Model):
     _name = 'ir.server.object.lines'


### PR DESCRIPTION
In neutralized databases, modifying records like `fetchmail.server`
re-activates the related archived cron job as a side effect, which
could impact production mailboxes. The initial solution to this was to
comment out the server action code linked to the cron job as an extra
precaution.

The impact of that solution is too broad, and it also means users have
to be aware of the need to uncomment the code if they do want a cron job
to run on a neutralized copy. It's been replaced by disabling
`ir.cron.toggle` instead: https://github.com/odoo/odoo/pull/85192