### PR TITLE
[FIX] base,mail: set integer widget on many2one_reference fields

### DIFF
--- a/addons/mail/views/mail_mail_views.xml
+++ b/addons/mail/views/mail_mail_views.xml
@@ -41,7 +41,7 @@
                                         <field name="message_type"/>
                                         <field name="mail_server_id"/>
                                         <field name="model"/>
-                                        <field name="res_id"/>
+                                        <field name="res_id" widget="integer"/>
                                     </group>
                                     <group string="Headers">
                                         <field name="message_id"/>
@@ -73,7 +73,7 @@
                     <field name="message_id" invisible="1"/>
                     <field name="recipient_ids" invisible="1"/>
                     <field name="model" invisible="1"/>
-                    <field name="res_id" invisible="1"/>
+                    <field name="res_id" invisible="1" widget="integer"/>
                     <field name="email_from" invisible="1"/>
                     <field name="state" invisible="1"/>
                     <field name="message_type" invisible="1"/>
@@ -103,7 +103,7 @@
                         <field name="author_id"/>
                         <field name="recipient_ids"/>
                         <field name="model"/>
-                        <field name="res_id"/>
+                        <field name="res_id" widget="integer"/>
                     </group>
                     <group expand="0" string="Group By">
                         <filter string="Status" name="status" domain="[]" context="{'group_by':'state'}"/>

--- a/addons/mail/views/mail_message_views.xml
+++ b/addons/mail/views/mail_message_views.xml
@@ -104,7 +104,7 @@
                     <field name="author_id"/>
                     <field name="partner_ids"/>
                     <field name="model"/>
-                    <field name="res_id"/>
+                    <field name="res_id" widget="integer"/>
                     <field name="parent_id"/>
                     <filter string="Has Mentions"
                             name="filter_has_mentions"

--- a/odoo/addons/base/views/ir_attachment_views.xml
+++ b/odoo/addons/base/views/ir_attachment_views.xml
@@ -20,7 +20,7 @@
                         <group string="Attached To" groups="base.group_no_one">
                             <field name="res_model"/>
                             <field name="res_field"/>
-                            <field name="res_id"/>
+                            <field name="res_id" widget="integer"/>
                             <field name="res_name"/>
                             <field name="company_id" groups="base.group_multi_company" options="{'no_create': True}"/>
                             <field name="public"/>
@@ -50,7 +50,7 @@
                     <field name="name"/>
                     <field name="res_model"/>
                     <field name="res_field"/>
-                    <field name="res_id"/>
+                    <field name="res_id" widget="integer"/>
                     <field name="type"/>
                     <field name="file_size"/>
                     <field name="company_id" groups="base.group_multi_company"/>

--- a/odoo/addons/base/views/ir_model_views.xml
+++ b/odoo/addons/base/views/ir_model_views.xml
@@ -478,7 +478,7 @@
                             <group>
                                 <field name="display_name"/>
                                 <field name="model"/>
-                                <field name="res_id"/>
+                                <field name="res_id" widget="integer"/>
                                 <field name="reference" widget="reference" string="Record"/>
                             </group>
                         </group>
@@ -494,7 +494,7 @@
                     <field name="display_name"/>
                     <field name="model" groups="base.group_no_one"/>
                     <field name="module" invisible="1"/>
-                    <field name="res_id"/>
+                    <field name="res_id" widget="integer"/>
                 </tree>
             </field>
         </record>
@@ -506,7 +506,7 @@
                     <filter string="Updatable" name="updatable" domain="[('noupdate', '=', False)]"/>
                     <field name="module"/>
                     <field name="model"/>
-                    <field name="res_id"/>
+                    <field name="res_id" widget="integer"/>
                     <field name="noupdate"/>
                     <group expand="0" string="Group By">
                         <filter string="Module" name="group_by_module" domain="[]" context="{'group_by':'module'}"/>


### PR DESCRIPTION
**Description of the issue/feature this PR addresses:**

Refining of https://github.com/odoo/odoo/commit/d3f6c3b579f39b313401c63d97b95ce690501591.

Commit https://github.com/odoo/odoo/commit/9920f20e4c7753bc17bea71dea3a90f7de687196 introduced a new field type in the ORM. However it is not referenced in various JS parts, thus possibly leading to crashes.

As this is basically an integer field, easy fix is to use an integer widget on those fields.

**Current behavior before PR:**

Some many2one_reference fields in views do not have the integer widget.

**Desired behavior after PR is merged:**

All many2one_reference fields in views have the integer widget.

**Related Enterprise PR:** https://github.com/odoo/enterprise/pull/24966

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr