### PR TITLE
[IMP] core,*: add helper for name_search

### DIFF
--- a/addons/account/models/account_journal.py
+++ b/addons/account/models/account_journal.py
@@ -38,6 +38,7 @@ class AccountJournal(models.Model):
     _order = 'sequence, type, code'
     _inherit = ['mail.thread', 'mail.activity.mixin']
     _check_company_auto = True
+    _rec_names_search = ['name', 'code']
 
     def _default_inbound_payment_methods(self):
         return self.env.ref('account.account_payment_method_manual_in')
@@ -690,17 +691,6 @@ class AccountJournal(models.Model):
                 name = "%s (%s)" % (name, journal.currency_id.name)
             res += [(journal.id, name)]
         return res
-
-    @api.model
-    def _name_search(self, name, args=None, operator='ilike', limit=100, name_get_uid=None):
-        args = args or []
-
-        if operator == 'ilike' and not (name or '').strip():
-            domain = []
-        else:
-            connector = '&' if operator in expression.NEGATIVE_TERM_OPERATORS else '|'
-            domain = [connector, ('code', operator, name), ('name', operator, name)]
-        return self._search(expression.AND([domain, args]), limit=limit, access_rights_uid=name_get_uid)
 
     def action_configure_bank_journal(self):
         """ This function is called by the "configure" button of bank journals,

--- a/addons/account/models/account_tax.py
+++ b/addons/account/models/account_tax.py
@@ -78,6 +78,7 @@ class AccountTax(models.Model):
     _description = 'Tax'
     _order = 'sequence,id'
     _check_company_auto = True
+    _rec_names_search = ['name', 'description']
 
     @api.model
     def _default_tax_group(self):
@@ -256,19 +257,6 @@ class AccountTax(models.Model):
                 name += ' (%s)' % tax_scope.get(record.tax_scope)
             name_list += [(record.id, name)]
         return name_list
-
-    @api.model
-    def _name_search(self, name, args=None, operator='ilike', limit=100, name_get_uid=None):
-        """ Returns a list of tuples containing id, name, as internally it is called {def name_get}
-            result format: {[(id, name), (id, name), ...]}
-        """
-        args = args or []
-        if operator == 'ilike' and not (name or '').strip():
-            domain = []
-        else:
-            connector = '&' if operator in expression.NEGATIVE_TERM_OPERATORS else '|'
-            domain = [connector, ('description', operator, name), ('name', operator, name)]
-        return self._search(expression.AND([domain, args]), limit=limit, access_rights_uid=name_get_uid)
 
     @api.model
     def _search(self, args, offset=0, limit=None, order=None, count=False, access_rights_uid=None):

--- a/addons/analytic/models/analytic_account.py
+++ b/addons/analytic/models/analytic_account.py
@@ -60,6 +60,7 @@ class AccountAnalyticAccount(models.Model):
     _description = 'Analytic Account'
     _order = 'code, name asc'
     _check_company_auto = True
+    _rec_names_search = ['name', 'code', 'partner_id']
 
     @api.model
     def read_group(self, domain, fields, groupby, offset=0, limit=None, orderby=False, lazy=True):
@@ -152,21 +153,6 @@ class AccountAnalyticAccount(models.Model):
                 name = name + ' - ' + analytic.partner_id.commercial_partner_id.name
             res.append((analytic.id, name))
         return res
-
-    @api.model
-    def _name_search(self, name, args=None, operator='ilike', limit=100, name_get_uid=None):
-        if operator not in ('ilike', 'like', '=', '=like', '=ilike', 'not ilike'):
-            return super(AccountAnalyticAccount, self)._name_search(name, args, operator, limit, name_get_uid=name_get_uid)
-        args = args or []
-        if operator == 'ilike' and not (name or '').strip():
-            domain = []
-        else:
-            # `partner_id` is in auto_join and the searches using ORs with auto_join fields doesn't work
-            # we have to cut the search in two searches ... https://github.com/odoo/odoo/issues/25175
-            partner_ids = self.env['res.partner']._search([('name', operator, name)], limit=limit, access_rights_uid=name_get_uid)
-            domain_operator = '&' if operator == 'not ilike' else '|'
-            domain = [domain_operator, domain_operator, ('code', operator, name), ('name', operator, name), ('partner_id', 'in', partner_ids)]
-        return self._search(expression.AND([domain, args]), limit=limit, access_rights_uid=name_get_uid)
 
 
 class AccountAnalyticLine(models.Model):

--- a/addons/base_address_extended/models/res_city.py
+++ b/addons/base_address_extended/models/res_city.py
@@ -8,6 +8,7 @@ class City(models.Model):
     _name = 'res.city'
     _description = 'City'
     _order = 'name'
+    _rec_names_search = ['name', 'zipcode']
 
     name = fields.Char("Name", required=True, translate=True)
     zipcode = fields.Char("Zip")
@@ -20,14 +21,3 @@ class City(models.Model):
             name = city.name if not city.zipcode else '%s (%s)' % (city.name, city.zipcode)
             res.append((city.id, name))
         return res
-
-    @api.model
-    def _name_search(self, name='', args=None, operator='ilike', limit=100, name_get_uid=None):
-        ''' Enable searching by zipcode of a city
-        '''
-        args = list(args or [])
-        domain = []
-        if name:
-            connector = '!' if operator in expression.NEGATIVE_TERM_OPERATORS else '|'
-            domain = [connector, ('zipcode', 'ilike', name), (self._rec_name, operator, name)]
-        return self._search(expression.AND([domain, args]), limit=limit, access_rights_uid=name_get_uid)

--- a/addons/fleet/models/fleet_vehicle.py
+++ b/addons/fleet/models/fleet_vehicle.py
@@ -22,6 +22,7 @@ class FleetVehicle(models.Model):
     _name = 'fleet.vehicle'
     _description = 'Vehicle'
     _order = 'license_plate asc, acquisition_date asc'
+    _rec_names_search = ['name', 'driver_id.name']
 
     def _get_default_state(self):
         state = self.env.ref('fleet.fleet_vehicle_state_registered', raise_if_not_found=False)
@@ -348,15 +349,6 @@ class FleetVehicle(models.Model):
         if 'co2' in fields:
             fields.remove('co2')
         return super(FleetVehicle, self).read_group(domain, fields, groupby, offset, limit, orderby, lazy)
-
-    @api.model
-    def _name_search(self, name, args=None, operator='ilike', limit=100, name_get_uid=None):
-        args = args or []
-        if operator == 'ilike' and not (name or '').strip():
-            domain = []
-        else:
-            domain = ['|', ('name', operator, name), ('driver_id.name', operator, name)]
-        return self._search(expression.AND([domain, args]), limit=limit, access_rights_uid=name_get_uid)
 
     def return_action_to_open(self):
         """ This opens the xml view specified in xml_id for the current vehicle """

--- a/addons/l10n_latam_invoice_document/models/l10n_latam_document_type.py
+++ b/addons/l10n_latam_invoice_document/models/l10n_latam_document_type.py
@@ -8,6 +8,7 @@ class L10nLatamDocumentType(models.Model):
     _name = 'l10n_latam.document.type'
     _description = 'Latam Document Type'
     _order = 'sequence, id'
+    _rec_names_search = ['name', 'code']
 
     active = fields.Boolean(default=True)
     sequence = fields.Integer(
@@ -42,12 +43,3 @@ class L10nLatamDocumentType(models.Model):
                 name = '(%s) %s' % (rec.code, name)
             result.append((rec.id, name))
         return result
-
-    @api.model
-    def _name_search(self, name, args=None, operator='ilike', limit=100, name_get_uid=None):
-        args = args or []
-        if operator == 'ilike' and not (name or '').strip():
-            domain = []
-        else:
-            domain = ['|', ('name', 'ilike', name), ('code', 'ilike', name)]
-        return self._search(expression.AND([domain, args]), limit=limit, access_rights_uid=name_get_uid)

--- a/addons/mail/models/mail_channel_partner.py
+++ b/addons/mail/models/mail_channel_partner.py
@@ -12,6 +12,7 @@ class ChannelPartner(models.Model):
     _name = 'mail.channel.partner'
     _description = 'Listeners of a Channel'
     _table = 'mail_channel_partner'
+    _rec_names_search = ['partner_id', 'guest_id']
 
     # identity
     partner_id = fields.Many2one('res.partner', string='Recipient', ondelete='cascade', index=True)
@@ -56,14 +57,6 @@ class ChannelPartner(models.Model):
 
     def name_get(self):
         return [(record.id, record.partner_id.name or record.guest_id.name) for record in self]
-
-    def _name_search(self, name='', args=None, operator='ilike', limit=100, name_get_uid=None):
-        domain = [[('partner_id', operator, name)], [('guest_id', operator, name)]]
-        if '!' in operator or 'not' in operator:
-            domain = expression.AND(domain)
-        else:
-            domain = expression.OR(domain)
-        return self._search(expression.AND([domain, args]), limit=limit, access_rights_uid=name_get_uid)
 
     def init(self):
         self.env.cr.execute("CREATE UNIQUE INDEX IF NOT EXISTS mail_channel_partner_partner_unique ON %s (channel_id, partner_id) WHERE partner_id IS NOT NULL" % self._table)

--- a/addons/maintenance/models/maintenance.py
+++ b/addons/maintenance/models/maintenance.py
@@ -6,6 +6,7 @@ from datetime import date, datetime, timedelta
 
 from odoo import api, fields, models, SUPERUSER_ID, _
 from odoo.exceptions import UserError
+from odoo.osv import expression
 from odoo.tools import DEFAULT_SERVER_DATE_FORMAT, DEFAULT_SERVER_DATETIME_FORMAT
 
 
@@ -103,11 +104,9 @@ class MaintenanceEquipment(models.Model):
     def _name_search(self, name, args=None, operator='ilike', limit=100, name_get_uid=None):
         args = args or []
         equipment_ids = []
-        if name:
+        if name and operator not in expression.NEGATIVE_TERM_OPERATORS and operator != '=':
             equipment_ids = self._search([('name', '=', name)] + args, limit=limit, access_rights_uid=name_get_uid)
-        if not equipment_ids:
-            equipment_ids = self._search([('name', operator, name)] + args, limit=limit, access_rights_uid=name_get_uid)
-        return equipment_ids
+        return equipment_ids or super()._name_search(name, args, operator, limit, name_get_uid)
 
     name = fields.Char('Equipment Name', required=True, translate=True)
     company_id = fields.Many2one('res.company', string='Company',

--- a/addons/mrp/models/mrp_bom.py
+++ b/addons/mrp/models/mrp_bom.py
@@ -15,6 +15,7 @@ class MrpBom(models.Model):
     _description = 'Bill of Material'
     _inherit = ['mail.thread']
     _rec_name = 'product_tmpl_id'
+    _rec_names_search = ['product_tmpl_id', 'code']
     _order = "sequence, id"
     _check_company_auto = True
 
@@ -207,16 +208,6 @@ class MrpBom(models.Model):
     def _unlink_except_running_mo(self):
         if self.env['mrp.production'].search([('bom_id', 'in', self.ids), ('state', 'not in', ['done', 'cancel'])], limit=1):
             raise UserError(_('You can not delete a Bill of Material with running manufacturing orders.\nPlease close or cancel it first.'))
-
-    @api.model
-    def _name_search(self, name='', args=None, operator='ilike', limit=100, name_get_uid=None):
-        args = args or []
-        domain = []
-        if (name or '').strip():
-            domain = ['|', (self._rec_name, operator, name), ('code', operator, name)]
-            if operator in NEGATIVE_TERM_OPERATORS:
-                domain = domain[1:]
-        return self._search(AND([domain, args]), limit=limit, access_rights_uid=name_get_uid)
 
     @api.model
     def _bom_find_domain(self, products, picking_type=None, company_id=False, bom_type=False):

--- a/addons/product/models/product_attribute.py
+++ b/addons/product/models/product_attribute.py
@@ -179,6 +179,7 @@ class ProductTemplateAttributeLine(models.Model):
 
     _name = "product.template.attribute.line"
     _rec_name = 'attribute_id'
+    _rec_names_search = ['attribute_id', 'value_ids']
     _description = 'Product Template Attribute Line'
     _order = 'attribute_id, id'
 
@@ -384,17 +385,6 @@ class ProductTemplateAttributeLine(models.Model):
         ptav_to_unlink.unlink()
         ProductTemplateAttributeValue.create(ptav_to_create)
         self.product_tmpl_id._create_variant_ids()
-
-    @api.model
-    def _name_search(self, name, args=None, operator='ilike', limit=100, name_get_uid=None):
-        # TDE FIXME: currently overriding the domain; however as it includes a
-        # search on a m2o and one on a m2m, probably this will quickly become
-        # difficult to compute - check if performance optimization is required
-        if name and operator in ('=', 'ilike', '=ilike', 'like', '=like'):
-            args = args or []
-            domain = ['|', ('attribute_id', operator, name), ('value_ids', operator, name)]
-            return self._search(expression.AND([domain, args]), limit=limit, access_rights_uid=name_get_uid)
-        return super(ProductTemplateAttributeLine, self)._name_search(name=name, args=args, operator=operator, limit=limit, name_get_uid=name_get_uid)
 
     def _without_no_variant_attributes(self):
         return self.filtered(lambda ptal: ptal.attribute_id.create_variant != 'no_variant')

--- a/addons/purchase/models/purchase.py
+++ b/addons/purchase/models/purchase.py
@@ -19,6 +19,7 @@ class PurchaseOrder(models.Model):
     _name = "purchase.order"
     _inherit = ['portal.mixin', 'mail.thread', 'mail.activity.mixin']
     _description = "Purchase Order"
+    _rec_names_search = ['name', 'partner_ref']
     _order = 'priority desc, id desc'
 
     @api.depends('order_line.price_total')
@@ -160,14 +161,6 @@ class PurchaseOrder(models.Model):
     def _compute_date_calendar_start(self):
         for order in self:
             order.date_calendar_start = order.date_approve if (order.state in ['purchase', 'done']) else order.date_order
-
-    @api.model
-    def _name_search(self, name, args=None, operator='ilike', limit=100, name_get_uid=None):
-        args = args or []
-        domain = []
-        if name:
-            domain = ['|', ('name', operator, name), ('partner_ref', operator, name)]
-        return self._search(expression.AND([domain, args]), limit=limit, access_rights_uid=name_get_uid)
 
     @api.depends('date_order', 'currency_id', 'company_id', 'company_id.currency_id')
     def _compute_currency_rate(self):

--- a/addons/sale/models/sale_order.py
+++ b/addons/sale/models/sale_order.py
@@ -41,6 +41,12 @@ class SaleOrder(models.Model):
         ('date_order_conditional_required', "CHECK( (state IN ('sale', 'done') AND date_order IS NOT NULL) OR state NOT IN ('sale', 'done') )", "A confirmed sales order requires a confirmation date."),
     ]
 
+    @property
+    def _rec_names_search(self):
+        if self._context.get('sale_show_partner_name'):
+            return ['name', 'partner_id.name']
+        return ['name']
+
     #=== FIELDS ===#
 
     name = fields.Char(
@@ -1236,19 +1242,6 @@ class SaleOrder(models.Model):
                 res.append((order.id, name))
             return res
         return super().name_get()
-
-    @api.model
-    def _name_search(self, name, args=None, operator='ilike', limit=100, name_get_uid=None):
-        if self._context.get('sale_show_partner_name'):
-            if operator == 'ilike' and not (name or '').strip():
-                domain = []
-            elif operator in ('ilike', 'like', '=', '=like', '=ilike'):
-                domain = expression.AND([
-                    args or [],
-                    ['|', ('name', operator, name), ('partner_id.name', operator, name)]
-                ])
-                return self._search(domain, limit=limit, access_rights_uid=name_get_uid)
-        return super()._name_search(name, args=args, operator=operator, limit=limit, name_get_uid=name_get_uid)
 
     #=== BUSINESS METHODS ===#
 

--- a/addons/sale/models/sale_order_line.py
+++ b/addons/sale/models/sale_order_line.py
@@ -12,6 +12,7 @@ from odoo.tools import float_is_zero, float_compare, float_round
 class SaleOrderLine(models.Model):
     _name = 'sale.order.line'
     _description = "Sales Order Line"
+    _rec_names_search = ['name', 'order_id.name']
     _order = 'order_id, sequence, id'
     _check_company_auto = True
 
@@ -1064,16 +1065,6 @@ class SaleOrderLine(models.Model):
                 name = '%s (%s)' % (name, so_line.order_partner_id.ref)
             result.append((so_line.id, name))
         return result
-
-    @api.model
-    def _name_search(self, name, args=None, operator='ilike', limit=100, name_get_uid=None):
-        if operator in ('ilike', 'like', '=', '=like', '=ilike'):
-            args = expression.AND([
-                args or [],
-                ['|', ('order_id.name', operator, name), ('name', operator, name)]
-            ])
-            return self._search(args, limit=limit, access_rights_uid=name_get_uid)
-        return super()._name_search(name, args=args, operator=operator, limit=limit, name_get_uid=name_get_uid)
 
     #=== HOOKS ===#
 

--- a/addons/stock/models/stock_location.py
+++ b/addons/stock/models/stock_location.py
@@ -19,6 +19,7 @@ class Location(models.Model):
     _parent_store = True
     _order = 'complete_name, id'
     _rec_name = 'complete_name'
+    _rec_names_search = ['complete_name', 'barcode']
     _check_company_auto = True
 
     @api.model
@@ -215,18 +216,6 @@ class Location(models.Model):
         res = super().create(vals_list)
         self.invalidate_cache(['warehouse_id'])
         return res
-
-    @api.model
-    def _name_search(self, name, args=None, operator='ilike', limit=100, name_get_uid=None):
-        """ search full name and barcode """
-        args = args or []
-        if operator == 'ilike' and not (name or '').strip():
-            domain = []
-        elif operator in expression.NEGATIVE_TERM_OPERATORS:
-            domain = [('barcode', operator, name), ('complete_name', operator, name)]
-        else:
-            domain = ['|', ('barcode', operator, name), ('complete_name', operator, name)]
-        return self._search(expression.AND([domain, args]), limit=limit, access_rights_uid=name_get_uid)
 
     def _get_putaway_strategy(self, product, quantity=0, package=None, packaging=None, additional_qty=None):
         """Returns the location where the product has to be put, if any compliant

--- a/addons/stock/models/stock_picking.py
+++ b/addons/stock/models/stock_picking.py
@@ -19,6 +19,7 @@ class PickingType(models.Model):
     _name = "stock.picking.type"
     _description = "Picking Type"
     _order = 'sequence, id'
+    _rec_names_search = ['name', 'warehouse_id.name']
     _check_company_auto = True
 
     def _default_show_operations(self):
@@ -163,14 +164,6 @@ class PickingType(models.Model):
                 name = picking_type.name
             res.append((picking_type.id, name))
         return res
-
-    @api.model
-    def _name_search(self, name, args=None, operator='ilike', limit=100, name_get_uid=None):
-        args = args or []
-        domain = []
-        if name:
-            domain = ['|', ('name', operator, name), ('warehouse_id.name', operator, name)]
-        return self._search(expression.AND([domain, args]), limit=limit, access_rights_uid=name_get_uid)
 
     @api.onchange('code')
     def _onchange_picking_code(self):

--- a/odoo/addons/base/models/ir_actions.py
+++ b/odoo/addons/base/models/ir_actions.py
@@ -728,6 +728,7 @@ class IrActionsTodo(models.Model):
     """
     _name = 'ir.actions.todo'
     _description = "Configuration Wizards"
+    _rec_name = 'action_id'
     _order = "sequence, id"
 
     action_id = fields.Many2one('ir.actions.actions', string='Action', required=True, index=True)
@@ -755,9 +756,6 @@ class IrActionsTodo(models.Model):
         if open_todo:
             open_todo.write({'state': 'done'})
 
-    def name_get(self):
-        return [(record.id, record.action_id.name) for record in self]
-
     def unlink(self):
         if self:
             try:
@@ -769,13 +767,6 @@ class IrActionsTodo(models.Model):
             except ValueError:
                 pass
         return super(IrActionsTodo, self).unlink()
-
-    @api.model
-    def _name_search(self, name, args=None, operator='ilike', limit=100, name_get_uid=None):
-        args = args or []
-        if name:
-            return self._search(expression.AND([[('action_id', operator, name)], args]), limit=limit, access_rights_uid=name_get_uid)
-        return super(IrActionsTodo, self)._name_search(name, args=args, operator=operator, limit=limit, name_get_uid=name_get_uid)
 
     def action_launch(self):
         """ Launch Action of Wizard"""

--- a/odoo/addons/base/models/ir_model.py
+++ b/odoo/addons/base/models/ir_model.py
@@ -147,6 +147,7 @@ class IrModel(models.Model):
     _name = 'ir.model'
     _description = "Models"
     _order = 'model'
+    _rec_names_search = ['name', 'model']
 
     def _default_field_id(self):
         if self.env.context.get('install_mode'):
@@ -247,15 +248,6 @@ class IrModel(models.Model):
         self.env.cr.execute("SELECT id FROM ir_model WHERE model=%s", (name,))
         result = self.env.cr.fetchone()
         return result and result[0]
-
-    # overridden to allow searching both on model name (field 'model') and model
-    # description (field 'name')
-    @api.model
-    def _name_search(self, name='', args=None, operator='ilike', limit=100, name_get_uid=None):
-        if args is None:
-            args = []
-        domain = args + ['|', ('model', operator, name), ('name', operator, name)]
-        return self._search(domain, limit=limit, access_rights_uid=name_get_uid)
 
     def _drop_table(self):
         for model in self:
@@ -1499,7 +1491,7 @@ class IrModelConstraint(models.Model):
         for data in self.sorted(key='id', reverse=True):
             name = tools.ustr(data.name)
             if data.model.model in self.env:
-                table = self.env[data.model.model]._table    
+                table = self.env[data.model.model]._table
             else:
                 table = data.model.model.replace('.', '_')
             typ = data.type

--- a/odoo/addons/base/models/ir_ui_view.py
+++ b/odoo/addons/base/models/ir_ui_view.py
@@ -127,19 +127,11 @@ class ViewCustom(models.Model):
     _name = 'ir.ui.view.custom'
     _description = 'Custom View'
     _order = 'create_date desc'  # search(limit=1) should return the last customization
+    _rec_name = 'user_id'
 
     ref_id = fields.Many2one('ir.ui.view', string='Original View', index=True, required=True, ondelete='cascade')
     user_id = fields.Many2one('res.users', string='User', index=True, required=True, ondelete='cascade')
     arch = fields.Text(string='View Architecture', required=True)
-
-    def name_get(self):
-        return [(rec.id, rec.user_id.name) for rec in self]
-
-    @api.model
-    def _name_search(self, name='', args=None, operator='ilike', limit=100, name_get_uid=None):
-        if name:
-            return self._search([('user_id', operator, name)] + (args or []), limit=limit, access_rights_uid=name_get_uid)
-        return super(ViewCustom, self)._name_search(name, args=args, operator=operator, limit=limit, name_get_uid=name_get_uid)
 
     def _auto_init(self):
         res = super(ViewCustom, self)._auto_init()

--- a/odoo/addons/base/models/res_partner.py
+++ b/odoo/addons/base/models/res_partner.py
@@ -133,6 +133,7 @@ class Partner(models.Model):
     _inherit = ['format.address.mixin', 'avatar.mixin']
     _name = "res.partner"
     _order = "display_name, id"
+    _rec_names_search = ['display_name', 'email', 'ref', 'vat']  # TODO vat must be sanitized the same way for storing/searching
 
     def _default_category(self):
         return self.env['res.partner.category'].browse(self._context.get('category_id'))
@@ -825,67 +826,6 @@ class Partner(models.Model):
             self = self.with_context(active_test=False)
         return super(Partner, self)._search(args, offset=offset, limit=limit, order=order,
                                             count=count, access_rights_uid=access_rights_uid)
-
-    def _get_name_search_order_by_fields(self):
-        return ''
-
-    @api.model
-    def _name_search(self, name, args=None, operator='ilike', limit=100, name_get_uid=None):
-        self = self.with_user(name_get_uid or self.env.uid)
-        # as the implementation is in SQL, we force the recompute of fields if necessary
-        self.recompute(['display_name'])
-        self.flush()
-        if args is None:
-            args = []
-        order_by_rank = self.env.context.get('res_partner_search_mode')
-        if (name or order_by_rank) and operator in ('=', 'ilike', '=ilike', 'like', '=like'):
-            self.check_access_rights('read')
-            where_query = self._where_calc(args)
-            self._apply_ir_rules(where_query, 'read')
-            from_clause, where_clause, where_clause_params = where_query.get_sql()
-            from_str = from_clause if from_clause else 'res_partner'
-            where_str = where_clause and (" WHERE %s AND " % where_clause) or ' WHERE '
-
-            # search on the name of the contacts and of its company
-            search_name = name
-            if operator in ('ilike', 'like'):
-                search_name = '%%%s%%' % name
-            if operator in ('=ilike', '=like'):
-                operator = operator[1:]
-
-            unaccent = get_unaccent_wrapper(self.env.cr)
-
-            fields = self._get_name_search_order_by_fields()
-
-            query = """SELECT res_partner.id
-                         FROM {from_str}
-                      {where} ({email} {operator} {percent}
-                           OR {display_name} {operator} {percent}
-                           OR {reference} {operator} {percent}
-                           OR {vat} {operator} {percent})
-                           -- don't panic, trust postgres bitmap
-                     ORDER BY {fields} {display_name} {operator} {percent} desc,
-                              {display_name}
-                    """.format(from_str=from_str,
-                               fields=fields,
-                               where=where_str,
-                               operator=operator,
-                               email=unaccent('res_partner.email'),
-                               display_name=unaccent('res_partner.display_name'),
-                               reference=unaccent('res_partner.ref'),
-                               percent=unaccent('%s'),
-                               vat=unaccent('res_partner.vat'),)
-
-            where_clause_params += [search_name]*3  # for email / display_name, reference
-            where_clause_params += [re.sub(r'[^a-zA-Z0-9\-\.]+', '', search_name) or None]  # for vat
-            where_clause_params += [search_name]  # for order by
-            if limit:
-                query += ' limit %s'
-                where_clause_params.append(limit)
-            self.env.cr.execute(query, where_clause_params)
-            return [row[0] for row in self.env.cr.fetchall()]
-
-        return super(Partner, self)._name_search(name, args, operator=operator, limit=limit, name_get_uid=name_get_uid)
 
     @api.model
     @api.returns('self', lambda value: value.id)


### PR DESCRIPTION
Most of the extensions of `_name_get` are very similar and only want to
search for the given string in multiple fields.
A lot of extensions also don't take into account the negative operators.
Some implementations were also really outdated and needlessly
complicated.


--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
