### PR TITLE
[FIX] mrp,stock: merge SM

### DIFF
--- a/addons/mrp/models/stock_move.py
+++ b/addons/mrp/models/stock_move.py
@@ -520,8 +520,3 @@ class StockMove(models.Model):
             self.move_line_ids = self._set_quantity_done_prepare_vals(quantity_done)
         else:
             super()._multi_line_quantity_done_set(quantity_done)
-
-    def _prepare_extra_move_vals(self, qty):
-        vals = super()._prepare_extra_move_vals(qty)
-        vals['date_deadline'] = self.date_deadline
-        return vals

--- a/addons/stock/models/stock_move.py
+++ b/addons/stock/models/stock_move.py
@@ -1580,6 +1580,7 @@ class StockMove(models.Model):
             'product_uom_qty': qty,
             'picking_id': self.picking_id.id,
             'price_unit': self.price_unit,
+            'date_deadline': self.date_deadline,
         }
         return vals
 


### PR DESCRIPTION
When an extra move is created, the latter may not be merged into the
initial one while it should

Partial backport of [1] (see issue 02 for details and explanations)

[1] 6981ae67af650e65208073d29f72db55db902376