### PR TITLE
[FIX] sale: Show sales from archived partners

### DIFF
--- a/addons/sale/models/res_partner.py
+++ b/addons/sale/models/res_partner.py
@@ -43,3 +43,11 @@ class ResPartner(models.Model):
             ('state', 'in', ['sent', 'sale', 'done'])
         ], limit=1)
         return can_edit_vat and not bool(has_so)
+
+    def action_view_sale_order(self):
+        action = self.env['ir.actions.act_window']._for_xml_id('sale.act_res_partner_2_sale_order')
+        if self.is_company:
+            action['domain'] = [('partner_id.commercial_partner_id.id', '=', self.id)]
+        else:
+            action['domain'] = [('partner_id.id', '=', self.id)]
+        return action

--- a/addons/sale/views/res_partner_views.xml
+++ b/addons/sale/views/res_partner_views.xml
@@ -4,7 +4,7 @@
             <field name="name">Quotations and Sales</field>
             <field name="res_model">sale.order</field>
             <field name="view_mode">tree,form,graph</field>
-            <field name="context">{'search_default_partner_id': active_id, 'default_partner_id': active_id}</field>
+            <field name="context">{'default_partner_id': active_id}</field>
             <field name="groups_id" eval="[(4, ref('sales_team.group_sale_salesman'))]"/>
             <field name="help" type="html">
               <p class="o_view_nocontent_smiling_face">
@@ -40,7 +40,7 @@
             <field name="groups_id" eval="[(4, ref('sales_team.group_sale_salesman'))]"/>
             <field name="arch" type="xml">
                 <div name="button_box" position="inside">
-                    <button class="oe_stat_button" type="action" name="%(sale.act_res_partner_2_sale_order)d" 
+                    <button class="oe_stat_button" type="object" name="action_view_sale_order"
                         groups="sales_team.group_sale_salesman"
                         icon="fa-usd">
                         <field string="Sales" name="sale_order_count" widget="statinfo"/>


### PR DESCRIPTION
Current behavior:
When you access sales tree view of a company, the sales of archived partners are not shown in the list.
But the sales count on the smart button is right.

Steps to reproduce:
- Add a partner to a company
- Create a sale with this new partner and confirm it
- Archive the new partner
- Go on the company contact page
- The smart button will show the number of sales
- Click the sale smart button
- The list is missing the new partner's sales

opw-2774862

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
