### PR TITLE
[REF] mail: turn 'ComposerTextInput/textareaPlaceholder' into field

### DIFF
--- a/addons/mail/static/src/components/composer_text_input/composer_text_input.js
+++ b/addons/mail/static/src/components/composer_text_input/composer_text_input.js
@@ -49,28 +49,6 @@ export class ComposerTextInput extends Component {
     }
 
     /**
-     * @returns {string}
-     */
-    get textareaPlaceholder() {
-        if (!this.composerView) {
-            return "";
-        }
-        if (!this.composerView.composer.thread) {
-            return "";
-        }
-        if (this.composerView.composer.thread.model === 'mail.channel') {
-            if (this.composerView.composer.thread.correspondent) {
-                return _.str.sprintf(this.env._t("Message %s..."), this.composerView.composer.thread.correspondent.nameOrDisplayName);
-            }
-            return _.str.sprintf(this.env._t("Message #%s..."), this.composerView.composer.thread.displayName);
-        }
-        if (this.composerView.composer.isLog) {
-            return this.env._t("Log an internal note...");
-        }
-        return this.env._t("Send a message to followers...");
-    }
-
-    /**
      * Saves the composer text input state in store
      */
     saveStateInStore() {

--- a/addons/mail/static/src/components/composer_text_input/composer_text_input.xml
+++ b/addons/mail/static/src/components/composer_text_input/composer_text_input.xml
@@ -10,7 +10,7 @@
                         isBelow="props.hasMentionSuggestionsBelowPosition"
                     />
                 </t>
-                <textarea class="o_ComposerTextInput_textarea o_ComposerTextInput_textareaStyle" t-att-class="{ 'o-composer-is-compact': props.isCompact }" t-esc="composerView.composer.textInputContent" t-att-placeholder="textareaPlaceholder" t-on-click="_onClickTextarea" t-on-focusin="_onFocusinTextarea" t-on-focusout="_onFocusoutTextarea" t-on-keydown="_onKeydownTextarea" t-on-keyup="_onKeyupTextarea" t-on-input="_onInputTextarea" t-ref="textarea"/>
+                <textarea class="o_ComposerTextInput_textarea o_ComposerTextInput_textareaStyle" t-att-class="{ 'o-composer-is-compact': props.isCompact }" t-esc="composerView.composer.textInputContent" t-att-placeholder="composerView.composer.placeholder" t-on-click="_onClickTextarea" t-on-focusin="_onFocusinTextarea" t-on-focusout="_onFocusoutTextarea" t-on-keydown="_onKeydownTextarea" t-on-keyup="_onKeyupTextarea" t-on-input="_onInputTextarea" t-ref="textarea"/>
                 <!--
                      This is an invisible textarea used to compute the composer
                      height based on the text content. We need it to downsize

--- a/addons/mail/static/src/models/composer/composer.js
+++ b/addons/mail/static/src/models/composer/composer.js
@@ -90,6 +90,25 @@ registerModel({
         },
         /**
          * @private
+         * @returns {string}
+         */
+        _computePlaceholder() {
+            if (!this.thread) {
+                return "";
+            }
+            if (this.thread.model === 'mail.channel') {
+                if (this.thread.correspondent) {
+                    return _.str.sprintf(this.env._t("Message %s..."), this.thread.correspondent.nameOrDisplayName);
+                }
+                return _.str.sprintf(this.env._t("Message #%s..."), this.thread.displayName);
+            }
+            if (this.isLog) {
+                return this.env._t("Log an internal note...");
+            }
+            return this.env._t("Send a message to followers...");
+        },
+        /**
+         * @private
          * @returns {Partner[]}
          */
         _computeRecipients() {
@@ -175,6 +194,12 @@ registerModel({
         messageViewInEditing: one('MessageView', {
             inverse: 'composerForEditing',
             readonly: true,
+        }),
+        /**
+         * Placeholder displayed in the composer textarea when it's empty
+         */
+        placeholder: attr({
+            compute: '_computePlaceholder',
         }),
         /**
          * Determines the extra `Partner` (on top of existing followers)


### PR DESCRIPTION
This commit moves the logic associated with the composer placeholder for two
reasons:

- move business logic from components to models
- allow to easily override the placeholder in other module.
  This is uselfull for the feature allowing to leave comments on a spreadsheet.

Task 2638411

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
