### PR TITLE
[FIX] l10n_it_edi: fix downpayment negative quantity

### DIFF
--- a/addons/l10n_it_edi/data/invoice_it_template.xml
+++ b/addons/l10n_it_edi/data/invoice_it_template.xml
@@ -18,9 +18,9 @@
                     <t t-esc="line.name[:1000]"/>
                     <t t-if="not line.name" t-esc="'NO NAME'"/>
                 </Descrizione>
-                <Quantita t-esc="format_numbers(line.quantity)"/>
+                <Quantita t-esc="format_numbers(abs(line.quantity))"/>
                 <UnitaMisura t-if="line.product_uom_id.category_id.measure_type != 'unit'" t-esc="line.product_uom_id.name"/>
-                <PrezzoUnitario t-esc="format_monetary(taxes['total_excluded'], currency)"/>
+                <PrezzoUnitario t-esc="'%.06f' % (line.price_subtotal / (( 1 - (line.discount or 0.0) / 100.0) * abs(line.quantity)) if line.discount != 100.0 else line.price_unit)"/>
                 <ScontoMaggiorazione t-if="line.discount != 0">
                     <!-- [2.2.1.10] -->
                     <Tipo t-esc="discount_type(line.discount)"/>


### PR DESCRIPTION
Issue

	- Install Accounting, l10n_it, l10n_it_edi
	- Create an italian company and configure
	  it, use italian chart of account
	- Create a SO & Confirm
	- Create a downpayment & register payment
	- Create an invoice with downpayment
	  deduction
	- Validate

	You can't send it to gvt

Cause

	Negative quantities are not allowed
	See http://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.2/Schema_del_file_xml_FatturaPA_versione_1.2.xsd

Solution

	Switch the signs of quantity & unit price if
	the line have a negative subtotal.

OPW-2257900

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
