### PR TITLE
[FIX] website_sale: strip category description from html tags

### DIFF
--- a/addons/website_sale/models/product_misc.py
+++ b/addons/website_sale/models/product_misc.py
@@ -194,7 +194,7 @@ class ProductPublicCategory(models.Model):
         if with_description:
             search_fields.append('website_description')
             fetch_fields.append('website_description')
-            mapping['description'] = {'name': 'website_description', 'type': 'text', 'match': True}
+            mapping['description'] = {'name': 'website_description', 'type': 'text', 'match': True, 'html': True}
         return {
             'model': 'product.public.category',
             'base_domain': [], # categories are not website-specific


### PR DESCRIPTION
Step to reproduce:
- In e-commerce go to a category
- Edit the page to add a text block at the beginning
- Save
- Go back to main page
- Search the category

Current behaviour:
- The search bar show the text block as the category description
 But the description also contains the html linked to the bloc
 which lead to ugly unhelpful description

Behaviour after PR:
- html tags are stripped from the description returned to
 the search bar

opw-2781450


--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
