### PR TITLE
[FIX] web : disable archive when active is readonly

### DIFF
--- a/addons/web/static/src/legacy/js/views/basic/basic_view.js
+++ b/addons/web/static/src/legacy/js/views/basic/basic_view.js
@@ -50,7 +50,9 @@ var BasicView = AbstractView.extend({
         this.rendererParams.viewType = this.viewType;
 
         this.controllerParams.confirmOnDelete = true;
-        this.controllerParams.archiveEnabled = 'active' in this.fields || 'x_active' in this.fields;
+        this.controllerParams.archiveEnabled = 'active' in this.fields ? !this.fields.active.readonly
+                                             : 'x_active' in this.fields ? !this.fields.x_active.readonly
+                                             : false;
         this.controllerParams.hasButtons =
                 'action_buttons' in params ? params.action_buttons : true;
         this.controllerParams.viewId = viewInfo.view_id;

--- a/addons/web/static/tests/legacy/views/list_tests.js
+++ b/addons/web/static/tests/legacy/views/list_tests.js
@@ -4032,6 +4032,30 @@ QUnit.module('Views', {
             "action wizard should have been opened");
     });
 
+    QUnit.test('archive/unarchive not available on active readonly models', async function (assert) {
+        assert.expect(2);
+
+        this.data.foo.fields.active = { string: 'Active', type: 'boolean', default: true, readonly: true };
+
+        const list = await createView({
+            View: ListView,
+            model: 'foo',
+            data: this.data,
+            arch: '<tree limit="3"><field name="display_name"/></tree>',
+            viewOptions: {
+                hasActionMenus: true,
+            },
+        });
+
+        await testUtils.dom.click(list.$('tbody .o_data_row:first td.o_list_record_selector:first input'));
+        assert.containsOnce(list, '.o_cp_action_menus', 'sidebar should be available');
+
+        await testUtils.dom.click(list.$('.o_cp_action_menus .dropdown-toggle:contains(Action)'));
+        assert.containsNone(list, 'a:contains(Archive)', 'Archive action should not be available');
+
+        list.destroy();
+    });
+
     QUnit.test('pager (ungrouped and grouped mode), default limit', async function (assert) {
         assert.expect(4);
 


### PR DESCRIPTION
Steps :
Install Sale / E-commerce.
Create product P (price = 100).
Create price list L aka product_pricelist.
Create price rule R (product = P, price = 50) aka product_pricelist_item.
Go to product P > Price Rules > archive R.

Issue :
This should not be possible, as product_pricelist_item.active is a
readonly field (related to pricelist_id.active).

Fix :
Make BasicView.controller.archiveEnabled depend on that.

opw-2760139




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
