### PR TITLE
[FIX] l10n_dk: add tax rep line on 0% taxes

### DIFF
--- a/addons/l10n_ch/data/account_vat2011_data.xml
+++ b/addons/l10n_ch/data/account_vat2011_data.xml
@@ -845,12 +845,20 @@
                     'repartition_type': 'base',
                     'plus_report_line_ids': [ref('account_tax_report_line_chtax_900')],
                 }),
+                (0,0, {
+                    'factor_percent': 100,
+                    'repartition_type': 'tax',
+                }),
             ]"/>
             <field name="refund_repartition_line_ids" eval="[(5, 0, 0),
                 (0,0, {
                     'factor_percent': 100,
                     'repartition_type': 'base',
                     'minus_report_line_ids': [ref('account_tax_report_line_chtax_900')],
+                }),
+                (0,0, {
+                    'factor_percent': 100,
+                    'repartition_type': 'tax',
                 }),
             ]"/>
         </record>
@@ -869,12 +877,20 @@
                     'repartition_type': 'base',
                     'plus_report_line_ids': [ref('account_tax_report_line_chtax_910')],
                 }),
+                (0,0, {
+                    'factor_percent': 100,
+                    'repartition_type': 'tax',
+                }),
             ]"/>
             <field name="refund_repartition_line_ids" eval="[(5, 0, 0),
                 (0,0, {
                     'factor_percent': 100,
                     'repartition_type': 'base',
                     'minus_report_line_ids': [ref('account_tax_report_line_chtax_910')],
+                }),
+                (0,0, {
+                    'factor_percent': 100,
+                    'repartition_type': 'tax',
                 }),
             ]"/>
         </record>

--- a/addons/l10n_dk/data/account_tax_template_data.xml
+++ b/addons/l10n_dk/data/account_tax_template_data.xml
@@ -83,12 +83,20 @@
                 'repartition_type': 'base',
                 'plus_report_line_ids': [ref('l10n_dk.account_tax_report_line_section_b_product_eu')],
             }),
+            (0,0, {
+                'factor_percent': 100,
+                'repartition_type': 'tax',
+            }),
         ]"/>
         <field name="refund_repartition_line_ids" eval="[(5, 0, 0),
             (0,0, {
                 'factor_percent': 100,
                 'repartition_type': 'base',
                 'minus_report_line_ids': [ref('l10n_dk.account_tax_report_line_section_b_product_eu')],
+            }),
+            (0,0, {
+                'factor_percent': 100,
+                'repartition_type': 'tax',
             }),
         ]"/>
     </record>
@@ -105,12 +113,20 @@
                 'repartition_type': 'base',
                 'plus_report_line_ids': [ref('l10n_dk.account_tax_report_line_section_b_services')],
             }),
+            (0,0, {
+                'factor_percent': 100,
+                'repartition_type': 'tax',
+            }),
         ]"/>
         <field name="refund_repartition_line_ids" eval="[(5, 0, 0),
             (0,0, {
                 'factor_percent': 100,
                 'repartition_type': 'base',
                 'minus_report_line_ids': [ref('l10n_dk.account_tax_report_line_section_b_services')],
+            }),
+            (0,0, {
+                'factor_percent': 100,
+                'repartition_type': 'tax',
             }),
         ]"/>
     </record>
@@ -129,12 +145,20 @@
                 'repartition_type': 'base',
                 'plus_report_line_ids': [ref('l10n_dk.account_tax_report_line_section_c')],
             }),
+            (0,0, {
+                'factor_percent': 100,
+                'repartition_type': 'tax',
+            }),
         ]"/>
         <field name="refund_repartition_line_ids" eval="[(5, 0, 0),
             (0,0, {
                 'factor_percent': 100,
                 'repartition_type': 'base',
                 'minus_report_line_ids': [ref('l10n_dk.account_tax_report_line_section_c')],
+            }),
+            (0,0, {
+                'factor_percent': 100,
+                'repartition_type': 'tax',
             }),
         ]"/>
     </record>

--- a/addons/l10n_fi/data/account_tax_template_data.xml
+++ b/addons/l10n_fi/data/account_tax_template_data.xml
@@ -564,12 +564,20 @@
               'repartition_type': 'base',
               'plus_report_line_ids':  [ref('tax_report_base_sales_goods_eu')],
             }),
+            (0,0, {
+              'factor_percent': 100,
+              'repartition_type': 'tax',
+            }),
         ]"/>
         <field name="refund_repartition_line_ids" eval="[(5, 0, 0),
             (0,0, {
               'factor_percent': 100,
               'repartition_type': 'base',
               'minus_report_line_ids':  [ref('tax_report_base_sales_goods_eu')],
+            }),
+            (0,0, {
+              'factor_percent': 100,
+              'repartition_type': 'tax',
             }),
         ]"/>
     </record>
@@ -589,12 +597,20 @@
               'repartition_type': 'base',
               'plus_report_line_ids':  [ref('tax_report_base_sales_service_eu')],
             }),
+            (0,0, {
+              'factor_percent': 100,
+              'repartition_type': 'tax',
+            }),
         ]"/>
         <field name="refund_repartition_line_ids" eval="[(5, 0, 0),
             (0,0, {
               'factor_percent': 100,
               'repartition_type': 'base',
               'minus_report_line_ids':  [ref('tax_report_base_sales_service_eu')],
+            }),
+            (0,0, {
+              'factor_percent': 100,
+              'repartition_type': 'tax',
             }),
         ]"/>
     </record>
@@ -887,13 +903,20 @@
             (0,0, {
               'factor_percent': 100,
               'repartition_type': 'base',
-
+            }),
+            (0,0, {
+              'factor_percent': 100,
+              'repartition_type': 'tax',
             }),
         ]"/>
         <field name="refund_repartition_line_ids" eval="[(5, 0, 0),
             (0,0, {
               'factor_percent': 100,
               'repartition_type': 'base',
+            }),
+            (0,0, {
+              'factor_percent': 100,
+              'repartition_type': 'tax',
             }),
         ]"/>
     </record>
@@ -944,12 +967,20 @@
               'repartition_type': 'base',
               'plus_report_line_ids':  [ref('tax_report_base_sales_construct_service')],
             }),
+            (0,0, {
+              'factor_percent': 100,
+              'repartition_type': 'tax',
+            }),
         ]"/>
         <field name="refund_repartition_line_ids" eval="[(5, 0, 0),
             (0,0, {
               'factor_percent': 100,
               'repartition_type': 'base',
               'minus_report_line_ids':  [ref('tax_report_base_sales_construct_service')],
+            }),
+            (0,0, {
+              'factor_percent': 100,
+              'repartition_type': 'tax',
             }),
         ]"/>
     </record>
@@ -1049,13 +1080,21 @@
               'factor_percent': 100,
               'repartition_type': 'base',
               'plus_report_line_ids':  [ref('tax_report_base_turnover_0_vat')],
-            })
+            }),
+            (0,0, {
+              'factor_percent': 100,
+              'repartition_type': 'tax',
+            }),
         ]"/>
         <field name="refund_repartition_line_ids" eval="[(5, 0, 0),
             (0,0, {
               'factor_percent': 100,
               'repartition_type': 'base',
               'minus_report_line_ids':  [ref('tax_report_base_turnover_0_vat')],
+            }),
+            (0,0, {
+              'factor_percent': 100,
+              'repartition_type': 'tax',
             }),
         ]"/>
     </record>
@@ -1215,12 +1254,20 @@
               'repartition_type': 'base',
               'plus_report_line_ids':  [ref('tax_report_base_turnover_0_vat')],
             }),
+            (0,0, {
+              'factor_percent': 100,
+              'repartition_type': 'tax',
+            }),
         ]"/>
         <field name="refund_repartition_line_ids" eval="[(5, 0, 0),
             (0,0, {
               'factor_percent': 100,
               'repartition_type': 'base',
               'minus_report_line_ids':  [ref('tax_report_base_turnover_0_vat')],
+            }),
+            (0,0, {
+              'factor_percent': 100,
+              'repartition_type': 'tax',
             }),
         ]"/>
     </record>


### PR DESCRIPTION
Every tax should have a repartition line even if it's a 0% tax
