### PR TITLE
[FIX] web: ignore numpad for hotkeys

### DIFF
--- a/addons/web/static/src/core/hotkeys/hotkey_service.js
+++ b/addons/web/static/src/core/hotkeys/hotkey_service.js
@@ -55,6 +55,13 @@ export const hotkeyService = {
                 return;
             }
 
+            if (event.code && event.code.indexOf("Numpad") === 0 && /^\d$/.test(event.key)) {
+                // Ignore all number keys from the Keypad because of a certain input method
+                // of (advance-)ASCII characters on Windows OS: ALT+[numerical code from keypad]
+                // See https://support.microsoft.com/en-us/office/insert-ascii-or-unicode-latin-based-symbols-and-characters-d13f58d3-7bcb-44a7-a4d5-972ee12e50e0#bm1
+                return;
+            }
+
             const hotkey = getActiveHotkey(event);
 
             // Do not dispatch if UI is blocked

--- a/addons/web/static/tests/core/hotkeys/hotkey_service_tests.js
+++ b/addons/web/static/tests/core/hotkeys/hotkey_service_tests.js
@@ -672,3 +672,22 @@ QUnit.test("protects editable elements: can bypassEditableProtection", async (as
         "the callback still gets called even if triggered from an editable"
     );
 });
+
+QUnit.test("ignore numpad keys", async (assert) => {
+    assert.expect(3);
+
+    const key = '1';
+
+    env.services.hotkey.add(`alt+${key}`, () => assert.step(key));
+    await nextTick();
+
+    let keydown = new KeyboardEvent("keydown", { key, code: "Numpad1", altKey: true });
+    window.dispatchEvent(keydown);
+    await nextTick();
+    assert.verifySteps([]);
+
+    keydown = new KeyboardEvent("keydown", { key: '&', code: "Digit1", altKey: true });
+    window.dispatchEvent(keydown);
+    await nextTick();
+    assert.verifySteps(['1']);
+});


### PR DESCRIPTION
To reproduce the issue:
(Need a Windows machine)
1. Install Stock
2. Inventory > Products > Products
3. Try to write the diameter symbol (ALT + 155) in the search bar

Error: When pressing the key '1' on the keyboard, the page is redirected
to the Inventory Overview page

Because of hotkeys, it is not possible to use the Windows feature that
allows users to write ASCII characters with ALT+[numerical code from
keypad].

OPW-2731632