### PR TITLE
[IMP] base: align version number with other elements in settings

### DIFF
--- a/addons/base_setup/static/src/xml/res_config_edition.xml
+++ b/addons/base_setup/static/src/xml/res_config_edition.xml
@@ -6,7 +6,7 @@
         <div class="col-12 o_setting_box" id="edition">
             <div class="o_setting_right_pane">
                 <div class="user-heading">
-                    <h3>
+                    <h3 class="px-0">
                         Odoo <t t-esc="widget.server_version"/>
                         (Community Edition)
                     </h3>


### PR DESCRIPTION
Technical note: We didn't change ".app_settings_block h3" because it is used
all over the place. Instead, we've overridden the margin and padding using
bootstrap classes on that specific element.

Task-2792977

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
