### PR TITLE
[FIX] stock: merge quants after unpacking

### DIFF
--- a/addons/stock/models/stock_quant.py
+++ b/addons/stock/models/stock_quant.py
@@ -538,15 +538,17 @@ The correction could unreserve some operations with problematics products.""") %
                             SELECT min(id) as to_update_quant_id,
                                 (array_agg(id ORDER BY id))[2:array_length(array_agg(id), 1)] as to_delete_quant_ids,
                                 SUM(reserved_quantity) as reserved_quantity,
-                                SUM(quantity) as quantity
+                                SUM(quantity) as quantity,
+                                MIN(in_date) as in_date
                             FROM stock_quant
-                            GROUP BY product_id, company_id, location_id, lot_id, package_id, owner_id, in_date
+                            GROUP BY product_id, company_id, location_id, lot_id, package_id, owner_id
                             HAVING count(id) > 1
                         ),
                         _up AS (
                             UPDATE stock_quant q
                                 SET quantity = d.quantity,
-                                    reserved_quantity = d.reserved_quantity
+                                    reserved_quantity = d.reserved_quantity,
+                                    in_date = d.in_date
                             FROM dupes d
                             WHERE d.to_update_quant_id = q.id
                         )

--- a/addons/stock/tests/test_quant.py
+++ b/addons/stock/tests/test_quant.py
@@ -699,3 +699,49 @@ class StockQuant(SavepointCase):
             inventory._action_done()
             quant = self.env['stock.quant'].search([('product_id', '=', self.product.id), ('location_id', '=', self.stock_location.id), ('quantity', '>', 0)])
             self.assertEqual(quant.in_date, tomorrow)
+
+    def test_unpack_and_quants_merging(self):
+        """
+        When unpacking a package, if there are already some quantities of the
+        packed product in the stock, the quant of the on hand quantity and the
+        one of the package should be merged
+        """
+        stock_location = self.env['stock.warehouse'].search([], limit=1).lot_stock_id
+        supplier_location = self.env.ref('stock.stock_location_suppliers')
+        picking_type_in = self.env.ref('stock.picking_type_in')
+
+        self.env['stock.quant']._update_available_quantity(self.product, stock_location, 1.0)
+
+        picking = self.env['stock.picking'].create({
+            'picking_type_id': picking_type_in.id,
+            'location_id': supplier_location.id,
+            'location_dest_id': stock_location.id,
+            'move_lines': [(0, 0, {
+                'name': 'In 10 x %s' % self.product.name,
+                'product_id': self.product.id,
+                'location_id': supplier_location.id,
+                'location_dest_id': stock_location.id,
+                'product_uom_qty': 10,
+                'product_uom': self.product.uom_id.id,
+            })],
+        })
+        picking.action_confirm()
+
+        package = self.env['stock.quant.package'].create({
+            'name': 'Super Package',
+        })
+        picking.move_lines.move_line_ids.write({
+            'qty_done': 10,
+            'result_package_id': package.id,
+        })
+        picking.button_validate()
+
+        package.unpack()
+
+        quant = self.env['stock.quant'].search([('product_id', '=', self.product.id), ('on_hand', '=', True)])
+        self.assertEqual(len(quant), 1)
+        # The quants merging is processed thanks to a SQL query (see StockQuant._merge_quants).
+        # At that point, the ORM is not aware of the new value. So we need to invalidate the
+        # cache to ensure that the value will be the newest
+        quant.invalidate_cache(fnames=['quantity'], ids=quant.ids)
+        self.assertEqual(quant.quantity, 11)


### PR DESCRIPTION
When unpacking a package, the quants are not merged

To reproduce the issue:
1. In Settings, enable "Delivery Packages"
2. Create a storable product P
3. Update its quantity: 5
4. Create a planned receipt R with 10 x P
5. Mark R as Todo
6. Put the 10 x P in pack (PK)
7. Validate R
8. Unpack PK
9. Consult the on-hand quantity of P

Error: There are two lines (one with 5 x P and another one with 10 x P).
Both lines should be merged

Backport of 5e08aa3def67d40bce39b2d95760c3221801e3dd

OPW-2713407