### PR TITLE
[FIX] hr_contract: fix infinite recursion on search

### DIFF
--- a/addons/hr_contract/models/hr_employee_public.py
+++ b/addons/hr_contract/models/hr_employee_public.py
@@ -1,10 +1,19 @@
 # -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
-from odoo import fields, models
+from odoo import fields, models, SUPERUSER_ID
 
 
 class HrEmployeePublic(models.Model):
     _inherit = "hr.employee.public"
 
     first_contract_date = fields.Date(related='employee_id.first_contract_date', groups="base.group_user")
+
+    # Due to _search in HrEmployee calling HrEmployeePublic's _search, this lead to recursion as _search on
+    # related field search on the original field.
+    # TODO in master : Remove + change first_contract_date to `fields.Date()`,
+    #  stored fields are handle in hr_employee_public
+    def _search(self, args, offset=0, limit=None, order=None, count=False, access_rights_uid=None):
+        if len(args) == 1 and args[0][0] == 'first_contract_date':
+            return self.env['hr.employee'].sudo()._search(args, offset, limit, order, count, access_rights_uid)
+        return super()._search(args, offset, limit, order, count, access_rights_uid)


### PR DESCRIPTION
Step to reproduce:
- Connect as Admin
- Remove all HR access rights from the Demo user
- Connect as Demo
- Go to Employees app
- Do an advanced search: search for employees with 'First Contract Date'
and the rest can be anything

Current behaviour:
- Traceback due to infinite recursion
- The recursion is due to employee search calling employee.public search
if there are no read access :
https://github.com/odoo/odoo/blob/15.0/addons/hr/models/hr_employee.py#L222
- And ORM call the comodel search when a field is related in :
https://github.com/odoo/odoo/blob/15.0/odoo/osv/expression.py#L721

Behaviour after PR:
- _search on 'first_contract_date' is switched to sudo

PR in master : https://github.com/odoo/odoo/pull/85735
The master PR show the correct fix but is not possible in stable

opw-2780100

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
