### PR TITLE
[FIX] account_edi_facturx: fix missing format for dates

### DIFF
--- a/addons/account_edi_facturx/data/facturx_templates.xml
+++ b/addons/account_edi_facturx/data/facturx_templates.xml
@@ -209,7 +209,7 @@
                         <ram:SpecifiedTradePaymentTerms>
                             <ram:Description t-if="record.invoice_payment_term_id" t-esc="record.invoice_payment_term_id.name"/>
                             <ram:DueDateDateTime t-if="record.invoice_date_due">
-                                <udt:DateTimeString t-esc="format_date(record.invoice_date_due)"/>
+                                <udt:DateTimeString format="102" t-esc="format_date(record.invoice_date_due)"/>
                             </ram:DueDateDateTime>
                         </ram:SpecifiedTradePaymentTerms>
 

--- a/addons/account_edi_facturx/tests/test_facturx.py
+++ b/addons/account_edi_facturx/tests/test_facturx.py
@@ -134,7 +134,7 @@ class TestAccountEdiFacturx(AccountEdiTestCommon):
                         </ApplicableTradeTax>
                         <SpecifiedTradePaymentTerms>
                             <DueDateDateTime>
-                                <DateTimeString>20170101</DateTimeString>
+                                <DateTimeString format="102">20170101</DateTimeString>
                             </DueDateDateTime>
                         </SpecifiedTradePaymentTerms>
                         <SpecifiedTradeSettlementHeaderMonetarySummation>
@@ -196,7 +196,7 @@ class TestAccountEdiFacturx(AccountEdiTestCommon):
                     </ApplicableTradeTax>
                     <SpecifiedTradePaymentTerms>
                         <DueDateDateTime>
-                            <DateTimeString>20170101</DateTimeString>
+                            <DateTimeString format="102">20170101</DateTimeString>
                         </DueDateDateTime>
                     </SpecifiedTradePaymentTerms>
                     <SpecifiedTradeSettlementHeaderMonetarySummation>


### PR DESCRIPTION
DateTimeString should have an attribute format="102" (date is of the form: AAAAMMJJ)
as specified in the factur-x documentation.

opw-2767359
