### PR TITLE
[FIX] sale:

### DIFF
--- a/addons/sale/models/sale_order_line.py
+++ b/addons/sale/models/sale_order_line.py
@@ -158,6 +158,10 @@ class SaleOrderLine(models.Model):
 
     @api.model_create_multi
     def create(self, vals_list):
+        for vals in vals_list:
+            if vals.get('display_type') or self.default_get(['display_type']).get('display_type'):
+                vals['product_uom_qty'] = 0.0
+
         lines = super().create(vals_list)
         for line in lines:
             if line.product_id and line.state == 'sale':
@@ -267,7 +271,7 @@ class SaleOrderLine(models.Model):
         related="product_id.product_tmpl_id", domain=[('sale_ok', '=', True)])
     product_updatable = fields.Boolean(compute='_compute_product_updatable', string='Can Edit Product')
     product_uom_qty = fields.Float(
-        string='Quantity', digits='Product Unit of Measure', required=True,
+        string='Quantity', digits='Product Unit of Measure', required=True, default=1.0,
         compute='_compute_product_uom_qty', store=True, readonly=False, precompute=True)
     product_uom = fields.Many2one(
         'uom.uom', string='Unit of Measure',
@@ -489,8 +493,6 @@ class SaleOrderLine(models.Model):
                 line.product_uom_qty = 0.0
                 continue
 
-            # Default value = 1.0
-            line.product_uom_qty = line.product_uom_qty or 1.0
             if not line.product_packaging_id:
                 continue
             packaging_uom = line.product_packaging_id.product_uom_id

--- a/addons/sale/tests/test_sale_order.py
+++ b/addons/sale/tests/test_sale_order.py
@@ -853,3 +853,12 @@ class TestSaleOrder(TestSaleCommon):
         name_search_data = self.env['sale.order.line'].name_search(name=self.sale_order.name)
         sol_ids_found = dict(name_search_data).keys()
         self.assertEqual(list(sol_ids_found), self.sale_order.order_line.ids)
+
+    def test_zero_quantity(self):
+        """
+            If the quantity set is 0 it should remain to 0
+            Test that changing the uom do not change the quantity
+        """
+        self.sol_product_order.product_uom_qty = 0.0
+        self.sol_product_order.product_uom = self.env['uom.uom'].search([('name', '=', 'Dozen')], limit=1)
+        self.assertEqual(self.sol_product_order.product_uom_qty, 0.0)


### PR DESCRIPTION
How to reproduce the issue
--------------------------

Set the quantity of a sale order line to 0.0
then change the product_uom of the line
it triggers the computation of the product_uom
and the quantity is changed to 1.0

After this commit
----------------

The default value is not embedded in the compute anymore
The value do not change each time the compute is triggered
if the value was 0.0





--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
