### PR TITLE
[FIX] stock: print all barcodes when picking qty done is at 0

### DIFF
--- a/addons/stock/report/picking_templates.xml
+++ b/addons/stock/report/picking_templates.xml
@@ -4,10 +4,16 @@
         <template id="label_transfer_template_view_zpl">
             <t t-foreach="docs" t-as="picking">
 
+                <t t-set="picking_qty_done" t-value="any(picking.move_lines.move_line_ids.mapped('qty_done'))"/>
                 <t t-foreach="picking.move_lines" t-as="move">
                     <t t-foreach="move.move_line_ids" t-as="move_line">
                         <t t-if="move_line.product_uom_id.category_id.measure_type == 'unit'">
-                            <t t-set="qty" t-value="int(move_line.qty_done)"/>
+                            <t t-if="picking_qty_done">
+                                <t t-set="qty" t-value="int(move_line.qty_done)"/>
+                            </t>
+                            <t t-else="">
+                                <t t-set="qty" t-value="int(move_line.product_uom_qty)"/>
+                            </t>
                         </t>
                         <t t-else="">
                             <t t-set="qty" t-value="1"/>
@@ -40,10 +46,16 @@
             <t t-call="web.basic_layout">
                 <div class="page">
                     <t t-foreach="docs" t-as="picking">
+                        <t t-set="picking_qty_done" t-value="any(picking.move_lines.move_line_ids.mapped('qty_done'))"/>
                         <t t-foreach="picking.move_lines" t-as="move">
                             <t t-foreach="move.move_line_ids" t-as="move_line">
                                 <t t-if="move_line.product_uom_id.category_id.measure_type == 'unit'">
-                                    <t t-set="qty" t-value="int(move_line.qty_done)"/>
+                                    <t t-if="picking_qty_done">
+                                        <t t-set="qty" t-value="int(move_line.qty_done)"/>
+                                    </t>
+                                    <t t-else="">
+                                        <t t-set="qty" t-value="int(move_line.product_uom_qty)"/>
+                                    </t>
                                 </t>
                                 <t t-else="">
                                     <t t-set="qty" t-value="1"/>


### PR DESCRIPTION
Steps to reproduce the bug:
- Go to Inventory > Transfers > Select a ready transfer with no qty done
- Print > barcodes (ZPL) or barcodes (PDF)

Problem:
The file is empty because there is no qty_done.

Solution:
If no qty is done, then print all barcodes as if picking is done.
It makes sense, for example, when a user wants to print the barcodes before the product is delivered

but if at least one move_line has a Qty_done then do not print the other move_lines which have a qty_done of 0

opw-2780365




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
