### PR TITLE
[IMP] mail: remove unused o-attachment-removed

### DIFF
--- a/addons/mail/static/src/components/attachment_card/attachment_card.js
+++ b/addons/mail/static/src/components/attachment_card/attachment_card.js
@@ -1,22 +1,10 @@
 /** @odoo-module **/
 
 import { registerMessagingComponent } from '@mail/utils/messaging_component';
-import { useComponentToModel } from '@mail/component_hooks/use_component_to_model/use_component_to_model';
-import { LegacyComponent } from "@web/legacy/legacy_component";
 
-export class AttachmentCard extends LegacyComponent {
+const { Component } = owl;
 
-    /**
-     * @override
-     */
-    setup() {
-        super.setup();
-        useComponentToModel({ fieldName: 'component', modelName: 'AttachmentCard' });
-    }
-
-    //--------------------------------------------------------------------------
-    // Public
-    //--------------------------------------------------------------------------
+export class AttachmentCard extends Component {
 
     /**
      * @returns {AttachmentCard}

--- a/addons/mail/static/src/components/attachment_image/attachment_image.js
+++ b/addons/mail/static/src/components/attachment_image/attachment_image.js
@@ -1,18 +1,10 @@
 /** @odoo-module **/
 
 import { registerMessagingComponent } from '@mail/utils/messaging_component';
-import { useComponentToModel } from '@mail/component_hooks/use_component_to_model/use_component_to_model';
-import { LegacyComponent } from "@web/legacy/legacy_component";
 
-export class AttachmentImage extends LegacyComponent {
+const { Component } = owl;
 
-    /**
-     * @override
-     */
-    setup() {
-        super.setup();
-        useComponentToModel({ fieldName: 'component', modelName: 'AttachmentImage' });
-    }
+export class AttachmentImage extends Component {
 
     /**
      * @returns {AttachmentImage}

--- a/addons/mail/static/src/models/attachment_card/attachment_card.js
+++ b/addons/mail/static/src/models/attachment_card/attachment_card.js
@@ -1,7 +1,7 @@
 /** @odoo-module **/
 
 import { registerModel } from '@mail/model/model_core';
-import { attr, one } from '@mail/model/model_field';
+import { one } from '@mail/model/model_field';
 import { insertAndReplace, replace } from '@mail/model/model_field_command';
 
 registerModel({
@@ -31,7 +31,6 @@ registerModel({
                 return;
             }
             if (this.attachmentList.composerViewOwner) {
-                this.component.trigger('o-attachment-removed', { attachmentLocalId: this.attachment.localId });
                 this.attachment.remove();
             } else {
                 this.update({ attachmentDeleteConfirmDialog: insertAndReplace() });
@@ -58,9 +57,5 @@ registerModel({
             readonly: true,
             required: true,
         }),
-        /**
-         * States the OWL component of this attachment card.
-         */
-        component: attr(),
     },
 });

--- a/addons/mail/static/src/models/attachment_image/attachment_image.js
+++ b/addons/mail/static/src/models/attachment_image/attachment_image.js
@@ -31,7 +31,6 @@ registerModel({
                 return;
             }
             if (this.attachmentList.composerViewOwner) {
-                this.component.trigger('o-attachment-removed', { attachmentLocalId: this.attachment.localId });
                 this.attachment.remove();
             } else {
                 this.update({ attachmentDeleteConfirmDialog: insertAndReplace() });
@@ -100,10 +99,6 @@ registerModel({
             readonly: true,
             required: true,
         }),
-        /**
-         * States the OWL component of this attachment image.
-         */
-        component: attr(),
         /**
          * Determines the max height of this attachment image in px.
          */


### PR DESCRIPTION
The event is no longer bound since 0df4b0029b9af321d36e830e68f3a2c70e1512b8

And it's fine in this case : the form view does not need to be updated when
removing a pending attachment from composer.