### PR TITLE
[13.0][FIX] web: widgetRenderAndInsert is returning a resolved Promise in all cases

### DIFF
--- a/addons/web/static/src/js/core/widget.js
+++ b/addons/web/static/src/js/core/widget.js
@@ -430,7 +430,7 @@ var Widget = core.Class.extend(mixins.PropertiesMixin, ServicesMixin, {
         var self = this;
         return this.willStart().then(function () {
             if (self.__parentedDestroyed) {
-                return;
+                return Promise.reject();
             }
             self.renderElement();
             insertion(target);


### PR DESCRIPTION
cc @Tecnativa TT35065

ping @pedrobaeza @Tardo 

Description of the issue/feature this PR addresses:
When some user use the TAB so fast on lines of a model, for example on the `stock.move` of any `stock.picking` he will take next error: 
```
Traceback:
Error: widget.$el is undefined
```
![imagen](https://user-images.githubusercontent.com/35952655/158615768-04a2acd7-ef19-4254-b753-13ce77d97f74.png)

Current behavior before PR:
When we use TAB so fast, the value of `self.__parentedDestroyed` takes a true value and it will return a resolved Promise that will be evaluated on https://github.com/odoo/odoo/blob/b20623c0e0426b0e13b2deea7481b949de9475bd/addons/web/static/src/js/views/basic/basic_renderer.js#L645-L660 but the widget.$el will be `undefined`

Desired behavior after PR is merged:
Doing this change, def will be a rejected Promise and will not do the then function.

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
