### PR TITLE
[FIX] l10n_de: fix uploaded document signature

### DIFF
--- a/addons/l10n_de/report/din5008_report.xml
+++ b/addons/l10n_de/report/din5008_report.xml
@@ -110,7 +110,7 @@
                         <span t-else="">
                             <t t-set="o" t-value="docs[0]" t-if="not o" />
                             <span t-if="'l10n_de_document_title' in o"><t t-esc="o.l10n_de_document_title"/></span>
-                            <span t-else="" t-field="o.name"/>
+                            <span t-elif="'name' in o" t-field="o.name"/>
                         </span>
                     </h2>
                     <t t-raw="0"/>


### PR DESCRIPTION
### Current behavior
While having DIN 5008 (`external_layout_din5008`) as document's layout, an error occurs when you try to validate & send a signed document, which has been uploaded

### Steps
- Install Germany - Accounting (`l10n_de`) and Sign
- Set Document's Layout to DIN 5008 (`external_layout_din5008`) in the Settings
- Go to Sign, then
  1. Upload a pdf
  2. Insert a signature field
  3. Send the document
- Sign the document with the link sent by email and click on "Validate & Send Completed Document" button

### Reason
`sign.request` doesn't have name field which is used in DIN 5008 layout [1]

[1] : https://github.com/odoo/odoo/blob/d5b8c26c46b1daf795a6b286af80bb4dad8072ff/addons/l10n_de/report/din5008_report.xml#L107

OPW-2763962
