### PR TITLE
[FIX] mrp: duplicating a processed production w/ done moves

### DIFF
--- a/addons/mrp/models/mrp_production.py
+++ b/addons/mrp/models/mrp_production.py
@@ -526,6 +526,11 @@ class MrpProduction(models.Model):
         if not values.get('procurement_group_id'):
             procurement_group_vals = self._prepare_procurement_group_vals(values)
             values['procurement_group_id'] = self.env["procurement.group"].create(procurement_group_vals).id
+        if values.get('move_raw_ids'):
+            duplicate_bom_line_list = [move_vals[2].get('bom_line_id') for move_vals in values.get('move_raw_ids')]
+            if len(duplicate_bom_line_list) != len(set(duplicate_bom_line_list)):
+                self = self.with_context(import_file=True)
+                del values['move_raw_ids']
         production = super(MrpProduction, self).create(values)
         production.move_raw_ids.write({
             'group_id': production.procurement_group_id.id,


### PR DESCRIPTION
**Description of the issue/feature this PR addresses:**
As it will duplicate several raw move lines with the same `bom_line_id` which is unexpected
and not implemented we make sure to remove in case of duplication all lines and recompute
as it would be done with imported raw moves.

**Current behavior before PR:**
Unhandled raw move lines will pollute the duplicated `mrp.production`

**Desired behavior after PR is merged:**
Cleanly duplicate without possible unclear raw move lines

Info: @wt-io-it




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
