### PR TITLE
[FIX] website_event_track: displays unpublished track warning for eve…

### DIFF
--- a/addons/website_event_track/controllers/event_track.py
+++ b/addons/website_event_track/controllers/event_track.py
@@ -366,6 +366,7 @@ class EventTrackController(http.Controller):
             'is_html_empty': is_html_empty,
             'hostname': request.httprequest.host.split(':')[0],
             'is_event_user': request.env.user.has_group('event.group_event_user'),
+            'user_event_manager': request.env.user.has_group('event.group_event_manager'),
         }
 
     @http.route("/event/track/toggle_reminder", type="json", auth="public", website=True)


### PR DESCRIPTION
…nt manager

Correction that enables the display of the "unpublished" red label next to the
track name that are not published for the user of the group event manager only.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
