### PR TITLE
[FIX] web_editor,website : fix products header edition

### DIFF
--- a/addons/web_editor/static/lib/odoo-editor/src/OdooEditor.js
+++ b/addons/web_editor/static/lib/odoo-editor/src/OdooEditor.js
@@ -198,6 +198,7 @@ export class OdooEditor extends EventTarget {
                 showEmptyElementHint: true,
                 defaultLinkAttributes: {},
                 plugins: [],
+                getReadOnlyAreas: () => [],
                 getContentEditableAreas: () => [],
                 getPowerboxElement: () => {
                     const selection = document.getSelection();
@@ -1626,6 +1627,9 @@ export class OdooEditor extends EventTarget {
             if (!node.isContentEditable) {
                 node.setAttribute('contenteditable', true);
             }
+        }
+        for (const node of this.options.getReadOnlyAreas()) {
+            node.setAttribute('contenteditable', false);
         }
         this.observerActive('_activateContenteditable');
     }

--- a/addons/web_editor/static/src/js/wysiwyg/widgets/link_tools.js
+++ b/addons/web_editor/static/src/js/wysiwyg/widgets/link_tools.js
@@ -166,11 +166,21 @@ const LinkTools = Link.extend({
      */
     _getLinkCustomClasses: function () {
         let textClass = this.customColors['color'];
-        if (!computeColorClasses(this.colorpickers['color'].getColorNames(), 'text-').includes(textClass)) {
+        const colorPickerFg = this.colorpickers['color'];
+        if (
+            !textClass ||
+            !colorPickerFg ||
+            !computeColorClasses(colorPickerFg.getColorNames(), 'text-').includes(textClass)
+        ) {
             textClass = '';
         }
         let fillClass = this.customColors['background-color'];
-        if (!computeColorClasses(this.colorpickers['background-color'].getColorNames(), 'bg-').includes(fillClass)) {
+        const colorPickerBg = this.colorpickers['background-color'];
+        if (
+            !fillClass ||
+            !colorPickerBg ||
+            !computeColorClasses(colorPickerBg.getColorNames(), 'bg-').includes(fillClass)
+        ) {
             fillClass = '';
         }
         return ` ${textClass} ${fillClass}`;

--- a/addons/web_editor/static/src/js/wysiwyg/wysiwyg.js
+++ b/addons/web_editor/static/src/js/wysiwyg/wysiwyg.js
@@ -141,6 +141,7 @@ const Wysiwyg = Widget.extend({
             showEmptyElementHint: this.options.showEmptyElementHint,
             controlHistoryFromDocument: this.options.controlHistoryFromDocument,
             getContentEditableAreas: this.options.getContentEditableAreas,
+            getReadOnlyAreas: this.options.getReadOnlyAreas,
             defaultLinkAttributes: this.options.userGeneratedContent ? {rel: 'ugc' } : {},
             allowCommandVideo: this.options.allowCommandVideo,
             getYoutubeVideoElement: getYoutubeVideoElement,

--- a/addons/website/static/src/js/menu/edit.js
+++ b/addons/website/static/src/js/menu/edit.js
@@ -334,6 +334,10 @@ var EditPageMenu = websiteNavbarData.WebsiteNavbarActionWidget.extend({
             return !$(el).closest('.o_not_editable').length;
         }).toArray();
     },
+
+    _getReadOnlyAreas () {
+        return [];
+    },
     /**
      * Call preventDefault of an event.
      *
@@ -419,6 +423,7 @@ var EditPageMenu = websiteNavbarData.WebsiteNavbarActionWidget.extend({
             powerboxCommands: this._getSnippetsCommands(),
             bindLinkTool: true,
             showEmptyElementHint: false,
+            getReadOnlyAreas: this._getReadOnlyAreas.bind(this),
         }, collaborationConfig);
         return wysiwygLoader.createWysiwyg(this,
             Object.assign(params, this.wysiwygOptions),

--- a/addons/website/static/src/js/menu/edit.js
+++ b/addons/website/static/src/js/menu/edit.js
@@ -315,7 +315,7 @@ var EditPageMenu = websiteNavbarData.WebsiteNavbarActionWidget.extend({
                     characterData: true,
                 });
             }
-        }
+        };
         observe();
 
         this.wysiwyg.odooEditor.addEventListener('observerUnactive', () => {
@@ -323,8 +323,8 @@ var EditPageMenu = websiteNavbarData.WebsiteNavbarActionWidget.extend({
                 processRecords(this.observer.takeRecords());
                 this.observer.disconnect();
             }
-        })
-        this.wysiwyg.odooEditor.addEventListener('observerActive', observe)
+        });
+        this.wysiwyg.odooEditor.addEventListener('observerActive', observe);
 
         $('body').addClass('editor_started');
     },

--- a/addons/website_sale/static/src/js/website_sale.editor.js
+++ b/addons/website_sale/static/src/js/website_sale.editor.js
@@ -47,6 +47,29 @@ WebsiteNewMenu.include({
 });
 });
 
+odoo.define('website_sale.editMenu', function (require) {
+    'use strict';
+
+var WebsiteEditMenu = require('website.editMenu');
+
+WebsiteEditMenu.include({
+    /**
+     * @override
+     */
+    _getContentEditableAreas () {
+        return $(this.savableSelector).not('input, [data-oe-readonly],[data-oe-type="monetary"],[data-oe-many2one-id], [data-oe-field="arch"]:empty').filter((_, el) => {
+            return !$(el).closest('.o_not_editable, .oe_website_sale .products_header').length;
+        }).toArray();
+    },
+    /**
+     * @override
+     */
+    _getReadOnlyAreas () {
+        return $("#wrapwrap").find('.oe_website_sale .products_header, .oe_website_sale .products_header a').toArray();
+    },
+});
+});
+
 //==============================================================================
 
 odoo.define('website_sale.editor', function (require) {


### PR DESCRIPTION
Prevent edition on e-commerce products header bar.
Since we cannot save any change done in the header object anyway,
And some edition would trigger error.
We put the all bar in a read-only mode.

task-2745151

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
