### PR TITLE
[IMP] website_event: include address in search of website event

### DIFF
--- a/addons/website_event/controllers/main.py
+++ b/addons/website_event/controllers/main.py
@@ -70,7 +70,7 @@ class WebsiteEventController(http.Controller):
         domain_search = {'website_specific': website.website_domain()}
 
         if searches['search']:
-            domain_search['search'] = [('name', 'ilike', searches['search'])]
+            domain_search['search'] = ['|', ('address_id.city', 'ilike', searches['search']), ('name', 'ilike', searches['search'])]
 
         current_date = None
         current_type = None


### PR DESCRIPTION
Before, when we used to search on the event page, only the name of the
event was considered while searching.
After this  commit, the user will be able to search not only the Name of
the event but also the Address of the event.

TaskId-2791031
