### PR TITLE
[FIX] l10n_ar/cl: starting sequence

### DIFF
--- a/addons/l10n_ar/demo/account_customer_refund_demo.xml
+++ b/addons/l10n_ar/demo/account_customer_refund_demo.xml
@@ -6,6 +6,7 @@
         <field name="reason">Mercadería defectuosa</field>
         <field name="refund_method">refund</field>
         <field name="move_ids" eval="[(4, ref('demo_invoice_3'), 0)]"/>
+        <field name="journal_id" model="account.move.reversal" eval="obj().env.ref('l10n_ar.demo_invoice_3').journal_id"/>
         <field name="date" eval="time.strftime('%Y-%m')+'-01'"/>
     </record>
 
@@ -16,6 +17,7 @@
         <field name="reason">Venta cancelada</field>
         <field name="refund_method">cancel</field>
         <field name="move_ids" eval="[(4, ref('demo_invoice_4'), 0)]"/>
+        <field name="journal_id" model="account.move.reversal" eval="obj().env.ref('l10n_ar.demo_invoice_4').journal_id"/>
         <field name="date" eval="time.strftime('%Y-%m')+'-01'"/>
     </record>
 
@@ -26,6 +28,7 @@
         <field name="reason">Venta cancelada</field>
         <field name="refund_method">cancel</field>
         <field name="move_ids" eval="[(4, ref('demo_invoice_16'), 0)]"/>
+        <field name="journal_id" model="account.move.reversal" eval="obj().env.ref('l10n_ar.demo_invoice_16').journal_id"/>
         <field name="date" eval="time.strftime('%Y-%m')+'-01'"/>
     </record>
 

--- a/addons/l10n_ar/models/account_move.py
+++ b/addons/l10n_ar/models/account_move.py
@@ -222,7 +222,7 @@ class AccountMove(models.Model):
     def _get_starting_sequence(self):
         """ If use documents then will create a new starting sequence using the document type code prefix and the
         journal document number with a 8 padding number """
-        if self.journal_id.l10n_latam_use_documents and self.env.company.country_id.code == "AR":
+        if self.journal_id.l10n_latam_use_documents and self.company_id.country_id.code == "AR":
             if self.l10n_latam_document_type_id:
                 return self._get_formatted_sequence()
         return super()._get_starting_sequence()

--- a/addons/l10n_cl/models/account_move.py
+++ b/addons/l10n_cl/models/account_move.py
@@ -100,7 +100,7 @@ class AccountMove(models.Model):
     def _get_starting_sequence(self):
         """ If use documents then will create a new starting sequence using the document type code prefix and the
         journal document number with a 6 padding number """
-        if self.journal_id.l10n_latam_use_documents and self.env.company.country_id.code == "CL":
+        if self.journal_id.l10n_latam_use_documents and self.company_id.country_id.code == "CL":
             if self.l10n_latam_document_type_id:
                 return self._l10n_cl_get_formatted_sequence()
         return super()._get_starting_sequence()


### PR DESCRIPTION
Two fixes:

1. Main fix: When getting l10n_ar/l10n_cl starting_squence check with the proper company (self.company_id) and not self.env.company_id
2. Demo data fix: use expo journal on demo expo refund

--
I confirm I have signed the CLA and read the PR guidelines at [www.odoo.com/submit-pr](http://www.odoo.com/submit-pr)