### PR TITLE
[FIX] stock_picking_batch: fix print of batch transfer

### DIFF
--- a/addons/stock_picking_batch/report/report_picking_batch.xml
+++ b/addons/stock_picking_batch/report/report_picking_batch.xml
@@ -70,55 +70,50 @@
                                         </th>
                                     </tr>
                                 </thead>
-                                <t t-foreach="locations" t-as="location">
-                                    <t t-set="loc_move_line" t-value="move_line_ids.filtered(lambda x: x.location_id==location)"/>
-                                    <t t-set="products" t-value="loc_move_line.mapped('product_id')"/>
-                                    <tbody>
-                                        <tr>
-                                            <td style="background-color:lightgrey" colspan="6" >
-                                                <p style="margin:0px"><strong>FROM</strong>
-                                                <span t-esc="loc_move_line.mapped('location_id').display_name"/></p>
-                                                <p style="margin:0px"><strong>TO</strong>
-                                                <span t-esc="loc_move_line.mapped('location_dest_id').display_name"/></p>
-                                            </td>
-                                        </tr>
-                                        <tr t-foreach="loc_move_line" t-as="move_operation">
-                                            <td>
-                                                <span t-field="move_operation.display_name"/>
-                                            </td>
-                                            <td>
-                                                <t t-if="not has_package">
-                                                    <t t-if="move_operation.state == 'done'">
-                                                        <span t-esc="sum(move_operation.mapped('qty_done'))"/>
+                                <t t-foreach="locations" t-as="location_from">
+                                    <t t-set="loc_move_line" t-value="move_line_ids.filtered(lambda x: x.location_id==location_from)"/>
+                                    <t t-foreach="loc_move_line.location_dest_id" t-as="location_dest">
+                                        <t t-set="move_lines" t-value="loc_move_line.filtered(lambda x: x.location_dest_id==location_dest)"/>
+                                        <t t-set="products" t-value="move_lines.product_id"/>
+                                        <tbody>
+                                            <tr>
+                                                <td style="background-color:lightgrey" colspan="6" >
+                                                    <p style="margin:0px"><strong>FROM</strong>
+                                                    <span t-esc="move_lines.location_id.display_name"/></p>
+                                                    <p style="margin:0px"><strong>TO</strong>
+                                                    <span t-esc="move_lines.location_dest_id.display_name"/></p>
+                                                </td>
+                                            </tr>
+                                            <tr t-foreach="move_lines" t-as="move_operation">
+                                                <td>
+                                                    <span t-field="move_operation.display_name"/>
+                                                </td>
+                                                <td>
+                                                    <span t-if="has_package or move_operation.state == 'done'"
+                                                          t-esc="sum(move_operation.mapped('qty_done'))"/>
+                                                    <span t-else="" t-esc="sum(move_operation.mapped('product_uom_qty'))"/>
+                                                    <span t-field="move_operation.uom_id" groups="move_operation.group_uom"/>
+                                                </td>
+                                                <td>
+                                                    <span t-esc="move_operation.picking_id.display_name"/>
+                                                </td>
+                                                <td t-if="has_serial_number" class="text-center h6" width="15%">
+                                                    <div t-if="move_operation.lot_id or move_operation.lot_name" t-field="move_operation.lot_id.name" t-options="{'widget': 'barcode', 'humanreadable': 1, 'width': 600, 'height': 100, 'img_style': 'width:100%;height:35px;'}"/>
+                                                </td>
+                                                <td width="15%" class="text-center" t-if="has_barcode">
+                                                    <span t-if="move_operation.product_id and move_operation.product_id.barcode">
+                                                        <div t-field="move_operation.product_id.barcode" t-options="{'widget': 'barcode', 'symbology': 'auto', 'width': 600, 'height': 100, 'img_style': 'width:100%;height:35px;'}"/>
+                                                    </span>
+                                                </td>
+                                                <td t-if="has_package" width="15%">
+                                                    <span t-field="move_operation.package_id"/>
+                                                    <t t-if="move_operation.result_package_id">
+                                                        <strong>→</strong> <span t-field="move_operation.result_package_id"/>
                                                     </t>
-                                                    <t t-else="">
-                                                        <span t-esc="sum(move_operation.mapped('product_uom_qty'))"/>
-                                                    </t>
-                                                </t>
-                                                <t t-if="has_package">
-                                                    <span t-esc="sum(move_operation.mapped('qty_done'))"/>
-                                                </t>
-                                                <span t-field="move_operation.uom_id" groups="move_operation.group_uom"/>
-                                            </td>
-                                            <td>
-                                                <span t-esc="move_operation.mapped('picking_id').display_name"/>
-                                            </td>
-                                            <td t-if="has_serial_number" class="text-center h6" width="15%">
-                                                <div t-if="move_operation.lot_id or move_operation.lot_name" t-field="move_operation.lot_id.name" t-options="{'widget': 'barcode', 'humanreadable': 1, 'width': 600, 'height': 100, 'img_style': 'width:100%;height:35px;'}"/>
-                                            </td>
-                                            <td width="15%" class="text-center" t-if="has_barcode">
-                                                <span t-if="move_operation.product_id and move_operation.product_id.barcode">
-                                                    <div t-field="move_operation.product_id.barcode" t-options="{'widget': 'barcode', 'symbology': 'auto', 'width': 600, 'height': 100, 'img_style': 'width:100%;height:35px;'}"/>
-                                                </span>
-                                            </td>
-                                            <td t-if="has_package" width="15%">
-                                                <span t-field="move_operation.package_id"/>
-                                                <t t-if="move_operation.result_package_id">
-                                                     <strong>→</strong> <span t-field="move_operation.result_package_id"/>
-                                                </t>
-                                            </td>
-                                        </tr>
-                                    </tbody>
+                                                </td>
+                                            </tr>
+                                        </tbody>
+                                    </t>
                                 </t>
                             </table>
                          </div>


### PR DESCRIPTION
Steps to reproduce the bug:
- Create a batch transfer with moves from the same warehouse to several locations, e.g:
    - Product A from `WH/stock` → `customer/stock1`
    - Product B from `WH/stock` → `customer/stock2`
- Try to print the batch transfers

Problem:
Traceback is triggered because we do a loop only on location_from

Solution:
- We need to loop over location_from and location destination
- Remove useless use of mapped

opw-2768518




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
