### PR TITLE
[IMP] website_slides: change set done button traceback to usererror

### DIFF
--- a/addons/website_slides/controllers/main.py
+++ b/addons/website_slides/controllers/main.py
@@ -68,7 +68,7 @@ class WebsiteSlides(WebsiteProfile):
     def _set_completed_slide(self, slide):
         # quiz use their specific mechanism to be marked as done
         if slide.slide_type == 'quiz' or slide.question_ids:
-            raise werkzeug.exceptions.Forbidden(_("Slide with questions must be marked as done when submitting all good answers "))
+            raise UserError(_("Slide with questions must be marked as done when submitting all good answers "))
         if slide.website_published and slide.channel_id.is_member:
             slide.action_set_completed()
         return True


### PR DESCRIPTION
Current behavior before PR:
it was showing traceback when user clicks on "Set Done" after
the creation of the quiz in slides.

Desired behavior after PR is merged:
now when user clicks on "Set Done" after the creation of
quiz, it will show Error Message to user instead of Traceback.

Task: https://www.odoo.com/web#id=2380233&cids=2&menu_id=3940&action=4043&model=project.task&view_type=form

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
