### PR TITLE
[IMP] stock_package_type: uom values from int to float

### DIFF
--- a/addons/stock/models/stock_package_type.py
+++ b/addons/stock/models/stock_package_type.py
@@ -16,9 +16,9 @@ class PackageType(models.Model):
 
     name = fields.Char('Package Type', required=True)
     sequence = fields.Integer('Sequence', default=1, help="The first in the sequence is the default one.")
-    height = fields.Integer('Height', help="Packaging Height")
-    width = fields.Integer('Width', help="Packaging Width")
-    packaging_length = fields.Integer('Length', help="Packaging Length")
+    height = fields.Float('Height', help="Packaging Height")
+    width = fields.Float('Width', help="Packaging Width")
+    packaging_length = fields.Float('Length', help="Packaging Length")
     base_weight = fields.Float(string='Weight', help='Weight of the package type')
     max_weight = fields.Float('Max Weight', help='Maximum weight shippable in this packaging')
     barcode = fields.Char('Barcode', copy=False)
@@ -29,9 +29,9 @@ class PackageType(models.Model):
 
     _sql_constraints = [
         ('barcode_uniq', 'unique(barcode)', "A barcode can only be assigned to one package type !"),
-        ('positive_height', 'CHECK(height>=0)', 'Height must be positive'),
-        ('positive_width', 'CHECK(width>=0)', 'Width must be positive'),
-        ('positive_length', 'CHECK(packaging_length>=0)', 'Length must be positive'),
+        ('positive_height', 'CHECK(height>=0.0)', 'Height must be positive'),
+        ('positive_width', 'CHECK(width>=0.0)', 'Width must be positive'),
+        ('positive_length', 'CHECK(packaging_length>=0.0)', 'Length must be positive'),
         ('positive_max_weight', 'CHECK(max_weight>=0.0)', 'Max Weight must be positive'),
     ]
 


### PR DESCRIPTION
Description of the issue/feature this PR addresses:

I do not see a good reason why height, width, length are integers.
It has been introduced in 2015 here: 2ff3749064c423dd17a767c120961733aec10a2c https://github.com/odoo/odoo/pull/9994

Having float is better : it's allow more expressiveness and is less prone to errors for our users.



Current behavior before PR:
User can't express values like 15,5

Desired behavior after PR is merged:
User can express the value he needs.



--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
