### PR TITLE
[FIX] account: update recipient bank info

### DIFF
--- a/addons/account/wizard/account_payment_register.py
+++ b/addons/account/wizard/account_payment_register.py
@@ -191,7 +191,11 @@ class AccountPaymentRegister(models.TransientModel):
 
         partner_bank_account = self.env['res.partner.bank']
         if move.is_invoice(include_receipts=True):
-            partner_bank_account = move.partner_bank_id._origin
+            if move.move_type == 'in_refund':
+                bank_ids = move.commercial_partner_id.bank_ids.filtered(lambda bank: bank.company_id in (False, move.company_id))
+                partner_bank_account = bank_ids and bank_ids[0]
+            else:
+                partner_bank_account = move.partner_bank_id._origin
 
         return {
             'partner_id': line.partner_id.id,


### PR DESCRIPTION
### Current behavior
For a credit note, the recipient bank is not updated and therefore corresponds to the one of the invoice (= the one of the company)

### Steps
- Install Invoice
- Create or edit a customer to add him a bank account
- Create an invoice for this customer and confirm it (company's bank account is correctly set in Other Info tab > Recipient Bank)
- Add a credit note
- Account number in Other Info tab > Recipient Bank is still the company's one and not the customer's

OPW-2765409
