### PR TITLE
[IMP] mrp, stock: Properly propagate qty changes when updating a MO qty

### DIFF
--- a/addons/mrp/wizard/change_production_qty.py
+++ b/addons/mrp/wizard/change_production_qty.py
@@ -33,13 +33,25 @@ class ChangeProductionQty(models.TransientModel):
         modification during production would not be taken into consideration.
         """
         modification = {}
+        push_moves = self.env['stock.move']
         for move in production.move_finished_ids:
             if move.state in ('done', 'cancel'):
                 continue
             qty = (new_qty - old_qty) * move.unit_factor
             modification[move] = (move.product_uom_qty + qty, move.product_uom_qty)
-            move.write({'product_uom_qty': move.product_uom_qty + qty})
+            if self._need_quantity_propagation(move, qty):
+                push_moves |= move.copy({'product_uom_qty': qty})
+            else:
+                move.write({'product_uom_qty': move.product_uom_qty + qty})
+
+        if push_moves:
+            push_moves._action_confirm()._action_assign()
+
         return modification
+
+    @api.model
+    def _need_quantity_propagation(self, move, qty):
+        return move.move_dest_ids and not float_is_zero(qty, precision_rounding=move.product_uom.rounding)
 
     def change_prod_qty(self):
         precision = self.env['decimal.precision'].precision_get('Product Unit of Measure')
@@ -71,9 +83,7 @@ class ChangeProductionQty(models.TransientModel):
                         else:
                             documents[key] = [value]
             production._log_manufacture_exception(documents)
-            finished_moves_modification = self._update_finished_moves(production, new_production_qty - qty_produced, old_production_qty - qty_produced)
-            if finished_moves_modification:
-                production._log_downside_manufactured_quantity(finished_moves_modification)
+            self._update_finished_moves(production, new_production_qty - qty_produced, old_production_qty - qty_produced)
             production.write({'product_qty': new_production_qty})
 
             for wo in production.workorder_ids:

--- a/addons/mrp_subcontracting/wizard/__init__.py
+++ b/addons/mrp_subcontracting/wizard/__init__.py
@@ -3,3 +3,4 @@
 
 from . import stock_picking_return
 from . import mrp_consumption_warning
+from . import change_production_qty

--- a/addons/mrp_subcontracting/wizard/change_production_qty.py
+++ b/addons/mrp_subcontracting/wizard/change_production_qty.py
@@ -1,0 +1,13 @@
+# -*- coding: utf-8 -*-
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from odoo import api, models
+
+
+class ChangeProductionQty(models.TransientModel):
+    _inherit = 'change.production.qty'
+
+    @api.model
+    def _need_quantity_propagation(self, move, qty):
+        res = super()._need_quantity_propagation(move, qty)
+        return res and not any(m.is_subcontract for m in move.move_dest_ids)


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
As of now, if any move is linked to a manufacturing order, such as :
- picking from stock to pre-production (like in two-step manufacturing)
- purchase order (components are MTO buy)
- picking from post-production to stock (like in three-step manufacturing)

Their quantities won't get updated when changing the quantity to produce, even though the required quantities for the components are updated within the MO. Same thing happens with the picking of the manufactured product that doesn't get updated in the outgoing picking.

Task-2797359

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
