### PR TITLE
[FIX] web: remove unwanted bg in tables

### DIFF
--- a/addons/web/static/src/legacy/scss/bootstrap_overridden.scss
+++ b/addons/web/static/src/legacy/scss/bootstrap_overridden.scss
@@ -96,7 +96,6 @@ $headings-color: $o-main-headings-color !default;
 $table-accent-bg: rgba($black, .01) !default;
 $table-hover-bg: rgba($black, .04) !default;
 $table-border-color: $gray-200 !default;
-$table-bg: $o-view-background-color !default;
 
 // Dropdowns
 //

--- a/addons/web/static/src/views/pivot/pivot_renderer.xml
+++ b/addons/web/static/src/views/pivot/pivot_renderer.xml
@@ -4,7 +4,7 @@
     <t t-name="web.PivotRenderer" owl="1">
         <div class="o_pivot table-responsive">
 
-            <table class="table-hover table table-sm table-bordered" t-att-class="{
+            <table class="table-hover table table-sm table-bordered bg-white" t-att-class="{
                 o_enable_linking: !model.metaData.disableLinking,
                 o_sample_data_disabled: model.useSampleModel,
             }">


### PR DESCRIPTION
Changes made in the commit 27bd6a681037d2794dac2453d7064be3a8d5bb36 apply a white background in every tables and create visual issues (e.g. the `o_inspector_table` on the right in `documents`).

This commit removes this global rule and applies a `bg-white` only to the pivot view.

task-2731553

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
