### PR TITLE
[FIX] analytic: remove translate from account.analytic.line name

### DIFF
--- a/addons/analytic/models/analytic_account.py
+++ b/addons/analytic/models/analytic_account.py
@@ -179,7 +179,7 @@ class AccountAnalyticLine(models.Model):
     def _default_user(self):
         return self.env.context.get('user_id', self.env.user.id)
 
-    name = fields.Char('Description', required=True, translate=True)
+    name = fields.Char('Description', required=True)
     date = fields.Date('Date', required=True, index=True, default=fields.Date.context_today)
     amount = fields.Monetary('Amount', required=True, default=0.0)
     unit_amount = fields.Float('Quantity', default=0.0)


### PR DESCRIPTION
`account.analytic.line` has been set as translatable in saas-15.1. In hindsight,
we can say it was clearly a bad idea as it introduced complexity and confusion.
This is why we are reverting it.

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
