### PR TITLE
[FIX] website_slides: added redirection for invalid slide URLs

### DIFF
--- a/addons/website_slides/controllers/main.py
+++ b/addons/website_slides/controllers/main.py
@@ -670,6 +670,9 @@ class WebsiteSlides(WebsiteProfile):
     def slide_view(self, slide, **kwargs):
         if not slide.channel_id.can_access_from_current_website() or not slide.active:
             raise werkzeug.exceptions.NotFound()
+        # redirection to channel's homepage for category slides
+        if slide.is_category:
+            return werkzeug.utils.redirect(slide.channel_id.website_url)
         self._set_viewed_slide(slide)
 
         values = self._get_slide_detail(slide)


### PR DESCRIPTION
Reproduction:
1. Install eLearning, delete sitemap.xml from Settings->Technical->
Database structure -> Attachment
2. Regenerate sitemap.xml by opening odoo.com(or localhost)/sitemap.xml
3. Open a URL, for example,
http://odoo14:6014/slides/slide/tools-and-methods-25
4. A ValueError is thrown

Reason: the URL generation for model slide.slide uses the default
method, which doesn’t filter out the category slides. An example of a
category is: http://odoo14:6014/slides/slide/unforgettable-tools-28 The
tools-and-methods is a category in the course content

Fix: Added a special case for category slides. If it's a category,
redirect to the channel's homepage

opw-2579913


I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
