### PR TITLE
[FIX] web: setting target "main" on action doesn't clear the breadcrumbs

### DIFF
--- a/addons/web/static/src/webclient/actions/action_service.js
+++ b/addons/web/static/src/webclient/actions/action_service.js
@@ -818,7 +818,7 @@ function makeActionManager(env) {
         action.controllers[view.type] = controller;
 
         const updateUIOptions = {
-            clearBreadcrumbs: options.clearBreadcrumbs,
+            clearBreadcrumbs: action.target === 'main' || options.clearBreadcrumbs ,
             onClose: options.onClose,
             stackPosition: options.stackPosition,
         };


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
The view opens in the content area and a new breadcrumb is added if action type is main.

Desired behaviour after PR is merged:
The view opens in main window and clears the breadcrumb.

Fixes #83865

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
