### PR TITLE
[FIX] hr_holidays: review allocation and time off validation error me…

### DIFF
--- a/addons/hr_holidays/models/hr_leave_allocation.py
+++ b/addons/hr_holidays/models/hr_leave_allocation.py
@@ -591,6 +591,13 @@ class HolidaysAllocation(models.Model):
     # Business methods
     ####################################################
 
+    def _get_request_unit_remaining_days(self):
+        self.ensure_one()
+        leave_units = 'number_of_days' if self.type_request_unit == 'day' else 'number_of_hours_display'
+        number_of_leave_days_hours = sum(self.taken_leave_ids.filtered(lambda leave: leave.state not in ['cancel', 'refuse']).mapped(leave_units))
+        remaining_allocation_days_hours = self.max_leaves - number_of_leave_days_hours
+        return remaining_allocation_days_hours, leave_units
+
     def _prepare_holiday_values(self, employees):
         self.ensure_one()
         return [{

--- a/addons/hr_holidays/static/src/js/form/allocation_leave_form.js
+++ b/addons/hr_holidays/static/src/js/form/allocation_leave_form.js
@@ -15,8 +15,12 @@ export const AllocationLeaveFormController = FormController.extend({
         if (formData.holiday_status_id) {
             let nameSearchContext = {'holiday_status_name_get': false};
             const employee_id = formData.employee_id;
-            if (employee_id) {
+            const date_from = formData.date_from;
+            const date_to = formData.date_to;
+            if (employee_id && date_from) {
                 nameSearchContext = {'holiday_status_name_get': true, 'employee_id': employee_id.data.id};
+                nameSearchContext.default_date_from = date_from;
+                nameSearchContext.default_date_to = date_to;
             }
             const nameSearch = await this._rpc({
                 model: 'hr.leave.type',
@@ -25,12 +29,13 @@ export const AllocationLeaveFormController = FormController.extend({
                 context: nameSearchContext,
                 limit: 1
             });
-            if (this.$el.find("div[name='holiday_status_id']").find('input')[0]) {
-                this.$el.find("div[name='holiday_status_id']").find('input')[0].value = nameSearch[0][1];
+            const holiday_input = this.$el.find("div[name='holiday_status_id']").find('input')[0];
+            if (holiday_input) {
+                holiday_input.value = nameSearch[0][1];
             }
         }
         return result;
-    }
+    },
 
 });
 

--- a/addons/hr_holidays/tests/test_automatic_leave_dates.py
+++ b/addons/hr_holidays/tests/test_automatic_leave_dates.py
@@ -29,9 +29,9 @@ class TestAutomaticLeaveDates(TestHrHolidaysCommon):
         employee.resource_calendar_id = calendar
 
         with Form(self.env['hr.leave'].with_context(default_employee_id=employee.id)) as leave_form:
-            leave_form.holiday_status_id = self.leave_type
             leave_form.request_date_from = date(2019, 9, 2)
             leave_form.request_date_to = date(2019, 9, 2)
+            leave_form.holiday_status_id = self.leave_type
             leave_form.request_unit_half = True
             leave_form.request_date_from_period = 'am'
 
@@ -62,9 +62,9 @@ class TestAutomaticLeaveDates(TestHrHolidaysCommon):
         employee.resource_calendar_id = calendar
 
         with Form(self.env['hr.leave'].with_context(default_employee_id=employee.id)) as leave_form:
-            leave_form.holiday_status_id = self.leave_type
             leave_form.request_date_from = date(2019, 9, 2)
             leave_form.request_date_to = date(2019, 9, 2)
+            leave_form.holiday_status_id = self.leave_type
             leave_form.request_unit_half = True
             leave_form.request_date_from_period = 'am'
 
@@ -106,9 +106,9 @@ class TestAutomaticLeaveDates(TestHrHolidaysCommon):
         employee.resource_calendar_id = calendar
 
         with Form(self.env['hr.leave'].with_context(default_employee_id=employee.id)) as leave_form:
-            leave_form.holiday_status_id = self.leave_type
             leave_form.request_date_from = date(2019, 9, 2)
             leave_form.request_date_to = date(2019, 9, 2)
+            leave_form.holiday_status_id = self.leave_type
             leave_form.request_unit_half = True
             leave_form.request_date_from_period = 'am'
 
@@ -135,9 +135,9 @@ class TestAutomaticLeaveDates(TestHrHolidaysCommon):
         employee = self.employee_emp
         employee.resource_calendar_id = calendar
         with Form(self.env['hr.leave'].with_context(default_employee_id=employee.id)) as leave_form:
-            leave_form.holiday_status_id = self.leave_type
             leave_form.request_date_from = date(2019, 9, 2)
             leave_form.request_date_to = date(2019, 9, 2)
+            leave_form.holiday_status_id = self.leave_type
             leave_form.request_unit_half = True
             # Ask for morning
             leave_form.request_date_from_period = 'am'
@@ -168,10 +168,10 @@ class TestAutomaticLeaveDates(TestHrHolidaysCommon):
         employee.resource_calendar_id = calendar
 
         with Form(self.env['hr.leave'].with_context(default_employee_id=employee.id)) as leave_form:
-            leave_form.holiday_status_id = self.leave_type
             # does not work on mondays
             leave_form.request_date_from = date(2019, 9, 2)
             leave_form.request_date_to = date(2019, 9, 2)
+            leave_form.holiday_status_id = self.leave_type
             leave_form.request_unit_half = True
             leave_form.request_date_from_period = 'am'
 
@@ -198,10 +198,10 @@ class TestAutomaticLeaveDates(TestHrHolidaysCommon):
         employee.resource_calendar_id = calendar
 
         with Form(self.env['hr.leave'].with_context(default_employee_id=employee.id)) as leave_form:
-            leave_form.holiday_status_id = self.leave_type
             # does not work on tuesdays
             leave_form.request_date_from = date(2019, 9, 3)
             leave_form.request_date_to = date(2019, 9, 3)
+            leave_form.holiday_status_id = self.leave_type
             leave_form.request_unit_half = True
             leave_form.request_date_from_period = 'am'
 
@@ -238,10 +238,10 @@ class TestAutomaticLeaveDates(TestHrHolidaysCommon):
         employee.resource_calendar_id = calendar
 
         with Form(self.env['hr.leave'].with_context(default_employee_id=employee.id)) as leave_form:
-            leave_form.holiday_status_id = self.leave_type
             # even week, works 2 hours
             leave_form.request_date_from = date(2019, 9, 2)
             leave_form.request_date_to = date(2019, 9, 2)
+            leave_form.holiday_status_id = self.leave_type
             leave_form.request_unit_half = True
             leave_form.request_date_from_period = 'am'
 
@@ -251,10 +251,10 @@ class TestAutomaticLeaveDates(TestHrHolidaysCommon):
             self.assertEqual(leave_form.date_to, datetime(2019, 9, 2, 10, 0, 0))
 
         with Form(self.env['hr.leave'].with_context(default_employee_id=employee.id)) as leave_form:
-            leave_form.holiday_status_id = self.leave_type
             # odd week, works 4 hours
             leave_form.request_date_from = date(2019, 9, 9)
             leave_form.request_date_to = date(2019, 9, 9)
+            leave_form.holiday_status_id = self.leave_type
             leave_form.request_unit_half = True
             leave_form.request_date_from_period = 'am'
 
@@ -282,10 +282,10 @@ class TestAutomaticLeaveDates(TestHrHolidaysCommon):
         employee.resource_calendar_id = calendar
 
         with Form(self.env['hr.leave'].with_context(default_employee_id=employee.id)) as leave_form:
-            leave_form.holiday_status_id = self.leave_type
             # even week, does not work
             leave_form.request_date_from = date(2019, 9, 2)
             leave_form.request_date_to = date(2019, 9, 2)
+            leave_form.holiday_status_id = self.leave_type
             leave_form.request_unit_half = True
             leave_form.request_date_from_period = 'am'
 

--- a/addons/hr_holidays/views/hr_leave_views.xml
+++ b/addons/hr_holidays/views/hr_leave_views.xml
@@ -263,7 +263,8 @@
                             <field name="employee_ids" invisible="1"/>
                         </div>
                         <group name="col_left">
-                            <field name="holiday_status_id" force_save="1" domain="['|', ('requires_allocation', '=', 'no'), '&amp;', ('has_valid_allocation', '=', True), '&amp;', ('virtual_remaining_leaves', '&gt;', 0), ('max_leaves', '>', '0')]" context="{'employee_id':employee_id, 'default_date_from':date_from}" options="{'no_create': True, 'no_open': True, 'request_type':'leave'}" class="w-100"/>
+                            <field name="holiday_status_id" force_save="1" domain="['|', ('requires_allocation', '=', 'no'), '&amp;', ('has_valid_allocation', '=', True), '&amp;', ('virtual_remaining_leaves', '&gt;', 0), ('max_leaves', '>', '0')]"
+                             context="{'employee_id':employee_id, 'default_date_from':date_from, 'default_date_to':date_to}" options="{'no_create': True, 'no_open': True, 'request_type':'leave'}" class="w-100"/>
                             <label for="request_date_from" string="Dates" id="label_dates"/>
                             <div>
                                 <field name="date_from" invisible="1" widget="daterange"/>
@@ -460,7 +461,8 @@
             <field name="holiday_status_id" position="replace"/>
             <div name="title" position="inside">
                 <h1 class="d-flex flex-row align-items-end justify-content-between o_hr_leave_title">
-                    <field name="holiday_status_id" options="{'no_open': True}" context="{'request_type':'leave', 'from_manager_leave_form': True ,'employee_id': employee_id}"/>
+                    <field name="holiday_status_id" options="{'no_open': True}" context="{'request_type':'leave', 'from_manager_leave_form': True ,'employee_id': employee_id, 'default_date_from':date_from, 'default_date_to':date_to}"
+                     domain="['|', ('requires_allocation', '=', 'no'), '&amp;', ('has_valid_allocation', '=', True), '&amp;', ('virtual_remaining_leaves', '&gt;', 0), ('max_leaves', '>', '0')]" />
                 </h1>
             </div>
             <field name="employee_id" position="replace"/>

--- a/addons/hr_work_entry_holidays/tests/test_performance.py
+++ b/addons/hr_work_entry_holidays/tests/test_performance.py
@@ -40,14 +40,14 @@ class TestWorkEntryHolidaysPerformance(TestWorkEntryHolidaysBase):
     def test_performance_leave_write(self):
         leave = self.create_leave(datetime(2018, 1, 1, 7, 0), datetime(2018, 1, 1, 18, 0))
 
-        with self.assertQueryCount(__system__=18, admin=18):
+        with self.assertQueryCount(__system__=19, admin=19):
             leave.date_to = datetime(2018, 1, 1, 19, 0)
         leave.action_refuse()
 
     @users('__system__', 'admin')
     @warmup
     def test_performance_leave_create(self):
-        with self.assertQueryCount(__system__=26, admin=27):  # 25/26 com
+        with self.assertQueryCount(__system__=28, admin=29):
             leave = self.create_leave(datetime(2018, 1, 1, 7, 0), datetime(2018, 1, 1, 18, 0))
         leave.action_refuse()
 


### PR DESCRIPTION
…ssages

- Do not allow selecting an allocated time off if the employee has no allocation in the selected period
- Display the available allocatiosn and dates in the validation error text if a time off is selected outside the allocation windows

If there is an allocation from Aug 1st to Aug 31st:
    - If a time off is taken between the 1st and 31st of August: ok
    - If a time off longer than the allocated days is taken between the 1st and 31st of August: Validation error message, missing allocated days
    - If a time off is taken before or after the 31st of August: impossible, the time off should not appear in the list
    - If there is a time off between 25/07 and 03/08: the allocated time off is displayed because of the month of August but it can't be validated

- Review the number of allocated days: it displays "0 days remaining out of 0 days" when there is an allocation

task-2667441

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
