### PR TITLE
[FIX] sale: only apply pricelist currency once

### DIFF
--- a/addons/sale/models/sale.py
+++ b/addons/sale/models/sale.py
@@ -1608,7 +1608,7 @@ class SaleOrderLine(models.Model):
                 'sale',
                 fiscal_position=self.order_id.fiscal_position_id,
                 product_price_unit=self._get_display_price(product),
-                product_currency=self.currency_id
+                product_currency=self.order_id.pricelist_id.currency_id or self.currency_id
             )
         self.update(vals)
 
@@ -1649,7 +1649,7 @@ class SaleOrderLine(models.Model):
                 'sale',
                 fiscal_position=self.order_id.fiscal_position_id,
                 product_price_unit=self._get_display_price(product),
-                product_currency=self.currency_id
+                product_currency=self.order_id.pricelist_id.currency_id or self.currency_id
             )
 
     def name_get(self):


### PR DESCRIPTION
Step to reproduce:
- Create a pricelist with a new currency
- Set the rate of the new currency to 1.5 (vs the company's curr)
- Create product with price 100 in company currency
- Create a SO
- First add customer and then pricelist
- Add product to SO

Current behaviour:
- Product price is 225 (new currency)
- Product price is updated twice in
 https://github.com/odoo/odoo/blob/625486a8382fde9033b73e2a4b4e7713cf4131c1/addons/sale/models/sale.py#L1604-L1612
 First in the _get_display_price and then because product_currency
 /self currency is not pricelist currency

Behaviour after PR:
- Set product currency to the currency used after
 `_get_display_price` if it's set else fallback on current
 behaviour

opw-2791369

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
