### PR TITLE
[FIX] web: Domain should be editable in debug even if invalid

### DIFF
--- a/addons/web/static/src/legacy/js/widgets/domain_selector.js
+++ b/addons/web/static/src/legacy/js/widgets/domain_selector.js
@@ -479,7 +479,7 @@ var DomainSelector = DomainTree.extend({
     start: function () {
         var self = this;
         return this._super.apply(this, arguments).then(function () {
-            if (self.invalidDomain) {
+            if (self.invalidDomain && !self.debug) {
                 var msg = _t("This domain is not supported.");
                 self.$el.html(msg);
             }


### PR DESCRIPTION
as specified in this comment, the domain selector should be editable
in debug mode even if it is unsupported.


https://github.com/odoo/odoo/blob/15301a1ddaf00e51688d8134b7cb19baf386577c/addons/web/static/src/legacy/js/widgets/domain_selector.js#L452-L462


opw-2746036