### PR TITLE
[FIX] l10n_fi: fix missing tax line

### DIFF
--- a/addons/l10n_fi/data/account_tax_template_data.xml
+++ b/addons/l10n_fi/data/account_tax_template_data.xml
@@ -118,12 +118,20 @@
               'repartition_type': 'base',
               'plus_report_line_ids':  [ref('tax_report_base_turnover_0_vat')],
             }),
+            (0,0, {
+              'factor_percent': 100,
+              'repartition_type': 'tax',
+            }),
         ]"/>
         <field name="refund_repartition_line_ids" eval="[(5, 0, 0),
             (0,0, {
               'factor_percent': 100,
               'repartition_type': 'base',
               'minus_report_line_ids':  [ref('tax_report_base_turnover_0_vat')],
+            }),
+            (0,0, {
+              'factor_percent': 100,
+              'repartition_type': 'tax',
             }),
         ]"/>
     </record>


### PR DESCRIPTION
Every tax should have a tax repartition line.
