### PR TITLE
[FIX] mail: mass mailing to same mail adress

### DIFF
--- a/addons/account/wizard/account_invoice_send.py
+++ b/addons/account/wizard/account_invoice_send.py
@@ -116,7 +116,10 @@ class AccountInvoiceSend(models.TransientModel):
     def _send_email(self):
         if self.is_email:
             # with_context : we don't want to reimport the file we just exported.
-            self.composer_id.with_context(no_new_invoice=True, mail_notify_author=self.env.user.partner_id in self.composer_id.partner_ids)._action_send_mail()
+            self.composer_id.with_context(no_new_invoice=True,
+                                          mail_notify_author=self.env.user.partner_id in self.composer_id.partner_ids,
+                                          mailing_document_based=True,
+                                          )._action_send_mail()
             if self.env.context.get('mark_invoice_as_sent'):
                 #Salesman send posted invoice, without the right to write
                 #but they should have the right to change this flag

--- a/addons/mail/wizard/mail_compose_message.py
+++ b/addons/mail/wizard/mail_compose_message.py
@@ -472,6 +472,8 @@ class MailComposer(models.TransientModel):
         blacklist_ids = self._get_blacklist_record_ids(mail_values_dict)
         optout_emails = self._get_optout_emails(mail_values_dict)
         done_emails = self._get_done_emails(mail_values_dict)
+        # in case of an invoice e.g.
+        mailing_document_based = self.env.context.get('mailing_document_based')
 
         for record_id, mail_values in mail_values_dict.items():
             recipients = recipients_info[record_id]
@@ -494,7 +496,7 @@ class MailComposer(models.TransientModel):
             elif optout_emails and mail_to in optout_emails:
                 mail_values['state'] = 'cancel'
                 mail_values['failure_type'] = 'mail_optout'
-            elif done_emails and mail_to in done_emails:
+            elif done_emails and mail_to in done_emails and not mailing_document_based:
                 mail_values['state'] = 'cancel'
                 mail_values['failure_type'] = 'mail_dup'
             # void of falsy values -> error
@@ -504,7 +506,7 @@ class MailComposer(models.TransientModel):
             elif not mail_to_normalized or not email_re.findall(mail_to):
                 mail_values['state'] = 'cancel'
                 mail_values['failure_type'] = 'mail_email_invalid'
-            elif done_emails is not None:
+            elif done_emails is not None and not mailing_document_based:
                 done_emails.append(mail_to)
 
         return mail_values_dict

--- a/addons/purchase/models/mail_compose_message.py
+++ b/addons/purchase/models/mail_compose_message.py
@@ -8,6 +8,8 @@ class MailComposeMessage(models.TransientModel):
     _inherit = 'mail.compose.message'
 
     def _action_send_mail(self, auto_commit=False):
-        if self.env.context.get('mark_rfq_as_sent') and self.model == 'purchase.order':
-            self = self.with_context(mail_notify_author=self.env.user.partner_id in self.partner_ids)
+        if self.model == 'purchase.order':
+            self = self.with_context(mailing_document_based=True)
+            if self.env.context.get('mark_rfq_as_sent'):
+                self = self.with_context(mail_notify_author=self.env.user.partner_id in self.partner_ids)
         return super(MailComposeMessage, self)._action_send_mail(auto_commit=auto_commit)

--- a/addons/sale/wizard/mail_compose_message.py
+++ b/addons/sale/wizard/mail_compose_message.py
@@ -8,6 +8,8 @@ class MailComposeMessage(models.TransientModel):
     _inherit = 'mail.compose.message'
 
     def _action_send_mail(self, auto_commit=False):
-        if self.env.context.get('mark_so_as_sent') and self.model == 'sale.order':
-            self = self.with_context(mail_notify_author=self.env.user.partner_id in self.partner_ids)
+        if self.model == 'sale.order':
+            self = self.with_context(mailing_document_based=True)
+            if self.env.context.get('mark_so_as_sent'):
+                self = self.with_context(mail_notify_author=self.env.user.partner_id in self.partner_ids)
         return super(MailComposeMessage, self)._action_send_mail(auto_commit=auto_commit)


### PR DESCRIPTION
Steps to repoduce:
- Accounting > Customers > Invoices:
	 select several invoices to send
- Action > Send & Print > (deselect Print) > Send & Print

Issue:
- It sends only one invoice per company

Cause:
- the mail_compose_message sets the status of an email as `cancel` when a mail has already been sent to a specific adress mail in the batch

Solution:
- If the use of mass mailing is document-based (e.g.: sending multiple invoices) it will allow to send multiple emails to the same adress

opw-2775121
