### PR TITLE
[FIX] hr_expense: fix traceback when attaching receipts

### DIFF
--- a/addons/hr_expense/models/hr_expense.py
+++ b/addons/hr_expense/models/hr_expense.py
@@ -367,6 +367,9 @@ class HrExpense(models.Model):
             'context': {'search_default_my_expenses': 1, 'search_default_no_report': 1},
         }
 
+    def attach_document(self, **kwargs):
+        pass
+
     # ----------------------------------------
     # ORM Overrides
     # ----------------------------------------


### PR DESCRIPTION
In community, when no hr_expense_extract is installed, and we click
on 'Attach Receipt', we get traceback.

AttributeError: type object 'hr.expense' has no attribute 'attach_document'

Originated from odoo/odoo#81904

task - 2704297

