### PR TITLE
[REF] web: give concrete views ownership of their root element

### DIFF
--- a/addons/web/static/src/views/graph/graph_view.xml
+++ b/addons/web/static/src/views/graph/graph_view.xml
@@ -46,25 +46,27 @@
     </t>
 
     <t t-name="web.GraphView" owl="1">
-        <Layout className="model.useSampleModel ? 'o_view_sample_data' : ''">
-            <t t-set-slot="control-panel-bottom-left">
-                <t t-call="{{ constructor.buttonTemplate }}"/>
-            </t>
-            <t t-if="model.data">
-                <t t-if="model.useSampleModel and props.info.noContentHelp" t-call="web.ActionHelper">
-                    <t t-set="noContentHelp" t-value="props.info.noContentHelp"/>
+        <div t-att-class="props.className">
+            <Layout className="model.useSampleModel ? 'o_view_sample_data' : ''">
+                <t t-set-slot="control-panel-bottom-left">
+                    <t t-call="{{ constructor.buttonTemplate }}"/>
                 </t>
-                <Renderer
-                    class="model.useSampleModel ? 'o_sample_data_disabled' : ''"
-                    model="model"
-                    onGraphClicked="(domain) => this.onGraphClicked(domain)"
-                    />
-            </t>
-            <t t-else="" t-call="web.NoContentHelper">
-                <t t-set="title">Invalid data</t>
-                <t t-set="description">Pie chart cannot mix positive and negative numbers. Try to change your domain to only display positive results</t>
-            </t>
-        </Layout>
+                <t t-if="model.data">
+                    <t t-if="model.useSampleModel and props.info.noContentHelp" t-call="web.ActionHelper">
+                        <t t-set="noContentHelp" t-value="props.info.noContentHelp"/>
+                    </t>
+                    <Renderer
+                        class="model.useSampleModel ? 'o_sample_data_disabled' : ''"
+                        model="model"
+                        onGraphClicked="(domain) => this.onGraphClicked(domain)"
+                        />
+                </t>
+                <t t-else="" t-call="web.NoContentHelper">
+                    <t t-set="title">Invalid data</t>
+                    <t t-set="description">Pie chart cannot mix positive and negative numbers. Try to change your domain to only display positive results</t>
+                </t>
+            </Layout>
+        </div>
     </t>
 
 </templates>

--- a/addons/web/static/src/views/helpers/standard_view_props.js
+++ b/addons/web/static/src/views/helpers/standard_view_props.js
@@ -33,4 +33,5 @@ export const standardViewProps = {
     resId: { type: Number, optional: 1 },
     resIds: { type: Array, optional: 1 },
     bannerRoute: { type: String, optional: 1 },
+    className: { type: String, optional: 1 },
 };

--- a/addons/web/static/src/views/pivot/pivot_view.xml
+++ b/addons/web/static/src/views/pivot/pivot_view.xml
@@ -17,26 +17,28 @@
     </t>
 
     <t t-name="web.PivotView" owl="1">
-        <Layout className="model.useSampleModel ? 'o_view_sample_data' : ''">
-            <t t-set-slot="control-panel-bottom-left">
-                <t t-call="{{ constructor.buttonTemplate }}"/>
-            </t>
-            <t t-set="displayNoContent" t-value="
-                props.info.noContentHelp !== false and (
-                    !(model.hasData() and model.metaData.activeMeasures.length) or
-                    model.useSampleModel
-                )"
-            />
-            <t t-if="displayNoContent">
-                <t t-if="props.info.noContentHelp" t-call="web.ActionHelper">
-                    <t t-set="noContentHelp" t-value="props.info.noContentHelp"/>
+        <div t-att-class="props.className">
+            <Layout className="model.useSampleModel ? 'o_view_sample_data' : ''">
+                <t t-set-slot="control-panel-bottom-left">
+                    <t t-call="{{ constructor.buttonTemplate }}"/>
                 </t>
-                <t t-else="" t-call="web.NoContentHelper"/>
-            </t>
-            <t t-if="model.hasData() and model.metaData.activeMeasures.length">
-                <Renderer model="model" onCellClicked="cell => this.onOpenView(cell)"/>
-            </t>
-        </Layout>
+                <t t-set="displayNoContent" t-value="
+                    props.info.noContentHelp !== false and (
+                        !(model.hasData() and model.metaData.activeMeasures.length) or
+                        model.useSampleModel
+                    )"
+                />
+                <t t-if="displayNoContent">
+                    <t t-if="props.info.noContentHelp" t-call="web.ActionHelper">
+                        <t t-set="noContentHelp" t-value="props.info.noContentHelp"/>
+                    </t>
+                    <t t-else="" t-call="web.NoContentHelper"/>
+                </t>
+                <t t-if="model.hasData() and model.metaData.activeMeasures.length">
+                    <Renderer model="model" onCellClicked="cell => this.onOpenView(cell)"/>
+                </t>
+            </Layout>
+        </div>
     </t>
 
 </templates>

--- a/addons/web/static/src/views/view.js
+++ b/addons/web/static/src/views/view.js
@@ -113,6 +113,7 @@ const STANDARD_PROPS = [
 
     "useSampleModel",
     "noContentHelp",
+    "className",
 
     "display",
     "globalState",
@@ -257,6 +258,7 @@ export class View extends Component {
             fields,
             resModel,
             useSampleModel: false,
+            className: `${this.props.className} o_view_controller o_${this.env.config.viewType}_view`,
         };
         if (this.props.globalState) {
             viewProps.globalState = this.props.globalState;
@@ -326,6 +328,7 @@ View.defaultProps = {
     context: {},
     loadActionMenus: false,
     loadIrFilters: false,
+    className: "",
 };
 
 View.searchMenuTypes = ["filter", "groupBy", "favorite"];

--- a/addons/web/static/src/views/view.xml
+++ b/addons/web/static/src/views/view.xml
@@ -2,9 +2,7 @@
 <templates xml:space="preserve">
 
   <t t-name="web.View" owl="1">
-    <div t-attf-class="o_action o_view_controller o_{{env.config.viewType}}_view" t-on-click="handleActionLinks">
-      <WithSearch t-props="withSearchProps"/>
-    </div>
+      <WithSearch t-props="withSearchProps" t-on-click="handleActionLinks"/>
   </t>
 
   <t t-name="web.ReportViewMeasures" owl="1">

--- a/addons/web/static/src/webclient/actions/action_container.js
+++ b/addons/web/static/src/webclient/actions/action_container.js
@@ -24,6 +24,6 @@ ActionContainer.components = { ActionDialog };
 ActionContainer.template = xml`
     <t t-name="web.ActionContainer">
       <div class="o_action_manager">
-        <t t-if="info.Component" t-component="info.Component" t-props="info.componentProps" t-key="info.id"/>
+        <t t-if="info.Component" t-component="info.Component" className="'o_action'" t-props="info.componentProps" t-key="info.id"/>
       </div>
     </t>`;

--- a/addons/web/static/tests/views/graph_view_tests.js
+++ b/addons/web/static/tests/views/graph_view_tests.js
@@ -310,7 +310,7 @@ QUnit.module("Views", (hooks) => {
     QUnit.test("simple bar chart rendering", async function (assert) {
         const graph = await makeView({ serverData, type: "graph", resModel: "foo" });
         const { measure, mode, order, stacked } = getGraphModelMetaData(graph);
-        assert.hasClass(target.querySelector(".o_graph_view"), "o_action o_view_controller");
+        assert.hasClass(target.querySelector(".o_graph_view"), "o_view_controller");
         assert.containsOnce(target, "div.o_graph_canvas_container canvas");
         assert.strictEqual(measure, "__count", `the active measure should be "__count" by default`);
         assert.strictEqual(mode, "bar", "should be in bar chart mode by default");

--- a/addons/web/static/tests/views/pivot_view_tests.js
+++ b/addons/web/static/tests/views/pivot_view_tests.js
@@ -219,7 +219,7 @@ QUnit.module("Views", (hooks) => {
             },
         });
 
-        assert.hasClass(target.querySelector(".o_pivot_view"), "o_action o_view_controller");
+        assert.hasClass(target.querySelector(".o_pivot_view"), "o_view_controller");
         assert.hasClass(target.querySelector("table"), "o_enable_linking");
         assert.containsOnce(
             target,

--- a/addons/web/static/tests/views/view_tests.js
+++ b/addons/web/static/tests/views/view_tests.js
@@ -78,7 +78,7 @@ QUnit.module("Views", (hooks) => {
                 this.template = xml`${this.props.arch}`;
             }
         }
-        ToyView.template = xml`<div t-att-class="class"><t t-call="{{ template }}"/></div>`;
+        ToyView.template = xml`<div t-attf-class="{{class}} {{props.className}}"><t t-call="{{ template }}"/></div>`;
         ToyView.type = "toy";
         ToyView.components = { Banner: OnboardingBanner };
 
@@ -143,9 +143,9 @@ QUnit.module("Views", (hooks) => {
             resModel: "animal",
             type: "toy",
         });
-        assert.containsOnce(target, ".o_toy_view.o_action.o_view_controller");
+        assert.containsOnce(target, ".o_toy_view.o_view_controller");
         assert.strictEqual(
-            target.querySelector(".o_toy_view .toy").innerHTML,
+            target.querySelector(".o_toy_view.toy").innerHTML,
             serverData.views["animal,false,toy"]
         );
     });
@@ -181,7 +181,7 @@ QUnit.module("Views", (hooks) => {
         });
         assert.containsOnce(target, ".o_toy_view");
         assert.strictEqual(
-            target.querySelector(".o_toy_view .toy").innerHTML,
+            target.querySelector(".o_toy_view.toy").innerHTML,
             serverData.views["animal,1,toy"]
         );
     });
@@ -220,7 +220,7 @@ QUnit.module("Views", (hooks) => {
         });
         assert.containsOnce(target, ".o_toy_view");
         assert.strictEqual(
-            target.querySelector(".o_toy_view .toy").innerHTML,
+            target.querySelector(".o_toy_view.toy").innerHTML,
             serverData.views["animal,1,toy"]
         );
     });
@@ -263,7 +263,7 @@ QUnit.module("Views", (hooks) => {
             });
             assert.containsOnce(target, ".o_toy_view");
             assert.strictEqual(
-                target.querySelector(".o_toy_view .toy").innerHTML,
+                target.querySelector(".o_toy_view.toy").innerHTML,
                 serverData.views["animal,false,toy"]
             );
         }
@@ -309,7 +309,7 @@ QUnit.module("Views", (hooks) => {
         });
         assert.containsOnce(target, ".o_toy_view");
         assert.strictEqual(
-            target.querySelector(".o_toy_view .toy").innerHTML,
+            target.querySelector(".o_toy_view.toy").innerHTML,
             serverData.views["animal,1,toy"]
         );
     });
@@ -341,7 +341,7 @@ QUnit.module("Views", (hooks) => {
         });
         assert.containsOnce(target, ".o_toy_view");
         assert.strictEqual(
-            target.querySelector(".o_toy_view .toy").innerHTML,
+            target.querySelector(".o_toy_view.toy").innerHTML,
             `<toy>Specific arch content</toy>`
         );
     });
@@ -378,7 +378,7 @@ QUnit.module("Views", (hooks) => {
         });
         assert.containsOnce(target, ".o_toy_view");
         assert.strictEqual(
-            target.querySelector(".o_toy_view .toy").innerHTML,
+            target.querySelector(".o_toy_view.toy").innerHTML,
             serverData.views["animal,false,toy"]
         );
     });
@@ -419,7 +419,7 @@ QUnit.module("Views", (hooks) => {
             });
             assert.containsOnce(target, ".o_toy_view");
             assert.strictEqual(
-                target.querySelector(".o_toy_view .toy").innerHTML,
+                target.querySelector(".o_toy_view.toy").innerHTML,
                 `<toy>Specific arch content</toy>`
             );
         }
@@ -458,7 +458,7 @@ QUnit.module("Views", (hooks) => {
             });
             assert.containsOnce(target, ".o_toy_view");
             assert.strictEqual(
-                target.querySelector(".o_toy_view .toy").innerHTML,
+                target.querySelector(".o_toy_view.toy").innerHTML,
                 `<toy>Specific arch content</toy>`
             );
         }
@@ -1204,9 +1204,9 @@ QUnit.module("Views", (hooks) => {
             resModel: "animal",
             type: "toy_imp",
         });
-        assert.containsOnce(target, ".o_toy_view .toy_imp");
+        assert.containsOnce(target, ".o_toy_view.toy_imp");
         assert.strictEqual(
-            target.querySelector(".o_toy_view .toy_imp").innerText,
+            target.querySelector(".o_toy_view.toy_imp").innerText,
             "Arch content (id=false)"
         );
     });
@@ -1227,9 +1227,9 @@ QUnit.module("Views", (hooks) => {
             type: "toy",
             viewId: 2,
         });
-        assert.containsOnce(target, ".o_toy_view .toy_imp");
+        assert.containsOnce(target, ".o_toy_view.toy_imp");
         assert.strictEqual(
-            target.querySelector(".o_toy_view .toy_imp").innerText,
+            target.querySelector(".o_toy_view.toy_imp").innerText,
             "Arch content (id=2)"
         );
     });
@@ -1246,9 +1246,9 @@ QUnit.module("Views", (hooks) => {
             arch: `<toy js_class="toy_imp">Specific arch content for specific class</toy>`,
             fields: {},
         });
-        assert.containsOnce(target, ".o_toy_view .toy_imp");
+        assert.containsOnce(target, ".o_toy_view.toy_imp");
         assert.strictEqual(
-            target.querySelector(".o_toy_view .toy_imp").innerText,
+            target.querySelector(".o_toy_view.toy_imp").innerText,
             "Specific arch content for specific class"
         );
     });
@@ -1277,7 +1277,7 @@ QUnit.module("Views", (hooks) => {
                 type: "toy_2",
                 viewId: 2,
             });
-            assert.containsOnce(target, ".o_toy_view .toy_imp", "jsClass from arch prefered");
+            assert.containsOnce(target, ".o_toy_view.toy_imp", "jsClass from arch prefered");
         }
     );
 
@@ -1301,7 +1301,7 @@ QUnit.module("Views", (hooks) => {
                 arch: `<toy js_class="toy_imp"/>`,
                 fields: {},
             });
-            assert.containsOnce(target, ".o_toy_view .toy_imp", "jsClass from arch prefered");
+            assert.containsOnce(target, ".o_toy_view.toy_imp", "jsClass from arch prefered");
         }
     );
 

--- a/addons/web/static/tests/webclient/actions/legacy_tests.js
+++ b/addons/web/static/tests/webclient/actions/legacy_tests.js
@@ -478,10 +478,10 @@ QUnit.module("ActionManager", (hooks) => {
 
         const webClient = await createWebClient({ serverData });
         await doAction(webClient, "testClientAction");
-        assert.verifySteps(['id: 0 props: {"breadcrumbs":[]}']);
+        assert.verifySteps(['id: 0 props: {"className":"o_action","breadcrumbs":[]}']);
 
         await click(document.getElementById("client_0"));
-        assert.verifySteps(['id: 1 props: {"chain":"never break","breadcrumbs":[]}']);
+        assert.verifySteps(['id: 1 props: {"chain":"never break","className":"o_action","breadcrumbs":[]}']);
     });
 
     QUnit.test("breadcrumbs are correct in stacked legacy client actions", async function (assert) {


### PR DESCRIPTION
This will be useful to allow concrete views to attach event listeners to
their root element among other things.