### PR TITLE
[FIX] mrp: quantity done on stock.move set as 0 when producing

### DIFF
--- a/addons/mrp/views/mrp_production_views.xml
+++ b/addons/mrp/views/mrp_production_views.xml
@@ -36,7 +36,7 @@
                     <field name="production_duration_expected" attrs="{'invisible': [('production_duration_expected', '=', 0)]}" groups="mrp.group_mrp_routings" widget="float_time" sum="Total expected duration" optional="show"/>
                     <field name="production_real_duration" attrs="{'invisible': [('production_real_duration', '=', 0)]}" groups="mrp.group_mrp_routings" widget="float_time" sum="Total real duration" optional="show"/>
                     <field name="company_id" readonly="1" groups="base.group_multi_company" optional="show"/>
-                    <field name="state" 
+                    <field name="state"
                            decoration-success="state in ('done', 'to_close')"
                            decoration-warning="state == 'progress'"
                            decoration-info="state in ('confirmed', 'draft')"
@@ -277,23 +277,6 @@
                                 <tree default_order="is_done,sequence" editable="bottom">
                                     <field name="product_id" force_save="1" required="1" context="{'default_detailed_type': 'product'}" attrs="{'readonly': ['|', '|', ('move_lines_count', '&gt;', 0), ('state', '=', 'cancel'), '&amp;', ('state', '!=', 'draft'), ('additional', '=', False) ]}"/>
                                     <field name="location_id" string="From" readonly="1" groups="stock.group_stock_multi_locations" optional="show"/>
-                                    <field name="move_line_ids" invisible="1">
-                                        <tree>
-                                            <field name="lot_id" invisible="1"/>
-                                            <field name="owner_id" invisible="1"/>
-                                            <field name="package_id" invisible="1"/>
-                                            <field name="result_package_id" invisible="1"/>
-                                            <field name="location_id" invisible="1"/>
-                                            <field name="location_dest_id" invisible="1"/>
-                                            <field name="qty_done" invisible="1"/>
-                                            <field name="product_id" invisible="1"/>
-                                            <field name="product_uom_id" invisible="1"/>
-                                            <field name="reserved_uom_qty" invisible="1"/>
-                                            <field name="state" invisible="1"/>
-                                            <field name="move_id" invisible="1"/>
-                                            <field name="id" invisible="1"/>
-                                        </tree>
-                                    </field>
                                     <field name="propagate_cancel" invisible="1"/>
                                     <field name="price_unit" invisible="1"/>
                                     <field name="company_id" invisible="1"/>
@@ -327,7 +310,6 @@
                                     <button type="object" name="action_product_forecast_report" title="Forecast Report" icon="fa-area-chart" attrs="{'column_invisible': [('parent.state', '!=', 'draft')], 'invisible': [('forecast_availability', '&lt;', 0)]}"/>
                                     <button type="object" name="action_product_forecast_report" title="Forecast Report" icon="fa-area-chart text-danger" attrs="{'column_invisible': [('parent.state', '!=', 'draft')], 'invisible': [('forecast_availability', '&gt;=', 0)]}"/>
                                     <field name="forecast_availability" string="Reserved" attrs="{'column_invisible': [('parent.state', 'in', ('draft', 'done'))]}" widget="forecast_widget"/>
-                                    <field name="is_quantity_done_editable" invisible="1"/>
                                     <field name="quantity_done" string="Consumed"
                                         decoration-success="not is_done and (quantity_done - should_consume_qty == 0)"
                                         decoration-warning="not is_done and (quantity_done - should_consume_qty &gt; 0.0001)"
@@ -357,25 +339,6 @@
                                     <field name="byproduct_id" invisible="1"/>
                                     <field name="product_id" context="{'default_detailed_type': 'product'}" domain="[('id', '!=', parent.product_id)]" required="1"/>
                                     <field name="location_dest_id" string="To" readonly="1" groups="stock.group_stock_multi_locations"/>
-
-                                    <field name="move_line_ids" invisible="1">
-                                        <tree>
-                                            <field name="lot_id" invisible="1"/>
-                                            <field name="owner_id" invisible="1"/>
-                                            <field name="package_id" invisible="1"/>
-                                            <field name="result_package_id" invisible="1"/>
-                                            <field name="location_id" invisible="1"/>
-                                            <field name="location_dest_id" invisible="1"/>
-                                            <field name="qty_done" invisible="1"/>
-                                            <field name="product_id" invisible="1"/>
-                                            <field name="product_uom_id" invisible="1"/>
-                                            <field name="reserved_uom_qty" invisible="1"/>
-                                            <field name="state" invisible="1"/>
-                                            <field name="move_id" invisible="1"/>
-                                            <field name="id" invisible="1"/>
-                                        </tree>
-                                    </field>
-
                                     <field name="company_id" invisible="1"/>
                                     <field name="product_uom_category_id" invisible="1"/>
                                     <field name="name" invisible="1"/>
@@ -397,8 +360,7 @@
                                     <field name="location_dest_id" domain="[('id', 'child_of', parent.location_dest_id)]" invisible="1"/>
                                     <field name="state" invisible="1" force_save="1"/>
                                     <field name="product_uom_qty" string="To Produce" force_save="1" attrs="{'readonly': ['&amp;', ('parent.state', '!=', 'draft'), '|', '&amp;', ('parent.state', 'not in', ('confirmed', 'progress', 'to_close')), ('parent.is_planned', '!=', True), ('parent.is_locked', '=', True)]}"/>
-                                    <field name="is_quantity_done_editable" invisible="1"/>
-                                    <field name="quantity_done" string="Produced" attrs="{'column_invisible': [('parent.state', '=', 'draft')], 'readonly': [('is_quantity_done_editable', '=', False)]}"/>
+                                    <field name="quantity_done" string="Produced" attrs="{'column_invisible': [('parent.state', '=', 'draft')], 'readonly': [('has_tracking', '=', True)]}"/>
                                     <field name="product_uom" groups="uom.group_uom"/>
                                     <field name="cost_share" optional="hide"/>
                                     <field name="show_details_visible" invisible="1"/>

--- a/addons/mrp_repair/tests/test_tracability.py
+++ b/addons/mrp_repair/tests/test_tracability.py
@@ -36,11 +36,12 @@ class TestRepairTraceability(TestMrpCommon):
         with mo_form.move_raw_ids.new() as move:
             move.product_id = product_to_remove
             move.product_uom_qty = 1
-            move.move_line_ids.lot_id = ptremove_lot  # Set component serial to B2
         mo = mo_form.save()
         mo.action_confirm()
         # Set serial to A1
         mo.lot_producing_id = ptrepair_lot
+        # Set component serial to B2
+        mo.move_raw_ids.move_line_ids.lot_id = ptremove_lot
         mo.button_mark_done()
 
         with Form(self.env['repair.order']) as ro_form:
@@ -61,7 +62,6 @@ class TestRepairTraceability(TestMrpCommon):
         with mo2_form.move_raw_ids.new() as move:
             move.product_id = product_to_remove
             move.product_uom_qty = 1
-            move.move_line_ids.lot_id = ptremove_lot  # Set component serial to B2 again, it is possible
         mo2 = mo2_form.save()
         mo2.action_confirm()
         # Set serial to A2
@@ -70,6 +70,8 @@ class TestRepairTraceability(TestMrpCommon):
             'product_id': product_to_repair.id,
             'company_id': self.env.user.company_id.id
         })
+        # Set component serial to B2 again, it is possible
+        mo2.move_raw_ids.move_line_ids.lot_id = ptremove_lot
         # We are not forbidden to use that serial number, so nothing raised here
         mo2.button_mark_done()
 


### PR DESCRIPTION
To reproduce:
    1. create a BOM with analytic account
    2. create a MO to produce 10 of the above product
    3. change producing qty to 5, SAVE the form.
    4. change producing qty to 10, SAVE the form.

It happens because the server receive at the same time a new
`stock.move.line` creation and a quantity_done to write on the
`stock.move`.




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
