### PR TITLE
[IMP] wslides, tools: generate a pdf preview when content added from …

### DIFF
--- a/addons/website_slides/models/slide_slide.py
+++ b/addons/website_slides/models/slide_slide.py
@@ -15,6 +15,7 @@ from werkzeug import urls
 
 from odoo import api, fields, models, _
 from odoo.addons.http_routing.models.ir_http import slug, url_for
+from odoo.addons.website_slides.tools import pdf_utils
 from odoo.exceptions import RedirectWarning, UserError, AccessError
 from odoo.http import request
 from odoo.tools import html2plaintext, sql
@@ -240,13 +241,13 @@ class Slide(models.Model):
         ('exclusion_html_content_and_url', "CHECK(html_content IS NULL OR url IS NULL)", "A slide is either filled with a url or HTML content. Not both.")
     ]
 
-    @api.depends('slide_category', 'source_type', 'image_binary_content')
+    @api.depends('slide_category', 'source_type', 'image_binary_content', 'document_binary_content')
     def _compute_image_1920(self):
         for slide in self:
             if slide.slide_category == 'infographic' and slide.source_type == 'local_file' and slide.image_binary_content:
                 slide.image_1920 = slide.image_binary_content
-            elif not slide.image_1920:
-                slide.image_1920 = False
+            elif slide.slide_category == 'document' and slide.slide_type == 'pdf' and slide.document_binary_content:
+                slide.image_1920 = pdf_utils.render_pdf_first_page_as_image(slide.document_binary_content)
 
     @api.depends('date_published', 'is_published')
     def _compute_is_new_slide(self):

--- a/addons/website_slides/tools/__init__.py
+++ b/addons/website_slides/tools/__init__.py
@@ -1,0 +1,4 @@
+# -*- coding: utf-8 -*-
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from . import pdf_utils

--- a/addons/website_slides/tools/pdf_utils.py
+++ b/addons/website_slides/tools/pdf_utils.py
@@ -1,0 +1,50 @@
+# -*- coding: utf-8 -*-
+import base64
+import io
+import logging
+import PyPDF2
+
+_logger = logging.getLogger(__name__)
+_wand_lib_imported = False
+_wand_lib_security_warning = False
+
+try:
+    from wand.image import Image
+    from wand.exceptions import PolicyError
+    _wand_lib_imported = True
+except ImportError:
+    _logger.info(
+        "The `wand` Python module is not installed, some pdf preview will be missing "
+        "Try: sudo apt-get install python3-wand."
+    )
+
+
+def render_pdf_first_page_as_image(pdf_binary_base64, resolution_dpi=300):
+    """ Render the first page of the provided pdf (in base 64) as an image (jpeg in base 64).
+
+        :param str pdf_binary_base64: pdf in binary base 64 encoded form
+        :param int resolution_dpi: rendering resolution in dpi
+
+        :return: image rendered in binary base 64 encoded form or None if an error has occurred (library missing, ...)
+    """
+    if not _wand_lib_imported:
+        return None
+    try:
+        pdf = PyPDF2.PdfFileReader(io.BytesIO(base64.b64decode(pdf_binary_base64)))
+        tmp_pdf = PyPDF2.PdfFileWriter()
+        tmp_pdf.addPage(pdf.getPage(0))
+
+        tmp_pdf_bytes = io.BytesIO()
+        tmp_pdf.write(tmp_pdf_bytes)
+        tmp_pdf_bytes.seek(0)
+
+        img = Image(file=tmp_pdf_bytes, resolution=resolution_dpi)
+        return base64.b64encode(img.make_blob('jpeg'))
+    except PolicyError as e:
+        global _wand_lib_security_warning
+        if not _wand_lib_security_warning:
+            _logger.warning(str(e))
+            _wand_lib_security_warning = True
+        return None
+    except Exception:
+        return None


### PR DESCRIPTION
…the back

When a pdf content was added from the back-end, no preview was generated while
when adding the content from the front-end, a preview was generated;
this solves this issue.

Technical notes:
- this functionality relies on an additional library: Wand
- it can optionally be installed on debian with the following command:
sudo apt-get install python3-wand
- Wand relies on additional software (ImageMagick, Ghostscript, ...) that can
 introduce security issues
- if the PDF preview is not working, please check that it is not disabled in
/etc/ImageMagick-X/policy.xml. You may have to comment the line
<policy domain="coder" rights="none" pattern="PDF" /> AFTER having checked
that it is safe to do.

Task-2750662

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
