### PR TITLE
[FIX] point_of_sale: prevent deletion of paid order

### DIFF
--- a/addons/point_of_sale/static/src/js/db.js
+++ b/addons/point_of_sale/static/src/js/db.js
@@ -502,7 +502,7 @@ var PosDB = core.Class.extend({
         var saved = this.load('unpaid_orders',[]);
         var orders = [];
         saved.forEach(function(o) {
-            if (ids.includes(o.id) && (o.data.server_id || o.data.lines.length)){
+            if (ids.includes(o.id) && (o.data.server_id || o.data.lines.length || o.data.paymentlines.length)){
                 orders.push(o);
             }
         });

--- a/addons/point_of_sale/static/src/js/models.js
+++ b/addons/point_of_sale/static/src/js/models.js
@@ -792,7 +792,7 @@ exports.PosModel = Backbone.Model.extend({
         }
         for (var i = 0; i < jsons.length; i++) {
             var json = jsons[i];
-            if (json.pos_session_id !== this.pos_session.id && json.lines.length > 0) {
+            if (json.pos_session_id !== this.pos_session.id && json.lines.length > 0 && json.paymentlines.length > 0) {
                 orders.push(new exports.Order({},{
                     pos:  this,
                     json: json,


### PR DESCRIPTION
When an order has payment line we should not be able to delete it has it
may contains payments processed by card.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
