### PR TITLE
[FIX] account: traceback when adding tax on a tax-free model

### DIFF
--- a/addons/account/models/account_reconcile_model.py
+++ b/addons/account/models/account_reconcile_model.py
@@ -370,13 +370,14 @@ class AccountReconcileModel(models.Model):
                 'analytic_tag_ids': [(6, 0, line.analytic_tag_ids.ids)],
                 'reconcile_model_id': self.id,
                 'journal_id': line.journal_id.id,
+                'tax_ids': [],
             }
             lines_vals_list.append(writeoff_line)
 
             residual_balance -= balance
 
             if line.tax_ids:
-                writeoff_line['tax_ids'] = [(6, None, line.tax_ids.ids)]
+                writeoff_line['tax_ids'] += [(6, None, line.tax_ids.ids)]
                 tax = line.tax_ids
                 # Multiple taxes with force_tax_included results in wrong computation, so we
                 # only allow to set the force_tax_included field if we have one tax selected


### PR DESCRIPTION
Have a Reconciliation model [DEMO] without tax
Create a bank statement
Open reconciliation widget
Select 'Manual Operation', select [DEMO], add any tax

Traceback will raise
This occur because the server will generate a line without `tax_ids`
field, that will remain undefined in the frontend

opw-2777191

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
