### PR TITLE
[FIX] delivery: use pricelist to compute shipping cost

### DIFF
--- a/addons/delivery/models/delivery_carrier.py
+++ b/addons/delivery/models/delivery_carrier.py
@@ -265,7 +265,7 @@ class DeliveryCarrier(models.Model):
                     'price': 0.0,
                     'error_message': _('Error: this delivery method is not available for this address.'),
                     'warning_message': False}
-        price = self.fixed_price
+        price = order.pricelist_id.get_product_price(self.product_id, 1.0, order.partner_id)
         company = self.company_id or order.company_id or self.env.company
         if company.currency_id and company.currency_id != order.currency_id:
             price = company.currency_id._convert(price, order.currency_id, company, fields.Date.today())


### PR DESCRIPTION
### Expected Behaviour
When adding a shipping cost in a SO, with the shipping method being associated to a product, the price should be calculated according to the price of the product in the order's pricelist if available

### Observed Behaviour
When adding a shipping cost related to a product, with a fixed price, the public price of the product is used instead of the price defined in the SO pricelist

### Reproducibility
1. Create a product "Test Shipping" with a public price of 10
2. Create a shipping method "Test Shipping" associated with the "Test Shipping" product
3. Create a pricelist "Test Pricelist", where the product "Test Product" has a cost of 15
4. Create a contact "Test Contact" associated with "Test Pricelist"
5. Create a So for the "Test Contact" with "Test Shipping" as shipping method -> Shipping cost will be 10 instead of 15.

### Fix Description
The issue here was that the price computed by the delivery carrier didn't took into account the selected pricelist. We tried to then change it in the delivery chooser wizard, but some issue with particular case (i.e. when the shipping cost should be 0 if the SO total is bigger than X) appeared, leading us to add the fix directly in the delivery_carrier
classe.

### Related Issues/PR
- opw-2754482

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
