### PR TITLE
[FIX] Restore odoo-bin as CLI

### DIFF
--- a/doc/cla/individual/Parselon.md
+++ b/doc/cla/individual/Parselon.md
@@ -1,0 +1,11 @@
+Argentina, march 4th 2022
+
+I hereby agree to the terms of the Odoo Individual Contributor License
+Agreement v1.0.
+
+I declare that I am authorized and able to make this agreement and sign this
+declaration.
+
+Signed,
+
+Matias Morales matiaslp_28@hotmail.com.ar https://github.com/Parselon

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,10 @@ setup(
     author_email=author_email,
     classifiers=[c for c in classifiers.split('\n') if c],
     license=license,
-    scripts=['setup/odoo'],
+    scripts=[
+        'setup/odoo',
+        'odoo-bin',
+    ],
     packages=find_packages(),
     package_dir={'%s' % lib_name: 'odoo'},
     include_package_data=True,


### PR DESCRIPTION
This PR fixes #84506

Restore `odoo-bin`, to be consistent with the documentation https://www.odoo.com/documentation/13.0/developer/misc/other/cmdline.html
The target branch is `13.0` to be ported to upper versions.

Current behavior before PR:
```pip install -e ./odoo
odoo-bin --version

bash: odoo-bin: command not found
```
Desired behavior after PR is merged:

```pip install -e ./odoo
odoo-bin --version

Odoo Server 13.0
```

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
