### PR TITLE
[FIX] account: fix liquidity journal currency

### DIFF
--- a/addons/account/models/account_bank_statement.py
+++ b/addons/account/models/account_bank_statement.py
@@ -585,7 +585,7 @@ class AccountBankStatementLine(models.Model):
         statement = self.statement_id
         journal = statement.journal_id
         company_currency = journal.company_id.currency_id
-        journal_currency = journal.currency_id if journal.currency_id != company_currency else False
+        journal_currency = journal.currency_id or company_currency
 
         if self.foreign_currency_id and journal_currency:
             currency_id = journal_currency.id

--- a/addons/account/tests/test_account_bank_statement.py
+++ b/addons/account/tests/test_account_bank_statement.py
@@ -334,11 +334,11 @@ class TestAccountBankStatementLine(TestAccountBankStatementCommon):
         cls.expected_bank_line = {
             'name': cls.statement_line.payment_ref,
             'partner_id': cls.statement_line.partner_id.id,
-            'currency_id': cls.currency_2.id,
+            'currency_id': cls.currency_1.id,
             'account_id': cls.statement.journal_id.default_account_id.id,
             'debit': 1250.0,
             'credit': 0.0,
-            'amount_currency': 2500.0,
+            'amount_currency': 1250.0,
         }
 
         cls.expected_counterpart_line = {
@@ -515,7 +515,7 @@ class TestAccountBankStatementLine(TestAccountBankStatementCommon):
         self._test_edition_customer_and_supplier_flows(
             80.0,               120.0,
             self.currency_1,    self.currency_2,
-            {'debit': 80.0,     'credit': 0.0,      'amount_currency': 120.0,       'currency_id': self.currency_2.id},
+            {'debit': 80.0,     'credit': 0.0,      'amount_currency': 80.0,        'currency_id': self.currency_1.id},
             {'debit': 0.0,      'credit': 80.0,     'amount_currency': -120.0,      'currency_id': self.currency_2.id},
         )
 
@@ -555,7 +555,7 @@ class TestAccountBankStatementLine(TestAccountBankStatementCommon):
         })
 
         self.assertRecordValues(statement.line_ids.move_id.line_ids, [
-            {'debit': 0.0,      'credit': 0.0,      'amount_currency': 10.0,        'currency_id': self.currency_2.id},
+            {'debit': 0.0,      'credit': 0.0,      'amount_currency': 0.0,         'currency_id': self.currency_1.id},
             {'debit': 0.0,      'credit': 0.0,      'amount_currency': -10.0,       'currency_id': self.currency_2.id},
         ])
 
@@ -579,7 +579,7 @@ class TestAccountBankStatementLine(TestAccountBankStatementCommon):
         })
 
         self.assertRecordValues(statement.line_ids.move_id.line_ids, [
-            {'debit': 10.0,     'credit': 0.0,      'amount_currency': 0.0,         'currency_id': self.currency_2.id},
+            {'debit': 10.0,     'credit': 0.0,      'amount_currency': 10.0,        'currency_id': self.currency_1.id},
             {'debit': 0.0,      'credit': 10.0,     'amount_currency': 0.0,         'currency_id': self.currency_2.id},
         ])
 
@@ -775,8 +775,8 @@ class TestAccountBankStatementLine(TestAccountBankStatementCommon):
                 **self.expected_bank_line,
                 'debit': 0.0,
                 'credit': 2000.0,
-                'amount_currency': -4000.0,
-                'currency_id': self.currency_3.id,
+                'amount_currency': -2000.0,
+                'currency_id': self.currency_1.id,
             },
             {
                 **self.expected_counterpart_line,
@@ -807,8 +807,8 @@ class TestAccountBankStatementLine(TestAccountBankStatementCommon):
                 'partner_id': self.statement_line.partner_id.id,
                 'debit': 0.0,
                 'credit': 2000.0,
-                'amount_currency': -4000.0,
-                'currency_id': self.currency_3.id,
+                'amount_currency': -2000.0,
+                'currency_id': self.currency_1.id,
             },
             {
                 **self.expected_counterpart_line,
@@ -1059,7 +1059,7 @@ class TestAccountBankStatementLine(TestAccountBankStatementCommon):
         self._test_reconciliation_customer_and_supplier_flows(
             80.0,               120.0,              -120.0,
             self.currency_1,    self.currency_2,    self.currency_2,
-            {'debit': 80.0,     'credit': 0.0,      'amount_currency': 120.0,       'currency_id': self.currency_2.id},
+            {'debit': 80.0,     'credit': 0.0,      'amount_currency': 80.0,        'currency_id': self.currency_1.id},
             {'debit': 0.0,      'credit': 80.0,     'amount_currency': -120.0,      'currency_id': self.currency_2.id},
         )
 
@@ -1067,7 +1067,7 @@ class TestAccountBankStatementLine(TestAccountBankStatementCommon):
         self._test_reconciliation_customer_and_supplier_flows(
             80.0,               120.0,              -480.0,
             self.currency_1,    self.currency_2,    self.currency_3,
-            {'debit': 80.0,     'credit': 0.0,      'amount_currency': 120.0,       'currency_id': self.currency_2.id},
+            {'debit': 80.0,     'credit': 0.0,      'amount_currency': 80.0,        'currency_id': self.currency_1.id},
             {'debit': 0.0,      'credit': 80.0,     'amount_currency': -120.0,      'currency_id': self.currency_2.id},
         )
 
@@ -1115,7 +1115,7 @@ class TestAccountBankStatementLine(TestAccountBankStatementCommon):
         self._test_reconciliation_customer_and_supplier_flows(
             80.0,               120.0,              -80.0,
             self.currency_1,    self.currency_2,    self.currency_1,
-            {'debit': 80.0,     'credit': 0.0,      'amount_currency': 120.0,       'currency_id': self.currency_2.id},
+            {'debit': 80.0,     'credit': 0.0,      'amount_currency': 80.0,        'currency_id': self.currency_1.id},
             {'debit': 0.0,      'credit': 80.0,     'amount_currency': -120.0,      'currency_id': self.currency_2.id},
         )
 
@@ -1267,7 +1267,7 @@ class TestAccountBankStatementLine(TestAccountBankStatementCommon):
             {
                 **self.expected_bank_line,
                 'amount_residual': 1250.0,
-                'amount_residual_currency': 2500.0,
+                'amount_residual_currency': 1250.0,
             },
         ])
 
@@ -1309,7 +1309,7 @@ class TestAccountBankStatementLine(TestAccountBankStatementCommon):
             {
                 **self.expected_bank_line,
                 'amount_residual': 1250.0,
-                'amount_residual_currency': 2500.0,
+                'amount_residual_currency': 1250.0,
             },
         ])
 
@@ -1347,7 +1347,7 @@ class TestAccountBankStatementLine(TestAccountBankStatementCommon):
             {
                 **self.expected_bank_line,
                 'amount_residual': 1250.0,
-                'amount_residual_currency': 2500.0,
+                'amount_residual_currency': 1250.0,
             },
         ])
 


### PR DESCRIPTION
Currently, if a liquidity journal has a currency set (e.g. Bank) the amount_currency shows lines according to the journal currency, which is correct. However, if the journal currency is the same as the company currency, the amount_currency shows the amount in the foreign currency that is not in fact held in the Bank.
Should be: follow the same logic for liquidity journals that have the same currency as the company (or set company currency by default) and show amount in journal/company currency.

Task: 2779310
