### PR TITLE
[IMP] account: Invoice / Bill Outstanding Debit / credit improvement

### DIFF
--- a/addons/account/i18n/account.pot
+++ b/addons/account/i18n/account.pot
@@ -7327,6 +7327,13 @@ msgid "Journal Entry Date"
 msgstr ""
 
 #. module: account
+#. openerp-web
+#: code:addons/account/static/src/xml/account_payment.xml:0
+#, python-format
+msgid "Journal Entry Info"
+msgstr ""
+
+#. module: account
 #: model:ir.model.fields.selection,name:account.selection__account_print_journal__sort_selection__move_name
 #: model_terms:ir.ui.view,arch_db:account.report_journal
 msgid "Journal Entry Number"
@@ -7443,6 +7450,13 @@ msgstr ""
 #. module: account
 #: model:ir.model.fields,help:account.field_account_automatic_entry_wizard__journal_id
 msgid "Journal where to create the entry."
+msgstr ""
+
+#. module: account
+#. openerp-web
+#: code:addons/account/static/src/xml/account_payment.xml:0
+#, python-format
+msgid "Journal:"
 msgstr ""
 
 #. module: account
@@ -15506,12 +15520,24 @@ msgstr ""
 
 #. module: account
 #: model_terms:ir.ui.view,arch_db:account.view_move_form
+msgid ""
+"for this customer. You can allocate them to mark this credit note as paid."
+msgstr ""
+
+#. module: account
+#: model_terms:ir.ui.view,arch_db:account.view_move_form
 msgid "for this customer. You can allocate them to mark this invoice as paid."
 msgstr ""
 
 #. module: account
 #: model_terms:ir.ui.view,arch_db:account.view_move_form
 msgid "for this vendor. You can allocate them to mark this bill as paid."
+msgstr ""
+
+#. module: account
+#: model_terms:ir.ui.view,arch_db:account.view_move_form
+msgid ""
+"for this vendor. You can allocate them to mark this credit note as paid."
 msgstr ""
 
 #. module: account
@@ -15589,12 +15615,12 @@ msgstr ""
 
 #. module: account
 #: model_terms:ir.ui.view,arch_db:account.view_move_form
-msgid "outstanding debits"
+msgid "outstanding credits"
 msgstr ""
 
 #. module: account
 #: model_terms:ir.ui.view,arch_db:account.view_move_form
-msgid "outstanding payments"
+msgid "outstanding debits"
 msgstr ""
 
 #. module: account

--- a/addons/account/models/account_move.py
+++ b/addons/account/models/account_move.py
@@ -1600,7 +1600,8 @@ class AccountMove(models.Model):
                     'move_id': line.move_id.id,
                     'position': move.currency_id.position,
                     'digits': [69, move.currency_id.decimal_places],
-                    'payment_date': fields.Date.to_string(line.date),
+                    'date': fields.Date.to_string(line.date),
+                    'account_payment_id': line.payment_id.id,
                 })
 
             if not payments_widget_vals['content']:
@@ -3321,6 +3322,7 @@ class AccountMove(models.Model):
             move.has_reconciled_entries = len(move.line_ids._reconciled_lines()) > 1
 
     def action_view_reverse_entry(self):
+        # DEPRECATED: REMOVED IN MASTER
         self.ensure_one()
 
         # Create action.

--- a/addons/account/static/src/css/account.css
+++ b/addons/account/static/src/css/account.css
@@ -27,16 +27,31 @@
 .oe_invoice_outstanding_credits_debits {
     clear: both;
     float: right;
-    min-width: 350px;
-}
-
-@media (max-width: 767.98px) {
-    .oe_invoice_outstanding_credits_debits {
-        min-width: initial;
-        width: 100%;
-    }
+    min-width: 260px;
+    padding-top: 20px;
 }
 
 .oe_account_terms {
     flex: auto !important;
+}
+
+@media (max-width: 991.98px) {
+    /* The purpose is to put the narration below the totals in the tab 'Invoice Lines'
+    instead of above for the mobile view */
+    .o_form_view .oe_invoice_lines_tab {
+        display: flex;
+        flex-direction: column-reverse;
+    }
+
+    .o_form_view .oe_invoice_lines_tab .oe_invoice_outstanding_credits_debits {
+        min-width: initial;
+        width: 50%;
+    }
+}
+
+@media (max-width: 767.98px) {
+    .o_form_view .oe_invoice_lines_tab .oe_invoice_outstanding_credits_debits {
+        min-width: initial;
+        width: 100%;
+    }
 }

--- a/addons/account/static/src/js/account_payment_field.js
+++ b/addons/account/static/src/js/account_payment_field.js
@@ -12,6 +12,7 @@ var _t = core._t;
 var ShowPaymentLineWidget = AbstractField.extend({
     events: _.extend({
         'click .outstanding_credit_assign': '_onOutstandingCreditAssign',
+        'click .open_account_move': '_onOpenPayment',
     }, AbstractField.prototype.events),
     supportedFieldTypes: ['char'],
 
@@ -36,6 +37,7 @@ var ShowPaymentLineWidget = AbstractField.extend({
      * @override
      */
     _render: function() {
+        this.viewAlreadyOpened = false;
         var self = this;
         var info = JSON.parse(this.value);
         if (!info) {
@@ -88,20 +90,23 @@ var ShowPaymentLineWidget = AbstractField.extend({
     _onOpenPayment: function (event) {
         var paymentId = parseInt($(event.target).attr('payment-id'));
         var moveId = parseInt($(event.target).attr('move-id'));
-        var res_model;
+        var resModel;
         var id;
         if (paymentId !== undefined && !isNaN(paymentId)){
-            res_model = "account.payment";
+            resModel = "account.payment";
             id = paymentId;
         } else if (moveId !== undefined && !isNaN(moveId)){
-            res_model = "account.move";
+            resModel = "account.move";
             id = moveId;
         }
         //Open form view of account.move with id = move_id
-        if (res_model && id) {
+        //viewAlreadyopened is a flag to prevent the user from clicking on another account.move/account.payment
+        //while the first one he clicked on is loading
+        if (!this.viewAlreadyOpened && resModel && id) {
+            this.viewAlreadyOpened = true;
             this.do_action({
                 type: 'ir.actions.act_window',
-                res_model: res_model,
+                res_model: resModel,
                 res_id: id,
                 views: [[false, 'form']],
                 target: 'current'

--- a/addons/account/static/src/xml/account_payment.xml
+++ b/addons/account/static/src/xml/account_payment.xml
@@ -6,7 +6,7 @@
         <div>
             <t t-if="outstanding">
                 <div>
-                    <strong class="float-left" id="outstanding"><t t-esc="title"></t></strong>
+                    <strong class="float-left" id="outstanding" t-esc="title"/>
                 </div>
             </t>
             <table style="width:100%;">
@@ -14,15 +14,28 @@
                     <tr>
                     <t t-if="outstanding">
                         <td>
-                            <a title="assign to invoice" role="button" class="oe_form_field btn btn-link outstanding_credit_assign" t-att-data-id="line.id" style="margin-right: 10px;" href="#" data-toggle="tooltip">Add</a>
+                            <a title="assign to invoice"
+                               role="button"
+                               class="oe_form_field btn btn-secondary outstanding_credit_assign"
+                               t-att-data-id="line.id"
+                               style="margin-right: 0px; padding-left: 5px; padding-right: 5px;"
+                               href="#"
+                               data-toggle="tooltip">Add</a>
                         </td>
-                        <td style="max-width: 30em;">
-                            <div class="oe_form_field" style="margin-right: 30px; text-overflow: ellipsis; overflow: hidden; white-space: nowrap;" t-att-title="line.date" data-toggle="tooltip"><t t-esc="line.journal_name"></t></div>
+                        <td style="max-width: 11em;">
+                            <a t-att-title="line.date"
+                               role="button"
+                               class="oe_form_field btn btn-link open_account_move"
+                               t-att-move-id="line.move_id"
+                               style="margin-right: 5px; text-overflow: ellipsis; overflow: hidden; white-space: nowrap; padding-left: 0px; width:100%; text-align:left;"
+                               data-toggle="tooltip"
+                               t-att-payment-id="account_payment_id"
+                               t-esc="line.journal_name"/>
                         </td>
                     </t>
                     <t t-if="!outstanding">
                         <td>
-                           <a role="button" tabindex="0" class="js_payment_info fa fa-info-circle" t-att-index="line.index" style="margin-right:5px;" aria-label="Info" title="Payment Info" data-toggle="tooltip"></a>
+                           <a role="button" tabindex="0" class="js_payment_info fa fa-info-circle" t-att-index="line.index" style="margin-right:5px;" aria-label="Info" title="Journal Entry Info" data-toggle="tooltip"></a>
                         </td>
                         <td>
                             <i class="o_field_widget text-right o_payment_label">Paid on <t t-esc="line.date"></t></i>
@@ -73,7 +86,7 @@
                     <td><t t-esc="date"/></td>
                 </tr>
                 <tr>
-                    <td><strong>Payment Journal: </strong></td>
+                    <td><strong>Journal: </strong></td>
                     <td><t t-esc="journal_name"/><span t-if="payment_method_name"> (<t t-esc="payment_method_name"/>)</span></td>
                 </tr>
             </table>

--- a/addons/account/views/account_move_views.xml
+++ b/addons/account/views/account_move_views.xml
@@ -654,13 +654,23 @@
                     </div>
                     <div groups="account.group_account_invoice,account.group_account_readonly"
                          class="alert alert-info mb-0" role="alert"
-                         attrs="{'invisible': ['|', '|', ('move_type', 'not in', ('out_invoice', 'out_refund')), ('invoice_has_outstanding', '=', False), ('payment_state', 'not in', ('not_paid', 'partial'))]}">
-                        You have <bold><a class="alert-link" href="#outstanding" role="button">outstanding payments</a></bold> for this customer. You can allocate them to mark this invoice as paid.
+                         attrs="{'invisible': ['|', '|', ('move_type', '!=', 'out_invoice'), ('invoice_has_outstanding', '=', False), ('payment_state', 'not in', ('not_paid', 'partial'))]}">
+                        You have <bold><a class="alert-link" href="#outstanding" role="button">outstanding credits</a></bold> for this customer. You can allocate them to mark this invoice as paid.
                     </div>
                     <div groups="account.group_account_invoice,account.group_account_readonly"
                          class="alert alert-info mb-0" role="alert"
-                         attrs="{'invisible': ['|', '|', ('move_type', 'not in', ('in_invoice', 'in_refund')), ('invoice_has_outstanding', '=', False), ('payment_state', 'not in', ('not_paid', 'partial'))]}">
+                         attrs="{'invisible': ['|', '|', ('move_type', '!=', 'in_invoice'), ('invoice_has_outstanding', '=', False), ('payment_state', 'not in', ('not_paid', 'partial'))]}">
                         You have <bold><a class="alert-link" href="#outstanding" role="button">outstanding debits</a></bold> for this vendor. You can allocate them to mark this bill as paid.
+                    </div>
+                    <div groups="account.group_account_invoice,account.group_account_readonly"
+                         class="alert alert-info mb-0" role="alert"
+                         attrs="{'invisible': ['|', '|', ('move_type', '!=', 'out_refund'), ('invoice_has_outstanding', '=', False), ('payment_state', 'not in', ('not_paid', 'partial'))]}">
+                        You have <bold><a class="alert-link" href="#outstanding" role="button">outstanding debits</a></bold> for this customer. You can allocate them to mark this credit note as paid.
+                    </div>
+                    <div groups="account.group_account_invoice,account.group_account_readonly"
+                         class="alert alert-info mb-0" role="alert"
+                         attrs="{'invisible': ['|', '|', ('move_type', '!=', 'in_refund'), ('invoice_has_outstanding', '=', False), ('payment_state', 'not in', ('not_paid', 'partial'))]}">
+                        You have <bold><a class="alert-link" href="#outstanding" role="button">outstanding credits</a></bold> for this vendor. You can allocate them to mark this credit note as paid.
                     </div>
                     <div class="alert alert-info mb-0" role="alert"
                          attrs="{'invisible': ['|', ('state', '!=', 'draft'), ('auto_post', '=', False)]}">
@@ -1036,24 +1046,26 @@
                                         </sheet>
                                     </form>
                                 </field>
-                                <group col="4">
-                                    <group colspan="3">
+                                <group col="12" class="oe_invoice_lines_tab">
+                                    <group colspan="8">
                                         <field name="narration" placeholder="Terms and Conditions" class="oe_inline" nolabel="1"/>
                                     </group>
                                     <!-- Totals (only invoices / receipts) -->
-                                    <group class="oe_subtotal_footer oe_right"
-                                        attrs="{'invisible': ['|', ('move_type', 'not in', ('out_invoice', 'out_refund', 'in_invoice', 'in_refund', 'out_receipt', 'in_receipt')),
-                                                                   ('payment_state' ,'=', 'invoicing_legacy')]}">
+                                    <group colspan="4">
+                                        <group class="oe_subtotal_footer oe_right"
+                                            attrs="{'invisible': ['|', ('move_type', 'not in', ('out_invoice', 'out_refund', 'in_invoice', 'in_refund', 'out_receipt', 'in_receipt')),
+                                                                       ('payment_state' ,'=', 'invoicing_legacy')]}">
 
-                                        <field name="tax_totals_json" widget="account-tax-totals-field" nolabel="1" colspan="2"/>
+                                            <field name="tax_totals_json" widget="account-tax-totals-field" nolabel="1" colspan="2"/>
 
-                                        <field name="invoice_payments_widget" colspan="2" nolabel="1" widget="payment"/>
-                                        <field name="amount_residual" class="oe_subtotal_footer_separator" attrs="{'invisible': [('state', '=', 'draft')]}"/>
+                                            <field name="invoice_payments_widget" colspan="2" nolabel="1" widget="payment"/>
+                                            <field name="amount_residual" class="oe_subtotal_footer_separator" attrs="{'invisible': [('state', '=', 'draft')]}"/>
+                                        </group>
+                                        <field name="invoice_outstanding_credits_debits_widget"
+                                            class="oe_invoice_outstanding_credits_debits"
+                                            colspan="2" nolabel="1" widget="payment"
+                                            attrs="{'invisible': ['|', ('state', '!=', 'posted'), ('move_type', 'in', ('out_receipt', 'in_receipt'))]}"/>
                                     </group>
-                                    <field name="invoice_outstanding_credits_debits_widget"
-                                        class="oe_invoice_outstanding_credits_debits"
-                                        colspan="2" nolabel="1" widget="payment"
-                                        attrs="{'invisible': ['|', ('state', '!=', 'posted'), ('move_type', 'in', ('out_receipt', 'in_receipt'))]}"/>
                                 </group>
                             </page>
                             <page id="aml_tab" string="Journal Items" groups="account.group_account_readonly">


### PR DESCRIPTION
Backporting https://github.com/odoo/odoo/pull/78550

This commit:

fixes the customer invoice/vendor bill outstanding debit/credit warning anchor link
improves the customer invoice/vendor bill outstanding section
fixes the customer invoice/vendor bill outstanding debit/credit warning messages when viewing an account move reversal
The anchor link did not work when pointing to a field (the id of a field is not propagated into the DOM).
Hence,the target field is put inside a div with the correct id.

The outstanding section is placed to the right, below the amount due and next to the description for clarity purpose.
The 'Add' button is turned into a secondary button (s.t. it is more noticeable). Each entry name is now a link to to the corresponding account move.

The warning messages are modified because they were not consistent and confusing when viewing an account move reversal.

task-2669132
