### PR TITLE
[FIX] core: name_get() should return "" instead of False

### DIFF
--- a/odoo/addons/test_new_api/tests/test_onchange.py
+++ b/odoo/addons/test_new_api/tests/test_onchange.py
@@ -601,6 +601,10 @@ class TestOnChange(SavepointCaseWithUserDemo):
         self.assertEqual(form.name, False)
         self.assertEqual(form.display_name, False)
 
+        record = form.save()
+        self.assertEqual(record.display_name, False)
+        self.assertEqual(record.name_get(), [(record.id, "")])
+
 
 class TestComputeOnchange(common.TransactionCase):
 

--- a/odoo/models.py
+++ b/odoo/models.py
@@ -1831,7 +1831,7 @@ class BaseModel(metaclass=MetaModel):
         """
         names = dict(self.name_get())
         for record in self:
-            record.display_name = names.get(record.id, False)
+            record.display_name = names.get(record.id) or False
 
     def name_get(self):
         """Returns a textual representation for the records in ``self``, with
@@ -1852,7 +1852,7 @@ class BaseModel(metaclass=MetaModel):
         if name in self._fields:
             convert = self._fields[name].convert_to_display_name
             for record in self:
-                result.append((record.id, convert(record[name], record)))
+                result.append((record.id, convert(record[name], record) or ""))
         else:
             for record in self:
                 result.append((record.id, "%s,%s" % (record._name, record.id)))


### PR DESCRIPTION
Because of 4347491670cb0e1bef64084badeccd5b09a95377, the method `name_get()` can now return records with `False` as label, and this makes code crash when it expects a string.  Make sure that `name_get()` always return strings as labels, while keeping `False` as empty value for the field `display_name`.