### PR TITLE
15.0 web editor allbold age

### DIFF
--- a/addons/web_editor/static/lib/odoo-editor/src/OdooEditor.js
+++ b/addons/web_editor/static/lib/odoo-editor/src/OdooEditor.js
@@ -42,7 +42,7 @@ import {
     isEmptyBlock,
     getUrlsInfosInString,
     URL_REGEX,
-    isBold,
+    isSelectionBold,
     YOUTUBE_URL_GET_VIDEO_ID,
     unwrapContents,
     peek,
@@ -1865,7 +1865,7 @@ export class OdooEditor extends EventTarget {
 
             // queryCommandState('bold') does not take stylesheets into account
             const button = this.toolbar.querySelector('#bold');
-            button.classList.toggle('active', isBold(closestStartContainer));
+            button.classList.toggle('active', isSelectionBold(this.editable));
 
             const fontSizeValue = this.toolbar.querySelector('#fontSizeCurrentValue');
             if (fontSizeValue) {

--- a/addons/web_editor/static/lib/odoo-editor/src/commands/commands.js
+++ b/addons/web_editor/static/lib/odoo-editor/src/commands/commands.js
@@ -19,6 +19,7 @@ import {
     insertText,
     isBlock,
     isBold,
+    isSelectionBold,
     isColorGradient,
     isContentTextNode,
     isShrunkBlock,
@@ -360,9 +361,7 @@ export const editorCommands = {
         const selection = editor.document.getSelection();
         if (!selection.rangeCount || selection.getRangeAt(0).collapsed) return;
         getDeepRange(editor.editable, { splitText: true, select: true, correctTripleClick: true });
-        const isAlreadyBold = getSelectedNodes(editor.editable)
-            .filter(n => n.nodeType === Node.TEXT_NODE && n.nodeValue.trim().length)
-            .every(n => isBold(n.parentElement));
+        const isAlreadyBold = isSelectionBold(editor.editable);
         applyInlineStyle(editor, el => {
             if (isAlreadyBold) {
                 const block = closestBlock(el);

--- a/addons/web_editor/static/lib/odoo-editor/src/commands/commands.js
+++ b/addons/web_editor/static/lib/odoo-editor/src/commands/commands.js
@@ -362,7 +362,7 @@ export const editorCommands = {
         getDeepRange(editor.editable, { splitText: true, select: true, correctTripleClick: true });
         const isAlreadyBold = getSelectedNodes(editor.editable)
             .filter(n => n.nodeType === Node.TEXT_NODE && n.nodeValue.trim().length)
-            .find(n => isBold(n.parentElement));
+            .every(n => isBold(n.parentElement));
         applyInlineStyle(editor, el => {
             if (isAlreadyBold) {
                 const block = closestBlock(el);

--- a/addons/web_editor/static/lib/odoo-editor/src/utils/utils.js
+++ b/addons/web_editor/static/lib/odoo-editor/src/utils/utils.js
@@ -867,6 +867,18 @@ export function isBold(node) {
     const fontWeight = +getComputedStyle(closestElement(node)).fontWeight;
     return fontWeight > 500 || fontWeight > +getComputedStyle(closestBlock(node)).fontWeight;
 }
+/**
+ * Return true if the current selection on the editable appears bold. The
+ * selection is considered to appear bold if every text node in it appears bold.
+ *
+ * @param {Element} editable
+ * @returns {boolean}
+ */
+export function isSelectionBold(editable) {
+    const selectedText = getSelectedNodes(editable)
+        .filter(n => n.nodeType === Node.TEXT_NODE && n.nodeValue.trim().length);
+    return selectedText.length && selectedText.every(n => isBold(n.parentElement));
+}
 
 export function isUnbreakable(node) {
     if (!node || node.nodeType === Node.TEXT_NODE) {


### PR DESCRIPTION
Take `<p>a<b>bcde</b>f</p>` and select the whole paragraph. If you click the "bold" button, you would expect the whole paragraph to become bold. Only if you only select "bcde" do you expect to unbold it. This is the behavior of other editors.
Odoo-editor so far was unbolding as long as a part of the selection was bold.

Currently the bold button is active when the closest start container is bold but it should be when pressing it would unbold, ie when the whole selection is bold. This harmonizes it with the behavior of italic and underline (which use browser defaults).

task-2754127

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
