### PR TITLE
[FIX] purchase_stock: Apply po_lead only to buy orderpoints

### DIFF
--- a/addons/purchase_stock/models/stock.py
+++ b/addons/purchase_stock/models/stock.py
@@ -300,7 +300,8 @@ class Orderpoint(models.Model):
 
     def _get_orderpoint_procurement_date(self):
         date = super()._get_orderpoint_procurement_date()
-        date -= relativedelta(days=self.company_id.po_lead)
+        if any(rule.action == 'buy' for rule in self.rule_ids):
+            date -= relativedelta(days=self.company_id.po_lead)
         return date
 
 


### PR DESCRIPTION
Changes made in #78199 would remove the Purchase Security Lead Time from
any orderpoint as long as the 'purchase_stock' module was installed,
whether the orderpoint was related to purchase or not.

Task-2721378

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
