### PR TITLE
[FIX] point_of_sale: Fix traceback for multistep routes in PoS

### DIFF
--- a/addons/point_of_sale/models/stock_picking.py
+++ b/addons/point_of_sale/models/stock_picking.py
@@ -131,7 +131,7 @@ class StockMove(models.Model):
         qty_fname = 'qty_done' if are_qties_done else 'product_uom_qty'
         for move in self:
             if related_order_lines[0].product_id == move.product_id and related_order_lines[0].product_id.tracking != 'none':
-                if self.picking_type_id.use_existing_lots or self.picking_type_id.use_create_lots:
+                if move.picking_type_id.use_existing_lots or move.picking_type_id.use_create_lots:
                     for line in related_order_lines:
                         sum_of_lots = 0
                         for lot in line.pack_lot_ids.filtered(lambda l: l.lot_name):
@@ -140,13 +140,13 @@ class StockMove(models.Model):
                             else:
                                 qty = abs(line.qty)
                             ml_vals = move._prepare_move_line_vals()
-                            if self.picking_type_id.use_existing_lots:
+                            if move.picking_type_id.use_existing_lots:
                                 existing_lot = self.env['stock.production.lot'].search([
                                     ('company_id', '=', self.company_id.id),
                                     ('product_id', '=', line.product_id.id),
                                     ('name', '=', lot.lot_name)
                                 ])
-                                if not existing_lot and self.picking_type_id.use_create_lots:
+                                if not existing_lot and move.picking_type_id.use_create_lots:
                                     existing_lot = self.env['stock.production.lot'].create({
                                         'company_id': self.company_id.id,
                                         'product_id': line.product_id.id,


### PR DESCRIPTION
Current behavior:
When you have multistep routes activated for a warehouse and SN/Lots activated
you have a traceback when trying to validate an order in the Point of sale

Steps to reproduce:
- In the Inventory App, set a 2 or 3-Step Delivery for a warehouse.
- Set a product to be tracked by Lots or Serial Number.
- Activate "Ship Later" in a POS shop.
- Set the 2 or 3-Step Delivery route in the "Ship Later" section.
- Open POS Shop.
- Select product that has a Lot/SN.
- Set any Customer.
- Set any payment method.
- Select "Ship Later".
- Validate Order.
- A traceback appears

opw-2779462

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
