### PR TITLE
[FIX] core: check rules before flush() in unlink()

### DIFF
--- a/odoo/addons/test_new_api/tests/test_new_fields.py
+++ b/odoo/addons/test_new_api/tests/test_new_fields.py
@@ -2295,6 +2295,24 @@ class TestFields(common.TransactionCase):
         with self.assertRaises(AccessError):
             record_user.read(['tags'])
 
+    def test_98_unlink_recompute(self):
+        move = self.env['test_new_api.move'].create({
+            'line_ids': [(0, 0, {'quantity': 42})],
+        })
+        line = move.line_ids
+        self.assertEqual(move.quantity, 42)
+
+        # create an ir.rule for lines that uses move.quantity
+        self.env['ir.rule'].create({
+            'model_id': self.env['ir.model']._get(line._name).id,
+            'domain_force': "[('move_id.quantity', '>=', 0)]",
+        })
+
+        # unlink the line, and check the recomputation of move.quantity
+        user = self.env.ref('base.user_demo')
+        line.with_user(user).unlink()
+        self.assertEqual(move.quantity, 0)
+
 
 class TestX2many(common.TransactionCase):
     def test_definition_many2many(self):

--- a/odoo/models.py
+++ b/odoo/models.py
@@ -3369,6 +3369,7 @@ Fields:
             return True
 
         self.check_access_rights('unlink')
+        self.check_access_rule('unlink')
         self._check_concurrency()
 
         # mark fields that depend on 'self' to recompute them after 'self' has
@@ -3377,8 +3378,6 @@ Fields:
         self.modified(self._fields, before=True)
 
         with self.env.norecompute():
-            self.check_access_rule('unlink')
-
             cr = self._cr
             Data = self.env['ir.model.data'].sudo().with_context({})
             Defaults = self.env['ir.default'].sudo()


### PR DESCRIPTION
Just before deleting records, we mark fields on dependent records as "to
compute", and their actual computation should happen after the records
have been deleted.  The problem is that checking security rules may
trigger the computations that have been prepared.  So we should check
security rules before marking dependent records.