### PR TITLE
[FIX] stock, mrp_subcontracting: fix subcontracting installation traceback

### DIFF
--- a/addons/stock/models/stock_warehouse.py
+++ b/addons/stock/models/stock_warehouse.py
@@ -303,7 +303,7 @@ class Warehouse(models.Model):
 
     def _create_or_update_sequences_and_picking_types(self):
         """ Create or update existing picking types for a warehouse.
-        Pikcing types are stored on the warehouse in a many2one. If the picking
+        Picking types are stored on the warehouse in a many2one. If the picking
         type exist this method will update it. The update values can be found in
         the method _get_picking_type_update_values. If the picking type does not
         exist it will be created with a new sequence associated to it.
@@ -896,8 +896,9 @@ class Warehouse(models.Model):
 
     def _get_picking_type_update_values(self):
         """ Return values in order to update the existing picking type when the
-        warehouse's delivery_steps or reception_steps are modify.
+        warehouse's delivery_steps or reception_steps are modified.
         """
+        self._check_company()
         input_loc, output_loc = self._get_input_output_locations(self.reception_steps, self.delivery_steps)
         return {
             'in_type_id': {


### PR DESCRIPTION
- Current behavior before PR:

Due to some misconfiguration on the routes, subcontracting installation is blocked by the following traceback:

```
Traceback (most recent call last):
File "/home/odoo/src/odoo/odoo/tools/convert.py", line 680, in _tag_root
f(rec)
File "/home/odoo/src/odoo/odoo/tools/convert.py", line 333, in _tag_function
_eval_xml(self, rec, env)
File "/home/odoo/src/odoo/odoo/tools/convert.py", line 204, in _eval_xml
return odoo.api.call_kw(model, method_name, args, kwargs)
File "/home/odoo/src/odoo/odoo/api.py", line 464, in call_kw
result = _call_kw_multi(method, model, args, kwargs)
File "/home/odoo/src/odoo/odoo/api.py", line 451, in _call_kw_multi
result = method(recs, *args, **kwargs)
File "/home/odoo/src/odoo/addons/mrp/models/stock_warehouse.py", line 281, in write
return super(StockWarehouse, self).write(vals)
File "/home/odoo/src/odoo/addons/stock/models/stock_warehouse.py", line 188, in write
picking_type_vals = warehouse._create_or_update_sequences_and_picking_types()
File "/home/odoo/src/odoo/addons/stock/models/stock_warehouse.py", line 332, in _create_or_update_sequences_and_picking_types
self[picking_type].update(values)
File "/home/odoo/src/odoo/odoo/models.py", line 5611, in update
record[name] = value
File "/home/odoo/src/odoo/odoo/models.py", line 5891, in __setitem__
return self._fields[key].__set__(self, value)
File "/home/odoo/src/odoo/odoo/fields.py", line 1217, in __set__
records.write({self.name: write_value})
File "/home/odoo/src/odoo/addons/stock/models/stock_picking.py", line 129, in write
return super(PickingType, self).write(vals)
File "/home/odoo/src/odoo/odoo/models.py", line 3908, in write
self._check_company()
File "/home/odoo/src/odoo/odoo/models.py", line 3531, in _check_company
raise UserError("\n".join(lines))
odoo.exceptions.UserError: Incompatible companies on records:
- 'Main Factory Warehouse: PoS Orders' belongs to company 'Zeitgeist (Manufacturing Division)' and 'Reference Sequence' (sequence_id: 'Main Factory Warehouse Picking POS') belongs to another company.

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
File "/home/odoo/src/odoo/odoo/addons/base/models/ir_http.py", line 237, in _dispatch
result = request.dispatch()
File "/home/odoo/src/odoo/odoo/http.py", line 688, in dispatch
result = self._call_function(**self.params)
File "/home/odoo/src/odoo/odoo/http.py", line 360, in _call_function
return checked_call(self.db, *args, **kwargs)
File "/home/odoo/src/odoo/odoo/service/model.py", line 94, in wrapper
return f(dbname, *args, **kwargs)
File "/home/odoo/src/odoo/odoo/http.py", line 349, in checked_call
result = self.endpoint(*a, **kw)
File "/home/odoo/src/odoo/odoo/http.py", line 917, in __call__
return self.method(*args, **kw)
File "/home/odoo/src/odoo/odoo/http.py", line 536, in response_wrap
response = f(*args, **kw)
File "/home/odoo/src/odoo/addons/web/controllers/main.py", line 1352, in call_button
action = self._call_kw(model, method, args, kwargs)
File "/home/odoo/src/odoo/addons/web/controllers/main.py", line 1340, in _call_kw
return call_kw(request.env[model], method, args, kwargs)
File "/home/odoo/src/odoo/odoo/api.py", line 464, in call_kw
result = _call_kw_multi(method, model, args, kwargs)
File "/home/odoo/src/odoo/odoo/api.py", line 451, in _call_kw_multi
result = method(recs, *args, **kwargs)
File "/home/odoo/src/odoo/odoo/addons/base/models/res_config.py", line 641, in execute
installation_status = self._install_modules(to_install)
File "/home/odoo/src/odoo/odoo/addons/base/models/res_config.py", line 36, in _install_modules
result = to_install_modules.button_immediate_install()
File "<decorator-gen-74>", line 2, in button_immediate_install
File "/home/odoo/src/odoo/odoo/addons/base/models/ir_module.py", line 74, in check_and_log
return method(self, *args, **kwargs)
File "/home/odoo/src/odoo/odoo/addons/base/models/ir_module.py", line 483, in button_immediate_install
return self._button_immediate_function(type(self).button_install)
File "/home/odoo/src/odoo/odoo/addons/base/models/ir_module.py", line 600, in _button_immediate_function
registry = modules.registry.Registry.new(self._cr.dbname, update_module=True)
File "/home/odoo/src/odoo/odoo/modules/registry.py", line 87, in new
odoo.modules.load_modules(registry, force_demo, status, update_module)
File "/home/odoo/src/odoo/odoo/modules/loading.py", line 474, in load_modules
processed_modules += load_marked_modules(cr, graph,
File "/home/odoo/src/odoo/odoo/modules/loading.py", line 363, in load_marked_modules
loaded, processed = load_module_graph(
File "/home/odoo/src/odoo/odoo/modules/loading.py", line 222, in load_module_graph
load_data(cr, idref, mode, kind='data', package=package)
File "/home/odoo/src/odoo/odoo/modules/loading.py", line 69, in load_data
tools.convert_file(cr, package.name, filename, idref, mode, noupdate, kind)
File "/home/odoo/src/odoo/odoo/tools/convert.py", line 745, in convert_file
convert_xml_import(cr, module, fp, idref, mode, noupdate)
File "/home/odoo/src/odoo/odoo/tools/convert.py", line 811, in convert_xml_import
obj.parse(doc.getroot())
File "/home/odoo/src/odoo/odoo/tools/convert.py", line 731, in parse
self._tag_root(de)
File "/home/odoo/src/odoo/odoo/tools/convert.py", line 680, in _tag_root
f(rec)
File "/home/odoo/src/odoo/odoo/tools/convert.py", line 693, in _tag_root
raise ParseError('while parsing %s:%s, somewhere inside\n%s' % (
Exception

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
File "/home/odoo/src/odoo/odoo/http.py", line 644, in _handle_exception
return super(JsonRequest, self)._handle_exception(exception)
File "/home/odoo/src/odoo/odoo/http.py", line 302, in _handle_exception
raise exception.with_traceback(None) from new_cause
odoo.tools.convert.ParseError: while parsing /home/odoo/src/odoo/addons/mrp_subcontracting/data/mrp_subcontracting_data.xml:10, somewhere inside
<function model="stock.warehouse" name="write">
<value model="stock.warehouse" eval="obj().env['stock.warehouse'].search([]).ids"/>
<value eval="{'subcontracting_to_resupply': True}"/>
</function>
```

- Desired behavior after PR is merged:

Checking the company of the values given to field names should solve the problem and fix the traceback.

opw-2713856
opw-2768145
opw-2755007

