### PR TITLE
[FIX] account: Impossible to set a python code tax on a product

### DIFF
--- a/addons/account/models/product.py
+++ b/addons/account/models/product.py
@@ -64,7 +64,7 @@ class ProductTemplate(models.Model):
     def _compute_tax_string(self):
         for record in self:
             currency = record.currency_id
-            res = record.taxes_id.compute_all(record.list_price)
+            res = record.taxes_id.compute_all(record.list_price, product=record, partner=self.env['res.partner'])
             joined = []
             included = res['total_included']
             if currency.compare_amounts(included, record.list_price):


### PR DESCRIPTION
Steps to reproduce the bug:

- Let's define a sale python tax T where Python Code = product.list_price
- Let's consider a product template PT
- Try to set T on PT

Bug:

A traceback was raised because variable product was not defined when evaluting
the python code in function compute_all (defined in module account_tax_python)

opw:2787007