### PR TITLE
[IMP]: website_sale : Allow bulk uploading of extra product media from the frontend

### DIFF
--- a/addons/website_sale/models/product_image.py
+++ b/addons/website_sale/models/product_image.py
@@ -1,6 +1,8 @@
 # -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
+import base64
+
 from odoo import api, fields, models, tools, _
 from odoo.exceptions import ValidationError
 
@@ -34,7 +36,8 @@ class ProductImage(models.Model):
     @api.onchange('video_url')
     def _onchange_video_url(self):
         if not self.image_1920:
-            self.image_1920 = get_video_thumbnail(self.video_url) or False
+            thumbnail = get_video_thumbnail(self.video_url)
+            self.image_1920 = thumbnail and base64.b64encode(thumbnail) or False
 
     @api.depends('video_url')
     def _compute_embed_code(self):

--- a/addons/website_sale/tests/__init__.py
+++ b/addons/website_sale/tests/__init__.py
@@ -16,3 +16,4 @@ from . import test_website_sale_show_compare_list_price
 from . import test_website_sale_visitor
 from . import test_website_sale_product
 from . import test_website_sale_shop_variant_exclusion
+from . import test_website_editor

--- a/addons/website_sale/tests/test_website_editor.py
+++ b/addons/website_sale/tests/test_website_editor.py
@@ -1,0 +1,186 @@
+# -*- coding: utf-8 -*-
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from odoo.addons.website_sale.controllers.main import WebsiteSale
+from odoo.addons.website.tools import MockRequest
+from odoo.exceptions import ValidationError
+from odoo.tests import HttpCase, tagged
+
+ATTACHMENT_DATA = [
+    b"iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAIAAACQd1PeAAAAEElEQVR4nGKqf3geEAAA//8EGgIyYKYzzgAAAABJRU5ErkJggg==",
+    b"iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAIAAACQd1PeAAAAEElEQVR4nGKqvvQEEAAA//8EBQI0GMlQsAAAAABJRU5ErkJggg==",
+    b"iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAIAAACQd1PeAAAAEElEQVR4nGKKLakBBAAA//8ChwFQsvFlAwAAAABJRU5ErkJggg==",
+    b"iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAIAAACQd1PeAAAAEElEQVR4nGJqkdoACAAA//8CfAFRzSyOUAAAAABJRU5ErkJggg==",
+    b"iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAIAAACQd1PeAAAAEElEQVR4nGLSfxgICAAA//8CrAFkoLBhpQAAAABJRU5ErkJggg==",
+]
+ATTACHMENT_COUNT = 5
+
+
+@tagged('post_install', '-at_install')
+class TestProductPictureController(HttpCase):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.website = cls.env['website'].browse(1)
+        cls.WebsiteSaleController = WebsiteSale()
+        cls.product = cls.env['product.product'].create({
+            'name': 'Storage Test Box',
+            'standard_price': 70.0,
+            'list_price': 79.0,
+            'website_published': True,
+        })
+
+        cls.attachments = cls.env['ir.attachment'].create([
+            {
+                'datas': ATTACHMENT_DATA[i],
+                'name': f'image0{i}.gif',
+                'public': True
+            }
+            for i in range(ATTACHMENT_COUNT)])
+
+    def _create_product_images(self):
+        with MockRequest(self.product.env, website=self.website):
+            self.WebsiteSaleController.add_product_images(
+                [{'id': attachment.id} for attachment in self.attachments],
+                self.product.id,
+                self.product.product_tmpl_id.id,
+            )
+
+    def test_bulk_image_upload(self):
+        # Turns attachments to product_images
+        self._create_product_images()
+
+        # Check if the media now exists on the product :
+        for i, image in enumerate(self.product.product_template_image_ids):
+            # Check if all names are now in the product
+            self.assertIn(image.name, self.attachments.mapped('name'))
+            # Check if image datas are the same
+            self.assertEqual(image.image_1920, ATTACHMENT_DATA[i])
+        # Check if exactly ATTACHMENT_COUNT images were saved (no dupes/misses?)
+        self.assertEqual(ATTACHMENT_COUNT, len(self.product.product_template_image_ids))
+
+    def test_image_clear(self):
+        # First create some images
+        self._create_product_images()
+        self.assertEqual(ATTACHMENT_COUNT, len(self.product.product_template_image_ids))
+
+        # Remove all images
+        # (Exception raised if error)
+        with MockRequest(self.product.env, website=self.website):
+            self.WebsiteSaleController.clear_product_images(
+                self.product.id,
+                self.product.product_tmpl_id.id,
+            )
+        # According to the product, there are no variants images.
+        self.assertEqual(0, len(self.product.product_template_image_ids))
+
+    def test_extra_images_with_new_variant(self):
+        # Test that adding images for a variant that is not yet created works
+        product_attribute = self.env['product.attribute'].create({
+            "name": "Test attribute",
+            "create_variant": "dynamic",
+        })
+        product_attribute_values = self.env['product.attribute.value'].create([
+            {
+                "name" : "Test Dynamic 1",
+                "attribute_id": product_attribute.id,
+                "sequence": 1,
+            },
+            {
+                "name" : "Test Dynamic 2",
+                "attribute_id": product_attribute.id,
+                "sequence": 2,
+            }
+        ])
+        product_template = self.env['product.template'].create({
+            "name": "test product",
+            "website_published": True,
+        })
+        product_template_attribute_line = self.env['product.template.attribute.line'].create({
+            "attribute_id": product_attribute.id,
+            "product_tmpl_id": product_template.id,
+            "value_ids": product_attribute_values,
+        })
+        self.assertEqual(0, len(product_template.product_variant_ids))
+        with MockRequest(product_template.env, website=self.website):
+            self.WebsiteSaleController.add_product_images(
+                [{'id': self.attachments[0].id}],
+                False,
+                product_template.id,
+                [product_template_attribute_line.product_template_value_ids[0].id],
+            )
+        self.assertEqual(1, len(product_template.product_variant_ids))
+
+    def test_resequence_images(self):
+        self._create_product_images()
+        with MockRequest(self.product.env, website=self.website):
+            # Test moving to first position
+            images = self.product._get_images()
+            data_source = images[2].image_1920
+            data_target = images[0].image_1920
+            self.WebsiteSaleController.resequence_product_image(
+                images[2]._name,
+                images[2].id,
+                'first',
+            )
+            images = self.product._get_images()
+            self.assertEqual(images[2].image_1920, data_target)
+            self.assertEqual(images[0].image_1920, data_source)
+            # Test moving one to the left
+            data_source = images[2].image_1920
+            data_target = images[1].image_1920
+            self.WebsiteSaleController.resequence_product_image(
+                images[2]._name,
+                images[2].id,
+                'left',
+            )
+            images = self.product._get_images()
+            self.assertEqual(images[2].image_1920, data_target)
+            self.assertEqual(images[1].image_1920, data_source)
+            # Test moving one to the right
+            data_source = images[2].image_1920
+            data_target = images[3].image_1920
+            self.WebsiteSaleController.resequence_product_image(
+                images[2]._name,
+                images[2].id,
+                'right',
+            )
+            images = self.product._get_images()
+            self.assertEqual(images[2].image_1920, data_target)
+            self.assertEqual(images[3].image_1920, data_source)
+            # Test moving one to the last position
+            data_source = images[2].image_1920
+            data_target = images[-1].image_1920
+            self.WebsiteSaleController.resequence_product_image(
+                images[2]._name,
+                images[2].id,
+                'last',
+            )
+            images = self.product._get_images()
+            self.assertEqual(images[2].image_1920, data_target)
+            self.assertEqual(images[-1].image_1920, data_source)
+            # Test moving an image with a video_url instead of image_1920
+            data_target = images[1].image_1920
+            images[2].video_url = "https://www.youtube.com/watch?v=dQw4w9WgXcQ"
+            self.WebsiteSaleController.resequence_product_image(
+                images[2]._name,
+                images[2].id,
+                'left',
+            )
+            images = self.product._get_images()
+            self.assertEqual(images[1].video_url, "https://www.youtube.com/watch?v=dQw4w9WgXcQ")
+            self.assertEqual(images[2].video_url, False)
+            self.assertEqual(images[2].image_1920, data_target)
+            # Test that it is not possible to move an "embedded" video to the first position
+            with self.assertRaises(ValidationError):
+                self.WebsiteSaleController.resequence_product_image(
+                    images[1]._name,
+                    images[1].id,
+                    'left',
+                )
+            with self.assertRaises(ValidationError):
+                self.WebsiteSaleController.resequence_product_image(
+                    images[1]._name,
+                    images[1].id,
+                    'first',
+                )

--- a/addons/website_sale/views/snippets/snippets.xml
+++ b/addons/website_sale/views/snippets/snippets.xml
@@ -196,6 +196,13 @@
                 <we-button data-set-image-layout="carousel">Carousel</we-button>
                 <we-button data-set-image-layout="grid">Grid</we-button>
             </we-select>
+            <we-row string="Main image">
+                <we-button class="o_we_bg_brand_primary" data-replace-main-image="true" data-no-preview="true">Replace</we-button>
+            </we-row>
+            <we-row string="Extra Images">
+                <we-button class="o_we_bg_success" data-add-images="true" data-no-preview="true">Add</we-button>
+                <we-button class="o_we_bg_danger" data-clear-images="true" data-no-preview="true">Remove all</we-button>
+            </we-row>
         </div>
         <div data-selector="#product_detail #o-carousel-product" data-no-check="true">
             <we-select string="Image Zoom" data-no-preview="true" data-reload="/">
@@ -275,6 +282,20 @@
                          data-no-preview="true"
                          data-reload="/"/>
         </div>
+    </xpath>
+</template>
+
+<template id="snippets_options_web_editor" inherit_id="web_editor.snippet_options" name="e-commerce base snippet options">
+    <xpath expr="//div[@data-js='ReplaceMedia']" position="inside">
+        <we-row string="Re-order">
+            <we-button class="fa fa-fw fa-angle-double-left" data-no-preview="true" title="Move to first" data-set-position="first" data-name="media_wsale_resequence"/>
+            <we-button class="fa fa-fw fa-angle-left" data-no-preview="true" title="Move to previous" data-set-position="left" data-name="media_wsale_resequence"/>
+            <we-button class="fa fa-fw fa-angle-right" data-no-preview="true" title="Move to next" data-set-position="right" data-name="media_wsale_resequence"/>
+            <we-button class="fa fa-fw fa-angle-double-right" data-no-preview="true" title="Move to last" data-set-position="last" data-name="media_wsale_resequence"/>
+        </we-row>
+    </xpath>
+    <xpath expr="//div[@data-js='ReplaceMedia']/we-row" position="inside">
+        <we-button class="o_we_bg_danger" data-remove-media="true" data-no-preview="true" data-name="media_wsale_remove">Remove</we-button>
     </xpath>
 </template>
 


### PR DESCRIPTION
Description of the issue/feature this PR addresses: task-2692189

https://www.odoo.com/web#id=2692189&cids=1&menu_id=4720&action=333&active_id=5157&model=project.task&view_type=form

Current behavior before PR:

No button to allow bulk uploading of extra media from the frontend

Desired behavior after PR is merged:

One button to upload multiple extra media at once and another to remove all extra media.
Also add a button to edit the main image

--
I confirm I have signed the CLA and read the PR guidelines at [www.odoo.com/submit-pr](http://www.odoo.com/submit-pr)