### PR TITLE
[FIX] web: add optional arg to disable escape of message

### DIFF
--- a/addons/web/static/src/legacy/utils.js
+++ b/addons/web/static/src/legacy/utils.js
@@ -222,6 +222,7 @@ export function makeLegacyNotificationService(legacyEnv) {
                 type,
                 className,
                 onClose,
+                escape = true,
             }) {
                 if (subtitle) {
                     title = [title, subtitle].filter(Boolean).join(" ");
@@ -240,7 +241,11 @@ export function makeLegacyNotificationService(legacyEnv) {
                     };
                 });
 
-                const removeFn = env.services.notification.add(_.escape(message), {
+                if (escape) {
+                    message = _.escape(message);
+                }
+
+                const removeFn = env.services.notification.add(message, {
                     sticky,
                     title,
                     type,


### PR DESCRIPTION
How to reproduce the bug ?

- install Purchase, Studio modules
- enable Purchase Agreements in Settings
- in Purchase, go to Orders > Purchase Agreements
- in the purchase agreement creation form, enable studio and modify the
"Confirm" button such that an agreement is requested.
- make sure to remove your user from the approval group OR switch to a
different user which is not part of the approval group.
- Go back to the purchase agreement creation form and try to confirm a
new agreement.

What is the bug ?

When you want to display a notification which contains html code, the
html tags will be partially escaped. A consequence of that is the fact
that the tags will not be considered correctly and will be displayed in
the message of the notification instead of being not visible and
formatting the message.

opw-2780867

Signed-off-by: Adrien Minet <admi@odoo.com>
--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
