### PR TITLE
[FIX] sale: hide archived taxes in SO edition form

### DIFF
--- a/addons/sale/views/sale_views.xml
+++ b/addons/sale/views/sale_views.xml
@@ -540,6 +540,7 @@
                                         widget="many2many_tags"
                                         options="{'no_create': True}"
                                         domain="[('type_tax_use','=','sale'),('company_id','=',parent.company_id)]"
+                                        context="{'active_test': True}"
                                         attrs="{'readonly': [('qty_invoiced', '&gt;', 0)]}"
                                         optional="show"
                                     />


### PR DESCRIPTION
Steps to reproduce:
===================
- Create a Sales tax
- Archive it
- Go to Sales and create a SO
The archived tax is available for SO line

Cause:
======
Context {'active_test: False'} is defined on tax_id field of SO line
to still display archived taxes on existing SO.
This context is passed to the field in the form view by default, allowing
archived taxes to be selected in SO creation/edition.

opw-2769057




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
