### PR TITLE
Improve accrual levels 

### DIFF
--- a/addons/hr_holidays/models/hr_leave_accrual_plan_level.py
+++ b/addons/hr_holidays/models/hr_leave_accrual_plan_level.py
@@ -27,7 +27,6 @@ class AccrualPlanLevel(models.Model):
     sequence = fields.Integer(
         string='sequence', compute='_compute_sequence', store=True,
         help='Sequence is generated automatically by start time delta.')
-    level = fields.Integer(compute='_compute_level', help='Level computed through the sequence.')
     accrual_plan_id = fields.Many2one('hr.leave.accrual.plan', "Accrual Plan", required=True)
     start_count = fields.Integer(
         "Start after",
@@ -146,19 +145,6 @@ class AccrualPlanLevel(models.Model):
         }
         for level in self:
             level.sequence = level.start_count * start_type_multipliers[level.start_type]
-
-    @api.depends('sequence', 'accrual_plan_id')
-    def _compute_level(self):
-        #Mapped level_ids.ids ordered by sequence per plan
-        mapped_level_ids = {}
-        for plan in self.accrual_plan_id:
-            # We can not use .ids here because we also deal with NewIds
-            mapped_level_ids[plan] = [level.id for level in plan.level_ids.sorted('sequence')]
-        for level in self:
-            if level.accrual_plan_id:
-                level.level = mapped_level_ids[level.accrual_plan_id].index(level.id) + 1
-            else:
-                level.level = 1
 
     @api.depends('first_day', 'second_day', 'first_month_day', 'second_month_day', 'yearly_day')
     def _compute_days_display(self):

--- a/addons/hr_holidays/models/hr_leave_accrual_plan_level.py
+++ b/addons/hr_holidays/models/hr_leave_accrual_plan_level.py
@@ -121,6 +121,8 @@ class AccrualPlanLevel(models.Model):
          ('lost', 'Lost')],
         string="At the end of the calendar year, unused accruals will be",
         default='postponed', required='True')
+    postpone_max_days = fields.Integer("Maximum amount of accruals to transfer",
+        help="Set a maximum of days an allocation keeps at the end of the year. 0 for no limit.")
 
     _sql_constraints = [
         ('check_dates',

--- a/addons/hr_holidays/models/hr_leave_allocation.py
+++ b/addons/hr_holidays/models/hr_leave_allocation.py
@@ -330,11 +330,22 @@ class HolidaysAllocation(models.Model):
     def _end_of_year_accrual(self):
         # to override in payroll
         today = fields.Date.today()
+        last_day_last_year = today + relativedelta(years=-1, month=12, day=31)
         for allocation in self:
             current_level = allocation._get_current_accrual_plan_level_id(today)[0]
-            if current_level and current_level.action_with_unused_accruals == 'lost':
+            if not current_level:
+                continue
+            nextcall = current_level._get_next_date(today)
+            if current_level.action_with_unused_accruals == 'lost':
                 # Allocations are lost but number_of_days should not be lower than leaves_taken
-                allocation.write({'number_of_days': allocation.leaves_taken, 'lastcall': today, 'nextcall': False})
+                allocation.write({'number_of_days': allocation.leaves_taken, 'lastcall': today, 'nextcall': nextcall})
+            elif current_level.action_with_unused_accruals == 'postponed' and current_level.postpone_max_days:
+                # Make sure the period was ran until the last day of last year
+                if allocation.nextcall:
+                    allocation.nextcall = last_day_last_year
+                allocation._process_accrual_plans(last_day_last_year, True)
+                number_of_days = min(allocation.number_of_days - allocation.leaves_taken, current_level.postpone_max_days) + allocation.leaves_taken
+                allocation.write({'number_of_days': number_of_days, 'lastcall': today, 'nextcall': nextcall})
 
     def _get_current_accrual_plan_level_id(self, date, level_ids=False):
         """
@@ -392,12 +403,13 @@ class HolidaysAllocation(models.Model):
             period_prorata = min(1, call_days / period_days) if period_days else 1
         return added_value * period_prorata
 
-    def _process_accrual_plans(self):
+    def _process_accrual_plans(self, date_to=False, force_period=False):
         """
         This method is part of the cron's process.
-        The goal of this method is to retroactively apply accrual plan levels and progress from nextcall to today
+        The goal of this method is to retroactively apply accrual plan levels and progress from nextcall to date_to or today.
+        If force_period is set, the accrual will run until date_to in a prorated way (used for end of year accrual actions).
         """
-        today = fields.Date.today()
+        date_to = date_to or fields.Date.today()
         first_allocation = _("""This allocation have already ran once, any modification won't be effective to the days allocated to the employee. If you need to change the configuration of the allocation, cancel and create a new one.""")
         for allocation in self:
             level_ids = allocation.accrual_plan_id.level_ids.sorted('sequence')
@@ -406,7 +418,7 @@ class HolidaysAllocation(models.Model):
             if not allocation.nextcall:
                 first_level = level_ids[0]
                 first_level_start_date = allocation.date_from + get_timedelta(first_level.start_count, first_level.start_type)
-                if today < first_level_start_date:
+                if date_to < first_level_start_date:
                     # Accrual plan is not configured properly or has not started
                     continue
                 allocation.lastcall = max(allocation.lastcall, first_level_start_date)
@@ -416,7 +428,7 @@ class HolidaysAllocation(models.Model):
                     allocation.nextcall = min(second_level_start_date - relativedelta(days=1), allocation.nextcall)
                 allocation._message_log(body=first_allocation)
             days_added_per_level = defaultdict(lambda: 0)
-            while allocation.nextcall <= today:
+            while allocation.nextcall <= date_to:
                 (current_level, current_level_idx) = allocation._get_current_accrual_plan_level_id(allocation.nextcall)
                 nextcall = current_level._get_next_date(allocation.nextcall)
                 # Since _get_previous_date returns the given date if it corresponds to a call date
@@ -424,29 +436,46 @@ class HolidaysAllocation(models.Model):
                 # this is used to prorate the first number of days given to the employee
                 period_start = current_level._get_previous_date(allocation.lastcall)
                 period_end = current_level._get_next_date(allocation.lastcall)
-                # If accruals are lost at the beginning of year, skip accrual until beginning of this year
-                if current_level.action_with_unused_accruals == 'lost':
-                    this_year_first_day = (today + relativedelta(day=1, month=1)).date()
-                    if period_end < this_year_first_day or period_start < period_end:
-                        allocation.lastcall = allocation.nextcall
-                        allocation.nextcall = nextcall
-                        continue
-                    else:
-                        period_start = max(period_start, this_year_first_day)
                 # Also prorate this accrual in the event that we are passing from one level to another
                 if current_level_idx < (len(level_ids) - 1) and allocation.accrual_plan_id.transition_mode == 'immediately':
                     next_level = level_ids[current_level_idx + 1]
                     current_level_last_date = allocation.date_from + get_timedelta(next_level.start_count, next_level.start_type) - relativedelta(days=1)
                     if allocation.nextcall != current_level_last_date:
                         nextcall = min(nextcall, current_level_last_date)
-                days_added_per_level[current_level] += allocation._process_accrual_plan_level(
+
+                gained_days = allocation._process_accrual_plan_level(
                     current_level, period_start, allocation.lastcall, period_end, allocation.nextcall)
+                days_added_per_level[current_level] += gained_days
+                # We have to check for end of year actions if it is within our period
+                #  since we can create retroactive allocations.
+                if allocation.lastcall.year < allocation.nextcall.year and\
+                    (current_level.action_with_unused_accruals == 'lost' or\
+                    current_level.postpone_max_days > 0):
+                    after_period_gains = allocation._process_accrual_plan_level(
+                        current_level, period_start, allocation.nextcall + relativedelta(day=1, month=1),
+                        period_end, allocation.nextcall)
+                    if current_level.action_with_unused_accruals == 'postponed':
+                        # Compute number of days kept
+                        allocation_days = allocation.number_of_days - allocation.leaves_taken
+                        allowed_to_keep = max(0, current_level.postpone_max_days - allocation_days)
+                        number_of_days = min(allocation_days, current_level.postpone_max_days)
+                        allocation.number_of_days = number_of_days + allocation.leaves_taken
+                        total_gained_days = sum(days_added_per_level.values())
+                        days_added_per_level.clear()
+                        days_added_per_level[current_level] = min(total_gained_days - after_period_gains, allowed_to_keep)
+                    else:
+                        allocation.number_of_days = allocation.leaves_taken
+                        days_added_per_level.clear()
+                    days_added_per_level[current_level] += after_period_gains
+
                 allocation.lastcall = allocation.nextcall
                 allocation.nextcall = nextcall
+                if force_period and allocation.nextcall > date_to:
+                    allocation.nextcall = date_to
+                    force_period = False
+
             if days_added_per_level:
-                number_of_days_to_add = 0
-                for value in days_added_per_level.values():
-                    number_of_days_to_add += value
+                number_of_days_to_add = sum(days_added_per_level.values())
                 # Let's assume the limit of the last level is the correct one
                 allocation.write({'number_of_days': min(allocation.number_of_days + number_of_days_to_add, current_level.maximum_leave)})
 

--- a/addons/hr_holidays/static/src/scss/accrual_plan_level.scss
+++ b/addons/hr_holidays/static/src/scss/accrual_plan_level.scss
@@ -22,6 +22,8 @@ $o-hr-holidays-border-color: gray('300');
     }
 
     .o_hr_holidays_plan_level_container {
+        counter-reset: o-hr-holidays-accrual-plan-level-counter;
+
         .o-kanban-button-new {
             padding: 2px 12px;
             margin: 0px 0px 0px 44px;
@@ -29,6 +31,7 @@ $o-hr-holidays-border-color: gray('300');
         }
 
         .o_kanban_view.o_kanban_ungrouped .o_kanban_record {
+            counter-increment: o-hr-holidays-accrual-plan-level-counter;
             display: flex;
             flex: 0 0 100%;
             border: 0px;
@@ -44,6 +47,10 @@ $o-hr-holidays-border-color: gray('300');
                 height: 100%;
                 margin-left: 8px;
                 border-left: 1px dashed darken($o-hr-holidays-border-color, 10%);
+            }
+
+            .o_hr_holidays_plan_level_level::before {
+                content: counter(o-hr-holidays-accrual-plan-level-counter);
             }
 
             // Whole record

--- a/addons/hr_holidays/views/hr_leave_accrual_views.xml
+++ b/addons/hr_holidays/views/hr_leave_accrual_views.xml
@@ -52,6 +52,7 @@
                             </div>
                         </div>
                         <field name="action_with_unused_accruals"/>
+                        <field name="postpone_max_days" attrs="{'invisible': [('action_with_unused_accruals', '!=', 'postponed')]}"/>
                     </group>
                 </sheet>
             </form>

--- a/addons/hr_holidays/views/hr_leave_accrual_views.xml
+++ b/addons/hr_holidays/views/hr_leave_accrual_views.xml
@@ -108,10 +108,10 @@
                             class="o_hr_holidays_plan_level_container o_hr_holidays_plan_level_hierarchy"
                             add-label="Add a new level"
                             >
-                            <kanban default_order="level">
+                            <kanban default_order="sequence">
+                                <field name="sequence"/>
                                 <field name="start_count"/>
                                 <field name="start_type"/>
-                                <field name="level"/>
                                 <field name="added_value"/>
                                 <field name="added_value_type"/>
                                 <field name="frequency"/>
@@ -131,7 +131,7 @@
                                     <div t-name="kanban-box">
                                         <div class="o_hr_holidays_body oe_kanban_global_click">
                                             <div class="o_hr_holidays_timeline text-center">
-                                                Level <field name="level"/>
+                                                Level <span class="o_hr_holidays_plan_level_level"/>
                                             </div>
                                             <t t-if="!read_only_mode">
                                                 <a type="edit" t-attf-class="oe_kanban_action oe_kanban_action_a text-black">


### PR DESCRIPTION
The level compute was a bit complicated and not accurate at all.
It is now done using css instead.
Adds a new option on accrual levels to limit the days that can be
post-poned year by year.

TaskId-2768674