### PR TITLE
[FIX] Prevent editing saved non editable DOM elements

### DIFF
--- a/addons/website/static/src/js/menu/edit.js
+++ b/addons/website/static/src/js/menu/edit.js
@@ -283,6 +283,11 @@ var EditPageMenu = websiteNavbarData.WebsiteNavbarActionWidget.extend({
         // 1. Make sure every .o_not_editable is not editable.
         // 2. Observe changes to mark dirty structures and fields.
         const processRecords = (records) => {
+            // Updating the contenteditable attribute will trigger an
+            // attributes mutation, however these will be filtered out by the
+            // filterMutationRecords method in the OdooEditor.
+            $('#wrap').find('.o_not_editable[contenteditable!=false]').attr('contenteditable', false);
+
             records = this.wysiwyg.odooEditor.filterMutationRecords(records);
             // Skip the step for this stack because if the editor undo the first
             // step that has a dirty element, the following code would have
@@ -292,9 +297,6 @@ var EditPageMenu = websiteNavbarData.WebsiteNavbarActionWidget.extend({
             for (const record of records) {
                 const $savable = $(record.target).closest(this.savableSelector);
 
-                if (record.attributeName === 'contenteditable') {
-                    continue;
-                }
                 $savable.not('.o_dirty').each(function () {
                     const $el = $(this);
                     if (!$el.closest('[data-oe-readonly]').length) {

--- a/addons/website/static/tests/tours/non_editable_content.js
+++ b/addons/website/static/tests/tours/non_editable_content.js
@@ -1,0 +1,31 @@
+/** @odoo-module */
+
+import tour from 'web_tour.tour';
+
+const checkNonEditable = {
+    trigger: 'section.s_company_team div.o_not_editable[contenteditable="false"]',
+    content: 'Check non editable parts.',
+    run: () => {},
+};
+
+tour.register('non_editable_content', {
+    test: true,
+    url: '?enable_editor=1',
+}, [{
+    trigger: '#snippet_feature .oe_snippet:has(span:contains("Team")) .oe_snippet_thumbnail',
+    content: 'Drag the Team block and drop it in your page.',
+    run: 'drag_and_drop #wrap',
+},
+checkNonEditable,
+{
+    trigger: '[data-action=save]:contains("Save")',
+    content: 'Click the Save button.',
+    extra_trigger: '.homepage',
+},
+{
+    trigger: '[data-action=edit]:contains("Edit")',
+    content: 'Click the Edit button.',
+    extra_trigger: '.homepage',
+},
+checkNonEditable,
+]);

--- a/addons/website/tests/test_ui.py
+++ b/addons/website/tests/test_ui.py
@@ -287,3 +287,6 @@ class TestUi(odoo.tests.HttpCase):
 
     def test_17_website_edit_menus(self):
         self.start_tour("/", "edit_menus", login="admin")
+
+    def test_18_website_non_editable_content(self):
+        self.start_tour("/", "non_editable_content", login="admin")


### PR DESCRIPTION
A problem occurs when adding a new snippet, having some non editable parts (for example: team or table of contents snippet). After saving the snippet to the page and entering edit mode again, the non editable parts become editable. This happens because the `contenteditable` attributes are removed when cleaning the page (by the `SnippetsMenu` widget), but are never added again when starting edit mode. This problem does not occur for newly added snippets because the `contenteditable` attribute is already present in the html added to the DOM.

Actually, the code responsible for making sure non editable parts are in fact non editable was removed by commit 1b80fe9b56acea09a6784691561df65fe6349f50. This removal was not necessary for the fix described (the fix is obtained by deactivating the observer at the appropriate times). Oddly enough, the comment describing the behavior was not removed from the code.

Restoring the original code fixes the problem. The deactivation of the observer before adding the `contenteditable` attribute is omitted, since these mutation records are always filtered out by the `OdooEditor` when calling the `filterMutationRecords` method.