### PR TITLE
[FIX]  survey:  align the timer layout in mobile view

### DIFF
--- a/addons/survey/views/survey_templates.xml
+++ b/addons/survey/views/survey_templates.xml
@@ -65,11 +65,11 @@
         <div class="o_survey_nav pt16 mb-2">
             <div class="container m-0 p-0">
                 <div class="row">
-                    <div  class="col-10">
+                    <div  class="col-8 col-lg-10">
                         <h1 t-if="answer.state == 'new' or survey.questions_layout != 'page_per_question'"
                             t-esc="survey.title" class="o_survey_main_title pt-4"></h1>
                     </div>
-                    <div class="o_survey_timer col-2 pt-4">
+                    <div class="o_survey_timer col-4 col-lg-2  pt-4">
                         <h1 class="o_survey_timer_container timer text-right">
                         </h1>
                     </div>


### PR DESCRIPTION
currently when we test survey, the timer layout is broken in mobile view as
the timer is going outside the mobile window.
after this commit when we open mobile layout it will be well aligned.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
