### PR TITLE
[FIX][13.0] base: updating 'base' should update all modules

### DIFF
--- a/odoo/addons/base/models/ir_module.py
+++ b/odoo/addons/base/models/ir_module.py
@@ -642,6 +642,16 @@ class Module(models.Model):
         self.update_list()
 
         todo = list(self)
+        if 'base' in self.mapped('name'):
+            # If an installed module is only present in the dependency graph through
+            # a new, uninstalled dependency, it will not have been selected yet.
+            # An update of 'base' should also update these modules, and as a consequence,
+            # install the new dependency.
+            todo.extend(self.search([
+                ('state', '=', 'installed'),
+                ('name', '!=', 'studio_customization'),
+                ('id', 'not in', self.ids),
+            ]))
         i = 0
         while i < len(todo):
             module = todo[i]


### PR DESCRIPTION
_Description of the issue/feature this PR addresses:_
If an installed module is only present in the dependency graph through a new, uninstalled dependency, it was not selected for upgrade when updating the base module (c.q. --update all)

_Current behavior before PR:_
I have a customization module beer, depending on base. I then split off a function of module beer to module yeast. Module yeast now depends on base, and I change the dependency of module beer from base to yeast. I upgrade my database with --update all. After the upgrade, module beer is not updated and module yeast is not installed. A message is logged module beer: Unmet dependencies: yeast

_Desired behavior after PR is merged:_
I upgrade my database with --update all. After the upgrade, module beer is updated and yeast is installed.

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
