### PR TITLE
[FIX] hr_expense: fix expense form view and correctly update expense state

### DIFF
--- a/addons/hr_expense/models/account_move_line.py
+++ b/addons/hr_expense/models/account_move_line.py
@@ -21,8 +21,9 @@ class AccountMoveLine(models.Model):
     def reconcile(self):
         # OVERRIDE
         not_paid_expenses = self.expense_id.filtered(lambda expense: expense.state != 'done')
-        not_paid_expense_sheets = not_paid_expenses.sheet_id
         res = super().reconcile()
+        # Do not consider expense sheet states if account_move_id is False, it means it has been just canceled
+        not_paid_expense_sheets = not_paid_expenses.sheet_id.filtered(lambda sheet: sheet.account_move_id)
         paid_expenses = not_paid_expenses.filtered(lambda expense: expense.currency_id.is_zero(expense.amount_residual))
         paid_expenses.write({'state': 'done'})
         not_paid_expense_sheets.filtered(lambda sheet: all(expense.state == 'done' for expense in sheet.expense_line_ids)).set_to_paid()

--- a/addons/hr_expense/views/hr_expense_views.xml
+++ b/addons/hr_expense/views/hr_expense_views.xml
@@ -156,11 +156,11 @@
                             </div>
                             <!-- YTI TO REMOVE IN MASTER START -->
                             <field name="amount_residual" widget='monetary' options="{'currency_field': 'currency_id'}" invisible="1"/>
-                            <div class="o_td_label" invisible="1">
-                                <field name="label_total_amount_company" nolabel="1" class="o_form_label" />
+                            <div class="o_td_label">
+                                <field name="label_total_amount_company" nolabel="1" class="o_form_label" invisible="1"/>
+                                <label for="total_amount_company" string="" attrs="{'invisible': [('same_currency', '=', True), ('product_has_cost', '=', False)]}"/>
                             </div>
                             <!-- YTI TO REMOVE IN MASTER END -->
-                            <label for="total_amount_company" string="" attrs="{'invisible': [('same_currency', '=', True), ('product_has_cost', '=', False)]}"/>
                             <div class="o_row d-flex" attrs="{'invisible': [('same_currency', '=', True), ('product_has_cost', '=', False)]}">
                                 <field name="total_amount_company" style="vertical-align: top;" widget='monetary' options="{'currency_field': 'company_currency_id'}"/>
                                 <field name="label_convert_rate"/>


### PR DESCRIPTION
If we cancel expense, depending on the account.move state (whether it is posted or not),
we either unlink the account_move_id (not posted), or reconcile it (posted).

Thus, when reconciling 'account.move.line', if the corresponding expense
does not have account_move_id, it means that expense has been canceled
and no need to mark that expense as 'done'.

related PR odoo/odoo#85338

task - 2774594


