### PR TITLE
[FIX] mail: remove reference to Jinja

### DIFF
--- a/addons/mail/i18n/mail.pot
+++ b/addons/mail/i18n/mail.pot
@@ -5741,6 +5741,11 @@ msgid "Restrict mail templates and Jinja rendering."
 msgstr ""
 
 #. module: mail
+#: model_terms:ir.ui.view,arch_db:mail.res_config_settings_view_form
+msgid "Restrict mail templates edition and QWEB placeholders usage."
+msgstr ""
+
+#. module: mail
 #: model_terms:ir.ui.view,arch_db:mail.view_mail_form
 #: model_terms:ir.ui.view,arch_db:mail.view_mail_tree
 msgid "Retry"

--- a/addons/mail/views/res_config_settings_views.xml
+++ b/addons/mail/views/res_config_settings_views.xml
@@ -89,7 +89,7 @@
                             <div class="o_setting_right_pane">
                                 <label for="restrict_template_rendering"/>
                                 <div class="text-muted" id="restrict_template_rendering">
-                                    Restrict mail templates and Jinja rendering.
+                                    Restrict mail templates edition and QWEB placeholders usage.
                                 </div>
                             </div>
                         </div>


### PR DESCRIPTION
Purpose
=======
Since 68182baff4bdf4b3bcc1f46b361f5a5b8ac9aa11 , Jinja mail templates
have been replaced by QWeb templates. But some reference to Jinja
in the mail settings have been forgotten. 

Task-2701037