### PR TITLE
[FIX] auth_totp_mail_enforce: browser falsy when using the Odoo app

### DIFF
--- a/addons/auth_totp_mail_enforce/models/res_users.py
+++ b/addons/auth_totp_mail_enforce/models/res_users.py
@@ -89,10 +89,12 @@ class Users(models.Model):
         context = {}
         if request:
             geoip = request.session.geoip
+            device = request.httprequest.user_agent.platform
+            browser = request.httprequest.user_agent.browser
             context.update({
                 'location': f"{geoip['city']}, {geoip['country_name']}" if geoip else None,
-                'device': request.httprequest.user_agent.platform.capitalize(),
-                'browser': request.httprequest.user_agent.browser.capitalize(),
+                'device': device and device.capitalize() or None,
+                'browser': browser and browser.capitalize() or None,
                 'ip': request.httprequest.environ['REMOTE_ADDR'],
             })
         email_values = {


### PR DESCRIPTION
When using the odoo app,
`request.httprequest.user_agent.browser` is `False`,
instead of a string expected.
Therefore, `capitalize` cannot be called

```
2022-03-02 09:44:01,267 1321846 ERROR dle-test1 odoo.addons.saas_trial.models.res_users: 2fa by email failed
Traceback (most recent call last):
  File "/home/odoo/src/custom/trial/saas_trial/models/res_users.py", line 267, in _send_totp_mail_code
    return super()._send_totp_mail_code()
  File "/home/odoo/src/odoo/saas-15.1/addons/auth_totp_mail_enforce/models/res_users.py", line 95, in _send_totp_mail_code
    'browser': request.httprequest.user_agent.browser.capitalize(),
AttributeError: 'NoneType' object has no attribute 'capitalize'
```