### PR TITLE
[FIX] stock_account: Return product with revaluation layer

### DIFF
--- a/addons/stock_account/models/stock_move.py
+++ b/addons/stock_account/models/stock_move.py
@@ -39,7 +39,9 @@ class StockMove(models.Model):
         precision = self.env['decimal.precision'].precision_get('Product Price')
         # If the move is a return, use the original move's price unit.
         if self.origin_returned_move_id and self.origin_returned_move_id.sudo().stock_valuation_layer_ids:
-            return self.origin_returned_move_id.sudo().stock_valuation_layer_ids[-1].unit_cost
+            layers = self.origin_returned_move_id.sudo().stock_valuation_layer_ids
+            quantity = sum(layers.mapped("quantity"))
+            return layers.currency_id.round(sum(layers.mapped("value")) / quantity) if not float_is_zero(quantity, layers.uom_id.rounding) else 0
         return price_unit if not float_is_zero(price_unit, precision) or self._should_force_price_unit() else self.product_id.standard_price
 
     @api.model

--- a/addons/stock_account/tests/test_stockvaluationlayer.py
+++ b/addons/stock_account/tests/test_stockvaluationlayer.py
@@ -515,6 +515,16 @@ class TestStockValuationAVCO(TestStockValuationCommon):
         self.assertEqual(self.product1.quantity_svl, 0)
         self.assertEqual(self.product1.standard_price, 1.01)
 
+    def test_return_delivery_2(self):
+        self.product1.write({"standard_price": 1})
+        move1 = self._make_out_move(self.product1, 10, create_picking=True, force_assign=True)
+        move2 = self._make_in_move(self.product1, 10, unit_cost=2)
+        move3 = self._make_return(move1, 10)
+
+        self.assertEqual(self.product1.value_svl, 20)
+        self.assertEqual(self.product1.quantity_svl, 10)
+        self.assertEqual(self.product1.standard_price, 2)
+
 
 class TestStockValuationFIFO(TestStockValuationCommon):
     def setUp(self):
@@ -684,6 +694,15 @@ class TestStockValuationFIFO(TestStockValuationCommon):
 
         returned = self._make_return(out_move02, 1)
         self.assertEqual(returned.stock_valuation_layer_ids.value, 0)
+
+    def test_return_delivery_3(self):
+        self.product1.write({"standard_price": 1})
+        move1 = self._make_out_move(self.product1, 10, create_picking=True, force_assign=True)
+        move2 = self._make_in_move(self.product1, 10, unit_cost=2)
+        move3 = self._make_return(move1, 10)
+
+        self.assertEqual(self.product1.value_svl, 20)
+        self.assertEqual(self.product1.quantity_svl, 10)
 
 
 class TestStockValuationChangeCostMethod(TestStockValuationCommon):


### PR DESCRIPTION
## How to reproduce:
1- Create Product Category "PC" AVCO|FIFO Automated.
2- Create Storable Product "P" with product category PC and unit cost to 1.
3- Create SO with 10 units of P.
4- Create PO with 10 units of P and unit cost of 2.
    Delivery of the SO should now have 2 IV layers, with one being "Revaluation of XXX (negative inventory)"
    Global IV of P should be 0 qty, 0 value.
5- Return the delivery order of SO.
6- Open valuation of the return

=> The value is 0, should be 20
In `_get_price_unit`, `price_unit` is taken on the last svl of the origin_returned_move_id, in our case it's the revaluation layer.
`_get_price_unit` now take all svls of origin_returned_move_id into account.

---
The logic for using all IV layers to compute the price_unit is as follows:
If you (1) Sold 10 P (uc 1)  , (2) Purchase 10 P (uc 2)  , (3) Return the 10 P from the SO
It should have the same end result as (1) Purchase 10 P (uc 2)  , (2) Sold 10 P  , (3) Return the 10 P from the SO
The end result for the last scenario is 10 qty, 20 value.
The former scenario should also have the 10 qty, 20 value, to do so it need to take into account the revaluation layer.

---
Bug introduced by https://github.com/odoo/odoo/pull/84274
Before the mentioned PR, when the unit_cost of the last valuation layer from the original stock move was 0 (aka: probably always the case when a revaluation layer was created), ` _get_price_unit()` would use the product standard_cost, making the issue mostly invisible.

OPW-2784033

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
