### PR TITLE
[FIX] website_sale_wishlist: correct variant selection

### DIFF
--- a/addons/website_sale_wishlist/static/src/js/website_sale_wishlist.js
+++ b/addons/website_sale_wishlist/static/src/js/website_sale_wishlist.js
@@ -75,11 +75,7 @@ publicWidget.registry.ProductWishlist = publicWidget.Widget.extend(VariantMixin,
         var self = this;
         var productID = $el.data('product-product-id');
         if ($el.hasClass('o_add_wishlist_dyn')) {
-            productID = $el.parent().find('.product_id').val();
-            if (!productID) { // case List View Variants
-                productID = $el.parent().find('input:checked').first().val();
-            }
-            productID = parseInt(productID, 10);
+            productID = parseInt($el.closest('.js_product').find('.product_id:checked').val());;
         }
         var $form = $el.closest('form');
         var templateId = $form.find('.product_template_id').val();

--- a/addons/website_sale_wishlist/static/tests/tours/website_sale_wishlist_admin.js
+++ b/addons/website_sale_wishlist/static/tests/tours/website_sale_wishlist_admin.js
@@ -1,0 +1,124 @@
+odoo.define('website_sale_wishlist_admin.tour', function (require) {
+'use strict';
+
+var rpc = require('web.rpc');
+var tour = require("web_tour.tour");
+
+tour.register('shop_wishlist_admin', {
+    test: false,
+    url: '/shop',
+},
+    [
+        {
+            content: "Create a product with always attribute and its values.",
+            trigger: 'body',
+            run: function () {
+                rpc.query({
+                    model: 'product.attribute',
+                    method: 'create',
+                    args: [{
+                        'name': "color",
+                        'display_type': 'color',
+                        'create_variant': 'always'
+                    }],
+                }).then(function (attributeId) {
+                    return rpc.query({
+                        model: 'product.template',
+                        method: 'create',
+                        args: [{
+                            'name': "Rock",
+                            'is_published': true,
+                            'attribute_line_ids': [[0, 0, {
+                                'attribute_id': attributeId,
+                                'value_ids': [
+                                    [0, 0, {
+                                        'name': "red",
+                                        'attribute_id': attributeId,
+                                    }],
+                                    [0, 0, {
+                                        'name': "blue",
+                                        'attribute_id': attributeId,
+                                    }],
+                                    [0, 0, {
+                                        'name': "black",
+                                        'attribute_id': attributeId,
+                                    }],
+                                ]
+                            }]],
+                        }],
+                    });
+                }).then(function () {
+                    window.location.href = '/shop?search=Rock';
+                });
+            },
+        },
+        {
+            content: "Go to Rock shop page",
+            trigger: 'a:contains("Rock"):first',
+        },
+        {
+            content: "check list view of variants is disabled initially (when on /product page)",
+            trigger: 'body:not(:has(.js_product_change))',
+            extra_trigger: '#product_details',
+        },
+        {
+            content: "open customize menu",
+            trigger: '#customize-menu > a',
+            extra_trigger: 'body:not(.notReady)',
+        },
+        {
+            content: "click on 'List View of Variants'",
+            trigger: '#customize-menu a:contains(List View of Variants)',
+        },
+        {
+            content: "check page loaded after list of variant customization enabled",
+            trigger: '.js_product_change',
+        },
+        {
+            content: "Add red product in wishlist",
+            trigger: '#product_detail .o_add_wishlist_dyn:not(".disabled")',
+        },
+        {
+            content: "Check that wishlist contains 1 items",
+            extra_trigger : '#product_detail .o_add_wishlist_dyn:disabled',
+            trigger: '.my_wish_quantity:contains(1)',
+            run: function () {
+                window.location.href = '/shop/wishlist';
+            }
+        },
+        {
+            content: "Check wishlist contains first variant",
+            trigger: '#o_comparelist_table tr:contains("red")',
+            run: function () {
+                window.location.href = '/shop?search=Rock';
+            }
+        },
+        {
+            content: "Go to Rock shop page",
+            trigger: 'a:contains("Rock"):first',
+        },
+        {
+            content: "Switch to black Rock",
+            trigger: '.js_product span:contains("black")',
+        },
+        {
+            content: "Switch to black Rock",
+            trigger: '#product_detail .o_add_wishlist_dyn:not(".disabled")',
+        },
+        {
+            content: "Check that black product was added",
+            extra_trigger : '#product_detail .o_add_wishlist_dyn:disabled',
+            trigger: '.my_wish_quantity:contains(2)',
+            run: function () {
+                window.location.href = '/shop/wishlist';
+            }
+        },
+        {
+            content: "Check wishlist contains both variants",
+            extra_trigger: '#o_comparelist_table tr:contains("red")',
+            trigger: '#o_comparelist_table tr:contains("black")',
+        },
+    ]
+);
+
+});

--- a/addons/website_sale_wishlist/tests/test_wishlist_process.py
+++ b/addons/website_sale_wishlist/tests/test_wishlist_process.py
@@ -8,3 +8,6 @@ import odoo.tests
 class TestUi(odoo.tests.HttpCase):
     def test_01_wishlist_tour(self):
         self.start_tour("/", 'shop_wishlist')
+
+    def test_02_wishlist_admin_tour(self):
+        self.start_tour("/", 'shop_wishlist_admin', login="admin")

--- a/addons/website_sale_wishlist/views/website_sale_wishlist_template.xml
+++ b/addons/website_sale_wishlist/views/website_sale_wishlist_template.xml
@@ -11,6 +11,7 @@
     <template id="assets_tests" name="Website Sale Wishlist Assets Tests" inherit_id="web.assets_tests">
         <xpath expr="." position="inside">
             <script type="text/javascript" src="/website_sale_wishlist/static/tests/tours/website_sale_wishlist.js"></script>
+            <script type="text/javascript" src="/website_sale_wishlist/static/tests/tours/website_sale_wishlist_admin.js"></script>
         </xpath>
     </template>
 


### PR DESCRIPTION
Step to reproduce:
- Create variants for product without grid
- Go to website
- Try to add variant of created product to wishlist

Current behaviour:
- Product ID is not properly fetched
- Product template is added to wishlist

Behaviour after PR:
- Product ID is properly fetched
- Product is added to wishlist

opw-2705883

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
