### PR TITLE
[FIX] account_fleet: Improve performance

### DIFF
--- a/addons/account_fleet/models/account_move.py
+++ b/addons/account_fleet/models/account_move.py
@@ -39,7 +39,7 @@ class AccountMove(models.Model):
 class AccountMoveLine(models.Model):
     _inherit = 'account.move.line'
 
-    vehicle_id = fields.Many2one('fleet.vehicle', string='Vehicle')
+    vehicle_id = fields.Many2one('fleet.vehicle', string='Vehicle', index=True)
     need_vehicle = fields.Boolean(compute='_compute_need_vehicle',
         help="Technical field to decide whether the vehicle_id field is editable")
 


### PR DESCRIPTION
By setting an index on the vehicle field and using a read_group we significantly improve the performance.
This is a backport of https://github.com/odoo/odoo/pull/80683 




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
