### PR TITLE
[FIX] account: repartition lines should have at least one tax line

### DIFF
--- a/addons/account/i18n/account.pot
+++ b/addons/account/i18n/account.pot
@@ -5763,6 +5763,14 @@ msgstr ""
 #: code:addons/account/models/account.py:0
 #, python-format
 msgid ""
+"Invoice and credit note repartition should have at least one tax repartition"
+" line."
+msgstr ""
+
+#. module: account
+#: code:addons/account/models/account.py:0
+#, python-format
+msgid ""
 "Invoice and credit note repartition should have the same number of lines."
 msgstr ""
 

--- a/addons/account/models/account.py
+++ b/addons/account/models/account.py
@@ -1387,6 +1387,10 @@ class AccountTax(models.Model):
             if len(invoice_repartition_line_ids) != len(refund_repartition_line_ids):
                 raise ValidationError(_("Invoice and credit note repartition should have the same number of lines."))
 
+            if not invoice_repartition_line_ids.filtered(lambda x: x.repartition_type == 'tax') or \
+                    not refund_repartition_line_ids.filtered(lambda x: x.repartition_type == 'tax'):
+                raise ValidationError(_("Invoice and credit note repartition should have at least one tax repartition line."))
+
             index = 0
             while index < len(invoice_repartition_line_ids):
                 inv_rep_ln = invoice_repartition_line_ids[index]


### PR DESCRIPTION
Add a check to ensure that the repartition lines have at least one tax line.

Reason: the compute_all fonction skips the taxes with no tax lines
because it only loops over the tax repartition lines to fill taxes_vals 
see https://github.com/odoo/odoo/blob/13.0/addons/account/models/account.py#L1813
