### PR TITLE
[14.0][FIX] account: Keep partner_id from counterpart_vals if existing

### DIFF
--- a/addons/account/models/account_bank_statement.py
+++ b/addons/account/models/account_bank_statement.py
@@ -715,7 +715,7 @@ class AccountBankStatementLine(models.Model):
             **counterpart_vals,
             'name': counterpart_vals.get('name', move_line.name if move_line else ''),
             'move_id': self.move_id.id,
-            'partner_id': self.partner_id.id or (move_line.partner_id.id if move_line else False),
+            'partner_id': self.partner_id.id or counterpart_vals.get('partner_id', move_line.partner_id.id if move_line else False),
             'currency_id': currency_id,
             'account_id': counterpart_vals.get('account_id', move_line.account_id.id if move_line else False),
             'debit': balance if balance > 0.0 else 0.0,


### PR DESCRIPTION
In case an open balance needs to be created on a receivable or
payable account after reconciliation, but no partner was defined
on the statement line, we want to keep the partner from the
counterpart values that was identified through reference matching.

Description of the issue/feature this PR addresses:

Error "Unable to create an open balance for a statement line without a partner set" is displayed although a partner can be identified through reference matching.

Current behavior before PR:

Error message is displayed.

Desired behavior after PR is merged:

Open balance is created properly.


OPW-2793384

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
