### PR TITLE
[FIX] web: alows users to edit related fields with studio

### DIFF
--- a/addons/web/static/src/js/views/basic/basic_model.js
+++ b/addons/web/static/src/js/views/basic/basic_model.js
@@ -3298,14 +3298,14 @@ var BasicModel = AbstractModel.extend({
         var type;
         for (var fieldName in fields) {
             type = fields[fieldName].type;
-
+            var dataFieldName = data[fieldName];
             if (type === 'many2many' || type === 'one2many') {
-                if (!data[fieldName]) {
+                if (!dataFieldName || !this.localData[dataFieldName]) {
                     // skip if this field is empty
                     continue;
                 }
                 commands[fieldName] = [];
-                var list = this.localData[data[fieldName]];
+                var list = this.localData[dataFieldName];
                 if (options.changesOnly && (!list._changes || !list._changes.length)) {
                     // if only changes are requested, skip if there is no change
                     continue;


### PR DESCRIPTION
In some case, the user cannot edit the related fields with studio.

Steps to reproduce:

On model "mail.activity":
    Add a "Many2one" field related to model "account.move" with domain "[('move_type', 'in', ('out_invoice', 'out_refund'))]". Named for the example as "x_studio_invoice_id".
    Add a "Many2one" field related to field "x_studio_invoice_id.partner_id". Named for the example as "x_studio_client_id".
    Add a "One2many" field related to field "x_studio_client_id.sale_order_ids". Named for the example as "x_studio_sale_order_ids".
    Add a "One2many" field related to field "x_studio_client_id.invoice_ids". Named for the example as "x_studio_invoice_ids".
    Add the fields to the form view.
    Create or edit a record:
    Set the "x_studio_invoice_id" field.
    When trying to select another invoice Odoo throws error:

Traceback:TypeError: Cannot read properties of undefined (reading 'res_ids')
    at Class._generateX2ManyCommands (/web/static/src/js/views/basic/basic_model.js:3311:38)
    at Class._generateChanges (/web/static/src/js/views/basic/basic_model.js:3189:29)
    at Class._generateX2ManyCommands (/web/static/src/js/views/basic/basic_model.js:3378:44)
    at Class._generateOnChangeData (/web/static/src/js/views/basic/basic_model.js:3244:33)
    at Class._performOnChange (/web/static/src/js/views/basic/basic_model.js:4185:32)
    at /web/static/src/js/views/basic/basic_model.js:1567:26 at new Promise (<anonymous>)
    at /web/static/src/js/views/basic/basic_model.js:1565:20

opw-2694855
