### PR TITLE
[FIX] website, web_tour: send parent menu id as integer in menu update

### DIFF
--- a/addons/web_tour/static/src/js/running_tour_action_helper.js
+++ b/addons/web_tour/static/src/js/running_tour_action_helper.js
@@ -34,6 +34,9 @@ var RunningTourActionHelper = core.Class.extend({
     drag_and_drop: function (to, element) {
         this._drag_and_drop(this._get_action_values(element), to);
     },
+    drag_move_and_drop: function (to, element) {
+        this._drag_move_and_drop(this._get_action_values(element), to);
+    },
     keydown: function (keyCodes, element) {
         this._keydown(this._get_action_values(element), keyCodes.split(/[,\s]+/));
     },
@@ -114,30 +117,25 @@ var RunningTourActionHelper = core.Class.extend({
         values.$element.trigger('focusout');
         values.$element.trigger('blur');
     },
+    _calculateCenter: function ($el, selector) {
+        const center = $el.offset();
+        if (selector && selector.indexOf('iframe') !== -1) {
+            const iFrameOffset = $('iframe').offset();
+            center.left += iFrameOffset.left;
+            center.top += iFrameOffset.top;
+        }
+        center.left += $el.outerWidth() / 2;
+        center.top += $el.outerHeight() / 2;
+        return center;
+    },
     _drag_and_drop: function (values, to) {
         var $to;
-        var elementCenter = values.
-        $element.offset();
-        elementCenter.left += values.$element.outerWidth() / 2;
-        elementCenter.top += values.$element.outerHeight() / 2;
+        const elementCenter = this._calculateCenter(values.$element);
         if (to) {
             $to = get_jquery_element_from_selector(to);
         } else {
             $to = $(document.body);
         }
-
-        const calculateCenter = () => {
-            const toCenter = $to.offset();
-
-            if (to && to.indexOf('iframe') !== -1) {
-                const iFrameOffset = $('iframe').offset();
-                toCenter.left += iFrameOffset.left;
-                toCenter.top += iFrameOffset.top;
-            }
-            toCenter.left += $to.outerWidth() / 2;
-            toCenter.top += $to.outerHeight() / 2;
-            return toCenter;
-        };
 
         values.$element.trigger($.Event("mouseenter"));
         values.$element.trigger($.Event("mousedown", {which: 1, pageX: elementCenter.left, pageY: elementCenter.top}));
@@ -148,12 +146,33 @@ var RunningTourActionHelper = core.Class.extend({
             $to = get_jquery_element_from_selector(to);
         }
 
-        let toCenter = calculateCenter();
+        let toCenter = this._calculateCenter($to, to);
         values.$element.trigger($.Event("mousemove", {which: 1, pageX: toCenter.left, pageY: toCenter.top}));
         // Recalculate the center as the mousemove might have made the element bigger.
-        toCenter = calculateCenter();
+        toCenter = this._calculateCenter($to, to);
         values.$element.trigger($.Event("mouseup", {which: 1, pageX: toCenter.left, pageY: toCenter.top}));
-     },
+    },
+    _drag_move_and_drop: function (values, params) {
+        // Extract parameters from string: '[deltaX,deltaY]@from => actualTo'.
+        const parts = /^\[(.+),(.+)\]@(.+) => (.+)/.exec(params);            
+        const initialMoveOffset = [parseInt(parts[1]), parseInt(parts[2])];
+        const fromSelector = parts[3];
+        const toSelector = parts[4];
+        // Click on element.
+        values.$element.trigger($.Event("mouseenter"));
+        const elementCenter = this._calculateCenter(values.$element);
+        values.$element.trigger($.Event("mousedown", {which: 1, pageX: elementCenter.left, pageY: elementCenter.top}));
+        // Drag through "from".
+        const fromCenter = this._calculateCenter(get_jquery_element_from_selector(fromSelector), fromSelector);
+        values.$element.trigger($.Event("mousemove", {
+            which: 1,
+            pageX: fromCenter.left + initialMoveOffset[0],
+            pageY: fromCenter.top + initialMoveOffset[1],
+        }));
+        // Drop into "to".
+        const toCenter = this._calculateCenter(get_jquery_element_from_selector(toSelector), toSelector);
+        values.$element.trigger($.Event("mouseup", {which: 1, pageX: toCenter.left, pageY: toCenter.top}));
+    },
     _keydown: function (values, keyCodes) {
         while (keyCodes.length) {
             const eventOptions = {};

--- a/addons/website/models/website_menu.py
+++ b/addons/website/models/website_menu.py
@@ -184,7 +184,7 @@ class Menu(models.Model):
             menu_id = self.browse(menu['id'])
             # if the url match a website.page, set the m2o relation
             # except if the menu url is '#', meaning it will be used as a menu container, most likely for a dropdown
-            if menu['url'] == '#':
+            if not menu['url'] or menu['url'] == '#':
                 if menu_id.page_id:
                     menu_id.page_id = None
             else:

--- a/addons/website/models/website_menu.py
+++ b/addons/website/models/website_menu.py
@@ -197,6 +197,9 @@ class Menu(models.Model):
                 if page:
                     menu['page_id'] = page.id
                     menu['url'] = page.url
+                    if isinstance(menu.get('parent_id'), str):
+                        # Avoid failure if parent_id is sent as a string from a customization.
+                        menu['parent_id'] = int(menu['parent_id'])
                 elif menu_id.page_id:
                     try:
                         # a page shouldn't have the same url as a controller

--- a/addons/website/static/src/js/menu/content.js
+++ b/addons/website/static/src/js/menu/content.js
@@ -646,7 +646,10 @@ var EditMenuDialog = weWidgets.Dialog.extend({
                 levels[menu.depth] = (levels[menu.depth] || 0) + 1;
                 var menuFields = this.flat[menu.id].fields;
                 menuFields['sequence'] = levels[menu.depth];
-                menuFields['parent_id'] = menu['parent_id'] || this.rootMenuID;
+                // JQuery's nestedSortable() extracts parent_ids as string.
+                // They must be ints when they are actual existing ids but
+                // remain as strings when they represent a creation ("new-##").
+                menuFields['parent_id'] = parseInt(menu['parent_id']) || menu['parent_id'] || this.rootMenuID;
                 data.push(menuFields);
             }
         });

--- a/addons/website/static/tests/tours/edit_menus.js
+++ b/addons/website/static/tests/tours/edit_menus.js
@@ -125,4 +125,34 @@ tour.register('edit_menus', {
         trigger: '#top_menu .nav-item a:contains("Modnar !!")',
         run: () => {}, // It's a check.
     },
+    // Nest menu item from the menu.
+    {
+        content: "Open Pages menu",
+        trigger: '.o_menu_sections a:contains("Pages")',
+    },
+    {
+        content: "Click on Edit Menu",
+        trigger: 'a.dropdown-item:contains("Edit Menu")',
+    },
+    {
+        content: "Drag item into parent",
+        trigger: '.oe_menu_editor li:contains("Contact us") > .ui-sortable-handle',
+        // Menu rows are 38px tall.
+        run: "drag_move_and_drop [50,38]@.oe_menu_editor li:contains('Home') > .ui-sortable-handle => .oe_menu_editor li:contains('Home') .ui-sortable-placeholder",
+    },
+    {
+        content: "Wait for drop",
+        trigger: '.oe_menu_editor li:contains("Home") ul li:contains("Contact us")',
+        run: () => {}, // It's a check.
+    },
+    clickOnSave,
+    {
+        content: "Menu item should have a child",
+        trigger: '#top_menu .nav-item a.dropdown-toggle:contains("Home")',
+    },
+    {
+        content: "When menu item is opened, child item must appear in the shown menu",
+        trigger: '#top_menu .nav-item:contains("Home") ul.show li a.dropdown-item:contains("Contact us")[href="/contactus"]',
+        run: () => {}, // It's a check.
+    },
 ]);


### PR DESCRIPTION
Since [1] nested menus were not saved anymore because model ids do not
support `str` anymore.

After this commit the menus update data contain an integer `parent_id`
making them understood again by the model.
The `parent_id`s returned by `nestedSortable()` are the ones obtained
through a regex match, and therefore are strings.

This PR also avoids a traceback that could happen during the update of menu that was saved without URL.

Steps to reproduce:
- go to the 'Home' web page
- click on 'Edit Menu' in the 'Pages' menu
- drag and drop a menu item to nest it (e.g. put 'Contact Us' inside 'Home')
- click on 'Save'
=> nested entry disappeared from the menu instead of being nested under its parent

[1]: https://github.com/odoo/odoo/commit/534087fa8d3c9947a918aa109f4030b5628a80d1

task-2781260

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
