### PR TITLE
[15.0][FIX] purchase: wrong rounding on currency conversion

### DIFF
--- a/addons/purchase/models/purchase.py
+++ b/addons/purchase/models/purchase.py
@@ -1187,7 +1187,8 @@ class PurchaseOrderLine(models.Model):
         price_unit = self.env['account.tax']._fix_tax_included_price_company(seller.price, self.product_id.supplier_taxes_id, self.taxes_id, self.company_id) if seller else 0.0
         if price_unit and seller and self.order_id.currency_id and seller.currency_id != self.order_id.currency_id:
             price_unit = seller.currency_id._convert(
-                price_unit, self.order_id.currency_id, self.order_id.company_id, self.date_order or fields.Date.today())
+                price_unit, self.order_id.currency_id, self.order_id.company_id, self.date_order or fields.Date.today(), round=False
+            )
 
         if seller and self.product_uom and seller.product_uom != self.product_uom:
             price_unit = seller.product_uom._compute_price(price_unit, self.product_uom)


### PR DESCRIPTION
*Impacted versions:*

15.0

*Steps to reproduce:*

- USD is the default currency and EUR is enabled as additional currency. Suppose 1 EUR = 1.5289
- Set Decimal Accuracy, for "Product Price", to 4 digits
- Edit Product "Office Lamp", Purchase tab. Set top supplier to "Azure Interior", Currency "EUR", Price 1.0
- Create a PO for "Azure Interior", USD currency, and add a line for "Office Lamp"

*Current behavior:*

- Unit price is rounded to two decoimals: 1.53

*Expected behavior:*

- Expected price should be rounded to four decimals: 1.5289

* Support ticket number submitted via odoo.com/help (optional):*:

2792423
