### PR TITLE
[FIX] mass_mailing: ensure proper padding around plain text mailing

### DIFF
--- a/addons/mass_mailing/static/src/scss/themes/theme_basic.scss
+++ b/addons/mass_mailing/static/src/scss/themes/theme_basic.scss
@@ -35,10 +35,8 @@
 .o_basic_theme {
     &.o_layout {
         margin: 0;
-        padding: 0;
+        padding: 24px 16px 10px;
         background-color: white !important;
-        padding-left: 1rem; 
-        padding-right: 1rem;
 
         &, p, h1, h2, h3, h4, h5, h6, span, ul, ol {
             color: black;


### PR DESCRIPTION
The plain-text mailing template had no top padding, which made it awkward to edit and tended to make users manually add space at the top of the mailing with paragraph breaks. This adds the same padding to the mailing as is applied to the editor in the Note module.

Note: since the mailing is plain-text, that padding shouldn't and isn't saved in the mail to send, resulting in a visible difference between the Mail Body and Mail Debug tabs. This is normal.

task-2760178

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
