### PR TITLE
[FIX] web: use latin as numbering system for dates in sample datas

### DIFF
--- a/addons/web/static/src/views/helpers/sample_server.js
+++ b/addons/web/static/src/views/helpers/sample_server.js
@@ -3,7 +3,7 @@
 import { groupBy as arrayGroupBy, sortBy as arraySortBy } from "@web/core/utils/arrays";
 import { registry } from "@web/core/registry";
 import { ORM } from "../../core/orm_service";
-import { parseDate } from "@web/core/l10n/dates";
+import { parseDate, serializeDate, serializeDateTime } from "@web/core/l10n/dates";
 
 class UnimplementedRouteError extends Error {}
 
@@ -236,10 +236,9 @@ export class SampleServer {
                 }
                 return false;
             case "date":
-            case "datetime": {
-                const format = field.type === "date" ? "yyyy-MM-dd" : "yyyy-MM-dd HH:mm:ss";
-                return this._getRandomDate(format);
-            }
+            case "datetime":
+                const datetime = this._getRandomDate();
+                return field.type === "date" ? serializeDate(datetime): serializeDateTime(datetime);
             case "float":
                 return this._getRandomFloat(SampleServer.MAX_FLOAT);
             case "integer": {
@@ -304,12 +303,11 @@ export class SampleServer {
 
     /**
      * @private
-     * @param {string} format
-     * @returns {moment}
+     * @returns {DateTime}
      */
-    _getRandomDate(format) {
+    _getRandomDate() {
         const delta = Math.floor((Math.random() - Math.random()) * SampleServer.DATE_DELTA);
-        return luxon.DateTime.local().plus({ hours: delta }).toFormat(format);
+        return luxon.DateTime.local().plus({ hours: delta });
     }
 
     /**


### PR DESCRIPTION
Steps to reproduce:

  - Set a new DB without demo data
  - Install Ecommerce
  - Switch language to Arabic
  - Try to open website module

Issue:

  Traceback raised.

Cause:

  When generating random sample data for website dashboard, it will use
  the current local to generate dates, who in this case have a non-latin
  numbering system, and therefore will break when trying to parse field
  value.

Solution:

  Use latin (`latn`) as numbering system.

opw-2743243