### PR TITLE
14.0 FIX https://github.com/odoo/odoo/issues/86216

### DIFF
--- a/doc/cla/individual/shurshilov.md
+++ b/doc/cla/individual/shurshilov.md
@@ -1,0 +1,11 @@
+Russia, 2022-03-11
+
+I hereby agree to the terms of the Odoo Individual Contributor License
+Agreement v1.0.
+
+I declare that I am authorized and able to make this agreement and sign this
+declaration.
+
+Signed,
+
+Artem Shurshilov shurshilov.a@yandex.ru https://github.com/shurshilov

--- a/odoo/addons/base/models/ir_actions_report.py
+++ b/odoo/addons/base/models/ir_actions_report.py
@@ -590,7 +590,7 @@ class IrActionsReport(models.Model):
             time=time,
             context_timestamp=lambda t: fields.Datetime.context_timestamp(self.with_context(tz=user.tz), t),
             user=user,
-            res_company=user.company_id,
+            res_company=self.env.company,
             website=website,
             web_base_url=self.env['ir.config_parameter'].sudo().get_param('web.base.url', default=''),
         )


### PR DESCRIPTION
Description of the issue/feature this PR addresses:

Current behavior before PR:
when printed any qweb template res_company always default from user.

Desired behavior after PR is merged:

when printed any qweb template res_company always take current (active) user


--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
