### PR TITLE
[FIX] purchase_requisition_stock: Exclude archived picking_type_in

### DIFF
--- a/addons/purchase_requisition_stock/models/purchase_requisition.py
+++ b/addons/purchase_requisition_stock/models/purchase_requisition.py
@@ -10,7 +10,7 @@ class PurchaseRequisition(models.Model):
     def _get_picking_in(self):
         pick_in = self.env.ref('stock.picking_type_in', raise_if_not_found=False)
         company = self.env.company
-        if not pick_in or pick_in.sudo().warehouse_id.company_id.id != company.id:
+        if not pick_in or not pick_in.active or pick_in.sudo().warehouse_id.company_id.id != company.id:
             pick_in = self.env['stock.picking.type'].search(
                 [('warehouse_id.company_id', '=', company.id), ('code', '=', 'incoming')],
                 limit=1,


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
https://watch.screencastify.com/v/DiEBenZoEptqqGVbDALy
Purchase Agreements would use the archived 'Receipt' operation type

Current behavior before PR:
The purchase agreement would use the operation type defined in the external identifier stock.picking_type_in without checking if it is archived.

Desired behavior after PR is merged:
After commit, if stock.picking_type_in record is archived, the purchase agreement search for another (non-archived) one.

OPW-2748495
Up to v.15

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
