### PR TITLE
[IMP] project: generic improvements

### DIFF
--- a/addons/project/data/project_demo.xml
+++ b/addons/project/data/project_demo.xml
@@ -212,6 +212,7 @@
             <field name="project_id" ref="project.project_project_1"/>
             <field name="name">Office planning</field>
             <field name="stage_id" ref="project_stage_2"/>
+            <field name="color">7</field>
             <field name="create_date" eval="DateTime.now() - relativedelta(months=5)"/>
         </record>
 
@@ -369,6 +370,7 @@
             <field name="kanban_state">blocked</field>
             <field name="create_date" eval="DateTime.now() - relativedelta(months=5)"/>
             <field name="date_deadline" eval="DateTime.now() + relativedelta(days=2)"/>
+            <field name="color">1</field>
         </record>
         <record id="project_1_task_5_mail_message_1" model="mail.message">
             <field name="model">project.task</field>
@@ -410,6 +412,7 @@
             <field name="stage_id" ref="project_stage_1"/>
             <field name="tag_ids" eval="[Command.set([ref('project_tags_01')])]"/>
             <field name="create_date" eval="DateTime.now() - relativedelta(months=5)"/>
+            <field name="color">11</field>
         </record>
         <record id="project_1_task_6_mail_message_1" model="mail.message">
             <field name="model">project.task</field>
@@ -448,6 +451,7 @@
             <field name="stage_id" ref="project_stage_1"/>
             <field name="create_date" eval="DateTime.now() - relativedelta(months=5)"/>
             <field name="date_deadline" eval="DateTime.now() + relativedelta(days=6)"/>
+            <field name="color">9</field>
         </record>
         <record id="project_1_task_7_mail_message_1" model="mail.message">
             <field name="model">project.task</field>
@@ -800,6 +804,7 @@ Send it ASAP, its urgent.</field>
             <field name="create_date" eval="DateTime.now() - relativedelta(months=5)"/>
             <field name="depend_on_ids" eval="[Command.link(ref('project.project_2_task_3'))]"/>
             <field name="date_deadline" eval="DateTime.now() + relativedelta(days=1)"/>
+            <field name="color">2</field>
         </record>
         <record id="project_2_task_4_mail_message_1" model="mail.message">
             <field name="model">project.task</field>
@@ -832,6 +837,7 @@ Send it ASAP, its urgent.</field>
             <field name="create_date" eval="DateTime.now() - relativedelta(months=5)"/>
             <field name="depend_on_ids" eval="[Command.link(ref('project.project_2_task_3'))]"/>
             <field name="date_deadline" eval="DateTime.now() + relativedelta(days=5)"/>
+            <field name="color">2</field>
         </record>
         <record id="project_2_task_5_mail_message_1" model="mail.message">
             <field name="model">project.task</field>
@@ -861,6 +867,7 @@ Send it ASAP, its urgent.</field>
             <field name="create_date" eval="DateTime.now() - relativedelta(months=5)"/>
             <field name="depend_on_ids" eval="[Command.link(ref('project.project_2_task_3'))]"/>
             <field name="date_deadline" eval="DateTime.now() + relativedelta(days=4)"/>
+            <field name="color">11</field>
         </record>
         <record id="project_2_task_6_mail_message_1" model="mail.message">
             <field name="model">project.task</field>
@@ -941,6 +948,7 @@ Send it ASAP, its urgent.</field>
             <field name="depend_on_ids"
                    eval="[Command.link(ref('project.project_2_task_7')), Command.link(ref('project.project_2_task_5')), Command.link(ref('project.project_2_task_4')), Command.link(ref('project.project_2_task_6'))]"/>
             <field name="date_deadline" eval="DateTime.now() + relativedelta(days=9)"/>
+            <field name="color">7</field>
         </record>
         <record id="project_2_task_8_mail_message_1" model="mail.message">
             <field name="model">project.task</field>
@@ -972,6 +980,7 @@ Send it ASAP, its urgent.</field>
             <field name="create_date" eval="DateTime.now() - relativedelta(months=5)"/>
             <field name="depend_on_ids" eval="[Command.link(ref('project.project_2_task_8'))]"/>
             <field name="date_deadline" eval="DateTime.now() + relativedelta(days=15)"/>
+            <field name="color">4</field>
         </record>
 
         <record id="project_2_task_10" model="project.task">
@@ -985,6 +994,7 @@ Send it ASAP, its urgent.</field>
             <field name="create_date" eval="DateTime.now() - relativedelta(months=5)"/>
             <field name="depend_on_ids" eval="[Command.link(ref('project.project_2_task_8'))]"/>
             <field name="date_deadline" eval="DateTime.now() + relativedelta(days=15)"/>
+            <field name="color">5</field>
         </record>
 
         <record id="project_2_task_11" model="project.task">
@@ -1058,6 +1068,7 @@ Send it ASAP, its urgent.</field>
             <field name="date_deadline" eval="DateTime.today() - relativedelta(days=5)"/>
             <field name="stage_id" ref="project_stage_2"/>
             <field name="tag_ids" eval="[Command.set([ref('project_tags_01')])]"/>
+            <field name="color">9</field>
         </record>
 
         <record id="project_3_task_4" model="project.task">

--- a/addons/project/models/ir_ui_menu.py
+++ b/addons/project/models/ir_ui_menu.py
@@ -11,4 +11,7 @@ class IrUiMenu(models.Model):
         res = super()._load_menus_blacklist()
         if not self.env.user.has_group('project.group_project_manager'):
             res.append(self.env.ref('project.rating_rating_menu_project').id)
+        if self.env.user.has_group('project.group_project_stages'):
+            res.append(self.env.ref('project.menu_projects').id)
+            res.append(self.env.ref('project.menu_projects_config').id)
         return res

--- a/addons/project/models/project.py
+++ b/addons/project/models/project.py
@@ -97,7 +97,7 @@ class ProjectTaskType(models.Model):
         string='Rating Email Template',
         domain=[('model', '=', 'project.task')],
         help="If set and if the project's rating configuration is 'Rating when changing stage', then an email will be sent to the customer when the task reaches this step.")
-    auto_validation_kanban_state = fields.Boolean('Automatic kanban status', default=False,
+    auto_validation_kanban_state = fields.Boolean('Automatic Kanban Status', default=False,
         help="Automatically modify the kanban state when the customer replies to the feedback for this stage.\n"
             " * Good feedback from the customer will update the kanban state to 'ready for the new stage' (green bullet).\n"
             " * Neutral or bad feedback will set the kanban state to 'blocked' (red bullet).\n")

--- a/addons/project/models/project.py
+++ b/addons/project/models/project.py
@@ -959,6 +959,12 @@ class Task(models.Model):
         return self.stage_find(project_id, [('fold', '=', False)])
 
     @api.model
+    def _default_personal_stage_type_id(self):
+        if self._context.get('default_project_id'):
+            return False
+        return self.env['project.task.type'].search([('user_id', '=', self.env.user.id)], limit=1).id
+
+    @api.model
     def _default_company_id(self):
         if self._context.get('default_project_id'):
             return self.env['project.project'].browse(self._context['default_project_id']).company_id
@@ -1035,7 +1041,7 @@ class Task(models.Model):
     # saying the field cannot be searched.
     personal_stage_type_id = fields.Many2one('project.task.type', string='Personal User Stage',
         compute='_compute_personal_stage_type_id', inverse='_inverse_personal_stage_type_id', store=False,
-        search='_search_personal_stage_type_id',
+        search='_search_personal_stage_type_id', default=_default_personal_stage_type_id,
         help="The current user's personal task stage.")
     partner_id = fields.Many2one('res.partner',
         string='Customer', recursive=True, tracking=True,

--- a/addons/project/models/project.py
+++ b/addons/project/models/project.py
@@ -1055,6 +1055,7 @@ class Task(models.Model):
         'res.company', string='Company', compute='_compute_company_id', store=True, readonly=False,
         required=True, copy=True, default=_default_company_id)
     color = fields.Integer(string='Color Index')
+    project_color = fields.Integer(related='project_id.color', string='Project Color')
     rating_active = fields.Boolean(string='Project Rating Status', related="project_id.rating_active")
     attachment_ids = fields.One2many('ir.attachment', compute='_compute_attachment_ids', string="Main Attachments",
         help="Attachments that don't come from a message.")

--- a/addons/project/static/src/js/project_calendar.js
+++ b/addons/project/static/src/js/project_calendar.js
@@ -37,6 +37,14 @@ export const ProjectCalendarView = CalendarView.extend({
         ControlPanel: ProjectControlPanel,
         Model: ProjectCalendarModel,
     }),
+
+    /**
+    * @override
+    */
+    init: function (viewInfo, params) {
+        this._super.apply(this, arguments);
+        this.controllerParams.displayName += " - Tasks by Deadline";
+    }
 });
 
 viewRegistry.add('project_calendar', ProjectCalendarView);

--- a/addons/project/static/src/js/project_calendar.js
+++ b/addons/project/static/src/js/project_calendar.js
@@ -1,6 +1,7 @@
 /** @odoo-module **/
 
 import CalendarController from 'web.CalendarController';
+import CalendarModel from 'web.CalendarModel';
 import CalendarView from 'web.CalendarView';
 import viewRegistry from 'web.view_registry';
 import { ProjectControlPanel } from '@project/js/project_control_panel';
@@ -18,10 +19,23 @@ const ProjectCalendarController = CalendarController.extend({
     },
 });
 
+const ProjectCalendarModel = CalendarModel.extend({
+    /**
+     * @private
+     * @override
+     */
+    _getFullCalendarOptions: function () {
+        const options = this._super(...arguments);
+        options.eventDurationEditable = false;
+        return options;
+    }
+})
+
 export const ProjectCalendarView = CalendarView.extend({
     config: Object.assign({}, CalendarView.prototype.config, {
         Controller: ProjectCalendarController,
         ControlPanel: ProjectControlPanel,
+        Model: ProjectCalendarModel,
     }),
 });
 

--- a/addons/project/static/src/js/project_form.js
+++ b/addons/project/static/src/js/project_form.js
@@ -125,9 +125,24 @@ export const FormDescriptionExpanderView = FormView.extend({
     }),
 })
 
+export const ProjectFormRenderer = FormDescriptionExpanderRenderer.extend({
+    /**
+     * @private
+     * @override
+     */
+    _renderStatButton: function (node) {
+        const $button = this._super.apply(this, arguments);
+        if ($button.attr('name') == 'action_open_parent_task' && this.state.data.parent_id) {
+            $button.prop('title', this.state.data.parent_id.data.display_name);
+        }
+        return $button;
+    },
+})
+
 export const ProjectFormView = FormDescriptionExpanderView.extend({
     config: Object.assign({}, FormDescriptionExpanderView.prototype.config, {
         Controller: ProjectFormController,
+        Renderer: ProjectFormRenderer,
     }),
 });
 

--- a/addons/project/static/src/js/widgets/status_with_color_widget.js
+++ b/addons/project/static/src/js/widgets/status_with_color_widget.js
@@ -17,6 +17,7 @@ export const StatusWithColor = FieldSelection.extend({
     init: function () {
         this._super.apply(this, arguments);
         this.color = this.recordData[this.nodeOptions.color_field];
+        this.hideLabel = this.nodeOptions.hide_label;
         if (this.nodeOptions.no_quick_edit) {
             this._canQuickEdit = false;
         }
@@ -29,6 +30,10 @@ export const StatusWithColor = FieldSelection.extend({
         this._super.apply(this, arguments);
         if (this.value) {
             this.$el.addClass('o_status_with_color');
+            if (this.hideLabel) {
+                this.$el.attr('title', this.$el.text());
+                this.$el.empty();
+            }
             this.$el.prepend(qweb.render(this._template, {
                 color: this.color,
             }));

--- a/addons/project/static/src/scss/project_form.scss
+++ b/addons/project/static/src/scss/project_form.scss
@@ -34,3 +34,11 @@
     color: darkred;
     font-style: italic;
 }
+
+.oe_title .o_favorite i.fa {
+    font-size: inherit;
+}
+
+.o_data_cell .o_favorite i.fa {
+    font-size: 1.35em;
+}

--- a/addons/project/views/project_views.xml
+++ b/addons/project/views/project_views.xml
@@ -1313,11 +1313,11 @@
             <field eval="2" name="priority"/>
             <field name="arch" type="xml">
                 <calendar date_start="date_deadline" string="Tasks" mode="month" 
-                          color="user_ids" event_limit="5" hide_time="true" 
+                          color="color" event_limit="5" hide_time="true" 
                           event_open_popup="true" quick_add="false" show_unusual_days="True"
                           js_class="project_calendar"
                           scales="month,year">
-                    <field name="project_id" widget="project_private_task" filters="1"/>
+                    <field name="project_id" widget="project_private_task" filters="1" color="color"/>
                     <field name="user_ids" widget="many2many_avatar_user"/>
                     <field name="partner_id" attrs="{'invisible': [('partner_id', '=', False)]}"/>
                     <field name="priority" widget="priority"/>
@@ -1326,6 +1326,18 @@
                     <field name="stage_id"/>
                     <field name="kanban_state"/>
                 </calendar>
+            </field>
+        </record>
+
+        <record id="view_task_all_calendar" model="ir.ui.view">
+            <field name="name">project.task.all.calendar</field>
+            <field name="model">project.task</field>
+            <field name="inherit_id" ref="view_task_calendar"/>
+            <field name="mode">primary</field>
+            <field name="arch" type="xml">
+                <xpath expr="//calendar" position="attributes">
+                    <attribute name="color">project_color</attribute>
+                </xpath>
             </field>
         </record>
 
@@ -1412,6 +1424,23 @@
             <field name="sequence" eval="1"/>
             <field name="view_mode">tree</field>
             <field name="act_window_id" ref="action_view_task"/>
+        </record>
+
+        <record id="open_view_all_task_list_kanban" model="ir.actions.act_window.view">
+            <field name="sequence" eval="10"/>
+            <field name="view_mode">kanban</field>
+            <field name="act_window_id" ref="action_view_all_task"/>
+        </record>
+        <record id="open_view_all_task_list_tree" model="ir.actions.act_window.view">
+            <field name="sequence" eval="20"/>
+            <field name="view_mode">tree</field>
+            <field name="act_window_id" ref="action_view_all_task"/>
+        </record>
+        <record id="open_view_all_task_list_calendar" model="ir.actions.act_window.view">
+            <field name="sequence" eval="40"/>
+            <field name="view_mode">calendar</field>
+            <field name="act_window_id" ref="action_view_all_task"/>
+            <field name="view_id" ref="view_task_all_calendar"/>
         </record>
 
         <menuitem name="My Tasks" id="menu_project_management" parent="menu_main_pm"

--- a/addons/project/views/project_views.xml
+++ b/addons/project/views/project_views.xml
@@ -1318,7 +1318,7 @@
                           event_open_popup="true" quick_add="false" show_unusual_days="True"
                           js_class="project_calendar"
                           scales="month,year">
-                    <field name="project_id" widget="project_private_task" filters="1" color="color"/>
+                    <field name="project_id" widget="project_private_task"/>
                     <field name="user_ids" widget="many2many_avatar_user"/>
                     <field name="partner_id" attrs="{'invisible': [('partner_id', '=', False)]}"/>
                     <field name="priority" widget="priority"/>
@@ -1338,6 +1338,10 @@
             <field name="arch" type="xml">
                 <xpath expr="//calendar" position="attributes">
                     <attribute name="color">project_color</attribute>
+                </xpath>
+                <xpath expr="//field[@name='project_id']" position="attributes">
+                    <attribute name="filters">1</attribute>
+                    <attribute name="color">color</attribute>
                 </xpath>
             </field>
         </record>

--- a/addons/project/views/project_views.xml
+++ b/addons/project/views/project_views.xml
@@ -833,6 +833,30 @@
             </field>
         </record>
 
+        <record id="view_project_calendar" model="ir.ui.view">
+            <field name="name">project.project.calendar</field>
+            <field name="model">project.project</field>
+            <field name="arch" type="xml">
+                <calendar
+                    date_start="date_start"
+                    date_stop="date"
+                    string="Projects"
+                    mode="month"
+                    scales="month,year"
+                    event_open_popup="true"
+                    quick_add="false"
+                    color="color">
+                    <field name="partner_id" attrs="{'invisible': [('partner_id', '=', False)]}"/>
+                    <field name="user_id" widget="many2one_avatar_user" attrs="{'invisible': [('user_id', '=', False)]}"/>
+                    <field name="is_favorite" widget="boolean_favorite" nolabel="1" string="Favorite"/>
+                    <field name="stage_id" groups="project.group_project_stages"/>
+                    <field name="last_update_color" invisible="1"/>
+                    <field name="last_update_status" string="Status" widget="status_with_color" options="{'color_field': 'last_update_color'}"/>
+                    <field name="tag_ids" widget="many2many_tags" options="{'color_field': 'color'}" attrs="{'invisible': [('tag_ids', '=', [])]}"/>
+                </calendar>
+            </field>
+        </record>
+
         <record id="view_project_kanban_inherit" model="ir.ui.view">
             <field name="name">project.kanban.inherit.project</field>
             <field name="model">project.project</field>
@@ -845,6 +869,7 @@
             </field>
         </record>
 
+        <!-- Please update both act_window when modifying one (open_view_project_all or open_view_project_all_group_stage) as one or the other is used in the menu menu_project -->
         <record id="open_view_project_all" model="ir.actions.act_window">
             <field name="name">Projects</field>
             <field name="res_model">project.project</field>
@@ -863,6 +888,26 @@
             </field>
         </record>
 
+        <!-- Please update both act_window when modifying one (open_view_project_all or open_view_project_all_group_stage) as one or the other is used in the menu menu_project -->
+        <record id="open_view_project_all_group_stage" model="ir.actions.act_window">
+            <field name="name">Projects</field>
+            <field name="res_model">project.project</field>
+            <field name="domain">[]</field>
+            <field name="view_mode">kanban,tree,form,calendar,activity</field>
+            <field name="view_id" ref="view_project_kanban_inherit"/>
+            <field name="search_view_id" ref="view_project_project_filter"/>
+            <field name="target">main</field>
+            <field name="help" type="html">
+                <p class="o_view_nocontent_smiling_face">
+                    No projects found. Let's create one!
+                </p>
+                <p>
+                    Projects contain tasks on the same topic, and each has its own dashboard.
+                </p>
+            </field>
+        </record>
+
+        <!-- Please update both act_window when modifying one (open_view_project_all_config or open_view_project_all_config_group_stage) as one or the other is used in the menu menu_project_config -->
         <record id="open_view_project_all_config" model="ir.actions.act_window">
             <field name="name">Projects</field>
             <field name="res_model">project.project</field>
@@ -881,6 +926,37 @@
                     Projects contain tasks on the same topic, and each has its own dashboard.
                 </p>
             </field>
+        </record>
+
+        <!-- Please update both act_window when modifying one (open_view_project_all_config or open_view_project_all_config_group_stage) as one or the other is used in the menu menu_project_config -->
+        <record id="open_view_project_all_config_group_stage" model="ir.actions.act_window">
+            <field name="name">Projects</field>
+            <field name="res_model">project.project</field>
+            <field name="domain">[]</field>
+            <field name="view_mode">tree,kanban,form,calendar,activity</field>
+            <field name="search_view_id" ref="view_project_project_filter"/>
+            <field name="context">{}</field>
+            <field name="help" type="html">
+                <p class="o_view_nocontent_smiling_face">
+                   No projects found. Let's create one!
+                </p>
+                <p>
+                    Projects contain tasks on the same topic, and each has its own dashboard.
+                </p>
+            </field>
+        </record>
+
+        <record id="open_view_project_all_config_group_stage_tree_action_view" model="ir.actions.act_window.view">
+            <field name="sequence" eval="10"/>
+            <field name="view_mode">tree</field>
+            <field name="act_window_id" ref="project.open_view_project_all_config_group_stage"/>
+            <field name="view_id" ref="view_project"/>
+        </record>
+        <record id="open_view_project_all_config_group_stage_kanban_action_view" model="ir.actions.act_window.view">
+            <field name="sequence" eval="20"/>
+            <field name="view_mode">kanban</field>
+            <field name="act_window_id" ref="project.open_view_project_all_config_group_stage"/>
+            <field name="view_id" ref="view_project_kanban"/>
         </record>
 
         <!-- Task -->
@@ -1484,7 +1560,9 @@
         <menuitem action="open_task_type_form" id="menu_project_config_project" name="Task Stages" parent="menu_project_config" sequence="10" groups="base.group_no_one"/>
 
         <menuitem action="open_view_project_all" id="menu_projects" name="Projects" parent="menu_main_pm" sequence="1"/>
+        <menuitem action="open_view_project_all_group_stage" id="menu_projects_group_stage" name="Projects" parent="menu_main_pm" sequence="1" groups="project.group_project_stages"/>
         <menuitem action="open_view_project_all_config" id="menu_projects_config" name="Projects" parent="menu_project_config" sequence="5"/>
+        <menuitem action="open_view_project_all_config_group_stage" id="menu_projects_config_group_stage" name="Projects" parent="menu_project_config" sequence="5" groups="project.group_project_stages"/>
 
         <!-- User Form -->
         <record id="act_res_users_2_project_task_opened" model="ir.actions.act_window">

--- a/addons/project/views/project_views.xml
+++ b/addons/project/views/project_views.xml
@@ -965,7 +965,7 @@
                     <div class="oe_title pr-0">
                         <h1 class="d-flex flex-row justify-content-between">
                             <field name="priority" widget="priority" class="mr-3"/>
-                            <field name="name" class="o_task_name text-truncate" placeholder="Task Title..." default_focus="1" />
+                            <field name="name" class="o_task_name text-truncate" placeholder="Task Title..."/>
                             <field name="kanban_state" widget="state_selection" class="ml-auto"/>
                         </h1>
                     </div>

--- a/addons/project/views/project_views.xml
+++ b/addons/project/views/project_views.xml
@@ -905,6 +905,7 @@
                         <button name="action_assign_to_me" string="Assign to Me" type="object" attrs="{'invisible': &quot;['|', ('user_ids', 'in', uid), ('user_ids', '=', [])]&quot;}" data-hotkey="q"/>
                         <button name="action_assign_to_me" string="Assign to Me" type="object" class="oe_highlight" attrs="{'invisible' : &quot;['|', ('user_ids', 'in', uid), ('user_ids', '!=', [])]&quot;}" data-hotkey="q"/>
                         <field name="stage_id" widget="statusbar" options="{'clickable': '1', 'fold_field': 'fold'}" attrs="{'invisible': [('project_id', '=', False), ('stage_id', '=', False)]}"/>
+                        <field name="personal_stage_type_id" widget="statusbar" options="{'clickable': '1', 'fold_field': 'fold'}" attrs="{'invisible': [('project_id', '!=', False)]}" domain="[('user_id', '=', uid)]"/>
                     </header>
                     <div class="alert alert-info oe_edit_only mb-0" role="status" attrs="{'invisible': ['|', ('recurring_task', '=', False), ('recurrence_id', '=', False)]}">
                         <p>Edit recurring task</p>

--- a/addons/project/views/project_views.xml
+++ b/addons/project/views/project_views.xml
@@ -1491,7 +1491,7 @@
             <field name="name">Tags</field>
             <field name="model">project.tags</field>
             <field name="arch" type="xml">
-                <tree string="Tags" editable="top" sample="1" multi_edit="1">
+                <tree string="Tags" editable="top" sample="1" multi_edit="1" default_order="name">
                     <field name="name"/>
                     <field name="color" widget="color_picker" optional="show"/>
                 </tree>

--- a/addons/project/views/project_views.xml
+++ b/addons/project/views/project_views.xml
@@ -442,7 +442,8 @@
                     </div>
                     <widget name="web_ribbon" title="Archived" bg_color="bg-danger" attrs="{'invisible': [('active', '=', True)]}"/>
                     <div class="oe_title">
-                        <h1>
+                        <h1 class="d-flex flex-row">
+                            <field name="is_favorite" nolabel="1" widget="boolean_favorite" class="mr-3"/>
                             <field name="name" class="o_text_overflow" placeholder="Project Name"/>
                         </h1>
                     </div>
@@ -612,6 +613,7 @@
                     <field name="sequence" optional="show" widget="handle"/>
                     <field name="message_needaction" invisible="1"/>
                     <field name="active" invisible="1"/>
+                    <field name="is_favorite" nolabel="1" width="1" widget="boolean_favorite"/>
                     <field name="display_name" string="Name" class="font-weight-bold"/>
                     <field name="partner_id" optional="show" string="Customer"/>
                     <field name="privacy_visibility" optional="hide"/>

--- a/addons/project/views/project_views.xml
+++ b/addons/project/views/project_views.xml
@@ -624,7 +624,7 @@
                     <field name="user_id" optional="show" string="Project Manager" widget="many2one_avatar_user" options="{'no_open':True, 'no_create': True, 'no_create_edit': True}"/>
                     <field name="last_update_color" invisible="1"/>
                     <field name="tag_ids" widget="many2many_tags" options="{'color_field': 'color'}" optional="hide"/>
-                    <field name="last_update_status" string="Status" optional="show" widget="status_with_color" options="{'color_field': 'last_update_color'}"/>
+                    <field name="last_update_status" string="Status" nolabel="1" optional="show" widget="status_with_color" options="{'color_field': 'last_update_color', 'hide_label': True}"/>
                     <field name="stage_id" options="{'no_open': True}" optional="show"/>
                 </tree>
             </field>

--- a/addons/project/views/project_views.xml
+++ b/addons/project/views/project_views.xml
@@ -219,12 +219,12 @@
                                 <field name="name"/>
                                 <field name="mail_template_id" context="{'default_model': 'project.task'}"/>
                                 <field name="rating_template_id" groups="project.group_project_rating" context="{'default_model': 'project.task'}"/>
-                                <field name="sequence" groups="base.group_no_one"/>
                                 <div class="alert alert-warning" role="alert" colspan='2' attrs="{'invisible': ['|', ('rating_template_id','=', False), ('disabled_rating_warning', '=', False)]}" groups="project.group_project_rating">
                                     <i class="fa fa-warning" title="Customer disabled on projects"/><b> Customer Ratings</b> are disabled on the following project(s) : <br/>
                                     <field name="disabled_rating_warning" class="mb-0" />
                                 </div>
                                 <field name="auto_validation_kanban_state" attrs="{'invisible': [('rating_template_id','=', False)]}" groups="project.group_project_rating"/>
+                                <field name="sequence" groups="base.group_no_one"/>
                             </group>
                             <group>
                                 <field name="fold"/>

--- a/addons/project_sms/views/project_task_type_views.xml
+++ b/addons/project_sms/views/project_task_type_views.xml
@@ -6,7 +6,7 @@
         <field name="model">project.task.type</field>
         <field name="inherit_id" ref="project.task_type_edit"/>
         <field name="arch" type="xml">
-            <field name="rating_template_id" position="after">
+            <field name="mail_template_id" position="before">
                 <field name="sms_template_id" context="{'default_model': 'project.task'}" options="{'no_quick_create': True}"/>
             </field>
         </field>

--- a/addons/web/static/src/legacy/js/views/calendar/calendar_view.js
+++ b/addons/web/static/src/legacy/js/views/calendar/calendar_view.js
@@ -179,7 +179,7 @@ var CalendarView = AbstractView.extend({
         this.controllerParams.showUnusualDays = utils.toBoolElse(attrs.show_unusual_days || '', false);
         this.controllerParams.mapping = mapping;
         this.controllerParams.context = params.context || {};
-        this.controllerParams.displayName = params.action && params.action.name;
+        this.controllerParams.displayName = params.displayName;
         this.controllerParams.scales = scales;
 
         this.rendererParams.displayFields = displayFields;


### PR DESCRIPTION
This PR brings the following improvements to project:

- Order the tags alphabetically in the project tags list view.
- Adds the parent task name as hover text for the "Parent task" button in the task form view.
- Disable resizing tasks with the mouse in the tasks calendar view.
- Add a star icon to toggle a project as favorite in the form and list views.
- Remove the "project status" label in the list view, and use it as hover text instead.
- Append "Tasks by Deadline" to the tasks calendar view title.
- Remove the default focus on the project name in the form view.
- Add the color of the project to the filters on the right side of the calendar view, and also use this color for the tasks of the corresponding project in the calendar.
- Move the 'Customer Ratings' warning to be right under the Rating Email Template field in the task stages settings view.
- Link private tasks to personal stages in the form view with a status bar.
- Hide the "Projects" filter on the right of the tasks calendar view when there is only one project in the context.
- Add a calendar and an activity view for projects when the "Project Stages" feature is enabled.

It also introduces a slight technical change to the calendar views, to use params.displayName instead of params.action.name for titles.

Related: https://github.com/odoo/enterprise/pull/25080

Task-2741733