### PR TITLE
[FIX] mail_plugin: allow to re-use the mock method

### DIFF
--- a/addons/mail_plugin/tests/common.py
+++ b/addons/mail_plugin/tests/common.py
@@ -2,11 +2,30 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 import json
+from contextlib import contextmanager
 from unittest.mock import patch
 
 from odoo.addons.mail.tests.common import mail_new_test_user
 from odoo.http import request
 from odoo.tests.common import HttpCase
+
+
+@contextmanager
+def mock_auth_method_outlook(login):
+    """Mock the Outlook auth method.
+
+    This must be used as a method decorator.
+
+    :param login: Login of the user used for the authentication
+    """
+    def patched_auth_method_outlook(*args, **kwargs):
+        request.uid = request.env['res.users'].search([('login', '=', login)], limit=1).id
+
+    with patch(
+            'odoo.addons.mail_plugin.models.ir_http.IrHttp'
+            '._auth_method_outlook',
+            new=patched_auth_method_outlook):
+        yield
 
 
 class TestMailPluginControllerCommon(HttpCase):
@@ -18,6 +37,7 @@ class TestMailPluginControllerCommon(HttpCase):
             groups="base.group_user,base.group_partner_manager",
         )
 
+    @mock_auth_method_outlook('employee')
     def mock_plugin_partner_get(self, name, email, patched_iap_enrich):
         """Simulate a HTTP call to /partner/get with the given email and name.
 
@@ -25,8 +45,6 @@ class TestMailPluginControllerCommon(HttpCase):
         The third argument "patched_iap_enrich" allow you to mock the IAP request and
         to return the response you want.
         """
-        def patched_auth_method_outlook(*args, **kwargs):
-            request.uid = self.user_test.id
 
         data = {
             "id": 0,
@@ -36,10 +54,6 @@ class TestMailPluginControllerCommon(HttpCase):
         }
 
         with patch(
-            "odoo.addons.mail_plugin.models.ir_http.IrHttp"
-            "._auth_method_outlook",
-            new=patched_auth_method_outlook,
-        ), patch(
             "odoo.addons.mail_plugin.controllers.mail_plugin.MailPluginController"
             "._iap_enrich",
             new=patched_iap_enrich,
@@ -55,15 +69,13 @@ class TestMailPluginControllerCommon(HttpCase):
 
         return result.json().get("result", {})
 
+    @mock_auth_method_outlook('employee')
     def mock_enrich_and_create_company(self, partner_id, patched_iap_enrich):
         """Simulate a HTTP call to /partner/enrich_and_create_company on the given partner.
 
         The third argument "patched_iap_enrich" allow you to mock the IAP request and
         to return the response you want.
         """
-        def patched_auth_method_outlook(*args, **kwargs):
-            request.uid = self.user_test.id
-
         data = {
             "id": 0,
             "jsonrpc": "2.0",
@@ -72,10 +84,6 @@ class TestMailPluginControllerCommon(HttpCase):
         }
 
         with patch(
-            "odoo.addons.mail_plugin.models.ir_http.IrHttp"
-            "._auth_method_outlook",
-            new=patched_auth_method_outlook,
-        ), patch(
             "odoo.addons.mail_plugin.controllers.mail_plugin.MailPluginController"
             "._iap_enrich",
             new=patched_iap_enrich,


### PR DESCRIPTION
Purpose
=======
Allow to re-use the method `mock_auth_method` used to mock the Outlook
authentication, to be able to write tests in other sub-modules.

Task-2782150