### PR TITLE
[ADD] hr_recruitment : Add active_id support to makeMeeting button

### DIFF
--- a/addons/hr_recruitment/models/__init__.py
+++ b/addons/hr_recruitment/models/__init__.py
@@ -9,3 +9,4 @@ from . import utm_campaign
 from . import utm_source
 from . import res_users
 from . import ir_ui_menu
+from . import mail_activity

--- a/addons/hr_recruitment/models/calendar.py
+++ b/addons/hr_recruitment/models/calendar.py
@@ -20,11 +20,11 @@ class CalendarEvent(models.Model):
         defaults = super(CalendarEvent, self).default_get(fields)
 
         # sync res_model / res_id to opportunity id (aka creating meeting from lead chatter)
-        if 'applicant_id' not in defaults:
+        if 'applicant_ids' not in defaults:
             res_model = defaults.get('res_model', False) or self.env.context.get('default_res_model')
             res_model_id = defaults.get('res_model_id', False) or self.env.context.get('default_res_model_id')
             if (res_model and res_model == 'hr.applicant') or (res_model_id and self.env['ir.model'].sudo().browse(res_model_id).model == 'hr.applicant'):
-                defaults['applicant_id'] = defaults.get('res_id', False) or self.env.context.get('default_res_id', False)
+                defaults['applicant_ids'] = defaults.get('res_id', False) or self.env.context.get('default_res_id', False)
 
         return defaults
 
@@ -33,7 +33,7 @@ class CalendarEvent(models.Model):
         applicant_id = self.env.context.get('active_id')
         if self.env.context.get('active_model') == 'hr.applicant' and applicant_id:
             for event in self:
-                if event.applicant_id.id == applicant_id:
+                if event.applicant_ids.ids == [applicant_id]:
                     event.is_highlighted = True
 
-    applicant_id = fields.Many2one('hr.applicant', string="Applicant", index='btree_not_null', ondelete='set null')
+    applicant_ids = fields.Many2many('hr.applicant', string="Applicants")

--- a/addons/hr_recruitment/models/mail_activity.py
+++ b/addons/hr_recruitment/models/mail_activity.py
@@ -1,0 +1,17 @@
+# -*- coding: utf-8 -*-
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from odoo import models
+
+
+class MailActivity(models.Model):
+    _inherit = "mail.activity"
+
+    def action_create_calendar_event(self):
+        action = super().action_create_calendar_event()
+        meeting_activity_type = self.env['mail.activity.type'].search([('category', '=', 'meeting')])
+
+        if action['context']['default_res_model'] == 'hr.applicant' and action['context']['default_activity_type_id'] in meeting_activity_type.ids:
+            action['context']['active_id'] = self.res_model_id
+            action['context']['active_model'] = self.res_model
+        return action


### PR DESCRIPTION
Adds fields active_id and active_model to the context of
action_makeMeeting to link a meeting type with another model.

Makes the smart button track all meetings with the same email as registered in the applicant's.

See also  [#enterprise:25057](https://github.com/odoo/enterprise/pull/25057)

Task-id : 2782177

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
