### PR TITLE
[FIX] sale_project,sale_timesheet: get SOLs linked to project

### DIFF
--- a/addons/account_sale_timesheet/models/project.py
+++ b/addons/account_sale_timesheet/models/project.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
-from odoo import fields, models, _
+from odoo import fields, models, _, _lt
 
 class Project(models.Model):
     _inherit = 'project.project'
@@ -17,7 +17,7 @@ class Project(models.Model):
         if self.user_has_groups('account.group_account_readonly'):
             buttons.append({
                 'icon': 'pencil-square-o',
-                'text': _('Invoices'),
+                'text': _lt('Invoices'),
                 'number': self.invoice_count,
                 'action_type': 'object',
                 'action': 'action_open_project_invoices',

--- a/addons/hr_timesheet/models/project.py
+++ b/addons/hr_timesheet/models/project.py
@@ -3,7 +3,7 @@
 
 from collections import defaultdict
 
-from odoo import models, fields, api, _
+from odoo import models, fields, api, _, _lt
 from odoo.exceptions import UserError, ValidationError, RedirectWarning
 
 
@@ -238,7 +238,7 @@ class Project(models.Model):
         if self.user_has_groups('hr_timesheet.group_hr_timesheet_user'):
             buttons.append({
                 'icon': 'clock-o',
-                'text': _('Recorded'),
+                'text': _lt('Recorded'),
                 'number': '%s %s' % (self.total_timesheet_time, self.env.company.timesheet_encode_uom_id.name),
                 'action_type': 'object',
                 'action': 'action_show_timesheets_by_employee_invoice_type',

--- a/addons/project/models/project.py
+++ b/addons/project/models/project.py
@@ -8,7 +8,7 @@ from collections import defaultdict
 from datetime import timedelta, datetime, time
 from random import randint
 
-from odoo import api, Command, fields, models, tools, SUPERUSER_ID, _
+from odoo import api, Command, fields, models, tools, SUPERUSER_ID, _, _lt
 from odoo.exceptions import UserError, ValidationError, AccessError
 from odoo.tools import format_amount
 from odoo.osv.expression import OR
@@ -733,7 +733,7 @@ class Project(models.Model):
         self.ensure_one()
         buttons = [{
             'icon': 'tasks',
-            'text': _('Tasks'),
+            'text': _lt('Tasks'),
             'number': self.task_count,
             'action_type': 'action',
             'action': 'project.act_project_project_2_project_task_all',

--- a/addons/project_hr_expense/models/project.py
+++ b/addons/project_hr_expense/models/project.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
-from odoo import api, fields, models, _
+from odoo import api, fields, models, _, _lt
 
 class Project(models.Model):
     _inherit = 'project.project'
@@ -49,7 +49,7 @@ class Project(models.Model):
         if self.user_has_groups('hr_expense.group_hr_expense_team_approver'):
             buttons.append({
                 'icon': 'money',
-                'text': _('Expenses'),
+                'text': _lt('Expenses'),
                 'number': self.expenses_count,
                 'action_type': 'object',
                 'action': 'action_open_project_expenses',

--- a/addons/project_mrp/models/project.py
+++ b/addons/project_mrp/models/project.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
-from odoo import fields, models, _
+from odoo import fields, models, _, _lt
 
 
 class Project(models.Model):
@@ -41,7 +41,7 @@ class Project(models.Model):
         if self.user_has_groups('mrp.group_mrp_user'):
             buttons.extend([{
                 'icon': 'wrench',
-                'text': _('Manufacturing Orders'),
+                'text': _lt('Manufacturing Orders'),
                 'number': self.production_count,
                 'action_type': 'object',
                 'action': 'action_view_mrp_production',

--- a/addons/project_purchase/models/project.py
+++ b/addons/project_purchase/models/project.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
-from odoo import api, fields, models, _
+from odoo import api, fields, models, _, _lt
 
 
 class Project(models.Model):
@@ -52,7 +52,7 @@ class Project(models.Model):
         if self.user_has_groups('purchase.group_purchase_user'):
             buttons.append({
                 'icon': 'credit-card',
-                'text': _('Purchase Orders'),
+                'text': _lt('Purchase Orders'),
                 'number': self.purchase_orders_count,
                 'action_type': 'object',
                 'action': 'action_open_project_purchase_orders',

--- a/addons/sale_project/models/project.py
+++ b/addons/sale_project/models/project.py
@@ -5,6 +5,8 @@ from ast import literal_eval
 
 from odoo import api, fields, models, _
 from odoo.exceptions import ValidationError, UserError
+from odoo.osv import expression
+from odoo.osv.query import Query
 
 
 class Project(models.Model):
@@ -73,12 +75,14 @@ class Project(models.Model):
 
     def _get_all_sales_orders(self):
         self.ensure_one()
-        return self.sale_order_id | self.task_ids.sale_order_id
+        # Equivalent to: self.sale_order_id | self.task_ids.sale_order_id
+        return self._fetch_sale_order_items({'project.task': ['|', ('stage_id.fold', '=', False), ('stage_id', '=', False)]}).order_id
 
     @api.depends('sale_order_id', 'task_ids.sale_order_id')
     def _compute_sale_order_count(self):
+        sale_order_items_per_project_id = self._fetch_sale_order_items_per_project_id({'project.task': ['|', ('stage_id.fold', '=', False), ('stage_id', '=', False)]})
         for project in self:
-            project.sale_order_count = len(project._get_all_sales_orders())
+            project.sale_order_count = len(sale_order_items_per_project_id.get(project.id, self.env['sale.order.line']).order_id)
 
     def action_view_sos(self):
         self.ensure_one()
@@ -127,6 +131,62 @@ class Project(models.Model):
     # ----------------------------
     #  Project Updates
     # ----------------------------
+
+    def _fetch_sale_order_items_per_project_id(self, domain_per_model=None):
+        if not self:
+            return {}
+        if len(self) == 1:
+            return {self.id: self._fetch_sale_order_items(domain_per_model)}
+        query_str, params = self._get_sale_order_items_query(domain_per_model).select('id', 'ARRAY_AGG(DISTINCT sale_line_id) AS sale_line_ids')
+        query = f"""
+            {query_str}
+            GROUP BY id
+        """
+        self._cr.execute(query, params)
+        return {row['id']: self.env['sale.order.line'].browse(row['sale_line_ids']) for row in self._cr.dictfetchall()}
+
+    def _fetch_sale_order_items(self, domain_per_model=None, limit=None, offset=None):
+        if not self:
+            return []
+        return self.env['sale.order.line'].browse(self._fetch_sale_order_item_ids(domain_per_model, limit, offset))
+
+    def _fetch_sale_order_item_ids(self, domain_per_model=None, limit=None, offset=None):
+        if not self:
+            return []
+        query = self._get_sale_order_items_query(domain_per_model)
+        query.limit = limit
+        query.offset = offset
+        query_str, params = query.select('DISTINCT sale_line_id')
+        self._cr.execute(query_str, params)
+        return [row[0] for row in self._cr.fetchall()]
+
+    def _get_sale_orders(self):
+        return self._get_sale_order_items().order_id
+
+    def _get_sale_order_items(self):
+        return self._fetch_sale_order_items()
+
+    def _get_sale_order_items_query(self, domain_per_model=None):
+        if domain_per_model is None:
+            domain_per_model = {}
+        project_domain = [('id', 'in', self.ids), ('sale_line_id', '!=', False)]
+        if 'project.project' in domain_per_model:
+            project_domain = expression.AND([project_domain, domain_per_model['project.project']])
+        project_query = self.env['project.project']._where_calc(project_domain)
+        self._apply_ir_rules(project_query, 'read')
+        project_query_str, project_params = project_query.select('id', 'sale_line_id')
+
+        Task = self.env['project.task']
+        task_domain = [('project_id', 'in', self.ids), ('sale_line_id', '!=', False)]
+        if Task._name in domain_per_model:
+            task_domain = expression.AND([task_domain, domain_per_model[Task._name]])
+        task_query = Task._where_calc(task_domain)
+        Task._apply_ir_rules(task_query, 'read')
+        task_query_str, task_params = task_query.select(f'{Task._table}.project_id AS id', f'{Task._table}.sale_line_id')
+
+        query = Query(self._cr, 'project_sale_order_item', ' UNION '.join([project_query_str, task_query_str]))
+        query._where_params = project_params + task_params
+        return query
 
     def _get_stat_buttons(self):
         buttons = super(Project, self)._get_stat_buttons()

--- a/addons/sale_project/models/project.py
+++ b/addons/sale_project/models/project.py
@@ -3,7 +3,7 @@
 
 from ast import literal_eval
 
-from odoo import api, fields, models, _
+from odoo import api, fields, models, _, _lt
 from odoo.exceptions import ValidationError, UserError
 from odoo.osv import expression
 from odoo.osv.query import Query
@@ -193,7 +193,7 @@ class Project(models.Model):
         if self.user_has_groups('sales_team.group_sale_salesman_all_leads'):
             buttons.append({
                 'icon': 'dollar',
-                'text': _('Sales Orders'),
+                'text': _lt('Sales Orders'),
                 'number': self.sale_order_count,
                 'action_type': 'object',
                 'action': 'action_view_sos',

--- a/addons/sale_project/tests/test_sale_project.py
+++ b/addons/sale_project/tests/test_sale_project.py
@@ -82,10 +82,11 @@ class TestSaleProject(TransactionCase):
         })
 
     def test_sale_order_with_project_task(self):
+        SaleOrder = self.env['sale.order'].with_context(tracking_disable=True)
         SaleOrderLine = self.env['sale.order.line'].with_context(tracking_disable=True)
 
         partner = self.env['res.partner'].create({'name': "Mur en béton"})
-        sale_order = self.env['sale.order'].with_context(tracking_disable=True).create({
+        sale_order = SaleOrder.create({
             'partner_id': partner.id,
             'partner_invoice_id': partner.id,
             'partner_shipping_id': partner.id,
@@ -139,3 +140,26 @@ class TestSaleProject(TransactionCase):
         # service_tracking 'project_only'
         self.assertFalse(so_line_order_only_project.task_id, "Task should not be created")
         self.assertTrue(so_line_order_only_project.project_id, "Sales order line should be linked to newly created project")
+
+        self.assertEqual(self.project_global._get_sale_order_items(), self.project_global.sale_line_id | self.project_global.tasks.sale_line_id, 'The _get_sale_order_items should returns all the SOLs linked to the project and its active tasks.')
+
+        sale_order_2 = SaleOrder.create({
+            'partner_id': partner.id,
+            'partner_invoice_id': partner.id,
+            'partner_shipping_id': partner.id,
+        })
+        sale_line_1_order_2 = SaleOrderLine.create({
+            'product_id': self.product_order_service1.id,
+            'product_uom_qty': 10,
+            'product_uom': self.product_order_service1.uom_id.id,
+            'price_unit': self.product_order_service1.list_price,
+            'order_id': sale_order_2.id,
+        })
+        task = self.env['project.task'].create({
+            'name': 'Task',
+            'sale_line_id': sale_line_1_order_2.id,
+            'project_id': self.project_global.id,
+        })
+        self.assertEqual(task.sale_line_id, sale_line_1_order_2)
+        self.assertIn(task.sale_line_id, self.project_global._get_sale_order_items())
+        self.assertEqual(self.project_global._get_sale_orders(), sale_order | sale_order_2)

--- a/addons/sale_project_account/models/project.py
+++ b/addons/sale_project_account/models/project.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
-from odoo import fields, models, _
+from odoo import fields, models, _, _lt
 
 class Project(models.Model):
     _inherit = 'project.project'
@@ -38,7 +38,7 @@ class Project(models.Model):
         if self.user_has_groups('account.group_account_readonly'):
             buttons.append({
                 'icon': 'pencil-square-o',
-                'text': _('Vendor Bills'),
+                'text': _lt('Vendor Bills'),
                 'number': self.vendor_bill_count,
                 'action_type': 'object',
                 'action': 'action_open_project_vendor_bills',

--- a/addons/sale_timesheet/models/project.py
+++ b/addons/sale_timesheet/models/project.py
@@ -4,7 +4,7 @@
 import json
 from collections import defaultdict
 
-from odoo import api, fields, models, _
+from odoo import api, fields, models, _, _lt
 from odoo.osv import expression
 from odoo.exceptions import ValidationError, UserError
 from odoo.tools import format_amount, float_is_zero, formatLang
@@ -433,7 +433,7 @@ class Project(models.Model):
         if self.user_has_groups('hr_timesheet.group_hr_timesheet_approver'):
             buttons.append({
                 'icon': 'clock-o',
-                'text': _('Billable Time'),
+                'text': _lt('Billable Time'),
                 'number': '%s %%' % (self.billable_percentage),
                 'action_type': 'object',
                 'action': 'action_billable_time_button',

--- a/addons/sale_timesheet/tests/__init__.py
+++ b/addons/sale_timesheet/tests/__init__.py
@@ -5,6 +5,7 @@ from . import common
 from . import common_reporting
 from . import test_sale_timesheet
 from . import test_sale_service
+from . import test_project
 from . import test_project_billing
 from . import test_reinvoice
 from . import test_reporting

--- a/addons/sale_timesheet/tests/test_project.py
+++ b/addons/sale_timesheet/tests/test_project.py
@@ -1,0 +1,101 @@
+# -*- coding: utf-8 -*-
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from odoo import Command
+
+from .common import TestCommonSaleTimesheet
+
+class TestProject(TestCommonSaleTimesheet):
+    def test_fetch_sale_order_items(self):
+        """ Test _fetch_sale_order_items and _get_sale_order_items methods
+
+            This test will check we have the SOLs linked to the project and its tasks.
+
+            Test Case:
+            =========
+            1) No SOLs and SO should be found on a non billable project
+            2) Sol linked to the project should be fetched
+            3) SOL linked to the project and its task should be fetched
+            4) Add a employee mapping and check the SOL of this mapping is fetched with the others.
+            5) remove the SOL linked to the project and check the SOL linked to the task is fetched
+            6) Add an additional domain in the tasks to check if we can fetch with an additional filter
+                for instance, only the SOLs linked to the folded tasks.
+            7) Set allàw_billable=False and check no SOL is found since the project is not billable.
+        """
+        self.assertFalse(self.project_non_billable._fetch_sale_order_items())
+        self.assertFalse(self.project_non_billable._get_sale_order_items())
+        self.assertFalse(self.project_non_billable._get_sale_orders())
+
+        sale_item = self.so.order_line[0]
+        self.project_global.sale_line_id = sale_item
+        self.project_global.write({
+            'sale_line_id': sale_item.id,
+        })
+        self.project_global.invalidate_cache()
+        expected_task_sale_order_items = self.project_global.tasks.sale_line_id
+        expected_sale_order_items = sale_item | expected_task_sale_order_items
+        self.assertEqual(self.project_global._fetch_sale_order_items(), expected_sale_order_items)
+        self.assertEqual(self.project_global._get_sale_order_items(), expected_sale_order_items)
+        self.assertEqual(self.project_global._get_sale_orders(), self.so)
+
+        task = self.env['project.task'].create({
+            'name': 'Task with SOL',
+            'project_id': self.project_global.id,
+            'sale_line_id': self.so.order_line[1].id,
+        })
+
+        self.assertEqual(task.project_id, self.project_global)
+        self.assertEqual(task.sale_line_id, self.so.order_line[1])
+        self.assertEqual(task.sale_order_id, self.so)
+        sale_lines = self.project_global._get_sale_order_items()
+        self.assertEqual(sale_lines, task.sale_line_id + self.project_global.sale_line_id, 'The Sales Order Items found should be the one linked to the project and the one of project task.')
+        self.assertEqual(self.project_global._get_sale_orders(), self.so, 'The Sales Order fetched should be the one of the both sale_lines fetched.')
+
+        employee_mapping = self.env['project.sale.line.employee.map'].create({
+            'project_id': self.project_global.id,
+            'employee_id': self.employee_user.id,
+            'sale_line_id': self.so.order_line[-1].id,
+        })
+        expected_sale_order_items |= employee_mapping.sale_line_id
+        self.assertEqual(self.project_global._get_sale_order_items(), expected_sale_order_items)
+        self.assertEqual(self.project_global._get_sale_orders(), expected_sale_order_items.order_id)
+
+        self.project_global.write({
+            'sale_line_id': False,
+        })
+        self.project_global.invalidate_cache()
+        expected_task_sale_order_items |= task.sale_line_id
+        self.assertEqual(self.project_global._get_sale_order_items(), expected_task_sale_order_items | employee_mapping.sale_line_id)
+        self.assertEqual(self.project_global._get_sale_orders(), self.so)
+
+        new_stage = self.env['project.task.type'].create({
+            'name': 'New',
+            'sequence': 1,
+            'project_ids': [Command.set(self.project_global.ids)],
+        })
+        done_stage = self.env['project.task.type'].create({
+            'name': 'Done',
+            'sequence': 2,
+            'project_ids': [Command.set(self.project_global.ids)],
+            'fold': True,
+        })
+        task.write({
+            'stage_id': done_stage.id,
+        })
+        self.env['project.task.type'].flush()
+        self.assertEqual(self.project_global._fetch_sale_order_items({'project.task': [('stage_id.fold', '=', False)]}), employee_mapping.sale_line_id)
+        self.assertEqual(self.project_global._fetch_sale_order_items({'project.task': [('stage_id.fold', '=', True)]}), task.sale_line_id | employee_mapping.sale_line_id)
+
+        task2 = self.env['project.task'].create({
+            'name': 'Task 2',
+            'project_id': self.project_global.id,
+            'sale_line_id': sale_item.id,
+            'stage_id': new_stage.id,
+        })
+
+        self.assertEqual(self.project_global._fetch_sale_order_items({'project.task': [('stage_id.fold', '=', False)]}), task2.sale_line_id | employee_mapping.sale_line_id)
+        self.assertEqual(self.project_global._fetch_sale_order_items({'project.task': [('stage_id.fold', '=', True)]}), task.sale_line_id | employee_mapping.sale_line_id)
+
+        self.project_global.allow_billable = False
+        self.assertFalse(self.project_global._get_sale_order_items())
+        self.assertFalse(self.project_global._get_sale_orders())


### PR DESCRIPTION
Before this commit, when we need to get all SOL linked to the project.
That is the SOL linked to the project and also the SOL linked to all
tasks of this project.

Technically, a fetch is made to get the SOL of the project, a fetch to
get all tasks of the project and then a fetch to get the SOL linked to
all tasks fetched, finally the union is made to avoid having duplicate
sale order items in the recordset
(`self.sale_line_id | self.tasks.sale_line_id`).

This way could be a performance issue if the project contained many
active tasks and so the project update could take more and more time to
compute the sold items shown in the right side panel of project update
view.

This commit does a query builder to fetch the SOLs linked to the project
and its active tasks to avoid doing the prefetchs.

part of task-2710808

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
