### PR TITLE
[FIX] product: fix Dymo report label

### DIFF
--- a/addons/product/report/product_product_templates.xml
+++ b/addons/product/report/product_product_templates.xml
@@ -104,13 +104,14 @@
                         <t t-if="barcode">
                             <!-- `quiet=0` to remove the left and right margins on the barcode -->
                             <div t-out="barcode" style="padding:0" t-options="{'widget': 'barcode', 'quiet': 0, 'symbology': 'auto', 'img_style': barcode_size}"/>
-                            <div class="o_label_name" style="line-height: 130%;height:2.7em;background-color: transparent;">
+                            <div class="o_label_name" style="line-height: 130%;height:2.0em;background-color: transparent;">
                                 <span t-out="barcode"/>
                             </div>
                         </t>
                     </div>
-                    <div class="o_label_name" style="line-height: 130%;height:2.7em;background-color: transparent;">
-                        <span t-field="product.display_name"/>
+                    <div class="o_label_name" style="line-height: 130%;height:2.0em;background-color: transparent;">
+                        <span t-if="product.is_product_variant" t-field="product.display_name"/>
+                        <span t-else="" t-field="product.name"/>
                     </div>
                     <div class="o_label_left_column">
                         <small class="text-nowrap" t-field="product.default_code"/>


### PR DESCRIPTION
Steps to reproduce the bug:
- Create a storable product:
    - Add a Barcode and an internal reference
- Click on Print Labels:
    - Select Dymo format
    - Add an Extra Content

Problem:
1:/ The extra content is not displayed because there is not enough space
2:/ The internal reference is displayed twice: in the display_name and in another line,
It's useless to display it twice, we should use name instead of display_name for the model `product_template`

opw-2791754




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
