### PR TITLE
[IMP] l10n_id

### DIFF
--- a/addons/l10n_id/data/account.account.template.csv
+++ b/addons/l10n_id/data/account.account.template.csv
@@ -1,158 +1,106 @@
 id,code,name,user_type_id:id,reconcile,chart_template_id:id
-a_1_111001,1111001,Petty Cash,account.data_account_type_liquidity,TRUE,l10n_id_chart
-a_1_111002,1111002,Cash in Hand,account.data_account_type_liquidity,TRUE,l10n_id_chart
-a_1_112001,1112001,Personal Mandiri,account.data_account_type_liquidity,TRUE,l10n_id_chart
-a_1_112002,1112002,Business Mandiri,account.data_account_type_liquidity,TRUE,l10n_id_chart
-a_1_112003,1112003,Muamalat,account.data_account_type_liquidity,TRUE,l10n_id_chart
-a_1_112004,1112004,BNI,account.data_account_type_liquidity,TRUE,l10n_id_chart
-a_1_112005,1112005,BCA,account.data_account_type_liquidity,TRUE,l10n_id_chart
-a_1_112006,1112006,BNI Giro,account.data_account_type_liquidity,TRUE,l10n_id_chart
-a_1_112007,1112007,Mandiri Giro,account.data_account_type_liquidity,TRUE,l10n_id_chart
-a_1_121001,1121001,Account Receivable,account.data_account_type_receivable,TRUE,l10n_id_chart
-a_1_1210011,11210011,Account Receivable (PoS),account.data_account_type_receivable,TRUE,l10n_id_chart
-a_1_121002,1121002,Employee Liabilities,account.data_account_type_current_assets,TRUE,l10n_id_chart
-a_1_130001,1130001,"Meat Inventory",account.data_account_type_current_assets,FALSE,l10n_id_chart
-a_1_130002,1130002,"Fish Inventory",account.data_account_type_current_assets,FALSE,l10n_id_chart
-a_1_130003,1130003,"Vegetables Inventory",account.data_account_type_current_assets,FALSE,l10n_id_chart
-a_1_130004,1130004,"Dried Goods Inventory",account.data_account_type_current_assets,FALSE,l10n_id_chart
-a_1_130005,1130005,"Fruit Inventory",account.data_account_type_current_assets,FALSE,l10n_id_chart
-a_1_130006,1130006,"Fresh Drink Inventory",account.data_account_type_current_assets,FALSE,l10n_id_chart
-a_1_130007,1130007,"Cigarette Inventory",account.data_account_type_current_assets,FALSE,l10n_id_chart
-a_1_130008,1130008,"Food Inventory",account.data_account_type_current_assets,FALSE,l10n_id_chart
-a_1_130009,1130009,"Drink Inventory",account.data_account_type_current_assets,FALSE,l10n_id_chart
-a_1_130010,1130010,"Processed Food Inventory",account.data_account_type_current_assets,FALSE,l10n_id_chart
-a_1_130011,1130011,"Toiletries Inventory",account.data_account_type_current_assets,FALSE,l10n_id_chart
-a_1_130012,1130012,"Book, Office Stationery, Accessories Inventory",account.data_account_type_current_assets,FALSE,l10n_id_chart
-a_1_130013,1130013,"Fashion & Textile Inventory",account.data_account_type_current_assets,FALSE,l10n_id_chart
-a_1_130014,1130014,"Cleaning Supplies Inventory",account.data_account_type_current_assets,FALSE,l10n_id_chart
-a_1_130015,1130015,"House Supplies Inventory",account.data_account_type_current_assets,FALSE,l10n_id_chart
-a_1_130016,1130016,"Electronic Inventory",account.data_account_type_current_assets,FALSE,l10n_id_chart
-a_1_130017,1130017,"Toys Inventory",account.data_account_type_current_assets,FALSE,l10n_id_chart
-a_1_130018,1130018,"Other Inventory",account.data_account_type_current_assets,FALSE,l10n_id_chart
-a_1_141001,1141001,"Building Rent",account.data_account_type_prepayments,FALSE,l10n_id_chart
-a_1_141002,1141002,"Prepaid Insurance",account.data_account_type_prepayments,FALSE,l10n_id_chart
-a_1_141003,1141003,"Prepaid Advertisement-Free",account.data_account_type_prepayments,FALSE,l10n_id_chart
-a_1_151001,1151001,"Prepaid Tax Pph 22",account.data_account_type_prepayments,FALSE,l10n_id_chart
-a_1_151002,1151002,"Prepaid Tax Pph 23",account.data_account_type_prepayments,FALSE,l10n_id_chart
-a_1_151003,1151003,"Prepaid Tax Pph 25",account.data_account_type_prepayments,FALSE,l10n_id_chart
-a_1_180000,1180000,"Down Payment",account.data_account_type_prepayments,FALSE,l10n_id_chart
-a_1_211003,1211003,"Owner Receivable",account.data_account_type_current_assets,TRUE,l10n_id_chart
-a_1_211004,1211004,"Other Receivable",account.data_account_type_current_assets,TRUE,l10n_id_chart
-a_1_221001,1221001,"Land",account.data_account_type_prepayments,FALSE,l10n_id_chart
-a_1_221002,1221002,"Office Building",account.data_account_type_prepayments,FALSE,l10n_id_chart
-a_1_221003,1221003,"Vehicle",account.data_account_type_prepayments,FALSE,l10n_id_chart
-a_1_221004,1221004,"Office Supplies",account.data_account_type_prepayments,FALSE,l10n_id_chart
-a_1_221005,1221005,"Software",account.data_account_type_prepayments,FALSE,l10n_id_chart
-a_1_221006,1221006,"Office Furniture",account.data_account_type_prepayments,FALSE,l10n_id_chart
-a_1_228101,1228101,"Accumulation Building Depreciation",account.data_account_type_prepayments,FALSE,l10n_id_chart
-a_1_228102,1228102,"Accumulation Vehicle Depreciation",account.data_account_type_prepayments,FALSE,l10n_id_chart
-a_1_228103,1228103,"Accumulation Office Supplies Depreciation",account.data_account_type_prepayments,FALSE,l10n_id_chart
-a_1_228104,1228104,"Accumulation Software Depreciation",account.data_account_type_prepayments,FALSE,l10n_id_chart
-a_1_228105,1228105,"Accumulation Office Furniture Depreciation",account.data_account_type_prepayments,FALSE,l10n_id_chart
-a_2_110001,2110001,"Trade Receivable",account.data_account_type_payable,TRUE,l10n_id_chart
-a_2_110002,2110002,"Shareholder Deposit",account.data_account_type_current_liabilities,FALSE,l10n_id_chart
-a_2_110003,2110003,"Third-Party Deposit",account.data_account_type_current_liabilities,FALSE,l10n_id_chart
-a_2_110004,2110004,"Salary Deposit",account.data_account_type_current_liabilities,FALSE,l10n_id_chart
-a_2_121001,2121001,"Tax Payable Pph 21",account.data_account_type_current_liabilities,FALSE,l10n_id_chart
-a_2_121002,2121002,"Tax Payable Pph 23",account.data_account_type_current_liabilities,FALSE,l10n_id_chart
-a_2_121003,2121003,"Tax Payable Pph 25",account.data_account_type_current_liabilities,FALSE,l10n_id_chart
-a_2_121004,2121004,"Tax Payable 4 (2)",account.data_account_type_current_liabilities,FALSE,l10n_id_chart
-a_2_121005,2121005,"Tax Payable Pph 29",account.data_account_type_current_liabilities,FALSE,l10n_id_chart
-a_2_122101,2122101,"VAT Purchase",account.data_account_type_current_liabilities,FALSE,l10n_id_chart
-a_2_122102,2122102,"VAT Sales",account.data_account_type_current_liabilities,FALSE,l10n_id_chart
-a_2_211001,2211001,"Bank Loan",account.data_account_type_current_liabilities,FALSE,l10n_id_chart
-a_2_211002,2211002,"Leasing Deposit",account.data_account_type_current_liabilities,FALSE,l10n_id_chart
-a_2_511001,2511001,"Accrued Payable Electricity",account.data_account_type_current_liabilities,FALSE,l10n_id_chart
-a_2_511002,2511002,"Accrued Payable Jamsostek",account.data_account_type_current_liabilities,FALSE,l10n_id_chart
-a_2_511003,2511003,"Accrued Payable Water",account.data_account_type_current_liabilities,FALSE,l10n_id_chart
-a_2_511004,2511004,"Accrued Payable Telp & Internet",account.data_account_type_current_liabilities,FALSE,l10n_id_chart
-a_2_511005,2511005,"Accrued Payable Security Management",account.data_account_type_current_liabilities,FALSE,l10n_id_chart
-a_2_511006,2511006,"Accrued Payable Bank",account.data_account_type_current_liabilities,FALSE,l10n_id_chart
-a_2_511007,2511007,"Accrued Payable PBB",account.data_account_type_current_liabilities,FALSE,l10n_id_chart
-a_2_511008,2511008,"Accrued Payable Business License",account.data_account_type_current_liabilities,FALSE,l10n_id_chart
-a_2_511009,2511009,"Accrued Payable Insurance",account.data_account_type_current_liabilities,FALSE,l10n_id_chart
-a_2_511010,2511010,"Accrued Payable Education",account.data_account_type_current_liabilities,FALSE,l10n_id_chart
-a_2_511011,2511011,"Accrued Payable Health Insurance/BPJS",account.data_account_type_current_liabilities,FALSE,l10n_id_chart
-a_2_811001,2811001,"Advance Sales",account.data_account_type_current_liabilities,FALSE,l10n_id_chart
-a_2_811002,2811002,"Customer Deposit",account.data_account_type_current_liabilities,FALSE,l10n_id_chart
-a_2_811003,2811003,"Bonus Point",account.data_account_type_current_liabilities,FALSE,l10n_id_chart
-a_2_900000,2900000,"Interim Stock",account.data_account_type_current_liabilities,FALSE,l10n_id_chart
-a_3_110001,3110001,"Authorized Capital",account.data_account_type_equity,FALSE,l10n_id_chart
-a_3_110002,3110002,"Paid Capital",account.data_account_type_equity,FALSE,l10n_id_chart
-a_3_110003,3110003,"Unpaid Capital",account.data_account_type_equity,FALSE,l10n_id_chart
-a_3_110004,3110004,"Prive (Personal Retrieval)",account.data_account_type_equity,FALSE,l10n_id_chart
-a_3_121001,3121001,"Capital Reserves",account.data_account_type_equity,FALSE,l10n_id_chart
-a_3_151001,3151001,"Past Profit & Loss",account.data_account_type_equity,FALSE,l10n_id_chart
-a_3_151002,3151002,"Ongoing Profit & Loss",account.data_account_type_equity,FALSE,l10n_id_chart
-a_3_900000,3900000,"Historical Balance",account.data_account_type_equity,TRUE,l10n_id_chart
-a_4_100001,4100001,"Sales",account.data_account_type_revenue,FALSE,l10n_id_chart
-a_4_200006,4200006,"Sales Refund",account.data_account_type_revenue,FALSE,l10n_id_chart
-a_4_200007,4200007,"Sales Discount",account.data_account_type_revenue,FALSE,l10n_id_chart
-a_5_100001,5100001,"Cost of Goods Sold",account.data_account_type_direct_costs,FALSE,l10n_id_chart
-a_6_110001,6110001,"Employee Salary",account.data_account_type_expenses,FALSE,l10n_id_chart
-a_6_110002,6110002,"Employee Bonus / Benefits",account.data_account_type_expenses,FALSE,l10n_id_chart
-a_6_110003,6110003,"Employee Health Benefits",account.data_account_type_expenses,FALSE,l10n_id_chart
-a_6_110004,6110004,"Employee Meal (Catering)",account.data_account_type_expenses,FALSE,l10n_id_chart
-a_6_110005,6110005,"Employee Overtime Pay",account.data_account_type_expenses,FALSE,l10n_id_chart
-a_6_110006,6110006,"Security Service Fee",account.data_account_type_expenses,FALSE,l10n_id_chart
-a_6_110007,6110007,"Work Uniform",account.data_account_type_expenses,FALSE,l10n_id_chart
-a_6_110008,6110008,"Employee Birthday Benefit",account.data_account_type_expenses,FALSE,l10n_id_chart
-a_6_110009,6110009,"Maternity Benefit",account.data_account_type_expenses,FALSE,l10n_id_chart
-a_6_110010,6110010,"Pph 21 Benefit",account.data_account_type_expenses,FALSE,l10n_id_chart
-a_6_211001,6211001,"Free Gift",account.data_account_type_expenses,FALSE,l10n_id_chart
-a_6_211002,6211002,Event,account.data_account_type_expenses,FALSE,l10n_id_chart
-a_6_211003,6211003,Advertising,account.data_account_type_expenses,FALSE,l10n_id_chart
-a_6_211004,6211004,"Shipping Merchandise",account.data_account_type_expenses,FALSE,l10n_id_chart
-a_6_311001,6311001,"Drinking Water",account.data_account_type_expenses,FALSE,l10n_id_chart
-a_6_311002,6311002,"Exercise Necessities",account.data_account_type_expenses,FALSE,l10n_id_chart
-a_6_311003,6311003,"Monthly Fee",account.data_account_type_expenses,FALSE,l10n_id_chart
-a_6_311004,6311004,"Donation",account.data_account_type_expenses,FALSE,l10n_id_chart
-a_6_311005,6311005,Internet,account.data_account_type_expenses,FALSE,l10n_id_chart
-a_6_311006,6311006,"Phone",account.data_account_type_expenses,FALSE,l10n_id_chart
-a_6_311007,6311007,"Prepaid Phone Bills",account.data_account_type_expenses,FALSE,l10n_id_chart
-a_6_311008,6311008,"Electricity",account.data_account_type_expenses,FALSE,l10n_id_chart
-a_6_311009,6311009,"Water (PDAM)",account.data_account_type_expenses,FALSE,l10n_id_chart
-a_6_311010,6311010,Research & Development,account.data_account_type_expenses,FALSE,l10n_id_chart
-a_6_311011,6311011,"Kitchen Necessities",account.data_account_type_expenses,FALSE,l10n_id_chart
-a_6_311012,6311012,"Office Equipment",account.data_account_type_expenses,FALSE,l10n_id_chart
-a_6_311013,6311013,"First Aid Kit",account.data_account_type_expenses,FALSE,l10n_id_chart
-a_6_311014,6311014,"Other Necessities",account.data_account_type_expenses,FALSE,l10n_id_chart
-a_6_311015,6311015,"K3 (Fire Extinguisher)",account.data_account_type_expenses,FALSE,l10n_id_chart
-a_6_311016,6311016,"Cleaning Equipment",account.data_account_type_expenses,FALSE,l10n_id_chart
-a_6_311018,6311018,"Owner Necessities",account.data_account_type_expenses,FALSE,l10n_id_chart
-a_6_411001,6411001,"Office Stationery",account.data_account_type_expenses,FALSE,l10n_id_chart
-a_6_411002,6411002,"Post Necessities",account.data_account_type_expenses,FALSE,l10n_id_chart
-a_6_411003,6411003,"Jilid & Photocopy",account.data_account_type_expenses,FALSE,l10n_id_chart
-a_6_411004,6411004,"Job Recruitment Advertisement",account.data_account_type_expenses,FALSE,l10n_id_chart
-a_6_411005,6411005,"Stamp",account.data_account_type_expenses,FALSE,l10n_id_chart
-a_6_511001,6511001,"Licensing Fees",account.data_account_type_expenses,FALSE,l10n_id_chart
-a_6_511002,6511002,"Bank Administration Fees",account.data_account_type_expenses,FALSE,l10n_id_chart
-a_6_511003,6511003,"Consultant Fees",account.data_account_type_expenses,FALSE,l10n_id_chart
-a_6_511004,6511004,"Rental Costs",account.data_account_type_expenses,FALSE,l10n_id_chart
-a_6_511006,6511006,"Building Maintenance Costs",account.data_account_type_expenses,FALSE,l10n_id_chart
-a_6_511007,6511007,"Electricity, Telephone, and Internet Installation Maintenance Costs",account.data_account_type_expenses,FALSE,l10n_id_chart
-a_6_511008,6511008,"Taxes",account.data_account_type_expenses,FALSE,l10n_id_chart
-a_6_511009,6511009,"Guest Accomodation",account.data_account_type_expenses,FALSE,l10n_id_chart
-a_6_511010,6511010,"Asset Maintenance Costs",account.data_account_type_expenses,FALSE,l10n_id_chart
-a_6_511011,6511011,"Shipping Costs",account.data_account_type_expenses,FALSE,l10n_id_chart
-a_6_611001,6611001,"Vehicle Fuel",account.data_account_type_expenses,FALSE,l10n_id_chart
-a_6_611002,6611002,"Vehicle Service",account.data_account_type_expenses,FALSE,l10n_id_chart
-a_6_611003,6611003,"Vehicle Parking & Toll Fee",account.data_account_type_expenses,FALSE,l10n_id_chart
-a_6_611004,6611004,"Vehicle Taxes",account.data_account_type_expenses,FALSE,l10n_id_chart
-a_6_611005,6611005,"Vehicle Insurance",account.data_account_type_expenses,FALSE,l10n_id_chart
-a_6_710001,6710001,"Land",account.data_account_type_expenses,FALSE,l10n_id_chart
-a_6_710002,6710002,"Office Building",account.data_account_type_expenses,FALSE,l10n_id_chart
-a_6_710003,6710003,"Vehicle",account.data_account_type_expenses,FALSE,l10n_id_chart
-a_6_710004,6710004,"Office Supplies",account.data_account_type_expenses,FALSE,l10n_id_chart
-a_6_710005,6710005,"Software",account.data_account_type_expenses,FALSE,l10n_id_chart
-a_6_710006,6710006,"Office Furniture",account.data_account_type_expenses,FALSE,l10n_id_chart
-a_6_900000,6900000,"Other Expenses",account.data_account_type_expenses,FALSE,l10n_id_chart
-a_8_110001,8110001,"Interest Income",account.data_account_type_other_income,FALSE,l10n_id_chart
-a_8_110002,8110002,"Deposit Income",account.data_account_type_other_income,FALSE,l10n_id_chart
-a_8_110003,8110003,"Foreign Exchange Gain",account.data_account_type_other_income,FALSE,l10n_id_chart
-a_8_110004,8110004,"Other Income",account.data_account_type_other_income,FALSE,l10n_id_chart
-a_8_110009,8110009,"Gain on Sale of Fixed Assets",account.data_account_type_other_income,FALSE,l10n_id_chart
-a_9_110001,9110001,"Interest Expense",account.data_account_type_expenses,FALSE,l10n_id_chart
-a_9_110002,9110002,"Bank Administration Expense",account.data_account_type_expenses,FALSE,l10n_id_chart
-a_9_110003,9110003,"Foreign Exchange Loss",account.data_account_type_expenses,FALSE,l10n_id_chart
-a_9_110009,9110009,"Loss on Sale of Fixed Assets",account.data_account_type_expenses,FALSE,l10n_id_chart
+l10n_id_11110001,11110001,Cash,account.data_account_type_liquidity,TRUE,l10n_id.l10n_id_chart
+l10n_id_11110010,11110010,Petty Cash,account.data_account_type_liquidity,TRUE,l10n_id.l10n_id_chart
+l10n_id_11110020,11110020,Cash in Hand,account.data_account_type_liquidity,TRUE,l10n_id.l10n_id_chart
+l10n_id_11120001,11120001,Bank Suspense Account,account.data_account_type_current_liabilities,TRUE,l10n_id.l10n_id_chart
+l10n_id_11120002,11120002,Outstanding Receipts,account.data_account_type_current_assets,TRUE,l10n_id.l10n_id_chart
+l10n_id_11120003,11120003,Outstanding Payments,account.data_account_type_current_assets,TRUE,l10n_id.l10n_id_chart
+l10n_id_11120004,11120004,Bank,account.data_account_type_liquidity,TRUE,l10n_id.l10n_id_chart
+l10n_id_11210010,11210010,Account Receivable,account.data_account_type_receivable,TRUE,l10n_id.l10n_id_chart
+l10n_id_11210011,11210011,Account Receivable (PoS),account.data_account_type_receivable,TRUE,l10n_id.l10n_id_chart
+l10n_id_11210020,11210020,Employee Liabilities,account.data_account_type_current_assets,TRUE,l10n_id.l10n_id_chart
+l10n_id_11300180,11300180,Other Inventory,account.data_account_type_current_assets,FALSE,l10n_id.l10n_id_chart
+l10n_id_11410010,11410010,Building Rent,account.data_account_type_prepayments,FALSE,l10n_id.l10n_id_chart
+l10n_id_11410020,11410020,Prepaid Insurance,account.data_account_type_prepayments,FALSE,l10n_id.l10n_id_chart
+l10n_id_11410030,11410030,Prepaid Advertisement-Free,account.data_account_type_prepayments,FALSE,l10n_id.l10n_id_chart
+l10n_id_11510010,11510010,Prepaid Tax PPh 21,account.data_account_type_prepayments,FALSE,l10n_id.l10n_id_chart
+l10n_id_11510020,11510020,Prepaid Tax Pph 22,account.data_account_type_prepayments,FALSE,l10n_id.l10n_id_chart
+l10n_id_11510030,11510030,Prepaid Tax Pph 23,account.data_account_type_prepayments,FALSE,l10n_id.l10n_id_chart
+l10n_id_11510040,11510040,Prepaid Tax Pph 25,account.data_account_type_prepayments,FALSE,l10n_id.l10n_id_chart
+l10n_id_11510050,11510050,Prepaid Tax Pph 28A,account.data_account_type_prepayments,FALSE,l10n_id.l10n_id_chart
+l10n_id_11510060,11510060,Prepaid Tax 4 (2),account.data_account_type_prepayments,FALSE,l10n_id.l10n_id_chart
+l10n_id_11800000,11800000,Down Payment,account.data_account_type_prepayments,FALSE,l10n_id.l10n_id_chart
+l10n_id_12210010,12210010,Office Building,account.data_account_type_fixed_assets,FALSE,l10n_id.l10n_id_chart
+l10n_id_12210020,12210020,Vehicle,account.data_account_type_fixed_assets,FALSE,l10n_id.l10n_id_chart
+l10n_id_12210030,12210030,Office Supplies,account.data_account_type_fixed_assets,FALSE,l10n_id.l10n_id_chart
+l10n_id_12281010,12281010,Accumulation Building Depreciation,account.data_account_type_prepayments,FALSE,l10n_id.l10n_id_chart
+l10n_id_12281020,12281020,Accumulation Vehicle Depreciation,account.data_account_type_prepayments,FALSE,l10n_id.l10n_id_chart
+l10n_id_12281030,12281030,Accumulation Office Supplies Depreciation,account.data_account_type_prepayments,FALSE,l10n_id.l10n_id_chart
+l10n_id_21100010,21100010,Trade Receivable,account.data_account_type_payable,TRUE,l10n_id.l10n_id_chart
+l10n_id_21100020,21100020,Shareholder Deposit,account.data_account_type_current_liabilities,FALSE,l10n_id.l10n_id_chart
+l10n_id_21100030,21100030,Third-Party Deposit,account.data_account_type_current_liabilities,FALSE,l10n_id.l10n_id_chart
+l10n_id_21100040,21100040,Salary Deposit,account.data_account_type_current_liabilities,FALSE,l10n_id.l10n_id_chart
+l10n_id_21210010,21210010,Tax Payable Pph 21,account.data_account_type_current_liabilities,FALSE,l10n_id.l10n_id_chart
+l10n_id_21210020,21210020,Tax Payable Pph 23,account.data_account_type_current_liabilities,FALSE,l10n_id.l10n_id_chart
+l10n_id_21210030,21210030,Tax Payable Pph 25,account.data_account_type_current_liabilities,FALSE,l10n_id.l10n_id_chart
+l10n_id_21210040,21210040,Tax Payable 4 (2),account.data_account_type_current_liabilities,FALSE,l10n_id.l10n_id_chart
+l10n_id_21210050,21210050,Tax Payable Pph 29,account.data_account_type_current_liabilities,FALSE,l10n_id.l10n_id_chart
+l10n_id_21221010,21221010,VAT Purchase,account.data_account_type_current_liabilities,FALSE,l10n_id.l10n_id_chart
+l10n_id_21221020,21221020,VAT Sales,account.data_account_type_current_liabilities,FALSE,l10n_id.l10n_id_chart
+l10n_id_22110010,22110010,Bank Loan,account.data_account_type_current_liabilities,FALSE,l10n_id.l10n_id_chart
+l10n_id_22110020,22110020,Leasing Deposit,account.data_account_type_current_liabilities,FALSE,l10n_id.l10n_id_chart
+l10n_id_25110010,25110010,Accrued Payable Electricity,account.data_account_type_current_liabilities,FALSE,l10n_id.l10n_id_chart
+l10n_id_25110020,25110020,Accrued Payable Jamsostek,account.data_account_type_current_liabilities,FALSE,l10n_id.l10n_id_chart
+l10n_id_25110030,25110030,Accrued Payable Water,account.data_account_type_current_liabilities,FALSE,l10n_id.l10n_id_chart
+l10n_id_25110040,25110040,Accrued Payable Telp & Internet,account.data_account_type_current_liabilities,FALSE,l10n_id.l10n_id_chart
+l10n_id_25110050,25110050,Accrued Payable Security Management,account.data_account_type_current_liabilities,FALSE,l10n_id.l10n_id_chart
+l10n_id_25110060,25110060,Accrued Payable Bank,account.data_account_type_current_liabilities,FALSE,l10n_id.l10n_id_chart
+l10n_id_25110070,25110070,Accrued Payable PBB,account.data_account_type_current_liabilities,FALSE,l10n_id.l10n_id_chart
+l10n_id_25110080,25110080,Accrued Payable Business License,account.data_account_type_current_liabilities,FALSE,l10n_id.l10n_id_chart
+l10n_id_25110090,25110090,Accrued Payable Insurance,account.data_account_type_current_liabilities,FALSE,l10n_id.l10n_id_chart
+l10n_id_25110100,25110100,Accrued Payable Education,account.data_account_type_current_liabilities,FALSE,l10n_id.l10n_id_chart
+l10n_id_25110110,25110110,Accrued Payable Health Insurance/BPJS,account.data_account_type_current_liabilities,FALSE,l10n_id.l10n_id_chart
+l10n_id_28110010,28110010,Advance Sales,account.data_account_type_current_liabilities,FALSE,l10n_id.l10n_id_chart
+l10n_id_28110020,28110020,Customer Deposit,account.data_account_type_current_liabilities,FALSE,l10n_id.l10n_id_chart
+l10n_id_29000000,29000000,Interim Stock,account.data_account_type_current_liabilities,FALSE,l10n_id.l10n_id_chart
+l10n_id_31100010,31100010,Authorized Capital,account.data_account_type_equity,FALSE,l10n_id.l10n_id_chart
+l10n_id_31100020,31100020,Paid Capital,account.data_account_type_equity,FALSE,l10n_id.l10n_id_chart
+l10n_id_31100030,31100030,Unpaid Capital,account.data_account_type_equity,FALSE,l10n_id.l10n_id_chart
+l10n_id_31100040,31100040,Prive (Personal Retrieval),account.data_account_type_equity,FALSE,l10n_id.l10n_id_chart
+l10n_id_31210010,31210010,Capital Reserves,account.data_account_type_equity,FALSE,l10n_id.l10n_id_chart
+l10n_id_31510010,31510010,Past Profit & Loss,account.data_account_type_equity,FALSE,l10n_id.l10n_id_chart
+l10n_id_31510020,31510020,Ongoing Profit & Loss,account.data_account_type_equity,FALSE,l10n_id.l10n_id_chart
+l10n_id_39000000,39000000,Historical Balance,account.data_account_type_equity,TRUE,l10n_id.l10n_id_chart
+l10n_id_41000010,41000010,Sales,account.data_account_type_revenue,FALSE,l10n_id.l10n_id_chart
+l10n_id_42000060,42000060,Sales Refund,account.data_account_type_revenue,FALSE,l10n_id.l10n_id_chart
+l10n_id_42000070,42000070,Sales Discount,account.data_account_type_revenue,FALSE,l10n_id.l10n_id_chart
+l10n_id_51000010,51000010,Cost of Goods Sold,account.data_account_type_direct_costs,FALSE,l10n_id.l10n_id_chart
+l10n_id_61100010,61100010,Employee Salary,account.data_account_type_expenses,FALSE,l10n_id.l10n_id_chart
+l10n_id_61100020,61100020,Employee Bonus / Benefits,account.data_account_type_expenses,FALSE,l10n_id.l10n_id_chart
+l10n_id_61100030,61100030,Employee Overtime Pay,account.data_account_type_expenses,FALSE,l10n_id.l10n_id_chart
+l10n_id_61100100,61100100,Pph 21 Benefit,account.data_account_type_expenses,FALSE,l10n_id.l10n_id_chart
+l10n_id_63110060,63110060,Phone,account.data_account_type_expenses,FALSE,l10n_id.l10n_id_chart
+l10n_id_63110080,63110080,Electricity,account.data_account_type_expenses,FALSE,l10n_id.l10n_id_chart
+l10n_id_63110100,63110100,Research & Development,account.data_account_type_expenses,FALSE,l10n_id.l10n_id_chart
+l10n_id_63110120,63110120,Office Equipment,account.data_account_type_expenses,FALSE,l10n_id.l10n_id_chart
+l10n_id_64110020,64110020,Post Necessities,account.data_account_type_expenses,FALSE,l10n_id.l10n_id_chart
+l10n_id_63110140,63110140,Other Necessities,account.data_account_type_expenses,FALSE,l10n_id.l10n_id_chart
+l10n_id_65110010,65110010,Licensing Fees,account.data_account_type_expenses,FALSE,l10n_id.l10n_id_chart
+l10n_id_65110020,65110020,Bank Administration Fees,account.data_account_type_expenses,FALSE,l10n_id.l10n_id_chart
+l10n_id_65110030,65110030,Consultant Fees,account.data_account_type_expenses,FALSE,l10n_id.l10n_id_chart
+l10n_id_65110040,65110040,Rental Costs,account.data_account_type_expenses,FALSE,l10n_id.l10n_id_chart
+l10n_id_65110050,65110050,Insurance Costs,account.data_account_type_expenses,FALSE,l10n_id.l10n_id_chart
+l10n_id_65110060,65110060,Building Maintenance Costs,account.data_account_type_expenses,FALSE,l10n_id.l10n_id_chart
+l10n_id_65110070,65110070,Taxes,account.data_account_type_expenses,FALSE,l10n_id.l10n_id_chart
+l10n_id_65110080,65110080,Asset Maintenance Costs,account.data_account_type_expenses,FALSE,l10n_id.l10n_id_chart
+l10n_id_65110090,65110090,Shipping Costs,account.data_account_type_expenses,FALSE,l10n_id.l10n_id_chart
+l10n_id_66110010,66110010,Vehicle Fuel,account.data_account_type_expenses,FALSE,l10n_id.l10n_id_chart
+l10n_id_66110020,66110020,Vehicle Service,account.data_account_type_expenses,FALSE,l10n_id.l10n_id_chart
+l10n_id_66110030,66110030,Vehicle Parking & Toll Fee,account.data_account_type_expenses,FALSE,l10n_id.l10n_id_chart
+l10n_id_66110040,66110040,Vehicle Taxes,account.data_account_type_expenses,FALSE,l10n_id.l10n_id_chart
+l10n_id_66110050,66110050,Vehicle Insurance,account.data_account_type_expenses,FALSE,l10n_id.l10n_id_chart
+l10n_id_67100010,67100010,Office Building,account.data_account_type_depreciation,FALSE,l10n_id.l10n_id_chart
+l10n_id_67100020,67100020,Vehicle,account.data_account_type_depreciation,FALSE,l10n_id.l10n_id_chart
+l10n_id_67100030,67100030,Office Supplies,account.data_account_type_depreciation,FALSE,l10n_id.l10n_id_chart
+l10n_id_69000000,69000000,Other Expenses,account.data_account_type_expenses,FALSE,l10n_id.l10n_id_chart
+l10n_id_81100010,81100010,Interest Income,account.data_account_type_other_income,FALSE,l10n_id.l10n_id_chart
+l10n_id_81100020,81100020,Deposit Income,account.data_account_type_other_income,FALSE,l10n_id.l10n_id_chart
+l10n_id_81100030,81100030,Foreign Exchange Gain,account.data_account_type_other_income,FALSE,l10n_id.l10n_id_chart
+l10n_id_81100040,81100040,Other Income,account.data_account_type_other_income,FALSE,l10n_id.l10n_id_chart
+l10n_id_81100050,81100050,Gain on Sale of Fixed Assets,account.data_account_type_other_income,FALSE,l10n_id.l10n_id_chart
+l10n_id_91100010,91100010,Interest Expense,account.data_account_type_expenses,FALSE,l10n_id.l10n_id_chart
+l10n_id_91100020,91100020,Foreign Exchange Loss,account.data_account_type_expenses,FALSE,l10n_id.l10n_id_chart
+l10n_id_91100030,91100030,Loss on Sale of Fixed Assets,account.data_account_type_expenses,FALSE,l10n_id.l10n_id_chart
+l10n_id_99900001,99900001,Cash Difference Loss,account.data_account_type_expenses,FALSE,l10n_id.l10n_id_chart
+l10n_id_99900002,99900002,Cash Difference Gain,account.data_account_type_revenue,FALSE,l10n_id.l10n_id_chart
+l10n_id_999999,999999,Undistributed Profits/Losses,account.data_unaffected_earnings,FALSE,l10n_id.l10n_id_chart

--- a/addons/l10n_id/data/account_chart_template_post_data.xml
+++ b/addons/l10n_id/data/account_chart_template_post_data.xml
@@ -1,16 +1,16 @@
 <?xml version="1.0" encoding="utf-8"?>
 <odoo>
     <record id="l10n_id_chart" model="account.chart.template">
-        <field name="property_account_receivable_id" ref="a_1_121001"/>
-        <field name="property_account_payable_id" ref="a_2_110001"/>
-        <field name="property_account_expense_categ_id" ref="a_5_100001"/>
-        <field name="property_account_income_categ_id" ref="a_4_100001"/>
-        <field name="property_stock_account_input_categ_id" ref="a_2_900000"/>
-        <field name="property_stock_account_output_categ_id" ref="a_2_900000"/>
-        <field name="property_stock_valuation_account_id" ref="a_1_130018"/>
-        <field name="income_currency_exchange_account_id" ref="a_8_110001"/>
-        <field name="expense_currency_exchange_account_id" ref="a_9_110001"/>
-        <field name="default_pos_receivable_account_id" ref="a_1_1210011"/>
+        <field name="property_account_receivable_id" ref="l10n_id_11210010"/>
+        <field name="property_account_payable_id" ref="l10n_id_21100010"/>
+        <field name="property_account_expense_categ_id" ref="l10n_id_51000010"/>
+        <field name="property_account_income_categ_id" ref="l10n_id_41000010"/>
+        <field name="property_stock_account_input_categ_id" ref="l10n_id_29000000"/>
+        <field name="property_stock_account_output_categ_id" ref="l10n_id_29000000"/>
+        <field name="property_stock_valuation_account_id" ref="l10n_id_11300180"/>
+        <field name="income_currency_exchange_account_id" ref="l10n_id_81100010"/>
+        <field name="expense_currency_exchange_account_id" ref="l10n_id_91100010"/>
+        <field name="default_pos_receivable_account_id" ref="l10n_id_11210011"/>
         <field name="use_anglo_saxon" eval="1"/>
     </record>
 </odoo>

--- a/addons/l10n_id/data/account_tax_template_data.xml
+++ b/addons/l10n_id/data/account_tax_template_data.xml
@@ -10,9 +10,9 @@
         <field name="description">ST1</field>
         <field name="chart_template_id" ref="l10n_id_chart"/>
         <field name="type_tax_use">sale</field>
-        <field name="name">10%</field>
+        <field name="name">11%</field>
         <field name="amount_type">percent</field>
-        <field name="amount">10.0</field>
+        <field name="amount">11.0</field>
         <field name="invoice_repartition_line_ids" eval="[(5, 0, 0),
             (0,0, {
                 'factor_percent': 100,
@@ -22,7 +22,7 @@
             (0,0, {
                 'factor_percent': 100,
                 'repartition_type': 'tax',
-                'account_id': ref('a_2_122101'),
+                'account_id': ref('l10n_id_21221020'),
             }),
         ]"/>
         <field name="refund_repartition_line_ids" eval="[(5, 0, 0),
@@ -34,7 +34,7 @@
             (0,0, {
                 'factor_percent': 100,
                 'repartition_type': 'tax',
-                'account_id': ref('a_2_122101'),
+                'account_id': ref('l10n_id_21221020'),
             }),
         ]"/>
     </record>
@@ -43,9 +43,9 @@
         <field name="description">PT1</field>
         <field name="chart_template_id" ref="l10n_id_chart"/>
         <field name="type_tax_use">purchase</field>
-        <field name="name">10%</field>
+        <field name="name">11%</field>
         <field name="amount_type">percent</field>
-        <field name="amount">10.0</field>
+        <field name="amount">11.0</field>
         <field name="invoice_repartition_line_ids" eval="[(5, 0, 0),
             (0,0, {
                 'factor_percent': 100,
@@ -55,7 +55,7 @@
             (0,0, {
                 'factor_percent': 100,
                 'repartition_type': 'tax',
-                'account_id': ref('a_2_122102'),
+                'account_id': ref('l10n_id_21221010'),
             }),
         ]"/>
         <field name="refund_repartition_line_ids" eval="[(5, 0, 0),
@@ -67,7 +67,7 @@
             (0,0, {
                 'factor_percent': 100,
                 'repartition_type': 'tax',
-                'account_id': ref('a_2_122102'),
+                'account_id': ref('l10n_id_21221010'),
             }),
         ]"/>
     </record>
@@ -87,7 +87,7 @@
             (0,0, {
                 'factor_percent': 100,
                 'repartition_type': 'tax',
-                'account_id': ref('a_2_122101'),
+                'account_id': ref('l10n_id_21221020'),
             }),
         ]"/>
         <field name="refund_repartition_line_ids" eval="[(5, 0, 0),
@@ -98,7 +98,7 @@
             (0,0, {
                 'factor_percent': 100,
                 'repartition_type': 'tax',
-                'account_id': ref('a_2_122101'),
+                'account_id': ref('l10n_id_21221020'),
             }),
         ]"/>
         </record>
@@ -118,7 +118,7 @@
             (0,0, {
                 'factor_percent': 100,
                 'repartition_type': 'tax',
-                'account_id': ref('a_2_122101'),
+                'account_id': ref('l10n_id_21221020'),
             }),
         ]"/>
         <field name="refund_repartition_line_ids" eval="[(5, 0, 0),
@@ -129,13 +129,13 @@
             (0,0, {
                 'factor_percent': 100,
                 'repartition_type': 'tax',
-                'account_id': ref('a_2_122101'),
+                'account_id': ref('l10n_id_21221020'),
             }),
         ]"/>
     </record>
 
-    <record id="tax_PT0" model="account.tax.template">
-        <field name="description">PT0</field>
+    <record id="tax_PT2" model="account.tax.template">
+        <field name="description">PT2</field>
         <field name="chart_template_id" ref="l10n_id_chart"/>
         <field name="type_tax_use">purchase</field>
         <field name="name">Exempt</field>
@@ -149,7 +149,7 @@
             (0,0, {
                 'factor_percent': 100,
                 'repartition_type': 'tax',
-                'account_id': ref('a_2_122102'),
+                'account_id': ref('l10n_id_21221010'),
             }),
         ]"/>
         <field name="refund_repartition_line_ids" eval="[(5, 0, 0),
@@ -160,13 +160,13 @@
             (0,0, {
                 'factor_percent': 100,
                 'repartition_type': 'tax',
-                'account_id': ref('a_2_122102'),
+                'account_id': ref('l10n_id_21221010'),
             }),
         ]"/>
     </record>
 
-    <record id="tax_PT2" model="account.tax.template">
-        <field name="description">PT2</field>
+    <record id="tax_PT0" model="account.tax.template">
+        <field name="description">PT0</field>
         <field name="chart_template_id" ref="l10n_id_chart"/>
         <field name="type_tax_use">purchase</field>
         <field name="name">0%</field>
@@ -180,7 +180,7 @@
             (0,0, {
                 'factor_percent': 100,
                 'repartition_type': 'tax',
-                'account_id': ref('a_2_122102'),
+                'account_id': ref('l10n_id_21221010'),
             }),
         ]"/>
         <field name="refund_repartition_line_ids" eval="[(5, 0, 0),
@@ -191,7 +191,7 @@
             (0,0, {
                 'factor_percent': 100,
                 'repartition_type': 'tax',
-                'account_id': ref('a_2_122102'),
+                'account_id': ref('l10n_id_21221010'),
             }),
         ]"/>
     </record>

--- a/addons/l10n_id_efaktur/models/account_move.py
+++ b/addons/l10n_id_efaktur/models/account_move.py
@@ -183,13 +183,7 @@ class AccountMove(models.Model):
             eTax['UANG_MUKA_DPP'] = int(abs(sum(lines.mapped('price_subtotal'))))
             eTax['UANG_MUKA_PPN'] = int(abs(sum(lines.mapped(lambda l: l.price_total - l.price_subtotal))))
 
-            company_npwp = company_id.partner_id.vat or '000000000000000'
-
             fk_values_list = ['FK'] + [eTax[f] for f in FK_HEAD_LIST[1:]]
-            eTax['JALAN'] = company_id.partner_id.l10n_id_tax_address or company_id.partner_id.street
-            eTax['NOMOR_TELEPON'] = company_id.phone or ''
-
-            lt_values_list = ['FAPR', company_npwp, company_id.name] + [eTax[f] for f in LT_HEAD_LIST[3:]]
 
             # HOW TO ADD 2 line to 1 line for free product
             free, sales = [], []
@@ -268,7 +262,6 @@ class AccountMove(models.Model):
                 total_discount += round(sale['DISKON'], 2)
 
             output_head += _csv_row(fk_values_list, delimiter)
-            output_head += _csv_row(lt_values_list, delimiter)
             for sale in sales:
                 of_values_list = ['OF'] + [str(sale[f]) for f in OF_HEAD_LIST[1:-2]] + ['0', '0']
                 output_head += _csv_row(of_values_list, delimiter)
@@ -277,7 +270,7 @@ class AccountMove(models.Model):
 
     def _prepare_etax(self):
         # These values are never set
-        return {'JUMLAH_PPNBM': 0, 'UANG_MUKA_PPNBM': 0, 'BLOK': '', 'NOMOR': '', 'RT': '', 'RW': '', 'KECAMATAN': '', 'KELURAHAN': '', 'KABUPATEN': '', 'PROPINSI': '', 'KODE_POS': '', 'JUMLAH_BARANG': 0, 'TARIF_PPNBM': 0, 'PPNBM': 0}
+        return {'JUMLAH_PPNBM': 0, 'UANG_MUKA_PPNBM': 0, 'JUMLAH_BARANG': 0, 'TARIF_PPNBM': 0, 'PPNBM': 0}
 
     def _generate_efaktur(self, delimiter):
         if self.filtered(lambda x: not x.l10n_id_kode_transaksi):


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
Improvement on Indonesian Localization. Changes include:
- Reducing the amount of Chart of Account only to essential and popular amongst end users)
- Updating taxes and update the referred Chart of Accounts to new ones
- Remove writing the row for "FAPR" on e-faktur csv document.
Task link: https://www.odoo.com/web#id=2783987&cids=5&menu_id=4720&action=333&active_id=967&model=project.task&view_type=form

Current behavior before PR:
Last update of the module was 2 years ago. There are too many chart of accounts on current l10n_id module that often confuses clients, hence resulting to them removing everything and import CoA they prepare on their own.
E-faktur currently also contains rows that shows client's information that is useless.

Desired behavior after PR is merged:
After researching into client's needs, government official documents, data for Indonesian localization accounting is collected. Now, CoA has been reduced to esssential and popular once, clients are expected to change too much from existing CoA.
Document should now conform to the current requirements often asked by end users.


--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
