### PR TITLE
[WIP] l10n_pt: add tax exemption reason

### DIFF
--- a/addons/l10n_pt/__init__.py
+++ b/addons/l10n_pt/__init__.py
@@ -3,3 +3,5 @@
 
 # Copyright (C) 2012 Thinkopen Solutions, Lda. All Rights Reserved
 # http://www.thinkopensolutions.com.
+
+from . import models

--- a/addons/l10n_pt/__manifest__.py
+++ b/addons/l10n_pt/__manifest__.py
@@ -23,6 +23,10 @@
            'data/account_tax_report.xml',
            'data/account_tax_data.xml',
            'data/account_chart_template_configure_data.xml',
+           'data/l10n_pt_tax_exemption_reason_data.xml',
+           'views/account_move_views.xml',
+           'views/product_views.xml',
+           'security/ir.model.access.csv',
            ],
     'license': 'LGPL-3',
 }

--- a/addons/l10n_pt/data/l10n_pt_tax_exemption_reason_data.xml
+++ b/addons/l10n_pt/data/l10n_pt_tax_exemption_reason_data.xml
@@ -1,0 +1,234 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <data noupdate="1">
+
+    <record id="l10n_pt_tax_exemption_reason_1" model="l10n.pt.tax.exemption.reason">
+      <field name="code">1</field>
+      <field name="name">Prestações de serviços efetuadas no exercício das profissões de médico, odontologista, psicólogo, parteiro, enfermeiro e outras profissões paramédicas</field>
+    </record>
+
+    <record id="l10n_pt_tax_exemption_reason_2" model="l10n.pt.tax.exemption.reason">
+      <field name="code">2</field>
+      <field name="name">Prestações de serviços médicos e sanitários e as operações com elas estreitamente conexas efectuadas por estabelecimentos hospitalares, clínicas, dispensários e similares</field>
+    </record>
+
+    <record id="l10n_pt_tax_exemption_reason_3" model="l10n.pt.tax.exemption.reason">
+      <field name="code">3</field>
+      <field name="name">Prestações de serviços efetuadas no exercício da sua atividade por protésicos dentários bem como as transmissões de próteses dentárias efetuadas por dentistas e protésicos dentários</field>
+    </record>
+
+    <record id="l10n_pt_tax_exemption_reason_4" model="l10n.pt.tax.exemption.reason">
+      <field name="code">4</field>
+      <field name="name">Transmissões de órgãos, sangue e leite humanos</field>
+    </record>
+
+    <record id="l10n_pt_tax_exemption_reason_5" model="l10n.pt.tax.exemption.reason">
+      <field name="code">5</field>
+      <field name="name">Transporte de doentes ou feridos em ambulâncias ou outros veículos apropriados efectuado por organismos devidamente autorizados</field>
+    </record>
+
+    <record id="l10n_pt_tax_exemption_reason_6" model="l10n.pt.tax.exemption.reason">
+      <field name="code">6</field>
+      <field name="name">Transmissões de bens e as prestações de serviços ligadas à segurança e assistência sociais e as transmissões de bens com elas conexas, efectuadas pelo sistema de segurança social, incluindo as instituições particulares de solidariedade social. Da mesma isenção beneficiam as pessoas físicas ou jurídicas que efectuem prestações de segurança ou assistência social por conta do respectivo sistema nacional, desde que não recebam em troca das mesmas qualquer contraprestação dos adquirentes dos bens ou destinatários dos serviços</field>
+    </record>
+
+    <record id="l10n_pt_tax_exemption_reason_7" model="l10n.pt.tax.exemption.reason">
+      <field name="code">7</field>
+      <field name="name">Prestações de serviços e as transmissões de bens estreitamente conexas, efetuadas no exercício da sua atividade habitual por creches, jardins-de-infância, centros de atividade de tempos livres, estabelecimentos para crianças e jovens desprovidos de meio familiar normal, lares residenciais, casas de trabalho, estabelecimentos para crianças e jovens deficientes, centros de reabilitação de inválidos, lares de idosos, centros de dia e centros de convívio para idosos, colónias de férias, albergues de juventude ou outros equipamentos sociais pertencentes a pessoas coletivas de direito público ou instituições particulares de solidariedade social ou cuja utilidade social seja, em qualquer caso, reconhecida pelas autoridades competentes, ainda que os serviços sejam prestados fora das suas instalações</field>
+    </record>
+
+    <record id="l10n_pt_tax_exemption_reason_8" model="l10n.pt.tax.exemption.reason">
+      <field name="code">8</field>
+      <field name="name">Prestações de serviços efectuadas por organismos sem finalidade lucrativa que explorem estabelecimentos ou instalações destinados à prática de actividades artísticas, desportivas, recreativas e de educação física a pessoas que pratiquem essas actividades</field>
+    </record>
+
+    <record id="l10n_pt_tax_exemption_reason_9" model="l10n.pt.tax.exemption.reason">
+      <field name="code">9</field>
+      <field name="name">Prestações de serviços que tenham por objecto o ensino, bem como as transmissões de bens e prestações de serviços conexas, como sejam o fornecimento de alojamento e alimentação, efectuadas por estabelecimentos integrados no Sistema Nacional de Educação ou reconhecidos como tendo fins análogos pelos ministérios competentes</field>
+    </record>
+
+    <record id="l10n_pt_tax_exemption_reason_10" model="l10n.pt.tax.exemption.reason">
+      <field name="code">10</field>
+      <field name="name">Prestações de serviços que tenham por objecto a formação profissional, bem como as transmissões de bens e prestações de serviços conexas, como sejam o fornecimento de alojamento, alimentação e material didáctico, efectuadas por organismos de direito público ou por entidades reconhecidas como tendo competência nos domínios da formação e reabilitação profissionais pelos ministérios competentes</field>
+    </record>
+
+    <record id="l10n_pt_tax_exemption_reason_11" model="l10n.pt.tax.exemption.reason">
+      <field name="code">11</field>
+      <field name="name">Prestações de serviços que consistam em lições ministradas a título pessoal sobre matérias do ensino escolar ou superior</field>
+    </record>
+
+    <record id="l10n_pt_tax_exemption_reason_12" model="l10n.pt.tax.exemption.reason">
+      <field name="code">12</field>
+      <field name="name">Locações de livros e outras publicações, partituras musicais, discos, bandas magnéticas e outros suportes de cultura e, em geral, as prestações de serviços e transmissões de bens com aquelas estreitamente conexas, desde que efectuadas por organismos sem finalidade lucrativa</field>
+    </record>
+
+    <record id="l10n_pt_tax_exemption_reason_13" model="l10n.pt.tax.exemption.reason">
+      <field name="code">13</field>
+      <field name="name">Prestações de serviços que consistam em proporcionar a visita, guiada ou não, a bibliotecas, arquivos, museus, galerias de arte, castelos, palácios, monumentos, parques, perímetros florestais, jardins botânicos, zoológicos e semelhantes, pertencentes ao Estado, outras pessoas coletivas de direito público ou organismos sem finalidade lucrativa, desde que efetuadas única e exclusivamente por intermédio dos seus próprios agentes. A presente isenção abrange também as transmissões de bens estreitamente conexas com as prestações de serviços referidas</field>
+    </record>
+
+    <record id="l10n_pt_tax_exemption_reason_14" model="l10n.pt.tax.exemption.reason">
+      <field name="code">14</field>
+      <field name="name">Prestações de serviços e as transmissões de bens com elas conexas, efectuadas por pessoas colectivas de direito público e organismos sem finalidade lucrativa, relativas a congressos, colóquios, conferências, seminários, cursos e manifestações análogas de natureza científica, cultural, educativa ou técnica</field>
+    </record>
+
+    <record id="l10n_pt_tax_exemption_reason_15a" model="l10n.pt.tax.exemption.reason">
+      <field name="code">15a</field>
+      <field name="name">Prestações de serviços efectuadas aos respectivos promotores: Por actores, chefes de orquestra, músicos e outros artistas, actuando quer individualmente quer integrados em conjuntos, para a execução de espectáculos teatrais, cinematográficos, coreográficos, musicais, de music-hall, de circo e outros, para a realização de filmes, e para a edição de discos e de outros suportes de som ou imagem</field>
+    </record>
+
+    <record id="l10n_pt_tax_exemption_reason_15b" model="l10n.pt.tax.exemption.reason">
+      <field name="code">15b</field>
+      <field name="name">Prestações de serviços efectuadas aos respectivos promotores: Por desportistas e artistas tauromáquicos, actuando quer individualmente quer integrados em grupos, em competições desportivas e espectáculos tauromáquicos</field>
+    </record>
+
+    <record id="l10n_pt_tax_exemption_reason_16" model="l10n.pt.tax.exemption.reason">
+      <field name="code">16</field>
+      <field name="name">Transmissão do direito de autor ou de direitos conexos e a autorização para a utilização da obra intelectual ou prestação, definidas no Código dos Direitos de Autor e dos Direitos Conexos, quando efetuadas pelos próprios titulares, seus herdeiros ou legatários, ou ainda por terceiros, por conta deles, ainda que o titular do direito seja pessoa coletiva, incluindo a consignação ou afetação, imposta por lei, dos montantes recebidos pelas respetivas entidades de gestão coletiva, a fins sociais, culturais e de investigação e divulgação dos direitos de autor e direitos conexos</field>
+    </record>
+
+    <record id="l10n_pt_tax_exemption_reason_17" model="l10n.pt.tax.exemption.reason">
+      <field name="code">17</field>
+      <field name="name">Transmissão de exemplares de qualquer obra literária, científica, técnica ou artística editada sob forma bibliográfica pelo autor, quando efectuada por este, seus herdeiros ou legatários, ou ainda por terceiros, por conta deles, salvo quando o autor for pessoa colectiva</field>
+    </record>
+
+    <record id="l10n_pt_tax_exemption_reason_18" model="l10n.pt.tax.exemption.reason">
+      <field name="code">18</field>
+      <field name="name">Cedência de pessoal por instituições religiosas ou filosóficas para a realização de actividades isentas nos termos deste diploma ou para fins de assistência espiritual</field>
+    </record>
+
+    <record id="l10n_pt_tax_exemption_reason_19" model="l10n.pt.tax.exemption.reason">
+      <field name="code">19</field>
+      <field name="name">Prestações de serviços e as transmissões de bens com elas conexas efectuadas no interesse colectivo dos seus associados por organismos sem finalidade lucrativa, desde que esses organismos prossigam objectivos de natureza política, sindical, religiosa, humanitária, filantrópica, recreativa, desportiva, cultural, cívica ou de representação de interesses económicos e a única contraprestação seja uma quota fixada nos termos dos estatutos</field>
+    </record>
+
+    <record id="l10n_pt_tax_exemption_reason_20" model="l10n.pt.tax.exemption.reason">
+      <field name="code">20</field>
+      <field name="name">Transmissões de bens e as prestações de serviços efectuadas por entidades cujas actividades habituais se encontram isentas nos termos dos n.os 2), 6), 7), 8), 9), 10), 12), 13), 14) e 19) deste artigo, aquando de manifestações ocasionais destinadas à angariação de fundos em seu proveito exclusivo, desde que esta isenção não provoque distorções de concorrência</field>
+    </record>
+
+    <record id="l10n_pt_tax_exemption_reason_21" model="l10n.pt.tax.exemption.reason">
+      <field name="code">21</field>
+      <field name="name">Prestações de serviços fornecidas aos seus membros por grupos autónomos de pessoas que exerçam uma actividade isenta, desde que tais serviços sejam directamente necessários ao exercício da actividade e os grupos se limitem a exigir dos seus membros o reembolso exacto da parte que lhes incumbe nas despesas comuns, desde que, porém, esta isenção não seja susceptível de provocar distorções de concorrência</field>
+    </record>
+
+    <record id="l10n_pt_tax_exemption_reason_22" model="l10n.pt.tax.exemption.reason">
+      <field name="code">22</field>
+      <field name="name">Para efeitos do disposto no número anterior considera-se que os membros do grupo autónomo ainda exercem uma actividade isenta, desde que a percentagem de dedução determinada nos termos do artigo 23.º não seja superior a 10 %</field>
+    </record>
+
+    <record id="l10n_pt_tax_exemption_reason_23" model="l10n.pt.tax.exemption.reason">
+      <field name="code">23</field>
+      <field name="name">Prestações de serviços e as transmissões de bens conexas efectuadas pelos serviços públicos postais, com excepção das telecomunicações</field>
+    </record>
+
+    <record id="l10n_pt_tax_exemption_reason_24" model="l10n.pt.tax.exemption.reason">
+      <field name="code">24</field>
+      <field name="name">Transmissões, pelo seu valor facial, de selos do correio em circulação ou de valores selados, e bem assim as respectivas comissões de venda</field>
+    </record>
+
+    <record id="l10n_pt_tax_exemption_reason_25" model="l10n.pt.tax.exemption.reason">
+      <field name="code">25</field>
+      <field name="name">Serviço público de remoção de lixos</field>
+    </record>
+
+    <record id="l10n_pt_tax_exemption_reason_26" model="l10n.pt.tax.exemption.reason">
+      <field name="code">26</field>
+      <field name="name">Prestações de serviços efectuadas por empresas funerárias e de cremação, bem como as transmissões de bens acessórias aos mesmos serviços</field>
+    </record>
+
+    <record id="l10n_pt_tax_exemption_reason_27a" model="l10n.pt.tax.exemption.reason">
+      <field name="code">27a</field>
+      <field name="name">Concessão e a negociação de créditos, sob qualquer forma, compreendendo operações de desconto e redesconto, bem como a sua administração ou gestão efectuada por quem os concedeu</field>
+    </record>
+
+    <record id="l10n_pt_tax_exemption_reason_27b" model="l10n.pt.tax.exemption.reason">
+      <field name="code">27b</field>
+      <field name="name">Negociação e a prestação de fianças, avales, cauções e outras garantias, bem como a administração ou gestão de garantias de créditos efectuada por quem os concedeu</field>
+    </record>
+
+    <record id="l10n_pt_tax_exemption_reason_27c" model="l10n.pt.tax.exemption.reason">
+      <field name="code">27c</field>
+      <field name="name">Operações, compreendendo a negociação, relativas a depósitos de fundos, contas correntes, pagamentos, transferências, recebimentos, cheques, efeitos de comércio e afins, com excepção das operações de simples cobrança de dívidas</field>
+    </record>
+
+    <record id="l10n_pt_tax_exemption_reason_27d" model="l10n.pt.tax.exemption.reason">
+      <field name="code">27d</field>
+      <field name="name">Operações, incluindo a negociação, que tenham por objecto divisas, notas bancárias e moedas, que sejam meios legais de pagamento, com excepção das moedas e notas que não sejam normalmente utilizadas como tal, ou que tenham interesse numismátic</field>
+    </record>
+
+    <record id="l10n_pt_tax_exemption_reason_27e" model="l10n.pt.tax.exemption.reason">
+      <field name="code">27e</field>
+      <field name="name">Operações e serviços, incluindo a negociação, mas com exclusão da simples guarda e administração ou gestão, relativos a acções, outras participações em sociedades ou associações, obrigações e demais títulos, com exclusão dos títulos representativos de mercadorias e dos títulos representativos de operações sobre bens imóveis quando efectuadas por um prazo inferior a 20 anos</field>
+    </record>
+
+    <record id="l10n_pt_tax_exemption_reason_27f" model="l10n.pt.tax.exemption.reason">
+      <field name="code">27f</field>
+      <field name="name">Serviços e operações relativos à colocação, tomada e compra firmes de emissões de títulos públicos ou privados</field>
+    </record>
+
+    <record id="l10n_pt_tax_exemption_reason_27g" model="l10n.pt.tax.exemption.reason">
+      <field name="code">27g</field>
+      <field name="name">Administração ou gestão de fundos de investimento</field>
+    </record>
+
+    <record id="l10n_pt_tax_exemption_reason_28" model="l10n.pt.tax.exemption.reason">
+      <field name="code">28</field>
+      <field name="name">Operações de seguro e resseguro, bem como as prestações de serviços conexas efectuadas pelos corretores e intermediários de seguro</field>
+    </record>
+
+    <record id="l10n_pt_tax_exemption_reason_29" model="l10n.pt.tax.exemption.reason">
+      <field name="code">29</field>
+      <field name="name">Locação de bens imóveis. Esta isenção não abrange:
+a) As prestações de serviços de alojamento, efectuadas no âmbito da actividade hoteleira ou de outras com funções análogas, incluindo parques de campismo;
+b) A locação de áreas para recolha ou estacionamento colectivo de veículos;
+c) A locação de máquinas e outros equipamentos de instalação fixa, bem como qualquer outra locação de bens imóveis de que resulte a transferência onerosa da exploração de estabelecimento comercial ou industrial;
+d) A locação de cofres-fortes;
+e) A locação de espaços para exposições ou publicidade;</field>
+    </record>
+
+    <record id="l10n_pt_tax_exemption_reason_30" model="l10n.pt.tax.exemption.reason">
+      <field name="code">30</field>
+      <field name="name">Operações sujeitas a imposto municipal sobre as transmissões onerosas de imóveis</field>
+    </record>
+
+    <record id="l10n_pt_tax_exemption_reason_31" model="l10n.pt.tax.exemption.reason">
+      <field name="code">31</field>
+      <field name="name">Lotaria da Santa Casa da Misericórdia, as apostas mútuas, o bingo, os sorteios e as lotarias instantâneas devidamente autorizados, bem como as respectivas comissões e todas as actividades sujeitas a impostos especiais sobre o jogo</field>
+    </record>
+
+    <record id="l10n_pt_tax_exemption_reason_32" model="l10n.pt.tax.exemption.reason">
+      <field name="code">32</field>
+      <field name="name">Transmissões de bens afectos exclusivamente a uma actividade isenta, quando não tenham sido objecto do direito à dedução e bem assim as transmissões de bens cuja aquisição ou afectação tenha sido feita com exclusão do direito à dedução nos termos do n.º 1 do artigo 21.º</field>
+    </record>
+
+    <record id="l10n_pt_tax_exemption_reason_34" model="l10n.pt.tax.exemption.reason">
+      <field name="code">34</field>
+      <field name="name">Prestações de serviços efectuadas por cooperativas que, não sendo de produção agrícola, desenvolvam uma actividade de prestação de serviços aos seus associados agricultores</field>
+    </record>
+
+    <record id="l10n_pt_tax_exemption_reason_35" model="l10n.pt.tax.exemption.reason">
+      <field name="code">35</field>
+      <field name="name">Prestações de serviços a seguir indicadas quando levadas a cabo por organismos sem finalidade lucrativa que sejam associações de cultura e recreio:
+a) Cedência de bandas de música;
+b) Sessões de teatro;
+c) Ensino de ballet e de música;</field>
+    </record>
+
+    <record id="l10n_pt_tax_exemption_reason_36" model="l10n.pt.tax.exemption.reason">
+      <field name="code">36</field>
+      <field name="name">Serviços de alimentação e bebidas fornecidos pelas entidades patronais aos seus empregados</field>
+    </record>
+
+    <record id="l10n_pt_tax_exemption_reason_37" model="l10n.pt.tax.exemption.reason">
+      <field name="code">37</field>
+      <field name="name">Actividades das empresas públicas de rádio e televisão que não tenham carácter comercial</field>
+    </record>
+
+    <record id="l10n_pt_tax_exemption_reason_38" model="l10n.pt.tax.exemption.reason">
+      <field name="code">38</field>
+      <field name="name">Prestações de serviços efetuadas por intérprete de língua gestual portuguesa</field>
+    </record>
+
+    </data>
+</odoo>

--- a/addons/l10n_pt/data/l10n_pt_tax_exemption_reason_data.xml
+++ b/addons/l10n_pt/data/l10n_pt_tax_exemption_reason_data.xml
@@ -2,232 +2,89 @@
 <odoo>
     <data noupdate="1">
 
-    <record id="l10n_pt_tax_exemption_reason_1" model="l10n.pt.tax.exemption.reason">
-      <field name="code">1</field>
-      <field name="name">Prestações de serviços efetuadas no exercício das profissões de médico, odontologista, psicólogo, parteiro, enfermeiro e outras profissões paramédicas</field>
+    <record id="l10n_pt_tax_exemption_reason_m01" model="l10n.pt.tax.exemption.reason">
+      <field name="code">M01</field>
+      <field name="name">Artigo 16.º n.º 6 do CIVA (ou similar)</field>
     </record>
 
-    <record id="l10n_pt_tax_exemption_reason_2" model="l10n.pt.tax.exemption.reason">
-      <field name="code">2</field>
-      <field name="name">Prestações de serviços médicos e sanitários e as operações com elas estreitamente conexas efectuadas por estabelecimentos hospitalares, clínicas, dispensários e similares</field>
+    <record id="l10n_pt_tax_exemption_reason_m02" model="l10n.pt.tax.exemption.reason">
+      <field name="code">M02</field>
+      <field name="name">Artigo 6.º do Decreto-Lei n.º 198/90, de 19 de Junho</field>
     </record>
 
-    <record id="l10n_pt_tax_exemption_reason_3" model="l10n.pt.tax.exemption.reason">
-      <field name="code">3</field>
-      <field name="name">Prestações de serviços efetuadas no exercício da sua atividade por protésicos dentários bem como as transmissões de próteses dentárias efetuadas por dentistas e protésicos dentários</field>
+    <record id="l10n_pt_tax_exemption_reason_m03" model="l10n.pt.tax.exemption.reason">
+      <field name="code">M03</field>
+      <field name="name">Exigibilidade de caixa</field>
     </record>
 
-    <record id="l10n_pt_tax_exemption_reason_4" model="l10n.pt.tax.exemption.reason">
-      <field name="code">4</field>
-      <field name="name">Transmissões de órgãos, sangue e leite humanos</field>
+    <record id="l10n_pt_tax_exemption_reason_m04" model="l10n.pt.tax.exemption.reason">
+      <field name="code">M04</field>
+      <field name="name">Isento Artigo 13.º do CIVA (ou similar)</field>
     </record>
 
-    <record id="l10n_pt_tax_exemption_reason_5" model="l10n.pt.tax.exemption.reason">
-      <field name="code">5</field>
-      <field name="name">Transporte de doentes ou feridos em ambulâncias ou outros veículos apropriados efectuado por organismos devidamente autorizados</field>
+    <record id="l10n_pt_tax_exemption_reason_m05" model="l10n.pt.tax.exemption.reason">
+      <field name="code">M05</field>
+      <field name="name">Isento Artigo 14.º do CIVA (ou similar</field>
     </record>
 
-    <record id="l10n_pt_tax_exemption_reason_6" model="l10n.pt.tax.exemption.reason">
-      <field name="code">6</field>
-      <field name="name">Transmissões de bens e as prestações de serviços ligadas à segurança e assistência sociais e as transmissões de bens com elas conexas, efectuadas pelo sistema de segurança social, incluindo as instituições particulares de solidariedade social. Da mesma isenção beneficiam as pessoas físicas ou jurídicas que efectuem prestações de segurança ou assistência social por conta do respectivo sistema nacional, desde que não recebam em troca das mesmas qualquer contraprestação dos adquirentes dos bens ou destinatários dos serviços</field>
+    <record id="l10n_pt_tax_exemption_reason_m06" model="l10n.pt.tax.exemption.reason">
+      <field name="code">M06</field>
+      <field name="name">Isento Artigo 15.º do CIVA (ou similar</field>
     </record>
 
-    <record id="l10n_pt_tax_exemption_reason_7" model="l10n.pt.tax.exemption.reason">
-      <field name="code">7</field>
-      <field name="name">Prestações de serviços e as transmissões de bens estreitamente conexas, efetuadas no exercício da sua atividade habitual por creches, jardins-de-infância, centros de atividade de tempos livres, estabelecimentos para crianças e jovens desprovidos de meio familiar normal, lares residenciais, casas de trabalho, estabelecimentos para crianças e jovens deficientes, centros de reabilitação de inválidos, lares de idosos, centros de dia e centros de convívio para idosos, colónias de férias, albergues de juventude ou outros equipamentos sociais pertencentes a pessoas coletivas de direito público ou instituições particulares de solidariedade social ou cuja utilidade social seja, em qualquer caso, reconhecida pelas autoridades competentes, ainda que os serviços sejam prestados fora das suas instalações</field>
+    <record id="l10n_pt_tax_exemption_reason_m07" model="l10n.pt.tax.exemption.reason">
+      <field name="code">M07</field>
+      <field name="name">Isento Artigo 9.º do CIVA (ou similar</field>
     </record>
 
-    <record id="l10n_pt_tax_exemption_reason_8" model="l10n.pt.tax.exemption.reason">
-      <field name="code">8</field>
-      <field name="name">Prestações de serviços efectuadas por organismos sem finalidade lucrativa que explorem estabelecimentos ou instalações destinados à prática de actividades artísticas, desportivas, recreativas e de educação física a pessoas que pratiquem essas actividades</field>
+    <record id="l10n_pt_tax_exemption_reason_m08" model="l10n.pt.tax.exemption.reason">
+      <field name="code">M08</field>
+      <field name="name">IVA – autoliquidação</field>
     </record>
 
-    <record id="l10n_pt_tax_exemption_reason_9" model="l10n.pt.tax.exemption.reason">
-      <field name="code">9</field>
-      <field name="name">Prestações de serviços que tenham por objecto o ensino, bem como as transmissões de bens e prestações de serviços conexas, como sejam o fornecimento de alojamento e alimentação, efectuadas por estabelecimentos integrados no Sistema Nacional de Educação ou reconhecidos como tendo fins análogos pelos ministérios competentes</field>
+    <record id="l10n_pt_tax_exemption_reason_m09" model="l10n.pt.tax.exemption.reason">
+      <field name="code">M09</field>
+      <field name="name">IVA - não confere direito a dedução</field>
     </record>
 
-    <record id="l10n_pt_tax_exemption_reason_10" model="l10n.pt.tax.exemption.reason">
-      <field name="code">10</field>
-      <field name="name">Prestações de serviços que tenham por objecto a formação profissional, bem como as transmissões de bens e prestações de serviços conexas, como sejam o fornecimento de alojamento, alimentação e material didáctico, efectuadas por organismos de direito público ou por entidades reconhecidas como tendo competência nos domínios da formação e reabilitação profissionais pelos ministérios competentes</field>
+    <record id="l10n_pt_tax_exemption_reason_m10" model="l10n.pt.tax.exemption.reason">
+      <field name="code">M10</field>
+      <field name="name">IVA – Regime de isenção</field>
     </record>
 
-    <record id="l10n_pt_tax_exemption_reason_11" model="l10n.pt.tax.exemption.reason">
-      <field name="code">11</field>
-      <field name="name">Prestações de serviços que consistam em lições ministradas a título pessoal sobre matérias do ensino escolar ou superior</field>
+    <record id="l10n_pt_tax_exemption_reason_m11" model="l10n.pt.tax.exemption.reason">
+      <field name="code">M11</field>
+      <field name="name">Regime particular do tabaco</field>
     </record>
 
-    <record id="l10n_pt_tax_exemption_reason_12" model="l10n.pt.tax.exemption.reason">
-      <field name="code">12</field>
-      <field name="name">Locações de livros e outras publicações, partituras musicais, discos, bandas magnéticas e outros suportes de cultura e, em geral, as prestações de serviços e transmissões de bens com aquelas estreitamente conexas, desde que efectuadas por organismos sem finalidade lucrativa</field>
+    <record id="l10n_pt_tax_exemption_reason_m12" model="l10n.pt.tax.exemption.reason">
+      <field name="code">M12</field>
+      <field name="name">Regime da margem de lucro – Agências de viagens</field>
     </record>
 
-    <record id="l10n_pt_tax_exemption_reason_13" model="l10n.pt.tax.exemption.reason">
-      <field name="code">13</field>
-      <field name="name">Prestações de serviços que consistam em proporcionar a visita, guiada ou não, a bibliotecas, arquivos, museus, galerias de arte, castelos, palácios, monumentos, parques, perímetros florestais, jardins botânicos, zoológicos e semelhantes, pertencentes ao Estado, outras pessoas coletivas de direito público ou organismos sem finalidade lucrativa, desde que efetuadas única e exclusivamente por intermédio dos seus próprios agentes. A presente isenção abrange também as transmissões de bens estreitamente conexas com as prestações de serviços referidas</field>
+    <record id="l10n_pt_tax_exemption_reason_m13" model="l10n.pt.tax.exemption.reason">
+      <field name="code">M13</field>
+      <field name="name">Regime da margem de lucro – Bens em segunda mão</field>
     </record>
 
-    <record id="l10n_pt_tax_exemption_reason_14" model="l10n.pt.tax.exemption.reason">
-      <field name="code">14</field>
-      <field name="name">Prestações de serviços e as transmissões de bens com elas conexas, efectuadas por pessoas colectivas de direito público e organismos sem finalidade lucrativa, relativas a congressos, colóquios, conferências, seminários, cursos e manifestações análogas de natureza científica, cultural, educativa ou técnica</field>
+    <record id="l10n_pt_tax_exemption_reason_m14" model="l10n.pt.tax.exemption.reason">
+      <field name="code">M14</field>
+      <field name="name">Regime da margem de lucro – Objetos de arte</field>
     </record>
 
-    <record id="l10n_pt_tax_exemption_reason_15a" model="l10n.pt.tax.exemption.reason">
-      <field name="code">15a</field>
-      <field name="name">Prestações de serviços efectuadas aos respectivos promotores: Por actores, chefes de orquestra, músicos e outros artistas, actuando quer individualmente quer integrados em conjuntos, para a execução de espectáculos teatrais, cinematográficos, coreográficos, musicais, de music-hall, de circo e outros, para a realização de filmes, e para a edição de discos e de outros suportes de som ou imagem</field>
+    <record id="l10n_pt_tax_exemption_reason_m15" model="l10n.pt.tax.exemption.reason">
+      <field name="code">M15</field>
+      <field name="name">Regime da margem de lucro – Objetos de coleção e antiguidades</field>
     </record>
 
-    <record id="l10n_pt_tax_exemption_reason_15b" model="l10n.pt.tax.exemption.reason">
-      <field name="code">15b</field>
-      <field name="name">Prestações de serviços efectuadas aos respectivos promotores: Por desportistas e artistas tauromáquicos, actuando quer individualmente quer integrados em grupos, em competições desportivas e espectáculos tauromáquicos</field>
+    <record id="l10n_pt_tax_exemption_reason_m16" model="l10n.pt.tax.exemption.reason">
+      <field name="code">M16</field>
+      <field name="name">Isento Artigo 14.º do RITI (ou similar)</field>
     </record>
 
-    <record id="l10n_pt_tax_exemption_reason_16" model="l10n.pt.tax.exemption.reason">
-      <field name="code">16</field>
-      <field name="name">Transmissão do direito de autor ou de direitos conexos e a autorização para a utilização da obra intelectual ou prestação, definidas no Código dos Direitos de Autor e dos Direitos Conexos, quando efetuadas pelos próprios titulares, seus herdeiros ou legatários, ou ainda por terceiros, por conta deles, ainda que o titular do direito seja pessoa coletiva, incluindo a consignação ou afetação, imposta por lei, dos montantes recebidos pelas respetivas entidades de gestão coletiva, a fins sociais, culturais e de investigação e divulgação dos direitos de autor e direitos conexos</field>
-    </record>
-
-    <record id="l10n_pt_tax_exemption_reason_17" model="l10n.pt.tax.exemption.reason">
-      <field name="code">17</field>
-      <field name="name">Transmissão de exemplares de qualquer obra literária, científica, técnica ou artística editada sob forma bibliográfica pelo autor, quando efectuada por este, seus herdeiros ou legatários, ou ainda por terceiros, por conta deles, salvo quando o autor for pessoa colectiva</field>
-    </record>
-
-    <record id="l10n_pt_tax_exemption_reason_18" model="l10n.pt.tax.exemption.reason">
-      <field name="code">18</field>
-      <field name="name">Cedência de pessoal por instituições religiosas ou filosóficas para a realização de actividades isentas nos termos deste diploma ou para fins de assistência espiritual</field>
-    </record>
-
-    <record id="l10n_pt_tax_exemption_reason_19" model="l10n.pt.tax.exemption.reason">
-      <field name="code">19</field>
-      <field name="name">Prestações de serviços e as transmissões de bens com elas conexas efectuadas no interesse colectivo dos seus associados por organismos sem finalidade lucrativa, desde que esses organismos prossigam objectivos de natureza política, sindical, religiosa, humanitária, filantrópica, recreativa, desportiva, cultural, cívica ou de representação de interesses económicos e a única contraprestação seja uma quota fixada nos termos dos estatutos</field>
-    </record>
-
-    <record id="l10n_pt_tax_exemption_reason_20" model="l10n.pt.tax.exemption.reason">
-      <field name="code">20</field>
-      <field name="name">Transmissões de bens e as prestações de serviços efectuadas por entidades cujas actividades habituais se encontram isentas nos termos dos n.os 2), 6), 7), 8), 9), 10), 12), 13), 14) e 19) deste artigo, aquando de manifestações ocasionais destinadas à angariação de fundos em seu proveito exclusivo, desde que esta isenção não provoque distorções de concorrência</field>
-    </record>
-
-    <record id="l10n_pt_tax_exemption_reason_21" model="l10n.pt.tax.exemption.reason">
-      <field name="code">21</field>
-      <field name="name">Prestações de serviços fornecidas aos seus membros por grupos autónomos de pessoas que exerçam uma actividade isenta, desde que tais serviços sejam directamente necessários ao exercício da actividade e os grupos se limitem a exigir dos seus membros o reembolso exacto da parte que lhes incumbe nas despesas comuns, desde que, porém, esta isenção não seja susceptível de provocar distorções de concorrência</field>
-    </record>
-
-    <record id="l10n_pt_tax_exemption_reason_22" model="l10n.pt.tax.exemption.reason">
-      <field name="code">22</field>
-      <field name="name">Para efeitos do disposto no número anterior considera-se que os membros do grupo autónomo ainda exercem uma actividade isenta, desde que a percentagem de dedução determinada nos termos do artigo 23.º não seja superior a 10 %</field>
-    </record>
-
-    <record id="l10n_pt_tax_exemption_reason_23" model="l10n.pt.tax.exemption.reason">
-      <field name="code">23</field>
-      <field name="name">Prestações de serviços e as transmissões de bens conexas efectuadas pelos serviços públicos postais, com excepção das telecomunicações</field>
-    </record>
-
-    <record id="l10n_pt_tax_exemption_reason_24" model="l10n.pt.tax.exemption.reason">
-      <field name="code">24</field>
-      <field name="name">Transmissões, pelo seu valor facial, de selos do correio em circulação ou de valores selados, e bem assim as respectivas comissões de venda</field>
-    </record>
-
-    <record id="l10n_pt_tax_exemption_reason_25" model="l10n.pt.tax.exemption.reason">
-      <field name="code">25</field>
-      <field name="name">Serviço público de remoção de lixos</field>
-    </record>
-
-    <record id="l10n_pt_tax_exemption_reason_26" model="l10n.pt.tax.exemption.reason">
-      <field name="code">26</field>
-      <field name="name">Prestações de serviços efectuadas por empresas funerárias e de cremação, bem como as transmissões de bens acessórias aos mesmos serviços</field>
-    </record>
-
-    <record id="l10n_pt_tax_exemption_reason_27a" model="l10n.pt.tax.exemption.reason">
-      <field name="code">27a</field>
-      <field name="name">Concessão e a negociação de créditos, sob qualquer forma, compreendendo operações de desconto e redesconto, bem como a sua administração ou gestão efectuada por quem os concedeu</field>
-    </record>
-
-    <record id="l10n_pt_tax_exemption_reason_27b" model="l10n.pt.tax.exemption.reason">
-      <field name="code">27b</field>
-      <field name="name">Negociação e a prestação de fianças, avales, cauções e outras garantias, bem como a administração ou gestão de garantias de créditos efectuada por quem os concedeu</field>
-    </record>
-
-    <record id="l10n_pt_tax_exemption_reason_27c" model="l10n.pt.tax.exemption.reason">
-      <field name="code">27c</field>
-      <field name="name">Operações, compreendendo a negociação, relativas a depósitos de fundos, contas correntes, pagamentos, transferências, recebimentos, cheques, efeitos de comércio e afins, com excepção das operações de simples cobrança de dívidas</field>
-    </record>
-
-    <record id="l10n_pt_tax_exemption_reason_27d" model="l10n.pt.tax.exemption.reason">
-      <field name="code">27d</field>
-      <field name="name">Operações, incluindo a negociação, que tenham por objecto divisas, notas bancárias e moedas, que sejam meios legais de pagamento, com excepção das moedas e notas que não sejam normalmente utilizadas como tal, ou que tenham interesse numismátic</field>
-    </record>
-
-    <record id="l10n_pt_tax_exemption_reason_27e" model="l10n.pt.tax.exemption.reason">
-      <field name="code">27e</field>
-      <field name="name">Operações e serviços, incluindo a negociação, mas com exclusão da simples guarda e administração ou gestão, relativos a acções, outras participações em sociedades ou associações, obrigações e demais títulos, com exclusão dos títulos representativos de mercadorias e dos títulos representativos de operações sobre bens imóveis quando efectuadas por um prazo inferior a 20 anos</field>
-    </record>
-
-    <record id="l10n_pt_tax_exemption_reason_27f" model="l10n.pt.tax.exemption.reason">
-      <field name="code">27f</field>
-      <field name="name">Serviços e operações relativos à colocação, tomada e compra firmes de emissões de títulos públicos ou privados</field>
-    </record>
-
-    <record id="l10n_pt_tax_exemption_reason_27g" model="l10n.pt.tax.exemption.reason">
-      <field name="code">27g</field>
-      <field name="name">Administração ou gestão de fundos de investimento</field>
-    </record>
-
-    <record id="l10n_pt_tax_exemption_reason_28" model="l10n.pt.tax.exemption.reason">
-      <field name="code">28</field>
-      <field name="name">Operações de seguro e resseguro, bem como as prestações de serviços conexas efectuadas pelos corretores e intermediários de seguro</field>
-    </record>
-
-    <record id="l10n_pt_tax_exemption_reason_29" model="l10n.pt.tax.exemption.reason">
-      <field name="code">29</field>
-      <field name="name">Locação de bens imóveis. Esta isenção não abrange:
-a) As prestações de serviços de alojamento, efectuadas no âmbito da actividade hoteleira ou de outras com funções análogas, incluindo parques de campismo;
-b) A locação de áreas para recolha ou estacionamento colectivo de veículos;
-c) A locação de máquinas e outros equipamentos de instalação fixa, bem como qualquer outra locação de bens imóveis de que resulte a transferência onerosa da exploração de estabelecimento comercial ou industrial;
-d) A locação de cofres-fortes;
-e) A locação de espaços para exposições ou publicidade;</field>
-    </record>
-
-    <record id="l10n_pt_tax_exemption_reason_30" model="l10n.pt.tax.exemption.reason">
-      <field name="code">30</field>
-      <field name="name">Operações sujeitas a imposto municipal sobre as transmissões onerosas de imóveis</field>
-    </record>
-
-    <record id="l10n_pt_tax_exemption_reason_31" model="l10n.pt.tax.exemption.reason">
-      <field name="code">31</field>
-      <field name="name">Lotaria da Santa Casa da Misericórdia, as apostas mútuas, o bingo, os sorteios e as lotarias instantâneas devidamente autorizados, bem como as respectivas comissões e todas as actividades sujeitas a impostos especiais sobre o jogo</field>
-    </record>
-
-    <record id="l10n_pt_tax_exemption_reason_32" model="l10n.pt.tax.exemption.reason">
-      <field name="code">32</field>
-      <field name="name">Transmissões de bens afectos exclusivamente a uma actividade isenta, quando não tenham sido objecto do direito à dedução e bem assim as transmissões de bens cuja aquisição ou afectação tenha sido feita com exclusão do direito à dedução nos termos do n.º 1 do artigo 21.º</field>
-    </record>
-
-    <record id="l10n_pt_tax_exemption_reason_34" model="l10n.pt.tax.exemption.reason">
-      <field name="code">34</field>
-      <field name="name">Prestações de serviços efectuadas por cooperativas que, não sendo de produção agrícola, desenvolvam uma actividade de prestação de serviços aos seus associados agricultores</field>
-    </record>
-
-    <record id="l10n_pt_tax_exemption_reason_35" model="l10n.pt.tax.exemption.reason">
-      <field name="code">35</field>
-      <field name="name">Prestações de serviços a seguir indicadas quando levadas a cabo por organismos sem finalidade lucrativa que sejam associações de cultura e recreio:
-a) Cedência de bandas de música;
-b) Sessões de teatro;
-c) Ensino de ballet e de música;</field>
-    </record>
-
-    <record id="l10n_pt_tax_exemption_reason_36" model="l10n.pt.tax.exemption.reason">
-      <field name="code">36</field>
-      <field name="name">Serviços de alimentação e bebidas fornecidos pelas entidades patronais aos seus empregados</field>
-    </record>
-
-    <record id="l10n_pt_tax_exemption_reason_37" model="l10n.pt.tax.exemption.reason">
-      <field name="code">37</field>
-      <field name="name">Actividades das empresas públicas de rádio e televisão que não tenham carácter comercial</field>
-    </record>
-
-    <record id="l10n_pt_tax_exemption_reason_38" model="l10n.pt.tax.exemption.reason">
-      <field name="code">38</field>
-      <field name="name">Prestações de serviços efetuadas por intérprete de língua gestual portuguesa</field>
+    <record id="l10n_pt_tax_exemption_reason_m99" model="l10n.pt.tax.exemption.reason">
+      <field name="code">M99</field>
+      <field name="name">Não sujeito; não tributado (ou similar)</field>
     </record>
 
     </data>

--- a/addons/l10n_pt/models/__init__.py
+++ b/addons/l10n_pt/models/__init__.py
@@ -1,0 +1,3 @@
+from . import account_move
+from . import l10n_pt_tax_exemption_reason
+from . import product_template

--- a/addons/l10n_pt/models/account_move.py
+++ b/addons/l10n_pt/models/account_move.py
@@ -1,0 +1,47 @@
+# -*- coding: utf-8 -*-
+
+from odoo import fields, models, api, _
+from odoo.exceptions import UserError
+from odoo.tools import float_is_zero
+
+
+class AccountMoveLine(models.Model):
+    _inherit = 'account.move.line'
+
+    l10n_pt_tax_exemption_reason = fields.Many2one(
+        string="Tax exemption reason",
+        related='product_id.l10n_pt_tax_exemption_reason',
+        help="Reason why we may exempt an item sale from any tax",
+        groups='account.group_account_invoice')
+
+    @api.onchange('product_id')
+    def _onchange_product_id(self):
+        super()._onchange_product_id()
+        for line in self:
+            if not line.product_id or line.display_type in ('line_section', 'line_note'):
+                continue
+
+            line.l10n_pt_tax_exemption_reason = line._get_computed_tax_exemption_reason()
+
+    def _get_computed_tax_exemption_reason(self):
+        self.ensure_one()
+
+        if not self.product_id:
+            return
+
+        if not self.product_id.l10n_pt_tax_exemption_reason:
+            return
+
+        return self.product_id.l10n_pt_tax_exemption_reason
+
+
+class AccountMove(models.Model):
+    _inherit = 'account.move'
+
+    def action_post(self):
+        for move in self:
+            for line in move.line_ids:
+                for tax in line.tax_ids:
+                    if float_is_zero(tax.amount, precision_digits=2) and not line.l10n_pt_tax_exemption_reason:
+                        raise UserError(_("A tax exemption reason must be filled for the lines with a VAT amount equal to zero."))
+        super().action_post()

--- a/addons/l10n_pt/models/l10n_pt_tax_exemption_reason.py
+++ b/addons/l10n_pt/models/l10n_pt_tax_exemption_reason.py
@@ -1,0 +1,10 @@
+from odoo import models, fields
+
+
+class TaxExemptionReason(models.Model):
+    _name = 'l10n.pt.tax.exemption.reason'
+    _description = 'Reasons why an item sale may be exempted from any tax according to ' \
+                   'https://info.portaldasfinancas.gov.pt/pt/informacao_fiscal/codigos_tributarios/civa_rep/Pages/iva9.aspx'
+
+    code = fields.Char('Code of the exemption reason', required=True)
+    name = fields.Text('Name of the exemption reason', required=True)

--- a/addons/l10n_pt/models/product_template.py
+++ b/addons/l10n_pt/models/product_template.py
@@ -1,0 +1,13 @@
+from odoo import models, fields
+from odoo.tools import float_is_zero
+
+
+class ProductTemplate(models.Model):
+    _name = "product.template"
+    _inherit = "product.template"
+
+    l10n_pt_tax_exemption_reason = fields.Many2one(
+        comodel_name='l10n.pt.tax.exemption.reason',
+        string="Tax exemption reason",
+        help="Reason why we may exempt an item sale from any tax",
+        groups='account.group_account_invoice')

--- a/addons/l10n_pt/models/product_template.py
+++ b/addons/l10n_pt/models/product_template.py
@@ -1,5 +1,4 @@
 from odoo import models, fields
-from odoo.tools import float_is_zero
 
 
 class ProductTemplate(models.Model):

--- a/addons/l10n_pt/security/ir.model.access.csv
+++ b/addons/l10n_pt/security/ir.model.access.csv
@@ -1,0 +1,3 @@
+id,name,model_id:id,group_id:id,perm_read,perm_write,perm_create,perm_unlink
+access_l10n_pt_tax_exemption_reason_readonly,l10n.pt.tax.exemption.reason readonly,model_l10n_pt_tax_exemption_reason,account.group_account_readonly,1,0,0,0
+access_l10n_pt_tax_exemption_reason_invoice,l10n.pt.tax.exemption.reason invoice,model_l10n_pt_tax_exemption_reason,account.group_account_invoice,1,1,1,1

--- a/addons/l10n_pt/views/account_move_views.xml
+++ b/addons/l10n_pt/views/account_move_views.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <data>
+        <record id="account_move_form_inherit_l10n_pt" model="ir.ui.view">
+            <field name="name">account.move.form.inherit.l10n.pt</field>
+            <field name="model">account.move</field>
+            <field name="inherit_id" ref="account.view_move_form"/>
+            <field name="arch" type="xml">
+                <xpath expr="//field[@name='tax_ids']" position="after">
+                    <field name="l10n_pt_tax_exemption_reason"
+                           attrs="{'invisible': [('parent.country_code', '!=', 'PT')]}"
+                           options="{'no_create': True}"
+                           groups="account.group_account_invoice"
+                    />
+                </xpath>
+            </field>
+        </record>
+    </data>
+</odoo>

--- a/addons/l10n_pt/views/product_views.xml
+++ b/addons/l10n_pt/views/product_views.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <data>
+        <record id="product_template_form_view_inherit_pt" model="ir.ui.view">
+            <field name="name">product.template.form.inherit.pt</field>
+            <field name="model">product.template</field>
+            <field name="priority">6</field>
+            <field name="inherit_id" ref="account.product_template_form_view"/>
+            <field name="arch" type="xml">
+                <xpath expr="//field[@name='taxes_id']" position="after">
+                    <field name="l10n_pt_tax_exemption_reason"
+                           options="{'no_create': True}"/>
+                </xpath>
+            </field>
+        </record>
+    </data>
+</odoo>


### PR DESCRIPTION
This PR adds the possibility to add a tax exemption reason to a product which will be displayed in the line of the invoice. This is necessary to fulfill Portugal's requirements.

Task-id: 2794377