### PR TITLE
[IMP] core: send json to http controllers

### DIFF
--- a/odoo/addons/test_http/controllers.py
+++ b/odoo/addons/test_http/controllers.py
@@ -1,6 +1,7 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 import json
 import logging
+import werkzeug
 from odoo import http
 from odoo.exceptions import UserError
 from odoo.http import request
@@ -72,6 +73,14 @@ class TestHttp(http.Controller):
     @http.route('/test_http/echo-json-context', type='json', auth='user', methods=['POST'], csrf=False)
     def echo_json_context(self, **kwargs):
         return request.env.context
+
+    @http.route('/test_http/echo-json-over-http', type='http', auth='none', methods=['POST'], csrf=False)
+    def echo_json_over_http(self):
+        try:
+            data = request.get_json_data()
+        except ValueError as exc:
+            raise werkzeug.exceptions.BadRequest("Invalid JSON data") from exc
+        return request.make_json_response(data)
 
     # =====================================================
     # Models

--- a/odoo/addons/test_http/tests/test_http.py
+++ b/odoo/addons/test_http/tests/test_http.py
@@ -187,13 +187,23 @@ class TestHttpEchoReplyHttpNoDB(TestHttpBase):
 
     @mute_logger('odoo.http')
     def test_echohttp4_post_json_nodb(self):
-        res = self.nodb_url_open('/test_http/echo-http-post', data='{}', headers=CT_JSON)
-        self.assertIn("Bad Request", res.text)
+        payload = json.dumps({'commander': 'Thor'})
+        res = self.nodb_url_open('/test_http/echo-http-post', data=payload, headers=CT_JSON)
+        self.assertEqual(res.status_code, 200)
+        self.assertEqual(res.text, '{}')
 
     def test_echohttp5_post_csrf(self):
         res = self.nodb_url_open('/test_http/echo-http-csrf?race=Asgard', data={'commander': 'Thor'})
         self.assertEqual(res.status_code, 303)
         self.assertEqual(urlparse(res.headers.get('Location', '')).path, '/web/database/selector')
+
+    def test_echohttp6_json_over_http(self):
+        payload = json.dumps({'commander': 'Thor'})
+        res = self.nodb_url_open('/test_http/echo-json-over-http', data=payload, headers=CT_JSON)
+        self.assertEqual(res.status_code, 200)
+        self.assertEqual(res.text, payload)
+        mimetype = res.headers['Content-Type'].partition(';')[0]
+        self.assertEqual(mimetype, 'application/json')
 
 
 @tagged('post_install', '-at_install')
@@ -247,8 +257,10 @@ class TestHttpEchoReplyHttpWithDB(TestHttpBase):
 
     @mute_logger('odoo.http')
     def test_echohttp4_post_json_db(self):
-        res = self.db_url_open('/test_http/echo-http-post', data='{}', headers=CT_JSON)
-        self.assertIn("Bad Request", res.text)
+        payload = json.dumps({'commander': 'Thor'})
+        res = self.db_url_open('/test_http/echo-http-post', data=payload, headers=CT_JSON)
+        self.assertEqual(res.status_code, 200)
+        self.assertEqual(res.text, '{}')
 
     @mute_logger('odoo.http')
     def test_echohttp5_post_no_csrf(self):


### PR DESCRIPTION
With this work we relax the http controller so that it accepts all
requests, including `Content-Type: application/json`. We also enrich
the framework with two new helper methods dedicated to serialaze json
requests and responses:

- `request.get_json_body()`, loads the json content from the request's
  body and returns the corresponding python object (usually a dict).
- `request.make_json_response(data)`, dumps `data` to json and makes an
  http response out of it.

Task: 2779837