### PR TITLE
[FIX] hr_expense : keep total when change taxes

### DIFF
--- a/addons/hr_expense/models/hr_expense.py
+++ b/addons/hr_expense/models/hr_expense.py
@@ -276,6 +276,10 @@ class HrExpense(models.Model):
                 exp.duplicate_expense_ids = [(6, 0, ids)]
                 expenses = expenses - exp
 
+    @api.onchange('product_id')
+    def _onchange_product_id(self):
+        self.quantity = 1
+
     @api.onchange('product_id', 'date', 'account_id')
     def _onchange_product_id_date_account_id(self):
         rec = self.env['account.analytic.default'].sudo().account_get(

--- a/addons/hr_expense/views/hr_expense_views.xml
+++ b/addons/hr_expense/views/hr_expense_views.xml
@@ -150,9 +150,9 @@
                                 <field name="quantity" class="oe_inline" attrs="{'readonly': [('sheet_is_editable', '=', False)]}"/>
                                 <field name="product_uom_id" required="1" options="{'no_open': True, 'no_create': True}" class="oe_inline" groups="uom.group_uom"/>
                             </div>
-                            <label for="total_amount" string="Total" attrs="{'invisible': [('product_has_cost', '=', True)]}"/>
+                            <label for="unit_amount" string="Total" attrs="{'invisible': [('product_has_cost', '=', True)]}"/>
                             <div class="o_row" attrs="{'invisible': [('product_has_cost', '=', True)]}">
-                                <field name="total_amount" widget='monetary' options="{'currency_field': 'currency_id'}" attrs="{'readonly': [('sheet_is_editable', '=', False)]}"/>
+                                <field name="unit_amount" widget='monetary' options="{'currency_field': 'currency_id'}" attrs="{'readonly': [('sheet_is_editable', '=', False)]}"/>
                                 <field name="currency_id" groups="base.group_multi_currency"/>
                             </div>
                             <!-- YTI TO REMOVE IN MASTER START -->
@@ -162,11 +162,11 @@
                                 <label for="total_amount_company" string="" attrs="{'invisible': [('same_currency', '=', True), ('product_has_cost', '=', False)]}"/>
                             </div>
                             <!-- YTI TO REMOVE IN MASTER END -->
-                            <div class="o_row d-flex" attrs="{'invisible': [('same_currency', '=', True), ('product_has_cost', '=', False)]}">
+                            <field name="tax_ids" widget="many2many_tags" groups="account.group_account_readonly" attrs="{'readonly': [('is_editable', '=', False)], 'invisible': [('product_has_cost', '=', True)]}"  context="{'default_company_id': company_id}"/>
+                            <div class="o_row d-flex" >
                                 <field name="total_amount_company" style="vertical-align: top;" widget='monetary' options="{'currency_field': 'company_currency_id'}"/>
                                 <field name="label_convert_rate"/>
                             </div>
-                            <field name="tax_ids" widget="many2many_tags" groups="account.group_account_readonly" attrs="{'readonly': [('is_editable', '=', False)], 'invisible': [('product_has_cost', '=', True)]}"  context="{'default_company_id': company_id}" placeholder="Included in price taxes" />
                         </group><group>
                             <field name="reference" groups="account.group_account_readonly" attrs="{'readonly': [('is_ref_editable', '=', False)], 'invisible': [('product_has_cost', '=', True)]}"/>
                             <field name="date" attrs="{'readonly': [('sheet_is_editable', '=', False)]}"/>


### PR DESCRIPTION
Steps :
Expense > create an expense in "My expense to report".
Select a product with cost = 0.
Write a price in total.
Select a tax.

Issue :
The total returns to zero.

Cause :
The 'total' field is the untaxed_amount.
When changing the tax, it is recomputed as follows :
expense.untaxed_amount = expense.unit_amount * expense.quantity
As unit_amount has remained zero, untaxed_amount's value is zero.

Fix :
The 'total' field is the unit_price and the qty = 1.

opw-2761677

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
