### PR TITLE
[FIX] sale_timesheet: prevent session timeout at the end of test tour

### DIFF
--- a/addons/sale_timesheet/static/tests/tours/sale_timesheet_tour.js
+++ b/addons/sale_timesheet/static/tests/tours/sale_timesheet_tour.js
@@ -368,6 +368,9 @@ tour.register('sale_timesheet_tour', {
     trigger: ".o_field_widget[name=description] h3:contains('Milestones')",
     content: "Milestones title must be in description",
     run: function () {},
-}]);
-
+},
+// This step is currently needed in order to prevent a session timeout at the end of the test.
+tour.stepUtils.toggleHomeMenu(),
+...tour.stepUtils.goToAppSteps("project.menu_main_pm", 'Go to the Project app.'),
+]);
 });


### PR DESCRIPTION
Prior to this commit:
- The test tour was falling in some circumstances, when additional reads
  were done right after the last step.

After this commit:
- Adding the last step which is returning the the project app menu will
  prevent having those additional reads after the last step.

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
