### PR TITLE
[FIX] mail: restore scroll in discuss app

### DIFF
--- a/addons/mail/static/src/components/discuss_container/discuss_container.scss
+++ b/addons/mail/static/src/components/discuss_container/discuss_container.scss
@@ -1,0 +1,3 @@
+.o_DiscussContainer {
+    min-height: 0;
+}


### PR DESCRIPTION
min-height 0 is necessary for flex elements to properly shrink smaller than
their content. It was missing on this newly introduced parent.

Follow up on https://github.com/odoo/odoo/commit/cbe1bc809538f690115e1632448258663e1f52e4

task-2793274