### PR TITLE
[FIX] sale_timesheet: Fix project profitability revenue

### DIFF
--- a/addons/sale_timesheet/report/project_profitability_report_analysis.py
+++ b/addons/sale_timesheet/report/project_profitability_report_analysis.py
@@ -199,7 +199,7 @@ class ProfitabilityAnalysis(models.Model):
                                     AND BILLL.id IS NULL
                                     AND RINVL.id IS NULL
                                     AND (SOL.id IS NULL
-                                        OR (SOL.is_expense IS NOT TRUE AND SOL.is_downpayment IS NOT TRUE AND SOL.is_service IS NOT TRUE))
+                                        OR (SOL.is_expense IS NOT TRUE AND SOL.is_downpayment IS NOT TRUE AND SOL.is_service IS NOT TRUE AND SOL.invoice_status = 'no'))
 
                                 UNION ALL
 
@@ -271,11 +271,11 @@ class ProfitabilityAnalysis(models.Model):
                                         ELSE 0.0
                                     END AS expense_amount_untaxed_invoiced,
                                     CASE
-                                        WHEN SOL.qty_delivered_method IN ('timesheet', 'manual') THEN (SOL.untaxed_amount_to_invoice / CASE COALESCE(S.currency_rate, 0) WHEN 0 THEN 1.0 ELSE S.currency_rate END)
+                                        WHEN SOL.qty_delivered_method IN ('timesheet', 'manual', 'stock_move') THEN (SOL.untaxed_amount_to_invoice / CASE COALESCE(S.currency_rate, 0) WHEN 0 THEN 1.0 ELSE S.currency_rate END)
                                         ELSE 0.0
                                     END AS amount_untaxed_to_invoice,
                                     CASE
-                                        WHEN SOL.qty_delivered_method IN ('timesheet', 'manual') THEN (SOL.untaxed_amount_invoiced / CASE COALESCE(S.currency_rate, 0) WHEN 0 THEN 1.0 ELSE S.currency_rate END)
+                                        WHEN SOL.qty_delivered_method IN ('timesheet', 'manual', 'stock_move') THEN (SOL.untaxed_amount_invoiced / CASE COALESCE(S.currency_rate, 0) WHEN 0 THEN 1.0 ELSE S.currency_rate END)
                                         ELSE 0.0
                                     END AS amount_untaxed_invoiced,
                                     S.date_order AS line_date


### PR DESCRIPTION
Current behavior:
When Inventory app is not installed, and use a service product that create a project and task. If you add a product in a task
and then go in the project profitability report the revenues of the product you just added will be counted twice

Steps to reproduce:
- Have all these app installed : Sales, field service, project, timesheet
- Make sure Inventory is not installed
- Make sure Time and material invoicing is activated in field service
- Create a product of type service, with invoicing based on timesheet and create project + task
- Create a quotation using this product and validate it
- Go in the task created
- Add a product with the task
- Go back in the quotation, create an invoice and validate it
- Go in the projects dashboard and click on the three dots of the project created by the quotation
- In this menu click Project Updates, you will see revenues is 2*price of the product you added

opw-2762629

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
