### PR TITLE
[FIX] web_editor, website, mass_mailing: fix snippets menu tabs

### DIFF
--- a/addons/mass_mailing/static/src/js/tours/mass_mailing_snippets_menu_tabs.js
+++ b/addons/mass_mailing/static/src/js/tours/mass_mailing_snippets_menu_tabs.js
@@ -1,0 +1,52 @@
+/** @odoo-module **/
+
+import tour from 'web_tour.tour';
+
+tour.register('mass_mailing_snippets_menu_tabs', {
+    test: true,
+    url: '/web',
+}, [
+    tour.stepUtils.showAppsMenuItem(), {
+        content: "Select the 'Email Marketing' app.",
+        trigger: '.o_app[data-menu-xmlid="mass_mailing.mass_mailing_menu_root"]',
+    },
+    {
+        content: "Click on the create button to create a new mailing.",
+        trigger: 'button.o_list_button_add',
+    },
+    {
+        content: "Click on the 'Start From Scratch' template.",
+        trigger: 'iframe #empty',
+    },
+    {
+        content: "Click on the 'select a template' tab.",
+        trigger: 'iframe .o_we_select_template',
+    },
+    {
+        content: "Click on the empty 'DRAG BUILDING BLOCKS HERE' area.",
+        extra_trigger: 'iframe .o_we_customize_panel .o_mail_theme_selector',
+        trigger: 'iframe .oe_structure.o_mail_no_options',
+    },
+    {
+        content: "Click on the 'select a template' tab.",
+        trigger: 'iframe .o_we_select_template',
+    },
+    {
+        content: "Verify that the customize panel is not empty.",
+        trigger: 'iframe .o_we_customize_panel > .o_mail_theme_selector',
+        run: () => null, // it's a check
+    },
+    {
+        content: "Click on the style tab.",
+        trigger: 'iframe .o_we_customize_snippet_btn',
+    },
+    {
+        content: "Click on the 'select a template' tab.",
+        trigger: 'iframe .o_we_select_template',
+    },
+    {
+        content: "Verify that the customize panel is not empty.",
+        trigger: 'iframe .o_we_customize_panel > .o_mail_theme_selector',
+        run: () => null, // it's a check
+    },
+]);

--- a/addons/mass_mailing/tests/test_mailing_ui.py
+++ b/addons/mass_mailing/tests/test_mailing_ui.py
@@ -21,3 +21,6 @@ class TestUi(HttpCaseWithUserDemo):
         # ensures both fields have different values.
         self.assertEqual(mail.body_arch, '<p><br></p>')
         self.assertEqual(mail.body_html, '<p style="margin:0px 0 14px 0;box-sizing:border-box;"><br></p>')
+
+    def test_02_mass_mailing_snippets_menu_tabs(self):
+        self.start_tour("/web", 'mass_mailing_snippets_menu_tabs', login="demo")

--- a/addons/web_editor/static/src/js/editor/snippets.editor.js
+++ b/addons/web_editor/static/src/js/editor/snippets.editor.js
@@ -1317,8 +1317,9 @@ var SnippetsMenu = Widget.extend({
             if ($oeStructure.length && !$oeStructure.children().length && this.$snippets) {
                 // If empty oe_structure, encourage using snippets in there by
                 // making them "wizz" in the panel.
-                this._updateRightPanelContent({content: [], tab: this.tabs.BLOCKS});
-                this.$snippets.odooBounce();
+                this._activateSnippet(false).then(() => {
+                    this.$snippets.odooBounce();
+                });
                 return;
             }
             this._activateSnippet($target);
@@ -2730,6 +2731,10 @@ var SnippetsMenu = Widget.extend({
     /**
      * Update the options pannel as being empty.
      *
+     * TODO review the utility of that function and how to call it (it was not
+     * called inside a mutex then we had to do it... there must be better things
+     * to do).
+     *
      * @private
      */
     _activateEmptyOptionsTab() {
@@ -2922,19 +2927,17 @@ var SnippetsMenu = Widget.extend({
      * @private
      */
     _onBlocksTabClick: function (ev) {
-        this._activateSnippet(false).then(() => {
-            this._updateRightPanelContent({
-                content: [],
-                tab: this.tabs.BLOCKS,
-            });
-        });
+        this._activateSnippet(false);
     },
     /**
      * @private
      */
     _onOptionsTabClick: function (ev) {
         if (!ev.currentTarget.classList.contains('active')) {
-            this._activateEmptyOptionsTab();
+            this._activateSnippet(false);
+            this._mutex.exec(() => {
+                this._activateEmptyOptionsTab();
+            });
         }
     },
     /**

--- a/addons/website/static/tests/tours/website_snippets_menu_tabs.js
+++ b/addons/website/static/tests/tours/website_snippets_menu_tabs.js
@@ -1,0 +1,33 @@
+/** @odoo-module **/
+
+import tour from 'web_tour.tour';
+import wTourUtils from 'website.tour_utils';
+
+tour.register("website_snippets_menu_tabs", {
+    test: true,
+    url: "/?enable_editor=1",
+}, [
+    wTourUtils.goToTheme(),
+    {
+        content: "Click on the empty 'DRAG BUILDING BLOCKS HERE' area.",
+        extra_trigger: 'we-customizeblock-option.snippet-option-ThemeColors',
+        trigger: 'main > .oe_structure.oe_empty',
+        run: 'click',
+    },
+    wTourUtils.goToTheme(),
+    {
+        content: "Verify that the customize panel is not empty.",
+        trigger: '.o_we_customize_panel > we-customizeblock-options',
+        run: () => null, // it's a check
+    },
+    {
+        content: "Click on the style tab.",
+        trigger: '#snippets_menu .o_we_customize_snippet_btn',
+    },
+    wTourUtils.goToTheme(),
+    {
+        content: "Verify that the customize panel is not empty.",
+        trigger: '.o_we_customize_panel > we-customizeblock-options',
+        run: () => null, // it's a check
+    },
+]);

--- a/addons/website/tests/test_ui.py
+++ b/addons/website/tests/test_ui.py
@@ -287,3 +287,6 @@ class TestUi(odoo.tests.HttpCase):
 
     def test_17_website_edit_menus(self):
         self.start_tour("/", "edit_menus", login="admin")
+
+    def test_18_website_snippets_menu_tabs(self):
+        self.start_tour("/?enable_editor=1", "website_snippets_menu_tabs", login="admin")


### PR DESCRIPTION
Before this commit, this bug was present in edit mode:

- Go into edit mode on an empty page.
- Click on the THEME tab on the right.
- Click on the empty "DRAG BUILDING BLOCKS HERE" area.
- Click on the THEME tab again.
- The content of THEME is empty.

It was because since this commit [1], clicking on an 'oeStructure'
activate the Blocks tab but without updating the options in the tabs.

Another similar bug was present when clicking the style tab and then
clicking on the theme tab.

About the first bug, actually a call of '_updateRightPanelContent' is
already done in '_activateSnippet()' (and the Blocks tab is activate by
default) so we only have to use '_activateSnippet(false)' to activate
the Blocks tab. This commit also remove '_updateRightPanelContent' from
the click event of the Blocks tab where it was not necessary.

For the second bug, we can't do the same fix, because it's not possible
to activate the options tab with only '_activateSnippet(false)' so we
had to combine the two functions.

[1]: https://github.com/odoo/odoo/commit/fbe048c202ff7878984adf26bef0651a45851f0a

task-2794266

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
