### PR TITLE
[FIX] l10n_it_edi: when importing invoice with multiple product.suppl…

### DIFF
--- a/addons/l10n_it_edi/models/account_edi_format.py
+++ b/addons/l10n_it_edi/models/account_edi_format.py
@@ -463,7 +463,7 @@ class AccountEdiFormat(models.Model):
                                             invoice_line_form.product_id = product
                                             break
                                     if partner:
-                                        product_supplier = self.env['product.supplierinfo'].search([('name', '=', partner.id), ('product_code', '=', code.text)])
+                                        product_supplier = self.env['product.supplierinfo'].search([('name', '=', partner.id), ('product_code', '=', code.text)], limit=1)
                                         if product_supplier and product_supplier.product_id:
                                             invoice_line_form.product_id = product_supplier.product_id
                                             break


### PR DESCRIPTION
…ier_info

Before, it would give a traceback when we would have a product.supplier_info
with the same code and partner used for multiple products.  This way, we
avoid this traceback.

opw-2703669

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
