### PR TITLE
[FIX] sale: undiscounted amount computation with tax included price 

### DIFF
--- a/addons/sale/models/sale.py
+++ b/addons/sale/models/sale.py
@@ -331,7 +331,7 @@ class SaleOrder(models.Model):
         for order in self:
             total = 0.0
             for line in order.order_line:
-                total += line.price_subtotal + line.price_unit * ((line.discount or 0.0) / 100.0) * line.product_uom_qty  # why is there a discount in a field named amount_undiscounted ??
+                total += (line.price_subtotal * 100)/(100-line.discount) if line.discount != 100 else (line.price_unit * line.product_uom_qty)
             order.amount_undiscounted = total
 
     @api.depends('state')

--- a/addons/sale/tests/test_sale_order.py
+++ b/addons/sale/tests/test_sale_order.py
@@ -619,6 +619,59 @@ class TestSaleOrder(TestCommonSaleNoChart):
         self.assertEqual(line.price_subtotal, 17527.41)
         self.assertEqual(line.untaxed_amount_to_invoice, line.price_subtotal)
 
+    def test_discount_and_amount_undiscounted(self):
+        """When adding a discount on a SO line, this test ensures that amount undiscounted is
+        consistent with the used tax"""
+        sale_order = self.env['sale.order'].create({
+            'partner_id': self.partner_customer_usd.id,
+            'order_line': [(0, 0, {
+                'product_id': self.product_deliver.id,
+                'product_uom_qty': 1,
+                'price_unit': 100.0,
+                'discount': 1.00,
+            })]
+        })
+        sale_order.action_confirm()
+        line = sale_order.order_line
+
+        # test discount and qty 1
+        self.assertEqual(sale_order.amount_undiscounted, 100.0)
+        self.assertEqual(line.price_subtotal, 99.0)
+
+        # more quantity 1 -> 3
+        sale_form = Form(sale_order)
+        with sale_form.order_line.edit(0) as line_form:
+            line_form.product_uom_qty = 3.0
+            line_form.price_unit = 100.0
+        sale_order = sale_form.save()
+
+        self.assertEqual(sale_order.amount_undiscounted, 300.0)
+        self.assertEqual(line.price_subtotal, 297.0)
+
+        # undiscounted
+        with sale_form.order_line.edit(0) as line_form:
+            line_form.discount = 0.0
+        sale_order = sale_form.save()
+        self.assertEqual(line.price_subtotal, 300.0)
+        self.assertEqual(sale_order.amount_undiscounted, 300.0)
+
+        # Same with an included-in-price tax
+        sale_order = sale_order.copy()
+        line = sale_order.order_line
+        line.tax_id = [(0, 0, {
+            'name': 'Super Tax',
+            'amount_type': 'percent',
+            'amount': 10.0,
+            'price_include': True,
+        })]
+        line.discount = 50.0
+        sale_order.action_confirm()
+
+        # 300 with 10% incl tax -> 272.72 total tax excluded without discount
+        # 136.36 price tax excluded with discount applied
+        self.assertEqual(sale_order.amount_undiscounted, 272.72)
+        self.assertEqual(line.price_subtotal, 136.36)
+
     def test_free_product_and_price_include_fixed_tax(self):
         """ Check that fixed tax include are correctly computed while the price_unit is 0
         """


### PR DESCRIPTION
Enable discounts
Have a price included tax 10%
Have a product with sales price 100$
Make a SO adding the product, the price incl. tax and a 1% discount
Open the portal page of the quotation

In the left recap sidebar the price before discount is reported to be
100.10 while it should be 100.0

opw-2759804


--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
