### PR TITLE
[FIX] mass_mailing: properly apply background color to cards

### DIFF
--- a/addons/mass_mailing/views/snippets_themes.xml
+++ b/addons/mass_mailing/views/snippets_themes.xml
@@ -956,15 +956,20 @@
             data-color-prefix="bg-"/>
     </div>
 
-    <!-- COLOR, BORDER | .s_three_columns | .s_comparisons -->
+    <!-- COLOR | .s_three_columns | .s_comparisons -->
     <div data-js="Box"
          data-selector=".s_three_columns .row > div, .s_comparisons .row > div"
-         data-target=".card">
-        <we-colorpicker string="Colors"
+         data-target=".card-body">
+        <we-colorpicker string="Background Color"
             data-select-style="true"
             data-no-transparency="true"
             data-css-property="background-color"
             data-color-prefix="bg-"/>
+    </div>
+    <!-- BORDER | .s_three_columns | .s_comparisons -->
+    <div data-js="Box"
+         data-selector=".s_three_columns .row > div, .s_comparisons .row > div"
+         data-target=".card">
         <t t-call="mass_mailing.snippet_options_border_widgets">
             <t t-set="so_rounded_no_dependencies" t-value="True"/>
         </t>


### PR DESCRIPTION
The background color option was applied to .card instead of .card-body. As a result, the color appeared to be applied to the border rather than to the card itself.

task-2788893

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
