### PR TITLE
[FIX] hr_attendance: Do not count tolerance into extra hours

### DIFF
--- a/addons/hr_attendance/models/hr_attendance.py
+++ b/addons/hr_attendance/models/hr_attendance.py
@@ -247,6 +247,11 @@ class HrAttendance(models.Model):
                             overtime_duration += post_work_time
                         # Global overtime including the thresholds
                         overtime_duration_real = sum(attendances.mapped('worked_hours')) - planned_work_duration
+                        # We don't want to count tolerance time into extra hours
+                        if overtime_duration_real > 0 and overtime_duration > 0:
+                            overtime_duration = min(overtime_duration_real, overtime_duration)
+                        elif overtime_duration_real < 0 and overtime_duration > 0:
+                            overtime_duration = 0
 
                 overtime = overtimes.filtered(lambda o: o.date == attendance_date)
                 if not float_is_zero(overtime_duration, 2) or unfinished_shifts:


### PR DESCRIPTION
Employee Checkin Check-out --> 9:00 - 16:37 [worked 7h 37m]
company's work hours are 8:00 - 12:00 -- 13:00 - 17:00
employee's tolerance is 60 min

Expected behavior - 0 extra hour (due to tolerance)
Before this fix - 1 extra hour


