### PR TITLE
[FIX] l10n_it_edi_sdicoop: adapt user registration on settings

### DIFF
--- a/addons/account_edi_proxy_client/__manifest__.py
+++ b/addons/account_edi_proxy_client/__manifest__.py
@@ -17,8 +17,6 @@ Odoo database.
     },
     'data': [
         'security/ir.model.access.csv',
-    ],
-    'demo': [
         'data/config_demo.xml',
     ],
     'installable': True,

--- a/addons/account_edi_proxy_client/models/account_edi_proxy_user.py
+++ b/addons/account_edi_proxy_client/models/account_edi_proxy_user.py
@@ -137,7 +137,7 @@ class AccountEdiProxyClientUser(models.Model):
         )
         if self._get_demo_state() == 'demo':
             # simulate registration
-            response = {'id_client': 'demo', 'refresh_token': 'demo'}
+            response = {'id_client': f'demo{company.id}', 'refresh_token': 'demo'}
         else:
             try:
                 # b64encode returns a bytestring, we need it as a string

--- a/addons/l10n_it_edi_sdicoop/models/res_config_settings.py
+++ b/addons/l10n_it_edi_sdicoop/models/res_config_settings.py
@@ -1,21 +1,28 @@
 # -*- coding: utf-8 -*-
 
-from odoo import api, models, fields
-
+from odoo import api, models, fields, _
+from odoo.exceptions import UserError
 
 class ResConfigSettings(models.TransientModel):
     _inherit = 'res.config.settings'
 
     is_edi_proxy_active = fields.Boolean(compute='_compute_is_edi_proxy_active')
+    l10n_it_edi_proxy_current_state = fields.Char(compute='_compute_l10n_it_edi_proxy_current_state')
+    l10n_it_edi_sdicoop_register = fields.Boolean(compute='_compute_l10n_it_edi_sdicoop_register', inverse='_set_l10n_it_edi_sdicoop_register_demo_mode')
     l10n_it_edi_sdicoop_demo_mode = fields.Selection(
         [('demo', 'Demo'),
          ('test', 'Test (experimental)'),
          ('prod', 'Official')],
         compute='_compute_l10n_it_edi_sdicoop_demo_mode',
-        inverse='_set_l10n_it_edi_sdicoop_demo_mode',
+        inverse='_set_l10n_it_edi_sdicoop_register_demo_mode',
         readonly=False)
 
-    @api.depends("is_edi_proxy_active")
+    def _create_proxy_user(self, company_id):
+        fattura_pa = self.env.ref('l10n_it_edi.edi_fatturaPA')
+        edi_identification = fattura_pa._get_proxy_identification(company_id)
+        self.env['account_edi_proxy_client.user']._register_proxy_user(company_id, fattura_pa, edi_identification)
+
+    @api.depends('company_id.account_edi_proxy_client_ids', 'company_id.account_edi_proxy_client_ids.active')
     def _compute_l10n_it_edi_sdicoop_demo_mode(self):
         for config in self:
             config.l10n_it_edi_sdicoop_demo_mode = self.env['account_edi_proxy_client.user']._get_demo_state()
@@ -29,6 +36,22 @@ class ResConfigSettings(models.TransientModel):
         for config in self:
             config.is_edi_proxy_active = config.company_id.account_edi_proxy_client_ids
 
+    @api.depends('company_id.account_edi_proxy_client_ids', 'company_id.account_edi_proxy_client_ids.active')
+    def _compute_l10n_it_edi_proxy_current_state(self):
+        fattura_pa = self.env.ref('l10n_it_edi.edi_fatturaPA')
+        for config in self:
+            proxy_user = config.company_id.account_edi_proxy_client_ids.search([
+                ('company_id', '=', config.company_id.id),
+                ('edi_format_id','=', fattura_pa.id),
+            ], limit=1)
+
+            config.l10n_it_edi_proxy_current_state = 'inactive' if not proxy_user else 'demo' if proxy_user.id_client[:4] == 'demo' else 'active'
+
+    @api.depends('company_id')
+    def _compute_l10n_it_edi_sdicoop_register(self):
+        """Needed because it expects a compute"""
+        self.l10n_it_edi_sdicoop_register = False
+
     def button_create_proxy_user(self):
         # For now, only fattura_pa uses the proxy.
         # To use it for more, we have to either make the activation of the proxy on a format basis
@@ -39,3 +62,40 @@ class ResConfigSettings(models.TransientModel):
             return
 
         self.env['account_edi_proxy_client.user']._register_proxy_user(self.company_id, fattura_pa, edi_identification)
+
+    def _set_l10n_it_edi_sdicoop_register_demo_mode(self):
+
+        fattura_pa = self.env.ref('l10n_it_edi.edi_fatturaPA')
+        for config in self:
+
+            proxy_user = self.env['account_edi_proxy_client.user'].search([
+                ('company_id', '=', config.company_id.id),
+                ('edi_format_id', '=', fattura_pa.id)
+            ], limit=1)
+
+            real_proxy_users = self.env['account_edi_proxy_client.user'].sudo().search([
+                ('id_client', 'not like', 'demo'),
+            ])
+
+            # Update the config as per the selected radio button
+            previous_demo_state = proxy_user._get_demo_state()
+            self.env['ir.config_parameter'].set_param('account_edi_proxy_client.demo', config.l10n_it_edi_sdicoop_demo_mode)
+
+            # If the user is trying to change from a state in which they have a registered official or testing proxy client
+            # to another state, we should stop them
+            if real_proxy_users and previous_demo_state != config.l10n_it_edi_sdicoop_demo_mode:
+                raise UserError(_("The company has already registered with the service as 'Test' or 'Official', it cannot change."))
+
+
+            if config.l10n_it_edi_sdicoop_register:
+                # There should only be one user at a time, if there are no users, register one
+                if not proxy_user:
+                    self._create_proxy_user(config.company_id)
+                    return
+
+                # If there is a demo user, and we are transitioning from demo to test or production, we should
+                # delete all demo users and then create the new user.
+                elif proxy_user.id_client[:4] == 'demo' and config.l10n_it_edi_sdicoop_demo_mode != 'demo':
+                    self.env['account_edi_proxy_client.user'].search([('id_client', '=like', 'demo%')]).sudo().unlink()
+                    self._create_proxy_user(config.company_id)
+

--- a/addons/l10n_it_edi_sdicoop/views/res_config_settings_views.xml
+++ b/addons/l10n_it_edi_sdicoop/views/res_config_settings_views.xml
@@ -12,43 +12,36 @@
                     <div class="row mt16 o_settings_container" id='account_edi'>
                         <div class="col-12 col-lg-6 o_setting_box">
                             <div class="o_setting_right_pane">
-                                <span class="o_form_label">Allow Odoo to process invoices</span>
-                                <div class="text-muted">
-                                    By clicking this button, I accept that Odoo may process my invoices.
-                                </div>
-                                <div class="content-group">
-                                    <field name="is_edi_proxy_active" invisible="True" />
-                                    <div class="row mt8">
-                                        <div class="col-lg-6" title="Register">
-                                            <button name="button_create_proxy_user"
-                                                    type="object"
-                                                    string="Register"
-                                                    class="btn-primary" icon="fa-lg fa-check"
-                                                    attrs="{'invisible':[('is_edi_proxy_active', '=', True)]}"/>
-                                            <button name="button_create_proxy_user"
-                                                    type="object"
-                                                    string="Already registered"
-                                                    disabled="1"
-                                                    class="btn-lnk" icon="fa-lg fa-check"
-                                                    attrs="{'invisible':[('is_edi_proxy_active', '=', False)]}"/>
-                                        </div>
-                                    </div>
-                                </div>
-                            </div>
-                        </div>
-                        <div class="col-12 col-lg-6 o_setting_box">
-                            <div class="o_setting_right_pane">
-                                <div class="content-group">
+                                <div class="group-content">
+                                    <field name="l10n_it_edi_proxy_current_state" invisible="1"/>
                                     <span class="o_form_label">
                                         Fattura Elettronica mode
                                     </span>
                                     <div class="text-muted">
                                         In demo mode Odoo will just simulate the sending of invoices to the government.<br/>
                                         In test mode (experimental) Odoo will send the invoices to a non-production service.
+                                        Saving this change will direct all companies on this database to this use this configuration.
+                                        Once registered for testing or official, the mode cannot be changed.
                                     </div>
                                     <field name="l10n_it_edi_sdicoop_demo_mode"
                                            widget="radio"
                                            options="{'horizontal': true}"/>
+                                </div>
+                                <div class="mt8 content-group" attrs="{'invisible': ['|',('l10n_it_edi_proxy_current_state','=','active'), '&amp;', ('l10n_it_edi_proxy_current_state','=','demo'), ('l10n_it_edi_sdicoop_demo_mode','=','demo')]}">
+                                    <span class="o_form_label">Allow Odoo to process invoices</span>
+                                    <div class="text-muted">
+                                        By checking this box, I accept that Odoo may process my invoices.
+                                    </div>
+                                    <div class="content-group">
+                                        <field name="l10n_it_edi_sdicoop_register"/>
+                                    </div>
+
+                                </div>
+                                <div class="text-success mt8" attrs="{'invisible': [('l10n_it_edi_proxy_current_state','in', ['inactive', 'demo'])]}">
+                                    An Official or Test service has been registered.
+                                </div>
+                                <div class="text-success mt8" attrs="{'invisible': ['|',('l10n_it_edi_proxy_current_state','!=', 'demo'), ('l10n_it_edi_sdicoop_demo_mode', '!=', 'demo')]}">
+                                    A Demo service is in use.
                                 </div>
                             </div>
                         </div>


### PR DESCRIPTION
To properly register account_edi_proxy_client.user when saving the res
config settings page, the radio buttons needed to be modified, and the
'register' button was adapted to be a checkbox instead.