### PR TITLE
[FIX] stock: reservable quantity must be positive

### DIFF
--- a/addons/stock/models/stock_move.py
+++ b/addons/stock/models/stock_move.py
@@ -1283,7 +1283,8 @@ class StockMove(models.Model):
                         grouped_move_lines_out[k] = sum(self.env['stock.move.line'].concat(*list(g)).mapped('product_qty'))
                     available_move_lines = {key: grouped_move_lines_in[key] - grouped_move_lines_out.get(key, 0) for key in grouped_move_lines_in.keys()}
                     # pop key if the quantity available amount to 0
-                    available_move_lines = dict((k, v) for k, v in available_move_lines.items() if v)
+                    rounding = move.product_id.uom_id.rounding
+                    available_move_lines = dict((k, v) for k, v in available_move_lines.items() if float_compare(v, 0, precision_rounding=rounding) > 0)
 
                     if not available_move_lines:
                         continue

--- a/addons/stock/tests/test_packing.py
+++ b/addons/stock/tests/test_packing.py
@@ -888,3 +888,53 @@ class TestPacking(SavepointCase):
         self.assertNotIn(packB, picking.package_level_ids)
         self.assertEqual(packB, bo.package_level_ids)
         self.assertEqual(bo.package_level_ids.state, 'assigned')
+
+    def test_2_steps_and_reservation(self):
+        """ When creating a backorder in a two steps flow, the reservation should be resilient 
+        to the change of quantity in any move of the chain. The test scenario is the following:
+                        
+                                     - move (5 units) CONFIRMED
+                                   /
+        move orig (10 units) DONE -
+                                   \ - move sibling (5 units) DONE
+                                   
+        The confirmed move can be assigned because on the 10 units validated on the move 
+        orig, only 5 have already been validated in the sibling move. If before the 
+        reservation the move orig is unlocked and the quantity is changed from 10 to 1, the 
+        confirmed move cannot reserve any quantity anymore but should be able to call 
+        action_assign without any error."""
+
+        self.env['stock.quant']._update_available_quantity(self.productA, self.stock_location, 20.0)
+        self.env['stock.quant']._update_available_quantity(self.productA, self.pack_location, 30.0)
+        ship_move_a = self.env['stock.move'].create({
+            'name': 'The ship move',
+            'product_id': self.productA.id,
+            'product_uom_qty': 20.0,
+            'product_uom': self.productA.uom_id.id,
+            'location_id': self.ship_location.id,
+            'location_dest_id': self.customer_location.id,
+            'warehouse_id': self.warehouse.id,
+            'picking_type_id': self.warehouse.out_type_id.id,
+            'procure_method': 'make_to_order',
+            'state': 'draft',
+        })
+        ship_move_a._assign_picking()
+        ship_move_a._action_confirm()
+        pack_move_a = ship_move_a.move_orig_ids[0]
+        pick_move_a = pack_move_a.move_orig_ids[0]
+
+        pick_move_a.quantity_done = 20
+        pick_move_a._action_done()
+
+        pack_move_a.quantity_done = 10
+        picking = pack_move_a.picking_id
+        action_data = picking.button_validate()
+        backorder_wizard = self.env[action_data['res_model']].browse(action_data['res_id'])
+        backorder_wizard.process()
+
+        # change validated quantity of the first step
+        pick_move_a.quantity_done = 5
+
+        # check the backorder can still be reserved
+        backorder = (pack_move_a.move_orig_ids.move_dest_ids - pack_move_a).picking_id
+        backorder.action_assign()


### PR DESCRIPTION
reserving a chained stock move will compare quantity validated by move
origs and quantity validated by sibling moves. If this number is
negative (i.e the move orig has been updated before reservation). This
can throw an error like "you cannot unreserve more...."

This commit ensure the reservable quantity is always >= 0.

opw: 2716369

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
