### PR TITLE
[FIX] orm: string pattern for Reference wasn't correct

### DIFF
--- a/odoo/fields.py
+++ b/odoo/fields.py
@@ -2312,7 +2312,7 @@ class Reference(Selection):
     """ Pseudo-relational field (no FK in database).
 
     The field value is stored as a :class:`string <str>` following the pattern
-    ``"res_model.res_id"`` in database.
+    ``"res_model,res_id"`` in database.
     """
     type = 'reference'
 


### PR DESCRIPTION
In reality the separator is a comma instead of a dot as can be seen
in the code a bit further below.
