### PR TITLE
[FIX] base res.currency

### DIFF
--- a/odoo/addons/base/models/res_currency.py
+++ b/odoo/addons/base/models/res_currency.py
@@ -192,7 +192,7 @@ class Currency(models.Model):
            :return: rounded float
         """
         self.ensure_one()
-        return tools.float_round(amount, precision_rounding=self.rounding)
+        return round(tools.float_round(amount, precision_rounding=self.rounding), self.decimal_places)
 
     def compare_amounts(self, amount1, amount2):
         """Compare ``amount1`` and ``amount2`` after rounding them according to the


### PR DESCRIPTION
Using the rounding method for each currency did not always cut off the last "remainder"

Example:
HUF: rounding to 2 decimal places

12.12 -- > 12.120000000001 




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
