### PR TITLE
[FIX] l10n_ch,l10n_fi: add tax rep line on taxes

### DIFF
--- a/addons/l10n_ch/data/account_vat2011_data.xml
+++ b/addons/l10n_ch/data/account_vat2011_data.xml
@@ -845,12 +845,20 @@
                     'repartition_type': 'base',
                     'plus_report_line_ids': [ref('account_tax_report_line_chtax_900')],
                 }),
+                (0,0, {
+                    'factor_percent': 100,
+                    'repartition_type': 'tax',
+                }),
             ]"/>
             <field name="refund_repartition_line_ids" eval="[(5, 0, 0),
                 (0,0, {
                     'factor_percent': 100,
                     'repartition_type': 'base',
                     'minus_report_line_ids': [ref('account_tax_report_line_chtax_900')],
+                }),
+                (0,0, {
+                    'factor_percent': 100,
+                    'repartition_type': 'tax',
                 }),
             ]"/>
         </record>
@@ -869,12 +877,20 @@
                     'repartition_type': 'base',
                     'plus_report_line_ids': [ref('account_tax_report_line_chtax_910')],
                 }),
+                (0,0, {
+                    'factor_percent': 100,
+                    'repartition_type': 'tax',
+                }),
             ]"/>
             <field name="refund_repartition_line_ids" eval="[(5, 0, 0),
                 (0,0, {
                     'factor_percent': 100,
                     'repartition_type': 'base',
                     'minus_report_line_ids': [ref('account_tax_report_line_chtax_910')],
+                }),
+                (0,0, {
+                    'factor_percent': 100,
+                    'repartition_type': 'tax',
                 }),
             ]"/>
         </record>

--- a/addons/l10n_fi/data/account_tax_template_data.xml
+++ b/addons/l10n_fi/data/account_tax_template_data.xml
@@ -118,12 +118,20 @@
               'repartition_type': 'base',
               'plus_report_line_ids':  [ref('tax_report_base_turnover_0_vat')],
             }),
+            (0,0, {
+              'factor_percent': 100,
+              'repartition_type': 'tax',
+            }),
         ]"/>
         <field name="refund_repartition_line_ids" eval="[(5, 0, 0),
             (0,0, {
               'factor_percent': 100,
               'repartition_type': 'base',
               'minus_report_line_ids':  [ref('tax_report_base_turnover_0_vat')],
+            }),
+            (0,0, {
+              'factor_percent': 100,
+              'repartition_type': 'tax',
             }),
         ]"/>
     </record>
@@ -545,6 +553,26 @@
         <field name="tax_group_id" ref="tax_group_0"/>
         <field name="type_tax_use">purchase</field>
         <field name="amount_type">percent</field>
+        <field name="invoice_repartition_line_ids" eval="[(5, 0, 0),
+            (0,0, {
+              'factor_percent': 100,
+              'repartition_type': 'base',
+            }),
+            (0,0, {
+              'factor_percent': 100,
+              'repartition_type': 'tax',
+            }),
+        ]"/>
+        <field name="refund_repartition_line_ids" eval="[(5, 0, 0),
+            (0,0, {
+              'factor_percent': 100,
+              'repartition_type': 'base',
+            }),
+            (0,0, {
+              'factor_percent': 100,
+              'repartition_type': 'tax',
+            }),
+        ]"/>
     </record>
 
     <!-- # Europe -->
@@ -564,12 +592,20 @@
               'repartition_type': 'base',
               'plus_report_line_ids':  [ref('tax_report_base_sales_goods_eu')],
             }),
+            (0,0, {
+              'factor_percent': 100,
+              'repartition_type': 'tax',
+            }),
         ]"/>
         <field name="refund_repartition_line_ids" eval="[(5, 0, 0),
             (0,0, {
               'factor_percent': 100,
               'repartition_type': 'base',
               'minus_report_line_ids':  [ref('tax_report_base_sales_goods_eu')],
+            }),
+            (0,0, {
+              'factor_percent': 100,
+              'repartition_type': 'tax',
             }),
         ]"/>
     </record>
@@ -589,12 +625,20 @@
               'repartition_type': 'base',
               'plus_report_line_ids':  [ref('tax_report_base_sales_service_eu')],
             }),
+            (0,0, {
+              'factor_percent': 100,
+              'repartition_type': 'tax',
+            }),
         ]"/>
         <field name="refund_repartition_line_ids" eval="[(5, 0, 0),
             (0,0, {
               'factor_percent': 100,
               'repartition_type': 'base',
               'minus_report_line_ids':  [ref('tax_report_base_sales_service_eu')],
+            }),
+            (0,0, {
+              'factor_percent': 100,
+              'repartition_type': 'tax',
             }),
         ]"/>
     </record>
@@ -887,13 +931,20 @@
             (0,0, {
               'factor_percent': 100,
               'repartition_type': 'base',
-
+            }),
+            (0,0, {
+              'factor_percent': 100,
+              'repartition_type': 'tax',
             }),
         ]"/>
         <field name="refund_repartition_line_ids" eval="[(5, 0, 0),
             (0,0, {
               'factor_percent': 100,
               'repartition_type': 'base',
+            }),
+            (0,0, {
+              'factor_percent': 100,
+              'repartition_type': 'tax',
             }),
         ]"/>
     </record>
@@ -944,12 +995,20 @@
               'repartition_type': 'base',
               'plus_report_line_ids':  [ref('tax_report_base_sales_construct_service')],
             }),
+            (0,0, {
+              'factor_percent': 100,
+              'repartition_type': 'tax',
+            }),
         ]"/>
         <field name="refund_repartition_line_ids" eval="[(5, 0, 0),
             (0,0, {
               'factor_percent': 100,
               'repartition_type': 'base',
               'minus_report_line_ids':  [ref('tax_report_base_sales_construct_service')],
+            }),
+            (0,0, {
+              'factor_percent': 100,
+              'repartition_type': 'tax',
             }),
         ]"/>
     </record>
@@ -1049,13 +1108,21 @@
               'factor_percent': 100,
               'repartition_type': 'base',
               'plus_report_line_ids':  [ref('tax_report_base_turnover_0_vat')],
-            })
+            }),
+            (0,0, {
+              'factor_percent': 100,
+              'repartition_type': 'tax',
+            }),
         ]"/>
         <field name="refund_repartition_line_ids" eval="[(5, 0, 0),
             (0,0, {
               'factor_percent': 100,
               'repartition_type': 'base',
               'minus_report_line_ids':  [ref('tax_report_base_turnover_0_vat')],
+            }),
+            (0,0, {
+              'factor_percent': 100,
+              'repartition_type': 'tax',
             }),
         ]"/>
     </record>
@@ -1215,12 +1282,20 @@
               'repartition_type': 'base',
               'plus_report_line_ids':  [ref('tax_report_base_turnover_0_vat')],
             }),
+            (0,0, {
+              'factor_percent': 100,
+              'repartition_type': 'tax',
+            }),
         ]"/>
         <field name="refund_repartition_line_ids" eval="[(5, 0, 0),
             (0,0, {
               'factor_percent': 100,
               'repartition_type': 'base',
               'minus_report_line_ids':  [ref('tax_report_base_turnover_0_vat')],
+            }),
+            (0,0, {
+              'factor_percent': 100,
+              'repartition_type': 'tax',
             }),
         ]"/>
     </record>


### PR DESCRIPTION
The taxes should have at least one tax repartition line (see https://github.com/odoo/odoo/pull/85771).

