### PR TITLE
[FIX] coupon: fix undeterministic error in test

### DIFF
--- a/addons/coupon/models/coupon.py
+++ b/addons/coupon/models/coupon.py
@@ -5,6 +5,7 @@ from dateutil.relativedelta import relativedelta
 
 from odoo import api, fields, models, _
 
+from uuid import uuid4
 
 class Coupon(models.Model):
     _name = 'coupon.coupon'
@@ -22,7 +23,7 @@ class Coupon(models.Model):
         Generate 8 bytes (64 bits) barcodes as 16 bytes barcodes are not
         compatible with all scanners.
          """
-        return str(random.getrandbits(64))
+        return str(uuid4())[:22]
 
     code = fields.Char(default=_generate_code, required=True, readonly=True)
     expiration_date = fields.Date('Expiration Date', compute='_compute_expiration_date')


### PR DESCRIPTION
The previous code generation for coupon used `getrandbits` which
provides a less randomised code than uuid4 causing undeterministic
errors during the tests.

TaskId-2786904
