### PR TITLE
[FIX] base: ensures that the proper attachment field is retrieved

### DIFF
--- a/odoo/addons/base/models/ir_http.py
+++ b/odoo/addons/base/models/ir_http.py
@@ -394,7 +394,7 @@ class IrHttp(models.AbstractModel):
                 filehash = record['checksum']
 
         if not content:
-            if model == 'ir.attachment':
+            if model == 'ir.attachment' and field in {'datas', 'raw'}:
                 content = record.raw
             elif (
                 field_def.related_field and


### PR DESCRIPTION
Before this commit, any field requested to `_binary_record_content()`
when the model was `ir.attachment` would be considered as `raw`.

This assumption works at the moment but could lead to unexpected
behavior down the line.

see https://github.com/odoo/odoo/pull/86005#discussion_r824420219

