### PR TITLE
[FIX] microsoft_calendar: avoid concurrent calls to API

### DIFF
--- a/addons/microsoft_calendar/controllers/main.py
+++ b/addons/microsoft_calendar/controllers/main.py
@@ -18,6 +18,12 @@ class MicrosoftCalendarController(http.Controller):
             this URL for authorization for example
         """
         if model == 'calendar.event':
+            env = request.env
+            lock_number = 1996
+            env.cr.execute("SELECT pg_try_advisory_xact_lock(%s)", (lock_number,))
+            locked_free = env.cr.fetchone()[0]
+            if not locked_free:
+                return {"status": "parallel_sync"}
             MicrosoftCal = MicrosoftCalendarService(request.env['microsoft.service'])
 
             # Checking that admin have already configured Microsoft API for microsoft synchronization !


### PR DESCRIPTION
Before this commit:
 Multiple calls to Microsoft API do happen.
 This API calls are mostly done by the
 `/microsoft_calendar/sync_data` http route,
 This route can be quite long to execute (~500 ms)
 and can be called in parallel through Odoo in the
 calendar app if - for instance - we click on
 different days in the calendar in quick succession.

 As such, it often ends up as `concurrent access`
 PSQL error in the logs and risk of being rate limited
 by Microsoft API.

After this commit:
 There is 2 main ways to limit this issue:
 1. Python -> PSQL lock:
  Current Odoo ORM does not propose a
  "shared" lock system.

  We can't lock a table like for the MRP scheduler, see:
  https://github.com/odoo/odoo/blob/ad6f15101627705818f83d2450c1f34116c0eb96/addons/stock/wizard/stock_scheduler_compute.py#L27-L34
  as this process don't use a particular table on which
  we can lock on easily without potential side effects.

  Fortunately, PSQL do propose a system of "arbitrary"
  locks called "Advisory Locks", see:
  https://www.postgresql.org/docs/9.6/explicit-locking.html#:~:text=13.3.5.%20Advisory%20Locks
  Note that, in order to be compatible with the ORM,
  the lock should be set at a transaction level
  (not session level). As such, if the request fails,
  the query will be rollback, which will release the lock.
  With that being considered, the more suitable kind
  of lock for this case would be an "exclusive transaction".

  `pg_try_advisory_xact_lock` function can be summarised as:
> Locks an application-defined resource, which can be
identified either by a single 64-bit key value or
two 32-bit key values
(note that these two key spaces do not overlap).
If another transaction already holds a lock on
the same resource identifier, this function will not wait
for the lock to become available.
It will either obtain the lock immediately and return true,
or return false if the lock cannot be acquired immediately.
If [the lock is] acquired, [it] is automatically released
at the end of the current transaction and
cannot be released explicitly"
  from:
  https://www.postgresql.org/docs/9.6/functions-admin.html#:~:text=pg_try_advisory_xact_lock

  The value set to this lock (to identify it), which is
  1996 in this case is an arbitraty integer value which
  must be the same to distinguish from other potential
  locks.
  More thought should be done in master version if
  this kind of locks are more used to avoid conflicts
  and ambiguity on the integer value.

  As a side note, if we would like to adapt the lock
  so that one call can be made per user, we can used
  the `two 32-bit key values` of the SQL function with
  the user id as one of the parameter and the key as the
  second.

 2. JavaScript -> use of `throttle`
  Throttle the number of calls made from the browser
  to the Odoo's server.
  Note that this won't be as effective as 1. as
  the request may come from different tabs/browsers.
  This is mostly to avoid spamming the `sync_data` calls
  when browsing in the calendar

 Results:
  One call to the Microsoft calendar API is done at a time.
  No matter the number of user using it in parallel or the
  number of calls which is made coming from the Calendar app

OPW-2749791

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
