### PR TITLE
[FIX] point_of_sale: Fix refund lst price change

### DIFF
--- a/addons/point_of_sale/static/src/js/Screens/TicketScreen/TicketScreen.js
+++ b/addons/point_of_sale/static/src/js/Screens/TicketScreen/TicketScreen.js
@@ -235,7 +235,6 @@ odoo.define('point_of_sale.TicketScreen', function (require) {
                 await destinationOrder.add_product(this.env.pos.db.get_product_by_id(orderline.productId), {
                     quantity: -qty,
                     price: orderline.price,
-                    lst_price: orderline.price,
                     extras: { price_manually_set: true },
                     merge: false,
                     refunded_orderline_id: orderline.id,


### PR DESCRIPTION
When we were doing a price modification on a product and this orderline was refund, the displayed price on the product screen was changed to the new value.

Example:
  - Default price: 33
  - Paying with a price set to: 2
  The order is refund:
  - Product price is set to 2
  It should only be 2 on the order refunded.

The fix doesn't change the price of the product after a refund anymore.

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
