### PR TITLE
[IMP] hr_holidays: add tooltip on allocation_validation_type field of…

### DIFF
--- a/addons/hr_holidays/models/hr_leave_type.py
+++ b/addons/hr_holidays/models/hr_leave_type.py
@@ -97,10 +97,9 @@ class HolidaysType(models.Model):
         ('officer', 'Approved by Time Off Officer'),
         ('no', 'No validation needed')], default='officer', string='Approval',
         compute='_compute_allocation_validation_type', store=True, readonly=False,
-        help="""Approved by Time Off Officer: The requested allocation must be validated by the time off approver set on the
-        employee's profile or by a member of the time off officer security group.\n
-        No validation needed: The requested allocation is automatically approved.
-        """)
+        help="""Select the level of approval needed in case of request by employee
+        - No validation needed: The employee's request is automatically approved.
+        - Approved by Time Off Officer: The employee's request need to be manually approved by the Time Off Officer.""")
     has_valid_allocation = fields.Boolean(compute='_compute_valid', search='_search_valid', help='This indicates if it is still possible to use this type of leave')
     time_type = fields.Selection([('leave', 'Time Off'), ('other', 'Other')], default='leave', string="Kind of Leave",
                                  help="Whether this should be computed as a holiday or as work time (eg: formation)")


### PR DESCRIPTION
… hr.leave.type

Since 15.0, the time off type can have different types of approval:
- No validation neededd
- Approved by Time Off Officer
- Set by Time Off Officer

This commit adds a tooltip on the allocation_validation_type to improve usability

task-2681288

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
