### PR TITLE
[ADD] l10n_se: Add missing tripartite trade taxes in the tax reports

### DIFF
--- a/addons/l10n_se/data/account_tax_template.xml
+++ b/addons/l10n_se/data/account_tax_template.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <odoo>
-    <data noupdate="1">
+    <data>
         <record id="sale_tax_25_goods" model="account.tax.template">
             <field name="chart_template_id" ref="l10nse_chart_template"/>
             <field name="name">Utgående moms 25%</field>
@@ -1141,6 +1141,164 @@
                     'factor_percent': -100,
                     'repartition_type': 'tax',
                     'account_id': ref('a2634')
+                })]"/>
+        </record>
+
+        <!--Tax template in triangular trade-->
+        <record id="triangular_tax_25_goods" model="account.tax.template">
+            <field name="chart_template_id" ref="l10nse_chart_template"/>
+            <field name="name">Trepartshandel - moms 25%</field>
+            <field name="description">T25</field>
+            <field name="amount">25</field>
+            <field name="type_tax_use">sale</field>
+            <field name="tax_group_id" ref="tax_group_25"/>
+            <field name="invoice_repartition_line_ids" eval="[(5, 0, 0),
+                (0, 0, {
+                    'factor_percent': 100,
+                    'repartition_type': 'base',
+                    'plus_report_line_ids': [ref('tax_report_line_37')],
+                    'minus_report_line_ids': [ref('tax_report_line_38')],
+                }),
+                (0, 0, {
+                    'factor_percent': 100,
+                    'repartition_type': 'tax',
+                    'account_id': ref('a2615'),
+                }),
+                (0, 0, {
+                    'factor_percent': -100,
+                    'repartition_type': 'tax',
+                    'account_id': ref('a2645'),
+                })]"/>
+            <field name="refund_repartition_line_ids" eval="[(5, 0, 0),
+                (0, 0, {
+                    'factor_percent': 100,
+                    'repartition_type': 'base',
+                    'minus_report_line_ids': [ref('tax_report_line_37')],
+                    'plus_report_line_ids': [ref('tax_report_line_38')],
+                }),
+                (0, 0, {
+                    'factor_percent': 100,
+                    'repartition_type': 'tax',
+                    'account_id': ref('a2615'),
+                }),
+                (0, 0, {
+                    'factor_percent': -100,
+                    'repartition_type': 'tax',
+                    'account_id': ref('a2645'),
+                })]"/>
+        </record>
+        <record id="triangular_tax_12_goods" model="account.tax.template">
+            <field name="chart_template_id" ref="l10nse_chart_template"/>
+            <field name="name">Trepartshandel - moms 12%</field>
+            <field name="description">T12</field>
+            <field name="amount">12</field>
+            <field name="type_tax_use">sale</field>
+            <field name="tax_group_id" ref="tax_group_25"/>
+            <field name="invoice_repartition_line_ids" eval="[(5, 0, 0),
+                (0, 0, {
+                    'factor_percent': 100,
+                    'repartition_type': 'base',
+                    'plus_report_line_ids': [ref('tax_report_line_37')],
+                    'minus_report_line_ids': [ref('tax_report_line_38')],
+                }),
+                (0, 0, {
+                    'factor_percent': 100,
+                    'repartition_type': 'tax',
+                    'account_id': ref('a2625'),
+                }),
+                (0, 0, {
+                    'factor_percent': -100,
+                    'repartition_type': 'tax',
+                    'account_id': ref('a2645'),
+                })]"/>
+            <field name="refund_repartition_line_ids" eval="[(5, 0, 0),
+                (0, 0, {
+                    'factor_percent': 100,
+                    'repartition_type': 'base',
+                    'minus_report_line_ids': [ref('tax_report_line_37')],
+                    'plus_report_line_ids': [ref('tax_report_line_38')],
+                }),
+                (0, 0, {
+                    'factor_percent': 100,
+                    'repartition_type': 'tax',
+                    'account_id': ref('a2625'),
+                }),
+                (0, 0, {
+                    'factor_percent': -100,
+                    'repartition_type': 'tax',
+                    'account_id': ref('a2645'),
+                })]"/>
+        </record>
+        <record id="triangular_tax_6_goods" model="account.tax.template">
+            <field name="chart_template_id" ref="l10nse_chart_template"/>
+            <field name="name">Trepartshandel - moms 6%</field>
+            <field name="description">T6</field>
+            <field name="amount">6</field>
+            <field name="type_tax_use">sale</field>
+            <field name="tax_group_id" ref="tax_group_25"/>
+            <field name="invoice_repartition_line_ids" eval="[(5, 0, 0),
+                (0, 0, {
+                    'factor_percent': 100,
+                    'repartition_type': 'base',
+                    'plus_report_line_ids': [ref('tax_report_line_37')],
+                    'minus_report_line_ids': [ref('tax_report_line_38')],
+                }),
+                (0, 0, {
+                    'factor_percent': 100,
+                    'repartition_type': 'tax',
+                    'account_id': ref('a2635'),
+                }),
+                (0, 0, {
+                    'factor_percent': -100,
+                    'repartition_type': 'tax',
+                    'account_id': ref('a2645'),
+                })]"/>
+            <field name="refund_repartition_line_ids" eval="[(5, 0, 0),
+                (0, 0, {
+                    'factor_percent': 100,
+                    'repartition_type': 'base',
+                    'minus_report_line_ids': [ref('tax_report_line_37')],
+                    'plus_report_line_ids': [ref('tax_report_line_38')],
+                }),
+                (0, 0, {
+                    'factor_percent': 100,
+                    'repartition_type': 'tax',
+                    'account_id': ref('a2635'),
+                }),
+                (0, 0, {
+                    'factor_percent': -100,
+                    'repartition_type': 'tax',
+                    'account_id': ref('a2645'),
+                })]"/>
+        </record>
+        <record id="triangular_tax_0_goods" model="account.tax.template">
+            <field name="chart_template_id" ref="l10nse_chart_template"/>
+            <field name="name">Trepartshandel - momsfrei</field>
+            <field name="description">T0</field>
+            <field name="amount">0</field>
+            <field name="type_tax_use">sale</field>
+            <field name="tax_group_id" ref="tax_group_25"/>
+            <field name="invoice_repartition_line_ids" eval="[(5, 0, 0),
+                (0, 0, {
+                    'factor_percent': 100,
+                    'repartition_type': 'base',
+                    'plus_report_line_ids': [ref('tax_report_line_37')],
+                    'minus_report_line_ids': [ref('tax_report_line_38')],
+                }),
+                (0, 0, {
+                    'factor_percent': 100,
+                    'repartition_type': 'tax',
+            })]"/>
+            <field name="refund_repartition_line_ids" eval="[(5, 0, 0),
+                (0, 0, {
+                    'factor_percent': 100,
+                    'repartition_type': 'base',
+                    'minus_report_line_ids': [ref('tax_report_line_37')],
+                    'plus_report_line_ids': [ref('tax_report_line_38')],
+                }),
+                (0, 0, {
+                    'factor_percent': 100,
+                    'repartition_type': 'tax',
                 })]"/>
         </record>
     </data>


### PR DESCRIPTION
Currently, the tax report contains the lines for tripartite trade,
but no taxes have been made for these.
As the EC list report use these taxes it, these needs to be implemented.
Also remove the noupdate=1 as it isn't needed and may induce problems in the future

**Task:** task-2759470
**Related to:**[ enterprise/24087](https://github.com/odoo/enterprise/pull/24087)

### Description of the issue/feature this PR addresses:
Add the tripartite/triangular EU tax in the default tax templates, as the EC listing report and VAT report requires it

### Current behavior before PR:
The user has to add the tax manually to use the report line

### Desired behavior after PR is merged:
New databases will get the new taxes by default. Older ones can add it manually


--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
