### PR TITLE
[IMP] project: merge identical measures in burndown chart

### DIFF
--- a/addons/project/report/project_task_burndown_chart_report.py
+++ b/addons/project/report/project_task_burndown_chart_report.py
@@ -25,7 +25,6 @@ class ReportProjectTaskBurndownChart(models.Model):
     date_assign = fields.Datetime(string='Assignment Date', readonly=True)
     date_deadline = fields.Date(string='Deadline', readonly=True)
     partner_id = fields.Many2one('res.partner', string='Customer', readonly=True)
-    nb_tasks = fields.Integer('# of Tasks', readonly=True, group_operator="sum")
     date_group_by = fields.Selection(
         (
             ('day', 'By Day'),
@@ -115,8 +114,7 @@ SELECT (task_id*10^7 + 10^6 + to_char(d, 'YYMMDD')::integer)::bigint as id,
        date_assign,
        date_deadline,
        partner_id,
-       'day' AS date_group_by,
-       1 AS nb_tasks
+       'day' AS date_group_by
   FROM all_moves_stage_task t
   JOIN LATERAL generate_series(t.date_begin, t.date_end-interval '1 day', '1 day') d ON TRUE
 
@@ -132,8 +130,7 @@ SELECT (task_id*10^7 + 2*10^6 + to_char(d, 'YYMMDD')::integer)::bigint as id,
        date_assign,
        date_deadline,
        partner_id,
-       'week' AS date_group_by,
-       1 AS nb_tasks
+       'week' AS date_group_by
   FROM all_moves_stage_task t
   JOIN LATERAL generate_series(t.date_begin, t.date_end, '1 week') d ON TRUE
  WHERE date_trunc('week', t.date_begin) <= date_trunc('week', d)
@@ -151,8 +148,7 @@ SELECT (task_id*10^7 + 3*10^6 + to_char(d, 'YYMMDD')::integer)::bigint as id,
        date_assign,
        date_deadline,
        partner_id,
-       'month' AS date_group_by,
-       1 AS nb_tasks
+       'month' AS date_group_by
   FROM all_moves_stage_task t
   JOIN LATERAL generate_series(t.date_begin, t.date_end, '1 month') d ON TRUE
  WHERE date_trunc('month', t.date_begin) <= date_trunc('month', d)
@@ -170,8 +166,7 @@ SELECT (task_id*10^7 + 4*10^6 + to_char(d, 'YYMMDD')::integer)::bigint as id,
        date_assign,
        date_deadline,
        partner_id,
-       'quarter' AS date_group_by,
-       1 AS nb_tasks
+       'quarter' AS date_group_by
   FROM all_moves_stage_task t
   JOIN LATERAL generate_series(t.date_begin, t.date_end, '3 month') d ON TRUE
  WHERE date_trunc('quarter', t.date_begin) <= date_trunc('quarter', d)
@@ -189,8 +184,7 @@ SELECT (task_id*10^7 + 5*10^6 + to_char(d, 'YYMMDD')::integer)::bigint as id,
        date_assign,
        date_deadline,
        partner_id,
-       'year' AS date_group_by,
-       1 AS nb_tasks
+       'year' AS date_group_by
   FROM all_moves_stage_task t
   JOIN LATERAL generate_series(t.date_begin, t.date_end, '1 year') d ON TRUE
  WHERE date_trunc('year', t.date_begin) <= date_trunc('year', d)

--- a/addons/project/report/project_task_burndown_chart_report_views.xml
+++ b/addons/project/report/project_task_burndown_chart_report_views.xml
@@ -33,7 +33,6 @@
             <graph string="Burndown Chart" type="line" sample="1" disable_linking="1" js_class="burndown_chart">
                 <field name="date" string="Date" interval="month"/>
                 <field name="stage_id"/>
-                <field name="nb_tasks" type="measure"/>
             </graph>
         </field>
     </record>
@@ -42,7 +41,7 @@
         <field name="name">project.task.burndown.chart.report.view.pivot</field>
         <field name="model">project.task.burndown.chart.report</field>
         <field name="arch" type="xml">
-            <pivot string="Burndown Chart" display_quantity="1" disable_linking="1" sample="1">
+            <pivot string="Burndown Chart" display_quantity="1" disable_linking="1" sample="1" js_class="burndown_chart_pivot">
                 <field name="date" type="row"/>
                 <field name="stage_id" type="row"/>
             </pivot>

--- a/addons/project/static/src/burndown_chart/burndown_chart_model.js
+++ b/addons/project/static/src/burndown_chart/burndown_chart_model.js
@@ -1,0 +1,14 @@
+/** @odoo-module **/
+
+import { GraphModel } from "@web/views/graph/graph_model";
+
+export class BurndownChartModel extends GraphModel {
+    /**
+     * @protected
+     * @override
+     */
+    async _loadDataPoints(metaData) {
+        metaData.measures.__count.string = '# of Tasks';
+        return super._loadDataPoints(metaData);
+    }
+}

--- a/addons/project/static/src/burndown_chart/burndown_chart_pivot_model.js
+++ b/addons/project/static/src/burndown_chart/burndown_chart_pivot_model.js
@@ -1,0 +1,14 @@
+/** @odoo-module **/
+
+import { PivotModel } from "@web/views/pivot/pivot_model";
+
+export class BurndownChartPivotModel extends PivotModel {
+    /**
+     * @protected
+     * @override
+     */
+    async _loadData(config, prune = true) {
+        config.metaData.measures.__count.string = '# of Tasks';
+        await super._loadData(config, prune);
+    }
+}

--- a/addons/project/static/src/burndown_chart/burndown_chart_pivot_view.js
+++ b/addons/project/static/src/burndown_chart/burndown_chart_pivot_view.js
@@ -1,0 +1,12 @@
+/** @odoo-module **/
+
+import { BurndownChartPivotModel } from "./burndown_chart_pivot_model";
+import { PivotView } from "@web/views/pivot/pivot_view";
+import { registry } from "@web/core/registry";
+
+const viewRegistry = registry.category("views");
+
+class BurndownChartPivotView extends PivotView {}
+BurndownChartPivotView.Model = BurndownChartPivotModel;
+
+viewRegistry.add("burndown_chart_pivot", BurndownChartPivotView);

--- a/addons/project/static/src/burndown_chart/burndown_chart_view.js
+++ b/addons/project/static/src/burndown_chart/burndown_chart_view.js
@@ -1,5 +1,6 @@
 /** @odoo-module **/
 
+import { BurndownChartModel } from "./burndown_chart_model";
 import { BurndownChartRenderer } from "./burndown_chart_renderer";
 import { GraphView } from "@web/views/graph/graph_view";
 import { registry } from "@web/core/registry";
@@ -9,5 +10,6 @@ const viewRegistry = registry.category("views");
 class BurndownChartView extends GraphView {}
 BurndownChartView.components = { ...GraphView.components, Renderer: BurndownChartRenderer };
 BurndownChartView.buttonTemplate = "project.BurndownChartView.Buttons";
+BurndownChartView.Model = BurndownChartModel;
 
 viewRegistry.add("burndown_chart", BurndownChartView);


### PR DESCRIPTION
In a project burndown chart, we currently have two measures, "Count" and "# of tasks".
Those measures are identical, but the default "Count" one is less explicit.

We only want to keep "# of tasks", but rather than discarding the default measure,
we could rename it and remove the other one.

This commit removes the "# of tasks" measure, and renames the default "Count"
into "# of tasks".

Task-2734458