### PR TITLE
[FIX] web_editor: use valid properties for hovered custom outline button

### DIFF
--- a/addons/web_editor/static/src/scss/web_editor.common.scss
+++ b/addons/web_editor/static/src/scss/web_editor.common.scss
@@ -788,15 +788,11 @@ blockquote {
 .btn-custom:hover, .btn-fill-custom:hover {
     filter: invert(0.2);
 }
-.btn-outline-custom {
-    &:not(:hover) {
-        background-color: transparent !important;
-        background-image: none !important;
-    }
-    &:hover {
-        background-color: '';
-        background-image: '';
-    }
+.btn-outline-custom:not(:hover) {
+    // Custom buttons have their fill color or gradient specified in their
+    // element style. They must only be shown on hover for outline buttons.
+    background-color: transparent !important;
+    background-image: none !important;
 }
 
 // Base snippet rules


### PR DESCRIPTION
Since [1] the CSS property reset for hovered outline buttons is using
invalid property values.

After this commit the color and image are only reset on non-hover:
- the `background-color` is already set to `none` by `.btn`,
- the `background-image` is only set if defined on the button's style -
there is no need to reset it.

[1]: https://github.com/odoo/odoo/commit/a010c91b5ee119cf54ed1a68a6ea06b2bc5f3978

task-2633169

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
