### PR TITLE
[ADD] cloc: count loc in style file and from imported module

### DIFF
--- a/addons/base_import_module/models/ir_module.py
+++ b/addons/base_import_module/models/ir_module.py
@@ -104,7 +104,13 @@ class IrModule(models.Model):
                     if attachment:
                         attachment.write(values)
                     else:
-                        IrAttachment.create(values)
+                        attachment = IrAttachment.create(values)
+                        self.env['ir.model.data'].create({
+                            'name': f"attachment_{url_path}".replace('.', '_'),
+                            'model': 'ir.attachment',
+                            'module': module,
+                            'res_id': attachment.id,
+                        })
 
         IrAsset = self.env['ir.asset']
         assets_vals = []
@@ -139,7 +145,7 @@ class IrModule(models.Model):
         # Create new assets and attach 'ir.model.data' records to them
         created_assets = IrAsset.create(assets_to_create)
         self.env['ir.model.data'].create([{
-            'name': f"{asset['bundle']}.{asset['path']}",
+            'name': f"{asset['bundle']}_{asset['path']}".replace(".", "_"),
             'model': 'ir.asset',
             'module': module,
             'res_id': asset.id,

--- a/addons/base_import_module/tests/test_cloc.py
+++ b/addons/base_import_module/tests/test_cloc.py
@@ -1,8 +1,22 @@
 # -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
+import json
+from io import BytesIO
+from zipfile import ZipFile
 
 from odoo.tools import cloc
 from odoo.addons.base.tests import test_cloc
+
+VALID_XML = """
+<templates id="template" xml:space="preserve">
+    <t t-name="stock_barcode.LineComponent">
+        <div t-if="line.picking_id and line.picking_id.origin" name="origin">
+            <i class="fa fa-fw fa-file" />
+            <span t-esc="line.picking_id.origin" />
+        </div>
+    </t>
+</templates>
+"""
 
 class TestClocFields(test_cloc.TestClocCustomization):
 
@@ -17,12 +31,76 @@ class TestClocFields(test_cloc.TestClocCustomization):
             'imported': True,
         })
         f1 = self.create_field('x_imported_field')
-        self.create_xml_id('import_field', f1.id, 'imported_module')
+        self.create_xml_id('import_field', 'ir.model.fields', f1.id, 'imported_module')
         cl = cloc.Cloc()
         cl.count_customization(self.env)
         self.assertEqual(cl.code.get('imported_module', 0), 1, 'Count fields with xml_id of imported module')
         f2 = self.create_field('x_base_field')
-        self.create_xml_id('base_field', f2.id, 'base')
+        self.create_xml_id('base_field', 'ir.model.fields', f2.id, 'base')
         cl = cloc.Cloc()
         cl.count_customization(self.env)
         self.assertEqual(cl.code.get('base', 0), 0, "Don't count fields from standard module")
+
+    def test_count_qweb_imported_module(self):
+        self.env['ir.module.module'].create({
+            'author': 'Odoo',
+            'imported': True,
+            'latest_version': '15.0.1.0.0',
+            'name': 'test_imported_module',
+            'state': 'installed',
+            'summary': 'Test imported module for cloc',
+        })
+        qweb_view = self.env['ir.ui.view'].create({
+            "name": "Qweb Test",
+            "type": "qweb",
+            "mode": "primary",
+            "arch_base": "<html>\n  <body>\n    <t t-out=\"Hello World\"/>\n  </body>\n</html>",
+        })
+        self.create_xml_id("qweb_view_test", 'ir.ui.view', qweb_view.id, 'test_imported_module')
+
+        # Add qweb view from non imported module
+        qweb_view = self.env['ir.ui.view'].create({
+            "name": "Qweb Test",
+            "type": "qweb",
+            "arch_base": "<html>\n  <body>\n    <t t-out=\"Hello World\"/>\n  </body>\n</html>",
+        })
+        self.create_xml_id("qweb_view_test", 'ir.ui.view', qweb_view.id)
+
+        # Add form view from module
+        form_view = self.env['ir.ui.view'].create({
+            "name": "Test partner",
+            "type": "form",
+            "model": "res.partner",
+            "arch_base": "<form>\n  <field name=\"name\" \n         invisible=\"1\" />\n</form>",
+        })
+        self.create_xml_id("form_view_test", 'ir.ui.view', form_view.id, 'test_imported_module')
+
+        cl = cloc.Cloc()
+        cl.count_customization(self.env)
+        self.assertEqual(cl.code.get('test_imported_module', 0), 5, "Count only qweb view from imported module")
+
+    def test_count_attachment_imported_module(self):
+        manifest_content = json.dumps({
+            'name': 'test_imported_module',
+            'description': 'Test',
+            'assets': {
+                'web.assets_backend': [
+                    'test_imported_module/static/src/js/test.js',
+                    'test_imported_module/static/src/css/test.scss',
+                ]
+            },
+            'license': 'LGPL-3',
+        })
+
+        stream = BytesIO()
+        with ZipFile(stream, 'w') as archive:
+            archive.writestr('test_imported_module/__manifest__.py', manifest_content)
+            archive.writestr('test_imported_module/static/src/js/test.js', test_cloc.JS_TEST)
+            archive.writestr('test_imported_module/static/src/js/test.scss', test_cloc.SCSS_TEST)
+            archive.writestr('test_imported_module/static/src/js/test.xml', VALID_XML)
+
+        # Import test module
+        self.env['ir.module.module'].import_zipfile(stream)
+        cl = cloc.Cloc()
+        cl.count_customization(self.env)
+        self.assertEqual(cl.code.get('test_imported_module', 0), 35)

--- a/addons/base_import_module/tests/test_import_module.py
+++ b/addons/base_import_module/tests/test_import_module.py
@@ -44,13 +44,13 @@ class TestImportModule(odoo.tests.TransactionCase):
 
         asset_data = self.env['ir.model.data'].search([('model', '=', 'ir.asset'), ('res_id', '=', asset.id)])
         self.assertEqual(asset_data.module, 'test_module')
-        self.assertEqual(asset_data.name, f'{bundle}.{path}')
+        self.assertEqual(asset_data.name, f'{bundle}_{path}'.replace(".", "_"))
 
         # Uninstall test module
         self.env['ir.module.module'].search([('name', '=', 'test_module')]).module_uninstall()
 
         attachment = self.env['ir.attachment'].search([('url', '=', path)])
-        self.assertEqual(len(attachment), 1)
+        self.assertEqual(len(attachment), 0)
 
         asset = self.env['ir.asset'].search([('name', '=', f'test_module.{bundle}.{path}')])
         self.assertEqual(len(asset), 0)


### PR DESCRIPTION
Context
-------

Web design specific require a lot of work and need maintenance.
So far the style files were not taken into account despite the
amount of maintenance they require.

With this commit they are going to be counted,
knowing they still can be excluded in the manifest.

Imported module allow to deploy frontend assets: stylesheet,
javascript, xml template and Qweb view that require
as well some maintenance. They are going to be counted

Implementation
--------------

- Add method to parse css and scss file
- Include .scss and .css file in the count

- Add external_id to attachment that store
  frontend asset of imported module
- Find all attachment with .js, .css, .scss, .xml
  from imported module
- Find qweb view from imported module
- cound the content of the attachment and the qweb view



--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
