### PR TITLE
[FIX] website_sale: allow public user to print order lines in email

### DIFF
--- a/addons/website_sale/models/sale_order.py
+++ b/addons/website_sale/models/sale_order.py
@@ -5,7 +5,7 @@ import random
 from datetime import datetime
 from dateutil.relativedelta import relativedelta
 
-from odoo import api, models, fields, _
+from odoo import api, models, fields, SUPERUSER_ID, _
 from odoo.http import request
 from odoo.osv import expression
 from odoo.exceptions import UserError, ValidationError
@@ -353,7 +353,7 @@ class SaleOrder(models.Model):
         sent_orders.write({'cart_recovery_email_sent': True})
 
     def action_confirm(self):
-        res = super(SaleOrder, self).action_confirm()
+        res = super(SaleOrder, self.with_user(SUPERUSER_ID)).action_confirm()
         for order in self:
             if not order.transaction_ids and not order.amount_total and self._context.get('send_email'):
                 order._send_order_confirmation_mail()


### PR DESCRIPTION
Reproduction:
1. Install Events, CRM, Sales, and payment acquirer Stripe
2. Set the e-mail template as default and with confirmation mail to
Sales Order: Confirmation Email
3. Create an event with paid tickets
4. Buy a ticket from an incognito page as an unregistered user, an error
 is thrown after payment because of no access right for order lines

Reason: the unregistered user has no access right for reading the order
lines and thus has an issue with the confirmation email generation

Fix: Use SUPERUSER_ID for action_confirm()

opw-2743272




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
