### PR TITLE
[FIX] website: prevent click on readonly stat button

### DIFF
--- a/addons/website/static/src/scss/website.backend.scss
+++ b/addons/website/static/src/scss/website.backend.scss
@@ -217,13 +217,8 @@
     }
 }
 
-.oe_stat_button {
-    &.o_stat_button_info:hover {
-        color: #666666 !important;
-        background-color: transparent !important;
-        opacity: 0.8 !important;
-        cursor: default !important;
-    }
+.oe_stat_button.o_stat_button_info {
+    pointer-events: none;
 }
 
 .o_kanban_view.o_theme_kanban {


### PR DESCRIPTION
When clicking on readonly stat button (website related), it would
sometimes raise a traceback since there is no action to redirect to.

Step to reproduce:
- Go to Website > Visitors > Visitors
- Select a Visitor to enter its form view
- Now, either:
  A. Enter edit mode
  B. Enter edit mode and discard (or save)
- Click on stat button

This will raise a traceback, since the `disabled` property is now gone.
Indeed, the framework is adding/removing that attribute when entering
or leaving edit mode.
See disableButtons()/enableButtons()` called by
_setEditMode()/_onDiscard()/..`

Note:
- With the new framework/owl, there is no TB as the `disabled`
attribute is not removed anymore.
- In 14.0, there is no issue despite the `disabled` attributed being
removed.

Fixes https://github.com/odoo/odoo/issues/78500
Closes https://github.com/odoo/odoo/pull/80884

Courtesy of @odooaktiv
