### PR TITLE
[IMP] hr_contract: disable email when a contract is about to end

### DIFF
--- a/addons/hr_contract/models/hr_contract.py
+++ b/addons/hr_contract/models/hr_contract.py
@@ -156,7 +156,7 @@ class Contract(models.Model):
         ])
 
         for contract in contracts:
-            contract.activity_schedule(
+            contract.with_context(mail_activity_quick_update=True).activity_schedule(
                 'mail.mail_activity_data_todo', contract.date_end,
                 _("The contract of %s is about to expire.", contract.employee_id.name),
                 user_id=contract.hr_responsible_id.id or self.env.uid)


### PR DESCRIPTION
When a contract is about to end, an activity is scheduled for the hr
responsible to act on it. Also, from task 2759601, a new warning was created
showing the contracts that are about to end. Therefore, sending an email to
the hr responsible started being too intrusive. This commit drops the email
sending for this case.

task-2759601

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
