### PR TITLE
[FIX] web_editor: initialize editor's tooltips

### DIFF
--- a/addons/web_editor/static/src/js/editor/snippets.editor.js
+++ b/addons/web_editor/static/src/js/editor/snippets.editor.js
@@ -1691,6 +1691,7 @@ var SnippetsMenu = Widget.extend({
         this.$('we-collapse-area > we-toggler').not($hierarchyTogglers).removeClass('active');
         $hierarchyTogglers.not(ev.currentTarget).addClass('active');
         ev.currentTarget.classList.toggle('active');
+        $('[title]').tooltip();
     },
     /**
      * Called when the overlay dimensions/positions should be recomputed.
@@ -1780,6 +1781,7 @@ var SnippetsMenu = Widget.extend({
         this.$('.o_we_add_snippet_btn').toggleClass('active', !customize);
         this.customizePanel.classList.toggle('d-none', !customize);
         this.$('.o_we_customize_snippet_btn').toggleClass('active', customize);
+        $('[title]').tooltip();
     },
 });
 


### PR DESCRIPTION
The editor offers bootstrap tooltips, but these were not all initialized
and therefore appeared as standard HTML tooltips. This PR fixes that
by initializing all the tooltips so that they all have the same style. (bootstrap style).

task-2777738

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
