### PR TITLE
[FIX] mail: allow user to delete other's attachments again

### DIFF
--- a/addons/mail/controllers/discuss.py
+++ b/addons/mail/controllers/discuss.py
@@ -262,7 +262,9 @@ class DiscussController(http.Controller):
     def mail_attachment_delete(self, attachment_id, access_token=None, **kwargs):
         attachment_sudo = request.env['ir.attachment'].browse(int(attachment_id)).sudo().exists()
         if not attachment_sudo:
-            raise NotFound()
+            target = request.env.user.partner_id
+            request.env['bus.bus']._sendone(target, 'ir.attachment/delete', {'id': attachment_id})
+            return
         if not request.env.user.share:
             # Check through standard access rights/rules for internal users.
             attachment_sudo.sudo(False)._delete_and_notify()

--- a/addons/mail/static/src/components/message/tests/message_tests.js
+++ b/addons/mail/static/src/components/message/tests/message_tests.js
@@ -701,7 +701,7 @@ QUnit.test('allow attachment delete on authored message', async function (assert
     );
 });
 
-QUnit.test('prevent attachment delete on non-authored message', async function (assert) {
+QUnit.test('prevent attachment delete on non-authored message in channels', async function (assert) {
     assert.expect(2);
 
     const { createMessageComponent } = await this.start();
@@ -711,6 +711,10 @@ QUnit.test('prevent attachment delete on non-authored message', async function (
             id: 10,
             name: "BLAH",
             mimetype: 'image/jpeg',
+            originThread: insertAndReplace({
+                id: 11,
+                model: 'mail.channel',
+            }),
         }),
         author: insert({ id: 11, display_name: "Guy" }),
         body: "<p>Test</p>",

--- a/addons/mail/static/src/models/attachment/attachment.js
+++ b/addons/mail/static/src/models/attachment/attachment.js
@@ -184,13 +184,15 @@ function factory(dependencies) {
             if (!this.messaging) {
                 return;
             }
-            return this.messages.length
-                ? this.messages.some(message => (
+
+            if (this.messages.length && this.originThread && this.originThread.model === 'mail.channel') {
+                return this.messages.some(message => (
                     message.canBeDeleted ||
                     (message.author && message.author === this.messaging.currentPartner) ||
                     (message.guestAuthor && message.guestAuthor === this.messaging.currentGuest)
-                ))
-                : true;
+                ));
+            }
+            return true;
         }
 
         /**


### PR DESCRIPTION
Before this PR, only author of the message and admin could delete attachments
inside the chatter.
This behavior is now restricted to the channels and allow users to delete
attachments inside the chatter.

task-2753295