### PR TITLE
[FIX] sale_stock: keep SM's UoM on generated SOL

### DIFF
--- a/addons/sale_stock/models/stock.py
+++ b/addons/sale_stock/models/stock.py
@@ -104,6 +104,7 @@ class StockPicking(models.Model):
                 'product_id': product.id,
                 'product_uom_qty': 0,
                 'qty_delivered': move.quantity_done,
+                'product_uom': move.product_uom.id,
             }
             if product.invoice_policy == 'delivery':
                 # Check if there is already a SO line for this product to get

--- a/addons/sale_stock/tests/test_sale_stock.py
+++ b/addons/sale_stock/tests/test_sale_stock.py
@@ -1048,6 +1048,39 @@ class TestSaleStock(TestSaleCommon, ValuationReconciliationTestCommon):
         picking.button_validate()
         self.assertEqual(so.order_line.mapped('qty_delivered'), [4.0], 'Sale: no conversion error on delivery in different uom"')
 
+    def test_17_deliver_more_and_multi_uom(self):
+        """
+        Deliver an additional product with a UoM different than its default one
+        This UoM should be the same on the generated SO line
+        """
+        uom_m_id = self.ref("uom.product_uom_meter")
+        uom_km_id = self.ref("uom.product_uom_km")
+        self.product_b.write({
+            'uom_id': uom_m_id,
+            'uom_po_id': uom_m_id,
+        })
+
+        so = self._get_new_sale_order(product=self.product_a)
+        so.action_confirm()
+
+        picking = so.picking_ids
+        self.env['stock.move'].create({
+            'picking_id': picking.id,
+            'location_id': picking.location_id.id,
+            'location_dest_id': picking.location_dest_id.id,
+            'name': self.product_b.name,
+            'product_id': self.product_b.id,
+            'product_uom_qty': 1,
+            'product_uom': uom_km_id,
+        })
+        action = picking.button_validate()
+        wizard = Form(self.env[action['res_model']].with_context(action['context'])).save()
+        wizard.process()
+
+        self.assertEqual(so.order_line[1].product_id, self.product_b)
+        self.assertEqual(so.order_line[1].qty_delivered, 1)
+        self.assertEqual(so.order_line[1].product_uom.id, uom_km_id)
+
 
 class TestSaleStockOnly(TestSaleCommon):
 


### PR DESCRIPTION
When delivering an additional product with a specific UoM, the generated
line on the sale order should have that same UoM

To reproduce the issue:
1. In Settings, enable "Units of Measure"
2. Create two products PA and PB (UoM of PB is the meter)
3. Create and confirm a SO with 1 x PA
4. On the picking, add 1 km(!) x PB
5. Validate the picking
6. Go back on the SO

Error: the line for PB is incorrect, its UoM is 'm', it should be 'km'

OPW-2761913