### PR TITLE
[FIX] mass_mailing: template change broken

### DIFF
--- a/addons/mass_mailing/static/src/js/mass_mailing_widget.js
+++ b/addons/mass_mailing/static/src/js/mass_mailing_widget.js
@@ -247,6 +247,8 @@ var MassMailingFieldHtml = FieldHtml.extend({
         }
         this.switchThemeLast = themeParams;
 
+        this.$lastContent = this.$content.find('.o_mail_wrapper_td').contents();
+
         this.$content.closest('body').removeClass(this._allClasses).addClass(themeParams.className);
 
         const old_layout = this.$content.find('.o_layout')[0];
@@ -476,7 +478,11 @@ var MassMailingFieldHtml = FieldHtml.extend({
             self._switchThemes(themeParams);
         });
         $themeSelector.on("mouseleave", ".dropdown-item", function (e) {
-            self._switchThemes(selectedTheme);
+            if (self.$lastContent) {
+                self._switchThemes(Object.assign({}, selectedTheme, {template: self.$lastContent}));
+            } else {
+                self._switchThemes(selectedTheme);
+            }
         });
         $themeSelector.on("click", '[data-toggle="dropdown"]', function (e) {
             var $menu = $themeSelector.find('.dropdown-menu');
@@ -499,6 +505,9 @@ var MassMailingFieldHtml = FieldHtml.extend({
             // Notify form view
             $themeSelector.find('.dropdown-item.selected').removeClass('selected');
             $themeSelector.find('.dropdown-item:eq(' + themesParams.indexOf(selectedTheme) + ')').addClass('selected');
+
+            // Invalidate previous content.
+            self.$lastContent = undefined;
         };
 
         $themeSelector.on("click", ".dropdown-item", selectTheme);

--- a/addons/mass_mailing/static/src/js/mass_mailing_widget.js
+++ b/addons/mass_mailing/static/src/js/mass_mailing_widget.js
@@ -250,7 +250,6 @@ var MassMailingFieldHtml = FieldHtml.extend({
         this.$content.closest('body').removeClass(this._allClasses).addClass(themeParams.className);
 
         const old_layout = this.$content.find('.o_layout')[0];
-        const $old_layout = $(old_layout);
 
         var $new_wrapper;
         var $newWrapperContent;
@@ -292,6 +291,7 @@ var MassMailingFieldHtml = FieldHtml.extend({
         }
         this.wysiwyg.trigger('reload_snippet_dropzones');
         this.trigger_up('iframe_updated', { $iframe: this.wysiwyg.$iframe });
+        this.wysiwyg.odooEditor.historyStep(true);
     },
 
     /**


### PR DESCRIPTION
- Pick a template for your new mailing, then change your mind and select another one in the "SELECT A TEMPLATE" tab. Then make a change in the mailing: your template change is rolled back. This is the bug that is fixed with this commit.
- Previewing templates in the "SELECT A TEMPLATE" tab of mass_mailing made one lose all their changes. This makes sure they are preserved and restored when needed.

task-2778411

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
