### PR TITLE
[FIX] web_editor: fix data-no-check on specific snippet options

### DIFF
--- a/addons/web_editor/static/src/js/editor/snippets.editor.js
+++ b/addons/web_editor/static/src/js/editor/snippets.editor.js
@@ -2049,12 +2049,11 @@ var SnippetsMenu = Widget.extend({
         }
 
         // Prepare the functions
-        var functions = {
-            is: function ($from) {
-                return $from.is(selector) && $from.filter(filterFunc).length !== 0;
-            },
-        };
+        const functions = {};
         if (noCheck) {
+            functions.is = function ($from) {
+                return $from.is(selector) && $from.filter(filterFunc).length !== 0;
+            };
             functions.closest = function ($from, parentNode) {
                 return $from.closest(selector, parentNode).filter(filterFunc);
             };
@@ -2062,6 +2061,11 @@ var SnippetsMenu = Widget.extend({
                 return ($from ? dom.cssFind($from, selector) : $(selector)).filter(filterFunc);
             };
         } else {
+            functions.is = function ($from) {
+                return $from.is(selector)
+                    && self.getEditableArea().find($from).addBack($from).length !== 0
+                    && $from.filter(filterFunc).length !== 0;
+            };
             functions.closest = function ($from, parentNode) {
                 var parents = self.getEditableArea().get();
                 return $from.closest(selector, parentNode).filter(function () {


### PR DESCRIPTION
Before this commit, if an option targeting an element had a
data-no-check attribute this had the effect that all other options
targeting this element were also displayed even if they did not have a
no-check attribute (no-check => display the option even if it is
a non-editable element).

The issue came from the is() function of _computeSelectorFunctions which
did not take into account the no-check as it should.

Note: this is fixed in stable only as custom apps may rely on the broken
behavior. An issue with this in stable can be met by *hiding* the
related unwanted options with `_computeVisibility`. No case of this
problem currently exists in the Odoo codebase (but it will, that's how
the bug was found).

task-2710582

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
