### PR TITLE
[FIX] hr_holidays: allow to edit 'nextcall' field

### DIFF
--- a/addons/hr_holidays/models/hr_leave_allocation.py
+++ b/addons/hr_holidays/models/hr_leave_allocation.py
@@ -138,7 +138,7 @@ class HolidaysAllocation(models.Model):
         ('years', 'Years')
         ], compute='_compute_from_holiday_status_id', store=True, string="Unit of time between two intervals", readonly=False,
         states={'cancel': [('readonly', True)], 'refuse': [('readonly', True)], 'validate1': [('readonly', True)], 'validate': [('readonly', True)]})
-    nextcall = fields.Date("Date of the next accrual allocation", default=False, readonly=True)
+    nextcall = fields.Date("Date of the next accrual allocation", default=False, readonly=True, tracking=True)
     max_leaves = fields.Float(compute='_compute_leaves')
     leaves_taken = fields.Float(compute='_compute_leaves')
 

--- a/addons/hr_holidays/views/hr_leave_allocation_views.xml
+++ b/addons/hr_holidays/views/hr_leave_allocation_views.xml
@@ -105,6 +105,7 @@
                                 <span class="ml8" attrs="{'invisible': [('type_request_unit', '=', 'hour')]}">Days</span>
                                 <span class="ml8" attrs="{'invisible': [('type_request_unit', '!=', 'hour')]}">Hours</span>
                             </div>
+                            <field name="nextcall" attrs="{'readonly': [('state', 'not in', ('draft','confirm'))], 'invisible': [('allocation_type', '!=', 'accrual')]}"/>
                         </group>
                         <group name="alloc_right_col">
                             <field name="employee_id" invisible="1" groups="hr_holidays.group_hr_holidays_user"/>


### PR DESCRIPTION
Issue: `Accrual Leave: Updates the number of leaves` is wrong
Steps:
1. On 20/11/2019: create a leave allocation with the Allocation Type is accrual. (1 day every 1 month)
2. Odoo bot runs 'Accrual Time Off' Scheduled Action to 20/06/2020, then it's disabled (active=False)
3. On 10/02/2022, 'Accrual Time Off' Scheduled Action is enabled (active=True). From this point on, the employee is allotted the daily leave, resulting in the wrong number of cumulative leave days of the employee.

Cause:
1. Date value of the next accrual allocation is 20/07/2020.
2. On 10/02/2022, 'Accrual Time Off' Scheduled Action is enabled (active=True). Odoo bot runs 'Accrual Time Off' Scheduled Action, then Date value of the next accrual allocation is 20/08/2020.
On 11/02/2022, Date value of the next accrual allocation is 20/09/2020,
...

Fix:
allows editing field 'nextcall' when record is in state 'draft` or 'confirm'

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
