### PR TITLE
[FIX] purchase_stock: include "to approve" PO in forecasted report

### DIFF
--- a/addons/purchase_stock/report/report_stock_forecasted.py
+++ b/addons/purchase_stock/report/report_stock_forecasted.py
@@ -9,7 +9,7 @@ class ReplenishmentReport(models.AbstractModel):
 
     def _compute_draft_quantity_count(self, product_template_ids, product_variant_ids, wh_location_ids):
         res = super()._compute_draft_quantity_count(product_template_ids, product_variant_ids, wh_location_ids)
-        domain = [('state', 'in', ['draft', 'sent'])]
+        domain = [('state', 'in', ['draft', 'sent', 'to approve'])]
         domain += self._product_purchase_domain(product_template_ids, product_variant_ids)
         warehouse_id = self.env.context.get('warehouse', False)
         if warehouse_id:

--- a/addons/purchase_stock/tests/test_purchase_stock_report.py
+++ b/addons/purchase_stock/tests/test_purchase_stock_report.py
@@ -2,6 +2,7 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 from odoo.tests.common import Form
+from odoo.addons.mail.tests.common import mail_new_test_user
 from odoo.addons.stock.tests.test_report import TestReportsCommon
 
 
@@ -145,3 +146,35 @@ class TestPurchaseStockReports(TestReportsCommon):
         self.assertEqual(draft_picking_qty_in, 0)
         self.assertEqual(draft_purchase_qty, 0)
         self.assertEqual(pending_qty_in, 0)
+
+    def test_approval_and_forecasted_qty(self):
+        """
+        When a PO is waiting for an approval, its quantities should be included
+        in the draft quantity count
+        """
+        self.env.company.po_double_validation = 'two_step'
+        self.env.company.po_double_validation_amount = 0
+
+        basic_purchase_user = mail_new_test_user(
+            self.env,
+            login='basic_purchase_user',
+            groups='base.group_user,purchase.group_purchase_user',
+        )
+
+        po_form = Form(self.env['purchase.order'])
+        po_form.partner_id = self.partner
+        with po_form.order_line.new() as line:
+            line.product_id = self.product
+            line.product_qty = 50
+        po_form.save()
+
+        po_form = Form(self.env['purchase.order'])
+        po_form.partner_id = self.partner
+        with po_form.order_line.new() as line:
+            line.product_id = self.product
+            line.product_qty = 100
+        po = po_form.save()
+        po.with_user(basic_purchase_user).button_confirm()
+
+        docs = self.get_report_forecast(product_template_ids=self.product_template.ids)[1]
+        self.assertEqual(docs['draft_purchase_qty'], 150)


### PR DESCRIPTION
When a PO is in the "To Approve" state, it disappears from the
forecasted report

To reproduce the issue:
1. In Settings, enable "Purchase Order Approval" with a minimum amount
equal to 0
2. Create a storable product P
3. With Marc Demo:
    - Create a PO with 50 x P
    - Consult the forecasted report of P: there are 50 x P "Forecasted +
Pending"
    - Confirm the PO (its state becomes "To Approve")
    - Consult the forecasted report of P

Error: The 50 x P disappeared: 0 On Hand, 0 Forecasted, 0 Forecasted +
Pending. We should still see 50 Forecasted + Pending

OPW-2774586