### PR TITLE
[FIX] Use openpyxl library to read xlsx files.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -18,6 +18,7 @@ lxml==4.6.2
 MarkupSafe==1.1.0
 num2words==0.5.6
 ofxparse==0.19
+openpyxl==3.0.9
 passlib==1.7.2
 Pillow==8.1.2  # could be 7.0.0 (Focal) when backported security patches are present
 polib==1.1.0


### PR DESCRIPTION
xlrd in its present versions dropped support for xlsx (modern excel files).
The recommended replacement is openpyxl.

Description of the issue/feature this PR addresses:
Need to support import of excel files.

Current behavior before PR:
Currently import fails when underlying library xrld has a recent version.

Desired behavior after PR is merged:
Addon base_import has again complete support for excel files.


--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
