### PR TITLE
[FIX] web: overlays can be toggled more than once

### DIFF
--- a/addons/web/static/src/core/hotkeys/hotkey_service.js
+++ b/addons/web/static/src/core/hotkeys/hotkey_service.js
@@ -77,7 +77,6 @@ export const hotkeyService = {
             if (!overlaysVisible && hotkey === hotkeyService.overlayModifier) {
                 addHotkeyOverlays(activeElement);
                 event.preventDefault();
-                overlaysVisible = true;
                 return;
             }
 
@@ -110,7 +109,6 @@ export const hotkeyService = {
             if (overlaysVisible) {
                 removeHotkeyOverlays();
                 event.preventDefault();
-                overlaysVisible = false;
             }
         }
 
@@ -203,6 +201,7 @@ export const hotkeyService = {
                 }
                 overlayParent.appendChild(overlay);
             }
+            overlaysVisible = true;
         }
 
         /**
@@ -212,6 +211,7 @@ export const hotkeyService = {
             for (const overlay of document.querySelectorAll(".o_web_hotkey_overlay")) {
                 overlay.remove();
             }
+            overlaysVisible = false;
         }
 
         /**

--- a/addons/web/static/tests/core/hotkeys/hotkey_service_tests.js
+++ b/addons/web/static/tests/core/hotkeys/hotkey_service_tests.js
@@ -263,6 +263,40 @@ QUnit.test("the overlay of hotkeys is correctly displayed on MacOs", async (asse
     assert.verifySteps([]);
 });
 
+QUnit.test("overlays can be toggled multiple times in a row", async (assert) => {
+    const eventArgs = { key: "alt", altKey: true, bubbles: true };
+    const pressOverlayModifier = () =>
+        document.activeElement.dispatchEvent(new KeyboardEvent("keydown", eventArgs));
+    const releaseOverlayModifier = () =>
+        document.activeElement.dispatchEvent(new KeyboardEvent("keyup", eventArgs));
+
+    class MyComponent extends Component {}
+    MyComponent.template = xml`<button data-hotkey="a"/>`;
+
+    await mount(MyComponent, target, { env });
+    assert.containsNone(target, ".o_web_hotkey_overlay");
+
+    // Display overlays
+    pressOverlayModifier();
+    await nextTick();
+    assert.containsOnce(target, ".o_web_hotkey_overlay");
+
+    // Hide overlays
+    releaseOverlayModifier();
+    await nextTick();
+    assert.containsNone(target, ".o_web_hotkey_overlay");
+
+    // Display overlays
+    pressOverlayModifier();
+    await nextTick();
+    assert.containsOnce(target, ".o_web_hotkey_overlay");
+
+    // Hide overlays
+    releaseOverlayModifier();
+    await nextTick();
+    assert.containsNone(target, ".o_web_hotkey_overlay");
+});
+
 QUnit.test("MacOS usability", async (assert) => {
     assert.expect(6);
 


### PR DESCRIPTION
Issue introduced with 030b1ba

Before this commit:
The hotkey overlays were not toggleable more than once in a row.

After this commit:
They can be.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
