### PR TITLE
[FIX] web_editor: make sure all external links open in new tab

### DIFF
--- a/addons/web_editor/static/src/js/backend/field_html.js
+++ b/addons/web_editor/static/src/js/backend/field_html.js
@@ -309,6 +309,7 @@ var FieldHtml = basic_fields.DebouncedField.extend(TranslatableFieldMixin, {
         var def = new Promise(function (resolve) {
             resolver = resolve;
         });
+        const externalLinkSelector = `a:not([href^="${location.origin}"]):not([href^="/"])`;
         if (this.nodeOptions.cssReadonly) {
             this.$iframe = $('<iframe class="o_readonly d-none"/>');
             this.$iframe.appendTo(this.$el);
@@ -374,6 +375,12 @@ var FieldHtml = basic_fields.DebouncedField.extend(TranslatableFieldMixin, {
                             self._onClick(ev);
                         }
                     });
+
+                    // Ensure all external links are opened in a new tab.
+                    for (const externalLink of cwindow.document.body.querySelectorAll(externalLinkSelector)) {
+                        externalLink.setAttribute('target', '_blank');
+                        externalLink.setAttribute('rel', 'noreferrer');
+                    }
                 });
             });
         } else {
@@ -381,6 +388,11 @@ var FieldHtml = basic_fields.DebouncedField.extend(TranslatableFieldMixin, {
             this.$content.appendTo(this.$el);
             this._qwebPlugin = new QWebPlugin();
             this._qwebPlugin.sanitizeElement(this.$content[0]);
+            // Ensure all external links are opened in a new tab.
+            for (const externalLink of this.$content.find(externalLinkSelector)) {
+                externalLink.setAttribute('target', '_blank');
+                externalLink.setAttribute('rel', 'noreferrer');
+            }
             resolver();
         }
 

--- a/addons/web_editor/static/tests/field_html_tests.js
+++ b/addons/web_editor/static/tests/field_html_tests.js
@@ -450,7 +450,7 @@ QUnit.module('web_editor', {}, function () {
             });
             let $field = form.$('.oe_form_field[name="body"]');
             assert.strictEqual($field.children('.o_readonly').html(),
-                '<p><a href="https://www.external.com" target="_blank">External website</a></p>',
+                '<p><a href="https://www.external.com" target="_blank" rel="noreferrer">External website</a></p>',
                 "should have rendered a div with correct content in readonly");
 
             const promise = new Promise((resolve) => _formResolveTestPromise = resolve);
@@ -478,7 +478,7 @@ QUnit.module('web_editor', {}, function () {
 
             $field = form.$('.oe_form_field[name="body"]');
             assert.strictEqual($field.children('.o_readonly').html(),
-                '<p><a href="https://www.external.com" target="_blank">External website</a></p>',
+                '<p><a href="https://www.external.com" target="_blank" rel="noreferrer">External website</a></p>',
                 "the link shouldn't change");
 
             testUtils.mock.unpatch(LinkDialog);
@@ -577,7 +577,7 @@ QUnit.module('web_editor', {}, function () {
 
             $field = form.$('.oe_form_field[name="body"]');
             assert.strictEqual($field.children('.o_readonly').html(),
-                '<p><a href="http://www.test.com" target="_blank">New external link</a></p>',
+                '<p><a href="http://www.test.com" target="_blank" rel="noreferrer">New external link</a></p>',
                 "the link should be created with the right format");
 
             testUtils.mock.unpatch(LinkDialog);


### PR DESCRIPTION
This collects all external links on clean the editor so as to make them open in a new tab.

task-2740021

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
