### PR TITLE
[FIX] hr_holidays : deduct correct # days on allocation

### DIFF
--- a/addons/hr_holidays/i18n/hr_holidays.pot
+++ b/addons/hr_holidays/i18n/hr_holidays.pot
@@ -3899,6 +3899,14 @@ msgstr ""
 #: code:addons/hr_holidays/models/hr_leave.py:0
 #, python-format
 msgid ""
+"You have several allocations for those type and period.\n"
+"Please split your request to fit in their number of days."
+msgstr ""
+
+#. module: hr_holidays
+#: code:addons/hr_holidays/models/hr_leave.py:0
+#, python-format
+msgid ""
 "You must be %s\'s Manager to approve this leave"
 msgstr ""
 

--- a/addons/hr_holidays/models/hr_leave.py
+++ b/addons/hr_holidays/models/hr_leave.py
@@ -291,6 +291,12 @@ class HolidaysRequest(models.Model):
                            self._table, ['date_to', 'date_from'])
         return res
 
+    @api.constrains('holiday_status_id', 'number_of_days')
+    def _check_allocation_duration(self):
+        for holiday in self:
+            if holiday.holiday_status_id.requires_allocation == 'yes' and holiday.number_of_days > holiday.holiday_allocation_id.number_of_days:
+                raise ValidationError(_("You have several allocations for those type and period.\nPlease split your request to fit in their number of days."))
+
     @api.depends_context('uid')
     def _compute_description(self):
         self.check_access_rights('read')
@@ -344,7 +350,7 @@ class HolidaysRequest(models.Model):
                 '&',
                 ('date_to', '=', False),
                 ('date_from', '<=', max(self.mapped('date_from'))),
-            ], ['id', 'date_from', 'date_to', 'holiday_status_id', 'employee_id'], order="date_to, id"
+            ], ['id', 'date_from', 'date_to', 'holiday_status_id', 'employee_id', 'number_of_days'], order="number_of_days desc, date_to, id"
         )
         allocations_dict = defaultdict(lambda: [])
         for allocation in allocations:


### PR DESCRIPTION
Steps :
Create, confirm and validate 2 overlapping leave allocations :
	> Type : T
	> Duration : 5 days
Create, confirm and approve a time off request in the overlapping period :
	> Type : T
	> Duration : 10 days
Go to the allocations.

Issue :
They have respectively 0 and 10 days taken.

Cause :
hr_leave.holiday_allocation_id is m2o, so 2 allocations cannot be
attributed to the same leave request.
_compute_from_holiday_status_id() sets the first valid (in terms of
validity dates) allocation to this field, without comparing the
number of leave days of the allocation and the request.

Fix :
Compare it. If no allocation has sufficient number of days, but their
sum is enough, ask the user to split them.

opw-2781530

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
