### PR TITLE
[FIX] purchase_requisition_stock: use superuser to check active status

### DIFF
--- a/addons/purchase_requisition_stock/models/purchase_requisition.py
+++ b/addons/purchase_requisition_stock/models/purchase_requisition.py
@@ -10,7 +10,7 @@ class PurchaseRequisition(models.Model):
     def _get_picking_in(self):
         pick_in = self.env.ref('stock.picking_type_in', raise_if_not_found=False)
         company = self.env.company
-        if not pick_in or not pick_in.active or pick_in.sudo().warehouse_id.company_id.id != company.id:
+        if not pick_in or not pick_in.sudo().active or pick_in.sudo().warehouse_id.company_id.id != company.id:
             pick_in = self.env['stock.picking.type'].search(
                 [('warehouse_id.company_id', '=', company.id), ('code', '=', 'incoming')],
                 limit=1,


### PR DESCRIPTION
Description of the issue/feature this PR addresses:

PR #85474 introduced a bug where in users are not able to create purchase
requisition in a multi company setup.

Current behavior before PR:

```
Due to security restrictions, you are not allowed to access 'Picking Type' (stock.picking.type) records.

Records: Company: Receipts (id=1)
User: Administrator (id=2)

This restriction is due to the following rules:
- Stock Operation Type multi-company

Note: this might be a multi-company issue.

Contact your administrator to request access if necessary.
```

Desired behavior after PR is merged:

Purhcase requisition gets created without any issues


--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
