### PR TITLE
[FIX] sale_margin: Correct computation of margin in groupby

### DIFF
--- a/addons/sale_margin/models/sale_order.py
+++ b/addons/sale_margin/models/sale_order.py
@@ -10,7 +10,7 @@ class SaleOrderLine(models.Model):
         "Margin", compute='_compute_margin',
         digits='Product Price', store=True, groups="base.group_user")
     margin_percent = fields.Float(
-        "Margin (%)", compute='_compute_margin', store=True, groups="base.group_user")
+        "Margin (%)", compute='_compute_margin', store=True, groups="base.group_user", group_operator="avg")
     purchase_price = fields.Float(
         string='Cost', compute="_compute_purchase_price",
         digits='Product Price', store=True, readonly=False,

--- a/addons/sale_margin/views/sale_margin_view.xml
+++ b/addons/sale_margin/views/sale_margin_view.xml
@@ -55,4 +55,15 @@
         </field>
     </record>
 
+    <record model="ir.ui.view" id="sale_margin_sale_order_pivot">
+        <field name="name">sale.order.margin.view.graph</field>
+        <field name="model">sale.order</field>
+        <field name="inherit_id" ref="sale.view_sale_order_graph"/>
+        <field name="arch" type="xml">
+            <graph position="inside">
+                <field name="margin_percent" invisible="1"/>
+            </graph>
+        </field>
+    </record>
+
 </odoo>


### PR DESCRIPTION
For now the sale margin is incorrectly computed in group by

opw-2767397