### PR TITLE
[IMP] convert: autofill sequence fields

### DIFF
--- a/addons/l10n_ae/data/account_tax_report_data.xml
+++ b/addons/l10n_ae/data/account_tax_report_data.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<odoo>
+<odoo auto_sequence="1">
     <record id="tax_report" model="account.report">
         <field name="name">Tax Report</field>
         <field name="root_report_id" ref="account.generic_tax_report"/>

--- a/addons/l10n_at/data/account_tax_report_data.xml
+++ b/addons/l10n_at/data/account_tax_report_data.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<odoo>
+<odoo auto_sequence="1">
     <record id="tax_report" model="account.report">
         <field name="name">Tax Report</field>
         <field name="root_report_id" ref="account.generic_tax_report"/>

--- a/addons/l10n_au/data/account_tax_report_data.xml
+++ b/addons/l10n_au/data/account_tax_report_data.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<odoo>
+<odoo auto_sequence="1">
     <record id="tax_report" model="account.report">
         <field name="name">BAS Report</field>
         <field name="root_report_id" ref="account.generic_tax_report"/>

--- a/addons/l10n_be/data/account_tax_report_data.xml
+++ b/addons/l10n_be/data/account_tax_report_data.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<odoo>
+<odoo auto_sequence="1">
     <record id="tax_report_vat" model="account.report">
         <field name="name">VAT Return</field>
         <field name="root_report_id" ref="account.generic_tax_report"/>

--- a/addons/l10n_bg/data/tax_report.xml
+++ b/addons/l10n_bg/data/tax_report.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<odoo>
+<odoo auto_sequence="1">
     <record id="l10n_bg_tax_report" model="account.report">
         <field name="name">Tax report</field>
         <field name="root_report_id" ref="account.generic_tax_report"/>

--- a/addons/l10n_bo/data/account_tax_report_data.xml
+++ b/addons/l10n_bo/data/account_tax_report_data.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<odoo>
+<odoo auto_sequence="1">
     <record id="tax_report" model="account.report">
         <field name="name">Tax Report</field>
         <field name="root_report_id" ref="account.generic_tax_report"/>

--- a/addons/l10n_br/data/account_tax_report_data.xml
+++ b/addons/l10n_br/data/account_tax_report_data.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<odoo>
+<odoo auto_sequence="1">
     <record id="tax_report" model="account.report">
         <field name="name">Tax Report</field>
         <field name="root_report_id" ref="account.generic_tax_report"/>

--- a/addons/l10n_ch/data/account_tax_report_data.xml
+++ b/addons/l10n_ch/data/account_tax_report_data.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<odoo>
+<odoo auto_sequence="1">
     <record id="tax_report" model="account.report">
         <field name="name">Tax Report</field>
         <field name="root_report_id" ref="account.generic_tax_report"/>
@@ -15,24 +15,20 @@
         <field name="line_ids">
             <record id="account_tax_report_line_chiffre_af" model="account.report.line">
                 <field name="name">I – TURNOVER</field>
-                <field name="sequence" eval="0"/> <!-- Sequence is force to avoid order problem when updating within the same version. -->
                 <field name="hierarchy_level">0</field>
                 <field name="children_ids">
                     <record id="account_tax_report_line_chtax_200" model="account.report.line">
                         <field name="name">200 Total amount of agreed or collected consideration incl. from supplies opted for taxation, transfer of supplies acc. to the notification procedure and supplies provided abroad (worldwide turnover)</field>
                         <field name="aggregation_formula">tax_ch_302a.balance + tax_ch_303a.balance + tax_ch_312a.balance + tax_ch_313a.balance + tax_ch_342a.balance + tax_ch_343a.balance + tax_ch_289.balance</field>
-                        <field name="sequence" eval="1"/>
                     </record>
                     <record id="account_tax_report_line_chtax_289" model="account.report.line">
                         <field name="name">289 Consideration reported in Ref. 200 from supplies exempt from the tax without credit (art. 21) where the option for their taxation according to art. 22 has been exercised</field>
                         <field name="code">tax_ch_289</field>
                         <field name="aggregation_formula">tax_ch_220.balance + tax_ch_221.balance + tax_ch_225.balance + tax_ch_230.balance + tax_ch_235.balance + tax_ch_280.balance</field>
-                        <field name="sequence" eval="2"/>
                         <field name="children_ids">
                             <record id="account_tax_report_line_chtax_220_289" model="account.report.line">
                                 <field name="name">220 Supplies exempt from the tax (e.g. export, art. 23) and supplies provided to institutional and individual beneficiaries that are exempt from liability for tax (art. 107 para. 1 lit. a)</field>
                                 <field name="code">tax_ch_220</field>
-                                <field name="sequence" eval="3"/>
                                 <field name="expression_ids">
                                     <record id="account_tax_report_line_chtax_220_289_tag" model="account.report.expression">
                                         <field name="label">balance</field>
@@ -44,7 +40,6 @@
                             <record id="account_tax_report_line_chtax_221" model="account.report.line">
                                 <field name="name">221 Supplies provided abroad (place of supply is abroad)</field>
                                 <field name="code">tax_ch_221</field>
-                                <field name="sequence" eval="4"/>
                                 <field name="expression_ids">
                                     <record id="account_tax_report_line_chtax_221_tag" model="account.report.expression">
                                         <field name="label">balance</field>
@@ -56,7 +51,6 @@
                             <record id="account_tax_report_line_chtax_225" model="account.report.line">
                                 <field name="name">225 Transfer of supplies according to the notification procedure (art. 38, please submit Form 764)</field>
                                 <field name="code">tax_ch_225</field>
-                                <field name="sequence" eval="5"/>
                                 <field name="expression_ids">
                                     <record id="account_tax_report_line_chtax_225_tag" model="account.report.expression">
                                         <field name="label">balance</field>
@@ -68,7 +62,6 @@
                             <record id="account_tax_report_line_chtax_230" model="account.report.line">
                                 <field name="name">230 Supplies provided on Swiss territory exempt from the tax without credit (art. 21) and where the option for their taxation according to art. 22 has not been exercised</field>
                                 <field name="code">tax_ch_230</field>
-                                <field name="sequence" eval="6"/>
                                 <field name="expression_ids">
                                     <record id="account_tax_report_line_chtax_230_tag" model="account.report.expression">
                                         <field name="label">balance</field>
@@ -80,7 +73,6 @@
                             <record id="account_tax_report_line_chtax_235" model="account.report.line">
                                 <field name="name">235 Reduction of consideration (discounts, rebates etc.)</field>
                                 <field name="code">tax_ch_235</field>
-                                <field name="sequence" eval="7"/>
                                 <field name="expression_ids">
                                     <record id="account_tax_report_line_chtax_235_tag" model="account.report.expression">
                                         <field name="label">balance</field>
@@ -92,7 +84,6 @@
                             <record id="account_tax_report_line_chtax_280" model="account.report.line">
                                 <field name="name">280 Miscellaneous (e.g. land value, purchase prices in case of margin taxation)</field>
                                 <field name="code">tax_ch_280</field>
-                                <field name="sequence" eval="8"/>
                                 <field name="expression_ids">
                                     <record id="account_tax_report_line_chtax_280_tag" model="account.report.expression">
                                         <field name="label">balance</field>
@@ -108,23 +99,19 @@
             <record id="account_tax_report_line_chtax_299" model="account.report.line">
                 <field name="name">299 Taxable turnover (Ref. 200 minus Ref. 289)</field>
                 <field name="aggregation_formula">tax_ch_302a.balance + tax_ch_303a.balance + tax_ch_312a.balance + tax_ch_313a.balance + tax_ch_342a.balance + tax_ch_343a.balance</field>
-                <field name="sequence" eval="9"/>
                 <field name="hierarchy_level">0</field>
             </record>
             <record id="account_tax_report_line_calc_impot" model="account.report.line">
                 <field name="name">II - TAX CALCULATION</field>
-                <field name="sequence" eval="10"/>
                 <field name="hierarchy_level">0</field>
                 <field name="children_ids">
                     <record id="account_tax_report_line_calc_impot_chiffre" model="account.report.line">
                         <field name="name">Taxable turnover</field>
                         <field name="aggregation_formula">tax_ch_302a.balance + tax_ch_312a.balance + tax_ch_342a.balance</field>
-                        <field name="sequence" eval="11"/>
                         <field name="children_ids">
                             <record id="account_tax_report_line_chtax_302a" model="account.report.line">
                                 <field name="name">302a Taxable turnover at 7.7% (TS) until 31.12.2023</field>
                                 <field name="code">tax_ch_302a</field>
-                                <field name="sequence" eval="12"/>
                                 <field name="expression_ids">
                                     <record id="account_tax_report_line_chtax_302a_tag" model="account.report.expression">
                                         <field name="label">balance</field>
@@ -136,7 +123,6 @@
                             <record id="account_tax_report_line_chtax_303a" model="account.report.line">
                                 <field name="name">303a Taxable turnover at 8.1% (TS) from 01.01.2024</field>
                                 <field name="code">tax_ch_303a</field>
-                                <field name="sequence" eval="13"/>
                                 <field name="expression_ids">
                                     <record id="account_tax_report_line_chtax_303a_tag" model="account.report.expression">
                                         <field name="label">balance</field>
@@ -148,7 +134,6 @@
                             <record id="account_tax_report_line_chtax_312a" model="account.report.line">
                                 <field name="name">312a Taxable turnover at 2.5% (TR) until 31.12.2023</field>
                                 <field name="code">tax_ch_312a</field>
-                                <field name="sequence" eval="14"/>
                                 <field name="expression_ids">
                                     <record id="account_tax_report_line_chtax_312a_tag" model="account.report.expression">
                                         <field name="label">balance</field>
@@ -160,7 +145,6 @@
                             <record id="account_tax_report_line_chtax_313a" model="account.report.line">
                                 <field name="name">313a Taxable turnover at 2.6% (TR) from 01.01.2024</field>
                                 <field name="code">tax_ch_313a</field>
-                                <field name="sequence" eval="15"/>
                                 <field name="expression_ids">
                                     <record id="account_tax_report_line_chtax_313a_tag" model="account.report.expression">
                                         <field name="label">balance</field>
@@ -172,7 +156,6 @@
                             <record id="account_tax_report_line_chtax_342a" model="account.report.line">
                                 <field name="name">342a Taxable turnover at 3.7% (TS) until 31.12.2023</field>
                                 <field name="code">tax_ch_342a</field>
-                                <field name="sequence" eval="16"/>
                                 <field name="expression_ids">
                                     <record id="account_tax_report_line_chtax_342a_tag" model="account.report.expression">
                                         <field name="label">balance</field>
@@ -184,7 +167,6 @@
                             <record id="account_tax_report_line_chtax_343a" model="account.report.line">
                                 <field name="name">343a Taxable turnover at 3.8% (TS) from 01.01.2024</field>
                                 <field name="code">tax_ch_343a</field>
-                                <field name="sequence" eval="17"/>
                                 <field name="expression_ids">
                                     <record id="account_tax_report_line_chtax_343a_tag" model="account.report.expression">
                                         <field name="label">balance</field>
@@ -198,12 +180,10 @@
                     <record id="account_tax_report_line_calc_impot_base" model="account.report.line">
                         <field name="name">Tax base on service acquisitions</field>
                         <field name="aggregation_formula">tax_ch_381A.balance + tax_ch_382A.balance + tax_ch_383A.balance</field>
-                        <field name="sequence" eval="18"/>
                         <field name="children_ids">
                             <record id="account_tax_report_line_chtax_381a" model="account.report.line">
                                 <field name="name">381a Acquisition tax</field>
                                 <field name="code">tax_ch_381A</field>
-                                <field name="sequence" eval="19"/>
                                 <field name="expression_ids">
                                     <record id="account_tax_report_line_chtax_381a_tag" model="account.report.expression">
                                         <field name="label">balance</field>
@@ -215,7 +195,6 @@
                             <record id="account_tax_report_line_chtax_382a" model="account.report.line">
                                 <field name="name">382a Acquisition tax until 31.12.2023</field>
                                 <field name="code">tax_ch_382A</field>
-                                <field name="sequence" eval="20"/>
                                 <field name="expression_ids">
                                     <record id="account_tax_report_line_chtax_382a_tag" model="account.report.expression">
                                         <field name="label">balance</field>
@@ -227,7 +206,6 @@
                             <record id="account_tax_report_line_chtax_383a" model="account.report.line">
                                 <field name="name">383a Acquisition tax from 01.01.2024</field>
                                 <field name="code">tax_ch_383A</field>
-                                <field name="sequence" eval="21"/>
                                 <field name="expression_ids">
                                     <record id="account_tax_report_line_chtax_383a_tag" model="account.report.expression">
                                         <field name="label">balance</field>
@@ -242,12 +220,10 @@
                         <field name="name">399 Total amount of tax due</field>
                         <field name="code">tax_ch_399</field>
                         <field name="aggregation_formula">tax_ch_302B.balance + tax_ch_303B.balance + tax_ch_312B.balance + tax_ch_313B.balance + tax_ch_342B.balance + tax_ch_343B.balance + tax_ch_381B.balance + tax_ch_382B.balance + tax_ch_383B.balance</field>
-                        <field name="sequence" eval="22"/>
                         <field name="children_ids">
                             <record id="account_tax_report_line_chtax_302b" model="account.report.line">
                                 <field name="name">302b Tax due at 7.7% (TS) until 31.12.2023</field>
                                 <field name="code">tax_ch_302B</field>
-                                <field name="sequence" eval="23"/>
                                 <field name="expression_ids">
                                     <record id="account_tax_report_line_chtax_302b_tag" model="account.report.expression">
                                         <field name="label">balance</field>
@@ -259,7 +235,6 @@
                             <record id="account_tax_report_line_chtax_303b" model="account.report.line">
                                 <field name="name">303b Tax due at 8.1% (TS) from 01.01.2024</field>
                                 <field name="code">tax_ch_303B</field>
-                                <field name="sequence" eval="24"/>
                                 <field name="expression_ids">
                                     <record id="account_tax_report_line_chtax_303b_tag" model="account.report.expression">
                                         <field name="label">balance</field>
@@ -271,7 +246,6 @@
                             <record id="account_tax_report_line_chtax_312b" model="account.report.line">
                                 <field name="name">312b Tax due at 2.5% (TR) until 31.12.2023</field>
                                 <field name="code">tax_ch_312B</field>
-                                <field name="sequence" eval="25"/>
                                 <field name="expression_ids">
                                     <record id="account_tax_report_line_chtax_312b_tag" model="account.report.expression">
                                         <field name="label">balance</field>
@@ -283,7 +257,6 @@
                             <record id="account_tax_report_line_chtax_313b" model="account.report.line">
                                 <field name="name">313b Tax due at 2.6% (TR) from 01.01.2024</field>
                                 <field name="code">tax_ch_313B</field>
-                                <field name="sequence" eval="26"/>
                                 <field name="expression_ids">
                                     <record id="account_tax_report_line_chtax_313b_tag" model="account.report.expression">
                                         <field name="label">balance</field>
@@ -295,7 +268,6 @@
                             <record id="account_tax_report_line_chtax_342b" model="account.report.line">
                                 <field name="name">342b Tax due at 3.7% (TS) until 31.12.2023</field>
                                 <field name="code">tax_ch_342B</field>
-                                <field name="sequence" eval="27"/>
                                 <field name="expression_ids">
                                     <record id="account_tax_report_line_chtax_342b_tag" model="account.report.expression">
                                         <field name="label">balance</field>
@@ -307,7 +279,6 @@
                             <record id="account_tax_report_line_chtax_343b" model="account.report.line">
                                 <field name="name">343b Tax due at 3.8% (TS) from 01.01.2024</field>
                                 <field name="code">tax_ch_343B</field>
-                                <field name="sequence" eval="28"/>
                                 <field name="expression_ids">
                                     <record id="account_tax_report_line_chtax_343b_tag" model="account.report.expression">
                                         <field name="label">balance</field>
@@ -319,7 +290,6 @@
                             <record id="account_tax_report_line_chtax_381b" model="account.report.line">
                                 <field name="name">381b Acquisition tax</field>
                                 <field name="code">tax_ch_381B</field>
-                                <field name="sequence" eval="29"/>
                                 <field name="expression_ids">
                                     <record id="account_tax_report_line_chtax_381b_tag" model="account.report.expression">
                                         <field name="label">balance</field>
@@ -331,7 +301,6 @@
                             <record id="account_tax_report_line_chtax_382b" model="account.report.line">
                                 <field name="name">382b Acquisition tax until 31.12.2023</field>
                                 <field name="code">tax_ch_382B</field>
-                                <field name="sequence" eval="30"/>
                                 <field name="expression_ids">
                                     <record id="account_tax_report_line_chtax_382b_tag" model="account.report.expression">
                                         <field name="label">balance</field>
@@ -343,7 +312,6 @@
                             <record id="account_tax_report_line_chtax_383b" model="account.report.line">
                                 <field name="name">383b Acquisition tax from 01.01.2024</field>
                                 <field name="code">tax_ch_383B</field>
-                                <field name="sequence" eval="31"/>
                                 <field name="expression_ids">
                                     <record id="account_tax_report_line_chtax_383b_tag" model="account.report.expression">
                                         <field name="label">balance</field>
@@ -360,13 +328,11 @@
                 <field name="name">479 Input VAT</field>
                 <field name="code">tax_ch_479</field>
                 <field name="aggregation_formula">tax_ch_400.balance + tax_ch_405.balance + tax_ch_410.balance + tax_ch_415.balance + tax_ch_420.balance</field>
-                <field name="sequence" eval="32"/>
                 <field name="hierarchy_level">0</field>
                 <field name="children_ids">
                     <record id="account_tax_report_line_chtax_400" model="account.report.line">
                         <field name="name">400 Input tax on cost of materials and supplies of services</field>
                         <field name="code">tax_ch_400</field>
-                        <field name="sequence" eval="33"/>
                         <field name="expression_ids">
                             <record id="account_tax_report_line_chtax_400_tag" model="account.report.expression">
                                 <field name="label">balance</field>
@@ -378,7 +344,6 @@
                     <record id="account_tax_report_line_chtax_405" model="account.report.line">
                         <field name="name">405 Input tax on investments and other operating costs</field>
                         <field name="code">tax_ch_405</field>
-                        <field name="sequence" eval="34"/>
                         <field name="expression_ids">
                             <record id="account_tax_report_line_chtax_405_tag" model="account.report.expression">
                                 <field name="label">balance</field>
@@ -390,7 +355,6 @@
                     <record id="account_tax_report_line_chtax_410" model="account.report.line">
                         <field name="name">410 De-taxation (art. 32, please enclose a detailed list)</field>
                         <field name="code">tax_ch_410</field>
-                        <field name="sequence" eval="35"/>
                         <field name="expression_ids">
                             <record id="account_tax_report_line_chtax_410_tag" model="account.report.expression">
                                 <field name="label">balance</field>
@@ -402,7 +366,6 @@
                     <record id="account_tax_report_line_chtax_415" model="account.report.line">
                         <field name="name">415 Correction of the input tax deduction: mixed use (art. 30), own use (art. 31)</field>
                         <field name="code">tax_ch_415</field>
-                        <field name="sequence" eval="36"/>
                         <field name="expression_ids">
                             <record id="account_tax_report_line_chtax_415_tag" model="account.report.expression">
                                 <field name="label">balance</field>
@@ -414,7 +377,6 @@
                     <record id="account_tax_report_line_chtax_420" model="account.report.line">
                         <field name="name">420 Reduction of the input tax deduction: Flow of funds, which are not deemed to be consideration, such as subsidies, tourist charges (art. 33 para. 2)</field>
                         <field name="code">tax_ch_420</field>
-                        <field name="sequence" eval="37"/>
                         <field name="expression_ids">
                             <record id="account_tax_report_line_chtax_420_tag" model="account.report.expression">
                                 <field name="label">balance</field>
@@ -427,7 +389,6 @@
             </record>
             <record id="account_tax_report_line_chtax_solde" model="account.report.line">
                 <field name="name">AMOUNT PAYABLE</field>
-                <field name="sequence" eval="38"/>
                 <field name="hierarchy_level">0</field>
                 <field name="expression_ids">
                     <record id="account_tax_report_line_chtax_solde_formula" model="account.report.expression">
@@ -440,7 +401,6 @@
                 <field name="children_ids">
                     <record id="account_tax_report_line_chtax_500" model="account.report.line">
                         <field name="name">500 Amount of VAT payable to AFC</field>
-                        <field name="sequence" eval="39"/>
                         <field name="expression_ids">
                             <record id="account_tax_report_line_chtax_500_formula" model="account.report.expression">
                                 <field name="label">balance</field>
@@ -452,7 +412,6 @@
                     </record>
                     <record id="account_tax_report_line_chtax_510" model="account.report.line">
                         <field name="name">510 Credit in favour of the taxable person</field>
-                        <field name="sequence" eval="40"/>
                         <field name="expression_ids">
                             <record id="account_tax_report_line_chtax_510_formula" model="account.report.expression">
                                 <field name="label">balance</field>
@@ -467,13 +426,11 @@
             <record id="account_tax_report_line_chtax_autres_mouv" model="account.report.line">
                 <field name="name">OTHER CASH FLOWS (art. 18 para. 2)</field>
                 <field name="aggregation_formula">tax_ch_900.balance + tax_ch_910.balance</field>
-                <field name="sequence" eval="41"/>
                 <field name="hierarchy_level">0</field>
                 <field name="children_ids">
                     <record id="account_tax_report_line_chtax_900" model="account.report.line">
                         <field name="name">900 Subsidies, tourist funds collected by tourist offices, contributions from cantonal water, sewage or waste funds (art. 18 para. 2 lit. a to c)</field>
                         <field name="code">tax_ch_900</field>
-                        <field name="sequence" eval="42"/>
                         <field name="expression_ids">
                             <record id="account_tax_report_line_chtax_900_tag" model="account.report.expression">
                                 <field name="label">balance</field>
@@ -485,7 +442,6 @@
                     <record id="account_tax_report_line_chtax_910" model="account.report.line">
                         <field name="name">910 Donations, dividends, payments of damages etc. (art. 18 para. 2 lit. d to l)</field>
                         <field name="code">tax_ch_910</field>
-                        <field name="sequence" eval="43"/>
                         <field name="expression_ids">
                             <record id="account_tax_report_line_chtax_910_tag" model="account.report.expression">
                                 <field name="label">balance</field>

--- a/addons/l10n_cl/data/account_tax_report_data.xml
+++ b/addons/l10n_cl/data/account_tax_report_data.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<odoo>
+<odoo auto_sequence="1">
     <record id="tax_report" model="account.report">
         <field name="name">Tax Report</field>
         <field name="root_report_id" ref="account.generic_tax_report"/>

--- a/addons/l10n_de/data/account_account_tags_data.xml
+++ b/addons/l10n_de/data/account_account_tags_data.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<odoo>
+<odoo auto_sequence="1">
     <record id="tax_report" model="account.report">
         <field name="name">Tax Report</field>
         <field name="root_report_id" ref="account.generic_tax_report"/>
@@ -15,31 +15,26 @@
         <field name="line_ids">
             <record id="tax_report_de_tag_01" model="account.report.line">
                 <field name="name">Assessment basis</field>
-                <field name="sequence">10</field>
                 <field name="aggregation_formula"></field>
                 <field name="children_ids">
                     <record id="tax_report_de_tag_17" model="account.report.line">
                         <field name="name">Declaration of the advance payment of turnover tax</field>
                         <field name="code">I_ANMELDUNG_DER_UMSATZSTEUERVORAUSZAHLUNG_ZEILE_17_GRUNDLAGE</field>
-                        <field name="sequence">20</field>
                         <field name="aggregation_formula"></field>
                         <field name="children_ids">
                             <record id="tax_report_de_tag_18" model="account.report.line">
                                 <field name="name">Goods and services</field>
                                 <field name="code">LIEFERUNGEN_UND_SONSTIGE_LEISTUNGEN_ZEILE_18_GRUNDLAGE</field>
-                                <field name="sequence">30</field>
                                 <field name="aggregation_formula">STEUERFREIE_UMSATZE_MIT_VORSTEUERABZUG_ZEILE_19.balance + DE_48.balance + STEUERPFLICHTIGE_UMSATZE_ZEILE_25.balance + AGG_DE_31.balance</field>
                                 <field name="children_ids">
                                     <record id="tax_report_de_tag_19" model="account.report.line">
                                         <field name="name">Taxable turnover</field>
                                         <field name="code">STEUERFREIE_UMSATZE_MIT_VORSTEUERABZUG_ZEILE_19</field>
-                                        <field name="sequence">40</field>
                                         <field name="aggregation_formula">DE_81_BASE.balance + DE_86_BASE.balance + DE_87.balance + DE_35.balance + DE_77.balance + DE_76.balance</field>
                                         <field name="children_ids">
                                             <record id="tax_report_de_tag_81" model="account.report.line">
                                                 <field name="name">81. at the tax rate of 19 % (line 12)</field>
                                                 <field name="code">DE_81_BASE</field>
-                                                <field name="sequence">50</field>
                                                 <field name="expression_ids">
                                                     <record id="tax_report_de_tag_81_tag" model="account.report.expression">
                                                         <field name="label">balance</field>
@@ -51,7 +46,6 @@
                                             <record id="tax_report_de_tag_86" model="account.report.line">
                                                 <field name="name">86. at the tax rate of 7 % (line 13)</field>
                                                 <field name="code">DE_86_BASE</field>
-                                                <field name="sequence">60</field>
                                                 <field name="expression_ids">
                                                     <record id="tax_report_de_tag_86_tag" model="account.report.expression">
                                                         <field name="label">balance</field>
@@ -63,7 +57,6 @@
                                             <record id="tax_report_de_tag_87" model="account.report.line">
                                                 <field name="name">87. at the tax rate of 0 % (line 14)</field>
                                                 <field name="code">DE_87</field>
-                                                <field name="sequence">70</field>
                                                 <field name="expression_ids">
                                                     <record id="tax_report_de_tag_87_tag" model="account.report.expression">
                                                         <field name="label">balance</field>
@@ -75,7 +68,6 @@
                                             <record id="tax_report_de_tag_35" model="account.report.line">
                                                 <field name="name">35. at other tax rates (line 15)</field>
                                                 <field name="code">DE_35</field>
-                                                <field name="sequence">80</field>
                                                 <field name="expression_ids">
                                                     <record id="tax_report_de_tag_35_tag" model="account.report.expression">
                                                         <field name="label">balance</field>
@@ -87,7 +79,6 @@
                                             <record id="tax_report_de_tag_77" model="account.report.line">
                                                 <field name="name">77. supplies of agricultural and forestry operations according to § 24 UStG to customers with VAT identification number (line 16)</field>
                                                 <field name="code">DE_77</field>
-                                                <field name="sequence">90</field>
                                                 <field name="expression_ids">
                                                     <record id="tax_report_de_tag_77_tag" model="account.report.expression">
                                                         <field name="label">balance</field>
@@ -99,7 +90,6 @@
                                             <record id="tax_report_de_tag_76" model="account.report.line">
                                                 <field name="name">76. transactions for which tax is payable under § 24 UStG (line 17)</field>
                                                 <field name="code">DE_76</field>
-                                                <field name="sequence">100</field>
                                                 <field name="expression_ids">
                                                     <record id="tax_report_de_tag_76_tag" model="account.report.expression">
                                                         <field name="label">balance</field>
@@ -113,13 +103,11 @@
                                     <record id="tax_report_de_tag_25" model="account.report.line">
                                         <field name="name">Tax-exempt transactions with input tax deduction</field>
                                         <field name="code">STEUERPFLICHTIGE_UMSATZE_ZEILE_25</field>
-                                        <field name="sequence">110</field>
                                         <field name="aggregation_formula">DE_41.balance + DE_44.balance + DE_49.balance + DE_43.balance</field>
                                         <field name="children_ids">
                                             <record id="tax_report_de_tag_41" model="account.report.line">
                                                 <field name="name">41. to customer with VAT number (line 18)</field>
                                                 <field name="code">DE_41</field>
-                                                <field name="sequence">120</field>
                                                 <field name="expression_ids">
                                                     <record id="tax_report_de_tag_41_tag" model="account.report.expression">
                                                         <field name="label">balance</field>
@@ -131,7 +119,6 @@
                                             <record id="tax_report_de_tag_44" model="account.report.line">
                                                 <field name="name">44. new vehicles to customers without VAT number (line 19)</field>
                                                 <field name="code">DE_44</field>
-                                                <field name="sequence">130</field>
                                                 <field name="expression_ids">
                                                     <record id="tax_report_de_tag_44_tag" model="account.report.expression">
                                                         <field name="label">balance</field>
@@ -143,7 +130,6 @@
                                             <record id="tax_report_de_tag_49" model="account.report.line">
                                                 <field name="name">49. new vehicles outside a company (line 20)</field>
                                                 <field name="code">DE_49</field>
-                                                <field name="sequence">140</field>
                                                 <field name="expression_ids">
                                                     <record id="tax_report_de_tag_49_tag" model="account.report.expression">
                                                         <field name="label">balance</field>
@@ -155,7 +141,6 @@
                                             <record id="tax_report_de_tag_43" model="account.report.line">
                                                 <field name="name">43. other tax-exempt transactions with input tax deduction (line 21)</field>
                                                 <field name="code">DE_43</field>
-                                                <field name="sequence">150</field>
                                                 <field name="expression_ids">
                                                     <record id="tax_report_de_tag_43_tag" model="account.report.expression">
                                                         <field name="label">balance</field>
@@ -169,7 +154,6 @@
                                     <record id="tax_report_de_tag_24" model="account.report.line">
                                         <field name="name">48. tax-exempt transactions without input tax deduction (line 22)</field>
                                         <field name="code">DE_48</field>
-                                        <field name="sequence">160</field>
                                         <field name="expression_ids">
                                             <record id="tax_report_de_tag_24_tag" model="account.report.expression">
                                                 <field name="label">balance</field>
@@ -181,13 +165,11 @@
                                     <record id="tax_report_de_tag_31" model="account.report.line">
                                         <field name="name">Intra-Community acquisitions</field>
                                         <field name="code">AGG_DE_31</field>
-                                        <field name="sequence">170</field>
                                         <field name="aggregation_formula">DE_91.balance + DE_89_BASE.balance + DE_93_BASE.balance + DE_90.balance + DE_95.balance + DE_94.balance</field>
                                         <field name="children_ids">
                                             <record id="tax_report_de_tag_91" model="account.report.line">
                                                 <field name="name">91. tax-free intra-Community acquisitions (line 23)</field>
                                                 <field name="code">DE_91</field>
-                                                <field name="sequence">180</field>
                                                 <field name="expression_ids">
                                                     <record id="tax_report_de_tag_91_tag" model="account.report.expression">
                                                         <field name="label">balance</field>
@@ -199,7 +181,6 @@
                                             <record id="tax_report_de_tag_89" model="account.report.line">
                                                 <field name="name">89. taxable intra-Community acquisitions at the rate of 19 % (line 24)</field>
                                                 <field name="code">DE_89_BASE</field>
-                                                <field name="sequence">190</field>
                                                 <field name="expression_ids">
                                                     <record id="tax_report_de_tag_89_tag" model="account.report.expression">
                                                         <field name="label">balance</field>
@@ -211,7 +192,6 @@
                                             <record id="tax_report_de_tag_93" model="account.report.line">
                                                 <field name="name">93. at the tax rate of 7 % (line 25)</field>
                                                 <field name="code">DE_93_BASE</field>
-                                                <field name="sequence">200</field>
                                                 <field name="expression_ids">
                                                     <record id="tax_report_de_tag_93_tag" model="account.report.expression">
                                                         <field name="label">balance</field>
@@ -223,7 +203,6 @@
                                             <record id="tax_report_de_tag_90" model="account.report.line">
                                                 <field name="name">90. at the tax rate of 0 % (line 26)</field>
                                                 <field name="code">DE_90</field>
-                                                <field name="sequence">210</field>
                                                 <field name="expression_ids">
                                                     <record id="tax_report_de_tag_90_tag" model="account.report.expression">
                                                         <field name="label">balance</field>
@@ -235,7 +214,6 @@
                                             <record id="tax_report_de_tag_95" model="account.report.line">
                                                 <field name="name">95. at other tax rates (line 27)</field>
                                                 <field name="code">DE_95</field>
-                                                <field name="sequence">220</field>
                                                 <field name="expression_ids">
                                                     <record id="tax_report_de_tag_95_tag" model="account.report.expression">
                                                         <field name="label">balance</field>
@@ -247,7 +225,6 @@
                                             <record id="tax_report_de_tag_94" model="account.report.line">
                                                 <field name="name">94. new vehicles from suppliers without (line 28)</field>
                                                 <field name="code">DE_94</field>
-                                                <field name="sequence">230</field>
                                                 <field name="expression_ids">
                                                     <record id="tax_report_de_tag_94_tag" model="account.report.expression">
                                                         <field name="label">balance</field>
@@ -263,13 +240,11 @@
                             <record id="tax_report_de_tag_46" model="account.report.line">
                                 <field name="name">The recipient of the service as the person liable to pay tax</field>
                                 <field name="code">LEISTUNGSEMPFANGER_ALS_STEUERSCHULDNER_ZEILE_46_GRUNDLAGE</field>
-                                <field name="sequence">240</field>
                                 <field name="aggregation_formula">DE_46.balance + DE_73.balance + DE_84.balance</field>
                                 <field name="children_ids">
                                     <record id="tax_report_de_tag_48" model="account.report.line">
                                         <field name="name">46. other taxable supplies by a trader established in the rest of the Community (line 29)</field>
                                         <field name="code">DE_46</field>
-                                        <field name="sequence">250</field>
                                         <field name="expression_ids">
                                             <record id="tax_report_de_tag_48_tag" model="account.report.expression">
                                                 <field name="label">balance</field>
@@ -281,7 +256,6 @@
                                     <record id="tax_report_de_tag_73" model="account.report.line">
                                         <field name="name">73. supplies of goods transferred by way of security and transactions falling under the GrEStG (line 30)</field>
                                         <field name="code">DE_73</field>
-                                        <field name="sequence">260</field>
                                         <field name="expression_ids">
                                             <record id="tax_report_de_tag_73_tag" model="account.report.expression">
                                                 <field name="label">balance</field>
@@ -293,7 +267,6 @@
                                     <record id="tax_report_de_tag_84" model="account.report.line">
                                         <field name="name">84. other benefits (line 31)</field>
                                         <field name="code">DE_84</field>
-                                        <field name="sequence">270</field>
                                         <field name="expression_ids">
                                             <record id="tax_report_de_tag_84_tag" model="account.report.expression">
                                                 <field name="label">balance</field>
@@ -307,13 +280,11 @@
                             <record id="tax_report_de_tag_37" model="account.report.line">
                                 <field name="name">Supplementary information on turnover</field>
                                 <field name="code">ERGANZENDE_ANGABEN_ZU_UMSATZEN_ZEILE_37_GRUNDLAGE</field>
-                                <field name="sequence">280</field>
                                 <field name="aggregation_formula">DE_42.balance + DE_60.balance + DE_21.balance + DE_45_BASE.balance</field>
                                 <field name="children_ids">
                                     <record id="tax_report_de_tag_42" model="account.report.line">
                                         <field name="name">42. triangular transactions (line 32)</field>
                                         <field name="code">DE_42</field>
-                                        <field name="sequence">280</field>
                                         <field name="expression_ids">
                                             <record id="tax_report_de_tag_42_tag" model="account.report.expression">
                                                 <field name="label">balance</field>
@@ -325,7 +296,6 @@
                                     <record id="tax_report_de_tag_60" model="account.report.line">
                                         <field name="name">60. other taxable transactions for which the recipient of the service is liable for the tax in accordance with Section 13b (5) UStG (line 33)</field>
                                         <field name="code">DE_60</field>
-                                        <field name="sequence">290</field>
                                         <field name="expression_ids">
                                             <record id="tax_report_de_tag_60_tag" model="account.report.expression">
                                                 <field name="label">balance</field>
@@ -337,7 +307,6 @@
                                     <record id="tax_report_de_tag_21" model="account.report.line">
                                         <field name="name">21. non-taxable other services (line 34)</field>
                                         <field name="code">DE_21</field>
-                                        <field name="sequence">300</field>
                                         <field name="expression_ids">
                                             <record id="tax_report_de_tag_21_tag" model="account.report.expression">
                                                 <field name="label">balance</field>
@@ -349,7 +318,6 @@
                                     <record id="tax_report_de_tag_45" model="account.report.line">
                                         <field name="name">45. other non-taxable transactions (line 35)</field>
                                         <field name="code">DE_45_BASE</field>
-                                        <field name="sequence">310</field>
                                         <field name="expression_ids">
                                             <record id="tax_report_de_tag_45_tag" model="account.report.expression">
                                                 <field name="label">balance</field>
@@ -366,31 +334,26 @@
             </record>
             <record id="tax_report_de_tag_02" model="account.report.line">
                 <field name="name">Tax</field>
-                <field name="sequence">320</field>
                 <field name="aggregation_formula">I_ANMELDUNG_DER_UMSATZSTEUERVORAUSZAHLUNG_ZEILE_17_STEUER.balance</field>
                 <field name="children_ids">
                     <record id="tax_report_de_tax_tag_17" model="account.report.line">
                         <field name="name">Declaration of the advance payment of turnover tax</field>
                         <field name="code">I_ANMELDUNG_DER_UMSATZSTEUERVORAUSZAHLUNG_ZEILE_17_STEUER</field>
-                        <field name="sequence">330</field>
                         <field name="aggregation_formula">LIEFERUNGEN_UND_SONSTIGE_LEISTUNGEN_ZEILE_18_STEUER.balance + LEISTUNGSEMPFANGER_ALS_STEUERSCHULDNER_ZEILE_46.balance + ABZIEHBARE_VORSTEUERBETRAGE_ZEILE_55.balance + ANDERE_STEUERBETRAGE_ZEILE_64.balance + DE_39.balance + DE_83.balance</field>
                         <field name="children_ids">
                             <record id="tax_report_de_tax_tag_18" model="account.report.line">
                                 <field name="name">Goods and services</field>
                                 <field name="code">LIEFERUNGEN_UND_SONSTIGE_LEISTUNGEN_ZEILE_18_STEUER</field>
-                                <field name="sequence">340</field>
                                 <field name="aggregation_formula">STEUERPFLICHT_UMSATZE_STEUER.balance + INNERGEMEINSCHAFTLICHE_ERWERBE_ZEILE_31_STEUER.balance</field>
                                 <field name="children_ids">
                                     <record id="tax_report_de_tax_tag_19" model="account.report.line">
                                         <field name="name">Taxable turnover</field>
                                         <field name="code">STEUERPFLICHT_UMSATZE_STEUER</field>
-                                        <field name="sequence">350</field>
                                         <field name="aggregation_formula">DE_81_TAX.balance + DE_86_TAX.balance + DE_36.balance + DE_80.balance</field>
                                         <field name="children_ids">
                                             <record id="tax_report_de_tag_26" model="account.report.line">
                                                 <field name="name">81. at the tax rate of 19 % (line 12)</field>
                                                 <field name="code">DE_81_TAX</field>
-                                                <field name="sequence">360</field>
                                                 <field name="expression_ids">
                                                     <record id="tax_report_de_tag_26_tag" model="account.report.expression">
                                                         <field name="label">balance</field>
@@ -402,7 +365,6 @@
                                             <record id="tax_report_de_tag_27" model="account.report.line">
                                                 <field name="name">86. at the tax rate of 7 % (line 13)</field>
                                                 <field name="code">DE_86_TAX</field>
-                                                <field name="sequence">370</field>
                                                 <field name="expression_ids">
                                                     <record id="tax_report_de_tag_27_tag" model="account.report.expression">
                                                         <field name="label">balance</field>
@@ -414,7 +376,6 @@
                                             <record id="tax_report_de_tag_36" model="account.report.line">
                                                 <field name="name">36. at other tax rates (line 15)</field>
                                                 <field name="code">DE_36</field>
-                                                <field name="sequence">380</field>
                                                 <field name="expression_ids">
                                                     <record id="tax_report_de_tag_36_tag" model="account.report.expression">
                                                         <field name="label">balance</field>
@@ -426,7 +387,6 @@
                                             <record id="tax_report_de_tag_80" model="account.report.line">
                                                 <field name="name">80. turnover for which tax is payable under § 24 UStG (line 17)</field>
                                                 <field name="code">DE_80</field>
-                                                <field name="sequence">390</field>
                                                 <field name="expression_ids">
                                                     <record id="tax_report_de_tag_80_tag" model="account.report.expression">
                                                         <field name="label">balance</field>
@@ -440,13 +400,11 @@
                                     <record id="tax_report_de_tax_tag_31" model="account.report.line">
                                         <field name="name">Intra-Community acquisitions</field>
                                         <field name="code">INNERGEMEINSCHAFTLICHE_ERWERBE_ZEILE_31_STEUER</field>
-                                        <field name="sequence">400</field>
                                         <field name="aggregation_formula">DE_89_TAX.balance + DE_93_TAX.balance + DE_98.balance + DE_96.balance</field>
                                         <field name="children_ids">
                                             <record id="tax_report_de_tag_33" model="account.report.line">
                                                 <field name="name">89. at the tax rate of 19 % (line 24)</field>
                                                 <field name="code">DE_89_TAX</field>
-                                                <field name="sequence">410</field>
                                                 <field name="expression_ids">
                                                     <record id="tax_report_de_tag_33_tag" model="account.report.expression">
                                                         <field name="label">balance</field>
@@ -458,7 +416,6 @@
                                             <record id="tax_report_de_tag_34" model="account.report.line">
                                                 <field name="name">93. at the tax rate of 7 % (line 25)</field>
                                                 <field name="code">DE_93_TAX</field>
-                                                <field name="sequence">420</field>
                                                 <field name="expression_ids">
                                                     <record id="tax_report_de_tag_34_tag" model="account.report.expression">
                                                         <field name="label">balance</field>
@@ -470,7 +427,6 @@
                                             <record id="tax_report_de_tag_98" model="account.report.line">
                                                 <field name="name">98. at other tax rates (line 27)</field>
                                                 <field name="code">DE_98</field>
-                                                <field name="sequence">430</field>
                                                 <field name="expression_ids">
                                                     <record id="tax_report_de_tag_98_tag" model="account.report.expression">
                                                         <field name="label">balance</field>
@@ -482,7 +438,6 @@
                                             <record id="tax_report_de_tag_96" model="account.report.line">
                                                 <field name="name">96. new vehicles from suppliers without VAT number at the general tax rate (line 28)</field>
                                                 <field name="code">DE_96</field>
-                                                <field name="sequence">440</field>
                                                 <field name="expression_ids">
                                                     <record id="tax_report_de_tag_96_tag" model="account.report.expression">
                                                         <field name="label">balance</field>
@@ -498,13 +453,11 @@
                             <record id="tax_report_de_tax_tag_46" model="account.report.line">
                                 <field name="name">Recipient of the service as the person liable to pay tax</field>
                                 <field name="code">LEISTUNGSEMPFANGER_ALS_STEUERSCHULDNER_ZEILE_46</field>
-                                <field name="sequence">450</field>
                                 <field name="aggregation_formula">DE_47.balance + DE_74.balance + DE_85.balance</field>
                                 <field name="children_ids">
                                     <record id="tax_report_de_tag_47" model="account.report.line">
                                         <field name="name">47. other taxable supplies by a trader established in the rest of the Community (line 29)</field>
                                         <field name="code">DE_47</field>
-                                        <field name="sequence">460</field>
                                         <field name="expression_ids">
                                             <record id="tax_report_de_tag_47_tag" model="account.report.expression">
                                                 <field name="label">balance</field>
@@ -516,7 +469,6 @@
                                     <record id="tax_report_de_tag_74" model="account.report.line">
                                         <field name="name">74. supplies of goods transferred by way of security and transactions falling under the GrEStG (line 30)</field>
                                         <field name="code">DE_74</field>
-                                        <field name="sequence">470</field>
                                         <field name="expression_ids">
                                             <record id="tax_report_de_tag_74_tag" model="account.report.expression">
                                                 <field name="label">balance</field>
@@ -528,7 +480,6 @@
                                     <record id="tax_report_de_tag_85" model="account.report.line">
                                         <field name="name">85. other benefits (line 31)</field>
                                         <field name="code">DE_85</field>
-                                        <field name="sequence">480</field>
                                         <field name="expression_ids">
                                             <record id="tax_report_de_tag_85_tag" model="account.report.expression">
                                                 <field name="label">balance</field>
@@ -542,13 +493,11 @@
                             <record id="tax_report_de_tax_tag_55" model="account.report.line">
                                 <field name="name">Deductible input tax amounts</field>
                                 <field name="code">ABZIEHBARE_VORSTEUERBETRAGE_ZEILE_55</field>
-                                <field name="sequence">490</field>
                                 <field name="aggregation_formula">DE_66.balance + DE_61.balance + DE_62.balance + DE_67.balance + DE_63.balance + DE_64.balance + DE_59.balance</field>
                                 <field name="children_ids">
                                     <record id="tax_report_de_tag_66" model="account.report.line">
                                         <field name="name">66. input tax amounts from invoices from other traders (line 37)</field>
                                         <field name="code">DE_66</field>
-                                        <field name="sequence">500</field>
                                         <field name="expression_ids">
                                             <record id="tax_report_de_tag_66_tag" model="account.report.expression">
                                                 <field name="label">balance</field>
@@ -560,7 +509,6 @@
                                     <record id="tax_report_de_tag_61" model="account.report.line">
                                         <field name="name">61. input tax amounts from the intra-Community acquisition of goods (line 38)</field>
                                         <field name="code">DE_61</field>
-                                        <field name="sequence">510</field>
                                         <field name="expression_ids">
                                             <record id="tax_report_de_tag_61_tag" model="account.report.expression">
                                                 <field name="label">balance</field>
@@ -572,7 +520,6 @@
                                     <record id="tax_report_de_tag_62" model="account.report.line">
                                         <field name="name">62. import turnover tax incurred (line 39)</field>
                                         <field name="code">DE_62</field>
-                                        <field name="sequence">520</field>
                                         <field name="expression_ids">
                                             <record id="tax_report_de_tag_62_tag" model="account.report.expression">
                                                 <field name="label">balance</field>
@@ -584,7 +531,6 @@
                                     <record id="tax_report_de_tag_67" model="account.report.line">
                                         <field name="name">67. input tax amounts from services within the meaning of § 13b UStG (line 40)</field>
                                         <field name="code">DE_67</field>
-                                        <field name="sequence">530</field>
                                         <field name="expression_ids">
                                             <record id="tax_report_de_tag_67_tag" model="account.report.expression">
                                                 <field name="label">balance</field>
@@ -596,7 +542,6 @@
                                     <record id="tax_report_de_tag_63" model="account.report.line">
                                         <field name="name">63. input tax amounts calculated according to general average rates (line 41)</field>
                                         <field name="code">DE_63</field>
-                                        <field name="sequence">540</field>
                                         <field name="expression_ids">
                                             <record id="tax_report_de_tag_63_tag" model="account.report.expression">
                                                 <field name="label">balance</field>
@@ -608,7 +553,6 @@
                                     <record id="tax_report_de_tag_59" model="account.report.line">
                                         <field name="name">59. input tax deduction for intra-Community supplies of new vehicles outside a business (line 42)</field>
                                         <field name="code">DE_59</field>
-                                        <field name="sequence">550</field>
                                         <field name="expression_ids">
                                             <record id="tax_report_de_tag_59_tag" model="account.report.expression">
                                                 <field name="label">balance</field>
@@ -620,7 +564,6 @@
                                     <record id="tax_report_de_tag_64" model="account.report.line">
                                         <field name="name">64. adjustment of the input tax deduction (line 43)</field>
                                         <field name="code">DE_64</field>
-                                        <field name="sequence">560</field>
                                         <field name="expression_ids">
                                             <record id="tax_report_de_tag_64_tag" model="account.report.expression">
                                                 <field name="label">balance</field>
@@ -634,13 +577,11 @@
                             <record id="tax_report_de_tax_tag_64" model="account.report.line">
                                 <field name="name">Other tax amounts</field>
                                 <field name="code">ANDERE_STEUERBETRAGE_ZEILE_64</field>
-                                <field name="sequence">570</field>
                                 <field name="aggregation_formula">DE_65.balance + DE_69.balance</field>
                                 <field name="children_ids">
                                     <record id="tax_report_de_tag_65" model="account.report.line">
                                         <field name="name">65. Tax due to change in the form of taxation and after-tax on taxed prepayments and similar due to change in tax rate (line 45)</field>
                                         <field name="code">DE_65</field>
-                                        <field name="sequence">580</field>
                                         <field name="expression_ids">
                                             <record id="tax_report_de_tag_65_tag" model="account.report.expression">
                                                 <field name="label">balance</field>
@@ -652,7 +593,6 @@
                                     <record id="tax_report_de_tag_69" model="account.report.line">
                                         <field name="name">69. tax amounts shown incorrectly or unjustifiably in invoices (line 46)</field>
                                         <field name="code">DE_69</field>
-                                        <field name="sequence">590</field>
                                         <field name="expression_ids">
                                             <record id="tax_report_de_tag_69_tag" model="account.report.expression">
                                                 <field name="label">balance</field>
@@ -666,7 +606,6 @@
                             <record id="tax_report_de_tag_39" model="account.report.line">
                                 <field name="name">39. deduction of the special advance payment for the extension of the standing period (line 48)</field>
                                 <field name="code">DE_39</field>
-                                <field name="sequence">600</field>
                                 <field name="expression_ids">
                                     <record id="tax_report_de_tag_39_tag" model="account.report.expression">
                                         <field name="label">balance</field>
@@ -678,7 +617,6 @@
                             <record id="tax_report_de_tag_83" model="account.report.line">
                                 <field name="name">83. remaining advance payment of sales tax (line 49)</field>
                                 <field name="code">DE_83</field>
-                                <field name="sequence">610</field>
                                 <field name="expression_ids">
                                     <record id="tax_report_de_tag_83_tag" model="account.report.expression">
                                         <field name="label">balance</field>
@@ -693,12 +631,10 @@
             </record>
             <record id="tax_report_de_tag_71" model="account.report.line">
                 <field name="name">Reduction</field>
-                <field name="sequence">620</field>
                 <field name="children_ids">
                     <record id="tax_report_de_tag_50" model="account.report.line">
                         <field name="name">50. Reduction of the tax base (line 50)</field>
                         <field name="code">50</field>
-                        <field name="sequence">630</field>
                         <field name="expression_ids">
                             <record id="tax_report_de_tag_50_tag" model="account.report.expression">
                                 <field name="label">balance</field>
@@ -710,7 +646,6 @@
                     <record id="tax_report_de_tag_37_74" model="account.report.line">
                         <field name="name">37. Reduction of deductible input tax amounts (line 51)</field>
                         <field name="code">37</field>
-                        <field name="sequence">640</field>
                         <field name="expression_ids">
                             <record id="tax_report_de_tag_37_74_tag" model="account.report.expression">
                                 <field name="label">balance</field>

--- a/addons/l10n_dk/data/account_tax_report_data.xml
+++ b/addons/l10n_dk/data/account_tax_report_data.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<odoo>
+<odoo auto_sequence="1">
     <record id="account_tax_report_skat_dk" model="account.report">
         <field name="name">VAT Report</field>
         <field name="root_report_id" ref="account.generic_tax_report"/>

--- a/addons/l10n_do/data/account_tax_report_data.xml
+++ b/addons/l10n_do/data/account_tax_report_data.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<odoo>
+<odoo auto_sequence="1">
     <record id="tax_report" model="account.report">
         <field name="name">Tax Report</field>
         <field name="root_report_id" ref="account.generic_tax_report"/>

--- a/addons/l10n_ec/data/account_tax_report_data.xml
+++ b/addons/l10n_ec/data/account_tax_report_data.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<odoo>
+<odoo auto_sequence="1">
     <record id="tax_report_104" model="account.report">
         <field name="name">104</field>
         <field name="root_report_id" ref="account.generic_tax_report"/>

--- a/addons/l10n_eg/data/account_tax_report_data.xml
+++ b/addons/l10n_eg/data/account_tax_report_data.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<odoo>
+<odoo auto_sequence="1">
     <record id="tax_report_vat_return" model="account.report">
         <field name="name">1. VAT Return</field>
         <field name="root_report_id" ref="account.generic_tax_report"/>

--- a/addons/l10n_et/data/account_tax_report_data.xml
+++ b/addons/l10n_et/data/account_tax_report_data.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<odoo>
+<odoo auto_sequence="1">
     <record id="tax_report" model="account.report">
         <field name="name">Tax Report</field>
         <field name="root_report_id" ref="account.generic_tax_report"/>

--- a/addons/l10n_fi/data/account_tax_report_line.xml
+++ b/addons/l10n_fi/data/account_tax_report_line.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<odoo>
+<odoo auto_sequence="1">
     <record id="vat_report" model="account.report">
         <field name="name">VAT Report</field>
         <field name="root_report_id" ref="account.generic_tax_report"/>

--- a/addons/l10n_fr/data/tax_report_data.xml
+++ b/addons/l10n_fr/data/tax_report_data.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<odoo>
+<odoo auto_sequence="1">
     <record id="tax_report" model="account.report">
         <field name="name">Tax Report</field>
         <field name="root_report_id" ref="account.generic_tax_report"/>
@@ -10,23 +10,19 @@
             <record id="tax_report_balance" model="account.report.column">
                 <field name="name">Balance</field>
                 <field name="expression_label">balance</field>
-                <field name="sequence" eval="0"/>
             </record>
         </field>
         <field name="line_ids">
             <record id="tax_report_montant_op_realisees" model="account.report.line">
                 <field name="name">A. Amount of operations carried out</field>
-                <field name="sequence" eval="1"/>
                 <field name="hierarchy_level">0</field>
                 <field name="children_ids">
                     <record id="tax_report_op_imposables_ht" model="account.report.line">
                         <field name="name">Taxable transactions (excl. VAT)</field>
-                        <field name="sequence" eval="2"/>
                         <field name="children_ids">
                             <record id="tax_report_A1" model="account.report.line">
                                 <field name="name">A1 - Sales, provision of services</field>
                                 <field name="code">box_A1</field>
-                                <field name="sequence" eval="3"/>
                                 <field name="expression_ids">
                                     <record id="tax_report_A1_tag" model="account.report.expression">
                                         <field name="label">balance</field>
@@ -38,7 +34,6 @@
                             <record id="tax_report_A2" model="account.report.line">
                                 <field name="name">A2 - Other taxable transactions</field>
                                 <field name="code">box_A2</field>
-                                <field name="sequence" eval="4"/>
                                 <field name="expression_ids">
                                     <record id="tax_report_A2_tag" model="account.report.expression">
                                         <field name="label">balance</field>
@@ -50,7 +45,6 @@
                             <record id="tax_report_A3" model="account.report.line">
                                 <field name="name">A3 - Intra-Community purchases of services</field>
                                 <field name="code">box_A3</field>
-                                <field name="sequence" eval="5"/>
                                 <field name="expression_ids">
                                     <record id="tax_report_A3_tag" model="account.report.expression">
                                         <field name="label">balance</field>
@@ -62,7 +56,6 @@
                             <record id="tax_report_A4" model="account.report.line">
                                 <field name="name">A4 - Imports (other than petroleum products)</field>
                                 <field name="code">box_A4</field>
-                                <field name="sequence" eval="6"/>
                                 <field name="expression_ids">
                                     <record id="tax_report_A4_tag" model="account.report.expression">
                                         <field name="label">balance</field>
@@ -74,7 +67,6 @@
                             <record id="tax_report_A5" model="account.report.line">
                                 <field name="name">A5 - Removal from suspensive tax regime (other than petroleum products)</field>
                                 <field name="code">box_A5</field>
-                                <field name="sequence" eval="7"/>
                                 <field name="expression_ids">
                                     <record id="tax_report_A5_tag" model="account.report.expression">
                                         <field name="label">balance</field>
@@ -86,7 +78,6 @@
                             <record id="tax_report_B1" model="account.report.line">
                                 <field name="name">B1 - Releases for consumption of petroleum products</field>
                                 <field name="code">box_B1</field>
-                                <field name="sequence" eval="8"/>
                                 <field name="expression_ids">
                                     <record id="tax_report_B1_tag" model="account.report.expression">
                                         <field name="label">balance</field>
@@ -98,7 +89,6 @@
                             <record id="tax_report_B2" model="account.report.line">
                                 <field name="name">B2 - Intra-Community acquisitions</field>
                                 <field name="code">box_B2</field>
-                                <field name="sequence" eval="9"/>
                                 <field name="expression_ids">
                                     <record id="tax_report_B2_tag" model="account.report.expression">
                                         <field name="label">balance</field>
@@ -110,7 +100,6 @@
                             <record id="tax_report_B3" model="account.report.line">
                                 <field name="name">B3 - Taxable supplies of electricity, natural gas, heat or cooling in France</field>
                                 <field name="code">box_B3</field>
-                                <field name="sequence" eval="10"/>
                                 <field name="expression_ids">
                                     <record id="tax_report_B3_tag" model="account.report.expression">
                                         <field name="label">balance</field>
@@ -122,7 +111,6 @@
                             <record id="tax_report_B4" model="account.report.line">
                                 <field name="name">B4 - Purchases of goods or services from a taxable person not established in France</field>
                                 <field name="code">box_B4</field>
-                                <field name="sequence" eval="11"/>
                                 <field name="expression_ids">
                                     <record id="tax_report_B4_tag" model="account.report.expression">
                                         <field name="label">balance</field>
@@ -134,7 +122,6 @@
                             <record id="tax_report_B5" model="account.report.line">
                                 <field name="name">B5 - Regularisations</field>
                                 <field name="code">box_B5</field>
-                                <field name="sequence" eval="12"/>
                                 <field name="expression_ids">
                                     <record id="tax_report_B5_tag" model="account.report.expression">
                                         <field name="label">balance</field>
@@ -147,12 +134,10 @@
                     </record>
                     <record id="tax_report_op_non_imposables" model="account.report.line">
                         <field name="name">Untaxed operations</field>
-                        <field name="sequence" eval="13"/>
                         <field name="children_ids">
                             <record id="tax_report_E1" model="account.report.line">
                                 <field name="name">E1 - Exports outside the EU</field>
                                 <field name="code">box_E1</field>
-                                <field name="sequence" eval="14"/>
                                 <field name="expression_ids">
                                     <record id="tax_report_E1_tag" model="account.report.expression">
                                         <field name="label">balance</field>
@@ -164,7 +149,6 @@
                             <record id="tax_report_E2" model="account.report.line">
                                 <field name="name">E2 - Other non-taxable transactions</field>
                                 <field name="code">box_E2</field>
-                                <field name="sequence" eval="15"/>
                                 <field name="expression_ids">
                                     <record id="tax_report_E2_tag" model="account.report.expression">
                                         <field name="label">balance</field>
@@ -176,7 +160,6 @@
                             <record id="tax_report_E3" model="account.report.line">
                                 <field name="name">E3 - Distance selling taxable in another Member State to non-taxable persons</field>
                                 <field name="code">box_E3</field>
-                                <field name="sequence" eval="16"/>
                                 <field name="expression_ids">
                                     <record id="tax_report_E3_tag" model="account.report.expression">
                                         <field name="label">balance</field>
@@ -188,7 +171,6 @@
                             <record id="tax_report_E4" model="account.report.line">
                                 <field name="name">E4 - Imports (other than petroleum products)</field>
                                 <field name="code">box_E4</field>
-                                <field name="sequence" eval="17"/>
                                 <field name="expression_ids">
                                     <record id="tax_report_E4_tag" model="account.report.expression">
                                         <field name="label">balance</field>
@@ -200,7 +182,6 @@
                             <record id="tax_report_E5" model="account.report.line">
                                 <field name="name">E5 - Removal from suspensive tax regime (other than petroleum products)</field>
                                 <field name="code">box_E5</field>
-                                <field name="sequence" eval="18"/>
                                 <field name="expression_ids">
                                     <record id="tax_report_E5_tag" model="account.report.expression">
                                         <field name="label">balance</field>
@@ -212,7 +193,6 @@
                             <record id="tax_report_E6" model="account.report.line">
                                 <field name="name">E6 - Imports under suspensive tax arrangements (other than petroleum products)</field>
                                 <field name="code">box_E6</field>
-                                <field name="sequence" eval="19"/>
                                 <field name="expression_ids">
                                     <record id="tax_report_E6_tag" model="account.report.expression">
                                         <field name="label">balance</field>
@@ -224,7 +204,6 @@
                             <record id="tax_report_F1" model="account.report.line">
                                 <field name="name">F1 - Intra-Community acquisitions</field>
                                 <field name="code">box_F1</field>
-                                <field name="sequence" eval="20"/>
                                 <field name="expression_ids">
                                     <record id="tax_report_F1_tag" model="account.report.expression">
                                         <field name="label">balance</field>
@@ -236,7 +215,6 @@
                             <record id="tax_report_F2" model="account.report.line">
                                 <field name="name">F2 - Intra-Community supplies to a taxable person</field>
                                 <field name="code">box_F2</field>
-                                <field name="sequence" eval="21"/>
                                 <field name="expression_ids">
                                     <record id="tax_report_F2_tag" model="account.report.expression">
                                         <field name="label">balance</field>
@@ -248,7 +226,6 @@
                             <record id="tax_report_F3" model="account.report.line">
                                 <field name="name">F3 - Non-taxable supplies of electricity, natural gas, heat or cooling in France</field>
                                 <field name="code">box_F3</field>
-                                <field name="sequence" eval="22"/>
                                 <field name="expression_ids">
                                     <record id="tax_report_F3_tag" model="account.report.expression">
                                         <field name="label">balance</field>
@@ -260,7 +237,6 @@
                             <record id="tax_report_F4" model="account.report.line">
                                 <field name="name">F4 - Releases for consumption of petroleum products</field>
                                 <field name="code">box_F4</field>
-                                <field name="sequence" eval="23"/>
                                 <field name="expression_ids">
                                     <record id="tax_report_F4_tag" model="account.report.expression">
                                         <field name="label">balance</field>
@@ -272,7 +248,6 @@
                             <record id="tax_report_F5" model="account.report.line">
                                 <field name="name">F5 - Imports of petroleum products under a suspensive tax regime</field>
                                 <field name="code">box_F5</field>
-                                <field name="sequence" eval="24"/>
                                 <field name="expression_ids">
                                     <record id="tax_report_F5_tag" model="account.report.expression">
                                         <field name="label">balance</field>
@@ -284,7 +259,6 @@
                             <record id="tax_report_F6" model="account.report.line">
                                 <field name="name">F6 - Franchise purchases</field>
                                 <field name="code">box_F6</field>
-                                <field name="sequence" eval="25"/>
                                 <field name="expression_ids">
                                     <record id="tax_report_F6_tag" model="account.report.expression">
                                         <field name="label">balance</field>
@@ -296,7 +270,6 @@
                             <record id="tax_report_F7" model="account.report.line">
                                 <field name="name">F7 - Sales of goods or services by a taxable person not established in France</field>
                                 <field name="code">box_F7</field>
-                                <field name="sequence" eval="26"/>
                                 <field name="expression_ids">
                                     <record id="tax_report_F7_tag" model="account.report.expression">
                                         <field name="label">balance</field>
@@ -308,7 +281,6 @@
                             <record id="tax_report_F8" model="account.report.line">
                                 <field name="name">F8 - Accruals</field>
                                 <field name="code">box_7B</field>
-                                <field name="sequence" eval="27"/>
                                 <field name="expression_ids">
                                     <record id="tax_report_F8_tag" model="account.report.expression">
                                         <field name="label">balance</field>
@@ -320,7 +292,6 @@
                             <record id="tax_report_F9" model="account.report.line">
                                 <field name="name">F9 - Internal transactions between members of a single taxable person</field>
                                 <field name="code">box_F9</field>
-                                <field name="sequence" eval="28"/>
                                 <field name="expression_ids">
                                     <record id="tax_report_F9_tag" model="account.report.expression">
                                         <field name="label">balance</field>
@@ -335,21 +306,17 @@
             </record>
             <record id="tax_report_decompte_tva" model="account.report.line">
                 <field name="name">B. Settlement of VAT to be paid</field>
-                <field name="sequence" eval="29"/>
                 <field name="hierarchy_level">0</field>
                 <field name="children_ids">
                     <record id="tax_report_tva_brute" model="account.report.line">
                         <field name="name">Gross VAT</field>
-                        <field name="sequence" eval="30"/>
                     </record>
                     <record id="tax_report_tva_brute_metropo" model="account.report.line">
                         <field name="name">Operations carried out in mainland France</field>
-                        <field name="sequence" eval="31"/>
                         <field name="children_ids">
                             <record id="tax_report_08_base" model="account.report.line">
                                 <field name="name">08 - Standard rate 20% (base)</field>
                                 <field name="code">box_08_base</field>
-                                <field name="sequence" eval="32"/>
                                 <field name="expression_ids">
                                     <record id="tax_report_08_base_tag" model="account.report.expression">
                                         <field name="label">balance</field>
@@ -361,7 +328,6 @@
                             <record id="tax_report_08_taxe" model="account.report.line">
                                 <field name="name">08 - Standard rate 20% (tax)</field>
                                 <field name="code">box_08_taxe</field>
-                                <field name="sequence" eval="33"/>
                                 <field name="expression_ids">
                                     <record id="tax_report_08_taxe_tag" model="account.report.expression">
                                         <field name="label">balance</field>
@@ -373,7 +339,6 @@
                             <record id="tax_report_09_base" model="account.report.line">
                                 <field name="name">09 - Reduced rate 5.5% (base)</field>
                                 <field name="code">box_09_base</field>
-                                <field name="sequence" eval="34"/>
                                 <field name="expression_ids">
                                     <record id="tax_report_09_base_tag" model="account.report.expression">
                                         <field name="label">balance</field>
@@ -385,7 +350,6 @@
                             <record id="tax_report_09_taxe" model="account.report.line">
                                 <field name="name">09 - Reduced rate 5.5% (tax)</field>
                                 <field name="code">box_09_taxe</field>
-                                <field name="sequence" eval="35"/>
                                 <field name="expression_ids">
                                     <record id="tax_report_09_taxe_tag" model="account.report.expression">
                                         <field name="label">balance</field>
@@ -397,7 +361,6 @@
                             <record id="tax_report_9B_base" model="account.report.line">
                                 <field name="name">9B - Reduced rate 10% (base)</field>
                                 <field name="code">box_9B_base</field>
-                                <field name="sequence" eval="36"/>
                                 <field name="expression_ids">
                                     <record id="tax_report_9B_base_tag" model="account.report.expression">
                                         <field name="label">balance</field>
@@ -409,7 +372,6 @@
                             <record id="tax_report_9B_taxe" model="account.report.line">
                                 <field name="name">9B - Reduced rate 10% (tax)</field>
                                 <field name="code">box_9B_taxe</field>
-                                <field name="sequence" eval="37"/>
                                 <field name="expression_ids">
                                     <record id="tax_report_9B_taxe_tag" model="account.report.expression">
                                         <field name="label">balance</field>
@@ -422,12 +384,10 @@
                     </record>
                     <record id="tax_report_tva_brute_dom" model="account.report.line">
                         <field name="name">Operations carried out in the DOM</field>
-                        <field name="sequence" eval="38"/>
                         <field name="children_ids">
                             <record id="tax_report_10_base" model="account.report.line">
                                 <field name="name">10 - Standard rate 8.5% (base)</field>
                                 <field name="code">box_10_base</field>
-                                <field name="sequence" eval="39"/>
                                 <field name="expression_ids">
                                     <record id="tax_report_10_base_tag" model="account.report.expression">
                                         <field name="label">balance</field>
@@ -439,7 +399,6 @@
                             <record id="tax_report_10_taxe" model="account.report.line">
                                 <field name="name">10 - Standard rate 8.5% (tax)</field>
                                 <field name="code">box_10_taxe</field>
-                                <field name="sequence" eval="40"/>
                                 <field name="expression_ids">
                                     <record id="tax_report_10_taxe_tag" model="account.report.expression">
                                         <field name="label">balance</field>
@@ -451,7 +410,6 @@
                             <record id="tax_report_11_base" model="account.report.line">
                                 <field name="name">11 - Reduced rate 2.1% (base)</field>
                                 <field name="code">box_11_base</field>
-                                <field name="sequence" eval="41"/>
                                 <field name="expression_ids">
                                     <record id="tax_report_11_base_tag" model="account.report.expression">
                                         <field name="label">balance</field>
@@ -463,7 +421,6 @@
                             <record id="tax_report_11_taxe" model="account.report.line">
                                 <field name="name">11 - Reduced rate 2.1% (tax)</field>
                                 <field name="code">box_11_taxe</field>
-                                <field name="sequence" eval="42"/>
                                 <field name="expression_ids">
                                     <record id="tax_report_11_taxe_tag" model="account.report.expression">
                                         <field name="label">balance</field>
@@ -476,12 +433,10 @@
                     </record>
                     <record id="tax_report_tva_brute_autre" model="account.report.line">
                         <field name="name">Transactions taxable at another rate (metropolitan France or DOM)</field>
-                        <field name="sequence" eval="43"/>
                         <field name="children_ids">
                             <record id="tax_report_T1_base" model="account.report.line">
                                 <field name="name">T1 - Transactions carried out in the French overseas departments and taxable at 1.75% (base)</field>
                                 <field name="code">box_T1_base</field>
-                                <field name="sequence" eval="44"/>
                                 <field name="expression_ids">
                                     <record id="tax_report_T1_base_tag" model="account.report.expression">
                                         <field name="label">balance</field>
@@ -493,7 +448,6 @@
                             <record id="tax_report_T1_taxe" model="account.report.line">
                                 <field name="name">T1 - Transactions carried out in the French overseas departments and taxable at 1.75% (tax)</field>
                                 <field name="code">box_T1_taxe</field>
-                                <field name="sequence" eval="45"/>
                                 <field name="expression_ids">
                                     <record id="tax_report_T1_taxe_tag" model="account.report.expression">
                                         <field name="label">balance</field>
@@ -505,7 +459,6 @@
                             <record id="tax_report_T2_base" model="account.report.line">
                                 <field name="name">T2 - Transactions carried out in the French overseas departments and taxable at 1.05% (base)</field>
                                 <field name="code">box_T2_base</field>
-                                <field name="sequence" eval="46"/>
                                 <field name="expression_ids">
                                     <record id="tax_report_T2_base_tag" model="account.report.expression">
                                         <field name="label">balance</field>
@@ -517,7 +470,6 @@
                             <record id="tax_report_T2_taxe" model="account.report.line">
                                 <field name="name">T2 - Transactions carried out in the French overseas departments and taxable at 1,05% (tax)</field>
                                 <field name="code">box_T2_taxe</field>
-                                <field name="sequence" eval="47"/>
                                 <field name="expression_ids">
                                     <record id="tax_report_T2_taxe_tag" model="account.report.expression">
                                         <field name="label">balance</field>
@@ -529,7 +481,6 @@
                             <record id="tax_report_T3_base" model="account.report.line">
                                 <field name="name">T3 - Transactions carried out in Corsica and taxable at the rate of 10% (base)</field>
                                 <field name="code">box_T3_base</field>
-                                <field name="sequence" eval="48"/>
                                 <field name="expression_ids">
                                     <record id="tax_report_T3_base_tag" model="account.report.expression">
                                         <field name="label">balance</field>
@@ -541,7 +492,6 @@
                             <record id="tax_report_T3_taxe" model="account.report.line">
                                 <field name="name">T3 - Transactions carried out in Corsica and taxable at the rate of 10% (tax)</field>
                                 <field name="code">box_T3_taxe</field>
-                                <field name="sequence" eval="49"/>
                                 <field name="expression_ids">
                                     <record id="tax_report_T3_taxe_tag" model="account.report.expression">
                                         <field name="label">balance</field>
@@ -553,7 +503,6 @@
                             <record id="tax_report_T4_base" model="account.report.line">
                                 <field name="name">T4 - Transactions carried out in Corsica and taxable at the rate of 2,1% (base)</field>
                                 <field name="code">box_T4_base</field>
-                                <field name="sequence" eval="50"/>
                                 <field name="expression_ids">
                                     <record id="tax_report_T4_base_tag" model="account.report.expression">
                                         <field name="label">balance</field>
@@ -565,7 +514,6 @@
                             <record id="tax_report_T4_taxe" model="account.report.line">
                                 <field name="name">T4 - Transactions carried out in Corsica and taxable at the rate of 2,1% (tax)</field>
                                 <field name="code">box_T4_taxe</field>
-                                <field name="sequence" eval="51"/>
                                 <field name="expression_ids">
                                     <record id="tax_report_T4_taxe_tag" model="account.report.expression">
                                         <field name="label">balance</field>
@@ -577,7 +525,6 @@
                             <record id="tax_report_T5_base" model="account.report.line">
                                 <field name="name">T5 - Transactions carried out in Corsica and taxable at the rate of 0,9% (base)</field>
                                 <field name="code">box_T5_base</field>
-                                <field name="sequence" eval="52"/>
                                 <field name="expression_ids">
                                     <record id="tax_report_T5_base_tag" model="account.report.expression">
                                         <field name="label">balance</field>
@@ -589,7 +536,6 @@
                             <record id="tax_report_T5_taxe" model="account.report.line">
                                 <field name="name">T5 - Transactions carried out in Corsica and taxable at the rate of 0,9% (tax)</field>
                                 <field name="code">box_T5_taxe</field>
-                                <field name="sequence" eval="53"/>
                                 <field name="expression_ids">
                                     <record id="tax_report_T5_taxe_tag" model="account.report.expression">
                                         <field name="label">balance</field>
@@ -601,7 +547,6 @@
                             <record id="tax_report_T6_base" model="account.report.line">
                                 <field name="name">T6 - Transactions carried out in mainland France at the rate of 2,1% (base)</field>
                                 <field name="code">box_T6_base</field>
-                                <field name="sequence" eval="54"/>
                                 <field name="expression_ids">
                                     <record id="tax_report_T6_base_tag" model="account.report.expression">
                                         <field name="label">balance</field>
@@ -613,7 +558,6 @@
                             <record id="tax_report_T6_taxe" model="account.report.line">
                                 <field name="name">T6 - Transactions carried out in mainland France at the rate of 2,1% (tax)</field>
                                 <field name="code">box_T6_taxe</field>
-                                <field name="sequence" eval="55"/>
                                 <field name="expression_ids">
                                     <record id="tax_report_T6_taxe_tag" model="account.report.expression">
                                         <field name="label">balance</field>
@@ -625,7 +569,6 @@
                             <record id="tax_report_T7_base" model="account.report.line">
                                 <field name="name">T7 - Withholding of VAT on copyright (base)</field>
                                 <field name="code">box_T7_base</field>
-                                <field name="sequence" eval="56"/>
                                 <field name="expression_ids">
                                     <record id="tax_report_T7_base_tag" model="account.report.expression">
                                         <field name="label">balance</field>
@@ -637,7 +580,6 @@
                             <record id="tax_report_T7_taxe" model="account.report.line">
                                 <field name="name">T7 - Withholding of VAT on copyright (tax)</field>
                                 <field name="code">box_T7_taxe</field>
-                                <field name="sequence" eval="57"/>
                                 <field name="expression_ids">
                                     <record id="tax_report_T7_taxe_tag" model="account.report.expression">
                                         <field name="label">balance</field>
@@ -649,7 +591,6 @@
                             <record id="tax_report_13_base" model="account.report.line">
                                 <field name="name">13 - Former rates (base)</field>
                                 <field name="code">box_13_base</field>
-                                <field name="sequence" eval="58"/>
                                 <field name="expression_ids">
                                     <record id="tax_report_13_base_tag" model="account.report.expression">
                                         <field name="label">balance</field>
@@ -661,7 +602,6 @@
                             <record id="tax_report_13_taxe" model="account.report.line">
                                 <field name="name">13 - Former rates (tax)</field>
                                 <field name="code">box_13_taxe</field>
-                                <field name="sequence" eval="59"/>
                                 <field name="expression_ids">
                                     <record id="tax_report_13_taxe_tag" model="account.report.expression">
                                         <field name="label">balance</field>
@@ -673,7 +613,6 @@
                             <record id="tax_report_14_base" model="account.report.line">
                                 <field name="name">14 - Transactions taxable at a particular rate (base)</field>
                                 <field name="code">box_14_base</field>
-                                <field name="sequence" eval="60"/>
                                 <field name="expression_ids">
                                     <record id="tax_report_14_base_tag" model="account.report.expression">
                                         <field name="label">balance</field>
@@ -685,7 +624,6 @@
                             <record id="tax_report_14_taxe" model="account.report.line">
                                 <field name="name">14 - Transactions taxable at a particular rate (tax)</field>
                                 <field name="code">box_14_taxe</field>
-                                <field name="sequence" eval="61"/>
                                 <field name="expression_ids">
                                     <record id="tax_report_14_taxe_tag" model="account.report.expression">
                                         <field name="label">balance</field>
@@ -698,12 +636,10 @@
                     </record>
                     <record id="tax_report_tva_brute_petrolier" model="account.report.line">
                         <field name="name">Oil products</field>
-                        <field name="sequence" eval="62"/>
                         <field name="children_ids">
                             <record id="tax_report_P1_base" model="account.report.line">
                                 <field name="name">P1 - Standard rate 20% (base)</field>
                                 <field name="code">box_P1_base</field>
-                                <field name="sequence" eval="63"/>
                                 <field name="expression_ids">
                                     <record id="tax_report_P1_base_tag" model="account.report.expression">
                                         <field name="label">balance</field>
@@ -715,7 +651,6 @@
                             <record id="tax_report_P1_taxe" model="account.report.line">
                                 <field name="name">P1 - Standard rate 20% (tax)</field>
                                 <field name="code">box_P1_taxe</field>
-                                <field name="sequence" eval="64"/>
                                 <field name="expression_ids">
                                     <record id="tax_report_P1_taxe_tag" model="account.report.expression">
                                         <field name="label">balance</field>
@@ -727,7 +662,6 @@
                             <record id="tax_report_P2_base" model="account.report.line">
                                 <field name="name">P2 - Reduced rate 13% (base)</field>
                                 <field name="code">box_P2_base</field>
-                                <field name="sequence" eval="65"/>
                                 <field name="expression_ids">
                                     <record id="tax_report_P2_base_tag" model="account.report.expression">
                                         <field name="label">balance</field>
@@ -739,7 +673,6 @@
                             <record id="tax_report_P2_taxe" model="account.report.line">
                                 <field name="name">P2 - Reduced rate 13% (tax)</field>
                                 <field name="code">box_P2_taxe</field>
-                                <field name="sequence" eval="66"/>
                                 <field name="expression_ids">
                                     <record id="tax_report_P2_taxe_tag" model="account.report.expression">
                                         <field name="label">balance</field>
@@ -752,12 +685,10 @@
                     </record>
                     <record id="tax_report_tva_brute_import" model="account.report.line">
                         <field name="name">Imports</field>
-                        <field name="sequence" eval="67"/>
                         <field name="children_ids">
                             <record id="tax_report_I1_base" model="account.report.line">
                                 <field name="name">I1 - Standard rate 20% (base)</field>
                                 <field name="code">box_I1_base</field>
-                                <field name="sequence" eval="68"/>
                                 <field name="expression_ids">
                                     <record id="tax_report_I1_base_tag" model="account.report.expression">
                                         <field name="label">balance</field>
@@ -769,7 +700,6 @@
                             <record id="tax_report_I1_taxe" model="account.report.line">
                                 <field name="name">I1 - Standard rate 20% (tax)</field>
                                 <field name="code">box_I1_taxe</field>
-                                <field name="sequence" eval="69"/>
                                 <field name="expression_ids">
                                     <record id="tax_report_I1_taxe_tag" model="account.report.expression">
                                         <field name="label">balance</field>
@@ -781,7 +711,6 @@
                             <record id="tax_report_I2_base" model="account.report.line">
                                 <field name="name">I2 - Reduced rate 10% (base)</field>
                                 <field name="code">box_I2_base</field>
-                                <field name="sequence" eval="70"/>
                                 <field name="expression_ids">
                                     <record id="tax_report_I2_base_tag" model="account.report.expression">
                                         <field name="label">balance</field>
@@ -793,7 +722,6 @@
                             <record id="tax_report_I2_taxe" model="account.report.line">
                                 <field name="name">I2 - Reduced rate 10% (tax)</field>
                                 <field name="code">box_I2_taxe</field>
-                                <field name="sequence" eval="71"/>
                                 <field name="expression_ids">
                                     <record id="tax_report_I2_taxe_tag" model="account.report.expression">
                                         <field name="label">balance</field>
@@ -805,7 +733,6 @@
                             <record id="tax_report_I3_base" model="account.report.line">
                                 <field name="name">I3 - Reduced rate 8.5% (base)</field>
                                 <field name="code">box_I3_base</field>
-                                <field name="sequence" eval="72"/>
                                 <field name="expression_ids">
                                     <record id="tax_report_I3_base_tag" model="account.report.expression">
                                         <field name="label">balance</field>
@@ -817,7 +744,6 @@
                             <record id="tax_report_I3_taxe" model="account.report.line">
                                 <field name="name">I3 - Reduced rate 8.5% (tax)</field>
                                 <field name="code">box_I3_taxe</field>
-                                <field name="sequence" eval="73"/>
                                 <field name="expression_ids">
                                     <record id="tax_report_I3_taxe_tag" model="account.report.expression">
                                         <field name="label">balance</field>
@@ -829,7 +755,6 @@
                             <record id="tax_report_I4_base" model="account.report.line">
                                 <field name="name">I4 - Reduced rate 5.5% (base)</field>
                                 <field name="code">box_I4_base</field>
-                                <field name="sequence" eval="74"/>
                                 <field name="expression_ids">
                                     <record id="tax_report_I4_base_tag" model="account.report.expression">
                                         <field name="label">balance</field>
@@ -841,7 +766,6 @@
                             <record id="tax_report_I4_taxe" model="account.report.line">
                                 <field name="name">I4 - Reduced rate 5.5% (tax)</field>
                                 <field name="code">box_I4_taxe</field>
-                                <field name="sequence" eval="75"/>
                                 <field name="expression_ids">
                                     <record id="tax_report_I4_taxe_tag" model="account.report.expression">
                                         <field name="label">balance</field>
@@ -853,7 +777,6 @@
                             <record id="tax_report_I5_base" model="account.report.line">
                                 <field name="name">I5 - Reduced rate 2.1% (base)</field>
                                 <field name="code">box_I5_base</field>
-                                <field name="sequence" eval="76"/>
                                 <field name="expression_ids">
                                     <record id="tax_report_I5_base_tag" model="account.report.expression">
                                         <field name="label">balance</field>
@@ -865,7 +788,6 @@
                             <record id="tax_report_I5_taxe" model="account.report.line">
                                 <field name="name">I5 - Reduced rate 2.1% (tax)</field>
                                 <field name="code">box_I5_taxe</field>
-                                <field name="sequence" eval="77"/>
                                 <field name="expression_ids">
                                     <record id="tax_report_I5_taxe_tag" model="account.report.expression">
                                         <field name="label">balance</field>
@@ -877,7 +799,6 @@
                             <record id="tax_report_I6_base" model="account.report.line">
                                 <field name="name">I6 - Reduced rate 1.05% (base)</field>
                                 <field name="code">box_I6_base</field>
-                                <field name="sequence" eval="78"/>
                                 <field name="expression_ids">
                                     <record id="tax_report_I6_base_tag" model="account.report.expression">
                                         <field name="label">balance</field>
@@ -889,7 +810,6 @@
                             <record id="tax_report_I6_taxe" model="account.report.line">
                                 <field name="name">I6 - Reduced rate 1.05% (tax)</field>
                                 <field name="code">box_I6_taxe</field>
-                                <field name="sequence" eval="79"/>
                                 <field name="expression_ids">
                                     <record id="tax_report_I6_taxe_tag" model="account.report.expression">
                                         <field name="label">balance</field>
@@ -901,7 +821,6 @@
                             <record id="tax_report_15" model="account.report.line">
                                 <field name="name">15 - Previously deducted VAT to be repaid</field>
                                 <field name="code">box_15</field>
-                                <field name="sequence" eval="80"/>
                                 <field name="expression_ids">
                                     <record id="tax_report_15_tag" model="account.report.expression">
                                         <field name="label">balance</field>
@@ -913,7 +832,6 @@
                                     <record id="tax_report_15_1" model="account.report.line">
                                         <field name="name">of which VAT on petroleum products</field>
                                         <field name="code">box_15_1</field>
-                                        <field name="sequence" eval="81"/>
                                         <field name="expression_ids">
                                             <record id="tax_report_15_1_tag" model="account.report.expression">
                                                 <field name="label">balance</field>
@@ -925,7 +843,6 @@
                                     <record id="tax_report_15_2" model="account.report.line">
                                         <field name="name">of which VAT on imported products excluding petroleum products</field>
                                         <field name="code">box_15_2</field>
-                                        <field name="sequence" eval="82"/>
                                         <field name="expression_ids">
                                             <record id="tax_report_15_2_tag" model="account.report.expression">
                                                 <field name="label">balance</field>
@@ -939,7 +856,6 @@
                             <record id="tax_report_5B" model="account.report.line">
                                 <field name="name">5B - Amounts to be added, including advance holiday pay</field>
                                 <field name="code">box_5B</field>
-                                <field name="sequence" eval="83"/>
                                 <field name="expression_ids">
                                     <record id="tax_report_5B_tag" model="account.report.expression">
                                         <field name="label">balance</field>
@@ -951,13 +867,11 @@
                             <record id="tax_report_16" model="account.report.line">
                                 <field name="name">16 - Total gross VAT due</field>
                                 <field name="code">box_16</field>
-                                <field name="sequence" eval="84"/>
                                 <field name="aggregation_formula">box_08_taxe.balance + box_09_taxe.balance + box_9B_taxe.balance + box_10_taxe.balance + box_11_taxe.balance + box_13_taxe.balance + box_14_taxe.balance + box_T1_taxe.balance + box_T2_taxe.balance + box_T3_taxe.balance + box_T4_taxe.balance + box_T5_taxe.balance + box_T6_taxe.balance + box_T7_taxe.balance + box_P1_taxe.balance + box_P2_taxe.balance + box_I1_taxe.balance + box_I2_taxe.balance + box_I3_taxe.balance + box_I4_taxe.balance + box_I5_taxe.balance + box_I6_taxe.balance + box_15.balance + box_5B.balance</field>
                             </record>
                             <record id="tax_report_17" model="account.report.line">
                                 <field name="name">17 - Of which VAT on intra-Community acquisitions</field>
                                 <field name="code">box_17</field>
-                                <field name="sequence" eval="85"/>
                                 <field name="expression_ids">
                                     <record id="tax_report_17_tag" model="account.report.expression">
                                         <field name="label">balance</field>
@@ -969,7 +883,6 @@
                             <record id="tax_report_18" model="account.report.line">
                                 <field name="name">18 - Of which VAT on transactions to Monaco</field>
                                 <field name="code">box_18</field>
-                                <field name="sequence" eval="86"/>
                                 <field name="expression_ids">
                                     <record id="tax_report_18_tag" model="account.report.expression">
                                         <field name="label">balance</field>
@@ -982,12 +895,10 @@
                     </record>
                     <record id="tax_report_tva_deductible" model="account.report.line">
                         <field name="name">Deductible VAT</field>
-                        <field name="sequence" eval="87"/>
                         <field name="children_ids">
                             <record id="tax_report_19" model="account.report.line">
                                 <field name="name">19 - Assets constituting fixed assets</field>
                                 <field name="code">box_19</field>
-                                <field name="sequence" eval="88"/>
                                 <field name="expression_ids">
                                     <record id="tax_report_19_tag" model="account.report.expression">
                                         <field name="label">balance</field>
@@ -999,7 +910,6 @@
                             <record id="tax_report_20" model="account.report.line">
                                 <field name="name">20 - Other goods and services</field>
                                 <field name="code">box_20</field>
-                                <field name="sequence" eval="89"/>
                                 <field name="expression_ids">
                                     <record id="tax_report_20_tag" model="account.report.expression">
                                         <field name="label">balance</field>
@@ -1011,7 +921,6 @@
                             <record id="tax_report_21" model="account.report.line">
                                 <field name="name">21 - Other deductible VAT</field>
                                 <field name="code">box_21</field>
-                                <field name="sequence" eval="90"/>
                                 <field name="expression_ids">
                                     <record id="tax_report_21_tag" model="account.report.expression">
                                         <field name="label">balance</field>
@@ -1023,7 +932,6 @@
                             <record id="tax_report_22" model="account.report.line">
                                 <field name="name">22 - Carry-over of credit from line 27 of the previous return</field>
                                 <field name="code">box_22</field>
-                                <field name="sequence" eval="91"/>
                                 <field name="expression_ids">
                                     <record id="tax_report_22_applied_carryover" model="account.report.expression">
                                         <field name="label">_applied_carryover_balance</field>
@@ -1046,7 +954,6 @@
                             <record id="tax_report_2C" model="account.report.line">
                                 <field name="name">2C - Amounts to be charged, including advance holiday pay</field>
                                 <field name="code">box_2C</field>
-                                <field name="sequence" eval="92"/>
                                 <field name="expression_ids">
                                     <record id="tax_report_2C_tag" model="account.report.expression">
                                         <field name="label">balance</field>
@@ -1058,7 +965,6 @@
                             <record id="tax_report_22A" model="account.report.line">
                                 <field name="name">22A - Enter the single tax rate applicable for the period if different from 100%</field>
                                 <field name="code">box_22A</field>
-                                <field name="sequence" eval="93"/>
                                 <field name="expression_ids">
                                     <record id="tax_report_22A_tag" model="account.report.expression">
                                         <field name="label">balance</field>
@@ -1070,13 +976,11 @@
                             <record id="tax_report_23" model="account.report.line">
                                 <field name="name">23 - Total deductible VAT</field>
                                 <field name="code">box_23</field>
-                                <field name="sequence" eval="94"/>
                                 <field name="aggregation_formula">box_19.balance + box_20.balance + box_21.balance + box_22.balance + box_2C.balance</field>
                             </record>
                             <record id="tax_report_24" model="account.report.line">
                                 <field name="name">24 - Of which deductible VAT on imports</field>
                                 <field name="code">box_24</field>
-                                <field name="sequence" eval="95"/>
                                 <field name="expression_ids">
                                     <record id="tax_report_24_tag" model="account.report.expression">
                                         <field name="label">balance</field>
@@ -1088,7 +992,6 @@
                             <record id="tax_report_2E" model="account.report.line">
                                 <field name="name">2E - Of which deductible VAT on petroleum products</field>
                                 <field name="code">box_2E</field>
-                                <field name="sequence" eval="96"/>
                                 <field name="expression_ids">
                                     <record id="tax_report_2E_tag" model="account.report.expression">
                                         <field name="label">balance</field>
@@ -1103,13 +1006,11 @@
             </record>
             <record id="tax_report_credit" model="account.report.line">
                 <field name="name">Credit</field>
-                <field name="sequence" eval="97"/>
                 <field name="hierarchy_level">0</field>
                 <field name="children_ids">
                     <record id="tax_report_25" model="account.report.line">
                         <field name="name">25 - VAT credit</field>
                         <field name="code">box_25</field>
-                        <field name="sequence" eval="98"/>
                         <field name="expression_ids">
                             <record id="tax_report_25_formula" model="account.report.expression">
                                 <field name="label">balance</field>
@@ -1122,7 +1023,6 @@
                     <record id="tax_report_TD" model="account.report.line">
                         <field name="name">TD - VAT Due</field>
                         <field name="code">box_TD</field>
-                        <field name="sequence" eval="99"/>
                         <field name="expression_ids">
                             <record id="tax_report_td_formula" model="account.report.expression">
                                 <field name="label">balance</field>
@@ -1136,17 +1036,14 @@
             </record>
             <record id="tax_report_regularisation" model="account.report.line">
                 <field name="name">Regularisation of domestic consumption taxes (TIC)</field>
-                <field name="sequence" eval="100"/>
                 <field name="hierarchy_level">0</field>
                 <field name="children_ids">
                     <record id="tax_report_credit_constate" model="account.report.line">
                         <field name="name">Recognised credit</field>
-                        <field name="sequence" eval="101"/>
                         <field name="children_ids">
                             <record id="tax_report_TICFE" model="account.report.line">
                                 <field name="name">TICFE</field>
                                 <field name="code">box_TICFE</field>
-                                <field name="sequence" eval="102"/>
                                 <field name="expression_ids">
                                     <record id="tax_report_TICFE_tag" model="account.report.expression">
                                         <field name="label">balance</field>
@@ -1158,7 +1055,6 @@
                             <record id="tax_report_TICGN" model="account.report.line">
                                 <field name="name">TICGN</field>
                                 <field name="code">box_TICGN</field>
-                                <field name="sequence" eval="103"/>
                                 <field name="expression_ids">
                                     <record id="tax_report_TICGN_tag" model="account.report.expression">
                                         <field name="label">balance</field>
@@ -1170,7 +1066,6 @@
                             <record id="tax_report_TICC" model="account.report.line">
                                 <field name="name">TICC</field>
                                 <field name="code">box_TICC</field>
-                                <field name="sequence" eval="104"/>
                                 <field name="expression_ids">
                                     <record id="tax_report_TICC_tag" model="account.report.expression">
                                         <field name="label">balance</field>
@@ -1182,19 +1077,16 @@
                             <record id="tax_report_TIC_total" model="account.report.line">
                                 <field name="name">Total</field>
                                 <field name="code">box_TIC_total</field>
-                                <field name="sequence" eval="105"/>
                                 <field name="aggregation_formula">box_TICFE.balance + box_TICGN.balance + box_TICC.balance</field>
                             </record>
                         </field>
                     </record>
                     <record id="tax_report_credit_impute" model="account.report.line">
                         <field name="name">Credit charged</field>
-                        <field name="sequence" eval="106"/>
                         <field name="children_ids">
                             <record id="tax_report_X1" model="account.report.line">
                                 <field name="name">X1</field>
                                 <field name="code">box_X1</field>
-                                <field name="sequence" eval="107"/>
                                 <field name="expression_ids">
                                     <record id="tax_report_X1_tag" model="account.report.expression">
                                         <field name="label">balance</field>
@@ -1206,7 +1098,6 @@
                             <record id="tax_report_X2" model="account.report.line">
                                 <field name="name">X2</field>
                                 <field name="code">box_X2</field>
-                                <field name="sequence" eval="108"/>
                                 <field name="expression_ids">
                                     <record id="tax_report_X2_tag" model="account.report.expression">
                                         <field name="label">balance</field>
@@ -1218,7 +1109,6 @@
                             <record id="tax_report_X3" model="account.report.line">
                                 <field name="name">X3</field>
                                 <field name="code">box_X3</field>
-                                <field name="sequence" eval="109"/>
                                 <field name="expression_ids">
                                     <record id="tax_report_X3_tag" model="account.report.expression">
                                         <field name="label">balance</field>
@@ -1230,49 +1120,41 @@
                             <record id="tax_report_X4" model="account.report.line">
                                 <field name="name">X4</field>
                                 <field name="code">box_X4</field>
-                                <field name="sequence" eval="110"/>
                                 <field name="aggregation_formula">box_X1.balance + box_X2.balance + box_X3.balance</field>
                             </record>
                         </field>
                     </record>
                     <record id="tax_report_reliquat" model="account.report.line">
                         <field name="name">Outstanding credit</field>
-                        <field name="sequence" eval="111"/>
                         <field name="children_ids">
                             <record id="tax_report_Y1" model="account.report.line">
                                 <field name="name">Y1</field>
                                 <field name="code">box_Y1</field>
-                                <field name="sequence" eval="112"/>
                                 <field name="aggregation_formula">box_TICFE.balance - box_X1.balance</field>
                             </record>
                             <record id="tax_report_Y2" model="account.report.line">
                                 <field name="name">Y2</field>
                                 <field name="code">box_Y2</field>
-                                <field name="sequence" eval="113"/>
                                 <field name="aggregation_formula">box_TICGN.balance - box_X2.balance</field>
                             </record>
                             <record id="tax_report_Y3" model="account.report.line">
                                 <field name="name">Y3</field>
                                 <field name="code">box_Y3</field>
-                                <field name="sequence" eval="114"/>
                                 <field name="aggregation_formula">box_TICC.balance - box_X3.balance</field>
                             </record>
                             <record id="tax_report_Y4" model="account.report.line">
                                 <field name="name">Y4</field>
                                 <field name="code">box_Y4</field>
-                                <field name="sequence" eval="115"/>
                                 <field name="aggregation_formula">box_Y1.balance + box_Y2.balance + box_Y3.balance</field>
                             </record>
                         </field>
                     </record>
                     <record id="tax_report_tic_tax" model="account.report.line">
                         <field name="name">Tax due</field>
-                        <field name="sequence" eval="116"/>
                         <field name="children_ids">
                             <record id="tax_report_Z1" model="account.report.line">
                                 <field name="name">Z1</field>
                                 <field name="code">box_Z1</field>
-                                <field name="sequence" eval="117"/>
                                 <field name="expression_ids">
                                     <record id="tax_report_Z1_tag" model="account.report.expression">
                                         <field name="label">balance</field>
@@ -1284,7 +1166,6 @@
                             <record id="tax_report_Z2" model="account.report.line">
                                 <field name="name">Z2</field>
                                 <field name="code">box_Z2</field>
-                                <field name="sequence" eval="118"/>
                                 <field name="expression_ids">
                                     <record id="tax_report_Z2_tag" model="account.report.expression">
                                         <field name="label">balance</field>
@@ -1296,7 +1177,6 @@
                             <record id="tax_report_Z3" model="account.report.line">
                                 <field name="name">Z3</field>
                                 <field name="code">box_Z3</field>
-                                <field name="sequence" eval="119"/>
                                 <field name="expression_ids">
                                     <record id="tax_report_Z3_tag" model="account.report.expression">
                                         <field name="label">balance</field>
@@ -1308,7 +1188,6 @@
                             <record id="tax_report_Z4" model="account.report.line">
                                 <field name="name">Z4</field>
                                 <field name="code">box_Z4</field>
-                                <field name="sequence" eval="120"/>
                                 <field name="aggregation_formula">box_Z1.balance + box_Z2.balance + box_Z3.balance</field>
                             </record>
                         </field>
@@ -1317,13 +1196,11 @@
             </record>
             <record id="tax_report_determination" model="account.report.line">
                 <field name="name">Determining the amount to be paid and/or VAT and/or TIC credits</field>
-                <field name="sequence" eval="121"/>
                 <field name="hierarchy_level">0</field>
                 <field name="children_ids">
                     <record id="tax_report_26" model="account.report.line">
                         <field name="name">26 - Repayment of credit requested on form n°3519 attached</field>
                         <field name="code">box_26</field>
-                        <field name="sequence" eval="122"/>
                         <field name="expression_ids">
                             <record id="tax_report_26_tag" model="account.report.expression">
                                 <field name="label">balance</field>
@@ -1335,7 +1212,6 @@
                     <record id="tax_report_AA" model="account.report.line">
                         <field name="name">AA - VAT credit transferred to the head company on the recapitulative return 3310-CA3G</field>
                         <field name="code">box_AA</field>
-                        <field name="sequence" eval="123"/>
                         <field name="expression_ids">
                             <record id="tax_report_AA_tag" model="account.report.expression">
                                 <field name="label">balance</field>
@@ -1348,7 +1224,6 @@
                     <record id="tax_report_27" model="account.report.line">
                         <field name="name">27 - Credit to be carried forward</field>
                         <field name="code">box_27</field>
-                        <field name="sequence" eval="124"/>
                         <field name="expression_ids">
                             <record id="tax_report_27_formula" model="account.report.expression">
                                 <field name="label">balance</field>
@@ -1368,24 +1243,20 @@
                     <record id="tax_report_Y5" model="account.report.line">
                         <field name="name">Y5 - Refund of TIC balance requested (carried forward from line Y4)</field>
                         <field name="code">box_Y5</field>
-                        <field name="sequence" eval="125"/>
                         <field name="aggregation_formula">box_Y4.balance</field>
                     </record>
                     <record id="tax_report_Y6" model="account.report.line">
                         <field name="name">Y6 - TIC credit transferred to the head company on the 3310-CA3G recapitulative return (carried forward from line Y4)</field>
                         <field name="code">box_Y6</field>
-                        <field name="sequence" eval="126"/>
                     </record>
                     <record id="tax_report_X5" model="account.report.line">
                         <field name="name">X5 - TIC credit offset against VAT (carried forward from line X4)</field>
                         <field name="code">box_X5</field>
-                        <field name="sequence" eval="127"/>
                         <field name="aggregation_formula">box_X4.balance</field>
                     </record>
                     <record id="tax_report_28" model="account.report.line">
                         <field name="name">28 - Net VAT due</field>
                         <field name="code">box_28</field>
-                        <field name="sequence" eval="128"/>
                         <field name="expression_ids">
                             <record id="tax_report_28_formula" model="account.report.expression">
                                 <field name="label">balance</field>
@@ -1398,7 +1269,6 @@
                     <record id="tax_report_29" model="account.report.line">
                         <field name="name">29 - Similar taxes calculated on schedule n°3310-A-SD</field>
                         <field name="code">box_29</field>
-                        <field name="sequence" eval="129"/>
                         <field name="expression_ids">
                             <record id="tax_report_29_tag" model="account.report.expression">
                                 <field name="label">balance</field>
@@ -1410,18 +1280,15 @@
                     <record id="tax_report_Z5" model="account.report.line">
                         <field name="name">Z5 - Total domestic consumption tax due (carried forward from line Z4)</field>
                         <field name="code">box_Z5</field>
-                        <field name="sequence" eval="130"/>
                         <field name="aggregation_formula">box_Z4.balance</field>
                     </record>
                     <record id="tax_report_AB" model="account.report.line">
                         <field name="name">AB - Total to be paid by the head company on the recapitulative declaration 3310-CA3G</field>
                         <field name="code">box_AB</field>
-                        <field name="sequence" eval="131"/>
                     </record>
                     <record id="tax_report_32" model="account.report.line">
                         <field name="name">32 - Total payable</field>
                         <field name="code">box_32</field>
-                        <field name="sequence" eval="132"/>
                         <field name="aggregation_formula">box_28.balance + box_29.balance + box_Z5.balance</field>
                     </record>
                 </field>

--- a/addons/l10n_gr/data/account_tax_report_data.xml
+++ b/addons/l10n_gr/data/account_tax_report_data.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<odoo>
+<odoo auto_sequence="1">
     <record id="tax_report" model="account.report">
         <field name="name">Tax Report</field>
         <field name="root_report_id" ref="account.generic_tax_report"/>

--- a/addons/l10n_hr/data/account_tax_report_data.xml
+++ b/addons/l10n_hr/data/account_tax_report_data.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<odoo>
+<odoo auto_sequence="1">
     <record id="tax_report" model="account.report">
         <field name="name">Tax Report</field>
         <field name="root_report_id" ref="account.generic_tax_report"/>

--- a/addons/l10n_hu/data/account_tax_report_data.xml
+++ b/addons/l10n_hu/data/account_tax_report_data.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<odoo>
+<odoo auto_sequence="1">
     <record id="tax_report" model="account.report">
         <field name="name">Tax Report</field>
         <field name="root_report_id" ref="account.generic_tax_report"/>

--- a/addons/l10n_il/data/account_tax_report_data.xml
+++ b/addons/l10n_il/data/account_tax_report_data.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<odoo>
+<odoo auto_sequence="1">
     <record id="vat_report" model="account.report">
         <field name="name">VAT Report (PCN874)</field>
         <field name="root_report_id" ref="account.generic_tax_report"/>

--- a/addons/l10n_in/data/account_tax_report_tcs_data.xml
+++ b/addons/l10n_in/data/account_tax_report_tcs_data.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<odoo>
+<odoo auto_sequence="1">
     <record id="tcs_report" model="account.report">
         <field name="name">TCS Report</field>
         <field name="root_report_id" ref="account.generic_tax_report"/>
@@ -10,13 +10,11 @@
             <record id="tcs_report_balance" model="account.report.column">
                 <field name="name">Balance</field>
                 <field name="expression_label">balance</field>
-                <field name="sequence" eval="1"/>
             </record>
         </field>
         <field name="line_ids">
             <record id="tcs_report_line_section_206c_1_alfhc" model="account.report.line">
                 <field name="name">Section 206C(1): Alcoholic Liquor for human consumption</field>
-                <field name="sequence" eval="1"/>
                 <field name="expression_ids">
                     <record id="tcs_report_line_section_206c_1_alfhc_tag" model="account.report.expression">
                         <field name="label">balance</field>
@@ -27,7 +25,6 @@
             </record>
             <record id="tcs_report_line_section_206c_1_tl" model="account.report.line">
                 <field name="name">Section 206C(1): Tendu leaves</field>
-                <field name="sequence" eval="2"/>
                 <field name="expression_ids">
                     <record id="tcs_report_line_section_206c_1_tl_tag" model="account.report.expression">
                         <field name="label">balance</field>
@@ -38,7 +35,6 @@
             </record>
             <record id="tcs_report_line_section_206c_1_touafl" model="account.report.line">
                 <field name="name">Section 206C(1): Timber obtained under a forest lease</field>
-                <field name="sequence" eval="3"/>
                 <field name="expression_ids">
                     <record id="tcs_report_line_section_206c_1_touafl_tag" model="account.report.expression">
                         <field name="label">balance</field>
@@ -49,7 +45,6 @@
             </record>
             <record id="tcs_report_line_section_206c_1_tobaotuafl" model="account.report.line">
                 <field name="name">Section 206C(1): Timber obtained by any mode other than under a forest lease</field>
-                <field name="sequence" eval="4"/>
                 <field name="expression_ids">
                     <record id="tcs_report_line_section_206c_1_tobaotuafl_tag" model="account.report.expression">
                         <field name="label">balance</field>
@@ -60,7 +55,6 @@
             </record>
             <record id="tcs_report_line_section_206c_1_aofpnbtotl" model="account.report.line">
                 <field name="name">Section 206C(1): Any other forest produce not being timber or tendu leaves</field>
-                <field name="sequence" eval="5"/>
                 <field name="expression_ids">
                     <record id="tcs_report_line_section_206c_1_aofpnbtotl_tag" model="account.report.expression">
                         <field name="label">balance</field>
@@ -71,7 +65,6 @@
             </record>
             <record id="tcs_report_line_section_206c_1_s" model="account.report.line">
                 <field name="name">Section 206C(1): Scrap</field>
-                <field name="sequence" eval="6"/>
                 <field name="expression_ids">
                     <record id="tcs_report_line_section_206c_1_s_tag" model="account.report.expression">
                         <field name="label">balance</field>
@@ -82,7 +75,6 @@
             </record>
             <record id="tcs_report_line_section_206c_1_mbcoloio" model="account.report.line">
                 <field name="name">Section 206C(1): Minrals, being coal or lignite or iron ore</field>
-                <field name="sequence" eval="7"/>
                 <field name="expression_ids">
                     <record id="tcs_report_line_section_206c_1_mbcoloio_tag" model="account.report.expression">
                         <field name="label">balance</field>
@@ -93,7 +85,6 @@
             </record>
             <record id="tcs_report_line_section_206c_1c_pl" model="account.report.line">
                 <field name="name">Section 206C(1C): Parking lot</field>
-                <field name="sequence" eval="8"/>
                 <field name="expression_ids">
                     <record id="tcs_report_line_section_206c_1c_pl_tag" model="account.report.expression">
                         <field name="label">balance</field>
@@ -104,7 +95,6 @@
             </record>
             <record id="tcs_report_line_section_206c_1c_tp" model="account.report.line">
                 <field name="name">Section 206C(1C): Toll plaza</field>
-                <field name="sequence" eval="9"/>
                 <field name="expression_ids">
                     <record id="tcs_report_line_section_206c_1c_tp_tag" model="account.report.expression">
                         <field name="label">balance</field>
@@ -115,7 +105,6 @@
             </record>
             <record id="tcs_report_line_section_206c_1c_maq" model="account.report.line">
                 <field name="name">Section 206C(1C): Mining and quarrying</field>
-                <field name="sequence" eval="10"/>
                 <field name="expression_ids">
                     <record id="tcs_report_line_section_206c_1c_maq_tag" model="account.report.expression">
                         <field name="label">balance</field>
@@ -126,7 +115,6 @@
             </record>
             <record id="tcs_report_line_section_206c_1f_mv" model="account.report.line">
                 <field name="name">Section 206C(1F): Motor Vehicle</field>
-                <field name="sequence" eval="11"/>
                 <field name="expression_ids">
                     <record id="tcs_report_line_section_206c_1f_mv_tag" model="account.report.expression">
                         <field name="label">balance</field>
@@ -137,7 +125,6 @@
             </record>
             <record id="tcs_report_line_section_206c_1g_som" model="account.report.line">
                 <field name="name">Section 206C(1G): Sum of money (above 7 lakhs) for remittance out of India</field>
-                <field name="sequence" eval="12"/>
                 <field name="expression_ids">
                     <record id="tcs_report_line_section_206c_1g_som_tag" model="account.report.expression">
                         <field name="label">balance</field>
@@ -148,7 +135,6 @@
             </record>
             <record id="tcs_report_line_section_206c_1g_soaotpp" model="account.report.line">
                 <field name="name">Section 206C(1G): Seller of an overseas tour program package</field>
-                <field name="sequence" eval="13"/>
                 <field name="expression_ids">
                     <record id="tcs_report_line_section_206c_1g_soaotpp_tag" model="account.report.expression">
                         <field name="label">balance</field>
@@ -159,7 +145,6 @@
             </record>
             <record id="tcs_report_line_section_206c_1h_sog" model="account.report.line">
                 <field name="name">Section 206C(1H): Sale of Goods</field>
-                <field name="sequence" eval="14"/>
                 <field name="expression_ids">
                     <record id="tcs_report_line_section_206c_1h_sog_tag" model="account.report.expression">
                         <field name="label">balance</field>

--- a/addons/l10n_in/data/account_tax_report_tds_data.xml
+++ b/addons/l10n_in/data/account_tax_report_tds_data.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<odoo>
+<odoo auto_sequence="1">
     <record id="tds_report" model="account.report">
         <field name="name">TDS Report</field>
         <field name="root_report_id" ref="account.generic_tax_report"/>
@@ -10,13 +10,11 @@
             <record id="tds_report_balance" model="account.report.column">
                 <field name="name">Balance</field>
                 <field name="expression_label">balance</field>
-                <field name="sequence" eval="1"/>
             </record>
         </field>
         <field name="line_ids">
             <record id="tds_report_line_section_192" model="account.report.line">
                 <field name="name">Section 192: Payment of salary</field>
-                <field name="sequence" eval="1"/>
                 <field name="expression_ids">
                     <record id="tds_report_line_section_192_tag" model="account.report.expression">
                         <field name="label">balance</field>
@@ -27,7 +25,6 @@
             </record>
             <record id="tds_report_line_section_192a" model="account.report.line">
                 <field name="name">Section 192A: Payment of accumulated balance of provident fund which is taxable in the hands of an employee</field>
-                <field name="sequence" eval="2"/>
                 <field name="expression_ids">
                     <record id="tds_report_line_section_192a_tag" model="account.report.expression">
                         <field name="label">balance</field>
@@ -38,7 +35,6 @@
             </record>
             <record id="tds_report_line_section_193" model="account.report.line">
                 <field name="name">Section 193: Interest on securities</field>
-                <field name="sequence" eval="3"/>
                 <field name="expression_ids">
                     <record id="tds_report_line_section_193_tag" model="account.report.expression">
                         <field name="label">balance</field>
@@ -49,7 +45,6 @@
             </record>
             <record id="tds_report_line_section_194" model="account.report.line">
                 <field name="name">Section 194: Income by way of dividend</field>
-                <field name="sequence" eval="4"/>
                 <field name="expression_ids">
                     <record id="tds_report_line_section_194_tag" model="account.report.expression">
                         <field name="label">balance</field>
@@ -60,7 +55,6 @@
             </record>
             <record id="tds_report_line_section_194a" model="account.report.line">
                 <field name="name">Section 194A: Income by way of interest other than &quot;Interest on securities&quot;</field>
-                <field name="sequence" eval="5"/>
                 <field name="expression_ids">
                     <record id="tds_report_line_section_194a_tag" model="account.report.expression">
                         <field name="label">balance</field>
@@ -71,7 +65,6 @@
             </record>
             <record id="tds_report_line_section_194b" model="account.report.line">
                 <field name="name">Section 194B: Income by way of winnings from lotteries, crossword puzzles, card games and other games of any sort</field>
-                <field name="sequence" eval="6"/>
                 <field name="expression_ids">
                     <record id="tds_report_line_section_194b_tag" model="account.report.expression">
                         <field name="label">balance</field>
@@ -82,7 +75,6 @@
             </record>
             <record id="tds_report_line_section_194bb" model="account.report.line">
                 <field name="name">Section 194BB: Income by way of winnings from horse races</field>
-                <field name="sequence" eval="7"/>
                 <field name="expression_ids">
                     <record id="tds_report_line_section_194bb_tag" model="account.report.expression">
                         <field name="label">balance</field>
@@ -93,7 +85,6 @@
             </record>
             <record id="tds_report_line_section_194c" model="account.report.line">
                 <field name="name">Section 194C: Payment to contractor/sub-contractor</field>
-                <field name="sequence" eval="8"/>
                 <field name="expression_ids">
                     <record id="tds_report_line_section_194c_tag" model="account.report.expression">
                         <field name="label">balance</field>
@@ -104,7 +95,6 @@
             </record>
             <record id="tds_report_line_section_194d" model="account.report.line">
                 <field name="name">Section 194D: Insurance commission</field>
-                <field name="sequence" eval="9"/>
                 <field name="expression_ids">
                     <record id="tds_report_line_section_194d_tag" model="account.report.expression">
                         <field name="label">balance</field>
@@ -115,7 +105,6 @@
             </record>
             <record id="tds_report_line_section_194da" model="account.report.line">
                 <field name="name">Section 194DA: Payment in respect of life insurance policy</field>
-                <field name="sequence" eval="10"/>
                 <field name="expression_ids">
                     <record id="tds_report_line_section_194da_tag" model="account.report.expression">
                         <field name="label">balance</field>
@@ -126,7 +115,6 @@
             </record>
             <record id="tds_report_line_section_194e" model="account.report.line">
                 <field name="name">Section 194E: Payment to non-resident sportsmen/sports association</field>
-                <field name="sequence" eval="11"/>
                 <field name="expression_ids">
                     <record id="tds_report_line_section_194e_tag" model="account.report.expression">
                         <field name="label">balance</field>
@@ -137,7 +125,6 @@
             </record>
             <record id="tds_report_line_section_194ee" model="account.report.line">
                 <field name="name">Section 194EE: Payment in respect of deposit under National Savings scheme</field>
-                <field name="sequence" eval="12"/>
                 <field name="expression_ids">
                     <record id="tds_report_line_section_194ee_tag" model="account.report.expression">
                         <field name="label">balance</field>
@@ -148,7 +135,6 @@
             </record>
             <record id="tds_report_line_section_194f" model="account.report.line">
                 <field name="name">Section 194F: Payment on account of repurchase of unit by Mutual Fund or Unit Trust of India</field>
-                <field name="sequence" eval="13"/>
                 <field name="expression_ids">
                     <record id="tds_report_line_section_194f_tag" model="account.report.expression">
                         <field name="label">balance</field>
@@ -159,7 +145,6 @@
             </record>
             <record id="tds_report_line_section_194g" model="account.report.line">
                 <field name="name">Section 194G: Commission, etc., on sale of lottery tickets</field>
-                <field name="sequence" eval="14"/>
                 <field name="expression_ids">
                     <record id="tds_report_line_section_194g_tag" model="account.report.expression">
                         <field name="label">balance</field>
@@ -170,7 +155,6 @@
             </record>
             <record id="tds_report_line_section_194h" model="account.report.line">
                 <field name="name">Section 194H: Commission or brokerage</field>
-                <field name="sequence" eval="15"/>
                 <field name="expression_ids">
                     <record id="tds_report_line_section_194h_tag" model="account.report.expression">
                         <field name="label">balance</field>
@@ -181,7 +165,6 @@
             </record>
             <record id="tds_report_line_section_194i" model="account.report.line">
                 <field name="name">Section 194-I: Rent</field>
-                <field name="sequence" eval="16"/>
                 <field name="expression_ids">
                     <record id="tds_report_line_section_194i_tag" model="account.report.expression">
                         <field name="label">balance</field>
@@ -192,7 +175,6 @@
             </record>
             <record id="tds_report_line_section_194ia" model="account.report.line">
                 <field name="name">Section 194-IA: Payment on transfer of certain immovable property other than agricultural land</field>
-                <field name="sequence" eval="17"/>
                 <field name="expression_ids">
                     <record id="tds_report_line_section_194ia_tag" model="account.report.expression">
                         <field name="label">balance</field>
@@ -203,7 +185,6 @@
             </record>
             <record id="tds_report_line_section_194ib" model="account.report.line">
                 <field name="name">Section 194-IB: Payment of rent by individual or HUF not liable to tax audit</field>
-                <field name="sequence" eval="18"/>
                 <field name="expression_ids">
                     <record id="tds_report_line_section_194ib_tag" model="account.report.expression">
                         <field name="label">balance</field>
@@ -214,7 +195,6 @@
             </record>
             <record id="tds_report_line_section_194ic" model="account.report.line">
                 <field name="name">Section 194-IC: Payment of monetary consideration under Joint Development Agreements</field>
-                <field name="sequence" eval="19"/>
                 <field name="expression_ids">
                     <record id="tds_report_line_section_194ic_tag" model="account.report.expression">
                         <field name="label">balance</field>
@@ -225,7 +205,6 @@
             </record>
             <record id="tds_report_line_section_194j" model="account.report.line">
                 <field name="name">Section 194J: Fees for professional or technical services</field>
-                <field name="sequence" eval="20"/>
                 <field name="expression_ids">
                     <record id="tds_report_line_section_194j_tag" model="account.report.expression">
                         <field name="label">balance</field>
@@ -236,7 +215,6 @@
             </record>
             <record id="tds_report_line_section_194k" model="account.report.line">
                 <field name="name">Section 194K: Income in respect of units payable to resident person</field>
-                <field name="sequence" eval="21"/>
                 <field name="expression_ids">
                     <record id="tds_report_line_section_194k_tag" model="account.report.expression">
                         <field name="label">balance</field>
@@ -247,7 +225,6 @@
             </record>
             <record id="tds_report_line_section_194la" model="account.report.line">
                 <field name="name">Section 194LA: Payment of compensation on acquisition of certain immovable property</field>
-                <field name="sequence" eval="22"/>
                 <field name="expression_ids">
                     <record id="tds_report_line_section_194la_tag" model="account.report.expression">
                         <field name="label">balance</field>
@@ -258,7 +235,6 @@
             </record>
             <record id="tds_report_line_section_194lba" model="account.report.line">
                 <field name="name">Section 194LBA(1): Business trust shall deduct tax while distributing, any interest received or receivable by it from a SPV or any income received from renting or leasing or letting out any real estate asset owned directly by it, to its unit holders.</field>
-                <field name="sequence" eval="23"/>
                 <field name="expression_ids">
                     <record id="tds_report_line_section_194lba_tag" model="account.report.expression">
                         <field name="label">balance</field>
@@ -269,7 +245,6 @@
             </record>
             <record id="tds_report_line_section_194lb" model="account.report.line">
                 <field name="name">Section 194LB: Payment of interest on infrastructure debt fund</field>
-                <field name="sequence" eval="24"/>
                 <field name="expression_ids">
                     <record id="tds_report_line_section_194lb_tag" model="account.report.expression">
                         <field name="label">balance</field>
@@ -280,7 +255,6 @@
             </record>
             <record id="tds_report_line_section_194lbb" model="account.report.line">
                 <field name="name">Section 194LBB: Investment fund paying an income to a unit holder [other than income which is exempt under Section 10(23FBB)]</field>
-                <field name="sequence" eval="25"/>
                 <field name="expression_ids">
                     <record id="tds_report_line_section_194lbb_tag" model="account.report.expression">
                         <field name="label">balance</field>
@@ -291,7 +265,6 @@
             </record>
             <record id="tds_report_line_section_194lbc" model="account.report.line">
                 <field name="name">Section 194LBC: Income in respect of investment made in a securitisation trust (specified in Explanation of section115TCA)</field>
-                <field name="sequence" eval="26"/>
                 <field name="expression_ids">
                     <record id="tds_report_line_section_194lbc_tag" model="account.report.expression">
                         <field name="label">balance</field>
@@ -302,7 +275,6 @@
             </record>
             <record id="tds_report_line_section_194m" model="account.report.line">
                 <field name="name">Section 194M: Payment of commission (not being insurance commission), brokerage, contractual fee, professional fee to a resident person by an Individual or a HUF who are not liable to deduct TDS under section 194C, 194H, or 194J.</field>
-                <field name="sequence" eval="27"/>
                 <field name="expression_ids">
                     <record id="tds_report_line_section_194m_tag" model="account.report.expression">
                         <field name="label">balance</field>
@@ -313,7 +285,6 @@
             </record>
             <record id="tds_report_line_section_194n" model="account.report.line">
                 <field name="name">Section 194N: Cash withdrawal during the previous year from one or more account maintained by a person with a banking company, co-operative society engaged in business of banking or a post office</field>
-                <field name="sequence" eval="28"/>
                 <field name="expression_ids">
                     <record id="tds_report_line_section_194n_tag" model="account.report.expression">
                         <field name="label">balance</field>
@@ -324,7 +295,6 @@
             </record>
             <record id="tds_report_line_section_194o" model="account.report.line">
                 <field name="name">Section 194-O: Payment or credit of amount by the e-commerce operator to e-commerce participant</field>
-                <field name="sequence" eval="29"/>
                 <field name="expression_ids">
                     <record id="tds_report_line_section_194o_tag" model="account.report.expression">
                         <field name="label">balance</field>
@@ -335,7 +305,6 @@
             </record>
             <record id="tds_report_line_section_194q" model="account.report.line">
                 <field name="name">Section 194Q: Purchase of goods</field>
-                <field name="sequence" eval="30"/>
                 <field name="expression_ids">
                     <record id="tds_report_line_section_194q_tag" model="account.report.expression">
                         <field name="label">balance</field>
@@ -346,7 +315,6 @@
             </record>
             <record id="tds_report_line_section_195" model="account.report.line">
                 <field name="name">Section 195: Payment of any other sum to a Non -resident</field>
-                <field name="sequence" eval="31"/>
                 <field name="expression_ids">
                     <record id="tds_report_line_section_195_tag" model="account.report.expression">
                         <field name="label">balance</field>

--- a/addons/l10n_it/data/account_tax_report_data.xml
+++ b/addons/l10n_it/data/account_tax_report_data.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<odoo>
+<odoo auto_sequence="1">
     <record id="tax_report_vat" model="account.report">
         <field name="name">VAT Report</field>
         <field name="root_report_id" ref="account.generic_tax_report"/>

--- a/addons/l10n_jp/data/account_tax_report_data.xml
+++ b/addons/l10n_jp/data/account_tax_report_data.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<odoo>
+<odoo auto_sequence="1">
     <record id="tax_report" model="account.report">
         <field name="name">Tax Report</field>
         <field name="root_report_id" ref="account.generic_tax_report"/>

--- a/addons/l10n_ke/data/account_tax_report_data.xml
+++ b/addons/l10n_ke/data/account_tax_report_data.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<odoo>
+<odoo auto_sequence="1">
     <record id="tax_report_ke" model="account.report">
         <field name="name">Tax Report</field>
         <field name="root_report_id" ref="account.generic_tax_report"/>
@@ -19,7 +19,6 @@
         <field name="line_ids">
             <record id="tax_report_line_general_rate_sales" model="account.report.line">
                 <field name="name">1. Taxable Sales (General Rate 16%)</field>
-                <field name="sequence">1</field>
                 <field name="code">box_1</field>
                 <field name="expression_ids">
                         <record id="tax_report_general_rate_sales_base_tag" model="account.report.expression">
@@ -36,7 +35,6 @@
             </record>
             <record id="tax_report_line_other_rate_sales" model="account.report.line">
                 <field name="name">2. Taxable Sales (Other Rate 8%)</field>
-                <field name="sequence">2</field>
                 <field name="code">box_2</field>
                 <field name="expression_ids">
                         <record id="tax_report_other_rate_sales_base_tag" model="account.report.expression">
@@ -53,7 +51,6 @@
             </record>
             <record id="tax_report_line_zero_rated_sales" model="account.report.line">
                 <field name="name">3. Sales (Zero Rated 0%)</field>
-                <field name="sequence">3</field>
                 <field name="code">box_3</field>
                 <field name="expression_ids">
                         <record id="tax_report_zero_rated_sales_base_tag" model="account.report.expression">
@@ -65,7 +62,6 @@
             </record>
             <record id="tax_report_line_exempt_sales" model="account.report.line">
                 <field name="name">4. Sales (Exempt)</field>
-                <field name="sequence">4</field>
                 <field name="code">box_4</field>
                 <field name="expression_ids">
                         <record id="tax_report_exempt_sales_base_tag" model="account.report.expression">
@@ -77,7 +73,6 @@
             </record>
             <record id="tax_report_line_total_sales" model="account.report.line">
                 <field name="name">5. Total Sales</field>
-                <field name="sequence">5</field>
                 <field name="code">box_5</field>
                 <field name="expression_ids">
                         <record id="tax_report_total_sales_base_tag" model="account.report.expression">
@@ -94,7 +89,6 @@
             </record>
             <record id="tax_report_line_output_vat" model="account.report.line">
                 <field name="name">6. Total Output VAT</field>
-                <field name="sequence">6</field>
                 <field name="code">box_6</field>
                 <field name="expression_ids">
                         <record id="tax_report_output_vat_base_tag" model="account.report.expression">
@@ -111,7 +105,6 @@
             </record>
             <record id="tax_report_line_general_rate_purchases" model="account.report.line">
                 <field name="name">7. Taxable Purchases (General Rate 16%)</field>
-                <field name="sequence">7</field>
                 <field name="code">box_7</field>
                 <field name="expression_ids">
                         <record id="tax_report_general_rate_purchases_base_tag" model="account.report.expression">
@@ -128,7 +121,6 @@
             </record>
             <record id="tax_report_line_other_rate_purchases" model="account.report.line">
                 <field name="name">8. Taxable Purchases (Other Rate 8%)</field>
-                <field name="sequence">8</field>
                 <field name="code">box_8</field>
                 <field name="expression_ids">
                         <record id="tax_report_other_rate_purchases_base_tag" model="account.report.expression">
@@ -145,7 +137,6 @@
             </record>
             <record id="tax_report_line_zero_rated_purchases" model="account.report.line">
                 <field name="name">9. Purchases (Zero Rated 0%)</field>
-                <field name="sequence">9</field>
                 <field name="code">box_9</field>
                 <field name="expression_ids">
                         <record id="tax_report_zero_rated_purchases_base_tag" model="account.report.expression">
@@ -157,7 +148,6 @@
             </record>
             <record id="tax_report_line_exempt_purchases" model="account.report.line">
                 <field name="name">10. Purchases (Exempt)</field>
-                <field name="sequence">10</field>
                 <field name="code">box_10</field>
                 <field name="expression_ids">
                         <record id="tax_report_exempt_purchases_base_tag" model="account.report.expression">
@@ -169,7 +159,6 @@
             </record>
             <record id="tax_report_line_total_purchases" model="account.report.line">
                 <field name="name">11. Total Purchases</field>
-                <field name="sequence">11</field>
                 <field name="code">box_11</field>
                 <field name="expression_ids">
                         <record id="tax_report_total_purchases_base_tag" model="account.report.expression">
@@ -186,7 +175,6 @@
             </record>
             <record id="tax_report_line_input_vat" model="account.report.line">
                 <field name="name">12. Total Input VAT</field>
-                <field name="sequence">12</field>
                 <field name="code">box_12</field>
                 <field name="expression_ids">
                         <record id="tax_report_input_vat_base_tag" model="account.report.expression">

--- a/addons/l10n_lu/data/account_tax_report_line.xml
+++ b/addons/l10n_lu/data/account_tax_report_line.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<odoo>
+<odoo auto_sequence="1">
     <record id="tax_report" model="account.report">
         <field name="name">Tax Report</field>
         <field name="root_report_id" ref="account.generic_tax_report"/>

--- a/addons/l10n_ma/data/account_tax_report_data.xml
+++ b/addons/l10n_ma/data/account_tax_report_data.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<odoo>
+<odoo auto_sequence="1">
     <record id="tax_report_vat" model="account.report">
         <field name="name">VAT Report</field>
         <field name="root_report_id" ref="account.generic_tax_report"/>
@@ -27,12 +27,10 @@
         </field>
         <field name="line_ids">
             <record id="tax_report_part_a" model="account.report.line">
-                <field name="sequence">1</field>
                 <field name="hierarchy_level">0</field>
                 <field name="name">A - Breakdown of total revenues</field>
                 <field name="children_ids">
                     <record id="tax_report_line_10" model="account.report.line">
-                        <field name="sequence">2</field>
                         <field name="hierarchy_level">3</field>
                         <field name="name">10 - Amount of the revenues realized, including non-taxable operations (excl. VAT)</field>
                         <field name="code">l10n_ma_vat_10</field>
@@ -45,7 +43,6 @@
                         </field>
                         <field name="children_ids">
                             <record id="tax_report_line_20" model="account.report.line">
-                                <field name="sequence">3</field>
                                 <field name="hierarchy_level">5</field>
                                 <field name="name">20 - Operations outside the scope of VAT</field>
                                 <field name="code">l10n_ma_vat_20</field>
@@ -58,7 +55,6 @@
                                 </field>
                             </record>
                             <record id="tax_report_line_30" model="account.report.line">
-                                <field name="sequence">4</field>
                                 <field name="hierarchy_level">5</field>
                                 <field name="name">30 - Exempt operations without right of deduction (Article 91 of the CGI)</field>
                                 <field name="code">l10n_ma_vat_30</field>
@@ -71,7 +67,6 @@
                                 </field>
                             </record>
                             <record id="tax_report_line_40" model="account.report.line">
-                                <field name="sequence">5</field>
                                 <field name="hierarchy_level">5</field>
                                 <field name="name">40 - Exempt operations with right of deduction (Article 92 of the CGI)</field>
                                 <field name="code">l10n_ma_vat_40</field>
@@ -84,7 +79,6 @@
                                 </field>
                             </record>
                             <record id="tax_report_line_50" model="account.report.line">
-                                <field name="sequence">6</field>
                                 <field name="hierarchy_level">5</field>
                                 <field name="name">50 - Operations carried out under suspension of VAT (Article 94 of the CGI)</field>
                                 <field name="code">l10n_ma_vat_50</field>
@@ -97,7 +91,6 @@
                                 </field>
                             </record>
                             <record id="tax_report_line_55" model="account.report.line">
-                                <field name="sequence">7</field>
                                 <field name="hierarchy_level">5</field>
                                 <field name="name">55 - Taxable operations made by mobile payment (Article 247 ter of the CGI)</field>
                                 <field name="code">l10n_ma_vat_55</field>
@@ -111,7 +104,6 @@
                                 </field>
                             </record>
                             <record id="tax_report_line_56" model="account.report.line">
-                                <field name="sequence">8</field>
                                 <field name="hierarchy_level">5</field>
                                 <field name="name">56 - Exempt, out-of-scope or suspended operations by mobile payment</field>
                                 <field name="code">l10n_ma_vat_56</field>
@@ -127,7 +119,6 @@
                         </field>
                     </record>
                     <record id="tax_report_line_60" model="account.report.line">
-                        <field name="sequence">9</field>
                         <field name="hierarchy_level">3</field>
                         <field name="name">60 - Taxable revenues to be allocated (difference line 10 - (20 + 30 + 40 + 50)) (excl. VAT)</field>
                         <field name="code">l10n_ma_vat_60</field>
@@ -142,7 +133,6 @@
                 </field>
             </record>
             <record id="tax_report_part_b" model="account.report.line">
-                <field name="sequence">10</field>
                 <field name="hierarchy_level">0</field>
                 <field name="name">B - Breakdown of taxable revenues</field>
                 <field name="code">l10n_ma_vat_b</field>
@@ -160,7 +150,6 @@
                 </field>
                 <field name="children_ids">
                     <record id="tax_report_part_b_20" model="account.report.line">
-                        <field name="sequence">11</field>
                         <field name="hierarchy_level">1</field>
                         <field name="name">Standard rate of 20% with right to deduct</field>
                         <field name="code">l10n_ma_vat_b_20</field>
@@ -178,7 +167,6 @@
                         </field>
                         <field name="children_ids">
                             <record id="tax_report_line_80" model="account.report.line">
-                                <field name="sequence">12</field>
                                 <field name="hierarchy_level">3</field>
                                 <field name="name">80 - Production and distribution operations</field>
                                 <field name="code">l10n_ma_vat_80</field>
@@ -196,7 +184,6 @@
                                 </field>
                             </record>
                             <record id="tax_report_line_81" model="account.report.line">
-                                <field name="sequence">13</field>
                                 <field name="hierarchy_level">3</field>
                                 <field name="name">81 - Services</field>
                                 <field name="code">l10n_ma_vat_81</field>
@@ -214,7 +201,6 @@
                                 </field>
                             </record>
                             <record id="tax_report_line_82" model="account.report.line">
-                                <field name="sequence">14</field>
                                 <field name="hierarchy_level">3</field>
                                 <field name="name">82 - Liberal professions referred to in article 89-I-12°-(b) of the CGI</field>
                                 <field name="code">l10n_ma_vat_82</field>
@@ -232,7 +218,6 @@
                                 </field>
                             </record>
                             <record id="tax_report_line_83" model="account.report.line">
-                                <field name="sequence">15</field>
                                 <field name="hierarchy_level">3</field>
                                 <field name="name">83 - Leasing operations</field>
                                 <field name="code">l10n_ma_vat_83</field>
@@ -250,7 +235,6 @@
                                 </field>
                             </record>
                             <record id="tax_report_line_87" model="account.report.line">
-                                <field name="sequence">16</field>
                                 <field name="hierarchy_level">3</field>
                                 <field name="name">87 - Operations of real estate works companies</field>
                                 <field name="code">l10n_ma_vat_87</field>
@@ -268,7 +252,6 @@
                                 </field>
                             </record>
                             <record id="tax_report_line_93" model="account.report.line">
-                                <field name="sequence">17</field>
                                 <field name="hierarchy_level">3</field>
                                 <field name="name">93 - Sales and delivery of used movable property</field>
                                 <field name="code">l10n_ma_vat_93</field>
@@ -286,7 +269,6 @@
                                 </field>
                             </record>
                             <record id="tax_report_line_94" model="account.report.line">
-                                <field name="sequence">18</field>
                                 <field name="hierarchy_level">3</field>
                                 <field name="name">94 - Self-supply of constructions</field>
                                 <field name="code">l10n_ma_vat_94</field>
@@ -304,7 +286,6 @@
                                 </field>
                             </record>
                             <record id="tax_report_line_95" model="account.report.line">
-                                <field name="sequence">19</field>
                                 <field name="hierarchy_level">3</field>
                                 <field name="name">95 - Margin regime referred to in articles 125 bis and 125 quater of the CGI</field>
                                 <field name="code">l10n_ma_vat_95</field>
@@ -322,7 +303,6 @@
                                 </field>
                             </record>
                             <record id="tax_report_line_102" model="account.report.line">
-                                <field name="sequence">20</field>
                                 <field name="hierarchy_level">3</field>
                                 <field name="name">102 - Other</field>
                                 <field name="code">l10n_ma_vat_102</field>
@@ -342,7 +322,6 @@
                         </field>
                     </record>
                     <record id="tax_report_part_b_14" model="account.report.line">
-                        <field name="sequence">21</field>
                         <field name="hierarchy_level">1</field>
                         <field name="name">Reduced rate of 14%</field>
                         <field name="code">l10n_ma_vat_b_14</field>
@@ -360,7 +339,6 @@
                         </field>
                         <field name="children_ids">
                             <record id="tax_report_part_b_14_d" model="account.report.line">
-                                <field name="sequence">22</field>
                                 <field name="hierarchy_level">2</field>
                                 <field name="name">With right to deduct</field>
                                 <field name="code">l10n_ma_vat_b_14_d</field>
@@ -378,7 +356,6 @@
                                 </field>
                                 <field name="children_ids">
                                     <record id="tax_report_line_84" model="account.report.line">
-                                        <field name="sequence">23</field>
                                         <field name="hierarchy_level">3</field>
                                         <field name="name">84 - Butter, excluding home-made butter referred to in Article 91 (I-A. 2°)</field>
                                         <field name="code">l10n_ma_vat_84</field>
@@ -396,7 +373,6 @@
                                         </field>
                                     </record>
                                     <record id="tax_report_line_88" model="account.report.line">
-                                        <field name="sequence">24</field>
                                         <field name="hierarchy_level">3</field>
                                         <field name="name">88 - Passenger and freight transport operations, excluding rail transport</field>
                                         <field name="code">l10n_ma_vat_88</field>
@@ -414,7 +390,6 @@
                                         </field>
                                     </record>
                                     <record id="tax_report_line_90" model="account.report.line">
-                                        <field name="sequence">25</field>
                                         <field name="hierarchy_level">3</field>
                                         <field name="name">90 - Electrical energy</field>
                                         <field name="code">l10n_ma_vat_90</field>
@@ -432,7 +407,6 @@
                                         </field>
                                     </record>
                                     <record id="tax_report_line_104" model="account.report.line">
-                                        <field name="sequence">26</field>
                                         <field name="hierarchy_level">3</field>
                                         <field name="name">104 - Other</field>
                                         <field name="code">l10n_ma_vat_104</field>
@@ -452,7 +426,6 @@
                                 </field>
                             </record>
                             <record id="tax_report_part_b_14_nd" model="account.report.line">
-                                <field name="sequence">27</field>
                                 <field name="hierarchy_level">2</field>
                                 <field name="name">Without right to deduct</field>
                                 <field name="code">l10n_ma_vat_b_14_nd</field>
@@ -470,7 +443,6 @@
                                 </field>
                                 <field name="children_ids">
                                     <record id="tax_report_line_91" model="account.report.line">
-                                        <field name="sequence">28</field>
                                         <field name="hierarchy_level">3</field>
                                         <field name="name">91 - Services rendered by any soliciting agent or insurance broker in respect of contracts brought by him to an insurance company</field>
                                         <field name="code">l10n_ma_vat_91</field>
@@ -492,7 +464,6 @@
                         </field>
                     </record>
                     <record id="tax_report_part_b_10" model="account.report.line">
-                        <field name="sequence">29</field>
                         <field name="hierarchy_level">1</field>
                         <field name="name">Reduced rate of 10% with right to deduct</field>
                         <field name="code">l10n_ma_vat_b_10</field>
@@ -510,7 +481,6 @@
                         </field>
                         <field name="children_ids">
                             <record id="tax_report_line_76" model="account.report.line">
-                                <field name="sequence">30</field>
                                 <field name="hierarchy_level">3</field>
                                 <field name="name">76 - Photovoltaic panels</field>
                                 <field name="code">l10n_ma_vat_76</field>
@@ -528,7 +498,6 @@
                                 </field>
                             </record>
                             <record id="tax_report_line_77" model="account.report.line">
-                                <field name="sequence">31</field>
                                 <field name="hierarchy_level">3</field>
                                 <field name="name">77 - Solar water heaters</field>
                                 <field name="code">l10n_ma_vat_77</field>
@@ -546,7 +515,6 @@
                                 </field>
                             </record>
                             <record id="tax_report_line_78" model="account.report.line">
-                                <field name="sequence">32</field>
                                 <field name="hierarchy_level">3</field>
                                 <field name="name">78 - Feed for livestock and farmyard animals as well as oil cakes used in their manufacture, excluding other simple feed</field>
                                 <field name="code">l10n_ma_vat_78</field>
@@ -564,7 +532,6 @@
                                 </field>
                             </record>
                             <record id="tax_report_line_79" model="account.report.line">
-                                <field name="sequence">33</field>
                                 <field name="hierarchy_level">3</field>
                                 <field name="name">79 - Equipment for exclusive agricultural use</field>
                                 <field name="code">l10n_ma_vat_79</field>
@@ -582,7 +549,6 @@
                                 </field>
                             </record>
                             <record id="tax_report_line_85" model="account.report.line">
-                                <field name="sequence">34</field>
                                 <field name="hierarchy_level">3</field>
                                 <field name="name">85 - Wood in logs, debarked or simply squared, cork in its natural state, firewood in bundles or sawn to short lengths and charcoal</field>
                                 <field name="code">l10n_ma_vat_85</field>
@@ -600,7 +566,6 @@
                                 </field>
                             </record>
                             <record id="tax_report_line_86" model="account.report.line">
-                                <field name="sequence">35</field>
                                 <field name="hierarchy_level">3</field>
                                 <field name="name">86 - Fishing gear and nets for professional marine fishermen</field>
                                 <field name="code">l10n_ma_vat_86</field>
@@ -618,7 +583,6 @@
                                 </field>
                             </record>
                             <record id="tax_report_line_89" model="account.report.line">
-                                <field name="sequence">36</field>
                                 <field name="hierarchy_level">3</field>
                                 <field name="name">89 - Accommodation and catering operations as well as services provided by cafés</field>
                                 <field name="code">l10n_ma_vat_89</field>
@@ -636,7 +600,6 @@
                                 </field>
                             </record>
                             <record id="tax_report_line_92" model="account.report.line">
-                                <field name="sequence">37</field>
                                 <field name="hierarchy_level">3</field>
                                 <field name="name">92 - Rental operations of buildings used as hotels</field>
                                 <field name="code">l10n_ma_vat_92</field>
@@ -654,7 +617,6 @@
                                 </field>
                             </record>
                             <record id="tax_report_line_96" model="account.report.line">
-                                <field name="sequence">38</field>
                                 <field name="hierarchy_level">3</field>
                                 <field name="name">96 - Cooking salt (rock or sea salt)</field>
                                 <field name="code">l10n_ma_vat_96</field>
@@ -672,7 +634,6 @@
                                 </field>
                             </record>
                             <record id="tax_report_line_97" model="account.report.line">
-                                <field name="sequence">39</field>
                                 <field name="hierarchy_level">3</field>
                                 <field name="name">97 - Milled rice and pasta</field>
                                 <field name="code">l10n_ma_vat_97</field>
@@ -690,7 +651,6 @@
                                 </field>
                             </record>
                             <record id="tax_report_line_98" model="account.report.line">
-                                <field name="sequence">40</field>
                                 <field name="hierarchy_level">3</field>
                                 <field name="name">98 - Food fluid oils excluding palm oil</field>
                                 <field name="code">l10n_ma_vat_98</field>
@@ -708,7 +668,6 @@
                                 </field>
                             </record>
                             <record id="tax_report_line_99" model="account.report.line">
-                                <field name="sequence">41</field>
                                 <field name="hierarchy_level">3</field>
                                 <field name="name">99 - Securities transactions</field>
                                 <field name="code">l10n_ma_vat_99</field>
@@ -726,7 +685,6 @@
                                 </field>
                             </record>
                             <record id="tax_report_line_100" model="account.report.line">
-                                <field name="sequence">42</field>
                                 <field name="hierarchy_level">3</field>
                                 <field name="name">100 - Banking and credit transactions and exchange commissions</field>
                                 <field name="code">l10n_ma_vat_100</field>
@@ -744,7 +702,6 @@
                                 </field>
                             </record>
                             <record id="tax_report_line_101" model="account.report.line">
-                                <field name="sequence">43</field>
                                 <field name="hierarchy_level">3</field>
                                 <field name="name">101 - Transactions involving shares and units shares</field>
                                 <field name="code">l10n_ma_vat_101</field>
@@ -762,7 +719,6 @@
                                 </field>
                             </record>
                             <record id="tax_report_line_103" model="account.report.line">
-                                <field name="sequence">44</field>
                                 <field name="hierarchy_level">3</field>
                                 <field name="name">103 - Operations of sale and delivery of works and objects of art</field>
                                 <field name="code">l10n_ma_vat_103</field>
@@ -780,7 +736,6 @@
                                 </field>
                             </record>
                             <record id="tax_report_line_105" model="account.report.line">
-                                <field name="sequence">45</field>
                                 <field name="hierarchy_level">3</field>
                                 <field name="name">105 - Operations of lawyers, interpreters, notaries, adouls, bailiffs and veterinarians</field>
                                 <field name="code">l10n_ma_vat_105</field>
@@ -798,7 +753,6 @@
                                 </field>
                             </record>
                             <record id="tax_report_line_108" model="account.report.line">
-                                <field name="sequence">46</field>
                                 <field name="hierarchy_level">3</field>
                                 <field name="name">108 - Petroleum gas and other gaseous hydrocarbons</field>
                                 <field name="code">l10n_ma_vat_108</field>
@@ -816,7 +770,6 @@
                                 </field>
                             </record>
                             <record id="tax_report_line_109" model="account.report.line">
-                                <field name="sequence">47</field>
                                 <field name="hierarchy_level">3</field>
                                 <field name="name">109 - Petroleum or shale oils, crude or refined</field>
                                 <field name="code">l10n_ma_vat_109</field>
@@ -834,7 +787,6 @@
                                 </field>
                             </record>
                             <record id="tax_report_line_112" model="account.report.line">
-                                <field name="sequence">48</field>
                                 <field name="hierarchy_level">3</field>
                                 <field name="name">112 - Ticket sales operations for museums, cinema and theater</field>
                                 <field name="code">l10n_ma_vat_112</field>
@@ -852,7 +804,6 @@
                                 </field>
                             </record>
                             <record id="tax_report_line_118" model="account.report.line">
-                                <field name="sequence">49</field>
                                 <field name="hierarchy_level">3</field>
                                 <field name="name">118 - Other</field>
                                 <field name="code">l10n_ma_vat_118</field>
@@ -872,7 +823,6 @@
                         </field>
                     </record>
                     <record id="tax_report_part_b_7" model="account.report.line">
-                        <field name="sequence">50</field>
                         <field name="hierarchy_level">1</field>
                         <field name="name">Reduced rate of 7% with right to deduct</field>
                         <field name="code">l10n_ma_vat_b_7</field>
@@ -890,7 +840,6 @@
                         </field>
                         <field name="children_ids">
                             <record id="tax_report_line_106" model="account.report.line">
-                                <field name="sequence">51</field>
                                 <field name="hierarchy_level">3</field>
                                 <field name="name">106 - Water delivered to the public distribution networks and sanitation services</field>
                                 <field name="code">l10n_ma_vat_106</field>
@@ -908,7 +857,6 @@
                                 </field>
                             </record>
                             <record id="tax_report_line_107" model="account.report.line">
-                                <field name="sequence">52</field>
                                 <field name="hierarchy_level">3</field>
                                 <field name="name">107 - Rental of water and electricity meters</field>
                                 <field name="code">l10n_ma_vat_107</field>
@@ -926,7 +874,6 @@
                                 </field>
                             </record>
                             <record id="tax_report_line_110" model="account.report.line">
-                                <field name="sequence">53</field>
                                 <field name="hierarchy_level">3</field>
                                 <field name="name">110 - Pharmaceutical products, raw materials and products used in their composition as well as non-returnable packaging of these products and materials</field>
                                 <field name="code">l10n_ma_vat_110</field>
@@ -944,7 +891,6 @@
                                 </field>
                             </record>
                             <record id="tax_report_line_111" model="account.report.line">
-                                <field name="sequence">54</field>
                                 <field name="hierarchy_level">3</field>
                                 <field name="name">111 - School supplies, products and materials in their composition</field>
                                 <field name="code">l10n_ma_vat_111</field>
@@ -962,7 +908,6 @@
                                 </field>
                             </record>
                             <record id="tax_report_line_113" model="account.report.line">
-                                <field name="sequence">55</field>
                                 <field name="hierarchy_level">3</field>
                                 <field name="name">113 - Refined or agglomerated sugar</field>
                                 <field name="code">l10n_ma_vat_113</field>
@@ -980,7 +925,6 @@
                                 </field>
                             </record>
                             <record id="tax_report_line_114" model="account.report.line">
-                                <field name="sequence">56</field>
                                 <field name="hierarchy_level">3</field>
                                 <field name="name">114 - Canned sardines</field>
                                 <field name="code">l10n_ma_vat_114</field>
@@ -998,7 +942,6 @@
                                 </field>
                             </record>
                             <record id="tax_report_line_115" model="account.report.line">
-                                <field name="sequence">57</field>
                                 <field name="hierarchy_level">3</field>
                                 <field name="name">115 - Milk powder</field>
                                 <field name="code">l10n_ma_vat_115</field>
@@ -1016,7 +959,6 @@
                                 </field>
                             </record>
                             <record id="tax_report_line_116" model="account.report.line">
-                                <field name="sequence">58</field>
                                 <field name="hierarchy_level">3</field>
                                 <field name="name">116 - Household soap</field>
                                 <field name="code">l10n_ma_vat_116</field>
@@ -1034,7 +976,6 @@
                                 </field>
                             </record>
                             <record id="tax_report_line_117" model="account.report.line">
-                                <field name="sequence">59</field>
                                 <field name="hierarchy_level">3</field>
                                 <field name="name">117 - Economy car and products and materials used in its in its manufacture</field>
                                 <field name="code">l10n_ma_vat_117</field>
@@ -1052,7 +993,6 @@
                                 </field>
                             </record>
                             <record id="tax_report_line_119" model="account.report.line">
-                                <field name="sequence">60</field>
                                 <field name="hierarchy_level">3</field>
                                 <field name="name">119 - Other</field>
                                 <field name="code">l10n_ma_vat_119</field>
@@ -1072,7 +1012,6 @@
                         </field>
                     </record>
                     <record id="tax_report_line_120" model="account.report.line">
-                        <field name="sequence">61</field>
                         <field name="hierarchy_level">2</field>
                         <field name="name">120 - Reversal of VAT in different ways (cessation, regularization, ...)</field>
                         <field name="code">l10n_ma_vat_120</field>
@@ -1086,7 +1025,6 @@
                         </field>
                     </record>
                     <record id="tax_report_line_121" model="account.report.line">
-                        <field name="sequence">62</field>
                         <field name="hierarchy_level">2</field>
                         <field name="name">121 - Withholding tax on the amount of commissions allocated by insurance companies to their brokers</field>
                         <field name="code">l10n_ma_vat_121</field>
@@ -1100,7 +1038,6 @@
                         </field>
                     </record>
                     <record id="tax_report_line_122" model="account.report.line">
-                        <field name="sequence">63</field>
                         <field name="hierarchy_level">2</field>
                         <field name="name">122 - Withholding tax on interest paid by credit institutions</field>
                         <field name="code">l10n_ma_vat_122</field>
@@ -1114,7 +1051,6 @@
                         </field>
                     </record>
                     <record id="tax_report_line_123" model="account.report.line">
-                        <field name="sequence">64</field>
                         <field name="hierarchy_level">2</field>
                         <field name="name">123 - Withholding tax on proceeds from securitization transactions</field>
                         <field name="code">l10n_ma_vat_123</field>
@@ -1128,7 +1064,6 @@
                         </field>
                     </record>
                     <record id="tax_report_line_124" model="account.report.line">
-                        <field name="sequence">65</field>
                         <field name="hierarchy_level">2</field>
                         <field name="name">124 - Withholding tax on transactions carried out by non-residents for the benefit of Moroccan customers excluded from the scope of application of VAT</field>
                         <field name="code">l10n_ma_vat_124</field>
@@ -1144,12 +1079,10 @@
                 </field>
             </record>
             <record id="tax_report_part_c" model="account.report.line">
-                <field name="sequence">66</field>
                 <field name="hierarchy_level">0</field>
                 <field name="name">C - Operations carried out with non-resident taxpayers (Article 115 of the CGI)</field>
                 <field name="children_ids">
                     <record id="tax_report_line_129" model="account.report.line">
-                        <field name="sequence">67</field>
                         <field name="hierarchy_level">3</field>
                         <field name="name">129 - Operations with non-resident taxpayers</field>
                         <field name="code">l10n_ma_vat_129</field>
@@ -1169,7 +1102,6 @@
                 </field>
             </record>
             <record id="tax_report_line_130" model="account.report.line">
-                <field name="sequence">68</field>
                 <field name="hierarchy_level">0</field>
                 <field name="name">130 - Total VAT Payable</field>
                 <field name="code">l10n_ma_vat_130</field>
@@ -1193,7 +1125,6 @@
                 </field>
             </record>
             <record id="tax_report_part_d" model="account.report.line">
-                <field name="sequence">69</field>
                 <field name="hierarchy_level">0</field>
                 <field name="name">D - Breakdown of deductions</field>
                 <field name="code">l10n_ma_vat_d</field>
@@ -1206,7 +1137,6 @@
                 </field>
                 <field name="children_ids">
                     <record id="tax_report_part_d_1" model="account.report.line">
-                        <field name="sequence">70</field>
                         <field name="hierarchy_level">1</field>
                         <field name="name">1 - NON-FIXED ASSETS PURCHASES</field>
                         <field name="code">l10n_ma_vat_d_1</field>
@@ -1219,7 +1149,6 @@
                         </field>
                         <field name="children_ids">
                             <record id="tax_report_part_d_1_1" model="account.report.line">
-                                <field name="sequence">71</field>
                                 <field name="hierarchy_level">2</field>
                                 <field name="name">Services</field>
                                 <field name="code">l10n_ma_vat_d_1_1</field>
@@ -1232,7 +1161,6 @@
                                 </field>
                                 <field name="children_ids">
                                     <record id="tax_report_line_140" model="account.report.line">
-                                        <field name="sequence">72</field>
                                         <field name="hierarchy_level">3</field>
                                         <field name="name">140 - Services (20%)</field>
                                         <field name="code">l10n_ma_vat_140</field>
@@ -1256,7 +1184,6 @@
                                         </field>
                                     </record>
                                     <record id="tax_report_line_141" model="account.report.line">
-                                        <field name="sequence">73</field>
                                         <field name="hierarchy_level">3</field>
                                         <field name="name">141 - Transportation (14%)</field>
                                         <field name="code">l10n_ma_vat_141</field>
@@ -1280,7 +1207,6 @@
                                         </field>
                                     </record>
                                     <record id="tax_report_line_142" model="account.report.line">
-                                        <field name="sequence">74</field>
                                         <field name="hierarchy_level">3</field>
                                         <field name="name">142 - Banking operation (10%)</field>
                                         <field name="code">l10n_ma_vat_142</field>
@@ -1304,7 +1230,6 @@
                                         </field>
                                     </record>
                                     <record id="tax_report_line_143" model="account.report.line">
-                                        <field name="sequence">75</field>
                                         <field name="hierarchy_level">3</field>
                                         <field name="name">143 - Hotels for travelers, and all real estate for tourism purposes (10%)</field>
                                         <field name="code">l10n_ma_vat_143</field>
@@ -1328,7 +1253,6 @@
                                         </field>
                                     </record>
                                     <record id="tax_report_line_144" model="account.report.line">
-                                        <field name="sequence">76</field>
                                         <field name="hierarchy_level">3</field>
                                         <field name="name">144 - Operations performed by lawyers, interpreters, notaries, adouls, bailiffs and veterinarians (10%)</field>
                                         <field name="code">l10n_ma_vat_144</field>
@@ -1352,7 +1276,6 @@
                                         </field>
                                     </record>
                                     <record id="tax_report_line_153" model="account.report.line">
-                                        <field name="sequence">77</field>
                                         <field name="hierarchy_level">3</field>
                                         <field name="name">153 - Other services (10%)</field>
                                         <field name="code">l10n_ma_vat_153</field>
@@ -1378,7 +1301,6 @@
                                 </field>
                             </record>
                             <record id="tax_report_part_d_1_2" model="account.report.line">
-                                <field name="sequence">78</field>
                                 <field name="hierarchy_level">2</field>
                                 <field name="name">Other non-fixed assets purchases</field>
                                 <field name="code">l10n_ma_vat_d_1_2</field>
@@ -1391,7 +1313,6 @@
                                 </field>
                                 <field name="children_ids">
                                     <record id="tax_report_line_145" model="account.report.line">
-                                        <field name="sequence">79</field>
                                         <field name="hierarchy_level">3</field>
                                         <field name="name">145 - Import purchases (20%)</field>
                                         <field name="code">l10n_ma_vat_145</field>
@@ -1415,7 +1336,6 @@
                                         </field>
                                     </record>
                                     <record id="tax_report_line_146" model="account.report.line">
-                                        <field name="sequence">80</field>
                                         <field name="hierarchy_level">3</field>
                                         <field name="name">146 - Domestic purchases (20%)</field>
                                         <field name="code">l10n_ma_vat_146</field>
@@ -1439,7 +1359,6 @@
                                         </field>
                                     </record>
                                     <record id="tax_report_line_147" model="account.report.line">
-                                        <field name="sequence">81</field>
                                         <field name="hierarchy_level">3</field>
                                         <field name="name">147 - Import purchases (14%)</field>
                                         <field name="code">l10n_ma_vat_147</field>
@@ -1463,7 +1382,6 @@
                                         </field>
                                     </record>
                                     <record id="tax_report_line_148" model="account.report.line">
-                                        <field name="sequence">82</field>
                                         <field name="hierarchy_level">3</field>
                                         <field name="name">148 - Domestic purchases (14%)</field>
                                         <field name="code">l10n_ma_vat_148</field>
@@ -1487,7 +1405,6 @@
                                         </field>
                                     </record>
                                     <record id="tax_report_line_149" model="account.report.line">
-                                        <field name="sequence">83</field>
                                         <field name="hierarchy_level">3</field>
                                         <field name="name">149 - Import purchases (10%)</field>
                                         <field name="code">l10n_ma_vat_149</field>
@@ -1511,7 +1428,6 @@
                                         </field>
                                     </record>
                                     <record id="tax_report_line_150" model="account.report.line">
-                                        <field name="sequence">84</field>
                                         <field name="hierarchy_level">3</field>
                                         <field name="name">150 - Domestic purchases (10%)</field>
                                         <field name="code">l10n_ma_vat_150</field>
@@ -1535,7 +1451,6 @@
                                         </field>
                                     </record>
                                     <record id="tax_report_line_151" model="account.report.line">
-                                        <field name="sequence">85</field>
                                         <field name="hierarchy_level">3</field>
                                         <field name="name">151 - Import purchases (7%)</field>
                                         <field name="code">l10n_ma_vat_151</field>
@@ -1559,7 +1474,6 @@
                                         </field>
                                     </record>
                                     <record id="tax_report_line_152" model="account.report.line">
-                                        <field name="sequence">86</field>
                                         <field name="hierarchy_level">3</field>
                                         <field name="name">152 - Domestic purchases (7%)</field>
                                         <field name="code">l10n_ma_vat_152</field>
@@ -1583,7 +1497,6 @@
                                         </field>
                                     </record>
                                     <record id="tax_report_line_155" model="account.report.line">
-                                        <field name="sequence">87</field>
                                         <field name="hierarchy_level">2</field>
                                         <field name="name">155 - Contract work (20%)</field>
                                         <field name="code">l10n_ma_vat_155</field>
@@ -1607,7 +1520,6 @@
                                         </field>
                                     </record>
                                     <record id="tax_report_line_156" model="account.report.line">
-                                        <field name="sequence">88</field>
                                         <field name="hierarchy_level">3</field>
                                         <field name="name">156 - Subcontracting (real estate work) (20%)</field>
                                         <field name="code">l10n_ma_vat_156</field>
@@ -1631,7 +1543,6 @@
                                         </field>
                                     </record>
                                     <record id="tax_report_line_158" model="account.report.line">
-                                        <field name="sequence">89</field>
                                         <field name="hierarchy_level">2</field>
                                         <field name="name">158 - Undisclosed VAT (Article 125 ter of the CGI)</field>
                                         <field name="code">l10n_ma_vat_158</field>
@@ -1660,7 +1571,6 @@
                         </field>
                     </record>
                     <record id="tax_report_part_d_2" model="account.report.line">
-                        <field name="sequence">90</field>
                         <field name="hierarchy_level">1</field>
                         <field name="name">2 - FIXED ASSETS</field>
                         <field name="code">l10n_ma_vat_d_2</field>
@@ -1673,7 +1583,6 @@
                         </field>
                         <field name="children_ids">
                             <record id="tax_report_line_162" model="account.report.line">
-                                <field name="sequence">91</field>
                                 <field name="hierarchy_level">3</field>
                                 <field name="name">162 - Import purchases (20%)</field>
                                 <field name="code">l10n_ma_vat_162</field>
@@ -1697,7 +1606,6 @@
                                 </field>
                             </record>
                             <record id="tax_report_line_163" model="account.report.line">
-                                <field name="sequence">92</field>
                                 <field name="hierarchy_level">3</field>
                                 <field name="name">163 - Domestic purchases (20%)</field>
                                 <field name="code">l10n_ma_vat_163</field>
@@ -1721,7 +1629,6 @@
                                 </field>
                             </record>
                             <record id="tax_report_line_164" model="account.report.line">
-                                <field name="sequence">93</field>
                                 <field name="hierarchy_level">3</field>
                                 <field name="name">164 - Self-supply other than constructions (20%)</field>
                                 <field name="code">l10n_ma_vat_164</field>
@@ -1745,7 +1652,6 @@
                                 </field>
                             </record>
                             <record id="tax_report_line_165" model="account.report.line">
-                                <field name="sequence">94</field>
                                 <field name="hierarchy_level">3</field>
                                 <field name="name">165 - Facilities and installations (20%)</field>
                                 <field name="code">l10n_ma_vat_165</field>
@@ -1769,7 +1675,6 @@
                                 </field>
                             </record>
                             <record id="tax_report_line_166" model="account.report.line">
-                                <field name="sequence">95</field>
                                 <field name="hierarchy_level">3</field>
                                 <field name="name">166 - Constructions (20%)</field>
                                 <field name="code">l10n_ma_vat_166</field>
@@ -1793,7 +1698,6 @@
                                 </field>
                             </record>
                             <record id="tax_report_line_167" model="account.report.line">
-                                <field name="sequence">96</field>
                                 <field name="hierarchy_level">3</field>
                                 <field name="name">167 - Self-supply of constructions (20%)</field>
                                 <field name="code">l10n_ma_vat_167</field>
@@ -1817,7 +1721,6 @@
                                 </field>
                             </record>
                             <record id="tax_report_line_168" model="account.report.line">
-                                <field name="sequence">97</field>
                                 <field name="hierarchy_level">3</field>
                                 <field name="name">168 - Other fixed assets (14%)</field>
                                 <field name="code">l10n_ma_vat_168</field>
@@ -1841,7 +1744,6 @@
                                 </field>
                             </record>
                             <record id="tax_report_line_160" model="account.report.line">
-                                <field name="sequence">98</field>
                                 <field name="hierarchy_level">3</field>
                                 <field name="name">160 - Other fixed assets (10%)</field>
                                 <field name="code">l10n_ma_vat_160</field>
@@ -1865,7 +1767,6 @@
                                 </field>
                             </record>
                             <record id="tax_report_line_169" model="account.report.line">
-                                <field name="sequence">99</field>
                                 <field name="hierarchy_level">3</field>
                                 <field name="name">169 - Other fixed assets (7%)</field>
                                 <field name="code">l10n_ma_vat_169</field>
@@ -1893,7 +1794,6 @@
                 </field>
             </record>
             <record id="tax_report_line_182" model="account.report.line">
-                <field name="sequence">100</field>
                 <field name="hierarchy_level">0</field>
                 <field name="name">182 - Total deductions (lines 140 to 169)</field>
                 <field name="code">l10n_ma_vat_182</field>
@@ -1906,12 +1806,10 @@
                 </field>
             </record>
             <record id="tax_report_part_ded" model="account.report.line">
-                <field name="sequence">101</field>
                 <field name="hierarchy_level">0</field>
                 <field name="name">Deduction adjustments</field>
                 <field name="children_ids">
                     <record id="tax_report_line_170" model="account.report.line">
-                        <field name="sequence">102</field>
                         <field name="hierarchy_level">3</field>
                         <field name="name">170 - Credit from previous period</field>
                         <field name="code">l10n_ma_vat_170</field>
@@ -1936,7 +1834,6 @@
                         </field>
                     </record>
                     <record id="tax_report_line_180" model="account.report.line">
-                        <field name="sequence">103</field>
                         <field name="hierarchy_level">3</field>
                         <field name="name">180 - Additional deduction of the pro-rata regularization</field>
                         <field name="code">l10n_ma_vat_180</field>
@@ -1950,7 +1847,6 @@
                         </field>
                     </record>
                     <record id="tax_report_line_181" model="account.report.line">
-                        <field name="sequence">104</field>
                         <field name="hierarchy_level">3</field>
                         <field name="name">181 - Cumulative tax credit fraction</field>
                         <field name="code">l10n_ma_vat_181</field>
@@ -1964,7 +1860,6 @@
                         </field>
                     </record>
                     <record id="tax_report_line_185" model="account.report.line">
-                        <field name="sequence">105</field>
                         <field name="hierarchy_level">3</field>
                         <field name="name">185 - Amount of cancelled credit, remaining chargeable, not reimbursed for investment property</field>
                         <field name="code">l10n_ma_vat_185</field>
@@ -1978,7 +1873,6 @@
                         </field>
                     </record>
                     <record id="tax_report_line_186" model="account.report.line">
-                        <field name="sequence">106</field>
                         <field name="hierarchy_level">3</field>
                         <field name="name">186 - Amount claimed as reimbursement for investment property (Article 103 bis of the CGI)</field>
                         <field name="code">l10n_ma_vat_186</field>
@@ -1992,7 +1886,6 @@
                         </field>
                     </record>
                     <record id="tax_report_line_187" model="account.report.line">
-                        <field name="sequence">107</field>
                         <field name="hierarchy_level">3</field>
                         <field name="name">187 - Amount of reimbursement authorized (Article 103 of the CGI)</field>
                         <field name="code">l10n_ma_vat_187</field>
@@ -2008,7 +1901,6 @@
                 </field>
             </record>
             <record id="tax_report_line_190" model="account.report.line">
-                <field name="sequence">108</field>
                 <field name="hierarchy_level">0</field>
                 <field name="name">190 - Total deductible VAT ((182 to 185) - (186 and 187))</field>
                 <field name="code">l10n_ma_vat_190</field>
@@ -2021,12 +1913,10 @@
                 </field>
             </record>
             <record id="tax_report_part_results" model="account.report.line">
-                <field name="sequence">109</field>
                 <field name="hierarchy_level">0</field>
                 <field name="name">VAT Results</field>
                 <field name="children_ids">
                     <record id="tax_report_line_200" model="account.report.line">
-                        <field name="sequence">110</field>
                         <field name="hierarchy_level">3</field>
                         <field name="name">200 - Payable VAT (130 - 190)</field>
                         <field name="code">l10n_ma_vat_200</field>
@@ -2040,7 +1930,6 @@
                         </field>
                     </record>
                     <record id="tax_report_line_201" model="account.report.line">
-                        <field name="sequence">111</field>
                         <field name="hierarchy_level">3</field>
                         <field name="name">201 - Credit (190 - 130)</field>
                         <field name="code">l10n_ma_vat_201</field>
@@ -2054,7 +1943,6 @@
                         </field>
                     </record>
                     <record id="tax_report_line_202" model="account.report.line">
-                        <field name="sequence">112</field>
                         <field name="hierarchy_level">3</field>
                         <field name="name">202 - 15% reduction of the credit for the period ((182 + 180) - 130) x 15%</field>
                         <field name="code">l10n_ma_vat_202</field>
@@ -2068,7 +1956,6 @@
                         </field>
                     </record>
                     <record id="tax_report_line_203" model="account.report.line">
-                        <field name="sequence">113</field>
                         <field name="hierarchy_level">3</field>
                         <field name="name">203 - Credit to be carried forward (201 - 202)</field>
                         <field name="code">l10n_ma_vat_203</field>
@@ -2089,7 +1976,6 @@
                         </field>
                     </record>
                     <record id="tax_report_line_204" model="account.report.line">
-                        <field name="sequence">114</field>
                         <field name="hierarchy_level">3</field>
                         <field name="name">204 - Credit with payment including VAT due under articles 115, 116 and 117 of the CGI</field>
                         <field name="code">l10n_ma_vat_204</field>

--- a/addons/l10n_nl/data/account_tax_report_data.xml
+++ b/addons/l10n_nl/data/account_tax_report_data.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<odoo>
+<odoo auto_sequence="1">
     <record id="tax_report" model="account.report">
         <field name="name">Tax report</field>
         <field name="root_report_id" ref="account.generic_tax_report"/>
@@ -15,14 +15,12 @@
         <field name="line_ids">
             <record id="tax_report_rub_1" model="account.report.line">
                 <field name="name">Section 1: Domestic performance</field>
-                <field name="sequence">10</field>
                 <field name="aggregation_formula">1A_OMZET.balance + 1B_OMZET.balance + 1C_OMZET.balance + 1D_OMZET.balance + 1E_OMZET.balance</field>
                 <field name="hierarchy_level">0</field>
                 <field name="children_ids">
                     <record id="tax_report_rub_1a" model="account.report.line">
                         <field name="name">1a. Supplies/services taxed at high rate (turnover)</field>
                         <field name="code">1A_OMZET</field>
-                        <field name="sequence">20</field>
                         <field name="expression_ids">
                             <record id="tax_report_rub_1a_tag" model="account.report.expression">
                                 <field name="label">balance</field>
@@ -34,7 +32,6 @@
                     <record id="tax_report_rub_1b" model="account.report.line">
                         <field name="name">1b. Supplies/services taxed at low rate (turnover)</field>
                         <field name="code">1B_OMZET</field>
-                        <field name="sequence">30</field>
                         <field name="expression_ids">
                             <record id="tax_report_rub_1b_tag" model="account.report.expression">
                                 <field name="label">balance</field>
@@ -46,7 +43,6 @@
                     <record id="tax_report_rub_1c" model="account.report.line">
                         <field name="name">1c. Supplies/services taxed at other rates except 0% (turnover)</field>
                         <field name="code">1C_OMZET</field>
-                        <field name="sequence">40</field>
                         <field name="expression_ids">
                             <record id="tax_report_rub_1c_tag" model="account.report.expression">
                                 <field name="label">balance</field>
@@ -58,7 +54,6 @@
                     <record id="tax_report_rub_1d" model="account.report.line">
                         <field name="name">1d. Private use (turnover)</field>
                         <field name="code">1D_OMZET</field>
-                        <field name="sequence">50</field>
                         <field name="expression_ids">
                             <record id="tax_report_rub_1d_tag" model="account.report.expression">
                                 <field name="label">balance</field>
@@ -70,7 +65,6 @@
                     <record id="tax_report_rub_1e" model="account.report.line">
                         <field name="name">1e. Supplies/services taxed at 0% or not taxed with you (turnover)</field>
                         <field name="code">1E_OMZET</field>
-                        <field name="sequence">60</field>
                         <field name="expression_ids">
                             <record id="tax_report_rub_1e_tag" model="account.report.expression">
                                 <field name="label">balance</field>
@@ -83,14 +77,12 @@
             </record>
             <record id="tax_report_rub_2" model="account.report.line">
                 <field name="name">Section 2: Domestic reverse charge arrangements (turnover)</field>
-                <field name="sequence">100</field>
                 <field name="aggregation_formula">2A_OMZET.balance</field>
                 <field name="hierarchy_level">0</field>
                 <field name="children_ids">
                     <record id="tax_report_rub_2a" model="account.report.line">
                         <field name="name">2a. Supplies/services where the collection of turnover tax has been transferred to you (turnover)</field>
                         <field name="code">2A_OMZET</field>
-                        <field name="sequence">110</field>
                         <field name="expression_ids">
                             <record id="tax_report_rub_2a_tag" model="account.report.expression">
                                 <field name="label">balance</field>
@@ -103,14 +95,12 @@
             </record>
             <record id="tax_report_rub_3" model="account.report.line">
                 <field name="name">Section 3: Performance to or from abroad (turnover)</field>
-                <field name="sequence">200</field>
                 <field name="aggregation_formula">3A_OMZET.balance + 3B_OMZET.balance + 3C_OMZET.balance</field>
                 <field name="hierarchy_level">0</field>
                 <field name="children_ids">
                     <record id="tax_report_rub_3a" model="account.report.line">
                         <field name="name">3a. Deliveries to countries outside the EU (exports) (turnover)</field>
                         <field name="code">3A_OMZET</field>
-                        <field name="sequence">210</field>
                         <field name="expression_ids">
                             <record id="tax_report_rub_3a_tag" model="account.report.expression">
                                 <field name="label">balance</field>
@@ -122,13 +112,11 @@
                     <record id="tax_report_rub_3b" model="account.report.line">
                         <field name="name">3b. Deliveries to/services in countries within the EU and A-B-C supply chain transactions (turnover)</field>
                         <field name="code">3B_OMZET</field>
-                        <field name="sequence">220</field>
                         <field name="aggregation_formula">3BL_OMZET.balance + 3BT_OMZET.balance</field>
                         <field name="children_ids">
                             <record id="tax_report_rub_3bl" model="account.report.line">
                                 <field name="name">3bl. Deliveries to/services in countries within the EU (turnover)</field>
                                 <field name="code">3BL_OMZET</field>
-                                <field name="sequence">223</field>
                                 <field name="expression_ids">
                                     <record id="tax_report_rub_3b_tag" model="account.report.expression">
                                         <field name="label">balance</field>
@@ -140,7 +128,6 @@
                             <record id="tax_report_rub_3bt" model="account.report.line">
                                 <field name="name">3bt. A-B-C supply chain transactions within the EU (turnover)</field>
                                 <field name="code">3BT_OMZET</field>
-                                <field name="sequence">226</field>
                                 <field name="expression_ids">
                                     <record id="tax_report_rub_3bt_tag" model="account.report.expression">
                                         <field name="label">balance</field>
@@ -154,7 +141,6 @@
                     <record id="tax_report_rub_3c" model="account.report.line">
                         <field name="name">3c. Installation/remote sales within the EU (turnover)</field>
                         <field name="code">3C_OMZET</field>
-                        <field name="sequence">230</field>
                         <field name="expression_ids">
                             <record id="tax_report_rub_3c_tag" model="account.report.expression">
                                 <field name="label">balance</field>
@@ -167,14 +153,12 @@
             </record>
             <record id="tax_report_rub_4" model="account.report.line">
                 <field name="name">Section 4: Services provided to you from abroad (turnover)</field>
-                <field name="sequence">300</field>
                 <field name="aggregation_formula">4A_OMZET.balance + 4B_OMZET.balance</field>
                 <field name="hierarchy_level">0</field>
                 <field name="children_ids">
                     <record id="tax_report_rub_4a" model="account.report.line">
                         <field name="name">4a. Supplies/services from countries outside the EU (imports) (turnover)</field>
                         <field name="code">4A_OMZET</field>
-                        <field name="sequence">310</field>
                         <field name="expression_ids">
                             <record id="tax_report_rub_4a_tag" model="account.report.expression">
                                 <field name="label">balance</field>
@@ -186,7 +170,6 @@
                     <record id="tax_report_rub_4b" model="account.report.line">
                         <field name="name">4b. Supplies/services from countries within the EU (turnover)</field>
                         <field name="code">4B_OMZET</field>
-                        <field name="sequence">320</field>
                         <field name="expression_ids">
                             <record id="tax_report_rub_4b_tag" model="account.report.expression">
                                 <field name="label">balance</field>
@@ -200,14 +183,12 @@
             <record id="tax_report_rub_btw_1" model="account.report.line">
                 <field name="name">Section 1: Domestic services (VAT)</field>
                 <field name="code">NLTAX_B1</field>
-                <field name="sequence">400</field>
                 <field name="aggregation_formula">1A_BTW.balance + 1B_BTW.balance + 1C_BTW.balance + 1D_BTW.balance + 1E_BTW.balance</field>
                 <field name="hierarchy_level">0</field>
                 <field name="children_ids">
                     <record id="tax_report_rub_btw_1a" model="account.report.line">
                         <field name="name">1a. Supplies/services taxed at 21% (VAT)</field>
                         <field name="code">1A_BTW</field>
-                        <field name="sequence">410</field>
                         <field name="expression_ids">
                             <record id="tax_report_rub_btw_1a_tag" model="account.report.expression">
                                 <field name="label">balance</field>
@@ -219,7 +200,6 @@
                     <record id="tax_report_rub_btw_1b" model="account.report.line">
                         <field name="name">1b. Supplies/services taxed at low rate (VAT)</field>
                         <field name="code">1B_BTW</field>
-                        <field name="sequence">420</field>
                         <field name="expression_ids">
                             <record id="tax_report_rub_btw_1b_tag" model="account.report.expression">
                                 <field name="label">balance</field>
@@ -231,7 +211,6 @@
                     <record id="tax_report_rub_btw_1c" model="account.report.line">
                         <field name="name">1c. Supplies/services taxed at other rates except 0% (VAT)</field>
                         <field name="code">1C_BTW</field>
-                        <field name="sequence">430</field>
                         <field name="expression_ids">
                             <record id="tax_report_rub_btw_1c_tag" model="account.report.expression">
                                 <field name="label">balance</field>
@@ -243,7 +222,6 @@
                     <record id="tax_report_rub_btw_1d" model="account.report.line">
                         <field name="name">1d. Private use (VAT)</field>
                         <field name="code">1D_BTW</field>
-                        <field name="sequence">440</field>
                         <field name="expression_ids">
                             <record id="tax_report_rub_btw_1d_tag" model="account.report.expression">
                                 <field name="label">balance</field>
@@ -255,7 +233,6 @@
                     <record id="tax_report_rub_btw_1e" model="account.report.line">
                         <field name="name">1e. Supplies/services taxed at 0% or not taxed with you (VAT)</field>
                         <field name="code">1E_BTW</field>
-                        <field name="sequence">450</field>
                         <field name="expression_ids">
                             <record id="tax_report_rub_btw_1e_tag" model="account.report.expression">
                                 <field name="label">balance</field>
@@ -268,14 +245,12 @@
             </record>
             <record id="tax_report_rub_btw_2" model="account.report.line">
                 <field name="name">Section 2: Domestic reverse charge (VAT) schemes</field>
-                <field name="sequence">500</field>
                 <field name="aggregation_formula">NLTAX_B2.balance</field>
                 <field name="hierarchy_level">0</field>
                 <field name="children_ids">
                     <record id="tax_report_rub_btw_2a" model="account.report.line">
                         <field name="name">2a. Supplies/services where the levy of Sales Tax has been transferred to you (VAT)</field>
                         <field name="code">NLTAX_B2</field>
-                        <field name="sequence">510</field>
                         <field name="expression_ids">
                             <record id="tax_report_rub_btw_2a_tag" model="account.report.expression">
                                 <field name="label">balance</field>
@@ -288,14 +263,12 @@
             </record>
             <record id="tax_report_rub_btw_4" model="account.report.line">
                 <field name="name">Section 4: Services provided to you from abroad (VAT)</field>
-                <field name="sequence">600</field>
                 <field name="aggregation_formula">NLTAX_B4a.balance + NLTAX_B4b.balance</field>
                 <field name="hierarchy_level">0</field>
                 <field name="children_ids">
                     <record id="tax_report_rub_btw_4a" model="account.report.line">
                         <field name="name">4a. Supplies/services from countries outside the EU (VAT)</field>
                         <field name="code">NLTAX_B4a</field>
-                        <field name="sequence">610</field>
                         <field name="expression_ids">
                             <record id="tax_report_rub_btw_4a_tag" model="account.report.expression">
                                 <field name="label">balance</field>
@@ -307,7 +280,6 @@
                     <record id="tax_report_rub_btw_4b" model="account.report.line">
                         <field name="name">4b. Supplies/services from countries within the EU (VAT)</field>
                         <field name="code">NLTAX_B4b</field>
-                        <field name="sequence">620</field>
                         <field name="expression_ids">
                             <record id="tax_report_rub_btw_4b_tag" model="account.report.expression">
                                 <field name="label">balance</field>
@@ -320,19 +292,16 @@
             </record>
             <record id="tax_report_rub_btw_5" model="account.report.line">
                 <field name="name">Section 5: Input tax, small business scheme and total (VAT)</field>
-                <field name="sequence">700</field>
                 <field name="aggregation_formula">NLTAX_B5b.balance + NLTAX_B5d.balance + NLTAX_B5e.balance + NLTAX_B5f.balance</field>
                 <field name="hierarchy_level">0</field>
                 <field name="children_ids">
                     <record id="tax_report_rub_btw_5a" model="account.report.line">
                         <field name="name">5a. Sales tax payable (headings 1a to 4b) (VAT)</field>
-                        <field name="sequence">710</field>
                         <field name="aggregation_formula">NLTAX_B1.balance + NLTAX_B2.balance + NLTAX_B4a.balance + NLTAX_B4b.balance</field>
                     </record>
                     <record id="tax_report_rub_btw_5b" model="account.report.line">
                         <field name="name">5b. Input tax (VAT)</field>
                         <field name="code">NLTAX_B5b</field>
-                        <field name="sequence">720</field>
                         <field name="expression_ids">
                             <record id="tax_report_rub_btw_5b_tag" model="account.report.expression">
                                 <field name="label">balance</field>
@@ -343,13 +312,11 @@
                     </record>
                     <record id="tax_report_rub_btw_5c" model="account.report.line">
                         <field name="name">5c. Subtotal (heading 5a minus 5b) (VAT)</field>
-                        <field name="sequence">730</field>
                         <field name="aggregation_formula">NLTAX_B1.balance + NLTAX_B2.balance + NLTAX_B4a.balance + NLTAX_B4b.balance - NLTAX_B5b.balance</field>
                     </record>
                     <record id="tax_report_rub_btw_5d" model="account.report.line">
                         <field name="name">5d. Reduction according to the small business scheme (VAT)</field>
                         <field name="code">NLTAX_B5d</field>
-                        <field name="sequence">740</field>
                         <field name="expression_ids">
                             <record id="tax_report_rub_btw_5d_tag" model="account.report.expression">
                                 <field name="label">balance</field>
@@ -361,7 +328,6 @@
                     <record id="tax_report_rub_btw_5e" model="account.report.line">
                         <field name="name">5e. Estimate previous return(s) (VAT)</field>
                         <field name="code">NLTAX_B5e</field>
-                        <field name="sequence">750</field>
                         <field name="expression_ids">
                             <record id="tax_report_rub_btw_5e_tag" model="account.report.expression">
                                 <field name="label">balance</field>
@@ -373,7 +339,6 @@
                     <record id="tax_report_rub_btw_5f" model="account.report.line">
                         <field name="name">5f. Estimate this return (VAT)</field>
                         <field name="code">NLTAX_B5f</field>
-                        <field name="sequence">760</field>
                         <field name="expression_ids">
                             <record id="tax_report_rub_btw_5f_tag" model="account.report.expression">
                                 <field name="label">balance</field>
@@ -385,7 +350,6 @@
                     <record id="tax_report_rub_btw_5g" model="account.report.line">
                         <field name="name">5g. Total payable/reclaimable (VAT)</field>
                         <field name="code">NLTAX_B5g</field>
-                        <field name="sequence">770</field>
                         <field name="aggregation_formula">NLTAX_B1.balance + NLTAX_B2.balance + NLTAX_B4a.balance + NLTAX_B4b.balance - NLTAX_B5b.balance - NLTAX_B5d.balance - NLTAX_B5e.balance - NLTAX_B5f.balance</field>
                     </record>
                 </field>

--- a/addons/l10n_no/data/account_tax_report_data.xml
+++ b/addons/l10n_no/data/account_tax_report_data.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<odoo>
+<odoo auto_sequence="1">
     <record id="tax_report" model="account.report">
         <field name="name">Tax Report</field>
         <field name="root_report_id" ref="account.generic_tax_report"/>
@@ -11,19 +11,16 @@
             <record id="tax_report_balance" model="account.report.column">
                 <field name="name">Balance</field>
                 <field name="expression_label">balance</field>
-                <field name="sequence" eval="1"/>
             </record>
         </field>
         <field name="line_ids">
             <record id="tax_report_line_sales_goods_services_homeland" model="account.report.line">
                 <field name="name">Sales of goods and services in Norway</field>
-                <field name="sequence" eval="1"/>
                 <field name="hierarchy_level">0</field>
                 <field name="children_ids">
                     <record id="tax_report_line_code_3" model="account.report.line">
                         <field name="name">3 Sales and withdrawals of goods and services (high rate 25%) - base</field>
                         <field name="code">BASE_3</field>
-                        <field name="sequence" eval="2"/>
                         <field name="expression_ids">
                             <record id="tax_report_line_code_3_tag" model="account.report.expression">
                                 <field name="label">balance</field>
@@ -35,7 +32,6 @@
                     <record id="tax_report_line_code_3_tax" model="account.report.line">
                         <field name="name">3 Sales and withdrawals of goods and services (high rate 25%) - tax</field>
                         <field name="code">TAX_3</field>
-                        <field name="sequence" eval="3"/>
                         <field name="expression_ids">
                             <record id="tax_report_line_code_3_tax_tag" model="account.report.expression">
                                 <field name="label">balance</field>
@@ -47,7 +43,6 @@
                     <record id="tax_report_line_code_31" model="account.report.line">
                         <field name="name">31 Sales and withdrawals of goods and services (medium rate 15%) - base</field>
                         <field name="code">BASE_31</field>
-                        <field name="sequence" eval="4"/>
                         <field name="expression_ids">
                             <record id="tax_report_line_code_31_tag" model="account.report.expression">
                                 <field name="label">balance</field>
@@ -59,7 +54,6 @@
                     <record id="tax_report_line_code_31_tax" model="account.report.line">
                         <field name="name">31 Sales and withdrawals of goods and services (medium rate 15%) - tax</field>
                         <field name="code">TAX_31</field>
-                        <field name="sequence" eval="5"/>
                         <field name="expression_ids">
                             <record id="tax_report_line_code_31_tax_tag" model="account.report.expression">
                                 <field name="label">balance</field>
@@ -71,7 +65,6 @@
                     <record id="tax_report_line_code_33" model="account.report.line">
                         <field name="name">33 Sales and withdrawals of goods and services (low rate 12%) - base</field>
                         <field name="code">BASE_33</field>
-                        <field name="sequence" eval="6"/>
                         <field name="expression_ids">
                             <record id="tax_report_line_code_33_tag" model="account.report.expression">
                                 <field name="label">balance</field>
@@ -83,7 +76,6 @@
                     <record id="tax_report_line_code_33_tax" model="account.report.line">
                         <field name="name">33 Sales and withdrawals of goods and services (low rate 12%) - tax</field>
                         <field name="code">TAX_33</field>
-                        <field name="sequence" eval="7"/>
                         <field name="expression_ids">
                             <record id="tax_report_line_code_33_tax_tag" model="account.report.expression">
                                 <field name="label">balance</field>
@@ -95,7 +87,6 @@
                     <record id="tax_report_line_code_5" model="account.report.line">
                         <field name="name">5 Sales and purchases of goods and services exempt from VAT (0%)</field>
                         <field name="code">BASE_5</field>
-                        <field name="sequence" eval="8"/>
                         <field name="expression_ids">
                             <record id="tax_report_line_code_5_tag" model="account.report.expression">
                                 <field name="label">balance</field>
@@ -107,7 +98,6 @@
                     <record id="tax_report_line_code_6" model="account.report.line">
                         <field name="name">6 Sales of goods and services exempt from the VAT Act (0%)</field>
                         <field name="code">BASE_6</field>
-                        <field name="sequence" eval="9"/>
                         <field name="expression_ids">
                             <record id="tax_report_line_code_6_tag" model="account.report.expression">
                                 <field name="label">balance</field>
@@ -120,13 +110,11 @@
             </record>
             <record id="tax_report_line_sales_goods_services_abroad" model="account.report.line">
                 <field name="name">Sales of goods and services abroad</field>
-                <field name="sequence" eval="10"/>
                 <field name="hierarchy_level">0</field>
                 <field name="children_ids">
                     <record id="tax_report_line_code_52" model="account.report.line">
                         <field name="name">52 Sales of goods and services abroad exempt from VAT (0%)</field>
                         <field name="code">BASE_52</field>
-                        <field name="sequence" eval="11"/>
                         <field name="expression_ids">
                             <record id="tax_report_line_code_52_tag" model="account.report.expression">
                                 <field name="label">balance</field>
@@ -139,13 +127,11 @@
             </record>
             <record id="tax_report_line_purchases_goods_services_homeland" model="account.report.line">
                 <field name="name">Purchases of goods and services in Norway</field>
-                <field name="sequence" eval="12"/>
                 <field name="hierarchy_level">0</field>
                 <field name="children_ids">
                     <record id="tax_report_line_code_1" model="account.report.line">
                         <field name="name">1 Purchases of goods and services with right of deduction (high rate 25%)</field>
                         <field name="code">TAX_1</field>
-                        <field name="sequence" eval="13"/>
                         <field name="expression_ids">
                             <record id="tax_report_line_code_1_tag" model="account.report.expression">
                                 <field name="label">balance</field>
@@ -157,7 +143,6 @@
                     <record id="tax_report_line_code_11" model="account.report.line">
                         <field name="name">11 Purchases of goods and services with right of deduction (medium rate 15%)</field>
                         <field name="code">TAX_11</field>
-                        <field name="sequence" eval="14"/>
                         <field name="expression_ids">
                             <record id="tax_report_line_code_11_tag" model="account.report.expression">
                                 <field name="label">balance</field>
@@ -169,7 +154,6 @@
                     <record id="tax_report_line_code_13" model="account.report.line">
                         <field name="name">13 Purchases of goods and services with right of deduction (low rate 12%)</field>
                         <field name="code">TAX_13</field>
-                        <field name="sequence" eval="15"/>
                         <field name="expression_ids">
                             <record id="tax_report_line_code_13_tag" model="account.report.expression">
                                 <field name="label">balance</field>
@@ -182,13 +166,11 @@
             </record>
             <record id="tax_report_line_purchases_goods_abroad" model="account.report.line">
                 <field name="name">Purchases of goods from abroad (imports)</field>
-                <field name="sequence" eval="16"/>
                 <field name="hierarchy_level">0</field>
                 <field name="children_ids">
                     <record id="tax_report_line_code_14" model="account.report.line">
                         <field name="name">14 Deduction on purchases of goods from abroad (VAT paid on importation, high rate 25%)</field>
                         <field name="code">TAX_14</field>
-                        <field name="sequence" eval="17"/>
                         <field name="expression_ids">
                             <record id="tax_report_line_code_14_tag" model="account.report.expression">
                                 <field name="label">balance</field>
@@ -200,7 +182,6 @@
                     <record id="tax_report_line_code_15" model="account.report.line">
                         <field name="name">15 Deduction on purchases of goods from abroad (VAT paid on importation, medium rate 15%)</field>
                         <field name="code">TAX_15</field>
-                        <field name="sequence" eval="18"/>
                         <field name="expression_ids">
                             <record id="tax_report_line_code_15_tag" model="account.report.expression">
                                 <field name="label">balance</field>
@@ -212,7 +193,6 @@
                     <record id="tax_report_line_code_81" model="account.report.line">
                         <field name="name">81 Purchase of goods from abroad with right of deduction (high rate 25%) - base</field>
                         <field name="code">BASE_81</field>
-                        <field name="sequence" eval="19"/>
                         <field name="expression_ids">
                             <record id="tax_report_line_code_81_tag" model="account.report.expression">
                                 <field name="label">balance</field>
@@ -224,7 +204,6 @@
                     <record id="tax_report_line_code_81_tax" model="account.report.line">
                         <field name="name">81 Purchase of goods from abroad with right of deduction (high rate 25%) - tax</field>
                         <field name="code">TAX_81</field>
-                        <field name="sequence" eval="20"/>
                         <field name="expression_ids">
                             <record id="tax_report_line_code_81_tax_tag" model="account.report.expression">
                                 <field name="label">balance</field>
@@ -236,7 +215,6 @@
                     <record id="tax_report_line_code_82" model="account.report.line">
                         <field name="name">82 Purchase of goods from abroad without right of deduction (high rate 25%) - base</field>
                         <field name="code">BASE_82</field>
-                        <field name="sequence" eval="21"/>
                         <field name="expression_ids">
                             <record id="tax_report_line_code_82_tag" model="account.report.expression">
                                 <field name="label">balance</field>
@@ -248,7 +226,6 @@
                     <record id="tax_report_line_code_82_tax" model="account.report.line">
                         <field name="name">82 Purchase of goods from abroad without right of deduction (high rate 25%) - tax</field>
                         <field name="code">TAX_82</field>
-                        <field name="sequence" eval="22"/>
                         <field name="expression_ids">
                             <record id="tax_report_line_code_82_tax_tag" model="account.report.expression">
                                 <field name="label">balance</field>
@@ -260,7 +237,6 @@
                     <record id="tax_report_line_code_83" model="account.report.line">
                         <field name="name">83 Purchase of goods from abroad with right of deduction (medium rate 15%) - base</field>
                         <field name="code">BASE_83</field>
-                        <field name="sequence" eval="23"/>
                         <field name="expression_ids">
                             <record id="tax_report_line_code_83_tag" model="account.report.expression">
                                 <field name="label">balance</field>
@@ -272,7 +248,6 @@
                     <record id="tax_report_line_code_83_tax" model="account.report.line">
                         <field name="name">83 Purchase of goods from abroad with right of deduction (medium rate 15%) - tax</field>
                         <field name="code">TAX_83</field>
-                        <field name="sequence" eval="24"/>
                         <field name="expression_ids">
                             <record id="tax_report_line_code_83_tax_tag" model="account.report.expression">
                                 <field name="label">balance</field>
@@ -284,7 +259,6 @@
                     <record id="tax_report_line_code_84" model="account.report.line">
                         <field name="name">84 Purchases of goods from abroad that are not deductible (medium rate 15%) - base</field>
                         <field name="code">BASE_84</field>
-                        <field name="sequence" eval="25"/>
                         <field name="expression_ids">
                             <record id="tax_report_line_code_84_tag" model="account.report.expression">
                                 <field name="label">balance</field>
@@ -296,7 +270,6 @@
                     <record id="tax_report_line_code_84_tax" model="account.report.line">
                         <field name="name">84 Purchases of goods from abroad that are not deductible (medium rate 15%) - tax</field>
                         <field name="code">TAX_84</field>
-                        <field name="sequence" eval="26"/>
                         <field name="expression_ids">
                             <record id="tax_report_line_code_84_tax_tag" model="account.report.expression">
                                 <field name="label">balance</field>
@@ -308,7 +281,6 @@
                     <record id="tax_report_line_code_85" model="account.report.line">
                         <field name="name">85 Purchases of goods from abroad on which VAT is not charged (zero rate 0%)</field>
                         <field name="code">BASE_85</field>
-                        <field name="sequence" eval="27"/>
                         <field name="expression_ids">
                             <record id="tax_report_line_code_85_tag" model="account.report.expression">
                                 <field name="label">balance</field>
@@ -321,13 +293,11 @@
             </record>
             <record id="tax_report_line_purchases_services_abroad" model="account.report.line">
                 <field name="name">Purchases of services from abroad (imports)</field>
-                <field name="sequence" eval="28"/>
                 <field name="hierarchy_level">0</field>
                 <field name="children_ids">
                     <record id="tax_report_line_code_86" model="account.report.line">
                         <field name="name">86 Purchase of services from abroad with right of deduction (high rate 25%) - base</field>
                         <field name="code">BASE_86</field>
-                        <field name="sequence" eval="29"/>
                         <field name="expression_ids">
                             <record id="tax_report_line_code_86_tag" model="account.report.expression">
                                 <field name="label">balance</field>
@@ -339,7 +309,6 @@
                     <record id="tax_report_line_code_86_tax" model="account.report.line">
                         <field name="name">86 Purchase of services from abroad with right of deduction (high rate 25%) - tax</field>
                         <field name="code">TAX_86</field>
-                        <field name="sequence" eval="30"/>
                         <field name="expression_ids">
                             <record id="tax_report_line_code_86_tax_tag" model="account.report.expression">
                                 <field name="label">balance</field>
@@ -351,7 +320,6 @@
                     <record id="tax_report_line_code_87" model="account.report.line">
                         <field name="name">87 Purchase of services from abroad without deductibility (high rate 25%) - base</field>
                         <field name="code">BASE_87</field>
-                        <field name="sequence" eval="31"/>
                         <field name="expression_ids">
                             <record id="tax_report_line_code_87_tag" model="account.report.expression">
                                 <field name="label">balance</field>
@@ -363,7 +331,6 @@
                     <record id="tax_report_line_code_87_tax" model="account.report.line">
                         <field name="name">87 Purchase of services from abroad without deductibility (high rate 25%) - tax</field>
                         <field name="code">TAX_87</field>
-                        <field name="sequence" eval="32"/>
                         <field name="expression_ids">
                             <record id="tax_report_line_code_87_tax_tag" model="account.report.expression">
                                 <field name="label">balance</field>
@@ -375,7 +342,6 @@
                     <record id="tax_report_line_code_88" model="account.report.line">
                         <field name="name">88 Purchase of services from abroad with right of deduction (low rate 12%) - base</field>
                         <field name="code">BASE_88</field>
-                        <field name="sequence" eval="33"/>
                         <field name="expression_ids">
                             <record id="tax_report_line_code_88_tag" model="account.report.expression">
                                 <field name="label">balance</field>
@@ -387,7 +353,6 @@
                     <record id="tax_report_line_code_88_tax" model="account.report.line">
                         <field name="name">88 Purchase of services from abroad with right of deduction (low rate 12%) - tax</field>
                         <field name="code">TAX_88</field>
-                        <field name="sequence" eval="34"/>
                         <field name="expression_ids">
                             <record id="tax_report_line_code_88_tax_tag" model="account.report.expression">
                                 <field name="label">balance</field>
@@ -399,7 +364,6 @@
                     <record id="tax_report_line_code_89" model="account.report.line">
                         <field name="name">89 Purchase of services from abroad without deductibility (low rate 12%) - base</field>
                         <field name="code">BASE_89</field>
-                        <field name="sequence" eval="35"/>
                         <field name="expression_ids">
                             <record id="tax_report_line_code_89_tag" model="account.report.expression">
                                 <field name="label">balance</field>
@@ -411,7 +375,6 @@
                     <record id="tax_report_line_code_89_tax" model="account.report.line">
                         <field name="name">89 Purchase of services from abroad without deductibility (low rate 12%) - tax</field>
                         <field name="code">TAX_89</field>
-                        <field name="sequence" eval="36"/>
                         <field name="expression_ids">
                             <record id="tax_report_line_code_89_tax_tag" model="account.report.expression">
                                 <field name="label">balance</field>
@@ -424,13 +387,11 @@
             </record>
             <record id="tax_report_line_fish_etc" model="account.report.line">
                 <field name="name">Fish, etc.</field>
-                <field name="sequence" eval="37"/>
                 <field name="hierarchy_level">0</field>
                 <field name="children_ids">
                     <record id="tax_report_line_code_12" model="account.report.line">
                         <field name="name">12 Purchase of fish and other marine wildlife resources (11.11%)</field>
                         <field name="code">TAX_12</field>
-                        <field name="sequence" eval="38"/>
                         <field name="expression_ids">
                             <record id="tax_report_line_code_12_tag" model="account.report.expression">
                                 <field name="label">balance</field>
@@ -442,7 +403,6 @@
                     <record id="tax_report_line_code_32" model="account.report.line">
                         <field name="name">32 Sale of fish and other marine wildlife resources (11.11%) - base</field>
                         <field name="code">BASE_32</field>
-                        <field name="sequence" eval="39"/>
                         <field name="expression_ids">
                             <record id="tax_report_line_code_32_tag" model="account.report.expression">
                                 <field name="label">balance</field>
@@ -454,7 +414,6 @@
                     <record id="tax_report_line_code_32_tax" model="account.report.line">
                         <field name="name">32 Sale of fish and other marine wildlife resources (11.11%) - tax</field>
                         <field name="code">TAX_32</field>
-                        <field name="sequence" eval="40"/>
                         <field name="expression_ids">
                             <record id="tax_report_line_code_32_tax_tag" model="account.report.expression">
                                 <field name="label">balance</field>
@@ -467,13 +426,11 @@
             </record>
             <record id="tax_report_line_emission_and_gold" model="account.report.line">
                 <field name="name">Carbon credits and gold</field>
-                <field name="sequence" eval="41"/>
                 <field name="hierarchy_level">0</field>
                 <field name="children_ids">
                     <record id="tax_report_line_code_51" model="account.report.line">
                         <field name="name">51 Sale of carbon credits and gold to traders (0%)</field>
                         <field name="code">BASE_51</field>
-                        <field name="sequence" eval="42"/>
                         <field name="expression_ids">
                             <record id="tax_report_line_code_51_tag" model="account.report.expression">
                                 <field name="label">balance</field>
@@ -485,7 +442,6 @@
                     <record id="tax_report_line_code_91" model="account.report.line">
                         <field name="name">91 Purchase of carbon credits and gold with deductibility (high rate 25%) - base</field>
                         <field name="code">BASE_91</field>
-                        <field name="sequence" eval="43"/>
                         <field name="expression_ids">
                             <record id="tax_report_line_code_91_tag" model="account.report.expression">
                                 <field name="label">balance</field>
@@ -497,7 +453,6 @@
                     <record id="tax_report_line_code_91_tax" model="account.report.line">
                         <field name="name">91 Purchase of carbon credits and gold with deductibility (high rate 25%) - tax</field>
                         <field name="code">TAX_91</field>
-                        <field name="sequence" eval="44"/>
                         <field name="expression_ids">
                             <record id="tax_report_line_code_91_tax_tag" model="account.report.expression">
                                 <field name="label">balance</field>
@@ -509,7 +464,6 @@
                     <record id="tax_report_line_code_92" model="account.report.line">
                         <field name="name">92 Purchase of carbon credits and gold without deductibility (high rate 25%) - base</field>
                         <field name="code">BASE_92</field>
-                        <field name="sequence" eval="45"/>
                         <field name="expression_ids">
                             <record id="tax_report_line_code_92_tag" model="account.report.expression">
                                 <field name="label">balance</field>
@@ -521,7 +475,6 @@
                     <record id="tax_report_line_code_92_tax" model="account.report.line">
                         <field name="name">92 Purchase of carbon credits and gold without deductibility (high rate 25%) - tax</field>
                         <field name="code">TAX_92</field>
-                        <field name="sequence" eval="46"/>
                         <field name="expression_ids">
                             <record id="tax_report_line_code_92_tax_tag" model="account.report.expression">
                                 <field name="label">balance</field>
@@ -534,13 +487,11 @@
             </record>
             <record id="tax_report_line_sum" model="account.report.line">
                 <field name="name">Sum</field>
-                <field name="sequence" eval="47"/>
                 <field name="hierarchy_level">0</field>
                 <field name="children_ids">
                     <record id="tax_report_line_to_be_paid" model="account.report.line">
                         <field name="name">Tax to pay</field>
                         <field name="code">SUM</field>
-                        <field name="sequence" eval="48"/>
                         <field name="expression_ids">
                             <record id="tax_report_line_to_be_paid_formula" model="account.report.expression">
                                 <field name="label">balance</field>

--- a/addons/l10n_nz/data/account_tax_report_data.xml
+++ b/addons/l10n_nz/data/account_tax_report_data.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<odoo>
+<odoo auto_sequence="1">
     <record id="tax_report" model="account.report">
         <field name="name">Tax Report</field>
         <field name="root_report_id" ref="account.generic_tax_report"/>

--- a/addons/l10n_pl/__manifest__.py
+++ b/addons/l10n_pl/__manifest__.py
@@ -25,6 +25,7 @@ Wewnętrzny numer wersji OpenGLOBE 1.02
     ],
     'data': [
         'data/res.country.state.csv',
+        'data/account.account.tag.csv',
         'data/account_tax_report_data.xml',
     ],
     'demo': [

--- a/addons/l10n_pl/data/account.account.tag.csv
+++ b/addons/l10n_pl/data/account.account.tag.csv
@@ -1,0 +1,2 @@
+"id","name","applicability","country_id/id"
+"gold_tag","Gold","taxes","base.pl"

--- a/addons/l10n_pl/data/account_tax_report_data.xml
+++ b/addons/l10n_pl/data/account_tax_report_data.xml
@@ -1,12 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<odoo>
-    <record id="gold_tag" model="account.account.tag">
-        <field name="name">Gold</field>
-        <field name="applicability">taxes</field>
-        <field name="country_id" ref="base.pl"/>
-    </record>
-
-
+<odoo auto_sequence="1">
     <record id="tax_report" model="account.report">
         <field name="name">Tax Report</field>
         <field name="root_report_id" ref="account.generic_tax_report"/>
@@ -23,13 +16,11 @@
             <record id="account_tax_report_line_razem_c" model="account.report.line">
                 <field name="name">Base - Total C</field>
                 <field name="aggregation_formula">PLTAXC_01_10.balance + PLTAXC_02_11.balance + PLTAXC_03_13.balance + PLTAXC_04_15.balance + PLTAXC_05_17.balance + PLTAXC_06_19.balance + PLTAXC_07_21.balance + PLTAXC_08_22.balance + PLTAXC_09_23.balance + PLTAXC_10_25.balance + PLTAXC_11_27.balance + PLTAXC_12_31.balance</field>
-                <field name="sequence">10</field>
                 <field name="hierarchy_level">0</field>
                 <field name="children_ids">
                     <record id="account_tax_report_line_kraj_zwolnione" model="account.report.line">
                         <field name="name">Base - Supply of goods/services, domestic, exempt</field>
                         <field name="code">PLTAXC_01_10</field>
-                        <field name="sequence">20</field>
                         <field name="expression_ids">
                             <record id="account_tax_report_line_kraj_zwolnione_tag" model="account.report.expression">
                                 <field name="label">balance</field>
@@ -41,7 +32,6 @@
                     <record id="account_tax_report_line_poza_kraj" model="account.report.line">
                         <field name="name">Base - Supply of goods/services, out of the country</field>
                         <field name="code">PLTAXC_02_11</field>
-                        <field name="sequence">30</field>
                         <field name="expression_ids">
                             <record id="account_tax_report_line_poza_kraj_tag" model="account.report.expression">
                                 <field name="label">balance</field>
@@ -53,7 +43,6 @@
                             <record id="account_tax_report_line_uslugi_art_100_1_4" model="account.report.line">
                                 <field name="name">Base - Services included in art. 100.1.4</field>
                                 <field name="code">PLTAXC_02a_12</field>
-                                <field name="sequence">40</field>
                                 <field name="expression_ids">
                                     <record id="account_tax_report_line_uslugi_art_100_1_4_tag" model="account.report.expression">
                                         <field name="label">balance</field>
@@ -65,7 +54,6 @@
                             <record id="account_tax_report_line_triangular_buyer_2nd_payer" model="account.report.line">
                                 <field name="name">Triangular transaction 2. VAT payer</field>
                                 <field name="code">PLTAXC_02a_12_Triangular</field>
-                                <field name="sequence">45</field>
                                 <field name="expression_ids">
                                     <record id="account_tax_report_line_triangular_buyer_2nd_payer_tag" model="account.report.expression">
                                         <field name="label">balance</field>
@@ -79,7 +67,6 @@
                     <record id="account_tax_report_line_uslugi_kraj_0" model="account.report.line">
                         <field name="name">Base - Supply of goods/services, domestic, 0%</field>
                         <field name="code">PLTAXC_03_13</field>
-                        <field name="sequence">50</field>
                         <field name="expression_ids">
                             <record id="account_tax_report_line_uslugi_kraj_0_tag" model="account.report.expression">
                                 <field name="label">tag</field>
@@ -96,7 +83,6 @@
                             <record id="account_tax_report_line_towary_art_129" model="account.report.line">
                                 <field name="name">Base - Goods under art. 129</field>
                                 <field name="code">PLTAXC_03_14</field>
-                                <field name="sequence">60</field>
                                 <field name="expression_ids">
                                     <record id="account_tax_report_line_towary_art_129_tag" model="account.report.expression">
                                         <field name="label">balance</field>
@@ -110,7 +96,6 @@
                     <record id="account_tax_report_line_kraj_3_lub_5" model="account.report.line">
                         <field name="name">Base - Supply of goods/services, domestic, 3% or 5%</field>
                         <field name="code">PLTAXC_04_15</field>
-                        <field name="sequence">70</field>
                         <field name="expression_ids">
                             <record id="account_tax_report_line_kraj_3_lub_5_tag" model="account.report.expression">
                                 <field name="label">balance</field>
@@ -122,7 +107,6 @@
                     <record id="account_tax_report_line_kraj_7_lub_8" model="account.report.line">
                         <field name="name">Base - Supply of goods/services, domestic, 7% or 8%</field>
                         <field name="code">PLTAXC_05_17</field>
-                        <field name="sequence">80</field>
                         <field name="expression_ids">
                             <record id="account_tax_report_line_kraj_7_lub_8_tag" model="account.report.expression">
                                 <field name="label">balance</field>
@@ -134,7 +118,6 @@
                     <record id="account_tax_report_line_kraj_22_lub_23" model="account.report.line">
                         <field name="name">Base - Supply of goods/services, domestic, 22% or 23%</field>
                         <field name="code">PLTAXC_06_19</field>
-                        <field name="sequence">90</field>
                         <field name="expression_ids">
                             <record id="account_tax_report_line_kraj_22_lub_23_tag" model="account.report.expression">
                                 <field name="label">balance</field>
@@ -146,7 +129,6 @@
                     <record id="account_tax_report_line_dostawa_towarow" model="account.report.line">
                         <field name="name">Base - Intra-Community supply of goods</field>
                         <field name="code">PLTAXC_07_21</field>
-                        <field name="sequence">100</field>
                         <field name="expression_ids">
                             <record id="account_tax_report_line_dostawa_towarow_tag" model="account.report.expression">
                                 <field name="label">balance</field>
@@ -158,7 +140,6 @@
                             <record id="account_tax_report_line_intracom_procedure_i_42" model="account.report.line">
                                 <field name="name">- under customs procedure 42</field>
                                 <field name="code">PLTAXC_07_21_I42</field>
-                                <field name="sequence">104</field>
                                 <field name="expression_ids">
                                     <record id="account_tax_report_line_intracom_procedure_i_42_tag" model="account.report.expression">
                                         <field name="label">balance</field>
@@ -170,7 +151,6 @@
                             <record id="account_tax_report_line_intracom_procedure_i_63" model="account.report.line">
                                 <field name="name">- under customs procedure 63</field>
                                 <field name="code">PLTAXC_07_21_I63</field>
-                                <field name="sequence">106</field>
                                 <field name="expression_ids">
                                     <record id="account_tax_report_line_intracom_procedure_i_63_tag" model="account.report.expression">
                                         <field name="label">balance</field>
@@ -184,7 +164,6 @@
                     <record id="account_tax_report_line_eksport_towarow" model="account.report.line">
                         <field name="name">Base - Export of goods</field>
                         <field name="code">PLTAXC_08_22</field>
-                        <field name="sequence">110</field>
                         <field name="expression_ids">
                             <record id="account_tax_report_line_eksport_towarow_tag" model="account.report.expression">
                                 <field name="label">balance</field>
@@ -196,7 +175,6 @@
                     <record id="account_tax_report_line_nabycie_towarow" model="account.report.line">
                         <field name="name">Base - Intra-Community acquisition of goods</field>
                         <field name="code">PLTAXC_09_23</field>
-                        <field name="sequence">120</field>
                         <field name="expression_ids">
                             <record id="account_tax_report_line_nabycie_towarow_tag" model="account.report.expression">
                                 <field name="label">balance</field>
@@ -208,7 +186,6 @@
                             <record id="account_tax_report_line_triangular_2nd_payer" model="account.report.line">
                                 <field name="name">Triangular transaction 2. VAT payer</field>
                                 <field name="code">PLTAXC_09_23_Triangular</field>
-                                <field name="sequence">160</field>
                                 <field name="expression_ids">
                                     <record id="account_tax_report_line_triangular_2nd_payer_tag" model="account.report.expression">
                                         <field name="label">balance</field>
@@ -222,7 +199,6 @@
                     <record id="account_tax_report_line_art_33a" model="account.report.line">
                         <field name="name">Base - Import of goods under art. 33a</field>
                         <field name="code">PLTAXC_10_25</field>
-                        <field name="sequence">130</field>
                         <field name="expression_ids">
                             <record id="account_tax_report_line_art_33a_tag" model="account.report.expression">
                                 <field name="label">balance</field>
@@ -234,7 +210,6 @@
                     <record id="account_tax_report_line_import_uslug" model="account.report.line">
                         <field name="name">Base - Importation of services</field>
                         <field name="code">PLTAXC_11_27</field>
-                        <field name="sequence">140</field>
                         <field name="expression_ids">
                             <record id="account_tax_report_line_import_uslug_tag" model="account.report.expression">
                                 <field name="label">balance</field>
@@ -246,7 +221,6 @@
                             <record id="account_tax_report_line_art_28b" model="account.report.line">
                                 <field name="name">Base - Acquisition under art. 28b</field>
                                 <field name="code">PLTAXC_11a_29</field>
-                                <field name="sequence">150</field>
                                 <field name="expression_ids">
                                     <record id="account_tax_report_line_art_28b_tag" model="account.report.expression">
                                         <field name="label">balance</field>
@@ -260,7 +234,6 @@
                     <record id="account_tax_report_line_podatnik_nabywca" model="account.report.line">
                         <field name="name">Base - Supply of goods, taxable person acquiring</field>
                         <field name="code">PLTAXC_12_31</field>
-                        <field name="sequence">160</field>
                         <field name="expression_ids">
                             <record id="account_tax_report_line_podatnik_nabywca_tag" model="account.report.expression">
                                 <field name="label">balance</field>
@@ -274,13 +247,11 @@
             <record id="account_tax_report_line_razem_d" model="account.report.line">
                 <field name="name">Base - Total D</field>
                 <field name="aggregation_formula">PLTAXD_02_40.balance + PLTAXD_02_42.balance</field>
-                <field name="sequence">170</field>
                 <field name="hierarchy_level">0</field>
                 <field name="children_ids">
                     <record id="account_tax_report_line_uslug_s_trwale" model="account.report.line">
                         <field name="name">Basis - Acquisition of goods and services, fixed assets</field>
                         <field name="code">PLTAXD_02_40</field>
-                        <field name="sequence">180</field>
                         <field name="expression_ids">
                             <record id="account_tax_report_line_uslug_s_trwale_tag" model="account.report.expression">
                                 <field name="label">balance</field>
@@ -292,7 +263,6 @@
                     <record id="account_tax_report_line_uslug_pozostalych" model="account.report.line">
                         <field name="name">Base - Purchase of other goods and services</field>
                         <field name="code">PLTAXD_02_42</field>
-                        <field name="sequence">190</field>
                         <field name="expression_ids">
                             <record id="account_tax_report_line_uslug_pozostalych_tag" model="account.report.expression">
                                 <field name="label">balance</field>
@@ -307,7 +277,6 @@
                 <field name="name">Tax - To be carried over</field>
                 <field name="code">PLTAX</field>
                 <field name="aggregation_formula" eval="False"/>
-                <field name="sequence">200</field>
                 <field name="hierarchy_level">0</field>
                 <field name="expression_ids">
                     <record id="account_tax_report_line_do_przeniesienia_formula" model="account.report.expression">
@@ -328,12 +297,10 @@
                         <field name="name">Tax - Total C</field>
                         <field name="code">PLTAXC</field>
                         <field name="aggregation_formula">PLTAXC_04_16.balance + PLTAXC_05_18.balance + PLTAXC_06_20.balance + PLTAXC_09_24.formula + PLTAXC_10_26.balance + PLTAXC_11_28.balance + PLTAXC_12_32.balance + PLTAXC_12_33.balance + PLTAXC_01_34.balance</field>
-                        <field name="sequence">210</field>
                         <field name="children_ids">
                             <record id="account_tax_report_line_podatek_kraj_3_lub_5" model="account.report.line">
                                 <field name="name">Tax - Supply of goods/services, domestic, 3% or 5%</field>
                                 <field name="code">PLTAXC_04_16</field>
-                                <field name="sequence">220</field>
                                 <field name="expression_ids">
                                     <record id="account_tax_report_line_podatek_kraj_3_lub_5_tag" model="account.report.expression">
                                         <field name="label">balance</field>
@@ -345,7 +312,6 @@
                             <record id="account_tax_report_line_podatek_kraj_7_lub_8" model="account.report.line">
                                 <field name="name">Tax - Supply of goods/services, domestic, 7% or 8%</field>
                                 <field name="code">PLTAXC_05_18</field>
-                                <field name="sequence">230</field>
                                 <field name="expression_ids">
                                     <record id="account_tax_report_line_podatek_kraj_7_lub_8_tag" model="account.report.expression">
                                         <field name="label">balance</field>
@@ -357,7 +323,6 @@
                             <record id="account_tax_report_line_podatek_kraj_22_lub_23" model="account.report.line">
                                 <field name="name">Tax - Supply of goods/services, domestic, 22% or 23%</field>
                                 <field name="code">PLTAXC_06_20</field>
-                                <field name="sequence">240</field>
                                 <field name="expression_ids">
                                     <record id="account_tax_report_line_podatek_kraj_22_lub_23_tag" model="account.report.expression">
                                         <field name="label">balance</field>
@@ -369,7 +334,6 @@
                             <record id="account_tax_report_line_podatek_nabycie_towarow" model="account.report.line">
                                 <field name="name">Tax - Intra-Community acquisition of goods</field>
                                 <field name="code">PLTAXC_09_24</field>
-                                <field name="sequence">250</field>
                                 <field name="expression_ids">
                                     <record id="account_tax_report_line_podatek_nabycie_towarow_tag" model="account.report.expression">
                                         <field name="label">balance</field>
@@ -386,7 +350,6 @@
                                     <record id="account_tax_report_line_podatek_transp_termin" model="account.report.line">
                                         <field name="name">Tax - Inter-Community acquisition of means of transport</field>
                                         <field name="code">PLTAXC_10_35</field>
-                                        <field name="sequence">260</field>
                                         <field name="expression_ids">
                                             <record id="account_tax_report_line_podatek_transp_termin_tag" model="account.report.expression">
                                                 <field name="label">balance</field>
@@ -400,7 +363,6 @@
                             <record id="account_tax_report_line_podatek_art_33a" model="account.report.line">
                                 <field name="name">Tax - Importation of goods under art. 33a</field>
                                 <field name="code">PLTAXC_10_26</field>
-                                <field name="sequence">270</field>
                                 <field name="expression_ids">
                                     <record id="account_tax_report_line_podatek_art_33a_tag" model="account.report.expression">
                                         <field name="label">balance</field>
@@ -412,7 +374,6 @@
                             <record id="account_tax_report_line_podatek_import_uslug" model="account.report.line">
                                 <field name="name">Tax - Importation of services</field>
                                 <field name="code">PLTAXC_11_28</field>
-                                <field name="sequence">280</field>
                                 <field name="expression_ids">
                                     <record id="account_tax_report_line_podatek_import_uslug_tag" model="account.report.expression">
                                         <field name="label">balance</field>
@@ -424,7 +385,6 @@
                                     <record id="account_tax_report_line_podatek_art_28b" model="account.report.line">
                                         <field name="name">Tax - Acquisition under art. 28b</field>
                                         <field name="code">PLTAXC_11a_30</field>
-                                        <field name="sequence">290</field>
                                         <field name="expression_ids">
                                             <record id="account_tax_report_line_podatek_art_28b_tag" model="account.report.expression">
                                                 <field name="label">balance</field>
@@ -438,7 +398,6 @@
                             <record id="account_tax_report_line_podatek_podatnik_nabywca" model="account.report.line">
                                 <field name="name">Tax - Supply of goods, taxable person acquiring</field>
                                 <field name="code">PLTAXC_12_32</field>
-                                <field name="sequence">300</field>
                                 <field name="expression_ids">
                                     <record id="account_tax_report_line_podatek_podatnik_nabywca_tag" model="account.report.expression">
                                         <field name="label">balance</field>
@@ -450,7 +409,6 @@
                             <record id="account_tax_report_line_podatek_art_14_5" model="account.report.line">
                                 <field name="name">Tax - From physical inventory under art. 14.5</field>
                                 <field name="code">PLTAXC_12_33</field>
-                                <field name="sequence">310</field>
                                 <field name="expression_ids">
                                     <record id="account_tax_report_line_podatek_art_14_5_tag" model="account.report.expression">
                                         <field name="label">balance</field>
@@ -462,7 +420,6 @@
                             <record id="account_tax_report_line_kasy_rejestrujace" model="account.report.line">
                                 <field name="name">Tax - Expenditure on cash registers</field>
                                 <field name="code">PLTAXC_01_34</field>
-                                <field name="sequence">320</field>
                                 <field name="expression_ids">
                                     <record id="account_tax_report_line_kasy_rejestrujace_tag" model="account.report.expression">
                                         <field name="label">balance</field>
@@ -474,7 +431,6 @@
                             <record id="account_tax_report_line_wewnątrzwspólnotowe_103_5a" model="account.report.line">
                                 <field name="name">Tax - Intra-Community acquisition of goods under art. 103 sec. 5a</field>
                                 <field name="code">PLTAXC_01_36</field>
-                                <field name="sequence">330</field>
                                 <field name="expression_ids">
                                     <record id="account_tax_report_line_wewnątrzwspólnotowe_103_5a_tag" model="account.report.expression">
                                         <field name="label">balance</field>
@@ -489,12 +445,10 @@
                         <field name="name">Tax - Total D</field>
                         <field name="code">PLTAXD</field>
                         <field name="aggregation_formula">PLTAXC_39.balance + PLTAXD_02_41.balance + PLTAXD_02_43.balance + PLTAXD_02_44.balance + PLTAXD_02_45.balance + PLTAXD_02_46.balance + PLTAXD_02_47.balance</field>
-                        <field name="sequence">340</field>
                         <field name="children_ids">
                             <record id="account_tax_report_line_podatek_deklaracji" model="account.report.line">
                                 <field name="name">Tax - Surplus from previous declaration</field>
                                 <field name="code">PLTAXC_39</field>
-                                <field name="sequence">350</field>
                                 <field name="expression_ids">
                                     <record id="account_tax_report_line_podatek_deklaracji_applied_carryover" model="account.report.expression">
                                         <field name="label">_applied_carryover_balance</field>
@@ -517,7 +471,6 @@
                             <record id="account_tax_report_line_podatek_s_trwale" model="account.report.line">
                                 <field name="name">Tax - Acquisition of goods and services, fixed assets</field>
                                 <field name="code">PLTAXD_02_41</field>
-                                <field name="sequence">360</field>
                                 <field name="expression_ids">
                                     <record id="account_tax_report_line_podatek_s_trwale_tag" model="account.report.expression">
                                         <field name="label">balance</field>
@@ -529,7 +482,6 @@
                             <record id="account_tax_report_line_podatek_uslug_pozostalych" model="account.report.line">
                                 <field name="name">Tax - Purchase of other goods and services</field>
                                 <field name="code">PLTAXD_02_43</field>
-                                <field name="sequence">370</field>
                                 <field name="expression_ids">
                                     <record id="account_tax_report_line_podatek_uslug_pozostalych_tag" model="account.report.expression">
                                         <field name="label">balance</field>
@@ -541,7 +493,6 @@
                             <record id="account_tax_report_line_podatek_s_trwalych" model="account.report.line">
                                 <field name="name">Tax - Adjustment of input tax on acquisition of fixed assets</field>
                                 <field name="code">PLTAXD_02_44</field>
-                                <field name="sequence">380</field>
                                 <field name="expression_ids">
                                     <record id="account_tax_report_line_podatek_s_trwalych_tag" model="account.report.expression">
                                         <field name="label">balance</field>
@@ -553,7 +504,6 @@
                             <record id="account_tax_report_line_podatek_pozostalych_nabyc" model="account.report.line">
                                 <field name="name">Tax - Adjustment of input tax on other acquisitions</field>
                                 <field name="code">PLTAXD_02_45</field>
-                                <field name="sequence">390</field>
                                 <field name="expression_ids">
                                     <record id="account_tax_report_line_podatek_pozostalych_nabyc_tag" model="account.report.expression">
                                         <field name="label">balance</field>
@@ -565,7 +515,6 @@
                             <record id="account_tax_report_line_korekta_art89b1" model="account.report.line">
                                 <field name="name">Tax - Input tax adjustments under art. 89b sec 1</field>
                                 <field name="code">PLTAXD_02_46</field>
-                                <field name="sequence">400</field>
                                 <field name="expression_ids">
                                     <record id="account_tax_report_line_korekta_art89b1_tag" model="account.report.expression">
                                         <field name="label">balance</field>
@@ -577,7 +526,6 @@
                             <record id="account_tax_report_line_korekta_art89b4" model="account.report.line">
                                 <field name="name">Tax - Input tax adjustments under art. 89b sec 4</field>
                                 <field name="code">PLTAXD_02_47</field>
-                                <field name="sequence">410</field>
                                 <field name="expression_ids">
                                     <record id="account_tax_report_line_korekta_art89b4_tag" model="account.report.expression">
                                         <field name="label">balance</field>
@@ -591,7 +539,6 @@
                     <record id="account_tax_report_line_podatek_okresie" model="account.report.line">
                         <field name="name">Tax - Expenditure on cash registers to be reimbursed in the period</field>
                         <field name="code">PLTAX_49</field>
-                        <field name="sequence">420</field>
                         <field name="expression_ids">
                             <record id="account_tax_report_line_podatek_okresie_tag" model="account.report.expression">
                                 <field name="label">balance</field>
@@ -604,7 +551,6 @@
                     <record id="account_tax_report_line_zaniechaniem_poboru" model="account.report.line">
                         <field name="name">Tax - Subject to non-collection</field>
                         <field name="code">PLTAX_50</field>
-                        <field name="sequence">430</field>
                         <field name="expression_ids">
                             <record id="account_tax_report_line_zaniechaniem_poboru_tag" model="account.report.expression">
                                 <field name="label">balance</field>

--- a/addons/l10n_pt/data/account_tax_report.xml
+++ b/addons/l10n_pt/data/account_tax_report.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<odoo>
+<odoo auto_sequence="1">
     <record id="tax_report_pt" model="account.report">
         <field name="name">Tax report</field>
         <field name="root_report_id" ref="account.generic_tax_report"/>

--- a/addons/l10n_ro/data/account_tax_report_data.xml
+++ b/addons/l10n_ro/data/account_tax_report_data.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<odoo>
+<odoo auto_sequence="1">
     <record id="tax_report" model="account.report">
         <field name="name">Romanian Tax Report</field>
         <field name="root_report_id" ref="account.generic_tax_report"/>
@@ -17,12 +17,10 @@
                 <field name="name">TAX BASE TRADE WITHIN AND OUTSIDE THE EU</field>
                 <field name="code">tax_ro_baza_intracom_eu</field>
                 <field name="aggregation_formula">tax_ro_baza_rd1.balance + tax_ro_baza_rd2.balance + tax_ro_baza_rd3.balance + tax_ro_baza_rd4.balance + tax_ro_baza_rd5.balance + tax_ro_baza_rd6.balance + tax_ro_baza_rd7.balance + tax_ro_baza_rd8.balance</field>
-                <field name="sequence" eval="10"/>
                 <field name="children_ids">
                     <record id="account_tax_report_ro_baza_rd1" model="account.report.line">
                         <field name="name">1 - TAX BASE - Intra-Community supplies of goods, exempt under Article 294(2)(a) and (d) of the Tax Code</field>
                         <field name="code">tax_ro_baza_rd1</field>
-                        <field name="sequence" eval="20"/>
                         <field name="expression_ids">
                             <record id="account_tax_report_ro_baza_rd1_tag" model="account.report.expression">
                                 <field name="label">balance</field>
@@ -34,7 +32,6 @@
                     <record id="account_tax_report_ro_baza_rd2" model="account.report.line">
                         <field name="name">2 - TAX BASE - Regularisation of intra-Community supplies exempted under Article 294(2)(a) and (d) of the Tax Code</field>
                         <field name="code">tax_ro_baza_rd2</field>
-                        <field name="sequence" eval="30"/>
                         <field name="expression_ids">
                             <record id="account_tax_report_ro_baza_rd2_tag" model="account.report.expression">
                                 <field name="label">balance</field>
@@ -46,7 +43,6 @@
                     <record id="account_tax_report_ro_baza_rd3" model="account.report.line">
                         <field name="name">3 - TAX BASE - Supplies of goods/services for which the place of supply is outside Romania, as well as intracom. supplies of goods, shield. under Art. 294 (2) (b) and (c) of the CF, of which:</field>
                         <field name="code">tax_ro_baza_rd3</field>
-                        <field name="sequence" eval="40"/>
                         <field name="expression_ids">
                             <record id="account_tax_report_ro_baza_rd3_tag" model="account.report.expression">
                                 <field name="label">balance</field>
@@ -58,7 +54,6 @@
                             <record id="account_tax_report_ro_baza_rd31" model="account.report.line">
                                 <field name="name">3.1 - TAX BASE - Intra-Community supplies of services not exempt in the Member State where the tax is due</field>
                                 <field name="code">tax_ro_baza_rd31</field>
-                                <field name="sequence" eval="50"/>
                                 <field name="expression_ids">
                                     <record id="account_tax_report_ro_baza_rd31_tag" model="account.report.expression">
                                         <field name="label">balance</field>
@@ -72,7 +67,6 @@
                     <record id="account_tax_report_ro_baza_rd4" model="account.report.line">
                         <field name="name">4 - TAX BASE - Adjustments for intra-Community supplies of services which are not exempt in the Member State where the tax is due</field>
                         <field name="code">tax_ro_baza_rd4</field>
-                        <field name="sequence" eval="60"/>
                         <field name="expression_ids">
                             <record id="account_tax_report_ro_baza_rd4_tag" model="account.report.expression">
                                 <field name="label">balance</field>
@@ -84,7 +78,6 @@
                     <record id="account_tax_report_ro_baza_rd5" model="account.report.line">
                         <field name="name">5 - TAX BASE - Intra-Community acquisitions of goods for which the purchaser is liable for VAT (reverse charge), of which:</field>
                         <field name="code">tax_ro_baza_rd5</field>
-                        <field name="sequence" eval="70"/>
                         <field name="expression_ids">
                             <record id="account_tax_report_ro_baza_rd5_tag" model="account.report.expression">
                                 <field name="label">balance</field>
@@ -96,7 +89,6 @@
                             <record id="account_tax_report_ro_baza_rd51" model="account.report.line">
                                 <field name="name">5.1 - TAX BASE - Intracom. purchases for which the purchaser is liable for VAT (IT) and the supplier is registered for VAT in the Member State from which the intracom. supply took place.</field>
                                 <field name="code">tax_ro_baza_rd51</field>
-                                <field name="sequence" eval="80"/>
                                 <field name="expression_ids">
                                     <record id="account_tax_report_ro_baza_rd51_tag" model="account.report.expression">
                                         <field name="label">balance</field>
@@ -110,7 +102,6 @@
                     <record id="account_tax_report_ro_baza_rd6" model="account.report.line">
                         <field name="name">6 - TAX BASE - Adjustments for intra-Community acquisitions of goods for which the purchaser is liable for VAT (reverse charge)</field>
                         <field name="code">tax_ro_baza_rd6</field>
-                        <field name="sequence" eval="90"/>
                         <field name="expression_ids">
                             <record id="account_tax_report_ro_baza_rd6_tag" model="account.report.expression">
                                 <field name="label">balance</field>
@@ -122,7 +113,6 @@
                     <record id="account_tax_report_ro_baza_rd7" model="account.report.line">
                         <field name="name">7 - TAX BASE - Purchases of goods other than those under items 5 and 6 and purchases of services for which the recipient in Romania is liable to pay VAT (reverse charge) of which:</field>
                         <field name="code">tax_ro_baza_rd7</field>
-                        <field name="sequence" eval="100"/>
                         <field name="expression_ids">
                             <record id="account_tax_report_ro_baza_rd7_tag" model="account.report.expression">
                                 <field name="label">balance</field>
@@ -134,7 +124,6 @@
                             <record id="account_tax_report_ro_baza_rd71" model="account.report.line">
                                 <field name="name">7.1 - TAX BASE - Intra-Community purchases of services for which the recipient is liable for VAT (reverse charge)</field>
                                 <field name="code">tax_ro_baza_rd71</field>
-                                <field name="sequence" eval="110"/>
                                 <field name="expression_ids">
                                     <record id="account_tax_report_ro_baza_rd71_tag" model="account.report.expression">
                                         <field name="label">balance</field>
@@ -148,7 +137,6 @@
                     <record id="account_tax_report_ro_baza_rd8" model="account.report.line">
                         <field name="name">8 - TAX BASE - Adjustments for intra-Community purchases of services for which the beneficiary is liable for VAT (reverse charge)</field>
                         <field name="code">tax_ro_baza_rd8</field>
-                        <field name="sequence" eval="120"/>
                         <field name="expression_ids">
                             <record id="account_tax_report_ro_baza_rd8_tag" model="account.report.expression">
                                 <field name="label">balance</field>
@@ -162,13 +150,11 @@
             <record id="account_tax_report_ro_tva_intracom_eu" model="account.report.line">
                 <field name="name">VAT INTRA AND EXTRA EU TRADE</field>
                 <field name="code">tax_ro_tva_intracom_eu</field>
-                <field name="sequence" eval="130"/>
                 <field name="aggregation_formula">tax_ro_tva_rd5.balance + tax_ro_tva_rd6.balance + tax_ro_tva_rd7.balance + tax_ro_tva_rd8.balance</field>
                 <field name="children_ids">
                     <record id="account_tax_report_ro_tva_rd5" model="account.report.line">
                         <field name="name">5 - VAT - Intra-Community acquisitions of goods for which the purchaser is liable to pay VAT (reverse charge), of which:</field>
                         <field name="code">tax_ro_tva_rd5</field>
-                        <field name="sequence" eval="140"/>
                         <field name="expression_ids">
                             <record id="account_tax_report_ro_tva_rd5_tag" model="account.report.expression">
                                 <field name="label">balance</field>
@@ -180,7 +166,6 @@
                             <record id="account_tax_report_ro_tva_rd51" model="account.report.line">
                                 <field name="name">5.1 - VAT - Intra-Community acquisitions for which the purchaser is liable for VAT (IT) and the supplier is registered for VAT in the Member State from which the intra-Community supply took place</field>
                                 <field name="code">tax_ro_tva_rd51</field>
-                                <field name="sequence" eval="150"/>
                                 <field name="expression_ids">
                                     <record id="account_tax_report_ro_tva_rd51_tag" model="account.report.expression">
                                         <field name="label">balance</field>
@@ -194,7 +179,6 @@
                     <record id="account_tax_report_ro_tva_rd6" model="account.report.line">
                         <field name="name">6 - VAT - Adjustments for intra-Community acquisitions of goods for which the purchaser is liable for VAT (reverse charge)</field>
                         <field name="code">tax_ro_tva_rd6</field>
-                        <field name="sequence" eval="160"/>
                         <field name="expression_ids">
                             <record id="account_tax_report_ro_tva_rd6_tag" model="account.report.expression">
                                 <field name="label">balance</field>
@@ -206,7 +190,6 @@
                     <record id="account_tax_report_ro_tva_rd7" model="account.report.line">
                         <field name="name">7 - VAT - Purchases of goods other than those under items 5 and 6 and purchases of services for which the recipient in Romania is liable to pay VAT (reverse charge) of which:</field>
                         <field name="code">tax_ro_tva_rd7</field>
-                        <field name="sequence" eval="170"/>
                         <field name="expression_ids">
                             <record id="account_tax_report_ro_tva_rd7_tag" model="account.report.expression">
                                 <field name="label">balance</field>
@@ -218,7 +201,6 @@
                             <record id="account_tax_report_ro_tva_rd71" model="account.report.line">
                                 <field name="name">7.1 - VAT - Intra-Community purchases of services for which the recipient is liable to pay VAT (reverse charge)</field>
                                 <field name="code">tax_ro_tva_rd71</field>
-                                <field name="sequence" eval="180"/>
                                 <field name="expression_ids">
                                     <record id="account_tax_report_ro_tva_rd71_tag" model="account.report.expression">
                                         <field name="label">balance</field>
@@ -232,7 +214,6 @@
                     <record id="account_tax_report_ro_tva_rd8" model="account.report.line">
                         <field name="name">8 - VAT - Adjustments relating to purchases of intra-Community services for which the beneficiary is liable to pay VAT (reverse charge)</field>
                         <field name="code">tax_ro_tva_rd8</field>
-                        <field name="sequence" eval="190"/>
                         <field name="expression_ids">
                             <record id="account_tax_report_ro_tva_rd8_tag" model="account.report.expression">
                                 <field name="label">balance</field>
@@ -246,13 +227,11 @@
             <record id="account_tax_report_ro_baza_livrari" model="account.report.line">
                 <field name="name">TAX BASE ON DOMESTIC SUPPLIES OF GOODS/SERVICES AND EXPORTS</field>
                 <field name="code">tax_ro_baza_livrari</field>
-                <field name="sequence" eval="200"/>
                 <field name="aggregation_formula">tax_ro_baza_rd9.balance + tax_ro_baza_rd10.balance + tax_ro_baza_rd11.balance + tax_ro_baza_rd12.balance + tax_ro_baza_rd13.balance + tax_ro_baza_rd14.balance + tax_ro_baza_rd15.balance + tax_ro_baza_rd16.balance + tax_ro_baza_rd17.balance + tax_ro_baza_rd18.balance</field>
                 <field name="children_ids">
                     <record id="account_tax_report_ro_baza_rd9" model="account.report.line">
                         <field name="name">9 - TAX BASE - Supplies of goods and services taxable at 19% rate</field>
                         <field name="code">tax_ro_baza_rd9</field>
-                        <field name="sequence" eval="210"/>
                         <field name="expression_ids">
                             <record id="account_tax_report_ro_baza_rd9_tag" model="account.report.expression">
                                 <field name="label">balance</field>
@@ -264,7 +243,6 @@
                             <record id="account_tax_report_ro_baza_rd91" model="account.report.line">
                                 <field name="name">9.1 - TAX BASE - Supplies of goods and services taxable at 19% rate</field>
                                 <field name="code">tax_ro_baza_rd91</field>
-                                <field name="sequence" eval="220"/>
                                 <field name="expression_ids">
                                     <record id="account_tax_report_ro_baza_rd91_tag" model="account.report.expression">
                                         <field name="label">balance</field>
@@ -276,7 +254,6 @@
                             <record id="account_tax_report_ro_baza_rd92" model="account.report.line">
                                 <field name="name">9.2 - TAX BASE - Non-deductible purchases of goods and services 50% taxable at 19% rate</field>
                                 <field name="code">tax_ro_baza_rd92</field>
-                                <field name="sequence" eval="230"/>
                                 <field name="aggregation_formula">0.5 * tax_ro_baza_rd242.balance</field>
                             </record>
                         </field>
@@ -284,7 +261,6 @@
                     <record id="account_tax_report_ro_baza_rd10" model="account.report.line">
                         <field name="name">10 - TAX BASE - Supplies of goods and services taxable at 9% rate</field>
                         <field name="code">tax_ro_baza_rd10</field>
-                        <field name="sequence" eval="240"/>
                         <field name="expression_ids">
                             <record id="account_tax_report_ro_baza_rd10_tag" model="account.report.expression">
                                 <field name="label">balance</field>
@@ -296,7 +272,6 @@
                             <record id="account_tax_report_ro_baza_rd101" model="account.report.line">
                                 <field name="name">10.1 - TAX BASE - Supplies of goods and services taxable at 9% rate</field>
                                 <field name="code">tax_ro_baza_rd101</field>
-                                <field name="sequence" eval="250"/>
                                 <field name="expression_ids">
                                     <record id="account_tax_report_ro_baza_rd101_tag" model="account.report.expression">
                                         <field name="label">balance</field>
@@ -308,7 +283,6 @@
                             <record id="account_tax_report_ro_baza_rd102" model="account.report.line">
                                 <field name="name">10_2 - TAX BASE - Non-deductible purchases of goods and services 50% taxable at 9% rate</field>
                                 <field name="code">tax_ro_baza_rd102</field>
-                                <field name="sequence" eval="260"/>
                                 <field name="aggregation_formula">0.5 * tax_ro_baza_rd252.balance</field>
                             </record>
                         </field>
@@ -316,7 +290,6 @@
                     <record id="account_tax_report_ro_baza_rd11" model="account.report.line">
                         <field name="name">11 - TAX BASE - Supplies of taxable goods at 5% rate</field>
                         <field name="code">tax_ro_baza_rd11</field>
-                        <field name="sequence" eval="270"/>
                         <field name="expression_ids">
                             <record id="account_tax_report_ro_baza_rd11_tag" model="account.report.expression">
                                 <field name="label">balance</field>
@@ -328,7 +301,6 @@
                             <record id="account_tax_report_ro_baza_rd111" model="account.report.line">
                                 <field name="name">11.1 - TAX BASE - Supplies of goods and services taxable at 5% rate</field>
                                 <field name="code">tax_ro_baza_rd111</field>
-                                <field name="sequence" eval="280"/>
                                 <field name="expression_ids">
                                     <record id="account_tax_report_ro_baza_rd111_tag" model="account.report.expression">
                                         <field name="label">balance</field>
@@ -340,7 +312,6 @@
                             <record id="account_tax_report_ro_baza_rd112" model="account.report.line">
                                 <field name="name">11.2 - TAX BASE - Non-deductible purchases of goods and services 50% taxable at 5% rate</field>
                                 <field name="code">tax_ro_baza_rd112</field>
-                                <field name="sequence" eval="290"/>
                                 <field name="aggregation_formula">0.5 * tax_ro_baza_rd262.balance</field>
                             </record>
                         </field>
@@ -348,7 +319,6 @@
                     <record id="account_tax_report_ro_baza_rd12" model="account.report.line">
                         <field name="name">12 - TAX BASE - Purchases of goods and services subject to simplification measures for which the beneficiary is liable to pay VAT (reverse charge) , of which:</field>
                         <field name="code">tax_ro_baza_rd12</field>
-                        <field name="sequence" eval="300"/>
                         <field name="expression_ids">
                             <record id="account_tax_report_ro_baza_rd12_tag" model="account.report.expression">
                                 <field name="label">balance</field>
@@ -360,7 +330,6 @@
                             <record id="account_tax_report_ro_baza_rd121" model="account.report.line">
                                 <field name="name">12.1 - TAX BASE - Purchases of goods and services, taxable at 19% rate</field>
                                 <field name="code">tax_ro_baza_rd121</field>
-                                <field name="sequence" eval="310"/>
                                 <field name="expression_ids">
                                     <record id="account_tax_report_ro_baza_rd121_tag" model="account.report.expression">
                                         <field name="label">balance</field>
@@ -372,7 +341,6 @@
                             <record id="account_tax_report_ro_baza_rd122" model="account.report.line">
                                 <field name="name">12.2 - TAX BASE - Purchases of goods and services, taxable at 9% rate</field>
                                 <field name="code">tax_ro_baza_rd122</field>
-                                <field name="sequence" eval="320"/>
                                 <field name="expression_ids">
                                     <record id="account_tax_report_ro_baza_rd122_tag" model="account.report.expression">
                                         <field name="label">balance</field>
@@ -384,7 +352,6 @@
                             <record id="account_tax_report_ro_baza_rd123" model="account.report.line">
                                 <field name="name">12.3 - TAX BASE - Purchases of goods and services, taxable at 5% rate</field>
                                 <field name="code">tax_ro_baza_rd123</field>
-                                <field name="sequence" eval="330"/>
                                 <field name="expression_ids">
                                     <record id="account_tax_report_ro_baza_rd123_tag" model="account.report.expression">
                                         <field name="label">balance</field>
@@ -398,7 +365,6 @@
                     <record id="account_tax_report_ro_baza_rd13" model="account.report.line">
                         <field name="name">13 - TAX BASE - Supplies of goods and services subject to simplification measures (reverse charge)</field>
                         <field name="code">tax_ro_baza_rd13</field>
-                        <field name="sequence" eval="340"/>
                         <field name="expression_ids">
                             <record id="account_tax_report_ro_baza_rd13_tag" model="account.report.expression">
                                 <field name="label">balance</field>
@@ -410,7 +376,6 @@
                     <record id="account_tax_report_ro_baza_rd14" model="account.report.line">
                         <field name="name">14 - TAX BASE - Exempt supplies of goods and services with the right to deduct, other than those under headings 1-3</field>
                         <field name="code">tax_ro_baza_rd14</field>
-                        <field name="sequence" eval="350"/>
                         <field name="expression_ids">
                             <record id="account_tax_report_ro_baza_rd14_tag" model="account.report.expression">
                                 <field name="label">balance</field>
@@ -422,7 +387,6 @@
                     <record id="account_tax_report_ro_baza_rd15" model="account.report.line">
                         <field name="name">15 - TAX BASE - Supplies of goods and services exempt without deduction</field>
                         <field name="code">tax_ro_baza_rd15</field>
-                        <field name="sequence" eval="360"/>
                         <field name="expression_ids">
                             <record id="account_tax_report_ro_baza_rd15_tag" model="account.report.expression">
                                 <field name="label">balance</field>
@@ -434,7 +398,6 @@
                     <record id="account_tax_report_ro_baza_rd16" model="account.report.line">
                         <field name="name">16 - TAX BASE - Regularisations collected tax</field>
                         <field name="code">tax_ro_baza_rd16</field>
-                        <field name="sequence" eval="370"/>
                         <field name="expression_ids">
                             <record id="account_tax_report_ro_baza_rd16_tag" model="account.report.expression">
                                 <field name="label">balance</field>
@@ -446,7 +409,6 @@
                     <record id="account_tax_report_ro_baza_rd17" model="account.report.line">
                         <field name="name">17 - TAX BASE - Intra-Community supply of services under Article 278(8) of the Tax Code for which the place of supply is in Romania</field>
                         <field name="code">tax_ro_baza_rd17</field>
-                        <field name="sequence" eval="380"/>
                         <field name="expression_ids">
                             <record id="account_tax_report_ro_baza_rd17_tag" model="account.report.expression">
                                 <field name="label">balance</field>
@@ -458,7 +420,6 @@
                     <record id="account_tax_report_ro_baza_rd18" model="account.report.line">
                         <field name="name">18 - TAX BASE - Adjustments for intra-Community supplies of services under Article 278(8) of the Tax Code for which the place of supply is in Romania</field>
                         <field name="code">tax_ro_baza_rd18</field>
-                        <field name="sequence" eval="390"/>
                         <field name="expression_ids">
                             <record id="account_tax_report_ro_baza_rd18_tag" model="account.report.expression">
                                 <field name="label">balance</field>
@@ -472,13 +433,11 @@
             <record id="account_tax_report_ro_tva_livrari" model="account.report.line">
                 <field name="name">VAT ON DOMESTIC SUPPLIES OF GOODS/SERVICES AND EXPORTS</field>
                 <field name="code">tax_ro_tva_livrari</field>
-                <field name="sequence" eval="400"/>
                 <field name="aggregation_formula">tax_ro_tva_rd9.balance + tax_ro_tva_rd10.balance + tax_ro_tva_rd11.balance + tax_ro_tva_rd12.balance + tax_ro_tva_rd16.balance + tax_ro_tva_rd17.balance + tax_ro_tva_rd18.balance</field>
                 <field name="children_ids">
                     <record id="account_tax_report_ro_tva_rd9" model="account.report.line">
                         <field name="name">9 - VAT - Supplies of goods and services taxable at 19% rate</field>
                         <field name="code">tax_ro_tva_rd9</field>
-                        <field name="sequence" eval="410"/>
                         <field name="expression_ids">
                             <record id="account_tax_report_ro_tva_rd9_tag" model="account.report.expression">
                                 <field name="label">balance</field>
@@ -490,7 +449,6 @@
                             <record id="account_tax_report_ro_tva_rd91" model="account.report.line">
                                 <field name="name">9.1 - VAT - Supplies of goods and services taxable at 19% rate</field>
                                 <field name="code">tax_ro_tva_rd91</field>
-                                <field name="sequence" eval="420"/>
                                 <field name="expression_ids">
                                     <record id="account_tax_report_ro_tva_rd91_tag" model="account.report.expression">
                                         <field name="label">balance</field>
@@ -502,7 +460,6 @@
                             <record id="account_tax_report_ro_tva_rd92" model="account.report.line">
                                 <field name="name">9.2 - VAT - Non-deductible purchases of goods and services 50% taxable at 19% rate</field>
                                 <field name="code">tax_ro_tva_rd92</field>
-                                <field name="sequence" eval="430"/>
                                 <field name="expression_ids">
                                     <record id="account_tax_report_ro_tva_rd92_tag" model="account.report.expression">
                                         <field name="label">balance</field>
@@ -516,7 +473,6 @@
                     <record id="account_tax_report_ro_tva_rd10" model="account.report.line">
                         <field name="name">10 - VAT - Supplies of goods and services taxable at 9% rate</field>
                         <field name="code">tax_ro_tva_rd10</field>
-                        <field name="sequence" eval="440"/>
                         <field name="expression_ids">
                             <record id="account_tax_report_ro_tva_rd10_tag" model="account.report.expression">
                                 <field name="label">balance</field>
@@ -528,7 +484,6 @@
                             <record id="account_tax_report_ro_tva_rd101" model="account.report.line">
                                 <field name="name">10.1 - VAT - Supplies of goods and services taxable at 9% rate</field>
                                 <field name="code">tax_ro_tva_rd101</field>
-                                <field name="sequence" eval="450"/>
                                 <field name="expression_ids">
                                     <record id="account_tax_report_ro_tva_rd101_tag" model="account.report.expression">
                                         <field name="label">balance</field>
@@ -540,7 +495,6 @@
                             <record id="account_tax_report_ro_tva_rd102" model="account.report.line">
                                 <field name="name">10.2 - VAT - Non-deductible purchases of goods and services 50% taxable at 9% rate</field>
                                 <field name="code">tax_ro_tva_rd102</field>
-                                <field name="sequence" eval="460"/>
                                 <field name="expression_ids">
                                     <record id="account_tax_report_ro_tva_rd102_tag" model="account.report.expression">
                                         <field name="label">balance</field>
@@ -554,7 +508,6 @@
                     <record id="account_tax_report_ro_tva_rd11" model="account.report.line">
                         <field name="name">11 - VAT - Supplies of taxable goods at 5% rate</field>
                         <field name="code">tax_ro_tva_rd11</field>
-                        <field name="sequence" eval="470"/>
                         <field name="expression_ids">
                             <record id="account_tax_report_ro_tva_rd11_tag" model="account.report.expression">
                                 <field name="label">balance</field>
@@ -566,7 +519,6 @@
                             <record id="account_tax_report_ro_tva_rd111" model="account.report.line">
                                 <field name="name">11.1 - VAT - Supplies of goods and services taxable at 5% rate</field>
                                 <field name="code">tax_ro_tva_rd111</field>
-                                <field name="sequence" eval="480"/>
                                 <field name="expression_ids">
                                     <record id="account_tax_report_ro_tva_rd111_tag" model="account.report.expression">
                                         <field name="label">balance</field>
@@ -578,7 +530,6 @@
                             <record id="account_tax_report_ro_tva_rd112" model="account.report.line">
                                 <field name="name">11.2 - VAT - Non-deductible purchases of goods and services 50% taxable at 5% rate</field>
                                 <field name="code">tax_ro_tva_rd112</field>
-                                <field name="sequence" eval="490"/>
                                 <field name="expression_ids">
                                     <record id="account_tax_report_ro_tva_rd112_tag" model="account.report.expression">
                                         <field name="label">balance</field>
@@ -592,7 +543,6 @@
                     <record id="account_tax_report_ro_tva_rd12" model="account.report.line">
                         <field name="name">12 - VAT - Purchases of goods and services subject to simplification measures for which the beneficiary is liable to pay VAT (reverse charge) , of which:</field>
                         <field name="code">tax_ro_tva_rd12</field>
-                        <field name="sequence" eval="500"/>
                         <field name="expression_ids">
                             <record id="account_tax_report_ro_tva_rd12_tag" model="account.report.expression">
                                 <field name="label">balance</field>
@@ -604,7 +554,6 @@
                             <record id="account_tax_report_ro_tva_rd121" model="account.report.line">
                                 <field name="name">12.1 - VAT - Purchases of goods and services, taxable at 19% rate</field>
                                 <field name="code">tax_ro_tva_rd121</field>
-                                <field name="sequence" eval="510"/>
                                 <field name="expression_ids">
                                     <record id="account_tax_report_ro_tva_rd121_tag" model="account.report.expression">
                                         <field name="label">balance</field>
@@ -616,7 +565,6 @@
                             <record id="account_tax_report_ro_tva_rd122" model="account.report.line">
                                 <field name="name">12.2 - VAT - Purchases of goods and services, taxable at 9% rate</field>
                                 <field name="code">tax_ro_tva_rd122</field>
-                                <field name="sequence" eval="520"/>
                                 <field name="expression_ids">
                                     <record id="account_tax_report_ro_tva_rd122_tag" model="account.report.expression">
                                         <field name="label">balance</field>
@@ -628,7 +576,6 @@
                             <record id="account_tax_report_ro_tva_rd123" model="account.report.line">
                                 <field name="name">12.3 - VAT - Purchases of goods and services, taxable at 5% rate</field>
                                 <field name="code">tax_ro_tva_rd123</field>
-                                <field name="sequence" eval="530"/>
                                 <field name="expression_ids">
                                     <record id="account_tax_report_ro_tva_rd123_tag" model="account.report.expression">
                                         <field name="label">balance</field>
@@ -642,7 +589,6 @@
                     <record id="account_tax_report_ro_tva_rd16" model="account.report.line">
                         <field name="name">16 - VAT - Regularisations collected tax</field>
                         <field name="code">tax_ro_tva_rd16</field>
-                        <field name="sequence" eval="540"/>
                         <field name="expression_ids">
                             <record id="account_tax_report_ro_tva_rd16_tag" model="account.report.expression">
                                 <field name="label">balance</field>
@@ -654,7 +600,6 @@
                     <record id="account_tax_report_ro_tva_rd17" model="account.report.line">
                         <field name="name">17 - VAT - Intra-Community supply of services under Article 278(8) of the Tax Code for which the place of supply is in Romania</field>
                         <field name="code">tax_ro_tva_rd17</field>
-                        <field name="sequence" eval="550"/>
                         <field name="expression_ids">
                             <record id="account_tax_report_ro_tva_rd17_tag" model="account.report.expression">
                                 <field name="label">balance</field>
@@ -666,7 +611,6 @@
                     <record id="account_tax_report_ro_tva_rd18" model="account.report.line">
                         <field name="name">18 - VAT - Adjustments for intra-Community supplies of services under Article 278(8) of the Tax Code for which the place of supply is in Romania</field>
                         <field name="code">tax_ro_tva_rd18</field>
-                        <field name="sequence" eval="560"/>
                         <field name="expression_ids">
                             <record id="account_tax_report_ro_tva_rd18_tag" model="account.report.expression">
                                 <field name="label">balance</field>
@@ -680,25 +624,21 @@
             <record id="account_tax_report_ro_baza_col" model="account.report.line">
                 <field name="name">Tax Base Total Fee COLLECTED</field>
                 <field name="code">total_tax_ro_baza_col</field>
-                <field name="sequence" eval="570"/>
                 <field name="aggregation_formula">tax_ro_baza_intracom_eu.balance + tax_ro_baza_livrari.balance</field>
             </record>
             <record id="account_tax_report_ro_tva_col" model="account.report.line">
                 <field name="name">VAT Total Tax COLLECTED</field>
                 <field name="code">total_tax_ro_tva_col</field>
-                <field name="sequence" eval="580"/>
                 <field name="aggregation_formula">tax_ro_tva_intracom_eu.balance + tax_ro_tva_livrari.balance</field>
             </record>
             <record id="account_tax_report_ro_baza_intracom_eu_achiz" model="account.report.line">
                 <field name="name">TAX BASIS OF INTRA-COMMUNITY ACQUISITIONS OF GOODS AND OTHER TAXABLE ACQUISITIONS OF GOODS AND SERVICES IN ROMANIA</field>
                 <field name="code">tax_ro_baza_intracom_eu_a</field>
-                <field name="sequence" eval="590"/>
                 <field name="aggregation_formula">tax_ro_baza_rd20.balance + tax_ro_baza_rd21.balance + tax_ro_baza_rd22.balance + tax_ro_baza_rd23.balance</field>
                 <field name="children_ids">
                     <record id="account_tax_report_ro_baza_rd20" model="account.report.line">
                         <field name="name">20 - TAX BASE - Intra-Community acquisitions of goods for which the purchaser is liable to pay VAT (reverse charge) (row 18=row 5), of which:</field>
                         <field name="code">tax_ro_baza_rd20</field>
-                        <field name="sequence" eval="600"/>
                         <field name="expression_ids">
                             <record id="account_tax_report_ro_baza_rd20_tag" model="account.report.expression">
                                 <field name="label">balance</field>
@@ -710,7 +650,6 @@
                             <record id="account_tax_report_ro_baza_rd201" model="account.report.line">
                                 <field name="name">20.1 - TAX BASE - Intracom. purchases for which the purchaser is liable for VAT (IT) and the supplier is registered for VAT in the Member State from which the supply took place (row 18.1=row 5.1)</field>
                                 <field name="code">tax_ro_baza_rd201</field>
-                                <field name="sequence" eval="610"/>
                                 <field name="expression_ids">
                                     <record id="account_tax_report_ro_baza_rd201_tag" model="account.report.expression">
                                         <field name="label">balance</field>
@@ -724,7 +663,6 @@
                     <record id="account_tax_report_ro_baza_rd21" model="account.report.line">
                         <field name="name">21 - TAX BASE - Adjustments for intra-Community acquisitions of goods for which the purchaser is liable for VAT (reverse charge) (row 19=row 6)</field>
                         <field name="code">tax_ro_baza_rd21</field>
-                        <field name="sequence" eval="620"/>
                         <field name="expression_ids">
                             <record id="account_tax_report_ro_baza_rd21_tag" model="account.report.expression">
                                 <field name="label">balance</field>
@@ -736,7 +674,6 @@
                     <record id="account_tax_report_ro_baza_rd22" model="account.report.line">
                         <field name="name">22 - TAX BASE - Purchases of goods, other than those under headings 18 and 19, and purchases of services for which the recipient in Romania is liable to pay VAT (reverse charge) (heading 20 = heading 7), of which:</field>
                         <field name="code">tax_ro_baza_rd22</field>
-                        <field name="sequence" eval="630"/>
                         <field name="expression_ids">
                             <record id="account_tax_report_ro_baza_rd22_tag" model="account.report.expression">
                                 <field name="label">balance</field>
@@ -748,7 +685,6 @@
                             <record id="account_tax_report_ro_baza_rd221" model="account.report.line">
                                 <field name="name">22.1 - TAX BASE - Intra-Community purchases of services for which the recipient is liable for VAT (reverse charge) (row 20.1=row 7.1)</field>
                                 <field name="code">tax_ro_baza_rd221</field>
-                                <field name="sequence" eval="640"/>
                                 <field name="expression_ids">
                                     <record id="account_tax_report_ro_baza_rd221_tag" model="account.report.expression">
                                         <field name="label">balance</field>
@@ -762,7 +698,6 @@
                     <record id="account_tax_report_ro_baza_rd23" model="account.report.line">
                         <field name="name">23 - TAX BASE - Adjustments for intra-Community purchases of services for which the beneficiary in Romania is liable to pay VAT (reverse charge) (row 21=row 8)</field>
                         <field name="code">tax_ro_baza_rd23</field>
-                        <field name="sequence" eval="650"/>
                         <field name="expression_ids">
                             <record id="account_tax_report_ro_baza_rd23_tag" model="account.report.expression">
                                 <field name="label">balance</field>
@@ -776,13 +711,11 @@
             <record id="account_tax_report_ro_tva_intracom_eu_achiz" model="account.report.line">
                 <field name="name">VAT ON INTRA-COMMUNITY ACQUISITIONS OF GOODS AND OTHER TAXABLE ACQUISITIONS OF GOODS AND SERVICES IN ROMANIA</field>
                 <field name="code">tax_ro_tva_intracom_eu_a</field>
-                <field name="sequence" eval="660"/>
                 <field name="aggregation_formula">tax_ro_tva_rd20.balance + tax_ro_tva_rd21.balance + tax_ro_tva_rd22.balance + tax_ro_tva_rd23.balance</field>
                 <field name="children_ids">
                     <record id="account_tax_report_ro_tva_rd20" model="account.report.line">
                         <field name="name">20 - VAT - Intra-Community acquisitions of goods for which the purchaser is liable to pay VAT (reverse charge) (row 18=row 5), of which:</field>
                         <field name="code">tax_ro_tva_rd20</field>
-                        <field name="sequence" eval="670"/>
                         <field name="expression_ids">
                             <record id="account_tax_report_ro_tva_rd20_tag" model="account.report.expression">
                                 <field name="label">balance</field>
@@ -794,7 +727,6 @@
                             <record id="account_tax_report_ro_tva_rd201" model="account.report.line">
                                 <field name="name">20.1 - VAT - Intracom. purchases for which the purchaser is liable for VAT (IT) and the supplier is registered for VAT in the Member State from which the supply took place (row 18.1=row 5.1)</field>
                                 <field name="code">tax_ro_tva_rd201</field>
-                                <field name="sequence" eval="680"/>
                                 <field name="expression_ids">
                                     <record id="account_tax_report_ro_tva_rd201_tag" model="account.report.expression">
                                         <field name="label">balance</field>
@@ -808,7 +740,6 @@
                     <record id="account_tax_report_ro_tva_rd21" model="account.report.line">
                         <field name="name">21 - VAT - Adjustments for intra-Community acquisitions of goods for which the purchaser is liable for VAT (reverse charge) (row 19=row 6)</field>
                         <field name="code">tax_ro_tva_rd21</field>
-                        <field name="sequence" eval="690"/>
                         <field name="expression_ids">
                             <record id="account_tax_report_ro_tva_rd21_tag" model="account.report.expression">
                                 <field name="label">balance</field>
@@ -820,7 +751,6 @@
                     <record id="account_tax_report_ro_tva_rd22" model="account.report.line">
                         <field name="name">22 - VAT - Purchases of goods, other than those under headings 18 and 19, and purchases of services for which the recipient in Romania is liable to pay VAT (reverse charge) (heading 20 = heading 7), of which:</field>
                         <field name="code">tax_ro_tva_rd22</field>
-                        <field name="sequence" eval="700"/>
                         <field name="expression_ids">
                             <record id="account_tax_report_ro_tva_rd22_tag" model="account.report.expression">
                                 <field name="label">balance</field>
@@ -832,7 +762,6 @@
                             <record id="account_tax_report_ro_tva_rd221" model="account.report.line">
                                 <field name="name">22.1 - VAT - Intra-Community purchases of services for which the recipient is liable for VAT (reverse charge) (row 20.1=row 7.1)</field>
                                 <field name="code">tax_ro_tva_rd221</field>
-                                <field name="sequence" eval="710"/>
                                 <field name="expression_ids">
                                     <record id="account_tax_report_ro_tva_rd221_tag" model="account.report.expression">
                                         <field name="label">balance</field>
@@ -846,7 +775,6 @@
                     <record id="account_tax_report_ro_tva_rd23" model="account.report.line">
                         <field name="name">23 - VAT - Adjustments for intra-Community purchases of services for which the beneficiary in Romania is liable to pay VAT (reverse charge) (row 21=row 8)</field>
                         <field name="code">tax_ro_tva_rd23</field>
-                        <field name="sequence" eval="720"/>
                         <field name="expression_ids">
                             <record id="account_tax_report_ro_tva_rd23_tag" model="account.report.expression">
                                 <field name="label">balance</field>
@@ -860,19 +788,16 @@
             <record id="account_tax_report_ro_baza_achiz" model="account.report.line">
                 <field name="name">TAX BASE ON DOMESTIC PURCHASES OF GOODS/SERVICES AND IMPORTS, EXEMPT OR NON-TAXABLE INTRA-COMMUNITY PURCHASES</field>
                 <field name="code">tax_ro_baza_achiz</field>
-                <field name="sequence" eval="730"/>
                 <field name="aggregation_formula">tax_ro_baza_rd24.balance + tax_ro_baza_rd25.balance + tax_ro_baza_rd26.balance + tax_ro_baza_rd27.balance + tax_ro_baza_rd30.balance</field>
                 <field name="children_ids">
                     <record id="account_tax_report_ro_baza_rd24" model="account.report.line">
                         <field name="name">24 - TAX BASE - Purchases of goods and services taxable at 19%, other than those under heading 27</field>
                         <field name="code">tax_ro_baza_rd24</field>
-                        <field name="sequence" eval="740"/>
                         <field name="aggregation_formula">tax_ro_baza_rd241.balance + 0.5 * tax_ro_baza_rd242.balance</field>
                         <field name="children_ids">
                             <record id="account_tax_report_ro_baza_rd241" model="account.report.line">
                                 <field name="name">24.1 - TAX BASE - Purchases of goods and services taxable at 19%, other than those under heading 27</field>
                                 <field name="code">tax_ro_baza_rd241</field>
-                                <field name="sequence" eval="750"/>
                                 <field name="expression_ids">
                                     <record id="account_tax_report_ro_baza_rd241_tag" model="account.report.expression">
                                         <field name="label">balance</field>
@@ -884,7 +809,6 @@
                             <record id="account_tax_report_ro_baza_rd242" model="account.report.line">
                                 <field name="name">24.2 - TAX BASE - Purchases of goods and services taxable at 19%, non-deductible 50%.</field>
                                 <field name="code">tax_ro_baza_rd242</field>
-                                <field name="sequence" eval="760"/>
                                 <field name="expression_ids">
                                     <record id="account_tax_report_ro_baza_rd242_tag" model="account.report.expression">
                                         <field name="label">balance</field>
@@ -898,13 +822,11 @@
                     <record id="account_tax_report_ro_baza_rd25" model="account.report.line">
                         <field name="name">25 - TAX BASE - Purchases of goods and services taxable at 9% rate</field>
                         <field name="code">tax_ro_baza_rd25</field>
-                        <field name="sequence" eval="770"/>
                         <field name="aggregation_formula">tax_ro_baza_rd251.balance + 0.5 * tax_ro_baza_rd252.balance</field>
                         <field name="children_ids">
                             <record id="account_tax_report_ro_baza_rd251" model="account.report.line">
                                 <field name="name">25.1 - TAX BASE - Purchases of goods and services taxable at 9% rate</field>
                                 <field name="code">tax_ro_baza_rd251</field>
-                                <field name="sequence" eval="780"/>
                                 <field name="expression_ids">
                                     <record id="account_tax_report_ro_baza_rd251_tag" model="account.report.expression">
                                         <field name="label">balance</field>
@@ -916,7 +838,6 @@
                             <record id="account_tax_report_ro_baza_rd252" model="account.report.line">
                                 <field name="name">25.2 - TAX BASE - Purchases of goods and services taxable at 9%, non-deductible at 50%</field>
                                 <field name="code">tax_ro_baza_rd252</field>
-                                <field name="sequence" eval="790"/>
                                 <field name="expression_ids">
                                     <record id="account_tax_report_ro_baza_rd252_tag" model="account.report.expression">
                                         <field name="label">balance</field>
@@ -930,13 +851,11 @@
                     <record id="account_tax_report_ro_baza_rd26" model="account.report.line">
                         <field name="name">26 - TAX BASE - Purchases of taxable goods at 5% rate</field>
                         <field name="code">tax_ro_baza_rd26</field>
-                        <field name="sequence" eval="800"/>
                         <field name="aggregation_formula">tax_ro_baza_rd261.balance + 0.5 * tax_ro_baza_rd262.balance</field>
                         <field name="children_ids">
                             <record id="account_tax_report_ro_baza_rd261" model="account.report.line">
                                 <field name="name">26.1 - TAX BASE - Purchases of taxable goods at 5% rate</field>
                                 <field name="code">tax_ro_baza_rd261</field>
-                                <field name="sequence" eval="810"/>
                                 <field name="expression_ids">
                                     <record id="account_tax_report_ro_baza_rd261_tag" model="account.report.expression">
                                         <field name="label">balance</field>
@@ -948,7 +867,6 @@
                             <record id="account_tax_report_ro_baza_rd262" model="account.report.line">
                                 <field name="name">26.2 - TAX BASE - Purchases of goods taxable at 5%, non-deductible 50%</field>
                                 <field name="code">tax_ro_baza_rd262</field>
-                                <field name="sequence" eval="820"/>
                                 <field name="expression_ids">
                                     <record id="account_tax_report_ro_baza_rd262_tag" model="account.report.expression">
                                         <field name="label">balance</field>
@@ -962,7 +880,6 @@
                     <record id="account_tax_report_ro_baza_rd27" model="account.report.line">
                         <field name="name">27 - TAX BASE - Purchases of goods and services subject to simplification measures for which the beneficiary is liable to pay VAT (reverse charge), of which (row 25=row 12)</field>
                         <field name="code">tax_ro_baza_rd27</field>
-                        <field name="sequence" eval="830"/>
                         <field name="expression_ids">
                             <record id="account_tax_report_ro_baza_rd27_tag" model="account.report.expression">
                                 <field name="label">balance</field>
@@ -974,7 +891,6 @@
                             <record id="account_tax_report_ro_baza_rd271" model="account.report.line">
                                 <field name="name">27.1 - TAX BASE - Purchases of goods and services, taxable at 19% (row 25.1=row 12.1)</field>
                                 <field name="code">tax_ro_baza_rd271</field>
-                                <field name="sequence" eval="840"/>
                                 <field name="expression_ids">
                                     <record id="account_tax_report_ro_baza_rd271_tag" model="account.report.expression">
                                         <field name="label">balance</field>
@@ -986,7 +902,6 @@
                             <record id="account_tax_report_ro_baza_rd272" model="account.report.line">
                                 <field name="name">27.2 - TAX BASE - Purchases of goods, taxable at 9% (row 25.2=row 12.2)</field>
                                 <field name="code">tax_ro_baza_rd272</field>
-                                <field name="sequence" eval="850"/>
                                 <field name="expression_ids">
                                     <record id="account_tax_report_ro_baza_rd272_tag" model="account.report.expression">
                                         <field name="label">balance</field>
@@ -998,7 +913,6 @@
                             <record id="account_tax_report_ro_baza_rd273" model="account.report.line">
                                 <field name="name">27.3 - TAX BASE - Purchases of goods, taxable at 5% (row 25.3=row 12.3)</field>
                                 <field name="code">tax_ro_baza_rd273</field>
-                                <field name="sequence" eval="860"/>
                                 <field name="expression_ids">
                                     <record id="account_tax_report_ro_baza_rd273_tag" model="account.report.expression">
                                         <field name="label">balance</field>
@@ -1012,7 +926,6 @@
                     <record id="account_tax_report_ro_baza_rd30" model="account.report.line">
                         <field name="name">30 - TAX BASE - Purchases of tax-exempt or non-taxable goods and services, of which:</field>
                         <field name="code">tax_ro_baza_rd30</field>
-                        <field name="sequence" eval="870"/>
                         <field name="expression_ids">
                             <record id="account_tax_report_ro_baza_rd30_tag" model="account.report.expression">
                                 <field name="label">balance</field>
@@ -1024,7 +937,6 @@
                             <record id="account_tax_report_ro_baza_rd301" model="account.report.line">
                                 <field name="name">30.1 - TAX BASE - Tax-exempt intra-Community purchases of services (not completed under the simplified method)</field>
                                 <field name="code">tax_ro_baza_rd301</field>
-                                <field name="sequence" eval="880"/>
                                 <field name="expression_ids">
                                     <record id="account_tax_report_ro_baza_rd301_tag" model="account.report.expression">
                                         <field name="label">balance</field>
@@ -1040,19 +952,16 @@
             <record id="account_tax_report_ro_tva_achiz" model="account.report.line">
                 <field name="name">VAT ON DOMESTIC PURCHASES OF GOODS/SERVICES AND IMPORTS, EXEMPT OR NON-TAXABLE INTRA-COMMUNITY PURCHASES</field>
                 <field name="code">tax_ro_tva_achiz</field>
-                <field name="sequence" eval="890"/>
                 <field name="aggregation_formula">tax_ro_tva_rd24.balance + tax_ro_tva_rd25.balance + tax_ro_tva_rd26.balance + tax_ro_tva_rd27.balance + tax_ro_tva_rd28.balance + tax_ro_tva_rd29.balance</field>
                 <field name="children_ids">
                     <record id="account_tax_report_ro_tva_rd24" model="account.report.line">
                         <field name="name">24 - VAT - Purchases of goods and services taxable at 19%, other than those under heading 27</field>
                         <field name="code">tax_ro_tva_rd24</field>
-                        <field name="sequence" eval="900"/>
                         <field name="aggregation_formula">tax_ro_tva_rd241.balance + tax_ro_tva_rd242.balance</field>
                         <field name="children_ids">
                             <record id="account_tax_report_ro_tva_rd241" model="account.report.line">
                                 <field name="name">24.1 - VAT - Purchases of goods and services taxable at 19%, other than those under heading 27</field>
                                 <field name="code">tax_ro_tva_rd241</field>
-                                <field name="sequence" eval="910"/>
                                 <field name="expression_ids">
                                     <record id="account_tax_report_ro_tva_rd241_tag" model="account.report.expression">
                                         <field name="label">balance</field>
@@ -1064,7 +973,6 @@
                             <record id="account_tax_report_ro_tva_rd242" model="account.report.line">
                                 <field name="name">24.2 - VAT - Purchases of goods and services taxable at 19%, non-deductible 50%.</field>
                                 <field name="code">tax_ro_tva_rd242</field>
-                                <field name="sequence" eval="920"/>
                                 <field name="expression_ids">
                                     <record id="account_tax_report_ro_tva_rd242_tag" model="account.report.expression">
                                         <field name="label">balance</field>
@@ -1078,7 +986,6 @@
                     <record id="account_tax_report_ro_tva_rd25" model="account.report.line">
                         <field name="name">25 - VAT - Purchases of goods and services taxable at 9% rate</field>
                         <field name="code">tax_ro_tva_rd25</field>
-                        <field name="sequence" eval="930"/>
                         <field name="expression_ids">
                             <record id="account_tax_report_ro_tva_rd25_tag" model="account.report.expression">
                                 <field name="label">balance</field>
@@ -1090,7 +997,6 @@
                             <record id="account_tax_report_ro_tva_rd251" model="account.report.line">
                                 <field name="name">25.1 - VAT - Purchases of goods and services taxable at 9% rate</field>
                                 <field name="code">tax_ro_tva_rd251</field>
-                                <field name="sequence" eval="940"/>
                                 <field name="expression_ids">
                                     <record id="account_tax_report_ro_tva_rd251_tag" model="account.report.expression">
                                         <field name="label">balance</field>
@@ -1102,7 +1008,6 @@
                             <record id="account_tax_report_ro_tva_rd252" model="account.report.line">
                                 <field name="name">25.2 - VAT - Purchases of goods and services taxable at 9%, non-deductible at 50%</field>
                                 <field name="code">tax_ro_tva_rd252</field>
-                                <field name="sequence" eval="950"/>
                                 <field name="expression_ids">
                                     <record id="account_tax_report_ro_tva_rd252_tag" model="account.report.expression">
                                         <field name="label">balance</field>
@@ -1116,13 +1021,11 @@
                     <record id="account_tax_report_ro_tva_rd26" model="account.report.line">
                         <field name="name">26 - VAT - Purchases of taxable goods at 5% rate</field>
                         <field name="code">tax_ro_tva_rd26</field>
-                        <field name="sequence" eval="960"/>
                         <field name="aggregation_formula">tax_ro_tva_rd261.balance + tax_ro_tva_rd262.balance</field>
                         <field name="children_ids">
                             <record id="account_tax_report_ro_tva_rd261" model="account.report.line">
                                 <field name="name">26.1 - VAT - Purchases of taxable goods at 5% rate</field>
                                 <field name="code">tax_ro_tva_rd261</field>
-                                <field name="sequence" eval="970"/>
                                 <field name="expression_ids">
                                     <record id="account_tax_report_ro_tva_rd261_tag" model="account.report.expression">
                                         <field name="label">balance</field>
@@ -1134,7 +1037,6 @@
                             <record id="account_tax_report_ro_tva_rd262" model="account.report.line">
                                 <field name="name">26.2 - VAT - Purchases of goods taxable at 5%, non-deductible 50%</field>
                                 <field name="code">tax_ro_tva_rd262</field>
-                                <field name="sequence" eval="980"/>
                                 <field name="expression_ids">
                                     <record id="account_tax_report_ro_tva_rd262_tag" model="account.report.expression">
                                         <field name="label">balance</field>
@@ -1148,7 +1050,6 @@
                     <record id="account_tax_report_ro_tva_rd27" model="account.report.line">
                         <field name="name">27 - VAT - Purchases of goods and services subject to simplification measures for which the beneficiary is liable to pay VAT (reverse charge), of which (row 25=row 12)</field>
                         <field name="code">tax_ro_tva_rd27</field>
-                        <field name="sequence" eval="990"/>
                         <field name="expression_ids">
                             <record id="account_tax_report_ro_tva_rd27_tag" model="account.report.expression">
                                 <field name="label">balance</field>
@@ -1160,7 +1061,6 @@
                             <record id="account_tax_report_ro_tva_rd271" model="account.report.line">
                                 <field name="name">27.1 - VAT - Purchases of goods and services, taxable at 19% (row 25.1=row 12.1)</field>
                                 <field name="code">tax_ro_tva_rd271</field>
-                                <field name="sequence" eval="1000"/>
                                 <field name="expression_ids">
                                     <record id="account_tax_report_ro_tva_rd271_tag" model="account.report.expression">
                                         <field name="label">balance</field>
@@ -1172,7 +1072,6 @@
                             <record id="account_tax_report_ro_tva_rd272" model="account.report.line">
                                 <field name="name">27.2 - VAT - Purchases of goods, taxable at 9% (row 25.2=row 12.2)</field>
                                 <field name="code">tax_ro_tva_rd272</field>
-                                <field name="sequence" eval="1010"/>
                                 <field name="expression_ids">
                                     <record id="account_tax_report_ro_tva_rd272_tag" model="account.report.expression">
                                         <field name="label">balance</field>
@@ -1184,7 +1083,6 @@
                             <record id="account_tax_report_ro_tva_rd273" model="account.report.line">
                                 <field name="name">27.3 - VAT - Purchases of goods, taxable at 5% (row 25.3=row 12.3)</field>
                                 <field name="code">tax_ro_tva_rd273</field>
-                                <field name="sequence" eval="1020"/>
                                 <field name="expression_ids">
                                     <record id="account_tax_report_ro_tva_rd273_tag" model="account.report.expression">
                                         <field name="label">balance</field>
@@ -1198,7 +1096,6 @@
                     <record id="account_tax_report_ro_tva_rd28" model="account.report.line">
                         <field name="name">28 - VAT - Flat-rate compensation for purchases of agricultural products and services from suppliers applying the special scheme for farmers</field>
                         <field name="code">tax_ro_tva_rd28</field>
-                        <field name="sequence" eval="1030"/>
                         <field name="expression_ids">
                             <record id="account_tax_report_ro_tva_rd28_tag" model="account.report.expression">
                                 <field name="label">balance</field>
@@ -1210,7 +1107,6 @@
                     <record id="account_tax_report_ro_tva_rd29" model="account.report.line">
                         <field name="name">29 - VAT - Flat-rate compensation adjustments</field>
                         <field name="code">tax_ro_tva_rd29</field>
-                        <field name="sequence" eval="1040"/>
                         <field name="expression_ids">
                             <record id="account_tax_report_ro_tva_rd29_tag" model="account.report.expression">
                                 <field name="label">balance</field>
@@ -1224,25 +1120,21 @@
             <record id="account_tax_report_ro_baza_total_rd31" model="account.report.line">
                 <field name="name">31 - TAX BASE - TOTAL DEDUCTIBLE TAX (amount from row 20 to row 29, except row 20.1,22.1, 27.1, 27.2, 27.3)</field>
                 <field name="code">tax_ro_baza_total_rd31</field>
-                <field name="sequence" eval="1050"/>
                 <field name="aggregation_formula">tax_ro_baza_intracom_eu_a.balance + tax_ro_baza_achiz.balance</field>
             </record>
             <record id="account_tax_report_ro_tva_total_rd31" model="account.report.line">
                 <field name="name">31 - VAT - TOTAL DEDUCTIBLE TAX (amount from row 20 to row 29, except row 20.1,22.1, 27.1, 27.2, 27.3)</field>
                 <field name="code">tax_ro_tva_total_rd31</field>
-                <field name="sequence" eval="1060"/>
                 <field name="aggregation_formula">tax_ro_tva_intracom_eu_a.balance + tax_ro_tva_achiz.balance</field>
             </record>
             <record id="account_tax_report_ro_tva_rd32" model="account.report.line">
                 <field name="name">32 - VAT - SUB-TOTAL TAX DEDUCTED PURSUANT TO ARTICLE 297 AND ARTICLE 298 OR ARTICLE 300 AND ARTICLE 298 (row 30&lt;=row 29)</field>
                 <field name="code">tax_ro_tva_rd32</field>
-                <field name="sequence" eval="1070"/>
                 <field name="aggregation_formula">tax_ro_tva_intracom_eu_a.balance + tax_ro_tva_achiz.balance</field>
             </record>
             <record id="account_tax_report_ro_tva_rd33" model="account.report.line">
                 <field name="name">33 - VAT - VAT actually refunded to foreign purchasers, including commission to authorised establishments</field>
                 <field name="code">tax_ro_tva_rd33</field>
-                <field name="sequence" eval="1080"/>
                 <field name="expression_ids">
                     <record id="account_tax_report_ro_tva_rd33_tag" model="account.report.expression">
                         <field name="label">balance</field>
@@ -1254,7 +1146,6 @@
             <record id="account_tax_report_ro_baza_rd34" model="account.report.line">
                 <field name="name">34 - TAX BASE - Deducted tax adjustments</field>
                 <field name="code">tax_ro_baza_rd34</field>
-                <field name="sequence" eval="1090"/>
                 <field name="expression_ids">
                     <record id="account_tax_report_ro_baza_rd34_tag" model="account.report.expression">
                         <field name="label">balance</field>
@@ -1266,7 +1157,6 @@
             <record id="account_tax_report_ro_tva_rd34" model="account.report.line">
                 <field name="name">34 - VAT - Deducted tax adjustments</field>
                 <field name="code">tax_ro_tva_rd34</field>
-                <field name="sequence" eval="1100"/>
                 <field name="expression_ids">
                     <record id="account_tax_report_ro_tva_rd34_tag" model="account.report.expression">
                         <field name="label">balance</field>
@@ -1278,7 +1168,6 @@
             <record id="account_tax_report_ro_tva_rd35" model="account.report.line">
                 <field name="name">35 - VAT - Pro-rata adjustments / adjustments for capital goods</field>
                 <field name="code">tax_ro_tva_rd35</field>
-                <field name="sequence" eval="1110"/>
                 <field name="expression_ids">
                     <record id="account_tax_report_ro_tva_rd35_tag" model="account.report.expression">
                         <field name="label">balance</field>
@@ -1290,13 +1179,11 @@
             <record id="account_tax_report_ro_tva_rd36" model="account.report.line">
                 <field name="name">36 - VAT - TOTAL TAX DEDUCTED (row 32+row 33+row 34+row 35)</field>
                 <field name="code">tax_ro_tva_rd36</field>
-                <field name="sequence" eval="1120"/>
                 <field name="aggregation_formula">tax_ro_tva_intracom_eu_a.balance + tax_ro_tva_achiz.balance + tax_ro_tva_rd33.balance + tax_ro_tva_rd34.balance + tax_ro_tva_rd35.balance</field>
             </record>
             <record id="account_tax_report_ro_tva_rd40" model="account.report.line">
                 <field name="name">40 - VAT - VAT differences to be paid established by the tax inspection authorities by means of a communicated decision and not paid by the date of submission of the VAT return</field>
                 <field name="code">tax_ro_tva_rd40</field>
-                <field name="sequence" eval="1130"/>
                 <field name="expression_ids">
                     <record id="account_tax_report_ro_tva_rd40_tag" model="account.report.expression">
                         <field name="label">balance</field>
@@ -1308,7 +1195,6 @@
             <record id="account_tax_report_ro_tva_rd43" model="account.report.line">
                 <field name="name">43 - VAT - Negative VAT differences established by the tax inspection authorities by decision communicated by the date of submission of the VAT return</field>
                 <field name="code">tax_ro_tva_rd43</field>
-                <field name="sequence" eval="1140"/>
                 <field name="expression_ids">
                     <record id="account_tax_report_ro_tva_rd43_tag" model="account.report.expression">
                         <field name="label">balance</field>

--- a/addons/l10n_rs/data/account_tax_report_data.xml
+++ b/addons/l10n_rs/data/account_tax_report_data.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<odoo>
+<odoo auto_sequence="1">
     <record id="tax_report_vat" model="account.report">
         <field name="name">VAT Report</field>
         <field name="root_report_id" ref="account.generic_tax_report"/>
@@ -10,23 +10,19 @@
             <record id="tax_report_vat_balance" model="account.report.column">
                 <field name="name">Balance</field>
                 <field name="expression_label">balance</field>
-                <field name="sequence" eval="1"/>
             </record>
         </field>
         <field name="line_ids">
             <record id="tax_report_title_operations" model="account.report.line">
                 <field name="name">Amount of fee without VAT</field>
-                <field name="sequence" eval="1"/>
                 <field name="hierarchy_level">0</field>
                 <field name="children_ids">
                     <record id="tax_report_title_operations_turnover" model="account.report.line">
                         <field name="name">I. Trade of goods and services</field>
-                        <field name="sequence" eval="2"/>
                         <field name="children_ids">
                             <record id="tax_report_line_001" model="account.report.line">
                                 <field name="name">001 - Turnover of goods and services exempt from VAT with the right to deduct previous tax</field>
                                 <field name="code">c001</field>
-                                <field name="sequence" eval="3"/>
                                 <field name="expression_ids">
                                     <record id="tax_report_line_001_tag" model="account.report.expression">
                                         <field name="label">balance</field>
@@ -38,7 +34,6 @@
                             <record id="tax_report_line_002" model="account.report.line">
                                 <field name="name">002 - Turnover of goods and services exempt from VAT without the right to deduct previous tax</field>
                                 <field name="code">c002</field>
-                                <field name="sequence" eval="4"/>
                                 <field name="expression_ids">
                                     <record id="tax_report_line_002_tag" model="account.report.expression">
                                         <field name="label">balance</field>
@@ -50,7 +45,6 @@
                             <record id="tax_report_line_003" model="account.report.line">
                                 <field name="name">003 - Turnover of goods and services at the general rate</field>
                                 <field name="code">c003</field>
-                                <field name="sequence" eval="5"/>
                                 <field name="expression_ids">
                                     <record id="tax_report_line_003_tag" model="account.report.expression">
                                         <field name="label">balance</field>
@@ -62,7 +56,6 @@
                             <record id="tax_report_line_004" model="account.report.line">
                                 <field name="name">004 - Turnover of goods and services at the special rate</field>
                                 <field name="code">c004</field>
-                                <field name="sequence" eval="6"/>
                                 <field name="expression_ids">
                                     <record id="tax_report_line_004_tag" model="account.report.expression">
                                         <field name="label">balance</field>
@@ -74,7 +67,6 @@
                             <record id="tax_report_line_005" model="account.report.line">
                                 <field name="name">005 - Total (001 + 002 + 003 + 004)</field>
                                 <field name="code">c005</field>
-                                <field name="sequence" eval="7"/>
                                 <field name="expression_ids">
                                     <record id="tax_report_line_005_formula" model="account.report.expression">
                                         <field name="label">balance</field>
@@ -87,12 +79,10 @@
                     </record>
                     <record id="tax_report_title_operations_previous_tax" model="account.report.line">
                         <field name="name">II. Previous Tax</field>
-                        <field name="sequence" eval="8"/>
                         <field name="children_ids">
                             <record id="tax_report_line_006" model="account.report.line">
                                 <field name="name">006 - Previous tax paid upon import</field>
                                 <field name="code">c006</field>
-                                <field name="sequence" eval="9"/>
                                 <field name="expression_ids">
                                     <record id="tax_report_line_006_tag" model="account.report.expression">
                                         <field name="label">balance</field>
@@ -104,7 +94,6 @@
                             <record id="tax_report_line_007" model="account.report.line">
                                 <field name="name">007 - VAT Compensation paid to the farmer</field>
                                 <field name="code">c007</field>
-                                <field name="sequence" eval="10"/>
                                 <field name="expression_ids">
                                     <record id="tax_report_line_007_tag" model="account.report.expression">
                                         <field name="label">balance</field>
@@ -116,7 +105,6 @@
                             <record id="tax_report_line_008" model="account.report.line">
                                 <field name="name">008 - Previous tax, except for the previous tax with item no. 6. and 7</field>
                                 <field name="code">c008</field>
-                                <field name="sequence" eval="11"/>
                                 <field name="expression_ids">
                                     <record id="tax_report_line_008_tag" model="account.report.expression">
                                         <field name="label">balance</field>
@@ -128,7 +116,6 @@
                             <record id="tax_report_line_009" model="account.report.line">
                                 <field name="name">009 - Total (006 + 007 + 008)</field>
                                 <field name="code">c009</field>
-                                <field name="sequence" eval="12"/>
                                 <field name="expression_ids">
                                     <record id="tax_report_line_009_formula" model="account.report.expression">
                                         <field name="label">balance</field>
@@ -143,17 +130,14 @@
             </record>
             <record id="tax_report_title_VAT" model="account.report.line">
                 <field name="name">VAT</field>
-                <field name="sequence" eval="13"/>
                 <field name="hierarchy_level">0</field>
                 <field name="children_ids">
                     <record id="tax_report_title_VAT_turnover" model="account.report.line">
                         <field name="name">I. Trade of goods and services</field>
-                        <field name="sequence" eval="14"/>
                         <field name="children_ids">
                             <record id="tax_report_line_103" model="account.report.line">
                                 <field name="name">103 - Turnover of goods and services at the general rate</field>
                                 <field name="code">c103</field>
-                                <field name="sequence" eval="15"/>
                                 <field name="expression_ids">
                                     <record id="tax_report_line_103_tag" model="account.report.expression">
                                         <field name="label">balance</field>
@@ -165,7 +149,6 @@
                             <record id="tax_report_line_104" model="account.report.line">
                                 <field name="name">104 - Turnover of goods and services at the special rate</field>
                                 <field name="code">c104</field>
-                                <field name="sequence" eval="16"/>
                                 <field name="expression_ids">
                                     <record id="tax_report_line_104_tag" model="account.report.expression">
                                         <field name="label">balance</field>
@@ -177,7 +160,6 @@
                             <record id="tax_report_line_105" model="account.report.line">
                                 <field name="name">105 - Total (103 + 104)</field>
                                 <field name="code">c105</field>
-                                <field name="sequence" eval="17"/>
                                 <field name="expression_ids">
                                     <record id="tax_report_line_105_formula" model="account.report.expression">
                                         <field name="label">balance</field>
@@ -190,12 +172,10 @@
                     </record>
                     <record id="tax_report_title_VAT_previous_tax" model="account.report.line">
                         <field name="name">II. Previous Tax</field>
-                        <field name="sequence" eval="18"/>
                         <field name="children_ids">
                             <record id="tax_report_line_106" model="account.report.line">
                                 <field name="name">106 - Previous tax paid upon import</field>
                                 <field name="code">c106</field>
-                                <field name="sequence" eval="19"/>
                                 <field name="expression_ids">
                                     <record id="tax_report_line_106_tag" model="account.report.expression">
                                         <field name="label">balance</field>
@@ -207,7 +187,6 @@
                             <record id="tax_report_line_107" model="account.report.line">
                                 <field name="name">107 - VAT Compensation paid to the farmer</field>
                                 <field name="code">c107</field>
-                                <field name="sequence" eval="20"/>
                                 <field name="expression_ids">
                                     <record id="tax_report_line_107_tag" model="account.report.expression">
                                         <field name="label">balance</field>
@@ -219,7 +198,6 @@
                             <record id="tax_report_line_108" model="account.report.line">
                                 <field name="name">108 - Previous tax, except for the previous tax with item no. 6. and 7</field>
                                 <field name="code">c108</field>
-                                <field name="sequence" eval="21"/>
                                 <field name="expression_ids">
                                     <record id="tax_report_line_108_tag" model="account.report.expression">
                                         <field name="label">balance</field>
@@ -231,7 +209,6 @@
                             <record id="tax_report_line_109" model="account.report.line">
                                 <field name="name">109 - Total (106 + 107 + 108)</field>
                                 <field name="code">c109</field>
-                                <field name="sequence" eval="22"/>
                                 <field name="expression_ids">
                                     <record id="tax_report_line_109_formula" model="account.report.expression">
                                         <field name="label">balance</field>
@@ -244,12 +221,10 @@
                     </record>
                     <record id="tax_report_title_VAT_liability" model="account.report.line">
                         <field name="name">III. Tax liability</field>
-                        <field name="sequence" eval="23"/>
                         <field name="children_ids">
                             <record id="tax_report_line_110" model="account.report.line">
                                 <field name="name">110 - Amount of VAT in tax period (105 - 109)</field>
                                 <field name="code">c110</field>
-                                <field name="sequence" eval="24"/>
                                 <field name="expression_ids">
                                     <record id="tax_report_line_110_formula" model="account.report.expression">
                                         <field name="label">balance</field>

--- a/addons/l10n_sa/data/account_tax_report_data.xml
+++ b/addons/l10n_sa/data/account_tax_report_data.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<odoo>
+<odoo auto_sequence="1">
     <record id="tax_report_vat_filing" model="account.report">
         <field name="name">VAT Filing Report</field>
         <field name="root_report_id" ref="account.generic_tax_report"/>

--- a/addons/l10n_se/data/account_tax_report_data.xml
+++ b/addons/l10n_se/data/account_tax_report_data.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<odoo>
+<odoo auto_sequence="1">
     <record id="tax_report" model="account.report">
         <field name="name">skatterapport</field>
         <field name="root_report_id" ref="account.generic_tax_report"/>

--- a/addons/l10n_sg/data/account_tax_report_data.xml
+++ b/addons/l10n_sg/data/account_tax_report_data.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<odoo>
+<odoo auto_sequence="1">
     <record id="tax_report" model="account.report">
         <field name="name">Singapore Tax Report</field>
         <field name="root_report_id" ref="account.generic_tax_report"/>

--- a/addons/l10n_si/data/account_tax_report_data.xml
+++ b/addons/l10n_si/data/account_tax_report_data.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<odoo>
+<odoo auto_sequence="1">
     <record id="tax_report" model="account.report">
         <field name="name">Tax Report</field>
         <field name="root_report_id" ref="account.generic_tax_report"/>
@@ -13,7 +13,6 @@
         <field name="line_ids">
             <record id="tax_report_I" model="account.report.line">
                 <field name="name">I. Supplies of goods and services (values excluding VAT)</field>
-                <field name="sequence">1000</field>
                 <field name="hierarchy_level">0</field>
                 <field name="expression_ids">
                     <record id="tax_report_I_formula" model="account.report.expression">
@@ -26,7 +25,6 @@
                     <record id="tax_report_11" model="account.report.line">
                         <field name="name">11. Supplies of goods and services</field>
                         <field name="code">c11</field>
-                        <field name="sequence">1110</field>
                         <field name="expression_ids">
                             <record id="tax_report_11_tag" model="account.report.expression">
                                 <field name="label">balance</field>
@@ -38,7 +36,6 @@
                     <record id="tax_report_11a" model="account.report.line">
                         <field name="name">11a. Supplies of goods and services in Slovenia, of which VAT is charged by the recipient</field>
                         <field name="code">c11a</field>
-                        <field name="sequence">1111</field>
                         <field name="expression_ids">
                             <record id="tax_report_11a_tag" model="account.report.expression">
                                 <field name="label">balance</field>
@@ -50,7 +47,6 @@
                     <record id="tax_report_12" model="account.report.line">
                         <field name="name">12. Deliveries of goods and services to other EU Member States</field>
                         <field name="code">c12</field>
-                        <field name="sequence">1120</field>
                         <field name="expression_ids">
                             <record id="tax_report_12_tag" model="account.report.expression">
                                 <field name="label">balance</field>
@@ -62,7 +58,6 @@
                     <record id="tax_report_13" model="account.report.line">
                         <field name="name">13. Sale of goods at a distance</field>
                         <field name="code">c13</field>
-                        <field name="sequence">1130</field>
                         <field name="expression_ids">
                             <record id="tax_report_13_tag" model="account.report.expression">
                                 <field name="label">balance</field>
@@ -74,7 +69,6 @@
                     <record id="tax_report_14" model="account.report.line">
                         <field name="name">14. Assembly and installation of goods in another Member State</field>
                         <field name="code">c14</field>
-                        <field name="sequence">1140</field>
                         <field name="expression_ids">
                             <record id="tax_report_14_tag" model="account.report.expression">
                                 <field name="label">balance</field>
@@ -86,7 +80,6 @@
                     <record id="tax_report_15" model="account.report.line">
                         <field name="name">15. Exempt supplies without the right to deduct VAT</field>
                         <field name="code">c15</field>
-                        <field name="sequence">1150</field>
                         <field name="expression_ids">
                             <record id="tax_report_15_tag" model="account.report.expression">
                                 <field name="label">balance</field>
@@ -99,7 +92,6 @@
             </record>
             <record id="tax_report_II" model="account.report.line">
                 <field name="name">II. VAT charged</field>
-                <field name="sequence">2000</field>
                 <field name="hierarchy_level">0</field>
                 <field name="expression_ids">
                     <record id="tax_report_II_formula" model="account.report.expression">
@@ -112,7 +104,6 @@
                     <record id="tax_report_21" model="account.report.line">
                         <field name="name">21. At a rate of 22%</field>
                         <field name="code">c21</field>
-                        <field name="sequence">2210</field>
                         <field name="expression_ids">
                             <record id="tax_report_21_tag" model="account.report.expression">
                                 <field name="label">balance</field>
@@ -124,7 +115,6 @@
                     <record id="tax_report_22" model="account.report.line">
                         <field name="name">22. At a rate of 9,5%</field>
                         <field name="code">c22</field>
-                        <field name="sequence">2220</field>
                         <field name="expression_ids">
                             <record id="tax_report_22_tag" model="account.report.expression">
                                 <field name="label">balance</field>
@@ -136,7 +126,6 @@
                     <record id="tax_report_22a" model="account.report.line">
                         <field name="name">22a. At a rate of 5%</field>
                         <field name="code">c22a</field>
-                        <field name="sequence">2221</field>
                         <field name="expression_ids">
                             <record id="tax_report_22a_tag" model="account.report.expression">
                                 <field name="label">balance</field>
@@ -148,7 +137,6 @@
                     <record id="tax_report_23" model="account.report.line">
                         <field name="name">23. 22% of acquisitions of goods from other EU Member States</field>
                         <field name="code">c23</field>
-                        <field name="sequence">2230</field>
                         <field name="expression_ids">
                             <record id="tax_report_23_tag" model="account.report.expression">
                                 <field name="label">balance</field>
@@ -160,7 +148,6 @@
                     <record id="tax_report_23a" model="account.report.line">
                         <field name="name">23a. Of the services received from other EU Member States at a rate of 22%</field>
                         <field name="code">c23a</field>
-                        <field name="sequence">2231</field>
                         <field name="expression_ids">
                             <record id="tax_report_23a_tag" model="account.report.expression">
                                 <field name="label">balance</field>
@@ -172,7 +159,6 @@
                     <record id="tax_report_24" model="account.report.line">
                         <field name="name">24. 9,5% of acquisitions of goods from other EU Member States</field>
                         <field name="code">c24</field>
-                        <field name="sequence">2240</field>
                         <field name="expression_ids">
                             <record id="tax_report_24_tag" model="account.report.expression">
                                 <field name="label">balance</field>
@@ -184,7 +170,6 @@
                     <record id="tax_report_24a" model="account.report.line">
                         <field name="name">24a. Of the services received from other EU Member States at the rate of 9,5%</field>
                         <field name="code">c24a</field>
-                        <field name="sequence">2241</field>
                         <field name="expression_ids">
                             <record id="tax_report_24a_tag" model="account.report.expression">
                                 <field name="label">balance</field>
@@ -196,7 +181,6 @@
                     <record id="tax_report_24b" model="account.report.line">
                         <field name="name">24b. Acquisitions of goods from other EU Member States at the rate of 5%</field>
                         <field name="code">c24b</field>
-                        <field name="sequence">2242</field>
                         <field name="expression_ids">
                             <record id="tax_report_24b_tag" model="account.report.expression">
                                 <field name="label">balance</field>
@@ -208,7 +192,6 @@
                     <record id="tax_report_24c" model="account.report.line">
                         <field name="name">24c. Of the services received from other EU Member States at the rate of 5%</field>
                         <field name="code">c24c</field>
-                        <field name="sequence">2243</field>
                         <field name="expression_ids">
                             <record id="tax_report_24c_tag" model="account.report.expression">
                                 <field name="label">balance</field>
@@ -220,7 +203,6 @@
                     <record id="tax_report_25" model="account.report.line">
                         <field name="name">25. On the basis of self-assessment as a recipient of goods and services at a rate of 22%</field>
                         <field name="code">c25</field>
-                        <field name="sequence">2250</field>
                         <field name="expression_ids">
                             <record id="tax_report_25_tag" model="account.report.expression">
                                 <field name="label">balance</field>
@@ -232,7 +214,6 @@
                     <record id="tax_report_25a" model="account.report.line">
                         <field name="name">25a. On the basis of self-assessment as a recipient of goods and services at a rate of 9,5%</field>
                         <field name="code">c25a</field>
-                        <field name="sequence">2251</field>
                         <field name="expression_ids">
                             <record id="tax_report_25a_tag" model="account.report.expression">
                                 <field name="label">balance</field>
@@ -244,7 +225,6 @@
                     <record id="tax_report_25b" model="account.report.line">
                         <field name="name">25b. On the basis of self-assessment as a recipient of goods and services at a rate of 5%</field>
                         <field name="code">c25b</field>
-                        <field name="sequence">2252</field>
                         <field name="expression_ids">
                             <record id="tax_report_25b_tag" model="account.report.expression">
                                 <field name="label">balance</field>
@@ -256,7 +236,6 @@
                     <record id="tax_report_26" model="account.report.line">
                         <field name="name">26. On the basis of self-assessment of imports</field>
                         <field name="code">c26</field>
-                        <field name="sequence">2260</field>
                         <field name="expression_ids">
                             <record id="tax_report_26_tag" model="account.report.expression">
                                 <field name="label">balance</field>
@@ -269,7 +248,6 @@
             </record>
             <record id="tax_report_III" model="account.report.line">
                 <field name="name">III. Purchases of goods and services (values excluding VAT)</field>
-                <field name="sequence">3000</field>
                 <field name="hierarchy_level">0</field>
                 <field name="expression_ids">
                     <record id="tax_report_III_formula" model="account.report.expression">
@@ -282,7 +260,6 @@
                     <record id="tax_report_31" model="account.report.line">
                         <field name="name">31. Purchases of goods and services</field>
                         <field name="code">c31</field>
-                        <field name="sequence">3310</field>
                         <field name="expression_ids">
                             <record id="tax_report_31_tag" model="account.report.expression">
                                 <field name="label">balance</field>
@@ -294,7 +271,6 @@
                     <record id="tax_report_31a" model="account.report.line">
                         <field name="name">31a. Purchases of goods and services in Slovenia, of which the recipient charges VAT</field>
                         <field name="code">c31a</field>
-                        <field name="sequence">3311</field>
                         <field name="expression_ids">
                             <record id="tax_report_31a_tag" model="account.report.expression">
                                 <field name="label">balance</field>
@@ -306,7 +282,6 @@
                     <record id="tax_report_32" model="account.report.line">
                         <field name="name">32. Acquisitions of goods from other EU Member States</field>
                         <field name="code">c32</field>
-                        <field name="sequence">3320</field>
                         <field name="expression_ids">
                             <record id="tax_report_32_tag" model="account.report.expression">
                                 <field name="label">balance</field>
@@ -318,7 +293,6 @@
                     <record id="tax_report_32a" model="account.report.line">
                         <field name="name">32a. Services received from other EU Member States</field>
                         <field name="code">c32a</field>
-                        <field name="sequence">3321</field>
                         <field name="expression_ids">
                             <record id="tax_report_32a_tag" model="account.report.expression">
                                 <field name="label">balance</field>
@@ -330,7 +304,6 @@
                     <record id="tax_report_33" model="account.report.line">
                         <field name="name">33. Exempt purchases of goods and services and exempt acquisitions of goods</field>
                         <field name="code">c33</field>
-                        <field name="sequence">3330</field>
                         <field name="expression_ids">
                             <record id="tax_report_33_tag" model="account.report.expression">
                                 <field name="label">balance</field>
@@ -342,7 +315,6 @@
                     <record id="tax_report_34" model="account.report.line">
                         <field name="name">34. Purchase value of real estate</field>
                         <field name="code">c34</field>
-                        <field name="sequence">3340</field>
                         <field name="expression_ids">
                             <record id="tax_report_34_tag" model="account.report.expression">
                                 <field name="label">balance</field>
@@ -354,7 +326,6 @@
                     <record id="tax_report_35" model="account.report.line">
                         <field name="name">35. Cost of other fixed assets</field>
                         <field name="code">c35</field>
-                        <field name="sequence">3350</field>
                         <field name="expression_ids">
                             <record id="tax_report_35_tag" model="account.report.expression">
                                 <field name="label">balance</field>
@@ -367,7 +338,6 @@
             </record>
             <record id="tax_report_IV" model="account.report.line">
                 <field name="name">IV. VAT deduction</field>
-                <field name="sequence">4000</field>
                 <field name="hierarchy_level">0</field>
                 <field name="expression_ids">
                     <record id="tax_report_IV_formula" model="account.report.expression">
@@ -380,7 +350,6 @@
                     <record id="tax_report_41" model="account.report.line">
                         <field name="name">41. From purchases of goods and services, acquisition of goods and services received from other EU Member States and from imports at a rate of 22%</field>
                         <field name="code">c41</field>
-                        <field name="sequence">4410</field>
                         <field name="expression_ids">
                             <record id="tax_report_41_tag" model="account.report.expression">
                                 <field name="label">balance</field>
@@ -392,7 +361,6 @@
                     <record id="tax_report_42" model="account.report.line">
                         <field name="name">42. From purchases of goods and services, acquisition of goods and services received from other EU Member States and from imports at a rate of 9,5%</field>
                         <field name="code">c42</field>
-                        <field name="sequence">4420</field>
                         <field name="expression_ids">
                             <record id="tax_report_42_tag" model="account.report.expression">
                                 <field name="label">balance</field>
@@ -404,7 +372,6 @@
                     <record id="tax_report_42a" model="account.report.line">
                         <field name="name">42a. From purchases of goods and services, acquisition of goods and services received from other EU Member States and from imports at a rate of 5%</field>
                         <field name="code">c42a</field>
-                        <field name="sequence">4421</field>
                         <field name="expression_ids">
                             <record id="tax_report_42a_tag" model="account.report.expression">
                                 <field name="label">balance</field>
@@ -416,7 +383,6 @@
                     <record id="tax_report_43" model="account.report.line">
                         <field name="name">43. Of the flat-rate compensation at the rate of 8%</field>
                         <field name="code">c43</field>
-                        <field name="sequence">4430</field>
                         <field name="expression_ids">
                             <record id="tax_report_43_tag" model="account.report.expression">
                                 <field name="label">balance</field>
@@ -429,7 +395,6 @@
             </record>
             <record id="tax_report_51" model="account.report.line">
                 <field name="name">51. VAT liability</field>
-                <field name="sequence">5100</field>
                 <field name="hierarchy_level">0</field>
                 <field name="expression_ids">
                     <record id="tax_report_51_formula" model="account.report.expression">
@@ -442,7 +407,6 @@
             </record>
             <record id="tax_report_52" model="account.report.line">
                 <field name="name">52. VAT surplus</field>
-                <field name="sequence">5200</field>
                 <field name="hierarchy_level">0</field>
                 <field name="expression_ids">
                     <record id="tax_report_52_formula" model="account.report.expression">

--- a/addons/l10n_th/data/account_tax_report_data.xml
+++ b/addons/l10n_th/data/account_tax_report_data.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<odoo>
+<odoo auto_sequence="1">
     <record id="tax_report" model="account.report">
         <field name="name">Tax Report</field>
         <field name="root_report_id" ref="account.generic_tax_report"/>

--- a/addons/l10n_uk/data/account_tax_report_data.xml
+++ b/addons/l10n_uk/data/account_tax_report_data.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<odoo>
+<odoo auto_sequence="1">
     <record id="tax_report" model="account.report">
         <field name="name">Tax Report</field>
         <field name="root_report_id" ref="account.generic_tax_report"/>

--- a/addons/l10n_uy/data/account_tax_report_data.xml
+++ b/addons/l10n_uy/data/account_tax_report_data.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<odoo>
+<odoo auto_sequence="1">
     <record id="tax_report" model="account.report">
         <field name="name">Tax Report</field>
         <field name="root_report_id" ref="account.generic_tax_report"/>

--- a/addons/l10n_vn/data/account_tax_report_data.xml
+++ b/addons/l10n_vn/data/account_tax_report_data.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<odoo>
+<odoo auto_sequence="1">
     <record id="tax_report" model="account.report">
         <field name="name">Tax Report</field>
         <field name="root_report_id" ref="account.generic_tax_report"/>

--- a/addons/l10n_za/data/account_tax_report_data.xml
+++ b/addons/l10n_za/data/account_tax_report_data.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<odoo>
+<odoo auto_sequence="1">
     <record id="tax_report" model="account.report">
         <field name="name">Tax Report</field>
         <field name="root_report_id" ref="account.generic_tax_report"/>

--- a/odoo/import_xml.rng
+++ b/odoo/import_xml.rng
@@ -314,6 +314,7 @@
                 <rng:name>data</rng:name>
             </rng:choice>
             <rng:optional><rng:attribute name="noupdate" /></rng:optional>
+            <rng:optional><rng:attribute name="auto_sequence" /></rng:optional>
             <rng:ref name="env"/>
             <rng:zeroOrMore>
                 <rng:choice>


### PR DESCRIPTION
Motivations:
* `sequence` is not super intuitive for new devs
* It makes "useless" noise in data files
* It is redundant when what we want to see in the file is the same as what we want to see on the user screen.
Do you understand anything related to sequences in here?
https://github.com/odoo/odoo/blob/15.0/addons/l10n_lu/data/account_tax_report_line.xml
Explicit is not always better than implicit.
* It is not implicit like using `id`  it is natural and visual and saves a lot of chore for adding and maintaining sequences.

Implementation
* It is optional, with the option set on root xml tags

_________________
In
* `odoo/addons/l10n_*`, we are gaining 2k+ lines of xml on `account.tax.report.line`
* `enterprise/l10n_*`, we are gaining 3k+ lines of xml on `account.financial.html.report.line`

This could be applied to other records like menuitems, or other models similar where it makes sense to declare in the same order as what we want to see on the user screen.



--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
