### PR TITLE
[FIX] web_editor: implement unlink without relying on execCommand

### DIFF
--- a/addons/web_editor/static/lib/odoo-editor/src/commands/commands.js
+++ b/addons/web_editor/static/lib/odoo-editor/src/commands/commands.js
@@ -41,6 +41,8 @@ import {
     getDeepestPosition,
     fillEmpty,
     isEmptyBlock,
+    unwrapContents,
+    getCursorDirection,
 } from '../utils/utils.js';
 
 const TEXT_CLASSES_REGEX = /\btext-[^\s]*\b/g;
@@ -453,25 +455,37 @@ export const editorCommands = {
     },
     unlink: editor => {
         const sel = editor.document.getSelection();
-        // we need to remove the contentEditable isolation of links
-        // before we apply the unlink, otherwise the command is not performed
-        // because the content editable root is the link
-        const closestEl = closestElement(sel.focusNode, 'a');
-        if(closestEl) {
-            closestEl.removeAttribute('class'); // To prevent firefox from adding unnecessary <span>.
+        const isCollapsed = sel.isCollapsed;
+        // If the selection is collapsed, unlink the whole link:
+        // `<a>a[]b</a>` => `a[]b`.
+        getDeepRange(editor.editable, { sel, splitText: true, select: true });
+        if (!isCollapsed) {
+            // If not, unlink only the part(s) of the link(s) that are selected:
+            // `<a>a[b</a>c<a>d</a>e<a>f]g</a>` => `<a>a</a>[bcdef]<a>g</a>`.
+            let { anchorNode, focusNode, anchorOffset, focusOffset } = sel;
+            const direction = getCursorDirection(anchorNode, anchorOffset, focusNode, focusOffset);
+            // Split the links around the selection.
+            const [startLink, endLink] = [closestElement(anchorNode, 'a'), closestElement(focusNode, 'a')];
+            if (startLink) {
+                anchorNode = splitAroundUntil(anchorNode, startLink);
+                anchorOffset = direction === DIRECTIONS.RIGHT ? 0 : nodeSize(anchorNode);
+                setSelection(anchorNode, anchorOffset, focusNode, focusOffset, true);
+            }
+            // Only split the end link if it was not already done above.
+            if (endLink && endLink.isConnected) {
+                focusNode = splitAroundUntil(focusNode, endLink);
+                focusOffset = direction === DIRECTIONS.RIGHT ? nodeSize(focusNode) : 0;
+                setSelection(anchorNode, anchorOffset, focusNode, focusOffset, true);
+            }
         }
-        if (closestEl && closestEl.getAttribute('contenteditable') === 'true') {
-            editor._activateContenteditable();
-        }
-        if (sel.isCollapsed) {
+        const targetedNodes = isCollapsed ? [sel.anchorNode] : getSelectedNodes(editor.editable);
+        const links = new Set(targetedNodes.map(node => closestElement(node, 'a')).filter(a => a));
+        if (links.size) {
             const cr = preserveCursor(editor.document);
-            const node = closestElement(sel.focusNode, 'a');
-            setSelection(node, 0, node, node.childNodes.length, false);
-            editor.document.execCommand('unlink');
+            for (const link of links) {
+                unwrapContents(link);
+            }
             cr();
-        } else {
-            editor.document.execCommand('unlink');
-            setSelection(sel.anchorNode, sel.anchorOffset, sel.focusNode, sel.focusOffset);
         }
     },
 

--- a/addons/web_editor/static/lib/odoo-editor/test/spec/link.test.js
+++ b/addons/web_editor/static/lib/odoo-editor/test/spec/link.test.js
@@ -302,6 +302,30 @@ describe('Link', () => {
                     },
                     contentAfter: '<p>abcd[]e</p>',
                 });
+                // With fontawesome at the start of the link.
+                await testEditor(BasicEditor, {
+                    contentBefore: '<p>a<a href="exist"><span class="fa fa-music" contenteditable="false">\u200B</span>bcd[]</a>e</p>',
+                    stepFunction: async editor => {
+                        await unlink(editor);
+                    },
+                    contentAfter: '<p>a<span class="fa fa-music" contenteditable="false"></span>bcd[]e</p>',
+                });
+                // With fontawesome at the middle of the link.
+                await testEditor(BasicEditor, {
+                    contentBefore: '<p>a<a href="exist">bc<span class="fa fa-music" contenteditable="false">\u200B</span>d[]</a>e</p>',
+                    stepFunction: async editor => {
+                        await unlink(editor);
+                    },
+                    contentAfter: '<p>abc<span class="fa fa-music" contenteditable="false"></span>d[]e</p>',
+                });
+                // With fontawesome at the end of the link.
+                await testEditor(BasicEditor, {
+                    contentBefore: '<p>a<a href="exist">bcd[]<span class="fa fa-music" contenteditable="false">\u200B</span></a>e</p>',
+                    stepFunction: async editor => {
+                        await unlink(editor);
+                    },
+                    contentAfter: '<p>abcd[]<span class="fa fa-music" contenteditable="false"></span>e</p>',
+                });
             });
             it('should remove the link if collapsed range in the middle a link', async () => {
                 await testEditor(BasicEditor, {
@@ -311,6 +335,30 @@ describe('Link', () => {
                     },
                     contentAfter: '<p>ab[]cde</p>',
                 });
+                // With fontawesome at the start of the link.
+                await testEditor(BasicEditor, {
+                    contentBefore: '<p>a<a href="exist"><span class="fa fa-music" contenteditable="false">\u200B</span>b[]cd</a>e</p>',
+                    stepFunction: async editor => {
+                        await unlink(editor);
+                    },
+                    contentAfter: '<p>a<span class="fa fa-music" contenteditable="false"></span>b[]cde</p>',
+                });
+                // With fontawesome at the middle of the link.
+                await testEditor(BasicEditor, {
+                    contentBefore: '<p>a<a href="exist">b[]c<span class="fa fa-music" contenteditable="false">\u200B</span>d</a>e</p>',
+                    stepFunction: async editor => {
+                        await unlink(editor);
+                    },
+                    contentAfter: '<p>ab[]c<span class="fa fa-music" contenteditable="false"></span>de</p>',
+                });
+                // With fontawesome at the end of the link.
+                await testEditor(BasicEditor, {
+                    contentBefore: '<p>a<a href="exist">b[]cd<span class="fa fa-music" contenteditable="false">\u200B</span></a>e</p>',
+                    stepFunction: async editor => {
+                        await unlink(editor);
+                    },
+                    contentAfter: '<p>ab[]cd<span class="fa fa-music" contenteditable="false"></span>e</p>',
+                });
             });
             it('should remove the link if collapsed range at the start of a link', async () => {
                 await testEditor(BasicEditor, {
@@ -319,6 +367,30 @@ describe('Link', () => {
                         await unlink(editor);
                     },
                     contentAfter: '<p>a[]bcde</p>',
+                });
+                // With fontawesome at the start of the link.
+                await testEditor(BasicEditor, {
+                    contentBefore: '<p>a<a href="exist"><span class="fa fa-music" contenteditable="false">\u200B</span>[]bcd</a>e</p>',
+                    stepFunction: async editor => {
+                        await unlink(editor);
+                    },
+                    contentAfter: '<p>a<span class="fa fa-music" contenteditable="false"></span>[]bcde</p>',
+                });
+                // With fontawesome at the middle of the link.
+                await testEditor(BasicEditor, {
+                    contentBefore: '<p>a<a href="exist">[]bc<span class="fa fa-music" contenteditable="false">\u200B</span>d</a>e</p>',
+                    stepFunction: async editor => {
+                        await unlink(editor);
+                    },
+                    contentAfter: '<p>a[]bc<span class="fa fa-music" contenteditable="false"></span>de</p>',
+                });
+                // With fontawesome at the end of the link.
+                await testEditor(BasicEditor, {
+                    contentBefore: '<p>a<a href="exist">[]bcd<span class="fa fa-music" contenteditable="false">\u200B</span></a>e</p>',
+                    stepFunction: async editor => {
+                        await unlink(editor);
+                    },
+                    contentAfter: '<p>a[]bcd<span class="fa fa-music" contenteditable="false"></span>e</p>',
                 });
             });
             it('should remove only the current link if collapsed range in the middle of a link', async () => {
@@ -330,10 +402,38 @@ describe('Link', () => {
                     },
                     contentAfter: '<p><a href="exist">a</a>bc[]de<a href="exist">f</a></p>',
                 });
+                // With fontawesome at the start of the link.
+                await testEditor(BasicEditor, {
+                    contentBefore:
+                        '<p><a href="exist">a</a>b<a href="exist"><span class="fa fa-music" contenteditable="false">\u200B</span>c[]d</a>e<a href="exist">f</a></p>',
+                    stepFunction: async editor => {
+                        await unlink(editor);
+                    },
+                    contentAfter: '<p><a href="exist">a</a>b<span class="fa fa-music" contenteditable="false"></span>c[]de<a href="exist">f</a></p>',
+                });
+                // With fontawesome at the middle of the link.
+                await testEditor(BasicEditor, {
+                    contentBefore:
+                        '<p><a href="exist">a</a>b<a href="exist">c<span class="fa fa-music" contenteditable="false">\u200B</span>d[]e</a>f<a href="exist">g</a></p>',
+                    stepFunction: async editor => {
+                        await unlink(editor);
+                    },
+                    contentAfter: '<p><a href="exist">a</a>bc<span class="fa fa-music" contenteditable="false"></span>d[]ef<a href="exist">g</a></p>',
+                });
+                // With fontawesome at the end of the link.
+                await testEditor(BasicEditor, {
+                    contentBefore:
+                        '<p><a href="exist">a</a>b<a href="exist">c[]d<span class="fa fa-music" contenteditable="false">\u200B</span></a>e<a href="exist">f</a></p>',
+                    stepFunction: async editor => {
+                        await unlink(editor);
+                    },
+                    contentAfter: '<p><a href="exist">a</a>bc[]d<span class="fa fa-music" contenteditable="false"></span>e<a href="exist">f</a></p>',
+                });
             });
         });
         describe('range not collapsed', () => {
             it('should remove the link in the selected range at the end of a link', async () => {
+                // FORWARD
                 await testEditor(BasicEditor, {
                     contentBefore: '<p>a<a href="exist">bc[d]</a>e</p>',
                     stepFunction: async editor => {
@@ -341,8 +441,17 @@ describe('Link', () => {
                     },
                     contentAfter: '<p>a<a href="exist">bc[</a>d]e</p>',
                 });
+                // BACKWARD
+                await testEditor(BasicEditor, {
+                    contentBefore: '<p>a<a href="exist">bc]d[</a>e</p>',
+                    stepFunction: async editor => {
+                        await unlink(editor);
+                    },
+                    contentAfter: '<p>a<a href="exist">bc]</a>d[e</p>',
+                });
             });
             it('should remove the link in the selected range in the middle of a link', async () => {
+                // FORWARD
                 await testEditor(BasicEditor, {
                     contentBefore: '<p>a<a href="exist">b[c]d</a>e</p>',
                     stepFunction: async editor => {
@@ -350,8 +459,17 @@ describe('Link', () => {
                     },
                     contentAfter: '<p>a<a href="exist">b[</a>c]<a href="exist">d</a>e</p>',
                 });
+                // BACKWARD
+                await testEditor(BasicEditor, {
+                    contentBefore: '<p>a<a href="exist">b]c[d</a>e</p>',
+                    stepFunction: async editor => {
+                        await unlink(editor);
+                    },
+                    contentAfter: '<p>a<a href="exist">b]</a>c[<a href="exist">d</a>e</p>',
+                });
             });
             it('should remove the link in the selected range at the start of a link', async () => {
+                // FORWARD
                 await testEditor(BasicEditor, {
                     contentBefore: '<p>a<a href="exist">[b]cd</a>e</p>',
                     stepFunction: async editor => {
@@ -359,8 +477,17 @@ describe('Link', () => {
                     },
                     contentAfter: '<p>a[b]<a href="exist">cd</a>e</p>',
                 });
+                // BACKWARD
+                await testEditor(BasicEditor, {
+                    contentBefore: '<p>a<a href="exist">]b[cd</a>e</p>',
+                    stepFunction: async editor => {
+                        await unlink(editor);
+                    },
+                    contentAfter: '<p>a]b[<a href="exist">cd</a>e</p>',
+                });
             });
             it('should remove the link in the selected range overlapping the end of a link', async () => {
+                // FORWARD
                 await testEditor(BasicEditor, {
                     contentBefore: '<p>a<a href="exist">bc[d</a>e]f</p>',
                     stepFunction: async editor => {
@@ -368,14 +495,31 @@ describe('Link', () => {
                     },
                     contentAfter: '<p>a<a href="exist">bc[</a>de]f</p>',
                 });
+                // BACKWARD
+                await testEditor(BasicEditor, {
+                    contentBefore: '<p>a<a href="exist">bc]d</a>e[f</p>',
+                    stepFunction: async editor => {
+                        await unlink(editor);
+                    },
+                    contentAfter: '<p>a<a href="exist">bc]</a>de[f</p>',
+                });
             });
             it('should remove the link in the selected range overlapping the start of a link', async () => {
+                // FORWARD
                 await testEditor(BasicEditor, {
                     contentBefore: '<p>a[b<a href="exist">c]de</a>f</p>',
                     stepFunction: async editor => {
                         await unlink(editor);
                     },
                     contentAfter: '<p>a[bc]<a href="exist">de</a>f</p>',
+                });
+                // BACKWARD
+                await testEditor(BasicEditor, {
+                    contentBefore: '<p>a]b<a href="exist">c[de</a>f</p>',
+                    stepFunction: async editor => {
+                        await unlink(editor);
+                    },
+                    contentAfter: '<p>a]bc[<a href="exist">de</a>f</p>',
                 });
             });
         });

--- a/addons/web_editor/static/src/js/wysiwyg/widgets/link_popover_widget.js
+++ b/addons/web_editor/static/src/js/wysiwyg/widgets/link_popover_widget.js
@@ -48,6 +48,7 @@ const LinkPopoverWidget = Widget.extend({
                 type: 'success',
                 message: _t("Link copied to clipboard."),
             });
+            this.popover.hide();
         });
 
         // init tooltips & popovers
@@ -118,9 +119,11 @@ const LinkPopoverWidget = Widget.extend({
                     !(
                         hierarchy.includes(this.$target[0]) ||
                         (hierarchy.includes(this.$el[0]) &&
-                            !hierarchy.some(x => x.tagName && x.tagName === 'A'))
+                            !hierarchy.some(x => x.tagName && x.tagName === 'A' && (x === this.$urlLink[0] || x === this.$fullUrl[0])))
                     )
                 ) {
+                    // Note: For buttons of the popover, their listeners should
+                    // handle the hide themselves to avoid race conditions.
                     this.popover.hide();
                 }
             }
@@ -256,6 +259,7 @@ const LinkPopoverWidget = Widget.extend({
             link: this.$target[0],
         });
         ev.stopImmediatePropagation();
+        this.popover.hide();
     },
     /**
      * Removes the link/anchor.
@@ -267,6 +271,7 @@ const LinkPopoverWidget = Widget.extend({
         ev.preventDefault();
         this.options.wysiwyg.removeLink();
         ev.stopImmediatePropagation();
+        this.popover.hide();
     },
 });
 


### PR DESCRIPTION
Before this commit when a button containing a text then an icon was unlinked in Chrome, all further buttons were also unlinked (see steps below).

It turns out this bug is due to the browser's `execCommand` implementation so this commit reimplements the feature without relying on it.

Steps to reproduce (in website module):

* drop Text+Image snippet twice
* inside first button type /image and insert a pictogram after the text
* click on the text of the first button => the link popover appears
* click on the unlink button of the popover
=> both buttons become flat texts in Chrome
=> nothing happens visually in Firefox, but the <a> actually gets
turned into a `<span>`

task-2778912