### PR TITLE
[IMP] website_event: improve web tracking

### DIFF
--- a/addons/test_event_full/tests/test_performance.py
+++ b/addons/test_event_full/tests/test_performance.py
@@ -444,7 +444,7 @@ class TestOnlineEventPerformance(EventPerformanceCase, UtilPerf):
         # website customer data
         with freeze_time(self.reference_now):
             self.authenticate('user_eventmanager', 'user_eventmanager')
-            with self.assertQueryCount(default=50):  # tef only: 49
+            with self.assertQueryCount(default=60):  # com runbot: 59 - ent runbot:60
                 self._test_url_open('/event')
 
     @warmup
@@ -452,7 +452,7 @@ class TestOnlineEventPerformance(EventPerformanceCase, UtilPerf):
         # website customer data
         with freeze_time(self.reference_now):
             self.authenticate(None, None)
-            with self.assertQueryCount(default=30):
+            with self.assertQueryCount(default=39):  # com runbot: 39 - ent runbot: 39
                 self._test_url_open('/event')
 
     # @warmup

--- a/addons/website/models/ir_http.py
+++ b/addons/website/models/ir_http.py
@@ -133,7 +133,7 @@ class Http(models.AbstractModel):
 
     @classmethod
     def _register_website_track(cls, response):
-        if getattr(response, 'status_code', 0) != 200:
+        if getattr(response, 'status_code', 0) != 200 or request.httprequest.headers.get('X-Disable-Tracking') == '1':
             return False
 
         template = False

--- a/addons/website_event/views/event_templates_list.xml
+++ b/addons/website_event/views/event_templates_list.xml
@@ -2,7 +2,7 @@
 <odoo>
 
 <!-- Index -->
-<template id="index" name="Events">
+<template id="index" name="Events" track="1">
     <t t-call="website.layout">
         <div id="wrap" class="o_wevent_index">
             <!-- Options -->


### PR DESCRIPTION
PURPOSE

When opening the event page on the website, there is a service worker in place
that pre-fetches all links in order to be able to work offline.
This commit aims to disable the page tracking for those prefetch requests to
avoid polluting the statistics with "fake" page views.

SPECS

- Add a preparation commit to introduce a "X-Disable-Tracking" header
- Put the header on all requests in the event module that prefetch content

See underlying commit for details.

Task-2476513