### PR TITLE
[FIX] qweb: do not allow rendering inline template

### DIFF
--- a/odoo/addons/base/models/ir_qweb.py
+++ b/odoo/addons/base/models/ir_qweb.py
@@ -636,22 +636,21 @@ class IrQWeb(models.AbstractModel):
         string document that contains ``element``, and ``ref`` if the uniq
         reference of the template (id, t-name or template).
 
-        :param template: template identifier, name or etree
+        :param template: template identifier or etree
         :param options: used to compile the template (the dict available for
             the rendering is frozen)
             ``load`` (function) overrides the load method
         """
+        assert template not in (False, None, ""), "template is required"
+
         # template is an xml etree already
         if isinstance(template, etree._Element):
             element = template
             document = etree.tostring(template, encoding='unicode')
             ref = None
-
         # template is xml as string
-        elif isinstance(template, str) and template.startswith('<'):
-            element = etree.fromstring(template)
-            document = template
-            ref = None
+        elif isinstance(template, str) and '<' in template:
+            raise ValueError('Inline templates must be passed as `etree` documents')
 
         # template is (id or ref) to a database stored template
         else:


### PR DESCRIPTION
During the merge of qweb/ir.qweb at commit 9ce5bc8881ae06b613ef61eb07453b224f62bae6,
the behavior of qweb was preserved instead of the one from ir.qweb.
Rendering inline templates should not be allowed as it is not needed and
include security risks.

Also, minimizing the number of possible types for template arguments
simplifies the API. An error message allows the developer to know how to
adapt his code.
