### PR TITLE
[FIX] mail: remove `oi` classes leftovers

### DIFF
--- a/addons/mail/static/src/components/rtc_controller/rtc_controller.xml
+++ b/addons/mail/static/src/components/rtc_controller/rtc_controller.xml
@@ -14,8 +14,8 @@
                             t-att-title="microphoneTitle"
                             t-on-click="rtcController.onClickMicrophone">
                             <div class="o_RtcController_buttonIconWrapper" t-att-class="{ 'o-isSmall': rtcController.isSmall }">
-                                <i class="oi" t-att-class="{
-                                    'oi-large': !rtcController.isSmall,
+                                <i class="fa" t-att-class="{
+                                    'fa-lg': !rtcController.isSmall,
                                     'fa-microphone': !messaging.rtc.currentRtcSession.isMute,
                                     'fa-microphone-slash': messaging.rtc.currentRtcSession.isMute,
                                     'text-danger': messaging.rtc.currentRtcSession.isMute,
@@ -30,8 +30,8 @@
                             t-att-title="headphoneTitle"
                             t-on-click="rtcController.onClickDeafen">
                             <div class="o_RtcController_buttonIconWrapper" t-att-class="{ 'o-isSmall': rtcController.isSmall }">
-                                <i class="oi" t-att-class="{
-                                    'oi-large': !rtcController.isSmall,
+                                <i class="fa" t-att-class="{
+                                    'fa-lg': !rtcController.isSmall,
                                     'fa-headphones': !messaging.rtc.currentRtcSession.isDeaf,
                                     'fa-deaf': messaging.rtc.currentRtcSession.isDeaf,
                                     'text-danger': messaging.rtc.currentRtcSession.isDeaf,
@@ -49,7 +49,7 @@
                             t-att-title="cameraTitle"
                             t-on-click="rtcController.onClickCamera">
                             <div class="o_RtcController_buttonIconWrapper" t-att-class="{ 'o-isSmall': rtcController.isSmall }">
-                                <i class="fa fa-video-camera" t-att-class="{ 'oi-large': !rtcController.isSmall }"/>
+                                <i class="fa fa-video-camera" t-att-class="{ 'fa-lg': !rtcController.isSmall }"/>
                             </div>
                         </button>
                         <t t-if="messaging.rtc.sendDisplay"><t t-set="displayTitle">Stop screen sharing</t></t>
@@ -63,7 +63,7 @@
                             t-att-title="displayTitle"
                             t-on-click="rtcController.onClickScreen">
                             <div class="o_RtcController_buttonIconWrapper" t-att-class="{ 'o-isSmall': rtcController.isSmall }">
-                                <i class="fa fa-desktop" t-att-class="{ 'oi-large': !rtcController.isSmall }"/>
+                                <i class="fa fa-desktop" t-att-class="{ 'fa-lg': !rtcController.isSmall }"/>
                             </div>
                         </button>
                         <Popover position="'top'">
@@ -73,7 +73,7 @@
                                 t-att-class="{ 'o-isSmall': rtcController.isSmall }"
                             >
                                 <div class="o_RtcController_buttonIconWrapper" t-att-class="{ 'o-isSmall': rtcController.isSmall }">
-                                    <i class="fa fa-ellipsis-h" t-att-class="{ 'oi-large': !rtcController.isSmall }"/>
+                                    <i class="fa fa-ellipsis-h" t-att-class="{ 'fa-lg': !rtcController.isSmall }"/>
                                 </div>
                             </button>
                             <t t-set-slot="opened">
@@ -89,7 +89,7 @@
                             t-att-disabled="rtcController.callViewer.threadView.thread.hasPendingRtcRequest"
                             t-on-click="rtcController.onClickToggleVideoCall">
                             <div class="o_RtcController_buttonIconWrapper" t-att-class="{ 'o-isSmall': rtcController.isSmall }">
-                                <i class="fa fa-video-camera" t-att-class="{ 'oi-large': !rtcController.isSmall }"/>
+                                <i class="fa fa-video-camera" t-att-class="{ 'fa-lg': !rtcController.isSmall }"/>
                             </div>
                         </button>
                     </t>
@@ -102,7 +102,7 @@
                                 t-att-disabled="rtcController.callViewer.threadView.thread.hasPendingRtcRequest"
                                 t-on-click="rtcController.onClickRejectCall">
                                 <div class="o_RtcController_buttonIconWrapper" t-att-class="{ 'o-isSmall': rtcController.isSmall }">
-                                    <i class="fa fa-phone" t-att-class="{ 'oi-large': !rtcController.isSmall }"/>
+                                    <i class="fa fa-phone" t-att-class="{ 'fa-lg': !rtcController.isSmall }"/>
                                 </div>
                             </button>
                         </t>
@@ -115,7 +115,7 @@
                             t-att-title="phoneTitle"
                             t-on-click="rtcController.onClickToggleAudioCall">
                             <div class="o_RtcController_buttonIconWrapper" t-att-class="{ 'o-isSmall': rtcController.isSmall }">
-                                <i class="fa fa-phone" t-att-class="{ 'oi-large': !rtcController.isSmall }"/>
+                                <i class="fa fa-phone" t-att-class="{ 'fa-lg': !rtcController.isSmall }"/>
                             </div>
                         </button>
                     </t>


### PR DESCRIPTION
During 28f910f some `oi` utility-classes that were supposed to be
removed have been forgotten, causing `fa` icons to don't be rendered
properly.

This commit will remove the unnecessary classes solving the render
issues.

task-2790138

enterprise:

- https://github.com/odoo/enterprise/pull/25128



--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
