### PR TITLE
[REF] models: refactor fields_view_get, load_views

### DIFF
--- a/addons/account/models/__init__.py
+++ b/addons/account/models/__init__.py
@@ -30,6 +30,7 @@ from . import account_incoterms
 from . import digest
 from . import res_users
 from . import ir_actions_report
+from . import ir_ui_view
 from . import res_currency
 from . import res_bank
 from . import mail_thread

--- a/addons/account/models/ir_ui_view.py
+++ b/addons/account/models/ir_ui_view.py
@@ -1,0 +1,11 @@
+# -*- coding: utf-8 -*-
+from odoo import models
+
+
+class IrUiView(models.Model):
+    _inherit = 'ir.ui.view'
+
+    def _postprocess_prepare_2many_inline_view_widgets(self):
+        widgets = super()._postprocess_prepare_2many_inline_view_widgets()
+        widgets.extend(['section_and_note_one2many'])
+        return widgets

--- a/addons/board/controllers/main.py
+++ b/addons/board/controllers/main.py
@@ -16,9 +16,9 @@ class Board(Controller):
         if action and action['res_model'] == 'board.board' and action['views'][0][1] == 'form' and action_id:
             # Maybe should check the content instead of model board.board ?
             view_id = action['views'][0][0]
-            board = request.env['board.board'].fields_view_get(view_id, 'form')
-            if board and 'arch' in board:
-                xml = ElementTree.fromstring(board['arch'])
+            board_arch = request.env['board.board'].view_get(view_id, 'form')
+            if board_arch:
+                xml = ElementTree.fromstring(board_arch)
                 column = xml.find('./board/column')
                 if column is not None:
                     new_action = ElementTree.Element('action', {

--- a/addons/board/controllers/main.py
+++ b/addons/board/controllers/main.py
@@ -16,10 +16,9 @@ class Board(Controller):
         if action and action['res_model'] == 'board.board' and action['views'][0][1] == 'form' and action_id:
             # Maybe should check the content instead of model board.board ?
             view_id = action['views'][0][0]
-            board_arch = request.env['board.board'].view_get(view_id, 'form')
+            board_arch, _view = request.env['board.board']._view_get(view_id, 'form')
             if board_arch:
-                xml = ElementTree.fromstring(board_arch)
-                column = xml.find('./board/column')
+                column = board_arch.find('./board/column')
                 if column is not None:
                     new_action = ElementTree.Element('action', {
                         'name': str(action_id),
@@ -29,7 +28,7 @@ class Board(Controller):
                         'domain': str(domain)
                     })
                     column.insert(0, new_action)
-                    arch = ElementTree.tostring(xml, encoding='unicode')
+                    arch = ElementTree.tostring(board_arch, encoding='unicode')
                     request.env['ir.ui.view.custom'].create({
                         'user_id': request.session.uid,
                         'ref_id': view_id,

--- a/addons/board/models/board.py
+++ b/addons/board/models/board.py
@@ -20,13 +20,13 @@ class Board(models.AbstractModel):
         return self
 
     @api.model
-    def fields_view_get(self, view_id=None, view_type='form', toolbar=False, submenu=False):
+    def view_get(self, view_id=None, view_type='form', **options):
         """
         Overrides orm field_view_get.
         @return: Dictionary of Fields, arch and toolbar.
         """
 
-        res = super(Board, self).fields_view_get(view_id=view_id, view_type=view_type, toolbar=toolbar, submenu=submenu)
+        res = super(Board, self).view_get(view_id=view_id, view_type=view_type, **options)
 
         custom_view = self.env['ir.ui.view.custom'].search([('user_id', '=', self.env.uid), ('ref_id', '=', view_id)], limit=1)
         if custom_view:

--- a/addons/crm/models/crm_lead.py
+++ b/addons/crm/models/crm_lead.py
@@ -862,16 +862,16 @@ class Lead(models.Model):
         return super(Lead, self.with_context(context)).copy(default=default)
 
     @api.model
-    def _fields_view_get(self, view_id=None, view_type='form', toolbar=False, submenu=False):
+    def _view_get(self, view_id=None, view_type='form', **options):
         if self._context.get('opportunity_id'):
             opportunity = self.browse(self._context['opportunity_id'])
             action = opportunity.get_formview_action()
             if action.get('views') and any(view_id for view_id in action['views'] if view_id[1] == view_type):
                 view_id = next(view_id[0] for view_id in action['views'] if view_id[1] == view_type)
-        res = super(Lead, self)._fields_view_get(view_id=view_id, view_type=view_type, toolbar=toolbar, submenu=submenu)
+        arch, view = super(Lead, self)._view_get(view_id=view_id, view_type=view_type, **options)
         if view_type == 'form':
-            res['arch'] = self._fields_view_get_address(res['arch'])
-        return res
+            arch = self._view_get_address(arch)
+        return arch, view
 
     @api.model
     def _read_group_stage_ids(self, stages, domain, order):

--- a/addons/google_spreadsheet/models/google_drive.py
+++ b/addons/google_spreadsheet/models/google_drive.py
@@ -26,8 +26,8 @@ class GoogleDrive(models.Model):
     def write_config_formula(self, attachment_id, spreadsheet_key, model, domain, groupbys, view_id):
         access_token = self.get_access_token(scope='https://www.googleapis.com/auth/spreadsheets')
 
-        fields = self.env[model].fields_view_get(view_id=view_id, view_type='tree')
-        doc = etree.XML(fields.get('arch'))
+        arch = self.env[model]._view_get(view_id=view_id, view_type='tree')[0]
+        doc = arch
         display_fields = []
         for node in doc.xpath("//field"):
             if node.get('modifiers'):

--- a/addons/hr/models/hr_employee.py
+++ b/addons/hr/models/hr_employee.py
@@ -217,10 +217,10 @@ class HrEmployeePrivate(models.Model):
         return self.env['hr.employee.public'].browse(self.ids).read(fields, load=load)
 
     @api.model
-    def load_views(self, views, options=None):
+    def view_get(self, view_id=None, view_type='form', **options):
         if self.check_access_rights('read', raise_exception=False):
-            return super(HrEmployeePrivate, self).load_views(views, options=options)
-        return self.env['hr.employee.public'].load_views(views, options=options)
+            return super(HrEmployeePrivate, self).view_get(view_id=view_id, view_type=view_type, **options)
+        return self.env['hr.employee.public'].view_get(view_id=view_id, view_type=view_type, **options)
 
     @api.model
     def _search(self, args, offset=0, limit=None, order=None, count=False, access_rights_uid=None):

--- a/addons/hr/models/res_users.py
+++ b/addons/hr/models/res_users.py
@@ -168,7 +168,7 @@ class User(models.Model):
         return super().SELF_WRITEABLE_FIELDS + HR_WRITABLE_FIELDS
 
     @api.model
-    def fields_view_get(self, view_id=None, view_type='form', toolbar=False, submenu=False):
+    def view_get(self, view_id=None, view_type='form', **options):
         # When the front-end loads the views it gets the list of available fields
         # for the user (according to its access rights). Later, when the front-end wants to
         # populate the view with data, it only asks to read those available fields.
@@ -181,11 +181,11 @@ class User(models.Model):
         original_user = self.env.user
         if profile_view and view_id == profile_view.id:
             self = self.with_user(SUPERUSER_ID)
-        result = super(User, self).fields_view_get(view_id=view_id, view_type=view_type, toolbar=toolbar, submenu=submenu)
+        result = super(User, self).view_get(view_id=view_id, view_type=view_type, **options)
         # Due to using the SUPERUSER the result will contain action that the user may not have access too
         # here we filter out actions that requires special implicit rights to avoid having unusable actions
         # in the dropdown menu.
-        if toolbar and self.env.user != original_user:
+        if options.get('toolbar') and self.env.user != original_user:
             self = self.with_user(original_user.id)
             if not self.user_has_groups("base.group_erp_manager"):
                 change_password_action = self.env.ref("base.change_password_wizard_action")

--- a/addons/hr_recruitment/models/hr_recruitment.py
+++ b/addons/hr_recruitment/models/hr_recruitment.py
@@ -416,10 +416,10 @@ class Applicant(models.Model):
         return nocontent_body % nocontent_values
 
     @api.model
-    def fields_view_get(self, view_id=None, view_type='form', toolbar=False, submenu=False):
+    def view_get(self, view_id=None, view_type='form', **options):
         if view_type == 'form' and self.user_has_groups('hr_recruitment.group_hr_recruitment_interviewer'):
             view_id = self.env.ref('hr_recruitment.hr_applicant_view_form_interviewer').id
-        return super().fields_view_get(view_id, view_type, toolbar, submenu)
+        return super().view_get(view_id, view_type, **options)
 
     def _notify_compute_recipients(self, message, msg_vals):
         """

--- a/addons/hr_timesheet/models/project.py
+++ b/addons/hr_timesheet/models/project.py
@@ -386,16 +386,16 @@ class Task(models.Model):
         return super().name_get()
 
     @api.model
-    def _fields_view_get(self, view_id=None, view_type='form', toolbar=False, submenu=False):
+    def _view_get(self, view_id=None, view_type='form', **options):
         """ Set the correct label for `unit_amount`, depending on company UoM """
-        result = super(Task, self)._fields_view_get(view_id=view_id, view_type=view_type, toolbar=toolbar, submenu=submenu)
+        arch, view = super(Task, self)._view_get(view_id=view_id, view_type=view_type, **options)
         # Use of sudo as the portal user doesn't have access to uom
-        result['arch'] = self.env['account.analytic.line'].sudo()._apply_timesheet_label(result['arch'])
+        arch = self.env['account.analytic.line'].sudo()._apply_timesheet_label(arch)
 
         if view_type in ['tree', 'pivot', 'graph'] and self.env.company.timesheet_encode_uom_id == self.env.ref('uom.product_uom_day'):
-            result['arch'] = self.env['account.analytic.line']._apply_time_label(result['arch'], related_model=self._name)
+            arch = self.env['account.analytic.line']._apply_time_label(arch, related_model=self._name)
 
-        return result
+        return arch, view
 
     @api.ondelete(at_uninstall=False)
     def _unlink_except_contains_entries(self):

--- a/addons/hr_timesheet/report/project_report.py
+++ b/addons/hr_timesheet/report/project_report.py
@@ -33,8 +33,8 @@ class ReportProjectTaskUser(models.Model):
         return super(ReportProjectTaskUser, self)._group_by() + group_by_append
 
     @api.model
-    def _fields_view_get(self, view_id=None, view_type='form', toolbar=False, submenu=False):
-        result = super(ReportProjectTaskUser, self)._fields_view_get(view_id=view_id, view_type=view_type, toolbar=toolbar, submenu=submenu)
+    def _view_get(self, view_id=None, view_type='form', **options):
+        arch, view = super(ReportProjectTaskUser, self)._view_get(view_id=view_id, view_type=view_type, **options)
         if view_type in ['pivot', 'graph'] and self.env.company.timesheet_encode_uom_id == self.env.ref('uom.product_uom_day'):
-            result['arch'] = self.env['account.analytic.line']._apply_time_label(result['arch'], related_model=self._name)
-        return result
+            arch = self.env['account.analytic.line']._apply_time_label(arch, related_model=self._name)
+        return arch, view

--- a/addons/membership/models/product.py
+++ b/addons/membership/models/product.py
@@ -18,10 +18,10 @@ class Product(models.Model):
     ]
 
     @api.model
-    def fields_view_get(self, view_id=None, view_type='form', toolbar=False, submenu=False):
+    def view_get(self, view_id=None, view_type='form', **options):
         if self._context.get('product') == 'membership_product':
             if view_type == 'form':
                 view_id = self.env.ref('membership.membership_products_form').id
             else:
                 view_id = self.env.ref('membership.membership_products_tree').id
-        return super(Product, self).fields_view_get(view_id=view_id, view_type=view_type, toolbar=toolbar, submenu=submenu)
+        return super(Product, self).view_get(view_id=view_id, view_type=view_type, **options)

--- a/addons/project/models/__init__.py
+++ b/addons/project/models/__init__.py
@@ -15,3 +15,4 @@ from . import res_config_settings
 from . import res_partner
 from . import digest
 from . import ir_ui_menu
+from . import ir_ui_view

--- a/addons/project/models/ir_ui_view.py
+++ b/addons/project/models/ir_ui_view.py
@@ -1,0 +1,11 @@
+# -*- coding: utf-8 -*-
+from odoo import models
+
+
+class IrUiView(models.Model):
+    _inherit = 'ir.ui.view'
+
+    def _postprocess_prepare_2many_inline_view_widgets(self):
+        widgets = super()._postprocess_prepare_2many_inline_view_widgets()
+        widgets.extend(['subtasks_one2many'])
+        return widgets

--- a/addons/project/tests/test_project_sharing_portal_access.py
+++ b/addons/project/tests/test_project_sharing_portal_access.py
@@ -2,6 +2,7 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 from collections import OrderedDict
+from lxml import etree
 from odoo import Command
 from odoo.exceptions import AccessError
 from odoo.tests import tagged
@@ -49,10 +50,11 @@ class TestProjectSharingPortalAccess(TestProjectSharingCommon):
 
     def test_readonly_fields(self):
         """ The fields are not writeable should not be editable by the portal user. """
-        view_infos = self.task_portal.fields_view_get(view_id=self.env.ref(self.project_sharing_form_view_xml_id).id)
+        view_infos = self.task_portal.view_get(view_id=self.env.ref(self.project_sharing_form_view_xml_id).id)
+        fields = [el.get('name') for el in etree.fromstring(view_infos['arch']).xpath('//field[not(ancestor::field)]')]
         project_task_fields = {
             field_name
-            for field_name, field_attrs in view_infos['fields'].items()
+            for field_name in fields
             if field_name not in self.write_protected_fields_task
         }
         with self.get_project_sharing_form_view(self.task_portal, self.user_portal) as form:

--- a/addons/resource/models/__init__.py
+++ b/addons/resource/models/__init__.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
+from . import ir_ui_view
 from . import resource
 from . import resource_mixin
 from . import res_company

--- a/addons/resource/models/ir_ui_view.py
+++ b/addons/resource/models/ir_ui_view.py
@@ -1,0 +1,11 @@
+# -*- coding: utf-8 -*-
+from odoo import models
+
+
+class IrUiView(models.Model):
+    _inherit = 'ir.ui.view'
+
+    def _postprocess_prepare_2many_inline_view_widgets(self):
+        widgets = super()._postprocess_prepare_2many_inline_view_widgets()
+        widgets.extend(['section_one2many'])
+        return widgets

--- a/addons/stock/models/product.py
+++ b/addons/stock/models/product.py
@@ -432,35 +432,33 @@ class Product(models.Model):
         return res
 
     @api.model
-    def fields_view_get(self, view_id=None, view_type='form', toolbar=False, submenu=False):
-        res = super(Product, self).fields_view_get(view_id=view_id, view_type=view_type, toolbar=toolbar, submenu=submenu)
+    def fields_get(self, allfields=None, attributes=None):
+        res = super(Product, self).fields_get(allfields=allfields, attributes=attributes)
         if self._context.get('location') and isinstance(self._context['location'], int):
             location = self.env['stock.location'].browse(self._context['location'])
-            fields = res.get('fields')
-            if fields:
-                if location.usage == 'supplier':
-                    if fields.get('virtual_available'):
-                        res['fields']['virtual_available']['string'] = _('Future Receipts')
-                    if fields.get('qty_available'):
-                        res['fields']['qty_available']['string'] = _('Received Qty')
-                elif location.usage == 'internal':
-                    if fields.get('virtual_available'):
-                        res['fields']['virtual_available']['string'] = _('Forecasted Quantity')
-                elif location.usage == 'customer':
-                    if fields.get('virtual_available'):
-                        res['fields']['virtual_available']['string'] = _('Future Deliveries')
-                    if fields.get('qty_available'):
-                        res['fields']['qty_available']['string'] = _('Delivered Qty')
-                elif location.usage == 'inventory':
-                    if fields.get('virtual_available'):
-                        res['fields']['virtual_available']['string'] = _('Future P&L')
-                    if fields.get('qty_available'):
-                        res['fields']['qty_available']['string'] = _('P&L Qty')
-                elif location.usage == 'production':
-                    if fields.get('virtual_available'):
-                        res['fields']['virtual_available']['string'] = _('Future Productions')
-                    if fields.get('qty_available'):
-                        res['fields']['qty_available']['string'] = _('Produced Qty')
+            if location.usage == 'supplier':
+                if fields.get('virtual_available'):
+                    res['virtual_available']['string'] = _('Future Receipts')
+                if fields.get('qty_available'):
+                    res['qty_available']['string'] = _('Received Qty')
+            elif location.usage == 'internal':
+                if fields.get('virtual_available'):
+                    res['virtual_available']['string'] = _('Forecasted Quantity')
+            elif location.usage == 'customer':
+                if fields.get('virtual_available'):
+                    res['virtual_available']['string'] = _('Future Deliveries')
+                if fields.get('qty_available'):
+                    res['qty_available']['string'] = _('Delivered Qty')
+            elif location.usage == 'inventory':
+                if fields.get('virtual_available'):
+                    res['virtual_available']['string'] = _('Future P&L')
+                if fields.get('qty_available'):
+                    res['qty_available']['string'] = _('P&L Qty')
+            elif location.usage == 'production':
+                if fields.get('virtual_available'):
+                    res['virtual_available']['string'] = _('Future Productions')
+                if fields.get('qty_available'):
+                    res['qty_available']['string'] = _('Produced Qty')
         return res
 
     def action_view_orderpoints(self):

--- a/addons/stock/models/product.py
+++ b/addons/stock/models/product.py
@@ -437,27 +437,27 @@ class Product(models.Model):
         if self._context.get('location') and isinstance(self._context['location'], int):
             location = self.env['stock.location'].browse(self._context['location'])
             if location.usage == 'supplier':
-                if fields.get('virtual_available'):
+                if res.get('virtual_available'):
                     res['virtual_available']['string'] = _('Future Receipts')
-                if fields.get('qty_available'):
+                if res.get('qty_available'):
                     res['qty_available']['string'] = _('Received Qty')
             elif location.usage == 'internal':
-                if fields.get('virtual_available'):
+                if res.get('virtual_available'):
                     res['virtual_available']['string'] = _('Forecasted Quantity')
             elif location.usage == 'customer':
-                if fields.get('virtual_available'):
+                if res.get('virtual_available'):
                     res['virtual_available']['string'] = _('Future Deliveries')
-                if fields.get('qty_available'):
+                if res.get('qty_available'):
                     res['qty_available']['string'] = _('Delivered Qty')
             elif location.usage == 'inventory':
-                if fields.get('virtual_available'):
+                if res.get('virtual_available'):
                     res['virtual_available']['string'] = _('Future P&L')
-                if fields.get('qty_available'):
+                if res.get('qty_available'):
                     res['qty_available']['string'] = _('P&L Qty')
             elif location.usage == 'production':
-                if fields.get('virtual_available'):
+                if res.get('virtual_available'):
                     res['virtual_available']['string'] = _('Future Productions')
-                if fields.get('qty_available'):
+                if res.get('qty_available'):
                     res['qty_available']['string'] = _('Produced Qty')
         return res
 

--- a/addons/web/models/__init__.py
+++ b/addons/web/models/__init__.py
@@ -4,5 +4,6 @@
 from . import ir_qweb_fields
 from . import ir_http
 from . import ir_ui_menu
+from . import ir_ui_view
 from . import models
 from . import base_document_layout

--- a/addons/web/models/ir_ui_view.py
+++ b/addons/web/models/ir_ui_view.py
@@ -1,0 +1,11 @@
+# -*- coding: utf-8 -*-
+from odoo import models
+
+
+class IrUiView(models.Model):
+    _inherit = 'ir.ui.view'
+
+    def _postprocess_prepare_2many_inline_view_widgets(self):
+        widgets = super()._postprocess_prepare_2many_inline_view_widgets()
+        widgets.extend(['one2many', 'many2many'])
+        return widgets

--- a/addons/web/models/models.py
+++ b/addons/web/models/models.py
@@ -245,15 +245,15 @@ class Base(models.AbstractModel):
         }
 
     @api.model
-    def fields_view_get(self, view_id=None, view_type='form', toolbar=False, submenu=False):
-        r = super().fields_view_get(view_id, view_type, toolbar, submenu)
+    def _view_get(self, view_id=None, view_type='form', **options):
+        arch, view = super()._view_get(view_id, view_type, **options)
         # avoid leaking the raw (un-rendered) template, also avoids bloating
         # the response payload for no reason. Only send the root node,
         # to send attributes such as `js_class`.
-        if r['type'] == 'qweb':
-            root = etree.fromstring(r['arch'])
-            r['arch'] = etree.tostring(etree.Element('qweb', root.attrib))
-        return r
+        if view_type == 'qweb':
+            root = arch
+            arch = etree.Element('qweb', root.attrib)
+        return arch, view
 
     @api.model
     def _search_panel_field_image(self, field_name, **kwargs):

--- a/addons/web/static/src/legacy/js/services/data_manager.js
+++ b/addons/web/static/src/legacy/js/services/data_manager.js
@@ -89,6 +89,9 @@ return core.Class.extend({
         if (shouldLoadViews) {
             // Views info should be loaded
             options.load_filters = shouldLoadFilters;
+            if (config.device.isMobile) {
+                options.mobile = config.device.isMobile;
+            }
             this._cache.views[viewsKey] = rpc.query({
                 args: [],
                 kwargs: { context, options, views: views_descr },

--- a/addons/web/static/src/views/view_service.js
+++ b/addons/web/static/src/views/view_service.js
@@ -1,6 +1,7 @@
 /** @odoo-module **/
 
 import { registry } from "@web/core/registry";
+import { device } from 'web.config';
 
 /**
  * @typedef {Object} IrFilter
@@ -65,14 +66,18 @@ export const viewService = {
         async function loadViews(params, options) {
             const key = JSON.stringify([params.resModel, params.views, params.context, options]);
             if (!cache[key]) {
+                var load_views_options = {
+                    action_id: options.actionId || false,
+                    load_filters: options.loadIrFilters || false,
+                    toolbar: options.loadActionMenus || false,
+                }
+                if (device.isMobile){
+                    load_views_options.mobile = device.isMobile;
+                }
                 cache[key] = orm
                     .call(params.resModel, "load_views", [], {
                         views: params.views,
-                        options: {
-                            action_id: options.actionId || false,
-                            load_filters: options.loadIrFilters || false,
-                            toolbar: options.loadActionMenus || false,
-                        },
+                        options: load_views_options,
                         context: params.context,
                     })
                     .then((result) => {

--- a/odoo/addons/base/models/ir_actions.py
+++ b/odoo/addons/base/models/ir_actions.py
@@ -214,7 +214,7 @@ class IrActionsActWindow(models.Model):
     @api.depends('res_model', 'search_view_id')
     def _compute_search_view(self):
         for act in self:
-            fvg = self.env[act.res_model].fields_view_get(act.search_view_id.id, 'search')
+            fvg = self.env[act.res_model].view_get(act.search_view_id.id, 'search')
             act.search_view = str(fvg)
 
     name = fields.Char(string='Action Name', translate=True)

--- a/odoo/addons/base/models/ir_module.py
+++ b/odoo/addons/base/models/ir_module.py
@@ -157,8 +157,8 @@ class Module(models.Model):
     _order = 'application desc,sequence,name'
 
     @api.model
-    def fields_view_get(self, view_id=None, view_type='form', toolbar=False, submenu=False):
-        res = super(Module, self).fields_view_get(view_id, view_type, toolbar=toolbar, submenu=False)
+    def view_get(self, view_id=None, view_type='form', **options):
+        res = super(Module, self).view_get(view_id, view_type, **options)
         if view_type == 'form' and res.get('toolbar',False):
             install_id = self.env.ref('base.action_server_module_immediate_install').id
             action = [rec for rec in res['toolbar']['action'] if rec.get('id', False) != install_id]

--- a/odoo/addons/base/models/res_currency.py
+++ b/odoo/addons/base/models/res_currency.py
@@ -295,13 +295,12 @@ class Currency(models.Model):
         arch, view = super(Currency, self)._view_get(view_id=view_id, view_type=view_type, **options)
         if view_type in ('tree', 'form'):
             currency_name = (self.env['res.company'].browse(self._context.get('company_id')) or self.env.company).currency_id.name
-            doc = arch
             for field in [['company_rate', _('Unit per %s', currency_name)],
                           ['inverse_company_rate', _('%s per Unit', currency_name)]]:
-                node = doc.xpath("//tree//field[@name='%s']" % field[0])
+                node = arch.xpath("//tree//field[@name='%s']" % field[0])
                 if node:
                     node[0].set('string', field[1])
-        return doc, view
+        return arch, view
 
 
 class CurrencyRate(models.Model):

--- a/odoo/addons/base/models/res_partner.py
+++ b/odoo/addons/base/models/res_partner.py
@@ -44,26 +44,23 @@ class FormatAddressMixin(models.AbstractModel):
     _name = "format.address.mixin"
     _description = 'Address Format'
 
-    def _fields_view_get_address(self, arch):
+    def _view_get_address(self, arch):
         # consider the country of the user, not the country of the partner we want to display
         address_view_id = self.env.company.country_id.address_view_id.sudo()
         if address_view_id and not self._context.get('no_address_format') and (not address_view_id.model or address_view_id.model == self._name):
             #render the partner address accordingly to address_view_id
-            doc = etree.fromstring(arch)
-            for address_node in doc.xpath("//div[hasclass('o_address_format')]"):
+            for address_node in arch.xpath("//div[hasclass('o_address_format')]"):
                 Partner = self.env['res.partner'].with_context(no_address_format=True)
-                sub_view = Partner.fields_view_get(
+                sub_arch, _sub_view = Partner._view_get(
                     view_id=address_view_id.id, view_type='form', toolbar=False, submenu=False)
-                sub_view_node = etree.fromstring(sub_view['arch'])
                 #if the model is different than res.partner, there are chances that the view won't work
                 #(e.g fields not present on the model). In that case we just return arch
                 if self._name != 'res.partner':
                     try:
-                        self.env['ir.ui.view'].postprocess_and_fields(sub_view_node, model=self._name)
+                        self.env['ir.ui.view'].postprocess_and_fields(sub_arch, model=self._name)
                     except ValueError:
                         return arch
-                address_node.getparent().replace(address_node, sub_view_node)
-            arch = etree.tostring(doc, encoding='unicode')
+                address_node.getparent().replace(address_node, sub_arch)
         return arch
 
 class PartnerCategory(models.Model):
@@ -345,13 +342,13 @@ class Partner(models.Model):
             partner.commercial_company_name = p.is_company and p.name or partner.company_name
 
     @api.model
-    def _fields_view_get(self, view_id=None, view_type='form', toolbar=False, submenu=False):
+    def _view_get(self, view_id=None, view_type='form', **options):
         if (not view_id) and (view_type == 'form') and self._context.get('force_email'):
             view_id = self.env.ref('base.view_partner_simple_form').id
-        res = super(Partner, self)._fields_view_get(view_id=view_id, view_type=view_type, toolbar=toolbar, submenu=submenu)
+        arch, view = super(Partner, self)._view_get(view_id=view_id, view_type=view_type, **options)
         if view_type == 'form':
-            res['arch'] = self._fields_view_get_address(res['arch'])
-        return res
+            arch = self._view_get_address(arch)
+        return arch, view
 
     @api.constrains('parent_id')
     def _check_parent_id(self):

--- a/odoo/addons/base/tests/test_acl.py
+++ b/odoo/addons/base/tests/test_acl.py
@@ -48,7 +48,7 @@ class TestACL(TransactionCaseWithUserDemo):
 
         # Verify the test environment first
         original_fields = currency.fields_get([])
-        form_view = currency.fields_view_get(False, 'form')
+        form_view = currency.view_get(False, 'form')
         view_arch = etree.fromstring(form_view.get('arch'))
         has_group_system = self.user_demo.has_group(GROUP_SYSTEM)
         self.assertFalse(has_group_system, "`demo` user should not belong to the restricted group before the test")
@@ -62,7 +62,7 @@ class TestACL(TransactionCaseWithUserDemo):
         self._set_field_groups(currency, 'decimal_places', GROUP_SYSTEM)
 
         fields = currency.fields_get([])
-        form_view = currency.fields_view_get(False, 'form')
+        form_view = currency.view_get(False, 'form')
         view_arch = etree.fromstring(form_view.get('arch'))
         self.assertNotIn('decimal_places', fields, "'decimal_places' field should be gone")
         self.assertEqual(view_arch.xpath("//field[@name='decimal_places']"), [],
@@ -74,7 +74,7 @@ class TestACL(TransactionCaseWithUserDemo):
         self.erp_system_group.users += self.user_demo
         has_group_system = self.user_demo.has_group(GROUP_SYSTEM)
         fields = currency.fields_get([])
-        form_view = currency.fields_view_get(False, 'form')
+        form_view = currency.view_get(False, 'form')
         view_arch = etree.fromstring(form_view.get('arch'))
         self.assertTrue(has_group_system, "`demo` user should now belong to the restricted group")
         self.assertIn('decimal_places', fields, "'decimal_places' field must be properly visible again")
@@ -130,7 +130,7 @@ class TestACL(TransactionCaseWithUserDemo):
         """ Test form view Create, Edit, Delete button visibility based on access right of model"""
         methods = ['create', 'edit', 'delete']
         company = self.env['res.company'].with_user(self.user_demo)
-        company_view = company.fields_view_get(False, 'form')
+        company_view = company.view_get(False, 'form')
         view_arch = etree.fromstring(company_view['arch'])
         for method in methods:
             self.assertEqual(view_arch.get(method), 'false')
@@ -140,7 +140,7 @@ class TestACL(TransactionCaseWithUserDemo):
         self.erp_system_group.users += self.user_demo
         methods = ['create', 'edit', 'delete']
         company = self.env['res.company'].with_user(self.user_demo)
-        company_view = company.fields_view_get(False, 'form')
+        company_view = company.view_get(False, 'form')
         view_arch = etree.fromstring(company_view['arch'])
         for method in methods:
             self.assertIsNone(view_arch.get(method))
@@ -149,7 +149,7 @@ class TestACL(TransactionCaseWithUserDemo):
         """ Test many2one field Create and Edit option visibility based on access rights of relation field""" 
         methods = ['create', 'write']
         company = self.env['res.company'].with_user(self.user_demo)
-        company_view = company.fields_view_get(False, 'form')
+        company_view = company.view_get(False, 'form')
         view_arch = etree.fromstring(company_view['arch'])
         field_node = view_arch.xpath("//field[@name='currency_id']")
         self.assertTrue(len(field_node), "currency_id field should be in company from view")
@@ -161,7 +161,7 @@ class TestACL(TransactionCaseWithUserDemo):
         self.erp_system_group.users += self.user_demo
         methods = ['create', 'write']
         company = self.env['res.company'].with_user(self.user_demo)
-        company_view = company.fields_view_get(False, 'form')
+        company_view = company.view_get(False, 'form')
         view_arch = etree.fromstring(company_view['arch'])
         field_node = view_arch.xpath("//field[@name='currency_id']")
         self.assertTrue(len(field_node), "currency_id field should be in company from view")

--- a/odoo/addons/base/tests/test_translate.py
+++ b/odoo/addons/base/tests/test_translate.py
@@ -638,8 +638,8 @@ class TestTranslationWrite(TransactionCase):
         self.assertEqual(fg['state']['selection'],
                          [('manual', 'Custo'), ('base', 'Pas touche!')])
 
-    def test_fields_view_get(self):
-        """ Test translations of field descriptions in fields_view_get(). """
+    def test_load_views(self):
+        """ Test translations of field descriptions in view_get(). """
         self.env['res.lang']._activate_lang('fr_FR')
 
         # add translation for the string of field ir.model.name
@@ -659,9 +659,9 @@ class TestTranslationWrite(TransactionCase):
         info = model.fields_get(['name'])
         self.assertEqual(info['name']['string'], LABEL)
 
-        # check that fields_view_get() also returns the expected label
-        info = model.fields_view_get()['fields']
-        self.assertEqual(info['name']['string'], LABEL)
+        # check that load_views() also returns the expected label
+        info = model.load_views([(False, 'form')])
+        info['model_fields'][model._name]['name']['string']
 
 
 class TestXMLTranslation(TransactionCase):

--- a/odoo/addons/base/tests/test_translate.py
+++ b/odoo/addons/base/tests/test_translate.py
@@ -661,7 +661,7 @@ class TestTranslationWrite(TransactionCase):
 
         # check that load_views() also returns the expected label
         info = model.load_views([(False, 'form')])
-        info['model_fields'][model._name]['name']['string']
+        info['models'][model._name]['name']['string']
 
 
 class TestXMLTranslation(TransactionCase):

--- a/odoo/addons/base/tests/test_views.py
+++ b/odoo/addons/base/tests/test_views.py
@@ -1257,8 +1257,7 @@ class TestViews(ViewCase):
         })
 
         view = self.View.with_context(check_view_ids=[view2.id, view3.id]) \
-                        .fields_view_get(view2.id, view_type='form')
-        self.assertEqual(view['type'], 'form')
+                        .view_get(view2.id, view_type='form')
         self.assertEqual(
             etree.fromstring(
                 view['arch'],
@@ -1285,8 +1284,7 @@ class TestViews(ViewCase):
             'inherit_id': view1.id,
             'arch': '<div position="inside">a<p/>b<p/>c</div>',
         })
-        view = self.View.with_context(check_view_ids=view2.ids).fields_view_get(view1.id)
-        self.assertEqual(view['type'], 'form')
+        view = self.View.with_context(check_view_ids=view2.ids).view_get(view1.id)
         self.assertEqual(
             view['arch'],
             '<form string="F">(<div>a<p/>b<p/>c</div>)</form>',
@@ -1305,8 +1303,7 @@ class TestViews(ViewCase):
             'inherit_id': view1.id,
             'arch': '<div position="after">a<p/>b<p/>c</div>',
         })
-        view = self.View.with_context(check_view_ids=view2.ids).fields_view_get(view1.id)
-        self.assertEqual(view['type'], 'form')
+        view = self.View.with_context(check_view_ids=view2.ids).view_get(view1.id)
         self.assertEqual(
             view['arch'],
             '<form string="F">(<div/>a<p/>b<p/>c)</form>',
@@ -1325,8 +1322,7 @@ class TestViews(ViewCase):
             'inherit_id': view1.id,
             'arch': '<div position="before">a<p/>b<p/>c</div>',
         })
-        view = self.View.with_context(check_view_ids=view2.ids).fields_view_get(view1.id)
-        self.assertEqual(view['type'], 'form')
+        view = self.View.with_context(check_view_ids=view2.ids).view_get(view1.id)
         self.assertEqual(
             view['arch'],
             '<form string="F">(a<p/>b<p/>c<div/>)</form>',
@@ -1379,8 +1375,7 @@ class TestViews(ViewCase):
         })
 
         view = self.View.with_context(check_view_ids=[view2.id, view3.id]) \
-                        .fields_view_get(view2.id, view_type='form')
-        self.assertEqual(view['type'], 'form')
+                        .view_get(view2.id, view_type='form')
         self.assertEqual(
             etree.fromstring(
                 view['arch'],
@@ -2330,13 +2325,13 @@ class TestViews(ViewCase):
         })
 
         # default view, no address_view defined
-        arch = self.env['res.partner'].fields_view_get(view_id=partner_view.id)['arch']
+        arch = self.env['res.partner'].view_get(view_id=partner_view.id)['arch']
         self.assertIn('"street"', arch)
         self.assertNotIn('"parent_name"', arch)
 
         # custom view, address_view defined
         self.env.company.country_id.address_view_id = address_view
-        arch = self.env['res.partner'].fields_view_get(view_id=partner_view.id)['arch']
+        arch = self.env['res.partner'].view_get(view_id=partner_view.id)['arch']
         self.assertNotIn('"street"', arch)
         self.assertIn('"parent_name"', arch)
         # weird result: <form> inside a <form>
@@ -3110,12 +3105,12 @@ class TestAccessRights(common.TransactionCase):
         with self.assertRaises(AccessError):
             self.env['ir.ui.view'].search([("model", '=', "res.partner"), ('type', '=', 'form')])
 
-        # but can call fields_view_get
-        self.env['res.partner'].fields_view_get(view_type='form')
+        # but can call view_get
+        self.env['res.partner'].view_get(view_type='form')
 
         # unless he does not have access to the model
         with self.assertRaises(AccessError):
-            self.env['ir.ui.view'].fields_view_get(view_type='form')
+            self.env['ir.ui.view'].view_get(view_type='form')
 
 @common.tagged('post_install', '-at_install', '-standard', 'migration')
 class TestAllViews(common.TransactionCase):
@@ -3142,7 +3137,7 @@ class TestRenderAllViews(common.TransactionCase):
                     for _ in range(5):
                         model.invalidate_cache()
                         before = time.perf_counter()
-                        model.fields_view_get()
+                        model.view_get()
                         times.append(time.perf_counter() - before)
                     count += 1
                     elapsed += min(times)

--- a/odoo/addons/base/wizard/base_module_upgrade.py
+++ b/odoo/addons/base/wizard/base_module_upgrade.py
@@ -23,8 +23,8 @@ class BaseModuleUpgrade(models.TransientModel):
     module_info = fields.Text('Apps to Update', readonly=True, default=_default_module_info)
 
     @api.model
-    def fields_view_get(self, view_id=None, view_type='form', toolbar=False, submenu=False):
-        res = super(BaseModuleUpgrade, self).fields_view_get(view_id, view_type, toolbar=toolbar,submenu=False)
+    def view_get(self, view_id=None, view_type='form', **options):
+        res = super(BaseModuleUpgrade, self).view_get(view_id, view_type, **options)
         if view_type != 'form':
             return res
 

--- a/odoo/addons/test_action_bindings/tests/test_bindings.py
+++ b/odoo/addons/test_action_bindings/tests/test_bindings.py
@@ -53,19 +53,19 @@ class TestBindingViewFilters(common.TransactionCase):
     def test_act_window(self):
         A = self.env['tab.a']
 
-        form_act = A.fields_view_get(toolbar=True)['toolbar']['action']
+        form_act = A.view_get(toolbar=True)['toolbar']['action']
         self.assertEqual(
             [a['name'] for a in form_act],
             ['Action 1', 'Action 2', 'Action 3'],
             "forms should have all actions")
 
-        list_act = A.fields_view_get(view_type='tree', toolbar=True)['toolbar']['action']
+        list_act = A.view_get(view_type='tree', toolbar=True)['toolbar']['action']
         self.assertEqual(
             [a['name'] for a in list_act],
             ['Action 1', 'Action 3'],
             "lists should not have the form-only action")
 
-        kanban_act = A.fields_view_get(view_type='kanban', toolbar=True)['toolbar']['action']
+        kanban_act = A.view_get(view_type='kanban', toolbar=True)['toolbar']['action']
         self.assertEqual(
             [a['name'] for a in kanban_act],
             ['Action 1'],
@@ -74,19 +74,19 @@ class TestBindingViewFilters(common.TransactionCase):
     def test_act_record(self):
         B = self.env['tab.b']
 
-        form_act = B.fields_view_get(toolbar=True)['toolbar']['action']
+        form_act = B.view_get(toolbar=True)['toolbar']['action']
         self.assertEqual(
             [a['name'] for a in form_act],
             ['Record 1', 'Record 2', 'Record 3'],
             "forms should have all actions")
 
-        list_act = B.fields_view_get(view_type='tree', toolbar=True)['toolbar']['action']
+        list_act = B.view_get(view_type='tree', toolbar=True)['toolbar']['action']
         self.assertEqual(
             [a['name'] for a in list_act],
             ['Record 1', 'Record 3'],
             "lists should not have the form-only action")
 
-        kanban_act = B.fields_view_get(view_type='kanban', toolbar=True)['toolbar']['action']
+        kanban_act = B.view_get(view_type='kanban', toolbar=True)['toolbar']['action']
         self.assertEqual(
             [a['name'] for a in kanban_act],
             ['Record 1'],

--- a/odoo/models.py
+++ b/odoo/models.py
@@ -1700,6 +1700,10 @@ class BaseModel(metaclass=MetaModel):
             view_ref_key = view_type + '_view_ref'
             view_ref = self._context.get(view_ref_key)
             if view_ref:
+                # Do not propagate <view_type>_view_ref
+                context = dict(self._context)
+                context.pop(view_ref_key)
+                View = View.with_context(context)
                 if '.' in view_ref:
                     module, view_ref = view_ref.split('.', 1)
                     query = "SELECT res_id FROM ir_model_data WHERE model='ir.ui.view' AND module=%s AND name=%s"
@@ -1880,7 +1884,7 @@ class BaseModel(metaclass=MetaModel):
         """
         names = dict(self.name_get())
         for record in self:
-            record.display_name = names.get(record.id) or False
+            record.display_name = names.get(record.id, False)
 
     def name_get(self):
         """Returns a textual representation for the records in ``self``, with
@@ -1901,7 +1905,7 @@ class BaseModel(metaclass=MetaModel):
         if name in self._fields:
             convert = self._fields[name].convert_to_display_name
             for record in self:
-                result.append((record.id, convert(record[name], record) or ""))
+                result.append((record.id, convert(record[name], record)))
         else:
             for record in self:
                 result.append((record.id, "%s,%s" % (record._name, record.id)))

--- a/odoo/tests/common.py
+++ b/odoo/tests/common.py
@@ -1861,8 +1861,9 @@ class Form(object):
             view_id = env.ref(view).id
         else:
             view_id = view or False
-        fvg = recordp.fields_view_get(view_id, 'form')
+        fvg = recordp.view_get(view_id, 'form')
         fvg['tree'] = etree.fromstring(fvg['arch'])
+        fvg['fields'] = self._get_view_fields(fvg['tree'], recordp)
 
         object.__setattr__(self, '_view', fvg)
 
@@ -1881,6 +1882,12 @@ class Form(object):
         else:
             self._init_from_defaults(self._model)
 
+    def _get_view_fields(self, node, model):
+        level = node.xpath('count(ancestor::field)')
+        fnames = set(el.get('name') for el in node.xpath('.//field[count(ancestor::field) = %s]' % level))
+        fields = {fname: info for fname, info in model.fields_get().items() if fname in fnames}
+        return fields
+
     def _o2m_set_edition_view(self, descr, node, level):
         default_view = next(
             (m for m in node.get('mode', 'tree').split(',') if m != 'form'),
@@ -1893,25 +1900,25 @@ class Form(object):
         # always fetch for simplicity, ensure we always have a tree and
         # a form view
         submodel = self._env[descr['relation']]
-        views = submodel.with_context(**refs) \
-            .load_views([(False, 'tree'), (False, 'form')])['fields_views']
-        # embedded views should take the priority on externals
-        views.update(descr['views'])
-        # re-set all resolved views on the descriptor
-        descr['views'] = views
+        views = {view.tag: view for view in node.xpath('./*[descendant::field]')}
+        for view_type in ['tree', 'form']:
+            # embedded views should take the priority on externals
+            if view_type not in views:
+                sub_fvg = submodel.with_context(**refs).view_get(view_type=view_type)
+                sub_node = etree.fromstring(sub_fvg['arch'])
+                views[view_type] = sub_node
+                node.append(sub_node)
         # if the default view is a kanban or a non-editable list, the
         # "edition controller" is the form view
-        edition = views['form']
-        edition['tree'] = etree.fromstring(edition['arch'])
-        if default_view == 'tree':
-            subarch = etree.fromstring(views['tree']['arch'])
-            if subarch.get('editable'):
-                edition = views['tree']
-                edition['tree'] = subarch
+        edition_view = 'tree' if default_view == 'tree' and views['tree'].get('editable') else 'form'
+        edition = {
+            'fields': self._get_view_fields(views[edition_view], submodel),
+            'tree': views[edition_view],
+        }
 
         # don't recursively process o2ms in o2ms
         self._process_fvg(submodel, edition, level=level-1)
-        descr['views']['edition'] = edition
+        descr['edition_view'] = edition
 
     def __str__(self):
         return "<%s %s(%s)>" % (
@@ -1921,8 +1928,7 @@ class Form(object):
         )
 
     def _process_fvg(self, model, fvg, level=2):
-        """ Post-processes to augment the fields_view_get with:
-
+        """ Post-processes to augment the view_get with:
         * an id field (may not be present if not in the view but needed)
         * pre-processed modifiers (map of modifier name to json-loaded domain)
         * pre-processed onchanges list
@@ -1932,7 +1938,7 @@ class Form(object):
         modifiers = fvg['modifiers'] = {'id': {'required': False, 'readonly': True}}
         contexts = fvg['contexts'] = {}
         order = fvg['fields_ordered'] = []
-        for f in fvg['tree'].xpath('//field[not(ancestor::field)]'):
+        for f in fvg['tree'].xpath('.//field[count(ancestor::field) = %s]' % fvg['tree'].xpath('count(ancestor::field)')):
             fname = f.get('name')
             order.append(fname)
 
@@ -1952,7 +1958,7 @@ class Form(object):
             if level and descr['type'] == 'one2many':
                 self._o2m_set_edition_view(descr, f, level)
 
-        fvg['onchange'] = model._onchange_spec(fvg)
+        fvg['onchange'] = model._onchange_spec({'arch': etree.tostring(fvg['tree'])})
 
     def _init_from_defaults(self, model):
         vals = self._values
@@ -2194,7 +2200,7 @@ class Form(object):
                     continue
 
             if descr['type'] == 'one2many':
-                subview = descr['views']['edition']
+                subview = descr['edition_view']
                 fields_ = subview['fields']
                 oldvals = v
                 v = []
@@ -2280,7 +2286,7 @@ class Form(object):
         values = {}
         for k, v in record.items():
             if fields[k]['type'] == 'one2many':
-                subfields = fields[k]['views']['edition']['fields']
+                subfields = fields[k]['edition_view']['fields']
                 it = values[k] = []
                 for (c, rid, vs) in v:
                     if c == 1 and isinstance(vs, UpdateDict):
@@ -2304,7 +2310,7 @@ class Form(object):
             return value[0]
         elif descr['type'] == 'one2many':
             # ignore o2ms nested in o2ms
-            if not descr['views']:
+            if not descr['edition_view']:
                 return []
 
             if current is None:
@@ -2313,7 +2319,7 @@ class Form(object):
             c = {t[1] for t in current if t[0] in (1, 2)}
             current_values = {c[1]: c[2] for c in current if c[0] == 1}
             # which view should this be???
-            subfields = descr['views']['edition']['fields']
+            subfields = descr['edition_view']['fields']
             # TODO: simplistic, unlikely to work if e.g. there's a 5 inbetween other commands
             for command in value:
                 if command[0] == 0:
@@ -2389,7 +2395,7 @@ class O2MForm(Form):
         object.__setattr__(self, '_model', m)
 
         # copy so we don't risk breaking it too much (?)
-        fvg = dict(proxy._descr['views']['edition'])
+        fvg = dict(proxy._descr['edition_view'])
         object.__setattr__(self, '_view', fvg)
         self._process_fvg(m, fvg)
 
@@ -2490,7 +2496,7 @@ class O2MProxy(X2MProxy):
         # reify records to a list so they can be manipulated easily?
         self._records = []
         model = self._model
-        fields = self._descr['views']['edition']['fields']
+        fields = self._descr['edition_view']['fields']
         for (command, rid, values) in self._parent._values[self._field]:
             if command == 0:
                 self._records.append(values)


### PR DESCRIPTION
The global goal is to rework `load_views` so it sends less/redundant
information and it gets called less by the webclient,
and to improve the performance in general

- `_fields_view_get`
    - Renamed `_view_get` (as the goal is to only return the view, and no
    longer the fields information, see below).
    - Arguments `toolbar=False, submenu=False` converted to a kwargs
    `**options`. The rationale is that `submenu` was already no longer
    used (deprecated) and the `mobile` options is introduced.
    The mobile options is necessary to tell the server to send the
    mobile views for x2many fields (kanban instead of tree). See below.
    Instead of adding a new argument each time we add a new option to
    `_fields_view_get`, it seems wiser to have a kwargs `**options`
    to avoid to re-write all overrides each time a new option is
    introduced.
    - Formely returned the arch in text and some of the view information
    in a dict.
    Now returns the view architecture as an etree node,
    and the view as a browse record
    The rationale is that all overrides of `_fields_view_get` were about
    modifying the arch only (e.g. changing the address
    format/re-organizing the address related field nodes of the
    partner according to the company country).
    To do so, all these overrides were doing `etree.fromstring` to parse
    the arch which was sent in text to convert it to an etree, then
    operations were done on the etree, and then `etree.tostring` was
    called to convert back the arch to string.
    With this change of signature to send the arch as an etree,
    all these back and forth `etree.fromstring` -> `etree.tostring` are
    avoided, allowing some performance gain and less code in the end.

- `fields_view_get`
    - Renamed `view_get` (as the goal is to only return the view, and no
    longer the fields information, read below).
    - Arguments `toolbar=False, submenu=False` converted to a kwargs
    `**options`. See above `_fields_view_get`.
    - Formely returned a dict with keys `arch`, `fields`, `name`, `type`, `view_id`,
    `field_parent`, `base_model`.
    Now still returns a dict, but with a cleanup in unused keys. See
    below.
    In addition, it adds in the architecture the sub views for x2many fields
    which are not already embedded. e.g. `<field name="line_ids"/>`
    now has it's sub-views automatically added,
    e.g. `<field name="line_ids><tree>...</tree></field>`.
    For the first level of x2many fields.
    This allow the web client to call less times `load_views`.
    For instance, when loading the form view of `product.product`,
    `load_views` was called 8 times. 1 time for the form view of
    `product.product`, and then 7 other times for the 7 x2many fields for
    which the views were not embedded in the main view.
    Now that the views are automatically added for x2many fields when
    they are not embedded, refreshing the `product.product` form only
    calls 1 time `load_views`, without a single change in the web client
    javascript code. See video below.
    Keys:
      - `arch` is left as before: the view architecture as text.
      - `fields` is removed. It used to be a subset of the model `fields_get` dict,
          with only the fields used by the view.
          The thing is, as `load_views` calls `fields_view_get` for multiple views,
          we ended up with a shit tons of redundant information, as the
          fields info (returned by fields_get) was set for each view in the
          resulting dict of `load_views`.
          Meaning, when `load_views` was called to get the kanban, tree and
          form views, and the `name`, `description`, `child_ids` fields were
          present in each views, the subset `fields_get` dict for these
          three fields was set three times in the result of `load_views`,
          once for each view.
          Even four times actually, because `load_views` calls `fields_get`
          independantly to send to the web client all fields of the model,
          whether or not the fields are actually used in the views which are
          sent.
          Now, the goal is for `load_views` to send only once the fields
          info.
      - `name` is removed as it wasn't used at all by the web client.
      - `type` is removed. It was unused.
      - `view_id` is left though it seems to be used by `web_studio` only.
          it could be removed and passed only in the context of a studio
          view edition maybe.
      - `field_parent` is removed, it was unused.
          https://github.com/odoo/odoo/blob/65cb9ef253f803c61a702569b06af6bf2d16b2cf/addons/web/static/src/views/view_service.js#L98
      - `base_model` is removed, it was unused.
          https://github.com/odoo/odoo/blob/65cb9ef253f803c61a702569b06af6bf2d16b2cf/addons/web/static/src/views/view_service.js#L97

- `load_views`
    - Formely returned a dict with keys `fields_views`, `fields`, `filters`
    - Now returns a dict with keys `views`, `model_fields`, `filters`
    - `views`: `{view_type: {}}` is a dict with the result of `fields_view_get` for each
        view type. It no longer contains the fields info, hence the rename
        `fields_views` to `views`.
    - `model_fields`: `{model_name: {}}` is a dict with the result of `fields_get` for every
        model implied in the view. It gives the `fields_get` for all
        models used in the view, and no longer only the `fields` of the
        model in which `load_views` was called. Hence the rename `fields`
        to `model_fields`.
    - The keys `fields_views` and `fields` are added with a compatibility
    layer the time the web client is adapted to use only the keys `views`
    and `model_fields`.

https://user-images.githubusercontent.com/5822488/157858696-66bbcf7c-2007-4a19-a838-508caed75510.mp4
