### PR TITLE
[FIX] hr_expense: changed taxes computation logic

### DIFF
--- a/addons/hr_expense/i18n/hr_expense.pot
+++ b/addons/hr_expense/i18n/hr_expense.pot
@@ -948,6 +948,11 @@ msgid "In Payment"
 msgstr ""
 
 #. module: hr_expense
+#: model_terms:ir.ui.view,arch_db:hr_expense.hr_expense_view_form
+msgid "Included in price taxes"
+msgstr ""
+
+#. module: hr_expense
 #: model_terms:ir.ui.view,arch_db:hr_expense.res_config_settings_view_form
 msgid "Incoming Emails"
 msgstr ""
@@ -1739,6 +1744,11 @@ msgstr ""
 #. module: hr_expense
 #: model:ir.model.fields,help:hr_expense.field_hr_expense_sheet__bank_journal_id
 msgid "The payment method used when the expense is paid by the company."
+msgstr ""
+
+#. module: hr_expense
+#: model:ir.model.fields,help:hr_expense.field_hr_expense__tax_ids
+msgid "The taxes should be \"Included In Price\""
 msgstr ""
 
 #. module: hr_expense

--- a/addons/hr_expense/models/hr_expense.py
+++ b/addons/hr_expense/models/hr_expense.py
@@ -72,7 +72,8 @@ class HrExpense(models.Model):
     quantity = fields.Float(required=True, readonly=True, states={'draft': [('readonly', False)], 'reported': [('readonly', False)], 'refused': [('readonly', False)]}, digits='Product Unit of Measure', default=1)
     tax_ids = fields.Many2many('account.tax', 'expense_tax', 'expense_id', 'tax_id',
         compute='_compute_from_product_id_company_id', store=True, readonly=False,
-        domain="[('company_id', '=', company_id), ('type_tax_use', '=', 'purchase')]", string='Taxes')
+        domain="[('company_id', '=', company_id), ('type_tax_use', '=', 'purchase'), ('price_include', '=', True)]", string='Taxes',
+        help="The taxes should be \"Included In Price\"")
     # TODO SGV can be removed
     untaxed_amount = fields.Float("Subtotal", store=True, compute='_compute_amount', digits='Account')
     amount_residual = fields.Monetary(string='Amount Due', compute='_compute_amount_residual')
@@ -152,9 +153,10 @@ class HrExpense(models.Model):
     @api.depends('quantity', 'unit_amount', 'tax_ids', 'currency_id')
     def _compute_amount(self):
         for expense in self:
-            expense.untaxed_amount = expense.unit_amount * expense.quantity
-            taxes = expense.tax_ids.compute_all(expense.unit_amount, expense.currency_id, expense.quantity, expense.product_id, expense.employee_id.user_id.partner_id)
-            expense.total_amount = taxes.get('total_included')
+            if expense.unit_amount:
+                expense.untaxed_amount = expense.unit_amount * expense.quantity
+                taxes = expense.tax_ids.compute_all(expense.unit_amount, expense.currency_id, expense.quantity, expense.product_id, expense.employee_id.user_id.partner_id)
+                expense.total_amount = taxes.get('total_included')
 
     @api.depends("sheet_id.account_move_id.line_ids")
     def _compute_amount_residual(self):

--- a/addons/hr_expense/tests/common.py
+++ b/addons/hr_expense/tests/common.py
@@ -52,3 +52,6 @@ class TestExpenseCommon(AccountTestInvoicingCommon):
 
         # Ensure products can be expensed.
         (cls.product_a + cls.product_b).write({'can_be_expensed': True})
+        # Taxes on the products are included in price
+        (cls.product_a.supplier_taxes_id + cls.product_b.supplier_taxes_id).write({'price_include': True})
+        cls.company_data['default_tax_purchase'].write({'price_include': True})

--- a/addons/hr_expense/tests/test_expenses.py
+++ b/addons/hr_expense/tests/test_expenses.py
@@ -67,9 +67,9 @@ class TestExpenses(TestExpenseCommon):
         """ Checking accounting move entries and analytic entries when submitting expense """
 
         # The expense employee is able to a create an expense sheet.
-        # The total should be 1725.0 because:
-        # - first line: 1000.0 (unit amount) + 150.0 (tax) = 1150.0
-        # - second line: (1500.0 (unit amount) + 225.0 (tax)) * 1/3 (rate) = 575.0.
+        # The total should be 1500.0 because:
+        # - first line: 1000.0 (unit amount), 130.43 (tax). But taxes are included in total thus - 1000
+        # - second line: (1500.0 (unit amount), 195.652 (tax)) - 65.22 (tax in company currency). total 1500.0 * 1/3 (rate) = 500
 
         expense_sheet = self.env['hr.expense.sheet'].create({
             'name': 'First Expense for employee',
@@ -102,7 +102,7 @@ class TestExpenses(TestExpenseCommon):
         })
 
         # Check expense sheet values.
-        self.assertRecordValues(expense_sheet, [{'state': 'draft', 'total_amount': 1725.0}])
+        self.assertRecordValues(expense_sheet, [{'state': 'draft', 'total_amount': 1500.0}])
 
         expense_sheet.action_submit_sheet()
         expense_sheet.approve_expense_sheets()
@@ -113,8 +113,8 @@ class TestExpenses(TestExpenseCommon):
             # Receivable line (company currency):
             {
                 'debit': 0.0,
-                'credit': 1150.0,
-                'amount_currency': -1150.0,
+                'credit': 1000.0,
+                'amount_currency': -1000.0,
                 'account_id': self.company_data['default_account_payable'].id,
                 'product_id': False,
                 'currency_id': self.company_data['currency'].id,
@@ -124,8 +124,8 @@ class TestExpenses(TestExpenseCommon):
             # Receivable line (foreign currency):
             {
                 'debit': 0.0,
-                'credit': 862.5,
-                'amount_currency': -1725.0,
+                'credit': 750,
+                'amount_currency': -1500.0,
                 'account_id': self.company_data['default_account_payable'].id,
                 'product_id': False,
                 'currency_id': self.currency_data['currency'].id,
@@ -134,9 +134,9 @@ class TestExpenses(TestExpenseCommon):
             },
             # Tax line (foreign currency):
             {
-                'debit': 112.5,
+                'debit': 97.83,
                 'credit': 0.0,
-                'amount_currency': 225.0,
+                'amount_currency': 195.652,
                 'account_id': self.company_data['default_account_tax_purchase'].id,
                 'product_id': False,
                 'currency_id': self.currency_data['currency'].id,
@@ -145,9 +145,9 @@ class TestExpenses(TestExpenseCommon):
             },
             # Tax line (company currency):
             {
-                'debit': 150.0,
+                'debit': 130.43,
                 'credit': 0.0,
-                'amount_currency': 150.0,
+                'amount_currency': 130.43,
                 'account_id': self.company_data['default_account_tax_purchase'].id,
                 'product_id': False,
                 'currency_id': self.company_data['currency'].id,
@@ -156,9 +156,9 @@ class TestExpenses(TestExpenseCommon):
             },
             # Product line (foreign currency):
             {
-                'debit': 750.0,
+                'debit': 652.17,
                 'credit': 0.0,
-                'amount_currency': 1500.0,
+                'amount_currency': 1304.348, # untaxed amount
                 'account_id': self.company_data['default_account_expense'].id,
                 'product_id': self.product_b.id,
                 'currency_id': self.currency_data['currency'].id,
@@ -167,9 +167,9 @@ class TestExpenses(TestExpenseCommon):
             },
             # Product line (company currency):
             {
-                'debit': 1000.0,
+                'debit': 869.57,
                 'credit': 0.0,
-                'amount_currency': 1000.0,
+                'amount_currency': 869.57,
                 'account_id': self.company_data['default_account_expense'].id,
                 'product_id': self.product_a.id,
                 'currency_id': self.company_data['currency'].id,
@@ -181,13 +181,13 @@ class TestExpenses(TestExpenseCommon):
         # Check expense analytic lines.
         self.assertRecordValues(expense_sheet.account_move_id.line_ids.analytic_line_ids.sorted('amount'), [
             {
-                'amount': -1000.0,
+                'amount': -869.57,
                 'date': fields.Date.from_string('2017-01-01'),
                 'account_id': self.analytic_account_1.id,
                 'currency_id': self.company_data['currency'].id,
             },
             {
-                'amount': -750.0,
+                'amount': -652.17,
                 'date': fields.Date.from_string('2017-01-01'),
                 'account_id': self.analytic_account_2.id,
                 'currency_id': self.company_data['currency'].id,

--- a/addons/hr_expense/tests/test_expenses_mail_import.py
+++ b/addons/hr_expense/tests/test_expenses_mail_import.py
@@ -28,7 +28,7 @@ class TestExpensesMailImport(TestExpenseCommon):
 
         self.assertRecordValues(expense, [{
             'product_id': self.product_a.id,
-            'total_amount': 920.0,
+            'total_amount': 800.0,
             'employee_id': self.expense_employee.id,
         }])
 

--- a/addons/hr_expense/views/hr_expense_views.xml
+++ b/addons/hr_expense/views/hr_expense_views.xml
@@ -165,7 +165,7 @@
                                 <field name="total_amount_company" style="vertical-align: top;" widget='monetary' options="{'currency_field': 'company_currency_id'}"/>
                                 <field name="label_convert_rate"/>
                             </div>
-                            <field name="tax_ids" widget="many2many_tags" groups="account.group_account_readonly" attrs="{'readonly': [('is_editable', '=', False)], 'invisible': [('product_has_cost', '=', True)]}"  context="{'default_company_id': company_id}"/>
+                            <field name="tax_ids" widget="many2many_tags" groups="account.group_account_readonly" attrs="{'readonly': [('is_editable', '=', False)], 'invisible': [('product_has_cost', '=', True)]}"  context="{'default_company_id': company_id}" placeholder="Included in price taxes" />
                         </group><group>
                             <field name="reference" groups="account.group_account_readonly" attrs="{'readonly': [('is_ref_editable', '=', False)], 'invisible': [('product_has_cost', '=', True)]}"/>
                             <field name="date"/>


### PR DESCRIPTION
Reproduction:
1. Install Expense, Accounting, then create a new expense
2. Choose category ”Food & beverages”, enter the amount paid
3. Choose a tax in Taxes
4. The amount paid is recomputed to 0

Reason: the expense form view changed in V15 but still uses the same
computation logic in V14. In V15, parameter product_has_cost=False is a
new use case where we directly input the total amount, and taxes here
are already included in the price.

Fix: in _compute_amount function, we need to check if there is
unit_amount. If yes, we follow the computation flow which is similar to
V14. If not, we calculate the taxes and other variables using the
total_amount. But the taxes here must be price_include=True. Otherwise,
the calculation will be wrong. To remind the customer, a tooltip and
default text are added to tax_ids field. The domain of tax_ids will only
include taxes with price_include=True.

opw-2747288




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
