### PR TITLE
[IMP] hr_holidays: make it possible to cancel in the past

### DIFF
--- a/addons/hr_work_entry_contract/tests/common.py
+++ b/addons/hr_work_entry_contract/tests/common.py
@@ -29,7 +29,7 @@ class TestWorkEntryBase(TransactionCase):
         })
 
         # I create a contract for "Richard"
-        cls.env['hr.contract'].create({
+        cls.richard_contract = cls.env['hr.contract'].create({
             'date_end': Date.today() + relativedelta(years=2),
             'date_start': Date.to_date('2018-01-01'),
             'name': 'Contract for Richard',


### PR DESCRIPTION
Prior to this commit there was no way for the employee to cancel a leave
in the past.
However when payroll is installed, it should be possible as long as no
payslip has been validated for that period.
It will now be possible to do that as long as the employee has a
contract active for the time off's period.
Otherwise the old rules still apply.

TaskId-2792249
