### PR TITLE
[FIX] sale_margin: Correct computation of margin in groupby

### DIFF
--- a/addons/sale_margin/models/sale_order.py
+++ b/addons/sale_margin/models/sale_order.py
@@ -73,7 +73,7 @@ class SaleOrderLine(models.Model):
 class SaleOrder(models.Model):
     _inherit = "sale.order"
 
-    margin = fields.Monetary(compute='_product_margin', help="It gives profitability by calculating the difference between the Unit Price and the cost.", currency_field='currency_id', store=True)
+    margin = fields.Monetary(compute='_product_margin', help="It gives profitability by calculating the difference between the Unit Price and the cost.", currency_field='currency_id', store=True, group_operator="avg")
 
     @api.depends('order_line.margin')
     def _product_margin(self):


### PR DESCRIPTION
For now the sale margin is incorrectly computed in group by

opw-2767397