### PR TITLE
[FIX] account_report: fix update of account report

### DIFF
--- a/addons/account/__manifest__.py
+++ b/addons/account/__manifest__.py
@@ -2,7 +2,7 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 {
     'name' : 'Invoicing',
-    'version' : '1.1',
+    'version' : '1.2',
     'summary': 'Invoices & Payments',
     'sequence': 10,
     'description': """

--- a/addons/account/i18n/account.pot
+++ b/addons/account/i18n/account.pot
@@ -9785,6 +9785,12 @@ msgid ""
 msgstr ""
 
 #. module: account
+#: code:addons/account/models/ir_module_module.py:0
+#, python-format
+msgid "Please update the Invoicing module before continuing."
+msgstr ""
+
+#. module: account
 #: model_terms:ir.ui.view,arch_db:account.bill_preview
 #: model_terms:ir.ui.view,arch_db:account.report_invoice_document
 msgid "Please use the following communication for your payment :"

--- a/addons/account/models/__init__.py
+++ b/addons/account/models/__init__.py
@@ -33,3 +33,4 @@ from . import ir_actions_report
 from . import res_currency
 from . import res_bank
 from . import mail_thread
+from . import ir_module_module

--- a/addons/account/models/ir_module_module.py
+++ b/addons/account/models/ir_module_module.py
@@ -1,0 +1,26 @@
+# -*- coding: utf-8 -*-
+from odoo import models, _
+from odoo.exceptions import UserError
+from odoo.release import series
+from odoo.tools import parse_version
+
+
+class IrModuleModule(models.Model):
+    _inherit = "ir.module.module"
+
+    def write(self, values):
+        """ Warn the user about updating account if they try to install account_reports with an out of date module
+
+            A change in stable added a dependency between account_reports and a template update in account.
+            It could cause a traceback when updating account_reports, or account_accountant with an out of date account
+            module. This will inform the user about what to do in such case, by asking him to update invoicing.
+        """
+        mod_names = self.mapped('name')
+        new_state = values.get('state')
+        if new_state in ('to upgrade', 'to install') and 'account_reports' in mod_names and 'account' not in mod_names:
+            invoicing_mod = self.env.ref('base.module_account')
+            # Do not install or update account_report if account version is not >= 1.2, and we are not also installing/updating it
+            if parse_version(invoicing_mod.latest_version) < parse_version(f'{series}.1.2') and invoicing_mod.state not in ('to install', 'to upgrade'):
+                raise UserError(_("Please update the Invoicing module before continuing."))
+
+        return super().write(values)


### PR DESCRIPTION
see https://github.com/odoo/odoo/pull/77771
https://github.com/odoo/enterprise/pull/23738

These PR are updating a template and adding a new dependency in
account_report. This has the side effect of making account report
raise a traceback when invoicing has not been updated prior to that.

With this change, we will bump the version of account and use it to
make sure that it has been updated as we would expect prior to updating
account_reports. If not, we will raise a user error with an explicit
message asking the user to update invoicing.

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
