### PR TITLE
[FIX] base: do not duplicate spaces for t-foreach

### DIFF
--- a/odoo/addons/base/models/ir_qweb.py
+++ b/odoo/addons/base/models/ir_qweb.py
@@ -1656,14 +1656,12 @@ class IrQWeb(models.AbstractModel):
         if not VARNAME_REGEXP.match(expr_as):
             raise ValueError(f'The varname {expr_as!r} can only contain alphanumeric characters and underscores.')
 
+        if el.tag.lower() == 't':
+            self._rstrip_text(options)
 
-        strip = self._rstrip_text(options)
         code = self._flush_text(options, level)
 
-        content_foreach = []
-        if strip and el.tag.lower() != 't':
-            self._append_text(strip, options)
-        content_foreach.extend(
+        content_foreach = (
             self._compile_directives(el, options, level + 1) +
             self._flush_text(options, level + 1, rstrip=True))
 

--- a/odoo/addons/base/tests/test_qweb.py
+++ b/odoo/addons/base/tests/test_qweb.py
@@ -1492,7 +1492,32 @@ class TestQWebBasic(TransactionCase):
 
         self.assertEqual(str(rendered).strip(), result.strip())
 
-    def test_space_remove_technical_space(self):
+    def test_space_remove_technical_space_t_foreach(self):
+        view = self.env['ir.ui.view'].create({
+            'name': 'master',
+            'type': 'qweb',
+            'arch_db': '''<t t-name='master'>
+                    <section>
+                        <article t-foreach="[0, 1, 2]" t-as="value" t-esc="value"/>
+                        <t t-foreach="[0, 1, 2]" t-as="value">
+                            <article t-esc="value"/>
+                        </t>
+                    </section>
+                </t>'''})
+
+        result = '''
+                    <section>
+                        <article>0</article><article>1</article><article>2</article>
+                            <article>0</article>
+                            <article>1</article>
+                            <article>2</article>
+                    </section>'''
+
+        rendered = self.env['ir.qweb']._render(view.id)
+
+        self.assertEqual(str(rendered), result)
+
+    def test_space_remove_technical_all(self):
         test = self.env['ir.ui.view'].create({
             'name': 'test',
             'type': 'qweb',
@@ -1576,8 +1601,7 @@ class TestQWebBasic(TransactionCase):
                         <article>
                             <div>
                 <span>0</span>
-                            </div>
-                            <div>
+                            </div><div>
                 <span>1</span>
                             </div>
 
@@ -1592,7 +1616,6 @@ class TestQWebBasic(TransactionCase):
                     </section>'''
 
         rendered = self.env['ir.qweb']._render(view.id)
-
         self.assertEqual(str(rendered), result)
 
 class FileSystemLoader(object):


### PR DESCRIPTION
The duplication was used to have a cleaner html page source code by
aligning the <script t-foreach/> for example. However, this behavior
seems difficult to understand and use. Additionally the behavior can be
done with a <t> tag and placing the script inside.