### PR TITLE
[14.0][FIX] l10n_ch: a qr report is generated although if the option is disabled

### DIFF
--- a/addons/l10n_ch/models/mail_template.py
+++ b/addons/l10n_ch/models/mail_template.py
@@ -37,7 +37,9 @@ class MailTemplate(models.Model):
                     isr_pdf = base64.b64encode(isr_pdf)
                     new_attachments.append((isr_report_name, isr_pdf))
 
-                if record.move_type == 'out_invoice' and record.partner_bank_id._eligible_for_qr_code('ch_qr', record.partner_id, record.currency_id):
+                if record.move_type == 'out_invoice' and \
+                        record.partner_bank_id._eligible_for_qr_code('ch_qr', record.partner_id, record.currency_id) and \
+                        record.display_qr_code:
                     # We add an attachment containing the QR-bill
                     qr_report_name = 'QR-bill-' + inv_print_name + '.pdf'
                     qr_pdf = self.env.ref('l10n_ch.l10n_ch_qr_report')._render_qweb_pdf(record.ids)[0]


### PR DESCRIPTION

Description of the issue/feature this PR addresses: QR file is generated although the option is disabled

Current behavior before PR: QR file is generated with a QR option disabled

Desired behavior after PR is merged: If the QR option is disabled, the QR document is not generated




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
