### PR TITLE
[FIX] product: fix performance bottleneck of populate

### DIFF
--- a/addons/product/models/product_packaging.py
+++ b/addons/product/models/product_packaging.py
@@ -30,10 +30,10 @@ class ProductPackaging(models.Model):
 
     @api.constrains('barcode')
     def _check_barcode_uniqueness(self):
-        """ With GS1 nomenclature, products and packagins use the same pattern. Therefore, we need
+        """ With GS1 nomenclature, products and packagings use the same pattern. Therefore, we need
         to ensure the uniqueness between products' barcodes and packagings' ones"""
-        condition = expression.OR([[('barcode', '=', b)] for b in self.mapped('barcode') if b])
-        if self.env['product.product'].search(condition, limit=1):
+        domain = [('barcode', 'in', [b for b in self.mapped('barcode') if b])]
+        if self.env['product.product'].search(domain, order="id", limit=1):
             raise ValidationError(_("A product already uses the barcode"))
 
     def _check_qty(self, product_qty, uom_id, rounding_method="HALF-UP"):

--- a/addons/product/models/product_product.py
+++ b/addons/product/models/product_product.py
@@ -174,10 +174,10 @@ class ProductProduct(models.Model):
 
     @api.constrains('barcode')
     def _check_barcode_uniqueness(self):
-        """ With GS1 nomenclature, products and packagins use the same pattern. Therefore, we need
+        """ With GS1 nomenclature, products and packagings use the same pattern. Therefore, we need
         to ensure the uniqueness between products' barcodes and packagings' ones"""
-        condition = expression.OR([[('barcode', '=', b)] for b in self.mapped('barcode') if b])
-        if self.env['product.packaging'].search(condition, limit=1):
+        domain = [('barcode', 'in', [b for b in self.mapped('barcode') if b])]
+        if self.env['product.packaging'].search(domain, order="id", limit=1):
             raise ValidationError(_("A packaging already uses the barcode"))
 
     def _get_invoice_policy(self):


### PR DESCRIPTION
Since 4911a26d2c242a999e1901ffc007a50449d03eac, `_check_barcode_uniqueness`
flush the default `_order` of `product.product` models (via many2one in the `_order`
of `product.packaging`). It creates a bottleneck (take > 10 minutes ) when we populate
(medium size) the `product.template` during `set_barcode_variant`.

Force the order to be trivial and simplify the domain with a 'in' instead of
multiple OR.