### PR TITLE
[FIX] lunch: allow order from different location

### DIFF
--- a/addons/lunch/models/lunch_order.py
+++ b/addons/lunch/models/lunch_order.py
@@ -122,6 +122,7 @@ class LunchOrder(models.Model):
 
     def write(self, values):
         merge_needed = 'note' in values or 'topping_ids_1' in values or 'topping_ids_2' in values or 'topping_ids_3' in values
+        default_location_id = self.env.user.last_lunch_location_id and self.env.user.last_lunch_location_id.id or False
 
         if merge_needed:
             lines_to_deactivate = self.env['lunch.order']
@@ -139,6 +140,7 @@ class LunchOrder(models.Model):
                     'product_id': values.get('product_id', line.product_id.id),
                     'note': values.get('note', line.note or False),
                     'toppings': toppings,
+                    'lunch_location_id': values.get('lunch_location_id', default_location_id),
                 })
                 if matching_lines:
                     lines_to_deactivate |= line
@@ -152,11 +154,13 @@ class LunchOrder(models.Model):
 
     @api.model
     def _find_matching_lines(self, values):
+        default_location_id = self.env.user.last_lunch_location_id and self.env.user.last_lunch_location_id.id or False
         domain = [
             ('user_id', '=', values.get('user_id', self.default_get(['user_id'])['user_id'])),
             ('product_id', '=', values.get('product_id', False)),
             ('date', '=', fields.Date.today()),
             ('note', '=', values.get('note', False)),
+            ('lunch_location_id', '=', values.get('lunch_location_id', default_location_id)),
         ]
         toppings = values.get('toppings', [])
         return self.search(domain).filtered(lambda line: (line.topping_ids_1 | line.topping_ids_2 | line.topping_ids_3).ids == toppings)


### PR DESCRIPTION
Step to reproduce:
- Have the same menu items in the different locations
- Order one item for Office 1 click " Order now"
- Choose different office
- Select the same item

Current Behaviour:
- There is no 'Order now' and you can see that both orders were made
from Office 1.
- If you select two different items, you can click 'Order now' twice,
but there is no button if items are the same

Behaviour:
- If you change location before adding an item already present
 you create a new line link to the new location and the 'Order now'
 button is present

opw-2769168

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
