### PR TITLE
[FIX] point_of_sale: PoS numpad frozen on amount due with terminal

### DIFF
--- a/addons/point_of_sale/static/src/js/Screens/PaymentScreen/PaymentScreen.js
+++ b/addons/point_of_sale/static/src/js/Screens/PaymentScreen/PaymentScreen.js
@@ -59,21 +59,16 @@ odoo.define('point_of_sale.PaymentScreen', function (require) {
         }
         addNewPaymentLine({ detail: paymentMethod }) {
             // original function: click_paymentmethods
-            if (this.currentOrder.electronic_payment_in_progress()) {
+            const paymentMethodRes = this.currentOrder.addNewPaymentLine(paymentMethod)
+            if (!paymentMethodRes) {
                 this.showPopup('ErrorPopup', {
                     title: this.env._t('Error'),
                     body: this.env._t('There is already an electronic payment in progress.'),
                 });
-                return false;
             } else {
-                this.currentOrder.add_paymentline(paymentMethod);
                 NumberBuffer.reset();
-                this.payment_interface = paymentMethod.payment_terminal;
-                if (this.payment_interface) {
-                    this.currentOrder.selected_paymentline.set_payment_status('pending');
-                }
-                return true;
             }
+            return paymentMethodRes;
         }
         _updateSelectedPaymentline() {
             if (this.paymentLines.every((line) => line.paid)) {

--- a/addons/point_of_sale/static/src/js/models.js
+++ b/addons/point_of_sale/static/src/js/models.js
@@ -3771,6 +3771,18 @@ exports.Order = Backbone.Model.extend({
         }
         return false;
     },
+    addNewPaymentLine(paymentMethod) {
+        // original function: click_paymentmethods
+        if (this.electronic_payment_in_progress()) {
+            return false;
+        } else {
+            const paymentLine = this.add_paymentline(paymentMethod);
+            if (paymentMethod.payment_terminal) {
+                this.selected_paymentline.set_payment_status('pending');
+            }
+            return paymentLine;
+        }
+    },
 });
 
 var OrderCollection = Backbone.Collection.extend({


### PR DESCRIPTION
To reproduce:
 1. Install PoS
 2. Configure a terminal payment method
 3. Open a PoS session
 4. Choose a customer with an amount due (like Azure Interior)
 5. Choose the payment method using the terminal
 -> Clicking on the numpad digits is ignored, the change value remain at 0

 After this commit:
 The numpad value does update the "Change" value accordingly

Enterprise PR: https://github.com/odoo/enterprise/pull/24717

 OPW-2765314

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
