### PR TITLE
[FIX] mail: `o_Activity_userAvatar` aspect-ratio

### DIFF
--- a/addons/mail/static/src/components/activity/activity.scss
+++ b/addons/mail/static/src/components/activity/activity.scss
@@ -2,6 +2,10 @@
 // Layout
 // ------------------------------------------------------------------
 
+.o_Activity_userAvatar {
+    object-fit: cover;
+}
+
 .o_Activity_detailsUserAvatar {
     object-fit: cover;
     height: 18px;
@@ -18,6 +22,7 @@
 
 .o_Activity_sidebar {
     width: $o-mail-thread-avatar-size;
+    height: $o-mail-thread-avatar-size;
 }
 
 // From python template

--- a/addons/mail/static/src/components/activity/activity.xml
+++ b/addons/mail/static/src/components/activity/activity.xml
@@ -5,9 +5,9 @@
         <div class="o_Activity d-flex p-2" t-attf-class="{{ className }}" t-on-click="activityView.onClickActivity" t-ref="root">
             <t t-if="activityView">
                 <div class="o_Activity_sidebar mr-3">
-                    <div class="o_Activity_user position-relative">
+                    <div class="o_Activity_user position-relative h-100 w-100">
                         <t t-if="activityView.activity.assignee">
-                            <img class="o_Activity_userAvatar rounded-circle w-100" t-attf-src="/web/image/res.users/{{ activityView.activity.assignee.id }}/avatar_128" t-att-alt="activityView.activity.assignee.nameOrDisplayName"/>
+                            <img class="o_Activity_userAvatar rounded-circle h-100 w-100" t-attf-src="/web/image/res.users/{{ activityView.activity.assignee.id }}/avatar_128" t-att-alt="activityView.activity.assignee.nameOrDisplayName"/>
                         </t>
                         <div class="o_Activity_iconContainer d-flex align-items-center justify-content-center rounded-circle w-50 h-50 text-white"
                             t-att-class="{


### PR DESCRIPTION
This commit fixes an issue causing the activity's avatar image to exceed
the available vertical space when in portrait mode.

The avatar's width/height are now fixed and its pic is set to cover the
available room only.

task-2795252




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
