### PR TITLE
[FIX] web_editor, website: initialize tooltips on we-button

### DIFF
--- a/addons/web_editor/static/src/js/editor/snippets.editor.js
+++ b/addons/web_editor/static/src/js/editor/snippets.editor.js
@@ -1414,7 +1414,7 @@ var SnippetsMenu = Widget.extend({
 
         // Add tooltips on we-title elements whose text overflows
         this.$el.tooltip({
-            selector: 'we-title, [data-tooltip="true"]',
+            selector: 'we-title, [title]',
             placement: 'bottom',
             delay: 100,
             title: function () {

--- a/addons/website/views/snippets/snippets.xml
+++ b/addons/website/views/snippets/snippets.xml
@@ -416,10 +416,10 @@
 
     <div data-js="CarouselItem"
          data-selector=".s_carousel .carousel-item, .s_quotes_carousel .carousel-item">
-        <we-button class="fa fa-fw fa-angle-left" data-slide="left" data-no-preview="true" data-tooltip="true" title="Move Backward"/>
-        <we-button class="fa fa-fw fa-angle-right mr-2" data-slide="right" data-no-preview="true" data-tooltip="true" title="Move Forward"/>
-        <we-button class="fa fa-fw fa-plus o_we_bg_success" data-add-slide-item="true" data-no-preview="true" data-tooltip="true" title="Add Slide"/>
-        <we-button class="fa fa-fw fa-minus o_we_bg_danger" data-remove-slide="true" data-no-preview="true" data-tooltip="true" title="Remove Slide"/>
+        <we-button class="fa fa-fw fa-angle-left" data-slide="left" data-no-preview="true" title="Move Backward"/>
+        <we-button class="fa fa-fw fa-angle-right mr-2" data-slide="right" data-no-preview="true" title="Move Forward"/>
+        <we-button class="fa fa-fw fa-plus o_we_bg_success" data-add-slide-item="true" data-no-preview="true" title="Add Slide"/>
+        <we-button class="fa fa-fw fa-minus o_we_bg_danger" data-remove-slide="true" data-no-preview="true" title="Remove Slide"/>
     </div>
 
     <!-- Accordion -->


### PR DESCRIPTION
The editor's buttons offer bootstrap tooltips but these were not all
initialized and therefore appeared as standard HTML tooltips. This
commit fixes that by initialising all the tooltips so that they all have
the same style (bootstrap). In addition, this PR corrects some
buttons in the block carousel that had two overlapping tooltips.

task-2777738

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
