### PR TITLE
[FIX] tools: conversion of %20 into space

### DIFF
--- a/odoo/tools/mail.py
+++ b/odoo/tools/mail.py
@@ -225,7 +225,6 @@ def html_sanitize(src, silent=True, sanitize_tags=True, sanitize_attributes=Fals
         cleaned = cleaned.replace(u'%24', u'$')
         cleaned = cleaned.replace(u'%7B', u'{')
         cleaned = cleaned.replace(u'%7D', u'}')
-        cleaned = cleaned.replace(u'%20', u' ')
         cleaned = cleaned.replace(u'%5B', u'[')
         cleaned = cleaned.replace(u'%5D', u']')
         cleaned = cleaned.replace(u'%7C', u'|')


### PR DESCRIPTION
Steps to reproduce:
In the chatter write a text containing `%20`.

Issue:
When sent, it is converted into a space ` `

Cause:
The body in https://github.com/odoo/odoo/blob/33764db718282f4e900c9fba00c9a925f0171b49/addons/mail/models/mail_message.py#L88
is has the parameter `sabitize_style` set to True. Therefore it will go through a reliquat of sanitization used to comply with the oldly used Junja/Mako

Solution:
Delete the `%20` from the sanitization step and only in Master.

opw-2747043
--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
