### PR TITLE
[FIX] point_of_sale: avoid syncing two times an order

### DIFF
--- a/addons/point_of_sale/models/pos_order.py
+++ b/addons/point_of_sale/models/pos_order.py
@@ -12,7 +12,7 @@ from odoo import api, fields, models, tools, _
 from odoo.tools import float_is_zero, float_round
 from odoo.exceptions import ValidationError, UserError
 from odoo.http import request
-from odoo.osv.expression import AND
+from odoo.osv.expression import AND, OR
 import base64
 
 _logger = logging.getLogger(__name__)
@@ -554,9 +554,10 @@ class PosOrder(models.Model):
         """
         order_ids = []
         for order in orders:
-            existing_order = False
+            existing_order_domain = [('pos_reference', '=', order['data']['name'])]
             if 'server_id' in order['data']:
-                existing_order = self.env['pos.order'].search(['|', ('id', '=', order['data']['server_id']), ('pos_reference', '=', order['data']['name'])], limit=1)
+                existing_order_domain = OR([existing_order_domain, ('id', '=', order['data']['server_id'])])
+            existing_order = self.env['pos.order'].search(existing_order_domain, limit=1)
             if (existing_order and existing_order.state == 'draft') or not existing_order:
                 order_ids.append(self._process_order(order, draft, existing_order))
 


### PR DESCRIPTION
When an order is sent to the server, we check that it has not been
created before to avoid duplicates of the order. When an order is sent
to the backend, it is possible that the javascript client don't get the
response from server because of a connection lost for example, and so
the order is created, but the front will try to sync it again.

Since changes made for order synchronization in the pos restraurant, we
are not checking anymore the order reference when we are not in
restaurant and so there cold be duplicates of order.

To avoid this issue, we are now checking it even when we don't have a
server_id (which is only there when it is not the first synchronization
of the order)

ISSUE-ID: 2762678

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
