### PR TITLE
[FIX] stock_picking_batch: Add multicompany rule for batch picking

### DIFF
--- a/addons/stock_picking_batch/__manifest__.py
+++ b/addons/stock_picking_batch/__manifest__.py
@@ -17,6 +17,7 @@ This module adds the batch transfer option in warehouse management
         'wizard/stock_picking_to_batch_views.xml',
         'report/stock_picking_batch_report_views.xml',
         'report/report_picking_batch.xml',
+        'security/stock_picking_batch_security.xml',
     ],
     'demo': [
         'data/stock_picking_batch_demo.xml',

--- a/addons/stock_picking_batch/security/stock_picking_batch_security.xml
+++ b/addons/stock_picking_batch/security/stock_picking_batch_security.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+<data noupdate="0">
+    <record model="ir.rule" id="stock_picking_batch_multicompany_rule">
+        <field name="name">stock.picking.batch multi-company</field>
+        <field name="model_id" ref="model_stock_picking_batch"/>
+        <field name="domain_force">[('company_id', 'in', company_ids)]</field>
+    </record>
+</data>
+</odoo>


### PR DESCRIPTION
Current behavior:
All batch transfers are shown in the tree view. But only the one for the allowed companies should be in the list

Steps to reproduce:
- Be in a multicompany environnement
- Activate batch picking
- Go in Inventory/Batch transfers

opw-2752617
--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
