### PR TITLE
[FIX] mail: ensures the usage of rtc session id for type consistency

### DIFF
--- a/addons/mail/static/src/models/messaging_notification_handler.js
+++ b/addons/mail/static/src/models/messaging_notification_handler.js
@@ -422,7 +422,7 @@ registerModel({
         /**
          * @private
          * @param {Object} data
-         * @param {string} data.sender
+         * @param {number} data.sender
          * @param {string[]} data.notifications
          */
         _handleNotificationRtcPeerToPeer({ sender, notifications }) {


### PR DESCRIPTION
Before this commit, mismatching types between String and Number would
cause inserts to register a change.

`rtc.js` used `rtcSession.peerToken`(String) and `rtcSession.id`(number)
interchangeably, this commit fixes this issue by favoring the usage
of `rtcSession.id`.
