### PR TITLE
[FIX][14.0] hr_timesheet: Can't access my timesheets when no longer the project allowed

### DIFF
--- a/addons/hr_timesheet/security/hr_timesheet_security.xml
+++ b/addons/hr_timesheet/security/hr_timesheet_security.xml
@@ -35,11 +35,7 @@
             <field name="model_id" ref="analytic.model_account_analytic_line"/>
             <field name="domain_force">[
                 ('user_id', '=', user.id),
-                ('project_id', '!=', False),
-                '|', '|',
-                    ('project_id.privacy_visibility', '!=', 'followers'),
-                    ('project_id.allowed_internal_user_ids', 'in', user.ids),
-                    ('task_id.allowed_user_ids', 'in', user.ids)
+                ('project_id', '!=', False)
             ]</field>
             <field name="groups" eval="[(4, ref('group_hr_timesheet_user'))]"/>
         </record>


### PR DESCRIPTION

Description of the issue/feature this PR addresses:

Current behavior before PR:
**Steps:**
1. Create a private project A
2. Add user Demo to Allowed Internal Users
3. User Demo create a timesheet that link to project A
4. Remove user Demo from Allowed Internal Users
5. User Demo cannot access timesheets

Desired behavior after PR is merged:



--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
