### PR TITLE
[FIX] fix editing received PO create empty picking

### DIFF
--- a/addons/purchase_stock/models/purchase.py
+++ b/addons/purchase_stock/models/purchase.py
@@ -333,6 +333,9 @@ class PurchaseOrderLine(models.Model):
         previous_product_qty = {line.id: line.product_uom_qty for line in lines}
         result = super(PurchaseOrderLine, self).write(values)
         if 'product_qty' in values:
+            lines = lines.filtered(lambda s: float_compare(
+                s.product_qty, previous_product_qty[s.id], s.product_uom.rounding
+                ))
             lines.with_context(previous_product_qty=previous_product_qty)._create_or_update_picking()
         return result
 

--- a/addons/purchase_stock/tests/test_create_picking.py
+++ b/addons/purchase_stock/tests/test_create_picking.py
@@ -64,6 +64,9 @@ class TestCreatePicking(common.TestProductCommon):
 
         # create new order line
         self.po.write({'order_line': [
+            (1, self.po.order_line[0].id, {
+                "product_qty": self.po.order_line[0].product_uom_qty
+                }),
             (0, 0, {
                 'name': self.product_id_2.name,
                 'product_id': self.product_id_2.id,
@@ -72,6 +75,8 @@ class TestCreatePicking(common.TestProductCommon):
                 'price_unit': 250.0,
                 'date_planned': datetime.today().strftime(DEFAULT_SERVER_DATETIME_FORMAT),
                 })]})
+        picking_count = self.env["stock.picking"].search_count([("origin", "=", self.po.name)])
+        self.assertEqual(picking_count, 2, 'New picking should be created')
         self.assertEqual(self.po.picking_count, 2, 'New picking should be created')
         moves = self.po.order_line.mapped('move_ids').filtered(lambda x: x.state not in ('done', 'cancel'))
         self.assertEqual(len(moves), 1, 'One moves should have been created')


### PR DESCRIPTION
Description of the issue/feature this PR addresses:

Editing a received PO can create empty picking

Example
- Create a PO
- Received it
- Edit the PO, change a quantity on the line and before saving set back the initial quantity
- Add a new line on the PO
- Save it

Current behavior before PR:
Odoo have created 2 pickings (one empty, one with a move line)


Desired behavior after PR is merged:
Odoo should have created only 1 picking



--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
