### PR TITLE
[FIX] web: uncheck all records in grouped list view

### DIFF
--- a/addons/web/static/src/js/views/list/list_controller.js
+++ b/addons/web/static/src/js/views/list/list_controller.js
@@ -76,7 +76,8 @@ var ListController = BasicController.extend({
      */
     getActiveDomain: function () {
         var self = this;
-        if (this.$('thead .o_list_record_selector input').prop('checked')) {
+        const $closedHeaders = this.$('tbody .o_group_header.o_group_has_content:not(.o_group_open)');
+        if (this.$('thead .o_list_record_selector input').prop('checked') && $closedHeaders.length === 0) {
             var searchQuery = this._controlPanel ? this._controlPanel.getSearchQuery() : {};
             var record = self.model.get(self.handle, {raw: true});
             return record.getDomain().concat(searchQuery.domain || []);

--- a/addons/web/static/src/js/views/list/list_renderer.js
+++ b/addons/web/static/src/js/views/list/list_renderer.js
@@ -1040,8 +1040,7 @@ var ListRenderer = BasicRenderer.extend({
         this.selection = [];
         var self = this;
         var $inputs = this.$('tbody .o_list_record_selector input:visible:not(:disabled)');
-        var $closedHeaders = this.$('tbody .o_group_header.o_group_has_content:not(.o_group_open)');
-        var allChecked = $inputs.length > 0 && $closedHeaders.length === 0;
+        var allChecked = $inputs.length > 0;
         $inputs.each(function (index, input) {
             if (input.checked) {
                 self.selection.push($(input).closest('tr').data('id'));

--- a/addons/web/static/tests/views/list_tests.js
+++ b/addons/web/static/tests/views/list_tests.js
@@ -1335,8 +1335,8 @@ QUnit.module('Views', {
 
         await testUtils.dom.click(list.$('.o_group_header:first()'));
 
-        assert.ok(!list.$('thead .o_list_record_selector input')[0].checked,
-            "Head selector should be unchecked");
+        assert.ok(list.$('thead .o_list_record_selector input')[0].checked,
+            "Head selector should be checked");
 
         list.destroy();
     });

--- a/addons/web/static/tests/widgets/data_export_tests.js
+++ b/addons/web/static/tests/widgets/data_export_tests.js
@@ -129,6 +129,191 @@ QUnit.module('widgets', {
         ]);
     });
 
+    QUnit.test('exporting all data in grouped list view', async function (assert) {
+        assert.expect(6);
+
+        testUtils.mock.patch(framework, {
+            blockUI: () => assert.step('block UI'),
+            unblockUI: () => assert.step('unblock UI'),
+        });
+
+        const list = await createView({
+            View: ListView,
+            model: 'partner',
+            data: this.data,
+            groupBy: ['foo'],
+            domain: [['bar', '!=', 'glou']],
+            arch: '<tree><field name="foo"/></tree>',
+            viewOptions: {
+                hasSidebar: true,
+            },
+            mockRPC: function (route) {
+                if (route === '/web/export/formats') {
+                    return Promise.resolve([
+                        {tag: 'csv', label: 'CSV'},
+                        {tag: 'xls', label: 'Excel'},
+                    ]);
+                }
+                if (route === '/web/export/get_fields') {
+                    return Promise.resolve([
+                        {
+                            field_type: "one2many",
+                            string: "Activities",
+                            required: false,
+                            value: "activity_ids/id",
+                            id: "activity_ids",
+                            params: {"model": "mail.activity", "prefix": "activity_ids", "name": "Activities"},
+                            relation_field: "res_id",
+                            children: true,
+                        }, {
+                            children: false,
+                            field_type: 'char',
+                            id: "foo",
+                            relation_field: null,
+                            required: false,
+                            string: 'Foo',
+                            value: "foo",
+                        }
+                    ]);
+                }
+                return this._super.apply(this, arguments);
+            },
+            session: {
+                get_file: function (params) {
+                    assert.step(params.url);
+                    const data = JSON.parse(params.data.data);
+                    assert.deepEqual(
+                        data,
+                        {
+                            "model": "partner",
+                            "fields": [{"name": "foo", "label": "Foo"}],
+                            "ids": false,
+                            "domain": [['bar', '!=', 'glou'], ['bar', '!=', 'glou']],
+                            "groupby": ["foo"],
+                            "context": {},
+                            "import_compat": false
+                        });
+                    params.complete();
+                },
+            },
+        });
+
+        // expand groups
+        await testUtils.dom.click(list.$('.o_group_header:eq(0)'));
+        await testUtils.dom.click(list.$('.o_group_header:eq(1)'));
+
+        await testUtils.dom.click(list.$('thead th.o_list_record_selector input'));
+
+        await testUtils.dom.click(list.sidebar.$('.o_dropdown_toggler_btn:contains(Action)'));
+        await testUtils.dom.click(list.sidebar.$('a:contains(Export)'));
+
+        assert.strictEqual($('.modal').length, 1, "a modal dialog should be open");
+
+        // select the field Description, click on add, then export and close
+        await testUtils.dom.click($('.modal .o_tree_column:contains(Foo) .o_add_field'));
+        await testUtils.dom.click($('.modal span:contains(Export)'));
+        await testUtils.dom.click($('.modal span:contains(Close)'));
+        assert.verifySteps([
+            'block UI',
+            '/web/export/csv',
+            'unblock UI',
+        ]);
+        list.destroy();
+        testUtils.mock.unpatch(framework);
+    });
+
+    QUnit.test('exporting a single group in grouped list view', async function (assert) {
+        assert.expect(6);
+
+        testUtils.mock.patch(framework, {
+            blockUI: () => assert.step('block UI'),
+            unblockUI: () => assert.step('unblock UI'),
+        });
+
+        const list = await createView({
+            View: ListView,
+            model: 'partner',
+            data: this.data,
+            groupBy: ['foo'],
+            domain: [['bar', '!=', 'glou']],
+            arch: '<tree><field name="foo"/></tree>',
+            viewOptions: {
+                hasSidebar: true,
+            },
+            mockRPC: function (route) {
+                if (route === '/web/export/formats') {
+                    return Promise.resolve([
+                        {tag: 'csv', label: 'CSV'},
+                        {tag: 'xls', label: 'Excel'},
+                    ]);
+                }
+                if (route === '/web/export/get_fields') {
+                    return Promise.resolve([
+                        {
+                            field_type: "one2many",
+                            string: "Activities",
+                            required: false,
+                            value: "activity_ids/id",
+                            id: "activity_ids",
+                            params: {"model": "mail.activity", "prefix": "activity_ids", "name": "Activities"},
+                            relation_field: "res_id",
+                            children: true,
+                        }, {
+                            children: false,
+                            field_type: 'char',
+                            id: "foo",
+                            relation_field: null,
+                            required: false,
+                            string: 'Foo',
+                            value: "foo",
+                        }
+                    ]);
+                }
+                return this._super.apply(this, arguments);
+            },
+            session: {
+                get_file: function (params) {
+                    assert.step(params.url);
+                    const data = JSON.parse(params.data.data);
+                    assert.deepEqual(
+                        data,
+                        {
+                            "model": "partner",
+                            "fields": [{"name": "foo", "label": "Foo"}],
+                            "ids": [1, 2],
+                            "domain": [["bar", "!=", "glou"]],
+                            "groupby": ["foo"],
+                            "context": {},
+                            "import_compat": false
+                        });
+                    params.complete();
+                },
+            },
+        });
+
+        // expand the first group
+        await testUtils.dom.click(list.$('.o_group_header:eq(0)'));
+
+        await testUtils.dom.click(list.$('thead th.o_list_record_selector input'));
+
+        await testUtils.dom.click(list.sidebar.$('.o_dropdown_toggler_btn:contains(Action)'));
+        await testUtils.dom.click(list.sidebar.$('a:contains(Export)'));
+
+        assert.strictEqual($('.modal').length, 1, "a modal dialog should be open");
+
+        // select the field Description, click on add, then export and close
+        await testUtils.dom.click($('.modal .o_tree_column:contains(Foo) .o_add_field'));
+        await testUtils.dom.click($('.modal span:contains(Export)'));
+        await testUtils.dom.click($('.modal span:contains(Close)'));
+        assert.verifySteps([
+            'block UI',
+            '/web/export/csv',
+            'unblock UI',
+        ]);
+        list.destroy();
+        testUtils.mock.unpatch(framework);
+    });
+
     QUnit.test('exporting view with non-exportable field', async function (assert) {
         assert.expect(0);
 


### PR DESCRIPTION
**Steps to follow**

  - Go to the manufacturing app -> master data -> products
  - Switch to the list view
  - Group by product type
  - Select all records with the top checkbox
  -> It stays unchecked
  -> you can't easily uncheck every record

**Cause of the issue**

  The export action verifies the header checkbox value in order to
  know if every record should be used.
  The header checkbox was initially unchecked when there was at least
  one folded group to avoid selecting the domain in that case.

**Solution**

  Check for folded groups in the `getActiveDomain` function (only used
  for the export) and keep the checkbox enabled when every visible
  record is checked (so those inside opened groups).

opw-2778885