### PR TITLE
[FIX] account: partner inconsistency

### DIFF
--- a/addons/account/i18n/account.pot
+++ b/addons/account/i18n/account.pot
@@ -7,7 +7,7 @@ msgstr ""
 "Project-Id-Version: Odoo Server 15.0\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2022-02-18 09:52+0000\n"
-"PO-Revision-Date: 2022-02-18 09:52+0000\n"
+"PO-Revision-Date: 2022-03-08 11:38+0000\n"
 "Last-Translator: \n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"
@@ -11536,6 +11536,12 @@ msgstr ""
 msgid ""
 "Some journal items already exist with this account but in other journals "
 "than the allowed ones."
+msgstr ""
+
+#. module: account
+#: code:addons/account/models/account_move.py:0
+#, python-format
+msgid "Some partner inconsistencies are detected. Please reload the page."
 msgstr ""
 
 #. module: account

--- a/addons/account/populate/account_move.py
+++ b/addons/account/populate/account_move.py
@@ -98,6 +98,7 @@ class AccountMove(models.Model):
             def get_line(account, label, balance=None, balance_sign=False, exclude_from_invoice_tab=False):
                 company_currency = account.company_id.currency_id
                 currency = self.env['res.currency'].browse(currency_id)
+                partner = self.env['res.partner'].browse(partner_id)
                 balance = balance or balance_sign * round(random.uniform(0, 1000))
                 amount_currency = company_currency._convert(balance, currency, account.company_id, date)
                 return (0, 0, {
@@ -105,7 +106,7 @@ class AccountMove(models.Model):
                     'debit': balance > 0 and balance or 0,
                     'credit': balance < 0 and -balance or 0,
                     'account_id': account.id,
-                    'partner_id': partner_id,
+                    'partner_id': partner.commercial_partner_id.id,
                     'currency_id': currency_id,
                     'amount_currency': amount_currency,
                     'exclude_from_invoice_tab': exclude_from_invoice_tab,

--- a/addons/account/tests/test_account_move_reconcile.py
+++ b/addons/account/tests/test_account_move_reconcile.py
@@ -2140,6 +2140,7 @@ class TestAccountMoveReconcile(AccountTestInvoicingCommon):
                     'debit': 100.0,
                     'credit': 0.0,
                     'account_id': self.company_data['default_account_revenue'].id,
+                    'partner_id': self.partner_a.id,
                     'tax_ids': [(6, 0, self.cash_basis_tax_a_third_amount.ids)],
                 }),
 
@@ -2148,6 +2149,7 @@ class TestAccountMoveReconcile(AccountTestInvoicingCommon):
                     'debit': 33.33,
                     'credit': 0.0,
                     'account_id': self.cash_basis_transfer_account.id,
+                    'partner_id': self.partner_a.id,
                     'tax_repartition_line_id': self.cash_basis_tax_a_third_amount.refund_repartition_line_ids.filtered(lambda line: line.repartition_type == 'tax').id,
                 }),
 
@@ -2156,6 +2158,7 @@ class TestAccountMoveReconcile(AccountTestInvoicingCommon):
                     'debit': 0.0,
                     'credit': 133.33,
                     'account_id': self.extra_receivable_account_1.id,
+                    'partner_id': self.partner_a.id,
                 }),
             ]
         })

--- a/addons/account/tests/test_sequence_mixin.py
+++ b/addons/account/tests/test_sequence_mixin.py
@@ -173,6 +173,8 @@ class TestSequenceMixin(TestSequenceMixinCommon):
             'partner_id': 1,
             'invoice_date': '2016-01-01',
         })
+        for doc in (invoice, invoice2, refund, refund2):
+            doc._onchange_partner_id()
         (invoice + invoice2).move_type = 'out_invoice'
         (refund + refund2).move_type = 'out_refund'
         all_moves = (entry + entry2 + invoice + invoice2 + refund + refund2)

--- a/addons/l10n_ar/demo/account_supplier_invoice_demo.xml
+++ b/addons/l10n_ar/demo/account_supplier_invoice_demo.xml
@@ -145,6 +145,7 @@
     <!-- create this lines manually to set taxes and prices -->
     <record id="demo_despacho_1_line_1" model="account.move.line" context="{'check_move_validity': False, 'allowed_company_ids': [ref('company_ri')]}">
         <field name="move_id" ref="demo_despacho_1"/>
+        <field name="partner_id" ref="l10n_ar.partner_afip"/>
         <field name="price_unit">5064.98</field>
         <field name="name">[AFIP_DESPACHO] Despacho de importación</field>
         <field name="quantity">1</field>
@@ -155,6 +156,7 @@
     </record>
     <record id="demo_despacho_1_line_2" model="account.move.line" context="{'check_move_validity': False, 'allowed_company_ids': [ref('company_ri')]}">
         <field name="move_id" ref="demo_despacho_1"/>
+        <field name="partner_id" ref="l10n_ar.partner_afip"/>
         <field name="price_unit">152.08</field>
         <field name="name">[AFIP_TASA_EST] Tasa Estadística</field>
         <field name="quantity">1</field>
@@ -165,6 +167,7 @@
     </record>
     <record id="demo_despacho_1_line_3" model="account.move.line" context="{'check_move_validity': False, 'allowed_company_ids': [ref('company_ri')]}">
         <field name="move_id" ref="demo_despacho_1"/>
+        <field name="partner_id" ref="l10n_ar.partner_afip"/>
         <field name="price_unit">10.0</field>
         <field name="name">[AFIP_ARANCEL] Arancel</field>
         <field name="quantity">1</field>
@@ -175,6 +178,7 @@
     </record>
     <record id="demo_despacho_1_line_4" model="account.move.line" context="{'check_move_validity': False, 'allowed_company_ids': [ref('company_ri')]}">
         <field name="move_id" ref="demo_despacho_1"/>
+        <field name="partner_id" ref="l10n_ar.partner_afip"/>
         <field name="price_unit">28.00</field>
         <field name="name">[AFIP_SERV_GUARDA] Servicio de Guarda</field>
         <field name="quantity">1</field>
@@ -186,6 +190,7 @@
     <record id="demo_despacho_1_line_5" model="account.move.line" context="{'check_move_validity': False, 'allowed_company_ids': [ref('company_ri')]}">
         <field name="name">FOB Total</field>
         <field name="move_id" ref="demo_despacho_1"/>
+        <field name="partner_id" ref="l10n_ar.partner_afip"/>
         <field name="price_unit">28936.06</field>
         <field name="quantity">1</field>
         <field name="product_uom_id" ref="uom.product_uom_unit"/>
@@ -195,6 +200,7 @@
     <record id="demo_despacho_1_line_6" model="account.move.line" context="{'check_move_validity': False, 'allowed_company_ids': [ref('company_ri')]}">
         <field name="name">Flete</field>
         <field name="move_id" ref="demo_despacho_1"/>
+        <field name="partner_id" ref="l10n_ar.partner_afip"/>
         <field name="price_unit">1350.00</field>
         <field name="quantity">1</field>
         <field name="product_uom_id" ref="uom.product_uom_unit"/>
@@ -204,6 +210,7 @@
     <record id="demo_despacho_1_line_7" model="account.move.line" context="{'check_move_validity': False, 'allowed_company_ids': [ref('company_ri')]}">
         <field name="name">Seguro</field>
         <field name="move_id" ref="demo_despacho_1"/>
+        <field name="partner_id" ref="l10n_ar.partner_afip"/>
         <field name="price_unit">130.21</field>
         <field name="quantity">1</field>
         <field name="product_uom_id" ref="uom.product_uom_unit"/>
@@ -213,6 +220,7 @@
     <record id="demo_despacho_1_line_8" model="account.move.line" context="{'check_move_validity': False, 'allowed_company_ids': [ref('company_ri')]}">
         <field name="name">-FOB Total</field>
         <field name="move_id" ref="demo_despacho_1"/>
+        <field name="partner_id" ref="l10n_ar.partner_afip"/>
         <field name="price_unit">-28936.06</field>
         <field name="quantity">1</field>
         <field name="product_uom_id" ref="uom.product_uom_unit"/>
@@ -222,6 +230,7 @@
     <record id="demo_despacho_1_line_9" model="account.move.line" context="{'check_move_validity': False, 'allowed_company_ids': [ref('company_ri')]}">
         <field name="name">-Flete</field>
         <field name="move_id" ref="demo_despacho_1"/>
+        <field name="partner_id" ref="l10n_ar.partner_afip"/>
         <field name="price_unit">-1350.00</field>
         <field name="quantity">1</field>
         <field name="product_uom_id" ref="uom.product_uom_unit"/>
@@ -231,6 +240,7 @@
     <record id="demo_despacho_1_line_10" model="account.move.line" context="{'check_move_validity': False, 'allowed_company_ids': [ref('company_ri')]}">
         <field name="name">-Seguro</field>
         <field name="move_id" ref="demo_despacho_1"/>
+        <field name="partner_id" ref="l10n_ar.partner_afip"/>
         <field name="price_unit">-130.21</field>
         <field name="quantity">1</field>
         <field name="product_uom_id" ref="uom.product_uom_unit"/>


### PR DESCRIPTION
How to reproduce:
Have 2 different tabs open on the same draft invoice
Tab 1: add a new invoice line
Tab 2: change the partner
Tab 1: save
Tab 2: save

Before the fix:
The new invoice line from tab 1 has the partner from before the change,
but the other lines have been updated to the new partner.

Expected:
All invoice lines have the same partner as the invoice itself

This use case can be reproduced like this manually, but it can happen
easily even on one tab because the OCR acts like the second tab if users
start to edit the invoice before it is scanned.

[opw-2777390](https://www.odoo.com/web#id=2777390&model=project.task)
[opw-2762347](https://www.odoo.com/web#id=2762347&model=project.task)
[opw-2741859](https://www.odoo.com/web#id=2741859&model=project.task)

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
