### PR TITLE
[FIX] {sale,purchase}_stock: compute delivered/received qty

### DIFF
--- a/addons/purchase_stock/models/purchase.py
+++ b/addons/purchase_stock/models/purchase.py
@@ -296,7 +296,7 @@ class PurchaseOrderLine(models.Model):
                     if move.state == 'done':
                         if move.location_dest_id.usage == "supplier":
                             if move.to_refund:
-                                total -= move.product_uom._compute_quantity(move.product_uom_qty, line.product_uom, rounding_method='HALF-UP')
+                                total -= move.product_uom._compute_quantity(move.product_uom_qty, line.product_uom, round=False)
                         elif move.origin_returned_move_id and move.origin_returned_move_id._is_dropshipped() and not move._is_dropshipped_returned():
                             # Edge case: the dropship is returned to the stock, no to the supplier.
                             # In this case, the received quantity on the PO is set although we didn't
@@ -311,9 +311,10 @@ class PurchaseOrderLine(models.Model):
                                 [("id", "child_of", move.warehouse_id.view_location_id.id)]
                             )
                         ):
-                            total -= move.product_uom._compute_quantity(move.product_uom_qty, line.product_uom, rounding_method='HALF-UP')
+                            total -= move.product_uom._compute_quantity(move.product_uom_qty, line.product_uom, round=False)
                         else:
-                            total += move.product_uom._compute_quantity(move.product_uom_qty, line.product_uom, rounding_method='HALF-UP')
+                            total += move.product_uom._compute_quantity(move.product_uom_qty, line.product_uom, round=False)
+                total = float_round(total, precision_rounding=line.product_uom.rounding, rounding_method='HALF-UP')
                 line._track_qty_received(total)
                 line.qty_received = total
 

--- a/addons/sale_stock/models/sale_order.py
+++ b/addons/sale_stock/models/sale_order.py
@@ -408,12 +408,12 @@ class SaleOrderLine(models.Model):
                 for move in outgoing_moves:
                     if move.state != 'done':
                         continue
-                    qty += move.product_uom._compute_quantity(move.product_uom_qty, line.product_uom, rounding_method='HALF-UP')
+                    qty += move.product_uom._compute_quantity(move.product_uom_qty, line.product_uom, round=False)
                 for move in incoming_moves:
                     if move.state != 'done':
                         continue
-                    qty -= move.product_uom._compute_quantity(move.product_uom_qty, line.product_uom, rounding_method='HALF-UP')
-                line.qty_delivered = qty
+                    qty -= move.product_uom._compute_quantity(move.product_uom_qty, line.product_uom, round=False)
+                line.qty_delivered = float_round(qty, precision_rounding=line.product_uom.rounding, rounding_method='HALF-UP')
 
     @api.model_create_multi
     def create(self, vals_list):


### PR DESCRIPTION
When using several UoMs, the delivered quantity of a POL can be bigger
than the reality

To reproduce the issue:
1. In Settings, enable "Units of Measure"
2. Create a new UoM U96:
    - Category: Unit
    - Type: Bigger
    - Bigger Ratio: 96
    - Rounding Precision: 1
3. Create a product P:
    - UoM: Unit
    - Purchase UoM: Unit
4. Create & Confirm a new PO with:
    - 2 U96 x P
5. Receive 144 units of P (with backorder)
    - Note that there is already an error: back to the PO, the received
quantity is 2 U96. This would mean that all P have been received, which
is not true
6. Process the backorder
7. Go back to the PO

Error: The qty received is now 3 U96. It's more than expected and than
reality

The current computation of the received quantity creates the confusion:
it rounds each SML and then sum the rounded values. So, in the above
case, from the first picking, we received 144 units, which means 1.5
U96. We round this value: 2 U96. Then, we do the same with the
backorder: 48 units = 0.5 U96 => 1 U96. Therefore: 2 U96 + 1 U96 = 3 U96

A similar issue occurs with the SO.

OPW-2748532