### PR TITLE
[FIX] point_of_sale: Reconcile fails

### DIFF
--- a/addons/point_of_sale/models/pos_session.py
+++ b/addons/point_of_sale/models/pos_session.py
@@ -422,11 +422,7 @@ class PosSession(models.Model):
                 invoice_receivables[key] = self._update_amounts(invoice_receivables[key], {'amount': order._get_amount_receivable()}, order.date_order)
                 # side loop to gather receivable lines by account for reconciliation
                 for move_line in order.account_move.line_ids.filtered(lambda aml: aml.account_id.internal_type == 'receivable' and not aml.reconciled):
-                    # NOTE: Negative (Positive) amount in the order's invoice's receivable line, will be paired to
-                    # the respective positive (negative) balance in session's invoice receivable lines. That's why the comparator to
-                    # calculate `key`s for `invoice_receivable_lines` in `_create_invoice_receivable_lines` is inverted.
-                    # The key ensures we don't reconcile invoice receivable lines with opposite sign together
-                    key = (order.partner_id.commercial_partner_id.id, order._get_amount_receivable() < 0, move_line.account_id.id)
+                    key = (order.partner_id.commercial_partner_id.id, move_line.account_id.id)
                     order_account_move_receivable_lines[key] |= move_line
             else:
                 order_taxes = defaultdict(tax_amounts)
@@ -596,7 +592,7 @@ class PosSession(models.Model):
             receivable_lines = MoveLine.create(vals)
             for receivable_line in receivable_lines:
                 if (not receivable_line.reconciled):
-                    key = (commercial_partner.id, receivable_line.balance > 0, account_id)
+                    key = (commercial_partner.id, account_id)
                     if key not in invoice_receivable_lines:
                         invoice_receivable_lines[key] = receivable_line
                     else:

--- a/addons/point_of_sale/tests/test_pos_basic_config.py
+++ b/addons/point_of_sale/tests/test_pos_basic_config.py
@@ -503,3 +503,272 @@ class TestPoSBasicConfig(TestPoSCommon):
         self.assertEqual(len(other_customer_invoice_receivable_counterpart), 1, msg='there should one aggregated invoice receivable counterpart for self.other_customer')
         self.assertEqual(bool(other_customer_invoice_receivable_counterpart.full_reconcile_id), True, msg='the aggregated receivable for self.other_customer should be reconciled')
         self.assertEqual(other_customer_invoice_receivable_counterpart.balance, -200, msg='aggregated balance should be -200')
+
+    def test_refund_customer_reconcile(self):
+        """ Test return invoiced order
+
+                2 orders
+                - 2nd order is returned
+
+                Orders
+                ======
+                +------------------+----------+-----------+----------+-----+-------+
+                | order            | payments | invoiced? | product  | qty | total |
+                +------------------+----------+-----------+----------+-----+-------+
+                | order 1          | bank     | yes       | product1 |   3 |    30 |
+                |                  |          |           | product2 |   2 |    40 |
+                |                  |          |           | product3 |   1 |    30 |
+                +------------------+----------+-----------+----------+-----+-------+
+                | order 2          | bank     | yes       | product1 |   3 |    30 |
+                |                  |          |           | product2 |   2 |    40 |
+                |                  |          |           | product3 |   1 |    30 |
+                +------------------+----------+-----------+----------+-----+-------+
+                | order 3 (return) | bank     | yes       | product1 |  -3 |   -30 |
+                |                  |          |           | product2 |  -2 |   -40 |
+                |                  |          |           | product3 |  -1 |   -30 |
+                +------------------+----------+-----------+----------+-----+-------+
+
+                Expected Result
+                ===============
+                +---------------------+---------+
+                | account             | balance |
+                +---------------------+---------+
+                | receivable          |    -100 |
+                | pos receivable bank |     100 |
+                +---------------------+---------+
+                | Total balance       |     0.0 |
+                +---------------------+---------+
+                """
+        start_qty_available = {
+            self.product1: self.product1.qty_available,
+            self.product2: self.product2.qty_available,
+            self.product3: self.product3.qty_available,
+        }
+
+        self.open_new_session()
+
+        # create orders
+        orders = []
+        orders.append(self.create_ui_order_data(
+            [(self.product1, 3), (self.product2, 2), (self.product3, 1)],
+            payments=[(self.bank_pm, 100)],
+            is_invoiced=True,
+            uid='12346-123-1234',
+            customer=self.customer
+        ))
+        orders.append(self.create_ui_order_data(
+            [(self.product1, 3), (self.product2, 2), (self.product3, 1)],
+            payments=[(self.bank_pm, 100)],
+            uid='12345-123-1234',
+            is_invoiced=True,
+            customer=self.customer
+        ))
+
+        # sync orders
+        order = self.env['pos.order'].create_from_ui(orders)
+
+        # check values before closing the session
+        self.assertEqual(2, self.pos_session.order_count)
+        orders_total = sum(order.amount_total for order in self.pos_session.order_ids)
+        self.assertAlmostEqual(orders_total, self.pos_session.total_payments_amount,
+                               msg='Total order amount should be equal to the total payment amount.')
+
+        # return order
+        order_to_return = self.pos_session.order_ids.filtered(
+            lambda order: '12345-123-1234' in order.pos_reference)
+        order_to_return.refund()
+        refund_order = self.pos_session.order_ids.filtered(
+            lambda order: order.state == 'draft')
+
+        # check if amount to pay
+        self.assertAlmostEqual(refund_order.amount_total - refund_order.amount_paid,
+                               -100)
+
+        # pay the refund
+        context_make_payment = {"active_ids": [refund_order.id],
+                                "active_id": refund_order.id}
+        make_payment = self.env['pos.make.payment'].with_context(
+            context_make_payment).create({
+            'payment_method_id': self.bank_pm.id,
+            'amount': -100,
+        })
+        make_payment.check()
+        self.assertEqual(refund_order.state, 'paid',
+                         'Payment is registered, order should be paid.')
+        self.assertAlmostEqual(refund_order.amount_paid, -100.0,
+                               msg='Amount paid for return order should be negative.')
+        refund_order.action_pos_order_invoice()
+        self.assertTrue(refund_order.account_move)
+        # check product qty_available after syncing the order
+        self.assertEqual(
+            self.product1.qty_available + 3,
+            start_qty_available[self.product1],
+        )
+        self.assertEqual(
+            self.product2.qty_available + 2,
+            start_qty_available[self.product2],
+        )
+        self.assertEqual(
+            self.product3.qty_available + 1,
+            start_qty_available[self.product3],
+        )
+
+        # picking and stock moves should be in done state
+        # no exception of return orders
+        for order in self.pos_session.order_ids:
+            self.assertEqual(
+                order.picking_id.state,
+                'done',
+                'Picking should be in done state.'
+            )
+            move_lines = order.picking_id.move_lines
+            self.assertEqual(
+                move_lines.mapped('state'),
+                ['done'] * len(move_lines),
+                'Move Lines should be in done state.'
+            )
+
+        # close the session
+        self.pos_session.action_pos_session_validate()
+
+        # check values after the session is closed
+        session_move = self.pos_session.move_id
+
+        sale_lines = session_move.line_ids.filtered(
+            lambda line: line.account_id == self.sale_account)
+        self.assertEqual(len(sale_lines), 0,
+                         msg='There should be no lines as all is invoiced.')
+        self.assertEqual(
+            sum(session_move.line_ids.filtered(
+                lambda line: line.partner_id == self.customer
+            ).mapped("balance")),
+            -100
+        )
+        receivable_line_bank = session_move.line_ids.filtered(
+            lambda line: self.bank_pm.name in line.name)
+        self.assertAlmostEqual(receivable_line_bank.balance, 100.0)
+        for order in self.pos_session.order_ids:
+            self.assertEqual(0, order.account_move.amount_residual)
+
+    def test_multiple_customers_reconcile(self):
+        """ Test return invoiced order from another customer
+
+                2 actions
+                - 1st order from one customer
+                - 2nd order is a refund from another customer
+
+                Orders
+                ======
+                +------------------+----------+-----------+----------+-----+-------+
+                | order            | payments | invoiced? | product  | qty | total |
+                +------------------+----------+-----------+----------+-----+-------+
+                | order 1          | bank     | yes       | product1 |   3 |    30 |
+                |                  |          | customer  | product2 |   2 |    40 |
+                |                  |          |           | product3 |   1 |    30 |
+                +------------------+----------+-----------+----------+-----+-------+
+                | order 2 (return) | bank     | yes       | product1 |  -3 |   -30 |
+                |                  |          | other     | product2 |  -2 |   -40 |
+                |                  |          | customer  | product3 |  -1 |   -30 |
+                +------------------+----------+-----------+----------+-----+-------+
+
+                Expected Result
+                ===============
+                +---------------------------+---------+
+                | account                   | balance |
+                +---------------------------+---------+
+                | receivable customer       |    -100 |
+                | receivable other customer |     100 |
+                | pos receivable bank       |       0 |
+                +---------------------------+---------+
+                | Total balance             |     0.0 |
+                +---------------------------+---------+
+                """
+        start_qty_available = {
+            self.product1: self.product1.qty_available,
+            self.product2: self.product2.qty_available,
+            self.product3: self.product3.qty_available,
+        }
+
+        self.open_new_session()
+
+        # create orders
+        orders = []
+        orders.append(self.create_ui_order_data(
+            [(self.product1, 3), (self.product2, 2), (self.product3, 1)],
+            payments=[(self.bank_pm, 100)],
+            is_invoiced=True,
+            uid='12346-123-1234',
+            customer=self.customer
+        ))
+        orders.append(self.create_ui_order_data(
+            [(self.product1, -3), (self.product2, -2), (self.product3, -1)],
+            payments=[(self.bank_pm, -100)],
+            uid='12345-123-1234',
+            is_invoiced=True,
+            customer=self.other_customer
+        ))
+
+        # sync orders
+        order = self.env['pos.order'].create_from_ui(orders)
+
+        # check values before closing the session
+        self.assertEqual(2, self.pos_session.order_count)
+        orders_total = sum(order.amount_total for order in self.pos_session.order_ids)
+        self.assertAlmostEqual(orders_total, self.pos_session.total_payments_amount,
+                               msg='Total order amount should be equal to the total payment amount.')
+        self.assertEqual(
+            self.product1.qty_available,
+            start_qty_available[self.product1],
+        )
+        self.assertEqual(
+            self.product2.qty_available,
+            start_qty_available[self.product2],
+        )
+        self.assertEqual(
+            self.product3.qty_available,
+            start_qty_available[self.product3],
+        )
+
+        # picking and stock moves should be in done state
+        # no exception of return orders
+        for order in self.pos_session.order_ids:
+            self.assertEqual(
+                order.picking_id.state,
+                'done',
+                'Picking should be in done state.'
+            )
+            move_lines = order.picking_id.move_lines
+            self.assertEqual(
+                move_lines.mapped('state'),
+                ['done'] * len(move_lines),
+                'Move Lines should be in done state.'
+            )
+
+        # close the session
+        self.pos_session.action_pos_session_validate()
+
+        # check values after the session is closed
+        session_move = self.pos_session.move_id
+
+        sale_lines = session_move.line_ids.filtered(
+            lambda line: line.account_id == self.sale_account)
+        self.assertEqual(len(sale_lines), 0,
+                         msg='There should be no lines as all is invoiced.')
+
+        self.assertEqual(
+            session_move.line_ids.filtered(
+                lambda line: line.partner_id == self.customer
+            ).balance,
+            -100
+        )
+        self.assertEqual(
+            session_move.line_ids.filtered(
+                lambda line: line.partner_id == self.other_customer
+            ).balance,
+            100
+        )
+        receivable_line_bank = session_move.line_ids.filtered(
+            lambda line: self.bank_pm.name in line.name)
+        self.assertAlmostEqual(receivable_line_bank.balance, 0.0)
+        for order in self.pos_session.order_ids:
+            self.assertEqual(0, order.account_move.amount_residual)


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
Fixes an error raised by #84827

Current behavior before PR:
The following error was found

1. Add the option Print invoices on customer requeston a Pos Config.
2. Open a session
3. Create 2 orders for the same customer and invoice them
4. Return one of the orders and invoice it

Two account moves will have amount_residual != 0 (the credit note and one of the orders) (tested on runbot)

Desired behavior after PR is merged:

The result is that all moves are reconciled.

In order to not loose it, I added tests for this issue and the issue fixed on #84827

@nle-odoo @agr-odoo @caburj

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
