### PR TITLE
[FIX] mail: channel duplication

### DIFF
--- a/addons/mail/models/mail_channel.py
+++ b/addons/mail/models/mail_channel.py
@@ -107,7 +107,7 @@ class Channel(models.Model):
     # depends=['...'] is for `test_mail/tests/common.py`, class Moderation, `setUpClass`
     channel_last_seen_partner_ids = fields.One2many('mail.channel.partner', 'channel_id', string='Last Seen', depends=['channel_partner_ids'])
     channel_partner_ids = fields.Many2many('res.partner', 'mail_channel_partner', 'channel_id', 'partner_id', string='Listeners', depends=['channel_last_seen_partner_ids'])
-    channel_message_ids = fields.Many2many('mail.message', 'mail_message_mail_channel_rel')
+    channel_message_ids = fields.Many2many('mail.message', 'mail_message_mail_channel_rel', copy=False)
     is_member = fields.Boolean('Is a member', compute='_compute_is_member')
     # access
     public = fields.Selection([


### PR DESCRIPTION
Messages are copied when duplicating a channel

Steps to reproduce:
1. Install Discuss
2. Write a message in the general channel in Discuss
3. Duplicate the general channel (user demo should be a member of this
channel) and give it another name
4. Connect as demo
5. The new message notification is on the general channel (and it should
be the duplicate channel
6. Mark the notification as read
7. Refresh the page
8. The notification is still there even though it has been marked as
read

Solution:
Do not copy the message of the original channel

Problem:
`channel_message_ids` is copied when duplicating a channel

opw-2731842