### PR TITLE
[FIX] payment: Exclude acquirers requiring tokenization when logged out

### DIFF
--- a/addons/payment/models/payment_acquirer.py
+++ b/addons/payment/models/payment_acquirer.py
@@ -314,6 +314,13 @@ class PaymentAcquirer(models.Model):
             domain = expression.AND([domain, [('allow_tokenization', '=', True)]])
 
         compatible_acquirers = self.env['payment.acquirer'].search(domain)
+
+        # Prevent the public user from saving a token for acquirers that require tokenization.
+        if self.env.user._is_public():
+            compatible_acquirers = compatible_acquirers.filtered(
+                lambda acq: not self._is_tokenization_required(provider=acq.provider, **kwargs)
+            )
+
         return compatible_acquirers
 
     @api.model


### PR DESCRIPTION
Current behavior:
Public user have access to payment method that require tokenization wich leads to error when they use it.
We should not show those payment methos to the public users (e.g We shouldn't show sepa direct debit because this method uses tokenization)

Steps to reproduce:
- Activate SEPA Direct Debit in the payment acquierers
- Select Bank as payment journal
- In the bank payment journal create an account number (e.g BE71096123456769), and select a Bank (e.g BNP)
- Create a new customer (type : company, country : spain, and an email)
- Create a quotation with this new customer
- Click on the "action" icon and click on generate payment link
- Open the link in an incognito window (to make sure you'r not connected in Odoo)
- Try to use the sepa direct debit
- An access error appears because public user do not have access to payment.token.

The error is happening here when trying to access the token 

https://github.com/odoo/odoo/blob/65cb9ef253f803c61a702569b06af6bf2d16b2cf/addons/payment/controllers/portal.py#L258-L262

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
