### PR TITLE
[FIX] auth_totp,web: TOTP login from mobile apps

### DIFF
--- a/addons/auth_totp/controllers/home.py
+++ b/addons/auth_totp/controllers/home.py
@@ -65,8 +65,12 @@ class Home(odoo.addons.web.controllers.main.Home):
                         httponly=True,
                         samesite='Lax'
                     )
+                # Crapy workaround for unupdatable Odoo Mobile App iOS (Thanks Apple :@)
+                request.session.should_touch = True
                 return response
 
+        # Crapy workaround for unupdatable Odoo Mobile App iOS (Thanks Apple :@)
+        request.session.should_touch = True
         return request.render('auth_totp.auth_totp_form', {
             'user': user,
             'error': error,

--- a/addons/auth_totp/tests/test_totp.py
+++ b/addons/auth_totp/tests/test_totp.py
@@ -114,4 +114,4 @@ class TestTOTP(HttpCase):
         }
         response = self.url_open("/web/session/authenticate", data=json.dumps(payload), headers=headers)
         data = response.json()
-        self.assertEqual(data['error']['data']['message'], "Reniewing an expired session for user that has multi-factor-authentication is not supported. Please use /web/login instead.")
+        self.assertEqual(data['result']['uid'], None)

--- a/addons/web/controllers/main.py
+++ b/addons/web/controllers/main.py
@@ -1191,6 +1191,8 @@ class Session(http.Controller):
 
     @http.route('/web/session/get_session_info', type='json', auth="user")
     def get_session_info(self):
+        # Crapy workaround for unupdatable Odoo Mobile App iOS (Thanks Apple :@)
+        request.session.should_touch = True
         return request.env['ir.http'].session_info()
 
     @http.route('/web/session/authenticate', type='json', auth="none")
@@ -1199,7 +1201,9 @@ class Session(http.Controller):
             raise AccessError("Database not found.")
         pre_uid = request.session.authenticate(db, login, password)
         if pre_uid != request.session.uid:
-            raise AccessError("Reniewing an expired session for user that has multi-factor-authentication is not supported. Please use /web/login instead.")
+            # Crapy workaround for unupdatable Odoo Mobile App iOS (Thanks Apple :@) and Android
+            # Correct behavior should be to raise AccessError("Renewing an expired session for user that has multi-factor-authentication is not supported. Please use /web/login instead.")
+            return {'uid': None}
 
         request.session.db = db
         registry = odoo.modules.registry.Registry(db)


### PR DESCRIPTION
Since PR odoo/odoo#78857 , the TOTP authentication support is broken
when used inside either Android or iOS mobile apps.

Due to our inability to update the iOS app (following review from
Apple), this commit aims at restoring the bare minimum requirements to
make the current mobile apps (specially iOS but also Android)
authentication workflow works.

As extended explanation:
- Set-Cookie header is expected to be sent even when session_id hasn't
  changed (iOS specific).
- Successful credentials check on `/web/session/authenticate` expect a
  successful response with a result containing `uid` set to `null` to
  mark the need of an additional totp handshake (both platforms).