### PR TITLE
[IMP] website_slides_forum: avoid error message when selecting forum

### DIFF
--- a/addons/website_slides_forum/views/slide_channel_views.xml
+++ b/addons/website_slides_forum/views/slide_channel_views.xml
@@ -15,7 +15,7 @@
                 </button>
             </xpath>
             <xpath expr="//field[@name='allow_comment']" position="after">
-                <field string="Forum" name="forum_id"/>
+                <field string="Forum" name="forum_id" domain="[('slide_channel_id', 'in', [active_id, False])]"/>
     		</xpath>
         </field>
     </record>


### PR DESCRIPTION
SPECIFICATION

Before this commit when setting a forum which was already selected
by another course one got an error message when saving.
This commit avoid this error message by only displaying the forum
which have no course attached to them.

LINKS

Task-2791247


--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
