### PR TITLE
[FIX] website_sale,web_editor: fix website sale tour

### DIFF
--- a/addons/web_editor/models/ir_qweb.py
+++ b/addons/web_editor/models/ir_qweb.py
@@ -28,7 +28,8 @@ from werkzeug import urls
 
 import odoo.modules
 
-from odoo import api, models, fields
+from odoo import _, api, models, fields
+from odoo.exceptions import ValidationError
 from odoo.tools import ustr, posix_to_ldml, pycompat
 from odoo.tools import html_escape as escape
 from odoo.tools.misc import get_lang, babel_locale_parse
@@ -178,8 +179,11 @@ class Float(models.AbstractModel):
     def from_html(self, model, field, element):
         lang = self.user_lang()
         value = element.text_content().strip()
-        return float(value.replace(lang.thousands_sep, '')
-                          .replace(lang.decimal_point, '.'))
+        try:
+            return float(value.replace(lang.thousands_sep, '')
+                              .replace(lang.decimal_point, '.'))
+        except:
+            raise ValidationError(_('You entered an invalid value, please try again.'))
 
 
 class ManyToOne(models.AbstractModel):
@@ -476,8 +480,11 @@ class Monetary(models.AbstractModel):
 
         value = element.find('span').text.strip()
 
-        return float(value.replace(lang.thousands_sep, '')
-                          .replace(lang.decimal_point, '.'))
+        try:
+            return float(value.replace(lang.thousands_sep, '')
+                              .replace(lang.decimal_point, '.'))
+        except:
+            raise ValidationError(_('You entered an invalid value, please try again.'))
 
 
 class Duration(models.AbstractModel):

--- a/addons/web_editor/static/src/js/wysiwyg/wysiwyg.js
+++ b/addons/web_editor/static/src/js/wysiwyg/wysiwyg.js
@@ -1848,13 +1848,13 @@ const Wysiwyg = Widget.extend({
                     // the DOM regeneration. Add markings instead, and returns a
                     // new rejection with all relevant info
                     var id = _.uniqueId('carlos_danger_');
-                    $el.addClass('o_dirty oe_carlos_danger ' + id);
+                    $el.addClass('o_dirty o_editable oe_carlos_danger ' + id);
                     $('.o_editable.' + id)
                         .removeClass(id)
                         .popover({
                             trigger: 'hover',
                             content: response.message.data.message || '',
-                            placement: 'auto top',
+                            placement: 'auto',
                         })
                         .popover('show');
                 });
@@ -1864,8 +1864,7 @@ const Wysiwyg = Widget.extend({
             window.onbeforeunload = null;
         }).guardedCatch((failed) => {
             // If there were errors, re-enable edition
-            this.cancel();
-            this.start();
+            this.cancel(false);
         });
     },
     // TODO unused => remove or reuse as it should be

--- a/addons/website_sale/static/src/js/tours/website_sale_shop.js
+++ b/addons/website_sale/static/src/js/tours/website_sale_shop.js
@@ -19,7 +19,7 @@ odoo.define("website_sale.tour_shop", function (require) {
     }, {
         trigger: ".modal-dialog #editor_new_product input[type=text]",
         content: _t("Enter a name for your new product"),
-        position: "right",
+        position: "left",
     }, {
         trigger: ".modal-footer button.btn-primary.btn-continue",
         content: Markup(_t("Click on <em>Continue</em> to create the product.")),
@@ -45,6 +45,7 @@ odoo.define("website_sale.tour_shop", function (require) {
         run: function (actions) {
             actions.auto(".modal-footer .btn-secondary");
         },
+        auto: true,
     }, {
         trigger: "button.o_we_add_snippet_btn",
         auto: true,

--- a/addons/website_sale/views/templates.xml
+++ b/addons/website_sale/views/templates.xml
@@ -310,7 +310,7 @@
                                 </table>
                             </div>
                             <t t-else="">
-                                <div class="text-center text-muted">
+                                <div class="text-center text-muted mt128 mb256">
                                     <t t-if="not search">
                                         <h3 class="mt8">No product defined</h3>
                                         <p t-if="category">No product defined in category "<strong t-esc="category.display_name"/>".</p>


### PR DESCRIPTION
This commit fixes some inconsistencies in the website_sale tour:
- The step "Upload an image" is removed;
- The tip position of the Product Name step is placed above the field
rather than on the rightside to avoid a horizontal scrollbar.

This commit fixes a traceback when the user defines a price on a product
that is not a number. The key pressed is validated during key down.

The "No product defined" text position is improved for empty searches.

task-2700198

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
