### PR TITLE
[FIX] sale: remove falsy onchange logic

### DIFF
--- a/addons/sale/models/sale_order.py
+++ b/addons/sale/models/sale_order.py
@@ -348,10 +348,6 @@ class SaleOrder(models.Model):
             tax_totals = account_move._get_tax_totals(order.partner_id, tax_lines_data, order.amount_total, order.amount_untaxed, order.currency_id)
             order.tax_totals_json = json.dumps(tax_totals)
 
-    @api.onchange('expected_date')
-    def _onchange_expected_date(self):
-        self.commitment_date = self.expected_date
-
     @api.depends('transaction_ids')
     def _compute_authorized_transaction_ids(self):
         for trans in self:
@@ -482,7 +478,7 @@ class SaleOrder(models.Model):
                 }
             }
 
-    @api.onchange('commitment_date')
+    @api.onchange('commitment_date', 'expected_date')
     def _onchange_commitment_date(self):
         """ Warn if the commitment dates is sooner than the expected date """
         if (self.commitment_date and self.expected_date and self.commitment_date < self.expected_date):


### PR DESCRIPTION
steps to reproduce:
- create a quotation
- define a delivery date
- add a product

Issue:
The delivery date changes

Solution:
Do not update the commitment_date everytime the expected date is
modified.

ref commit: https://github.com/odoo/odoo/commit/4d04ac20569d72aac1640a9e9b1453fd2ae306ba
opw-2764719
--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
