### PR TITLE
[IMP][14.0]point_of_sale: return value for _create_order_picking method

### DIFF
--- a/addons/point_of_sale/models/pos_order.py
+++ b/addons/point_of_sale/models/pos_order.py
@@ -575,6 +575,7 @@ class PosOrder(models.Model):
 
             pickings = self.env['stock.picking']._create_picking_from_pos_order_lines(destination_id, self.lines, picking_type, self.partner_id)
             pickings.write({'pos_session_id': self.session_id.id, 'pos_order_id': self.id, 'origin': self.name})
+            return pickings
 
     def add_payment(self, data):
         """Create a new payment for the order"""


### PR DESCRIPTION
This PR
======
Because there is no way to get the picking created by the _create order picking method, I added a return value for inheritance purposes.



--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
