### PR TITLE
[IMP] web: prevent committing files that will fail test_eslint

### DIFF
--- a/addons/web/tooling/_package.json
+++ b/addons/web/tooling/_package.json
@@ -20,7 +20,8 @@
     },
     "lint-staged": {
         "*.{js,md}": [
-            "prettier-eslint --write"
+            "prettier-eslint --write",
+            "eslint"
         ]
     }
 }


### PR DESCRIPTION
Currently, we lint and auto-format non-legacy files in web. The tool
that we use for this linting and formatting unfortunately does not
propagate any linting errors except for parsing errors. This means that
it's possible to commit files of which we know in advance that they will
break CI. This commit simply relints the files in a standalone manner
after they've been formatted, so that if there is a linting error, the
commit will be aborted.

It is still possible to commit non-conforming code (eg to save work in
progress before switching branches) by committing with the --no-verify
git flag
