### PR TITLE
Fix payment_buckaroo & payment_sips tests when running with a non-default port

### DIFF
--- a/addons/payment_buckaroo/tests/test_buckaroo.py
+++ b/addons/payment_buckaroo/tests/test_buckaroo.py
@@ -12,6 +12,9 @@ from ..controllers.main import BuckarooController
 class BuckarooTest(BuckarooCommon):
 
     def test_redirect_form_values(self):
+        self.patch(self, 'base_url', 'http://localhost:8069')
+        self.patch(type(self.env['base']), 'get_base_url', lambda _: 'http://localhost:8069')
+
         return_url = self._build_url(BuckarooController._return_url)
         expected_values = {
             'Brq_websitekey': self.buckaroo.buckaroo_website_key,

--- a/addons/payment_sips/tests/test_sips.py
+++ b/addons/payment_sips/tests/test_sips.py
@@ -41,6 +41,9 @@ class SipsTest(SipsCommon):
             "Payulatam: transaction reference wasn't correctly singularized.")
 
     def test_redirect_form_values(self):
+        self.patch(self, 'base_url', 'http://localhost:8069')
+        self.patch(type(self.env['base']), 'get_base_url', lambda _: 'http://localhost:8069')
+
         tx = self.create_transaction(flow="redirect")
 
         with mute_logger('odoo.addons.payment.models.payment_transaction'):


### PR DESCRIPTION
For payment_buckaroo and payment_sips (at least) running with a non-standard port is an issue to the `test_redirect_form_value` tests: while the form and test will use respectively the base_url and the
configuration port, both check a response signature which is predicated upon a base url of `http://localhost:8069`.

This means the test does not pass when run with a different port, and may not pass if the database was installed with a different port either (because this may have caused the `web.base_url` to be set to the installation port).

The other payment modules don't seem to have such signature verification and thus apparently don't mind running with non-default port.
