### PR TITLE
[FIX] hr_holidays: HR leave only approvable by time off officer

### DIFF
--- a/addons/hr_holidays/i18n/hr_holidays.pot
+++ b/addons/hr_holidays/i18n/hr_holidays.pot
@@ -3207,6 +3207,12 @@ msgid ""
 msgstr ""
 
 #. module: hr_holidays
+#: code:addons/hr_holidays/models/hr_leave_allocation.py:0
+msgid ""
+"You must either be a Time off Officer or Time off Manager to approve this leave"
+""
+
+#. module: hr_holidays
 #: code:addons/hr_holidays/models/hr_leave.py:0
 #, python-format
 msgid ""

--- a/addons/hr_holidays/models/hr_leave.py
+++ b/addons/hr_holidays/models/hr_leave.py
@@ -1152,6 +1152,9 @@ class HolidaysRequest(models.Model):
                         if not is_officer and self.env.user != holiday.employee_id.leave_manager_id:
                             raise UserError(_('You must be either %s\'s manager or Time off Manager to approve this leave') % (holiday.employee_id.name))
 
+                    if not is_officer and (state == 'validate' and val_type == 'hr') and holiday.holiday_type == 'employee':
+                        raise UserError(_('You must either be a Time off Officer or Time off Manager to approve this leave'))
+
     # ------------------------------------------------------------
     # Activity methods
     # ------------------------------------------------------------


### PR DESCRIPTION
Step to reproduce:
- Create a time off type T with approval 'time off officer'
- As user U create a time off request of type T
- Login as the manager of U (which should not be a time off
 officer)
- Approve the time off of U

Current Behaviour:
- Time off is approved

Behaviour after PR:
- Time off is not approved and an error is raised

opw-2753845

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
