### PR TITLE
[I18N] mail: add missing func _ for messages

### DIFF
--- a/addons/mail/i18n/mail.pot
+++ b/addons/mail/i18n/mail.pot
@@ -795,6 +795,13 @@ msgid ""
 msgstr ""
 
 #. module: mail
+#: code:addons/mail/models/mail_blacklist.py:0
+#: code:addons/mail/models/mail_thread_blacklist.py:0
+#, python-format
+msgid "Are you sure you want to unblacklist this Email Address?"
+msgstr ""
+
+#. module: mail
 #. openerp-web
 #: code:addons/mail/static/src/components/activity/activity.xml:0
 #: code:addons/mail/static/src/xml/activity.xml:0
@@ -6623,6 +6630,14 @@ msgstr ""
 msgid ""
 "You cannot use anything else than unaccented latin characters in the alias "
 "address."
+msgstr ""
+
+#. module: mail
+#: code:addons/mail/models/mail_thread_blacklist.py:0
+#, python-format
+msgid ""
+"You do not have the access right to unblacklist emails. Please contact your "
+"administrator."
 msgstr ""
 
 #. module: mail

--- a/addons/mail/models/mail_blacklist.py
+++ b/addons/mail/models/mail_blacklist.py
@@ -96,7 +96,7 @@ class MailBlackList(models.Model):
 
     def mail_action_blacklist_remove(self):
         return {
-            'name': 'Are you sure you want to unblacklist this Email Address?',
+            'name': _('Are you sure you want to unblacklist this Email Address?'),
             'type': 'ir.actions.act_window',
             'view_mode': 'form',
             'res_model': 'mail.blacklist.remove',

--- a/addons/mail/models/mail_thread_blacklist.py
+++ b/addons/mail/models/mail_thread_blacklist.py
@@ -116,11 +116,11 @@ class MailBlackListMixin(models.AbstractModel):
         can_access = self.env['mail.blacklist'].check_access_rights('write', raise_exception=False)
         if can_access:
             return {
-                'name': 'Are you sure you want to unblacklist this Email Address?',
+                'name': _('Are you sure you want to unblacklist this Email Address?'),
                 'type': 'ir.actions.act_window',
                 'view_mode': 'form',
                 'res_model': 'mail.blacklist.remove',
                 'target': 'new',
             }
         else:
-            raise AccessError("You do not have the access right to unblacklist emails. Please contact your administrator.")
+            raise AccessError(_("You do not have the access right to unblacklist emails. Please contact your administrator."))


### PR DESCRIPTION
Some messages came without translation function `_()`. This PR adds `_()` for those and update the `mail.pot` to reflect the changes




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
