### PR TITLE
[FIX] web: read ICP in sudo

### DIFF
--- a/addons/web/controllers/profiling.py
+++ b/addons/web/controllers/profiling.py
@@ -29,6 +29,6 @@ class Profiling(Controller):
         context = {
             'profile': profile,
             'url_root': request.httprequest.url_root,
-            'cdn': icp.get_param('speedscope_cdn', "https://cdn.jsdelivr.net/npm/speedscope@1.13.0/dist/release/")
+            'cdn': icp.sudo().get_param('speedscope_cdn', "https://cdn.jsdelivr.net/npm/speedscope@1.13.0/dist/release/")
         }
         return request.render('web.view_speedscope_index', context)


### PR DESCRIPTION
Allow non-admins to access the `/web/speedscope/` routes (given correct
access rights).
