### PR TITLE
[FIX] hr: fix employee ux

### DIFF
--- a/addons/hr/models/hr_employee.py
+++ b/addons/hr/models/hr_employee.py
@@ -66,7 +66,7 @@ class HrEmployeePrivate(models.Model):
     ], string='Marital Status', groups="hr.group_hr_user", default='single', tracking=True)
     spouse_complete_name = fields.Char(string="Spouse Complete Name", groups="hr.group_hr_user", tracking=True)
     spouse_birthdate = fields.Date(string="Spouse Birthdate", groups="hr.group_hr_user", tracking=True)
-    children = fields.Integer(string='Number of Dependant Children', groups="hr.group_hr_user", tracking=True)
+    children = fields.Integer(string='Number of Dependent Children', groups="hr.group_hr_user", tracking=True)
     place_of_birth = fields.Char('Place of Birth', groups="hr.group_hr_user", tracking=True)
     country_of_birth = fields.Many2one('res.country', string="Country of Birth", groups="hr.group_hr_user", tracking=True)
     birthday = fields.Date('Date of Birth', groups="hr.group_hr_user", tracking=True)

--- a/addons/hr/views/hr_employee_views.xml
+++ b/addons/hr/views/hr_employee_views.xml
@@ -118,7 +118,7 @@
                             <page name="personal_information" string="Private Information" groups="hr.group_hr_user">
                                 <group>
                                     <group string="Private Contact">
-                                        <group>
+                                        <group colspan="2">
                                             <field name="address_home_id"
                                                 context="{
                                                     'show_address': 1,
@@ -139,11 +139,15 @@
                                         </group>
                                     </group>
                                     <group>
-                                        <group string="Family Status" colspan="2">
-                                            <field name="marital"/>
-                                            <field name="spouse_complete_name" attrs="{'invisible': [('marital', 'not in', ['married', 'cohabitant'])]}" groups="hr.group_hr_user"/>
-                                            <field name="spouse_birthdate" attrs="{'invisible': [('marital', 'not in', ['married', 'cohabitant'])]}" groups="hr.group_hr_user"/>
-                                            <field name="children"/>
+                                        <group name="family_status" string="Family Status" colspan="2">
+                                            <group colspan="2">
+                                                <field name="marital"/>
+                                                <field name="spouse_complete_name" attrs="{'invisible': [('marital', 'not in', ['married', 'cohabitant'])]}" groups="hr.group_hr_user"/>
+                                                <field name="spouse_birthdate" attrs="{'invisible': [('marital', 'not in', ['married', 'cohabitant'])]}" groups="hr.group_hr_user"/>
+                                            </group>
+                                            <group name="children" col="4" colspan="2">
+                                                <field name="children"/>
+                                            </group>
                                         </group>
                                         <group string="Emergency" colspan="2">
                                             <field name="emergency_contact"/>


### PR DESCRIPTION
After installing l10n_be_hr_payroll, the address, email, phone and bank account number take half of the dedicated space.

This commit makes the fields take the dedicated space

task-2790206

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
