### PR TITLE
[IMP] l10n_pt: add QR code to PT invoices

### DIFF
--- a/addons/account/views/report_invoice.xml
+++ b/addons/account/views/report_invoice.xml
@@ -21,7 +21,7 @@
                         <t t-else="">Tax ID</t>: <span t-field="o.partner_id.vat"/></div>
                 </t>
                 <div class="page">
-                    <h2 class="mt-4">
+                    <h2 class="mt-4" id="title">
                         <span t-if="o.move_type == 'out_invoice' and o.state == 'posted'">Invoice</span>
                         <span t-if="o.move_type == 'out_invoice' and o.state == 'draft'">Draft Invoice</span>
                         <span t-if="o.move_type == 'out_invoice' and o.state == 'cancel'">Cancelled Invoice</span>

--- a/addons/l10n_pt/__init__.py
+++ b/addons/l10n_pt/__init__.py
@@ -3,3 +3,5 @@
 
 # Copyright (C) 2012 Thinkopen Solutions, Lda. All Rights Reserved
 # http://www.thinkopensolutions.com.
+
+from . import models

--- a/addons/l10n_pt/__manifest__.py
+++ b/addons/l10n_pt/__manifest__.py
@@ -23,6 +23,7 @@
            'data/account_tax_report.xml',
            'data/account_tax_data.xml',
            'data/account_chart_template_configure_data.xml',
+           'views/report_invoice.xml',
            ],
     'license': 'LGPL-3',
 }

--- a/addons/l10n_pt/models/__init__.py
+++ b/addons/l10n_pt/models/__init__.py
@@ -1,0 +1,4 @@
+# -*- encoding: utf-8 -*-
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from . import account_move

--- a/addons/l10n_pt/models/account_move.py
+++ b/addons/l10n_pt/models/account_move.py
@@ -2,7 +2,7 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 import json
-import stdnum
+from stdnum.pt import nif
 
 from odoo import api, fields, models, _
 from odoo.exceptions import UserError
@@ -20,7 +20,7 @@ class AccountMove(models.Model):
             if record.company_id.account_fiscal_country_id.code != "PT":
                 continue
 
-            company_vat_not_ok = not record.company_id.vat or not stdnum.pt.vat.is_valid(record.company_id.vat)
+            company_vat_not_ok = not record.company_id.vat or not nif.is_valid(record.company_id.vat)
             partner_country_not_ok = not record.partner_id.country_id
             record_type_not_ok = record.move_type not in {'out_invoice', 'out_refund', 'out_receipt'}
 

--- a/addons/l10n_pt/models/account_move.py
+++ b/addons/l10n_pt/models/account_move.py
@@ -2,7 +2,7 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 import json
-from stdnum.pt import nif
+import stdnum.pt.nif
 
 from odoo import api, fields, models, _
 from odoo.exceptions import UserError
@@ -20,7 +20,7 @@ class AccountMove(models.Model):
             if record.company_id.account_fiscal_country_id.code != "PT":
                 continue
 
-            company_vat_not_ok = not record.company_id.vat or not nif.is_valid(record.company_id.vat)
+            company_vat_not_ok = not record.company_id.vat or not stdnum.pt.nif.is_valid(record.company_id.vat)
             partner_country_not_ok = not record.partner_id.country_id
             record_type_not_ok = record.move_type not in {'out_invoice', 'out_refund', 'out_receipt'}
 

--- a/addons/l10n_pt/models/account_move.py
+++ b/addons/l10n_pt/models/account_move.py
@@ -84,10 +84,10 @@ class AccountMove(models.Model):
                 "out_receipt": "FR",
             }
             qr_code_str += f"D:{invoice_type_map[move.move_type]}*"
-            qr_code_str += f"E:N*"
+            qr_code_str += "E:N*"
             qr_code_str += f"F:{format_date(self.env, move.date, date_format='yyyyMMdd')}*"
             qr_code_str += f"G:{(move.move_type + ' ' + move.name)[:60]}*"
-            qr_code_str += f"H:0*"
+            qr_code_str += "H:0*"
             qr_code_str += f"I1:{move.company_id.account_fiscal_country_id.code}*"
 
             base_vat_exempt = get_base_and_vat(move, 'IVA 0%')
@@ -112,8 +112,8 @@ class AccountMove(models.Model):
             tax_amounts = json.loads(move.tax_totals_json)
             qr_code_str += f"N:{format_amount(convert_to_eur(tax_amounts['amount_total'] - tax_amounts['amount_untaxed'], move))}*"
             qr_code_str += f"O:{format_amount(convert_to_eur(tax_amounts['amount_total'], move))}*"
-            qr_code_str += f"Q:TODO*"  # TODO: Fill with Hash
-            qr_code_str += f"R:0*"  # TODO: Fill Certifiate number
+            qr_code_str += "Q:TODO*"  # TODO: Fill with Hash
+            qr_code_str += "R:0*"  # TODO: Fill Certifiate number
 
             if qr_code_str[-1] == "*":
                 qr_code_str = qr_code_str[:-1]

--- a/addons/l10n_pt/models/account_move.py
+++ b/addons/l10n_pt/models/account_move.py
@@ -1,0 +1,120 @@
+# -*- coding: utf-8 -*-
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+import json
+import stdnum
+
+from odoo import api, fields, models, _
+from odoo.exceptions import UserError
+from odoo.tools import format_date, float_repr
+
+
+class AccountMove(models.Model):
+    _inherit = 'account.move'
+
+    l10n_pt_qr_code_str = fields.Char(string='Portuguese QR Code', compute='_compute_qr_code_str')
+
+    def check_necessary_fields(self):
+        # Check needed values are filled before creating the QR code
+        for record in self:  # record is of type account.move
+            if record.company_id.account_fiscal_country_id.code != "PT":
+                continue
+
+            company_vat_not_ok = not record.company_id.vat or not stdnum.pt.vat.is_valid(record.company_id.vat)
+            partner_country_not_ok = not record.partner_id.country_id
+            record_type_not_ok = record.move_type not in {'out_invoice', 'out_refund', 'out_receipt'}
+
+            if company_vat_not_ok or partner_country_not_ok or record_type_not_ok:
+                error_msg = _("Some fields required for the generation of the document are missing or invalid. Please verify them:\n")
+                error_msg += _('The `VAT` of your company should be defined and match the following format: PT123456789\n') if company_vat_not_ok else ""
+                error_msg += _('The `country of the customer should be defined.\n') if partner_country_not_ok else ""
+                error_msg += _('The type of document should either be an invoice, a credit note, or a receipt\n') if record_type_not_ok else ""
+                raise UserError(error_msg)
+
+    def preview_invoice(self):
+        self.check_necessary_fields()
+        return super().preview_invoice()
+
+    def action_invoice_sent(self):
+        self.check_necessary_fields()
+        return super().action_invoice_sent()
+
+    @api.depends('partner_id', 'currency_id', 'date', 'move_type', 'display_name', 'amount_total',
+                 'amount_untaxed', 'company_id', 'company_id.vat', 'company_id.account_fiscal_country_id', 'partner_id.country_id')
+    def _compute_qr_code_str(self):
+        """ Generate the informational QR code for Portugal invoicing.
+        E.g.: A:509445535*B:123456823*C:BE*D:FT*E:N*F:20220103*G:FT 01P2022/1*H:0*I1:PT*I7:325.20*I8:74.80*N:74.80*O:400.00*P:0.00*Q:P0FE*R:2230
+        """
+
+        def convert_to_eur(amount, account_move):
+            """Convert amount to EUR based on the rate of a given account_move's date"""
+            pt_currency = self.env.ref('base.EUR')
+            return account_move.currency_id._convert(amount, pt_currency, account_move.company_id, account_move.date)
+
+        def format_amount(amount):
+            """Format amount to 2 decimals as per SAF-T (PT) requirements"""
+            return float_repr(amount, 2)
+
+        def get_base_and_vat(account_move, vat_name):
+            """Returns the base and value tax for each type of tax"""
+            amount_by_group = json.loads(account_move.tax_totals_json)['groups_by_subtotal']['Untaxed Amount']
+            vat_names = [line['tax_group_name'] for line in amount_by_group]
+            vat_values = [line['tax_group_amount'] for line in amount_by_group]
+            vat_bases = [line['tax_group_base_amount'] for line in amount_by_group]
+            if vat_name not in vat_names:
+                return False
+            index = vat_names.index(vat_name)
+            return {'base': format_amount(convert_to_eur(vat_bases[index], account_move)),
+                    'vat': format_amount(convert_to_eur(vat_values[index], account_move))}
+
+        for move in self:  # record is of type account.move
+            if move.company_id.account_fiscal_country_id.code != "PT":
+                move.l10n_pt_qr_code_str = ""
+                continue
+
+            company_vat = move.company_id.vat[2:] if move.company_id.vat.startswith('PT') else move.company_id.vat
+
+            qr_code_str = ""
+            qr_code_str += f"A:{company_vat}*"
+            qr_code_str += f"B:{move.partner_id.vat or '999999990'}*"
+            qr_code_str += f"C:{move.partner_id.country_id.code}*"
+            invoice_type_map = {
+                "out_invoice": "FT",
+                "out_refund": "NC",
+                "out_receipt": "FR",
+            }
+            qr_code_str += f"D:{invoice_type_map[move.move_type]}*"
+            qr_code_str += f"E:N*"
+            qr_code_str += f"F:{format_date(self.env, move.date, date_format='yyyyMMdd')}*"
+            qr_code_str += f"G:{(move.move_type + ' ' + move.name)[:60]}*"
+            qr_code_str += f"H:0*"
+            qr_code_str += f"I1:{move.company_id.account_fiscal_country_id.code}*"
+
+            base_vat_exempt = get_base_and_vat(move, 'IVA 0%')
+            if base_vat_exempt:
+                qr_code_str += f"I2:{base_vat_exempt['base']}*"
+
+            base_vat_reduced = get_base_and_vat(move, 'IVA 6%')
+            if base_vat_reduced:
+                qr_code_str += f"I3:{base_vat_reduced['base']}*"
+                qr_code_str += f"I4:{base_vat_reduced['vat']}*"
+
+            base_vat_intermediate = get_base_and_vat(move, 'IVA 13%')
+            if base_vat_intermediate:
+                qr_code_str += f"I5:{base_vat_intermediate['base']}*"
+                qr_code_str += f"I6:{base_vat_intermediate['vat']}*"
+
+            base_vat_normal = get_base_and_vat(move, 'IVA 23%')
+            if base_vat_normal:
+                qr_code_str += f"I7:{base_vat_normal['base']}*"
+                qr_code_str += f"I8:{base_vat_normal['vat']}*"
+
+            tax_amounts = json.loads(move.tax_totals_json)
+            qr_code_str += f"N:{format_amount(convert_to_eur(tax_amounts['amount_total'] - tax_amounts['amount_untaxed'], move))}*"
+            qr_code_str += f"O:{format_amount(convert_to_eur(tax_amounts['amount_total'], move))}*"
+            qr_code_str += f"Q:TODO*"  # TODO: Fill with Hash
+            qr_code_str += f"R:0*"  # TODO: Fill Certifiate number
+
+            if qr_code_str[-1] == "*":
+                qr_code_str = qr_code_str[:-1]
+            move.l10n_pt_qr_code_str = qr_code_str

--- a/addons/l10n_pt/tests/__init__.py
+++ b/addons/l10n_pt/tests/__init__.py
@@ -1,0 +1,4 @@
+# -*- coding: utf-8 -*-
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from . import test_pt_qr_code

--- a/addons/l10n_pt/tests/test_pt_qr_code.py
+++ b/addons/l10n_pt/tests/test_pt_qr_code.py
@@ -1,0 +1,120 @@
+# -*- coding: utf-8 -*-
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+from odoo.addons.account.tests.common import AccountTestInvoicingCommon
+from odoo import fields
+from odoo.tests import tagged, Form
+
+
+@tagged('post_install', '-at_install')
+class PortugalQRCodeTest(AccountTestInvoicingCommon):
+
+    @classmethod
+    def setUpClass(cls, chart_template_ref='l10n_pt.pt_chart_template'):
+        super().setUpClass(chart_template_ref=chart_template_ref)
+
+        cls.tax23 = cls.env['account.tax'].search([('company_id', '=', cls.company_data['company'].id), ('name', '=', 'IVA23')])
+        cls.tax13 = cls.env['account.tax'].search([('company_id', '=', cls.company_data['company'].id), ('name', '=', 'IVA13')])
+        cls.tax6 = cls.env['account.tax'].search([('company_id', '=', cls.company_data['company'].id), ('name', '=', 'IVA6')])
+        cls.tax0 = cls.env['account.tax'].search([('company_id', '=', cls.company_data['company'].id), ('name', '=', 'IVA0')])
+
+        cls.company_data['company'].write({
+            'city': 'Lisboa',
+            'zip': '1234-789',
+            'vat': 'PT123456789',
+            'company_registry': '123456',
+            'phone': '+47 11 11 11 11',
+            'country_id': cls.env.ref('base.pt').id
+        })
+
+        cls.partner_a['country_id'] = cls.env.ref('base.be').id
+
+        cls.invoice = cls.env['account.move'].create({
+            'move_type': 'out_invoice',
+            'partner_id': cls.partner_a.id,
+            'date': fields.Date.from_string('2022-01-01'),
+            'name': 'INV/2022/00001',
+            'invoice_line_ids': [
+                (0, 0, {
+                    'name': 'Name 0',
+                    'product_id': cls.product_a.id,
+                    'quantity': 1,
+                    'price_unit': 100,
+                    'tax_ids': [cls.tax23.id],
+                }),
+                (0, 0, {
+                    'name': 'Name 1',
+                    'product_id': cls.product_a.id,
+                    'quantity': 1,
+                    'price_unit': 200,
+                    'tax_ids': [cls.tax23.id],
+                }),
+                (0, 0, {
+                    'name': 'Name 2',
+                    'product_id': cls.product_b.id,
+                    'quantity': 1,
+                    'price_unit': 100,
+                    'tax_ids': [cls.tax13.id],
+                }),
+                (0, 0, {
+                    'name': 'Name 3',
+                    'product_id': cls.product_a.id,
+                    'quantity': 1,
+                    'price_unit': 100,
+                    'tax_ids': [cls.tax6.id],
+                }),
+                (0, 0, {
+                    'name': 'Name 4',
+                    'product_id': cls.product_b.id,
+                    'quantity': 1,
+                    'price_unit': 100,
+                    'tax_ids': [cls.tax0.id],
+                })
+            ]
+        })
+
+    def test_pt_qr_code_multiple_taxes(self):
+        """Ensures that all possible taxes are correctly computed and exported"""
+        self.invoice.preview_invoice()  # Triggers the _compute_qr_code_str method
+        self.assertEqual(self.invoice.l10n_pt_qr_code_str,
+                         'A:123456789*B:999999990*C:BE*D:FT*E:N*F:20220101*G:out_invoice INV/2022/00001*H:0'
+                         '*I1:PT*I2:100.00*I3:100.00*I4:6.00*I5:100.00*I6:13.00*I7:300.00*I8:69.00'
+                         '*N:88.00*O:688.00*Q:TODO*R:0')
+
+    def test_pt_qr_code_different_currency(self):
+        """Ensures that any foreign currency is correctly converted to EUR"""
+        self.env['res.currency.rate'].create({
+            'name': '2022-01-01',
+            'rate': 1.25,
+            'currency_id': self.env.ref('base.USD').id,
+            'company_id': self.company_data['company'].id,
+        })
+        self.maxDiff = None
+
+        move_form = Form(self.invoice)
+        move_form.date = '2022-01-01'
+        move_form.currency_id = self.env.ref('base.USD')
+        move_form.save()
+
+        self.invoice.preview_invoice()
+        self.assertEqual(self.invoice.l10n_pt_qr_code_str,
+                         'A:123456789*B:999999990*C:BE*D:FT*E:N*F:20220101*G:out_invoice INV/2022/00001*H:0'
+                         '*I1:PT*I2:80.00*I3:80.00*I4:4.80*I5:80.00*I6:10.40*I7:240.00*I8:55.20'
+                         '*N:70.40*O:550.40*Q:TODO*R:0')
+
+    def test_pt_qr_code_credit_note(self):
+        """Test different types of moves, e.g. a credit note"""
+        self.invoice.action_post()
+        move_reversal = self.env['account.move.reversal'].with_context(active_model='account.move', active_ids=self.invoice.ids).create({
+            'date': fields.Date.from_string('2022-01-01'),
+            'reason': 'no reason',
+            'refund_method': 'refund',
+            'journal_id': self.invoice.journal_id.id,
+        })
+        reversal = move_reversal.reverse_moves()
+        credit_note = self.env['account.move'].browse(reversal['res_id'])
+        credit_note['name'] = 'RINV/2022/00001'
+        credit_note.preview_invoice()
+        self.assertEqual(credit_note.l10n_pt_qr_code_str,
+                         'A:123456789*B:999999990*C:BE*D:NC*E:N*F:20220101*G:out_refund RINV/2022/00001*H:0'
+                         '*I1:PT*I2:100.00*I3:100.00*I4:6.00*I5:100.00*I6:13.00*I7:300.00*I8:69.00'
+                         '*N:88.00*O:688.00*Q:TODO*R:0')

--- a/addons/l10n_pt/tests/test_pt_qr_code.py
+++ b/addons/l10n_pt/tests/test_pt_qr_code.py
@@ -5,7 +5,7 @@ from odoo import fields
 from odoo.tests import tagged, Form
 
 
-@tagged('post_install', '-at_install')
+@tagged('post_install', 'post_install_l10n', '-at_install')
 class PortugalQRCodeTest(AccountTestInvoicingCommon):
 
     @classmethod

--- a/addons/l10n_pt/views/report_invoice.xml
+++ b/addons/l10n_pt/views/report_invoice.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <template id="report_invoice" inherit_id="account.report_invoice_document">
+        <xpath expr="//h2[@id='title']" position="after">
+            <img t-if="o.l10n_pt_qr_code_str"
+                 style="display:block;margin:0.25cm;"
+                 t-att-src="'/report/barcode/?barcode_type=%s&amp;value=%s&amp;width=%s&amp;height=%s'%('QR', o.l10n_pt_qr_code_str, 150, 150)"/>
+        </xpath>
+    </template>
+</odoo>


### PR DESCRIPTION
Starting 1 January 2022, invoices should contain a QR code which holds multiple information about the invoice (such as the document id, the document date, taxes, ...) following a specific format.

Official specifications https://info.portaldasfinancas.gov.pt/pt/docs/Conteudos_1pagina/Documents/QR_Code_Technical_Specifications.pdf

This PR implements this QR code and adds it to the invoices

task-2700432