### PR TITLE
[FIX] web_editor: ensure powerbox gets selection from owner document

### DIFF
--- a/addons/web_editor/static/src/js/wysiwyg/wysiwyg.js
+++ b/addons/web_editor/static/src/js/wysiwyg/wysiwyg.js
@@ -109,7 +109,7 @@ const Wysiwyg = Widget.extend({
             getYoutubeVideoElement: getYoutubeVideoElement,
             getContextFromParentRect: options.getContextFromParentRect,
             getPowerboxElement: () => {
-                const selection = document.getSelection();
+                const selection = (this.options.document || document).getSelection();
                 if (selection.isCollapsed && selection.rangeCount) {
                     const node = closestElement(selection.anchorNode, 'P, DIV');
                     return !(node && node.hasAttribute && node.hasAttribute('data-oe-model')) && node;


### PR DESCRIPTION
When checking if the powerbox should open, we check the selection but that was done on the global document, which returns a wrong selection for the editable if it's in an iframe. As a result, the powerbox never opened in mass_mailing.

task-2778414

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
