### PR TITLE
[IMP] mass_mailing_{sms}: add group name to manage xpath

### DIFF
--- a/addons/mass_mailing/views/mailing_mailing_views.xml
+++ b/addons/mass_mailing/views/mailing_mailing_views.xml
@@ -318,7 +318,7 @@
                             </page>
                             <page string="Settings" name="settings">
                                 <group>
-                                    <group string="Email Content" attrs="{'invisible': [('mailing_type', '!=', 'mail')]}">
+                                    <group string="Email Content" name="email_content" attrs="{'invisible': [('mailing_type', '!=', 'mail')]}">
                                         <field class="o_text_overflow" name="preview" string="Preview Text" attrs="{'readonly': [('state', 'in', ('sending', 'done'))]}" widget="char_emojis" placeholder="e.g. Check it out before it's too late!"/>
                                         <field name="email_from" attrs="{'readonly': [('state', 'in', ('sending', 'done'))]}"/>
                                         <label for="reply_to"/>

--- a/addons/mass_mailing_sms/views/mailing_mailing_views.xml
+++ b/addons/mass_mailing_sms/views/mailing_mailing_views.xml
@@ -123,7 +123,7 @@
                         options='{"enable_emojis": True}'/>
                 </page>
             </xpath>
-            <xpath expr="//page[@name='settings']/group/group[1]" position="after">
+            <xpath expr="//page[@name='settings']/group/group[@name='email_content']" position="after">
                 <group string="Options" attrs="{'invisible': [('mailing_type', '!=', 'sms')]}">
                     <field name="sms_allow_unsubscribe" attrs="{'invisible': [('mailing_type', '!=', 'sms')], 'readonly': [('state', 'in', ('sending', 'done'))]}"/>
                 </group>


### PR DESCRIPTION
PURPOSE

In the SMS marketing, The settings tab have 'Include opt-out link' field
inside 'Options' group with the indexing number in the xpath.

SPECIFICATIONS

An Options group is added to display the Include opt-out link field in 
an sms marketing.

With this Commit,

We have added the name of the group to 'Email Content' to minimize the
indexing on xpath.

PR #86555
Task-2710557



--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
