### PR TITLE
[FIX] sale: use a non-integer quantity for the packaging quantity

### DIFF
--- a/addons/sale/models/sale_order_line.py
+++ b/addons/sale/models/sale_order_line.py
@@ -410,7 +410,9 @@ class SaleOrderLine(models.Model):
             self.product_packaging_id = False
         # suggest biggest suitable packaging
         if self.product_id and self.product_uom_qty and self.product_uom:
-            self.product_packaging_id = self.product_id.packaging_ids.filtered('sales')._find_suitable_product_packaging(self.product_uom_qty, self.product_uom)
+            product_packaging_id = self.product_id.packaging_ids.filtered('sales')._find_suitable_product_packaging(self.product_uom_qty, self.product_uom)
+            if product_packaging_id:
+                self.product_packaging_id = product_packaging_id
 
     @api.onchange('product_packaging_id')
     def _onchange_product_packaging_id(self):


### PR DESCRIPTION
The product packaging of a sale order disappears if the user enters a
packaging quantity that can't completely fill a packaging with no excess

Steps to reproduce:
1. Install Sales and Inventory
2. Enable Product Packagings in Settings > Inventory > Products
3. Open a product form and in the Inventory tab, add one packaging of
100 units
4. Create a sale order for that product
5. Select the packaging
6. Enter a non-integer number for the packaging quantity
7. The packaging and packaging quantity disappears

Solution:
Don't overwrite the `product_packaging_id` if no suitable packaging has
been found

opw-2767499