### PR TITLE
[IMP] payment, sale: prevent paying for a canceled SO/invoice

### DIFF
--- a/addons/payment/controllers/portal.py
+++ b/addons/payment/controllers/portal.py
@@ -103,6 +103,15 @@ class PaymentPortal(portal.CustomerPortal):
         company = request.env['res.company'].sudo().browse(company_id)
         currency_id = currency_id or company.currency_id.id
 
+        if invoice_id:
+            invoice_sudo = request.env['account.move'].sudo().browse(invoice_id).exists()
+            if not invoice_sudo:
+                raise ValidationError(_("The provided parameters are invalid."))
+
+            # Interrupt the payment flow if the invoice has been canceled.
+            if invoice_sudo.state == 'cancel':
+                amount = 0.0
+
         # Make sure that the company passed as parameter matches the partner's company.
         PaymentPortal._ensure_matching_companies(partner_sudo, company)
 

--- a/addons/sale/controllers/portal.py
+++ b/addons/sale/controllers/portal.py
@@ -354,6 +354,11 @@ class PaymentPortal(payment_portal.PaymentPortal):
         rendering_context_values = super()._get_custom_rendering_context_values(**kwargs)
         if sale_order_id:
             rendering_context_values['sale_order_id'] = sale_order_id
+
+            # Interrupt the payment flow if the sales order has been canceled.
+            order_sudo = request.env['sale.order'].sudo().browse(sale_order_id)
+            if order_sudo.state == 'cancel':
+                rendering_context_values['amount'] = 0.0
         return rendering_context_values
 
     def _create_transaction(self, *args, sale_order_id=None, custom_create_values=None, **kwargs):


### PR DESCRIPTION
Before this commit, sales orders/invoices that had been canceled could
still be paid from a payment link. Now, when trying to pay for a
canceled sales order/invoice, the amount to pay is set to zero.
    
Task - 2735019