### PR TITLE
[IMP] mail: revert of "set an integer widget on many2one_reference field"

### DIFF
--- a/addons/mail/views/mail_activity_views.xml
+++ b/addons/mail/views/mail_activity_views.xml
@@ -104,7 +104,7 @@
                         <field name="activity_category" invisible="1" />
                         <field name="res_model" invisible="1"/>
                         <field name="res_model_id" invisible="1"/>
-                        <field name="res_id" invisible="1" widget="integer"/>
+                        <field name="res_id" invisible="1"/>
                         <field name="chaining_type" invisible="1"/>
                         <field name="previous_activity_type_id"/>
                         <field name="has_recommended_activities"/>

--- a/addons/mail/views/mail_followers_views.xml
+++ b/addons/mail/views/mail_followers_views.xml
@@ -10,7 +10,7 @@
             <field name="arch" type="xml">
                 <tree string="Followers">
                     <field name="res_model"/>
-                    <field name="res_id" widget="integer"/>
+                    <field name="res_id"/>
                     <field name="partner_id"/>
                 </tree>
             </field>
@@ -28,7 +28,7 @@
                                 <field name="partner_id"/>
                             </group>
                             <group>
-                                <field name="res_id" widget="integer"/>
+                                <field name="res_id"/>
                                 <field name="subtype_ids" widget="many2many_tags"/>
                             </group>
                         </group>

--- a/addons/mail/views/mail_message_views.xml
+++ b/addons/mail/views/mail_message_views.xml
@@ -12,7 +12,7 @@
                     <field name="subject"/>
                     <field name="author_id"/>
                     <field name="model"/>
-                    <field name="res_id" widget="integer"/>
+                    <field name="res_id"/>
                 </tree>
             </field>
         </record>
@@ -42,7 +42,7 @@
                             </group>
                             <group>
                                 <field name="model"/>
-                                <field name="res_id" widget="integer"/>
+                                <field name="res_id"/>
                                 <field name="record_name"/>
                                 <field name="parent_id"/>
                             </group>


### PR DESCRIPTION
Revert of https://github.com/odoo/odoo/commit/d3f6c3b579f39b313401c63d97b95ce690501591.

Cleanup. The JS has already been adapted to many2one_reference fields.

**Description of the issue/feature this PR addresses:**

Commit https://github.com/odoo/odoo/commit/d3f6c3b579f39b313401c63d97b95ce690501591 was done as a quick fix, before the framework actually made that field type globally supported. But nowadays, the framework has been adapted already. Thus, we can revert that commit as there is no need to specify the widget manually in those cases anymore.

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
