### PR TITLE
[IMP] website: reduce SQL queries to serve pages

### DIFF
--- a/addons/http_routing/models/ir_http.py
+++ b/addons/http_routing/models/ir_http.py
@@ -515,8 +515,8 @@ class IrHttp(models.AbstractModel):
         result = super(IrHttp, cls)._dispatch()
 
         cook_lang = request.httprequest.cookies.get('frontend_lang')
-        if request.is_frontend and cook_lang != request.lang.code and hasattr(result, 'set_cookie'):
-            result.set_cookie('frontend_lang', request.lang.code)
+        if request.is_frontend and cook_lang != request.lang._get_cached('code') and hasattr(result, 'set_cookie'):
+            result.set_cookie('frontend_lang', request.lang._get_cached('code'))
 
         return result
 

--- a/addons/test_website/tests/test_performance.py
+++ b/addons/test_website/tests/test_performance.py
@@ -7,5 +7,5 @@ from odoo.addons.website.tests.test_performance import UtilPerf
 class TestPerformance(UtilPerf):
     def test_10_perf_sql_website_controller_minimalist(self):
         url = '/empty_controller_test'
-        self.assertEqual(self._get_url_hot_query(url), 3)
-        self.assertEqual(self._get_url_hot_query(url, cache=False), 3)
+        self.assertEqual(self._get_url_hot_query(url), 2)
+        self.assertEqual(self._get_url_hot_query(url, cache=False), 2)

--- a/addons/test_website/tests/test_performance.py
+++ b/addons/test_website/tests/test_performance.py
@@ -7,5 +7,5 @@ from odoo.addons.website.tests.test_performance import UtilPerf
 class TestPerformance(UtilPerf):
     def test_10_perf_sql_website_controller_minimalist(self):
         url = '/empty_controller_test'
-        self.assertEqual(self._get_url_hot_query(url), 2)
-        self.assertEqual(self._get_url_hot_query(url, cache=False), 2)
+        self.assertEqual(self._get_url_hot_query(url), 1)
+        self.assertEqual(self._get_url_hot_query(url, cache=False), 1)

--- a/addons/website/controllers/main.py
+++ b/addons/website/controllers/main.py
@@ -73,7 +73,8 @@ class Website(Home):
         # prefetch all menus (it will prefetch website.page too)
         top_menu = request.website.menu_id
 
-        homepage = request.website.homepage_id
+        homepage_id = request.website._get_cached('homepage_id')
+        homepage = homepage_id and request.env['website.page'].browse(homepage_id)
         if homepage and (homepage.sudo().is_visible or request.env.user.has_group('base.group_user')) and homepage.url != '/':
             return request.env['ir.http'].reroute(homepage.url)
 

--- a/addons/website/models/ir_http.py
+++ b/addons/website/models/ir_http.py
@@ -227,7 +227,10 @@ class Http(models.AbstractModel):
         # If the company of the website is not in the allowed companies of the user, set the main
         # company of the user.
         website_company_id = request.website._get_cached('company_id')
-        if website_company_id in request.env.user.company_ids.ids:
+        if request.website.is_public_user():
+            # avoid a read on res_company_user_rel in case of public user
+            context['allowed_company_ids'] = [website_company_id]
+        elif website_company_id in request.env.user.company_ids.ids:
             context['allowed_company_ids'] = [website_company_id]
         else:
             context['allowed_company_ids'] = request.env.user.company_id.ids

--- a/addons/website/models/ir_http.py
+++ b/addons/website/models/ir_http.py
@@ -280,6 +280,8 @@ class Http(models.AbstractModel):
 
         if page:
             # prefetch all menus (it will prefetch website.page too)
+            menu_pages_ids = request.website._get_menu_page_ids()
+            page.browse([page.id] + menu_pages_ids).mapped('view_id.name')
             request.website.menu_id
 
         if page and (request.website.is_publisher() or page.is_visible):

--- a/addons/website/models/ir_ui_view.py
+++ b/addons/website/models/ir_ui_view.py
@@ -464,7 +464,7 @@ class View(models.Model):
                 main_object=self,
                 website=request.website,
                 is_view_active=request.website.is_view_active,
-                res_company=request.website.company_id.sudo(),
+                res_company=request.env['res.company'].browse(request.website._get_cached('company_id')).sudo(),
                 translatable=translatable,
                 editable=editable,
             ))

--- a/addons/website/models/website.py
+++ b/addons/website/models/website.py
@@ -1357,6 +1357,7 @@ class Website(models.Model):
             'user_id': self.user_id.id,
             'company_id': self.company_id.id,
             'default_lang_id': self.default_lang_id.id,
+            'homepage_id': self.homepage_id.id,
         }
 
     def _get_cached(self, field):

--- a/addons/website/models/website.py
+++ b/addons/website/models/website.py
@@ -174,6 +174,11 @@ class Website(models.Model):
     def _get_menu_ids(self):
         return self.env['website.menu'].search([('website_id', '=', self.id)]).ids
 
+    # self.env.uid for ir.rule groups on menu
+    @tools.ormcache('self.env.uid', 'self.id')
+    def _get_menu_page_ids(self):
+        return self.env['website.menu'].search([('website_id', '=', self.id)]).page_id.ids
+
     @api.model
     def create(self, vals):
         self._handle_create_write(vals)

--- a/addons/website/models/website_menu.py
+++ b/addons/website/models/website_menu.py
@@ -96,7 +96,7 @@ class Menu(models.Model):
 
     def write(self, values):
         res = super().write(values)
-        if 'website_id' in values or 'group_ids' in values or 'sequence' in values:
+        if 'website_id' in values or 'group_ids' in values or 'sequence' in values or 'page_id' in values:
             self.clear_caches()
         return res
 

--- a/addons/website/tests/test_performance.py
+++ b/addons/website/tests/test_performance.py
@@ -106,7 +106,7 @@ class TestWebsitePerformance(UtilPerf):
 
     def test_20_perf_sql_queries_homepage(self):
         # homepage "/" has its own controller
-        self.assertEqual(self._get_url_hot_query('/'), 15)
+        self.assertEqual(self._get_url_hot_query('/'), 14)
         self.assertEqual(self._get_url_hot_query('/', cache=False), 17)
 
     def test_30_perf_sql_queries_page_no_layout(self):

--- a/addons/website/tests/test_performance.py
+++ b/addons/website/tests/test_performance.py
@@ -89,31 +89,31 @@ class TestWebsitePerformance(UtilPerf):
 
     def test_10_perf_sql_queries_page(self):
         # standard untracked website.page
-        self.assertEqual(self._get_url_hot_query(self.page.url), 8)
-        self.assertEqual(self._get_url_hot_query(self.page.url, cache=False), 11)
+        self.assertEqual(self._get_url_hot_query(self.page.url), 7)
+        self.assertEqual(self._get_url_hot_query(self.page.url, cache=False), 10)
         self.menu.unlink()
-        self.assertEqual(self._get_url_hot_query(self.page.url), 10)
-        self.assertEqual(self._get_url_hot_query(self.page.url, cache=False), 13)
+        self.assertEqual(self._get_url_hot_query(self.page.url), 9)
+        self.assertEqual(self._get_url_hot_query(self.page.url, cache=False), 12)
 
     def test_15_perf_sql_queries_page(self):
         # standard tracked website.page
         self.page.track = True
-        self.assertEqual(self._get_url_hot_query(self.page.url), 16)
-        self.assertEqual(self._get_url_hot_query(self.page.url, cache=False), 19)
+        self.assertEqual(self._get_url_hot_query(self.page.url), 15)
+        self.assertEqual(self._get_url_hot_query(self.page.url, cache=False), 18)
         self.menu.unlink()
-        self.assertEqual(self._get_url_hot_query(self.page.url), 18)
-        self.assertEqual(self._get_url_hot_query(self.page.url, cache=False), 21)
+        self.assertEqual(self._get_url_hot_query(self.page.url), 17)
+        self.assertEqual(self._get_url_hot_query(self.page.url, cache=False), 20)
 
     def test_20_perf_sql_queries_homepage(self):
         # homepage "/" has its own controller
-        self.assertEqual(self._get_url_hot_query('/'), 17)
-        self.assertEqual(self._get_url_hot_query('/', cache=False), 18)
+        self.assertEqual(self._get_url_hot_query('/'), 16)
+        self.assertEqual(self._get_url_hot_query('/', cache=False), 17)
 
     def test_30_perf_sql_queries_page_no_layout(self):
         # website.page with no call to layout templates
         self.page.arch = '<div>I am a blank page</div>'
-        self.assertEqual(self._get_url_hot_query(self.page.url), 8)
-        self.assertEqual(self._get_url_hot_query(self.page.url, cache=False), 9)
+        self.assertEqual(self._get_url_hot_query(self.page.url), 7)
+        self.assertEqual(self._get_url_hot_query(self.page.url, cache=False), 8)
 
     def test_40_perf_sql_queries_page_multi_level_menu(self):
         # menu structure should not impact SQL requests
@@ -131,8 +131,8 @@ class TestWebsitePerformance(UtilPerf):
         menu_bb.parent_id = menu_b
         menu_aa.parent_id = menu_a
 
-        self.assertEqual(self._get_url_hot_query(self.page.url), 8)
-        self.assertEqual(self._get_url_hot_query(self.page.url, cache=False), 11)
+        self.assertEqual(self._get_url_hot_query(self.page.url), 7)
+        self.assertEqual(self._get_url_hot_query(self.page.url, cache=False), 10)
 
     def test_50_perf_sql_web_assets(self):
         # assets route /web/assets/..

--- a/addons/website/tests/test_performance.py
+++ b/addons/website/tests/test_performance.py
@@ -113,7 +113,7 @@ class TestWebsitePerformance(UtilPerf):
         # website.page with no call to layout templates
         self.page.arch = '<div>I am a blank page</div>'
         self.assertEqual(self._get_url_hot_query(self.page.url), 7)
-        self.assertEqual(self._get_url_hot_query(self.page.url, cache=False), 8)
+        self.assertEqual(self._get_url_hot_query(self.page.url, cache=False), 7)
 
     def test_40_perf_sql_queries_page_multi_level_menu(self):
         # menu structure should not impact SQL requests

--- a/addons/website/tests/test_performance.py
+++ b/addons/website/tests/test_performance.py
@@ -92,8 +92,8 @@ class TestWebsitePerformance(UtilPerf):
         self.assertEqual(self._get_url_hot_query(self.page.url), 7)
         self.assertEqual(self._get_url_hot_query(self.page.url, cache=False), 10)
         self.menu.unlink()
-        self.assertEqual(self._get_url_hot_query(self.page.url), 9)
-        self.assertEqual(self._get_url_hot_query(self.page.url, cache=False), 12)
+        self.assertEqual(self._get_url_hot_query(self.page.url), 7)
+        self.assertEqual(self._get_url_hot_query(self.page.url, cache=False), 10)
 
     def test_15_perf_sql_queries_page(self):
         # standard tracked website.page
@@ -101,8 +101,8 @@ class TestWebsitePerformance(UtilPerf):
         self.assertEqual(self._get_url_hot_query(self.page.url), 15)
         self.assertEqual(self._get_url_hot_query(self.page.url, cache=False), 18)
         self.menu.unlink()
-        self.assertEqual(self._get_url_hot_query(self.page.url), 17)
-        self.assertEqual(self._get_url_hot_query(self.page.url, cache=False), 20)
+        self.assertEqual(self._get_url_hot_query(self.page.url), 15)
+        self.assertEqual(self._get_url_hot_query(self.page.url, cache=False), 18)
 
     def test_20_perf_sql_queries_homepage(self):
         # homepage "/" has its own controller

--- a/addons/website/tests/test_performance.py
+++ b/addons/website/tests/test_performance.py
@@ -106,7 +106,7 @@ class TestWebsitePerformance(UtilPerf):
 
     def test_20_perf_sql_queries_homepage(self):
         # homepage "/" has its own controller
-        self.assertEqual(self._get_url_hot_query('/'), 16)
+        self.assertEqual(self._get_url_hot_query('/'), 15)
         self.assertEqual(self._get_url_hot_query('/', cache=False), 17)
 
     def test_30_perf_sql_queries_page_no_layout(self):

--- a/addons/website/tests/test_performance.py
+++ b/addons/website/tests/test_performance.py
@@ -89,30 +89,30 @@ class TestWebsitePerformance(UtilPerf):
 
     def test_10_perf_sql_queries_page(self):
         # standard untracked website.page
-        self.assertEqual(self._get_url_hot_query(self.page.url), 7)
+        self.assertEqual(self._get_url_hot_query(self.page.url), 6)
         self.assertEqual(self._get_url_hot_query(self.page.url, cache=False), 10)
         self.menu.unlink()
-        self.assertEqual(self._get_url_hot_query(self.page.url), 7)
+        self.assertEqual(self._get_url_hot_query(self.page.url), 6)
         self.assertEqual(self._get_url_hot_query(self.page.url, cache=False), 10)
 
     def test_15_perf_sql_queries_page(self):
         # standard tracked website.page
         self.page.track = True
-        self.assertEqual(self._get_url_hot_query(self.page.url), 15)
+        self.assertEqual(self._get_url_hot_query(self.page.url), 14)
         self.assertEqual(self._get_url_hot_query(self.page.url, cache=False), 18)
         self.menu.unlink()
-        self.assertEqual(self._get_url_hot_query(self.page.url), 15)
+        self.assertEqual(self._get_url_hot_query(self.page.url), 14)
         self.assertEqual(self._get_url_hot_query(self.page.url, cache=False), 18)
 
     def test_20_perf_sql_queries_homepage(self):
         # homepage "/" has its own controller
-        self.assertEqual(self._get_url_hot_query('/'), 14)
+        self.assertEqual(self._get_url_hot_query('/'), 13)
         self.assertEqual(self._get_url_hot_query('/', cache=False), 17)
 
     def test_30_perf_sql_queries_page_no_layout(self):
         # website.page with no call to layout templates
         self.page.arch = '<div>I am a blank page</div>'
-        self.assertEqual(self._get_url_hot_query(self.page.url), 7)
+        self.assertEqual(self._get_url_hot_query(self.page.url), 6)
         self.assertEqual(self._get_url_hot_query(self.page.url, cache=False), 7)
 
     def test_40_perf_sql_queries_page_multi_level_menu(self):
@@ -131,7 +131,7 @@ class TestWebsitePerformance(UtilPerf):
         menu_bb.parent_id = menu_b
         menu_aa.parent_id = menu_a
 
-        self.assertEqual(self._get_url_hot_query(self.page.url), 7)
+        self.assertEqual(self._get_url_hot_query(self.page.url), 6)
         self.assertEqual(self._get_url_hot_query(self.page.url, cache=False), 10)
 
     def test_50_perf_sql_web_assets(self):

--- a/addons/website_blog/tests/test_performance.py
+++ b/addons/website_blog/tests/test_performance.py
@@ -13,8 +13,8 @@ class TestBlogPerformance(UtilPerf):
             self.env['website'].search([]).channel_id = False
 
     def test_10_perf_sql_blog_standard_data(self):
-        self.assertEqual(self._get_url_hot_query('/blog'), 27)
-        self.assertEqual(self._get_url_hot_query('/blog', cache=False), 26)
+        self.assertEqual(self._get_url_hot_query('/blog'), 26)
+        self.assertEqual(self._get_url_hot_query('/blog', cache=False), 25)
 
     def test_20_perf_sql_blog_bigger_data_scaling(self):
         BlogPost = self.env['blog.post']
@@ -26,10 +26,10 @@ class TestBlogPerformance(UtilPerf):
         for blog_post in blog_posts:
             blog_post.tag_ids += blog_tags
             blog_tags = blog_tags[:-1]
-        self.assertEqual(self._get_url_hot_query('/blog'), 27)
-        self.assertEqual(self._get_url_hot_query('/blog', cache=False), 26)
-        self.assertEqual(self._get_url_hot_query(blog_post[0].website_url), 30)
-        self.assertEqual(self._get_url_hot_query(blog_post[0].website_url, cache=False), 29)
+        self.assertEqual(self._get_url_hot_query('/blog'), 26)
+        self.assertEqual(self._get_url_hot_query('/blog', cache=False), 25)
+        self.assertEqual(self._get_url_hot_query(blog_post[0].website_url), 29)
+        self.assertEqual(self._get_url_hot_query(blog_post[0].website_url, cache=False), 28)
 
     def test_30_perf_sql_blog_bigger_data_scaling(self):
         BlogPost = self.env['blog.post']

--- a/odoo/models.py
+++ b/odoo/models.py
@@ -3355,11 +3355,11 @@ Fields:
             for field in fields_pre:
                 values = next(cols)
                 if context.get('lang') and not field.inherited and callable(field.translate):
-                    translate = field.get_trans_func(fetched)
                     values = list(values)
-                    for index in range(len(ids)):
-                        values[index] = translate(ids[index], values[index])
-
+                    if any(values):
+                        translate = field.get_trans_func(fetched)
+                        for index in range(len(ids)):
+                            values[index] = translate(ids[index], values[index])
                 # store values in cache
                 self.env.cache.update(fetched, field, values)
 


### PR DESCRIPTION
Multiple one line improvements to reduce SQL Queries to serve pages.
Not only it does reduce SQL Queries but it mainly completely remove the read of some tables like lang, website, company_rel, translation etc.

Basically, this is removing ~4 queries in almost every serve page flows (regular page / homepage / empty page / page with no menu).
This is quite good as some of those flows are lowered from 10 requests to 6.