### PR TITLE
[FIX] google_calendar: apply changes for another organizer's event

### DIFF
--- a/addons/google_calendar/views/google_calendar_views.xml
+++ b/addons/google_calendar/views/google_calendar_views.xml
@@ -10,4 +10,19 @@
             </field>
         </field>
     </record>
+    <record id="view_google_calendar_form" model="ir.ui.view">
+        <field name="name">google_calendar.event.calendar.form</field>
+        <field name="model">calendar.event</field>
+        <field name="inherit_id" ref="calendar.view_calendar_event_form"/>
+        <field name="arch" type="xml">
+            <xpath expr="//field[@name='active']" position="after">
+                <field name="google_id" invisible="1"/>
+            </xpath>
+            <xpath expr="//field[@name='user_id']" position="attributes">
+                <attribute name="attrs">
+                    {'readonly': [('google_id', '!=', False)]}
+                </attribute>
+            </xpath>
+        </field>
+    </record>
 </odoo>


### PR DESCRIPTION
Before this commit: a user could create an event for another user,
but it would be created on google for the current user. Also, when
you modify another users' event, it would apply on the Odoo calendar,
but Google wouldn't accept it.

Steps to reproduce the issue:

1. Create two Odoo users, and sync a Google account for each.
2. Login with the first user, create an event, and put the second user
as responsible.
 => event organizer in the google calendar is the first user

3. Create another event with the first user, and don't change
the responsible person. (organizer should be the first user)
4. Login with the second user and modify the event's date.
 => event date wouldn't change on the google

The solution is to use the organizer's token if it's synced with google.

opw-2761908

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
