### PR TITLE
[FIX] cli: use V15 url for manifest

### DIFF
--- a/odoo/cli/templates/default/__manifest__.py.template
+++ b/odoo/cli/templates/default/__manifest__.py.template
@@ -14,7 +14,7 @@
     'website': "http://www.yourcompany.com",
 
     # Categories can be used to filter modules in modules listing
-    # Check https://github.com/odoo/odoo/blob/14.0/odoo/addons/base/data/ir_module_category_data.xml
+    # Check https://github.com/odoo/odoo/blob/15.0/odoo/addons/base/data/ir_module_category_data.xml
     # for the full list
     'category': 'Uncategorized',
     'version': '0.1',


### PR DESCRIPTION
Description of the issue/feature this PR addresses: Correct version link

Current behavior before PR: The link in the manifest is wrong

Desired behavior after PR is merged: The link in the manifest is correct




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
