### PR TITLE
[FIX] portal: remove hardcoded line-height rule for o_page_header class

### DIFF
--- a/addons/portal/static/src/scss/portal.scss
+++ b/addons/portal/static/src/scss/portal.scss
@@ -206,7 +206,6 @@ li > p {
     border-bottom-width: $border-width;
     border-bottom-style: solid;
     border-bottom-color: $border-color;
-    line-height: 2.1rem;
 }
 .o_page_header {
     @extend %o-page-header;


### PR DESCRIPTION
Steps to reproduce:

  - Install website_appointment module
  - Change website theme and select : Cobalt Theme
  - Go to website
  - In menu, click on Appointment
  - Select anyone, select any date and confirm appointment

Issue:

  Title text on each other.

Cause:

  The custom page_header class (in portal module) override the default
  line-height with 2.1 rem (instead of 1.1).
  In some themes, the headings tags font-size has been changed with
  3.875rem (instead of 2.5rem).
  => font-size is too big regarding the line-height

Solution:

  Remove line-height rule.

ref. commit: https://github.com/odoo/odoo/commit/86ab1c55b4229afb74f630b5041a8354c705f849

opw-2745485