### PR TITLE
[FIX] account: accrual and lock dates

### DIFF
--- a/addons/account/i18n/account.pot
+++ b/addons/account/i18n/account.pot
@@ -12974,6 +12974,18 @@ msgid ""
 msgstr ""
 
 #. module: account
+#: code:addons/account/wizard/account_automatic_entry_wizard.py:0
+#, python-format
+msgid "The date of some related entries is protected by a lock date"
+msgstr ""
+
+#. module: account
+#: code:addons/account/wizard/account_automatic_entry_wizard.py:0
+#, python-format
+msgid "The date selected is protected by a lock date"
+msgstr ""
+
+#. module: account
 #: code:addons/account/models/account_payment_term.py:0
 #, python-format
 msgid "The day of the month used for this term must be strictly positive."


### PR DESCRIPTION
Do not allow users to create accrual entries for locked periods.
This would either create an entry for another date, since the date is
changed automatically by `_get_accounting_date` when posting.
Reproduce:
* Set a lock date
* Do an automatic entry for either changing the account or the period
  before that lock date

Or it would traceback because the date would be changed automatically
and no matching would be possible when changing the period.
* Set a lock date
* Create an automatic entry to change the period of an entry before the
  tax lock date




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
