### PR TITLE
[FIX] base: do not overwrite the overwrite value

### DIFF
--- a/odoo/addons/base/models/ir_translation.py
+++ b/odoo/addons/base/models/ir_translation.py
@@ -803,6 +803,7 @@ class IrTranslation(models.Model):
                 continue
             for lang in langs:
                 lang_code = tools.get_iso_codes(lang)
+                lang_overwrite = overwrite
                 base_lang_code = None
                 if '_' in lang_code:
                     base_lang_code = lang_code.split('_')[0]
@@ -812,28 +813,28 @@ class IrTranslation(models.Model):
                     base_trans_file = get_module_resource(module_name, 'i18n', base_lang_code + '.po')
                     if base_trans_file:
                         _logger.info('module %s: loading base translation file %s for language %s', module_name, base_lang_code, lang)
-                        tools.trans_load(self._cr, base_trans_file, lang, verbose=False, overwrite=overwrite)
-                        overwrite = True  # make sure the requested translation will override the base terms later
+                        tools.trans_load(self._cr, base_trans_file, lang, verbose=False, overwrite=lang_overwrite)
+                        lang_overwrite = True  # make sure the requested translation will override the base terms later
 
                     # i18n_extra folder is for additional translations handle manually (eg: for l10n_be)
                     base_trans_extra_file = get_module_resource(module_name, 'i18n_extra', base_lang_code + '.po')
                     if base_trans_extra_file:
                         _logger.info('module %s: loading extra base translation file %s for language %s', module_name, base_lang_code, lang)
-                        tools.trans_load(self._cr, base_trans_extra_file, lang, verbose=False, overwrite=overwrite)
-                        overwrite = True  # make sure the requested translation will override the base terms later
+                        tools.trans_load(self._cr, base_trans_extra_file, lang, verbose=False, overwrite=lang_overwrite)
+                        lang_overwrite = True  # make sure the requested translation will override the base terms later
 
                 # Step 2: then load the main translation file, possibly overriding the terms coming from the base language
                 trans_file = get_module_resource(module_name, 'i18n', lang_code + '.po')
                 if trans_file:
                     _logger.info('module %s: loading translation file (%s) for language %s', module_name, lang_code, lang)
-                    tools.trans_load(self._cr, trans_file, lang, verbose=False, overwrite=overwrite)
+                    tools.trans_load(self._cr, trans_file, lang, verbose=False, overwrite=lang_overwrite)
                 elif lang_code != 'en_US':
                     _logger.info('module %s: no translation for language %s', module_name, lang_code)
 
                 trans_extra_file = get_module_resource(module_name, 'i18n_extra', lang_code + '.po')
                 if trans_extra_file:
                     _logger.info('module %s: loading extra translation file (%s) for language %s', module_name, lang_code, lang)
-                    tools.trans_load(self._cr, trans_extra_file, lang, verbose=False, overwrite=overwrite)
+                    tools.trans_load(self._cr, trans_extra_file, lang, verbose=False, overwrite=lang_overwrite)
         return True
 
     @api.model


### PR DESCRIPTION
The signature of the _load_module_terms was changed at ac63556e239a to
pass explicit parameters instead of values hidden in the context

The previous code used working on a copy of the context when modifing
the 'overwrite' key. This was no longer the case after ac63556e23.

In case multiple languages are updated at the same time (as when a
module is updated), the 'overwrite' value is set to True after the
first loop.

To reproduce:
1. Create empty db with language English and without demo data
2. Activate languages fr_FR, fr_BE and fr_CH
3. Install module "note"
4. Now change in the fr.po the msgstr for this msgid:
   "By sticky note Category" -> "Par catégorie de note collante FR"
   and in the fr_BE.po the msgstr for this msgid:
   "By sticky note Category" -> "Par catégorie de note collante BE"
5. Now update the module note without overwriting translations
   (--i18n-overwrite option not set)
Observed behaviour:
The translations are overriden

opw-2760359
