### PR TITLE
[MERGE][IMP] auth_signup,portal,web: welcome external users w/o portal

### DIFF
--- a/addons/account/models/account_move.py
+++ b/addons/account/models/account_move.py
@@ -3307,7 +3307,7 @@ class AccountMove(models.Model):
 
         def is_internal_partner(partner):
             # Helper to know if the partner is an internal one.
-            return partner.user_ids and all(user.has_group('base.group_user') for user in partner.user_ids)
+            return partner.user_ids and all(user._is_internal() for user in partner.user_ids)
 
         extra_domain = False
         if custom_values.get('company_id'):

--- a/addons/auth_oauth/controllers/main.py
+++ b/addons/auth_oauth/controllers/main.py
@@ -149,7 +149,7 @@ class OAuthController(http.Controller):
                 resp.autocorrect_location_header = False
 
                 # Since /web is hardcoded, verify user has right to land on it
-                if werkzeug.urls.url_parse(resp.location).path == '/web' and not request.env.user.has_group('base.group_user'):
+                if werkzeug.urls.url_parse(resp.location).path == '/web' and not request.env.user._is_internal():
                     resp.location = '/'
                 return resp
             except AttributeError:

--- a/addons/auth_signup/__manifest__.py
+++ b/addons/auth_signup/__manifest__.py
@@ -22,6 +22,7 @@ Allow users to sign up and reset their password
         'views/res_config_settings_views.xml',
         'views/res_users_views.xml',
         'views/auth_signup_login_templates.xml',
+        'views/webclient_templates.xml',
         ],
     'bootstrap': True,
     'assets': {

--- a/addons/auth_signup/models/res_config_settings.py
+++ b/addons/auth_signup/models/res_config_settings.py
@@ -16,7 +16,7 @@ class ResConfigSettings(models.TransientModel):
             ('b2c', 'Free sign up'),
         ],
         string='Customer Account',
-        default='b2b',
+        default='b2c',
         config_parameter='auth_signup.invitation_scope')
     auth_signup_template_user_id = fields.Many2one(
         'res.users',

--- a/addons/auth_signup/models/res_partner.py
+++ b/addons/auth_signup/models/res_partner.py
@@ -41,7 +41,7 @@ class ResPartner(models.Model):
         """ proxy for function field towards actual implementation """
         result = self.sudo()._get_signup_url_for_action()
         for partner in self:
-            if any(u.has_group('base.group_user') for u in partner.user_ids if u != self.env.user):
+            if any(u._is_internal() for u in partner.user_ids if u != self.env.user):
                 self.env['res.users'].check_access_rights('write')
             partner.signup_url = result.get(partner.id, False)
 
@@ -105,7 +105,7 @@ class ResPartner(models.Model):
         """ Get a signup token related to the partner if signup is enabled.
             If the partner already has a user, get the login parameter.
         """
-        if not self.env.user.has_group('base.group_user') and not self.env.is_admin():
+        if not self.env.user._is_internal() and not self.env.is_admin():
             raise exceptions.AccessDenied()
 
         res = defaultdict(dict)

--- a/addons/auth_signup/views/webclient_templates.xml
+++ b/addons/auth_signup/views/webclient_templates.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+
+    <template id="login_successful" inherit_id="web.login_successful">
+        <xpath expr="//div[hasclass('oe_login_form')]/p" position="before">
+            <p class="alert alert-success" t-if="account_created" role="status">
+                Registration successful.
+            </p>
+            <!-- Remove parameter from URL, do not show "Account created" if page is refreshed -->
+            <script defer="defer" type="text/javascript">
+                window.history.replaceState({}, null, '/web/login_successful');
+            </script>
+        </xpath>
+    </template>
+
+</odoo>

--- a/addons/auth_totp_mail_enforce/models/res_users.py
+++ b/addons/auth_totp_mail_enforce/models/res_users.py
@@ -31,7 +31,7 @@ class Users(models.Model):
         otp_required = False
         if ICP.get_param('auth_totp.policy') == 'all_required':
             otp_required = True
-        elif ICP.get_param('auth_totp.policy') == 'employee_required' and self.has_group('base.group_user'):
+        elif ICP.get_param('auth_totp.policy') == 'employee_required' and self._is_internal():
             otp_required = True
         if otp_required:
             return 'totp_mail'

--- a/addons/auth_totp_portal/models/res_users.py
+++ b/addons/auth_totp_portal/models/res_users.py
@@ -8,7 +8,7 @@ class Users(models.Model):
     _inherit = 'res.users'
 
     def get_totp_invite_url(self):
-        if not self.has_group('base.group_user'):
+        if not self._is_internal():
             return '/my/security'
         else:
             return super(Users, self).get_totp_invite_url()

--- a/addons/barcodes/models/ir_http.py
+++ b/addons/barcodes/models/ir_http.py
@@ -9,7 +9,7 @@ class IrHttp(models.AbstractModel):
 
     def session_info(self):
         res = super(IrHttp, self).session_info()
-        if self.env.user.has_group('base.group_user'):
+        if self.env.user._is_internal():
             res['max_time_between_keys_in_ms'] = int(
                 self.env['ir.config_parameter'].sudo().get_param('barcode.max_time_between_keys_in_ms', default='55'))
         return res

--- a/addons/base_setup/models/ir_http.py
+++ b/addons/base_setup/models/ir_http.py
@@ -9,6 +9,6 @@ class IrHttp(models.AbstractModel):
 
     def session_info(self):
         result = super(IrHttp, self).session_info()
-        if request.env.user.has_group('base.group_user'):
+        if request.env.user._is_internal():
             result['show_effect'] = bool(request.env['ir.config_parameter'].sudo().get_param('base_setup.show_effect'))
         return result

--- a/addons/digest/models/digest.py
+++ b/addons/digest/models/digest.py
@@ -86,7 +86,7 @@ class Digest(models.Model):
     # ------------------------------------------------------------
 
     def action_subscribe(self):
-        if self.env.user.has_group('base.group_user') and self.env.user not in self.user_ids:
+        if self.env.user._is_internal() and self.env.user not in self.user_ids:
             self._action_subscribe_users(self.env.user)
 
     def _action_subscribe_users(self, users):
@@ -95,7 +95,7 @@ class Digest(models.Model):
         self.sudo().user_ids |= users
 
     def action_unsubscribe(self):
-        if self.env.user.has_group('base.group_user') and self.env.user in self.user_ids:
+        if self.env.user._is_internal() and self.env.user in self.user_ids:
             self._action_unsubscribe_users(self.env.user)
 
     def _action_unsubscribe_users(self, users):

--- a/addons/hr_presence/controllers/bus_controller.py
+++ b/addons/hr_presence/controllers/bus_controller.py
@@ -11,7 +11,7 @@ class BusController(main.BusController):
 
     @route('/longpolling/poll', type="json", auth="public")
     def poll(self, channels, last, options=None):
-        if request.env.user.has_group('base.group_user'):
+        if request.env.user._is_internal():
             ip_address = request.httprequest.remote_addr
             users_log = request.env['res.users.log'].search_count([
                 ('create_uid', '=', request.env.user.id),

--- a/addons/hr_timesheet/models/ir_http.py
+++ b/addons/hr_timesheet/models/ir_http.py
@@ -13,7 +13,7 @@ class Http(models.AbstractModel):
             widget to apply, depending on the current company.
         """
         result = super(Http, self).session_info()
-        if request.env.user.has_group('base.group_user'):
+        if request.env.user._is_internal():
             company_ids = request.env.user.company_ids
 
             for company in company_ids:

--- a/addons/mail/models/ir_http.py
+++ b/addons/mail/models/ir_http.py
@@ -12,7 +12,7 @@ class IrHttp(models.AbstractModel):
     def session_info(self):
         user = request.env.user
         result = super(IrHttp, self).session_info()
-        if self.env.user.has_group('base.group_user'):
+        if self.env.user._is_internal():
             result['notification_type'] = user.notification_type
         assets_discuss_public_hash = HomeStaticTemplateHelpers.get_qweb_templates_checksum(debug=request.session.debug, bundle='mail.assets_discuss_public')
         result['cache_hashes']['assets_discuss_public'] = assets_discuss_public_hash

--- a/addons/mail/models/mail_thread.py
+++ b/addons/mail/models/mail_thread.py
@@ -1773,7 +1773,7 @@ class MailThread(models.AbstractModel):
             if filtered_attachment_ids:
                 filtered_attachment_ids.write({'res_model': model, 'res_id': res_id})
             # prevent public and portal users from using attachments that are not theirs
-            if not self.env.user.has_group('base.group_user'):
+            if not self.env.user._is_internal():
                 attachment_ids = filtered_attachment_ids.ids
 
             m2m_attachment_ids += [Command.link(id) for id in attachment_ids]
@@ -2264,7 +2264,7 @@ class MailThread(models.AbstractModel):
          * either call the standard implementation _notify_cancel_by_type_generic
          * or implements their own logic
         """
-        if not self.env.user.has_group('base.group_user'):
+        if not self.env.user._is_internal():
             raise exceptions.AccessError(_("Access Denied"))
         self.check_access_rights('read')
 

--- a/addons/mail_bot/models/ir_http.py
+++ b/addons/mail_bot/models/ir_http.py
@@ -9,6 +9,6 @@ class Http(models.AbstractModel):
 
     def session_info(self):
         res = super(Http, self).session_info()
-        if self.env.user.has_group('base.group_user'):
+        if self.env.user._is_internal():
             res['odoobot_initialized'] = self.env.user.odoobot_state not in [False, 'not_initialized']
         return res

--- a/addons/mail_bot/models/res_users.py
+++ b/addons/mail_bot/models/res_users.py
@@ -23,7 +23,7 @@ class Users(models.Model):
         return super().SELF_READABLE_FIELDS + ['odoobot_state']
 
     def _init_messaging(self):
-        if self.odoobot_state in [False, 'not_initialized'] and self.has_group('base.group_user'):
+        if self.odoobot_state in [False, 'not_initialized'] and self._is_internal():
             self._init_odoobot()
         return super()._init_messaging()
 

--- a/addons/portal/controllers/mail.py
+++ b/addons/portal/controllers/mail.py
@@ -173,7 +173,7 @@ class PortalChatter(http.Controller):
             'options': {
                 'message_count': message_data['message_count'],
                 'is_user_public': is_user_public,
-                'is_user_employee': request.env.user.has_group('base.group_user'),
+                'is_user_employee': request.env.user._is_internal(),
                 'is_user_publisher': request.env.user.has_group('website.group_website_publisher'),
                 'display_composer': display_composer,
                 'partner_id': request.env.user.partner_id.id

--- a/addons/portal/controllers/portal.py
+++ b/addons/portal/controllers/portal.py
@@ -299,7 +299,7 @@ class CustomerPortal(Controller):
 
         # Avoid using sudo or creating access_token when not necessary: internal
         # users can create attachments, as opposed to public and portal users.
-        if not request.env.user.has_group('base.group_user'):
+        if not request.env.user._is_internal():
             IrAttachment = IrAttachment.sudo().with_context(binary_field_real_user=IrAttachment.env.user)
             access_token = IrAttachment._generate_access_token()
 

--- a/addons/portal/controllers/web.py
+++ b/addons/portal/controllers/web.py
@@ -3,6 +3,7 @@
 
 from odoo import http
 from odoo.addons.web.controllers.home import Home as WebHome
+from odoo.addons.web.controllers.utils import is_user_internal
 from odoo.http import request
 
 
@@ -10,17 +11,17 @@ class Home(WebHome):
 
     @http.route()
     def index(self, *args, **kw):
-        if request.session.uid and not request.env['res.users'].sudo().browse(request.session.uid).has_group('base.group_user'):
+        if request.session.uid and not is_user_internal(request.session.uid):
             return request.redirect_query('/my', query=request.params)
         return super().index(*args, **kw)
 
     def _login_redirect(self, uid, redirect=None):
-        if not redirect and not request.env['res.users'].sudo().browse(uid).has_group('base.group_user'):
+        if not redirect and not is_user_internal(uid):
             redirect = '/my'
         return super()._login_redirect(uid, redirect=redirect)
 
     @http.route()
     def web_client(self, s_action=None, **kw):
-        if request.session.uid and not request.env['res.users'].sudo().browse(request.session.uid).has_group('base.group_user'):
+        if request.session.uid and not is_user_internal(request.session.uid):
             return request.redirect_query('/my', query=request.params)
         return super().web_client(s_action, **kw)

--- a/addons/portal/tests/__init__.py
+++ b/addons/portal/tests/__init__.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
+from . import test_login
 from . import test_message_format_portal
 from . import test_tours
 from . import test_portal_wizard

--- a/addons/portal/tests/test_login.py
+++ b/addons/portal/tests/test_login.py
@@ -1,0 +1,11 @@
+# -*- coding: utf-8 -*-
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from odoo.addons.web.tests.test_login import TestWebLoginCommon
+
+
+class TestWebLoginPortal(TestWebLoginCommon):
+    def test_web_login_external(self):
+        res_post = self.login('portal_user', 'portal_user')
+        # ensure we end up on the right page
+        self.assertEqual(res_post.request.path_url, '/my')

--- a/addons/portal/wizard/portal_wizard.py
+++ b/addons/portal/wizard/portal_wizard.py
@@ -100,7 +100,7 @@ class PortalWizardUser(models.TransientModel):
         for portal_wizard_user in self:
             user = portal_wizard_user.user_id
 
-            if user and user.has_group('base.group_user'):
+            if user and user._is_internal():
                 portal_wizard_user.is_internal = True
                 portal_wizard_user.is_portal = False
             elif user and user.has_group('base.group_portal'):

--- a/addons/project/models/project.py
+++ b/addons/project/models/project.py
@@ -951,7 +951,7 @@ class Project(models.Model):
             return False
         if self.env.user.has_group('base.group_portal'):
             return self.env.user.partner_id in self.collaborator_ids.partner_id
-        return self.env.user.has_group('base.group_user')
+        return self.env.user._is_internal()
 
     def _add_collaborators(self, partners):
         self.ensure_one()

--- a/addons/survey/models/survey_survey.py
+++ b/addons/survey/models/survey_survey.py
@@ -481,7 +481,7 @@ class Survey(models.Model):
                 # no signup possible -> should be a not public user (employee or portal users)
                 if not self.users_can_signup and (not user or user._is_public()):
                     raise exceptions.UserError(_('Creating token for external people is not allowed for surveys requesting authentication.'))
-            if self.access_mode == 'internal' and (not user or not user.has_group('base.group_user')):
+            if self.access_mode == 'internal' and (not user or not user._is_internal()):
                 raise exceptions.UserError(_('Creating token for anybody else than employees is not allowed for internal surveys.'))
             if check_attempts and not self._has_attempts_left(partner or (user and user.partner_id), email, invite_token):
                 raise exceptions.UserError(_('No attempts left.'))

--- a/addons/web/controllers/utils.py
+++ b/addons/web/controllers/utils.py
@@ -201,7 +201,7 @@ def _get_login_redirect_url(uid, redirect=None):
 
 
 def is_user_internal(uid):
-    return request.env['res.users'].sudo().browse(uid).has_group('base.group_user')
+    return request.env['res.users'].browse(uid)._is_internal()
 
 
 def _local_web_translations(trans_file):

--- a/addons/web/controllers/utils.py
+++ b/addons/web/controllers/utils.py
@@ -185,8 +185,9 @@ def _get_login_redirect_url(uid, redirect=None):
     """ Decide if user requires a specific post-login redirect, e.g. for 2FA, or if they are
     fully logged and can proceed to the requested URL
     """
-    if request.session.uid: # fully logged
-        return redirect or '/web'
+    if request.session.uid:  # fully logged
+        return redirect or ('/web' if is_user_internal(request.session.uid)
+                            else '/web/login_successful')
 
     # partial session (MFA)
     url = request.env(user=uid)['res.users'].browse(uid)._mfa_url()
@@ -197,6 +198,10 @@ def _get_login_redirect_url(uid, redirect=None):
     qs = parsed.decode_query()
     qs['redirect'] = redirect
     return parsed.replace(query=werkzeug.urls.url_encode(qs)).to_url()
+
+
+def is_user_internal(uid):
+    return request.env['res.users'].sudo().browse(uid).has_group('base.group_user')
 
 
 def _local_web_translations(trans_file):

--- a/addons/web/tests/test_login.py
+++ b/addons/web/tests/test_login.py
@@ -1,28 +1,47 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
-from odoo.tests.common import HttpCase, new_test_user
+from odoo import http
+from odoo.tests.common import get_db_name, HttpCase, Opener, new_test_user
 
-class TestWebLogin(HttpCase):
-    def test_web_login(self):
-        new_test_user(self.env, 'jackoneill', context={'lang': 'en_US'})
 
-        # get login form
-        res_get = self.url_open('/web/login')
-        res_get.raise_for_status()
-        csrf_anchor = '<input type="hidden" name="csrf_token" value="'
-        csrf_token = res_get.text.partition(csrf_anchor)[2].partition('"')[0]
+class TestWebLoginCommon(HttpCase):
+    def setUp(self):
+        super().setUp()
+        new_test_user(self.env, 'portal_user', groups='base.group_portal')
 
-        # login
-        res_post = self.url_open('/web/login', data={
-            'login': 'jackoneill',
-            'password': 'jackoneill',
-            'csrf_token': csrf_token,
+    def login(self, username, password):
+        """Log in with provided credentials and return response to POST request or raises for status."""
+        self.session = http.root.session_store.new()
+        self.session.update(http.DEFAULT_SESSION, db=get_db_name())
+
+        opener = Opener(self.cr)
+        opener.cookies['session_id'] = self.session.sid
+
+        res_post = opener.post(self.base_url() + '/web/login', data={
+            'login': username,
+            'password': password,
+            'csrf_token': http.Request.csrf_token(self),
         })
         res_post.raise_for_status()
 
+        return res_post
+
+
+class TestWebLogin(TestWebLoginCommon):
+    def test_web_login(self):
+        new_test_user(self.env, 'jackoneill', context={'lang': 'en_US'})
+
+        res_post = self.login('jackoneill', 'jackoneill')
         # ensure we are logged-in
         self.url_open(
             '/web/session/check',
             headers={'Content-Type': 'application/json'},
             data='{}'
         ).raise_for_status()
+        # ensure we end up on the right page for internal users.
+        self.assertEqual(res_post.request.path_url, '/web')
+
+    def test_web_login_external(self):
+        res_post = self.login('portal_user', 'portal_user')
+        # ensure we end up on the right page for external users. Valid without portal installed.
+        self.assertEqual(res_post.request.path_url, '/web/login_successful')

--- a/addons/web/views/webclient_templates.xml
+++ b/addons/web/views/webclient_templates.xml
@@ -173,6 +173,19 @@
         </t>
     </template>
 
+    <template id="web.login_successful" name="Login successful">
+        <t t-call="web.login_layout">
+            <div class="oe_login_form">
+                <p>
+                    You are logged in.
+                </p>
+                <div t-attf-class="clearfix oe_login_buttons text-center mb-1 pt-3">
+                    <a class="btn btn-primary btn-block" href="/web/session/logout">Log out</a>
+                </div>
+            </div>
+        </t>
+    </template>
+
     <template id="web.test_helpers">
         <t t-call-assets="web.tests_assets" t-js="False"/>
         <style>

--- a/addons/web_editor/controllers/bus.py
+++ b/addons/web_editor/controllers/bus.py
@@ -25,7 +25,7 @@ class EditorCollaborationController(BusController):
                         res_id = int(match[3])
 
                         # Verify access to the edition channel.
-                        if not request.env.user.has_group('base.group_user'):
+                        if not request.env.user._is_internal():
                             raise AccessDenied()
 
                         document = request.env[model_name].browse([res_id])

--- a/addons/web_editor/controllers/main.py
+++ b/addons/web_editor/controllers/main.py
@@ -189,7 +189,7 @@ class Web_Editor(http.Controller):
     def video_url_data(self, video_url, autoplay=False, loop=False,
                        hide_controls=False, hide_fullscreen=False, hide_yt_logo=False,
                        hide_dm_logo=False, hide_dm_share=False):
-        if not request.env.user.has_group('base.group_user'):
+        if not request.env.user._is_internal():
             raise werkzeug.exceptions.Forbidden()
         return get_video_url_data(
             video_url, autoplay=autoplay, loop=loop,

--- a/addons/website/controllers/main.py
+++ b/addons/website/controllers/main.py
@@ -75,7 +75,7 @@ class Website(Home):
 
         homepage_id = request.website._get_cached('homepage_id')
         homepage = homepage_id and request.env['website.page'].browse(homepage_id)
-        if homepage and (homepage.sudo().is_visible or request.env.user.has_group('base.group_user')) and homepage.url != '/':
+        if homepage and (homepage.sudo().is_visible or request.env.user._is_internal()) and homepage.url != '/':
             request.env['ir.http'].reroute(homepage.url)
 
         website_page = request.env['ir.http']._serve_page()
@@ -127,7 +127,7 @@ class Website(Home):
         the frontend
         """
         if not redirect and request.params.get('login_success'):
-            if request.env['res.users'].browse(uid).has_group('base.group_user'):
+            if request.env['res.users'].browse(uid)._is_internal():
                 redirect = '/web?' + request.httprequest.query_string.decode()
             else:
                 redirect = '/my'

--- a/odoo/addons/base/models/ir_attachment.py
+++ b/odoo/addons/base/models/ir_attachment.py
@@ -430,7 +430,7 @@ class IrAttachment(models.Model):
         if self.env.is_superuser():
             return True
         # Always require an internal user (aka, employee) to access to a attachment
-        if not (self.env.is_admin() or self.env.user.has_group('base.group_user')):
+        if not (self.env.is_admin() or self.env.user._is_internal()):
             raise AccessError(_("Sorry, you are not allowed to access this document."))
         # collect the records to check (by model)
         model_ids = defaultdict(set)            # {model_name: set(ids)}

--- a/odoo/addons/base/models/res_partner.py
+++ b/odoo/addons/base/models/res_partner.py
@@ -608,7 +608,7 @@ class Partner(models.Model):
             del vals['is_company']
         result = result and super(Partner, self).write(vals)
         for partner in self:
-            if any(u.has_group('base.group_user') for u in partner.user_ids if u != self.env.user):
+            if any(u._is_internal() for u in partner.user_ids if u != self.env.user):
                 self.env['res.users'].check_access_rights('write')
             partner._fields_sync(vals)
         return result

--- a/odoo/addons/test_new_api/tests/test_new_fields.py
+++ b/odoo/addons/test_new_api/tests/test_new_fields.py
@@ -1419,7 +1419,7 @@ class TestFields(TransactionCaseWithUserDemo):
         record.with_user(user0).foo = 'yes we can'
 
         # add ir.rule to prevent access on record
-        self.assertTrue(user0.has_group('base.group_user'))
+        self.assertTrue(user0._is_internal())
         rule = self.env['ir.rule'].create({
             'model_id': self.env['ir.model']._get_id(record._name),
             'groups': [self.env.ref('base.group_user').id],


### PR DESCRIPTION
When portal is not installed and `auth_signup.invitation_scope` is "b2c",
visitors can create an account, leading to a blank page. Still, accounts can be
required for several use cases in apps that do not require portal (such as
survey).

We here add a landing page for users that created an account but have no
requested redirections and cannot be redirected to a customer portal either.

Tests are added to check this behavior.

auth_signup_uninvited is also updated in model to be consistent with config
data.

The PR also adds a `_is_internal` method for `res.users` and updates the 
codebase to use it.


Task-2762102
See odoo/enterprise#27603
