### PR TITLE
[FIX] sale: take into account taxes on orderline

### DIFF
--- a/addons/sale/models/sale.py
+++ b/addons/sale/models/sale.py
@@ -1608,7 +1608,8 @@ class SaleOrderLine(models.Model):
                 'sale',
                 fiscal_position=self.order_id.fiscal_position_id,
                 product_price_unit=self._get_display_price(product),
-                product_currency=self.currency_id
+                product_currency=self.currency_id,
+                taxes=self.tax_id
             )
         self.update(vals)
 
@@ -1649,7 +1650,8 @@ class SaleOrderLine(models.Model):
                 'sale',
                 fiscal_position=self.order_id.fiscal_position_id,
                 product_price_unit=self._get_display_price(product),
-                product_currency=self.currency_id
+                product_currency=self.currency_id,
+                taxes=self.tax_id,
             )
 
     def name_get(self):

--- a/addons/sale/tests/test_onchange.py
+++ b/addons/sale/tests/test_onchange.py
@@ -82,8 +82,13 @@ class TestOnchangeProductId(TransactionCase):
             'price_include': True,
         })
         tax_include_dst = self.tax_model.create({
-            'name': "Exclude tax",
+            'name': "Include tax after map",
             'amount': 6.00,
+            'price_include': True,
+        })
+        tax_include_extra = self.tax_model.create({
+            'name': "Extra tax",
+            'amount': 10.00,
             'price_include': True,
         })
 
@@ -114,12 +119,14 @@ class TestOnchangeProductId(TransactionCase):
         with order_form.order_line.new() as line:
             line.name = product_product.name
             line.product_id = product_product
+            line.tax_id.add(tax_include_extra)
             line.product_uom_qty = 1.0
             line.product_uom = uom
         sale_order = order_form.save()
 
         # Check the unit price of SO line
-        self.assertRecordValues(sale_order.order_line, [{'price_unit': 106}])
+        self.assertRecordValues(sale_order.order_line, [{'price_unit': 116}])
+        self.assertRecordValues(sale_order, [{'amount_tax': 16}])
 
     def test_pricelist_application(self):
         """ Test different prices are correctly applied based on dates """


### PR DESCRIPTION
Fixup of https://github.com/odoo/odoo/pull/83728
Taxes on the sale order line would be overwritten by the product taxes

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
