### PR TITLE
[FIX] tests: m2m fields with sub-view tests fails in `tests.Form`

### DIFF
--- a/odoo/tests/common.py
+++ b/odoo/tests/common.py
@@ -51,7 +51,6 @@ import odoo
 from odoo import api
 from odoo.models import BaseModel
 from odoo.exceptions import AccessError
-from odoo.fields import Command
 from odoo.modules.registry import Registry
 from odoo.osv.expression import normalize_domain, TRUE_LEAF, FALSE_LEAF
 from odoo.service import security
@@ -1993,8 +1992,11 @@ class Form(object):
             return O2MProxy(self, field)
         return v
 
-    def _get_modifier(self, field, modifier, default=False, modmap=None, vals=None):
-        d = (modmap or self._view['modifiers'])[field].get(modifier, default)
+    def _get_modifier(self, field, modifier, default=False, view=None, modmap=None, vals=None):
+        if view is None:
+            view = self._view
+
+        d = (modmap or view['modifiers'])[field].get(modifier, default)
         if isinstance(d, bool):
             return d
 
@@ -2035,19 +2037,10 @@ class Form(object):
                     # we're looking up the "current view" so bits might be
                     # missing when processing o2ms in the parent (see
                     # values_to_save:1450 or so)
-                    f_ = self._view['fields'].get(f, {'type': None})
+                    f_ = view['fields'].get(f, {'type': None})
                     if f_['type'] == 'many2many':
                         # field value should be [(6, _, ids)], we want just the ids
                         field_val = field_val[0][2] if field_val else []
-
-                    # in an embedded view, the modifiers' view is not self._view so the fields for the domains cannot be
-                    # found but we have the field name and it's value, so we can guess a m2m field in a hack-ish way
-                    if f_['type'] is None and f.endswith('_ids') and len(field_val) == 1:
-                        try:
-                            if field_val[0][0] == Command.SET:
-                                field_val = field_val[0][2]
-                        except (IndexError, TypeError):
-                            pass
 
                 stack.append(self._OPS[op](field_val, val))
             else:
@@ -2184,7 +2177,7 @@ class Form(object):
 
             get_modifier = functools.partial(
                 self._get_modifier,
-                f, modmap=view['modifiers'],
+                f, view=view,
                 vals=modifiers_values or record_values
             )
             descr = fields[f]
@@ -2414,11 +2407,11 @@ class O2MForm(Form):
             if hasattr(vals, '_changed'):
                 self._changed.update(vals._changed)
 
-    def _get_modifier(self, field, modifier, default=False, modmap=None, vals=None):
+    def _get_modifier(self, field, modifier, default=False, view=None, modmap=None, vals=None):
         if vals is None:
             vals = {**self._values, '•parent•': self._proxy._parent._values}
 
-        return super()._get_modifier(field, modifier, default=default, modmap=modmap, vals=vals)
+        return super()._get_modifier(field, modifier, default=default, view=view, modmap=modmap, vals=vals)
 
     def _onchange_values(self):
         values = super(O2MForm, self)._onchange_values()

--- a/odoo/tests/common.py
+++ b/odoo/tests/common.py
@@ -1992,7 +1992,7 @@ class Form(object):
             return O2MProxy(self, field)
         return v
 
-    def _get_modifier(self, field, modifier, default=False, view=None, modmap=None, vals=None):
+    def _get_modifier(self, /, field, modifier, *, default=False, view=None, modmap=None, vals=None):
         if view is None:
             view = self._view
 
@@ -2407,7 +2407,7 @@ class O2MForm(Form):
             if hasattr(vals, '_changed'):
                 self._changed.update(vals._changed)
 
-    def _get_modifier(self, field, modifier, default=False, view=None, modmap=None, vals=None):
+    def _get_modifier(self, /, field, modifier, *, default=False, view=None, modmap=None, vals=None):
         if vals is None:
             vals = {**self._values, '•parent•': self._proxy._parent._values}
 


### PR DESCRIPTION
In the `tests.Form` class, in case of embedded views the values of m2m fields in the modifiers of the sub-view evaluated as `[(6, _, [ids])]` instead of a simple list, this is a hack-ish fix the better fix as recommended in previous commits in this file is to redesign the model and keep x2m fields as simple lists instead.

Description of the issue/feature this PR addresses:
Consider this view:
```
<form string="The Parent">
    <field name="line_ids>
        <field name="cond_ids" />
        <field name="foo" attrs="{'required': [('cond_ids', '=', [])]}"
    </field>
 </form>
 ```
 Adding a record with empty `cond_ids` and empty `foo` is possible in the browser, but doing it with `odoo.tests.Form` raises `foo is a required field ('required': [('cond_ids', '=', [])])"`

Desired behavior after PR is merged:
`tests.Form` works the same as the JS form view 

This is far from a perfect solution, but it works in 99% of the cases. The other 1% were already failing.

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
