### PR TITLE
[FIX] l10n_in_purchase: traceback on bill auto-complete

### DIFF
--- a/addons/l10n_in_purchase/models/account_move.py
+++ b/addons/l10n_in_purchase/models/account_move.py
@@ -10,7 +10,7 @@ class AccountMove(models.Model):
     @api.onchange('purchase_vendor_bill_id', 'purchase_id')
     def _onchange_purchase_auto_complete(self):
         purchase_order_id = self.purchase_vendor_bill_id.purchase_order_id or self.purchase_id
-        if purchase_order_id and self.l10n_in_company_country_code == 'IN':
+        if purchase_order_id and purchase_order_id.l10n_in_company_country_code == 'IN':
             journal_id = self.purchase_vendor_bill_id.purchase_order_id.l10n_in_journal_id or self.purchase_id.l10n_in_journal_id
             if journal_id:
                 self.journal_id = journal_id


### PR DESCRIPTION
1. Create a PO from Indian vendor [DEMO], confirm it, receive the products.
2. Go to Accounting app, manually create the vendor bill:
  - select the Vendor [DEMO]
  - in auto-complete field select the one created at 1.

Traceback will raise because the field l10n_in_company_country_code
was removed from account.move in
17610e8ca97b2e5315cc063ee3973f81ab910f5e

opw-2745052

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
