### PR TITLE
[FIX] web: properly bind colorpicker to its owner document

### DIFF
--- a/addons/web/static/src/legacy/js/widgets/colorpicker.js
+++ b/addons/web/static/src/legacy/js/widgets/colorpicker.js
@@ -40,7 +40,10 @@ var ColorpickerWidget = Widget.extend({
         this.selectedHexValue = '';
 
         // Needs to be bound on document to work in all possible cases.
-        const $document = $(parent.el && parent.el.ownerDocument || document);
+        const $document = $(
+            (parent.el && parent.el.parentElement && parent.el.ownerDocument)
+            || (parent.options && parent.options.$editable && parent.options.$editable[0] && parent.options.$editable[0].ownerDocument)
+            || document);
         $document.on(`mousemove.${this.uniqueId}`, _.throttle((ev) => {
             this._onMouseMovePicker(ev);
             this._onMouseMoveSlider(ev);


### PR DESCRIPTION
In mass_mailing, the colorpicker is in an iframe. There was code to make sure it was bound to its owner document but that code was faulty since it was executed before the colorpicker was appended to the DOM. As a result, all features of the colorpicker that relied on the position of the mouse (eg, selecting a color in an xy selector by dragging a cursor) were broken.
This fixes it by using the owner document of the parent class' editable if defined, rather than that of the parent class' element.

task-2778415

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
