### PR TITLE
[FIX] account: confirm move with rule_type set

### DIFF
--- a/addons/account/models/account_move.py
+++ b/addons/account/models/account_move.py
@@ -677,7 +677,7 @@ class AccountMove(models.Model):
             self.line_ids -= to_remove
 
         # ==== Mount base lines ====
-        for line in self.line_ids.filtered(lambda line: not line.tax_repartition_line_id):
+        for line in self.line_ids.filtered(lambda line: not line.tax_repartition_line_id and not line.display_type):
             # Don't call compute_all if there is no tax.
             if not line.tax_ids:
                 if not recompute_tax_base_amount:


### PR DESCRIPTION
Steps to reproduce:

- With two company, A (main company) and B
- On company B, set rule_type on 'invoice_on_refund'
- Create an invoice with company B as customer
- Create a section line and a product line
- Save and Confirm

Issue:

Traceback - ValueError: Expected singleton: res.currency()

With this commit, we filter to exclude section and note lines
from the computation method.

opw-2755468

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
