### PR TITLE
[FIX][14.0]account: account admin can't Add a Bank Account

### DIFF
--- a/addons/account/views/res_partner_bank_views.xml
+++ b/addons/account/views/res_partner_bank_views.xml
@@ -18,6 +18,7 @@
         <record id="action_new_bank_setting" model="ir.actions.server">
             <field name="name">Add a Bank Account</field>
             <field name="model_id" ref="model_res_company"/>
+            <field name="groups_id" eval="[(6, 0, [ref('group_account_manager')])]" />
             <field name="state">code</field>
             <field name="code">
 action = model.setting_init_bank_account_action()


### PR DESCRIPTION
Account admin can't open act.server Add a Bank Account

Img:
![Screenshot from 2022-03-17 10-14-17](https://user-images.githubusercontent.com/66937593/158729798-7a4d088e-7727-4fd9-9df7-7431b1bd349d.png)
![Screenshot from 2022-03-17 10-14-25](https://user-images.githubusercontent.com/66937593/158729803-487b4e99-06e8-4dcf-8a32-2f961dd59a60.png)




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
