### PR TITLE
[FIX] mail: add check valid email address

### DIFF
--- a/addons/mail/i18n/mail.pot
+++ b/addons/mail/i18n/mail.pot
@@ -42,6 +42,14 @@ msgid "%(activity_name)s: %(summary)s assigned to you"
 msgstr ""
 
 #. module: mail
+#: code:addons/mail/models/res_partner.py:0
+#, python-format
+msgid ""
+"%(email)s is not recognized as a valid email. This is required to create a "
+"new customer."
+msgstr ""
+
+#. module: mail
 #: code:addons/mail/wizard/mail_wizard_invite.py:0
 #, python-format
 msgid "%(user_name)s invited you to follow %(document)s document: %(title)s"

--- a/addons/mail/models/res_partner.py
+++ b/addons/mail/models/res_partner.py
@@ -83,6 +83,8 @@ class Partner(models.Model):
             raise ValueError(_('An email is required for find_or_create to work'))
 
         parsed_name, parsed_email = self._parse_partner_name(email)
+        if not parsed_email and assert_valid_email:
+            raise ValueError(_('%(email)s is not recognized as a valid email. This is required to create a new customer.'))
         if parsed_email:
             email_normalized = tools.email_normalize(parsed_email)
             if email_normalized:

--- a/addons/mail/tests/test_res_partner.py
+++ b/addons/mail/tests/test_res_partner.py
@@ -95,6 +95,9 @@ class TestPartner(MailCommon):
             check_partner=new6, should_create=True
         )
 
+        with self.assertRaises(ValueError):
+            self.env['res.partner'].find_or_create("Raoul chirurgiens-dentistes.fr", assert_valid_email=True)
+
     def test_res_partner_log_portal_group(self):
         Users = self.env['res.users']
         subtype_note = self.env.ref('mail.mt_note')


### PR DESCRIPTION
Purpose
=======
The method find_or_create of res.partner overwritten in mail does not
take into account the parameter assert_valid_email. This commit adds a
simple check and test.
