### PR TITLE
[IMP] mail, *: make start method handle cleanup

### DIFF
--- a/addons/calendar/static/tests/systray_activity_menu_tests.js
+++ b/addons/calendar/static/tests/systray_activity_menu_tests.js
@@ -1,6 +1,6 @@
 /** @odoo-module **/
 
-import { afterEach, beforeEach, start } from '@mail/utils/test_utils';
+import { beforeEach, start } from '@mail/utils/test_utils';
 import ActivityMenu from '@mail/js/systray/systray_activity_menu';
 
 import testUtils from 'web.test_utils';
@@ -38,9 +38,6 @@ QUnit.module('ActivityMenu', {
                 }],
             },
         });
-    },
-    afterEach() {
-        afterEach(this);
     },
 });
 

--- a/addons/hr/static/tests/m2x_avatar_employee_tests.js
+++ b/addons/hr/static/tests/m2x_avatar_employee_tests.js
@@ -1,7 +1,6 @@
 /** @odoo-module **/
 
 import {
-    afterEach,
     afterNextRender,
     beforeEach,
     start,
@@ -50,9 +49,6 @@ QUnit.module('hr', {}, function () {
                 { id: 12, display_name: "Luigi" },
                 { id: 13, display_name: "Yoshi" }
             );
-        },
-        afterEach() {
-            afterEach(this);
         },
     });
 

--- a/addons/hr_holidays/static/src/components/partner_im_status_icon/tests/partner_im_status_icon_tests.js
+++ b/addons/hr_holidays/static/src/components/partner_im_status_icon/tests/partner_im_status_icon_tests.js
@@ -1,7 +1,6 @@
 /** @odoo-module **/
 
 import {
-    afterEach,
     beforeEach,
     createRootMessagingComponent,
     start,
@@ -28,9 +27,6 @@ QUnit.module('partner_im_status_icon_tests.js', {
             this.env = env;
             this.widget = widget;
         };
-    },
-    afterEach() {
-        afterEach(this);
     },
 });
 

--- a/addons/hr_holidays/static/src/components/thread_icon/tests/thread_icon_tests.js
+++ b/addons/hr_holidays/static/src/components/thread_icon/tests/thread_icon_tests.js
@@ -1,7 +1,6 @@
 /** @odoo-module **/
 
 import {
-    afterEach,
     beforeEach,
     createRootMessagingComponent,
     start,
@@ -29,9 +28,6 @@ QUnit.module('thread_icon_tests.js', {
             this.widget = widget;
         };
 
-    },
-    afterEach() {
-        afterEach(this);
     },
 });
 

--- a/addons/hr_holidays/static/src/components/thread_view/tests/thread_view_tests.js
+++ b/addons/hr_holidays/static/src/components/thread_view/tests/thread_view_tests.js
@@ -2,7 +2,6 @@
 
 import { insertAndReplace, link } from '@mail/model/model_field_command';
 import {
-    afterEach,
     beforeEach,
     start,
 } from '@mail/utils/test_utils';
@@ -16,16 +15,12 @@ QUnit.module('thread_view_tests.js', {
 
         this.start = async params => {
             const res = await start({ ...params, data: this.data });
-            const { afterEvent, apps, env, widget } = res;
+            const { afterEvent, env, widget } = res;
             this.afterEvent = afterEvent;
-            this.apps = apps;
             this.env = env;
             this.widget = widget;
             return res;
         };
-    },
-    afterEach() {
-        afterEach(this);
     },
 });
 

--- a/addons/im_livechat/static/src/components/chat_window_manager/tests/chat_window_manager_tests.js
+++ b/addons/im_livechat/static/src/components/chat_window_manager/tests/chat_window_manager_tests.js
@@ -1,7 +1,6 @@
 /** @odoo-module **/
 
 import {
-    afterEach,
     afterNextRender,
     beforeEach,
     start,
@@ -27,9 +26,6 @@ QUnit.module('chat_window_manager_tests.js', {
             this.widget = widget;
             return res;
         };
-    },
-    afterEach() {
-        afterEach(this);
     },
 });
 

--- a/addons/im_livechat/static/src/components/composer/tests/composer_tests.js
+++ b/addons/im_livechat/static/src/components/composer/tests/composer_tests.js
@@ -1,6 +1,6 @@
 /** @odoo-module **/
 
-import { afterEach, beforeEach, start } from '@mail/utils/test_utils';
+import { beforeEach, start } from '@mail/utils/test_utils';
 
 QUnit.module('im_livechat', {}, function () {
 QUnit.module('components', {}, function () {
@@ -16,9 +16,6 @@ QUnit.module('composer_tests.js', {
             this.widget = widget;
             return res;
         };
-    },
-    afterEach() {
-        afterEach(this);
     },
 });
 

--- a/addons/im_livechat/static/src/components/discuss/tests/discuss_tests.js
+++ b/addons/im_livechat/static/src/components/discuss/tests/discuss_tests.js
@@ -1,7 +1,6 @@
 /** @odoo-module **/
 
 import {
-    afterEach,
     afterNextRender,
     beforeEach,
     nextAnimationFrame,
@@ -26,9 +25,6 @@ QUnit.module('discuss_tests.js', {
             this.env = env;
             this.widget = widget;
         };
-    },
-    afterEach() {
-        afterEach(this);
     },
 });
 

--- a/addons/im_livechat/static/src/components/discuss_sidebar_category/tests/discuss_sidebar_category_tests.js
+++ b/addons/im_livechat/static/src/components/discuss_sidebar_category/tests/discuss_sidebar_category_tests.js
@@ -1,7 +1,6 @@
 /** @odoo-module **/
 
 import {
-    afterEach,
     afterNextRender,
     beforeEach,
     start,
@@ -23,9 +22,6 @@ QUnit.module('discuss_sidebar_category_tests.js', {
             this.env = env;
             this.widget = widget;
         };
-    },
-    afterEach() {
-        afterEach(this);
     },
 });
 

--- a/addons/im_livechat/static/src/components/discuss_sidebar_category_item/tests/discuss_sidebar_category_item_tests.js
+++ b/addons/im_livechat/static/src/components/discuss_sidebar_category_item/tests/discuss_sidebar_category_item_tests.js
@@ -1,7 +1,6 @@
 /** @odoo-module **/
 
 import {
-    afterEach,
     beforeEach,
     start,
 } from '@mail/utils/test_utils';
@@ -22,9 +21,6 @@ QUnit.module('discuss_sidebar_category_item_tests.js', {
             this.env = env;
             this.widget = widget;
         };
-    },
-    afterEach() {
-        afterEach(this);
     },
 });
 

--- a/addons/im_livechat/static/src/components/messaging_menu/tests/messaging_menu_tests.js
+++ b/addons/im_livechat/static/src/components/messaging_menu/tests/messaging_menu_tests.js
@@ -1,7 +1,6 @@
 /** @odoo-module **/
 
 import {
-    afterEach,
     afterNextRender,
     beforeEach,
     start,
@@ -23,9 +22,6 @@ QUnit.module('messaging_menu_tests.js', {
             this.widget = widget;
             return res;
         };
-    },
-    afterEach() {
-        afterEach(this);
     },
 });
 

--- a/addons/im_livechat/static/src/components/thread_icon/tests/thread_icon_tests.js
+++ b/addons/im_livechat/static/src/components/thread_icon/tests/thread_icon_tests.js
@@ -1,7 +1,6 @@
 /** @odoo-module **/
 
 import {
-    afterEach,
     afterNextRender,
     beforeEach,
     createRootMessagingComponent,
@@ -29,9 +28,6 @@ QUnit.module('thread_icon_tests.js', {
             this.env = env;
             this.widget = widget;
         };
-    },
-    afterEach() {
-        afterEach(this);
     },
 });
 

--- a/addons/im_livechat/static/src/components/thread_textual_typing_status/tests/thread_textual_typing_status_tests.js
+++ b/addons/im_livechat/static/src/components/thread_textual_typing_status/tests/thread_textual_typing_status_tests.js
@@ -1,7 +1,6 @@
 /** @odoo-module **/
 
 import {
-    afterEach,
     afterNextRender,
     beforeEach,
     createRootMessagingComponent,
@@ -29,9 +28,6 @@ QUnit.module('thread_textual_typing_status_tests.js', {
             this.env = env;
             this.widget = widget;
         };
-    },
-    afterEach() {
-        afterEach(this);
     },
 });
 

--- a/addons/mail/static/src/components/activity/tests/activity_tests.js
+++ b/addons/mail/static/src/components/activity/tests/activity_tests.js
@@ -1,6 +1,6 @@
 /** @odoo-module **/
 
-import { afterEach, afterNextRender, beforeEach, start } from '@mail/utils/test_utils';
+import { afterNextRender, beforeEach, start } from '@mail/utils/test_utils';
 
 import Bus from 'web.Bus';
 import { date_to_str } from 'web.time';
@@ -14,15 +14,11 @@ QUnit.module('activity_tests.js', {
 
         this.start = async params => {
             const res = await start({ ...params, data: this.data });
-            const { apps, env, widget } = res;
-            this.apps = apps;
+            const { env, widget } = res;
             this.env = env;
             this.widget = widget;
             return res;
         };
-    },
-    afterEach() {
-        afterEach(this);
     },
 });
 

--- a/addons/mail/static/src/components/activity_mark_done_popover/tests/activity_mark_done_popover_tests.js
+++ b/addons/mail/static/src/components/activity_mark_done_popover/tests/activity_mark_done_popover_tests.js
@@ -1,6 +1,6 @@
 /** @odoo-module **/
 
-import { afterEach, beforeEach, start } from '@mail/utils/test_utils';
+import { beforeEach, start } from '@mail/utils/test_utils';
 
 import Bus from 'web.Bus';
 
@@ -13,15 +13,11 @@ QUnit.module('activity_mark_done_popover_tests.js', {
 
         this.start = async params => {
             const res = await start({ ...params, data: this.data });
-            const { apps, env, widget } = res;
-            this.apps = apps;
+            const { env, widget } = res;
             this.env = env;
             this.widget = widget;
             return res;
         };
-    },
-    afterEach() {
-        afterEach(this);
     },
 });
 

--- a/addons/mail/static/src/components/attachment_box/tests/attachment_box_tests.js
+++ b/addons/mail/static/src/components/attachment_box/tests/attachment_box_tests.js
@@ -1,7 +1,6 @@
 /** @odoo-module **/
 
 import {
-    afterEach,
     afterNextRender,
     beforeEach,
     dragenterFiles,
@@ -28,9 +27,6 @@ QUnit.module('attachment_box_tests.js', {
             this.widget = res.widget;
             return res;
         };
-    },
-    afterEach() {
-        afterEach(this);
     },
 });
 

--- a/addons/mail/static/src/components/attachment_image/tests/attachment_image_tests.js
+++ b/addons/mail/static/src/components/attachment_image/tests/attachment_image_tests.js
@@ -2,7 +2,6 @@
 
 import { link } from '@mail/model/model_field_command';
 import {
-    afterEach,
     beforeEach,
     start,
 } from '@mail/utils/test_utils';
@@ -16,16 +15,12 @@ QUnit.module('attachment_image_tests.js', {
 
         this.start = async params => {
             const res = await start({ ...params, data: this.data });
-            const { afterEvent, apps, env, widget } = res;
+            const { afterEvent, env, widget } = res;
             this.afterEvent = afterEvent;
-            this.apps = apps;
             this.env = env;
             this.widget = widget;
             return res;
         };
-    },
-    afterEach() {
-        afterEach(this);
     },
 });
 

--- a/addons/mail/static/src/components/attachment_list/tests/attachment_list_tests.js
+++ b/addons/mail/static/src/components/attachment_list/tests/attachment_list_tests.js
@@ -3,7 +3,6 @@
 import { link } from '@mail/model/model_field_command';
 
 import {
-    afterEach,
     afterNextRender,
     beforeEach,
     start,
@@ -18,16 +17,12 @@ QUnit.module('attachment_list_tests.js', {
 
         this.start = async params => {
             const res = await start({ ...params, data: this.data });
-            const { afterEvent, apps, env, widget } = res;
+            const { afterEvent, env, widget } = res;
             this.afterEvent = afterEvent;
-            this.apps = apps;
             this.env = env;
             this.widget = widget;
             return res;
         };
-    },
-    afterEach() {
-        afterEach(this);
     },
 });
 

--- a/addons/mail/static/src/components/channel_invitation_form/tests/channel_invitation_form_tests.js
+++ b/addons/mail/static/src/components/channel_invitation_form/tests/channel_invitation_form_tests.js
@@ -1,7 +1,6 @@
 /** @odoo-module **/
 
 import {
-    afterEach,
     afterNextRender,
     beforeEach,
     start,
@@ -23,9 +22,6 @@ QUnit.module('channel_invitation_form_tests.js', {
             this.env = env;
             this.widget = widget;
         };
-    },
-    afterEach() {
-        afterEach(this);
     },
 });
 

--- a/addons/mail/static/src/components/chat_window_manager/tests/chat_window_manager_tests.js
+++ b/addons/mail/static/src/components/chat_window_manager/tests/chat_window_manager_tests.js
@@ -2,7 +2,6 @@
 
 import { makeDeferred } from '@mail/utils/deferred/deferred';
 import {
-    afterEach,
     afterNextRender,
     beforeEach,
     nextAnimationFrame,
@@ -33,9 +32,6 @@ QUnit.module('chat_window_manager_tests.js', {
             this.widget = widget;
             return res;
         };
-    },
-    afterEach() {
-        afterEach(this);
     },
 });
 

--- a/addons/mail/static/src/components/chatter/tests/chatter_suggested_recipient_tests.js
+++ b/addons/mail/static/src/components/chatter/tests/chatter_suggested_recipient_tests.js
@@ -1,6 +1,6 @@
 /** @odoo-module **/
 
-import { afterEach, afterNextRender, beforeEach, start } from '@mail/utils/test_utils';
+import { afterNextRender, beforeEach, start } from '@mail/utils/test_utils';
 
 QUnit.module('mail', {}, function () {
 QUnit.module('components', {}, function () {
@@ -18,9 +18,6 @@ QUnit.module('chatter_suggested_recipients_tests.js', {
             this.widget = widget;
             return res;
         };
-    },
-    afterEach() {
-        afterEach(this);
     },
 });
 

--- a/addons/mail/static/src/components/chatter/tests/chatter_tests.js
+++ b/addons/mail/static/src/components/chatter/tests/chatter_tests.js
@@ -1,6 +1,6 @@
 /** @odoo-module **/
 
-import { afterEach, afterNextRender, beforeEach, nextAnimationFrame, start } from '@mail/utils/test_utils';
+import { afterNextRender, beforeEach, nextAnimationFrame, start } from '@mail/utils/test_utils';
 
 QUnit.module('mail', {}, function () {
 QUnit.module('components', {}, function () {
@@ -16,9 +16,6 @@ QUnit.module('chatter_tests.js', {
             this.widget = widget;
             return res;
         };
-    },
-    afterEach() {
-        afterEach(this);
     },
 });
 

--- a/addons/mail/static/src/components/chatter_topbar/tests/chatter_topbar_tests.js
+++ b/addons/mail/static/src/components/chatter_topbar/tests/chatter_topbar_tests.js
@@ -1,6 +1,6 @@
 /** @odoo-module **/
 
-import { afterEach, afterNextRender, beforeEach, nextAnimationFrame, start } from '@mail/utils/test_utils';
+import { afterNextRender, beforeEach, nextAnimationFrame, start } from '@mail/utils/test_utils';
 
 import { makeTestPromise } from 'web.test_utils';
 
@@ -20,9 +20,6 @@ QUnit.module('chatter_topbar_tests.js', {
             this.widget = widget;
             return res;
         };
-    },
-    afterEach() {
-        afterEach(this);
     },
 });
 

--- a/addons/mail/static/src/components/composer/tests/composer_tests.js
+++ b/addons/mail/static/src/components/composer/tests/composer_tests.js
@@ -2,7 +2,6 @@
 
 import { insertAndReplace } from '@mail/model/model_field_command';
 import {
-    afterEach,
     afterNextRender,
     beforeEach,
     dragenterFiles,
@@ -28,16 +27,12 @@ QUnit.module('composer_tests.js', {
 
         this.start = async params => {
             const res = await start({ ...params, data: this.data });
-            const { afterEvent, apps, env, widget } = res;
+            const { afterEvent, env, widget } = res;
             this.afterEvent = afterEvent;
-            this.apps = apps;
             this.env = env;
             this.widget = widget;
             return res;
         };
-    },
-    afterEach() {
-        afterEach(this);
     },
 });
 

--- a/addons/mail/static/src/components/composer_suggestion/tests/composer_suggestion_canned_response_tests.js
+++ b/addons/mail/static/src/components/composer_suggestion/tests/composer_suggestion_canned_response_tests.js
@@ -1,6 +1,6 @@
 /** @odoo-module **/
 
-import { afterEach, beforeEach, start } from '@mail/utils/test_utils';
+import { beforeEach, start } from '@mail/utils/test_utils';
 
 QUnit.module('mail', {}, function () {
 QUnit.module('components', {}, function () {
@@ -16,9 +16,6 @@ QUnit.module('composer_suggestion_canned_response_tests.js', {
             this.widget = widget;
             return res;
         };
-    },
-    afterEach() {
-        afterEach(this);
     },
 });
 

--- a/addons/mail/static/src/components/composer_suggestion/tests/composer_suggestion_channel_tests.js
+++ b/addons/mail/static/src/components/composer_suggestion/tests/composer_suggestion_channel_tests.js
@@ -1,6 +1,6 @@
 /** @odoo-module **/
 
-import { afterEach, beforeEach, start } from '@mail/utils/test_utils';
+import { beforeEach, start } from '@mail/utils/test_utils';
 
 QUnit.module('mail', {}, function () {
 QUnit.module('components', {}, function () {
@@ -16,9 +16,6 @@ QUnit.module('composer_suggestion_channel_tests.js', {
             this.widget = widget;
             return res;
         };
-    },
-    afterEach() {
-        afterEach(this);
     },
 });
 

--- a/addons/mail/static/src/components/composer_suggestion/tests/composer_suggestion_command_tests.js
+++ b/addons/mail/static/src/components/composer_suggestion/tests/composer_suggestion_command_tests.js
@@ -1,6 +1,6 @@
 /** @odoo-module **/
 
-import { afterEach, beforeEach, start } from '@mail/utils/test_utils';
+import { beforeEach, start } from '@mail/utils/test_utils';
 
 QUnit.module('mail', {}, function () {
 QUnit.module('components', {}, function () {
@@ -16,9 +16,6 @@ QUnit.module('composer_suggestion_command_tests.js', {
             this.widget = widget;
             return res;
         };
-    },
-    afterEach() {
-        afterEach(this);
     },
 });
 

--- a/addons/mail/static/src/components/composer_suggestion/tests/composer_suggestion_partner_tests.js
+++ b/addons/mail/static/src/components/composer_suggestion/tests/composer_suggestion_partner_tests.js
@@ -1,6 +1,6 @@
 /** @odoo-module **/
 
-import { afterEach, beforeEach, start } from '@mail/utils/test_utils';
+import { beforeEach, start } from '@mail/utils/test_utils';
 
 QUnit.module('mail', {}, function () {
 QUnit.module('components', {}, function () {
@@ -16,9 +16,6 @@ QUnit.module('composer_suggestion_partner_tests.js', {
             this.widget = widget;
             return res;
         };
-    },
-    afterEach() {
-        afterEach(this);
     },
 });
 

--- a/addons/mail/static/src/components/dialog_manager/tests/dialog_manager_tests.js
+++ b/addons/mail/static/src/components/dialog_manager/tests/dialog_manager_tests.js
@@ -2,7 +2,6 @@
 
 import { makeDeferred } from '@mail/utils/deferred/deferred';
 import {
-    afterEach,
     beforeEach,
     nextAnimationFrame,
     start,
@@ -24,9 +23,6 @@ QUnit.module('dialog_manager_tests.js', {
             this.env = env;
             this.widget = widget;
         };
-    },
-    afterEach() {
-        afterEach(this);
     },
 });
 

--- a/addons/mail/static/src/components/discuss/tests/discuss_inbox_tests.js
+++ b/addons/mail/static/src/components/discuss/tests/discuss_inbox_tests.js
@@ -1,7 +1,6 @@
 /** @odoo-module **/
 
 import {
-    afterEach,
     afterNextRender,
     beforeEach,
     nextAnimationFrame,
@@ -26,9 +25,6 @@ QUnit.module('discuss_inbox_tests.js', {
             this.env = env;
             this.widget = widget;
         };
-    },
-    afterEach() {
-        afterEach(this);
     },
 });
 

--- a/addons/mail/static/src/components/discuss/tests/discuss_message_edit_tests.js
+++ b/addons/mail/static/src/components/discuss/tests/discuss_message_edit_tests.js
@@ -1,6 +1,6 @@
 /** @odoo-module **/
 
-import { afterEach, beforeEach, start } from '@mail/utils/test_utils';
+import { beforeEach, start } from '@mail/utils/test_utils';
 
 QUnit.module('mail', {}, function () {
 QUnit.module('components', {}, function () {
@@ -19,9 +19,6 @@ QUnit.module('discuss_message_edit_tests.js', {
             this.widget = widget;
             return res;
         };
-    },
-    afterEach() {
-        afterEach(this);
     },
 });
 

--- a/addons/mail/static/src/components/discuss/tests/discuss_pinned_tests.js
+++ b/addons/mail/static/src/components/discuss/tests/discuss_pinned_tests.js
@@ -1,7 +1,6 @@
 /** @odoo-module **/
 
 import {
-    afterEach,
     afterNextRender,
     beforeEach,
     start,
@@ -23,9 +22,6 @@ QUnit.module('discuss_pinned_tests.js', {
             this.env = env;
             this.widget = widget;
         };
-    },
-    afterEach() {
-        afterEach(this);
     },
 });
 

--- a/addons/mail/static/src/components/discuss/tests/discuss_sidebar_tests.js
+++ b/addons/mail/static/src/components/discuss/tests/discuss_sidebar_tests.js
@@ -2,7 +2,6 @@
 
 import { makeDeferred } from '@mail/utils/deferred/deferred';
 import {
-    afterEach,
     afterNextRender,
     beforeEach,
     nextAnimationFrame,
@@ -25,9 +24,6 @@ QUnit.module('discuss_sidebar_tests.js', {
             this.env = env;
             this.widget = widget;
         };
-    },
-    afterEach() {
-        afterEach(this);
     },
 });
 

--- a/addons/mail/static/src/components/discuss/tests/discuss_tests.js
+++ b/addons/mail/static/src/components/discuss/tests/discuss_tests.js
@@ -3,7 +3,6 @@
 import BusService from 'bus.BusService';
 
 import {
-    afterEach,
     afterNextRender,
     beforeEach,
     nextAnimationFrame,
@@ -28,16 +27,12 @@ QUnit.module('discuss_tests.js', {
                 data: this.data,
                 hasDiscuss: true,
             }));
-            const { afterEvent, apps, env, widget } = res;
+            const { afterEvent, env, widget } = res;
             this.afterEvent = afterEvent;
-            this.apps = apps;
             this.env = env;
             this.widget = widget;
             return res;
         };
-    },
-    afterEach() {
-        afterEach(this);
     },
 });
 

--- a/addons/mail/static/src/components/discuss_mobile_mailbox_selection/mobile_tests/discuss_mobile_mailbox_selection_tests.js
+++ b/addons/mail/static/src/components/discuss_mobile_mailbox_selection/mobile_tests/discuss_mobile_mailbox_selection_tests.js
@@ -1,7 +1,6 @@
 /** @odoo-module **/
 
 import {
-    afterEach,
     afterNextRender,
     beforeEach,
     start,
@@ -35,9 +34,6 @@ QUnit.module('discuss_mobile_mailbox_selection_tests.js', {
             this.env = env;
             this.widget = widget;
         };
-    },
-    afterEach() {
-        afterEach(this);
     },
 });
 

--- a/addons/mail/static/src/components/discuss_sidebar_category/tests/discuss_sidebar_category_tests.js
+++ b/addons/mail/static/src/components/discuss_sidebar_category/tests/discuss_sidebar_category_tests.js
@@ -1,7 +1,6 @@
 /** @odoo-module **/
 
 import {
-    afterEach,
     afterNextRender,
     beforeEach,
     start,
@@ -23,9 +22,6 @@ QUnit.module('discuss_sidebar_category_tests.js', {
             this.env = env;
             this.widget = widget;
         };
-    },
-    afterEach() {
-        afterEach(this);
     },
 });
 

--- a/addons/mail/static/src/components/discuss_sidebar_category_item/tests/discuss_sidebar_category_item_tests.js
+++ b/addons/mail/static/src/components/discuss_sidebar_category_item/tests/discuss_sidebar_category_item_tests.js
@@ -1,7 +1,6 @@
 /** @odoo-module **/
 
 import {
-    afterEach,
     afterNextRender,
     beforeEach,
     start,
@@ -25,9 +24,6 @@ QUnit.module('discuss_sidebar_category_item_tests.js', {
             this.env = env;
             this.widget = widget;
         };
-    },
-    afterEach() {
-        afterEach(this);
     },
 });
 

--- a/addons/mail/static/src/components/file_uploader/tests/file_uploader_tests.js
+++ b/addons/mail/static/src/components/file_uploader/tests/file_uploader_tests.js
@@ -1,6 +1,6 @@
 /** @odoo-module **/
 
-import { afterEach, beforeEach, start } from '@mail/utils/test_utils';
+import { beforeEach, start } from '@mail/utils/test_utils';
 
 import { file } from 'web.test_utils';
 
@@ -11,19 +11,14 @@ QUnit.module('file_uploader', {}, function () {
 QUnit.module('file_uploader_tests.js', {
     async beforeEach() {
         await beforeEach(this);
-        this.apps = [];
 
         this.start = async params => {
             const res = await start({ ...params, data: this.data });
-            const { apps, env, widget } = res;
+            const { env, widget } = res;
             this.env = env;
-            this.apps = apps;
             this.widget = widget;
             return res;
         };
-    },
-    afterEach() {
-        afterEach(this);
     },
 });
 

--- a/addons/mail/static/src/components/follow_button/tests/follow_button_tests.js
+++ b/addons/mail/static/src/components/follow_button/tests/follow_button_tests.js
@@ -1,7 +1,6 @@
 /** @odoo-module **/
 
 import {
-    afterEach,
     afterNextRender,
     beforeEach,
     createRootMessagingComponent,
@@ -30,9 +29,6 @@ QUnit.module('follow_button_tests.js', {
             this.env = env;
             this.widget = widget;
         };
-    },
-    afterEach() {
-        afterEach(this);
     },
 });
 

--- a/addons/mail/static/src/components/follower/tests/follower_tests.js
+++ b/addons/mail/static/src/components/follower/tests/follower_tests.js
@@ -3,7 +3,6 @@
 import { insert, link } from '@mail/model/model_field_command';
 import { makeDeferred } from '@mail/utils/deferred/deferred';
 import {
-    afterEach,
     afterNextRender,
     beforeEach,
     createRootMessagingComponent,
@@ -33,9 +32,6 @@ QUnit.module('follower_tests.js', {
             this.env = env;
             this.widget = widget;
         };
-    },
-    afterEach() {
-        afterEach(this);
     },
 });
 

--- a/addons/mail/static/src/components/follower_list_menu/tests/follower_list_menu_tests.js
+++ b/addons/mail/static/src/components/follower_list_menu/tests/follower_list_menu_tests.js
@@ -2,7 +2,6 @@
 
 import { insert, link } from '@mail/model/model_field_command';
 import {
-    afterEach,
     afterNextRender,
     beforeEach,
     createRootMessagingComponent,
@@ -33,9 +32,6 @@ QUnit.module('follower_list_menu_tests.js', {
             this.env = env;
             this.widget = widget;
         };
-    },
-    afterEach() {
-        afterEach(this);
     },
 });
 

--- a/addons/mail/static/src/components/follower_subtype/tests/follower_subtype_tests.js
+++ b/addons/mail/static/src/components/follower_subtype/tests/follower_subtype_tests.js
@@ -2,7 +2,6 @@
 
 import { insert, link } from '@mail/model/model_field_command';
 import {
-    afterEach,
     afterNextRender,
     beforeEach,
     createRootMessagingComponent,
@@ -34,9 +33,6 @@ QUnit.module('follower_subtype_tests.js', {
             this.env = env;
             this.widget = widget;
         };
-    },
-    afterEach() {
-        afterEach(this);
     },
 });
 

--- a/addons/mail/static/src/components/message/tests/message_tests.js
+++ b/addons/mail/static/src/components/message/tests/message_tests.js
@@ -3,7 +3,6 @@
 import { insert, insertAndReplace, link, replace } from '@mail/model/model_field_command';
 import { makeDeferred } from '@mail/utils/deferred/deferred';
 import {
-    afterEach,
     afterNextRender,
     beforeEach,
     createRootMessagingComponent,
@@ -22,16 +21,12 @@ QUnit.module('message_tests.js', {
 
         this.start = async params => {
             const res = await start({ ...params, data: this.data });
-            const { afterEvent, apps, env, widget } = res;
+            const { afterEvent, env, widget } = res;
             this.afterEvent = afterEvent;
-            this.apps = apps;
             this.env = env;
             this.widget = widget;
             return res;
         };
-    },
-    afterEach() {
-        afterEach(this);
     },
 });
 

--- a/addons/mail/static/src/components/message_seen_indicator/tests/message_seen_indicator_tests.js
+++ b/addons/mail/static/src/components/message_seen_indicator/tests/message_seen_indicator_tests.js
@@ -2,7 +2,6 @@
 
 import { insert, insertAndReplace, link } from '@mail/model/model_field_command';
 import {
-    afterEach,
     beforeEach,
     createRootMessagingComponent,
     start,
@@ -33,9 +32,6 @@ QUnit.module('message_seen_indicator_tests.js', {
             this.env = env;
             this.widget = widget;
         };
-    },
-    afterEach() {
-        afterEach(this);
     },
 });
 

--- a/addons/mail/static/src/components/messaging_menu/tests/messaging_menu_tests.js
+++ b/addons/mail/static/src/components/messaging_menu/tests/messaging_menu_tests.js
@@ -1,7 +1,6 @@
 /** @odoo-module **/
 
 import {
-    afterEach,
     afterNextRender,
     beforeEach,
     start,
@@ -26,9 +25,6 @@ QUnit.module('messaging_menu_tests.js', {
             this.widget = widget;
             return res;
         };
-    },
-    afterEach() {
-        afterEach(this);
     },
 });
 

--- a/addons/mail/static/src/components/notification_list/tests/notification_list_notification_group_tests.js
+++ b/addons/mail/static/src/components/notification_list/tests/notification_list_notification_group_tests.js
@@ -1,6 +1,6 @@
 /** @odoo-module **/
 
-import { afterEach, afterNextRender, beforeEach, start, } from '@mail/utils/test_utils';
+import { afterNextRender, beforeEach, start, } from '@mail/utils/test_utils';
 
 import Bus from 'web.Bus';
 
@@ -20,9 +20,6 @@ QUnit.module('notification_list_notification_group_tests.js', {
             this.widget = widget;
             return res;
         };
-    },
-    afterEach() {
-        afterEach(this);
     },
 });
 

--- a/addons/mail/static/src/components/notification_list/tests/notification_list_tests.js
+++ b/addons/mail/static/src/components/notification_list/tests/notification_list_tests.js
@@ -1,6 +1,6 @@
 /** @odoo-module **/
 
-import { afterEach, afterNextRender, beforeEach, start } from '@mail/utils/test_utils';
+import { afterNextRender, beforeEach, start } from '@mail/utils/test_utils';
 
 QUnit.module('mail', {}, function () {
 QUnit.module('components', {}, function () {
@@ -18,9 +18,6 @@ QUnit.module('notification_list_tests.js', {
             this.widget = widget;
             return res;
         };
-    },
-    afterEach() {
-        afterEach(this);
     },
 });
 

--- a/addons/mail/static/src/components/partner_im_status_icon/tests/partner_im_status_icon_tests.js
+++ b/addons/mail/static/src/components/partner_im_status_icon/tests/partner_im_status_icon_tests.js
@@ -1,7 +1,6 @@
 /** @odoo-module **/
 
 import {
-    afterEach,
     afterNextRender,
     beforeEach,
     createRootMessagingComponent,
@@ -29,9 +28,6 @@ QUnit.module('partner_im_status_icon_tests.js', {
             this.env = env;
             this.widget = widget;
         };
-    },
-    afterEach() {
-        afterEach(this);
     },
 });
 

--- a/addons/mail/static/src/components/thread_icon/tests/thread_icon_tests.js
+++ b/addons/mail/static/src/components/thread_icon/tests/thread_icon_tests.js
@@ -1,7 +1,6 @@
 /** @odoo-module **/
 
 import {
-    afterEach,
     afterNextRender,
     beforeEach,
     createRootMessagingComponent,
@@ -30,9 +29,6 @@ QUnit.module('thread_icon_tests.js', {
             this.widget = widget;
         };
 
-    },
-    afterEach() {
-        afterEach(this);
     },
 });
 

--- a/addons/mail/static/src/components/thread_needaction_preview/tests/thread_needaction_preview_tests.js
+++ b/addons/mail/static/src/components/thread_needaction_preview/tests/thread_needaction_preview_tests.js
@@ -1,6 +1,6 @@
 /** @odoo-module **/
 
-import { afterEach, afterNextRender, beforeEach, start } from '@mail/utils/test_utils';
+import { afterNextRender, beforeEach, start } from '@mail/utils/test_utils';
 
 import Bus from 'web.Bus';
 
@@ -21,9 +21,6 @@ QUnit.module('thread_needaction_preview_tests.js', {
             this.widget = widget;
             return res;
         };
-    },
-    afterEach() {
-        afterEach(this);
     },
 });
 

--- a/addons/mail/static/src/components/thread_preview/tests/thread_preview_tests.js
+++ b/addons/mail/static/src/components/thread_preview/tests/thread_preview_tests.js
@@ -1,6 +1,6 @@
 /** @odoo-module **/
 
-import { afterEach, afterNextRender, beforeEach, start } from '@mail/utils/test_utils';
+import { afterNextRender, beforeEach, start } from '@mail/utils/test_utils';
 
 QUnit.module('mail', {}, function () {
 QUnit.module('components', {}, function () {
@@ -18,9 +18,6 @@ QUnit.module('thread_preview_tests.js', {
             this.widget = widget;
             return res;
         };
-    },
-    afterEach() {
-        afterEach(this);
     },
 });
 

--- a/addons/mail/static/src/components/thread_textual_typing_status/tests/thread_textual_typing_status_tests.js
+++ b/addons/mail/static/src/components/thread_textual_typing_status/tests/thread_textual_typing_status_tests.js
@@ -1,7 +1,6 @@
 /** @odoo-module **/
 
 import {
-    afterEach,
     afterNextRender,
     beforeEach,
     createRootMessagingComponent,
@@ -30,9 +29,6 @@ QUnit.module('thread_textual_typing_status_tests.js', {
             this.env = env;
             this.widget = widget;
         };
-    },
-    async afterEach() {
-        afterEach(this);
     },
 });
 

--- a/addons/mail/static/src/components/thread_view/tests/thread_view_tests.js
+++ b/addons/mail/static/src/components/thread_view/tests/thread_view_tests.js
@@ -2,7 +2,6 @@
 
 import { insert, insertAndReplace, link } from '@mail/model/model_field_command';
 import {
-    afterEach,
     afterNextRender,
     beforeEach,
     dragenterFiles,
@@ -18,16 +17,12 @@ QUnit.module('thread_view_tests.js', {
 
         this.start = async params => {
             const res = await start({ ...params, data: this.data });
-            const { afterEvent, apps, env, widget } = res;
+            const { afterEvent, env, widget } = res;
             this.afterEvent = afterEvent;
-            this.apps = apps;
             this.env = env;
             this.widget = widget;
             return res;
         };
-    },
-    afterEach() {
-        afterEach(this);
     },
 });
 

--- a/addons/mail/static/src/model/tests/model_field_command/clear_tests.js
+++ b/addons/mail/static/src/model/tests/model_field_command/clear_tests.js
@@ -2,7 +2,6 @@
 
 import { clear, insertAndReplace } from '@mail/model/model_field_command';
 import {
-    afterEach,
     beforeEach,
     start,
 } from '@mail/utils/test_utils';
@@ -20,9 +19,6 @@ QUnit.module('clear_tests.js', {
             this.env = env;
             this.widget = widget;
         };
-    },
-    afterEach() {
-        afterEach(this);
     },
 });
 QUnit.test('clear: should set attribute field undefined if there is no default value', async function (assert) {

--- a/addons/mail/static/src/model/tests/model_field_command/insert_and_replace_tests.js
+++ b/addons/mail/static/src/model/tests/model_field_command/insert_and_replace_tests.js
@@ -2,7 +2,6 @@
 
 import { insertAndReplace } from '@mail/model/model_field_command';
 import {
-    afterEach,
     beforeEach,
     start,
 } from '@mail/utils/test_utils';
@@ -20,9 +19,6 @@ QUnit.module('insert_and_replace_tests.js', {
             this.env = env;
             this.widget = widget;
         };
-    },
-    afterEach() {
-        afterEach(this);
     },
 });
 

--- a/addons/mail/static/src/model/tests/model_field_command/insert_tests.js
+++ b/addons/mail/static/src/model/tests/model_field_command/insert_tests.js
@@ -2,7 +2,6 @@
 
 import { insert, insertAndReplace } from '@mail/model/model_field_command';
 import {
-    afterEach,
     beforeEach,
     start,
 } from '@mail/utils/test_utils';
@@ -20,9 +19,6 @@ QUnit.module('insert_tests.js', {
             this.env = env;
             this.widget = widget;
         };
-    },
-    afterEach() {
-        afterEach(this);
     },
 });
 

--- a/addons/mail/static/src/model/tests/model_field_command/link_tests.js
+++ b/addons/mail/static/src/model/tests/model_field_command/link_tests.js
@@ -2,7 +2,6 @@
 
 import { insertAndReplace, link } from '@mail/model/model_field_command';
 import {
-    afterEach,
     beforeEach,
     start,
 } from '@mail/utils/test_utils';
@@ -20,9 +19,6 @@ QUnit.module('field_command_link_tests.js', {
             this.env = env;
             this.widget = widget;
         };
-    },
-    afterEach() {
-        afterEach(this);
     },
 });
 

--- a/addons/mail/static/src/model/tests/model_field_command/replace_tests.js
+++ b/addons/mail/static/src/model/tests/model_field_command/replace_tests.js
@@ -2,7 +2,6 @@
 
 import { insertAndReplace, replace } from '@mail/model/model_field_command';
 import {
-    afterEach,
     beforeEach,
     start,
 } from '@mail/utils/test_utils';
@@ -20,9 +19,6 @@ QUnit.module('replace_tests.js', {
             this.env = env;
             this.widget = widget;
         };
-    },
-    afterEach() {
-        afterEach(this);
     },
 });
 

--- a/addons/mail/static/src/model/tests/model_field_command/set_tests.js
+++ b/addons/mail/static/src/model/tests/model_field_command/set_tests.js
@@ -6,7 +6,6 @@ import {
     set
 } from '@mail/model/model_field_command';
 import {
-    afterEach,
     beforeEach,
     start,
 } from '@mail/utils/test_utils';
@@ -24,9 +23,6 @@ QUnit.module('set_tests.js', {
             this.env = env;
             this.widget = widget;
         };
-    },
-    afterEach() {
-        afterEach(this);
     },
 });
 

--- a/addons/mail/static/src/model/tests/model_field_command/unlink_all_tests.js
+++ b/addons/mail/static/src/model/tests/model_field_command/unlink_all_tests.js
@@ -2,7 +2,6 @@
 
 import { insertAndReplace, unlinkAll } from '@mail/model/model_field_command';
 import {
-    afterEach,
     beforeEach,
     start,
 } from '@mail/utils/test_utils';
@@ -20,9 +19,6 @@ QUnit.module('unlink_all_tests.js', {
             this.env = env;
             this.widget = widget;
         };
-    },
-    afterEach() {
-        afterEach(this);
     },
 });
 

--- a/addons/mail/static/src/model/tests/model_field_command/unlink_tests.js
+++ b/addons/mail/static/src/model/tests/model_field_command/unlink_tests.js
@@ -2,7 +2,6 @@
 
 import { insertAndReplace, unlink } from '@mail/model/model_field_command';
 import {
-    afterEach,
     beforeEach,
     start,
 } from '@mail/utils/test_utils';
@@ -20,9 +19,6 @@ QUnit.module('unlink_tests.js', {
             this.env = env;
             this.widget = widget;
         };
-    },
-    afterEach() {
-        afterEach(this);
     },
 });
 

--- a/addons/mail/static/src/models/attachment/tests/attachment_tests.js
+++ b/addons/mail/static/src/models/attachment/tests/attachment_tests.js
@@ -1,6 +1,6 @@
 /** @odoo-module **/
 
-import { afterEach, beforeEach, start } from '@mail/utils/test_utils';
+import { beforeEach, start } from '@mail/utils/test_utils';
 
 QUnit.module('mail', {}, function () {
 QUnit.module('models', {}, function () {
@@ -16,9 +16,6 @@ QUnit.module('attachment_tests.js', {
             this.env = env;
             this.widget = widget;
         };
-    },
-    afterEach() {
-        afterEach(this);
     },
 });
 

--- a/addons/mail/static/src/models/message/tests/message_tests.js
+++ b/addons/mail/static/src/models/message/tests/message_tests.js
@@ -1,7 +1,7 @@
 /** @odoo-module **/
 
 import { insert, insertAndReplace, link } from '@mail/model/model_field_command';
-import { afterEach, beforeEach, start } from '@mail/utils/test_utils';
+import { beforeEach, start } from '@mail/utils/test_utils';
 
 import { str_to_datetime } from 'web.time';
 
@@ -19,9 +19,6 @@ QUnit.module('message_tests.js', {
             this.env = env;
             this.widget = widget;
         };
-    },
-    afterEach() {
-        afterEach(this);
     },
 });
 

--- a/addons/mail/static/src/models/messaging/tests/messaging_tests.js
+++ b/addons/mail/static/src/models/messaging/tests/messaging_tests.js
@@ -1,6 +1,6 @@
 /** @odoo-module **/
 
-import { afterEach, beforeEach, start } from '@mail/utils/test_utils';
+import { beforeEach, start } from '@mail/utils/test_utils';
 
 QUnit.module('mail', {}, function () {
 QUnit.module('models', {}, function () {
@@ -16,9 +16,6 @@ QUnit.module('messaging_tests.js', {
             this.env = env;
             this.widget = widget;
         };
-    },
-    afterEach() {
-        afterEach(this);
     },
 }, function () {
 

--- a/addons/mail/static/src/models/messaging_menu/tests/messaging_menu_tests.js
+++ b/addons/mail/static/src/models/messaging_menu/tests/messaging_menu_tests.js
@@ -1,6 +1,6 @@
 /** @odoo-module **/
 
-import { afterEach, beforeEach, start } from '@mail/utils/test_utils';
+import { beforeEach, start } from '@mail/utils/test_utils';
 
 QUnit.module('mail', {}, function () {
 QUnit.module('models', {}, function () {
@@ -13,9 +13,6 @@ QUnit.module('messaging_menu_tests.js', {
             const { env } = await start({ data: this.data, ...params });
             this.env = env;
         };
-    },
-    afterEach() {
-        afterEach(this);
     },
 });
 

--- a/addons/mail/static/src/models/thread/tests/thread_tests.js
+++ b/addons/mail/static/src/models/thread/tests/thread_tests.js
@@ -1,7 +1,7 @@
 /** @odoo-module **/
 
 import { insert } from '@mail/model/model_field_command';
-import { afterEach, beforeEach, start } from '@mail/utils/test_utils';
+import { beforeEach, start } from '@mail/utils/test_utils';
 
 QUnit.module('mail', {}, function () {
 QUnit.module('models', {}, function () {
@@ -17,9 +17,6 @@ QUnit.module('thread_tests.js', {
             this.env = env;
             this.widget = widget;
         };
-    },
-    afterEach() {
-        afterEach(this);
     },
 });
 

--- a/addons/mail/static/src/utils/throttle/tests/throttle_tests.js
+++ b/addons/mail/static/src/utils/throttle/tests/throttle_tests.js
@@ -1,6 +1,6 @@
 /** @odoo-module **/
 
-import { afterEach, beforeEach, start } from '@mail/utils/test_utils';
+import { beforeEach, start } from '@mail/utils/test_utils';
 import throttle from '@mail/utils/throttle/throttle';
 import { nextTick } from '@mail/utils/utils';
 
@@ -30,7 +30,6 @@ QUnit.module('throttle_tests.js', {
         for (const t of this.throttles) {
             t.clear();
         }
-        afterEach(this);
     },
 });
 

--- a/addons/mail/static/src/utils/timer/tests/timer_tests.js
+++ b/addons/mail/static/src/utils/timer/tests/timer_tests.js
@@ -1,6 +1,6 @@
 /** @odoo-module **/
 
-import { afterEach, beforeEach, nextTick, start } from '@mail/utils/test_utils';
+import { beforeEach, nextTick, start } from '@mail/utils/test_utils';
 import Timer from '@mail/utils/timer/timer';
 
 const { TimerClearedError } = Timer;
@@ -29,7 +29,6 @@ QUnit.module('timer_tests.js', {
         for (const timer of this.timers) {
             timer.clear();
         }
-        afterEach(this);
     },
 });
 

--- a/addons/mail/static/src/widgets/form_renderer/tests/form_renderer_tests.js
+++ b/addons/mail/static/src/widgets/form_renderer/tests/form_renderer_tests.js
@@ -2,7 +2,6 @@
 
 import { makeDeferred } from '@mail/utils/deferred/deferred';
 import {
-    afterEach,
     afterNextRender,
     beforeEach,
     nextAnimationFrame,
@@ -47,9 +46,6 @@ QUnit.module('form_renderer_tests.js', {
                 this.widget = widget;
             });
         };
-    },
-    afterEach() {
-        afterEach(this);
     },
 });
 

--- a/addons/mail/static/src/widgets/notification_alert/tests/notification_alert_tests.js
+++ b/addons/mail/static/src/widgets/notification_alert/tests/notification_alert_tests.js
@@ -1,6 +1,6 @@
 /** @odoo-module **/
 
-import { afterEach, beforeEach, start } from '@mail/utils/test_utils';
+import { beforeEach, start } from '@mail/utils/test_utils';
 
 import FormView from 'web.FormView';
 
@@ -26,9 +26,6 @@ QUnit.module('notification_alert_tests.js', {
             }, params));
             this.widget = widget;
         };
-    },
-    afterEach() {
-        afterEach(this);
     },
 });
 

--- a/addons/mail/static/tests/chatter_tests.js
+++ b/addons/mail/static/tests/chatter_tests.js
@@ -1,6 +1,6 @@
 /** @odoo-module **/
 
-import { afterEach, beforeEach, start } from '@mail/utils/test_utils';
+import { beforeEach, start } from '@mail/utils/test_utils';
 
 import FormView from 'web.FormView';
 import ListView from 'web.ListView';
@@ -96,9 +96,6 @@ QUnit.module('Chatter', {
                 relation_field: "res_id",
             },
         });
-    },
-    afterEach() {
-        afterEach(this);
     },
 });
 
@@ -396,9 +393,6 @@ QUnit.module('FieldMany2ManyTagsEmail', {
             { id: 12, display_name: "gold", email: 'coucou@petite.perruche' },
             { id: 14, display_name: "silver", email: '' }
         );
-    },
-    afterEach() {
-        afterEach(this);
     },
 });
 

--- a/addons/mail/static/tests/clock_model_tests.js
+++ b/addons/mail/static/tests/clock_model_tests.js
@@ -1,7 +1,7 @@
 /** @odoo-module **/
 
 import { insertAndReplace } from '@mail/model/model_field_command';
-import { afterEach, beforeEach, start } from '@mail/utils/test_utils';
+import { beforeEach, start } from '@mail/utils/test_utils';
 
 QUnit.module('mail', {}, function () {
 QUnit.module('clock_model_tests', {
@@ -16,9 +16,6 @@ QUnit.module('clock_model_tests', {
             this.widget = widget;
             return res;
         };
-    },
-    afterEach() {
-        afterEach(this);
     },
 });
 

--- a/addons/mail/static/tests/m2x_avatar_user_tests.js
+++ b/addons/mail/static/tests/m2x_avatar_user_tests.js
@@ -1,7 +1,7 @@
 /** @odoo-module **/
 
 import { Many2OneAvatarUser } from '@mail/js/m2x_avatar_user';
-import { afterEach, beforeEach, start } from '@mail/utils/test_utils';
+import { beforeEach, start } from '@mail/utils/test_utils';
 import { click, getFixture, legacyExtraNextTick, patchWithCleanup, triggerHotkey } from "@web/../tests/helpers/utils";
 import { doAction } from '@web/../tests/webclient/helpers';
 import { registry } from "@web/core/registry";
@@ -51,9 +51,6 @@ QUnit.module('mail', {}, function () {
             );
 
             target = getFixture();
-        },
-        afterEach() {
-            afterEach(this);
         },
     });
 

--- a/addons/mail/static/tests/systray/systray_activity_menu_tests.js
+++ b/addons/mail/static/tests/systray/systray_activity_menu_tests.js
@@ -2,7 +2,6 @@
 
 import ActivityMenu from '@mail/js/systray/systray_activity_menu';
 import {
-    afterEach,
     afterNextRender,
     beforeEach,
     start,
@@ -82,9 +81,6 @@ QUnit.module('ActivityMenu', {
         this.session = {
             uid: 10,
         };
-    },
-    afterEach() {
-        afterEach(this);
     },
 });
 

--- a/addons/mail/static/tests/webclient/commands/mail_providers_tests.js
+++ b/addons/mail/static/tests/webclient/commands/mail_providers_tests.js
@@ -1,6 +1,6 @@
 /** @odoo-module **/
 
-import { afterEach, afterNextRender, beforeEach, start } from '@mail/utils/test_utils';
+import { afterNextRender, beforeEach, start } from '@mail/utils/test_utils';
 import { editSearchBar } from '@web/../tests/core/commands/command_service_tests';
 import { click, getFixture, nextTick, patchWithCleanup, triggerHotkey } from "@web/../tests/helpers/utils";
 import { browser } from '@web/core/browser/browser';
@@ -21,9 +21,6 @@ QUnit.module('mail', {}, function () {
                 },
             });
             registry.category("command_categories").add("default", { label: ("default") });
-        },
-        afterEach() {
-            afterEach(this);
         },
     });
 

--- a/addons/mail_bot/static/src/models/messaging_initializer/tests/messaging_initializer_tests.js
+++ b/addons/mail_bot/static/src/models/messaging_initializer/tests/messaging_initializer_tests.js
@@ -1,6 +1,6 @@
 /** @odoo-module **/
 
-import { afterEach, beforeEach, start } from '@mail/utils/test_utils';
+import { beforeEach, start } from '@mail/utils/test_utils';
 
 QUnit.module('mail_bot', {}, function () {
 QUnit.module('models', {}, function () {
@@ -16,9 +16,6 @@ QUnit.module('messaging_initializer_tests.js', {
             this.env = env;
             this.widget = widget;
         };
-    },
-    afterEach() {
-        afterEach(this);
     },
 });
 

--- a/addons/note/static/tests/systray_activity_menu_tests.js
+++ b/addons/note/static/tests/systray_activity_menu_tests.js
@@ -1,7 +1,7 @@
 /** @odoo-module **/
 
 import ActivityMenu from '@mail/js/systray/systray_activity_menu';
-import { afterEach, beforeEach, start } from '@mail/utils/test_utils';
+import { beforeEach, start } from '@mail/utils/test_utils';
 
 import testUtils from 'web.test_utils';
 
@@ -30,9 +30,6 @@ QUnit.module("ActivityMenu", {
                 records: [],
             }
         });
-    },
-    afterEach() {
-        afterEach(this);
     },
 });
 

--- a/addons/sms/static/src/components/message/tests/message_tests.js
+++ b/addons/sms/static/src/components/message/tests/message_tests.js
@@ -3,7 +3,6 @@
 import { insert, insertAndReplace } from '@mail/model/model_field_command';
 import { makeDeferred } from '@mail/utils/deferred/deferred';
 import {
-    afterEach,
     afterNextRender,
     beforeEach,
     start,
@@ -20,16 +19,12 @@ QUnit.module('message_tests.js', {
 
         this.start = async params => {
             const res = await start({ ...params, data: this.data });
-            const { afterEvent, apps, env, widget } = res;
+            const { afterEvent, env, widget } = res;
             this.afterEvent = afterEvent;
-            this.apps = apps;
             this.env = env;
             this.widget = widget;
             return res;
         };
-    },
-    afterEach() {
-        afterEach(this);
     },
 });
 

--- a/addons/sms/static/src/components/notification_list/tests/notification_list_notification_group_tests.js
+++ b/addons/sms/static/src/components/notification_list/tests/notification_list_notification_group_tests.js
@@ -1,6 +1,6 @@
 /** @odoo-module **/
 
-import { afterEach, beforeEach, start } from '@mail/utils/test_utils';
+import { beforeEach, start } from '@mail/utils/test_utils';
 
 import Bus from 'web.Bus';
 
@@ -20,9 +20,6 @@ QUnit.module('notification_list_notification_group_tests.js', {
             this.widget = widget;
             return res;
         };
-    },
-    afterEach() {
-        afterEach(this);
     },
 });
 

--- a/addons/snailmail/static/src/components/message/tests/message_tests.js
+++ b/addons/snailmail/static/src/components/message/tests/message_tests.js
@@ -2,7 +2,6 @@
 
 import { insert, insertAndReplace } from '@mail/model/model_field_command';
 import {
-    afterEach,
     afterNextRender,
     beforeEach,
     start,
@@ -19,16 +18,12 @@ QUnit.module('message_tests.js', {
 
         this.start = async params => {
             const res = await start({ ...params, data: this.data });
-            const { afterEvent, apps, env, widget } = res;
+            const { afterEvent, env, widget } = res;
             this.afterEvent = afterEvent;
-            this.apps = apps;
             this.env = env;
             this.widget = widget;
             return res;
         };
-    },
-    afterEach() {
-        afterEach(this);
     },
 });
 

--- a/addons/snailmail/static/src/components/notification_list/tests/notification_list_notification_group_tests.js
+++ b/addons/snailmail/static/src/components/notification_list/tests/notification_list_notification_group_tests.js
@@ -1,6 +1,6 @@
 /** @odoo-module **/
 
-import { afterEach, beforeEach, start } from '@mail/utils/test_utils';
+import { beforeEach, start } from '@mail/utils/test_utils';
 
 import Bus from 'web.Bus';
 
@@ -20,9 +20,6 @@ QUnit.module('notification_list_notification_group_tests.js', {
             this.widget = widget;
             return res;
         };
-    },
-    afterEach() {
-        afterEach(this);
     },
 });
 

--- a/addons/website_livechat/static/src/components/discuss/tests/discuss_tests.js
+++ b/addons/website_livechat/static/src/components/discuss/tests/discuss_tests.js
@@ -1,7 +1,6 @@
 /** @odoo-module **/
 
 import {
-    afterEach,
     beforeEach,
     start,
 } from '@mail/utils/test_utils';
@@ -22,9 +21,6 @@ QUnit.module('discuss_tests.js', {
             this.env = env;
             this.widget = widget;
         };
-    },
-    afterEach() {
-        afterEach(this);
     },
 });
 

--- a/addons/website_livechat/static/src/models/messaging_notification_handler/tests/messaging_notification_handler_tests.js
+++ b/addons/website_livechat/static/src/models/messaging_notification_handler/tests/messaging_notification_handler_tests.js
@@ -1,7 +1,6 @@
 /** @odoo-module **/
 
 import {
-    afterEach,
     afterNextRender,
     beforeEach,
     start,
@@ -24,9 +23,6 @@ QUnit.module('messaging_notification_handler_tests.js', {
             this.env = env;
             this.widget = widget;
         };
-    },
-    afterEach() {
-        afterEach(this);
     },
 });
 

--- a/addons/website_slides/static/src/components/activity/tests/activity_tests.js
+++ b/addons/website_slides/static/src/components/activity/tests/activity_tests.js
@@ -1,6 +1,6 @@
 /** @odoo-module **/
 
-import { afterEach, beforeEach, start } from '@mail/utils/test_utils';
+import { beforeEach, start } from '@mail/utils/test_utils';
 
 QUnit.module('website_slides', {}, function () {
 QUnit.module('components', {}, function () {
@@ -10,15 +10,11 @@ QUnit.module('activity_tests.js', {
         await beforeEach(this);
         this.start = async params => {
             const res = await start({ ...params, data: this.data });
-            const { apps, env, widget } = res;
-            this.apps = apps;
+            const { env, widget } = res;
             this.env = env;
             this.widget = widget;
             return res;
         };
-    },
-    afterEach() {
-        afterEach(this);
     },
 });
 


### PR DESCRIPTION
*: calendar, hr, hr_holidays, im_livechat, mail, mail_bot, note, sms, snailmail,
website_livechat, website_slides.

This commit help prepares the remove of beforeEach function in the
mail test suite. Cleanup was relying on beforeEach adding widgets,
components, unpatch method 'this'. We need to clean things up without
using either beforeEach or 'this'.

enterprise: https://github.com/odoo/enterprise/pull/25283

task-2792108