### PR TITLE
[MOV] mail: move tracking values tests to the test_mail module

### DIFF
--- a/addons/mail/static/tests/helpers/mock_models.js
+++ b/addons/mail/static/tests/helpers/mock_models.js
@@ -212,22 +212,6 @@ export class MockModels {
                 },
                 records: [],
             },
-            'mail.test.tracking.value': {
-                fields: {
-                    boolean_field: { string: 'Boolean', tracking: true, type: 'boolean' },
-                    char_field: { string: 'Char', tracking: true, type: 'char' },
-                    date_field: { string: 'Date', tracking: true, type: 'date' },
-                    datetime_field: { string: 'Datetime', tracking: true, type: 'datetime' },
-                    float_field: { string: 'Float', tracking: true, type: 'float' },
-                    integer_field: { string: 'Integer', tracking: true, type: 'integer' },
-                    monetary_field: { string: 'Monetary', tracking: true, type: 'monetary' },
-                    partner_id: { relation: 'res.partner', string: 'Partner', tracking: true, type: 'many2one' },
-                    selection_field: { string: 'Selection', tracking: true, type: 'selection', selection: [['first', 'FIRST']] },
-                    text_field: { string: 'Text', tracking: true, type: 'text' },
-                    message_ids: { string: 'Messages', type: 'one2many', relation: 'mail.message' },
-                },
-                records: [],
-            },
             'mail.template': {
                 fields: {
                     name: { string: "Name", type: "char" },

--- a/addons/test_mail/__manifest__.py
+++ b/addons/test_mail/__manifest__.py
@@ -19,6 +19,14 @@ tests independently to functional aspects of other models. """,
     ],
     'demo': [
     ],
+    'assets': {
+        'web.qunit_suite_tests': [
+            'test_mail/static/tests/*',
+        ],
+        'web.tests_assets': [
+            'test_mail/static/tests/helpers/*',
+        ],
+    },
     'installable': True,
     'application': False,
     'license': 'LGPL-3',

--- a/addons/test_mail/static/tests/helpers/mock_models.js
+++ b/addons/test_mail/static/tests/helpers/mock_models.js
@@ -1,0 +1,38 @@
+/** @odoo-module **/
+
+import { MockModels } from '@mail/../tests/helpers/mock_models';
+import { patch } from 'web.utils';
+
+patch(MockModels, 'test_mail/static/tests/helpers/mock_models.js', {
+
+    //----------------------------------------------------------------------
+    // Public
+    //----------------------------------------------------------------------
+
+    /**
+     * @override
+     */
+    generateData() {
+        const data = this._super(...arguments);
+        Object.assign(data, {
+            'mail.test.tracking.value': {
+                fields: {
+                    boolean_field: { string: 'Boolean', tracking: true, type: 'boolean' },
+                    char_field: { string: 'Char', tracking: true, type: 'char' },
+                    date_field: { string: 'Date', tracking: true, type: 'date' },
+                    datetime_field: { string: 'Datetime', tracking: true, type: 'datetime' },
+                    float_field: { string: 'Float', tracking: true, type: 'float' },
+                    integer_field: { string: 'Integer', tracking: true, type: 'integer' },
+                    monetary_field: { string: 'Monetary', tracking: true, type: 'monetary' },
+                    partner_id: { relation: 'res.partner', string: 'Partner', tracking: true, type: 'many2one' },
+                    selection_field: { string: 'Selection', tracking: true, type: 'selection', selection: [['first', 'FIRST']] },
+                    text_field: { string: 'Text', tracking: true, type: 'text' },
+                    message_ids: { string: 'Messages', type: 'one2many', relation: 'mail.message' },
+                },
+                records: [],
+            },
+        });
+        return data;
+    },
+
+});

--- a/addons/test_mail/static/tests/tracking_value_tests.js
+++ b/addons/test_mail/static/tests/tracking_value_tests.js
@@ -8,7 +8,7 @@ import {
 import FormView from 'web.FormView';
 import testUtils from 'web.test_utils';
 
-QUnit.module('mail', {}, function () {
+QUnit.module('test_mail', {}, function () {
 QUnit.module('tracking_value_tests.js', {
     async beforeEach() {
         await beforeEach(this);


### PR DESCRIPTION
This move is done to prepare the use of server side model definitions during tests.
Indeed, a model having all type of tracked fields will be needed to ease tracking
value testing. This model will be added to the test_mail module so the tracking
value tests need to be there as well.

[](https://github.com/tsm-odoo)task-2767820
