### PR TITLE
[FIX] l10n_it_edi: we need for precision in the price unit in case e.…

### DIFF
--- a/addons/l10n_it_edi/data/invoice_it_template.xml
+++ b/addons/l10n_it_edi/data/invoice_it_template.xml
@@ -20,7 +20,7 @@
                 </Descrizione>
                 <Quantita t-esc="format_numbers(line.quantity)"/>
                 <UnitaMisura t-if="line.product_uom_id.category_id != env.ref('uom.product_uom_categ_unit')" t-esc="line.product_uom_id.name"/>
-                <PrezzoUnitario t-esc="format_monetary(taxes['total_excluded'], currency)"/>
+                <PrezzoUnitario t-esc="'%.06f' % (line.price_subtotal / (( 1 - (line.discount or 0.0) / 100.0) * line.quantity))"/>
                 <ScontoMaggiorazione t-if="line.discount != 0">
                     <!-- [2.2.1.10] -->
                     <Tipo t-esc="discount_type(line.discount)"/>


### PR DESCRIPTION
…g. of tax included

According to the spec, the PrezzoUnitario should be the unit price
without the taxes.  If we use taxes included, this can be problematic.
That is because there is another rule that says that the PrezzoUnitario
* Quantita - Sconto should be within 0.01 precision of the PrezzoTotale.

So, with taxes included and a price unit only rounded to 2 decimals, you
easily go out of that limit.

The solution is to increase the precision on the price_unit (6 decimals
should not cause side effects and precise enough for most cases)
and to do the calculation differently by calculating it again from the
price_subtotal on the invoice line.

Task id: 2764978

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
