### PR TITLE
[FIX] sale: Force login if SO contains subscription products

### DIFF
--- a/addons/payment/controllers/portal.py
+++ b/addons/payment/controllers/portal.py
@@ -90,7 +90,9 @@ class PaymentPortal(portal.CustomerPortal):
             partner_sudo = user_sudo.partner_id
         else:
             partner_sudo = request.env['res.partner'].sudo().browse(partner_id).exists()
-            if not partner_sudo:
+            if not partner_sudo or request.env['payment.acquirer'].sudo()._is_tokenization_required(
+                **kwargs  # Force login if partner doesn't exist or if tokenization is required
+            ):
                 return request.redirect(
                     # Escape special characters to avoid loosing original params when redirected
                     f'/web/login?redirect={urllib.parse.quote(request.httprequest.full_path)}'


### PR DESCRIPTION
Fix an issue where a public user can pay a sale order containing a
product attached to a subscription template but that is not linked to
an already existing subscription. In that case, we would need to create
a token and that is impossible for a public user.

task-2791241

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
