### PR TITLE
[FIX]IOTBox no cut and dirty print in some printers

### DIFF
--- a/addons/hw_drivers/iot_handlers/drivers/PrinterDriver.py
+++ b/addons/hw_drivers/iot_handlers/drivers/PrinterDriver.py
@@ -34,7 +34,7 @@ RECEIPT_PRINTER_COMMANDS = {
     },
     'escpos': {
         'center': b'\x1b\x61\x01',  # ESC a n
-        'cut': b'\x1d\x56\x41\n',  # GS V m
+        'cut': b'\n\x1d\x56\x41\n',  # GS V m
         'title': b'\x1b\x21\x30%s\x1b\x21\x00',  # ESC ! n
         'drawers': [b'\x1b\x3d\x01', b'\x1b\x70\x00\x19\x19', b'\x1b\x70\x01\x19\x19']  # ESC = n then ESC p m t1 t2
     }


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
Some printers are not cuting receipt, then in a receipt after not cut,
print garbage (hex code), because is not finalized cuting command, then

Current behavior before PR:
- first receipt print fine but not cut
- second receipt print garbage not cut
.....

Desired behavior after PR is merged:

"clear" buffer before cut command, with a simple newline

--
I confirm I have signed the CLA and read the PR guidelines at
www.odoo.com/submit-pr

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
