### PR TITLE
[IMP] website_crm_partner_assign: improve the kanban card view

### DIFF
--- a/addons/website_crm_partner_assign/views/crm_lead_views.xml
+++ b/addons/website_crm_partner_assign/views/crm_lead_views.xml
@@ -146,15 +146,15 @@
                     <field name="partner_assigned_id"/>
                 </field>
                 <xpath expr="//span[@t-esc='record.partner_id.value']" position="replace">
-                    <t t-if="record.partner_id.value or record.partner_assigned_id.value">
-                        <span class="o_text_overflow">
-                            <t t-esc="record.partner_id.value"/>
-                            <t t-if="record.partner_assigned_id.value">
-                                <i class="fa fa-arrow-circle-right" aria-label="Arrow icon" title="Arrow"/>
-                                <t t-esc="record.partner_assigned_id.value"/>
-                            </t>
-                        </span>
-                    </t>
+                    <span class="o_text_overflow"
+                        t-esc="record.partner_id.value"
+                        t-att-title="record.partner_id.value"
+                        t-if="record.partner_id.value"/>
+                    <span class="o_text_overflow" t-if="record.partner_assigned_id.value">
+                        <i class="fa fa-arrow-circle-right" aria-label="Assigned Partner" title="Assigned Partner"/>
+                        <span t-att-title="record.partner_assigned_id.value"
+                            t-esc="record.partner_assigned_id.value"/>
+                    </span>
                 </xpath>
             </field>
         </record>


### PR DESCRIPTION
Currently, if we have both customer and assigned partner names,
they are displayed in a single line separated by an arrow icon.
however, if we have long customer name, the arrow icon and
partner name are not visible on card.

This PR improves the display of names by making a few changes
    - breaking the line before the arrow icon.
    - customer and partner names now have a tooltip with their full names.
    - removing the arrow tooltip.

taskID: 2763930
