### PR TITLE
[IMP] l10n_pt: refactor taxes and tax report

### DIFF
--- a/addons/l10n_pt/data/account_tax_data.xml
+++ b/addons/l10n_pt/data/account_tax_data.xml
@@ -2,6 +2,8 @@
 <odoo>
     <data noupdate="1">
 
+<!--    Taxes Portugal Continental-->
+
         <record id="iva23" model="account.tax.template">
             <field name="chart_template_id" ref="pt_chart_template"/>
             <field name="name">IVA23</field>
@@ -14,96 +16,28 @@
                 (0,0, {
                     'factor_percent': 100,
                     'repartition_type': 'base',
-                    'plus_report_line_ids': [ref('tax_report_pt_base_vendas_faturas_normal')],
+                    'plus_report_line_ids': [ref('tax_report_pt_base_vendas_normal')],
                 }),
 
                 (0,0, {
                     'factor_percent': 100,
                     'repartition_type': 'tax',
-                    'plus_report_line_ids': [ref('tax_report_pt_tax_vendas_faturas_normal')],
                     'account_id': ref('chart_2433'),
+                    'plus_report_line_ids': [ref('tax_report_pt_tax_vendas_normal')],
                 }),
             ]"/>
             <field name="refund_repartition_line_ids" eval="[(5, 0, 0),
                 (0,0, {
                     'factor_percent': 100,
                     'repartition_type': 'base',
-                    'plus_report_line_ids': [ref('tax_report_pt_base_vendas_notas_credito_normal')],
-                }),
-
-                (0,0, {
-                    'factor_percent': 100,
-                    'repartition_type': 'tax',
-                    'plus_report_line_ids': [ref('tax_report_pt_tax_vendas_notas_credito_normal')],
-                    'account_id': ref('chart_2433'),
-                }),
-            ]"/>
-        </record>
-
-        <record id="iva22" model="account.tax.template">
-            <field name="chart_template_id" ref="pt_chart_template"/>
-            <field name="name">IVA22</field>
-            <field name="description">IVA22 (taxa normal Madeira)</field>
-            <field name="amount">22</field>
-            <field name="type_tax_use">sale</field>
-            <field name="amount_type">percent</field>
-            <field name="tax_group_id" ref="tax_group_iva_22"/>
-            <field name="invoice_repartition_line_ids" eval="[(5, 0, 0),
-                (0,0, {
-                    'factor_percent': 100,
-                    'repartition_type': 'base',
+                    'minus_report_line_ids': [ref('tax_report_pt_base_vendas_normal')],
                 }),
 
                 (0,0, {
                     'factor_percent': 100,
                     'repartition_type': 'tax',
                     'account_id': ref('chart_2433'),
-                }),
-            ]"/>
-            <field name="refund_repartition_line_ids" eval="[(5, 0, 0),
-                (0,0, {
-                    'factor_percent': 100,
-                    'repartition_type': 'base',
-                }),
-
-                (0,0, {
-                    'factor_percent': 100,
-                    'repartition_type': 'tax',
-                    'account_id': ref('chart_2433'),
-                }),
-            ]"/>
-        </record>
-
-        <record id="iva16" model="account.tax.template">
-            <field name="chart_template_id" ref="pt_chart_template"/>
-            <field name="name">IVA16</field>
-            <field name="description">IVA16 (taxa normal Açores)</field>
-            <field name="amount">16</field>
-            <field name="type_tax_use">sale</field>
-            <field name="amount_type">percent</field>
-            <field name="tax_group_id" ref="tax_group_iva_16"/>
-            <field name="invoice_repartition_line_ids" eval="[(5, 0, 0),
-                (0,0, {
-                    'factor_percent': 100,
-                    'repartition_type': 'base',
-                }),
-
-                (0,0, {
-                    'factor_percent': 100,
-                    'repartition_type': 'tax',
-                    'account_id': ref('chart_2433'),
-                }),
-            ]"/>
-            <field name="refund_repartition_line_ids" eval="[(5, 0, 0),
-                (0,0, {
-                    'factor_percent': 100,
-                    'repartition_type': 'base',
-                }),
-
-                (0,0, {
-                    'factor_percent': 100,
-                    'repartition_type': 'tax',
-                    'account_id': ref('chart_2433'),
+                    'minus_report_line_ids': [ref('tax_report_pt_tax_vendas_normal')],
                 }),
             ]"/>
         </record>
@@ -121,96 +55,28 @@
                 (0,0, {
                     'factor_percent': 100,
                     'repartition_type': 'base',
-                    'plus_report_line_ids': [ref('tax_report_pt_base_vendas_faturas_intermedia')],
+                    'plus_report_line_ids': [ref('tax_report_pt_base_vendas_intermedia')],
                 }),
 
                 (0,0, {
                     'factor_percent': 100,
                     'repartition_type': 'tax',
-                    'plus_report_line_ids': [ref('tax_report_pt_tax_vendas_faturas_intermedia')],
                     'account_id': ref('chart_2433'),
+                    'plus_report_line_ids': [ref('tax_report_pt_tax_vendas_intermedia')],
                 }),
             ]"/>
             <field name="refund_repartition_line_ids" eval="[(5, 0, 0),
                 (0,0, {
                     'factor_percent': 100,
                     'repartition_type': 'base',
-                    'plus_report_line_ids': [ref('tax_report_pt_base_vendas_notas_credito_intermedia')],
-                }),
-
-                (0,0, {
-                    'factor_percent': 100,
-                    'repartition_type': 'tax',
-                    'plus_report_line_ids': [ref('tax_report_pt_tax_vendas_notas_credito_intermedia')],
-                    'account_id': ref('chart_2433'),
-                }),
-            ]"/>
-        </record>
-
-        <record id="iva12" model="account.tax.template">
-            <field name="chart_template_id" ref="pt_chart_template"/>
-            <field name="name">IVA12</field>
-            <field name="description">IVA12 (taxa intermédia Madeira)</field>
-            <field name="amount">12</field>
-            <field name="type_tax_use">sale</field>
-            <field name="amount_type">percent</field>
-            <field name="tax_group_id" ref="tax_group_iva_12"/>
-            <field name="invoice_repartition_line_ids" eval="[(5, 0, 0),
-                (0,0, {
-                    'factor_percent': 100,
-                    'repartition_type': 'base',
+                    'minus_report_line_ids': [ref('tax_report_pt_base_vendas_intermedia')],
                 }),
 
                 (0,0, {
                     'factor_percent': 100,
                     'repartition_type': 'tax',
                     'account_id': ref('chart_2433'),
-                }),
-            ]"/>
-            <field name="refund_repartition_line_ids" eval="[(5, 0, 0),
-                (0,0, {
-                    'factor_percent': 100,
-                    'repartition_type': 'base',
-                }),
-
-                (0,0, {
-                    'factor_percent': 100,
-                    'repartition_type': 'tax',
-                    'account_id': ref('chart_2433'),
-                }),
-            ]"/>
-        </record>
-
-        <record id="iva9" model="account.tax.template">
-            <field name="chart_template_id" ref="pt_chart_template"/>
-            <field name="name">IVA9</field>
-            <field name="description">IVA9 (taxa intermédia Açores)</field>
-            <field name="amount">9</field>
-            <field name="type_tax_use">sale</field>
-            <field name="amount_type">percent</field>
-            <field name="tax_group_id" ref="tax_group_iva_9"/>
-            <field name="invoice_repartition_line_ids" eval="[(5, 0, 0),
-                (0,0, {
-                    'factor_percent': 100,
-                    'repartition_type': 'base',
-                }),
-
-                (0,0, {
-                    'factor_percent': 100,
-                    'repartition_type': 'tax',
-                    'account_id': ref('chart_2433'),
-                }),
-            ]"/>
-            <field name="refund_repartition_line_ids" eval="[(5, 0, 0),
-                (0,0, {
-                    'factor_percent': 100,
-                    'repartition_type': 'base',
-                }),
-
-                (0,0, {
-                    'factor_percent': 100,
-                    'repartition_type': 'tax',
-                    'account_id': ref('chart_2433'),
+                    'minus_report_line_ids': [ref('tax_report_pt_tax_vendas_intermedia')],
                 }),
             ]"/>
         </record>
@@ -228,96 +94,28 @@
                 (0,0, {
                     'factor_percent': 100,
                     'repartition_type': 'base',
-                    'plus_report_line_ids': [ref('tax_report_pt_base_vendas_faturas_reduzida')],
+                    'plus_report_line_ids': [ref('tax_report_pt_base_vendas_reduzida')],
                 }),
 
                 (0,0, {
                     'factor_percent': 100,
                     'repartition_type': 'tax',
-                    'plus_report_line_ids': [ref('tax_report_pt_tax_vendas_faturas_reduzida')],
                     'account_id': ref('chart_2433'),
+                    'plus_report_line_ids': [ref('tax_report_pt_tax_vendas_reduzida')],
                 }),
             ]"/>
             <field name="refund_repartition_line_ids" eval="[(5, 0, 0),
                 (0,0, {
                     'factor_percent': 100,
                     'repartition_type': 'base',
-                    'plus_report_line_ids': [ref('tax_report_pt_base_vendas_notas_credito_reduzida')],
-                }),
-
-                (0,0, {
-                    'factor_percent': 100,
-                    'repartition_type': 'tax',
-                    'plus_report_line_ids': [ref('tax_report_pt_tax_vendas_notas_credito_reduzida')],
-                    'account_id': ref('chart_2433'),
-                }),
-            ]"/>
-        </record>
-
-        <record id="iva5" model="account.tax.template">
-            <field name="chart_template_id" ref="pt_chart_template"/>
-            <field name="name">IVA5</field>
-            <field name="description">IVA5 (taxa reduzida Madeira)</field>
-            <field name="amount">5</field>
-            <field name="type_tax_use">sale</field>
-            <field name="amount_type">percent</field>
-            <field name="tax_group_id" ref="tax_group_iva_5"/>
-            <field name="invoice_repartition_line_ids" eval="[(5, 0, 0),
-                (0,0, {
-                    'factor_percent': 100,
-                    'repartition_type': 'base',
+                    'minus_report_line_ids': [ref('tax_report_pt_base_vendas_reduzida')],
                 }),
 
                 (0,0, {
                     'factor_percent': 100,
                     'repartition_type': 'tax',
                     'account_id': ref('chart_2433'),
-                }),
-            ]"/>
-            <field name="refund_repartition_line_ids" eval="[(5, 0, 0),
-                (0,0, {
-                    'factor_percent': 100,
-                    'repartition_type': 'base',
-                }),
-
-                (0,0, {
-                    'factor_percent': 100,
-                    'repartition_type': 'tax',
-                    'account_id': ref('chart_2433'),
-                }),
-            ]"/>
-        </record>
-
-        <record id="iva4" model="account.tax.template">
-            <field name="chart_template_id" ref="pt_chart_template"/>
-            <field name="name">IVA4</field>
-            <field name="description">IVA4 (taxa reduzida Açores)</field>
-            <field name="amount">4</field>
-            <field name="type_tax_use">sale</field>
-            <field name="amount_type">percent</field>
-            <field name="tax_group_id" ref="tax_group_iva_4"/>
-            <field name="invoice_repartition_line_ids" eval="[(5, 0, 0),
-                (0,0, {
-                    'factor_percent': 100,
-                    'repartition_type': 'base',
-                }),
-
-                (0,0, {
-                    'factor_percent': 100,
-                    'repartition_type': 'tax',
-                    'account_id': ref('chart_2433'),
-                }),
-            ]"/>
-            <field name="refund_repartition_line_ids" eval="[(5, 0, 0),
-                (0,0, {
-                    'factor_percent': 100,
-                    'repartition_type': 'base',
-                }),
-
-                (0,0, {
-                    'factor_percent': 100,
-                    'repartition_type': 'tax',
-                    'account_id': ref('chart_2433'),
+                    'minus_report_line_ids': [ref('tax_report_pt_tax_vendas_reduzida')],
                 }),
             ]"/>
         </record>
@@ -335,13 +133,12 @@
                 (0,0, {
                     'factor_percent': 100,
                     'repartition_type': 'base',
-                    'plus_report_line_ids': [ref('tax_report_pt_base_vendas_faturas_isento')],
+                    'plus_report_line_ids': [ref('tax_report_pt_base_vendas_isento')],
                 }),
 
                 (0,0, {
                     'factor_percent': 100,
                     'repartition_type': 'tax',
-                    'plus_report_line_ids': [ref('tax_report_pt_tax_vendas_faturas_isento')],
                     'account_id': ref('chart_2433'),
                 }),
             ]"/>
@@ -349,13 +146,84 @@
                 (0,0, {
                     'factor_percent': 100,
                     'repartition_type': 'base',
-                    'plus_report_line_ids': [ref('tax_report_pt_base_vendas_notas_credito_isento')],
+                    'minus_report_line_ids': [ref('tax_report_pt_base_vendas_isento')],
                 }),
 
                 (0,0, {
                     'factor_percent': 100,
                     'repartition_type': 'tax',
-                    'plus_report_line_ids': [ref('tax_report_pt_tax_vendas_notas_credito_isento')],
+                    'account_id': ref('chart_2433'),
+                }),
+            ]"/>
+        </record>
+
+        <record id="iva0eu" model="account.tax.template">
+            <field name="chart_template_id" ref="pt_chart_template"/>
+            <field name="description">IVA0 EU (Autoliquidação, Reverse-charge)</field>
+            <field name="name">IVA0 EU (Autoliquidação, Reverse-charge)</field>
+            <field name="price_include" eval="0"/>
+            <field name="active" eval="False"/>
+            <field name="amount">0</field>
+            <field name="amount_type">percent</field>
+            <field name="type_tax_use">sale</field>
+            <field name="tax_group_id" ref="tax_group_iva_0"/>
+            <field name="invoice_repartition_line_ids" eval="[(5, 0, 0),
+                (0,0, {
+                    'factor_percent': 100,
+                    'repartition_type': 'base',
+                    'plus_report_line_ids': [ref('tax_report_pt_base_vendas_eu0')],
+                }),
+                (0,0, {
+                    'factor_percent': 100,
+                    'repartition_type': 'tax',
+                    'account_id': ref('chart_2433'),
+                }),
+            ]"/>
+            <field name="refund_repartition_line_ids" eval="[(5, 0, 0),
+                (0,0, {
+                    'factor_percent': 100,
+                    'repartition_type': 'base',
+                    'minus_report_line_ids': [ref('tax_report_pt_base_vendas_eu0')],
+                }),
+                (0,0, {
+                    'factor_percent': 100,
+                    'repartition_type': 'tax',
+                    'account_id': ref('chart_2433'),
+                }),
+            ]"/>
+        </record>
+
+        <record id="iva0non-eu" model="account.tax.template">
+            <field name="chart_template_id" ref="pt_chart_template"/>
+            <field name="description">IVA0 Non-EU</field>
+            <field name="name">IVA0 Non-EU</field>
+            <field name="price_include" eval="0"/>
+            <field name="active" eval="False"/>
+            <field name="amount">0</field>
+            <field name="amount_type">percent</field>
+            <field name="type_tax_use">sale</field>
+            <field name="tax_group_id" ref="tax_group_iva_0"/>
+            <field name="invoice_repartition_line_ids" eval="[(5, 0, 0),
+                (0,0, {
+                    'factor_percent': 100,
+                    'repartition_type': 'base',
+                    'plus_report_line_ids': [ref('tax_report_pt_base_vendas_non_eu0')],
+                }),
+                (0,0, {
+                    'factor_percent': 100,
+                    'repartition_type': 'tax',
+                    'account_id': ref('chart_2433'),
+                }),
+            ]"/>
+            <field name="refund_repartition_line_ids" eval="[(5, 0, 0),
+                (0,0, {
+                    'factor_percent': 100,
+                    'repartition_type': 'base',
+                    'minus_report_line_ids': [ref('tax_report_pt_base_vendas_non_eu0')],
+                }),
+                (0,0, {
+                    'factor_percent': 100,
+                    'repartition_type': 'tax',
                     'account_id': ref('chart_2433'),
                 }),
             ]"/>
@@ -373,96 +241,28 @@
                 (0,0, {
                     'factor_percent': 100,
                     'repartition_type': 'base',
-                    'plus_report_line_ids': [ref('tax_report_pt_base_despesas_faturas_normal')],
+                    'plus_report_line_ids': [ref('tax_report_pt_base_despesas_normal')],
                 }),
 
                 (0,0, {
                     'factor_percent': 100,
                     'repartition_type': 'tax',
-                    'plus_report_line_ids': [ref('tax_report_pt_tax_despesas_faturas_normal')],
                     'account_id': ref('chart_2432'),
+                    'plus_report_line_ids': [ref('tax_report_pt_tax_despesas_normal')],
                 }),
             ]"/>
             <field name="refund_repartition_line_ids" eval="[(5, 0, 0),
                 (0,0, {
                     'factor_percent': 100,
                     'repartition_type': 'base',
-                    'plus_report_line_ids': [ref('tax_report_pt_base_despesas_notas_credito_normal')],
-                }),
-
-                (0,0, {
-                    'factor_percent': 100,
-                    'repartition_type': 'tax',
-                    'plus_report_line_ids': [ref('tax_report_pt_tax_despesas_notas_credito_normal')],
-                    'account_id': ref('chart_2432'),
-                }),
-            ]"/>
-        </record>
-
-        <record id="compiva22" model="account.tax.template">
-            <field name="chart_template_id" ref="pt_chart_template"/>
-            <field name="name">IVA22 compra</field>
-            <field name="description">IVA22 compra (taxa normal Madeira)</field>
-            <field name="amount">22</field>
-            <field name="amount_type">percent</field>
-            <field name="type_tax_use">purchase</field>
-            <field name="tax_group_id" ref="tax_group_iva_22"/>
-            <field name="invoice_repartition_line_ids" eval="[(5, 0, 0),
-                (0,0, {
-                    'factor_percent': 100,
-                    'repartition_type': 'base',
+                    'minus_report_line_ids': [ref('tax_report_pt_base_despesas_normal')],
                 }),
 
                 (0,0, {
                     'factor_percent': 100,
                     'repartition_type': 'tax',
                     'account_id': ref('chart_2432'),
-                }),
-            ]"/>
-            <field name="refund_repartition_line_ids" eval="[(5, 0, 0),
-                (0,0, {
-                    'factor_percent': 100,
-                    'repartition_type': 'base',
-                }),
-
-                (0,0, {
-                    'factor_percent': 100,
-                    'repartition_type': 'tax',
-                    'account_id': ref('chart_2432'),
-                }),
-            ]"/>
-        </record>
-
-        <record id="compiva16" model="account.tax.template">
-            <field name="chart_template_id" ref="pt_chart_template"/>
-            <field name="name">IVA16 compra</field>
-            <field name="description">IVA16 compra (taxa normal Açores)</field>
-            <field name="amount">16</field>
-            <field name="amount_type">percent</field>
-            <field name="type_tax_use">purchase</field>
-            <field name="tax_group_id" ref="tax_group_iva_16"/>
-            <field name="invoice_repartition_line_ids" eval="[(5, 0, 0),
-                (0,0, {
-                    'factor_percent': 100,
-                    'repartition_type': 'base',
-                }),
-
-                (0,0, {
-                    'factor_percent': 100,
-                    'repartition_type': 'tax',
-                    'account_id': ref('chart_2432'),
-                }),
-            ]"/>
-            <field name="refund_repartition_line_ids" eval="[(5, 0, 0),
-                (0,0, {
-                    'factor_percent': 100,
-                    'repartition_type': 'base',
-                }),
-
-                (0,0, {
-                    'factor_percent': 100,
-                    'repartition_type': 'tax',
-                    'account_id': ref('chart_2432'),
+                    'minus_report_line_ids': [ref('tax_report_pt_tax_despesas_normal')],
                 }),
             ]"/>
         </record>
@@ -479,96 +279,28 @@
                 (0,0, {
                     'factor_percent': 100,
                     'repartition_type': 'base',
-                    'plus_report_line_ids': [ref('tax_report_pt_base_despesas_faturas_intermedia')],
+                    'plus_report_line_ids': [ref('tax_report_pt_base_despesas_intermedia')],
                 }),
 
                 (0,0, {
                     'factor_percent': 100,
                     'repartition_type': 'tax',
-                    'plus_report_line_ids': [ref('tax_report_pt_tax_despesas_faturas_intermedia')],
                     'account_id': ref('chart_2432'),
+                    'plus_report_line_ids': [ref('tax_report_pt_tax_despesas_intermedia')],
                 }),
             ]"/>
             <field name="refund_repartition_line_ids" eval="[(5, 0, 0),
                 (0,0, {
                     'factor_percent': 100,
                     'repartition_type': 'base',
-                    'plus_report_line_ids': [ref('tax_report_pt_base_despesas_notas_credito_intermedia')],
-                }),
-
-                (0,0, {
-                    'factor_percent': 100,
-                    'repartition_type': 'tax',
-                    'plus_report_line_ids': [ref('tax_report_pt_tax_despesas_notas_credito_intermedia')],
-                    'account_id': ref('chart_2432'),
-                }),
-            ]"/>
-        </record>
-
-        <record id="compiva12" model="account.tax.template">
-            <field name="chart_template_id" ref="pt_chart_template"/>
-            <field name="name">IVA12 compra</field>
-            <field name="description">IVA12 compra (taxa intermédia Madeira)</field>
-            <field name="amount">12</field>
-            <field name="amount_type">percent</field>
-            <field name="type_tax_use">purchase</field>
-            <field name="tax_group_id" ref="tax_group_iva_12"/>
-            <field name="invoice_repartition_line_ids" eval="[(5, 0, 0),
-                (0,0, {
-                    'factor_percent': 100,
-                    'repartition_type': 'base',
+                    'minus_report_line_ids': [ref('tax_report_pt_base_despesas_intermedia')],
                 }),
 
                 (0,0, {
                     'factor_percent': 100,
                     'repartition_type': 'tax',
                     'account_id': ref('chart_2432'),
-                }),
-            ]"/>
-            <field name="refund_repartition_line_ids" eval="[(5, 0, 0),
-                (0,0, {
-                    'factor_percent': 100,
-                    'repartition_type': 'base',
-                }),
-
-                (0,0, {
-                    'factor_percent': 100,
-                    'repartition_type': 'tax',
-                    'account_id': ref('chart_2432'),
-                }),
-            ]"/>
-        </record>
-
-        <record id="compiva9" model="account.tax.template">
-            <field name="chart_template_id" ref="pt_chart_template"/>
-            <field name="name">IVA9 compra</field>
-            <field name="description">IVA9 compra (taxa intermédia Açores)</field>
-            <field name="amount">9</field>
-            <field name="amount_type">percent</field>
-            <field name="type_tax_use">purchase</field>
-            <field name="tax_group_id" ref="tax_group_iva_9"/>
-            <field name="invoice_repartition_line_ids" eval="[(5, 0, 0),
-                (0,0, {
-                    'factor_percent': 100,
-                    'repartition_type': 'base',
-                }),
-
-                (0,0, {
-                    'factor_percent': 100,
-                    'repartition_type': 'tax',
-                    'account_id': ref('chart_2432'),
-                }),
-            ]"/>
-            <field name="refund_repartition_line_ids" eval="[(5, 0, 0),
-                (0,0, {
-                    'factor_percent': 100,
-                    'repartition_type': 'base',
-                }),
-
-                (0,0, {
-                    'factor_percent': 100,
-                    'repartition_type': 'tax',
-                    'account_id': ref('chart_2432'),
+                    'minus_report_line_ids': [ref('tax_report_pt_tax_despesas_intermedia')],
                 }),
             ]"/>
         </record>
@@ -585,96 +317,28 @@
                 (0,0, {
                     'factor_percent': 100,
                     'repartition_type': 'base',
-                    'plus_report_line_ids': [ref('tax_report_pt_base_despesas_faturas_reduzida')],
+                    'plus_report_line_ids': [ref('tax_report_pt_base_despesas_reduzida')],
                 }),
 
                 (0,0, {
                     'factor_percent': 100,
                     'repartition_type': 'tax',
-                    'plus_report_line_ids': [ref('tax_report_pt_tax_despesas_faturas_reduzida')],
                     'account_id': ref('chart_2432'),
+                    'plus_report_line_ids': [ref('tax_report_pt_tax_despesas_reduzida')],
                 }),
             ]"/>
             <field name="refund_repartition_line_ids" eval="[(5, 0, 0),
                 (0,0, {
                     'factor_percent': 100,
                     'repartition_type': 'base',
-                    'plus_report_line_ids': [ref('tax_report_pt_base_despesas_notas_credito_reduzida')],
-                }),
-
-                (0,0, {
-                    'factor_percent': 100,
-                    'repartition_type': 'tax',
-                    'plus_report_line_ids': [ref('tax_report_pt_tax_despesas_notas_credito_reduzida')],
-                    'account_id': ref('chart_2432'),
-                }),
-            ]"/>
-        </record>
-
-        <record id="compiva5" model="account.tax.template">
-            <field name="chart_template_id" ref="pt_chart_template"/>
-            <field name="name">IVA5 compra</field>
-            <field name="description">IVA5 compra (taxa reduzida Madeira)</field>
-            <field name="amount">5</field>
-            <field name="amount_type">percent</field>
-            <field name="type_tax_use">purchase</field>
-            <field name="tax_group_id" ref="tax_group_iva_5"/>
-            <field name="invoice_repartition_line_ids" eval="[(5, 0, 0),
-                (0,0, {
-                    'factor_percent': 100,
-                    'repartition_type': 'base',
+                    'minus_report_line_ids': [ref('tax_report_pt_base_despesas_reduzida')],
                 }),
 
                 (0,0, {
                     'factor_percent': 100,
                     'repartition_type': 'tax',
                     'account_id': ref('chart_2432'),
-                }),
-            ]"/>
-            <field name="refund_repartition_line_ids" eval="[(5, 0, 0),
-                (0,0, {
-                    'factor_percent': 100,
-                    'repartition_type': 'base',
-                }),
-
-                (0,0, {
-                    'factor_percent': 100,
-                    'repartition_type': 'tax',
-                    'account_id': ref('chart_2432'),
-                }),
-            ]"/>
-        </record>
-
-        <record id="compiva4" model="account.tax.template">
-            <field name="chart_template_id" ref="pt_chart_template"/>
-            <field name="name">IVA4 compra</field>
-            <field name="description">IVA4 compra (taxa reduzida Açores)</field>
-            <field name="amount">4</field>
-            <field name="amount_type">percent</field>
-            <field name="type_tax_use">purchase</field>
-            <field name="tax_group_id" ref="tax_group_iva_4"/>
-            <field name="invoice_repartition_line_ids" eval="[(5, 0, 0),
-                (0,0, {
-                    'factor_percent': 100,
-                    'repartition_type': 'base',
-                }),
-
-                (0,0, {
-                    'factor_percent': 100,
-                    'repartition_type': 'tax',
-                    'account_id': ref('chart_2432'),
-                }),
-            ]"/>
-            <field name="refund_repartition_line_ids" eval="[(5, 0, 0),
-                (0,0, {
-                    'factor_percent': 100,
-                    'repartition_type': 'base',
-                }),
-
-                (0,0, {
-                    'factor_percent': 100,
-                    'repartition_type': 'tax',
-                    'account_id': ref('chart_2432'),
+                    'minus_report_line_ids': [ref('tax_report_pt_tax_despesas_reduzida')],
                 }),
             ]"/>
         </record>
@@ -691,13 +355,12 @@
                 (0,0, {
                     'factor_percent': 100,
                     'repartition_type': 'base',
-                    'plus_report_line_ids': [ref('tax_report_pt_base_despesas_faturas_isento')],
+                    'plus_report_line_ids': [ref('tax_report_pt_base_despesas_isento')],
                 }),
 
                 (0,0, {
                     'factor_percent': 100,
                     'repartition_type': 'tax',
-                    'plus_report_line_ids': [ref('tax_report_pt_tax_despesas_faturas_isento')],
                     'account_id': ref('chart_2432'),
                 }),
             ]"/>
@@ -705,14 +368,1457 @@
                 (0,0, {
                     'factor_percent': 100,
                     'repartition_type': 'base',
-                    'plus_report_line_ids': [ref('tax_report_pt_base_despesas_notas_credito_isento')],
+                    'minus_report_line_ids': [ref('tax_report_pt_base_despesas_isento')],
                 }),
 
                 (0,0, {
                     'factor_percent': 100,
                     'repartition_type': 'tax',
-                    'plus_report_line_ids': [ref('tax_report_pt_tax_despesas_notas_credito_isento')],
                     'account_id': ref('chart_2432'),
+                }),
+            ]"/>
+        </record>
+
+        <record id="compiva23_eu_bens" model="account.tax.template">
+            <field name="chart_template_id" ref="pt_chart_template"/>
+            <field name="name">IVA23 compra (aquisição de bens EU)</field>
+            <field name="description">IVA23 compra (aquisição de bens EU) (taxa normal Portugal Continental)</field>
+            <field name="amount">23</field>
+            <field name="active" eval="False"/>
+            <field name="amount_type">percent</field>
+            <field name="type_tax_use">purchase</field>
+            <field name="tax_scope">consu</field>
+            <field name="tax_group_id" ref="tax_group_iva_23"/>
+            <field name="invoice_repartition_line_ids" eval="[(5, 0, 0),
+                (0,0, {
+                    'factor_percent': 100,
+                    'repartition_type': 'base',
+                    'plus_report_line_ids': [ref('tax_report_pt_base_despesas_eu_bens')],
+                }),
+
+                (0,0, {
+                    'factor_percent': 100,
+                    'repartition_type': 'tax',
+                    'account_id': ref('chart_2432'),
+                    'plus_report_line_ids': [ref('tax_report_pt_tax_despesas_eu_bens')],
+                }),
+
+                (0,0, {
+                    'factor_percent': -100,
+                    'repartition_type': 'tax',
+                    'account_id': ref('chart_2433'),
+                    'minus_report_line_ids': [ref('tax_report_pt_tax_despesas_normal')],
+                }),
+            ]"/>
+            <field name="refund_repartition_line_ids" eval="[(5, 0, 0),
+                (0,0, {
+                    'factor_percent': 100,
+                    'repartition_type': 'base',
+                    'minus_report_line_ids': [ref('tax_report_pt_base_despesas_eu_bens')],
+                }),
+
+                (0,0, {
+                    'factor_percent': 100,
+                    'repartition_type': 'tax',
+                    'account_id': ref('chart_2432'),
+                    'minus_report_line_ids': [ref('tax_report_pt_tax_despesas_eu_bens')],
+                }),
+
+                (0,0, {
+                    'factor_percent': -100,
+                    'repartition_type': 'tax',
+                    'account_id': ref('chart_2433'),
+                    'plus_report_line_ids': [ref('tax_report_pt_tax_despesas_normal')],
+                }),
+            ]"/>
+        </record>
+
+        <record id="compiva23_eu_servicos" model="account.tax.template">
+            <field name="chart_template_id" ref="pt_chart_template"/>
+            <field name="name">IVA23 compra (aquisição de serviços EU)</field>
+            <field name="description">IVA23 compra (aquisição de serviços EU) (taxa normal Portugal Continental)</field>
+            <field name="amount">23</field>
+            <field name="active" eval="False"/>
+            <field name="amount_type">percent</field>
+            <field name="type_tax_use">purchase</field>
+            <field name="tax_scope">service</field>
+            <field name="tax_group_id" ref="tax_group_iva_23"/>
+            <field name="invoice_repartition_line_ids" eval="[(5, 0, 0),
+                (0,0, {
+                    'factor_percent': 100,
+                    'repartition_type': 'base',
+                    'plus_report_line_ids': [ref('tax_report_pt_base_despesas_eu_servicos')],
+                }),
+
+                (0,0, {
+                    'factor_percent': 100,
+                    'repartition_type': 'tax',
+                    'account_id': ref('chart_2432'),
+                    'plus_report_line_ids': [ref('tax_report_pt_tax_despesas_eu_servicos')],
+                }),
+
+                (0,0, {
+                    'factor_percent': -100,
+                    'repartition_type': 'tax',
+                    'account_id': ref('chart_2433'),
+                    'minus_report_line_ids': [ref('tax_report_pt_tax_despesas_normal')],
+                }),
+            ]"/>
+            <field name="refund_repartition_line_ids" eval="[(5, 0, 0),
+                (0,0, {
+                    'factor_percent': 100,
+                    'repartition_type': 'base',
+                    'minus_report_line_ids': [ref('tax_report_pt_base_despesas_eu_servicos')],
+                }),
+
+                (0,0, {
+                    'factor_percent': 100,
+                    'repartition_type': 'tax',
+                    'account_id': ref('chart_2432'),
+                    'minus_report_line_ids': [ref('tax_report_pt_tax_despesas_eu_servicos')],
+                }),
+
+                (0,0, {
+                    'factor_percent': -100,
+                    'repartition_type': 'tax',
+                    'account_id': ref('chart_2433'),
+                    'minus_report_line_ids': [ref('tax_report_pt_tax_despesas_normal')],
+                }),
+            ]"/>
+        </record>
+
+        <record id="compiva13_eu_bens" model="account.tax.template">
+            <field name="chart_template_id" ref="pt_chart_template"/>
+            <field name="name">IVA13 compra (aquisição de bens EU)</field>
+            <field name="description">IVA13 compra (aquisição de bens EU) (taxa intermédia Portugal Continental)</field>
+            <field name="amount">13</field>
+            <field name="active" eval="False"/>
+            <field name="amount_type">percent</field>
+            <field name="type_tax_use">purchase</field>
+            <field name="tax_scope">consu</field>
+            <field name="tax_group_id" ref="tax_group_iva_13"/>
+            <field name="invoice_repartition_line_ids" eval="[(5, 0, 0),
+                (0,0, {
+                    'factor_percent': 100,
+                    'repartition_type': 'base',
+                    'plus_report_line_ids': [ref('tax_report_pt_base_despesas_eu_bens')],
+                }),
+
+                (0,0, {
+                    'factor_percent': 100,
+                    'repartition_type': 'tax',
+                    'account_id': ref('chart_2432'),
+                    'plus_report_line_ids': [ref('tax_report_pt_tax_despesas_eu_bens')],
+                }),
+
+                (0,0, {
+                    'factor_percent': -100,
+                    'repartition_type': 'tax',
+                    'account_id': ref('chart_2433'),
+                    'minus_report_line_ids': [ref('tax_report_pt_tax_despesas_intermedia')],
+                }),
+            ]"/>
+            <field name="refund_repartition_line_ids" eval="[(5, 0, 0),
+                (0,0, {
+                    'factor_percent': 100,
+                    'repartition_type': 'base',
+                    'minus_report_line_ids': [ref('tax_report_pt_base_despesas_eu_bens')],
+                }),
+
+                (0,0, {
+                    'factor_percent': 100,
+                    'repartition_type': 'tax',
+                    'account_id': ref('chart_2432'),
+                    'minus_report_line_ids': [ref('tax_report_pt_tax_despesas_eu_bens')],
+                }),
+
+                (0,0, {
+                    'factor_percent': -100,
+                    'repartition_type': 'tax',
+                    'account_id': ref('chart_2433'),
+                    'plus_report_line_ids': [ref('tax_report_pt_tax_despesas_intermedia')],
+                }),
+            ]"/>
+        </record>
+
+        <record id="compiva13_eu_servicos" model="account.tax.template">
+            <field name="chart_template_id" ref="pt_chart_template"/>
+            <field name="name">IVA13 compra (aquisição de serviços EU)</field>
+            <field name="description">IVA13 compra (aquisição de serviços EU) (taxa intermédia Portugal Continental)</field>
+            <field name="amount">13</field>
+            <field name="active" eval="False"/>
+            <field name="amount_type">percent</field>
+            <field name="type_tax_use">purchase</field>
+            <field name="tax_scope">service</field>
+            <field name="tax_group_id" ref="tax_group_iva_13"/>
+            <field name="invoice_repartition_line_ids" eval="[(5, 0, 0),
+                (0,0, {
+                    'factor_percent': 100,
+                    'repartition_type': 'base',
+                    'plus_report_line_ids': [ref('tax_report_pt_base_despesas_eu_servicos')],
+                }),
+
+                (0,0, {
+                    'factor_percent': 100,
+                    'repartition_type': 'tax',
+                    'account_id': ref('chart_2432'),
+                    'plus_report_line_ids': [ref('tax_report_pt_tax_despesas_eu_servicos')],
+                }),
+
+                (0,0, {
+                    'factor_percent': -100,
+                    'repartition_type': 'tax',
+                    'account_id': ref('chart_2433'),
+                    'minus_report_line_ids': [ref('tax_report_pt_tax_despesas_intermedia')],
+                }),
+            ]"/>
+            <field name="refund_repartition_line_ids" eval="[(5, 0, 0),
+                (0,0, {
+                    'factor_percent': 100,
+                    'repartition_type': 'base',
+                    'minus_report_line_ids': [ref('tax_report_pt_base_despesas_eu_servicos')],
+                }),
+
+                (0,0, {
+                    'factor_percent': 100,
+                    'repartition_type': 'tax',
+                    'account_id': ref('chart_2432'),
+                    'minus_report_line_ids': [ref('tax_report_pt_tax_despesas_eu_servicos')],
+                }),
+
+                (0,0, {
+                    'factor_percent': -100,
+                    'repartition_type': 'tax',
+                    'account_id': ref('chart_2433'),
+                    'minus_report_line_ids': [ref('tax_report_pt_tax_despesas_intermedia')],
+                }),
+            ]"/>
+        </record>
+
+        <record id="compiva6_eu_bens" model="account.tax.template">
+            <field name="chart_template_id" ref="pt_chart_template"/>
+            <field name="name">IVA6 compra (aquisição de bens EU)</field>
+            <field name="description">IVA6 compra (aquisição de bens EU) (taxa reduzida Portugal Continental)</field>
+            <field name="amount">6</field>
+            <field name="active" eval="False"/>
+            <field name="amount_type">percent</field>
+            <field name="type_tax_use">purchase</field>
+            <field name="tax_scope">consu</field>
+            <field name="tax_group_id" ref="tax_group_iva_6"/>
+            <field name="invoice_repartition_line_ids" eval="[(5, 0, 0),
+                (0,0, {
+                    'factor_percent': 100,
+                    'repartition_type': 'base',
+                    'plus_report_line_ids': [ref('tax_report_pt_base_despesas_eu_bens')],
+                }),
+
+                (0,0, {
+                    'factor_percent': 100,
+                    'repartition_type': 'tax',
+                    'account_id': ref('chart_2432'),
+                    'plus_report_line_ids': [ref('tax_report_pt_tax_despesas_eu_bens')],
+                }),
+
+                (0,0, {
+                    'factor_percent': -100,
+                    'repartition_type': 'tax',
+                    'account_id': ref('chart_2433'),
+                    'minus_report_line_ids': [ref('tax_report_pt_tax_despesas_reduzida')],
+                }),
+            ]"/>
+            <field name="refund_repartition_line_ids" eval="[(5, 0, 0),
+                (0,0, {
+                    'factor_percent': 100,
+                    'repartition_type': 'base',
+                    'minus_report_line_ids': [ref('tax_report_pt_base_despesas_eu_bens')],
+                }),
+
+                (0,0, {
+                    'factor_percent': 100,
+                    'repartition_type': 'tax',
+                    'account_id': ref('chart_2432'),
+                    'minus_report_line_ids': [ref('tax_report_pt_tax_despesas_eu_bens')],
+                }),
+
+                (0,0, {
+                    'factor_percent': -100,
+                    'repartition_type': 'tax',
+                    'account_id': ref('chart_2433'),
+                    'plus_report_line_ids': [ref('tax_report_pt_tax_despesas_reduzida')],
+                }),
+            ]"/>
+        </record>
+
+        <record id="compiva6_eu_servicos" model="account.tax.template">
+            <field name="chart_template_id" ref="pt_chart_template"/>
+            <field name="name">IVA6 compra (aquisição de serviços EU)</field>
+            <field name="description">IVA6 compra (aquisição de serviços EU) (taxa reduzida Portugal Continental)</field>
+            <field name="amount">6</field>
+            <field name="active" eval="False"/>
+            <field name="amount_type">percent</field>
+            <field name="type_tax_use">purchase</field>
+            <field name="tax_scope">service</field>
+            <field name="tax_group_id" ref="tax_group_iva_6"/>
+            <field name="invoice_repartition_line_ids" eval="[(5, 0, 0),
+                (0,0, {
+                    'factor_percent': 100,
+                    'repartition_type': 'base',
+                    'plus_report_line_ids': [ref('tax_report_pt_base_despesas_eu_servicos')],
+                }),
+
+                (0,0, {
+                    'factor_percent': 100,
+                    'repartition_type': 'tax',
+                    'account_id': ref('chart_2432'),
+                    'plus_report_line_ids': [ref('tax_report_pt_tax_despesas_eu_servicos')],
+                }),
+
+                (0,0, {
+                    'factor_percent': -100,
+                    'repartition_type': 'tax',
+                    'account_id': ref('chart_2433'),
+                    'minus_report_line_ids': [ref('tax_report_pt_tax_despesas_reduzida')],
+                }),
+            ]"/>
+            <field name="refund_repartition_line_ids" eval="[(5, 0, 0),
+                (0,0, {
+                    'factor_percent': 100,
+                    'repartition_type': 'base',
+                    'minus_report_line_ids': [ref('tax_report_pt_base_despesas_eu_servicos')],
+                }),
+
+                (0,0, {
+                    'factor_percent': 100,
+                    'repartition_type': 'tax',
+                    'account_id': ref('chart_2432'),
+                    'minus_report_line_ids': [ref('tax_report_pt_tax_despesas_eu_servicos')],
+                }),
+
+                (0,0, {
+                    'factor_percent': -100,
+                    'repartition_type': 'tax',
+                    'account_id': ref('chart_2433'),
+                    'minus_report_line_ids': [ref('tax_report_pt_tax_despesas_reduzida')],
+                }),
+            ]"/>
+        </record>
+
+<!--    Taxes Madeira-->
+
+        <record id="iva22" model="account.tax.template">
+            <field name="chart_template_id" ref="pt_chart_template"/>
+            <field name="name">IVA22</field>
+            <field name="description">IVA22 (taxa normal Madeira)</field>
+            <field name="amount">22</field>
+            <field name="type_tax_use">sale</field>
+            <field name="amount_type">percent</field>
+            <field name="active" eval="False"/>
+            <field name="tax_group_id" ref="tax_group_iva_22"/>
+            <field name="invoice_repartition_line_ids" eval="[(5, 0, 0),
+                (0,0, {
+                    'factor_percent': 100,
+                    'repartition_type': 'base',
+                    'plus_report_line_ids': [ref('tax_report_pt_base_vendas_normal')],
+                }),
+
+                (0,0, {
+                    'factor_percent': 100,
+                    'repartition_type': 'tax',
+                    'account_id': ref('chart_2433'),
+                    'plus_report_line_ids': [ref('tax_report_pt_tax_vendas_normal')],
+                }),
+            ]"/>
+            <field name="refund_repartition_line_ids" eval="[(5, 0, 0),
+                (0,0, {
+                    'factor_percent': 100,
+                    'repartition_type': 'base',
+                    'minus_report_line_ids': [ref('tax_report_pt_base_vendas_normal')],
+                }),
+
+                (0,0, {
+                    'factor_percent': 100,
+                    'repartition_type': 'tax',
+                    'account_id': ref('chart_2433'),
+                    'minus_report_line_ids': [ref('tax_report_pt_tax_vendas_normal')],
+                }),
+            ]"/>
+        </record>
+
+        <record id="iva12" model="account.tax.template">
+            <field name="chart_template_id" ref="pt_chart_template"/>
+            <field name="name">IVA12</field>
+            <field name="description">IVA12 (taxa intermédia Madeira)</field>
+            <field name="amount">12</field>
+            <field name="type_tax_use">sale</field>
+            <field name="amount_type">percent</field>
+            <field name="active" eval="False"/>
+            <field name="tax_group_id" ref="tax_group_iva_12"/>
+            <field name="invoice_repartition_line_ids" eval="[(5, 0, 0),
+                (0,0, {
+                    'factor_percent': 100,
+                    'repartition_type': 'base',
+                    'plus_report_line_ids': [ref('tax_report_pt_base_vendas_intermedia')],
+                }),
+
+                (0,0, {
+                    'factor_percent': 100,
+                    'repartition_type': 'tax',
+                    'account_id': ref('chart_2433'),
+                    'plus_report_line_ids': [ref('tax_report_pt_tax_vendas_intermedia')],
+                }),
+            ]"/>
+            <field name="refund_repartition_line_ids" eval="[(5, 0, 0),
+                (0,0, {
+                    'factor_percent': 100,
+                    'repartition_type': 'base',
+                    'minus_report_line_ids': [ref('tax_report_pt_base_vendas_intermedia')],
+                }),
+
+                (0,0, {
+                    'factor_percent': 100,
+                    'repartition_type': 'tax',
+                    'account_id': ref('chart_2433'),
+                    'minus_report_line_ids': [ref('tax_report_pt_tax_vendas_intermedia')],
+                }),
+            ]"/>
+        </record>
+
+        <record id="iva5" model="account.tax.template">
+            <field name="chart_template_id" ref="pt_chart_template"/>
+            <field name="name">IVA5</field>
+            <field name="description">IVA5 (taxa reduzida Madeira)</field>
+            <field name="amount">5</field>
+            <field name="type_tax_use">sale</field>
+            <field name="amount_type">percent</field>
+            <field name="active" eval="False"/>
+            <field name="tax_group_id" ref="tax_group_iva_5"/>
+            <field name="invoice_repartition_line_ids" eval="[(5, 0, 0),
+                (0,0, {
+                    'factor_percent': 100,
+                    'repartition_type': 'base',
+                    'plus_report_line_ids': [ref('tax_report_pt_base_vendas_reduzida')],
+                }),
+
+                (0,0, {
+                    'factor_percent': 100,
+                    'repartition_type': 'tax',
+                    'account_id': ref('chart_2433'),
+                    'plus_report_line_ids': [ref('tax_report_pt_tax_vendas_reduzida')],
+                }),
+            ]"/>
+            <field name="refund_repartition_line_ids" eval="[(5, 0, 0),
+                (0,0, {
+                    'factor_percent': 100,
+                    'repartition_type': 'base',
+                    'minus_report_line_ids': [ref('tax_report_pt_base_vendas_reduzida')],
+                }),
+
+                (0,0, {
+                    'factor_percent': 100,
+                    'repartition_type': 'tax',
+                    'account_id': ref('chart_2433'),
+                    'minus_report_line_ids': [ref('tax_report_pt_tax_vendas_reduzida')],
+                }),
+            ]"/>
+        </record>
+
+        <record id="compiva22" model="account.tax.template">
+            <field name="chart_template_id" ref="pt_chart_template"/>
+            <field name="name">IVA22 compra</field>
+            <field name="description">IVA22 compra (taxa normal Madeira)</field>
+            <field name="amount">22</field>
+            <field name="amount_type">percent</field>
+            <field name="type_tax_use">purchase</field>
+            <field name="active" eval="False"/>
+            <field name="tax_group_id" ref="tax_group_iva_22"/>
+            <field name="invoice_repartition_line_ids" eval="[(5, 0, 0),
+                (0,0, {
+                    'factor_percent': 100,
+                    'repartition_type': 'base',
+                    'plus_report_line_ids': [ref('tax_report_pt_base_despesas_normal')],
+                }),
+
+                (0,0, {
+                    'factor_percent': 100,
+                    'repartition_type': 'tax',
+                    'account_id': ref('chart_2432'),
+                    'plus_report_line_ids': [ref('tax_report_pt_tax_despesas_normal')],
+                }),
+            ]"/>
+            <field name="refund_repartition_line_ids" eval="[(5, 0, 0),
+                (0,0, {
+                    'factor_percent': 100,
+                    'repartition_type': 'base',
+                    'minus_report_line_ids': [ref('tax_report_pt_base_despesas_normal')],
+                }),
+
+                (0,0, {
+                    'factor_percent': 100,
+                    'repartition_type': 'tax',
+                    'account_id': ref('chart_2432'),
+                    'minus_report_line_ids': [ref('tax_report_pt_tax_despesas_normal')],
+                }),
+            ]"/>
+        </record>
+
+        <record id="compiva12" model="account.tax.template">
+            <field name="chart_template_id" ref="pt_chart_template"/>
+            <field name="name">IVA12 compra</field>
+            <field name="description">IVA12 compra (taxa intermédia Madeira)</field>
+            <field name="amount">12</field>
+            <field name="amount_type">percent</field>
+            <field name="type_tax_use">purchase</field>
+            <field name="active" eval="False"/>
+            <field name="tax_group_id" ref="tax_group_iva_12"/>
+            <field name="invoice_repartition_line_ids" eval="[(5, 0, 0),
+                (0,0, {
+                    'factor_percent': 100,
+                    'repartition_type': 'base',
+                    'plus_report_line_ids': [ref('tax_report_pt_base_despesas_intermedia')],
+                }),
+
+                (0,0, {
+                    'factor_percent': 100,
+                    'repartition_type': 'tax',
+                    'account_id': ref('chart_2432'),
+                    'plus_report_line_ids': [ref('tax_report_pt_tax_despesas_intermedia')],
+                }),
+            ]"/>
+            <field name="refund_repartition_line_ids" eval="[(5, 0, 0),
+                (0,0, {
+                    'factor_percent': 100,
+                    'repartition_type': 'base',
+                    'minus_report_line_ids': [ref('tax_report_pt_base_despesas_intermedia')],
+                }),
+
+                (0,0, {
+                    'factor_percent': 100,
+                    'repartition_type': 'tax',
+                    'account_id': ref('chart_2432'),
+                    'minus_report_line_ids': [ref('tax_report_pt_tax_despesas_intermedia')],
+                }),
+            ]"/>
+        </record>
+
+        <record id="compiva5" model="account.tax.template">
+            <field name="chart_template_id" ref="pt_chart_template"/>
+            <field name="name">IVA5 compra</field>
+            <field name="description">IVA5 compra (taxa reduzida Madeira)</field>
+            <field name="amount">5</field>
+            <field name="amount_type">percent</field>
+            <field name="type_tax_use">purchase</field>
+            <field name="active" eval="False"/>
+            <field name="tax_group_id" ref="tax_group_iva_5"/>
+            <field name="invoice_repartition_line_ids" eval="[(5, 0, 0),
+                (0,0, {
+                    'factor_percent': 100,
+                    'repartition_type': 'base',
+                    'plus_report_line_ids': [ref('tax_report_pt_base_despesas_reduzida')],
+                }),
+
+                (0,0, {
+                    'factor_percent': 100,
+                    'repartition_type': 'tax',
+                    'account_id': ref('chart_2432'),
+                    'plus_report_line_ids': [ref('tax_report_pt_tax_despesas_reduzida')],
+                }),
+            ]"/>
+            <field name="refund_repartition_line_ids" eval="[(5, 0, 0),
+                (0,0, {
+                    'factor_percent': 100,
+                    'repartition_type': 'base',
+                    'minus_report_line_ids': [ref('tax_report_pt_base_despesas_reduzida')],
+                }),
+
+                (0,0, {
+                    'factor_percent': 100,
+                    'repartition_type': 'tax',
+                    'account_id': ref('chart_2432'),
+                    'minus_report_line_ids': [ref('tax_report_pt_tax_despesas_reduzida')],
+                }),
+            ]"/>
+        </record>
+
+        <record id="compiva22_eu_bens" model="account.tax.template">
+            <field name="chart_template_id" ref="pt_chart_template"/>
+            <field name="name">IVA22 compra (aquisição de bens EU)</field>
+            <field name="description">IVA22 compra (aquisição de bens EU) (taxa normal Portugal Madeira)</field>
+            <field name="amount">22</field>
+            <field name="active" eval="False"/>
+            <field name="amount_type">percent</field>
+            <field name="type_tax_use">purchase</field>
+            <field name="tax_scope">consu</field>
+            <field name="tax_group_id" ref="tax_group_iva_22"/>
+            <field name="invoice_repartition_line_ids" eval="[(5, 0, 0),
+                (0,0, {
+                    'factor_percent': 100,
+                    'repartition_type': 'base',
+                    'plus_report_line_ids': [ref('tax_report_pt_base_despesas_eu_bens')],
+                }),
+
+                (0,0, {
+                    'factor_percent': 100,
+                    'repartition_type': 'tax',
+                    'account_id': ref('chart_2432'),
+                    'plus_report_line_ids': [ref('tax_report_pt_tax_despesas_eu_bens')],
+                }),
+
+                (0,0, {
+                    'factor_percent': -100,
+                    'repartition_type': 'tax',
+                    'account_id': ref('chart_2433'),
+                    'minus_report_line_ids': [ref('tax_report_pt_tax_despesas_normal')],
+                }),
+            ]"/>
+            <field name="refund_repartition_line_ids" eval="[(5, 0, 0),
+                (0,0, {
+                    'factor_percent': 100,
+                    'repartition_type': 'base',
+                    'minus_report_line_ids': [ref('tax_report_pt_base_despesas_eu_bens')],
+                }),
+
+                (0,0, {
+                    'factor_percent': 100,
+                    'repartition_type': 'tax',
+                    'account_id': ref('chart_2432'),
+                    'minus_report_line_ids': [ref('tax_report_pt_tax_despesas_eu_bens')],
+                }),
+
+                (0,0, {
+                    'factor_percent': -100,
+                    'repartition_type': 'tax',
+                    'account_id': ref('chart_2433'),
+                    'plus_report_line_ids': [ref('tax_report_pt_tax_despesas_normal')],
+                }),
+            ]"/>
+        </record>
+
+        <record id="compiva22_eu_servicos" model="account.tax.template">
+            <field name="chart_template_id" ref="pt_chart_template"/>
+            <field name="name">IVA22 compra (aquisição de serviços EU)</field>
+            <field name="description">IVA22 compra (aquisição de serviços EU) (taxa normal Portugal Madeira)</field>
+            <field name="amount">22</field>
+            <field name="amount_type">percent</field>
+            <field name="type_tax_use">purchase</field>
+            <field name="tax_scope">service</field>
+            <field name="active" eval="False"/>
+            <field name="tax_group_id" ref="tax_group_iva_22"/>
+            <field name="invoice_repartition_line_ids" eval="[(5, 0, 0),
+                (0,0, {
+                    'factor_percent': 100,
+                    'repartition_type': 'base',
+                    'plus_report_line_ids': [ref('tax_report_pt_base_despesas_eu_servicos')],
+                }),
+
+                (0,0, {
+                    'factor_percent': 100,
+                    'repartition_type': 'tax',
+                    'account_id': ref('chart_2432'),
+                    'plus_report_line_ids': [ref('tax_report_pt_tax_despesas_eu_servicos')],
+                }),
+
+                (0,0, {
+                    'factor_percent': -100,
+                    'repartition_type': 'tax',
+                    'account_id': ref('chart_2433'),
+                    'minus_report_line_ids': [ref('tax_report_pt_tax_despesas_normal')],
+                }),
+            ]"/>
+            <field name="refund_repartition_line_ids" eval="[(5, 0, 0),
+                (0,0, {
+                    'factor_percent': 100,
+                    'repartition_type': 'base',
+                    'minus_report_line_ids': [ref('tax_report_pt_base_despesas_eu_servicos')],
+                }),
+
+                (0,0, {
+                    'factor_percent': 100,
+                    'repartition_type': 'tax',
+                    'account_id': ref('chart_2432'),
+                    'minus_report_line_ids': [ref('tax_report_pt_tax_despesas_eu_servicos')],
+                }),
+
+                (0,0, {
+                    'factor_percent': -100,
+                    'repartition_type': 'tax',
+                    'account_id': ref('chart_2433'),
+                    'minus_report_line_ids': [ref('tax_report_pt_tax_despesas_normal')],
+                }),
+            ]"/>
+        </record>
+
+        <record id="compiva12_eu_bens" model="account.tax.template">
+            <field name="chart_template_id" ref="pt_chart_template"/>
+            <field name="name">IVA12 compra (aquisição de bens EU)</field>
+            <field name="description">IVA12 compra (aquisição de bens EU) (taxa intermédia Portugal Madeira)</field>
+            <field name="amount">12</field>
+            <field name="amount_type">percent</field>
+            <field name="type_tax_use">purchase</field>
+            <field name="tax_scope">consu</field>
+            <field name="active" eval="False"/>
+            <field name="tax_group_id" ref="tax_group_iva_12"/>
+            <field name="invoice_repartition_line_ids" eval="[(5, 0, 0),
+                (0,0, {
+                    'factor_percent': 100,
+                    'repartition_type': 'base',
+                    'plus_report_line_ids': [ref('tax_report_pt_base_despesas_eu_bens')],
+                }),
+
+                (0,0, {
+                    'factor_percent': 100,
+                    'repartition_type': 'tax',
+                    'account_id': ref('chart_2432'),
+                    'plus_report_line_ids': [ref('tax_report_pt_tax_despesas_eu_bens')],
+                }),
+
+                (0,0, {
+                    'factor_percent': -100,
+                    'repartition_type': 'tax',
+                    'account_id': ref('chart_2433'),
+                    'minus_report_line_ids': [ref('tax_report_pt_tax_despesas_intermedia')],
+                }),
+            ]"/>
+            <field name="refund_repartition_line_ids" eval="[(5, 0, 0),
+                (0,0, {
+                    'factor_percent': 100,
+                    'repartition_type': 'base',
+                    'minus_report_line_ids': [ref('tax_report_pt_base_despesas_eu_bens')],
+                }),
+
+                (0,0, {
+                    'factor_percent': 100,
+                    'repartition_type': 'tax',
+                    'account_id': ref('chart_2432'),
+                    'minus_report_line_ids': [ref('tax_report_pt_tax_despesas_eu_bens')],
+                }),
+
+                (0,0, {
+                    'factor_percent': -100,
+                    'repartition_type': 'tax',
+                    'account_id': ref('chart_2433'),
+                    'plus_report_line_ids': [ref('tax_report_pt_tax_despesas_intermedia')],
+                }),
+            ]"/>
+        </record>
+
+        <record id="compiva12_eu_servicos" model="account.tax.template">
+            <field name="chart_template_id" ref="pt_chart_template"/>
+            <field name="name">IVA12 compra (aquisição de serviços EU)</field>
+            <field name="description">IVA12 compra (aquisição de serviços EU) (taxa intermédia Portugal Madeira)</field>
+            <field name="amount">12</field>
+            <field name="amount_type">percent</field>
+            <field name="type_tax_use">purchase</field>
+            <field name="tax_scope">service</field>
+            <field name="active" eval="False"/>
+            <field name="tax_group_id" ref="tax_group_iva_12"/>
+            <field name="invoice_repartition_line_ids" eval="[(5, 0, 0),
+                (0,0, {
+                    'factor_percent': 100,
+                    'repartition_type': 'base',
+                    'plus_report_line_ids': [ref('tax_report_pt_base_despesas_eu_servicos')],
+                }),
+
+                (0,0, {
+                    'factor_percent': 100,
+                    'repartition_type': 'tax',
+                    'account_id': ref('chart_2432'),
+                    'plus_report_line_ids': [ref('tax_report_pt_tax_despesas_eu_servicos')],
+                }),
+
+                (0,0, {
+                    'factor_percent': -100,
+                    'repartition_type': 'tax',
+                    'account_id': ref('chart_2433'),
+                    'minus_report_line_ids': [ref('tax_report_pt_tax_despesas_intermedia')],
+                }),
+            ]"/>
+            <field name="refund_repartition_line_ids" eval="[(5, 0, 0),
+                (0,0, {
+                    'factor_percent': 100,
+                    'repartition_type': 'base',
+                    'minus_report_line_ids': [ref('tax_report_pt_base_despesas_eu_servicos')],
+                }),
+
+                (0,0, {
+                    'factor_percent': 100,
+                    'repartition_type': 'tax',
+                    'account_id': ref('chart_2432'),
+                    'minus_report_line_ids': [ref('tax_report_pt_tax_despesas_eu_servicos')],
+                }),
+
+                (0,0, {
+                    'factor_percent': -100,
+                    'repartition_type': 'tax',
+                    'account_id': ref('chart_2433'),
+                    'minus_report_line_ids': [ref('tax_report_pt_tax_despesas_intermedia')],
+                }),
+            ]"/>
+        </record>
+
+        <record id="compiva5_eu_bens" model="account.tax.template">
+            <field name="chart_template_id" ref="pt_chart_template"/>
+            <field name="name">IVA5 compra (aquisição de bens EU)</field>
+            <field name="description">IVA5 compra (aquisição de bens EU) (taxa reduzida Portugal Madeira)</field>
+            <field name="amount">5</field>
+            <field name="amount_type">percent</field>
+            <field name="type_tax_use">purchase</field>
+            <field name="tax_scope">consu</field>
+            <field name="active" eval="False"/>
+            <field name="tax_group_id" ref="tax_group_iva_5"/>
+            <field name="invoice_repartition_line_ids" eval="[(5, 0, 0),
+                (0,0, {
+                    'factor_percent': 100,
+                    'repartition_type': 'base',
+                    'plus_report_line_ids': [ref('tax_report_pt_base_despesas_eu_bens')],
+                }),
+
+                (0,0, {
+                    'factor_percent': 100,
+                    'repartition_type': 'tax',
+                    'account_id': ref('chart_2432'),
+                    'plus_report_line_ids': [ref('tax_report_pt_tax_despesas_eu_bens')],
+                }),
+
+                (0,0, {
+                    'factor_percent': -100,
+                    'repartition_type': 'tax',
+                    'account_id': ref('chart_2433'),
+                    'minus_report_line_ids': [ref('tax_report_pt_tax_despesas_reduzida')],
+                }),
+            ]"/>
+            <field name="refund_repartition_line_ids" eval="[(5, 0, 0),
+                (0,0, {
+                    'factor_percent': 100,
+                    'repartition_type': 'base',
+                    'minus_report_line_ids': [ref('tax_report_pt_base_despesas_eu_bens')],
+                }),
+
+                (0,0, {
+                    'factor_percent': 100,
+                    'repartition_type': 'tax',
+                    'account_id': ref('chart_2432'),
+                    'minus_report_line_ids': [ref('tax_report_pt_tax_despesas_eu_bens')],
+                }),
+
+                (0,0, {
+                    'factor_percent': -100,
+                    'repartition_type': 'tax',
+                    'account_id': ref('chart_2433'),
+                    'plus_report_line_ids': [ref('tax_report_pt_tax_despesas_reduzida')],
+                }),
+            ]"/>
+        </record>
+
+        <record id="compiva5_eu_servicos" model="account.tax.template">
+            <field name="chart_template_id" ref="pt_chart_template"/>
+            <field name="name">IVA5 compra (aquisição de serviços EU)</field>
+            <field name="description">IVA5 compra (aquisição de serviços EU) (taxa reduzida Portugal Madeira)</field>
+            <field name="amount">5</field>
+            <field name="amount_type">percent</field>
+            <field name="type_tax_use">purchase</field>
+            <field name="tax_scope">service</field>
+            <field name="active" eval="False"/>
+            <field name="tax_group_id" ref="tax_group_iva_5"/>
+            <field name="invoice_repartition_line_ids" eval="[(5, 0, 0),
+                (0,0, {
+                    'factor_percent': 100,
+                    'repartition_type': 'base',
+                    'plus_report_line_ids': [ref('tax_report_pt_base_despesas_eu_servicos')],
+                }),
+
+                (0,0, {
+                    'factor_percent': 100,
+                    'repartition_type': 'tax',
+                    'account_id': ref('chart_2432'),
+                    'plus_report_line_ids': [ref('tax_report_pt_tax_despesas_eu_servicos')],
+                }),
+
+                (0,0, {
+                    'factor_percent': -100,
+                    'repartition_type': 'tax',
+                    'account_id': ref('chart_2433'),
+                    'minus_report_line_ids': [ref('tax_report_pt_tax_despesas_reduzida')],
+                }),
+            ]"/>
+            <field name="refund_repartition_line_ids" eval="[(5, 0, 0),
+                (0,0, {
+                    'factor_percent': 100,
+                    'repartition_type': 'base',
+                    'minus_report_line_ids': [ref('tax_report_pt_base_despesas_eu_servicos')],
+                }),
+
+                (0,0, {
+                    'factor_percent': 100,
+                    'repartition_type': 'tax',
+                    'account_id': ref('chart_2432'),
+                    'minus_report_line_ids': [ref('tax_report_pt_tax_despesas_eu_servicos')],
+                }),
+
+                (0,0, {
+                    'factor_percent': -100,
+                    'repartition_type': 'tax',
+                    'account_id': ref('chart_2433'),
+                    'minus_report_line_ids': [ref('tax_report_pt_tax_despesas_reduzida')],
+                }),
+            ]"/>
+        </record>
+
+<!--    Taxes Azores-->
+
+        <record id="iva16" model="account.tax.template">
+            <field name="chart_template_id" ref="pt_chart_template"/>
+            <field name="name">IVA16</field>
+            <field name="description">IVA16 (taxa normal Açores)</field>
+            <field name="amount">16</field>
+            <field name="type_tax_use">sale</field>
+            <field name="amount_type">percent</field>
+            <field name="active" eval="False"/>
+            <field name="tax_group_id" ref="tax_group_iva_16"/>
+            <field name="invoice_repartition_line_ids" eval="[(5, 0, 0),
+                (0,0, {
+                    'factor_percent': 100,
+                    'repartition_type': 'base',
+                    'plus_report_line_ids': [ref('tax_report_pt_base_vendas_normal')],
+                }),
+
+                (0,0, {
+                    'factor_percent': 100,
+                    'repartition_type': 'tax',
+                    'account_id': ref('chart_2433'),
+                    'plus_report_line_ids': [ref('tax_report_pt_tax_vendas_normal')],
+                }),
+            ]"/>
+            <field name="refund_repartition_line_ids" eval="[(5, 0, 0),
+                (0,0, {
+                    'factor_percent': 100,
+                    'repartition_type': 'base',
+                    'minus_report_line_ids': [ref('tax_report_pt_base_vendas_normal')],
+                }),
+
+                (0,0, {
+                    'factor_percent': 100,
+                    'repartition_type': 'tax',
+                    'account_id': ref('chart_2433'),
+                    'minus_report_line_ids': [ref('tax_report_pt_tax_vendas_normal')],
+                }),
+            ]"/>
+        </record>
+
+        <record id="iva9" model="account.tax.template">
+            <field name="chart_template_id" ref="pt_chart_template"/>
+            <field name="name">IVA9</field>
+            <field name="description">IVA9 (taxa intermédia Açores)</field>
+            <field name="amount">9</field>
+            <field name="type_tax_use">sale</field>
+            <field name="amount_type">percent</field>
+            <field name="active" eval="False"/>
+            <field name="tax_group_id" ref="tax_group_iva_9"/>
+            <field name="invoice_repartition_line_ids" eval="[(5, 0, 0),
+                (0,0, {
+                    'factor_percent': 100,
+                    'repartition_type': 'base',
+                    'plus_report_line_ids': [ref('tax_report_pt_base_vendas_intermedia')],
+                }),
+
+                (0,0, {
+                    'factor_percent': 100,
+                    'repartition_type': 'tax',
+                    'account_id': ref('chart_2433'),
+                    'plus_report_line_ids': [ref('tax_report_pt_tax_vendas_intermedia')],
+                }),
+            ]"/>
+            <field name="refund_repartition_line_ids" eval="[(5, 0, 0),
+                (0,0, {
+                    'factor_percent': 100,
+                    'repartition_type': 'base',
+                    'minus_report_line_ids': [ref('tax_report_pt_base_vendas_intermedia')],
+                }),
+
+                (0,0, {
+                    'factor_percent': 100,
+                    'repartition_type': 'tax',
+                    'account_id': ref('chart_2433'),
+                    'minus_report_line_ids': [ref('tax_report_pt_tax_vendas_intermedia')],
+                }),
+            ]"/>
+        </record>
+
+        <record id="iva4" model="account.tax.template">
+            <field name="chart_template_id" ref="pt_chart_template"/>
+            <field name="name">IVA4</field>
+            <field name="description">IVA4 (taxa reduzida Açores)</field>
+            <field name="amount">4</field>
+            <field name="type_tax_use">sale</field>
+            <field name="amount_type">percent</field>
+            <field name="active" eval="False"/>
+            <field name="tax_group_id" ref="tax_group_iva_4"/>
+            <field name="invoice_repartition_line_ids" eval="[(5, 0, 0),
+                (0,0, {
+                    'factor_percent': 100,
+                    'repartition_type': 'base',
+                    'plus_report_line_ids': [ref('tax_report_pt_base_vendas_reduzida')],
+                }),
+
+                (0,0, {
+                    'factor_percent': 100,
+                    'repartition_type': 'tax',
+                    'account_id': ref('chart_2433'),
+                    'plus_report_line_ids': [ref('tax_report_pt_tax_vendas_reduzida')],
+                }),
+            ]"/>
+            <field name="refund_repartition_line_ids" eval="[(5, 0, 0),
+                (0,0, {
+                    'factor_percent': 100,
+                    'repartition_type': 'base',
+                    'minus_report_line_ids': [ref('tax_report_pt_base_vendas_reduzida')],
+                }),
+
+                (0,0, {
+                    'factor_percent': 100,
+                    'repartition_type': 'tax',
+                    'account_id': ref('chart_2433'),
+                    'minus_report_line_ids': [ref('tax_report_pt_tax_vendas_reduzida')],
+                }),
+            ]"/>
+        </record>
+
+        <record id="compiva16" model="account.tax.template">
+            <field name="chart_template_id" ref="pt_chart_template"/>
+            <field name="name">IVA16 compra</field>
+            <field name="description">IVA16 compra (taxa normal Açores)</field>
+            <field name="amount">16</field>
+            <field name="amount_type">percent</field>
+            <field name="type_tax_use">purchase</field>
+            <field name="active" eval="False"/>
+            <field name="tax_group_id" ref="tax_group_iva_16"/>
+            <field name="invoice_repartition_line_ids" eval="[(5, 0, 0),
+                (0,0, {
+                    'factor_percent': 100,
+                    'repartition_type': 'base',
+                    'plus_report_line_ids': [ref('tax_report_pt_base_despesas_normal')],
+                }),
+
+                (0,0, {
+                    'factor_percent': 100,
+                    'repartition_type': 'tax',
+                    'account_id': ref('chart_2432'),
+                    'plus_report_line_ids': [ref('tax_report_pt_tax_despesas_normal')],
+                }),
+            ]"/>
+            <field name="refund_repartition_line_ids" eval="[(5, 0, 0),
+                (0,0, {
+                    'factor_percent': 100,
+                    'repartition_type': 'base',
+                    'minus_report_line_ids': [ref('tax_report_pt_base_despesas_normal')],
+                }),
+
+                (0,0, {
+                    'factor_percent': 100,
+                    'repartition_type': 'tax',
+                    'account_id': ref('chart_2432'),
+                    'minus_report_line_ids': [ref('tax_report_pt_tax_despesas_normal')],
+                }),
+            ]"/>
+        </record>
+
+        <record id="compiva9" model="account.tax.template">
+            <field name="chart_template_id" ref="pt_chart_template"/>
+            <field name="name">IVA9 compra</field>
+            <field name="description">IVA9 compra (taxa intermédia Açores)</field>
+            <field name="amount">9</field>
+            <field name="amount_type">percent</field>
+            <field name="type_tax_use">purchase</field>
+            <field name="active" eval="False"/>
+            <field name="tax_group_id" ref="tax_group_iva_9"/>
+            <field name="invoice_repartition_line_ids" eval="[(5, 0, 0),
+                (0,0, {
+                    'factor_percent': 100,
+                    'repartition_type': 'base',
+                    'plus_report_line_ids': [ref('tax_report_pt_base_despesas_intermedia')],
+                }),
+
+                (0,0, {
+                    'factor_percent': 100,
+                    'repartition_type': 'tax',
+                    'account_id': ref('chart_2432'),
+                    'plus_report_line_ids': [ref('tax_report_pt_tax_despesas_intermedia')],
+                }),
+            ]"/>
+            <field name="refund_repartition_line_ids" eval="[(5, 0, 0),
+                (0,0, {
+                    'factor_percent': 100,
+                    'repartition_type': 'base',
+                    'minus_report_line_ids': [ref('tax_report_pt_base_despesas_intermedia')],
+                }),
+
+                (0,0, {
+                    'factor_percent': 100,
+                    'repartition_type': 'tax',
+                    'account_id': ref('chart_2432'),
+                    'minus_report_line_ids': [ref('tax_report_pt_tax_despesas_intermedia')],
+                }),
+            ]"/>
+        </record>
+
+        <record id="compiva4" model="account.tax.template">
+            <field name="chart_template_id" ref="pt_chart_template"/>
+            <field name="name">IVA4 compra</field>
+            <field name="description">IVA4 compra (taxa reduzida Açores)</field>
+            <field name="amount">4</field>
+            <field name="amount_type">percent</field>
+            <field name="type_tax_use">purchase</field>
+            <field name="active" eval="False"/>
+            <field name="tax_group_id" ref="tax_group_iva_4"/>
+            <field name="invoice_repartition_line_ids" eval="[(5, 0, 0),
+                (0,0, {
+                    'factor_percent': 100,
+                    'repartition_type': 'base',
+                    'plus_report_line_ids': [ref('tax_report_pt_base_despesas_reduzida')],
+                }),
+
+                (0,0, {
+                    'factor_percent': 100,
+                    'repartition_type': 'tax',
+                    'account_id': ref('chart_2432'),
+                    'plus_report_line_ids': [ref('tax_report_pt_tax_despesas_reduzida')],
+                }),
+            ]"/>
+            <field name="refund_repartition_line_ids" eval="[(5, 0, 0),
+                (0,0, {
+                    'factor_percent': 100,
+                    'repartition_type': 'base',
+                    'minus_report_line_ids': [ref('tax_report_pt_base_despesas_reduzida')],
+                }),
+
+                (0,0, {
+                    'factor_percent': 100,
+                    'repartition_type': 'tax',
+                    'account_id': ref('chart_2432'),
+                    'minus_report_line_ids': [ref('tax_report_pt_tax_despesas_reduzida')],
+                }),
+            ]"/>
+        </record>
+
+        <record id="compiva16_eu_bens" model="account.tax.template">
+            <field name="chart_template_id" ref="pt_chart_template"/>
+            <field name="name">IVA16 compra (aquisição de bens EU)</field>
+            <field name="description">IVA16 compra (aquisição de bens EU) (taxa normal Portugal Açores)</field>
+            <field name="amount">16</field>
+            <field name="active" eval="False"/>
+            <field name="amount_type">percent</field>
+            <field name="type_tax_use">purchase</field>
+            <field name="tax_scope">consu</field>
+            <field name="tax_group_id" ref="tax_group_iva_16"/>
+            <field name="invoice_repartition_line_ids" eval="[(5, 0, 0),
+                (0,0, {
+                    'factor_percent': 100,
+                    'repartition_type': 'base',
+                    'plus_report_line_ids': [ref('tax_report_pt_base_despesas_eu_bens')],
+                }),
+
+                (0,0, {
+                    'factor_percent': 100,
+                    'repartition_type': 'tax',
+                    'account_id': ref('chart_2432'),
+                    'plus_report_line_ids': [ref('tax_report_pt_tax_despesas_eu_bens')],
+                }),
+
+                (0,0, {
+                    'factor_percent': -100,
+                    'repartition_type': 'tax',
+                    'account_id': ref('chart_2433'),
+                    'minus_report_line_ids': [ref('tax_report_pt_tax_despesas_normal')],
+                }),
+            ]"/>
+            <field name="refund_repartition_line_ids" eval="[(5, 0, 0),
+                (0,0, {
+                    'factor_percent': 100,
+                    'repartition_type': 'base',
+                    'minus_report_line_ids': [ref('tax_report_pt_base_despesas_eu_bens')],
+                }),
+
+                (0,0, {
+                    'factor_percent': 100,
+                    'repartition_type': 'tax',
+                    'account_id': ref('chart_2432'),
+                    'minus_report_line_ids': [ref('tax_report_pt_tax_despesas_eu_bens')],
+                }),
+
+                (0,0, {
+                    'factor_percent': -100,
+                    'repartition_type': 'tax',
+                    'account_id': ref('chart_2433'),
+                    'plus_report_line_ids': [ref('tax_report_pt_tax_despesas_normal')],
+                }),
+            ]"/>
+        </record>
+
+        <record id="compiva16_eu_servicos" model="account.tax.template">
+            <field name="chart_template_id" ref="pt_chart_template"/>
+            <field name="name">IVA16 compra (aquisição de serviços EU)</field>
+            <field name="description">IVA16 compra (aquisição de serviços EU) (taxa normal Portugal Açores)</field>
+            <field name="amount">16</field>
+            <field name="active" eval="False"/>
+            <field name="amount_type">percent</field>
+            <field name="type_tax_use">purchase</field>
+            <field name="tax_scope">service</field>
+            <field name="tax_group_id" ref="tax_group_iva_16"/>
+            <field name="invoice_repartition_line_ids" eval="[(5, 0, 0),
+                (0,0, {
+                    'factor_percent': 100,
+                    'repartition_type': 'base',
+                    'plus_report_line_ids': [ref('tax_report_pt_base_despesas_eu_servicos')],
+                }),
+
+                (0,0, {
+                    'factor_percent': 100,
+                    'repartition_type': 'tax',
+                    'account_id': ref('chart_2432'),
+                    'plus_report_line_ids': [ref('tax_report_pt_tax_despesas_eu_servicos')],
+                }),
+
+                (0,0, {
+                    'factor_percent': -100,
+                    'repartition_type': 'tax',
+                    'account_id': ref('chart_2433'),
+                    'minus_report_line_ids': [ref('tax_report_pt_tax_despesas_normal')],
+                }),
+            ]"/>
+            <field name="refund_repartition_line_ids" eval="[(5, 0, 0),
+                (0,0, {
+                    'factor_percent': 100,
+                    'repartition_type': 'base',
+                    'minus_report_line_ids': [ref('tax_report_pt_base_despesas_eu_servicos')],
+                }),
+
+                (0,0, {
+                    'factor_percent': 100,
+                    'repartition_type': 'tax',
+                    'account_id': ref('chart_2432'),
+                    'minus_report_line_ids': [ref('tax_report_pt_tax_despesas_eu_servicos')],
+                }),
+
+                (0,0, {
+                    'factor_percent': -100,
+                    'repartition_type': 'tax',
+                    'account_id': ref('chart_2433'),
+                    'minus_report_line_ids': [ref('tax_report_pt_tax_despesas_normal')],
+                }),
+            ]"/>
+        </record>
+
+        <record id="compiva9_eu_bens" model="account.tax.template">
+            <field name="chart_template_id" ref="pt_chart_template"/>
+            <field name="name">IVA9 compra (aquisição de bens EU)</field>
+            <field name="description">IVA9 compra (aquisição de bens EU) (taxa intermédia Portugal Açores)</field>
+            <field name="amount">9</field>
+            <field name="active" eval="False"/>
+            <field name="amount_type">percent</field>
+            <field name="type_tax_use">purchase</field>
+            <field name="tax_scope">consu</field>
+            <field name="tax_group_id" ref="tax_group_iva_9"/>
+            <field name="invoice_repartition_line_ids" eval="[(5, 0, 0),
+                (0,0, {
+                    'factor_percent': 100,
+                    'repartition_type': 'base',
+                    'plus_report_line_ids': [ref('tax_report_pt_base_despesas_eu_bens')],
+                }),
+
+                (0,0, {
+                    'factor_percent': 100,
+                    'repartition_type': 'tax',
+                    'account_id': ref('chart_2432'),
+                    'plus_report_line_ids': [ref('tax_report_pt_tax_despesas_eu_bens')],
+                }),
+
+                (0,0, {
+                    'factor_percent': -100,
+                    'repartition_type': 'tax',
+                    'account_id': ref('chart_2433'),
+                    'minus_report_line_ids': [ref('tax_report_pt_tax_despesas_intermedia')],
+                }),
+            ]"/>
+            <field name="refund_repartition_line_ids" eval="[(5, 0, 0),
+                (0,0, {
+                    'factor_percent': 100,
+                    'repartition_type': 'base',
+                    'minus_report_line_ids': [ref('tax_report_pt_base_despesas_eu_bens')],
+                }),
+
+                (0,0, {
+                    'factor_percent': 100,
+                    'repartition_type': 'tax',
+                    'account_id': ref('chart_2432'),
+                    'minus_report_line_ids': [ref('tax_report_pt_tax_despesas_eu_bens')],
+                }),
+
+                (0,0, {
+                    'factor_percent': -100,
+                    'repartition_type': 'tax',
+                    'account_id': ref('chart_2433'),
+                    'plus_report_line_ids': [ref('tax_report_pt_tax_despesas_intermedia')],
+                }),
+            ]"/>
+        </record>
+
+        <record id="compiva9_eu_servicos" model="account.tax.template">
+            <field name="chart_template_id" ref="pt_chart_template"/>
+            <field name="name">IVA9 compra (aquisição de serviços EU)</field>
+            <field name="description">IVA9 compra (aquisição de serviços EU) (taxa intermédia Portugal Açores)</field>
+            <field name="amount">9</field>
+            <field name="active" eval="False"/>
+            <field name="amount_type">percent</field>
+            <field name="type_tax_use">purchase</field>
+            <field name="tax_scope">service</field>
+            <field name="tax_group_id" ref="tax_group_iva_9"/>
+            <field name="invoice_repartition_line_ids" eval="[(5, 0, 0),
+                (0,0, {
+                    'factor_percent': 100,
+                    'repartition_type': 'base',
+                    'plus_report_line_ids': [ref('tax_report_pt_base_despesas_eu_servicos')],
+                }),
+
+                (0,0, {
+                    'factor_percent': 100,
+                    'repartition_type': 'tax',
+                    'account_id': ref('chart_2432'),
+                    'plus_report_line_ids': [ref('tax_report_pt_tax_despesas_eu_servicos')],
+                }),
+
+                (0,0, {
+                    'factor_percent': -100,
+                    'repartition_type': 'tax',
+                    'account_id': ref('chart_2433'),
+                    'minus_report_line_ids': [ref('tax_report_pt_tax_despesas_intermedia')],
+                }),
+            ]"/>
+            <field name="refund_repartition_line_ids" eval="[(5, 0, 0),
+                (0,0, {
+                    'factor_percent': 100,
+                    'repartition_type': 'base',
+                    'minus_report_line_ids': [ref('tax_report_pt_base_despesas_eu_servicos')],
+                }),
+
+                (0,0, {
+                    'factor_percent': 100,
+                    'repartition_type': 'tax',
+                    'account_id': ref('chart_2432'),
+                    'minus_report_line_ids': [ref('tax_report_pt_tax_despesas_eu_servicos')],
+                }),
+
+                (0,0, {
+                    'factor_percent': -100,
+                    'repartition_type': 'tax',
+                    'account_id': ref('chart_2433'),
+                    'minus_report_line_ids': [ref('tax_report_pt_tax_despesas_intermedia')],
+                }),
+            ]"/>
+        </record>
+
+        <record id="compiva4_eu_bens" model="account.tax.template">
+            <field name="chart_template_id" ref="pt_chart_template"/>
+            <field name="name">IVA4 compra (aquisição de bens EU)</field>
+            <field name="description">IVA4 compra (aquisição de bens EU) (taxa reduzida Portugal Açores)</field>
+            <field name="amount">4</field>
+            <field name="active" eval="False"/>
+            <field name="amount_type">percent</field>
+            <field name="type_tax_use">purchase</field>
+            <field name="tax_scope">consu</field>
+            <field name="tax_group_id" ref="tax_group_iva_4"/>
+            <field name="invoice_repartition_line_ids" eval="[(5, 0, 0),
+                (0,0, {
+                    'factor_percent': 100,
+                    'repartition_type': 'base',
+                    'plus_report_line_ids': [ref('tax_report_pt_base_despesas_eu_bens')],
+                }),
+
+                (0,0, {
+                    'factor_percent': 100,
+                    'repartition_type': 'tax',
+                    'account_id': ref('chart_2432'),
+                    'plus_report_line_ids': [ref('tax_report_pt_tax_despesas_eu_bens')],
+                }),
+
+                (0,0, {
+                    'factor_percent': -100,
+                    'repartition_type': 'tax',
+                    'account_id': ref('chart_2433'),
+                    'minus_report_line_ids': [ref('tax_report_pt_tax_despesas_reduzida')],
+                }),
+            ]"/>
+            <field name="refund_repartition_line_ids" eval="[(5, 0, 0),
+                (0,0, {
+                    'factor_percent': 100,
+                    'repartition_type': 'base',
+                    'minus_report_line_ids': [ref('tax_report_pt_base_despesas_eu_bens')],
+                }),
+
+                (0,0, {
+                    'factor_percent': 100,
+                    'repartition_type': 'tax',
+                    'account_id': ref('chart_2432'),
+                    'minus_report_line_ids': [ref('tax_report_pt_tax_despesas_eu_bens')],
+                }),
+
+                (0,0, {
+                    'factor_percent': -100,
+                    'repartition_type': 'tax',
+                    'account_id': ref('chart_2433'),
+                    'plus_report_line_ids': [ref('tax_report_pt_tax_despesas_reduzida')],
+                }),
+            ]"/>
+        </record>
+
+        <record id="compiva4_eu_servicos" model="account.tax.template">
+            <field name="chart_template_id" ref="pt_chart_template"/>
+            <field name="name">IVA4 compra (aquisição de serviços EU)</field>
+            <field name="description">IVA4 compra (aquisição de serviços EU) (taxa reduzida Portugal Açores)</field>
+            <field name="amount">4</field>
+            <field name="active" eval="False"/>
+            <field name="amount_type">percent</field>
+            <field name="type_tax_use">purchase</field>
+            <field name="tax_scope">service</field>
+            <field name="tax_group_id" ref="tax_group_iva_4"/>
+            <field name="invoice_repartition_line_ids" eval="[(5, 0, 0),
+                (0,0, {
+                    'factor_percent': 100,
+                    'repartition_type': 'base',
+                    'plus_report_line_ids': [ref('tax_report_pt_base_despesas_eu_servicos')],
+                }),
+
+                (0,0, {
+                    'factor_percent': 100,
+                    'repartition_type': 'tax',
+                    'account_id': ref('chart_2432'),
+                    'plus_report_line_ids': [ref('tax_report_pt_tax_despesas_eu_servicos')],
+                }),
+
+                (0,0, {
+                    'factor_percent': -100,
+                    'repartition_type': 'tax',
+                    'account_id': ref('chart_2433'),
+                    'minus_report_line_ids': [ref('tax_report_pt_tax_despesas_reduzida')],
+                }),
+            ]"/>
+            <field name="refund_repartition_line_ids" eval="[(5, 0, 0),
+                (0,0, {
+                    'factor_percent': 100,
+                    'repartition_type': 'base',
+                    'minus_report_line_ids': [ref('tax_report_pt_base_despesas_eu_servicos')],
+                }),
+
+                (0,0, {
+                    'factor_percent': 100,
+                    'repartition_type': 'tax',
+                    'account_id': ref('chart_2432'),
+                    'minus_report_line_ids': [ref('tax_report_pt_tax_despesas_eu_servicos')],
+                }),
+
+                (0,0, {
+                    'factor_percent': -100,
+                    'repartition_type': 'tax',
+                    'account_id': ref('chart_2433'),
+                    'minus_report_line_ids': [ref('tax_report_pt_tax_despesas_reduzida')],
                 }),
             ]"/>
         </record>

--- a/addons/l10n_pt/data/account_tax_report.xml
+++ b/addons/l10n_pt/data/account_tax_report.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <odoo>
     <record id="tax_report" model="account.tax.report">
-        <field name="name">Relatório de IVA</field>
+        <field name="name">Declaração Periódica de IVA</field>
         <field name="country_id" ref="base.pt"/>
     </record>
 
@@ -17,173 +17,145 @@
         <field name="parent_id" ref="tax_report_pt_base"/>
         <field name="report_id" ref="tax_report"/>
         <field name="sequence">1</field>
-        <field name="formula">None</field>
     </record>
 
-    <record id="tax_report_pt_base_vendas_faturas" model="account.tax.report.line">
-        <field name="name">Faturas/Notas de débito</field>
+    <record id="tax_report_pt_base_vendas_normal" model="account.tax.report.line">
+        <field name="name">Normal (Campo 3)</field>
+        <field name="code">tax_report_pt_base_vendas_normal</field>
+        <field name="tag_name">Campo 3</field>
         <field name="parent_id" ref="tax_report_pt_base_vendas"/>
         <field name="report_id" ref="tax_report"/>
         <field name="sequence">1</field>
     </record>
 
-    <record id="tax_report_pt_base_vendas_faturas_normal" model="account.tax.report.line">
-        <field name="name">Normal</field>
-        <field name="tag_name">tax_report_pt_base_vendas_faturas_normal</field>
-        <field name="parent_id" ref="tax_report_pt_base_vendas_faturas"/>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence">1</field>
-    </record>
-
-    <record id="tax_report_pt_base_vendas_faturas_intermedia" model="account.tax.report.line">
-        <field name="name">Intermédia</field>
-        <field name="tag_name">tax_report_pt_base_vendas_faturas_intermedia</field>
-        <field name="parent_id" ref="tax_report_pt_base_vendas_faturas"/>
+    <record id="tax_report_pt_base_vendas_intermedia" model="account.tax.report.line">
+        <field name="name">Intermédia (Campo 5)</field>
+        <field name="code">tax_report_pt_base_vendas_intermedia</field>
+        <field name="tag_name">Campo 5</field>
+        <field name="parent_id" ref="tax_report_pt_base_vendas"/>
         <field name="report_id" ref="tax_report"/>
         <field name="sequence">2</field>
     </record>
 
-    <record id="tax_report_pt_base_vendas_faturas_reduzida" model="account.tax.report.line">
-        <field name="name">Reduzida</field>
-        <field name="tag_name">tax_report_pt_base_vendas_faturas_reduzida</field>
-        <field name="parent_id" ref="tax_report_pt_base_vendas_faturas"/>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence">3</field>
-    </record>
-
-    <record id="tax_report_pt_base_vendas_faturas_isento" model="account.tax.report.line">
-        <field name="name">Isento</field>
-        <field name="tag_name">tax_report_pt_base_vendas_faturas_isento</field>
-        <field name="parent_id" ref="tax_report_pt_base_vendas_faturas"/>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence">4</field>
-    </record>
-
-    <record id="tax_report_pt_base_vendas_notas_credito" model="account.tax.report.line">
-        <field name="name">Notas de crédito</field>
+    <record id="tax_report_pt_base_vendas_reduzida" model="account.tax.report.line">
+        <field name="name">Reduzida (Campo 1)</field>
+        <field name="code">tax_report_pt_base_vendas_reduzida</field>
+        <field name="tag_name">Campo 1</field>
         <field name="parent_id" ref="tax_report_pt_base_vendas"/>
         <field name="report_id" ref="tax_report"/>
         <field name="sequence">3</field>
     </record>
 
-    <record id="tax_report_pt_base_vendas_notas_credito_normal" model="account.tax.report.line">
-        <field name="name">Normal</field>
-        <field name="tag_name">tax_report_pt_base_vendas_notas_credito_normal</field>
-        <field name="parent_id" ref="tax_report_pt_base_vendas_notas_credito"/>
+    <record id="tax_report_pt_base_vendas_isento" model="account.tax.report.line">
+        <field name="name">Isento (Campo 8)</field>
+        <field name="code">tax_report_pt_base_vendas_isento</field>
+        <field name="tag_name">Campo 8</field>
+        <field name="parent_id" ref="tax_report_pt_base_vendas"/>
         <field name="report_id" ref="tax_report"/>
-        <field name="sequence">1</field>
+        <field name="sequence">4</field>
     </record>
 
-    <record id="tax_report_pt_base_vendas_notas_credito_intermedia" model="account.tax.report.line">
-        <field name="name">Intermédia</field>
-        <field name="tag_name">tax_report_pt_base_vendas_notas_credito_intermedia</field>
-        <field name="parent_id" ref="tax_report_pt_base_vendas_notas_credito"/>
+    <record id="tax_report_pt_base_vendas_eu" model="account.tax.report.line">
+        <field name="name">Vendas EU</field>
+        <field name="code">tax_report_pt_base_vendas_eu</field>
+        <field name="parent_id" ref="tax_report_pt_base"/>
         <field name="report_id" ref="tax_report"/>
         <field name="sequence">2</field>
     </record>
 
-    <record id="tax_report_pt_base_vendas_notas_credito_reduzida" model="account.tax.report.line">
-        <field name="name">Reduzida</field>
-        <field name="tag_name">tax_report_pt_base_vendas_notas_credito_reduzida</field>
-        <field name="parent_id" ref="tax_report_pt_base_vendas_notas_credito"/>
+    <record id="tax_report_pt_base_vendas_eu0" model="account.tax.report.line">
+        <field name="name">Isento EU (Campo 7)</field>
+        <field name="code">tax_report_pt_base_vendas_eu0</field>
+        <field name="tag_name">Campo 7</field>
+        <field name="parent_id" ref="tax_report_pt_base_vendas_eu"/>
+        <field name="report_id" ref="tax_report"/>
+        <field name="sequence">1</field>
+    </record>
+
+    <record id="tax_report_pt_base_vendas_non_eu" model="account.tax.report.line">
+        <field name="name">Vendas Non-EU</field>
+        <field name="code">tax_report_pt_base_vendas_non_eu</field>
+        <field name="parent_id" ref="tax_report_pt_base"/>
         <field name="report_id" ref="tax_report"/>
         <field name="sequence">3</field>
     </record>
 
-    <record id="tax_report_pt_base_vendas_notas_credito_isento" model="account.tax.report.line">
-        <field name="name">Isento</field>
-        <field name="tag_name">tax_report_pt_base_vendas_notas_credito_isento</field>
-        <field name="parent_id" ref="tax_report_pt_base_vendas_notas_credito"/>
+    <record id="tax_report_pt_base_vendas_non_eu0" model="account.tax.report.line">
+        <field name="name">Isento Non-EU</field>
+        <field name="code">tax_report_pt_base_vendas_non_eu0</field>
+        <field name="tag_name">Isento Non-EU</field>
+        <field name="parent_id" ref="tax_report_pt_base_vendas_non_eu"/>
         <field name="report_id" ref="tax_report"/>
-        <field name="sequence">4</field>
+        <field name="sequence">1</field>
     </record>
 
     <record id="tax_report_pt_base_despesas" model="account.tax.report.line">
         <field name="name">Despesas</field>
         <field name="parent_id" ref="tax_report_pt_base"/>
         <field name="report_id" ref="tax_report"/>
-        <field name="sequence">2</field>
-        <field name="formula">None</field>
+        <field name="sequence">4</field>
     </record>
 
-    <record id="tax_report_pt_base_despesas_faturas" model="account.tax.report.line">
-        <field name="name">Faturas</field>
+    <record id="tax_report_pt_base_despesas_normal" model="account.tax.report.line">
+        <field name="name">Normal</field>
+        <field name="code">tax_report_pt_base_despesas_normal</field>
+        <field name="tag_name">Normal</field>
         <field name="parent_id" ref="tax_report_pt_base_despesas"/>
         <field name="report_id" ref="tax_report"/>
         <field name="sequence">1</field>
     </record>
 
-    <record id="tax_report_pt_base_despesas_faturas_normal" model="account.tax.report.line">
-        <field name="name">Normal</field>
-        <field name="tag_name">tax_report_pt_base_despesas_faturas_normal</field>
-        <field name="parent_id" ref="tax_report_pt_base_despesas_faturas"/>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence">1</field>
-    </record>
-
-    <record id="tax_report_pt_base_despesas_faturas_intermedia" model="account.tax.report.line">
+    <record id="tax_report_pt_base_despesas_intermedia" model="account.tax.report.line">
         <field name="name">Intermédia</field>
-        <field name="tag_name">tax_report_pt_base_despesas_faturas_intermedia</field>
-        <field name="parent_id" ref="tax_report_pt_base_despesas_faturas"/>
+        <field name="code">tax_report_pt_base_despesas_intermedia</field>
+        <field name="tag_name">Intermédia</field>
+        <field name="parent_id" ref="tax_report_pt_base_despesas"/>
         <field name="report_id" ref="tax_report"/>
         <field name="sequence">2</field>
     </record>
 
-    <record id="tax_report_pt_base_despesas_faturas_reduzida" model="account.tax.report.line">
+    <record id="tax_report_pt_base_despesas_reduzida" model="account.tax.report.line">
         <field name="name">Reduzida</field>
-        <field name="tag_name">tax_report_pt_base_despesas_faturas_reduzida</field>
-        <field name="parent_id" ref="tax_report_pt_base_despesas_faturas"/>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence">3</field>
-    </record>
-
-    <record id="tax_report_pt_base_despesas_faturas_isento" model="account.tax.report.line">
-        <field name="name">Isento</field>
-        <field name="tag_name">tax_report_pt_base_despesas_faturas_isento</field>
-        <field name="parent_id" ref="tax_report_pt_base_despesas_faturas"/>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence">4</field>
-    </record>
-
-    <record id="tax_report_pt_base_despesas_notas_credito" model="account.tax.report.line">
-        <field name="name">Notas de crédito</field>
+        <field name="code">tax_report_pt_base_despesas_reduzida</field>
+        <field name="tag_name">Reduzida</field>
         <field name="parent_id" ref="tax_report_pt_base_despesas"/>
         <field name="report_id" ref="tax_report"/>
         <field name="sequence">3</field>
     </record>
 
-    <record id="tax_report_pt_base_despesas_notas_credito_normal" model="account.tax.report.line">
-        <field name="name">Normal</field>
-        <field name="tag_name">tax_report_pt_base_despesas_notas_credito_normal</field>
-        <field name="parent_id" ref="tax_report_pt_base_despesas_notas_credito"/>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence">1</field>
-    </record>
-
-    <record id="tax_report_pt_base_despesas_notas_credito_intermedia" model="account.tax.report.line">
-        <field name="name">Intermédia</field>
-        <field name="tag_name">tax_report_pt_base_despesas_notas_credito_intermedia</field>
-        <field name="parent_id" ref="tax_report_pt_base_despesas_notas_credito"/>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence">2</field>
-    </record>
-
-    <record id="tax_report_pt_base_despesas_notas_credito_reduzida" model="account.tax.report.line">
-        <field name="name">Reduzida</field>
-        <field name="tag_name">tax_report_pt_base_despesas_notas_credito_reduzida</field>
-        <field name="parent_id" ref="tax_report_pt_base_despesas_notas_credito"/>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence">3</field>
-    </record>
-
-    <record id="tax_report_pt_base_despesas_notas_credito_isento" model="account.tax.report.line">
+    <record id="tax_report_pt_base_despesas_isento" model="account.tax.report.line">
         <field name="name">Isento</field>
-        <field name="tag_name">tax_report_pt_base_despesas_notas_credito_isento</field>
-        <field name="parent_id" ref="tax_report_pt_base_despesas_notas_credito"/>
+        <field name="code">tax_report_pt_base_despesas_isento</field>
+        <field name="tag_name">Isento</field>
+        <field name="parent_id" ref="tax_report_pt_base_despesas"/>
         <field name="report_id" ref="tax_report"/>
         <field name="sequence">4</field>
     </record>
 
+    <record id="tax_report_pt_base_despesas_eu" model="account.tax.report.line">
+        <field name="name">Despesas EU</field>
+        <field name="parent_id" ref="tax_report_pt_base"/>
+        <field name="report_id" ref="tax_report"/>
+        <field name="sequence">5</field>
+    </record>
+
+    <record id="tax_report_pt_base_despesas_eu_bens" model="account.tax.report.line">
+        <field name="name">Acquisições de bens EU (Campo 12)</field>
+        <field name="code">tax_report_pt_base_despesas_eu_bens</field>
+        <field name="tag_name">Campo 12</field>
+        <field name="parent_id" ref="tax_report_pt_base_despesas_eu"/>
+        <field name="report_id" ref="tax_report"/>
+        <field name="sequence">1</field>
+    </record>
+
+    <record id="tax_report_pt_base_despesas_eu_servicos" model="account.tax.report.line">
+        <field name="name">Prestações de serviços EU (Campo 16)</field>
+        <field name="code">tax_report_pt_base_despesas_eu_servicos</field>
+        <field name="tag_name">Campo 16</field>
+        <field name="parent_id" ref="tax_report_pt_base_despesas_eu"/>
+        <field name="report_id" ref="tax_report"/>
+        <field name="sequence">2</field>
+    </record>
 
     <record id="tax_report_pt_iva" model="account.tax.report.line">
         <field name="name">IVA</field>
@@ -194,192 +166,148 @@
 
     <record id="tax_report_pt_tax_vendas" model="account.tax.report.line">
         <field name="name">Vendas</field>
+        <field name="code">tax_report_pt_tax_vendas</field>
         <field name="parent_id" ref="tax_report_pt_iva"/>
         <field name="report_id" ref="tax_report"/>
         <field name="sequence">1</field>
-        <field name="formula">None</field>
     </record>
 
-    <record id="tax_report_pt_tax_vendas_faturas" model="account.tax.report.line">
-        <field name="name">Faturas/Notas de débito (Total IVA liquidado)</field>
-        <field name="code">tax_report_pt_tax_vendas_faturas</field>
+    <record id="tax_report_pt_tax_vendas_normal" model="account.tax.report.line">
+        <field name="name">Normal (Campo 4)</field>
+        <field name="code">tax_report_pt_tax_vendas_normal</field>
+        <field name="tag_name">Campo 4</field>
         <field name="parent_id" ref="tax_report_pt_tax_vendas"/>
         <field name="report_id" ref="tax_report"/>
         <field name="sequence">1</field>
     </record>
 
-    <record id="tax_report_pt_tax_vendas_faturas_normal" model="account.tax.report.line">
-        <field name="name">Normal</field>
-        <field name="tag_name">tax_report_pt_tax_vendas_faturas_normal</field>
-        <field name="parent_id" ref="tax_report_pt_tax_vendas_faturas"/>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence">1</field>
-    </record>
-
-    <record id="tax_report_pt_tax_vendas_faturas_intermedia" model="account.tax.report.line">
-        <field name="name">Intermédia</field>
-        <field name="tag_name">tax_report_pt_tax_vendas_faturas_intermedia</field>
-        <field name="parent_id" ref="tax_report_pt_tax_vendas_faturas"/>
+    <record id="tax_report_pt_tax_vendas_intermedia" model="account.tax.report.line">
+        <field name="name">Intermédia (Campo 6)</field>
+        <field name="code">tax_report_pt_tax_vendas_intermedia</field>
+        <field name="tag_name">Campo 6</field>
+        <field name="parent_id" ref="tax_report_pt_tax_vendas"/>
         <field name="report_id" ref="tax_report"/>
         <field name="sequence">2</field>
     </record>
 
-    <record id="tax_report_pt_tax_vendas_faturas_reduzida" model="account.tax.report.line">
-        <field name="name">Reduzida</field>
-        <field name="tag_name">tax_report_pt_tax_vendas_faturas_reduzida</field>
-        <field name="parent_id" ref="tax_report_pt_tax_vendas_faturas"/>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence">3</field>
-    </record>
-
-    <record id="tax_report_pt_tax_vendas_faturas_isento" model="account.tax.report.line">
-        <field name="name">Isento</field>
-        <field name="tag_name">tax_report_pt_tax_vendas_faturas_isento</field>
-        <field name="parent_id" ref="tax_report_pt_tax_vendas_faturas"/>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence">4</field>
-    </record>
-
-    <record id="tax_report_pt_tax_vendas_notas_credito" model="account.tax.report.line">
-        <field name="name">Notas de crédito (Total IVA regularizado a favor da empresa)</field>
-        <field name="code">tax_report_pt_tax_vendas_notas_credito</field>
+    <record id="tax_report_pt_tax_vendas_reduzida" model="account.tax.report.line">
+        <field name="name">Reduzida (Campo 2)</field>
+        <field name="code">tax_report_pt_tax_vendas_reduzida</field>
+        <field name="tag_name">Campo 2</field>
         <field name="parent_id" ref="tax_report_pt_tax_vendas"/>
         <field name="report_id" ref="tax_report"/>
         <field name="sequence">3</field>
-    </record>
-
-    <record id="tax_report_pt_tax_vendas_notas_credito_normal" model="account.tax.report.line">
-        <field name="name">Normal</field>
-        <field name="tag_name">tax_report_pt_tax_vendas_notas_credito_normal</field>
-        <field name="parent_id" ref="tax_report_pt_tax_vendas_notas_credito"/>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence">1</field>
-    </record>
-
-    <record id="tax_report_pt_tax_vendas_notas_credito_intermedia" model="account.tax.report.line">
-        <field name="name">Intermédia</field>
-        <field name="tag_name">tax_report_pt_tax_vendas_notas_credito_intermedia</field>
-        <field name="parent_id" ref="tax_report_pt_tax_vendas_notas_credito"/>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence">2</field>
-    </record>
-
-    <record id="tax_report_pt_tax_vendas_notas_credito_reduzida" model="account.tax.report.line">
-        <field name="name">Reduzida</field>
-        <field name="tag_name">tax_report_pt_tax_vendas_notas_credito_reduzida</field>
-        <field name="parent_id" ref="tax_report_pt_tax_vendas_notas_credito"/>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence">3</field>
-    </record>
-
-    <record id="tax_report_pt_tax_vendas_notas_credito_isento" model="account.tax.report.line">
-        <field name="name">Isento</field>
-        <field name="tag_name">tax_report_pt_tax_vendas_notas_credito_isento</field>
-        <field name="parent_id" ref="tax_report_pt_tax_vendas_notas_credito"/>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence">4</field>
     </record>
 
     <record id="tax_report_pt_tax_despesas" model="account.tax.report.line">
         <field name="name">Despesas</field>
+        <field name="code">tax_report_pt_tax_despesas</field>
         <field name="parent_id" ref="tax_report_pt_iva"/>
         <field name="report_id" ref="tax_report"/>
         <field name="sequence">2</field>
+    </record>
+
+    <record id="tax_report_pt_tax_despesas_normal" model="account.tax.report.line">
+        <field name="name">Normal (Campo 22)</field>
+        <field name="code">tax_report_pt_tax_despesas_normal</field>
+        <field name="tag_name">Campo 22</field>
+        <field name="parent_id" ref="tax_report_pt_tax_despesas"/>
+        <field name="report_id" ref="tax_report"/>
+        <field name="sequence">1</field>
+    </record>
+
+    <record id="tax_report_pt_tax_despesas_intermedia" model="account.tax.report.line">
+        <field name="name">Intermédia (Campo 23)</field>
+        <field name="code">tax_report_pt_tax_despesas_intermedia</field>
+        <field name="tag_name">Campo 23</field>
+        <field name="parent_id" ref="tax_report_pt_tax_despesas"/>
+        <field name="report_id" ref="tax_report"/>
+        <field name="sequence">2</field>
+    </record>
+
+    <record id="tax_report_pt_tax_despesas_reduzida" model="account.tax.report.line">
+        <field name="name">Reduzida (Campo 21)</field>
+        <field name="code">tax_report_pt_tax_despesas_reduzida</field>
+        <field name="tag_name">Campo 21</field>
+        <field name="parent_id" ref="tax_report_pt_tax_despesas"/>
+        <field name="report_id" ref="tax_report"/>
+        <field name="sequence">3</field>
+    </record>
+
+    <record id="tax_report_pt_tax_despesas_eu" model="account.tax.report.line">
+        <field name="name">Despesas EU</field>
+        <field name="code">tax_report_pt_tax_despesas_eu</field>
+        <field name="parent_id" ref="tax_report_pt_iva"/>
+        <field name="report_id" ref="tax_report"/>
+        <field name="sequence">3</field>
+    </record>
+
+    <record id="tax_report_pt_tax_despesas_eu_bens" model="account.tax.report.line">
+        <field name="name">Acquisições de bens EU (Campo 13)</field>
+        <field name="code">tax_report_pt_tax_despesas_eu_bens</field>
+        <field name="tag_name">Campo 13</field>
+        <field name="parent_id" ref="tax_report_pt_tax_despesas_eu"/>
+        <field name="report_id" ref="tax_report"/>
+        <field name="sequence">4</field>
+    </record>
+
+    <record id="tax_report_pt_tax_despesas_eu_servicos" model="account.tax.report.line">
+        <field name="name">Prestações de serviços EU (Campo 17)</field>
+        <field name="code">tax_report_pt_tax_despesas_eu_servicos</field>
+        <field name="tag_name">Campo 17</field>
+        <field name="parent_id" ref="tax_report_pt_tax_despesas_eu"/>
+        <field name="report_id" ref="tax_report"/>
+        <field name="sequence">5</field>
+    </record>
+
+    <record id="tax_report_pt_tax_totais" model="account.tax.report.line">
+        <field name="name">TOTAIS</field>
+        <field name="code">tax_report_pt_tax_totals</field>
+        <field name="report_id" ref="tax_report"/>
+        <field name="sequence">3</field>
         <field name="formula">None</field>
     </record>
 
-    <record id="tax_report_pt_tax_despesas_faturas" model="account.tax.report.line">
-        <field name="name">Faturas (Total IVA dedutível)</field>
-        <field name="code">tax_report_pt_tax_despesas_faturas</field>
-        <field name="parent_id" ref="tax_report_pt_tax_despesas"/>
+    <record id="tax_report_pt_tax_totais_base" model="account.tax.report.line">
+        <field name="name">Total da base tributável (Campo 90)</field>
+        <field name="parent_id" ref="tax_report_pt_tax_totais"/>
         <field name="report_id" ref="tax_report"/>
         <field name="sequence">1</field>
+        <field name="formula">tax_report_pt_base_vendas_normal + tax_report_pt_base_vendas_intermedia + tax_report_pt_base_vendas_reduzida + tax_report_pt_base_vendas_isento + tax_report_pt_base_vendas_eu0 + tax_report_pt_base_despesas_eu_bens + tax_report_pt_base_despesas_eu_servicos</field>
     </record>
 
-    <record id="tax_report_pt_tax_despesas_faturas_normal" model="account.tax.report.line">
-        <field name="name">Normal</field>
-        <field name="tag_name">tax_report_pt_tax_despesas_faturas_normal</field>
-        <field name="parent_id" ref="tax_report_pt_tax_despesas_faturas"/>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence">1</field>
-    </record>
-
-    <record id="tax_report_pt_tax_despesas_faturas_intermedia" model="account.tax.report.line">
-        <field name="name">Intermédia</field>
-        <field name="tag_name">tax_report_pt_tax_despesas_faturas_intermedia</field>
-        <field name="parent_id" ref="tax_report_pt_tax_despesas_faturas"/>
+    <record id="tax_report_pt_tax_totais_iva_pagar" model="account.tax.report.line">
+        <field name="name">Total do imposto a favor do sujeito passivo (Campo 91)</field>
+        <field name="code">tax_report_pt_tax_totais_iva_pagar</field>
+        <field name="parent_id" ref="tax_report_pt_tax_totais"/>
         <field name="report_id" ref="tax_report"/>
         <field name="sequence">2</field>
+        <field name="formula">tax_report_pt_tax_despesas_normal + tax_report_pt_tax_despesas_intermedia + tax_report_pt_tax_despesas_reduzida</field>
     </record>
 
-    <record id="tax_report_pt_tax_despesas_faturas_reduzida" model="account.tax.report.line">
-        <field name="name">Reduzida</field>
-        <field name="tag_name">tax_report_pt_tax_despesas_faturas_reduzida</field>
-        <field name="parent_id" ref="tax_report_pt_tax_despesas_faturas"/>
+    <record id="tax_report_pt_tax_totais_iva_recuperar" model="account.tax.report.line">
+        <field name="name">Total do imposto a favor do estado (Campo 92)</field>
+        <field name="code">tax_report_pt_tax_totais_iva_recuperar</field>
+        <field name="parent_id" ref="tax_report_pt_tax_totais"/>
         <field name="report_id" ref="tax_report"/>
         <field name="sequence">3</field>
+        <field name="formula">tax_report_pt_tax_vendas_normal + tax_report_pt_tax_vendas_intermedia + tax_report_pt_tax_vendas_reduzida + tax_report_pt_tax_despesas_eu_bens + tax_report_pt_tax_despesas_eu_servicos</field>
     </record>
 
-    <record id="tax_report_pt_tax_despesas_faturas_isento" model="account.tax.report.line">
-        <field name="name">Isento</field>
-        <field name="tag_name">tax_report_pt_tax_despesas_faturas_isento</field>
-        <field name="parent_id" ref="tax_report_pt_tax_despesas_faturas"/>
+    <record id="tax_report_pt_tax_totais_pagar" model="account.tax.report.line">
+        <field name="name">Imposto a entragar ao Estado (Campo 93)</field>
+        <field name="code">tax_report_pt_tax_totais_pagar</field>
+        <field name="parent_id" ref="tax_report_pt_tax_totais"/>
         <field name="report_id" ref="tax_report"/>
         <field name="sequence">4</field>
-    </record>
-
-    <record id="tax_report_pt_tax_despesas_notas_credito" model="account.tax.report.line">
-        <field name="name">Notas de crédito (Total IVA regularizado a favor do Estado)</field>
-        <field name="code">tax_report_pt_tax_despesas_notas_credito</field>
-        <field name="parent_id" ref="tax_report_pt_tax_despesas"/>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence">3</field>
-    </record>
-
-    <record id="tax_report_pt_tax_despesas_notas_credito_normal" model="account.tax.report.line">
-        <field name="name">Normal</field>
-        <field name="tag_name">tax_report_pt_tax_despesas_notas_credito_normal</field>
-        <field name="parent_id" ref="tax_report_pt_tax_despesas_notas_credito"/>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence">1</field>
-    </record>
-
-    <record id="tax_report_pt_tax_despesas_notas_credito_intermedia" model="account.tax.report.line">
-        <field name="name">Intermédia</field>
-        <field name="tag_name">tax_report_pt_tax_despesas_notas_credito_intermedia</field>
-        <field name="parent_id" ref="tax_report_pt_tax_despesas_notas_credito"/>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence">2</field>
-    </record>
-
-    <record id="tax_report_pt_tax_despesas_notas_credito_reduzida" model="account.tax.report.line">
-        <field name="name">Reduzida</field>
-        <field name="tag_name">tax_report_pt_tax_despesas_notas_credito_reduzida</field>
-        <field name="parent_id" ref="tax_report_pt_tax_despesas_notas_credito"/>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence">3</field>
-    </record>
-
-    <record id="tax_report_pt_tax_despesas_notas_credito_isento" model="account.tax.report.line">
-        <field name="name">Isento</field>
-        <field name="tag_name">tax_report_pt_tax_despesas_notas_credito_isento</field>
-        <field name="parent_id" ref="tax_report_pt_tax_despesas_notas_credito"/>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence">4</field>
-    </record>
-
-    <record id="tax_report_pt_tax_total_pagar" model="account.tax.report.line">
-        <field name="name">TOTAL IVA A PAGAR</field>
-        <field name="code">tax_report_pt_tax_total_pagar</field>
-        <field name="report_id" ref="tax_report"/>
-        <field name="sequence">3</field>
-        <field name="formula">max(0, tax_report_pt_tax_vendas_faturas - tax_report_pt_tax_vendas_notas_credito - tax_report_pt_tax_despesas_faturas + tax_report_pt_tax_despesas_notas_credito)</field>
+        <field name="formula">max(0, tax_report_pt_tax_totais_iva_recuperar - tax_report_pt_tax_totais_iva_pagar)</field>
     </record>
 
     <record id="tax_report_pt_tax_total_receber" model="account.tax.report.line">
-        <field name="name">TOTAL IVA A RECEBER</field>
+        <field name="name">Crédito a recuperar (Campo 94)</field>
+        <field name="parent_id" ref="tax_report_pt_tax_totais"/>
         <field name="report_id" ref="tax_report"/>
-        <field name="sequence">4</field>
-        <field name="formula">max(0, -tax_report_pt_tax_vendas_faturas + tax_report_pt_tax_vendas_notas_credito + tax_report_pt_tax_despesas_faturas - tax_report_pt_tax_despesas_notas_credito)</field>
+        <field name="sequence">5</field>
+        <field name="formula">max(0, tax_report_pt_tax_totais_iva_pagar - tax_report_pt_tax_totais_iva_recuperar)</field>
     </record>
 </odoo>


### PR DESCRIPTION
This commit refactors the taxes of Portugal:
- the taxes in the islands (Azores and Maidera)
- the tax exemption (in applicable cases such as sale to EU B2B and purchase from EU B2B)
- the reverse charge in the EU (in case of a purchase)

And updates the tax report to reflect these changes.

Links:
About the EU reverse charge: https://europa.eu/youreurope/business/taxation/vat/cross-border-vat/index_en.htm
Tax report template: https://info.portaldasfinancas.gov.pt/pt/apoio_contribuinte/modelos_formularios/iva/Documents/declaracao_periodica_IVA.pdf
Information on how to complete the tax report: https://www.occ.pt/news/_manual/ColecaoIVA2019.pdf
Annoted template with more information based on the 338-page document:
[declaracao_periodica_IVA.pdf](https://github.com/odoo/odoo/files/8124845/declaracao_periodica_IVA.pdf)

Task: 2755518