### PR TITLE
[imp] account: add unique constraints on journal group names

### DIFF
--- a/addons/account/models/account_journal.py
+++ b/addons/account/models/account_journal.py
@@ -28,6 +28,9 @@ class AccountJournalGroup(models.Model):
         check_company=True)
     sequence = fields.Integer(default=10)
 
+    _sql_constraints = [
+        ('uniq_name', 'unique(company_id, name)', 'A journal group name must be unique per company.'),
+    ]
 
 class AccountJournal(models.Model):
     _name = "account.journal"


### PR DESCRIPTION
Journal groups name are used as an identifier in reports,
namely on financial reports when a company has different reporting requirements
- on company level
- on consolidated level
- according to IFRS standards

This will add a constraints to ensure that groups name are unique.

Task id #2759252

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
