### PR TITLE
[FIX] base: ensures that raw related fields are not treated as base64

### DIFF
--- a/odoo/addons/base/models/ir_http.py
+++ b/odoo/addons/base/models/ir_http.py
@@ -396,6 +396,12 @@ class IrHttp(models.AbstractModel):
         if not content:
             if model == 'ir.attachment':
                 content = record.raw
+            elif (
+                field_def.related_field and
+                field_def.related_field.name == 'raw' and
+                field_def.related_field.model_name == 'ir.attachment'
+            ):
+                content = record[field] or b''
             else:
                 data = record[field] or b''
                 content = base64.b64decode(data)


### PR DESCRIPTION
Before this commit, since the refactor of some base64 decoding flows and
the addition of the raw field*, reading the content of a field that was
related to the `raw` field of `ir.attachment` was treated as reading a
base64 encoded content. This commit fixes this issue.

*https://github.com/odoo/enterprise/commit/680db8197731dae175027f81a705c38b0abf94da

task-2785146

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
