### PR TITLE
[IMP] link_tracker: make different trackers from labels

### DIFF
--- a/addons/link_tracker/__init__.py
+++ b/addons/link_tracker/__init__.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
-from . import models
 from . import controller
+from . import models
+from . import tools

--- a/addons/link_tracker/models/link_tracker.py
+++ b/addons/link_tracker/models/link_tracker.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
+import logging
 import random
 import string
 
@@ -13,6 +14,8 @@ from odoo.osv import expression
 
 
 LINK_TRACKER_UNIQUE_FIELDS = ('url', 'campaign_id', 'medium_id', 'source_id', 'label')
+
+_logger = logging.getLogger(__name__)
 
 
 class LinkTracker(models.Model):
@@ -187,24 +190,55 @@ class LinkTracker(models.Model):
         return links
 
     @api.model
-    def search_or_create(self, vals):
-        if 'url' not in vals:
-            raise ValueError(_('Creating a Link Tracker without URL is not possible'))
-        if vals['url'].startswith(('?', '#')):
-            raise UserError(_("%r is not a valid link, links cannot redirect to the current page.", vals['url']))
-        vals['url'] = tools.validate_url(vals['url'])
+    def search_or_create(self, vals_list):
+        """Get existing or newly created records matching vals_list items in preserved order supporting duplicates."""
+        if not isinstance(vals_list, list):
+            _logger.warning("Deprecated usage of LinkTracker.search_or_create which now expects a list of dictionaries as input.")
+            vals_list = [vals_list]
 
-        search_domain = [
-            (fname, '=', value)
-            for fname, value in vals.items()
-            if fname in {*LINK_TRACKER_UNIQUE_FIELDS}
-        ]
-        result = self.search(search_domain, limit=1)
+        def _format_key(obj):
+            """Generate unique 'key' of trackers, allowing to find duplicates."""
+            return tuple(
+                (field_name, obj[field_name].id if isinstance(obj[field_name], models.BaseModel) else obj[field_name])
+                for field_name in LINK_TRACKER_UNIQUE_FIELDS
+            )
 
-        if result:
-            return result
+        def _format_key_domain(field_values):
+            """Handle "label" being False / '' and be defensive."""
+            return expression.AND([
+                [(field_name, '=', value) if value or field_name != 'label' else ('label', 'in', (False, ''))]
+                for field_name, value in field_values
+            ])
 
-        return self.create(vals)
+        errors = set()
+        for vals in vals_list:
+            if 'url' not in vals:
+                raise ValueError(_('Creating a Link Tracker without URL is not possible'))
+            if vals['url'].startswith(('?', '#')):
+                errors.add(_("%r is not a valid link, links cannot redirect to the current page.", vals['url']))
+            vals['url'] = tools.validate_url(vals['url'])
+            # fill vals to use direct accessor in _format_key
+            self._add_missing_default_values(vals)
+            vals.update({key: False for key in LINK_TRACKER_UNIQUE_FIELDS if not vals.get(key)})
+        if errors:
+            raise UserError("\n".join(errors))
+
+        # Find unique keys of trackers, then fetch existing trackers
+        unique_keys = {_format_key(vals) for vals in vals_list}
+        found_trackers = self.search(expression.OR([_format_key_domain(key) for key in unique_keys]))
+        key_to_trackers_map = {_format_key(tracker): tracker for tracker in found_trackers}
+
+        if len(unique_keys) != len(found_trackers):
+            # Create trackers for values with unique keys not found
+            seen_keys = set(key_to_trackers_map.keys())
+            new_trackers = self.create([
+                vals for vals in vals_list
+                if (key := _format_key(vals)) not in seen_keys and not seen_keys.add(key)
+            ])
+            key_to_trackers_map.update((_format_key(tracker), tracker) for tracker in new_trackers)
+
+        # Build final recordset following input order
+        return self.browse([key_to_trackers_map[_format_key(vals)].id for vals in vals_list])
 
     @api.model
     def convert_links(self, html, vals, blacklist=None):

--- a/addons/link_tracker/tests/test_link_tracker.py
+++ b/addons/link_tracker/tests/test_link_tracker.py
@@ -36,24 +36,92 @@ class TestLinkTracker(common.TransactionCase, MockLinkTracker):
         self.assertEqual(len(set(link_trackers.mapped('code'))), 3)
 
     def test_search_or_create(self):
-        link_tracker_1 = self.env['link.tracker'].create({
+        values_1, values_2, values_3 = [
+            {'url': 'https://odoo.com', 'title': 'Odoo'},
+            {'url': 'https://odoo.be', 'title': 'Odoo'},
+            {'url': 'https://odoo.com', 'title': 'Odoo New', 'label': 'New one!'}  # title is not in unique constraint
+        ]
+        expected_values_1, expected_values_2, expected_values_3 = [
+            {
+                'campaign_id': self.env['utm.campaign'],
+                'label': False,
+                'medium_id': self.env['utm.medium'],
+                'source_id': self.env['utm.source'],
+                'title': 'Odoo',
+                'url': 'https://odoo.com',
+            }, {
+                'campaign_id': self.env['utm.campaign'],
+                'label': False,
+                'medium_id': self.env['utm.medium'],
+                'source_id': self.env['utm.source'],
+                'title': 'Odoo',
+                'url': 'https://odoo.be',
+            }, {
+                'campaign_id': self.env['utm.campaign'],
+                'label': 'New one!',
+                'medium_id': self.env['utm.medium'],
+                'source_id': self.env['utm.source'],
+                'title': 'Odoo New',
+                'url': 'https://odoo.com',
+            },
+        ]
+        link_tracker_1 = self.env['link.tracker'].create(values_1)
+        link_tracker_1_dupe = self.env['link.tracker'].search_or_create([values_1])
+        self.assertEqual(link_tracker_1, link_tracker_1_dupe)
+        for fname, value in expected_values_1.items():
+            self.assertEqual(link_tracker_1[fname], value)
+
+        link_tracker_2 = self.env['link.tracker'].search_or_create([values_2])
+        self.assertNotEqual(link_tracker_1, link_tracker_2)
+        for fname, value in expected_values_2.items():
+            self.assertEqual(link_tracker_2[fname], value)
+
+        # Two different checks that order is preserved
+        vals_456 = [values_2, values_3, values_1]
+        # When created records need to be created
+        link_tracker_4, link_tracker_5, link_tracker_6 = self.env['link.tracker'].search_or_create(vals_456)
+        self.assertEqual(link_tracker_4, link_tracker_2,
+                         'Is coming from values_2, created before')
+        self.assertEqual(link_tracker_6, link_tracker_1,
+                         'Is coming from values_1, created before')
+        self.assertNotIn(link_tracker_5, link_tracker_1 + link_tracker_2,
+                         'Is a new one due to label diff')
+        for fname, value in expected_values_3.items():
+            self.assertEqual(link_tracker_5[fname], value)
+
+        # When records are found, but not in order of vals_list in database
+        link_tracker_7, link_tracker_8, link_tracker_9 = self.env['link.tracker'].search_or_create(vals_456)
+        self.assertListEqual((link_tracker_7 + link_tracker_8 + link_tracker_9).ids,
+                             (link_tracker_4 + link_tracker_5 + link_tracker_6).ids)
+
+        # Also handles duplicates
+        vals_3131 = [values_3, values_1, values_3, values_1]
+        trackers_3131 = self.env['link.tracker'].search_or_create(vals_3131)
+        self.assertListEqual(trackers_3131.ids, (link_tracker_5 + link_tracker_1 + link_tracker_5 + link_tracker_1).ids)
+
+        # Also handles duplicates in non-existing records mixed with existing records
+        values_4 = {'url': 'https://odoo.com', 'label': 'A different one'}
+        vals_3434 = [values_3, values_4, values_3, values_4]
+        trackers_3434 = self.env['link.tracker'].search_or_create(vals_3434)
+        new_tracker = trackers_3434[1]
+        self.assertListEqual(trackers_3434.ids, (link_tracker_5 + new_tracker + link_tracker_5 + new_tracker).ids)
+
+        # Also if only non-existing records values are passed
+        values_5 = {'url': 'https://odoo.com', 'label': 'Yet another label'}
+        expected_values_5 = {
+            'campaign_id': self.env['utm.campaign'],
+            'label': 'Yet another label',
+            'medium_id': self.env['utm.medium'],
+            'source_id': self.env['utm.source'],
+            'title': 'Test_TITLE',
             'url': 'https://odoo.com',
-            'title': 'Odoo',
-        })
-
-        link_tracker_2 = self.env['link.tracker'].search_or_create({
-            'url': 'https://odoo.com',
-            'title': 'Odoo',
-        })
-
-        self.assertEqual(link_tracker_1, link_tracker_2)
-
-        link_tracker_3 = self.env['link.tracker'].search_or_create({
-            'url': 'https://odoo.be',
-            'title': 'Odoo',
-        })
-
-        self.assertNotEqual(link_tracker_1, link_tracker_3)
+        }
+        vals_55 = [values_5, values_5]
+        trackers_55 = self.env['link.tracker'].search_or_create(vals_55)
+        new_tracker = trackers_55[0]
+        self.assertListEqual(trackers_55.ids, (new_tracker + new_tracker).ids)
+        for fname, value in expected_values_5.items():
+            self.assertEqual(new_tracker[fname], value)
 
     def test_constraint(self):
         campaign_id = self.env['utm.campaign'].search([], limit=1)

--- a/addons/link_tracker/tests/test_link_tracker.py
+++ b/addons/link_tracker/tests/test_link_tracker.py
@@ -68,11 +68,19 @@ class TestLinkTracker(common.TransactionCase, MockLinkTracker):
             'title': 'Odoo',
             'campaign_id': campaign_id.id,
         })
+        self.assertEqual(link_1.label, False)
 
         with self.assertRaises(UserError):
             self.env['link.tracker'].create({
                 'url': 'https://odoo.com',
                 'title': 'Odoo',
+            })
+
+        with self.assertRaises(UserError):
+            self.env['link.tracker'].create({
+                'url': 'https://odoo.com',
+                'title': 'Odoo',
+                'label': '',
             })
 
         with self.assertRaises(UserError):
@@ -86,7 +94,8 @@ class TestLinkTracker(common.TransactionCase, MockLinkTracker):
                 'url': '2nd url',
                 'title': 'Odoo',
                 'campaign_id': campaign_id.id,
-                'medium_id': self.env['utm.medium'].search([], limit=1).id
+                'medium_id': self.env['utm.medium'].search([], limit=1).id,
+                'label': ''
             })
 
         # test in batch
@@ -96,6 +105,10 @@ class TestLinkTracker(common.TransactionCase, MockLinkTracker):
 
         with self.assertRaises(UserError):
             (link_1 | link_2).write({'medium_id': False})
+
+        # Adding a label on one makes them different
+        link_1.label = 'Something'
+        (link_1 | link_2).write({'medium_id': False})
 
     def test_no_external_tracking(self):
         self.env['ir.config_parameter'].set_param('link_tracker.no_external_tracking', '1')

--- a/addons/link_tracker/tests/test_mail_render_mixin.py
+++ b/addons/link_tracker/tests/test_mail_render_mixin.py
@@ -2,8 +2,10 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 import re
 
+from markupsafe import Markup
+
 from odoo.tests import common, tagged
-from odoo.tools import TEXT_URL_REGEX
+from odoo.tools import TEXT_URL_REGEX, mute_logger
 
 
 @tagged('-at_install', 'post_install')
@@ -14,12 +16,17 @@ class TestMailRenderMixin(common.HttpCase):
         super().setUpClass()
         cls.base_url = cls.env["mail.render.mixin"].get_base_url()
 
+    @mute_logger("odoo.tests.common.requests")
     def test_shorten_links(self):
         test_links = [
             '<a href="https://gitlab.com" title="title" fake="fake">test_label</a>',
             '<a href="https://test_542152qsdqsd.com"/>',
             """<a href="https://third_test_54212.com">
                     <img src="imagesrc"/>
+                </a>
+            """,
+            """<a href="https://fourthtesthasnolabel.com">
+                    <img/><!-- Really what is this -->
                 </a>
             """,
             """<a
@@ -31,6 +38,8 @@ class TestMailRenderMixin(common.HttpCase):
             '<a href="https://test_escaped.com" title="title" fake="fake"> test_escaped &lt; &gt; </a>',
             '<a href="https://url_with_params.com?a=b&c=d">label</a>',
             '<a href="#"></a>',
+            '<a href="mailto:afunemail@somewhere.com">email label</a>',
+            '<a href="https://www.odoo.com?test=%20+3&amp;this=that">THERE > there</a>',
         ]
 
         self.env["mail.render.mixin"]._shorten_links("".join(test_links), {})
@@ -38,6 +47,8 @@ class TestMailRenderMixin(common.HttpCase):
         trackers_to_find = [
             [("url", "=", "https://gitlab.com"), ("label", "=", "test_label")],
             [("url", "=", "https://test_542152qsdqsd.com")],
+            [("url", "=", "https://third_test_54212.com"), ("label", "=", "[media] imagesrc")],
+            [("url", "=", "https://fourthtesthasnolabel.com"), ("label", "=", False)],
             [
                 ("url", "=", "https://test_strange_html.com"),
                 ("label", "=", "test_strange_html_label"),
@@ -51,17 +62,143 @@ class TestMailRenderMixin(common.HttpCase):
                 ("label", "=", "label"),
             ],
             [("url", "=", self.base_url + '#')],
+            [("url", "=", "https://www.odoo.com?test=%20+3&this=that"), ("label", "=", "THERE > there")],  # lxml unescaped
         ]
         trackers_to_fail = [
-            [("url", "=", "https://test_542152qsdqsd.com"), ("label", "ilike", "_")]
+            [("url", "=", "https://test_542152qsdqsd.com"), ("label", "ilike", "_")],
+            [("url", "ilike", "%mailto:afunemail@somewhere.com")],
         ]
 
         for tracker_to_find in trackers_to_find:
-            self.assertTrue(self.env["link.tracker"].search(tracker_to_find))
+            with self.subTest(tracker_to_find=tracker_to_find):
+                self.assertTrue(self.env["link.tracker"].search(tracker_to_find))
 
         for tracker_to_fail in trackers_to_fail:
-            self.assertFalse(self.env["link.tracker"].search(tracker_to_fail))
+            with self.subTest(tracker_to_fail=tracker_to_fail):
+                self.assertFalse(self.env["link.tracker"].search(tracker_to_fail))
 
+    @mute_logger("odoo.tests.common.requests")
+    def test_shorten_links_html_different_labels(self):
+        # Covers multiple additions from web_editor's convert_inline.js classToStyle
+        content = """<p>There is a <a href="https://www.odoo.com">logo.png</a> here,
+<a href="https://www.odoo.com">there</a>, and in this
+<a href="https://www.odoo.com"><!--[if mso]><img src="https://www.odoo.com/logo.png" alt="image" style="1"/><![endif]-->
+<!--[if !mso]><!--><img src="https://www.odoo.com/logo.png" style="2" alt="image"/><!--<![endif]--></a>
+and also <a href="https://www.odoo.com">
+    <p class="o_outlook_hack" style="text-align: center; margin: 0px;"><img src="https://www.odoo.com/logo.png" fakealt="image3" alt="image2's trouble"></img></p>
+</a>
+Single/Nested quotes are not <a href="https://www.odoo.com"><img src='https://www.odoo.com/logo.png' alt='"scary"'/></a>
+Nor escaped <a href="https://www.odoo.com">  <img src="https://www.odoo.com/logo.png" alt="ins \' ide"></a>
+Nor escaped <a href="https://www.odoo.com"> blurp <img src="https://www.odoo.com/logo.png" alt="ins \' ide"></a>
+Without matched label because inside tags are a pain and rare: <a href="https://www.odoo.com"><em>here</em></a>
+Without alt, filename is used: <a href="https://www.odoo.com"><img src="https://www.odoo.com/logo.png"></a>
+And here is the same: <a href="https://www.odoo.com"><img src="https://www.odoo.com/logo.png"></a></p>"""
+
+        expected_pattern = re.compile(
+            rf"""<p>There is a <a href="{self.base_url}/r/(\w+)+">logo.png</a> here,
+<a href="{self.base_url}/r/(\w+)+">there</a>, and in this
+<a href="{self.base_url}/r/(\w+)+"><!--\[if mso]><img src="https://www.odoo.com/logo.png" alt="image" style="1"/><!\[endif]-->
+<!--\[if !mso]><!--><img src="https://www.odoo.com/logo.png" style="2" alt="image"/><!--<!\[endif]--></a>
+and also <a href="{self.base_url}/r/(\w+)+">
+    <p class="o_outlook_hack" style="text-align: center; margin: 0px;"><img src="https://www.odoo.com/logo.png" fakealt="image3" alt="image2\'s trouble"/></p>
+</a>
+Single/Nested quotes are not <a href="{self.base_url}/r/(\w+)+"><img src="https://www.odoo.com/logo.png" alt="&quot;scary&quot;"/></a>
+Nor escaped <a href="{self.base_url}/r/(\w+)+">  <img src="https://www.odoo.com/logo.png" alt="ins \' ide"/></a>
+Nor escaped <a href="{self.base_url}/r/(\w+)+"> blurp <img src="https://www.odoo.com/logo.png" alt="ins \' ide"/></a>
+Without matched label because inside tags are a pain and rare: <a href="{self.base_url}/r/(\w+)+"><em>here</em></a>
+Without alt, filename is used: <a href="{self.base_url}/r/(\w+)+"><img src="https://www.odoo.com/logo.png"/></a>
+And here is the same: <a href="{self.base_url}/r/(\w+)+"><img src="https://www.odoo.com/logo.png"/></a></p>"""
+        )
+
+        new_content = self.env["mail.render.mixin"]._shorten_links(content, {})
+        self.assertRegex(new_content, expected_pattern)
+
+        trackers_to_find = [
+            [("url", "=", "https://www.odoo.com"), ("label", "=", "logo.png")],
+            [("url", "=", "https://www.odoo.com"), ("label", "=", "there")],
+            [("url", "=", "https://www.odoo.com"), ("label", "=", "[media] image")],
+            [("url", "=", "https://www.odoo.com"), ("label", "=", "[media] image2's trouble")],
+            [("url", "=", "https://www.odoo.com"), ("label", "=", "blurp")],
+            [("url", "=", "https://www.odoo.com"), ("label", "=", '[media] "scary"')],
+            [("url", "=", "https://www.odoo.com"), ("label", "=", "[media] ins ' ide")],
+            [("url", "=", "https://www.odoo.com"), ("label", "=", False)],
+            [("url", "=", "https://www.odoo.com"), ("label", "=", "[media] logo.png")],
+        ]
+        for tracker_to_find in trackers_to_find:
+            with self.subTest(tracker_to_find=tracker_to_find):
+                self.assertTrue(
+                    self.env["link.tracker"].search(tracker_to_find),
+                    f"Tracker labeled {tracker_to_find[1][2]} was not found.",
+                )
+
+        link_pattern = re.compile(rf'href="({self.base_url}/r/(\w+)+)"', flags=re.DOTALL)
+        matches = link_pattern.findall(new_content)
+
+        def assert_different_shortcode(idx1, idx2):
+            self.assertNotEqual(
+                matches[idx1][0],
+                matches[idx2][0],
+                f"Different labels {trackers_to_find[idx1][1][2]} and {trackers_to_find[idx2][1][2]} should have different short codes.",
+            )
+
+        # Making sure that no replacement of the wrong line has been performed with the other
+        for idx in range(len(trackers_to_find) - 2):
+            assert_different_shortcode(idx, idx + 1)
+        self.assertNotEqual(matches[0], matches[8])
+        self.assertEqual(
+            matches[8], matches[9], "Links to the same image without alt should be covered by the same tracker."
+        )
+
+    @mute_logger("odoo.tests.common.requests")
+    def test_shorten_links_html_including_base_url(self):
+        content = f"""<p>
+This is a link: <a href="https://www.worldcommunitygrid.org">https://www.worldcommunitygrid.org</a><br/>
+This is another: <a href="{self.base_url}/web#debug=1&more=2">{self.base_url}</a><br/>
+And a third: <a href="{self.base_url}">Here</a>
+And a forth: <a href="{self.base_url}">Here</a>
+And a fifth: <a href="{self.base_url}">Here too</a>
+And a 6th: <a href="/web">Here2</a><br>
+And a 7th: <a href="{self.base_url}/web">Here2</a><br>
+And a last, more complex: <a href="https://boinc.berkeley.edu/forum_thread.php?id=14544&postid=106833">There!</a>
+</p>"""
+
+        expected_pattern = re.compile(
+            rf"""<p>
+This is a link: <a href="{self.base_url}/r/(\w+)">https://www.worldcommunitygrid.org</a><br/>
+This is another: <a href="{self.base_url}/r/(\w+)">{self.base_url}</a><br/>
+And a third: <a href="{self.base_url}/r/(\w+)">Here</a>
+And a forth: <a href="{self.base_url}/r/(\w+)">Here</a>
+And a fifth: <a href="{self.base_url}/r/(\w+)">Here too</a>
+And a 6th: <a href="{self.base_url}/r/(\w+)">Here2</a><br/>
+And a 7th: <a href="{self.base_url}/r/(\w+)">Here2</a><br/>
+And a last, more complex: <a href="{self.base_url}/r/(\w+)">There!</a>
+</p>"""
+        )
+        new_content = self.env["mail.render.mixin"]._shorten_links(content, {})
+
+        self.assertRegex(new_content, expected_pattern)
+        matches = expected_pattern.search(new_content).groups()
+        # 3rd and 4th, 6th and 7th lead to the same short_urls
+        self.assertEqual(matches[2], matches[3])
+        self.assertEqual(matches[5], matches[6])
+        # The others not.
+        self.assertNotEqual(matches[0], matches[1])
+        self.assertNotEqual(matches[0], matches[2])
+        self.assertNotEqual(matches[1], matches[2])
+        self.assertNotEqual(matches[3], matches[4])
+        self.assertNotEqual(matches[4], matches[5])
+
+    @mute_logger("odoo.tests.common.requests")
+    def test_shorten_links_html_markup(self):
+        content = Markup('<p>A link: <a href="https://www.worldcommunitygrid.org">Link</a></p>')
+
+        new_content = self.env["mail.render.mixin"]._shorten_links(content, {})
+        self.assertTrue(isinstance(new_content, Markup))
+
+        expected_pattern = re.compile(rf'<p>A link: <a href="{self.base_url}/r/\w+">Link</a></p>')
+        self.assertRegex(new_content, expected_pattern)
+
+    @mute_logger("odoo.tests.common.requests")
     def test_shorten_links_html_skip_shorts(self):
         old_content = self.env["mail.render.mixin"]._shorten_links(
             'This is a link: <a href="https://test_542152qsdqsd.com">old</a>', {})
@@ -71,62 +208,29 @@ class TestMailRenderMixin(common.HttpCase):
         self.assertRegex(created_short_url, "{base_url}/r/[\\w]+".format(base_url=self.base_url))
 
         new_content = self.env["mail.render.mixin"]._shorten_links(
-            'Reusing this old <a href="{old_short_url}">link</a> with a new <a href="https://odoo.com">one</a>'
-            .format(old_short_url=created_short_url),
-            {}
+            f'Reusing this old <a href="{created_short_url}">link</a> with a new <a href="https://odoo.com">one</a>', {}
         )
         expected = re.compile(
-            'Reusing this old <a href="{old_short_url}">link</a> with a new <a href="{base_url}/r/[\\w]+">one</a>'
-            .format(old_short_url=created_short_url, base_url=self.base_url)
+            rf'Reusing this old <a href="{created_short_url}">link</a> with a new <a href="{self.base_url}/r/\w+">one</a>'
         )
         self.assertRegex(new_content, expected)
 
-    def test_shorten_links_html_including_base_url(self):
-        content = (
-            'This is a link: <a href="https://www.worldcommunitygrid.org">https://www.worldcommunitygrid.org</a><br/>\n'
-            'This is another: <a href="{base_url}/web#debug=1&more=2">{base_url}</a><br/>\n'
-            'And a third: <a href="{base_url}">Here</a>\n'
-            'And a forth: <a href="{base_url}">Here</a>\n'
-            'And a fifth: <a href="{base_url}">Here too</a>\n'
-            'And a 6th: <a href="/web">Here</a><br>\n'
-            'And a last, more complex: <a href="https://boinc.berkeley.edu/forum_thread.php?id=14544&postid=106833">There!</a>'
-            .format(base_url=self.base_url)
-        )
-        expected_pattern = re.compile(
-            'This is a link: <a href="{base_url}/r/[\\w]+">https://www.worldcommunitygrid.org</a><br/>\n'
-            'This is another: <a href="{base_url}/r/[\\w]+">{base_url}</a><br/>\n'
-            'And a third: <a href="{base_url}/r/([\\w]+)">Here</a>\n'
-            'And a forth: <a href="{base_url}/r/([\\w]+)">Here</a>\n'
-            'And a fifth: <a href="{base_url}/r/([\\w]+)">Here too</a>\n'
-            'And a 6th: <a href="{base_url}/r/([\\w]+)">Here</a><br>\n'
-            'And a last, more complex: <a href="{base_url}/r/([\\w]+)">There!</a>'
-            .format(base_url=self.base_url)
-        )
-        new_content = self.env["mail.render.mixin"]._shorten_links(content, {})
-
-        self.assertRegex(new_content, expected_pattern)
-        matches = expected_pattern.search(new_content).groups()
-        # 3rd and 4th lead to the same short_url
-        self.assertEqual(matches[0], matches[1])
-        # 5th has different label but should currently lead to the same link
-        self.assertEqual(matches[1], matches[2])
-
+    @mute_logger("odoo.tests.common.requests")
     def test_shorten_links_text_including_base_url(self):
-        content = (
-            'This is a link: https://www.worldcommunitygrid.org\n'
-            'This is another: {base_url}/web#debug=1&more=2\n'
-            'A third: {base_url}\n'
-            'A forth: {base_url}\n'
-            'And a last, with question mark: https://boinc.berkeley.edu/forum_thread.php?id=14544&postid=106833'
-            .format(base_url=self.base_url)
-        )
+        content = f"""
+This is a link: https://www.worldcommunitygrid.org
+This is another: {self.base_url}/web#debug=1&more=2
+A third: {self.base_url}
+A forth: {self.base_url}
+And a last, with question mark: https://boinc.berkeley.edu/forum_thread.php?id=14544&postid=106833"""
+
         expected_pattern = re.compile(
-            'This is a link: {base_url}/r/[\\w]+\n'
-            'This is another: {base_url}/r/[\\w]+\n'
-            'A third: {base_url}/r/([\\w]+)\n'
-            'A forth: {base_url}/r/([\\w]+)\n'
-            'And a last, with question mark: {base_url}/r/([\\w]+)'
-            .format(base_url=self.base_url)
+            rf"""
+This is a link: {self.base_url}/r/\w+
+This is another: {self.base_url}/r/\w+
+A third: {self.base_url}/r/(\w+)
+A forth: {self.base_url}/r/(\w+)
+And a last, with question mark: {self.base_url}/r/(\w+)"""
         )
         new_content = self.env["mail.render.mixin"]._shorten_links_text(content, {})
 
@@ -141,15 +245,10 @@ class TestMailRenderMixin(common.HttpCase):
         created_short_url_match = re.search(TEXT_URL_REGEX, old_content)
         self.assertIsNotNone(created_short_url_match)
         created_short_url = created_short_url_match[0]
-        self.assertRegex(created_short_url, "{base_url}/r/[\\w]+".format(base_url=self.base_url))
+        self.assertRegex(created_short_url, rf"{self.base_url}/r/\w+")
 
         new_content = self.env["mail.render.mixin"]._shorten_links_text(
-            'Reusing this old link {old_short_url} with a new one, https://odoo.com</a>'
-            .format(old_short_url=created_short_url),
-            {}
+            f'Reusing this old link {created_short_url} with a new one, https://odoo.com</a>', {}
         )
-        expected = re.compile(
-            'Reusing this old link {old_short_url} with a new one, {base_url}/r/[\\w]+'
-            .format(old_short_url=created_short_url, base_url=self.base_url)
-        )
+        expected = re.compile(rf'Reusing this old link {created_short_url} with a new one, {self.base_url}/r/\w+')
         self.assertRegex(new_content, expected)

--- a/addons/link_tracker/tools/__init__.py
+++ b/addons/link_tracker/tools/__init__.py
@@ -1,0 +1,3 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from . import html

--- a/addons/link_tracker/tools/html.py
+++ b/addons/link_tracker/tools/html.py
@@ -1,0 +1,62 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+import re
+from typing import Iterable
+
+import lxml
+
+MAX_LABEL_LENGTH = 40  # arbitrary
+
+
+def find_links_with_urls_and_labels(root_node, base_url, skip_regex=None, skip_prefix=None, skip_list=None):
+    """Return lxml link nodes and respective matching urls (made absolute) and labels found in `root_node`.
+
+    :param lxml.etree._Element root_node: The root node to process
+    :param str base_url: base url to prefix relative hrefs
+    :param str skip_regex: URL pattern to skip
+    :param str skip_prefix: str prefix to skip
+    :param Iterable[str] skip_list: URLS to skip
+
+    :rtype: (list[lxml.etree._Element], list[dict])
+    """
+    link_nodes, urls_and_labels = [], []
+
+    for link_node in root_node.iter(tag="a"):
+        original_url = link_node.get("href")
+        absolute_url = base_url + original_url if original_url.startswith(('/', '?', '#')) else original_url
+        if (
+            (skip_regex and re.search(skip_regex, absolute_url))
+            or (skip_prefix and absolute_url.startswith(skip_prefix))
+            or (skip_list and any(s in absolute_url for s in skip_list))
+        ):
+            continue
+
+        if link_node.text and (stripped_text := link_node.text.strip()):
+            label = stripped_text[:MAX_LABEL_LENGTH]
+        else:
+            children = link_node.getchildren()
+            label = _get_label_from_elements(children)[:MAX_LABEL_LENGTH]
+
+        link_nodes.append(link_node)
+        urls_and_labels.append({'url': absolute_url, 'label': label})
+
+    return link_nodes, urls_and_labels
+
+
+def _get_label_from_elements(elements: Iterable[lxml.etree._Element], image_prefix: str = "[media] ") -> str:
+    """Return the first label that can be extracted from a collection of elements"""
+    for element in elements:
+        if element.tag == "img":
+            if img_alt := element.get("alt"):
+                return f"{image_prefix}{img_alt}"
+            if img_src := element.get("src"):
+                img_src_tail = img_src.split("/")[-1]
+                return f"{image_prefix}{img_src_tail}"
+            return ""
+        if isinstance(element, lxml.html.HtmlComment):  # A known "hack"
+            continue
+        if element.tag == "p" and element.get("class") == "o_outlook_hack":
+            children = element.getchildren()
+            if label := _get_label_from_elements(children):
+                return label
+    return ""

--- a/addons/mass_mailing_themes/views/mass_mailing_themes_templates.xml
+++ b/addons/mass_mailing_themes/views/mass_mailing_themes_templates.xml
@@ -49,6 +49,7 @@
             }
         </style>
         <t t-set="now" t-value="datetime.datetime.now()"/>
+        <t t-set="website_url_or_none" t-value="(company_id.website) or '#'"/>
         <div class="s_header_social o_mail_block_header_social o_mail_snippet_general pt16 pb16" data-snippet="s_mail_block_header_social" style="background-color: rgb(26, 36, 54) !important;" data-name="Header Social">
             <div class="container">
                 <div class="row">
@@ -100,7 +101,7 @@
                                     </div>
                                 </div>
                                 <p>Learn through workshops, product demos, and inspiring talks from Odoo Experts and Partners.</p>
-                                <a class="btn btn-primary" href="http://">See what we've got planned</a>
+                                <a class="btn btn-primary" t-att-href="website_url_or_none">See what we've got planned</a>
                             </div>
                         </div>
                     </div>
@@ -116,7 +117,7 @@
                                     </div>
                                 </div>
                                 <p>Create your very own chat room or join an existing one that sparks your interest.</p>
-                                <a class="btn btn-primary" href="http://">Go to the chatrooms</a>
+                                <a class="btn btn-primary" t-att-href="website_url_or_none">Go to the chatrooms</a>
                             </div>
                         </div>
                     </div>
@@ -132,7 +133,7 @@
                                     </div>
                                 </div>
                                 <p>Experience everything from a virtual exhibitor's hall to multiple interactive presentations and demos.</p>
-                                <a class="btn btn-primary" href="http://">Find out more</a>
+                                <a class="btn btn-primary" t-att-href="website_url_or_none">Find out more</a>
                             </div>
                         </div>
                     </div>
@@ -147,7 +148,7 @@
                         <p style="text-align: center;"><font style="color: rgb(255, 255, 255);">Zero, zilch, nada! Odoo Experience is free for everyone!</font></p>
                     </div>
                     <div class="col-lg-12" style="text-align: center;">
-                        <a class="btn btn-primary btn-lg" href="http://">Register now!</a>
+                        <a class="btn btn-primary btn-lg" t-att-href="website_url_or_none">Register now!</a>
                     </div>
                 </div>
             </div>
@@ -203,11 +204,12 @@
             }
         </style>
         <t t-set="now" t-value="datetime.datetime.now()"/>
+        <t t-set="website_url_or_none" t-value="(company_id.website) or '#'"/>
         <div class="s_header_social o_mail_block_header_social o_mail_snippet_general pt40 pb32" data-snippet="s_mail_block_header_social" data-name="Header Social">
             <div class="container">
                 <div class="row">
                     <div class="col-lg-4">
-                        <a t-att-href="(company_id.website) or '#'" style="text-decoration:none;float:none;" target="_blank">
+                        <a t-att-href="website_url_or_none" style="text-decoration:none;float:none;" target="_blank">
                             <img border="0" width="189" style="height:auto; max-width:100%; width: 189px;" src="/mass_mailing_themes/static/src/img/theme_blogging/tech_logo.png" class="img-fluid"/>
                         </a>
                     </div>
@@ -268,7 +270,7 @@
                             <div class="col-lg-8 s_media_list_body">
                                 <h3>The future of smartphone video production</h3>
                                 <p>Modern smartphones have all the built-in tech equal to a majority of the current professional cameras.</p>
-                                <a class="btn btn-primary" href="http://"><span class="fa fa-play" />&amp;nbsp;&amp;nbsp;WATCH VIDEO</a>
+                                <a class="btn btn-primary" t-att-href="website_url_or_none"><span class="fa fa-play" />&amp;nbsp;&amp;nbsp;WATCH VIDEO</a>
                                 &amp;nbsp;&amp;nbsp;&amp;nbsp;&amp;nbsp;
                                 <a class="btn btn-link" href="#">READ MORE</a>
                             </div>
@@ -291,7 +293,7 @@
                             <div class="col-lg-8 s_media_list_body pt16 pb16">
                                 <h3>5 Ways Drones Can Better Your Live Events</h3>
                                 <p>One clever use of drones is for delivering gifts — but another that's becoming popular for event safety purposes.</p>
-                                <a class="btn btn-primary" href="http://">READ MORE</a>
+                                <a class="btn btn-primary" t-att-href="website_url_or_none">READ MORE</a>
                             </div>
                         </div>
                     </div>
@@ -312,7 +314,7 @@
                             <div class="col-lg-8 s_media_list_body">
                                 <h3>How to Code a Website Without Experience</h3>
                                 <p>Anyone with an ounce of business acumen knows that any business that wants to succeed needs a website.</p>
-                                <a class="btn btn-primary" href="http://">READ MORE</a>
+                                <a class="btn btn-primary" t-att-href="website_url_or_none">READ MORE</a>
                             </div>
                         </div>
                     </div>
@@ -377,6 +379,7 @@
         </style>
         <t t-set="now" t-value="datetime.datetime.now()"/>
         <t t-set="future_date" t-value="(datetime.date.today() + datetime.timedelta(days=30))"/>
+        <t t-set="website_url_or_none" t-value="(company_id.website) or '#'"/>
         <div class="s_header_logo o_mail_block_header_logo o_mail_snippet_general" data-snippet="s_mail_block_header_logo" data-name="Centered Logo" style="background-color: rgb(36, 37, 48) !important;">
             <div class="container">
                 <div class="row">
@@ -385,7 +388,7 @@
                         <br/><span style="font-weight: bolder"><font style="color: rgb(255, 255, 255);">SHIPPING</font></span></p>
                     </div>
                     <div class="col-lg-4 pt16 pb16" style="text-align: center;">
-                        <a style="text-decoration:none; text-align:center;" t-att-href="(company_id.website) or '#'" target="_blank">
+                        <a style="text-decoration:none; text-align:center;" t-att-href="website_url_or_none" target="_blank">
                             <img border="0" src="/mass_mailing_themes/static/src/img/theme_coupon/vip_logo.png" style="height: auto; max-width: 100%; width: 105px;" width="105" class="img-fluid"/>
                         </a>
                     </div>
@@ -426,7 +429,7 @@
                 <font style="color: rgb(113, 114, 127);">*But hurry! Offer ends on <t t-out="future_date.strftime('%m/%d/%Y')"/></font><br/>
             </p>
             <p style="text-align:center;">
-                <a class="btn btn-primary btn-lg" href="http://">Redeem it now</a>
+                <a class="btn btn-primary btn-lg" t-att-href="website_url_or_none">Redeem it now</a>
             </p>
         </div>
         <div class="s_call_to_action o_mail_snippet_general o_cc o_cc3 pt24 pb24" data-snippet="s_call_to_action" data-name="Call to Action" style="background-color: rgb(36, 37, 48) !important;">
@@ -436,7 +439,7 @@
                         <h3 style="text-align: center;">Thank you for being one of our most loyal customers.</h3>
                         <p style="text-align: center;">Join the community to see our latest news, events, discounts and much more!</p>
                         <p style="text-align: center;">
-                            <a class="btn btn-primary" href="http://">Join us</a>
+                            <a class="btn btn-primary" t-att-href="website_url_or_none">Join us</a>
                         </p>
                     </div>
                 </div>
@@ -799,12 +802,13 @@
             }
         </style>
         <t t-set="now" t-value="datetime.datetime.now()"/>
+        <t t-set="website_url_or_none" t-value="(company_id.website) or '#'"/>
         <div class="s_header_text_social o_mail_block_header_text_social o_mail_snippet_general pt16 pb16" data-snippet="s_mail_block_header_text_social" data-name="Left Text">
             <div class="container">
                 <div class="row">
                     <div class="col-lg-4 pt16 pb16">
                         <h1>
-                            <a t-att-href="(company_id.website) or '#'" target="_blank">
+                            <a t-att-href="website_url_or_none" target="_blank">
                                 <span style="color: rgb(255, 187, 0) !important; font-size: 32px" class="fa fa-1x fa-sun-o" />
                             </a><span style="font-size: 32px;"><font style="font-weight: bolder; color: rgb(255, 255, 255); background-color: rgb(255, 187, 0);">SOLAR</font></span>
                         </h1>
@@ -839,7 +843,7 @@
             </table>
             <br/>
             <p style="text-align:center;">
-                <a role="button" class="btn btn-primary btn-lg" href="http://">Visit the website</a>
+                <a role="button" class="btn btn-primary btn-lg" t-att-href="website_url_or_none">Visit the website</a>
             </p>
         </div>
         <div class="s_hr pt16 pb16" data-snippet="s_hr" data-name="Separator">
@@ -939,7 +943,7 @@
                 border-color: #543427;
             }
             hr {
-                background-color: rgba(0,0,0,0); 
+                background-color: rgba(0,0,0,0);
             }
         </style>
         <div class="s_header_social o_mail_block_header_social o_mail_snippet_general" style="background-color: rgb(238, 233, 226) !important;" data-snippet="s_mail_block_header_social" data-name="Left Logo">
@@ -1493,7 +1497,7 @@
             </div>
         </div>
     </template>
-    
+
     <!-- Training -->
     <template id="theme_training_template">
         <style id="design-element">
@@ -1581,7 +1585,7 @@
                     </div>
                 </div>
             </div>
-        </div>    
+        </div>
         <div class="container s_allow_columns">
             <div class="row">
                 <div class="offset-lg-1 col-lg-10">

--- a/addons/test_mass_mailing/tests/test_link_tracker.py
+++ b/addons/test_mass_mailing/tests/test_link_tracker.py
@@ -10,9 +10,9 @@ class TestLinkTracker(common.TestMassMailCommon):
     def setUp(self):
         super(TestLinkTracker, self).setUp()
 
-        self.link = self.env['link.tracker'].search_or_create({
+        self.link = self.env['link.tracker'].search_or_create([{
             'url': 'https://www.example.com'
-        })
+        }])
 
         self.click = self.env['link.tracker.click'].create({
             'link_id': self.link.id,

--- a/addons/website_links/controller/main.py
+++ b/addons/website_links/controller/main.py
@@ -10,7 +10,7 @@ class WebsiteUrl(http.Controller):
     def create_shorten_url(self, **post):
         if 'url' not in post or post['url'] == '':
             return {'error': 'empty_url'}
-        return request.env['link.tracker'].search_or_create(post).read()
+        return request.env['link.tracker'].search_or_create([post]).read()
 
     @http.route('/r', type='http', auth='user', website=True)
     def shorten_url(self, **post):

--- a/addons/website_links/static/src/js/website_links.js
+++ b/addons/website_links/static/src/js/website_links.js
@@ -457,11 +457,12 @@ publicWidget.registry.websiteLinks = publicWidget.Widget.extend({
         ev.stopPropagation();
 
         // Get URL and UTMs
-        var campaignID = $('#campaign-select').attr('value');
-        var mediumID = $('#channel-select').attr('value');
-        var sourceID = $('#source-select').attr('value');
+        const campaignID = document.querySelector('#campaign-select').value;
+        const mediumID = document.querySelector('#channel-select').value;
+        const sourceID = document.querySelector('#source-select').value;
 
-        var params = {};
+        const label = document.querySelector('#label');
+        const params = { label: label.value || undefined };
         params.url = $('#url').val();
         if (campaignID !== '') {
             params.campaign_id = parseInt(campaignID);
@@ -502,7 +503,7 @@ publicWidget.registry.websiteLinks = publicWidget.Widget.extend({
                 $('#campaign-select').select2('val', '');
                 $('#channel-select').select2('val', '');
                 $('#source-select').select2('val', '');
-
+                label.value = '';
                 $('.o_website_links_utm_forms').hide();
             }
         });

--- a/addons/website_links/tests/test_ui.py
+++ b/addons/website_links/tests/test_ui.py
@@ -18,10 +18,10 @@ class TestUi(odoo.tests.HttpCase):
         self.startPatcher(patcher)
 
     def test_01_test_ui(self):
-        self.env['link.tracker'].search_or_create({
+        self.env['link.tracker'].search_or_create([{
             'campaign_id': self.env['utm.campaign'].create({'name': 'Sale'}).id,
             'medium_id': self.env['utm.medium'].create({'name': 'Website'}).id,
             'source_id': self.env['utm.source'].create({'name': 'Search'}).id,
             'url': self.env["ir.config_parameter"].sudo().get_param("web.base.url") + '/contactus',
-        })
+        }])
         self.start_tour("/", 'website_links_tour', login="admin")

--- a/addons/website_links/views/website_links_graphs.xml
+++ b/addons/website_links/views/website_links_graphs.xml
@@ -54,40 +54,38 @@
                                 </p>
                             </div>
                         </div>
-
-                        <t t-if="campaign_id">
-                            <div class="row">
-                                <div class="col-md-2">
-                                    <p><strong>Campaign</strong></p>
-                                </div>
-                                <div class="col-md-10">
-                                    <p><t t-esc="campaign_id[1]"/></p>
-                                </div>
+                        <div t-if="campaign_id" class="row">
+                            <div class="col-md-2">
+                                <p><strong>Campaign</strong></p>
                             </div>
-                        </t>
-
-                        <t t-if="medium_id">
-                            <div class="row">
-                                <div class="col-md-2">
-                                    <p><strong>Medium</strong></p>
-                                </div>
-                                <div class="col-md-10">
-                                    <p><t t-esc="medium_id[1]"/></p>
-                                </div>
+                            <div class="col-md-10">
+                                <p><t t-esc="campaign_id[1]"/></p>
                             </div>
-                        </t>
-
-                        <t t-if="source_id">
-                            <div class="row">
-                                <div class="col-md-2">
-                                    <p><strong>Source</strong></p>
-                                </div>
-                                <div class="col-md-10">
-                                    <p><t t-esc="source_id[1]"/></p>
-                                </div>
+                        </div>
+                        <div t-if="medium_id" class="row">
+                            <div class="col-md-2">
+                                <p><strong>Medium</strong></p>
                             </div>
-                        </t>
-
+                            <div class="col-md-10">
+                                <p><t t-esc="medium_id[1]"/></p>
+                            </div>
+                        </div>
+                        <div t-if="source_id" class="row">
+                            <div class="col-md-2">
+                                <p><strong>Source</strong></p>
+                            </div>
+                            <div class="col-md-10">
+                                <p><t t-esc="source_id[1]"/></p>
+                            </div>
+                        </div>
+                        <div t-if="label" class="row" >
+                            <div class="col-md-2">
+                                <p><strong>Label</strong></p>
+                            </div>
+                            <div class="col-md-10">
+                                <p t-out="label"/>
+                            </div>
+                        </div>
 
                         <h1 class="o_page_header">Statistics
                             <small class="float-end d-none d-md-block mt16" id="filters">

--- a/addons/website_links/views/website_links_template.xml
+++ b/addons/website_links/views/website_links_template.xml
@@ -12,7 +12,6 @@
 
                                 <div class="mb-3 row">
                                     <label class="col-md-3 col-form-label text-start">URL</label>
-
                                     <div class="col-md-9">
                                         <input type="text" id="url" class="form-control required-form-control"  required="True" placeholder="e.g. https://www.odoo.com/contactus" t-att-value="u"/>
                                     </div>
@@ -20,26 +19,43 @@
 
                                 <div class="o_website_links_utm_forms">
                                     <div class="mb-3 row">
-                                        <label class="col-md-3 col-form-label">Campaign <i class="fa fa-info-circle" data-bs-toggle="tooltip" data-bs-placement="top" role="img" aria-label="Tooltip info" title="Defines the context of your link. It might be an event you want to promote or a special promotion."></i></label>
-
+                                        <label class="col-md-3 col-form-label">
+                                            Campaign
+                                            <i class="fa fa-info-circle" data-bs-toggle="tooltip" data-bs-placement="top" role="img" aria-label="Tooltip info"
+                                                title="Defines the context of your link. It might be an event you want to promote or a special promotion."/>
+                                        </label>
                                         <div class="col-md-9">
                                             <input type="hidden" class="form-control" id="campaign-select"/>
                                         </div>
                                     </div>
-
                                     <div class="mb-3 row">
-                                        <label class="col-md-3 col-form-label">Medium <i class="fa fa-info-circle" data-bs-toggle="tooltip" data-bs-placement="top" role="img" aria-label="Tooltip info" title="Defines the medium used to share your link. It might be an email, or a Facebook Ads for instance."></i></label>
-
+                                        <label class="col-md-3 col-form-label">
+                                            Medium
+                                            <i class="fa fa-info-circle" data-bs-toggle="tooltip" data-bs-placement="top" role="img" aria-label="Tooltip info"
+                                                title="Defines the medium used to share your link. It might be an email, or a Facebook Ads for instance."/>
+                                        </label>
                                         <div class="col-md-9">
                                             <input type="hidden" class="form-control" id="channel-select" />
                                         </div>
                                     </div>
-
                                     <div class="mb-3 row">
-                                        <label class="col-md-3 col-form-label">Source <i class="fa fa-info-circle" data-bs-toggle="tooltip" data-bs-placement="top" role="img" aria-label="Tooltip info" title="Defines the source from which your traffic will come from, Facebook or Twitter for instance."></i></label>
-
+                                        <label class="col-md-3 col-form-label">
+                                            Source
+                                            <i class="fa fa-info-circle" data-bs-toggle="tooltip" data-bs-placement="top" role="img" aria-label="Tooltip info"
+                                                title="Defines the source from which your traffic will come from, Facebook or Twitter for instance."/>
+                                        </label>
                                         <div class="col-md-9">
                                             <input type="hidden" class="form-control" id="source-select" />
+                                        </div>
+                                    </div>
+                                    <div class="mb-3 row">
+                                        <label class="col-md-3 col-form-label">
+                                            Label
+                                            <i class="fa fa-info-circle" data-bs-toggle="tooltip" data-bs-placement="top" role="img" aria-label="Tooltip info"
+                                                title="Defines a label to ease reporting."/>
+                                        </label>
+                                        <div class="col-md-9">
+                                            <input type="text" id="label" class="form-control" placeholder="e.g. &quot;Black Friday Mailing Campaign&quot;" />
                                         </div>
                                     </div>
                                 </div>
@@ -47,7 +63,6 @@
                                 <div class="mb-3 row">
                                     <div class="offset-md-3 col-md-9">
                                         <button type="submit" class="btn btn-primary" id="btn_shorten_url" data-clipboard-text="">Get tracked link</button>
-
                                         <span id="generated_tracked_link" style="display:none;" class="text-muted"></span>
                                     </div>
                                 </div>

--- a/odoo/tools/mail.py
+++ b/odoo/tools/mail.py
@@ -290,7 +290,8 @@ def html_sanitize(src, silent=True, sanitize_tags=True, sanitize_attributes=Fals
 # HTML/Text management
 # ----------------------------------------------------------
 
-URL_REGEX = r'(\bhref=[\'"](?!mailto:|tel:|sms:)([^\'"]+)[\'"])'
+URL_SKIP_PROTOCOL_REGEX = r'mailto:|tel:|sms:'
+URL_REGEX = rf'''(\bhref=['"](?!{URL_SKIP_PROTOCOL_REGEX})([^'"]+)['"])'''
 TEXT_URL_REGEX = r'https?://[\w@:%.+&~#=/-]+(?:\?\S+)?'
 # retrieve inner content of the link
 HTML_TAG_URL_REGEX = URL_REGEX + r'([^<>]*>([^<>]+)<\/)?'


### PR DESCRIPTION
Purpose: Independently track clicks resolving to the same url from
different links on the same mailing if associated with a different label.

Note that as we add a criterion in the unicity constraint, we are adding a
dimension that wasn't used before. Therefore, no problem should arise in
existing databases.

Expanding the regex pattern matching lead to much less readable code.

Ill-formed urls are updated in the mailing templates.

Tests are included and their formatting is condensed and uniformized.

Task-2788965