### PR TITLE
[FIX] account: correct tax_tag_invert value for base line on cash basis reversal

### DIFF
--- a/addons/account/models/account_move.py
+++ b/addons/account/models/account_move.py
@@ -2682,7 +2682,7 @@ class AccountMove(models.Model):
             amount_currency = -line_vals.get('amount_currency', 0.0)
             balance = line_vals['credit'] - line_vals['debit']
 
-            if 'tax_tag_invert' in line_vals:
+            if 'tax_tag_invert' in line_vals and not self.tax_cash_basis_origin_move_id:
                 # This is an editable computed field; we want to it recompute itself
                 del line_vals['tax_tag_invert']
 


### PR DESCRIPTION
Consider the following case:

1) Create a 42% cash basis tax, impacting different grids on each repartition line
2) Create a misc entry using this tax, with the same lines as an invoice, with base amount of 100
3) Create a payment and reconcile it with the invoice-like move from step 2. This will create a cash basis move.
4) Cancel reconciliation
===> In the tax report, instead of seeing 0 in the base grid, we see 200. Amounts are doubled instead of being cancelled, they shouldn't. Tax grid is fine.

This is due to the fact tax_tag_invert is going to be computed, and will hence not have the same value as on the original move, since debit and credit on base and tax lines are inverted in the reverse move. Tax line is fine because it relies on tax_repartition_line_id, which is kept from the original move.

We now force keeping the same value for those moves as in the original one, to force full cancellation.

OPW 2769340
