### PR TITLE
[FIX] web: fix filter between date

### DIFF
--- a/addons/web/static/src/search/filter_menu/custom_filter_item.js
+++ b/addons/web/static/src/search/filter_menu/custom_filter_item.js
@@ -174,9 +174,9 @@ export class CustomFilterItem extends Component {
                     condition.value.push(DateTime.local());
                 }
                 if (genericType === "datetime") {
-                    condition.value[0].set({ hour: 0, minute: 0, second: 0 });
+                    condition.value[0] = condition.value[0].set({ hour: 0, minute: 0, second: 0 });
                     if (operator.symbol === "between") {
-                        condition.value[1].set({ hour: 23, minute: 59, second: 59 });
+                        condition.value[1] = condition.value[1].set({ hour: 23, minute: 59, second: 59 });
                     }
                 }
                 break;

--- a/addons/web/static/tests/search/custom_filter_item_tests.js
+++ b/addons/web/static/tests/search/custom_filter_item_tests.js
@@ -442,13 +442,15 @@ QUnit.module("Search", (hooks) => {
     );
 
     QUnit.test("custom filter datetime with equal operator", async function (assert) {
-        assert.expect(4);
+        assert.expect(5);
 
         const originalZoneName = luxon.Settings.defaultZoneName;
         luxon.Settings.defaultZoneName = new luxon.FixedOffsetZone.instance(-240);
         registerCleanup(() => {
             luxon.Settings.defaultZoneName = originalZoneName;
         });
+
+        patchDate(2017, 1, 22, 12, 30, 0);
 
         const controlPanel = await makeWithSearch({
             serverData,
@@ -470,6 +472,12 @@ QUnit.module("Search", (hooks) => {
         assert.strictEqual(
             controlPanel.el.querySelector(".o_generator_menu_operator").value,
             "between"
+        );
+        assert.deepEqual(
+            [...controlPanel.el.querySelectorAll(".o_generator_menu_value input")].map(
+                (v) => v.value
+            ),
+            ["02/22/2017 00:00:00", "02/22/2017 23:59:59"]
         );
 
         await editConditionOperator(controlPanel, 0, "=");
@@ -489,13 +497,15 @@ QUnit.module("Search", (hooks) => {
     });
 
     QUnit.test("custom filter datetime between operator", async function (assert) {
-        assert.expect(4);
+        assert.expect(5);
 
         const originalZoneName = luxon.Settings.defaultZoneName;
         luxon.Settings.defaultZoneName = new luxon.FixedOffsetZone.instance(-240);
         registerCleanup(() => {
             luxon.Settings.defaultZoneName = originalZoneName;
         });
+
+        patchDate(2017, 1, 22, 12, 30, 0);
 
         const controlPanel = await makeWithSearch({
             serverData,
@@ -516,6 +526,12 @@ QUnit.module("Search", (hooks) => {
         assert.strictEqual(
             controlPanel.el.querySelector(".o_generator_menu_operator").value,
             "between"
+        );
+        assert.deepEqual(
+            [...controlPanel.el.querySelectorAll(".o_generator_menu_value input")].map(
+                (v) => v.value
+            ),
+            ["02/22/2017 00:00:00", "02/22/2017 23:59:59"]
         );
 
         await editConditionValue(controlPanel, 0, "02/22/2017 11:00:00", 0); // in TZ


### PR DESCRIPTION
The set method returns a newly-constructed DateTime as stated in the
documentation: https://moment.github.io/luxon/api-docs/index.html#datetimeset

Description of the issue/feature this PR addresses:

Current behavior before PR:

The datetime filter for the between operator uses the current time for both datetime

Desired behavior after PR is merged:

The upper and lower bound of the filter are 00:00:00 and 23:59:59 by default


--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
