### PR TITLE
[FIX] stock: set partner for inter-warehouse transfers

### DIFF
--- a/addons/stock/tests/test_warehouse.py
+++ b/addons/stock/tests/test_warehouse.py
@@ -256,10 +256,12 @@ class TestWarehouse(TestStockCommon):
             'code': 'STK',
         })
 
+        distribution_partner = self.env['res.partner'].create({'name': 'Distribution Center'})
         warehouse_distribution = self.env['stock.warehouse'].create({
             'name': 'Dist.',
             'code': 'DIST',
-            'resupply_wh_ids': [(6, 0, [warehouse_stock.id])]
+            'resupply_wh_ids': [(6, 0, [warehouse_stock.id])],
+            'partner_id': distribution_partner.id,
         })
 
         warehouse_shop = self.env['stock.warehouse'].create({
@@ -315,6 +317,9 @@ class TestWarehouse(TestStockCommon):
         self.assertTrue(self.env['stock.move'].search([('location_id', '=', warehouse_distribution.lot_stock_id.id)]))
         self.assertTrue(self.env['stock.move'].search([('location_dest_id', '=', warehouse_shop.lot_stock_id.id)]))
         self.assertTrue(self.env['stock.move'].search([('location_id', '=', warehouse_shop.lot_stock_id.id)]))
+
+        self.assertTrue(self.env['stock.picking'].search([('location_id', '=', self.env.company.internal_transit_location_id.id), ('partner_id', '=', distribution_partner.id)]))
+        self.assertTrue(self.env['stock.picking'].search([('location_dest_id', '=', self.env.company.internal_transit_location_id.id), ('partner_id', '=', distribution_partner.id)]))
 
     def test_mutiple_resupply_warehouse(self):
         """ Simulate the following situation:


### PR DESCRIPTION
The inter-warehouse transfers do not have any partner defined.

To reproduce the issue:
(Let WH01 be the default warehouse)
1. In Settings, enable:
    - Multi-Warehouses
    - Multi-Step Routes
2. Create a second warehouse WH02
3. On WH2, enable "Resupply From WH01"
4. Create a product P:
    - Storable
    - Routes:
        - WH02: Supply Product from WH01
    - Reordering rules:
        - Min = Max = 1
        - Warehouse: WH02
        - Location: WH02/Stock
5. Update the quantity of P:
    - 1 x P in WH01/Stock
6. Run the scheduler
7. Open the generated pickings for P

Error: None of the picking has a `partner_id` ("Receive From"/"Delivery
Address")

Partial backport of af13e76629d0ad1684f2be26a578f210ea4f1552

OPW-2779150