### PR TITLE
[FIX] sale: Wrong currency conversion with pricelist

### DIFF
--- a/addons/sale/models/sale.py
+++ b/addons/sale/models/sale.py
@@ -1608,7 +1608,7 @@ class SaleOrderLine(models.Model):
                 'sale',
                 fiscal_position=self.order_id.fiscal_position_id,
                 product_price_unit=self._get_display_price(product),
-                product_currency=self.currency_id
+                product_currency=self.order_id.currency_id
             )
         self.update(vals)
 
@@ -1649,7 +1649,7 @@ class SaleOrderLine(models.Model):
                 'sale',
                 fiscal_position=self.order_id.fiscal_position_id,
                 product_price_unit=self._get_display_price(product),
-                product_currency=self.currency_id
+                product_currency=self.order_id.currency_id
             )
 
     def name_get(self):


### PR DESCRIPTION
Steps to reproduce the issue:

- Let's consider a company C in $ and the rate conversion from $ to € is 0.5
- Let's consider a product P
- Let's consider a pricelist PL1 in € such as P is set to 100€
- Let's consider a pricelist PL2 in $ such as P id set to 100$
- Create a sale order SO with PL1
- Create a line with P

Bug:

The unit price of P was 200€ instead of 100€ because field currency_id was not set on the line
when trying to pass it to function _get_tax_included_unit_price

opw:2789324