### PR TITLE
[FIX] web: run tooling only on branches starting with master

### DIFF
--- a/addons/web/tooling/_husky/pre-commit
+++ b/addons/web/tooling/_husky/pre-commit
@@ -1,4 +1,7 @@
 #!/bin/bash
 . "$(dirname "$0")/_/husky.sh"
 
-npm run format-staged
+# run tooling only on branches that start with master to avoid linting noise in stable
+if [[ $(git branch --show-current) == master* ]]; then
+    npm run format-staged
+fi


### PR DESCRIPTION
Previously, the tooling for web ran on all branches, this can cause
problems because it will automatically lint all files that have been
changed on commit, which can cause a lot of noise in the diff which is
undesirable in stable branches, as it makes forward ports more
difficult, among other things.

This commit adds a condition in the tooling so that it only runs on
branches whose name starts with master to fix this issue.
