### PR TITLE
[FIX] web: do not crash when attempting to consume a tour

### DIFF
--- a/addons/web/static/src/legacy/root_widget.js
+++ b/addons/web/static/src/legacy/root_widget.js
@@ -6,14 +6,8 @@ odoo.define("root.widget", function (require) {
     // need to wait for owl.Component.env to be set by web.legacySetup
     require("web.legacySetup");
     const { ComponentAdapter } = require("web.OwlCompatibility");
-    // Here we simply Object.create() the ComponentAdapter class
-    // It is sufficient to do so as all is needed is the _trigger_up method.
-    // This method uses "this.env" and if it is not set there is a fallback to
-    // the owl.Component prototype env.
-    //
-    // NB: standaloneAdapter directly instantiate a new App accessing some env
-    //     properties doing so. In the qunit test suite, web.legacySetup does not
-    //     set owl.Component.env directly as a fresh new env is needed for each test.
-    //     Hence using standaloneAdapter would crash.
-    return Object.create(ComponentAdapter); // for its method _trigger_up
+    // for its method _trigger_up. We can't use a standalone adapter because it
+    // attempt to call env.isDebug which is not defined in the tests when this
+    // module is loaded.
+    return new ComponentAdapter({ Component: owl.Component }, owl.Component.env);
 });


### PR DESCRIPTION
Previously, when completing the last step of a tour by hand, the tour
manager attempts to make an RPC to consume the tour in the backend. This
used to crash with an error saying parent._trigger_up is not defined.
This was caused by the root.widget, which is the tour manager parent,
not being a real instance of ComponentAdapter, but an object created
with the ComponentAdapter as it's protorype. To give it access to
_trigger_up, it should be created with the ComponentAdapter's prototype
as its prototype, but this would still fail as it wouldn't have the
correct environment containing the rpc service.

The simple solution is to create a real instance of the ComponentAdapter
by hand. Although owl 2 does not support instanciating components by
hand and mounting them later, we will never mount this component or use
any of its owl features, we are simply using it to replace what used to
be the ServiceProvider in legacy.
