### PR TITLE
[FIX] stock: make the location current stock view non-editable

### DIFF
--- a/addons/stock/views/stock_quant_views.xml
+++ b/addons/stock/views/stock_quant_views.xml
@@ -180,11 +180,13 @@
         <field name="context">{'search_default_internal_loc': 1, 'search_default_productgroup':1, 'search_default_locationgroup':1}</field>
         <field name="res_model">stock.quant</field>
     </record>
+
     <record model="ir.actions.act_window" id="location_open_quants"> <!-- Used in location -->
         <field name="context">{'search_default_productgroup': 1}</field>
         <field name="domain">[('location_id', 'child_of', active_ids)]</field>
         <field name="name">Current Stock</field>
         <field name="res_model">stock.quant</field>
+        <field name="view_id" ref="view_stock_quant_tree"/>
     </record>
 
     <record id="quant_package_search_view" model="ir.ui.view">


### PR DESCRIPTION
Steps to reproduce the bug:
- Enable “Storage Locations” option in the inventory settings
- Go to Inventory > Configuration > Warehouse > locations
- Choose any Location > Click on Current stock > Select any product
- Try to add two line

Problem:
Traceback is triggered, Because the line should not be added twice(like in “Inventory Adjustments” view)
and as in the `_onchange_location_or_product_id` we access the quantity,
it should be only one quant: https://github.com/odoo/odoo/blob/15.0/addons/stock/models/stock_quant.py#L517

In v14, this list view is not editable, but since the refactor in v15 added the new view `stock.quant.inventory.tree.editable`,
it is being called by this action

Solution:
set the `view_id` to `stock.quant.tree`, which is the view it was previously using

opw-2779795


https://user-images.githubusercontent.com/78867936/158364388-ca8a3837-26ee-4ef1-a04a-bcbc6c0d8e95.mp4





--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
