### PR TITLE
[FIX] payment_stripe: fix base url for webhook url

### DIFF
--- a/addons/payment_stripe/models/payment_acquirer.py
+++ b/addons/payment_stripe/models/payment_acquirer.py
@@ -153,7 +153,7 @@ class PaymentAcquirer(models.Model):
         }
 
     def _get_stripe_webhook_url(self):
-        return self.company_id.get_base_url() + StripeController._webhook_url
+        return self.get_base_url() + StripeController._webhook_url
 
     # === BUSINESS METHODS - PAYMENT FLOW === #
 


### PR DESCRIPTION
This commit fixes the webhook base url to use the override defined in
the payment acquirer model.

It ensures the base url follows the same logic as the success and cancel
urls defined in the `checkout/sessions` request payload.

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
