### PR TITLE
[FIX] account_edi_proxy_client: don't update the demo state

### DIFF
--- a/addons/account_edi_proxy_client/__init__.py
+++ b/addons/account_edi_proxy_client/__init__.py
@@ -1,1 +1,6 @@
 from . import models
+from odoo import api, SUPERUSER_ID
+
+def _create_demo_config_param(cr, registry):
+    env = api.Environment(cr, SUPERUSER_ID, {})
+    env['ir.config_parameter'].set_param('account_edi_proxy_client.demo', 'demo')

--- a/addons/account_edi_proxy_client/__manifest__.py
+++ b/addons/account_edi_proxy_client/__manifest__.py
@@ -17,9 +17,9 @@ Odoo database.
     },
     'data': [
         'security/ir.model.access.csv',
-        'data/config_demo.xml',
     ],
     'installable': True,
     'application': False,
     'license': 'LGPL-3',
+    'post_init_hook': '_create_demo_config_param',
 }

--- a/addons/account_edi_proxy_client/data/config_demo.xml
+++ b/addons/account_edi_proxy_client/data/config_demo.xml
@@ -1,9 +1,0 @@
-<?xml version="1.0" ?>
-<odoo>
-
-    <record id="account_edi_proxy_client_demo" model="ir.config_parameter">
-        <field name="key">account_edi_proxy_client.demo</field>
-        <field name="value">demo</field>
-    </record>
-
-</odoo>


### PR DESCRIPTION
The issue is that the config param is data, which means that when the
module is updated, the config parameter will be updated (i.e. reset to
the 'demo' state), which will cause havoc on client databases. Even if
we set the record to 'noupdate=1', the existing clients will have the
record updated.

The solution is to remove the config param from the data entirely, thus
preventing it from being updated when updating the module, and instead
have a 'post_init_hook' that sets the parameter to 'demo' (this will
only happen when the module is installed, and never again).