### PR TITLE
[WIP] web, l10n_it_edi_sdicoop: fix problem

### DIFF
--- a/addons/l10n_it_edi_sdicoop/views/res_config_settings_views.xml
+++ b/addons/l10n_it_edi_sdicoop/views/res_config_settings_views.xml
@@ -44,7 +44,8 @@
                                     </span>
                                     <div class="text-muted">
                                         In demo mode Odoo will just simulate the sending of invoices to the government.<br/>
-                                        In test mode (experimental) Odoo will send the invoices to a non-production service.
+                                        In test mode (experimental) Odoo will send the invoices to a non-production service.<br/>
+                                        <p><b>Please save before clicking the register button. </b></p>
                                     </div>
                                     <field name="l10n_it_edi_sdicoop_demo_mode"
                                            widget="radio"

--- a/odoo/addons/base/static/src/js/res_config_settings.js
+++ b/odoo/addons/base/static/src/js/res_config_settings.js
@@ -380,7 +380,6 @@ var BaseSettingController = FormController.extend({
                     text: _t('Discard'),
                     close: true,
                     click: () => {
-                        resolve(true);
                         reset();
                     },
                 }, {


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
When you get the wizard in the settings to save the changes or discard them, when you click discard, it will still apply the button you clicked which triggered the wizard.  Also, when I saved, non stored fields are not saved.  

I do not know if this removing of resolve does not introduce other problems elsewhere.  
![Screenshot from 2022-02-26 00-53-58](https://user-images.githubusercontent.com/3832699/155820112-257df29c-b7c4-4ff5-912b-117643b94024.png)





--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
