### PR TITLE
[FIX] website: nonexisting record id in URL =>404

### DIFF
--- a/addons/http_routing/models/ir_http.py
+++ b/addons/http_routing/models/ir_http.py
@@ -637,7 +637,8 @@ class IrHttp(models.AbstractModel):
         # minimal setup to serve frontend pages
         if not request.uid:
             cls._auth_method_public()
-        request.registry['ir.http']._frontend_pre_dispatch()
+        cls._handle_debug()
+        cls._frontend_pre_dispatch()
         request.params = request.get_http_params()
 
         code, values = cls._get_exception_code_values(exception)
@@ -650,7 +651,9 @@ class IrHttp(models.AbstractModel):
         except Exception:
             code, html = 418, request.env['ir.ui.view']._render_template('http_routing.http_error', values)
 
-        return werkzeug.wrappers.Response(html, status=code, content_type='text/html;charset=utf-8')
+        response = werkzeug.wrappers.Response(html, status=code, content_type='text/html;charset=utf-8')
+        cls._post_dispatch(response)
+        return response
 
     @api.model
     @tools.ormcache('path', 'query_args')

--- a/addons/test_website/tests/test_controller_args.py
+++ b/addons/test_website/tests/test_controller_args.py
@@ -31,3 +31,7 @@ class TestWebsiteControllerArgs(odoo.tests.HttpCase):
         req = self.url_open('/ignore_args/kw?a=valueA&b=valueB')
         self.assertEqual(req.status_code, 200)
         self.assertEqual(req.json(), {'a': 'valueA', 'kw': {'b': 'valueB'}})
+
+        req = self.url_open('/test_website/country/whatever-999999')
+        self.assertEqual(req.status_code, 404,
+                         "Model converter record does not exist, return a 404.")

--- a/addons/web/models/ir_http.py
+++ b/addons/web/models/ir_http.py
@@ -45,16 +45,20 @@ class Http(models.AbstractModel):
         return any(bot in user_agent for bot in cls.bots)
 
     @classmethod
-    def _pre_dispatch(cls, rule, args):
-        super()._pre_dispatch(rule, args)
+    def _handle_debug(cls):
         debug = request.httprequest.args.get('debug')
         if debug is not None:
             request.session.debug = ','.join(
                      mode if mode in ALLOWED_DEBUG_MODES
                 else '1' if str2bool(mode, mode)
                 else ''
-                for mode in (debug or '1').split(',')
+                for mode in (debug or '').split(',')
             )
+
+    @classmethod
+    def _pre_dispatch(cls, rule, args):
+        super()._pre_dispatch(rule, args)
+        cls._handle_debug()
 
     def webclient_rendering_context(self):
         return {

--- a/addons/website/models/ir_http.py
+++ b/addons/website/models/ir_http.py
@@ -326,12 +326,14 @@ class Http(models.AbstractModel):
         if not request.uid:
             cls._auth_method_public()
         cls._frontend_pre_dispatch()
+        cls._handle_debug()
         request.params = request.get_http_params()
 
         website_page = cls._serve_page()
         if website_page:
             website_page.flatten()
             cls._register_website_track(website_page)
+            cls._post_dispatch(website_page)
             return website_page
 
         redirect = cls._serve_redirect()

--- a/addons/website/models/website.py
+++ b/addons/website/models/website.py
@@ -20,7 +20,7 @@ from odoo.addons.website.models.ir_http import sitemap_qs2dom
 from odoo.addons.website.tools import similarity_score, text_from_html
 from odoo.addons.portal.controllers.portal import pager
 from odoo.addons.iap.tools import iap_tools
-from odoo.exceptions import UserError, AccessError
+from odoo.exceptions import UserError, AccessError, MissingError
 from odoo.http import request
 from odoo.modules.module import get_resource_path, get_manifest
 from odoo.osv.expression import AND, OR, FALSE_DOMAIN, get_unaccent_wrapper
@@ -1310,7 +1310,7 @@ class Website(models.Model):
 
             router = http.root.get_db_router(request.db).bind('')
             path = router.build(rule.endpoint, args)
-        except (NotFound, AccessError):
+        except (NotFound, AccessError, MissingError):
             # The build method returns a quoted URL so convert in this case for consistency.
             path = urls.url_quote_plus(request.httprequest.path, safe='/')
         lang_path = f'/{lang.url_code}' if lang != self.default_lang_id else ''

--- a/addons/website/tests/test_page.py
+++ b/addons/website/tests/test_page.py
@@ -1,5 +1,7 @@
 # coding: utf-8
+from odoo.addons.website.tools import MockRequest
 from odoo.tests import common, HttpCase, tagged
+from odoo.tools import mute_logger
 
 
 @tagged('-at_install', 'post_install')
@@ -202,7 +204,7 @@ class WithContext(HttpCase):
         super().setUp()
         Page = self.env['website.page']
         View = self.env['ir.ui.view']
-        base_view = View.create({
+        self.base_view = View.create({
             'name': 'Base',
             'type': 'qweb',
             'arch': '''<t name="Homepage" t-name="website.base_view">
@@ -213,7 +215,7 @@ class WithContext(HttpCase):
             'key': 'test.base_view',
         })
         self.page = Page.create({
-            'view_id': base_view.id,
+            'view_id': self.base_view.id,
             'url': '/page_1',
             'is_published': True,
         })
@@ -250,3 +252,14 @@ class WithContext(HttpCase):
             '/page_1',
             [p['loc'] for p in pages],
         )
+
+    @mute_logger('odoo.addons.http_routing.models.ir_http')
+    def test_03_error_page_debug(self):
+        with MockRequest(self.env, website=self.env['website'].browse(1)):
+            self.base_view.arch = self.base_view.arch.replace('I am a generic page', '<t t-esc="15/0"/>')
+            r = self.url_open(self.page.url)
+            self.assertEqual(r.status_code, 500, "15/0 raise a 500 error page")
+            self.assertNotIn('ZeroDivisionError: division by zero', r.text, "Error should not be shown when not in debug.")
+            r = self.url_open(self.page.url + '?debug=1')
+            self.assertEqual(r.status_code, 500, "15/0 raise a 500 error page (2)")
+            self.assertIn('ZeroDivisionError: division by zero', r.text, "Error should be shown in debug.")

--- a/addons/website/tests/test_page.py
+++ b/addons/website/tests/test_page.py
@@ -253,13 +253,23 @@ class WithContext(HttpCase):
             [p['loc'] for p in pages],
         )
 
-    @mute_logger('odoo.addons.http_routing.models.ir_http')
+    @mute_logger('odoo.http')
     def test_03_error_page_debug(self):
         with MockRequest(self.env, website=self.env['website'].browse(1)):
             self.base_view.arch = self.base_view.arch.replace('I am a generic page', '<t t-esc="15/0"/>')
+
+            # first call, no debug, traceback should not be visible
             r = self.url_open(self.page.url)
             self.assertEqual(r.status_code, 500, "15/0 raise a 500 error page")
             self.assertNotIn('ZeroDivisionError: division by zero', r.text, "Error should not be shown when not in debug.")
+
+            # second call, enable debug, traceback should be visible
             r = self.url_open(self.page.url + '?debug=1')
+            self.assertEqual(r.status_code, 500, "15/0 raise a 500 error page (2)")
+            self.assertIn('ZeroDivisionError: division by zero', r.text, "Error should be shown in debug.")
+
+            # third call, no explicit debug but it should be enabled by
+            # the session, traceback should be visible
+            r = self.url_open(self.page.url)
             self.assertEqual(r.status_code, 500, "15/0 raise a 500 error page (2)")
             self.assertIn('ZeroDivisionError: division by zero', r.text, "Error should be shown in debug.")

--- a/odoo/addons/test_http/tests/test_http.py
+++ b/odoo/addons/test_http/tests/test_http.py
@@ -392,6 +392,19 @@ class TestHttpMisc(TestHttpBase):
             self.assertEqual(res.json()['REMOTE_ADDR'], client_ip)
             self.assertEqual(res.json()['HTTP_HOST'], host)
 
+    @mute_logger('odoo.http')  # greeting_none called ignoring args {'debug'}
+    def test_misc3_debug_mode(self):
+        session = self.authenticate(None, None)
+        self.assertEqual(session.debug, '')
+        self.db_url_open('/test_http/greeting').raise_for_status()
+        self.assertEqual(session.debug, '')
+        self.db_url_open('/test_http/greeting?debug=1').raise_for_status()
+        self.assertEqual(session.debug, '1')
+        self.db_url_open('/test_http/greeting').raise_for_status()
+        self.assertEqual(session.debug, '1')
+        self.db_url_open('/test_http/greeting?debug=').raise_for_status()
+        self.assertEqual(session.debug, '')
+
 
 @tagged('post_install', '-at_install')
 class TestHttpCors(TestHttpBase):


### PR DESCRIPTION
Install the website_sale and open '/shop/whatever-9999' in your browser,
the response is a 500 Internal Error instead of a 404 Page not Found.

Because `request.endpoint` has been murdered by the httpocalypse, we
must re-match to get the endpoint later used to re-build the URL. When
an URL contains a record-id but that record does not exists, matching
the URL will raise a `odoo.exceptions.MissingError`.

There is a unittest arriving via #85318 