### PR TITLE
[FIX] mail: make default mode for channel 'groups', not 'public'

### DIFF
--- a/addons/mail/models/mail_channel.py
+++ b/addons/mail/models/mail_channel.py
@@ -932,7 +932,7 @@ class Channel(models.Model):
         return channel_info
 
     @api.model
-    def channel_create(self, name, privacy='public'):
+    def channel_create(self, name, privacy='groups'):
         """ Create a channel and add the current partner, broadcast it (to make the user directly
             listen to it when polling)
             :param name : the name of the channel to create

--- a/addons/mail/static/src/js/discuss.js
+++ b/addons/mail/static/src/js/discuss.js
@@ -679,7 +679,7 @@ var Discuss = AbstractAction.extend({
                     if (self._lastSearchVal) {
                         if (ui.item.special) {
                             if (ui.item.special === 'public') {
-                                self.call('mail_service', 'createChannel', self._lastSearchVal, 'public');
+                                self.call('mail_service', 'createChannel', self._lastSearchVal, 'groups');
                             } else {
                                 self.call('mail_service', 'createChannel', self._lastSearchVal, 'private');
                             }


### PR DESCRIPTION
It's currently confusing: the default value is already 'groups', but the create
method is actually giving another default.

task-2749643