### PR TITLE
[FIX] website_sale: Abandoned Cart not showing if less than 1h

### DIFF
--- a/addons/website_sale/models/crm_team.py
+++ b/addons/website_sale/models/crm_team.py
@@ -45,7 +45,7 @@ class CrmTeam(models.Model):
             'type': 'ir.actions.act_window',
             'view_mode': 'tree,form',
             'domain': [('is_abandoned_cart', '=', True)],
-            'search_view_id': self.env.ref('sale.sale_order_view_search_inherit_sale').id,
+            'search_view_id': [self.env.ref('sale.sale_order_view_search_inherit_sale').id],
             'context': {
                 'search_default_team_id': self.id,
                 'default_team_id': self.id,


### PR DESCRIPTION
Step to reproduce :
- Change 'Cart is abandonned after X hour' in website settings
 with X < 1 (i.e. 0.5)
- Change the quotation date of a quotation Q to be now-35 minutes
- Check Abandonned cart view

Current behaviour:
- Q is not visible in abandonned cart

Behaviour after PR:
- Q is visible in abandonned cart

This seems to be a partial back port of 4a1c516b016d71bf8a60725c61c2f8009463862e
See this commit for more explanation

opw-2783655


--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
