### PR TITLE
[FIX] {purchase_,}stock, product, sale_purchase: POL description

### DIFF
--- a/addons/product/models/product.py
+++ b/addons/product/models/product.py
@@ -419,10 +419,10 @@ class ProductProduct(models.Model):
             args.append((('categ_id', 'child_of', self._context['search_default_categ_id'])))
         return super(ProductProduct, self)._search(args, offset=offset, limit=limit, order=order, count=count, access_rights_uid=access_rights_uid)
 
-    @api.depends_context('display_default_code')
+    @api.depends_context('display_default_code', 'seller_id')
     def _compute_display_name(self):
         # `display_name` is calling `name_get()`` which is overidden on product
-        # to depend on `display_default_code`
+        # to depend on `display_default_code` and `seller_id`
         return super()._compute_display_name()
 
     def name_get(self):
@@ -474,8 +474,8 @@ class ProductProduct(models.Model):
             variant = product.product_template_attribute_value_ids._get_combination_name()
 
             name = variant and "%s (%s)" % (product.name, variant) or product.name
-            sellers = []
-            if partner_ids:
+            sellers = self.env['product.supplierinfo'].sudo().browse(self.env.context.get('seller_id')) or []
+            if not sellers and partner_ids:
                 product_supplier_info = supplier_info_by_template.get(product.product_tmpl_id, [])
                 sellers = [x for x in product_supplier_info if x.product_id and x.product_id == product]
                 if not sellers:

--- a/addons/purchase/models/purchase.py
+++ b/addons/purchase/models/purchase.py
@@ -728,6 +728,8 @@ class PurchaseOrderLine(models.Model):
             price_unit = seller.product_uom._compute_price(price_unit, self.product_uom)
 
         self.price_unit = price_unit
+        product_ctx = {'seller_id': seller.id, 'lang': get_lang(self.env, self.partner_id.lang).code}
+        self.name = self._get_product_purchase_description(self.product_id.with_context(**product_ctx))
 
     @api.depends('product_uom', 'product_qty', 'product_id.uom_id')
     def _compute_product_uom_qty(self):

--- a/addons/sale_purchase/models/sale_order.py
+++ b/addons/sale_purchase/models/sale_order.py
@@ -6,6 +6,7 @@ from dateutil.relativedelta import relativedelta
 from odoo import api, fields, models, _
 from odoo.exceptions import UserError
 from odoo.tools import float_compare
+from odoo.tools.misc import get_lang
 
 
 class SaleOrder(models.Model):
@@ -220,22 +221,25 @@ class SaleOrderLine(models.Model):
 
         # compute unit price
         price_unit = 0.0
-        if supplierinfo:
-            price_unit = self.env['account.tax'].sudo()._fix_tax_included_price_company(supplierinfo.price, self.product_id.supplier_taxes_id, taxes, self.company_id)
-            if purchase_order.currency_id and supplierinfo.currency_id != purchase_order.currency_id:
-                price_unit = supplierinfo.currency_id.compute(price_unit, purchase_order.currency_id)
 
         # purchase line description in supplier lang
         product_in_supplier_lang = self.product_id.with_context(
             lang=supplierinfo.name.lang,
-            partner_id=supplierinfo.name.id,
         )
-        name = '[%s] %s' % (self.product_id.default_code, product_in_supplier_lang.display_name)
+        if supplierinfo:
+            price_unit = self.env['account.tax'].sudo()._fix_tax_included_price_company(supplierinfo.price, self.product_id.supplier_taxes_id, taxes, self.company_id)
+            if purchase_order.currency_id and supplierinfo.currency_id != purchase_order.currency_id:
+                price_unit = supplierinfo.currency_id.compute(price_unit, purchase_order.currency_id)
+            product_in_supplier_lang = product_in_supplier_lang.with_context(seller_id=supplierinfo.id)
+        else:
+            product_in_supplier_lang = product_in_supplier_lang.with_context(partner_id=purchase_order.partner_id.id)
+
+        name = product_in_supplier_lang.display_name
         if product_in_supplier_lang.description_purchase:
             name += '\n' + product_in_supplier_lang.description_purchase
 
         return {
-            'name': '[%s] %s' % (self.product_id.default_code, self.name) if self.product_id.default_code else self.name,
+            'name': name,
             'product_qty': purchase_qty_uom,
             'product_id': self.product_id.id,
             'product_uom': self.product_id.uom_po_id.id,

--- a/addons/sale_purchase/tests/test_sale_purchase.py
+++ b/addons/sale_purchase/tests/test_sale_purchase.py
@@ -256,3 +256,32 @@ class TestSalePurchase(TestCommonSalePurchaseNoChart):
         self.assertEqual(purchase_line2.sale_line_id, self.sol1_service_purchase_1, "The 2nd PO line came from the SO line sol1_service_purchase_1")
         self.assertEqual(purchase_line2.product_qty, delta, "The quantity of the new PO line is the quantity added on the Sale Line, after first PO confirmation")
 
+    def test_pol_description(self):
+        service = self.env['product.product'].create({
+            'name': 'Super Product',
+            'type': 'service',
+            'service_to_purchase': True,
+            'seller_ids': [(0, 0, {
+                'name': self.partner_vendor_service.id,
+                'min_qty': 1,
+                'price': 10,
+                'product_code': 'C01',
+                'product_name': 'Name01',
+                'sequence': 1,
+            })]
+        })
+
+        so = self.env['sale.order'].create({
+            'partner_id': self.partner_customer_usd.id,
+            'order_line': [
+                (0, 0, {
+                    'name': service.name,
+                    'product_id': service.id,
+                    'product_uom_qty': 1,
+                })
+            ],
+        })
+        so.action_confirm()
+
+        po = self.env['purchase.order'].search([('partner_id', '=', self.partner_vendor_service.id)], order='id desc', limit=1)
+        self.assertEqual(po.order_line.name, "[C01] Name01")


### PR DESCRIPTION
**ISSUE 01 (fixed thanks to a backport):**

Suppose a product with several suppliers, all with the same partner. On
the purchase order, the product description will always be based on the
last supplier

To reproduce the issue:
1. Create a vendor V
2. Create a product P:
    - Type: Storable
    - In Purchase, add a line L01:
        - Vendor: V
        - Vendor Product Name: Name01
        - Vendor Product Code: C01
        - Quantity: 1
        - Price: 10
    - In Purchase, add a second line L02:
        - Vendor: V
        - Vendor Product Name: Name02
        - Vendor Product Code: C02
        - Quantity: 20
        - Price: 2
    - Once P is saved, ensure the lines order in the purchase tab:
        - L01
        - L02
3. Create a PO with vendor V
4. Add a line with 1 x P

Error: The description is incorrect ("[C02] Name02" instead of "[C01]
Name01")

Partial backport of https://github.com/odoo/odoo/commit/9fae8e2aa15cefefec8052fd9a072f0e288510a0
(All details about issue are explained in the commit description)


**ISSUE 02**

When confirming a sale order, if a purchase order is generated, the
descriptions of the PO's lines won't be adapted to the vendor

To reproduce the issue:
1. Create a vendor V
2. Create a product P:
    - Type: Service
    - In Purchase, add a line L01:
        - Vendor: V
        - Vendor Product Name: Name01
        - Vendor Product Code: C01
    - Purchase Automatically: True
3. Create and Confirm a SO with 1 x P
4. Open the generated PO

Error: The description is incorrect (it's the standard name of P instead
of "[C01] Name01")

OPW-2777702