### PR TITLE
[FIX] l10n_it_edi: limit IdDocumento field length, prevent PrezzoUnitario 0 division bug

### DIFF
--- a/addons/l10n_it_edi/data/invoice_it_template.xml
+++ b/addons/l10n_it_edi/data/invoice_it_template.xml
@@ -147,7 +147,7 @@
                             </DatiBollo>
                         </DatiGeneraliDocumento>
                         <DatiOrdineAcquisto t-if="record.ref">
-                            <IdDocumento t-esc="record.ref" />
+                            <IdDocumento t-esc="record.ref[:20]" />
                         </DatiOrdineAcquisto>
                         <DatiDDT t-if="record.l10n_it_ddt_id">
                             <!--2.1.8-->

--- a/addons/l10n_it_edi/data/invoice_it_template.xml
+++ b/addons/l10n_it_edi/data/invoice_it_template.xml
@@ -20,7 +20,7 @@
                 </Descrizione>
                 <Quantita t-esc="format_numbers(line.quantity)"/>
                 <UnitaMisura t-if="line.product_uom_id.category_id != env.ref('uom.product_uom_categ_unit')" t-esc="line.product_uom_id.name"/>
-                <PrezzoUnitario t-esc="'%.06f' % (line.price_subtotal / (( 1 - (line.discount or 0.0) / 100.0) * line.quantity))"/>
+                <PrezzoUnitario t-esc="'%.06f' % (line.price_subtotal / (( 1 - (line.discount or 0.0) / 100.0) * line.quantity) if line.discount != 100.0 else line.price_unit)"/>
                 <ScontoMaggiorazione t-if="line.discount != 0">
                     <!-- [2.2.1.10] -->
                     <Tipo t-esc="discount_type(line.discount)"/>


### PR DESCRIPTION
Fixes for a couple of bugs discovered with the l10n_it_edi xml export.

The first was that the IdDocumento field was not constrained to the length of 20 characters expected by the edi, to fix this we slice the string at 20 characters.

The second was that the PrezzoUnitario field is calculated using a formula to get the unit price of the invoice lines 
(the reason for this is to solve the problem of roundings when the price is included, see: https://github.com/odoo/odoo/commit/5e745ecaaa2471aeb91c5cc048c345e44d1b0061)
The problem is that if the discount is 100%, a ZeroDivisionError will occur. To fix this we just use the unit price directly when the discount is 100%.
