### PR TITLE
[IMP] l10n_it_edi_proxy: ack does not make sense and only risks delet…

### DIFF
--- a/addons/l10n_it_edi_sdicoop/models/account_edi_format.py
+++ b/addons/l10n_it_edi_sdicoop/models/account_edi_format.py
@@ -217,7 +217,6 @@ class AccountEdiFormat(models.Model):
                     'error': _('The invoice was successfully transmitted to the Public Administration and we are waiting for confirmation'),
                     'blocking_level': 'info',
                 }
-                proxy_acks.append(id_transaction)
                 continue
             elif state == 'not_found':
                 # Invoice does not exist on proxy. Either it does not belong to this proxy_user or it was not created correctly when


### PR DESCRIPTION
…ing newer messages on the server

Actually, the risk is almost nothing to not send acks of received messages.

Doing the ack is a bigger risk if right before the ack a newer
message would arrive.  This state is the default state
that does not need to be acked at all as there is no file
associated with it.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
