### PR TITLE
[FIX] mrp: done qty were missed to be taken into consideration for ...

### DIFF
--- a/addons/mrp/wizard/change_production_qty.py
+++ b/addons/mrp/wizard/change_production_qty.py
@@ -36,9 +36,19 @@ class ChangeProductionQty(models.TransientModel):
         for move in production.move_finished_ids:
             if move.state in ('done', 'cancel'):
                 continue
-            qty = (new_qty - old_qty) * move.unit_factor
+            done_qty = sum(production.move_finished_ids.filtered(
+                lambda r:
+                    r.product_id == move.product_id and
+                    r.state == 'done'
+                ).mapped('product_uom_qty')
+            )
+            qty = (new_qty - old_qty) * move.unit_factor + done_qty
             modification[move] = (move.product_uom_qty + qty, move.product_uom_qty)
-            move.write({'product_uom_qty': move.product_uom_qty + qty})
+            if (move.product_uom_qty + qty) > 0:
+                move.write({'product_uom_qty': move.product_uom_qty + qty})
+            else:
+                move._action_cancel()
+
         return modification
 
     def change_prod_qty(self):


### PR DESCRIPTION
**Description of the issue/feature this PR addresses:**

... qty changed finished product moves

which would create negative moves for closed production orders and therefore messing up forecasted quantities
without the possibility for a normal user to cleanup (delete or cancel)

**Current behavior before PR:**
Posted moves are not taken into consideration which is messing up production order pretty bad on quantity changes

**Desired behavior after PR is merged:**
Changing quantities is safe again 😉 

Info: @wt-io-it



--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
