### PR TITLE
[FIX] point_of_sale: Cash in/out button not working with comma

### DIFF
--- a/addons/point_of_sale/static/src/js/Popups/CashMovePopup.js
+++ b/addons/point_of_sale/static/src/js/Popups/CashMovePopup.js
@@ -18,7 +18,7 @@ odoo.define('point_of_sale.CashMovePopup', function (require) {
         }
         confirm() {
             try {
-                parse.float(this.state.inputAmount);
+                parse.float(this.state.inputAmount.replace(",", "."));
             } catch (error) {
                 this.state.inputHasError = true;
                 this.errorMessage = this.env._t('Invalid amount');
@@ -38,7 +38,7 @@ odoo.define('point_of_sale.CashMovePopup', function (require) {
         }
         getPayload() {
             return {
-                amount: parse.float(this.state.inputAmount),
+                amount: parse.float(this.state.inputAmount.replace(",", ".")),
                 reason: this.state.inputReason.trim(),
                 type: this.state.inputType,
             };


### PR DESCRIPTION
Current behavior:
When using a comma in the cash in/out button the amount is not correctly parsed.

Steps to reproduce:
- Set language to en_US
- Install PoS
- Try to use the cash in/out button of the PoS
- In the amount input enter something with a comma (123,4€)
- The popup message says that you cashed in/out 1234€ instead of 123.4€

opw-2762426

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
