### PR TITLE
[FIX] core: python 3.10 support of collections

### DIFF
--- a/odoo/models.py
+++ b/odoo/models.py
@@ -6309,9 +6309,9 @@ Fields:
 
         return result
 
-collections.Set.register(BaseModel)
+collections.abc.Set.register(BaseModel)
 # not exactly true as BaseModel doesn't have __reversed__, index or count
-collections.Sequence.register(BaseModel)
+collections.abc.Sequence.register(BaseModel)
 
 class RecordCache(MutableMapping):
     """ A mapping from field names to values, to read and update the cache of a record. """

--- a/odoo/tests/common.py
+++ b/odoo/tests/common.py
@@ -2295,7 +2295,7 @@ class O2MProxy(X2MProxy):
         del self._records[index]
         self._parent._perform_onchange([self._field])
 
-class M2MProxy(X2MProxy, collections.Sequence):
+class M2MProxy(X2MProxy, collections.abc.Sequence):
     """ M2MProxy()
 
     Behaves as a :class:`~collection.Sequence` of recordsets, can be


### PR DESCRIPTION
collections.Set was deprecated since 3.6 and removed at 3.10
https://github.com/python/cpython/blob/3.9/Lib/collections/__init__.py#L62-L65

