### PR TITLE
[FIX] payment: link tokens to refund transactions

### DIFF
--- a/addons/payment/models/payment_transaction.py
+++ b/addons/payment/models/payment_transaction.py
@@ -597,6 +597,7 @@ class PaymentTransaction(models.Model):
             'reference': self._compute_reference(self.provider, prefix=f'R-{self.reference}'),
             'amount': -(amount_to_refund or self.amount),
             'currency_id': self.currency_id.id,
+            'token_id': self.token_id.id,
             'operation': 'refund',
             'source_transaction_id': self.id,
             'partner_id': self.partner_id.id,


### PR DESCRIPTION
Whenever making a refund for a transaction with a saved token
the token will appear also on the refund transaction.
It is useful to keep track of which token was used in each
transaction, this remains true for refunds.
The token will also appear on the payments.

task-2694760