### PR TITLE
[FIX] tooltip: Avoid calling the .show function for elements having t…

### DIFF
--- a/addons/web/static/lib/bootstrap/js/tooltip.js
+++ b/addons/web/static/lib/bootstrap/js/tooltip.js
@@ -693,7 +693,7 @@
       }
 
       context._timeout = setTimeout(function () {
-        if (context._hoverState === HoverState.SHOW) {
+        if (context._hoverState === HoverState.SHOW && !context.element.className.includes("o_invisible_modifier")) {
           context.show();
         }
       }, context.config.delay.show);


### PR DESCRIPTION
…he "o_invisible_modifier" class

Description of the issue/feature this PR addresses:
Fix for the ticket: 2720853
When creating a activity, a Javascript error can occur: 'Uncaught Javascript Error > Please use show on visible elements'.


--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
