### PR TITLE
[FIX] l10n_it_edi: Mismatching IdCodice

### DIFF
--- a/addons/l10n_it_edi/data/invoice_it_template.xml
+++ b/addons/l10n_it_edi/data/invoice_it_template.xml
@@ -52,7 +52,7 @@
                     <DatiTrasmissione>
                         <IdTrasmittente>
                             <IdPaese t-esc="get_vat_country(record.company_id.vat)"/>
-                            <IdCodice t-esc="get_vat_number(record.company_id.vat)"/>
+                            <IdCodice t-esc="record.company_id.l10n_it_codice_fiscale or get_vat_number(record.company_id.vat)"/>
                         </IdTrasmittente>
                         <ProgressivoInvio t-esc="record.name.replace('/','')[-10:]"/>
                         <FormatoTrasmissione t-esc="formato_trasmissione"/>
@@ -72,7 +72,7 @@
                                 <IdPaese t-esc="get_vat_country(record.company_id.vat)"/>
                                 <IdCodice t-esc="get_vat_number(record.company_id.vat)"/>
                             </IdFiscaleIVA>
-                            <CodiceFiscale t-if="record.company_id.l10n_it_codice_fiscale and not test_mode" t-esc="record.company_id.l10n_it_codice_fiscale"/>
+                            <CodiceFiscale t-if="record.company_id.l10n_it_codice_fiscale" t-esc="record.company_id.l10n_it_codice_fiscale"/>
                             <Anagrafica>
                                 <Denominazione t-esc="record.company_id.partner_id.display_name"/>
                             </Anagrafica>


### PR DESCRIPTION
When codice fiscale is not the same as the partita IVA, the template was
utilising the wrong value for IdCodice in <IdTrasmittente>. It should
use the value of codice fiscale, and if it's not found, then use the vat
value (e.g. when it's not an Italian company).
