### PR TITLE
[IMP] portal: hide `js_language_selector` in print

### DIFF
--- a/addons/portal/views/portal_templates.xml
+++ b/addons/portal/views/portal_templates.xml
@@ -47,7 +47,7 @@
     <template id="language_selector" name="Language Selector">
         <t t-set="active_lang" t-value="list(filter(lambda lg : lg[0] == lang, languages))[0]"/>
         <t t-set="language_selector_visible" t-value="len(languages) &gt; 1"/>
-        <div t-attf-class="js_language_selector #{_div_classes}" t-if="language_selector_visible">
+        <div t-attf-class="js_language_selector #{_div_classes} d-print-none" t-if="language_selector_visible">
             <button t-attf-class="btn btn-sm btn-outline-secondary border-0 dropdown-toggle #{_btn_class}" type="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="true">
                 <span t-if="not no_text"
                         class="align-middle"


### PR DESCRIPTION
Prior this commit, the language selector was visible when a page was
printed.
After this commit, this element is hidden because it's not necessary to
print it.

task-2779458

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
