### PR TITLE
[FIX] web: Improve traceback with invalid model on contact field

### DIFF
--- a/odoo/addons/base/i18n/base.pot
+++ b/odoo/addons/base/i18n/base.pot
@@ -22535,6 +22535,12 @@ msgstr ""
 #. module: base
 #: code:addons/base/models/ir_qweb_fields.py:0
 #, python-format
+msgid "The contact widget is only allowed on a partner field."
+msgstr ""
+
+#. module: base
+#: code:addons/base/models/ir_qweb_fields.py:0
+#, python-format
 msgid "The value send to monetary field is not a number."
 msgstr ""
 

--- a/odoo/addons/base/models/ir_qweb_fields.py
+++ b/odoo/addons/base/models/ir_qweb_fields.py
@@ -660,6 +660,9 @@ class Contact(models.AbstractModel):
         if not value:
             return ''
 
+        if not isinstance(value, models.Model) or not value._name == 'res.partner':
+            raise TypeError(_("The contact widget is only allowed on a partner field."))
+
         opf = options and options.get('fields') or ["name", "address", "phone", "mobile", "email"]
         opsep = options and options.get('separator') or "\n"
         value = value.sudo().with_context(show_address=True)


### PR DESCRIPTION
This commit changes the error message that appears when a user tries to put the contact widget on an invalid field.

The traceback was `AttributeError: 'str' object has no attribute 'sudo'`

With this commit : `TypeError: The contact widget is only allowed on a partner field.`

opw-2745581