### PR TITLE
[FIX] point_of_sale: invisible empty fields in the pos payment

### DIFF
--- a/addons/point_of_sale/views/pos_payment_views.xml
+++ b/addons/point_of_sale/views/pos_payment_views.xml
@@ -12,9 +12,9 @@
                         <field name="amount" />
                         <field name="pos_order_id" />
                         <field name="payment_method_id" />
-                        <field name="card_type" attrs="{'invisible': [('card_type', '=', False)]}"/>
-                        <field name="cardholder_name" attrs="{'invisible': [('cardholder_name', '=', False)]}"/>
-                        <field name="transaction_id" attrs="{'invisible': [('transaction_id', '=', False)]}"/>
+                        <field name="card_type" attrs="{'invisible': ['|', ('card_type', '=', False), ('card_type', '=', '')]}"/>
+                        <field name="cardholder_name" attrs="{'invisible': ['|', ('cardholder_name', '=', False), ('cardholder_name', '=', '')]}"/>
+                        <field name="transaction_id" attrs="{'invisible': ['|', ('transaction_id', '=', False), ('transaction_id', '=', '')]}"/>
                         <field name="session_id" />
                     </group>
                 </sheet>


### PR DESCRIPTION
Before this commit: if a pos payment is created by Ingenico,
"Type of card used", "Cardholder Name", and "Payment Transaction ID"
would be empty in the view. That's because they initialize with
an empty string.

To reproduce the problem, create a payment with Ingenico at the point
of sale and check the payment.

The solution is to add the empty string to the domain of its view to
make it invisible.

opw-2704999
