### PR TITLE
[14.0][FIX] sale_timesheet: Don't alter _create_invoices signature

### DIFF
--- a/addons/sale_timesheet/models/sale_order.py
+++ b/addons/sale_timesheet/models/sale_order.py
@@ -63,16 +63,16 @@ class SaleOrder(models.Model):
             action = {'type': 'ir.actions.act_window_close'}
         return action
 
-    def _create_invoices(self, grouped=False, final=False, start_date=None, end_date=None):
-        """ Override the _create_invoice method in sale.order model in sale module
-            Add new parameter in this method, to invoice sale.order with a date. This date is used in sale_make_invoice_advance_inv into this module.
-            :param start_date: the start date of the period
-            :param end_date: the end date of the period
-            :return {account.move}: the invoices created
+    def _create_invoices(self, grouped=False, final=False, date=None):
+        """Link timesheets to the created invoices. Date interval is injected in the
+        context in sale_make_invoice_advance_inv wizard.
         """
-        moves = super(SaleOrder, self)._create_invoices(grouped, final)
-        moves._link_timesheets_to_invoice(start_date, end_date)
+        moves = super()._create_invoices(grouped=grouped, final=final, date=date)
+        context = self.env.context
+        if context.get("timesheet_start_date") and context.get("timesheet_end_date"):
+            moves._link_timesheets_to_invoice(context["timesheet_start_date"], context["timesheet_end_date"])
         return moves
+
 
 class SaleOrderLine(models.Model):
     _inherit = "sale.order.line"

--- a/addons/sale_timesheet/wizard/sale_make_invoice_advance.py
+++ b/addons/sale_timesheet/wizard/sale_make_invoice_advance.py
@@ -40,7 +40,10 @@ class SaleAdvancePaymentInv(models.TransientModel):
             if self.date_start_invoice_timesheet or self.date_end_invoice_timesheet:
                 sale_orders.mapped('order_line')._recompute_qty_to_invoice(self.date_start_invoice_timesheet, self.date_end_invoice_timesheet)
 
-            sale_orders._create_invoices(final=self.deduct_down_payments, start_date=self.date_start_invoice_timesheet, end_date=self.date_end_invoice_timesheet)
+            sale_orders.with_context(
+                timesheet_start_date=self.date_start_invoice_timesheet,
+                timesheet_end_date=self.date_end_invoice_timesheet
+            )._create_invoices(final=self.deduct_down_payments)
 
             if self._context.get('open_invoices', False):
                 return sale_orders.action_view_invoice()


### PR DESCRIPTION
Modifying the signature of a method in a children module breaks things, as other modules not being aware of the change will call super method without the proper arguments. This also applies to adding new keyword arguments, as these arguments are not propagated through the super call chain, and you'll lose the value in the best case, or have a crash in the worst one.

This overwrite is not only adding 2 new keyword arguments, but also removing an existing one (`date=None`).

In this commit, a different technique is used to achieve the same result, injecting the values we want to have in the method
`_create_invoices` in the context.

@Tecnativa TT34133

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
