### PR TITLE
[FIX] website: keep table of contents title & menu entries sync

### DIFF
--- a/addons/website/i18n/website.pot
+++ b/addons/website/i18n/website.pot
@@ -9485,6 +9485,13 @@ msgstr ""
 
 #. module: website
 #. openerp-web
+#: code:addons/website/static/src/js/menu/translate.js:0
+#, python-format
+msgid "This translation is not editable."
+msgstr ""
+
+#. module: website
+#. openerp-web
 #: code:addons/website/static/src/js/menu/seo.js:0
 #, python-format
 msgid ""
@@ -9710,6 +9717,13 @@ msgstr ""
 #: code:addons/website/static/src/js/menu/translate.js:0
 #, python-format
 msgid "Translate Attribute"
+msgstr ""
+
+#. module: website
+#. openerp-web
+#: code:addons/website/static/src/js/menu/translate.js:0
+#, python-format
+msgid "Translate header in the text. Menu is generated automatically."
 msgstr ""
 
 #. module: website

--- a/addons/website/static/src/js/menu/edit.js
+++ b/addons/website/static/src/js/menu/edit.js
@@ -314,6 +314,11 @@ var EditPageMenu = websiteNavbarData.WebsiteNavbarActionWidget.extend({
                         this.classList.add('o_dirty');
                     }
                 });
+                if (this.options.processRecordsCallback) {
+                    for (const el of $savable) {
+                        this.options.processRecordsCallback(record, el);
+                    }
+                }
             }
         };
         this.observer = new MutationObserver(processRecords);

--- a/addons/website/static/src/js/menu/translate.js
+++ b/addons/website/static/src/js/menu/translate.js
@@ -178,6 +178,21 @@ var TranslatePageMenu = websiteNavbarData.WebsiteNavbarActionWidget.extend({
             devicePreview: false,
         };
 
+        const showNotification = ev => {
+            let message = _t('This translation is not editable.');
+            if (ev.target.closest('.s_table_of_content_navbar_wrap')) {
+                message = _t('Translate header in the text. Menu is generated automatically.');
+            }
+            this.displayNotification({
+                type: 'info',
+                message: message,
+                sticky: false,
+            });
+        };
+        for (const translationEl of $('.o_not_editable [data-oe-translation-id]').not(':o_editable')) {
+            translationEl.addEventListener('click', showNotification);
+        }
+
         this.translator = new EditorMenu(this, {
             wysiwygOptions: params,
             savableSelector: savableSelector,
@@ -186,8 +201,14 @@ var TranslatePageMenu = websiteNavbarData.WebsiteNavbarActionWidget.extend({
                     .not('[data-oe-readonly]');
             },
             beforeEditorActive: async () => {
-                var attrs = ['placeholder', 'title', 'alt', 'value'];
                 const $editable = self._getEditableArea();
+                // Remove styles from table of content menu entries.
+                for (const el of $editable.filter('.s_table_of_content_navbar .table_of_content_link span[data-oe-translation-id]')) {
+                    const text = el.textContent; // Get text from el.
+                    el.textContent = text; // Replace all of el's content with that text.
+                }
+
+                var attrs = ['placeholder', 'title', 'alt', 'value'];
                 const translationRegex = /<span [^>]*data-oe-translation-id="([0-9]+)"[^>]*>(.*)<\/span>/;
                 let $edited = $();
                 _.each(attrs, function (attr) {
@@ -245,6 +266,19 @@ var TranslatePageMenu = websiteNavbarData.WebsiteNavbarActionWidget.extend({
 
                 self._markTranslatableNodes();
                 this.$translations.filter('input[type=hidden].o_translatable_input_hidden').prop('type', 'text');
+            },
+            processRecordsCallback(record, el) {
+                const tocMainEl = el.closest('.s_table_of_content_main');
+                const headerEl = el.closest('h1, h2');
+                if (!tocMainEl || !headerEl) {
+                    return;
+                }
+                const headerIndex = [...tocMainEl.querySelectorAll('h1, h2')].indexOf(headerEl);
+                const tocMenuEl = tocMainEl.closest('.s_table_of_content').querySelectorAll('.table_of_content_link > span')[headerIndex];
+                if (tocMenuEl.textContent !== headerEl.textContent) {
+                    tocMenuEl.textContent = headerEl.textContent;
+                    tocMenuEl.classList.add('o_dirty');
+                }
             },
         });
 

--- a/addons/website/static/src/snippets/s_table_of_content/000.js
+++ b/addons/website/static/src/snippets/s_table_of_content/000.js
@@ -12,6 +12,7 @@ const TableOfContent = publicWidget.Widget.extend({
      * @override
      */
     async start() {
+        this._stripNavbarStyles();
         await this._super(...arguments);
         this.$scrollingElement = $().getScrollingElement();
         this.previousPosition = -1;
@@ -31,6 +32,23 @@ const TableOfContent = publicWidget.Widget.extend({
     // Private
     //--------------------------------------------------------------------------
 
+    /**
+     * @private
+     */
+    _stripNavbarStyles() {
+        // TODO Introduce a `disabledInTranslateMode` flag instead.
+        // Ignore in translation mode.
+        if (this.el.querySelector('[data-oe-translation-id]')) {
+            return;
+        }
+
+        // This is needed for styles added on translations when the master text
+        // has no style.
+        for (const el of this.el.querySelectorAll('.s_table_of_content_navbar .table_of_content_link')) {
+            const text = el.textContent; // Get text from el.
+            el.textContent = text; // Replace all of el's content with that text.
+        }
+    },
     /**
      * @private
      */


### PR DESCRIPTION
The table of contents menu entries are generated automatically which
poses a problem in translation mode. The menu translation entries
are not be editable separately, but the users might be trying to.

This commit shows a notification when the user clicks on the menu
entries while in translation mode, explaining that they are generated
from the title entries.
It was initially intended to use a tooltip - but the amount of code
needed to display a tooltip without marking the DOM as modified is
needlessly complex.
Additionally, the translation widget updates the generated links of
table of content headers to keep them synchronized.
This could not be done by matching the translation id because those
are different when a style is applied to the header.

To avoid that styles applied on a plain text during translation were
also appearing in the navigation menu, an attempt at adding a span
around them to make sure that their translation was distinct from the
one inside the main content. But this led to the risk of losing
existing translations.
Because of this, and because that situation seems unlikely, any
remaining style in the navigation menu is instead stripped when the
table of content is started to maintain consistency with what is shown
during translation.

task-2752391