### PR TITLE
[FIX] base: prevent wrong regeneration of assets

### DIFF
--- a/odoo/addons/base/models/assetsbundle.py
+++ b/odoo/addons/base/models/assetsbundle.py
@@ -183,9 +183,11 @@ class AssetsBundle(object):
     @func.lazy_property
     def last_modified(self):
         """Returns last modified date of linked files"""
+        assets = [WebAsset(self, url=f['url'], filename=f['filename'], inline=f['content'])
+            for f in self.files
+            if f['atype'] in ['text/sass', "text/scss", "text/less", "text/css", "text/javascript"]]
         return max(itertools.chain(
-            (asset.last_modified for asset in self.javascripts),
-            (asset.last_modified for asset in self.stylesheets),
+            (asset.last_modified for asset in assets),
         ))
 
     @func.lazy_property


### PR DESCRIPTION
Assets bundle are wrongly regenerated on the following circumstance.
The use of multiples tag `t-call-assets` in some xml template(s) with:
- at least one `t-call-assets` with `t-js` or `t-css` to false
- at least one `t-call-assets` without `t-js` nor `t-css`

In mass_mailing, the buggy regeneration of assets happens at a critical moment
and break the url of a previously generated asset. That url was however saved
in a javascript cache and therefore the bundle is inaccessible. No css style is
therefore applied to the page.

Note 1: the bug for the previous specific case in mass_mailing only
appears if within all the files defined for the bundle
`web_editor.wysiwyg_assets`, the last modified file (mtime) was of
type javascript. No visible bug would appear if the last modified file
was of type stylesheet (css, scss, ...). However, the asset would be
regenerated at a time where the cache should be used (invisible for the user).

Note 2: in order to reproduce the bug systematically without this commit,
it is necessary to disable the browser cache. Otherwise, if the
browser has the broken url in cache, no http request will be made and the bug
will not appears.

The bundles are wrongly regenerated because of how the url is
generated. Part of the url is generated using the "version" of the
bundle. The version is defined using a checksum. The checksum uses
information about the *last modified* file of the bundle. And this is
where bug arises.

If the bundle was called with `t-js="false"` the list of file didn't
include js files.
- The version for the `css` bundle will be A
If the bundle was called with `t-css="false"` the list of file didn't
include css files.
- The version for the `js` bundle will be B
If the bundle was called without `t-js` nor `t-css` the list includes
all js and css files.
- The version for the `js` bundle **and** the `css` bundle will be A
  if the last modified file type is javascript or B if it is a stylesheet.

This commit change the behavior to always consider all the files last
modification within bundles in order to derive the version.

Thus:
If the bundle was called with `t-js="false"` the list of file didn't
include js files.
- The version for the `css` bundle will be A
If the bundle was called with `t-css="false"` the list of file didn't
include css files.
- The version for the `js` bundle will be A
If the bundle was called without `t-js` nor `t-css` the list of file
includes.
- The version for the `js` bundle **and** the `css` bundle will be A.

Example:

assetsA has two files:
```
file1.css
file2.js
```

file1.css was last modified at time A
file2.js was last modified at time B

bundle A
```xml
<template name="template_a">
    <t t-call-assets="assetsA" t-js="false"/>
</template>
<template name="template_b">
    <t t-call-assets="assetsA" t-css="false"/>
</template>
<template name="template_c">
    <t t-call-assets="assetsA"/>
</template>
```

In a javascript file:
```js
const ajax = require('web.ajax');
await ajax.loadAsset({assetLibs: ['template_a']});
await ajax.loadAsset({assetLibs: ['template_b']});
await ajax.loadAsset({assetLibs: ['template_c']});
await ajax.loadAsset({assetLibs: ['template_a']});
```

Whenever loading a assets of a template, the urls for the css and javascript
files are saved into a cache until the next browser reload.

In this example, without this commit:
- the first `ajax.loadAsset` `template_a` generate a css asset with version X
  -> a css file is generated and the url of the css file is
     `/web/assets/version_X...min.css` and is saved in the javascript
     cache for `template_a`
- the `ajax.loadAsset` `template_b` generate a js asset with version Y
  -> a js file is generated and the url of the js file is
  `/web/assets/version_Y...js`
- the `ajax.loadAsset` `template_c` generate a css **and** js asset
  with version Y if time A (a css file) is bigger than time B (a js
  file):
    -> a css file is generated and the url of the css file is
       `/web/assets/version_X...min.css` and is saved in the
       javascript cache for `template_c`
    -> a js file is generated and the url of the js file is
    `/web/assets/version_X...js`
  if time B (a js file) is bigger than time a (a css file)
    -> a css file is generated and the url of the css file
       is`/web/assets/version_Y...min.css` and is saved in the
       javascript cache for `template_c`
    -> a js file is generated and the url of the css file is
    `/web/assets/version_Y...js`
    --> because the css file is re-generated (the version changed from
        X to Y), the url in the javascript cache is no longer valid.
- the last `ajax.loadAsset` `template_a` use the url in its cache and
  either the css url or the js url would no longer will be available
  and a http error will trigger if the code tries to access it.

  Task-2778413





--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
