### PR TITLE
[FIX]mail_plugin: res.partner write method return added

### DIFF
--- a/addons/mail_plugin/models/res_partner.py
+++ b/addons/mail_plugin/models/res_partner.py
@@ -43,7 +43,7 @@ class ResPartner(models.Model):
         return partner
 
     def write(self, vals):
-        super(ResPartner, self).write(vals)
+        res = super(ResPartner, self).write(vals)
 
         if 'iap_enrich_info' in vals or 'iap_search_domain' in vals:
             # Not done with inverse method so we do need to search
@@ -67,3 +67,4 @@ class ResPartner(models.Model):
                         'iap_search_domain': vals.get('iap_search_domain'),
                     } for partner in missing_partners
                 ])
+        return res

--- a/doc/cla/corporate/sprint-it.md
+++ b/doc/cla/corporate/sprint-it.md
@@ -15,4 +15,5 @@ List of contributors:
 Elmeri Niemelä niemela.elmeri@gmail.com https://github.com/elmeriniemela
 Ivan Avdouevski ivan.avdouevski@sprintit.fi https://github.com/sprintit
 Johan Tötterman johan.totterman@sprintit.fi https://github.com/juppe
+Joonas Hartonen joonas.hartonen@sprintit.fi https://github.com/jhartonen
 Roy Nurmi roy.nurmi@sprintit.fi 


### PR DESCRIPTION
Before, when calling write on res.partner records via XMLRPC, and having mail_plugin installed, there was no value returned. This would cause the following fault and stop the process:

```
xmlrpc.client.Fault:
Fault cannot marshal None unless allow_none is enabled: 
'Traceback (most recent call last):
  File "/opt/odoo/odoo/odoo/addons/base/controllers/rpc.py", line 84, in xmlrpc_1
    response = self._xmlrpc(service)
  File "/opt/odoo/odoo/odoo/addons/base/controllers/rpc.py", line 74, in _xmlrpc
    return dumps((result,), methodresponse=1, allow_none=False)
  File "/usr/lib/python3.8/xmlrpc/client.py", line 968, in dumps
    data = m.dumps(params)
  File "/usr/lib/python3.8/xmlrpc/client.py", line 501, in dumps
    dump(v, write)
  File "/usr/lib/python3.8/xmlrpc/client.py", line 523, in __dump
    f(self, value, write)
  File "/usr/lib/python3.8/xmlrpc/client.py", line 527, in dump_nil
    raise TypeError("cannot marshal None unless allow_none is enabled")
TypeError: cannot marshal None unless allow_none is enabled'
```

Odoo log would show this:
`
2022-03-12 06:48:10,822 1196 INFO odoo15 odoo.service.model: The method write of the object res.partner can not return None !`

After, we return a value from the super write method, which allows the process to continue.




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
