### PR TITLE
[FIX] l10n_de_stock: delivery slip template data

### DIFF
--- a/addons/l10n_de_stock/models/stock.py
+++ b/addons/l10n_de_stock/models/stock.py
@@ -9,14 +9,7 @@ class StockPicking(models.Model):
     l10n_de_addresses = fields.Binary(compute='_compute_l10n_de_addresses')
 
     def _compute_l10n_de_template_data(self):
-        for record in self:
-            record.l10n_de_template_data = data = []
-            if record.origin:
-                data.append((_("Order"), record.origin))
-            if record.state == 'done':
-                data.append((_("Shipping Date"), format_date(self.env, record.date_done)))
-            else:
-                data.append((_("Shipping Date"), format_date(self.env, record.scheduled_date)))
+        self.l10n_de_template_data = []
 
     def _compute_l10n_de_addresses(self):
         for record in self:


### PR DESCRIPTION
Delivery slip with the document layout `external_layout_din5008` should
not contain two times the order number and shipping date

Steps to reproduce:
1. Install Sales and Inventory apps and l10n_de module
2. Select the german company
3. Create and confirm a sale order with and specify a customer and a
product
4. Open the delivery through the Delivery smart button
5. Print the Delivery Slip
6. The order and shipping date are displayed two times; once on the top
right, another time under the document title

Solution:
`l10n_de_template_data` set to null because it's a redundant information
The order number and shipping date that it previously contained were
already displayed in the report template
https://github.com/odoo/odoo/blob/ec90e9bfee208761f8247b55260895990b7614ed/addons/stock/report/report_deliveryslip.xml#L49-L53
so `l10n_de_template_data` should be removed and this is the simplest
way without touching din5008_report.xml

opw-2761919