### PR TITLE
[FIX] website: enable autostart on youtube video snippet

### DIFF
--- a/addons/website/static/src/js/content/snippets.animation.js
+++ b/addons/website/static/src/js/content/snippets.animation.js
@@ -653,49 +653,117 @@ registry.mediaVideo = publicWidget.Widget.extend({
         // TODO: this code should be refactored to make more sense and be better
         // integrated with Odoo (this refactoring should be done in master).
 
-        var def = this._super.apply(this, arguments);
+        var proms = [this._super(...arguments)];
+
+        this.autoplay = false;
+        this.isMobileEnv = config.device.size_class <= config.device.SIZES.LG && config.device.touch;
+
         if (this.$target.children('iframe').length) {
-            // There already is an <iframe/>, do nothing. This is the normal
-            // case. The whole code that follows is only there to ensure
-            // compatibility with videos added before bug fixes or new Odoo
-            // versions where the <iframe/> element is properly saved.
-            return def;
+            this.$iframe = this.$target.children('iframe')[0];
+            this.iframeID = this.$iframe.id || _.uniqueId('o_video_iframe_');
+            this.videoSrc = this.$iframe.src;
+        } else {
+            this.$iframe = false;
+            this.iframeID = _.uniqueId('o_video_iframe_');
+
+            // Depending on version / compatibility / instance,
+            // the src is saved in the 'data-src' attribute or the
+            // 'data-oe-expression' one (the latter is used as a workaround in 10.0
+            // system but should obviously be reviewed in master).
+
+            this.videoSrc = this.$target.data('oe-expression') || this.$target.data('src');
+            var src = _.escape(this.videoSrc);
+            // Validate the src to only accept supported domains we can trust
+            var m = src.match(/^(?:https?:)?\/\/([^/?#]+)/);
+            if (!m) {
+                // Unsupported protocol or wrong URL format, don't inject iframe
+                return Promise.all(proms);
+            }
+            var domain = m[1].replace(/^www\./, '');
+            var supportedDomains = ['youtu.be', 'youtube.com', 'youtube-nocookie.com', 'instagram.com', 'vine.co', 'player.vimeo.com', 'vimeo.com', 'dailymotion.com', 'player.youku.com', 'youku.com'];
+            if (!_.contains(supportedDomains, domain)) {
+                // Unsupported domain, don't inject iframe
+                return Promise.all(proms);
+            }
         }
 
-        // Bug fix / compatibility: empty the <div/> element as all information
-        // to rebuild the iframe should have been saved on the <div/> element
-        this.$target.empty();
+        this.isYoutubeVideo = this.videoSrc.indexOf('youtube') >= 0;
 
-        // Add extra content for size / edition
-        this.$target.append(
-            '<div class="css_editable_mode_display">&nbsp;</div>' +
-            '<div class="media_iframe_video_size">&nbsp;</div>'
-        );
+        if (this.isYoutubeVideo && this.isMobileEnv) {
+            var query = new URLSearchParams(new URL(this.videoSrc).search);
+            this.autoplay = query.get('autoplay') === '1';
+            this.videoSrc += query.get('enablejsapi') === '1' ? '' : "&enablejsapi=1";
 
-        // Rebuild the iframe. Depending on version / compatibility / instance,
-        // the src is saved in the 'data-src' attribute or the
-        // 'data-oe-expression' one (the latter is used as a workaround in 10.0
-        // system but should obviously be reviewed in master).
-        var src = _.escape(this.$target.data('oe-expression') || this.$target.data('src'));
-        // Validate the src to only accept supported domains we can trust
-        var m = src.match(/^(?:https?:)?\/\/([^/?#]+)/);
-        if (!m) {
-            // Unsupported protocol or wrong URL format, don't inject iframe
-            return def;
+            if (!window.YT) {
+                var oldOnYoutubeIframeAPIReady = window.onYouTubeIframeAPIReady;
+                proms.push(new Promise(resolve => {
+                    window.onYouTubeIframeAPIReady = () => {
+                        if (oldOnYoutubeIframeAPIReady) {
+                            oldOnYoutubeIframeAPIReady();
+                        }
+                        return resolve();
+                    };
+                }));
+                $('<script/>', {
+                    src: 'https://www.youtube.com/iframe_api',
+                }).appendTo('head');
+            }
         }
-        var domain = m[1].replace(/^www\./, '');
-        var supportedDomains = ['youtu.be', 'youtube.com', 'youtube-nocookie.com', 'instagram.com', 'vine.co', 'player.vimeo.com', 'vimeo.com', 'dailymotion.com', 'player.youku.com', 'youku.com'];
-        if (!_.contains(supportedDomains, domain)) {
-            // Unsupported domain, don't inject iframe
-            return def;
-        }
-        this.$target.append($('<iframe/>', {
-            src: src,
-            frameborder: '0',
-            allowfullscreen: 'allowfullscreen',
-        }));
 
-        return def;
+        if (this.$iframe) {
+            // There already is an <iframe/>, do nothing, except if must
+            // must update src attribute because the video src changed
+            // (in case with a have Youtube video to enable api).
+            // Check first if not same link to avoid refresh iframe video.
+            if (this.$iframe.src != this.videoSrc) {
+                this.$iframe.src = this.videoSrc;
+            }
+        } else {
+            // Rebuild the iframe.
+            // The whole code that follows is only
+            // there to ensure compatibility with videos added before bug fixes
+            // or new Odoo versions where the <iframe/> element is properly saved.
+
+            // Bug fix / compatibility: empty the <div/> element as all information
+            // to rebuild the iframe should have been saved on the <div/> element
+            this.$target.empty();
+
+            // Add extra content for size / edition
+            this.$target.append(
+                '<div class="css_editable_mode_display">&nbsp;</div>' +
+                '<div class="media_iframe_video_size">&nbsp;</div>'
+            );
+            this.$iframe = $('<iframe/>', {
+                id: this.iframeID,
+                src: this.videoSrc,
+                frameborder: '0',
+                allowfullscreen: 'allowfullscreen',
+            })
+            this.$target.append(this.$iframe);
+        }
+
+        return Promise.all(proms).then(() => this._autoStartVideo());;
+    },
+    /**
+    * Auto start video if 'autoplay' is set.
+    *
+    * @private
+    */
+    _autoStartVideo: function () {
+        var self = this;
+        // YouTube does not allow to auto-play video in mobile devices,
+        // so we have to play the video manually.
+        if (this.isMobileEnv && this.isYoutubeVideo) {
+            new window.YT.Player(this.iframeID, {
+                events: {
+                    onReady: ev => {
+                        if (self.autoplay) {
+                            ev.target.playVideo();
+                        }
+                    },
+                }
+            });
+        }
     },
 });
 


### PR DESCRIPTION
Steps to reproduce:

  - Install website module
  - Go to Homepage and edit it
  - Add an `Image - Text` block
  - Double-click on the picture
  - click on video and past a YouTube video link
  - Select `Autoplay` option
  - Save and refresh
  - Open the website on an iPhone (or use Chrome debugger)

Issue:

  Video does not autostart.

Cause:

  YouTube does not autostart videos on mobile device.

Solution:

  When video snippet started, start video with YouTube API.

opw-2607308