### PR TITLE
[FIX] payment: force CardExpiry year to 2 digits

### DIFF
--- a/addons/payment/static/lib/jquery.payment/jquery.payment.js
+++ b/addons/payment/static/lib/jquery.payment/jquery.payment.js
@@ -637,6 +637,9 @@
     year = parts[3] || '';
     if (year.length > 0) {
       sep = ' / ';
+      // Force year to 2 digits
+      if (year.length === 4 )
+        year = year.substr(-2);
     } else if (sep === ' /') {
       mon = mon.substring(0, 1);
       sep = '';


### PR DESCRIPTION
Description of the issue/feature this PR addresses:

In odoo payment the cc_expiry.maxlength is limited to 7 characters

https://github.com/odoo/odoo/blob/75785db4c8d0c0be9fb7b8dfc2cd7b8209181c21/addons/payment_test/views/payment_test_templates.xml#L19 https://github.com/odoo/odoo/blob/75785db4c8d0c0be9fb7b8dfc2cd7b8209181c21/addons/payment_ingenico/views/payment_ingenico_templates.xml#L54

Current behavior before PR:

But your [$.payment.formatExpiry](https://github.com/odoo/odoo/blob/14.0/addons/payment/static/lib/jquery.payment/jquery.payment.js#L629) can return 9 characters
![Screenshot(20)](https://user-images.githubusercontent.com/35231827/157748056-c4fa8e4a-1504-41a9-afbc-99743e5491fe.png)

We can see in when the user use autofill

https://user-images.githubusercontent.com/35231827/158241834-6ac71745-140f-4a4b-9b13-72a3f9733ecf.mov

Desired behavior after PR is merged:

https://user-images.githubusercontent.com/35231827/158241806-912c044e-0446-48a1-9e04-4e2a26ab4adc.mov

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
