### PR TITLE
[IMP] base: remove postmaster-odoo default bounce

### DIFF
--- a/odoo/addons/base/models/ir_mail_server.py
+++ b/odoo/addons/base/models/ir_mail_server.py
@@ -440,11 +440,11 @@ class IrMailServer(models.Model):
         If "mail.catchall.domain" is not set, return None.
 
         '''
-        get_param = self.env['ir.config_parameter'].sudo().get_param
-        postmaster = get_param('mail.bounce.alias', default='postmaster-odoo')
-        domain = get_param('mail.catchall.domain')
-        if postmaster and domain:
-            return '%s@%s' % (postmaster, domain)
+        ICP = self.env['ir.config_parameter'].sudo()
+        bounce_alias = ICP.get_param('mail.bounce.alias')
+        domain = ICP.get_param('mail.catchall.domain')
+        if bounce_alias and domain:
+            return '%s@%s' % (bounce_alias, domain)
         return
 
     @api.model


### PR DESCRIPTION
Coming from odoo/odoo@a4597fe34fcfa8dae28b156410080346bb33af33 . This code is not necessary anymore since we better
handle From, SMTP-From, as well as allowing mail server filtering. We can
now use standard aliases and servers instead of relying on hardcoded value
"postmaster-odoo".

Task-2710804 (Mail: Clean MailThread API)
