### PR TITLE
[FIX] web_editor: initialize editor's tooltips

### DIFF
--- a/addons/web_editor/static/src/js/editor/snippets.editor.js
+++ b/addons/web_editor/static/src/js/editor/snippets.editor.js
@@ -1414,7 +1414,7 @@ var SnippetsMenu = Widget.extend({
 
         // Add tooltips on we-title elements whose text overflows
         this.$el.tooltip({
-            selector: 'we-title, [data-tooltip="true"]',
+            selector: 'we-title, [title]',
             placement: 'bottom',
             delay: 100,
             title: function () {

--- a/addons/web_editor/static/src/js/editor/snippets.options.js
+++ b/addons/web_editor/static/src/js/editor/snippets.options.js
@@ -1791,6 +1791,7 @@ const DatetimePickerUserValueWidget = InputUserValueWidget.extend({
         libObject._getTemplate = function () {
             const $template = oldFunc.call(this, ...arguments);
             $template.addClass('o_we_no_overlay o_we_datetimepicker');
+            $template.find('[title]').tooltip();
             return $template;
         };
     },

--- a/addons/web_editor/static/src/js/wysiwyg/widgets/color_palette.js
+++ b/addons/web_editor/static/src/js/wysiwyg/widgets/color_palette.js
@@ -300,7 +300,7 @@ const ColorPaletteWidget = Widget.extend({
             });
             await this.colorPicker.appendTo(this.sections['custom-colors']);
         }
-        //$('[title]').tooltip();
+        $('[title]').tooltip();
 
         return res;
     },

--- a/addons/web_editor/static/src/js/wysiwyg/widgets/color_palette.js
+++ b/addons/web_editor/static/src/js/wysiwyg/widgets/color_palette.js
@@ -300,6 +300,8 @@ const ColorPaletteWidget = Widget.extend({
             });
             await this.colorPicker.appendTo(this.sections['custom-colors']);
         }
+        $('[title]').tooltip();
+
         return res;
     },
     /**

--- a/addons/web_editor/static/src/js/wysiwyg/widgets/color_palette.js
+++ b/addons/web_editor/static/src/js/wysiwyg/widgets/color_palette.js
@@ -300,7 +300,7 @@ const ColorPaletteWidget = Widget.extend({
             });
             await this.colorPicker.appendTo(this.sections['custom-colors']);
         }
-        $('[title]').tooltip();
+        //$('[title]').tooltip();
 
         return res;
     },

--- a/addons/website/static/src/js/tours/tour_utils.js
+++ b/addons/website/static/src/js/tours/tour_utils.js
@@ -79,7 +79,7 @@ function changeOption(optionName, weName = '', optionTooltipLabel = '', position
     // The trigger is data-original-title because the bootstrap tooltip have to
     // be initialized.
     return {
-        trigger: `${option_block} ${weName}, ${option_block} [title='${weName}']`,
+        trigger: `${option_block} ${weName}, ${option_block} [data-original-title='${weName}, ${option_block} [title='${weName}']`,
         content: Markup(_.str.sprintf(_t("<b>Click</b> on this option to change the %s of the block."), optionTooltipLabel)),
         position: position,
         run: "click",

--- a/addons/website/static/src/js/tours/tour_utils.js
+++ b/addons/website/static/src/js/tours/tour_utils.js
@@ -76,8 +76,10 @@ function changeImage(snippet, position = "bottom") {
 */
 function changeOption(optionName, weName = '', optionTooltipLabel = '', position = "bottom") {
     const option_block = `we-customizeblock-option[class='snippet-option-${optionName}']`
+    // The trigger is data-original-title because the bootstrap tooltip have to
+    // be initialized.
     return {
-        trigger: `${option_block} ${weName}, ${option_block} [title='${weName}']`,
+        trigger: `${option_block} ${weName}, ${option_block} [data-original-title='${weName}']`,
         content: Markup(_.str.sprintf(_t("<b>Click</b> on this option to change the %s of the block."), optionTooltipLabel)),
         position: position,
         run: "click",

--- a/addons/website/static/src/js/tours/tour_utils.js
+++ b/addons/website/static/src/js/tours/tour_utils.js
@@ -79,7 +79,7 @@ function changeOption(optionName, weName = '', optionTooltipLabel = '', position
     // The trigger is data-original-title because the bootstrap tooltip have to
     // be initialized.
     return {
-        trigger: `${option_block} ${weName}, ${option_block} [data-original-title='${weName}']`,
+        trigger: `${option_block} ${weName}, ${option_block} [title='${weName}']`,
         content: Markup(_.str.sprintf(_t("<b>Click</b> on this option to change the %s of the block."), optionTooltipLabel)),
         position: position,
         run: "click",

--- a/addons/website/views/snippets/snippets.xml
+++ b/addons/website/views/snippets/snippets.xml
@@ -414,10 +414,10 @@
 
     <div data-js="CarouselItem"
          data-selector=".s_carousel .carousel-item, .s_quotes_carousel .carousel-item">
-        <we-button class="fa fa-fw fa-angle-left" data-slide="left" data-no-preview="true" data-tooltip="true" title="Move Backward"/>
-        <we-button class="fa fa-fw fa-angle-right mr-2" data-slide="right" data-no-preview="true" data-tooltip="true" title="Move Forward"/>
-        <we-button class="fa fa-fw fa-plus o_we_bg_success" data-add-slide-item="true" data-no-preview="true" data-tooltip="true" title="Add Slide"/>
-        <we-button class="fa fa-fw fa-minus o_we_bg_danger" data-remove-slide="true" data-no-preview="true" data-tooltip="true" title="Remove Slide"/>
+        <we-button class="fa fa-fw fa-angle-left" data-slide="left" data-no-preview="true" title="Move Backward"/>
+        <we-button class="fa fa-fw fa-angle-right mr-2" data-slide="right" data-no-preview="true" title="Move Forward"/>
+        <we-button class="fa fa-fw fa-plus o_we_bg_success" data-add-slide-item="true" data-no-preview="true" title="Add Slide"/>
+        <we-button class="fa fa-fw fa-minus o_we_bg_danger" data-remove-slide="true" data-no-preview="true" title="Remove Slide"/>
     </div>
 
     <!-- Accordion -->


### PR DESCRIPTION
The editor offers bootstrap tooltips, but these were not all initialized
and therefore appeared as standard HTML tooltips. This PR fixes that
by initializing all the tooltips so that they all have the same style. (bootstrap style).

task-2777738

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
