### PR TITLE
[FIX] base: correct float calculation

### DIFF
--- a/odoo/addons/base/models/res_currency.py
+++ b/odoo/addons/base/models/res_currency.py
@@ -192,7 +192,7 @@ class Currency(models.Model):
            :return: rounded float
         """
         self.ensure_one()
-        return tools.float_round(amount, precision_rounding=self.rounding)
+        return round(tools.float_round(amount, precision_rounding=self.rounding), self.decimal_places)
 
     def compare_amounts(self, amount1, amount2):
         """Compare ``amount1`` and ``amount2`` after rounding them according to the

--- a/odoo/tools/float_utils.py
+++ b/odoo/tools/float_utils.py
@@ -97,6 +97,8 @@ def float_round(value, precision_digits=None, precision_rounding=None, rounding_
         rounded_value = round(normalized_value)     # round to integer
 
     result = rounded_value * rounding_factor # de-normalize
+    if precision_digits:
+        builtins.round(result, precision_digits)
     return result
 
 def float_is_zero(value, precision_digits=None, precision_rounding=None):


### PR DESCRIPTION
# Test
eur = self.env["res.currency"].search([("name", "=", "EUR")])
eur.decimal_places -> 2

## Before this commit
eur.round(12.124999) -> 12.120000000000001
eur.round(12.115) -> 12.120000000000001

## After this commit
eur.round(12.124999) -> 12.12
eur.round(12.115) -> 12.12

# Explanation
Because the res.currency.round() method is called from a lot of places in the Odoo code, it is convenient to call the float_repr() there, so it returns with the correctly represented float number, and not with a monster.

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
