### PR TITLE
[FIX] website: remove presentation indent from search highlight loop

### DIFF
--- a/addons/website/views/website_templates.xml
+++ b/addons/website/views/website_templates.xml
@@ -2438,7 +2438,8 @@ Sitemap: <t t-esc="url_root"/>sitemap.xml
 </template>
 
 <template id="search_text_with_highlight" name="Website Searchbox item highlight">
-    <span t-foreach="enumerate(parts)" t-as="part" t-att-class="'text-primary' if part[0] % 2 else None" t-esc="part[1]"/>
+    <!-- Zero-width space in front to prevent presentation indent from happening -->
+    &amp;#8203;<span t-foreach="enumerate(parts)" t-as="part" t-att-class="'text-primary' if part[0] % 2 else None" t-esc="part[1]"/>
 </template>
 
 <template id="index_management">


### PR DESCRIPTION
Since [1] returns are inserted between the blocks of a `t-foreach`, this
makes spaces appear in the rendering of the search results of search
boxes on the website.

After this commit, this is prevented by adding a zero-width space before
the looped block.

Steps to reproduce:
- open any searchable website element: e.g. blog or shop
- type in "o" inside the search box
=> the displayed results surround the highlighted "o" with spaces

[1]: https://github.com/odoo/odoo/commit/8ae4d92a5870e60b9b101b7379f04bba74b31d65

task-2791196

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
