### PR TITLE
[IMP] hr: add a name to the recruitement tab on hr_job form

### DIFF
--- a/addons/hr/views/hr_job_views.xml
+++ b/addons/hr/views/hr_job_views.xml
@@ -22,7 +22,7 @@
                             <page string="Job Description">
                                 <field name="description" options="{'collaborative': true}" attrs="{'invisible': [('state', '!=', 'recruit')]}"/>
                             </page>
-                            <page string="Recruitment">
+                            <page string="Recruitment" name="recruitment_page">
                                 <group>
                                     <group name="recruitment">
                                         <field name="company_id" options="{'no_create': True}" groups="base.group_multi_company"/>


### PR DESCRIPTION
A Payroll tab needs to be added on the hr_job form as part of task-2693292.

This commit adds a name to the tab to be able to add the Payroll tab.

task-2693292

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
