### PR TITLE
[IMP] {*_,,}event{,,_sms}: update sms reminder template

### DIFF
--- a/addons/event/data/event_demo.xml
+++ b/addons/event/data/event_demo.xml
@@ -144,6 +144,7 @@
         <field name="user_id" ref="base.user_demo"/>
         <field name="date_begin" eval="(DateTime.today()+ timedelta(days=130)).strftime('%Y-%m-%d 20:15:00')"/>
         <field name="date_end" eval="(DateTime.today()+ timedelta(days=133)).strftime('%Y-%m-%d 00:30:00')"/>
+        <field name="date_tz">Europe/London</field>
         <field name="event_type_id" ref="event_type_0"/>
         <field name="address_id" ref="event.res_partner_location_1"/>
         <field name="stage_id" ref="event_stage_announced"/>

--- a/addons/event/models/event_registration.py
+++ b/addons/event/models/event_registration.py
@@ -4,7 +4,7 @@
 from dateutil.relativedelta import relativedelta
 
 from odoo import _, api, fields, models, SUPERUSER_ID
-from odoo.tools import format_datetime
+from odoo.tools import format_date
 from odoo.exceptions import AccessError, ValidationError
 
 
@@ -296,7 +296,7 @@ class EventRegistration(models.Model):
     # TOOLS
     # ------------------------------------------------------------
 
-    def get_date_range_str(self):
+    def get_date_range_str(self, lang_code=False):
         self.ensure_one()
         today = fields.Datetime.now()
         event_date = self.event_begin_date
@@ -312,7 +312,7 @@ class EventRegistration(models.Model):
         elif event_date.month == (today + relativedelta(months=+1)).month:
             return _('next month')
         else:
-            return _('on %(date)s', date=format_datetime(self.env, self.event_begin_date, tz=self.event_id.date_tz, dt_format='medium'))
+            return _('on %(date)s', date=format_date(self.env, self.event_begin_date, lang_code=lang_code, date_format='medium'))
 
     def _get_registration_summary(self):
         self.ensure_one()

--- a/addons/event/tests/test_event_internals.py
+++ b/addons/event/tests/test_event_internals.py
@@ -79,7 +79,7 @@ class TestEventData(TestEventInternalsCommon):
             self.assertEqual(registration.get_date_range_str(), u'next month')
 
             event.date_begin = datetime(2020, 3, 1, 10, 0, 0)
-            self.assertEqual(registration.get_date_range_str(), u'on Mar 1, 2020, 11:00:00 AM')
+            self.assertEqual(registration.get_date_range_str(), u'on Mar 1, 2020')
 
             # Is actually 8:30 to 20:00 in Mexico
             event.write({

--- a/addons/event/views/event_views.xml
+++ b/addons/event/views/event_views.xml
@@ -572,8 +572,8 @@
                             <group string="Attendee" name="attendee">
                                 <field class="o_text_overflow" name="name"/>
                                 <field name="email"/>
-                                <field name="phone" class="o_force_ltr"/>
-                                <field name="mobile" class="o_force_ltr"/>
+                                <field name="phone" class="o_force_ltr" widget="phone" options="{'enable_sms': false}"/>
+                                <field name="mobile" class="o_force_ltr" widget="phone"/>
                             </group>
                             <group string="Event Information" name="event">
                                 <field class="o_text_overflow" name="event_id" attrs="{'readonly': [('state', '!=', 'draft')]}" options="{'no_create': True}"/>

--- a/addons/event_sms/data/sms_data.xml
+++ b/addons/event_sms/data/sms_data.xml
@@ -11,7 +11,8 @@
     <record id="sms_template_data_event_reminder" model="sms.template">
         <field name="name">Event: Reminder</field>
         <field name="model_id" ref="event.model_event_registration"/>
-        <field name="body">{{ object.event_id.organizer_id.name or object.event_id.company_id.name or user.env.company.name }}: We are excited to remind you that the {{ object.event_id.name }} event is starting {{ object.get_date_range_str() }}. We confirm your registration and hope to meet you there.</field>
+        <field name="body">Ready for "{{ object.event_id.name }}" {{ object.get_date_range_str(object.partner_id.lang) }}?
+{{ 'It starts at %s' % format_time(time=object.event_begin_date, tz=object.event_id.date_tz, time_format='short', lang_code=object.partner_id.lang) + (', at %s' % object.event_id.address_inline if object.event_id.address_inline else '') + '.\nSee you there!' if object.event_id.address_inline or 'website_published' not in object.event_id._fields else 'Join us on %s/event/%i !' % (object.get_base_url(), object.event_id.id) }}</field>
         <field name="lang">{{ object.partner_id.lang }}</field>
     </record>
 

--- a/addons/website_event/models/event_event.py
+++ b/addons/website_event/models/event_event.py
@@ -417,7 +417,7 @@ class Event(models.Model):
             'details': self.name,
         }
         if self.address_id:
-            params.update(location=self.sudo().address_id.contact_address.replace('\n', ' '))
+            params.update(location=self.address_inline)
         encoded_params = werkzeug.urls.url_encode(params)
         google_url = GOOGLE_CALENDAR_URL + encoded_params
         iCal_url = '/event/%d/ics?%s' % (self.id, encoded_params)


### PR DESCRIPTION
* = website

Change the wording of the sms reminder template to make it sound friendlier and
more complete. The sms will include the event address if it is defined.
Otherwise, it will link to the event page if website is installed.

A one line-formatted version of the venue is added to the model to be used in
the template and other places.

This required to update `event_registration.get_date_range_str` to not include
the time when describing an event happening more than a month from the current
date, which makes sense as there is no reason to specify the time only in that
case, and we add the time somewhere else when it's useful anyway.

For consistency, Wembley Stadium is updated to London timezone in the demo
data.

Task-2777183
