### PR TITLE
[FIX] mail: missing ARIA attributes after OWL

### DIFF
--- a/addons/mail/i18n/mail.pot
+++ b/addons/mail/i18n/mail.pot
@@ -602,6 +602,7 @@ msgstr ""
 #. module: mail
 #. openerp-web
 #: code:addons/mail/static/src/components/composer/composer.xml:0
+#: code:addons/mail/static/src/components/composer/composer.xml:0
 #, python-format
 msgid "Add attachment"
 msgstr ""
@@ -851,6 +852,7 @@ msgstr ""
 #. module: mail
 #. openerp-web
 #: code:addons/mail/static/src/components/attachment_box/attachment_box.xml:0
+#: code:addons/mail/static/src/components/chatter_topbar/chatter_topbar.xml:0
 #: model:ir.model.fields,field_description:mail.field_mail_compose_message__attachment_ids
 #: model:ir.model.fields,field_description:mail.field_mail_mail__attachment_ids
 #: model:ir.model.fields,field_description:mail.field_mail_message__attachment_ids
@@ -930,14 +932,6 @@ msgstr ""
 #. module: mail
 #: model:ir.model.fields,field_description:mail.field_mail_channel__moderation_notify
 msgid "Automatic notification"
-msgstr ""
-
-#. module: mail
-#. openerp-web
-#: code:addons/mail/static/src/components/follower/follower.xml:0
-#: code:addons/mail/static/src/components/message/message.xml:0
-#, python-format
-msgid "Avatar"
 msgstr ""
 
 #. module: mail
@@ -1699,6 +1693,13 @@ msgid "Delivery Failed"
 msgstr ""
 
 #. module: mail
+#. openerp-web
+#: code:addons/mail/static/src/components/message/message.xml:0
+#, python-format
+msgid "Delivery failure"
+msgstr ""
+
+#. module: mail
 #: model:ir.model.fields,field_description:mail.field_mail_channel__description
 #: model:ir.model.fields,field_description:mail.field_mail_message_subtype__description
 #: model:ir.model.fields,field_description:mail.field_mail_shortcode__description
@@ -1921,6 +1922,8 @@ msgstr ""
 #. openerp-web
 #: code:addons/mail/static/src/components/attachment/attachment.xml:0
 #: code:addons/mail/static/src/components/attachment/attachment.xml:0
+#: code:addons/mail/static/src/components/attachment/attachment.xml:0
+#: code:addons/mail/static/src/components/attachment/attachment.xml:0
 #: code:addons/mail/static/src/components/attachment_viewer/attachment_viewer.xml:0
 #: code:addons/mail/static/src/components/attachment_viewer/attachment_viewer.xml:0
 #: code:addons/mail/static/src/xml/thread.xml:0
@@ -2008,6 +2011,7 @@ msgstr ""
 
 #. module: mail
 #. openerp-web
+#: code:addons/mail/static/src/components/follower/follower.xml:0
 #: code:addons/mail/static/src/components/follower/follower.xml:0
 #, python-format
 msgid "Edit subscription"
@@ -2170,6 +2174,13 @@ msgstr ""
 #: model:ir.ui.menu,name:mail.menu_mail_mail
 #: model_terms:ir.ui.view,arch_db:mail.view_mail_tree
 msgid "Emails"
+msgstr ""
+
+#. module: mail
+#. openerp-web
+#: code:addons/mail/static/src/components/composer/composer.xml:0
+#, python-format
+msgid "Emojis"
 msgstr ""
 
 #. module: mail
@@ -2409,6 +2420,8 @@ msgid "Follow"
 msgstr ""
 
 #. module: mail
+#. openerp-web
+#: code:addons/mail/static/src/components/follower_list_menu/follower_list_menu.xml:0
 #: model:ir.actions.act_window,name:mail.action_view_followers
 #: model:ir.model.fields,field_description:mail.field_mail_blacklist__message_follower_ids
 #: model:ir.model.fields,field_description:mail.field_mail_channel__message_follower_ids
@@ -2419,6 +2432,7 @@ msgstr ""
 #: model:ir.model.fields,field_description:mail.field_res_users__message_follower_ids
 #: model:ir.ui.menu,name:mail.menu_email_followers
 #: model_terms:ir.ui.view,arch_db:mail.view_followers_tree
+#, python-format
 msgid "Followers"
 msgstr ""
 
@@ -2499,6 +2513,7 @@ msgstr ""
 
 #. module: mail
 #. openerp-web
+#: code:addons/mail/static/src/components/composer/composer.xml:0
 #: code:addons/mail/static/src/components/composer/composer.xml:0
 #, python-format
 msgid "Full composer"
@@ -3466,6 +3481,7 @@ msgstr ""
 #. module: mail
 #. openerp-web
 #: code:addons/mail/static/src/components/message/message.xml:0
+#: code:addons/mail/static/src/components/message/message.xml:0
 #: code:addons/mail/static/src/components/thread_needaction_preview/thread_needaction_preview.xml:0
 #: code:addons/mail/static/src/components/thread_preview/thread_preview.xml:0
 #, python-format
@@ -3474,6 +3490,7 @@ msgstr ""
 
 #. module: mail
 #. openerp-web
+#: code:addons/mail/static/src/components/message/message.xml:0
 #: code:addons/mail/static/src/components/message/message.xml:0
 #, python-format
 msgid "Mark as Todo"
@@ -3516,12 +3533,15 @@ msgid "Merged with the following partners:"
 msgstr ""
 
 #. module: mail
+#. openerp-web
+#: code:addons/mail/static/src/models/message/message.js:0
 #: model:ir.model,name:mail.model_mail_message
 #: model:ir.model.fields,field_description:mail.field_mail_mail__mail_message_id
 #: model:ir.model.fields,field_description:mail.field_mail_notification__mail_message_id
 #: model:ir.model.fields,field_description:mail.field_mail_resend_message__mail_message_id
 #: model:ir.model.fields,field_description:mail.field_mail_wizard_invite__message
 #: model_terms:ir.ui.view,arch_db:mail.mail_message_view_form
+#, python-format
 msgid "Message"
 msgstr ""
 
@@ -4122,10 +4142,13 @@ msgid "Normalized Email"
 msgstr ""
 
 #. module: mail
+#. openerp-web
+#: code:addons/mail/static/src/models/message/message.js:0
 #: model:ir.model.fields,field_description:mail.field_ir_actions_server__activity_note
 #: model:ir.model.fields,field_description:mail.field_ir_cron__activity_note
 #: model:ir.model.fields,field_description:mail.field_mail_activity__note
 #: model:mail.message.subtype,name:mail.mt_note
+#, python-format
 msgid "Note"
 msgstr ""
 
@@ -5021,6 +5044,8 @@ msgstr ""
 #. openerp-web
 #: code:addons/mail/static/src/components/attachment/attachment.xml:0
 #: code:addons/mail/static/src/components/attachment/attachment.xml:0
+#: code:addons/mail/static/src/components/attachment/attachment.xml:0
+#: code:addons/mail/static/src/components/attachment/attachment.xml:0
 #, python-format
 msgid "Remove"
 msgstr ""
@@ -5052,6 +5077,7 @@ msgstr ""
 #. module: mail
 #. openerp-web
 #: code:addons/mail/static/src/components/follower/follower.xml:0
+#: code:addons/mail/static/src/components/follower/follower.xml:0
 #, python-format
 msgid "Remove this follower"
 msgstr ""
@@ -5065,6 +5091,7 @@ msgstr ""
 
 #. module: mail
 #. openerp-web
+#: code:addons/mail/static/src/components/message/message.xml:0
 #: code:addons/mail/static/src/components/message/message.xml:0
 #: model_terms:ir.ui.view,arch_db:mail.view_mail_form
 #, python-format
@@ -5677,8 +5704,11 @@ msgid "System Parameter"
 msgstr ""
 
 #. module: mail
+#. openerp-web
+#: code:addons/mail/static/src/models/message/message.js:0
 #: model:ir.model.fields.selection,name:mail.selection__mail_compose_message__message_type__notification
 #: model:ir.model.fields.selection,name:mail.selection__mail_message__message_type__notification
+#, python-format
 msgid "System notification"
 msgstr ""
 
@@ -6405,6 +6435,13 @@ msgstr ""
 #: model:ir.model.fields,field_description:mail.field_ir_actions_act_window_view__view_mode
 #: model:ir.model.fields,field_description:mail.field_ir_ui_view__type
 msgid "View Type"
+msgstr ""
+
+#. module: mail
+#. openerp-web
+#: code:addons/mail/static/src/components/attachment/attachment.xml:0
+#, python-format
+msgid "View image"
 msgstr ""
 
 #. module: mail

--- a/addons/mail/static/src/components/activity/activity.js
+++ b/addons/mail/static/src/components/activity/activity.js
@@ -164,7 +164,8 @@ class Activity extends Component {
     /**
      * @private
      */
-    _onClickDetailsButton() {
+    _onClickDetailsButton(ev) {
+        ev.preventDefault();
         this.state.areDetailsVisible = !this.state.areDetailsVisible;
     }
 

--- a/addons/mail/static/src/components/activity/activity.xml
+++ b/addons/mail/static/src/components/activity/activity.xml
@@ -47,7 +47,7 @@
                                 <t t-esc="assignedUserText"/>
                             </div>
                         </t>
-                        <a class="o_Activity_detailsButton btn btn-link" t-on-click="_onClickDetailsButton" role="button">
+                        <a href="#" class="o_Activity_detailsButton btn btn-link" t-att-aria-expanded="state.areDetailsVisible ? 'true' : 'false'" t-on-click="_onClickDetailsButton" role="button">
                             <i class="fa fa-info-circle" role="img" title="Info"/>
                         </a>
                     </div>

--- a/addons/mail/static/src/components/activity_box/activity_box.js
+++ b/addons/mail/static/src/components/activity_box/activity_box.js
@@ -45,7 +45,8 @@ class ActivityBox extends Component {
     /**
      * @private
      */
-    _onClickTitle() {
+    _onClickTitle(ev) {
+        ev.preventDefault();
         this.chatter.toggleActivityBoxVisibility();
     }
 

--- a/addons/mail/static/src/components/activity_box/activity_box.xml
+++ b/addons/mail/static/src/components/activity_box/activity_box.xml
@@ -4,7 +4,7 @@
     <t t-name="mail.ActivityBox" owl="1">
         <div class="o_ActivityBox">
             <t t-if="chatter and chatter.thread">
-                <a role="button" class="o_ActivityBox_title btn" t-on-click="_onClickTitle">
+                <a href="#" role="button" class="o_ActivityBox_title btn" t-att-aria-expanded="chatter.isActivityBoxVisible ? 'true' : 'false'" t-on-click="_onClickTitle">
                     <hr class="o_ActivityBox_titleLine" />
                     <span class="o_ActivityBox_titleText">
                         <i class="fa fa-fw" t-att-class="chatter.isActivityBoxVisible ? 'fa-caret-down' : 'fa-caret-right'"/>

--- a/addons/mail/static/src/components/attachment/attachment.xml
+++ b/addons/mail/static/src/components/attachment/attachment.xml
@@ -9,7 +9,7 @@
                 'o-has-card-details': attachment and detailsMode === 'card',
                 'o-temporary': attachment and attachment.isTemporary,
                 'o-viewable': attachment and attachment.isViewable,
-            }" t-att-title="attachment ? attachment.displayName : undefined" t-att-data-attachment-local-id="attachment ? attachment.localId : undefined"
+            }" t-att-title="attachment ? attachment.displayName : undefined" role="menu" t-att-aria-label="attachment and attachment.displayName" t-att-data-attachment-local-id="attachment ? attachment.localId : undefined"
         >
             <t t-if="attachment">
                 <!-- Image style-->
@@ -21,7 +21,7 @@
                         'o-large': props.imageSize === 'large',
                         'o-medium': props.imageSize === 'medium',
                         'o-small': props.imageSize === 'small',
-                    }" t-att-href="attachmentUrl" t-att-style="imageStyle" t-att-data-mimetype="attachment.mimetype"
+                    }" t-att-href="attachmentUrl" t-att-style="imageStyle" role="menuitem" aria-label="View image" t-att-tabindex="attachment.isViewable ? 0 : -1" t-att-aria-disabled="!attachment.isViewable" t-att-data-mimetype="attachment.mimetype"
                 >
                     <t t-if="(props.showFilename or props.showExtension) and detailsMode === 'hover'">
                         <div class="o_Attachment_imageOverlay">
@@ -43,14 +43,14 @@
                                     <div class="o_Attachment_action o_Attachment_actionUnlink"
                                         t-att-class="{
                                             'o-pretty': attachment.isLinkedToComposer,
-                                        }" t-on-click="_onClickUnlink" title="Remove"
+                                        }" tabindex="0" aria-label="Remove" role="menuitem" t-on-click="_onClickUnlink" title="Remove"
                                     >
                                         <i class="fa fa-times"/>
                                     </div>
                                 </t>
                                 <!-- Download button -->
                                 <t t-if="props.isDownloadable and !attachment.isTemporary" t-key="'download'">
-                                    <div class="o_Attachment_action o_Attachment_actionDownload" t-on-click="_onClickDownload" title="Download">
+                                    <div class="o_Attachment_action o_Attachment_actionDownload" tabindex="0" role="menuitem" aria-label="Download" t-on-click="_onClickDownload" title="Download">
                                         <i class="fa fa-download"/>
                                     </div>
                                 </t>
@@ -90,13 +90,13 @@
                         </t>
                         <!-- Remove button -->
                         <t t-if="props.isEditable">
-                            <div class="o_Attachment_asideItem o_Attachment_asideItemUnlink" t-att-class="{ 'o-pretty': attachment.isLinkedToComposer }" t-on-click="_onClickUnlink" title="Remove">
+                            <div class="o_Attachment_asideItem o_Attachment_asideItemUnlink" t-att-class="{ 'o-pretty': attachment.isLinkedToComposer }" tabindex="0" role="menuitem" aria-label="Remove" t-on-click="_onClickUnlink" title="Remove">
                                 <i class="fa fa-times"/>
                             </div>
                         </t>
                         <!-- Download button -->
                         <t t-if="props.isDownloadable and !attachment.isTemporary">
-                            <div class="o_Attachment_asideItem o_Attachment_asideItemDownload" t-on-click="_onClickDownload" title="Download">
+                            <div class="o_Attachment_asideItem o_Attachment_asideItemDownload" tabindex="0" role="menuitem" aria-label="Download" t-on-click="_onClickDownload" title="Download">
                                 <i class="fa fa-download"/>
                             </div>
                         </t>

--- a/addons/mail/static/src/components/chatter_topbar/chatter_topbar.xml
+++ b/addons/mail/static/src/components/chatter_topbar/chatter_topbar.xml
@@ -37,8 +37,8 @@
                     </t>
                     <div class="o-autogrow"/>
                         <div class="o_ChatterTopbar_rightSection">
-                            <button class="btn btn-link o_ChatterTopbar_button o_ChatterTopbar_buttonAttachments" type="button" t-att-disabled="chatter.isDisabled" t-on-click="_onClickAttachments">
-                                <i class="fa fa-paperclip"/>
+                            <button class="btn btn-link o_ChatterTopbar_button o_ChatterTopbar_buttonAttachments" type="button" t-att-disabled="chatter.isDisabled" t-att-aria-expanded="chatter.isAttachmentBoxVisible ? 'true' : 'false'" t-on-click="_onClickAttachments">
+                                <i class="fa fa-paperclip" role="img" aria-label="Attachments"/>
                                 <t t-if="chatter.isDisabled or !chatter.isShowingAttachmentsLoading">
                                     <span class="o_ChatterTopbar_buttonCount o_ChatterTopbar_buttonAttachmentsCount" t-esc="chatter.thread ? chatter.thread.allAttachments.length : 0"/>
                                 </t>

--- a/addons/mail/static/src/components/composer/composer.xml
+++ b/addons/mail/static/src/components/composer/composer.xml
@@ -97,13 +97,15 @@
                             </t>
                             <div class="o_Composer_primaryToolButtons" t-att-class="{ 'o-composer-is-compact': props.isCompact }">
                                 <Popover position="'top'" t-on-o-emoji-selection="_onEmojiSelection">
-                                    <!-- TODO FIXME o-open not possible to code due to https://github.com/odoo/owl/issues/693 -->
+                                    <!-- TODO FIXME o-open and aria-expanded not possible to code due to https://github.com/odoo/owl/issues/693 -->
                                     <button class="o_Composer_button o_Composer_buttonEmojis o_Composer_toolButton btn btn-light"
                                         t-att-class="{
                                             'o-open': false and state.displayed,
                                             'o-mobile': env.messaging.device.isMobile,
                                         }"
                                         t-on-keydown="_onKeydownEmojiButton"
+                                        aria-label="Emojis"
+                                        t-att-aria-expanded="false and (state.displayed ? 'true' : 'false')"
                                     >
                                         <i class="fa fa-smile-o"/>
                                     </button>
@@ -111,11 +113,11 @@
                                         <EmojisPopover t-ref="emojisPopover"/>
                                     </t>
                                 </Popover>
-                                <button class="o_Composer_button o_Composer_buttonAttachment o_Composer_toolButton btn btn-light fa fa-paperclip" t-att-class="{ 'o-mobile': env.messaging.device.isMobile }" title="Add attachment" type="button" t-on-click="_onClickAddAttachment"/>
+                                <button class="o_Composer_button o_Composer_buttonAttachment o_Composer_toolButton btn btn-light fa fa-paperclip" t-att-class="{ 'o-mobile': env.messaging.device.isMobile }" title="Add attachment" aria-label="Add attachment" type="button" t-on-click="_onClickAddAttachment"/>
                             </div>
                             <t t-if="props.isExpandable">
                                 <div class="o_Composer_secondaryToolButtons">
-                                    <button class="btn btn-light fa fa-expand o_Composer_button o_Composer_buttonFullComposer o_Composer_toolButton" t-att-class="{ 'o-mobile': env.messaging.device.isMobile }" title="Full composer" type="button" t-on-click="_onClickFullComposer"/>
+                                    <button class="btn btn-light fa fa-expand o_Composer_button o_Composer_buttonFullComposer o_Composer_toolButton" t-att-class="{ 'o-mobile': env.messaging.device.isMobile }" title="Full composer" aria-label="Full composer" type="button" t-on-click="_onClickFullComposer"/>
                                 </div>
                             </t>
                         </div>

--- a/addons/mail/static/src/components/follower/follower.xml
+++ b/addons/mail/static/src/components/follower/follower.xml
@@ -4,15 +4,15 @@
     <t t-name="mail.Follower" owl="1">
         <div class="o_Follower">
             <t t-if="follower">
-                <a class="o_Follower_details" t-att-class="{ 'o-inactive': !follower.isActive }" href="#" t-on-click="_onClickDetails">
-                    <img class="o_Follower_avatar" t-attf-src="/web/image/{{ follower.resModel }}/{{ follower.resId }}/image_128" alt="Avatar"/>
+                <a class="o_Follower_details" t-att-class="{ 'o-inactive': !follower.isActive }" href="#" role="menuitem" t-on-click="_onClickDetails">
+                    <img class="o_Follower_avatar" t-attf-src="/web/image/{{ follower.resModel }}/{{ follower.resId }}/image_128" alt=""/>
                     <span class="o_Follower_name" t-esc="follower.name or follower.displayName"/>
                 </a>
                 <t t-if="follower.isEditable">
-                    <button class="btn btn-icon o_Follower_button o_Follower_editButton" title="Edit subscription" t-on-click="_onClickEdit">
+                    <button class="btn btn-icon o_Follower_button o_Follower_editButton" title="Edit subscription" aria-label="Edit subscription" t-on-click="_onClickEdit">
                         <i class="fa fa-pencil"/>
                     </button>
-                    <button class="btn btn-icon o_Follower_button o_Follower_removeButton" title="Remove this follower" t-on-click="_onClickRemove">
+                    <button class="btn btn-icon o_Follower_button o_Follower_removeButton" title="Remove this follower" aria-label="Remove this follower" t-on-click="_onClickRemove">
                         <i class="fa fa-remove"/>
                     </button>
                 </t>

--- a/addons/mail/static/src/components/follower_list_menu/follower_list_menu.xml
+++ b/addons/mail/static/src/components/follower_list_menu/follower_list_menu.xml
@@ -4,8 +4,8 @@
     <t t-name="mail.FollowerListMenu" owl="1">
         <div class="o_FollowerListMenu" t-on-keydown="_onKeydown">
             <div class="o_FollowerListMenu_followers" t-ref="dropdown">
-                <button class="o_FollowerListMenu_buttonFollowers btn btn-link" t-att-disabled="props.isDisabled" t-on-click="_onClickFollowersButton" title="Show Followers">
-                    <i class="fa fa-user"/>
+                <button class="o_FollowerListMenu_buttonFollowers btn btn-link" t-att-disabled="props.isDisabled" title="Show Followers" t-att-aria-expanded="state.isDropdownOpen ? 'true' : 'false'" t-on-click="_onClickFollowersButton">
+                    <i class="fa fa-user" role="img" aria-label="Followers"/>
                     <span class="o_FollowerListMenu_buttonFollowersCount pl-1" t-esc="thread.followers.length"/>
                 </button>
 

--- a/addons/mail/static/src/components/message/message.xml
+++ b/addons/mail/static/src/components/message/message.xml
@@ -12,13 +12,13 @@
                 'o-selected': props.isSelected,
                 'o-squashed': props.isSquashed,
                 'o-starred': message and message.isStarred,
-            }" t-on-click="_onClick" t-att-data-message-local-id="message and message.localId"
+            }" role="group" t-att-aria-label="message and message.messageTypeText" t-on-click="_onClick" t-att-data-message-local-id="message and message.localId"
         >
             <t t-if="message" name="rootCondition">
                 <div class="o_Message_sidebar" t-att-class="{ 'o-message-squashed': props.isSquashed }">
                     <t t-if="!props.isSquashed">
                         <div class="o_Message_authorAvatarContainer o_Message_sidebarItem">
-                            <img class="o_Message_authorAvatar rounded-circle" t-att-class="{ o_Message_authorRedirect: hasAuthorOpenChat, o_redirect: hasAuthorOpenChat }" t-att-src="avatar" t-on-click="_onClickAuthorAvatar" t-att-title="hasAuthorOpenChat ? OPEN_CHAT : ''" alt="Avatar"/>
+                            <img class="o_Message_authorAvatar rounded-circle" t-att-class="{ o_Message_authorRedirect: hasAuthorOpenChat, o_redirect: hasAuthorOpenChat }" t-att-src="avatar" role="button" tabindex="0" t-on-click="_onClickAuthorAvatar" t-att-title="hasAuthorOpenChat ? OPEN_CHAT : ''" t-att-alt="hasAuthorOpenChat ? OPEN_CHAT : ''"/>
                             <t t-if="message.author and message.author.im_status">
                                 <PartnerImStatusIcon
                                     class="o_Message_partnerImStatusIcon"
@@ -61,7 +61,7 @@
                     <t t-if="!props.isSquashed">
                         <div class="o_Message_header">
                             <t t-if="message.author">
-                                <div class="o_Message_authorName o_Message_authorRedirect o_redirect" t-on-click="_onClickAuthorName" title="Open profile">
+                                <div class="o_Message_authorName o_Message_authorRedirect o_redirect" role="link" tabindex="0" t-on-click="_onClickAuthorName" title="Open profile">
                                     <t t-if="threadView and threadView.thread">
                                         <t t-esc="threadView.thread.getMemberName(message.author)"/>
                                     </t>
@@ -103,8 +103,8 @@
                             </t>
                             <t t-if="threadView and message.originThread and message.originThread === threadView.thread and message.notifications.length > 0">
                                 <t t-if="message.failureNotifications.length > 0">
-                                    <span class="o_Message_notificationIconClickable o-error" t-on-click="_onClickFailure">
-                                        <i name="failureIcon" class="o_Message_notificationIcon fa fa-envelope"/>
+                                    <span class="o_Message_notificationIconClickable o-error" role="button" tabindex="0" t-on-click="_onClickFailure">
+                                        <i name="failureIcon" class="o_Message_notificationIcon fa fa-envelope" role="img" aria-label="Delivery failure"/>
                                     </span>
                                 </t>
                                 <t t-else="">
@@ -129,7 +129,7 @@
                                             'o-message-selected': props.isSelected,
                                             'o-message-starred': message.isStarred,
                                             'o-mobile': env.messaging.device.isMobile,
-                                        }" t-on-click="_onClickStar" title="Mark as Todo"
+                                        }" role="button" tabindex="0" aria-label="Mark as Todo" t-att-aria-pressed="message.isStarred ? 'true' : 'false'" t-on-click="_onClickStar" title="Mark as Todo"
                                     />
                                 </t>
                                 <t t-if="props.hasReplyIcon">
@@ -137,7 +137,7 @@
                                         t-att-class="{
                                             'o-message-selected': props.isSelected,
                                             'o-mobile': env.messaging.device.isMobile,
-                                        }" t-on-click="_onClickReply" title="Reply"
+                                        }" role="button" tabindex="0" aria-label="Reply" t-on-click="_onClickReply" title="Reply"
                                     />
                                 </t>
                                 <t t-if="props.hasMarkAsReadIcon">
@@ -145,7 +145,7 @@
                                         t-att-class="{
                                             'o-message-selected': props.isSelected,
                                             'o-mobile': env.messaging.device.isMobile,
-                                        }" t-on-click="_onClickMarkAsRead" title="Mark as Read"
+                                        }" role="button" tabindex="0" aria-label="Mark as Read" t-on-click="_onClickMarkAsRead" title="Mark as Read"
                                     />
                                 </t>
                             </div>
@@ -173,7 +173,7 @@
                             <ul class="o_Message_trackingValues">
                                 <t t-foreach="trackingValues" t-as="value" t-key="value.id">
                                     <li>
-                                        <div class="o_Message_trackingValue">
+                                        <div class="o_Message_trackingValue" role="group">
                                             <div class="o_Message_trackingValueFieldName o_Message_trackingValueItem" t-esc="value.changed_field"/>
                                             <t t-if="value.old_value">
                                                 <div class="o_Message_trackingValueOldValue o_Message_trackingValueItem" t-esc="value.old_value"/>

--- a/addons/mail/static/src/models/message/message.js
+++ b/addons/mail/static/src/models/message/message.js
@@ -499,6 +499,20 @@ function factory(dependencies) {
 
         /**
          * @private
+         * @returns {string}
+         */
+        _computeMessageTypeText() {
+            if (this.message_type === 'notification') {
+                return this.env._t("System notification");
+            }
+            if (!this.is_discussion && !this.is_notification) {
+                return this.env._t("Note");
+            }
+            return this.env._t("Message");
+        }
+
+        /**
+         * @private
          * @returns {mail.messaging}
          */
         _computeMessaging() {
@@ -723,6 +737,14 @@ function factory(dependencies) {
          */
         isStarred: attr({
             default: false,
+        }),
+        messageTypeText: attr({
+            compute: '_computeMessageTypeText',
+            dependencies: [
+                'message_type',
+                'is_discussion',
+                'is_notification',
+            ],
         }),
         message_type: attr(),
         messaging: many2one('mail.messaging', {


### PR DESCRIPTION
After the refactor performed on 3fea5b213 to start using OWL, a lot of
ARIA attributes were lost.

ARIA attributes are required to ensure good compatibility with asistive
technologies and keyboard users.

This commit reintroduces such attributes, which include:
- `aria-label`: used for elements with title but no text
- `role`: mainly used for elements that behaves as buttons or links
- `aria-expanded`: used on buttons that toggle menus or content, e.g.
  button to open attachments or followers
- And another ones like `aria-pressed`, `tabindex`, etc


--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
