### PR TITLE
[FIX] account: avoid computing account on empty linked invoice

### DIFF
--- a/addons/account/models/account_payment.py
+++ b/addons/account/models/account_payment.py
@@ -370,7 +370,7 @@ class account_payment(models.Model):
     def _compute_destination_account_id(self):
         self.destination_account_id = False
         for payment in self:
-            if payment.invoice_ids:
+            if payment.invoice_ids and payment.invoice_ids[0].line_ids:
                 payment.destination_account_id = payment.invoice_ids[0].mapped(
                     'line_ids.account_id').filtered(
                         lambda account: account.user_type_id.type in ('receivable', 'payable'))[0]


### PR DESCRIPTION
Upon payment registration, current invoice(s) will be linked to created
payment. After that, if the invoice get reset and cleared all invoice
lines, computing destination account will raising index error because
there is no lines in the invoice for computation.

Description of the issue/feature this PR addresses:

1. Create a bill A
2. Register payment B from bill A
3. Reset bill A to draft and clear all the invoice lines, cancel the bill (optional)
4. Access `destination_account_id` on payment B

Current behavior before PR:

Index error will be raised because bill A has no lines in it

Desired behavior after PR is merged:

No error will be raised


--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
