### PR TITLE
[FIX] account_edi: avoid savepoint error and inform the user correctly

### DIFF
--- a/addons/account_edi/i18n/account_edi.pot
+++ b/addons/account_edi/i18n/account_edi.pot
@@ -83,6 +83,12 @@ msgid "Display Name"
 msgstr ""
 
 #. module: account_edi
+#: model_terms:ir.ui.view,arch_db:account_edi.view_move_form_inherit
+#: model_terms:ir.ui.view,arch_db:account_edi.view_payment_form_inherit
+msgid "Download"
+msgstr ""
+
+#. module: account_edi
 #: model:ir.actions.server,name:account_edi.ir_cron_edi_network_ir_actions_server
 #: model:ir.cron,cron_name:account_edi.ir_cron_edi_network
 #: model:ir.cron,name:account_edi.ir_cron_edi_network
@@ -103,6 +109,11 @@ msgstr ""
 #. module: account_edi
 #: model:ir.model.fields,help:account_edi.field_account_journal__compatible_edi_ids
 msgid "EDI format that support moves in this journal"
+msgstr ""
+
+#. module: account_edi
+#: model:ir.model.fields,field_description:account_edi.field_account_edi_document__edi_content
+msgid "Edi Content"
 msgstr ""
 
 #. module: account_edi
@@ -176,18 +187,6 @@ msgid "Error"
 msgstr ""
 
 #. module: account_edi
-#: code:addons/account_edi/models/account_edi_document.py:0
-#, python-format
-msgid "Error when cancelling the journal entry."
-msgstr ""
-
-#. module: account_edi
-#: code:addons/account_edi/models/account_edi_document.py:0
-#, python-format
-msgid "Error when processing the journal entry."
-msgstr ""
-
-#. module: account_edi
 #: model:ir.model.fields,field_description:account_edi.field_account_edi_document__edi_format_name
 msgid "Format Name"
 msgstr ""
@@ -211,6 +210,15 @@ msgstr ""
 #: model:ir.model.fields,field_description:account_edi.field_ir_attachment__id
 #: model:ir.model.fields,field_description:account_edi.field_mail_template__id
 msgid "ID"
+msgstr ""
+
+#. module: account_edi
+#: code:addons/account_edi/models/account_move.py:0
+#, python-format
+msgid ""
+"Invalid invoice configuration:\n"
+"\n"
+"%s"
 msgstr ""
 
 #. module: account_edi
@@ -309,11 +317,6 @@ msgid "State"
 msgstr ""
 
 #. module: account_edi
-#: model:ir.model.fields,help:account_edi_extended.field_account_edi_document__error
-msgid "The text of the last error that happened during Electronic Invoice operation."
-msgstr ""
-
-#. module: account_edi
 #: model:ir.model.fields,help:account_edi.field_account_bank_statement_line__edi_web_services_to_process
 #: model:ir.model.fields,help:account_edi.field_account_move__edi_web_services_to_process
 #: model:ir.model.fields,help:account_edi.field_account_payment__edi_web_services_to_process
@@ -346,8 +349,21 @@ msgid "The payment will be sent asynchronously to :"
 msgstr ""
 
 #. module: account_edi
+#: model:ir.model.fields,help:account_edi.field_account_edi_document__error
+msgid ""
+"The text of the last error that happened during Electronic Invoice "
+"operation."
+msgstr ""
+
+#. module: account_edi
 #: model:ir.model.constraint,message:account_edi.constraint_account_edi_format_unique_code
 msgid "This code already exists"
+msgstr ""
+
+#. module: account_edi
+#: code:addons/account_edi/models/account_edi_document.py:0
+#, python-format
+msgid "This document is being sent by another process already. "
 msgstr ""
 
 #. module: account_edi


### PR DESCRIPTION
Before, when sending an invoice for the first time, it would give
a "cannot find savepoint" traceback upon wanting to release it.

We avoid that error by putting less code in the with statement,
so the savepoint gets released a lot earlier while the record
remains locked for the rest of the transaction.

We also put a nice error message if the user can not send at the
moment because another process is already sending.  (might happen
more often in v15)

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:

![Screenshot from 2022-02-28 15-37-55](https://user-images.githubusercontent.com/3832699/156006320-19681e7a-3232-4ffc-abf3-d0eed31e1bf9.png)



--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
