### PR TITLE
[FIX] point_of_sale: Set right company on PoS stock_move

### DIFF
--- a/addons/point_of_sale/models/pos_order.py
+++ b/addons/point_of_sale/models/pos_order.py
@@ -519,6 +519,7 @@ class PosOrder(models.Model):
             for line in order.lines.filtered(lambda l: l.product_id.type in ['product', 'consu'] and not float_is_zero(l.qty, precision_rounding=l.product_id.uom_id.rounding)):
                 moves |= Move.create({
                     'name': line.name,
+                    'company_id': line.company_id.id,
                     'product_uom': line.product_id.uom_id.id,
                     'picking_id': order_picking.id if line.qty >= 0 else return_picking.id,
                     'picking_type_id': picking_type.id if line.qty >= 0 else return_pick_type.id,


### PR DESCRIPTION
Current behavior:
When you are in a multicompany environnement and using a PoS that is not part of the current active company
the stock moves created from this PoS will have wrong company set.

Steps to reproduce:
- Create two companies like A and B
- Create a POS for Company A
- Select both company A and B but active company B as main company
- Create a POS session and complete an order
- When closing the session you will see 1 Picking Errors
- There is an error because the company in the stock_move is different than the one from the PoS

opw-2731739

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
