### PR TITLE
[REF] point_of_sale,*pos*: temporary screen API improvement

### DIFF
--- a/addons/point_of_sale/static/src/js/Chrome.js
+++ b/addons/point_of_sale/static/src/js/Chrome.js
@@ -266,9 +266,18 @@ odoo.define('point_of_sale.Chrome', function(require) {
         }
         __showTempScreen(event) {
             const { name, props, resolve } = event.detail;
+            const Component = this.constructor.components[name];
+            if (!Component) {
+                throw new Error(
+                    `'${name}' is not registered as a PosComponent. Make sure to define it and register with 'Registries.Component.add'.`
+                );
+            }
+            if (!Component.isTempScreen) {
+                throw new Error(`Cannot show '${name}' as a temporary screen. Use TemporaryScreenMixin to declare it.`);
+            }
             this.tempScreen.isShown = true;
             this.tempScreen.name = name;
-            this.tempScreen.component = this.constructor.components[name];
+            this.tempScreen.component = Component;
             this.tempScreenProps = Object.assign({}, props, { resolve });
         }
         __closeTempScreen() {

--- a/addons/point_of_sale/static/src/js/Misc/ScreenControllerMixin.js
+++ b/addons/point_of_sale/static/src/js/Misc/ScreenControllerMixin.js
@@ -1,0 +1,61 @@
+/* @odoo-module */
+
+import { useListener } from '@web/core/utils/hooks';
+
+/**
+ * Allows a component to have controls to 2 types of screens -
+ * main and temporary.
+ */
+const ScreenControllerMixin = function (PosComponent) {
+    class ScreenController extends PosComponent {
+        setup() {
+            super.setup();
+            useListener('show-main-screen', this._onShowMainScreen);
+            useListener('show-temp-screen', this._onShowTempScreen);
+            useListener('close-temp-screen', this._onCloseTempScreen);
+            this.mainScreen = owl.useState({
+                name: null,
+                props: {},
+                component: null,
+            });
+            this.tempScreen = owl.useState({
+                name: null,
+                props: {},
+                component: null,
+                isShown: false,
+            });
+        }
+        _onShowMainScreen(event) {
+            const { name, props } = event.detail;
+            this.mainScreen.name = name;
+            this.mainScreen.component = this.constructor.components[name];
+            this.mainScreen.props = props || {};
+        }
+        _onShowTempScreen(event) {
+            const { name, props, resolve } = event.detail;
+            const Component = this.constructor.components[name];
+            if (!Component) {
+                throw new Error(
+                    `'${name}' is not registered as a PosComponent. Make sure to define it and register with 'Registries.Component.add'.`
+                );
+            }
+            if (!Component.isTempScreen) {
+                throw new Error(`Cannot show '${name}' as a temporary screen. Use TemporaryScreenMixin to declare it.`);
+            }
+            this.tempScreen.isShown = true;
+            this.tempScreen.name = name;
+            this.tempScreen.component = Component;
+            this.tempScreen.props = Object.assign({}, props, { resolve });
+        }
+        _onCloseTempScreen(event) {
+            this.tempScreen.props.resolve(event.detail);
+            this.tempScreen.isShown = false;
+            this.tempScreen.name = null;
+            this.tempScreen.component = null;
+            this.tempScreen.props = {};
+        }
+    }
+    return ScreenController;
+};
+
+export default ScreenControllerMixin;

--- a/addons/point_of_sale/static/src/js/Misc/TemporaryScreenMixin.js
+++ b/addons/point_of_sale/static/src/js/Misc/TemporaryScreenMixin.js
@@ -37,8 +37,7 @@ const TemporaryScreenMixin = function (Component) {
          * @param {any} payload - is any information sent to the caller of `showTempScreen`.
          */
         closeWith(confirmed, payload) {
-            this.props.resolve({ confirmed, payload });
-            this.trigger('close-temp-screen');
+            this.trigger('close-temp-screen', { confirmed, payload });
         }
     }
 

--- a/addons/point_of_sale/static/src/js/Misc/TemporaryScreenMixin.js
+++ b/addons/point_of_sale/static/src/js/Misc/TemporaryScreenMixin.js
@@ -1,0 +1,51 @@
+/* @odoo-module */
+
+/**
+ * Use this mixin to create a component that will be shown in fullscreen.
+ * (Technically, the currently shown screen is hidden, not unmounted, in order
+ * to show this screen.) The declared screen that uses this mixin should bind
+ * `closeWith` to some event that will be triggered by the user; or, call it
+ * inside another method. Calling `closeWith` closes the temporary screen.
+ *
+ * The temporary screen can be shown anytime by any PosComponent like so:
+ *
+ * ```
+ * const { confirmed, payload } = await this.showTempScreen(popupScreenName, screenProps);
+ * ```
+ *
+ * When the screen closes, call to `showTempScreen` resolves to a record
+ * `{ confirmed: boolean, payload?: any }`. This mimics a dialog-like feature.
+ */
+const TemporaryScreenMixin = function (Component) {
+    class TemporaryScreen extends Component {
+        /**
+         * Assign this method to an event handler like so:
+         *
+         * ```xml
+         *  <div t-on-click="() => this.closeWith(true, payload)">Button</div>
+         * ```
+         *
+         * or call it inside another method:
+         *
+         * ```js
+         * _onAnotherMethod() {
+         *   // do something, say compute the payload
+         *   this.closeWith(true, payload);
+         * }
+         * ```
+         * @param {boolean} confirmed - is a boolean representing whether the user confirmed the screen or not
+         * @param {any} payload - is any information sent to the caller of `showTempScreen`.
+         */
+        closeWith(confirmed, payload) {
+            this.props.resolve({ confirmed, payload });
+            this.trigger('close-temp-screen');
+        }
+    }
+
+    // Mark the component as a temporary screen.
+    TemporaryScreen.isTempScreen = true;
+
+    return TemporaryScreen;
+};
+
+export default TemporaryScreenMixin;

--- a/addons/point_of_sale/static/src/js/Screens/ClientListScreen/ClientListScreen.js
+++ b/addons/point_of_sale/static/src/js/Screens/ClientListScreen/ClientListScreen.js
@@ -3,11 +3,10 @@ odoo.define('point_of_sale.ClientListScreen', function(require) {
 
     const PosComponent = require('point_of_sale.PosComponent');
     const Registries = require('point_of_sale.Registries');
+    const TemporaryScreenMixin = require('@point_of_sale/js/Misc/TemporaryScreenMixin')[Symbol.for('default')];
     const { isConnectionError } = require('point_of_sale.utils');
-
     const { debounce } = require("@web/core/utils/timing");
     const { useListener } = require("@web/core/utils/hooks");
-
     const { onWillUnmount } = owl;
 
     /**
@@ -25,7 +24,7 @@ odoo.define('point_of_sale.ClientListScreen', function(require) {
      *
      * @props client - originally selected client
      */
-    class ClientListScreen extends PosComponent {
+    class ClientListScreen extends TemporaryScreenMixin(PosComponent) {
         setup() {
             super.setup();
             useListener('click-save', () => this.env.bus.trigger('save-customer'));
@@ -58,13 +57,11 @@ odoo.define('point_of_sale.ClientListScreen', function(require) {
                 this.state.detailIsShown = false;
                 this.render();
             } else {
-                this.props.resolve({ confirmed: false, payload: false });
-                this.trigger('close-temp-screen');
+                this.closeWith(false);
             }
         }
         confirm() {
-            this.props.resolve({ confirmed: true, payload: this.state.selectedClient });
-            this.trigger('close-temp-screen');
+            this.closeWith(true, this.state.selectedClient);
         }
         // Getters
 

--- a/addons/point_of_sale/static/src/js/Screens/ScaleScreen/ScaleScreen.js
+++ b/addons/point_of_sale/static/src/js/Screens/ScaleScreen/ScaleScreen.js
@@ -2,12 +2,13 @@ odoo.define('point_of_sale.ScaleScreen', function(require) {
     'use strict';
 
     const PosComponent = require('point_of_sale.PosComponent');
+    const TemporaryScreenMixin = require('@point_of_sale/js/Misc/TemporaryScreenMixin')[Symbol.for('default')];
     const { round_precision: round_pr } = require('web.utils');
     const Registries = require('point_of_sale.Registries');
 
     const { onMounted, onWillUnmount, useExternalListener, useState } = owl;
 
-    class ScaleScreen extends PosComponent {
+    class ScaleScreen extends TemporaryScreenMixin(PosComponent) {
         /**
          * @param {Object} props
          * @param {Object} props.product The product to weight.
@@ -28,15 +29,13 @@ odoo.define('point_of_sale.ScaleScreen', function(require) {
             this.env.proxy_queue.clear();
         }
         back() {
-            this.props.resolve({ confirmed: false, payload: null });
-            this.trigger('close-temp-screen');
+            this.closeWith(false);
         }
         confirm() {
-            this.props.resolve({
+            this.closeWith(true, {
                 confirmed: true,
                 payload: { weight: this.state.weight },
             });
-            this.trigger('close-temp-screen');
         }
         _onHotkeys(event) {
             if (event.key === 'Escape') {

--- a/addons/point_of_sale/static/src/xml/Chrome.xml
+++ b/addons/point_of_sale/static/src/xml/Chrome.xml
@@ -35,7 +35,7 @@
                                     <t isShown="!tempScreen.isShown" t-component="mainScreen.component"
                                        t-props="mainScreenPropsFielded" t-key="mainScreen.name" />
                                     <t t-if="tempScreen.isShown" t-component="tempScreen.component"
-                                       t-props="tempScreenProps" t-key="tempScreen.name" />
+                                       t-props="tempScreen.props" t-key="tempScreen.name" />
                                 </div>
                             </div>
                         </div>

--- a/addons/pos_hr/static/src/js/LoginScreen.js
+++ b/addons/pos_hr/static/src/js/LoginScreen.js
@@ -3,11 +3,12 @@ odoo.define('pos_hr.LoginScreen', function (require) {
     'use strict';
 
     const PosComponent = require('point_of_sale.PosComponent');
+    const TemporaryScreenMixin = require('@point_of_sale/js/Misc/TemporaryScreenMixin')[Symbol.for('default')];
     const Registries = require('point_of_sale.Registries');
     const useSelectEmployee = require('pos_hr.useSelectEmployee');
     const { useBarcodeReader } = require('point_of_sale.custom_hooks');
 
-    class LoginScreen extends PosComponent {
+    class LoginScreen extends TemporaryScreenMixin(PosComponent) {
         setup() {
             super.setup();
             const { selectEmployee, askPin } = useSelectEmployee();
@@ -21,14 +22,9 @@ odoo.define('pos_hr.LoginScreen', function (require) {
             );
         }
         back() {
-            this.props.resolve({ confirmed: false, payload: false });
-            this.trigger('close-temp-screen');
+            this.closeWith(false);
             this.env.pos.hasLoggedIn = true;
             this.env.posbus.trigger('start-cash-control');
-        }
-        confirm() {
-            this.props.resolve({ confirmed: true, payload: true });
-            this.trigger('close-temp-screen');
         }
         get shopName() {
             return this.env.pos.config.name;

--- a/addons/pos_restaurant/static/src/js/Screens/BillScreen.js
+++ b/addons/pos_restaurant/static/src/js/Screens/BillScreen.js
@@ -2,13 +2,13 @@ odoo.define('pos_restaurant.BillScreen', function (require) {
     'use strict';
 
     const ReceiptScreen = require('point_of_sale.ReceiptScreen');
+    const TemporaryScreenMixin = require('@point_of_sale/js/Misc/TemporaryScreenMixin')[Symbol.for('default')];
     const Registries = require('point_of_sale.Registries');
 
     const BillScreen = (ReceiptScreen) => {
-        class BillScreen extends ReceiptScreen {
+        class BillScreen extends TemporaryScreenMixin(ReceiptScreen) {
             confirm() {
-                this.props.resolve({ confirmed: true, payload: null });
-                this.trigger('close-temp-screen');
+                this.closeWith(true, null);
             }
             whenClosing() {
                 this.confirm();


### PR DESCRIPTION
In this change, we are now required to explicitly declare a component
to be a temporary screen in order to use it as temporary screen.
We do that with the use of the TemporaryScreenMixin.

Trying to call `showTempScreen` on non-temporary screen will now result
to an error.

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
