### PR TITLE
[FIX] stock_picking_batch: Fix batched pickings validation

### DIFF
--- a/addons/stock_picking_batch/models/stock_picking.py
+++ b/addons/stock_picking_batch/models/stock_picking.py
@@ -119,6 +119,14 @@ class StockPicking(models.Model):
                 picking._find_auto_batch()
         return res
 
+    def _action_done(self):
+        res = super()._action_done()
+        for picking in self:
+            if picking.batch_id and any(picking.state != 'done' for picking in picking.batch_id.picking_ids):
+                picking.batch_id = None
+
+        return res
+
     def _should_show_transfers(self):
         if len(self.batch_id) == 1 and self == self.batch_id.picking_ids:
             return False

--- a/addons/stock_picking_batch/tests/test_batch_picking.py
+++ b/addons/stock_picking_batch/tests/test_batch_picking.py
@@ -449,3 +449,8 @@ class TestBatchPicking(TransactionCase):
         self.assertTrue(picking_out_3.batch_id)
         self.assertEqual(picking_out_1.batch_id.id, picking_out_3.batch_id.id)
         self.assertFalse(picking_out_2.batch_id)
+        # If Picking 1 is validated without Picking 3, Picking 1 should be removed from the batch
+        picking_out_1.move_ids.quantity_done = 10
+        picking_out_1.button_validate()
+        self.assertFalse(picking_out_1.batch_id)
+        self.assertEqual(len(picking_out_3.batch_id.picking_ids), 1)


### PR DESCRIPTION
If a picking is in a batch, the point is to process it as a whole. Yet,
it is possible to validate a single picking (putting it in a 'done'
state), inside of an 'in_progress' batch. This raises inconsistencies
between the state of the batch as a whole and the state of some of it
pickings.

Therefore, when a single batched picking is validated in a batch that
still contains other non-done pickings, the picking is removed from the
batch.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
