### PR TITLE
[FIX] web_editor: initialize editor's tooltips

### DIFF
--- a/addons/web_editor/static/src/js/editor/snippets.editor.js
+++ b/addons/web_editor/static/src/js/editor/snippets.editor.js
@@ -1169,7 +1169,7 @@ var SnippetsMenu = Widget.extend({
 
         // Add tooltips on we-title elements whose text overflows
         this.$el.tooltip({
-            selector: 'we-title',
+            selector: 'we-title, [title]',
             placement: 'bottom',
             delay: 100,
             title: function () {

--- a/addons/web_editor/static/src/js/editor/snippets.options.js
+++ b/addons/web_editor/static/src/js/editor/snippets.options.js
@@ -1654,6 +1654,7 @@ const DatetimePickerUserValueWidget = InputUserValueWidget.extend({
         libObject._getTemplate = function () {
             const $template = oldFunc.call(this, ...arguments);
             $template.addClass('o_we_no_overlay o_we_datetimepicker');
+            $template.find('[title]').tooltip();
             return $template;
         };
     },

--- a/addons/web_editor/static/src/js/wysiwyg/widgets/color_palette.js
+++ b/addons/web_editor/static/src/js/wysiwyg/widgets/color_palette.js
@@ -150,6 +150,7 @@ const ColorPaletteWidget = Widget.extend({
         if (this.options.excluded.includes('custom')) {
             this.colorPicker.$el.addClass('d-none');
         }
+        $('[title]').tooltip();
 
         return res;
     },

--- a/addons/website/static/src/js/tours/tour_utils.js
+++ b/addons/website/static/src/js/tours/tour_utils.js
@@ -106,8 +106,10 @@ function changeImage(snippet, position = "bottom") {
 */
 function changeOption(optionName, weName = '', optionTooltipLabel = '', position = "bottom") {
     const option_block = `we-customizeblock-option[class='snippet-option-${optionName}']`
+    // The trigger is data-original-title because the bootstrap tooltip have to
+    // be initialized.
     return {
-        trigger: `${option_block} ${weName}, ${option_block} [title='${weName}']`,
+        trigger: `${option_block} ${weName}, ${option_block} [data-original-title='${weName}']`,
         content: _.str.sprintf(_t("<b>Click</b> on this option to change the %s of the block."), optionTooltipLabel),
         position: position,
         run: "click",


### PR DESCRIPTION
The editor offers bootstrap tooltips, but these were not all initialized
and therefore appeared as standard HTML tooltips. This PR fixes that
by initializing all the tooltips so that they all have the same style. (bootstrap style).

task-2777738

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
