### PR TITLE
[FIX] payment_buckaroo: preserve plus sign for creating signature

### DIFF
--- a/addons/payment_buckaroo/models/payment.py
+++ b/addons/payment_buckaroo/models/payment.py
@@ -73,7 +73,7 @@ class AcquirerBuckaroo(models.Model):
                     break
 
             items = sorted(values.items(), key=lambda pair: pair[0].lower())
-            sign = ''.join('%s=%s' % (k, urls.url_unquote_plus(v)) for k, v in items)
+            sign = ''.join('%s=%s' % (k, v) for k, v in items)
         else:
             sign = ''.join('%s=%s' % (k, get_value(k)) for k in keys)
         # Add the pre-shared secret key at the end of the signature


### PR DESCRIPTION
Before this commit: all of the plus sign was converted to the space for
creating a signature, but for example, if a payment reference contains
a plus (+++___+++), it would create a different shasign.

How to reproduce the issue: add a plus sign in the payment reference
and complete the payment process.

This conversion was added with this commit:
https://github.com/odoo/odoo/commit/e63cf3c13cedb735

But it seems Buckaroo implementation has been changed, and the 
problem in this commit is not reproducible anymore.


The solution is to use the values without any conversion. The values
are sent to the server, not in URL format, and the plus sign here is
the actual plus sign.


opw-2681969
