### PR TITLE
[FIX] web: correct test many2one

### DIFF
--- a/addons/web/static/tests/legacy/fields/relational_fields/field_many2one_tests.js
+++ b/addons/web/static/tests/legacy/fields/relational_fields/field_many2one_tests.js
@@ -3673,7 +3673,7 @@ QUnit.module('fields', {}, function () {
                 "partner,false,search": '<search></search>',
                 'turtle,false,list':`
                         <tree readonly="1">
-                            <field name="product_id" widget="product_configurator"/>
+                            <field name="product_id" widget="many2one"/>
                         </tree>`,
                 "product,false,search": '<search></search>',
                 "product,false,form": '<form></form>',


### PR DESCRIPTION
Bug introduced in odoo/odoo#84361

Used wrong widget for template test. Product configurator is
only defined in module sale.

opw-2748041

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
