### PR TITLE
[FIX] hr_attendance: fix wrong widget being used

### DIFF
--- a/addons/hr_attendance/views/hr_employee_view.xml
+++ b/addons/hr_attendance/views/hr_employee_view.xml
@@ -46,7 +46,7 @@
                         help="Worked hours last month">
                     <div class="o_field_widget o_stat_info">
                         <span class="o_stat_value">
-                            <field name="hours_last_month_display"/> Hours
+                            <field name="hours_last_month_display" widget="float_time"/> Hours
                         </span>
                         <span class="o_stat_text">
                             Last Month
@@ -100,7 +100,7 @@
                         help="Worked hours last month">
                     <div class="o_field_widget o_stat_info">
                         <span class="o_stat_value">
-                            <field name="hours_last_month_display"/> Hours
+                            <field name="hours_last_month_display" widget="float_time"/> Hours
                         </span>
                         <span class="o_stat_text">
                             Last Month


### PR DESCRIPTION
The smartbutton for the number of hours in the attendance smart button
on employees and user did not use the right widget and could display
invalid data like '1.8 hours last month'.

TaskId-
