### PR TITLE
[FIX] mail: make RTC work

### DIFF
--- a/addons/mail/static/src/components/rtc_controller/rtc_controller.xml
+++ b/addons/mail/static/src/components/rtc_controller/rtc_controller.xml
@@ -32,7 +32,7 @@
                             <div class="o_RtcController_buttonIconWrapper" t-att-class="{ 'o-isSmall': rtcController.isSmall }">
                                 <i class="oi" t-att-class="{
                                     'oi-large': !rtcController.isSmall,
-                                    'fa-headphones: !messaging.rtc.currentRtcSession.isDeaf,
+                                    'fa-headphones': !messaging.rtc.currentRtcSession.isDeaf,
                                     'fa-deaf': messaging.rtc.currentRtcSession.isDeaf,
                                     'text-danger': messaging.rtc.currentRtcSession.isDeaf,
                                 }"/>


### PR DESCRIPTION
Oversight of https://github.com/odoo/odoo/pull/85651
Commit above made changes to some icons from `oi-` to `fa-`.
Doing so, there was unfortunately a typo, and the template was not valid.
As a result, RTC did not work.