### PR TITLE
l10n_de_purchase: Fixed purchase document title in German localisation.

### DIFF
--- a/addons/l10n_de_purchase/models/purchase.py
+++ b/addons/l10n_de_purchase/models/purchase.py
@@ -32,9 +32,9 @@ class PurchaseOrder(models.Model):
 
     def _compute_l10n_de_document_title(self):
         for record in self:
-            if record.state == 'draft':
+            if record.state in ['draft', 'sent', 'to approve']:
                 record.l10n_de_document_title = _("Request for Quotation")
-            elif record.state in ['sent', 'to approve', 'purchase', 'done']:
+            elif record.state in ['purchase', 'done']:
                 record.l10n_de_document_title = _("Purchase Order")
             elif record.state == 'cancel':
                 record.l10n_de_document_title = _("Cancelled Purchase Order")


### PR DESCRIPTION
Description of the issue/feature this PR addresses:

The purchase order document in the German localization (l10n_de_purchase) is titled "Purchase Order" way too early. This can lead to confusion. In the worst case, the vendor will treat the request for quotation as purchase order.

Current behavior before PR:

If the document has been sent once and then is sent again (either to the same recipient, or another), the document is titled "Purchase Order", which will most definitely be treated as such by the recipient.

Desired behavior after PR is merged:

As long as the document is not confirmed (states "draft", "sent", "to approve"), the title has to be "Request for Quotation". After that (states "purchase", "done"), the title has to be "Purchase Order".

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
