### PR TITLE
[FIX] project: fix rating stat button UX in project update

### DIFF
--- a/addons/project/models/project.py
+++ b/addons/project/models/project.py
@@ -758,9 +758,15 @@ class Project(models.Model):
             'sequence': 3,
         }]
         if self.user_has_groups('project.group_project_rating'):
+            if self.rating_avg >= 3.66:
+                icon = 'smile-o text-success'
+            elif self.rating_avg >= 2.33:
+                icon = 'meh-o text-warning'
+            else:
+                icon = 'frown-o text-danger'
             buttons.append({
-                'icon': 'smile-o',
-                'text': _lt('Satisfaction'),
+                'icon': icon,
+                'text': _('Satisfaction'),
                 'number': f'{round(100 * self.rating_avg_percentage, 2)} %',
                 'action_type': 'object',
                 'action': 'action_view_all_rating',


### PR DESCRIPTION
before this PR,
in the project update right-side panel view rating stat button's icon is
static it does not update depending on rating percentage and percentage
not showing properly.

This PR display rating average percentage in project update right
side panel view's rating stat button instead of just displaying
rating_avg_percentange field's value and rating stat button's icon will
update depending on rating percentage.

task-2758779

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
