### PR TITLE
[FIX] mass_mailing: show the snippets menu in the editor

### DIFF
--- a/addons/mass_mailing/static/src/js/mass_mailing_widget.js
+++ b/addons/mass_mailing/static/src/js/mass_mailing_widget.js
@@ -346,6 +346,12 @@ var MassMailingFieldHtml = FieldHtml.extend({
         var $snippets = $snippetsSideBar.find(".oe_snippet");
         var $snippets_menu = $snippetsSideBar.find("#snippets_menu");
 
+        for (const button of $snippets_menu.get(0).children) {
+            if (button.textContent === 'Select a template') {
+                button.style.display = 'none';
+            }
+        }
+
         if (config.device.isMobile) {
             $snippetsSideBar.hide();
             this.$content.attr('style', 'padding-left: 0px !important');

--- a/addons/mass_mailing/static/src/scss/mass_mailing.ui.scss
+++ b/addons/mass_mailing/static/src/scss/mass_mailing.ui.scss
@@ -8,7 +8,6 @@
 
 .o_mail_theme_selector {
     > a {
-        @include o-position-absolute(0, 0, auto, 0);
         height: $o-we-toolbar-height;
         line-height: $o-we-toolbar-height;
         border-radius: 0;
@@ -47,7 +46,7 @@
 
         &.show {
             bottom: 31px !important;
-            top: -2px !important;
+            top: 41px !important;
             right: 3px !important;
         }
 


### PR DESCRIPTION
In the editor menu, the buttons 'Blocks', 'Style', and 'Select a
template' are not visible because they are hidden by the theme selector
When clicking on 'Change Style' in fullscreen, the dropdown menu hides
the button so it is impossible to exit the theme selector without
choosing one

Steps to reproduce:
1. Install Email Marketing
2. Create new mailing
3. Select a Mail Body (except 'Plain Text')
4. The buttons are hidden by the button 'Change Style'
5. Go in fullscreen and click on 'Change Style'
6. The dropdown menu hides the button so we cannot exit the theme
selector properly

Solution:
Delete the absolute position of the theme selector
Put the dropdown menu lower so that it doesn't hide the 'Change Style'
button
Hide the 'Select a template' button because it is useless

opw-2743460