### PR TITLE
[FIX] sale_mrp: MO link missing with 3steps manufacture

### DIFF
--- a/addons/mrp/models/stock_rule.py
+++ b/addons/mrp/models/stock_rule.py
@@ -97,7 +97,11 @@ class StockRule(models.Model):
                 # Create now the procurement group that will be assigned to the new MO
                 # This ensure that the outgoing move PostProduction -> Stock is linked to its MO
                 # rather than the original record (MO or SO)
-                procurement.values['group_id'] = self.env["procurement.group"].create({'name': name})
+                group = procurement.values.get('group_id')
+                if group:
+                    procurement.values['group_id'] = group.copy({'name': name})
+                else:
+                    procurement.values['group_id'] = self.env["procurement.group"].create({'name': name})
         return super()._run_pull(procurements)
 
     def _get_custom_move_fields(self):

--- a/addons/sale_mrp/tests/test_multistep_manufacturing.py
+++ b/addons/sale_mrp/tests/test_multistep_manufacturing.py
@@ -132,3 +132,20 @@ class TestMultistepManufacturing(TestMrpCommon):
         exception = self.env['mail.activity'].search([('res_model', '=', 'mrp.production'),
                                                       ('res_id', '=', manufaturing_from_so.id)])
         self.assertEqual(len(exception.ids), 1, 'When user cancelled child manufacturing, exception must be generated on parent manufacturing.')
+
+    def test_manufacturing_step_three(self):
+        """ Testing for Step-3 """
+        with Form(self.warehouse) as warehouse:
+            warehouse.manufacture_steps = 'pbm_sam'
+        self.sale_order.action_confirm()
+
+        mo = self.env['mrp.production'].search([
+            ('origin', '=', self.sale_order.name),
+            ('product_id', '=', self.product_manu.id),
+        ])
+
+        self.assertEqual(self.sale_order.mrp_production_count, 1)
+        self.assertEqual(mo.sale_order_count, 1)
+
+        self.assertEqual(self.sale_order.action_view_mrp_production()['res_id'], mo.id)
+        self.assertEqual(mo.action_view_sale_orders()['res_id'], self.sale_order.id)


### PR DESCRIPTION
To reproduce the issue:
1. Storable product with MTO and manufacture route
2. On your warehouse set 3 steps manufacture
3. Create and Confirm a SO for this product

Error: The smart button linking the Manufacturing order does not appear
on the MO.

Problem was introduced by [1] and fixed by [2,3]. Moreover, [1] wasn't
deployed on versions >14.0 so there was no need for [2] on these
versions ([3] has been merged on all versions). However, [1] have
recently been deployed on next versions ([4]) so we need to FW [2] too
without disturbing the improvements from [3].

[1] 7ab0ac3e56949e5015bb2dcfd2af34b56dee92c8
[2] 96b56ea350c283d824468c591d42e4aeeada0d69
[3] 475e6b3cb027b3127b8e46fd8c9f90abc35162d7
[4] 7d7976a61d0af41ebb4df2e24ba222f6570f689c

OPW-2778883