### PR TITLE
[FIX] sale_coupon: discount applied on the price exc. taxes

### DIFF
--- a/addons/sale_coupon/models/sale_order.py
+++ b/addons/sale_coupon/models/sale_order.py
@@ -157,7 +157,8 @@ class SaleOrder(models.Model):
             }]
         reward_dict = {}
         lines = self._get_paid_order_lines()
-        amount_total = sum(self._get_base_order_lines(program).mapped('price_subtotal'))
+        amount_total = sum([any(line.tax_id.mapped('price_include')) and line.price_total or line.price_subtotal
+                            for line in self._get_base_order_lines(program)])
         if program.discount_apply_on == 'cheapest_product':
             line = self._get_cheapest_line()
             if line:

--- a/addons/sale_coupon/tests/test_program_numbers.py
+++ b/addons/sale_coupon/tests/test_program_numbers.py
@@ -730,7 +730,7 @@ class TestSaleCouponProgramNumbers(TestSaleCouponCommon):
         })
 
         order = self.empty_order
-        orderline = self.env['sale.order.line'].create([
+        self.env['sale.order.line'].create([
         {
             'product_id': self.conferenceChair.id,
             'name': 'Conference Chair',
@@ -772,10 +772,7 @@ class TestSaleCouponProgramNumbers(TestSaleCouponCommon):
         }).process_coupon()
         self.assertEqual(order.amount_total, 0.0, "The promotion program should not make the order total go below 0")
         order.recompute_coupon_lines()
-        #TODO fix numbers
-        self.assertEqual(order.amount_total, 9.09, "The promotion program should not be altered after recomputation")
-        self.assertEqual(order.amount_tax, 8.18)
-        self.assertEqual(order.amount_untaxed, 0.91)
+        self.assertEqual(order.amount_total, 0.0, "The promotion program should not be altered after recomputation")
 
         order.order_line[3:].unlink() #remove all coupon
 
@@ -790,10 +787,38 @@ class TestSaleCouponProgramNumbers(TestSaleCouponCommon):
                 'coupon_code': 'test_10pc'
             }).process_coupon()
         order.recompute_coupon_lines()
-        #TODO fix numbers
-        self.assertEqual(order.amount_tax, 9.01)
-        self.assertEqual(order.amount_untaxed, 0.08)
-        self.assertEqual(order.amount_total, 9.09, "The promotion program should not be altered after recomputation")
+        self.assertEqual(order.amount_total, 0.0, "The promotion program should not be altered after recomputation")
+
+    def test_program_percentage_discount_on_product_included_tax(self):
+        # test 100% percentage discount (tax included)
+
+        program = self.env['sale.coupon.program'].create({
+            'name': '100% discount',
+            'promo_code_usage': 'no_code_needed',
+            'program_type': 'promotion_program',
+            'discount_percentage': 100.0,
+            'rule_minimum_amount_tax_inclusion': 'tax_included',
+        })
+        self.tax_10pc_incl.price_include = True
+
+        self.drawerBlack.taxes_id = self.tax_10pc_incl
+        order = self.empty_order
+        order.order_line = self.env['sale.order.line'].create({
+            'product_id': self.drawerBlack.id,
+            'product_uom_qty': 1.0,
+            'order_id': order.id,
+        })
+        order.recompute_coupon_lines()
+        self.assertEqual(len(order.order_line.ids), 2, "The discount should be applied")
+        self.assertEqual(order.amount_total, 0.0, "Order should be 0 as it is a 100% discount")
+
+        # test 95% percentage discount (tax included)
+        program.discount_percentage = 95
+        order.recompute_coupon_lines()
+        # lst_price is 25$ so total now should be 1.25$ (1.14$ + 0.11$ taxes)
+        self.assertEqual(len(order.order_line.ids), 2, "The discount should be applied")
+        self.assertAlmostEqual(order.amount_tax, 0.11, places=2)
+        self.assertAlmostEqual(order.amount_untaxed, 1.14, places=2)
 
     def test_program_discount_on_multiple_specific_products(self):
         """ Ensure a discount on multiple specific products is correctly computed.


### PR DESCRIPTION
If applied, this commit will fix the following bug by making
the maximum discount = price + tax instead of just price

Steps to reproduce:

1- install sale - website - ecommerce
2- set VAT included in price on the applied VAT code
3- set Product Prices in Website Setting to 'Tax-Included'
4- create promotion program with 100% discount on total order
5- Add product to cart with a VAT code with setting Included in Price
6- add promotion code

Result:
- 100% discount is applied on the excl. VAT amount, resulting in a
remaining amount

Expected result:
- 100% discount is applied to incl. VAT amount, resulting in a
zero-amount order

Bug:

the ```price_subtotal``` is used to calculate the order total amount

Fix:

use ```price_total``` which includes tax

OPW-2765883
