### PR TITLE
[FIX] mass_mailing: correct behavior of mass_mailing tour

### DIFF
--- a/addons/mass_mailing/static/src/js/tours/mass_mailing_tour.js
+++ b/addons/mass_mailing/static/src/js/tours/mass_mailing_tour.js
@@ -28,7 +28,7 @@ odoo.define('mass_mailing.mass_mailing_tour', function (require) {
     }, {
         trigger: 'input[name="subject"]',
         content: Markup(_t('Pick the <b>email subject</b>.')),
-        position: 'right',
+        position: 'bottom',
         run: 'text ' + now.format("MMMM") + " Newsletter",
     }, {
         trigger: 'div[name="contact_list_ids"] > .o_input_dropdown > input[type="text"]',

--- a/addons/mass_mailing/static/src/js/tours/mass_mailing_tour.js
+++ b/addons/mass_mailing/static/src/js/tours/mass_mailing_tour.js
@@ -51,7 +51,7 @@ odoo.define('mass_mailing.mass_mailing_tour', function (require) {
         edition: 'community',
         run: 'click',
     }, {
-        trigger: 'div[name="body_arch"] iframe div.o_mail_block_text',
+        trigger: 'div[name="body_arch"] iframe div.s_text_block',
         content: _t('Click on this paragraph to edit it.'),
         position: 'top',
         edition: 'enterprise',


### PR DESCRIPTION
- The mass_mailing tour had a droplet to the right of the mailing's title, which was not so obvious to the eye so this moves it to the bottom.
- After choosing a template, the mass_mailing tour is supposed to tell us to click in a paragraph to edit it. It was targeting a snippet that doesn't exist anymore so the class name had to be adapted for it to work again.

task-2778417
task-2778418

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
