### PR TITLE
[FIX] stock: use inventory adjustment name as a reference

### DIFF
--- a/addons/stock/models/stock_quant.py
+++ b/addons/stock/models/stock_quant.py
@@ -292,8 +292,6 @@ class StockQuant(models.Model):
         return action
 
     def action_apply_inventory(self):
-        # Update the context to prevent recursive call from write method
-        self = self.with_context({'inventory_report_mode': False})
         products_tracked_without_lot = []
         for quant in self:
             rounding = quant.product_uom_id.rounding

--- a/addons/stock/tests/test_quant_inventory_mode.py
+++ b/addons/stock/tests/test_quant_inventory_mode.py
@@ -2,7 +2,7 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 from odoo.addons.mail.tests.common import mail_new_test_user
-from odoo.tests.common import TransactionCase
+from odoo.tests.common import Form, TransactionCase
 from odoo.exceptions import AccessError, UserError
 
 
@@ -247,6 +247,23 @@ class TestEditableQuant(TransactionCase):
             {'qty_done': 25},
             {'qty_done': 0},
         ])
+
+    def test_edit_quant_5(self):
+        """ Create a quant with inventory mode and check that the inventory adjustment reason
+            is used as a reference in the `stock.move` """
+        default_wh = self.env['stock.warehouse'].search([('company_id', '=', self.env.company.id)], limit=1)
+        default_stock_location = default_wh.lot_stock_id
+        quant = self.Quant.create({
+            'product_id': self.product.id,
+            'location_id': default_stock_location.id,
+            'inventory_quantity': 1,
+        })
+        form_wizard = Form(self.env['stock.inventory.adjustment.name'].with_context(
+            default_quant_ids=quant.ids
+        ))
+        form_wizard.inventory_adjustment_name = "Inventory Adjustment - Test"
+        form_wizard.save().action_apply()
+        self.assertTrue(self.env['stock.move'].search([('reference', '=', 'Inventory Adjustment - Test')], limit=1))
 
     def test_sn_warning(self):
         """ Checks that a warning is given when reusing an existing SN


### PR DESCRIPTION
**Steps to reproduce the bug:**
- Create a storable product “Test”
- Go to inventory > Operations > Inventory Adjustments
- Add a new line > Choose the “Test” product > Qty = 1*
- Select this line > Click on the “Apply” button
- You have the possibility to enter an “Inventory Reference / Reason”
- Go To reporting > stock moves

**Problem:**
The reference is “Product Quantity Updated” instead of the inventory adjustment name.

In the "action_apply" function, we give the name in the context: https://github.com/odoo/odoo/blob/15.0/addons/stock/wizard/stock_inventory_adjustment_name.py#L27

So that it is then used when creating the `stock.move`: https://github.com/odoo/odoo/blob/15.0/addons/stock/models/stock_quant.py#L800

But the context is destroyed here because we give a dict instead of a key :  https://github.com/odoo/odoo/blob/15.0/addons/stock/models/stock_quant.py#L296

**Solution:**
Remove the context override because it was done here: https://github.com/odoo/odoo/pull/83884
with the explanation that it's due to the write being called too many times here:
https://github.com/odoo/odoo/blob/8b155b695823dfa954464ad0d5dd07445ece2471/addons/stock/models/stock_quant.py#L244-L248

but then this later PR: https://github.com/odoo/odoo/pull/84771 deletes the same problem lines.

opw-2762169




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
