### PR TITLE
[FIX] payment: update SIPS urls

### DIFF
--- a/addons/payment_sips/models/payment.py
+++ b/addons/payment_sips/models/payment.py
@@ -47,8 +47,8 @@ class AcquirerSips(models.Model):
     provider = fields.Selection(selection_add=[('sips', 'Sips')])
     sips_merchant_id = fields.Char('Merchant ID', help="Used for production only", required_if_provider='sips', groups='base.group_user')
     sips_secret = fields.Char('Secret Key', size=64, required_if_provider='sips', groups='base.group_user')
-    sips_test_url = fields.Char("Test url", required_if_provider='sips', default='https://payment-webinit.simu.sips-atos.com/paymentInit')
-    sips_prod_url = fields.Char("Production url", required_if_provider='sips', default='https://payment-webinit.sips-atos.com/paymentInit')
+    sips_test_url = fields.Char("Test url", required_if_provider='sips', default='https://payment-webinit.simu.sips-services.com/paymentInit')
+    sips_prod_url = fields.Char("Production url", required_if_provider='sips', default='https://payment-webinit.sips-services.com/paymentInit')
     sips_version = fields.Char("Interface Version", required_if_provider='sips', default='HP_2.3')
 
     def _sips_generate_shasign(self, values):


### PR DESCRIPTION
### Current behavior
SIPS urls aren't available anymore and lead to a 410 error page

### Reason
URLs have been updated and should be replaced i.e. previous URL : https://payment-webinit.simu.sips-atos.com/paymentInit
should be replaced by https://payment-webinit.simu.sips-services.com/paymentInit according to SIPS docs [1]

[1] : https://documentation.sips.worldline.com/en/WLSIPS.317-UG-Sips-Paypage-POST.html#Step-3-Doing-tests-in-the-simulation-environment_

OPW-2780969
