### PR TITLE
[FIX] stock: apply missing rename

### DIFF
--- a/addons/stock/report/report_stock_reception.py
+++ b/addons/stock/report/report_stock_reception.py
@@ -310,7 +310,7 @@ class ReceptionReport(models.AbstractModel):
                             break
                         else:
                             move_line_id.move_id = out
-                            reserved_amount_to_remain -= move_line_id.product_qty
+                            reserved_amount_to_remain -= move_line_id.reserved_qty
                     (out | new_out)._compute_reserved_availability()
                 out.move_orig_ids = False
                 new_out._recompute_state()


### PR DESCRIPTION
Previous refactoring: odoo/odoo@3b06565 switched move_line.product_qty
to move_line.reserved_qty. This line was missed during the refactoring
so we fix it now.

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
