### PR TITLE
[FIX] website_sale: changed domain for Online Sales Analysis

### DIFF
--- a/addons/website_sale/views/sale_report_views.xml
+++ b/addons/website_sale/views/sale_report_views.xml
@@ -59,7 +59,8 @@
         <field name="name">Online Sales Analysis</field>
         <field name="res_model">sale.report</field>
         <field name="view_mode">pivot,graph</field>
-        <field name="domain">[('state','in',('sale', 'done')), ('website_id', '!=', False)]</field>
+        <field name="domain">[('website_id', '!=', False)]</field>
+        <field name="context">{'search_default_confirmed': 1}</field>
         <field name="search_view_id" ref="sale_report_view_search_website"/>
         <field name="help" type="html">
             <p class="o_view_nocontent_empty_folder">


### PR DESCRIPTION
Reproduction:
1. Install eCommerce, and complete a checkout using the Wire Transfer
   payment, but don’t confirm the order at the website backend
2. Go to Orders > Unpaid Orders, the new created order should be there
3. Go to Reporting > Online Sales, select the "Unpaid Orders" filter
4. No pivot table shown for the unpaid orders

Reason: the pivot table is restricted for confirmed orders only (‘sale’
or ‘done’), the unpaid orders filter in Reporting has a different domain
from Orders

Fix: Remove the domain constraint for pivot table. Set the "Confirmed
Orders" filter to default

opw-2754932


--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
