### PR TITLE
[FIX] packaging: speedup kvm windows build

### DIFF
--- a/setup/package.py
+++ b/setup/package.py
@@ -389,12 +389,11 @@ class KVM(object):
     def start(self):
         kvm_cmd = [
             "kvm",
-            "-cpu", "core2duo",
-            "-smp", "2,sockets=2,cores=1,threads=1",
-            "-net", "nic,model=rtl8139",
+            "-cpu", "Skylake-Server",
+            "-net", "nic,macaddr=52:54:00:12:34:56,model=virtio-net-pci",
             "-net", "user,hostfwd=tcp:127.0.0.1:10022-:22,hostfwd=tcp:127.0.0.1:18069-:8069,hostfwd=tcp:127.0.0.1:15432-:5432",
-            "-m", "1024",
-            "-drive", "file=%s,snapshot=on" % self.image,
+            "-m", "2048",
+            "-drive", "if=virtio,file=%s,snapshot=on" % self.image,
             "-nographic"
         ]
         logging.info("Starting kvm: {}".format(" ".join(kvm_cmd)))


### PR DESCRIPTION
With this commit, the qemu/kvm VM is using the virtio drivers for
network and drive. This drastically improves performances and avoid
timeout on build system.

Also, the NIC mac address is fixed in order to not confuse the windows
system.

The CPU model was deprecated so it's changed to a more recent one and
its topology is simplified.

Finally, 1024 MiB of memory seemed a bit short for windows.
