### PR TITLE
[FIX] sale_management: send confirmation email access error

### DIFF
--- a/addons/sale_management/models/sale_order.py
+++ b/addons/sale_management/models/sale_order.py
@@ -3,7 +3,7 @@
 
 from datetime import timedelta
 
-from odoo import api, fields, models, _
+from odoo import api, fields, models, SUPERUSER_ID, _
 from odoo.exceptions import UserError, ValidationError
 
 
@@ -150,6 +150,9 @@ class SaleOrder(models.Model):
 
     def action_confirm(self):
         res = super(SaleOrder, self).action_confirm()
+        if self.env.su:
+            self = self.with_user(SUPERUSER_ID)
+
         for order in self:
             if order.sale_order_template_id and order.sale_order_template_id.mail_template_id:
                 self.sale_order_template_id.mail_template_id.send_mail(order.id)


### PR DESCRIPTION
Before this commit:
If the Quotation Template is enabled on the sale setting and
it contains a confirmation email, the public user on the website
would get a traceback when trying to complete an order.

How to reproduce the error?

1. Set a payment acquirer
2. Enable the quotation template in the sale setting
3. Set the "Sales Order: Send by email" as the confirmation mail
4. Complete an order on the website as the public user

With these steps you will get a traceback at the end.

opw-2783094


--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
