### PR TITLE
[FIX] web_editor: decode base64 of uploaded non-image documents

### DIFF
--- a/addons/web_editor/controllers/main.py
+++ b/addons/web_editor/controllers/main.py
@@ -199,10 +199,11 @@ class Web_Editor(http.Controller):
 
     @http.route('/web_editor/attachment/add_data', type='json', auth='user', methods=['POST'], website=True)
     def add_data(self, name, data, is_image, quality=0, width=0, height=0, res_id=False, res_model='ir.ui.view', **kwargs):
+        data = b64decode(data)
         if is_image:
             format_error_msg = _("Uploaded image's format is not supported. Try with: %s", ', '.join(SUPPORTED_IMAGE_EXTENSIONS))
             try:
-                data = tools.image_process(b64decode(data), size=(width, height), quality=quality, verify_resolution=True)
+                data = tools.image_process(data, size=(width, height), quality=quality, verify_resolution=True)
                 mimetype = guess_mimetype(data)
                 if mimetype not in SUPPORTED_IMAGE_MIMETYPES:
                     return {'error': format_error_msg}

--- a/addons/web_editor/tests/__init__.py
+++ b/addons/web_editor/tests/__init__.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
+from . import test_controller
 from . import test_converter
 from . import test_odoo_editor
 from . import test_views

--- a/addons/web_editor/tests/test_controller.py
+++ b/addons/web_editor/tests/test_controller.py
@@ -1,0 +1,32 @@
+# -*- coding: utf-8 -*-
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from odoo.tools.json import scriptsafe as json_safe
+
+import odoo.tests
+from odoo.tests.common import HttpCase
+
+
+@odoo.tests.tagged('-at_install', 'post_install')
+class TestController(HttpCase):
+    def test_01_upload_document(self):
+        self.authenticate('admin', 'admin')
+        # Upload document.
+        response = self.url_open(
+            '/web_editor/attachment/add_data',
+            headers={'Content-Type': 'application/json'},
+            data=json_safe.dumps({'params': {
+                'name': 'test.txt',
+                'data': 'SGVsbG8gd29ybGQ=',  # base64 Hello world
+                'is_image': False,
+            }})
+        ).json()
+        self.assertFalse('error' in response, 'Upload failed: %s' % response.get('error', {}).get('message'))
+        attachment_id = response['result']['id']
+        checksum = response['result']['checksum']
+        # Download document and check content.
+        response = self.url_open(
+            '/web/content/%s?unique=%s&download=true' % (attachment_id, checksum)
+        )
+        self.assertEqual(200, response.status_code, 'Expect response')
+        self.assertEqual(b'Hello world', response.content, 'Expect raw content')


### PR DESCRIPTION
Since [1] non-image documents uploaded in web editor were stored as
received in base64 without being decoded.
This led to downloading them as they were stored in base64.

After this commit uploaded documents are base64-decoded before being
stored.

Steps to reproduce:
- edit a web page
- drop a "Text - Image" snippet
- replace the image
- upload a document (PDF, TXT...)
- save page
- download document
=> received document was base64-encoded

[1]: https://github.com/odoo/odoo/commit/6b8752604898bf2b583b7f5334e35f6a1583595e

task-2782269

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
