### PR TITLE
[FIX] web_editor: fix onChange event

### DIFF
--- a/addons/web_editor/static/lib/odoo-editor/src/OdooEditor.js
+++ b/addons/web_editor/static/lib/odoo-editor/src/OdooEditor.js
@@ -204,6 +204,7 @@ export class OdooEditor extends EventTarget {
                         return closestElement(selection.anchorNode, 'P, DIV');
                     }
                 },
+                onChange: () => {},
                 isHintBlacklisted: () => false,
                 filterMutationRecords: (records) => records,
                 _t: string => string,
@@ -719,6 +720,7 @@ export class OdooEditor extends EventTarget {
         this._checkStepUnbreakable = true;
         this._recordHistorySelection();
         this.dispatchEvent(new Event('historyStep'));
+        this.options.onChange();
         this.multiselectionRefresh();
     }
     // apply changes according to some records

--- a/addons/web_editor/static/src/js/backend/field_html.js
+++ b/addons/web_editor/static/src/js/backend/field_html.js
@@ -44,7 +44,6 @@ var FieldHtml = basic_fields.DebouncedField.extend(TranslatableFieldMixin, {
         wysiwyg_change: '_onChange',
         wysiwyg_attachment: '_onAttachmentChange',
     },
-
     /**
      * @override
      */
@@ -467,7 +466,7 @@ var FieldHtml = basic_fields.DebouncedField.extend(TranslatableFieldMixin, {
      * @param {OdooEvent} ev
      */
     _onChange: function (ev) {
-        this._doDebouncedAction.apply(this, arguments);
+        this._doAction();
 
         var $lis = this.$content.find('.note-editable ul.o_checklist > li:not(:has(> ul.o_checklist))');
         if (!$lis.length) {

--- a/addons/web_editor/static/src/js/wysiwyg/wysiwyg.js
+++ b/addons/web_editor/static/src/js/wysiwyg/wysiwyg.js
@@ -158,6 +158,7 @@ const Wysiwyg = Widget.extend({
                 });
             },
             commands: commands,
+            onChange: options.onChange,
             plugins: options.editorPlugins,
         }, editorCollaborationOptions));
 
@@ -1674,8 +1675,8 @@ const Wysiwyg = Widget.extend({
     _editorOptions: function () {
         var self = this;
         var options = Object.assign({}, this.defaultOptions, this.options);
-        options.onChange = function (html, $editable) {
-            $editable.trigger('content_changed');
+        options.onChange = function () {
+            self.$editable.trigger('content_changed');
             self.trigger_up('wysiwyg_change');
         };
         options.onUpload = function (attachments) {


### PR DESCRIPTION
Ensure the `onChange()` callback is called
after each history steps in the editor.

Call the `_doAction()` directly, to avoid using the
disabled `_doDebouncedAction()`.

task-2760436


--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
