### PR TITLE
[FIX] point_of_sale: cash rounding refund

### DIFF
--- a/addons/point_of_sale/static/src/js/models.js
+++ b/addons/point_of_sale/static/src/js/models.js
@@ -3359,7 +3359,7 @@ exports.Order = Backbone.Model.extend({
                 if (utils.float_is_zero(rounding_applied, this.pos.currency.decimals)){
                     // https://xkcd.com/217/
                     return 0;
-                } else if(this.get_total_with_tax() < this.pos.cash_rounding[0].rounding) {
+                } else if(Math.abs(this.get_total_with_tax()) < this.pos.cash_rounding[0].rounding) {
                     return 0;
                 } else if(this.pos.cash_rounding[0].rounding_method === "UP" && rounding_applied < 0 && remaining > 0) {
                     rounding_applied += this.pos.cash_rounding[0].rounding;


### PR DESCRIPTION
Cash rounding value were not added with negative amount.
For example if you made an order:
  - amount of the order: 1.98
  - rounding value: 0.05
  - amount to pay: 2.00
The refund of this order should be:
  - amount of the order: - 1.98
  - amount to pay: - 2.00
  - amount to pay before the fix: - 1.98

Because when we added the latest fix that allowed payment lower than the cash rounding value (for example an order amount of 0.03 with a cash rounding for 0.05), the negative amount were not taken into account.
Whenever a negative amount had to be paid, the condition was triggered and return a 0 as rounding to apply (-1.98 < 0.05 => true).
Now we check the absolute value of the total amount to consider if we need to apply a rounding.

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
