### PR TITLE
[IMP] account: allow trying to upload the same file

### DIFF
--- a/addons/account/static/src/js/bills_tree_upload.js
+++ b/addons/account/static/src/js/bills_tree_upload.js
@@ -42,6 +42,9 @@ odoo.define('account.upload.bill.mixin', function (require) {
                 context: this.initialState.context,
             }).then(function(result) {
                 self.do_action(result);
+            }).catch(function () {
+                // Reset the file input, allowing to select again the same file if needed
+                self.$('.o_vendor_bill_upload .o_input_file').val('');
             });
         },
 


### PR DESCRIPTION
Since https://github.com/odoo/odoo/commit/cb6c6224be4eaa80091f51f957059de889332e68
we are now raising possible errors when uploading an invoice.
In 14.0+ we are allowing via a redirect warning to change the status of
the currency without changing the page but the upload only starts when
you change the uploaded file.
So the following flow does not work:
    - Try to upload a bill with MXN currency
    - With MXN being inactive, it raises an error. Using the redirect warning action
      we activate the currency, clos the modale window and try to upload
      again.
    - The upload won't work until we refresh the page, because the value
      of the input file does not change (or we need to select another
      one, then the first one again)
This change reset the file input if there is an error raised during the
upload allowing to select the same file more than once without reloading.

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
