### PR TITLE
[FIX] sale: discount is calculated on wrong price

### DIFF
--- a/addons/sale/models/sale.py
+++ b/addons/sale/models/sale.py
@@ -477,24 +477,10 @@ class SaleOrder(models.Model):
 
     def update_prices(self):
         self.ensure_one()
-        lines_to_update = []
         for line in self._get_update_prices_lines():
-            product = line.product_id.with_context(
-                partner=self.partner_id,
-                quantity=line.product_uom_qty,
-                date=self.date_order,
-                pricelist=self.pricelist_id.id,
-                uom=line.product_uom.id
-            )
-            price_unit = self.env['account.tax']._fix_tax_included_price_company(
-                line._get_display_price(product), line.product_id.taxes_id, line.tax_id, line.company_id)
-            if self.pricelist_id.discount_policy == 'without_discount' and price_unit:
-                price_discount_unrounded = self.pricelist_id.get_product_price(product, line.product_uom_qty, self.partner_id, self.date_order, line.product_uom.id)
-                discount = max(0, (price_unit - price_discount_unrounded) * 100 / price_unit)
-            else:
-                discount = 0
-            lines_to_update.append((1, line.id, {'price_unit': price_unit, 'discount': discount}))
-        self.update({'order_line': lines_to_update})
+            line.product_uom_change()
+            line.discount = 0  # Force 0 as discount for the cases when _onchange_discount directly returns
+            line._onchange_discount()
         self.show_update_pricelist = False
         self.message_post(body=_("Product prices have been recomputed according to pricelist <b>%s<b> ", self.pricelist_id.display_name))
 

--- a/addons/sale/tests/test_sale_pricelist.py
+++ b/addons/sale/tests/test_sale_pricelist.py
@@ -71,6 +71,18 @@ class TestSaleOrder(TestSaleCommon):
             'percent_price': 20,
         })
 
+        # Create a pricelist without discount policy: percentage on all products
+        cls.pricelist_discount_excl_global = cls.env['product.pricelist'].create({
+            'name': 'Pricelist C',
+            'discount_policy': 'without_discount',
+            'company_id': cls.env.company.id,
+            'item_ids': [(0, 0, {
+                'applied_on': '3_global',
+                'compute_price': 'percentage',
+                'percent_price': 54,
+            })],
+        })
+
         # create a generic Sale Order with all classical products and empty pricelist
         cls.sale_order = SaleOrder.create({
             'partner_id': cls.partner_a.id,
@@ -164,18 +176,7 @@ class TestSaleOrder(TestSaleCommon):
 
     def test_sale_change_of_pricelists_excluded_value_discount(self):
         """ Test SO with the pricelist 'discount displayed' and check displayed percentage value after multiple changes of pricelist """
-
-        # Create a pricelist without discount policy: percentage on all products
-        pricelist_discount_excl_global = self.env['product.pricelist'].create({
-            'name': 'Pricelist C',
-            'discount_policy': 'without_discount',
-            'company_id': self.env.company.id,
-            'item_ids': [(0, 0, {
-                'applied_on': '3_global',
-                'compute_price': 'percentage',
-                'percent_price': 54,
-            })],
-        })
+        self.env.user.write({'groups_id': [(4, self.env.ref('product.group_discount_per_so_line').id)]})
 
         # Create a product with a very low price
         amazing_product = self.env['product.product'].create({
@@ -200,7 +201,7 @@ class TestSaleOrder(TestSaleCommon):
         })
 
         # Change the pricelist
-        sale_order.write({'pricelist_id': pricelist_discount_excl_global.id})
+        sale_order.write({'pricelist_id': self.pricelist_discount_excl_global.id})
         # Update Prices
         sale_order.update_prices()
 
@@ -220,5 +221,81 @@ class TestSaleOrder(TestSaleCommon):
         )
         self.assertFalse(
             sale_order.order_line.tax_id,
+            "Wrong tax applied for specified product & pricelist"
+        )
+
+    def test_sale_change_of_pricelists_excluded_value_discount_on_tax_included_price_mapped_to_tax_excluded_price(self):
+        self.env.user.write({'groups_id': [(4, self.env.ref('product.group_discount_per_so_line').id)]})
+
+        # setting up the taxes:
+        tax_a = self.tax_sale_a.copy()
+        tax_b = self.tax_sale_a.copy()
+        tax_a.price_include = True
+        tax_b.amount = 6
+
+        # setting up fiscal position:
+        fiscal_pos = self.fiscal_pos_a.copy()
+        fiscal_pos.auto_apply = True
+        country = self.env["res.country"].search([('name', '=', 'Belgium')], limit=1)
+        fiscal_pos.country_id = country
+        fiscal_pos.tax_ids = [
+            (0, None,
+             {
+                 'tax_src_id': tax_a.id,
+                 'tax_dest_id': tax_b.id
+             })
+        ]
+
+        # setting up partner:
+        self.partner_a.country_id = country
+
+        # creating product:
+
+        my_product = self.env['product.product'].create({
+            'name': 'my Product',
+            'lst_price': 115,
+            'taxes_id': [tax_a.id]
+        })
+
+        # creating SO
+
+        sale_order = self.env['sale.order'].create({
+            'partner_id': self.partner_a.id,
+            'partner_invoice_id': self.partner_a.id,
+            'partner_shipping_id': self.partner_a.id,
+            'pricelist_id': self.company_data['default_pricelist'].id,
+            'order_line': [(0, 0, {
+                'name': my_product.name,
+                'product_id': my_product.id,
+                'product_uom_qty': 1,
+                'product_uom': my_product.uom_id.id,
+            })],
+        })
+
+        # Apply fiscal position
+
+        sale_order.fiscal_position_id = fiscal_pos.id
+        # Change the pricelist
+        sale_order.write({'pricelist_id': self.pricelist_discount_excl_global.id})
+        # Update Prices
+        sale_order.update_prices()
+
+
+        # Check that the discount displayed is the correct one
+        self.assertEqual(
+            sale_order.order_line.discount, 54,
+            "Wrong discount computed for specified product & pricelist"
+        )
+        # Additional to check for overall consistency
+        self.assertEqual(
+            sale_order.order_line.price_unit, 100,
+            "Wrong unit price computed for specified product & pricelist"
+        )
+        self.assertEqual(
+            sale_order.order_line.price_subtotal, 46,
+            "Wrong subtotal price computed for specified product & pricelist"
+        )
+        self.assertEqual(
+            sale_order.order_line.tax_id.id, tax_b.id,
             "Wrong tax applied for specified product & pricelist"
         )


### PR DESCRIPTION
If applied, this commit will fix the following bug by changing the
price used in the discount calculation equation to be the real price.
the two prices differs when mapping a tax inculded price to a tax
excluded price

Steps to reproduce:

1- install sales - accounting
2- create a product p with customer tax t
3- create a fiscal position for a country (belgium for example) that
maps t to a lower value tax.
3- create a pricelist pl with discount d
4- create a new SO, add a customer from belgium, add p, then select pl,
 click on update prices
5- the discount is not d, it is calculated based on
(p price - customer tax)

in comparison to:
4- create a new SO, add a customer from belgium,  select pl first, add p
5- the discount is d.

Bug:

the wrong price is being used for discount calculation

Fix:

calculate and use the correct price similar to the normal behavoir when
the pricelist is selected first

OPW-2745421