### PR TITLE
[FIX] core: support controllers outside addons

### DIFF
--- a/odoo/http.py
+++ b/odoo/http.py
@@ -577,6 +577,12 @@ def _generate_routing_rules(modules, nodb_only, converters=None):
         defined at the given ``modules`` (often system wide modules or
         installed modules). Modules in this context are Odoo addons.
         """
+        # Controllers defined outside of odoo addons are outside of the
+        # controller inheritance/extension mechanism.
+        yield from (ctrl() for ctrl in Controller.children_classes.get('', []))
+
+        # Controllers defined inside of odoo addons can be extended in
+        # other installed addons. Rebuild the class inheritance here.
         highest_controllers = []
         for module in modules:
             highest_controllers.extend(Controller.children_classes.get(module, []))


### PR DESCRIPTION
With the iot-box it is possible to download modules from an odoo server
into the iot-box. Those odoo modules are `exec`-like and exposed on the
box. With those modules come some controllers. Because they were
`exec`-like, they lack a python module name which makes
`_generate_routing_rules` to reject them.

With this fix, we authorise to declare controllers outside of odoo
addons. Those controllers cannot be extended, nor can they override
other controllers.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
