### PR TITLE
[BP][IMP] l10n_ar:_sanitize vat number method

### DIFF
--- a/addons/l10n_ar/models/res_partner.py
+++ b/addons/l10n_ar/models/res_partner.py
@@ -112,9 +112,12 @@ class ResPartner(models.Model):
             except Exception as error:
                 raise ValidationError(repr(error))
 
-    @api.model
     def _get_id_number_sanitize(self):
-        """ Sanitize the identification number. Return the digits/integer value of the identification number """
+        """ Sanitize the identification number. Return the digits/integer value of the identification number
+        If not vat number defined return 0 """
+        self.ensure_one()
+        if not self.vat:
+            return 0
         if self.l10n_latam_identification_type_id.l10n_ar_afip_code in ['80', '86']:
             # Compact is the number clean up, remove all separators leave only digits
             res = int(stdnum.ar.cuit.compact(self.vat))


### PR DESCRIPTION
latam 725 / adhoc 49495
---

* fix traceback when vat is not defined, return directly 0.
* remove api.model
* add ensure_one() to avoid misuse of the method

X-original-commit: 5cd4df745462fcc12b9d92def9cf903ebd0df143
Original PR 14.0 https://github.com/odoo/odoo/pull/84760
Related to https://github.com/odoo/enterprise/pull/25116

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
