### PR TITLE
[13.0][FIX] event: localized dates in display name

### DIFF
--- a/addons/event/models/event.py
+++ b/addons/event/models/event.py
@@ -6,6 +6,7 @@ import pytz
 from odoo import _, api, fields, models, SUPERUSER_ID
 from odoo.tools import format_datetime
 from odoo.exceptions import AccessError, UserError, ValidationError
+from odoo.tools.misc import format_date
 from odoo.tools.translate import html_translate
 
 from dateutil.relativedelta import relativedelta
@@ -313,9 +314,9 @@ class EventEvent(models.Model):
         for event in self:
             date_begin = fields.Datetime.from_string(event.date_begin)
             date_end = fields.Datetime.from_string(event.date_end)
-            dates = [fields.Date.to_string(fields.Datetime.context_timestamp(event, dt)) for dt in [date_begin, date_end] if dt]
+            dates = (fields.Datetime.context_timestamp(event, dt).date() for dt in [date_begin, date_end] if dt)
             dates = sorted(set(dates))
-            result.append((event.id, '%s (%s)' % (event.name, ' - '.join(dates))))
+            result.append((event.id, '%s (%s)' % (event.name, ' - '.join(format_date(self.env, date) for date in dates))))
         return result
 
     @api.model


### PR DESCRIPTION
FW of #70479

Without this patch, an event display name looks like "My event (2021-05-06)", which is a date format that looks good only to computers, cyborgs and programmers. Most humans prefer other formats.

After this patch, dates should look familiar to everyone, according to their current lang configuration.


cc @Tecnativa TT35095

--
I confirm I have signed the CLA and read the PR guidelines at [www.odoo.com/submit-pr](http://www.odoo.com/submit-pr)

