### PR TITLE
[FIX] mass_mailing: prevent selection change into zone outside snippets

### DIFF
--- a/addons/mass_mailing/static/src/js/wysiwyg.js
+++ b/addons/mass_mailing/static/src/js/wysiwyg.js
@@ -5,6 +5,25 @@ var Wysiwyg = require('web_editor.wysiwyg');
 var MassMailingSnippetsMenu = require('mass_mailing.snippets.editor');
 
 const MassMailingWysiwyg = Wysiwyg.extend({
+    //--------------------------------------------------------------------------
+    // Public
+    //--------------------------------------------------------------------------
+
+    start: async function () {
+        const res = await this._super(...arguments);
+        // Prevent selection change outside of snippets.
+        this.$editable.on('mousedown', e => {
+            if ($(e.target).is('.o_editable:empty') || e.target.querySelector('.o_editable')) {
+                e.preventDefault();
+            }
+        });
+        return res;
+    },
+
+    //--------------------------------------------------------------------------
+    // Private
+    //--------------------------------------------------------------------------
+
     /**
      * @override
      */


### PR DESCRIPTION
When starting with an empty mailing, it was possible to click in the document and start typing, while this should not be allowed since that zone is not really editable. We want to only allow writing into snippets.

task-2778412

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
