### PR TITLE
[FIX] auth_ldap : add system parameter to disable referral chasing

### DIFF
--- a/addons/auth_ldap/models/res_company_ldap.py
+++ b/addons/auth_ldap/models/res_company_ldap.py
@@ -7,6 +7,7 @@ from ldap.filter import filter_format
 
 from odoo import _, api, fields, models, tools
 from odoo.exceptions import AccessDenied
+from odoo.tools.misc import str2bool
 from odoo.tools.pycompat import to_text
 
 _logger = logging.getLogger(__name__)
@@ -74,6 +75,9 @@ class CompanyLDAP(models.Model):
         uri = 'ldap://%s:%d' % (conf['ldap_server'], conf['ldap_server_port'])
 
         connection = ldap.initialize(uri)
+        ldap_chase_ref_disabled = self.env['ir.config_parameter'].sudo().get_param('auth_ldap.disable_chase_ref')
+        if str2bool(ldap_chase_ref_disabled):
+            connection.set_option(ldap.OPT_REFERRALS, ldap.OPT_OFF)
         if conf['ldap_tls']:
             connection.start_tls_s()
         return connection


### PR DESCRIPTION
To reproduce
============

- Using ldap server with Microsoft Active Directory
- Set up ldap authentication on Odoo
- Trying to log with a username/password from ldap on Odoo doesn't work

Purpose
=======

Because referral chasing is enabled by default, python-ldap ends up requesting
a completely different unrelated server.

Specification
=============

To solve the issue, a system parameter `disable_ldap_chase_ref` must be created
to have the possibility to disable referral chasing by setting its value to `True`.

opw-2724800
