### PR TITLE
[FIX] hr_holidays: The `Accrual Leave: Updates the number of leaves` is wrong

### DIFF
--- a/addons/hr_holidays/models/hr_leave_allocation.py
+++ b/addons/hr_holidays/models/hr_leave_allocation.py
@@ -183,9 +183,9 @@ class HolidaysAllocation(models.Model):
             if holiday.nextcall:
                 values['nextcall'] = holiday.nextcall + delta
             else:
-                values['nextcall'] = holiday.date_from
-                while values['nextcall'] <= datetime.combine(today, time(0, 0, 0)):
-                    values['nextcall'] += delta
+                values['nextcall'] = holiday.date_from.date()
+            while values['nextcall'] <= today:
+                values['nextcall'] += delta
 
             period_start = datetime.combine(today, time(0, 0, 0)) - delta
             period_end = datetime.combine(today, time(0, 0, 0))


### PR DESCRIPTION
Issue: `Accrual Leave: Updates the number of leaves` is wrong

Steps:
1. On 20/11/2019: create a leave allocation with the Allocation Type is accrual. (1 day every 1 month)
2. Odoo bot runs 'Accrual Time Off' Scheduled Action to 20/06/2020, then it's disabled (active=False)
3. On 10/02/2022, 'Accrual Time Off' Scheduled Action is enabled (active=True). From this point on, the employee is allotted the daily leave, resulting in the wrong number of cumulative leave days of the employee.

Cause:
1. Date value of the next accrual allocation is 20/07/2020.
2. On 10/02/2022, 'Accrual Time Off' Scheduled Action is enabled (active=True). Odoo bot runs 'Accrual Time Off' Scheduled Action, then Date value of the next accrual allocation is 20/08/2020.
On 11/02/2022, Date value of the next accrual allocation is 20/09/2020,
...

Expect:
Employees are allocated by the Accrual Allocation Cycle

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
