### PR TITLE
[FIX] hr_contract: fix infinite recursion on search

### DIFF
--- a/addons/hr_contract/models/hr_employee_public.py
+++ b/addons/hr_contract/models/hr_employee_public.py
@@ -7,4 +7,4 @@ from odoo import fields, models
 class HrEmployeePublic(models.Model):
     _inherit = "hr.employee.public"
 
-    first_contract_date = fields.Date(related='employee_id.first_contract_date', groups="base.group_user")
+    first_contract_date = fields.Date()


### PR DESCRIPTION
Step to reproduce:
- Connect as Admin
- Remove all HR access rights from the Demo user
- Connect as Demo
- Go to Employees app
- Do an advanced search: search for employees with 'First Contract Date'
 and the rest can be anything

Current behaviour:
- Traceback due to infinite recursion
- The recursion is due to employee search calling employee.public search
if there are no read access :
https://github.com/odoo/odoo/blob/15.0/addons/hr/models/hr_employee.py#L222
- And ORM call the comodel search when a field is related in :
https://github.com/odoo/odoo/blob/15.0/odoo/osv/expression.py#L721

Behaviour after PR:
- Public employee data is a view from employee data for stored field
- Change contract_first_date to stored fields so it directly a view from
employee

opw-2780100


--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
