### PR TITLE
[REF] web: change `$dark` variable

### DIFF
--- a/addons/web/static/src/legacy/scss/bootstrap_overridden.scss
+++ b/addons/web/static/src/legacy/scss/bootstrap_overridden.scss
@@ -23,6 +23,7 @@ $black:    #000 !default;
 
 $primary: $o-brand-primary !default;
 $secondary: $white !default;
+$dark: $o-gray-900 !default;
 
 $success: $o-success !default;
 $info: $o-info !default;


### PR DESCRIPTION
Prior this commit, the dark color was the same as the Bootstrap color.
It wasn't contrasted enough and was therefore replaced by raw css in
some situations.

To keep consistency with the overall layout, this commit applies the
darkest gray as the $dark variable to improve the value and now
encourages the use of utility classes instead of raw values.

Requires:
- https://github.com/odoo/enterprise/pull/25100

task-2788931

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
