### PR TITLE
[FIX] account: onchange invoice_date on import

### DIFF
--- a/addons/account/models/account_move.py
+++ b/addons/account/models/account_move.py
@@ -2638,6 +2638,13 @@ class AccountMove(models.Model):
                 elif move.is_purchase_document(include_receipts=True):
                     raise UserError(_("The Bill/Refund date is required to validate this document."))
 
+            # Handle the case when the invoice_date is different from the move date. This is happening when importing
+            # datas on an existing record with a different invoice_date, as the onchange is not triggered during import
+            # /!\ 'check_move_validity' must be there since the dynamic lines will be recomputed outside the 'onchange'
+            # environment.
+            if move.is_sale_document(include_receipts=True) and move.invoice_date != move.date:
+                move.with_context(check_move_validity=False)._onchange_invoice_date()
+
             # When the accounting date is prior to the tax lock date, move it automatically to the next available date.
             # /!\ 'check_move_validity' must be there since the dynamic lines will be recomputed outside the 'onchange'
             # environment.


### PR DESCRIPTION
With this commit, when posting an invoice, we trigger the
onchange_invoice_date if the accounting_date is different
from the move date. This is happening when we import datas
on an existing record with a change of invoice date, as the
onchange is not triggered during the import.

Steps:

- Create an invoice with invoice_date = today, and confirm it
-> date == invoice_date
- Reset invoice to draft
- On the tree view, select invoice -> actions -> export
- Check 'I want to update data' and export
- On the generated file, modify the invoice_date to today - X
- On the tree view -> Favorites -> import records
- Load the file and import it
- Confirm the invoice
-> invoice_date == today - X, date == today

opw-2753425

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
