### PR TITLE
[FIX] account: currency writeoff suggestion

### DIFF
--- a/addons/account/models/account_reconcile_model.py
+++ b/addons/account/models/account_reconcile_model.py
@@ -459,6 +459,23 @@ class AccountReconcileModel(models.Model):
 
         return lines_vals_list + writeoff_vals_list
 
+    def _prepare_widget_writeoff_vals(self, st_line_id, write_off_vals):
+        fixed_write_off_vals = dict(write_off_vals, currency_id=st_line_id.company_id.currency_id.id)
+        counterpart_vals = st_line_id._prepare_counterpart_move_line_vals(fixed_write_off_vals)
+
+        return {
+            'name': counterpart_vals['name'],
+            'balance': counterpart_vals['amount_currency'],
+            'debit': counterpart_vals['debit'],
+            'credit': counterpart_vals['credit'],
+            'account_id': counterpart_vals['account_id'],
+            'currency_id': counterpart_vals['currency_id'],
+            'analytic_account_id': counterpart_vals.get('analytic_account_id'),
+            'analytic_tag_ids': counterpart_vals.get('analytic_tag_ids', []),
+            'reconcile_model_id': self.id,
+            'journal_id': counterpart_vals['journal_id']
+        }
+
     ####################################################
     # RECONCILIATION CRITERIA
     ####################################################


### PR DESCRIPTION
When having a bank statement line in foreign currency, the writeoff line is display with the right sign but with the amount in company currency.

This is happening in two scenarios :

1 - With a bank journal in foreign currency, and a reconciliation model
with 'rule_type' 'invoice_matching' and 'match_total_amount' at 90 for example.
Create an invoice in the foreign currency for price 100, and create a bank
statement on the journal with a line amount of 90 (payment_ref set with the
invoice name). Then confirm and reconcile -> the writeoff amount is display with
the right currency sign, but in company currency

2 - With a bank journal in company currency, and a reconciliation model
with 'rule_type' 'writeoff_suggestion'. Create a bank statement with a line
with amount X, amount_currency Y, foreign_currency set. Confirm and reconcile
-> writeoff amount is the amount with the foreign currency sign, instead of the amount_currency.

opw-2695846
opw-2731737

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
