### PR TITLE
[FIX] payment_stripe: fix stripe webhook url

### DIFF
--- a/addons/payment_stripe/models/payment_acquirer.py
+++ b/addons/payment_stripe/models/payment_acquirer.py
@@ -153,7 +153,7 @@ class PaymentAcquirer(models.Model):
         }
 
     def _get_stripe_webhook_url(self):
-        return self.get_base_url() + StripeController._webhook_url
+        return url_join(self.get_base_url(), StripeController._webhook_url)
 
     # === BUSINESS METHODS - PAYMENT FLOW === #
 


### PR DESCRIPTION
Prior to this commit, the url build using the concatenation between the
base url and the webhook url path produced a wrong url with two
consecutive slash.

This commit prevent from building a wrong url, using the url_join api
method.

In the commit https://github.com/odoo/odoo/commit/d3f4619b731d71ccd2af26b9fa148d2957773680 , the base url was fixed but there was a
remaining url-join error.

Original commit: https://github.com/odoo/odoo/commit/4296b2653dc6d39720408593bac8db11768ee112