### PR TITLE
[FIX] point_of_sale: cash rounding refund

### DIFF
--- a/addons/pos_cash_rounding/static/src/js/pos_cash_rounding.js
+++ b/addons/pos_cash_rounding/static/src/js/pos_cash_rounding.js
@@ -63,7 +63,7 @@ models.Order = models.Order.extend({
                 if (utils.float_is_zero(rounding_applied, this.pos.currency.decimals)){
                     // https://xkcd.com/217/
                     return 0;
-                } else if(this.get_total_with_tax() < this.pos.cash_rounding[0].rounding) {
+                } else if(Math.abs(this.get_total_with_tax()) < this.pos.cash_rounding[0].rounding) {
                     return 0;
                 } else if(this.pos.cash_rounding[0].rounding_method === "UP" && rounding_applied < 0 && remaining > 0) {
                     rounding_applied += this.pos.cash_rounding[0].rounding;


### PR DESCRIPTION
Cash rounding value were not added with negative amount.
For example if you made an order:
  - amount of the order: 1.98
  - rounding value: 0.05
  - amount to pay: 2.00
The refund of this order should be:
  - amount of the order: - 1.98
  - amount to pay: - 2.00
  - amount to pay before the fix: - 1.98

This fix takes into account negative value when applying cash rounding.

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
