### PR TITLE
[FIX] web_editor: prevent editor powerbox hint duplication

### DIFF
--- a/addons/web_editor/static/lib/odoo-editor/src/OdooEditor.js
+++ b/addons/web_editor/static/lib/odoo-editor/src/OdooEditor.js
@@ -1496,6 +1496,7 @@ export class OdooEditor extends EventTarget {
         const result = this._protect(() => this._applyRawCommand(...args));
         this.sanitize();
         this.historyStep();
+        this._handleCommandHint();
         return result;
     }
     /**
@@ -2368,6 +2369,9 @@ export class OdooEditor extends EventTarget {
         this.observerUnactive();
         for (const hint of this.editable.querySelectorAll('.oe-hint')) {
             hint.classList.remove('oe-hint', 'oe-command-temporary-hint');
+            if (hint.classList.length === 0) {
+                hint.removeAttribute('class');
+            }
             hint.removeAttribute('placeholder');
         }
         this.cleanForSave();
@@ -2450,6 +2454,9 @@ export class OdooEditor extends EventTarget {
             if (hint.classList.contains('oe-command-temporary-hint') || !isEmptyBlock(hint)) {
                 this.observerUnactive();
                 hint.classList.remove('oe-hint', 'oe-command-temporary-hint');
+                if (hint.classList.length === 0) {
+                    hint.removeAttribute('class');
+                }
                 hint.removeAttribute('placeholder');
                 this.observerActive();
             }


### PR DESCRIPTION
Whenever the browser is lagging between multiple enter,
the command hints were not being updated until the browser
main thread process the event queue.

Task-2728794




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
