### PR TITLE
[FIX] website_sale: 1024px image in 2 image per columns

### DIFF
--- a/addons/website_sale/views/templates.xml
+++ b/addons/website_sale/views/templates.xml
@@ -298,7 +298,7 @@
                                                         t-att-data-ribbon-id="td_product['ribbon'].id">
                                                         <div t-attf-class="o_wsale_product_grid_wrapper o_wsale_product_grid_wrapper_#{td_product['x']}_#{td_product['y']}">
                                                             <t t-call="website_sale.products_item">
-                                                                <t t-set="product_image_big" t-value="td_product['x'] + td_product['y'] &gt; 2"/>
+                                                                <t t-set="product_image_big" t-value="td_product['x'] + td_product['y'] &gt; 2 or ppr &lt;= 2"/>
                                                             </t>
                                                         </div>
                                                     </td>


### PR DESCRIPTION
Setting an image to take two columns (50%) will use the 1024 pixels
images instead of 256.

Setting 2 columns per line instead of default 4 will set similar size of
cells, but the image size is not adapted so you will often get very big
margin without an option to make the image bigger (without template
change or just changing each image individually).

opw-2733505