### PR TITLE
[FIX] project: remove `doc_count` field in project kanban view

### DIFF
--- a/addons/project/views/project_views.xml
+++ b/addons/project/views/project_views.xml
@@ -655,7 +655,6 @@
                     <field name="rating_active" />
                     <field name="analytic_account_id"/>
                     <field name="date"/>
-                    <field name="doc_count"/>
                     <field name="privacy_visibility"/>
                     <field name="last_update_color"/>
                     <field name="last_update_status"/>


### PR DESCRIPTION
Before this commit, the `doc_count` field is defined into the kanban
view of `project.project` model but it is never used. Since it is
defined into the view, the compute of this field is unnecessary
called.

This commit removes `doc_count` field in the kanban view of project to
avoid computing the view since this field is never used.

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
