### PR TITLE
[FIX] website: wrong fw-port of commit 971f324c419

### DIFF
--- a/addons/website/models/mixins.py
+++ b/addons/website/models/mixins.py
@@ -285,7 +285,7 @@ class WebsitePublishedMultiMixin(WebsitePublishedMixin):
     def open_website_url(self):
         return {
             'type': 'ir.actions.act_url',
-            'url': url_join(self.website_id._get_http_domain(), self.website_url) if self.website_id else self.website_url,
+            'url': url_join(self.website_id.domain, self.website_url) if self.website_id else self.website_url,
             'target': 'self',
         }
 


### PR DESCRIPTION
Since commit https://github.com/odoo/odoo/commit/7d8a8ddea0b363732f2177ad589a3e0e10e2fb6c, we should use domain instead of _get_http_domain()
that was removed.

Description of the issue/feature this PR addresses:
opw-2774121

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
