### PR TITLE
[FIX] board,project: Allow user to add project_graph to dashboard

### DIFF
--- a/addons/board/static/src/add_to_board/add_to_board.js
+++ b/addons/board/static/src/add_to_board/add_to_board.js
@@ -34,9 +34,10 @@ export class AddToBoard extends Component {
     //---------------------------------------------------------------------
 
     async addToBoard() {
-        const { domain } = this.env.searchModel;
+        const { domain, globalContext } = this.env.searchModel;
         const { context } = this.env.searchModel.getIrFilterValues();
         const contextToSave = {
+            ...globalContext,
             ...context,
             orderedBy: this.env.searchModel.orderBy,
             dashboard_merge_domains_contexts: false,

--- a/addons/project/__manifest__.py
+++ b/addons/project/__manifest__.py
@@ -82,6 +82,9 @@
             'project/static/src/scss/project_rightpanel.scss',
             'project/static/src/scss/project_widgets.scss',
         ],
+        "web.assets_backend_legacy_lazy": [
+            'project/static/src/js/*_legacy.js',
+        ],
         'web.assets_frontend': [
             'project/static/src/scss/portal_rating.scss',
             'project/static/src/js/portal_rating.js',

--- a/addons/project/static/src/js/project_graph_legacy.js
+++ b/addons/project/static/src/js/project_graph_legacy.js
@@ -1,0 +1,13 @@
+/** @odoo-module **/
+
+import GraphView from 'web.GraphView';
+import { ProjectControlPanel } from '@project/js/project_control_panel';
+import viewRegistry from 'web.view_registry';
+
+export const ProjectGraphView = GraphView.extend({
+  config: Object.assign({}, GraphView.prototype.config, {
+    ControlPanel: ProjectControlPanel,
+  }),
+});
+
+viewRegistry.add('project_graph', ProjectGraphView);

--- a/addons/project/static/src/js/project_pivot_legacy.js
+++ b/addons/project/static/src/js/project_pivot_legacy.js
@@ -1,0 +1,13 @@
+/** @odoo-module **/
+
+import PivotView from 'web.PivotView';
+import { ProjectControlPanel } from '@project/js/project_control_panel';
+import viewRegistry from 'web.view_registry';
+
+export const ProjectPivotView = PivotView.extend({
+  config: Object.assign({}, PivotView.prototype.config, {
+    ControlPanel: ProjectControlPanel,
+  }),
+});
+
+viewRegistry.add('project_pivot', ProjectPivotView);


### PR DESCRIPTION
If we add the graph view of project in the dashboard
And we access the dashboard a traceback appears

Cause: Unable to evaluate the context because the following information
is missing: "active_id" which is used in the domain

https://github.com/odoo/odoo/blob/4d864c05dfa8f9be25d41bbae318f75a61d0cde2/addons/board/static/src/legacy/js/board_view.js#L254

the solution is to add `globalContext` to the `contextToSave`

https://github.com/odoo/odoo/blob/7e77bb74bfa1bfef92c6d385dedc2d89e0040780/addons/board/static/src/add_to_board/add_to_board.js#L37-L43

`View` is `undefined` because the `project_graph` view is made with OWL
and board is still in legacy

https://github.com/odoo/odoo/blob/4d864c05dfa8f9be25d41bbae318f75a61d0cde2/addons/board/static/src/legacy/js/board_view.js#L274

Since https://github.com/odoo/odoo/pull/84864

The solution is to add a legacy version of the `project_graph`

Apply the same fix to `project_pivot`

opw-2791672