### PR TITLE
[13.0][FIX] product_matrix: Don't populate attributes that don't create variants

### DIFF
--- a/addons/product_matrix/models/product_template.py
+++ b/addons/product_matrix/models/product_template.py
@@ -13,7 +13,9 @@ class ProductTemplate(models.Model):
         company_id = kwargs.get('company_id', None) or self.company_id or self.env.company
         currency_id = kwargs.get('currency_id', None) or self.currency_id
         display_extra = kwargs.get('display_extra_price', False)
-        attribute_lines = self.valid_product_template_attribute_line_ids
+        attribute_lines = self.valid_product_template_attribute_line_ids.filtered(
+            lambda line: line.attribute_id.create_variant != "no_variant"
+        )
 
         Attrib = self.env['product.template.attribute.value']
         first_line_attributes = attribute_lines[0].product_template_value_ids._only_active()


### PR DESCRIPTION
**Steps to reproduce:**

- Create a template with 2 attributes:

  * Attribute 1. Name: *Color*. Variants Creation Mode: Instantly. Values: White, Black.
  * Attribute 2. Name: *Certifications*. Variants Creation Mode: Never. Values: ISO 1, EN-343, OP-12.

- Select "Order Grid Entry" on "Sales Variant Selection" section.
- Create a sales order and select such template.

**Current behavior:**

A grid popup is opened with a 2D matrix crossing *Color* with *Certifications*.

| Template | Black | White |
|----------|-------|-------|
| ISO 1    |      0|      0|
| EN-343   |      0|      0|
| OP-12    |      0|      0|

Inserting numbers on the same matrix column will create several lines of the same product variant. Even worse, the matrix can't be invoked again in such case.

**Expected behavior:**

Only *Color* should be shown in the grid, not *Certifications*.

The criteria for showing a dimension shouldn't be only the number of attribute values, but the create variant option.

@Tecnativa TT35078

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
