### PR TITLE
[FIX] stock_picking: stock move with default partner_id

### DIFF
--- a/addons/stock/models/stock_picking.py
+++ b/addons/stock/models/stock_picking.py
@@ -583,19 +583,22 @@ class Picking(models.Model):
         # As the on_change in one2many list is WIP, we will overwrite the locations on the stock moves here
         # As it is a create the format will be a list of (0, 0, dict)
         moves = vals.get('move_lines', []) + vals.get('move_ids_without_package', [])
-        if moves and vals.get('location_id') and vals.get('location_dest_id'):
+        if moves and ((vals.get('location_id') and vals.get('location_dest_id')) or vals.get('partner_id')):
             for move in moves:
                 if len(move) == 3 and move[0] == 0:
-                    move[2]['location_id'] = vals['location_id']
-                    move[2]['location_dest_id'] = vals['location_dest_id']
-                    # When creating a new picking, a move can have no `company_id` (create before
-                    # picking type was defined) or a different `company_id` (the picking type was
-                    # changed for an another company picking type after the move was created).
-                    # So, we define the `company_id` in one of these cases.
-                    picking_type = self.env['stock.picking.type'].browse(vals['picking_type_id'])
-                    if 'picking_type_id' not in move[2] or move[2]['picking_type_id'] != picking_type.id:
-                        move[2]['picking_type_id'] = picking_type.id
-                        move[2]['company_id'] = picking_type.company_id.id
+                    if vals.get('location_id') and vals.get('location_dest_id'):
+                        move[2]['location_id'] = vals['location_id']
+                        move[2]['location_dest_id'] = vals['location_dest_id']
+                        # When creating a new picking, a move can have no `company_id` (create before
+                        # picking type was defined) or a different `company_id` (the picking type was
+                        # changed for an another company picking type after the move was created).
+                        # So, we define the `company_id` in one of these cases.
+                        picking_type = self.env['stock.picking.type'].browse(vals['picking_type_id'])
+                        if 'picking_type_id' not in move[2] or move[2]['picking_type_id'] != picking_type.id:
+                            move[2]['picking_type_id'] = picking_type.id
+                            move[2]['company_id'] = picking_type.company_id.id
+                    if vals.get('partner_id'):
+                        move[2]['partner_id'] = vals.get('partner_id')
         # make sure to write `schedule_date` *after* the `stock.move` creation in
         # order to get a determinist execution of `_set_scheduled_date`
         scheduled_date = vals.pop('scheduled_date', False)
@@ -628,6 +631,8 @@ class Picking(models.Model):
             after_vals['location_id'] = vals['location_id']
         if vals.get('location_dest_id'):
             after_vals['location_dest_id'] = vals['location_dest_id']
+        if 'partner_id' in vals:
+            after_vals['partner_id'] = vals['partner_id']
         if after_vals:
             self.mapped('move_lines').filtered(lambda move: not move.scrapped).write(after_vals)
         if vals.get('move_lines'):

--- a/addons/stock/tests/test_stock_flow.py
+++ b/addons/stock/tests/test_stock_flow.py
@@ -1976,3 +1976,25 @@ class TestStockFlow(TestStockCommon):
         picking = f.save()
 
         self.assertEquals(f.state, 'confirmed')
+
+    def test_stock_move_with_partner_id(self):
+        """ Ensure that the partner_id of the picking entry is
+        transmitted to the SM upon object creation.
+        """
+        partner_1 = self.env['res.partner'].create({'name': 'Hubert Bonisseur de la Bath'})
+        partner_2 = self.env['res.partner'].create({'name': 'Donald Clairvoyant du Bled'})
+        product = self.env['product.product'].create({'name': 'Un petit coup de polish', 'type': 'product'})
+        wh = self.env['stock.warehouse'].search([('company_id', '=', self.env.company.id)], limit=1)
+
+        f = Form(self.env['stock.picking'])
+        f.partner_id = partner_1
+        f.picking_type_id = wh.out_type_id
+        with f.move_ids_without_package.new() as move:
+            move.product_id = product
+            move.product_uom_qty = 5
+        picking = f.save()
+
+        self.assertEqual(picking.move_lines.partner_id, partner_1)
+
+        picking.write({'partner_id': partner_2.id})
+        self.assertEqual(picking.move_lines.partner_id, partner_2)


### PR DESCRIPTION
Product Moves doesn't contain its partner_id (Destination Address)
unless the partner is manually updated from the Stock Picking form.

To reproduce the issue:
1. Create a new "Planned Transfer" (e.g.: on a Delivery Order)
2. Fill in mandatory fields
3. Enter some "Product Operations" AFTER having selected a "Delivery
   Address". THEN, save.
4. Now, go to "Reporting > Stock Moves" while in debug mode and group by:
   "Destination Address"
5. The newly created "Stock Moves" will be included underneath the
   "Undefined" section while they should be underneath the section
associated to the "Delivery Address" choosed in Step 3

Solution: The partner_id must be linked into the "Stock Move" form, which is
inside the "Stock Picking" form

OPW-2784805