### PR TITLE
[FIX] website_sale_delivery: verify delivery cost are applied

### DIFF
--- a/addons/website_sale/static/tests/tours/website_sale_buy.js
+++ b/addons/website_sale/static/tests/tours/website_sale_buy.js
@@ -61,6 +61,7 @@ tour.register('shop_buy_product', {
         {
             content: "go to checkout",
             extra_trigger: '#cart_products input.js_quantity:propValue(1)',
+            extra_trigger: 'body:not([rpc-done])',
             trigger: 'a[href*="/shop/checkout"]',
         },
         {

--- a/addons/website_sale_delivery/static/tests/tours/website_sale_buy.js
+++ b/addons/website_sale_delivery/static/tests/tours/website_sale_buy.js
@@ -1,0 +1,32 @@
+odoo.define("website_sale_delivery.website_sale_tour", function (require) {
+"use strict";
+/**
+ * Add custom steps to handle the optional products modal introduced
+ * by the product configurator module.
+ */
+var tour = require('web_tour.tour');
+require('website_sale.tour');
+var website_sale = require('website_sale.website_sale');
+
+website_sale.include({
+    _onChangeCartQuantity(event) {
+        super._onChangeCartQuantity.apply(this, event);
+        $('body').attr('rpc-done', 1);
+    },
+});
+
+
+var addCartStepIndex = _.findIndex(tour.tours.shop_buy_product.steps, function (step) {
+    return (step.id === 'set one');
+});
+
+tour.tours.shop_buy_product.steps.splice(addCartStepIndex + 1, 0,         {
+            content: "wait for delivery race condition",
+            trigger: 'body[view-event-id]',
+            run: () => {
+                const $body = $('body');
+                $body.removeAttr('rpc-done');
+            }
+});
+
+});


### PR DESCRIPTION
Step to reproduce:
- As a portal user:
- Add a product to cart
- Proceed with order until 'Confirm Order' stage
- In another tab (Do not close main tab):
	- Go to cart and reduce the product qty to 0
	- Go to shop and add the product to cart
- On main tab click on 'Pay Now'

Current behaviour:
- Delivery charges and taxes are not taken into account for
 payment
- Delivery charge are added when reaching 'confirm order' page if
 you do not reload the page, you can continue without adding them

Behaviour After PR:
- Check if delivery is set in back-end when trying to proceed
 with transaction
- Error if delivery is not set

opw-2778347


--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
