### PR TITLE
[FIX] delivery: update_prices does ignore shipping rate

### DIFF
--- a/addons/delivery/models/sale_order.py
+++ b/addons/delivery/models/sale_order.py
@@ -37,6 +37,11 @@ class SaleOrder(models.Model):
         if delivery_line:
             self.recompute_delivery_price = True
 
+    def _get_update_prices_lines(self):
+        """ Exclude delivery lines from price list recomputation based on product instead of carrier """
+        lines = super()._get_update_prices_lines()
+        return lines.filtered(lambda line: not line.is_delivery)
+
     def _remove_delivery_line(self):
         delivery_lines = self.env['sale.order.line'].search([('order_id', 'in', self.ids), ('is_delivery', '=', True)])
         if not delivery_lines:

--- a/addons/sale/models/sale_order.py
+++ b/addons/sale/models/sale_order.py
@@ -497,10 +497,14 @@ class SaleOrder(models.Model):
         else:
             self.show_update_pricelist = False
 
+    def _get_update_prices_lines(self):
+        """ Hook to exclude specific lines which should not be updated based on price list recomputation """
+        return self.order_line.filtered(lambda line: not line.display_type)
+
     def update_prices(self):
         self.ensure_one()
         lines_to_update = []
-        for line in self.order_line.filtered(lambda line: not line.display_type):
+        for line in self._get_update_prices_lines():
             product = line.product_id.with_context(
                 partner=self.partner_id,
                 quantity=line.product_uom_qty,


### PR DESCRIPTION
As sale does not know about special lines it will always update
the price based on product and price list instead of applying the correct
shipping rate, so we do skip those lines by using a newly introduced hook method

Info: @wt-io-it

Forward port of https://github.com/odoo/odoo/pull/85884




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
