### PR TITLE
[ADD]: l10n_pe: Add BS & Pnl reports menu items

### DIFF
--- a/addons/l10n_pe/README.rst
+++ b/addons/l10n_pe/README.rst
@@ -34,7 +34,7 @@ Taxes:
 'GRA': {'name': 'FRE', 'code': 'Z'},
 'EXO': {'name': 'VAT', 'code': 'E'},
 'INA': {'name': 'FRE', 'code': 'O'},
-'OTROS': {'name': 'OTH', 'code': 'S'},
+'OTHERS': {'name': 'OTH', 'code': 'S'},
 
 We added on this module the 3 concepts in taxes (necessary for the EDI
 signature)

--- a/addons/l10n_pe/__init__.py
+++ b/addons/l10n_pe/__init__.py
@@ -1,4 +1,11 @@
+# -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 from . import models
 from . import demo
+
+from odoo import api, SUPERUSER_ID
+
+def load_translations(cr, registry):
+    env = api.Environment(cr, SUPERUSER_ID, {})
+    env.ref('l10n_pe.pe_chart_template').process_coa_translations()

--- a/addons/l10n_pe/__manifest__.py
+++ b/addons/l10n_pe/__manifest__.py
@@ -4,7 +4,7 @@
     "version": "2.0",
     'summary': "PCGE Simplified",
     'category': 'Accounting/Localizations/Account Charts',
-    'author': 'Vauxoo, Odoo',
+    'author': 'Vauxoo, Odoo SA',
     'website': 'https://www.odoo.com/documentation/user/14.0/accounting/fiscal_localizations/localizations/peru.html',
     'license': 'LGPL-3',
     'depends': [
@@ -31,6 +31,7 @@
         'data/l10n_pe.res.city.district.csv',
         'data/res_country_data.xml',
         'data/l10n_latam_identification_type_data.xml',
+        'data/menuitem_data.xml',
     ],
     'demo': [
         'demo/demo_company.xml',

--- a/addons/l10n_pe/data/account.account.template.csv
+++ b/addons/l10n_pe/data/account.account.template.csv
@@ -1,1229 +1,1229 @@
 id,code,name,user_type_id:id,chart_template_id:id,reconcile
-chart0111,0111,Bienes y valores entregados,account.data_account_off_sheet,pe_chart_template,False
-chart0112,0112,Derechos sobre instrumentos financiero,account.data_account_off_sheet,pe_chart_template,False
-chart0113,0113,Otras cuentas de orden deudora,account.data_account_off_sheet,pe_chart_template,False
-chart0114,0114,Deudoras por contra,account.data_account_off_sheet,pe_chart_template,False
-chart0126,0126,Bienes y valores recibido,account.data_account_off_sheet,pe_chart_template,False
-chart0127,0127,Compromisos sobre instrumentos financieros,account.data_account_off_sheet,pe_chart_template,False
-chart0128,0128,Otras cuentas de orden acreedoras,account.data_account_off_sheet,pe_chart_template,False
-chart0129,0129,Acreedoras por contra,account.data_account_off_sheet,pe_chart_template,False
-chart0211,0211,Bienes y valores entregados,account.data_account_off_sheet,pe_chart_template,False
-chart0213,0213,Derechos sobre instrumentos financieros,account.data_account_off_sheet,pe_chart_template,False
-chart0214,0214,Otras cuentas de orden deudoras,account.data_account_off_sheet,pe_chart_template,False
-chart0215,0215,Contrapartida cuentas de orden deudora,account.data_account_off_sheet,pe_chart_template,False
-chart0226,0226,Bienes y valores recibidos,account.data_account_off_sheet,pe_chart_template,False
-chart0227,0227,Compromisos sobre instrumentos financieros,account.data_account_off_sheet,pe_chart_template,False
-chart0228,0228,Otras cuentas de orden acreedoras,account.data_account_off_sheet,pe_chart_template,False
-chart0229,0229,Contrapartidacuentas de orden acreedoras,account.data_account_off_sheet,pe_chart_template,False
-chart101,101,Caja,account.data_account_type_liquidity,pe_chart_template,False
-chart102,102,Fondos fijos,account.data_account_type_liquidity,pe_chart_template,False
-chart1031,1031,Fondos fijos - Efectivo en tránsito,account.data_account_type_liquidity,pe_chart_template,False
-chart1032,1032,Fondos fijos - Cheques en tránsito,account.data_account_type_liquidity,pe_chart_template,False
-chart1041,1041,Cuentas corrientes en instituciones financieras - Cuentas corrientes operativas,account.data_account_type_liquidity,pe_chart_template,False
-chart1042,1042,Cuentas corrientes en instituciones financieras - Cuentas corrientes para fines específicos,account.data_account_type_liquidity,pe_chart_template,False
-chart1051,1051,Otros equivalentes de efectivo - Otro equivalentes de efectivo,account.data_account_type_liquidity,pe_chart_template,False
-chart1061,1061,Depósitos en instituciones financieras - Depósitos de ahorro,account.data_account_type_liquidity,pe_chart_template,False
-chart1062,1062,Depósitos en instituciones financieras - Depósitos a plazo,account.data_account_type_liquidity,pe_chart_template,False
-chart1071,1071,Fondos sujetos a restricción - Fondos en garantía,account.data_account_type_liquidity,pe_chart_template,False
-chart1072,1072,Fondos sujetos a restricción - Fondos retenidos por mandato de la autoridad,account.data_account_type_liquidity,pe_chart_template,False
-chart1073,1073,Fondos sujetos a restricción - Otros fondos sujetos a restricción,account.data_account_type_liquidity,pe_chart_template,False
-chart11111,11111,Inversiones mantenidas para negociación - Valores emitidos o garantizados por el Estado - Costo,account.data_account_type_receivable,pe_chart_template,True
-chart11112,11112,Inversiones mantenidas para negociación - Valores emitidos o garantizados por el Estado - Valor Razonable,account.data_account_type_receivable,pe_chart_template,True
-chart11121,11121,Inversiones mantenidas para negociación - Valores emitidos por el sistema financiero - Costo,account.data_account_type_receivable,pe_chart_template,True
-chart11122,11122,Inversiones mantenidas para negociación - Valores emitidos por el sistema financiero - Valor Razonable,account.data_account_type_receivable,pe_chart_template,True
-chart11131,11131,Inversiones mantenidas para negociación - Valores emitidos por entidades - Costo,account.data_account_type_receivable,pe_chart_template,True
-chart11132,11132,Inversiones mantenidas para negociación - Valores emitidos por entidades - Valor Razonable,account.data_account_type_receivable,pe_chart_template,True
-chart11141,11141,Inversiones mantenidas para negociación - Otros títulos representativos de deuda - Costo,account.data_account_type_receivable,pe_chart_template,True
-chart11142,11142,Inversiones mantenidas para negociación - Otros títulos representativos de deuda - Valor Razonable,account.data_account_type_receivable,pe_chart_template,True
-chart11151,11151,Inversiones mantenidas para negociación - Participaciones en entidades - Costo,account.data_account_type_receivable,pe_chart_template,True
-chart11152,11152,Inversiones mantenidas para negociación - Participaciones en entidades - Valor Razonable,account.data_account_type_receivable,pe_chart_template,True
-chart11211,11211,Otras inversiones financieras - Otras inversiones financieras - Costo,account.data_account_type_receivable,pe_chart_template,True
-chart11212,11212,Otras inversiones financieras - Otras inversiones financieras - Valor Razonable,account.data_account_type_receivable,pe_chart_template,True
-chart11311,11311,Activos financieros – Acuerdo de compra - Inversiones mantenidas para negociación – Acuerdo de compra - Costo,account.data_account_type_receivable,pe_chart_template,True
-chart11312,11312,Activos financieros – Acuerdo de compra - Inversiones mantenidas para negociación – Acuerdo de compra - Valor Razonable,account.data_account_type_receivable,pe_chart_template,True
-chart11321,11321,Activos financieros – Acuerdo de compra - Otras inversiones financieras - Costo,account.data_account_type_receivable,pe_chart_template,True
-chart11322,11322,Activos financieros – Acuerdo de compra - Otras inversiones financieras - Valor Razonable,account.data_account_type_receivable,pe_chart_template,True
-chart1211,1211,"Facturas, boletas y otros comprobantes por cobrar - No emitidas",account.data_account_type_receivable,pe_chart_template,True
-chart1212,1212,"Facturas, boletas y otros comprobantes por cobrar - Emitidas en cartera",account.data_account_type_receivable,pe_chart_template,True
-chart1213,1213,"Facturas, boletas y otros comprobantes por cobrar - En cobranza",account.data_account_type_receivable,pe_chart_template,True
-chart1214,1214,"Facturas, boletas y otros comprobantes por cobrar - En descuento",account.data_account_type_receivable,pe_chart_template,True
-chart1215,1215,"Facturas, boletas y otros comprobantes por cobrar - En cobranza PoS",account.data_account_type_receivable,pe_chart_template,True
-chart122,122,Anticipos de clientes,account.data_account_type_receivable,pe_chart_template,True
-chart1232,1232,Letras por cobrar - En cartera,account.data_account_type_receivable,pe_chart_template,True
-chart1233,1233,Letras por cobrar - En cobranza,account.data_account_type_receivable,pe_chart_template,True
-chart1234,1234,Letras por cobrar - En descuento,account.data_account_type_receivable,pe_chart_template,True
-chart1311,1311,"Facturas, boletas y otros comprobantes por cobrar - No emitidas",account.data_account_type_receivable,pe_chart_template,True
-chart1312,1312,"Facturas, boletas y otros comprobantes por cobrar - En cartera",account.data_account_type_receivable,pe_chart_template,True
-chart1313,1313,"Facturas, boletas y otros comprobantes por cobrar - En cobranza",account.data_account_type_receivable,pe_chart_template,True
-chart1314,1314,"Facturas, boletas y otros comprobantes por cobrar - En descuento",account.data_account_type_receivable,pe_chart_template,True
-chart1321,1321,Anticipos recibidos - Anticipos recibidos,account.data_account_type_receivable,pe_chart_template,True
-chart1331,1331,Letras por cobrar - En cartera,account.data_account_type_receivable,pe_chart_template,True
-chart1332,1332,Letras por cobrar - En cobranza,account.data_account_type_receivable,pe_chart_template,True
-chart1333,1333,Letras por cobrar - En descuento,account.data_account_type_receivable,pe_chart_template,True
-chart1411,1411,Personal - Préstamos,account.data_account_type_receivable,pe_chart_template,True
-chart1412,1412,Personal - Adelanto de remuneraciones,account.data_account_type_receivable,pe_chart_template,True
-chart1413,1413,Personal - Entregas a rendir cuenta,account.data_account_type_receivable,pe_chart_template,True
-chart1419,1419,Personal - Otras cuentas por cobrar al personal,account.data_account_type_receivable,pe_chart_template,True
-chart1421,1421,Accionistas (o socios) - Suscripciones por cobrar a socios o accionistas,account.data_account_type_receivable,pe_chart_template,True
-chart1422,1422,Accionistas (o socios) - Préstamos,account.data_account_type_receivable,pe_chart_template,True
-chart1431,1431,Directores - Préstamos,account.data_account_type_receivable,pe_chart_template,True
-chart1432,1432,Directores - Adelanto de dietas,account.data_account_type_receivable,pe_chart_template,True
-chart1433,1433,Directores - Entregas a rendir cuenta,account.data_account_type_receivable,pe_chart_template,True
-chart149,149,Diversas,account.data_account_type_receivable,pe_chart_template,True
-chart1611,1611,Préstamos - Con garantía,account.data_account_type_receivable,pe_chart_template,True
-chart1612,1612,Préstamos - Sin garantía,account.data_account_type_receivable,pe_chart_template,True
-chart1621,1621,Reclamaciones a terceros - Compañías aseguradoras,account.data_account_type_receivable,pe_chart_template,True
-chart1622,1622,Reclamaciones a terceros - Transportadoras,account.data_account_type_receivable,pe_chart_template,True
-chart1623,1623,Reclamaciones a terceros - Servicios públicos,account.data_account_type_receivable,pe_chart_template,True
-chart1624,1624,Reclamaciones a terceros - Tributos,account.data_account_type_receivable,pe_chart_template,True
-chart1629,1629,Reclamaciones a terceros - Otras,account.data_account_type_receivable,pe_chart_template,True
-chart1631,1631,"Intereses, regalías y dividendos - Intereses",account.data_account_type_receivable,pe_chart_template,True
-chart1632,1632,"Intereses, regalías y dividendos - Regalías",account.data_account_type_receivable,pe_chart_template,True
-chart1633,1633,"Intereses, regalías y dividendos - Dividendos",account.data_account_type_receivable,pe_chart_template,True
-chart1641,1641,Depósitos otorgados en garantía - Préstamos de instituciones financieras,account.data_account_type_receivable,pe_chart_template,True
-chart1642,1642,Depósitos otorgados en garantía - Préstamos de instituciones no financieras,account.data_account_type_receivable,pe_chart_template,True
-chart1643,1643,Depósitos otorgados en garantía - Depósitos en garantía por alquileres,account.data_account_type_receivable,pe_chart_template,True
-chart1649,1649,Depósitos otorgados en garantía - Otros depósitos en garantía,account.data_account_type_receivable,pe_chart_template,True
-chart1651,1651,Venta de activo inmovilizado - Inversión mobiliaria,account.data_account_type_receivable,pe_chart_template,True
-chart1652,1652,Venta de activo inmovilizado - Propiedades de inversión,account.data_account_type_receivable,pe_chart_template,True
-chart1653,1653,"Venta de activo inmovilizado - Propiedad, planta y equipo",account.data_account_type_receivable,pe_chart_template,True
-chart1654,1654,Venta de activo inmovilizado - Intangibles,account.data_account_type_receivable,pe_chart_template,True
-chart1655,1655,Venta de activo inmovilizado - Activos biológicos,account.data_account_type_receivable,pe_chart_template,True
-chart1659,1659,Venta de activo inmovilizado - Otros activos inmovilizados,account.data_account_type_receivable,pe_chart_template,True
-chart16611,16611,Activos por instrumentos financieros - Instrumentos financieros primarios - Costo,account.data_account_type_receivable,pe_chart_template,True
-chart16612,16612,Activos por instrumentos financieros - Instrumentos financieros primarios - Valor razonable,account.data_account_type_receivable,pe_chart_template,True
-chart16621,16621,Activos por instrumentos financieros - Instrumentos financieros derivados - Costo,account.data_account_type_receivable,pe_chart_template,True
-chart16622,16622,Activos por instrumentos financieros - Instrumentos financieros derivados - Valor razonable,account.data_account_type_receivable,pe_chart_template,True
-chart1671,1671,Tributos por acreditar - Pagos a cuenta del impuesto a la renta,account.data_account_type_receivable,pe_chart_template,True
-chart1672,1672,Tributos por acreditar - Pagos a cuenta de ITAN,account.data_account_type_receivable,pe_chart_template,True
-chart1673,1673,Tributos por acreditar - IGV por acreditar en compras,account.data_account_type_receivable,pe_chart_template,True
-chart1674,1674,Tributos por acreditar - IGV por acreditar no domiciliados,account.data_account_type_receivable,pe_chart_template,True
-chart1675,1675,Tributos por acreditar - Obras por impuestos,account.data_account_type_receivable,pe_chart_template,True
-chart1691,1691,Otras cuentas por cobrar diversas - Entregas a rendir cuenta a terceros,account.data_account_type_receivable,pe_chart_template,True
-chart1699,1699,Otras cuentas por cobrar diversas - Otras cuentas por cobrar diversas,account.data_account_type_receivable,pe_chart_template,True
-chart1711,1711,Préstamos - Con garantía,account.data_account_type_receivable,pe_chart_template,True
-chart1712,1712,Préstamos - Sin garantía,account.data_account_type_receivable,pe_chart_template,True
-chart1731,1731,"Intereses, regalías y dividendos - Intereses",account.data_account_type_receivable,pe_chart_template,True
-chart1732,1732,"Intereses, regalías y dividendos - Regalías",account.data_account_type_receivable,pe_chart_template,True
-chart1733,1733,"Intereses, regalías y dividendos - Dividendos",account.data_account_type_receivable,pe_chart_template,True
-chart1741,1741,Depósitos otorgados en garantía - Préstamos de instituciones financieras,account.data_account_type_receivable,pe_chart_template,True
-chart1742,1742,Depósitos otorgados en garantía - Préstamos de instituciones no financieras,account.data_account_type_receivable,pe_chart_template,True
-chart1743,1743,Depósitos otorgados en garantía - Depósitos en garantía por alquileres,account.data_account_type_receivable,pe_chart_template,True
-chart1749,1749,Depósitos otorgados en garantía - Otros depósitos en garantía,account.data_account_type_receivable,pe_chart_template,True
-chart1751,1751,Venta de activo inmovilizado - Inversión mobiliaria,account.data_account_type_receivable,pe_chart_template,True
-chart1752,1752,Venta de activo inmovilizado - Propiedades de inversión,account.data_account_type_receivable,pe_chart_template,True
-chart1753,1753,"Venta de activo inmovilizado - Propiedad, planta y equipo",account.data_account_type_receivable,pe_chart_template,True
-chart1754,1754,Venta de activo inmovilizado - Intangibles,account.data_account_type_receivable,pe_chart_template,True
-chart1755,1755,Venta de activo inmovilizado - Activos biológicos,account.data_account_type_receivable,pe_chart_template,True
-chart1759,1759,Venta de activo inmovilizado - Otros activos inmovilizados,account.data_account_type_receivable,pe_chart_template,True
-chart17611,17611,Activos por instrumentos financieros - Instrumentos financieros primarios - Costo,account.data_account_type_receivable,pe_chart_template,True
-chart17612,17612,Activos por instrumentos financieros - Instrumentos financieros primarios - Valor razonable,account.data_account_type_receivable,pe_chart_template,True
-chart17621,17621,Activos por instrumentos financieros - Instrumentos financieros derivados - Costo,account.data_account_type_receivable,pe_chart_template,True
-chart17622,17622,Activos por instrumentos financieros - Instrumentos financieros derivados - Valor razonable,account.data_account_type_receivable,pe_chart_template,True
-chart179,179,Otras cuentas por cobrar diversas,account.data_account_type_receivable,pe_chart_template,True
-chart181,181,Costos financieros,account.data_account_type_prepayments,pe_chart_template,False
-chart182,182,Seguros,account.data_account_type_prepayments,pe_chart_template,False
-chart183,183,Alquileres,account.data_account_type_prepayments,pe_chart_template,False
-chart184,184,Primas pagadas por opciones,account.data_account_type_prepayments,pe_chart_template,False
-chart185,185,Mantenimiento de activos inmovilizados,account.data_account_type_prepayments,pe_chart_template,False
-chart189,189,Otros gastos contratados por anticipado,account.data_account_type_prepayments,pe_chart_template,False
-chart1911,1911,"Cuentas por cobrar comerciales – Terceros - Facturas, boletas y otros comprobantes por cobrar",account.data_account_type_receivable,pe_chart_template,True
-chart1913,1913,Cuentas por cobrar comerciales – Terceros - Letras por cobrar,account.data_account_type_receivable,pe_chart_template,True
-chart1921,1921,"Cuentas por cobrar comerciales – Relacionadas - Facturas, boletas y otros comprobantes por cobrar",account.data_account_type_receivable,pe_chart_template,True
-chart1923,1923,Cuentas por cobrar comerciales – Relacionadas - Letras por cobrar,account.data_account_type_receivable,pe_chart_template,True
-chart1931,1931,"Cuentas por cobrar al personal, a los accionistas (socios) y directores - Personal",account.data_account_type_receivable,pe_chart_template,True
-chart1932,1932,"Cuentas por cobrar al personal, a los accionistas (socios) y directores - Accionistas (o socios)",account.data_account_type_receivable,pe_chart_template,True
-chart1933,1933,"Cuentas por cobrar al personal, a los accionistas (socios) y directores - Directores",account.data_account_type_receivable,pe_chart_template,True
-chart1939,1939,"Cuentas por cobrar al personal, a los accionistas (socios) y directores - Diversas",account.data_account_type_receivable,pe_chart_template,True
-chart1941,1941,Cuentas por cobrar diversas – Terceros - Préstamos,account.data_account_type_receivable,pe_chart_template,True
-chart1942,1942,Cuentas por cobrar diversas – Terceros - Reclamaciones a terceros,account.data_account_type_receivable,pe_chart_template,True
-chart1943,1943,"Cuentas por cobrar diversas – Terceros - Intereses, regalías y dividendos",account.data_account_type_receivable,pe_chart_template,True
-chart1944,1944,Cuentas por cobrar diversas – Terceros - Depósitos otorgados en garantía,account.data_account_type_receivable,pe_chart_template,True
-chart1945,1945,Cuentas por cobrar diversas – Terceros - Venta de activo inmovilizado,account.data_account_type_receivable,pe_chart_template,True
-chart1946,1946,Cuentas por cobrar diversas – Terceros - Activos por instrumentos financieros,account.data_account_type_receivable,pe_chart_template,True
-chart1949,1949,Cuentas por cobrar diversas – Terceros - Otras cuentas por cobrar diversas,account.data_account_type_receivable,pe_chart_template,True
-chart1951,1951,Cuentas por cobrar diversas – Relacionadas - Préstamos,account.data_account_type_receivable,pe_chart_template,True
-chart1953,1953,"Cuentas por cobrar diversas – Relacionadas - Intereses, regalías y dividendos",account.data_account_type_receivable,pe_chart_template,True
-chart1954,1954,Cuentas por cobrar diversas – Relacionadas - Depósitos otorgados en garantía,account.data_account_type_receivable,pe_chart_template,True
-chart1955,1955,Cuentas por cobrar diversas – Relacionadas - Venta de activo inmovilizado,account.data_account_type_receivable,pe_chart_template,True
-chart1956,1956,Cuentas por cobrar diversas – Relacionadas - Activos por instrumentos financieros,account.data_account_type_receivable,pe_chart_template,True
-chart1959,1959,Cuentas por cobrar diversas – Relacionadas - Otras cuentas por cobrar diversas,account.data_account_type_receivable,pe_chart_template,True
-chart20111,20111,Mercaderías - Mercaderías - Costo,account.data_account_type_current_assets,pe_chart_template,False
-chart20114,20114,Mercaderías - Mercaderías - Valor razonable,account.data_account_type_current_assets,pe_chart_template,False
-chart21111,21111,Productos terminados - Productos terminados - Costo,account.data_account_type_current_assets,pe_chart_template,False
-chart21113,21113,Productos terminados - Productos terminados - Costo de financiación,account.data_account_type_current_assets,pe_chart_template,False
-chart21114,21114,Productos terminados - Productos terminados - Valor razonable,account.data_account_type_current_assets,pe_chart_template,False
-chart21511,21511,Inventario de servicios terminados - Servicios terminados - Costo,account.data_account_type_current_assets,pe_chart_template,False
-chart221,221,Subproductos,account.data_account_type_current_assets,pe_chart_template,False
-chart222,222,Desechos y desperdicios,account.data_account_type_current_assets,pe_chart_template,False
-chart23111,23111,Productos en proceso - Productos en proceso - Costo,account.data_account_type_current_assets,pe_chart_template,False
-chart23113,23113,Productos en proceso - Productos en proceso - Costo de financiación,account.data_account_type_current_assets,pe_chart_template,False
-chart23511,23511,Inventario de servicios en proceso - Servicios en proceso - Costo,account.data_account_type_current_assets,pe_chart_template,False
-chart24111,24111,Materias primas - Materias primas - Costo,account.data_account_type_current_assets,pe_chart_template,False
-chart24114,24114,Materias primas - Materias primas - Valor razonable,account.data_account_type_current_assets,pe_chart_template,False
-chart251,251,Materiales auxiliares,account.data_account_type_current_assets,pe_chart_template,False
-chart2521,2521,Suministros - Combustibles,account.data_account_type_current_assets,pe_chart_template,False
-chart2522,2522,Suministros - Lubricantes,account.data_account_type_current_assets,pe_chart_template,False
-chart2523,2523,Suministros - Energía,account.data_account_type_current_assets,pe_chart_template,False
-chart2524,2524,Suministros - Otros suministros,account.data_account_type_current_assets,pe_chart_template,False
-chart253,253,Repuestos,account.data_account_type_current_assets,pe_chart_template,False
-chart261,261,Envases,account.data_account_type_current_assets,pe_chart_template,False
-chart262,262,Embalajes,account.data_account_type_current_assets,pe_chart_template,False
-chart27111,27111,Propiedades de inversión - Terrenos - Costo,account.data_account_type_current_assets,pe_chart_template,False
-chart27112,27112,Propiedades de inversión - Terrenos - Revaluación,account.data_account_type_current_assets,pe_chart_template,False
-chart27114,27114,Propiedades de inversión - Terrenos - Valor razonable,account.data_account_type_current_assets,pe_chart_template,False
-chart27121,27121,Propiedades de inversión - Edificaciones - Costo,account.data_account_type_current_assets,pe_chart_template,False
-chart27122,27122,Propiedades de inversión - Edificaciones - Revaluación,account.data_account_type_current_assets,pe_chart_template,False
-chart27123,27123,Propiedades de inversión - Edificaciones - Costos de financiación,account.data_account_type_current_assets,pe_chart_template,False
-chart27124,27124,Propiedades de inversión - Edificaciones - Valor razonable,account.data_account_type_current_assets,pe_chart_template,False
-chart27201,27201,"Propiedad, planta y equipo - Planta productora en producción - Costo",account.data_account_type_current_assets,pe_chart_template,False
-chart27202,27202,"Propiedad, planta y equipo - Planta productora en producción - Revaluación",account.data_account_type_current_assets,pe_chart_template,False
-chart27203,27203,"Propiedad, planta y equipo - Planta productora en producción - Costo de financiación",account.data_account_type_current_assets,pe_chart_template,False
-chart27204,27204,"Propiedad, planta y equipo - Planta productora en producción - Valor razonable",account.data_account_type_current_assets,pe_chart_template,False
-chart27211,27211,"Propiedad, planta y equipo - Planta productora en desarrollo - Costo",account.data_account_type_current_assets,pe_chart_template,False
-chart27212,27212,"Propiedad, planta y equipo - Planta productora en desarrollo - Revaluación",account.data_account_type_current_assets,pe_chart_template,False
-chart27213,27213,"Propiedad, planta y equipo - Planta productora en desarrollo - Costo de financiación",account.data_account_type_current_assets,pe_chart_template,False
-chart27214,27214,"Propiedad, planta y equipo - Planta productora en desarrollo - Valor razonable",account.data_account_type_current_assets,pe_chart_template,False
-chart27221,27221,"Propiedad, planta y equipo - Terrenos - Costo",account.data_account_type_current_assets,pe_chart_template,False
-chart27222,27222,"Propiedad, planta y equipo - Terrenos - Revaluación",account.data_account_type_current_assets,pe_chart_template,False
-chart27231,27231,"Propiedad, planta y equipo - Edificaciones - Costo",account.data_account_type_current_assets,pe_chart_template,False
-chart27232,27232,"Propiedad, planta y equipo - Edificaciones - Revaluación",account.data_account_type_current_assets,pe_chart_template,False
-chart27233,27233,"Propiedad, planta y equipo - Edificaciones - Costo de financiación",account.data_account_type_current_assets,pe_chart_template,False
-chart27241,27241,"Propiedad, planta y equipo - Maquinarias y equipos de explotación - Costo",account.data_account_type_current_assets,pe_chart_template,False
-chart27242,27242,"Propiedad, planta y equipo - Maquinarias y equipos de explotación - Revaluación",account.data_account_type_current_assets,pe_chart_template,False
-chart27243,27243,"Propiedad, planta y equipo - Maquinarias y equipos de explotación - Costo de financiación",account.data_account_type_current_assets,pe_chart_template,False
-chart27251,27251,"Propiedad, planta y equipo - Unidades de transporte - Costo",account.data_account_type_current_assets,pe_chart_template,False
-chart27252,27252,"Propiedad, planta y equipo - Unidades de transporte - Revaluación",account.data_account_type_current_assets,pe_chart_template,False
-chart27261,27261,"Propiedad, planta y equipo - Muebles y enseres - Costo",account.data_account_type_current_assets,pe_chart_template,False
-chart27262,27262,"Propiedad, planta y equipo - Muebles y enseres - Revaluación",account.data_account_type_current_assets,pe_chart_template,False
-chart27271,27271,"Propiedad, planta y equipo - Equipos diversos - Costo",account.data_account_type_current_assets,pe_chart_template,False
-chart27272,27272,"Propiedad, planta y equipo - Equipos diversos - Revaluación",account.data_account_type_current_assets,pe_chart_template,False
-chart27281,27281,"Propiedad, planta y equipo - Herramientas y unidades de reemplazo - Costo",account.data_account_type_current_assets,pe_chart_template,False
-chart27282,27282,"Propiedad, planta y equipo - Herramientas y unidades de reemplazo - Revaluación",account.data_account_type_current_assets,pe_chart_template,False
-chart27291,27291,"Propiedad, planta y equipo - Obras en curso - Costo",account.data_account_type_current_assets,pe_chart_template,False
-chart27292,27292,"Propiedad, planta y equipo - Obras en curso - Revaluación",account.data_account_type_current_assets,pe_chart_template,False
-chart27311,27311,"Intangibles - Concesiones, licencias y derechos - Costo",account.data_account_type_current_assets,pe_chart_template,False
-chart27312,27312,"Intangibles - Concesiones, licencias y derechos - Revaluación",account.data_account_type_current_assets,pe_chart_template,False
-chart27321,27321,Intangibles - Patentes y propiedad industrial - Costo,account.data_account_type_current_assets,pe_chart_template,False
-chart27322,27322,Intangibles - Patentes y propiedad industrial - Revaluación,account.data_account_type_current_assets,pe_chart_template,False
-chart27331,27331,Intangibles - Programas de computadora (software) - Costo,account.data_account_type_current_assets,pe_chart_template,False
-chart27332,27332,Intangibles - Programas de computadora (software) - Revaluación,account.data_account_type_current_assets,pe_chart_template,False
-chart27341,27341,Intangibles - Costos de exploración y desarrollo - Costo,account.data_account_type_current_assets,pe_chart_template,False
-chart27342,27342,Intangibles - Costos de exploración y desarrollo - Revaluación,account.data_account_type_current_assets,pe_chart_template,False
-chart27351,27351,"Intangibles - Fórmulas, diseños y prototipos - Costo",account.data_account_type_current_assets,pe_chart_template,False
-chart27352,27352,"Intangibles - Fórmulas, diseños y prototipos - Revaluación",account.data_account_type_current_assets,pe_chart_template,False
-chart27391,27391,Intangibles - Otros activos intangibles - Costo,account.data_account_type_current_assets,pe_chart_template,False
-chart27392,27392,Intangibles - Otros activos intangibles - Revaluación,account.data_account_type_current_assets,pe_chart_template,False
-chart27411,27411,Activos biológicos - Activos biológicos en producción - Costo,account.data_account_type_current_assets,pe_chart_template,False
-chart27413,27413,Activos biológicos - Activos biológicos en producción - Costos de financiación,account.data_account_type_current_assets,pe_chart_template,False
-chart27414,27414,Activos biológicos - Activos biológicos en producción - Valor razonable,account.data_account_type_current_assets,pe_chart_template,False
-chart27421,27421,Activos biológicos - Activos biológicos en desarrollo - Costo,account.data_account_type_current_assets,pe_chart_template,False
-chart27423,27423,Activos biológicos - Activos biológicos en desarrollo - Costos de financiación,account.data_account_type_current_assets,pe_chart_template,False
-chart27424,27424,Activos biológicos - Activos biológicos en desarrollo - Valor razonable,account.data_account_type_current_assets,pe_chart_template,False
-chart27521,27521,Depreciación acumulada – Propiedades de inversión - Edificaciones - Costo,account.data_account_type_current_assets,pe_chart_template,False
-chart27522,27522,Depreciación acumulada – Propiedades de inversión - Edificaciones - Revaluación,account.data_account_type_current_assets,pe_chart_template,False
-chart27523,27523,Depreciación acumulada – Propiedades de inversión - Edificaciones - Costo de financiación,account.data_account_type_current_assets,pe_chart_template,False
-chart27601,27601,"Depreciación acumulada – Propiedad, planta y equipo - Planta productora en producción - Costo",account.data_account_type_current_assets,pe_chart_template,False
-chart27602,27602,"Depreciación acumulada – Propiedad, planta y equipo - Planta productora en producción - Revaluación",account.data_account_type_current_assets,pe_chart_template,False
-chart27603,27603,"Depreciación acumulada – Propiedad, planta y equipo - Planta productora en producción - Costo de financiación",account.data_account_type_current_assets,pe_chart_template,False
-chart27604,27604,"Depreciación acumulada – Propiedad, planta y equipo - Planta productora en producción - Valor razonable",account.data_account_type_current_assets,pe_chart_template,False
-chart27621,27621,"Depreciación acumulada – Propiedad, planta y equipo - Edificaciones - Costo",account.data_account_type_current_assets,pe_chart_template,False
-chart27622,27622,"Depreciación acumulada – Propiedad, planta y equipo - Edificaciones - Revaluación",account.data_account_type_current_assets,pe_chart_template,False
-chart27623,27623,"Depreciación acumulada – Propiedad, planta y equipo - Edificaciones - Costo de financiación",account.data_account_type_current_assets,pe_chart_template,False
-chart27631,27631,"Depreciación acumulada – Propiedad, planta y equipo - Maquinarias y equipo de explotación - Costo",account.data_account_type_current_assets,pe_chart_template,False
-chart27632,27632,"Depreciación acumulada – Propiedad, planta y equipo - Maquinarias y equipo de explotación - Revaluación",account.data_account_type_current_assets,pe_chart_template,False
-chart27633,27633,"Depreciación acumulada – Propiedad, planta y equipo - Maquinarias y equipo de explotación - Costo de financiación",account.data_account_type_current_assets,pe_chart_template,False
-chart27641,27641,"Depreciación acumulada – Propiedad, planta y equipo - Unidades de transporte - Costo",account.data_account_type_current_assets,pe_chart_template,False
-chart27642,27642,"Depreciación acumulada – Propiedad, planta y equipo - Unidades de transporte - Revaluación",account.data_account_type_current_assets,pe_chart_template,False
-chart27651,27651,"Depreciación acumulada – Propiedad, planta y equipo - Muebles y enseres - Costo",account.data_account_type_current_assets,pe_chart_template,False
-chart27652,27652,"Depreciación acumulada – Propiedad, planta y equipo - Muebles y enseres - Revaluación",account.data_account_type_current_assets,pe_chart_template,False
-chart27661,27661,"Depreciación acumulada – Propiedad, planta y equipo - Equipos diversos - Costo",account.data_account_type_current_assets,pe_chart_template,False
-chart27662,27662,"Depreciación acumulada – Propiedad, planta y equipo - Equipos diversos - Revaluación",account.data_account_type_current_assets,pe_chart_template,False
-chart27671,27671,"Depreciación acumulada – Propiedad, planta y equipo - Herramientas y unidades de reemplazo - Costo",account.data_account_type_current_assets,pe_chart_template,False
-chart27672,27672,"Depreciación acumulada – Propiedad, planta y equipo - Herramientas y unidades de reemplazo - Revaluación",account.data_account_type_current_assets,pe_chart_template,False
-chart27711,27711,"Amortización acumulada – Intangibles - Concesiones, licencias y derechos - Costo",account.data_account_type_current_assets,pe_chart_template,False
-chart27712,27712,"Amortización acumulada – Intangibles - Concesiones, licencias y derechos - Revaluación",account.data_account_type_current_assets,pe_chart_template,False
-chart27721,27721,Amortización acumulada – Intangibles - Patentes y propiedad industrial - Costo,account.data_account_type_current_assets,pe_chart_template,False
-chart27722,27722,Amortización acumulada – Intangibles - Patentes y propiedad industrial - Revaluación,account.data_account_type_current_assets,pe_chart_template,False
-chart27731,27731,Amortización acumulada – Intangibles - Programas de computadora (software) - Costo,account.data_account_type_current_assets,pe_chart_template,False
-chart27732,27732,Amortización acumulada – Intangibles - Programas de computadora (software) - Revaluación,account.data_account_type_current_assets,pe_chart_template,False
-chart27741,27741,Amortización acumulada – Intangibles - Costos de exploración y desarrollo - Costo,account.data_account_type_current_assets,pe_chart_template,False
-chart27742,27742,Amortización acumulada – Intangibles - Costos de exploración y desarrollo - Revaluación,account.data_account_type_current_assets,pe_chart_template,False
-chart27751,27751,"Amortización acumulada – Intangibles - Fórmulas, diseños y prototipos - Costo",account.data_account_type_current_assets,pe_chart_template,False
-chart27752,27752,"Amortización acumulada – Intangibles - Fórmulas, diseños y prototipos - Revaluación",account.data_account_type_current_assets,pe_chart_template,False
-chart27791,27791,Amortización acumulada – Intangibles - Otros activos intangibles - Costo,account.data_account_type_current_assets,pe_chart_template,False
-chart27792,27792,Amortización acumulada – Intangibles - Otros activos intangibles - Revaluación,account.data_account_type_current_assets,pe_chart_template,False
-chart27811,27811,Depreciación acumulada – Activos biológicos - Activos biológicos en producción - Costo,account.data_account_type_current_assets,pe_chart_template,False
-chart27813,27813,Depreciación acumulada – Activos biológicos - Activos biológicos en producción - Costo de financiación,account.data_account_type_current_assets,pe_chart_template,False
-chart27821,27821,Depreciación acumulada – Activos biológicos - Activos biológicos en desarrollo - Costo,account.data_account_type_current_assets,pe_chart_template,False
-chart27823,27823,Depreciación acumulada – Activos biológicos - Activos biológicos en desarrollo - Costo de financiación,account.data_account_type_current_assets,pe_chart_template,False
-chart27910,27910,Desvalorización acumulada - Propiedad de inversión - Planta productora en producción,account.data_account_type_current_assets,pe_chart_template,False
-chart27911,27911,Desvalorización acumulada - Propiedad de inversión - Planta productora en desarrollo,account.data_account_type_current_assets,pe_chart_template,False
-chart27912,27912,Desvalorización acumulada - Propiedad de inversión - Terrenos,account.data_account_type_current_assets,pe_chart_template,False
-chart27913,27913,Desvalorización acumulada - Propiedad de inversión - Edificaciones,account.data_account_type_current_assets,pe_chart_template,False
-chart27930,27930,"Desvalorización acumulada - Propiedad, planta y equipo - Plantas productoras en producción",account.data_account_type_current_assets,pe_chart_template,False
-chart27931,27931,"Desvalorización acumulada - Propiedad, planta y equipo - Planta productora en desarrollo",account.data_account_type_current_assets,pe_chart_template,False
-chart27932,27932,"Desvalorización acumulada - Propiedad, planta y equipo - Terrenos",account.data_account_type_current_assets,pe_chart_template,False
-chart27933,27933,"Desvalorización acumulada - Propiedad, planta y equipo - Edificaciones",account.data_account_type_current_assets,pe_chart_template,False
-chart27934,27934,"Desvalorización acumulada - Propiedad, planta y equipo - Maquinarias y equipos de explotación",account.data_account_type_current_assets,pe_chart_template,False
-chart27935,27935,"Desvalorización acumulada - Propiedad, planta y equipo - Unidades de transporte",account.data_account_type_current_assets,pe_chart_template,False
-chart27936,27936,"Desvalorización acumulada - Propiedad, planta y equipo - Muebles y enseres",account.data_account_type_current_assets,pe_chart_template,False
-chart27937,27937,"Desvalorización acumulada - Propiedad, planta y equipo - Equipos diversos",account.data_account_type_current_assets,pe_chart_template,False
-chart27938,27938,"Desvalorización acumulada - Propiedad, planta y equipo - Herramientas y unidades de reemplazo",account.data_account_type_current_assets,pe_chart_template,False
-chart27941,27941,"Desvalorización acumulada - Intangibles - Concesiones, licencias y otros derechos",account.data_account_type_current_assets,pe_chart_template,False
-chart27942,27942,Desvalorización acumulada - Intangibles - Patentes y propiedad industrial,account.data_account_type_current_assets,pe_chart_template,False
-chart27943,27943,Desvalorización acumulada - Intangibles - Programas de computadora (software),account.data_account_type_current_assets,pe_chart_template,False
-chart27944,27944,Desvalorización acumulada - Intangibles - Costos de exploración y desarrollo,account.data_account_type_current_assets,pe_chart_template,False
-chart27945,27945,"Desvalorización acumulada - Intangibles - Fórmulas, diseños y prototipos",account.data_account_type_current_assets,pe_chart_template,False
-chart27949,27949,Desvalorización acumulada - Intangibles - Otros activos intangibles,account.data_account_type_current_assets,pe_chart_template,False
-chart27951,27951,Desvalorización acumulada - Activos biológicos - Activos biológicos en producción,account.data_account_type_current_assets,pe_chart_template,False
-chart27952,27952,Desvalorización acumulada - Activos biológicos - Activos biológicos en desarrollo,account.data_account_type_current_assets,pe_chart_template,False
-chart281,281,Mercaderías,account.data_account_type_current_assets,pe_chart_template,False
-chart284,284,Materias primas,account.data_account_type_current_assets,pe_chart_template,False
-chart285,285,"Materiales auxiliares, suministros y repuestos",account.data_account_type_current_assets,pe_chart_template,False
-chart286,286,Envases y embalajes,account.data_account_type_current_assets,pe_chart_template,False
-chart29111,29111,Mercaderías - Mercaderías - Costo,account.data_account_type_current_assets,pe_chart_template,False
-chart29211,29211,Productos terminados - Productos terminados - Costo,account.data_account_type_current_assets,pe_chart_template,False
-chart29213,29213,Productos terminados - Productos terminados - Costo de financiación,account.data_account_type_current_assets,pe_chart_template,False
-chart29251,29251,Productos terminados - Inventario de servicios terminados - Costo,account.data_account_type_current_assets,pe_chart_template,False
-chart2931,2931,"Subproductos, desechos y desperdicios - Subproductos",account.data_account_type_current_assets,pe_chart_template,False
-chart2932,2932,"Subproductos, desechos y desperdicios - Desechos y desperdicios",account.data_account_type_current_assets,pe_chart_template,False
-chart29411,29411,Productos en proceso - Productos en proceso - Costo,account.data_account_type_current_assets,pe_chart_template,False
-chart29413,29413,Productos en proceso - Productos en proceso - Costo de financiación,account.data_account_type_current_assets,pe_chart_template,False
-chart2945,2945,Productos en proceso - Inventario de servicios en proceso,account.data_account_type_current_assets,pe_chart_template,False
-chart29511,29511,Materias primas - Materias primas - Costo,account.data_account_type_current_assets,pe_chart_template,False
-chart2961,2961,"Materiales auxiliares, suministros y repuestos - Materiales auxiliares",account.data_account_type_current_assets,pe_chart_template,False
-chart2962,2962,"Materiales auxiliares, suministros y repuestos - Suministros",account.data_account_type_current_assets,pe_chart_template,False
-chart2963,2963,"Materiales auxiliares, suministros y repuestos - Repuestos",account.data_account_type_current_assets,pe_chart_template,False
-chart2971,2971,Envases y embalajes - Envases,account.data_account_type_current_assets,pe_chart_template,False
-chart2972,2972,Envases y embalajes - Embalajes,account.data_account_type_current_assets,pe_chart_template,False
-chart2981,2981,Existencias por recibir - Mercaderías,account.data_account_type_current_assets,pe_chart_template,False
-chart2982,2982,Existencias por recibir - Materias primas,account.data_account_type_current_assets,pe_chart_template,False
-chart2983,2983,"Existencias por recibir - Materiales auxiliares, suministros y repuestos",account.data_account_type_current_assets,pe_chart_template,False
-chart2984,2984,Existencias por recibir - Envases y embalajes,account.data_account_type_current_assets,pe_chart_template,False
-chart30111,30111,Inversiones a ser mantenidas hasta el vencimiento - Instrumentos financieros representativos de deuda - Costo,account.data_account_type_fixed_assets,pe_chart_template,False
-chart30114,30114,Inversiones a ser mantenidas hasta el vencimiento - Instrumentos financieros representativos de deuda - Valor razonable,account.data_account_type_fixed_assets,pe_chart_template,False
-chart3021,3021,Instrumentos financieros representativos de derecho patrimonial - Certificados de suscripción preferente,account.data_account_type_fixed_assets,pe_chart_template,False
-chart30221,30221,Instrumentos financieros representativos de derecho patrimonial - Acciones representativas de capital social – Comunes - Costo,account.data_account_type_fixed_assets,pe_chart_template,False
-chart30224,30224,Instrumentos financieros representativos de derecho patrimonial - Acciones representativas de capital social – Comunes - Valor razonable,account.data_account_type_fixed_assets,pe_chart_template,False
-chart30225,30225,Instrumentos financieros representativos de derecho patrimonial - Acciones representativas de capital social – Comunes - Participación patrimonial,account.data_account_type_fixed_assets,pe_chart_template,False
-chart30231,30231,Instrumentos financieros representativos de derecho patrimonial - Acciones representativas de capital social – Preferentes - Costo,account.data_account_type_fixed_assets,pe_chart_template,False
-chart30234,30234,Instrumentos financieros representativos de derecho patrimonial - Acciones representativas de capital social – Preferentes - Valor razonable,account.data_account_type_fixed_assets,pe_chart_template,False
-chart30235,30235,Instrumentos financieros representativos de derecho patrimonial - Acciones representativas de capital social – Preferentes - Participación patrimonial,account.data_account_type_fixed_assets,pe_chart_template,False
-chart30241,30241,Instrumentos financieros representativos de derecho patrimonial - Acciones de inversión - Costo,account.data_account_type_fixed_assets,pe_chart_template,False
-chart30244,30244,Instrumentos financieros representativos de derecho patrimonial - Acciones de inversión - Valor razonable,account.data_account_type_fixed_assets,pe_chart_template,False
-chart30245,30245,Instrumentos financieros representativos de derecho patrimonial - Acciones de inversión - Participación patrimonial,account.data_account_type_fixed_assets,pe_chart_template,False
-chart30281,30281,Instrumentos financieros representativos de derecho patrimonial - Otros títulos representativos de patrimonio - Costo,account.data_account_type_fixed_assets,pe_chart_template,False
-chart30284,30284,Instrumentos financieros representativos de derecho patrimonial - Otros títulos representativos de patrimonio - Valor razonable,account.data_account_type_fixed_assets,pe_chart_template,False
-chart30285,30285,Instrumentos financieros representativos de derecho patrimonial - Otros títulos representativos de patrimonio - Participación patrimonial,account.data_account_type_fixed_assets,pe_chart_template,False
-chart30311,30311,Certificados de participación en fondos - Cuotas - Fondos de inversión - Costo,account.data_account_type_fixed_assets,pe_chart_template,False
-chart30314,30314,Certificados de participación en fondos - Cuotas - Fondos de inversión - Valor razonable,account.data_account_type_fixed_assets,pe_chart_template,False
-chart30321,30321,Certificados de participación en fondos - Cuotas - Fondos mutuos - Costo,account.data_account_type_fixed_assets,pe_chart_template,False
-chart30324,30324,Certificados de participación en fondos - Cuotas - Fondos mutuos - Valor razonable,account.data_account_type_fixed_assets,pe_chart_template,False
-chart30411,30411,Participaciones en acuerdos conjuntos - Operaciones conjuntas - Costo,account.data_account_type_fixed_assets,pe_chart_template,False
-chart30414,30414,Participaciones en acuerdos conjuntos - Operaciones conjuntas - Valor razonable,account.data_account_type_fixed_assets,pe_chart_template,False
-chart30415,30415,Participaciones en acuerdos conjuntos - Operaciones conjuntas - Participación patrimonial,account.data_account_type_fixed_assets,pe_chart_template,False
-chart30421,30421,Participaciones en acuerdos conjuntos - Negocios conjuntos - Costo,account.data_account_type_fixed_assets,pe_chart_template,False
-chart30424,30424,Participaciones en acuerdos conjuntos - Negocios conjuntos - Valor razonable,account.data_account_type_fixed_assets,pe_chart_template,False
-chart30425,30425,Participaciones en acuerdos conjuntos - Negocios conjuntos - Participación patrimonial,account.data_account_type_fixed_assets,pe_chart_template,False
-chart30811,30811,Inversiones mobiliarias – Acuerdos de compra - Instrumentos financieros representativos de deuda – Acuerdo de compra - Costo,account.data_account_type_fixed_assets,pe_chart_template,False
-chart30814,30814,Inversiones mobiliarias – Acuerdos de compra - Instrumentos financieros representativos de deuda – Acuerdo de compra - Valor razonable,account.data_account_type_fixed_assets,pe_chart_template,False
-chart30821,30821,Inversiones mobiliarias – Acuerdos de compra - Instrumentos financieros representativos de derecho patrimonial – Acuerdo de compra - Costo,account.data_account_type_fixed_assets,pe_chart_template,False
-chart30824,30824,Inversiones mobiliarias – Acuerdos de compra - Instrumentos financieros representativos de derecho patrimonial – Acuerdo de compra - Valor razonable,account.data_account_type_fixed_assets,pe_chart_template,False
-chart31111,31111,Terrenos - Urbanos - Costo,account.data_account_type_fixed_assets,pe_chart_template,False
-chart31112,31112,Terrenos - Urbanos - Revaluación,account.data_account_type_fixed_assets,pe_chart_template,False
-chart31114,31114,Terrenos - Urbanos - Valor razonable,account.data_account_type_fixed_assets,pe_chart_template,False
-chart31121,31121,Terrenos - Rurales - Costo,account.data_account_type_fixed_assets,pe_chart_template,False
-chart31122,31122,Terrenos - Rurales - Revaluación,account.data_account_type_fixed_assets,pe_chart_template,False
-chart31124,31124,Terrenos - Rurales - Valor razonable,account.data_account_type_fixed_assets,pe_chart_template,False
-chart31211,31211,Edificaciones - Edificaciones - Costo,account.data_account_type_fixed_assets,pe_chart_template,False
-chart31212,31212,Edificaciones - Edificaciones - Revaluación,account.data_account_type_fixed_assets,pe_chart_template,False
-chart31213,31213,Edificaciones - Edificaciones - Costos de financiación,account.data_account_type_fixed_assets,pe_chart_template,False
-chart31214,31214,Edificaciones - Edificaciones - Valor razonable,account.data_account_type_fixed_assets,pe_chart_template,False
-chart31311,31311,Construcciones en curso - Edificaciones - Costo,account.data_account_type_fixed_assets,pe_chart_template,False
-chart31312,31312,Construcciones en curso - Edificaciones - Revaluación,account.data_account_type_fixed_assets,pe_chart_template,False
-chart31313,31313,Construcciones en curso - Edificaciones - Costos de financiación,account.data_account_type_fixed_assets,pe_chart_template,False
-chart31314,31314,Construcciones en curso - Edificaciones - Valor razonable,account.data_account_type_fixed_assets,pe_chart_template,False
-chart32111,32111,Propiedades de inversión - Arrendamiento financiero - Terrenos - Costo,account.data_account_type_fixed_assets,pe_chart_template,False
-chart32112,32112,Propiedades de inversión - Arrendamiento financiero - Terrenos - Revaluación,account.data_account_type_fixed_assets,pe_chart_template,False
-chart32114,32114,Propiedades de inversión - Arrendamiento financiero - Terrenos - Valor razonable,account.data_account_type_fixed_assets,pe_chart_template,False
-chart32121,32121,Propiedades de inversión - Arrendamiento financiero - Edificaciones - Costo,account.data_account_type_fixed_assets,pe_chart_template,False
-chart32122,32122,Propiedades de inversión - Arrendamiento financiero - Edificaciones - Revaluación,account.data_account_type_fixed_assets,pe_chart_template,False
-chart32123,32123,Propiedades de inversión - Arrendamiento financiero - Edificaciones - Costo de financiación,account.data_account_type_fixed_assets,pe_chart_template,False
-chart32124,32124,Propiedades de inversión - Arrendamiento financiero - Edificaciones - Valor razonable,account.data_account_type_fixed_assets,pe_chart_template,False
-chart32201,32201,"Propiedad, planta y equipo - Arrendamiento financiero - Planta productora en producción - Costo",account.data_account_type_fixed_assets,pe_chart_template,False
-chart32202,32202,"Propiedad, planta y equipo - Arrendamiento financiero - Planta productora en producción - Revaluación",account.data_account_type_fixed_assets,pe_chart_template,False
-chart32203,32203,"Propiedad, planta y equipo - Arrendamiento financiero - Planta productora en producción - Costo de financiación",account.data_account_type_fixed_assets,pe_chart_template,False
-chart32211,32211,"Propiedad, planta y equipo - Arrendamiento financiero - Planta productora en desarrollo - Costo",account.data_account_type_fixed_assets,pe_chart_template,False
-chart32212,32212,"Propiedad, planta y equipo - Arrendamiento financiero - Planta productora en desarrollo - Revaluación",account.data_account_type_fixed_assets,pe_chart_template,False
-chart32213,32213,"Propiedad, planta y equipo - Arrendamiento financiero - Planta productora en desarrollo - Costo de financiación",account.data_account_type_fixed_assets,pe_chart_template,False
-chart32221,32221,"Propiedad, planta y equipo - Arrendamiento financiero - Terrenos - Costo",account.data_account_type_fixed_assets,pe_chart_template,False
-chart32222,32222,"Propiedad, planta y equipo - Arrendamiento financiero - Terrenos - Revaluación",account.data_account_type_fixed_assets,pe_chart_template,False
-chart32231,32231,"Propiedad, planta y equipo - Arrendamiento financiero - Edificaciones - Costo",account.data_account_type_fixed_assets,pe_chart_template,False
-chart32232,32232,"Propiedad, planta y equipo - Arrendamiento financiero - Edificaciones - Revaluación",account.data_account_type_fixed_assets,pe_chart_template,False
-chart32233,32233,"Propiedad, planta y equipo - Arrendamiento financiero - Edificaciones - Costo de financiación",account.data_account_type_fixed_assets,pe_chart_template,False
-chart32241,32241,"Propiedad, planta y equipo - Arrendamiento financiero - Maquinaria y equipo de explotación - Costo",account.data_account_type_fixed_assets,pe_chart_template,False
-chart32242,32242,"Propiedad, planta y equipo - Arrendamiento financiero - Maquinaria y equipo de explotación - Revaluación",account.data_account_type_fixed_assets,pe_chart_template,False
-chart32243,32243,"Propiedad, planta y equipo - Arrendamiento financiero - Maquinaria y equipo de explotación - Costo de financiación",account.data_account_type_fixed_assets,pe_chart_template,False
-chart32251,32251,"Propiedad, planta y equipo - Arrendamiento financiero - Unidades de transporte - Costo",account.data_account_type_fixed_assets,pe_chart_template,False
-chart32252,32252,"Propiedad, planta y equipo - Arrendamiento financiero - Unidades de transporte - Revaluación",account.data_account_type_fixed_assets,pe_chart_template,False
-chart32261,32261,"Propiedad, planta y equipo - Arrendamiento financiero - Muebles y enseres - Costo",account.data_account_type_fixed_assets,pe_chart_template,False
-chart32262,32262,"Propiedad, planta y equipo - Arrendamiento financiero - Muebles y enseres - Revaluación",account.data_account_type_fixed_assets,pe_chart_template,False
-chart32271,32271,"Propiedad, planta y equipo - Arrendamiento financiero - Equipos diversos - Costo",account.data_account_type_fixed_assets,pe_chart_template,False
-chart32272,32272,"Propiedad, planta y equipo - Arrendamiento financiero - Equipos diversos - Revaluación",account.data_account_type_fixed_assets,pe_chart_template,False
-chart32281,32281,"Propiedad, planta y equipo - Arrendamiento financiero - Herramientas y unidades de reemplazo - Costo",account.data_account_type_fixed_assets,pe_chart_template,False
-chart32282,32282,"Propiedad, planta y equipo - Arrendamiento financiero - Herramientas y unidades de reemplazo - Revaluación",account.data_account_type_fixed_assets,pe_chart_template,False
-chart32301,32301,"Propiedad, planta y equipo - Arrendamiento operativo - Planta productora en producción - Costo",account.data_account_type_fixed_assets,pe_chart_template,False
-chart32302,32302,"Propiedad, planta y equipo - Arrendamiento operativo - Planta productora en producción - Revaluación",account.data_account_type_fixed_assets,pe_chart_template,False
-chart32321,32321,"Propiedad, planta y equipo - Arrendamiento operativo - Terrenos - Costo",account.data_account_type_fixed_assets,pe_chart_template,False
-chart32331,32331,"Propiedad, planta y equipo - Arrendamiento operativo - Edificaciones - Costo",account.data_account_type_fixed_assets,pe_chart_template,False
-chart32332,32332,"Propiedad, planta y equipo - Arrendamiento operativo - Edificaciones - Revaluación",account.data_account_type_fixed_assets,pe_chart_template,False
-chart32341,32341,"Propiedad, planta y equipo - Arrendamiento operativo - Maquinaria y equipo de explotación - Costo",account.data_account_type_fixed_assets,pe_chart_template,False
-chart32342,32342,"Propiedad, planta y equipo - Arrendamiento operativo - Maquinaria y equipo de explotación - Revaluación",account.data_account_type_fixed_assets,pe_chart_template,False
-chart32351,32351,"Propiedad, planta y equipo - Arrendamiento operativo - Unidades de transporte - Costo",account.data_account_type_fixed_assets,pe_chart_template,False
-chart32352,32352,"Propiedad, planta y equipo - Arrendamiento operativo - Unidades de transporte - Revaluación",account.data_account_type_fixed_assets,pe_chart_template,False
-chart32361,32361,"Propiedad, planta y equipo - Arrendamiento operativo - Equipos diversos - Costo",account.data_account_type_fixed_assets,pe_chart_template,False
-chart32362,32362,"Propiedad, planta y equipo - Arrendamiento operativo - Equipos diversos - Revaluación",account.data_account_type_fixed_assets,pe_chart_template,False
-chart33011,33011,Planta productora - Planta productora en producción - Costo,account.data_account_type_fixed_assets,pe_chart_template,False
-chart33012,33012,Planta productora - Planta productora en producción - Revaluación,account.data_account_type_fixed_assets,pe_chart_template,False
-chart33013,33013,Planta productora - Planta productora en producción - Costo de financiación,account.data_account_type_fixed_assets,pe_chart_template,False
-chart33014,33014,Planta productora - Planta productora en producción - Valor razonable,account.data_account_type_fixed_assets,pe_chart_template,False
-chart33021,33021,Planta productora - Planta productora en desarrollo - Costo,account.data_account_type_fixed_assets,pe_chart_template,False
-chart33022,33022,Planta productora - Planta productora en desarrollo - Revaluación,account.data_account_type_fixed_assets,pe_chart_template,False
-chart33023,33023,Planta productora - Planta productora en desarrollo - Costo de financiación,account.data_account_type_fixed_assets,pe_chart_template,False
-chart33024,33024,Planta productora - Planta productora en desarrollo - Valor razonable,account.data_account_type_fixed_assets,pe_chart_template,False
-chart33111,33111,Terrenos - Terrenos - Costo,account.data_account_type_fixed_assets,pe_chart_template,False
-chart33112,33112,Terrenos - Terrenos - Revaluación,account.data_account_type_fixed_assets,pe_chart_template,False
-chart33211,33211,Edificaciones - Edificaciones - Costo,account.data_account_type_fixed_assets,pe_chart_template,False
-chart33212,33212,Edificaciones - Edificaciones - Revaluación,account.data_account_type_fixed_assets,pe_chart_template,False
-chart33213,33213,Edificaciones - Edificaciones - Costo de financiación,account.data_account_type_fixed_assets,pe_chart_template,False
-chart33241,33241,Edificaciones - Instalaciones - Costo,account.data_account_type_fixed_assets,pe_chart_template,False
-chart33242,33242,Edificaciones - Instalaciones - Revaluación,account.data_account_type_fixed_assets,pe_chart_template,False
-chart33243,33243,Edificaciones - Instalaciones - Costo de financiación,account.data_account_type_fixed_assets,pe_chart_template,False
-chart33251,33251,Edificaciones - Mejoras en locales arrendados. - Costo,account.data_account_type_fixed_assets,pe_chart_template,False
-chart33252,33252,Edificaciones - Mejoras en locales arrendados. - Revaluación,account.data_account_type_fixed_assets,pe_chart_template,False
-chart33253,33253,Edificaciones - Mejoras en locales arrendados. - Costo de Financiación,account.data_account_type_fixed_assets,pe_chart_template,False
-chart33311,33311,Maquinaria y equipo de explotación - Maquinaria y equipo de explotación - Costo,account.data_account_type_fixed_assets,pe_chart_template,False
-chart33312,33312,Maquinaria y equipo de explotación - Maquinaria y equipo de explotación - Revaluación,account.data_account_type_fixed_assets,pe_chart_template,False
-chart33313,33313,Maquinaria y equipo de explotación - Maquinaria y equipo de explotación - Costo de financiación,account.data_account_type_fixed_assets,pe_chart_template,False
-chart33411,33411,Unidades de transporte - Vehículos motorizados - Costo,account.data_account_type_fixed_assets,pe_chart_template,False
-chart33412,33412,Unidades de transporte - Vehículos motorizados - Revaluación,account.data_account_type_fixed_assets,pe_chart_template,False
-chart33421,33421,Unidades de transporte - Vehículos no motorizados - Costo,account.data_account_type_fixed_assets,pe_chart_template,False
-chart33422,33422,Unidades de transporte - Vehículos no motorizados - Revaluación,account.data_account_type_fixed_assets,pe_chart_template,False
-chart33511,33511,Muebles y enseres - Muebles - Costo,account.data_account_type_fixed_assets,pe_chart_template,False
-chart33512,33512,Muebles y enseres - Muebles - Revaluación,account.data_account_type_fixed_assets,pe_chart_template,False
-chart33521,33521,Muebles y enseres - Enseres - Costo,account.data_account_type_fixed_assets,pe_chart_template,False
-chart33522,33522,Muebles y enseres - Enseres - Revaluación,account.data_account_type_fixed_assets,pe_chart_template,False
-chart33611,33611,Equipos diversos - Equipo para procesamiento de información - Costo,account.data_account_type_fixed_assets,pe_chart_template,False
-chart33612,33612,Equipos diversos - Equipo para procesamiento de información - Revaluación,account.data_account_type_fixed_assets,pe_chart_template,False
-chart33621,33621,Equipos diversos - Equipo de comunicación - Costo,account.data_account_type_fixed_assets,pe_chart_template,False
-chart33622,33622,Equipos diversos - Equipo de comunicación - Revaluación,account.data_account_type_fixed_assets,pe_chart_template,False
-chart33631,33631,Equipos diversos - Equipo de seguridad - Costo,account.data_account_type_fixed_assets,pe_chart_template,False
-chart33632,33632,Equipos diversos - Equipo de seguridad - Revaluación,account.data_account_type_fixed_assets,pe_chart_template,False
-chart33641,33641,Equipos diversos - Equipo de medio ambiente - Costo,account.data_account_type_fixed_assets,pe_chart_template,False
-chart33642,33642,Equipos diversos - Equipo de medio ambiente - Revaluación,account.data_account_type_fixed_assets,pe_chart_template,False
-chart33691,33691,Equipos diversos - Otros equipos - Costo,account.data_account_type_fixed_assets,pe_chart_template,False
-chart33692,33692,Equipos diversos - Otros equipos - Revaluación,account.data_account_type_fixed_assets,pe_chart_template,False
-chart33711,33711,Herramientas y unidades de reemplazo - Herramientas - Costo,account.data_account_type_fixed_assets,pe_chart_template,False
-chart33712,33712,Herramientas y unidades de reemplazo - Herramientas - Revaluación,account.data_account_type_fixed_assets,pe_chart_template,False
-chart33721,33721,Herramientas y unidades de reemplazo - Unidades de reemplazo - Costo,account.data_account_type_fixed_assets,pe_chart_template,False
-chart33722,33722,Herramientas y unidades de reemplazo - Unidades de reemplazo - Revaluación,account.data_account_type_fixed_assets,pe_chart_template,False
-chart3381,3381,Unidades por recibir - Maquinaria y equipo de explotación,account.data_account_type_fixed_assets,pe_chart_template,False
-chart3382,3382,Unidades por recibir - Equipo de transporte,account.data_account_type_fixed_assets,pe_chart_template,False
-chart3383,3383,Unidades por recibir - Muebles y enseres,account.data_account_type_fixed_assets,pe_chart_template,False
-chart3386,3386,Unidades por recibir - Equipos diversos,account.data_account_type_fixed_assets,pe_chart_template,False
-chart3387,3387,Unidades por recibir - Herramientas y unidades de reemplazo,account.data_account_type_fixed_assets,pe_chart_template,False
-chart3391,3391,Obras en curso - Adecuación de terrenos,account.data_account_type_fixed_assets,pe_chart_template,False
-chart33921,33921,Obras en curso - Edificaciones en curso - Costo,account.data_account_type_fixed_assets,pe_chart_template,False
-chart33922,33922,Obras en curso - Edificaciones en curso - Costo de financiación,account.data_account_type_fixed_assets,pe_chart_template,False
-chart33931,33931,Obras en curso - Maquinaria en montaje - Costo,account.data_account_type_fixed_assets,pe_chart_template,False
-chart33932,33932,Obras en curso - Maquinaria en montaje - Costo de financiación,account.data_account_type_fixed_assets,pe_chart_template,False
-chart34111,34111,"Concesiones, licencias y otros derechos - Derechos por concesiones - Costo",account.data_account_type_fixed_assets,pe_chart_template,False
-chart34112,34112,"Concesiones, licencias y otros derechos - Derechos por concesiones - Revaluación",account.data_account_type_fixed_assets,pe_chart_template,False
-chart34121,34121,"Concesiones, licencias y otros derechos - Licencias - Costo",account.data_account_type_fixed_assets,pe_chart_template,False
-chart34122,34122,"Concesiones, licencias y otros derechos - Licencias - Revaluación",account.data_account_type_fixed_assets,pe_chart_template,False
-chart34191,34191,"Concesiones, licencias y otros derechos - Otros derechos - Costo",account.data_account_type_fixed_assets,pe_chart_template,False
-chart34192,34192,"Concesiones, licencias y otros derechos - Otros derechos - Revaluación",account.data_account_type_fixed_assets,pe_chart_template,False
-chart34211,34211,Patentes y propiedad industrial - Patentes - Costo,account.data_account_type_fixed_assets,pe_chart_template,False
-chart34212,34212,Patentes y propiedad industrial - Patentes - Revaluación,account.data_account_type_fixed_assets,pe_chart_template,False
-chart34221,34221,Patentes y propiedad industrial - Marcas - Costo,account.data_account_type_fixed_assets,pe_chart_template,False
-chart34222,34222,Patentes y propiedad industrial - Marcas - Revaluación,account.data_account_type_fixed_assets,pe_chart_template,False
-chart34311,34311,Programas de computadora (software) - Aplicaciones informáticas - Costo,account.data_account_type_fixed_assets,pe_chart_template,False
-chart34312,34312,Programas de computadora (software) - Aplicaciones informáticas - Revaluación,account.data_account_type_fixed_assets,pe_chart_template,False
-chart34411,34411,Costos de exploración y desarrollo - Costos de exploración - Costo,account.data_account_type_fixed_assets,pe_chart_template,False
-chart34412,34412,Costos de exploración y desarrollo - Costos de exploración - Revaluación,account.data_account_type_fixed_assets,pe_chart_template,False
-chart34413,34413,Costos de exploración y desarrollo - Costos de exploración - Costo de financiación,account.data_account_type_fixed_assets,pe_chart_template,False
-chart34421,34421,Costos de exploración y desarrollo - Costos de desarrollo - Costo,account.data_account_type_fixed_assets,pe_chart_template,False
-chart34422,34422,Costos de exploración y desarrollo - Costos de desarrollo - Revaluación,account.data_account_type_fixed_assets,pe_chart_template,False
-chart34423,34423,Costos de exploración y desarrollo - Costos de desarrollo - Costo de financiación,account.data_account_type_fixed_assets,pe_chart_template,False
-chart34511,34511,"Fórmulas, diseños y prototipos - Fórmulas - Costo",account.data_account_type_fixed_assets,pe_chart_template,False
-chart34512,34512,"Fórmulas, diseños y prototipos - Fórmulas - Revaluación",account.data_account_type_fixed_assets,pe_chart_template,False
-chart34521,34521,"Fórmulas, diseños y prototipos - Diseños y prototipos - Costo",account.data_account_type_fixed_assets,pe_chart_template,False
-chart34522,34522,"Fórmulas, diseños y prototipos - Diseños y prototipos - Revaluación",account.data_account_type_fixed_assets,pe_chart_template,False
-chart3471,3471,Plusvalía mercantil - Plusvalía mercantil,account.data_account_type_fixed_assets,pe_chart_template,False
-chart34911,34911,Otros activos intangibles - Otros activos intangibles - Costo,account.data_account_type_fixed_assets,pe_chart_template,False
-chart34912,34912,Otros activos intangibles - Otros activos intangibles - Revaluación,account.data_account_type_fixed_assets,pe_chart_template,False
-chart35111,35111,Activos biológicos en producción - De origen animal - Costo,account.data_account_type_fixed_assets,pe_chart_template,False
-chart35113,35113,Activos biológicos en producción - De origen animal - Costo de financiación,account.data_account_type_fixed_assets,pe_chart_template,False
-chart35114,35114,Activos biológicos en producción - De origen animal - Valor razonable,account.data_account_type_fixed_assets,pe_chart_template,False
-chart35121,35121,Activos biológicos en producción - De origen vegetal - Costo,account.data_account_type_fixed_assets,pe_chart_template,False
-chart35123,35123,Activos biológicos en producción - De origen vegetal - Costo de financiación,account.data_account_type_fixed_assets,pe_chart_template,False
-chart35124,35124,Activos biológicos en producción - De origen vegetal - Valor razonable,account.data_account_type_fixed_assets,pe_chart_template,False
-chart35211,35211,Activos biológicos en desarrollo - De origen animal - Costo,account.data_account_type_fixed_assets,pe_chart_template,False
-chart35213,35213,Activos biológicos en desarrollo - De origen animal - Costo de financiación,account.data_account_type_fixed_assets,pe_chart_template,False
-chart35214,35214,Activos biológicos en desarrollo - De origen animal - Valor razonable,account.data_account_type_fixed_assets,pe_chart_template,False
-chart35221,35221,Activos biológicos en desarrollo - De origen vegetal - Costo,account.data_account_type_fixed_assets,pe_chart_template,False
-chart35223,35223,Activos biológicos en desarrollo - De origen vegetal - Costo de financiación,account.data_account_type_fixed_assets,pe_chart_template,False
-chart35224,35224,Activos biológicos en desarrollo - De origen vegetal - Valor razonable,account.data_account_type_fixed_assets,pe_chart_template,False
-chart36111,36111,Terrenos - Costo,account.data_account_type_fixed_assets,pe_chart_template,False
-chart36112,36112,Terrenos - Revaluación,account.data_account_type_fixed_assets,pe_chart_template,False
-chart36121,36121,Edificaciones - Costo,account.data_account_type_fixed_assets,pe_chart_template,False
-chart36122,36122,Edificaciones - Revaluación,account.data_account_type_fixed_assets,pe_chart_template,False
-chart36123,36123,Edificaciones - Costo de financiación,account.data_account_type_fixed_assets,pe_chart_template,False
-chart36131,36131,Construcciones en curso - edificaciones - Costo,account.data_account_type_fixed_assets,pe_chart_template,False
-chart36132,36132,Construcciones en curso - edificaciones - Revaluación,account.data_account_type_fixed_assets,pe_chart_template,False
-chart36133,36133,Construcciones en curso - edificaciones - Costo de financiación,account.data_account_type_fixed_assets,pe_chart_template,False
-chart36211,36211,Arrendamiento financiero - Terrenos - Costo,account.data_account_type_fixed_assets,pe_chart_template,False
-chart36212,36212,Arrendamiento financiero - Terrenos - Revaluación,account.data_account_type_fixed_assets,pe_chart_template,False
-chart36221,36221,Arrendamiento financiero - Edificaciones - Costo,account.data_account_type_fixed_assets,pe_chart_template,False
-chart36222,36222,Arrendamiento financiero - Edificaciones - Revaluación,account.data_account_type_fixed_assets,pe_chart_template,False
-chart36223,36223,Arrendamiento financiero - Edificaciones - Costo de financiación,account.data_account_type_fixed_assets,pe_chart_template,False
-chart36311,36311,Arrendamiento financiero - Terrenos - Costo,account.data_account_type_fixed_assets,pe_chart_template,False
-chart36312,36312,Arrendamiento financiero - Terrenos - Revaluación,account.data_account_type_fixed_assets,pe_chart_template,False
-chart36321,36321,Arrendamiento financiero - Edificaciones - Costo,account.data_account_type_fixed_assets,pe_chart_template,False
-chart36322,36322,Arrendamiento financiero - Edificaciones - Revaluación,account.data_account_type_fixed_assets,pe_chart_template,False
-chart36323,36323,Arrendamiento financiero - Edificaciones - Costo de financiación,account.data_account_type_fixed_assets,pe_chart_template,False
-chart36331,36331,Arrendamiento financiero - Maquinaria y equipo de explotación - Costo,account.data_account_type_fixed_assets,pe_chart_template,False
-chart36332,36332,Arrendamiento financiero - Maquinaria y equipo de explotación - Revaluación,account.data_account_type_fixed_assets,pe_chart_template,False
-chart36333,36333,Arrendamiento financiero - Maquinaria y equipo de explotación - Costo de financiación,account.data_account_type_fixed_assets,pe_chart_template,False
-chart36341,36341,Arrendamiento financiero - Unidades de transporte - Costo,account.data_account_type_fixed_assets,pe_chart_template,False
-chart36342,36342,Arrendamiento financiero - Unidades de transporte - Revaluación,account.data_account_type_fixed_assets,pe_chart_template,False
-chart36351,36351,Arrendamiento financiero - Muebles y enseres - Costo,account.data_account_type_fixed_assets,pe_chart_template,False
-chart36352,36352,Arrendamiento financiero - Muebles y enseres - Revaluación,account.data_account_type_fixed_assets,pe_chart_template,False
-chart36361,36361,Arrendamiento financiero - Equipos diversos - Costo,account.data_account_type_fixed_assets,pe_chart_template,False
-chart36362,36362,Arrendamiento financiero - Equipos diversos - Revaluación,account.data_account_type_fixed_assets,pe_chart_template,False
-chart36401,36401,Planta productora en producción - Costo,account.data_account_type_fixed_assets,pe_chart_template,False
-chart36402,36402,Planta productora en producción - Planta productora en producción - Revaluación,account.data_account_type_fixed_assets,pe_chart_template,False
-chart36403,36403,Planta productora en producción - Planta productora en producción - Costo de financiación,account.data_account_type_fixed_assets,pe_chart_template,False
-chart36405,36405,Planta productora en producción - Planta productora en desarrollo - Costo,account.data_account_type_fixed_assets,pe_chart_template,False
-chart36406,36406,Planta productora en producción - Planta productora en desarrollo - Revaluación,account.data_account_type_fixed_assets,pe_chart_template,False
-chart36407,36407,Planta productora en producción - Planta productora en desarrollo - Costo de financiación,account.data_account_type_fixed_assets,pe_chart_template,False
-chart36408,36408,Planta productora en producción - Planta productora en desarrollo - Valor razonable,account.data_account_type_fixed_assets,pe_chart_template,False
-chart36411,36411,Terrenos - Costo,account.data_account_type_fixed_assets,pe_chart_template,False
-chart36412,36412,Terrenos - Revaluación,account.data_account_type_fixed_assets,pe_chart_template,False
-chart36421,36421,Edificaciones - Edificaciones - Costo,account.data_account_type_fixed_assets,pe_chart_template,False
-chart36422,36422,Edificaciones - Edificaciones - Revaluación,account.data_account_type_fixed_assets,pe_chart_template,False
-chart36423,36423,Edificaciones - Edificaciones - Costo de financiación,account.data_account_type_fixed_assets,pe_chart_template,False
-chart36424,36424,Edificaciones - Instalaciones - Costo,account.data_account_type_fixed_assets,pe_chart_template,False
-chart36425,36425,Edificaciones - Instalaciones - Revaluación,account.data_account_type_fixed_assets,pe_chart_template,False
-chart36426,36426,Edificaciones - Instalaciones - Costo de financiación,account.data_account_type_fixed_assets,pe_chart_template,False
-chart36427,36427,Edificaciones - Mejoras en locales arrendados - Costo,account.data_account_type_fixed_assets,pe_chart_template,False
-chart36428,36428,Edificaciones - Mejoras en locales arrendados - Revaluación,account.data_account_type_fixed_assets,pe_chart_template,False
-chart36429,36429,Edificaciones - Mejoras en locales arrendados - Costo de financiación,account.data_account_type_fixed_assets,pe_chart_template,False
-chart36431,36431,Maquinaria y equipo de explotación - Costo,account.data_account_type_fixed_assets,pe_chart_template,False
-chart36432,36432,Maquinaria y equipo de explotación - Revaluación,account.data_account_type_fixed_assets,pe_chart_template,False
-chart36433,36433,Maquinaria y equipo de explotación - Costo de financiación,account.data_account_type_fixed_assets,pe_chart_template,False
-chart36441,36441,Unidades de transporte - Costo,account.data_account_type_fixed_assets,pe_chart_template,False
-chart36442,36442,Unidades de transporte - Revaluación,account.data_account_type_fixed_assets,pe_chart_template,False
-chart36451,36451,Muebles y enseres - Costo,account.data_account_type_fixed_assets,pe_chart_template,False
-chart36452,36452,Muebles y enseres - Revaluación,account.data_account_type_fixed_assets,pe_chart_template,False
-chart36461,36461,Equipos diversos - Costo,account.data_account_type_fixed_assets,pe_chart_template,False
-chart36462,36462,Equipos diversos - Revaluación,account.data_account_type_fixed_assets,pe_chart_template,False
-chart36471,36471,Herramientas y unidades de reemplazo - Herramientas - Costo,account.data_account_type_fixed_assets,pe_chart_template,False
-chart36491,36491,Obras en curso - Costo,account.data_account_type_fixed_assets,pe_chart_template,False
-chart36492,36492,Obras en curso - Revaluación,account.data_account_type_fixed_assets,pe_chart_template,False
-chart36511,36511,"Concesiones, licencias y otros derechos - Costo",account.data_account_type_fixed_assets,pe_chart_template,False
-chart36512,36512,"Concesiones, licencias y otros derechos - Revaluación",account.data_account_type_fixed_assets,pe_chart_template,False
-chart36521,36521,Patentes y propiedad industrial - Costo,account.data_account_type_fixed_assets,pe_chart_template,False
-chart36522,36522,Patentes y propiedad industrial - Revaluación,account.data_account_type_fixed_assets,pe_chart_template,False
-chart36531,36531,Programas de computadora (software) - Costo,account.data_account_type_fixed_assets,pe_chart_template,False
-chart36532,36532,Programas de computadora (software) - Revaluación,account.data_account_type_fixed_assets,pe_chart_template,False
-chart36541,36541,Costos de exploración y desarrollo - Costo,account.data_account_type_fixed_assets,pe_chart_template,False
-chart36542,36542,Costos de exploración y desarrollo - Revaluación,account.data_account_type_fixed_assets,pe_chart_template,False
-chart36543,36543,Costos de exploración y desarrollo - Costo de financiación,account.data_account_type_fixed_assets,pe_chart_template,False
-chart36551,36551,"Fórmulas, diseños y prototipos - Costo",account.data_account_type_fixed_assets,pe_chart_template,False
-chart36552,36552,"Fórmulas, diseños y prototipos - Revaluación",account.data_account_type_fixed_assets,pe_chart_template,False
-chart3657,3657,Plusvalía mercantil,account.data_account_type_fixed_assets,pe_chart_template,False
-chart36591,36591,Otros activos intangibles - Costo,account.data_account_type_fixed_assets,pe_chart_template,False
-chart36592,36592,Otros activos intangibles - Revaluación,account.data_account_type_fixed_assets,pe_chart_template,False
-chart36611,36611,Activos biológicos en producción - Costo,account.data_account_type_fixed_assets,pe_chart_template,False
-chart36613,36613,Activos biológicos en producción - Costo de financiación,account.data_account_type_fixed_assets,pe_chart_template,False
-chart36621,36621,Activos biológicos en desarrollo - Costo,account.data_account_type_fixed_assets,pe_chart_template,False
-chart36622,36622,Activos biológicos en desarrollo - Costo de financiación,account.data_account_type_fixed_assets,pe_chart_template,False
-chart36711,36711,Inversiones a ser mantenidas hasta el vencimiento - Costo,account.data_account_type_fixed_assets,pe_chart_template,False
-chart36721,36721,Inversiones financieras representativas de derecho patrimonial - Costo,account.data_account_type_fixed_assets,pe_chart_template,False
-chart36731,36731,Otras inversiones financieras - Costo,account.data_account_type_fixed_assets,pe_chart_template,False
-chart3711,3711,Impuesto a la renta diferido - Impuesto a la renta diferido – Patrimonio,account.data_account_type_fixed_assets,pe_chart_template,False
-chart3712,3712,Impuesto a la renta diferido - Impuesto a la renta diferido – Resultados,account.data_account_type_fixed_assets,pe_chart_template,False
-chart3721,3721,Participaciones de los trabajadores diferidas - Participaciones de los trabajadores diferidas – Patrimonio,account.data_account_type_fixed_assets,pe_chart_template,False
-chart3722,3722,Participaciones de los trabajadores diferidas - Participaciones de los trabajadores diferidas – Resultados,account.data_account_type_fixed_assets,pe_chart_template,False
-chart3731,3731,Intereses diferidos - Intereses no devengados en transacciones con terceros,account.data_account_type_fixed_assets,pe_chart_template,False
-chart3732,3732,Intereses diferidos - Intereses no devengados en medición a valor descontado,account.data_account_type_fixed_assets,pe_chart_template,False
-chart3811,3811,Bienes de arte y cultura - Obras de arte,account.data_account_type_fixed_assets,pe_chart_template,False
-chart3812,3812,Bienes de arte y cultura - Biblioteca,account.data_account_type_fixed_assets,pe_chart_template,False
-chart3813,3813,Bienes de arte y cultura - Otros,account.data_account_type_fixed_assets,pe_chart_template,False
-chart3821,3821,Diversos - Monedas y joyas,account.data_account_type_fixed_assets,pe_chart_template,False
-chart3822,3822,Diversos - Bienes entregados en comodato,account.data_account_type_fixed_assets,pe_chart_template,False
-chart3823,3823,Diversos - Bienes recibidos en pago (adjudicados y realizables),account.data_account_type_fixed_assets,pe_chart_template,False
-chart3829,3829,Diversos - Otros,account.data_account_type_fixed_assets,pe_chart_template,False
-chart39111,39111,Depreciación acumulada propiedades de inversión - Edificaciones - Costo,account.data_account_type_fixed_assets,pe_chart_template,False
-chart39112,39112,Depreciación acumulada propiedades de inversión - Edificaciones - Revaluación,account.data_account_type_fixed_assets,pe_chart_template,False
-chart39113,39113,Depreciación acumulada propiedades de inversión - Edificaciones - Costo de financiación,account.data_account_type_fixed_assets,pe_chart_template,False
-chart39211,39211,Depreciación acumulada propiedades de inversión - Arrendamiento financiero - Edificaciones - Costo,account.data_account_type_fixed_assets,pe_chart_template,False
-chart39212,39212,Depreciación acumulada propiedades de inversión - Arrendamiento financiero - Edificaciones - Revaluación,account.data_account_type_fixed_assets,pe_chart_template,False
-chart39213,39213,Depreciación acumulada propiedades de inversión - Arrendamiento financiero - Edificaciones - Costo de financiación,account.data_account_type_fixed_assets,pe_chart_template,False
-chart39321,39321,"Depreciación acumulada propiedad, planta y equipo - Arrendamiento financiero - Edificaciones - Costo",account.data_account_type_fixed_assets,pe_chart_template,False
-chart39322,39322,"Depreciación acumulada propiedad, planta y equipo - Arrendamiento financiero - Edificaciones - Revaluación",account.data_account_type_fixed_assets,pe_chart_template,False
-chart39323,39323,"Depreciación acumulada propiedad, planta y equipo - Arrendamiento financiero - Edificaciones - Costo de financiación",account.data_account_type_fixed_assets,pe_chart_template,False
-chart39331,39331,"Depreciación acumulada propiedad, planta y equipo - Arrendamiento financiero - Maquinarias y equipos de explotación - Costo",account.data_account_type_fixed_assets,pe_chart_template,False
-chart39332,39332,"Depreciación acumulada propiedad, planta y equipo - Arrendamiento financiero - Maquinarias y equipos de explotación - Revaluación",account.data_account_type_fixed_assets,pe_chart_template,False
-chart39333,39333,"Depreciación acumulada propiedad, planta y equipo - Arrendamiento financiero - Maquinarias y equipos de explotación - Costo de financiación",account.data_account_type_fixed_assets,pe_chart_template,False
-chart39341,39341,"Depreciación acumulada propiedad, planta y equipo - Arrendamiento financiero - Unidades de transporte - Costo",account.data_account_type_fixed_assets,pe_chart_template,False
-chart39342,39342,"Depreciación acumulada propiedad, planta y equipo - Arrendamiento financiero - Unidades de transporte - Revaluación",account.data_account_type_fixed_assets,pe_chart_template,False
-chart39351,39351,"Depreciación acumulada propiedad, planta y equipo - Arrendamiento financiero - Muebles y enseres - Costo",account.data_account_type_fixed_assets,pe_chart_template,False
-chart39361,39361,"Depreciación acumulada propiedad, planta y equipo - Arrendamiento financiero - Equipos diversos - Costo",account.data_account_type_fixed_assets,pe_chart_template,False
-chart39362,39362,"Depreciación acumulada propiedad, planta y equipo - Arrendamiento financiero - Equipos diversos - Revaluación",account.data_account_type_fixed_assets,pe_chart_template,False
-chart39410,39410,Depreciación acumulada - Arrendamiento operativo - Activos por derecho de uso - arrendamiento operativo - Plantas productoras,account.data_account_type_fixed_assets,pe_chart_template,False
-chart39411,39411,Depreciación acumulada - Arrendamiento operativo - Activos por derecho de uso - arrendamiento operativo - Terrenos,account.data_account_type_fixed_assets,pe_chart_template,False
-chart39412,39412,Depreciación acumulada - Arrendamiento operativo - Activos por derecho de uso - arrendamiento operativo - Edificaciones,account.data_account_type_fixed_assets,pe_chart_template,False
-chart39413,39413,Depreciación acumulada - Arrendamiento operativo - Activos por derecho de uso - arrendamiento operativo - Maquinarias y equipos de explotación,account.data_account_type_fixed_assets,pe_chart_template,False
-chart39414,39414,Depreciación acumulada - Arrendamiento operativo - Activos por derecho de uso - arrendamiento operativo - Unidades de transporte,account.data_account_type_fixed_assets,pe_chart_template,False
-chart39415,39415,Depreciación acumulada - Arrendamiento operativo - Activos por derecho de uso - arrendamiento operativo - Equipos diversos,account.data_account_type_fixed_assets,pe_chart_template,False
-chart39520,39520,"Depreciación acumulada de propiedad, planta y equipo - Depreciación acumulada - Costo - Plantas productoras",account.data_account_type_fixed_assets,pe_chart_template,False
-chart39521,39521,"Depreciación acumulada de propiedad, planta y equipo - Depreciación acumulada - Costo - Edificaciones",account.data_account_type_fixed_assets,pe_chart_template,False
-chart39522,39522,"Depreciación acumulada de propiedad, planta y equipo - Depreciación acumulada - Costo - Instalaciones",account.data_account_type_fixed_assets,pe_chart_template,False
-chart39523,39523,"Depreciación acumulada de propiedad, planta y equipo - Depreciación acumulada - Costo - Mejoras en locales arrendados",account.data_account_type_fixed_assets,pe_chart_template,False
-chart39524,39524,"Depreciación acumulada de propiedad, planta y equipo - Depreciación acumulada - Costo - Maquinarias y equipos de explotación",account.data_account_type_fixed_assets,pe_chart_template,False
-chart39525,39525,"Depreciación acumulada de propiedad, planta y equipo - Depreciación acumulada - Costo - Unidades de transporte",account.data_account_type_fixed_assets,pe_chart_template,False
-chart39526,39526,"Depreciación acumulada de propiedad, planta y equipo - Depreciación acumulada - Costo - Muebles y enseres",account.data_account_type_fixed_assets,pe_chart_template,False
-chart39527,39527,"Depreciación acumulada de propiedad, planta y equipo - Depreciación acumulada - Costo - Equipos diversos",account.data_account_type_fixed_assets,pe_chart_template,False
-chart39528,39528,"Depreciación acumulada de propiedad, planta y equipo - Depreciación acumulada - Costo - Herramientas",account.data_account_type_fixed_assets,pe_chart_template,False
-chart39529,39529,"Depreciación acumulada de propiedad, planta y equipo - Depreciación acumulada - Costo - Unidades de reemplazo",account.data_account_type_fixed_assets,pe_chart_template,False
-chart39530,39530,"Depreciación acumulada de propiedad, planta y equipo - Propiedad, planta y equipo - Revaluación - Plantas productoras",account.data_account_type_fixed_assets,pe_chart_template,False
-chart39531,39531,"Depreciación acumulada de propiedad, planta y equipo - Propiedad, planta y equipo - Revaluación - Edificaciones",account.data_account_type_fixed_assets,pe_chart_template,False
-chart39532,39532,"Depreciación acumulada de propiedad, planta y equipo - Propiedad, planta y equipo - Revaluación - Instalaciones",account.data_account_type_fixed_assets,pe_chart_template,False
-chart39533,39533,"Depreciación acumulada de propiedad, planta y equipo - Propiedad, planta y equipo - Revaluación - Mejoras en locales arrendados",account.data_account_type_fixed_assets,pe_chart_template,False
-chart39534,39534,"Depreciación acumulada de propiedad, planta y equipo - Propiedad, planta y equipo - Revaluación - Maquinarias y equipos de explotación",account.data_account_type_fixed_assets,pe_chart_template,False
-chart39535,39535,"Depreciación acumulada de propiedad, planta y equipo - Propiedad, planta y equipo - Revaluación - Unidades de transporte",account.data_account_type_fixed_assets,pe_chart_template,False
-chart39536,39536,"Depreciación acumulada de propiedad, planta y equipo - Propiedad, planta y equipo - Revaluación - Muebles y enseres",account.data_account_type_fixed_assets,pe_chart_template,False
-chart39537,39537,"Depreciación acumulada de propiedad, planta y equipo - Propiedad, planta y equipo - Revaluación - Equipos diversos",account.data_account_type_fixed_assets,pe_chart_template,False
-chart39538,39538,"Depreciación acumulada de propiedad, planta y equipo - Propiedad, planta y equipo - Revaluación - Herramientas y unidades de reemplazo",account.data_account_type_fixed_assets,pe_chart_template,False
-chart39540,39540,"Depreciación acumulada de propiedad, planta y equipo - Propiedad, planta y equipo - Costo de financiación - Plantas productoras",account.data_account_type_fixed_assets,pe_chart_template,False
-chart39541,39541,"Depreciación acumulada de propiedad, planta y equipo - Propiedad, planta y equipo - Costo de financiación - Edificaciones",account.data_account_type_fixed_assets,pe_chart_template,False
-chart39542,39542,"Depreciación acumulada de propiedad, planta y equipo - Propiedad, planta y equipo - Costo de financiación - Maquinarias y equipos de explotación",account.data_account_type_fixed_assets,pe_chart_template,False
-chart39550,39550,"Depreciación acumulada de propiedad, planta y equipo - Propiedad, planta y equipo - Valor razonable - Plantas productoras",account.data_account_type_fixed_assets,pe_chart_template,False
-chart39611,39611,"Amortización acumulada - Intangibles – Costo - Concesiones, licencias y otros derechos",account.data_account_type_fixed_assets,pe_chart_template,False
-chart39612,39612,Amortización acumulada - Intangibles – Costo - Patentes y propiedad industrial,account.data_account_type_fixed_assets,pe_chart_template,False
-chart39613,39613,Amortización acumulada - Intangibles – Costo - Programas de computadora (software),account.data_account_type_fixed_assets,pe_chart_template,False
-chart39614,39614,Amortización acumulada - Intangibles – Costo - Costos de exploración y desarrollo,account.data_account_type_fixed_assets,pe_chart_template,False
-chart39615,39615,"Amortización acumulada - Intangibles – Costo - Fórmulas, diseños y prototipos",account.data_account_type_fixed_assets,pe_chart_template,False
-chart39619,39619,Amortización acumulada - Intangibles – Costo - Otros activos intangibles,account.data_account_type_fixed_assets,pe_chart_template,False
-chart39621,39621,"Amortización acumulada - Intangibles – Revaluación - Concesiones, licencias y otros derechos",account.data_account_type_fixed_assets,pe_chart_template,False
-chart39622,39622,Amortización acumulada - Intangibles – Revaluación - Patentes y propiedad industrial,account.data_account_type_fixed_assets,pe_chart_template,False
-chart39623,39623,Amortización acumulada - Intangibles – Revaluación - Programas de computadora (software),account.data_account_type_fixed_assets,pe_chart_template,False
-chart39624,39624,Amortización acumulada - Intangibles – Revaluación - Costos de exploración y desarrollo,account.data_account_type_fixed_assets,pe_chart_template,False
-chart39625,39625,"Amortización acumulada - Intangibles – Revaluación - Fórmulas, diseños y prototipos",account.data_account_type_fixed_assets,pe_chart_template,False
-chart39629,39629,Amortización acumulada - Intangibles – Revaluación - Otros activos intangibles,account.data_account_type_fixed_assets,pe_chart_template,False
-chart39633,39633,Amortización acumulada - Intangibles – Costos de financiación - Programas de computadora,account.data_account_type_fixed_assets,pe_chart_template,False
-chart39634,39634,Amortización acumulada - Intangibles – Costos de financiación - Costos de exploración,account.data_account_type_fixed_assets,pe_chart_template,False
-chart39635,39635,Amortización acumulada - Intangibles – Costos de financiación - Costos de desarrollo,account.data_account_type_fixed_assets,pe_chart_template,False
-chart39811,39811,Depreciación acumulada - Activos biológicos en producción - Activos biológicos en producción - Costo - Activos biológicos en producción,account.data_account_type_fixed_assets,pe_chart_template,False
-chart40111,40111,Gobierno nacional - Impuesto general a las ventas - IGV – Cuenta propia,account.data_account_type_current_liabilities,pe_chart_template,False
-chart40112,40112,Gobierno nacional - Impuesto general a las ventas - IGV – Servicios prestados por no domiciliados,account.data_account_type_current_liabilities,pe_chart_template,False
-chart40113,40113,Gobierno nacional - Impuesto general a las ventas - IGV – Régimen de percepciones,account.data_account_type_current_liabilities,pe_chart_template,False
-chart40114,40114,Gobierno nacional - Impuesto general a las ventas - IGV – Régimen de retenciones,account.data_account_type_current_liabilities,pe_chart_template,False
-chart40115,40115,Gobierno nacional - Impuesto general a las ventas - IGV – Importaciones,account.data_account_type_current_liabilities,pe_chart_template,False
-chart40116,40116,Gobierno nacional - Impuesto general a las ventas - IGV – Destinado a operaciones gravadas,account.data_account_type_current_liabilities,pe_chart_template,False
-chart40117,40117,Gobierno nacional - Impuesto general a las ventas - IGV -Destinado a operaciones comunes,account.data_account_type_current_liabilities,pe_chart_template,False
-chart4012,4012,Gobierno nacional - Impuesto selectivo al consumo,account.data_account_type_current_liabilities,pe_chart_template,False
-chart40151,40151,Gobierno nacional - Derechos aduaneros - Derechos arancelarios,account.data_account_type_current_liabilities,pe_chart_template,False
-chart40152,40152,Gobierno nacional - Derechos aduaneros - Otros derechos arancelarios,account.data_account_type_current_liabilities,pe_chart_template,False
-chart40171,40171,Gobierno nacional - Impuesto a la renta - Renta de tercera categoría,account.data_account_type_current_liabilities,pe_chart_template,False
-chart40172,40172,Gobierno nacional - Impuesto a la renta - Renta de cuarta categoría,account.data_account_type_current_liabilities,pe_chart_template,False
-chart40173,40173,Gobierno nacional - Impuesto a la renta - Renta de quinta categoría,account.data_account_type_current_liabilities,pe_chart_template,False
-chart40174,40174,Gobierno nacional - Impuesto a la renta - Renta de no domiciliados,account.data_account_type_current_liabilities,pe_chart_template,False
-chart40175,40175,Gobierno nacional - Impuesto a la renta - Otras retenciones,account.data_account_type_current_liabilities,pe_chart_template,False
-chart40181,40181,Gobierno nacional - Otros impuestos y contraprestaciones - Impuesto a las transacciones financieras,account.data_account_type_current_liabilities,pe_chart_template,False
-chart40182,40182,Gobierno nacional - Otros impuestos y contraprestaciones - Impuesto a los juegos de casino y tragamonedas,account.data_account_type_current_liabilities,pe_chart_template,False
-chart40183,40183,Gobierno nacional - Otros impuestos y contraprestaciones - Tasas por la prestación de servicios públicos,account.data_account_type_current_liabilities,pe_chart_template,False
-chart40184,40184,Gobierno nacional - Otros impuestos y contraprestaciones - Regalías,account.data_account_type_current_liabilities,pe_chart_template,False
-chart40185,40185,Gobierno nacional - Otros impuestos y contraprestaciones - Impuesto a los dividendos,account.data_account_type_current_liabilities,pe_chart_template,False
-chart40186,40186,Gobierno nacional - Otros impuestos y contraprestaciones - Impuesto temporal a los activos netos,account.data_account_type_current_liabilities,pe_chart_template,False
-chart40189,40189,Gobierno nacional - Otros impuestos y contraprestaciones - Otros impuestos,account.data_account_type_current_liabilities,pe_chart_template,False
-chart402,402,Certificados tributarios,account.data_account_type_current_liabilities,pe_chart_template,False
-chart4031,4031,Instituciones públicas - ESSALUD,account.data_account_type_current_liabilities,pe_chart_template,False
-chart4032,4032,Instituciones públicas - ONP,account.data_account_type_current_liabilities,pe_chart_template,False
-chart4033,4033,Instituciones públicas - Contribución al SENATI,account.data_account_type_current_liabilities,pe_chart_template,False
-chart4034,4034,Instituciones públicas - Contribución al SENCICO,account.data_account_type_current_liabilities,pe_chart_template,False
-chart4039,4039,Instituciones públicas - Otras instituciones,account.data_account_type_current_liabilities,pe_chart_template,False
-chart405,405,Gobiernos regionales,account.data_account_type_current_liabilities,pe_chart_template,False
-chart40611,40611,Gobiernos locales - Impuestos - Impuesto al patrimonio vehicular,account.data_account_type_current_liabilities,pe_chart_template,False
-chart40612,40612,Gobiernos locales - Impuestos - Impuesto a las apuestas,account.data_account_type_current_liabilities,pe_chart_template,False
-chart40613,40613,Gobiernos locales - Impuestos - Impuesto a los juegos,account.data_account_type_current_liabilities,pe_chart_template,False
-chart40614,40614,Gobiernos locales - Impuestos - Impuesto de alcabala,account.data_account_type_current_liabilities,pe_chart_template,False
-chart40615,40615,Gobiernos locales - Impuestos - Impuesto predial,account.data_account_type_current_liabilities,pe_chart_template,False
-chart40616,40616,Gobiernos locales - Impuestos - Impuesto a los espectáculos públicos no deportivos,account.data_account_type_current_liabilities,pe_chart_template,False
-chart4062,4062,Gobiernos locales - Contribuciones,account.data_account_type_current_liabilities,pe_chart_template,False
-chart40631,40631,Gobiernos locales - Tasas - Licencia de apertura de establecimientos,account.data_account_type_current_liabilities,pe_chart_template,False
-chart40632,40632,Gobiernos locales - Tasas - Transporte público,account.data_account_type_current_liabilities,pe_chart_template,False
-chart40633,40633,Gobiernos locales - Tasas - Estacionamiento de vehículos,account.data_account_type_current_liabilities,pe_chart_template,False
-chart40634,40634,Gobiernos locales - Tasas - Servicios públicos o arbitrios,account.data_account_type_current_liabilities,pe_chart_template,False
-chart40635,40635,Gobiernos locales - Tasas - Servicios administrativos o derechos,account.data_account_type_current_liabilities,pe_chart_template,False
-chart409,409,Otros costos administrativos e intereses,account.data_account_type_current_liabilities,pe_chart_template,False
-chart4111,4111,Remuneraciones por pagar - Sueldos y salarios por pagar,account.data_account_type_payable,pe_chart_template,True
-chart4112,4112,Remuneraciones por pagar - Comisiones por pagar,account.data_account_type_payable,pe_chart_template,True
-chart4113,4113,Remuneraciones por pagar - Remuneraciones en especie por pagar,account.data_account_type_payable,pe_chart_template,True
-chart4114,4114,Remuneraciones por pagar - Gratificaciones por pagar,account.data_account_type_payable,pe_chart_template,True
-chart4115,4115,Remuneraciones por pagar - Vacaciones por pagar,account.data_account_type_payable,pe_chart_template,True
-chart413,413,Participaciones de los trabajadores por pagar,account.data_account_type_payable,pe_chart_template,True
-chart4151,4151,Beneficios sociales de los trabajadores por pagar - Compensación por tiempo de servicios,account.data_account_type_payable,pe_chart_template,True
-chart4152,4152,Beneficios sociales de los trabajadores por pagar - Adelanto de compensación por tiempo de servicios,account.data_account_type_payable,pe_chart_template,True
-chart4153,4153,Beneficios sociales de los trabajadores por pagar - Pensiones y jubilaciones,account.data_account_type_payable,pe_chart_template,True
-chart417,417,Administradoras de fondos de pensiones,account.data_account_type_payable,pe_chart_template,True
-chart419,419,Otras remuneraciones y participaciones por pagar,account.data_account_type_payable,pe_chart_template,True
-chart4211,4211,"Facturas, boletas y otros comprobantes por pagar - No emitidas",account.data_account_type_payable,pe_chart_template,True
-chart4212,4212,"Facturas, boletas y otros comprobantes por pagar - Emitidas",account.data_account_type_payable,pe_chart_template,True
-chart422,422,Anticipos a proveedores,account.data_account_type_payable,pe_chart_template,True
-chart423,423,Letras por pagar,account.data_account_type_payable,pe_chart_template,True
-chart424,424,Honorarios por pagar,account.data_account_type_payable,pe_chart_template,True
-chart4311,4311,"Facturas, boletas y otros comprobantes por pagar - No emitidas",account.data_account_type_payable,pe_chart_template,True
-chart4312,4312,"Facturas, boletas y otros comprobantes por pagar - Emitidas",account.data_account_type_payable,pe_chart_template,True
-chart4321,4321,Anticipos otorgados - Anticipos otorgados,account.data_account_type_payable,pe_chart_template,True
-chart4331,4331,Letras por pagar - Letras por pagar,account.data_account_type_payable,pe_chart_template,True
-chart4341,4341,Honorarios por pagar - Honorarios por pagar,account.data_account_type_payable,pe_chart_template,True
-chart4411,4411,"Accionistas ( socios, partícipes) - Préstamos",account.data_account_type_non_current_liabilities,pe_chart_template,False
-chart4412,4412,"Accionistas ( socios, partícipes) - Dividendos",account.data_account_type_non_current_liabilities,pe_chart_template,False
-chart4419,4419,"Accionistas ( socios, partícipes) - Otras cuentas por pagar",account.data_account_type_non_current_liabilities,pe_chart_template,False
-chart4421,4421,Directores - Dietas,account.data_account_type_non_current_liabilities,pe_chart_template,False
-chart4429,4429,Directores - Otras cuentas por pagar,account.data_account_type_non_current_liabilities,pe_chart_template,False
-chart4511,4511,Préstamos de instituciones financieras y otras entidades - Instituciones financieras,account.data_account_type_current_liabilities,pe_chart_template,False
-chart4512,4512,Préstamos de instituciones financieras y otras entidades - Otras entidades,account.data_account_type_current_liabilities,pe_chart_template,False
-chart452,452,Contratos de arrendamiento financiero,account.data_account_type_current_liabilities,pe_chart_template,False
-chart4531,4531,Obligaciones emitidas - Bonos emitidos,account.data_account_type_current_liabilities,pe_chart_template,False
-chart4532,4532,Obligaciones emitidas - Bonos titulizados,account.data_account_type_current_liabilities,pe_chart_template,False
-chart4533,4533,Obligaciones emitidas - Papeles comerciales,account.data_account_type_current_liabilities,pe_chart_template,False
-chart4539,4539,Obligaciones emitidas - Otras obligaciones,account.data_account_type_current_liabilities,pe_chart_template,False
-chart4541,4541,Otros Instrumentos financieros por pagar - Letras,account.data_account_type_current_liabilities,pe_chart_template,False
-chart4542,4542,Otros Instrumentos financieros por pagar - Papeles comerciales,account.data_account_type_current_liabilities,pe_chart_template,False
-chart4543,4543,Otros Instrumentos financieros por pagar - Bonos,account.data_account_type_current_liabilities,pe_chart_template,False
-chart4544,4544,Otros Instrumentos financieros por pagar - Pagarés,account.data_account_type_current_liabilities,pe_chart_template,False
-chart4545,4545,Otros Instrumentos financieros por pagar - Facturas conformadas,account.data_account_type_current_liabilities,pe_chart_template,False
-chart4549,4549,Otros Instrumentos financieros por pagar - Otras obligaciones financieras,account.data_account_type_current_liabilities,pe_chart_template,False
-chart45511,45511,Costos de financiación por pagar - Préstamos de instituciones financieras y otras entidades - Instituciones financieras,account.data_account_type_current_liabilities,pe_chart_template,False
-chart45512,45512,Costos de financiación por pagar - Préstamos de instituciones financieras y otras entidades - Otras entidades,account.data_account_type_current_liabilities,pe_chart_template,False
-chart4552,4552,Costos de financiación por pagar - Contratos de arrendamiento financiero,account.data_account_type_current_liabilities,pe_chart_template,False
-chart45531,45531,Costos de financiación por pagar - Obligaciones emitidas - Bonos emitidos,account.data_account_type_current_liabilities,pe_chart_template,False
-chart45532,45532,Costos de financiación por pagar - Obligaciones emitidas - Bonos titulizados,account.data_account_type_current_liabilities,pe_chart_template,False
-chart45533,45533,Costos de financiación por pagar - Obligaciones emitidas - Papeles comerciales,account.data_account_type_current_liabilities,pe_chart_template,False
-chart45539,45539,Costos de financiación por pagar - Obligaciones emitidas - Otras obligaciones,account.data_account_type_current_liabilities,pe_chart_template,False
-chart45541,45541,Costos de financiación por pagar - Otros instrumentos financieros por pagar - Letras,account.data_account_type_current_liabilities,pe_chart_template,False
-chart45542,45542,Costos de financiación por pagar - Otros instrumentos financieros por pagar - Papeles comerciales,account.data_account_type_current_liabilities,pe_chart_template,False
-chart45543,45543,Costos de financiación por pagar - Otros instrumentos financieros por pagar - Bonos,account.data_account_type_current_liabilities,pe_chart_template,False
-chart45544,45544,Costos de financiación por pagar - Otros instrumentos financieros por pagar - Pagarés,account.data_account_type_current_liabilities,pe_chart_template,False
-chart45545,45545,Costos de financiación por pagar - Otros instrumentos financieros por pagar - Facturas conformadas,account.data_account_type_current_liabilities,pe_chart_template,False
-chart45549,45549,Costos de financiación por pagar - Otros instrumentos financieros por pagar - Otras obligaciones financieras,account.data_account_type_current_liabilities,pe_chart_template,False
-chart456,456,Préstamos con compromisos de recompra,account.data_account_type_current_liabilities,pe_chart_template,False
-chart461,461,Reclamaciones de terceros,account.data_account_type_payable,pe_chart_template,True
-chart4641,4641,Pasivos por instrumentos financieros - Instrumentos financieros primarios,account.data_account_type_payable,pe_chart_template,True
-chart46421,46421,Pasivos por instrumentos financieros - Instrumentos financieros derivados - Cartera de negociación,account.data_account_type_payable,pe_chart_template,True
-chart46422,46422,Pasivos por instrumentos financieros - Instrumentos financieros derivados - Instrumentos de cobertura,account.data_account_type_payable,pe_chart_template,True
-chart4651,4651,Pasivos por compra de activo inmovilizado - Inversiones mobiliarias,account.data_account_type_payable,pe_chart_template,True
-chart4652,4652,Pasivos por compra de activo inmovilizado - Propiedades de inversión,account.data_account_type_payable,pe_chart_template,True
-chart4653,4653,Pasivos por compra de activo inmovilizado - Activos adquiridos en arrendamiento financiero,account.data_account_type_payable,pe_chart_template,True
-chart4654,4654,"Pasivos por compra de activo inmovilizado - Propiedad, planta y equipo",account.data_account_type_payable,pe_chart_template,True
-chart4655,4655,Pasivos por compra de activo inmovilizado - Intangibles,account.data_account_type_payable,pe_chart_template,True
-chart4656,4656,Pasivos por compra de activo inmovilizado - Activos biológicos,account.data_account_type_payable,pe_chart_template,True
-chart466,466,Participación de terceros en acuerdos conjuntos,account.data_account_type_payable,pe_chart_template,True
-chart467,467,Depósitos recibidos en garantía,account.data_account_type_payable,pe_chart_template,True
-chart4691,4691,Otras cuentas por pagar diversas - Subsidios gubernamentales,account.data_account_type_payable,pe_chart_template,True
-chart4692,4692,Otras cuentas por pagar diversas - Donaciones condicionadas,account.data_account_type_payable,pe_chart_template,True
-chart4699,4699,Otras cuentas por pagar diversas - Otras cuentas por pagar,account.data_account_type_payable,pe_chart_template,True
-chart471,471,Préstamos,account.data_account_type_payable,pe_chart_template,True
-chart472,472,Costos de financiación,account.data_account_type_payable,pe_chart_template,True
-chart473,473,Anticipos recibidos,account.data_account_type_payable,pe_chart_template,True
-chart474,474,Regalías,account.data_account_type_payable,pe_chart_template,True
-chart475,475,Dividendos,account.data_account_type_payable,pe_chart_template,True
-chart476,476,Depósitos recibidos en garantía,account.data_account_type_payable,pe_chart_template,True
-chart4771,4771,Pasivo por compra de activo inmovilizado - Inversiones mobiliarias,account.data_account_type_payable,pe_chart_template,True
-chart4772,4772,Pasivo por compra de activo inmovilizado - Inversiones inmobiliarias,account.data_account_type_payable,pe_chart_template,True
-chart4773,4773,Pasivo por compra de activo inmovilizado - Activos adquiridos en arrendamiento financiero,account.data_account_type_payable,pe_chart_template,True
-chart4774,4774,"Pasivo por compra de activo inmovilizado - Propiedad, planta y equipo",account.data_account_type_payable,pe_chart_template,True
-chart4775,4775,Pasivo por compra de activo inmovilizado - Intangibles,account.data_account_type_payable,pe_chart_template,True
-chart4776,4776,Pasivo por compra de activo inmovilizado - Activos biológicos,account.data_account_type_payable,pe_chart_template,True
-chart4791,4791,Otras cuentas por pagar diversas - Otras cuentas por pagar diversas,account.data_account_type_payable,pe_chart_template,True
-chart481,481,Provisión para litigios,account.data_account_type_non_current_liabilities,pe_chart_template,False
-chart482,482,"Provisión por desmantelamiento, retiro o rehabilitación del inmovilizado",account.data_account_type_non_current_liabilities,pe_chart_template,False
-chart483,483,Provisión para reestructuraciones,account.data_account_type_non_current_liabilities,pe_chart_template,False
-chart484,484,Provisión para protección y remediación del medio ambiente,account.data_account_type_non_current_liabilities,pe_chart_template,False
-chart485,485,Provisión para gastos de responsabilidad social,account.data_account_type_non_current_liabilities,pe_chart_template,False
-chart486,486,Provisión para garantías,account.data_account_type_non_current_liabilities,pe_chart_template,False
-chart487,487,Provisión por activos por derecho de uso,account.data_account_type_non_current_liabilities,pe_chart_template,False
-chart489,489,Otras provisiones,account.data_account_type_non_current_liabilities,pe_chart_template,False
-chart4911,4911,Impuesto a la renta diferido - Impuesto a la renta diferido – Patrimonio,account.data_account_type_current_liabilities,pe_chart_template,False
-chart4912,4912,Impuesto a la renta diferido - Impuesto a la renta diferido – Resultados,account.data_account_type_current_liabilities,pe_chart_template,False
-chart4921,4921,Participaciones de los trabajadores diferidas - Participaciones de los trabajadores diferidas – Patrimonio,account.data_account_type_current_liabilities,pe_chart_template,False
-chart4922,4922,Participaciones de los trabajadores diferidas - Participaciones de los trabajadores diferidas – Resultados,account.data_account_type_current_liabilities,pe_chart_template,False
-chart4931,4931,Intereses diferidos - Intereses no devengados en transacciones con terceros,account.data_account_type_current_liabilities,pe_chart_template,False
-chart4932,4932,Intereses diferidos - Intereses no devengados en medición a valor descontado,account.data_account_type_current_liabilities,pe_chart_template,False
-chart494,494,Ganancia en venta con arrendamiento financiero paralelo,account.data_account_type_current_liabilities,pe_chart_template,False
-chart495,495,Subsidios recibidos diferidos,account.data_account_type_current_liabilities,pe_chart_template,False
-chart496,496,Ingresos diferidos,account.data_account_type_current_liabilities,pe_chart_template,False
-chart497,497,Costos diferidos,account.data_account_type_current_liabilities,pe_chart_template,False
-chart5011,5011,Capital social - Acciones,account.data_account_type_equity,pe_chart_template,False
-chart5012,5012,Capital social - Participaciones,account.data_account_type_equity,pe_chart_template,False
-chart502,502,Acciones en tesorería,account.data_account_type_equity,pe_chart_template,False
-chart511,511,Acciones de inversión,account.data_account_type_equity,pe_chart_template,False
-chart512,512,Acciones de inversión en tesorería,account.data_account_type_equity,pe_chart_template,False
-chart521,521,Primas (descuento) de acciones,account.data_account_type_equity,pe_chart_template,False
-chart5221,5221,Capitalizaciones en trámite - Aportes,account.data_account_type_equity,pe_chart_template,False
-chart5222,5222,Capitalizaciones en trámite - Reservas,account.data_account_type_equity,pe_chart_template,False
-chart5223,5223,Capitalizaciones en trámite - Acreencias,account.data_account_type_equity,pe_chart_template,False
-chart5224,5224,Capitalizaciones en trámite - Utilidades,account.data_account_type_equity,pe_chart_template,False
-chart523,523,Reducciones de capital pendientes de formalización,account.data_account_type_equity,pe_chart_template,False
-chart561,561,Diferencia en cambio de inversiones permanentes en entidades extranjeras,account.data_account_type_equity,pe_chart_template,False
-chart562,562,Instrumentos financieros – Coberturas,account.data_account_type_equity,pe_chart_template,False
-chart5631,5631,Resultado en activos o pasivos financieros mantenidos para negociación - Ganancia,account.data_account_type_equity,pe_chart_template,False
-chart5632,5632,Resultado en activos o pasivos financieros mantenidos para negociación - Pérdida,account.data_account_type_equity,pe_chart_template,False
-chart5641,5641,Resultado en otros activos o pasivos por inversiones financieras - Ganancia,account.data_account_type_equity,pe_chart_template,False
-chart5642,5642,Resultado en otros activos o pasivos por inversiones financieras - Pérdida,account.data_account_type_equity,pe_chart_template,False
-chart5651,5651,Resultado en activos o pasivos financieros mantenidos para negociación – Compra o venta convencional fecha de liquidación - Ganancia,account.data_account_type_equity,pe_chart_template,False
-chart5652,5652,Resultado en activos o pasivos financieros mantenidos para negociación – Compra o venta convencional fecha de liquidación - Pérdida,account.data_account_type_equity,pe_chart_template,False
-chart57111,57111,Excedente de revaluación - Propiedad de inversión - Adquisición directa,account.data_account_type_equity,pe_chart_template,False
-chart57112,57112,Excedente de revaluación - Propiedad de inversión - Arrendamiento financiero,account.data_account_type_equity,pe_chart_template,False
-chart57121,57121,"Excedente de revaluación - Propiedad, planta y equipo - Adquisición directa",account.data_account_type_equity,pe_chart_template,False
-chart57122,57122,"Excedente de revaluación - Propiedad, planta y equipo - Arrendamiento financiero",account.data_account_type_equity,pe_chart_template,False
-chart5713,5713,Excedente de revaluación - Intangibles,account.data_account_type_equity,pe_chart_template,False
-chart5714,5714,Excedente de revaluación - Activos por derecho de uso - arrendamiento operativo,account.data_account_type_equity,pe_chart_template,False
-chart572,572,Excedente de revaluación – Acciones liberadas recibidas,account.data_account_type_equity,pe_chart_template,False
-chart573,573,Participación en excedente de revaluación – Inversiones en entidades relacionadas,account.data_account_type_equity,pe_chart_template,False
-chart581,581,Reinversión,account.data_account_type_equity,pe_chart_template,False
+chart0111,0111,Goods and securities delivered,account.data_account_off_sheet,pe_chart_template,False
+chart0112,0112,Rights on financial instruments,account.data_account_off_sheet,pe_chart_template,False
+chart0113,0113,Other debit memorandum accounts,account.data_account_off_sheet,pe_chart_template,False
+chart0114,0114,Debitors offset,account.data_account_off_sheet,pe_chart_template,False
+chart0126,0126,Goods and values received,account.data_account_off_sheet,pe_chart_template,False
+chart0127,0127,Commitments on financial instruments,account.data_account_off_sheet,pe_chart_template,False
+chart0128,0128,Other credit memorandum accounts,account.data_account_off_sheet,pe_chart_template,False
+chart0129,0129,Creditors offset,account.data_account_off_sheet,pe_chart_template,False
+chart0211,0211,Goods and securities delivered,account.data_account_off_sheet,pe_chart_template,False
+chart0213,0213,Rights on financial instruments,account.data_account_off_sheet,pe_chart_template,False
+chart0214,0214,Other debit memorandum accounts,account.data_account_off_sheet,pe_chart_template,False
+chart0215,0215,Offsetting accounts debit memorandum,account.data_account_off_sheet,pe_chart_template,False
+chart0226,0226,Goods and values received,account.data_account_off_sheet,pe_chart_template,False
+chart0227,0227,Commitments on financial instruments,account.data_account_off_sheet,pe_chart_template,False
+chart0228,0228,Other credit memorandum accounts,account.data_account_off_sheet,pe_chart_template,False
+chart0229,0229,Counterpart creditor memorandum accounts,account.data_account_off_sheet,pe_chart_template,False
+chart101,101,Cash,account.data_account_type_liquidity,pe_chart_template,False
+chart102,102,Fixed funds,account.data_account_type_liquidity,pe_chart_template,False
+chart1031,1031,Fixed funds - Cash in transit,account.data_account_type_liquidity,pe_chart_template,False
+chart1032,1032,Fixed funds - Checks in transit,account.data_account_type_liquidity,pe_chart_template,False
+chart1041,1041,Current accounts in financial institutions - Operating checking accounts,account.data_account_type_liquidity,pe_chart_template,False
+chart1042,1042,Current accounts in financial institutions - Current accounts for specific purposes,account.data_account_type_liquidity,pe_chart_template,False
+chart1051,1051,Other cash equivalents - Other cash equivalents,account.data_account_type_liquidity,pe_chart_template,False
+chart1061,1061,Deposits in financial institutions - Savings deposits,account.data_account_type_liquidity,pe_chart_template,False
+chart1062,1062,Deposits in financial institutions - Time deposits,account.data_account_type_liquidity,pe_chart_template,False
+chart1071,1071,Restricted Funds - Funds in guarantee,account.data_account_type_liquidity,pe_chart_template,False
+chart1072,1072,Restricted Funds - Funds withheld by mandate of the authority,account.data_account_type_liquidity,pe_chart_template,False
+chart1073,1073,Restricted Funds - Other restricted funds,account.data_account_type_liquidity,pe_chart_template,False
+chart11111,11111,Investments held for trading - Securities issued or guaranteed by the State - Costs,account.data_account_type_current_assets,pe_chart_template,True
+chart11112,11112,Investments held for trading - Securities issued or guaranteed by the State - Fair value,account.data_account_type_current_assets,pe_chart_template,True
+chart11121,11121,Investments held for trading - Securities issued by the financial system - Costs,account.data_account_type_current_assets,pe_chart_template,True
+chart11122,11122,Investments held for trading - Securities issued by the financial system - Fair value,account.data_account_type_current_assets,pe_chart_template,True
+chart11131,11131,Investments held for trading - Securities issued by entities - Costs,account.data_account_type_current_assets,pe_chart_template,True
+chart11132,11132,Investments held for trading - Securities issued by entities - Fair value,account.data_account_type_current_assets,pe_chart_template,True
+chart11141,11141,Investments held for trading - Other debt instruments - Costs,account.data_account_type_current_assets,pe_chart_template,True
+chart11142,11142,Investments held for trading - Other debt instruments - Fair value,account.data_account_type_current_assets,pe_chart_template,True
+chart11151,11151,Investments held for trading - Holdings in entities - Costs,account.data_account_type_current_assets,pe_chart_template,True
+chart11152,11152,Investments held for trading - Holdings in entities - Fair value,account.data_account_type_current_assets,pe_chart_template,True
+chart11211,11211,Other financial investments - Other financial investments - Costs,account.data_account_type_current_assets,pe_chart_template,True
+chart11212,11212,Other financial investments - Other financial investments - Fair value,account.data_account_type_current_assets,pe_chart_template,True
+chart11311,11311,Financial assets – Purchase agreements - Investments held for trading – Purchase agreements - Costs,account.data_account_type_current_assets,pe_chart_template,True
+chart11312,11312,Financial assets – Purchase agreements - Investments held for trading – Purchase agreements - Fair value,account.data_account_type_current_assets,pe_chart_template,True
+chart11321,11321,Financial assets – Purchase agreements - Other financial investments - Costs,account.data_account_type_current_assets,pe_chart_template,True
+chart11322,11322,Financial assets – Purchase agreements - Other financial investments - Fair value,account.data_account_type_current_assets,pe_chart_template,True
+chart1211,1211,"Invoices, tickets and other receipts receivable - Not issued",account.data_account_type_receivable,pe_chart_template,True
+chart1212,1212,"Invoices, tickets and other receipts receivable - Issued in portfolio",account.data_account_type_receivable,pe_chart_template,True
+chart1213,1213,"Invoices, tickets and other receipts receivable - In collection",account.data_account_type_receivable,pe_chart_template,True
+chart1214,1214,"Invoices, tickets and other receipts receivable - Off sale",account.data_account_type_receivable,pe_chart_template,True
+chart1215,1215,"Accounts receivable ... - Invoices, tickets and other receipts receivable not issued (PoS)",account.data_account_type_receivable,pe_chart_template,True
+chart122,122,Advances from customers,account.data_account_type_receivable,pe_chart_template,True
+chart1232,1232,Bills to be collected - In portfolio,account.data_account_type_receivable,pe_chart_template,True
+chart1233,1233,Bills to be collected - In collection,account.data_account_type_receivable,pe_chart_template,True
+chart1234,1234,Bills to be collected - Off sale,account.data_account_type_receivable,pe_chart_template,True
+chart1311,1311,"Invoices, tickets and other receipts receivable - Not issued",account.data_account_type_receivable,pe_chart_template,True
+chart1312,1312,"Invoices, tickets and other receipts receivable - In portfolio",account.data_account_type_receivable,pe_chart_template,True
+chart1313,1313,"Invoices, tickets and other receipts receivable - In collection",account.data_account_type_receivable,pe_chart_template,True
+chart1314,1314,"Invoices, tickets and other receipts receivable - Off sale",account.data_account_type_receivable,pe_chart_template,True
+chart1321,1321,Advances received - Advances received,account.data_account_type_receivable,pe_chart_template,True
+chart1331,1331,Bills to be collected - In portfolio,account.data_account_type_receivable,pe_chart_template,True
+chart1332,1332,Bills to be collected - In collection,account.data_account_type_receivable,pe_chart_template,True
+chart1333,1333,Bills to be collected - Off sale,account.data_account_type_receivable,pe_chart_template,True
+chart1411,1411,Staff - Loans,account.data_account_type_receivable,pe_chart_template,True
+chart1412,1412,Staff - Salary advance,account.data_account_type_receivable,pe_chart_template,True
+chart1413,1413,Staff - Deliveries to account,account.data_account_type_receivable,pe_chart_template,True
+chart1419,1419,Staff - Other accounts receivable from staff,account.data_account_type_receivable,pe_chart_template,True
+chart1421,1421,Shareholders (or partners) - Subscriptions receivable from partners or shareholders,account.data_account_type_receivable,pe_chart_template,True
+chart1422,1422,Shareholders (or partners) - Loans,account.data_account_type_receivable,pe_chart_template,True
+chart1431,1431,Directors - Loans,account.data_account_type_receivable,pe_chart_template,True
+chart1432,1432,Directors - Advance of daily subsistence allowance,account.data_account_type_receivable,pe_chart_template,True
+chart1433,1433,Directors - Deliveries to account,account.data_account_type_receivable,pe_chart_template,True
+chart149,149,Various,account.data_account_type_receivable,pe_chart_template,True
+chart1611,1611,Loans - With guarantee,account.data_account_type_receivable,pe_chart_template,True
+chart1612,1612,Loans - Whithout garantee,account.data_account_type_receivable,pe_chart_template,True
+chart1621,1621,Claims to third parties - Insurance companies,account.data_account_type_receivable,pe_chart_template,True
+chart1622,1622,Claims to third parties - Transportation,account.data_account_type_receivable,pe_chart_template,True
+chart1623,1623,Claims to third parties - Public services,account.data_account_type_receivable,pe_chart_template,True
+chart1624,1624,Claims to third parties - Taxes,account.data_account_type_receivable,pe_chart_template,True
+chart1629,1629,Claims to third parties - Others,account.data_account_type_receivable,pe_chart_template,True
+chart1631,1631,"Interest, royalties and dividends - Interests",account.data_account_type_receivable,pe_chart_template,True
+chart1632,1632,"Interest, royalties and dividends - Royalties",account.data_account_type_receivable,pe_chart_template,True
+chart1633,1633,"Interest, royalties and dividends - Dividends",account.data_account_type_receivable,pe_chart_template,True
+chart1641,1641,Deposits granted in guarantee - Loans from financial institutions,account.data_account_type_receivable,pe_chart_template,True
+chart1642,1642,Deposits granted in guarantee - Loans from non-financial institutions,account.data_account_type_receivable,pe_chart_template,True
+chart1643,1643,Deposits granted in guarantee - Security deposits for rentals,account.data_account_type_receivable,pe_chart_template,True
+chart1649,1649,Deposits granted in guarantee - Other security deposits,account.data_account_type_receivable,pe_chart_template,True
+chart1651,1651,Sale of fixed assets - Property investment,account.data_account_type_receivable,pe_chart_template,True
+chart1652,1652,Sale of fixed assets - Investment property,account.data_account_type_receivable,pe_chart_template,True
+chart1653,1653,"Sale of fixed assets - Property, plant and equipment",account.data_account_type_receivable,pe_chart_template,True
+chart1654,1654,Sale of fixed assets - Intangibles,account.data_account_type_receivable,pe_chart_template,True
+chart1655,1655,Sale of fixed assets - Biological assets,account.data_account_type_receivable,pe_chart_template,True
+chart1659,1659,Sale of fixed assets - Otros activos inmovilizados,account.data_account_type_receivable,pe_chart_template,True
+chart16611,16611,Assets for financial instruments - Primary financial instruments - Costs,account.data_account_type_receivable,pe_chart_template,True
+chart16612,16612,Assets for financial instruments - Primary financial instruments - Fair value,account.data_account_type_receivable,pe_chart_template,True
+chart16621,16621,Assets for financial instruments - Derivative financial instruments - Costs,account.data_account_type_receivable,pe_chart_template,True
+chart16622,16622,Assets for financial instruments - Derivative financial instruments - Fair value,account.data_account_type_receivable,pe_chart_template,True
+chart1671,1671,Taxes to be credited - Payments on account of income tax,account.data_account_type_receivable,pe_chart_template,True
+chart1672,1672,Taxes to be credited - ITAN account payments,account.data_account_type_receivable,pe_chart_template,True
+chart1673,1673,Taxes to be credited - IGV to be credited on purchases,account.data_account_type_receivable,pe_chart_template,True
+chart1674,1674,Taxes to be credited - IGV to credit non-residents,account.data_account_type_receivable,pe_chart_template,True
+chart1675,1675,Taxes to be credited - Works for taxes,account.data_account_type_receivable,pe_chart_template,True
+chart1691,1691,Other sundry accounts receivable - Deliveries to account to third parties,account.data_account_type_receivable,pe_chart_template,True
+chart1699,1699,Other sundry accounts receivable - Other sundry accounts receivable,account.data_account_type_receivable,pe_chart_template,True
+chart1711,1711,Loans - With guarantee,account.data_account_type_receivable,pe_chart_template,True
+chart1712,1712,Loans - Whithout garantee,account.data_account_type_receivable,pe_chart_template,True
+chart1731,1731,"Interest, royalties and dividends - Interests",account.data_account_type_receivable,pe_chart_template,True
+chart1732,1732,"Interest, royalties and dividends - Royalties",account.data_account_type_receivable,pe_chart_template,True
+chart1733,1733,"Interest, royalties and dividends - Dividends",account.data_account_type_receivable,pe_chart_template,True
+chart1741,1741,Deposits granted in guarantee - Loans from financial institutions,account.data_account_type_receivable,pe_chart_template,True
+chart1742,1742,Deposits granted in guarantee - Loans from non-financial institutions,account.data_account_type_receivable,pe_chart_template,True
+chart1743,1743,Deposits granted in guarantee - Security deposits for rentals,account.data_account_type_receivable,pe_chart_template,True
+chart1749,1749,Deposits granted in guarantee - Other security deposits,account.data_account_type_receivable,pe_chart_template,True
+chart1751,1751,Sale of fixed assets - Property investment,account.data_account_type_receivable,pe_chart_template,True
+chart1752,1752,Sale of fixed assets - Investment property,account.data_account_type_receivable,pe_chart_template,True
+chart1753,1753,"Sale of fixed assets - Property, plant and equipment",account.data_account_type_receivable,pe_chart_template,True
+chart1754,1754,Sale of fixed assets - Intangibles,account.data_account_type_receivable,pe_chart_template,True
+chart1755,1755,Sale of fixed assets - Biological assets,account.data_account_type_receivable,pe_chart_template,True
+chart1759,1759,Sale of fixed assets - Otros activos inmovilizados,account.data_account_type_receivable,pe_chart_template,True
+chart17611,17611,Assets for financial instruments - Primary financial instruments - Costs,account.data_account_type_receivable,pe_chart_template,True
+chart17612,17612,Assets for financial instruments - Primary financial instruments - Fair value,account.data_account_type_receivable,pe_chart_template,True
+chart17621,17621,Assets for financial instruments - Derivative financial instruments - Costs,account.data_account_type_receivable,pe_chart_template,True
+chart17622,17622,Assets for financial instruments - Derivative financial instruments - Fair value,account.data_account_type_receivable,pe_chart_template,True
+chart179,179,Other sundry accounts receivable,account.data_account_type_receivable,pe_chart_template,True
+chart181,181,Financial costs,account.data_account_type_prepayments,pe_chart_template,False
+chart182,182,Insurance,account.data_account_type_prepayments,pe_chart_template,False
+chart183,183,Leasings,account.data_account_type_prepayments,pe_chart_template,False
+chart184,184,Premiums paid for options,account.data_account_type_prepayments,pe_chart_template,False
+chart185,185,Maintenance of fixed assets,account.data_account_type_prepayments,pe_chart_template,False
+chart189,189,Other expenses contracted in advance,account.data_account_type_prepayments,pe_chart_template,False
+chart1911,1911,"Trade accounts receivable – Third parties - Invoices, tickets and other receipts receivable",account.data_account_type_receivable,pe_chart_template,True
+chart1913,1913,Trade accounts receivable – Third parties - Bills to be collected,account.data_account_type_receivable,pe_chart_template,True
+chart1921,1921,"Trade accounts receivable – Associated - Invoices, tickets and other receipts receivable",account.data_account_type_receivable,pe_chart_template,True
+chart1923,1923,Trade accounts receivable – Associated - Bills to be collected,account.data_account_type_receivable,pe_chart_template,True
+chart1931,1931,"Accounts receivable from staff, shareholders (partners) and directors - Personal",account.data_account_type_receivable,pe_chart_template,True
+chart1932,1932,"Accounts receivable from staff, shareholders (partners) and directors - Shareholders (or partners)",account.data_account_type_receivable,pe_chart_template,True
+chart1933,1933,"Accounts receivable from staff, shareholders (partners) and directors - Directors",account.data_account_type_receivable,pe_chart_template,True
+chart1939,1939,"Accounts receivable from staff, shareholders (partners) and directors - Various",account.data_account_type_receivable,pe_chart_template,True
+chart1941,1941,Various accounts receivable – Third parties - Loans,account.data_account_type_receivable,pe_chart_template,True
+chart1942,1942,Various accounts receivable – Third parties - Claims to third parties,account.data_account_type_receivable,pe_chart_template,True
+chart1943,1943,"Various accounts receivable – Third parties - Interest, royalties and dividends",account.data_account_type_receivable,pe_chart_template,True
+chart1944,1944,Various accounts receivable – Third parties - Deposits granted in guarantee,account.data_account_type_receivable,pe_chart_template,True
+chart1945,1945,Various accounts receivable – Third parties - Sale of fixed assets,account.data_account_type_receivable,pe_chart_template,True
+chart1946,1946,Various accounts receivable – Third parties - Assets for financial instruments,account.data_account_type_receivable,pe_chart_template,True
+chart1949,1949,Various accounts receivable – Third parties - Other sundry accounts receivable,account.data_account_type_receivable,pe_chart_template,True
+chart1951,1951,Various accounts receivable – Associated - Loans,account.data_account_type_receivable,pe_chart_template,True
+chart1953,1953,"Various accounts receivable – Associated - Interest, royalties and dividends",account.data_account_type_receivable,pe_chart_template,True
+chart1954,1954,Various accounts receivable – Associated - Deposits granted in guarantee,account.data_account_type_receivable,pe_chart_template,True
+chart1955,1955,Various accounts receivable – Associated - Sale of fixed assets,account.data_account_type_receivable,pe_chart_template,True
+chart1956,1956,Various accounts receivable – Associated - Assets for financial instruments,account.data_account_type_receivable,pe_chart_template,True
+chart1959,1959,Various accounts receivable – Associated - Other sundry accounts receivable,account.data_account_type_receivable,pe_chart_template,True
+chart20111,20111,Merchandise - Merchandise - Costs,account.data_account_type_current_assets,pe_chart_template,False
+chart20114,20114,Merchandise - Merchandise - Fair value,account.data_account_type_current_assets,pe_chart_template,False
+chart21111,21111,Finished products - Finished products - Costs,account.data_account_type_current_assets,pe_chart_template,False
+chart21113,21113,Finished products - Finished products - Financing costs,account.data_account_type_current_assets,pe_chart_template,False
+chart21114,21114,Finished products - Finished products - Fair value,account.data_account_type_current_assets,pe_chart_template,False
+chart21511,21511,Inventory of finished services - Finished services - Costs,account.data_account_type_current_assets,pe_chart_template,False
+chart221,221,By-products,account.data_account_type_current_assets,pe_chart_template,False
+chart222,222,Scrap and waste,account.data_account_type_current_assets,pe_chart_template,False
+chart23111,23111,Products in process - Products in process - Costs,account.data_account_type_current_assets,pe_chart_template,False
+chart23113,23113,Products in process - Products in process - Financing costs,account.data_account_type_current_assets,pe_chart_template,False
+chart23511,23511,Inventory of services in process - Services in process - Costs,account.data_account_type_current_assets,pe_chart_template,False
+chart24111,24111,Raw Materials - Raw Materials - Costs,account.data_account_type_current_assets,pe_chart_template,False
+chart24114,24114,Raw Materials - Raw Materials - Fair value,account.data_account_type_current_assets,pe_chart_template,False
+chart251,251,Auxiliary materials,account.data_account_type_current_assets,pe_chart_template,False
+chart2521,2521,Supplies - Fuels,account.data_account_type_current_assets,pe_chart_template,False
+chart2522,2522,Supplies - Lubricants,account.data_account_type_current_assets,pe_chart_template,False
+chart2523,2523,Supplies - Energy,account.data_account_type_current_assets,pe_chart_template,False
+chart2524,2524,Supplies - Other supplies,account.data_account_type_current_assets,pe_chart_template,False
+chart253,253,Spare parts,account.data_account_type_current_assets,pe_chart_template,False
+chart261,261,Containers,account.data_account_type_current_assets,pe_chart_template,False
+chart262,262,Packaging,account.data_account_type_current_assets,pe_chart_template,False
+chart27111,27111,Investment property - Land - Costs,account.data_account_type_current_assets,pe_chart_template,False
+chart27112,27112,Investment property - Land - Revaluation,account.data_account_type_current_assets,pe_chart_template,False
+chart27114,27114,Investment property - Land - Fair value,account.data_account_type_current_assets,pe_chart_template,False
+chart27121,27121,Investment property - Buildings - Costs,account.data_account_type_current_assets,pe_chart_template,False
+chart27122,27122,Investment property - Buildings - Revaluation,account.data_account_type_current_assets,pe_chart_template,False
+chart27123,27123,Investment property - Buildings - Financing costs,account.data_account_type_current_assets,pe_chart_template,False
+chart27124,27124,Investment property - Buildings - Fair value,account.data_account_type_current_assets,pe_chart_template,False
+chart27201,27201,"Property, plant and equipment - Production plant in production - Costs",account.data_account_type_current_assets,pe_chart_template,False
+chart27202,27202,"Property, plant and equipment - Production plant in production - Revaluation",account.data_account_type_current_assets,pe_chart_template,False
+chart27203,27203,"Property, plant and equipment - Production plant in production - Financing costs",account.data_account_type_current_assets,pe_chart_template,False
+chart27204,27204,"Property, plant and equipment - Production plant in production - Fair value",account.data_account_type_current_assets,pe_chart_template,False
+chart27211,27211,"Property, plant and equipment - Production plant in development - Costs",account.data_account_type_current_assets,pe_chart_template,False
+chart27212,27212,"Property, plant and equipment - Production plant in development - Revaluation",account.data_account_type_current_assets,pe_chart_template,False
+chart27213,27213,"Property, plant and equipment - Production plant in development - Financing costs",account.data_account_type_current_assets,pe_chart_template,False
+chart27214,27214,"Property, plant and equipment - Production plant in development - Fair value",account.data_account_type_current_assets,pe_chart_template,False
+chart27221,27221,"Property, plant and equipment - Land - Costs",account.data_account_type_current_assets,pe_chart_template,False
+chart27222,27222,"Property, plant and equipment - Land - Revaluation",account.data_account_type_current_assets,pe_chart_template,False
+chart27231,27231,"Property, plant and equipment - Buildings - Costs",account.data_account_type_current_assets,pe_chart_template,False
+chart27232,27232,"Property, plant and equipment - Buildings - Revaluation",account.data_account_type_current_assets,pe_chart_template,False
+chart27233,27233,"Property, plant and equipment - Buildings - Financing costs",account.data_account_type_current_assets,pe_chart_template,False
+chart27241,27241,"Property, plant and equipment - Machinery and exploitation equipment - Costs",account.data_account_type_current_assets,pe_chart_template,False
+chart27242,27242,"Property, plant and equipment - Machinery and exploitation equipment - Revaluation",account.data_account_type_current_assets,pe_chart_template,False
+chart27243,27243,"Property, plant and equipment - Machinery and exploitation equipment - Financing costs",account.data_account_type_current_assets,pe_chart_template,False
+chart27251,27251,"Property, plant and equipment - Transport units - Costs",account.data_account_type_current_assets,pe_chart_template,False
+chart27252,27252,"Property, plant and equipment - Transport units - Revaluation",account.data_account_type_current_assets,pe_chart_template,False
+chart27261,27261,"Property, plant and equipment - Furniture and fixtures - Costs",account.data_account_type_current_assets,pe_chart_template,False
+chart27262,27262,"Property, plant and equipment - Furniture and fixtures - Revaluation",account.data_account_type_current_assets,pe_chart_template,False
+chart27271,27271,"Property, plant and equipment - Miscellaneous equipment - Costs",account.data_account_type_current_assets,pe_chart_template,False
+chart27272,27272,"Property, plant and equipment - Miscellaneous equipment - Revaluation",account.data_account_type_current_assets,pe_chart_template,False
+chart27281,27281,"Property, plant and equipment - Replacement tools and units - Costs",account.data_account_type_current_assets,pe_chart_template,False
+chart27282,27282,"Property, plant and equipment - Replacement tools and units - Revaluation",account.data_account_type_current_assets,pe_chart_template,False
+chart27291,27291,"Property, plant and equipment - Work in progress - Costs",account.data_account_type_current_assets,pe_chart_template,False
+chart27292,27292,"Property, plant and equipment - Work in progress - Revaluation",account.data_account_type_current_assets,pe_chart_template,False
+chart27311,27311,"Intangibles - Concessions, licenses and rights - Costs",account.data_account_type_current_assets,pe_chart_template,False
+chart27312,27312,"Intangibles - Concessions, licenses and rights - Revaluation",account.data_account_type_current_assets,pe_chart_template,False
+chart27321,27321,Intangibles - Patents and industrial property - Costs,account.data_account_type_current_assets,pe_chart_template,False
+chart27322,27322,Intangibles - Patents and industrial property - Revaluation,account.data_account_type_current_assets,pe_chart_template,False
+chart27331,27331,Intangibles - Softwares - Costs,account.data_account_type_current_assets,pe_chart_template,False
+chart27332,27332,Intangibles - Softwares - Revaluation,account.data_account_type_current_assets,pe_chart_template,False
+chart27341,27341,Intangibles - Exploration and development costs - Costs,account.data_account_type_current_assets,pe_chart_template,False
+chart27342,27342,Intangibles - Exploration and development costs - Revaluation,account.data_account_type_current_assets,pe_chart_template,False
+chart27351,27351,"Intangibles - Formulas, designs and prototypes - Costs",account.data_account_type_current_assets,pe_chart_template,False
+chart27352,27352,"Intangibles - Formulas, designs and prototypes - Revaluation",account.data_account_type_current_assets,pe_chart_template,False
+chart27391,27391,Intangibles - Other intangible assets - Costs,account.data_account_type_current_assets,pe_chart_template,False
+chart27392,27392,Intangibles - Other intangible assets - Revaluation,account.data_account_type_current_assets,pe_chart_template,False
+chart27411,27411,Biological assets - Biological assets in production - Costs,account.data_account_type_current_assets,pe_chart_template,False
+chart27413,27413,Biological assets - Biological assets in production - Financing costs,account.data_account_type_current_assets,pe_chart_template,False
+chart27414,27414,Biological assets - Biological assets in production - Fair value,account.data_account_type_current_assets,pe_chart_template,False
+chart27421,27421,Biological assets - Biological assets under development - Costs,account.data_account_type_current_assets,pe_chart_template,False
+chart27423,27423,Biological assets - Biological assets under development - Financing costs,account.data_account_type_current_assets,pe_chart_template,False
+chart27424,27424,Biological assets - Biological assets under development - Fair value,account.data_account_type_current_assets,pe_chart_template,False
+chart27521,27521,Accumulated depreciation – Investment property - Buildings - Costs,account.data_account_type_current_assets,pe_chart_template,False
+chart27522,27522,Accumulated depreciation – Investment property - Buildings - Revaluation,account.data_account_type_current_assets,pe_chart_template,False
+chart27523,27523,Accumulated depreciation – Investment property - Buildings - Financing costs,account.data_account_type_current_assets,pe_chart_template,False
+chart27601,27601,"Accumulated depreciation – Property, plant and equipment - Production plant in production - Costs",account.data_account_type_current_assets,pe_chart_template,False
+chart27602,27602,"Accumulated depreciation – Property, plant and equipment - Production plant in production - Revaluation",account.data_account_type_current_assets,pe_chart_template,False
+chart27603,27603,"Accumulated depreciation – Property, plant and equipment - Production plant in production - Financing costs",account.data_account_type_current_assets,pe_chart_template,False
+chart27604,27604,"Accumulated depreciation – Property, plant and equipment - Production plant in production - Fair value",account.data_account_type_current_assets,pe_chart_template,False
+chart27621,27621,"Accumulated depreciation – Property, plant and equipment - Buildings - Costs",account.data_account_type_current_assets,pe_chart_template,False
+chart27622,27622,"Accumulated depreciation – Property, plant and equipment - Buildings - Revaluation",account.data_account_type_current_assets,pe_chart_template,False
+chart27623,27623,"Accumulated depreciation – Property, plant and equipment - Buildings - Financing costs",account.data_account_type_current_assets,pe_chart_template,False
+chart27631,27631,"Accumulated depreciation – Property, plant and equipment - Machinery and operating equipment - Costs",account.data_account_type_current_assets,pe_chart_template,False
+chart27632,27632,"Accumulated depreciation – Property, plant and equipment - Machinery and operating equipment - Revaluation",account.data_account_type_current_assets,pe_chart_template,False
+chart27633,27633,"Accumulated depreciation – Property, plant and equipment - Machinery and operating equipment - Financing costs",account.data_account_type_current_assets,pe_chart_template,False
+chart27641,27641,"Accumulated depreciation – Property, plant and equipment - Transport units - Costs",account.data_account_type_current_assets,pe_chart_template,False
+chart27642,27642,"Accumulated depreciation – Property, plant and equipment - Transport units - Revaluation",account.data_account_type_current_assets,pe_chart_template,False
+chart27651,27651,"Accumulated depreciation – Property, plant and equipment - Furniture and fixtures - Costs",account.data_account_type_current_assets,pe_chart_template,False
+chart27652,27652,"Accumulated depreciation – Property, plant and equipment - Furniture and fixtures - Revaluation",account.data_account_type_current_assets,pe_chart_template,False
+chart27661,27661,"Accumulated depreciation – Property, plant and equipment - Miscellaneous equipment - Costs",account.data_account_type_current_assets,pe_chart_template,False
+chart27662,27662,"Accumulated depreciation – Property, plant and equipment - Miscellaneous equipment - Revaluation",account.data_account_type_current_assets,pe_chart_template,False
+chart27671,27671,"Accumulated depreciation – Property, plant and equipment - Replacement tools and units - Costs",account.data_account_type_current_assets,pe_chart_template,False
+chart27672,27672,"Accumulated depreciation – Property, plant and equipment - Replacement tools and units - Revaluation",account.data_account_type_current_assets,pe_chart_template,False
+chart27711,27711,"Accumulated amortization – Intangibles - Concessions, licenses and rights - Costs",account.data_account_type_current_assets,pe_chart_template,False
+chart27712,27712,"Accumulated amortization – Intangibles - Concessions, licenses and rights - Revaluation",account.data_account_type_current_assets,pe_chart_template,False
+chart27721,27721,Accumulated amortization – Intangibles - Patents and industrial property - Costs,account.data_account_type_current_assets,pe_chart_template,False
+chart27722,27722,Accumulated amortization – Intangibles - Patents and industrial property - Revaluation,account.data_account_type_current_assets,pe_chart_template,False
+chart27731,27731,Accumulated amortization – Intangibles - Softwares - Costs,account.data_account_type_current_assets,pe_chart_template,False
+chart27732,27732,Accumulated amortization – Intangibles - Softwares - Revaluation,account.data_account_type_current_assets,pe_chart_template,False
+chart27741,27741,Accumulated amortization – Intangibles - Exploration and development costs - Costs,account.data_account_type_current_assets,pe_chart_template,False
+chart27742,27742,Accumulated amortization – Intangibles - Exploration and development costs - Revaluation,account.data_account_type_current_assets,pe_chart_template,False
+chart27751,27751,"Accumulated amortization – Intangibles - Formulas, designs and prototypes - Costs",account.data_account_type_current_assets,pe_chart_template,False
+chart27752,27752,"Accumulated amortization – Intangibles - Formulas, designs and prototypes - Revaluation",account.data_account_type_current_assets,pe_chart_template,False
+chart27791,27791,Accumulated amortization – Intangibles - Other intangible assets - Costs,account.data_account_type_current_assets,pe_chart_template,False
+chart27792,27792,Accumulated amortization – Intangibles - Other intangible assets - Revaluation,account.data_account_type_current_assets,pe_chart_template,False
+chart27811,27811,Accumulated depreciation – Biological assets - Biological assets in production - Costs,account.data_account_type_current_assets,pe_chart_template,False
+chart27813,27813,Accumulated depreciation – Biological assets - Biological assets in production - Financing costs,account.data_account_type_current_assets,pe_chart_template,False
+chart27821,27821,Accumulated depreciation – Biological assets - Biological assets under development - Costs,account.data_account_type_current_assets,pe_chart_template,False
+chart27823,27823,Accumulated depreciation – Biological assets - Biological assets under development - Financing costs,account.data_account_type_current_assets,pe_chart_template,False
+chart27910,27910,Accumulated impairment - Investment property - Production plant in production,account.data_account_type_current_assets,pe_chart_template,False
+chart27911,27911,Accumulated impairment - Investment property - Production plant in development,account.data_account_type_current_assets,pe_chart_template,False
+chart27912,27912,Accumulated impairment - Investment property - Land,account.data_account_type_current_assets,pe_chart_template,False
+chart27913,27913,Accumulated impairment - Investment property - Buildings,account.data_account_type_current_assets,pe_chart_template,False
+chart27930,27930,"Accumulated impairment - Property, plant and equipment - Production plants in production",account.data_account_type_current_assets,pe_chart_template,False
+chart27931,27931,"Accumulated impairment - Property, plant and equipment - Production plant in development",account.data_account_type_current_assets,pe_chart_template,False
+chart27932,27932,"Accumulated impairment - Property, plant and equipment - Land",account.data_account_type_current_assets,pe_chart_template,False
+chart27933,27933,"Accumulated impairment - Property, plant and equipment - Buildings",account.data_account_type_current_assets,pe_chart_template,False
+chart27934,27934,"Accumulated impairment - Property, plant and equipment - Machinery and exploitation equipment",account.data_account_type_current_assets,pe_chart_template,False
+chart27935,27935,"Accumulated impairment - Property, plant and equipment - Transport units",account.data_account_type_current_assets,pe_chart_template,False
+chart27936,27936,"Accumulated impairment - Property, plant and equipment - Furniture and fixtures",account.data_account_type_current_assets,pe_chart_template,False
+chart27937,27937,"Accumulated impairment - Property, plant and equipment - Miscellaneous equipment",account.data_account_type_current_assets,pe_chart_template,False
+chart27938,27938,"Accumulated impairment - Property, plant and equipment - Replacement tools and units",account.data_account_type_current_assets,pe_chart_template,False
+chart27941,27941,"Accumulated impairment - Intangibles - Concessions, licenses and other rights",account.data_account_type_current_assets,pe_chart_template,False
+chart27942,27942,Accumulated impairment - Intangibles - Patents and industrial property,account.data_account_type_current_assets,pe_chart_template,False
+chart27943,27943,Accumulated impairment - Intangibles - Softwares,account.data_account_type_current_assets,pe_chart_template,False
+chart27944,27944,Accumulated impairment - Intangibles - Exploration and development costs,account.data_account_type_current_assets,pe_chart_template,False
+chart27945,27945,"Accumulated impairment - Intangibles - Formulas, designs and prototypes",account.data_account_type_current_assets,pe_chart_template,False
+chart27949,27949,Accumulated impairment - Intangibles - Other intangible assets,account.data_account_type_current_assets,pe_chart_template,False
+chart27951,27951,Accumulated impairment - Biological assets - Biological assets in production,account.data_account_type_current_assets,pe_chart_template,False
+chart27952,27952,Accumulated impairment - Biological assets - Biological assets under development,account.data_account_type_current_assets,pe_chart_template,False
+chart281,281,Merchandise,account.data_account_type_current_assets,pe_chart_template,False
+chart284,284,Raw Materials,account.data_account_type_current_assets,pe_chart_template,False
+chart285,285,"Auxiliary materials, supplies and spare parts",account.data_account_type_current_assets,pe_chart_template,False
+chart286,286,Containers and packaging,account.data_account_type_current_assets,pe_chart_template,False
+chart29111,29111,Merchandise - Merchandise - Costs,account.data_account_type_current_assets,pe_chart_template,False
+chart29211,29211,Finished products - Finished products - Costs,account.data_account_type_current_assets,pe_chart_template,False
+chart29213,29213,Finished products - Finished products - Financing costs,account.data_account_type_current_assets,pe_chart_template,False
+chart29251,29251,Finished products - Inventory of finished services - Costs,account.data_account_type_current_assets,pe_chart_template,False
+chart2931,2931,"By-products, waste and scrap - By-products",account.data_account_type_current_assets,pe_chart_template,False
+chart2932,2932,"By-products, waste and scrap - Scrap and waste",account.data_account_type_current_assets,pe_chart_template,False
+chart29411,29411,Products in process - Products in process - Costs,account.data_account_type_current_assets,pe_chart_template,False
+chart29413,29413,Products in process - Products in process - Financing costs,account.data_account_type_current_assets,pe_chart_template,False
+chart2945,2945,Products in process - Inventory of services in process,account.data_account_type_current_assets,pe_chart_template,False
+chart29511,29511,Raw Materials - Raw Materials - Costs,account.data_account_type_current_assets,pe_chart_template,False
+chart2961,2961,"Auxiliary materials, supplies and spare parts - Auxiliary materials",account.data_account_type_current_assets,pe_chart_template,False
+chart2962,2962,"Auxiliary materials, supplies and spare parts - Supplies",account.data_account_type_current_assets,pe_chart_template,False
+chart2963,2963,"Auxiliary materials, supplies and spare parts - Spare parts",account.data_account_type_current_assets,pe_chart_template,False
+chart2971,2971,Containers and packaging - Containers,account.data_account_type_current_assets,pe_chart_template,False
+chart2972,2972,Containers and packaging - Packaging,account.data_account_type_current_assets,pe_chart_template,False
+chart2981,2981,Stock to be received - Merchandise,account.data_account_type_current_assets,pe_chart_template,False
+chart2982,2982,Stock to be received - Raw Materials,account.data_account_type_current_assets,pe_chart_template,False
+chart2983,2983,"Stock to be received - Auxiliary materials, supplies and spare parts",account.data_account_type_current_assets,pe_chart_template,False
+chart2984,2984,Stock to be received - Containers and packaging,account.data_account_type_current_assets,pe_chart_template,False
+chart30111,30111,Investments to be held until maturity - Debt financial instruments - Costs,account.data_account_type_non_current_assets,pe_chart_template,False
+chart30114,30114,Investments to be held until maturity - Debt financial instruments - Fair value,account.data_account_type_non_current_assets,pe_chart_template,False
+chart3021,3021,Financial instruments representative of economic rights - Preferred Subscription Certificates,account.data_account_type_non_current_assets,pe_chart_template,False
+chart30221,30221,Financial instruments representative of economic rights - Shares representing capital stock – Common - Costs,account.data_account_type_non_current_assets,pe_chart_template,False
+chart30224,30224,Financial instruments representative of economic rights - Shares representing capital stock – Common - Fair value,account.data_account_type_non_current_assets,pe_chart_template,False
+chart30225,30225,Financial instruments representative of economic rights - Shares representing capital stock – Common - Equity participation,account.data_account_type_non_current_assets,pe_chart_template,False
+chart30231,30231,Financial instruments representative of economic rights - Shares representing capital stock – Preferences - Costs,account.data_account_type_non_current_assets,pe_chart_template,False
+chart30234,30234,Financial instruments representative of economic rights - Shares representing capital stock – Preferences - Fair value,account.data_account_type_non_current_assets,pe_chart_template,False
+chart30235,30235,Financial instruments representative of economic rights - Shares representing capital stock – Preferences - Equity participation,account.data_account_type_non_current_assets,pe_chart_template,False
+chart30241,30241,Financial instruments representative of economic rights - Investment shares - Costs,account.data_account_type_non_current_assets,pe_chart_template,False
+chart30244,30244,Financial instruments representative of economic rights - Investment shares - Fair value,account.data_account_type_non_current_assets,pe_chart_template,False
+chart30245,30245,Financial instruments representative of economic rights - Investment shares - Equity participation,account.data_account_type_non_current_assets,pe_chart_template,False
+chart30281,30281,Financial instruments representative of economic rights - Other titles representing equity - Costs,account.data_account_type_non_current_assets,pe_chart_template,False
+chart30284,30284,Financial instruments representative of economic rights - Other titles representing equity - Fair value,account.data_account_type_non_current_assets,pe_chart_template,False
+chart30285,30285,Financial instruments representative of economic rights - Other titles representing equity - Equity participation,account.data_account_type_non_current_assets,pe_chart_template,False
+chart30311,30311,Certificates of participation in funds - Dues - Investment funds - Costs,account.data_account_type_non_current_assets,pe_chart_template,False
+chart30314,30314,Certificates of participation in funds - Dues - Investment funds - Fair value,account.data_account_type_non_current_assets,pe_chart_template,False
+chart30321,30321,Certificates of participation in funds - Dues - Mutual funds - Costs,account.data_account_type_non_current_assets,pe_chart_template,False
+chart30324,30324,Certificates of participation in funds - Dues - Mutual funds - Fair value,account.data_account_type_non_current_assets,pe_chart_template,False
+chart30411,30411,Participations in joint agreements - Joint operations - Costs,account.data_account_type_non_current_assets,pe_chart_template,False
+chart30414,30414,Participations in joint agreements - Joint operations - Fair value,account.data_account_type_non_current_assets,pe_chart_template,False
+chart30415,30415,Participations in joint agreements - Joint operations - Equity participation,account.data_account_type_non_current_assets,pe_chart_template,False
+chart30421,30421,Participations in joint agreements - Joint ventures - Costs,account.data_account_type_non_current_assets,pe_chart_template,False
+chart30424,30424,Participations in joint agreements - Joint ventures - Fair value,account.data_account_type_non_current_assets,pe_chart_template,False
+chart30425,30425,Participations in joint agreements - Joint ventures - Equity participation,account.data_account_type_non_current_assets,pe_chart_template,False
+chart30811,30811,Securities investments – Purchase agreements - Debt financial instruments – Purchase agreements - Costs,account.data_account_type_non_current_assets,pe_chart_template,False
+chart30814,30814,Securities investments – Purchase agreements - Debt financial instruments – Purchase agreements - Fair value,account.data_account_type_non_current_assets,pe_chart_template,False
+chart30821,30821,Securities investments – Purchase agreements - Financial instruments representative of economic rights – Purchase agreements - Costs,account.data_account_type_non_current_assets,pe_chart_template,False
+chart30824,30824,Securities investments – Purchase agreements - Financial instruments representative of economic rights – Purchase agreements - Fair value,account.data_account_type_non_current_assets,pe_chart_template,False
+chart31111,31111,Land - Urban - Costs,account.data_account_type_fixed_assets,pe_chart_template,False
+chart31112,31112,Land - Urban - Revaluation,account.data_account_type_fixed_assets,pe_chart_template,False
+chart31114,31114,Land - Urban - Fair value,account.data_account_type_fixed_assets,pe_chart_template,False
+chart31121,31121,Land - Rural - Costs,account.data_account_type_fixed_assets,pe_chart_template,False
+chart31122,31122,Land - Rural - Revaluation,account.data_account_type_fixed_assets,pe_chart_template,False
+chart31124,31124,Land - Rural - Fair value,account.data_account_type_fixed_assets,pe_chart_template,False
+chart31211,31211,Buildings - Buildings - Costs,account.data_account_type_fixed_assets,pe_chart_template,False
+chart31212,31212,Buildings - Buildings - Revaluation,account.data_account_type_fixed_assets,pe_chart_template,False
+chart31213,31213,Buildings - Buildings - Financing costs,account.data_account_type_fixed_assets,pe_chart_template,False
+chart31214,31214,Buildings - Buildings - Fair value,account.data_account_type_fixed_assets,pe_chart_template,False
+chart31311,31311,Constructions in progress - Buildings - Costs,account.data_account_type_fixed_assets,pe_chart_template,False
+chart31312,31312,Constructions in progress - Buildings - Revaluation,account.data_account_type_fixed_assets,pe_chart_template,False
+chart31313,31313,Constructions in progress - Buildings - Financing costs,account.data_account_type_fixed_assets,pe_chart_template,False
+chart31314,31314,Constructions in progress - Buildings - Fair value,account.data_account_type_fixed_assets,pe_chart_template,False
+chart32111,32111,Investment property - Financial leasing - Land - Costs,account.data_account_type_fixed_assets,pe_chart_template,False
+chart32112,32112,Investment property - Financial leasing - Land - Revaluation,account.data_account_type_fixed_assets,pe_chart_template,False
+chart32114,32114,Investment property - Financial leasing - Land - Fair value,account.data_account_type_fixed_assets,pe_chart_template,False
+chart32121,32121,Investment property - Financial leasing - Buildings - Costs,account.data_account_type_fixed_assets,pe_chart_template,False
+chart32122,32122,Investment property - Financial leasing - Buildings - Revaluation,account.data_account_type_fixed_assets,pe_chart_template,False
+chart32123,32123,Investment property - Financial leasing - Buildings - Financing costs,account.data_account_type_fixed_assets,pe_chart_template,False
+chart32124,32124,Investment property - Financial leasing - Buildings - Fair value,account.data_account_type_fixed_assets,pe_chart_template,False
+chart32201,32201,"Property, plant and equipment - Financial leasing - Production plant in production - Costs",account.data_account_type_fixed_assets,pe_chart_template,False
+chart32202,32202,"Property, plant and equipment - Financial leasing - Production plant in production - Revaluation",account.data_account_type_fixed_assets,pe_chart_template,False
+chart32203,32203,"Property, plant and equipment - Financial leasing - Production plant in production - Financing costs",account.data_account_type_fixed_assets,pe_chart_template,False
+chart32211,32211,"Property, plant and equipment - Financial leasing - Production plant in development - Costs",account.data_account_type_fixed_assets,pe_chart_template,False
+chart32212,32212,"Property, plant and equipment - Financial leasing - Production plant in development - Revaluation",account.data_account_type_fixed_assets,pe_chart_template,False
+chart32213,32213,"Property, plant and equipment - Financial leasing - Production plant in development - Financing costs",account.data_account_type_fixed_assets,pe_chart_template,False
+chart32221,32221,"Property, plant and equipment - Financial leasing - Land - Costs",account.data_account_type_fixed_assets,pe_chart_template,False
+chart32222,32222,"Property, plant and equipment - Financial leasing - Land - Revaluation",account.data_account_type_fixed_assets,pe_chart_template,False
+chart32231,32231,"Property, plant and equipment - Financial leasing - Buildings - Costs",account.data_account_type_fixed_assets,pe_chart_template,False
+chart32232,32232,"Property, plant and equipment - Financial leasing - Buildings - Revaluation",account.data_account_type_fixed_assets,pe_chart_template,False
+chart32233,32233,"Property, plant and equipment - Financial leasing - Buildings - Financing costs",account.data_account_type_fixed_assets,pe_chart_template,False
+chart32241,32241,"Property, plant and equipment - Financial leasing - Machinery and exploitation equipment - Costs",account.data_account_type_fixed_assets,pe_chart_template,False
+chart32242,32242,"Property, plant and equipment - Financial leasing - Machinery and exploitation equipment - Revaluation",account.data_account_type_fixed_assets,pe_chart_template,False
+chart32243,32243,"Property, plant and equipment - Financial leasing - Machinery and exploitation equipment - Financing costs",account.data_account_type_fixed_assets,pe_chart_template,False
+chart32251,32251,"Property, plant and equipment - Financial leasing - Transport units - Costs",account.data_account_type_fixed_assets,pe_chart_template,False
+chart32252,32252,"Property, plant and equipment - Financial leasing - Transport units - Revaluation",account.data_account_type_fixed_assets,pe_chart_template,False
+chart32261,32261,"Property, plant and equipment - Financial leasing - Furniture and fixtures - Costs",account.data_account_type_fixed_assets,pe_chart_template,False
+chart32262,32262,"Property, plant and equipment - Financial leasing - Furniture and fixtures - Revaluation",account.data_account_type_fixed_assets,pe_chart_template,False
+chart32271,32271,"Property, plant and equipment - Financial leasing - Miscellaneous equipment - Costs",account.data_account_type_fixed_assets,pe_chart_template,False
+chart32272,32272,"Property, plant and equipment - Financial leasing - Miscellaneous equipment - Revaluation",account.data_account_type_fixed_assets,pe_chart_template,False
+chart32281,32281,"Property, plant and equipment - Financial leasing - Replacement tools and units - Costs",account.data_account_type_fixed_assets,pe_chart_template,False
+chart32282,32282,"Property, plant and equipment - Financial leasing - Replacement tools and units - Revaluation",account.data_account_type_fixed_assets,pe_chart_template,False
+chart32301,32301,"Property, plant and equipment - Operating lease - Production plant in production - Costs",account.data_account_type_fixed_assets,pe_chart_template,False
+chart32302,32302,"Property, plant and equipment - Operating lease - Production plant in production - Revaluation",account.data_account_type_fixed_assets,pe_chart_template,False
+chart32321,32321,"Property, plant and equipment - Operating lease - Land - Costs",account.data_account_type_fixed_assets,pe_chart_template,False
+chart32331,32331,"Property, plant and equipment - Operating lease - Buildings - Costs",account.data_account_type_fixed_assets,pe_chart_template,False
+chart32332,32332,"Property, plant and equipment - Operating lease - Buildings - Revaluation",account.data_account_type_fixed_assets,pe_chart_template,False
+chart32341,32341,"Property, plant and equipment - Operating lease - Machinery and exploitation equipment - Costs",account.data_account_type_fixed_assets,pe_chart_template,False
+chart32342,32342,"Property, plant and equipment - Operating lease - Machinery and exploitation equipment - Revaluation",account.data_account_type_fixed_assets,pe_chart_template,False
+chart32351,32351,"Property, plant and equipment - Operating lease - Transport units - Costs",account.data_account_type_fixed_assets,pe_chart_template,False
+chart32352,32352,"Property, plant and equipment - Operating lease - Transport units - Revaluation",account.data_account_type_fixed_assets,pe_chart_template,False
+chart32361,32361,"Property, plant and equipment - Operating lease - Miscellaneous equipment - Costs",account.data_account_type_fixed_assets,pe_chart_template,False
+chart32362,32362,"Property, plant and equipment - Operating lease - Miscellaneous equipment - Revaluation",account.data_account_type_fixed_assets,pe_chart_template,False
+chart33011,33011,Producing plant - Production plant in production - Costs,account.data_account_type_fixed_assets,pe_chart_template,False
+chart33012,33012,Producing plant - Production plant in production - Revaluation,account.data_account_type_fixed_assets,pe_chart_template,False
+chart33013,33013,Producing plant - Production plant in production - Financing costs,account.data_account_type_fixed_assets,pe_chart_template,False
+chart33014,33014,Producing plant - Production plant in production - Fair value,account.data_account_type_fixed_assets,pe_chart_template,False
+chart33021,33021,Producing plant - Production plant in development - Costs,account.data_account_type_fixed_assets,pe_chart_template,False
+chart33022,33022,Producing plant - Production plant in development - Revaluation,account.data_account_type_fixed_assets,pe_chart_template,False
+chart33023,33023,Producing plant - Production plant in development - Financing costs,account.data_account_type_fixed_assets,pe_chart_template,False
+chart33024,33024,Producing plant - Production plant in development - Fair value,account.data_account_type_fixed_assets,pe_chart_template,False
+chart33111,33111,Land - Land - Costs,account.data_account_type_fixed_assets,pe_chart_template,False
+chart33112,33112,Land - Land - Revaluation,account.data_account_type_fixed_assets,pe_chart_template,False
+chart33211,33211,Buildings - Buildings - Costs,account.data_account_type_fixed_assets,pe_chart_template,False
+chart33212,33212,Buildings - Buildings - Revaluation,account.data_account_type_fixed_assets,pe_chart_template,False
+chart33213,33213,Buildings - Buildings - Financing costs,account.data_account_type_fixed_assets,pe_chart_template,False
+chart33241,33241,Buildings - Installations - Costs,account.data_account_type_fixed_assets,pe_chart_template,False
+chart33242,33242,Buildings - Installations - Revaluation,account.data_account_type_fixed_assets,pe_chart_template,False
+chart33243,33243,Buildings - Installations - Financing costs,account.data_account_type_fixed_assets,pe_chart_template,False
+chart33251,33251,Buildings - Improvements in leased premises. - Costs,account.data_account_type_fixed_assets,pe_chart_template,False
+chart33252,33252,Buildings - Improvements in leased premises. - Revaluation,account.data_account_type_fixed_assets,pe_chart_template,False
+chart33253,33253,Buildings - Improvements in leased premises. - Financing costs,account.data_account_type_fixed_assets,pe_chart_template,False
+chart33311,33311,Machinery and exploitation equipment - Machinery and exploitation equipment - Costs,account.data_account_type_fixed_assets,pe_chart_template,False
+chart33312,33312,Machinery and exploitation equipment - Machinery and exploitation equipment - Revaluation,account.data_account_type_fixed_assets,pe_chart_template,False
+chart33313,33313,Machinery and exploitation equipment - Machinery and exploitation equipment - Financing costs,account.data_account_type_fixed_assets,pe_chart_template,False
+chart33411,33411,Transport units - Motor vehicles - Costs,account.data_account_type_fixed_assets,pe_chart_template,False
+chart33412,33412,Transport units - Motor vehicles - Revaluation,account.data_account_type_fixed_assets,pe_chart_template,False
+chart33421,33421,Transport units - Non-motorized vehicles - Costs,account.data_account_type_fixed_assets,pe_chart_template,False
+chart33422,33422,Transport units - Non-motorized vehicles - Revaluation,account.data_account_type_fixed_assets,pe_chart_template,False
+chart33511,33511,Furniture and fixtures - Furnitures - Costs,account.data_account_type_fixed_assets,pe_chart_template,False
+chart33512,33512,Furniture and fixtures - Furnitures - Revaluation,account.data_account_type_fixed_assets,pe_chart_template,False
+chart33521,33521,Furniture and fixtures - Equipment - Costs,account.data_account_type_fixed_assets,pe_chart_template,False
+chart33522,33522,Furniture and fixtures - Equipment - Revaluation,account.data_account_type_fixed_assets,pe_chart_template,False
+chart33611,33611,Miscellaneous equipment - Information processing equipment - Costs,account.data_account_type_fixed_assets,pe_chart_template,False
+chart33612,33612,Miscellaneous equipment - Information processing equipment - Revaluation,account.data_account_type_fixed_assets,pe_chart_template,False
+chart33621,33621,Miscellaneous equipment - Communication equipment - Costs,account.data_account_type_fixed_assets,pe_chart_template,False
+chart33622,33622,Miscellaneous equipment - Communication equipment - Revaluation,account.data_account_type_fixed_assets,pe_chart_template,False
+chart33631,33631,Miscellaneous equipment - Security equipment - Costs,account.data_account_type_fixed_assets,pe_chart_template,False
+chart33632,33632,Miscellaneous equipment - Security equipment - Revaluation,account.data_account_type_fixed_assets,pe_chart_template,False
+chart33641,33641,Miscellaneous equipment - Environmental equipment - Costs,account.data_account_type_fixed_assets,pe_chart_template,False
+chart33642,33642,Miscellaneous equipment - Environmental equipment - Revaluation,account.data_account_type_fixed_assets,pe_chart_template,False
+chart33691,33691,Miscellaneous equipment - Other equipments - Costs,account.data_account_type_fixed_assets,pe_chart_template,False
+chart33692,33692,Miscellaneous equipment - Other equipments - Revaluation,account.data_account_type_fixed_assets,pe_chart_template,False
+chart33711,33711,Replacement tools and units - Tools - Costs,account.data_account_type_fixed_assets,pe_chart_template,False
+chart33712,33712,Replacement tools and units - Tools - Revaluation,account.data_account_type_fixed_assets,pe_chart_template,False
+chart33721,33721,Replacement tools and units - Replacement units - Costs,account.data_account_type_fixed_assets,pe_chart_template,False
+chart33722,33722,Replacement tools and units - Replacement units - Revaluation,account.data_account_type_fixed_assets,pe_chart_template,False
+chart3381,3381,Units to receive - Machinery and exploitation equipment,account.data_account_type_fixed_assets,pe_chart_template,False
+chart3382,3382,Units to receive - Transportation equipment,account.data_account_type_fixed_assets,pe_chart_template,False
+chart3383,3383,Units to receive - Furniture and fixtures,account.data_account_type_fixed_assets,pe_chart_template,False
+chart3386,3386,Units to receive - Miscellaneous equipment,account.data_account_type_fixed_assets,pe_chart_template,False
+chart3387,3387,Units to receive - Replacement tools and units,account.data_account_type_fixed_assets,pe_chart_template,False
+chart3391,3391,Work in progress - Landscaping,account.data_account_type_fixed_assets,pe_chart_template,False
+chart33921,33921,Work in progress - Buildings in progress - Costs,account.data_account_type_fixed_assets,pe_chart_template,False
+chart33922,33922,Work in progress - Buildings in progress - Financing costs,account.data_account_type_fixed_assets,pe_chart_template,False
+chart33931,33931,Work in progress - Assembly machinery - Costs,account.data_account_type_fixed_assets,pe_chart_template,False
+chart33932,33932,Work in progress - Assembly machinery - Financing costs,account.data_account_type_fixed_assets,pe_chart_template,False
+chart34111,34111,"Concessions, licenses and other rights - Rights for concessions - Costs",account.data_account_type_non_current_assets,pe_chart_template,False
+chart34112,34112,"Concessions, licenses and other rights - Rights for concessions - Revaluation",account.data_account_type_non_current_assets,pe_chart_template,False
+chart34121,34121,"Concessions, licenses and other rights - License - Costs",account.data_account_type_non_current_assets,pe_chart_template,False
+chart34122,34122,"Concessions, licenses and other rights - License - Revaluation",account.data_account_type_non_current_assets,pe_chart_template,False
+chart34191,34191,"Concessions, licenses and other rights - Other rights - Costs",account.data_account_type_non_current_assets,pe_chart_template,False
+chart34192,34192,"Concessions, licenses and other rights - Other rights - Revaluation",account.data_account_type_non_current_assets,pe_chart_template,False
+chart34211,34211,Patents and industrial property - Patents - Costs,account.data_account_type_non_current_assets,pe_chart_template,False
+chart34212,34212,Patents and industrial property - Patents - Revaluation,account.data_account_type_non_current_assets,pe_chart_template,False
+chart34221,34221,Patents and industrial property - Brands - Costs,account.data_account_type_non_current_assets,pe_chart_template,False
+chart34222,34222,Patents and industrial property - Brands - Revaluation,account.data_account_type_non_current_assets,pe_chart_template,False
+chart34311,34311,Softwares - Computer applications - Costs,account.data_account_type_non_current_assets,pe_chart_template,False
+chart34312,34312,Softwares - Computer applications - Revaluation,account.data_account_type_non_current_assets,pe_chart_template,False
+chart34411,34411,Exploration and development costs - Exploration costs - Costs,account.data_account_type_non_current_assets,pe_chart_template,False
+chart34412,34412,Exploration and development costs - Exploration costs - Revaluation,account.data_account_type_non_current_assets,pe_chart_template,False
+chart34413,34413,Exploration and development costs - Exploration costs - Financing costs,account.data_account_type_non_current_assets,pe_chart_template,False
+chart34421,34421,Exploration and development costs - Development costs - Costs,account.data_account_type_non_current_assets,pe_chart_template,False
+chart34422,34422,Exploration and development costs - Development costs - Revaluation,account.data_account_type_non_current_assets,pe_chart_template,False
+chart34423,34423,Exploration and development costs - Development costs - Financing costs,account.data_account_type_non_current_assets,pe_chart_template,False
+chart34511,34511,"Formulas, designs and prototypes - Formulas - Costs",account.data_account_type_non_current_assets,pe_chart_template,False
+chart34512,34512,"Formulas, designs and prototypes - Formulas - Revaluation",account.data_account_type_non_current_assets,pe_chart_template,False
+chart34521,34521,"Formulas, designs and prototypes - Designs and prototypes - Costs",account.data_account_type_non_current_assets,pe_chart_template,False
+chart34522,34522,"Formulas, designs and prototypes - Designs and prototypes - Revaluation",account.data_account_type_non_current_assets,pe_chart_template,False
+chart3471,3471,Goodwill - Goodwill,account.data_account_type_non_current_assets,pe_chart_template,False
+chart34911,34911,Other intangible assets - Other intangible assets - Costs,account.data_account_type_non_current_assets,pe_chart_template,False
+chart34912,34912,Other intangible assets - Other intangible assets - Revaluation,account.data_account_type_non_current_assets,pe_chart_template,False
+chart35111,35111,Biological assets in production - Animal origin - Costs,account.data_account_type_non_current_assets,pe_chart_template,False
+chart35113,35113,Biological assets in production - Animal origin - Financing costs,account.data_account_type_non_current_assets,pe_chart_template,False
+chart35114,35114,Biological assets in production - Animal origin - Fair value,account.data_account_type_non_current_assets,pe_chart_template,False
+chart35121,35121,Biological assets in production - Vegetal origin - Costs,account.data_account_type_non_current_assets,pe_chart_template,False
+chart35123,35123,Biological assets in production - Vegetal origin - Financing costs,account.data_account_type_non_current_assets,pe_chart_template,False
+chart35124,35124,Biological assets in production - Vegetal origin - Fair value,account.data_account_type_non_current_assets,pe_chart_template,False
+chart35211,35211,Biological assets under development - Animal origin - Costs,account.data_account_type_non_current_assets,pe_chart_template,False
+chart35213,35213,Biological assets under development - Animal origin - Financing costs,account.data_account_type_non_current_assets,pe_chart_template,False
+chart35214,35214,Biological assets under development - Animal origin - Fair value,account.data_account_type_non_current_assets,pe_chart_template,False
+chart35221,35221,Biological assets under development - Vegetal origin - Costs,account.data_account_type_non_current_assets,pe_chart_template,False
+chart35223,35223,Biological assets under development - Vegetal origin - Financing costs,account.data_account_type_non_current_assets,pe_chart_template,False
+chart35224,35224,Biological assets under development - Vegetal origin - Fair value,account.data_account_type_non_current_assets,pe_chart_template,False
+chart36111,36111,Land - Costs,account.data_account_type_fixed_assets,pe_chart_template,False
+chart36112,36112,Land - Revaluation,account.data_account_type_fixed_assets,pe_chart_template,False
+chart36121,36121,Buildings - Costs,account.data_account_type_fixed_assets,pe_chart_template,False
+chart36122,36122,Buildings - Revaluation,account.data_account_type_fixed_assets,pe_chart_template,False
+chart36123,36123,Buildings - Financing costs,account.data_account_type_fixed_assets,pe_chart_template,False
+chart36131,36131,Constructions in progress - Buildings - Costs,account.data_account_type_fixed_assets,pe_chart_template,False
+chart36132,36132,Constructions in progress - Buildings - Revaluation,account.data_account_type_fixed_assets,pe_chart_template,False
+chart36133,36133,Constructions in progress - Buildings - Financing costs,account.data_account_type_fixed_assets,pe_chart_template,False
+chart36211,36211,Financial leasing - Land - Costs,account.data_account_type_non_current_assets,pe_chart_template,False
+chart36212,36212,Financial leasing - Land - Revaluation,account.data_account_type_non_current_assets,pe_chart_template,False
+chart36221,36221,Financial leasing - Buildings - Costs,account.data_account_type_non_current_assets,pe_chart_template,False
+chart36222,36222,Financial leasing - Buildings - Revaluation,account.data_account_type_non_current_assets,pe_chart_template,False
+chart36223,36223,Financial leasing - Buildings - Financing costs,account.data_account_type_non_current_assets,pe_chart_template,False
+chart36311,36311,Financial leasing - Land - Costs,account.data_account_type_non_current_assets,pe_chart_template,False
+chart36312,36312,Financial leasing - Land - Revaluation,account.data_account_type_non_current_assets,pe_chart_template,False
+chart36321,36321,Financial leasing - Buildings - Costs,account.data_account_type_non_current_assets,pe_chart_template,False
+chart36322,36322,Financial leasing - Buildings - Revaluation,account.data_account_type_non_current_assets,pe_chart_template,False
+chart36323,36323,Financial leasing - Buildings - Financing costs,account.data_account_type_non_current_assets,pe_chart_template,False
+chart36331,36331,Financial leasing - Machinery and exploitation equipment - Costs,account.data_account_type_non_current_assets,pe_chart_template,False
+chart36332,36332,Financial leasing - Machinery and exploitation equipment - Revaluation,account.data_account_type_non_current_assets,pe_chart_template,False
+chart36333,36333,Financial leasing - Machinery and exploitation equipment - Financing costs,account.data_account_type_non_current_assets,pe_chart_template,False
+chart36341,36341,Financial leasing - Transport units - Costs,account.data_account_type_non_current_assets,pe_chart_template,False
+chart36342,36342,Financial leasing - Transport units - Revaluation,account.data_account_type_non_current_assets,pe_chart_template,False
+chart36351,36351,Financial leasing - Furniture and fixtures - Costs,account.data_account_type_non_current_assets,pe_chart_template,False
+chart36352,36352,Financial leasing - Furniture and fixtures - Revaluation,account.data_account_type_non_current_assets,pe_chart_template,False
+chart36361,36361,Financial leasing - Miscellaneous equipment - Costs,account.data_account_type_non_current_assets,pe_chart_template,False
+chart36362,36362,Financial leasing - Miscellaneous equipment - Revaluation,account.data_account_type_non_current_assets,pe_chart_template,False
+chart36401,36401,Production plant in production - Costs,account.data_account_type_fixed_assets,pe_chart_template,False
+chart36402,36402,Production plant in production - Production plant in production - Revaluation,account.data_account_type_fixed_assets,pe_chart_template,False
+chart36403,36403,Production plant in production - Production plant in production - Financing costs,account.data_account_type_fixed_assets,pe_chart_template,False
+chart36405,36405,Production plant in production - Production plant in development - Costs,account.data_account_type_fixed_assets,pe_chart_template,False
+chart36406,36406,Production plant in production - Production plant in development - Revaluation,account.data_account_type_fixed_assets,pe_chart_template,False
+chart36407,36407,Production plant in production - Production plant in development - Financing costs,account.data_account_type_fixed_assets,pe_chart_template,False
+chart36408,36408,Production plant in production - Production plant in development - Fair value,account.data_account_type_fixed_assets,pe_chart_template,False
+chart36411,36411,Land - Costs,account.data_account_type_fixed_assets,pe_chart_template,False
+chart36412,36412,Land - Revaluation,account.data_account_type_fixed_assets,pe_chart_template,False
+chart36421,36421,Buildings - Buildings - Costs,account.data_account_type_fixed_assets,pe_chart_template,False
+chart36422,36422,Buildings - Buildings - Revaluation,account.data_account_type_fixed_assets,pe_chart_template,False
+chart36423,36423,Buildings - Buildings - Financing costs,account.data_account_type_fixed_assets,pe_chart_template,False
+chart36424,36424,Buildings - Installations - Costs,account.data_account_type_fixed_assets,pe_chart_template,False
+chart36425,36425,Buildings - Installations - Revaluation,account.data_account_type_fixed_assets,pe_chart_template,False
+chart36426,36426,Buildings - Installations - Financing costs,account.data_account_type_fixed_assets,pe_chart_template,False
+chart36427,36427,Buildings - Improvements in leased premises - Costs,account.data_account_type_fixed_assets,pe_chart_template,False
+chart36428,36428,Buildings - Improvements in leased premises - Revaluation,account.data_account_type_fixed_assets,pe_chart_template,False
+chart36429,36429,Buildings - Improvements in leased premises - Financing costs,account.data_account_type_fixed_assets,pe_chart_template,False
+chart36431,36431,Machinery and exploitation equipment - Costs,account.data_account_type_fixed_assets,pe_chart_template,False
+chart36432,36432,Machinery and exploitation equipment - Revaluation,account.data_account_type_fixed_assets,pe_chart_template,False
+chart36433,36433,Machinery and exploitation equipment - Financing costs,account.data_account_type_fixed_assets,pe_chart_template,False
+chart36441,36441,Transport units - Costs,account.data_account_type_fixed_assets,pe_chart_template,False
+chart36442,36442,Transport units - Revaluation,account.data_account_type_fixed_assets,pe_chart_template,False
+chart36451,36451,Furniture and fixtures - Costs,account.data_account_type_fixed_assets,pe_chart_template,False
+chart36452,36452,Furniture and fixtures - Revaluation,account.data_account_type_fixed_assets,pe_chart_template,False
+chart36461,36461,Miscellaneous equipment - Costs,account.data_account_type_fixed_assets,pe_chart_template,False
+chart36462,36462,Miscellaneous equipment - Revaluation,account.data_account_type_fixed_assets,pe_chart_template,False
+chart36471,36471,Replacement tools and units - Tools - Costs,account.data_account_type_fixed_assets,pe_chart_template,False
+chart36491,36491,Work in progress - Costs,account.data_account_type_fixed_assets,pe_chart_template,False
+chart36492,36492,Work in progress - Revaluation,account.data_account_type_fixed_assets,pe_chart_template,False
+chart36511,36511,"Concessions, licenses and other rights - Costs",account.data_account_type_non_current_assets,pe_chart_template,False
+chart36512,36512,"Concessions, licenses and other rights - Revaluation",account.data_account_type_non_current_assets,pe_chart_template,False
+chart36521,36521,Patents and industrial property - Costs,account.data_account_type_non_current_assets,pe_chart_template,False
+chart36522,36522,Patents and industrial property - Revaluation,account.data_account_type_non_current_assets,pe_chart_template,False
+chart36531,36531,Softwares - Costs,account.data_account_type_non_current_assets,pe_chart_template,False
+chart36532,36532,Softwares - Revaluation,account.data_account_type_non_current_assets,pe_chart_template,False
+chart36541,36541,Exploration and development costs - Costs,account.data_account_type_non_current_assets,pe_chart_template,False
+chart36542,36542,Exploration and development costs - Revaluation,account.data_account_type_non_current_assets,pe_chart_template,False
+chart36543,36543,Exploration and development costs - Financing costs,account.data_account_type_non_current_assets,pe_chart_template,False
+chart36551,36551,"Formulas, designs and prototypes - Costs",account.data_account_type_non_current_assets,pe_chart_template,False
+chart36552,36552,"Formulas, designs and prototypes - Revaluation",account.data_account_type_non_current_assets,pe_chart_template,False
+chart3657,3657,Goodwill,account.data_account_type_non_current_assets,pe_chart_template,False
+chart36591,36591,Other intangible assets - Costs,account.data_account_type_non_current_assets,pe_chart_template,False
+chart36592,36592,Other intangible assets - Revaluation,account.data_account_type_non_current_assets,pe_chart_template,False
+chart36611,36611,Biological assets in production - Costs,account.data_account_type_non_current_assets,pe_chart_template,False
+chart36613,36613,Biological assets in production - Financing costs,account.data_account_type_non_current_assets,pe_chart_template,False
+chart36621,36621,Biological assets under development - Costs,account.data_account_type_non_current_assets,pe_chart_template,False
+chart36622,36622,Biological assets under development - Financing costs,account.data_account_type_non_current_assets,pe_chart_template,False
+chart36711,36711,Investments to be held until maturity - Costs,account.data_account_type_non_current_assets,pe_chart_template,False
+chart36721,36721,Financial investments representative of patrimonial right - Costs,account.data_account_type_non_current_assets,pe_chart_template,False
+chart36731,36731,Other financial investments - Costs,account.data_account_type_non_current_assets,pe_chart_template,False
+chart3711,3711,Deferred income tax - Deferred income tax – Heritage,account.data_account_type_non_current_liabilities,pe_chart_template,False
+chart3712,3712,Deferred income tax - Deferred income tax – Results,account.data_account_type_non_current_liabilities,pe_chart_template,False
+chart3721,3721,Deferred employee shares - Deferred employee shares – Heritage,account.data_account_type_non_current_assets,pe_chart_template,False
+chart3722,3722,Deferred employee shares - Deferred employee shares – Results,account.data_account_type_non_current_assets,pe_chart_template,False
+chart3731,3731,Deferred interest - Unearned interest in transactions with third parties,account.data_account_type_non_current_assets,pe_chart_template,False
+chart3732,3732,Deferred interest - Unearned interest on discounted value measurement,account.data_account_type_non_current_assets,pe_chart_template,False
+chart3811,3811,Art and culture goods - Works of art,account.data_account_type_non_current_assets,pe_chart_template,False
+chart3812,3812,Art and culture goods - Library,account.data_account_type_non_current_assets,pe_chart_template,False
+chart3813,3813,Art and culture goods - Others,account.data_account_type_non_current_assets,pe_chart_template,False
+chart3821,3821,Misc. - Coins and jewelry,account.data_account_type_non_current_assets,pe_chart_template,False
+chart3822,3822,Misc. - Goods delivered on loan,account.data_account_type_non_current_assets,pe_chart_template,False
+chart3823,3823,Misc. - Assets received in payment (awarded and realizable),account.data_account_type_non_current_assets,pe_chart_template,False
+chart3829,3829,Misc. - Others,account.data_account_type_non_current_assets,pe_chart_template,False
+chart39111,39111,Accumulated depreciation investment properties - Buildings - Costs,account.data_account_type_non_current_assets,pe_chart_template,False
+chart39112,39112,Accumulated depreciation investment properties - Buildings - Revaluation,account.data_account_type_non_current_assets,pe_chart_template,False
+chart39113,39113,Accumulated depreciation investment properties - Buildings - Financing costs,account.data_account_type_non_current_assets,pe_chart_template,False
+chart39211,39211,Accumulated depreciation investment properties - Financial leasing - Buildings - Costs,account.data_account_type_non_current_assets,pe_chart_template,False
+chart39212,39212,Accumulated depreciation investment properties - Financial leasing - Buildings - Revaluation,account.data_account_type_non_current_assets,pe_chart_template,False
+chart39213,39213,Accumulated depreciation investment properties - Financial leasing - Buildings - Financing costs,account.data_account_type_non_current_assets,pe_chart_template,False
+chart39321,39321,"Accumulated depreciation property, plant and equipment - Financial leasing - Buildings - Costs",account.data_account_type_fixed_assets,pe_chart_template,False
+chart39322,39322,"Accumulated depreciation property, plant and equipment - Financial leasing - Buildings - Revaluation",account.data_account_type_fixed_assets,pe_chart_template,False
+chart39323,39323,"Accumulated depreciation property, plant and equipment - Financial leasing - Buildings - Financing costs",account.data_account_type_fixed_assets,pe_chart_template,False
+chart39331,39331,"Accumulated depreciation property, plant and equipment - Financial leasing - Machinery and exploitation equipment - Costs",account.data_account_type_fixed_assets,pe_chart_template,False
+chart39332,39332,"Accumulated depreciation property, plant and equipment - Financial leasing - Machinery and exploitation equipment - Revaluation",account.data_account_type_fixed_assets,pe_chart_template,False
+chart39333,39333,"Accumulated depreciation property, plant and equipment - Financial leasing - Machinery and exploitation equipment - Financing costs",account.data_account_type_fixed_assets,pe_chart_template,False
+chart39341,39341,"Accumulated depreciation property, plant and equipment - Financial leasing - Transport units - Costs",account.data_account_type_fixed_assets,pe_chart_template,False
+chart39342,39342,"Accumulated depreciation property, plant and equipment - Financial leasing - Transport units - Revaluation",account.data_account_type_fixed_assets,pe_chart_template,False
+chart39351,39351,"Accumulated depreciation property, plant and equipment - Financial leasing - Furniture and fixtures - Costs",account.data_account_type_fixed_assets,pe_chart_template,False
+chart39361,39361,"Accumulated depreciation property, plant and equipment - Financial leasing - Miscellaneous equipment - Costs",account.data_account_type_fixed_assets,pe_chart_template,False
+chart39362,39362,"Accumulated depreciation property, plant and equipment - Financial leasing - Miscellaneous equipment - Revaluation",account.data_account_type_fixed_assets,pe_chart_template,False
+chart39410,39410,Accumulated depreciation - Operating lease - Right-of-use assets - Operating lease - Production plants,account.data_account_type_non_current_assets,pe_chart_template,False
+chart39411,39411,Accumulated depreciation - Operating lease - Right-of-use assets - Operating lease - Land,account.data_account_type_non_current_assets,pe_chart_template,False
+chart39412,39412,Accumulated depreciation - Operating lease - Right-of-use assets - Operating lease - Buildings,account.data_account_type_non_current_assets,pe_chart_template,False
+chart39413,39413,Accumulated depreciation - Operating lease - Right-of-use assets - Operating lease - Machinery and exploitation equipment,account.data_account_type_non_current_assets,pe_chart_template,False
+chart39414,39414,Accumulated depreciation - Operating lease - Right-of-use assets - Operating lease - Transport units,account.data_account_type_non_current_assets,pe_chart_template,False
+chart39415,39415,Accumulated depreciation - Operating lease - Right-of-use assets - Operating lease - Miscellaneous equipment,account.data_account_type_non_current_assets,pe_chart_template,False
+chart39520,39520,"Accumulated depreciation of property, plant and equipment - Accumulated depreciation - Costs - Production plants",account.data_account_type_fixed_assets,pe_chart_template,False
+chart39521,39521,"Accumulated depreciation of property, plant and equipment - Accumulated depreciation - Costs - Buildings",account.data_account_type_fixed_assets,pe_chart_template,False
+chart39522,39522,"Accumulated depreciation of property, plant and equipment - Accumulated depreciation - Costs - Installations",account.data_account_type_fixed_assets,pe_chart_template,False
+chart39523,39523,"Accumulated depreciation of property, plant and equipment - Accumulated depreciation - Costs - Improvements in leased premises",account.data_account_type_fixed_assets,pe_chart_template,False
+chart39524,39524,"Accumulated depreciation of property, plant and equipment - Accumulated depreciation - Costs - Machinery and exploitation equipment",account.data_account_type_fixed_assets,pe_chart_template,False
+chart39525,39525,"Accumulated depreciation of property, plant and equipment - Accumulated depreciation - Costs - Transport units",account.data_account_type_fixed_assets,pe_chart_template,False
+chart39526,39526,"Accumulated depreciation of property, plant and equipment - Accumulated depreciation - Costs - Furniture and fixtures",account.data_account_type_fixed_assets,pe_chart_template,False
+chart39527,39527,"Accumulated depreciation of property, plant and equipment - Accumulated depreciation - Costs - Miscellaneous equipment",account.data_account_type_fixed_assets,pe_chart_template,False
+chart39528,39528,"Accumulated depreciation of property, plant and equipment - Accumulated depreciation - Costs - Tools",account.data_account_type_fixed_assets,pe_chart_template,False
+chart39529,39529,"Accumulated depreciation of property, plant and equipment - Accumulated depreciation - Costs - Replacement units",account.data_account_type_fixed_assets,pe_chart_template,False
+chart39530,39530,"Accumulated depreciation of property, plant and equipment - Property, plant and equipment - Revaluation - Production plants",account.data_account_type_fixed_assets,pe_chart_template,False
+chart39531,39531,"Accumulated depreciation of property, plant and equipment - Property, plant and equipment - Revaluation - Buildings",account.data_account_type_fixed_assets,pe_chart_template,False
+chart39532,39532,"Accumulated depreciation of property, plant and equipment - Property, plant and equipment - Revaluation - Installations",account.data_account_type_fixed_assets,pe_chart_template,False
+chart39533,39533,"Accumulated depreciation of property, plant and equipment - Property, plant and equipment - Revaluation - Improvements in leased premises",account.data_account_type_fixed_assets,pe_chart_template,False
+chart39534,39534,"Accumulated depreciation of property, plant and equipment - Property, plant and equipment - Revaluation - Machinery and exploitation equipment",account.data_account_type_fixed_assets,pe_chart_template,False
+chart39535,39535,"Accumulated depreciation of property, plant and equipment - Property, plant and equipment - Revaluation - Transport units",account.data_account_type_fixed_assets,pe_chart_template,False
+chart39536,39536,"Accumulated depreciation of property, plant and equipment - Property, plant and equipment - Revaluation - Furniture and fixtures",account.data_account_type_fixed_assets,pe_chart_template,False
+chart39537,39537,"Accumulated depreciation of property, plant and equipment - Property, plant and equipment - Revaluation - Miscellaneous equipment",account.data_account_type_fixed_assets,pe_chart_template,False
+chart39538,39538,"Accumulated depreciation of property, plant and equipment - Property, plant and equipment - Revaluation - Replacement tools and units",account.data_account_type_fixed_assets,pe_chart_template,False
+chart39540,39540,"Accumulated depreciation of property, plant and equipment - Property, plant and equipment - Financing costs - Production plants",account.data_account_type_fixed_assets,pe_chart_template,False
+chart39541,39541,"Accumulated depreciation of property, plant and equipment - Property, plant and equipment - Financing costs - Buildings",account.data_account_type_fixed_assets,pe_chart_template,False
+chart39542,39542,"Accumulated depreciation of property, plant and equipment - Property, plant and equipment - Financing costs - Machinery and exploitation equipment",account.data_account_type_fixed_assets,pe_chart_template,False
+chart39550,39550,"Accumulated depreciation of property, plant and equipment - Property, plant and equipment - Fair value - Production plants",account.data_account_type_fixed_assets,pe_chart_template,False
+chart39611,39611,"Accumulated amortization - Intangibles – Costs - Concessions, licenses and other rights",account.data_account_type_non_current_assets,pe_chart_template,False
+chart39612,39612,Accumulated amortization - Intangibles – Costs - Patents and industrial property,account.data_account_type_non_current_assets,pe_chart_template,False
+chart39613,39613,Accumulated amortization - Intangibles – Costs - Softwares,account.data_account_type_non_current_assets,pe_chart_template,False
+chart39614,39614,Accumulated amortization - Intangibles – Costs - Exploration and development costs,account.data_account_type_non_current_assets,pe_chart_template,False
+chart39615,39615,"Accumulated amortization - Intangibles – Costs - Formulas, designs and prototypes",account.data_account_type_non_current_assets,pe_chart_template,False
+chart39619,39619,Accumulated amortization - Intangibles – Costs - Other intangible assets,account.data_account_type_non_current_assets,pe_chart_template,False
+chart39621,39621,"Accumulated amortization - Intangibles – Revaluation - Concessions, licenses and other rights",account.data_account_type_non_current_assets,pe_chart_template,False
+chart39622,39622,Accumulated amortization - Intangibles – Revaluation - Patents and industrial property,account.data_account_type_non_current_assets,pe_chart_template,False
+chart39623,39623,Accumulated amortization - Intangibles – Revaluation - Softwares,account.data_account_type_non_current_assets,pe_chart_template,False
+chart39624,39624,Accumulated amortization - Intangibles – Revaluation - Exploration and development costs,account.data_account_type_non_current_assets,pe_chart_template,False
+chart39625,39625,"Accumulated amortization - Intangibles – Revaluation - Formulas, designs and prototypes",account.data_account_type_non_current_assets,pe_chart_template,False
+chart39629,39629,Accumulated amortization - Intangibles – Revaluation - Other intangible assets,account.data_account_type_non_current_assets,pe_chart_template,False
+chart39633,39633,Accumulated amortization - Intangibles – Financing costs - Softwares,account.data_account_type_non_current_assets,pe_chart_template,False
+chart39634,39634,Accumulated amortization - Intangibles – Financing costs - Exploration costs,account.data_account_type_non_current_assets,pe_chart_template,False
+chart39635,39635,Accumulated amortization - Intangibles – Financing costs - Development costs,account.data_account_type_non_current_assets,pe_chart_template,False
+chart39811,39811,Accumulated depreciation - Biological assets in production - Biological assets in production - Costs - Biological assets in production,account.data_account_type_non_current_assets,pe_chart_template,False
+chart40111,40111,National government - General sales tax - IGV – Own account,account.data_account_type_current_liabilities,pe_chart_template,False
+chart40112,40112,National government - General sales tax - IGV – Services provided by non-residents,account.data_account_type_current_liabilities,pe_chart_template,False
+chart40113,40113,National government - General sales tax - IGV – Perception regime,account.data_account_type_current_liabilities,pe_chart_template,False
+chart40114,40114,National government - General sales tax - IGV – Withholding regime,account.data_account_type_current_liabilities,pe_chart_template,False
+chart40115,40115,National government - General sales tax - IGV – Imports,account.data_account_type_current_liabilities,pe_chart_template,False
+chart40116,40116,National government - General sales tax - IGV – Intended for taxed operations,account.data_account_type_current_liabilities,pe_chart_template,False
+chart40117,40117,National government - General sales tax - IGV - Intended for common operations,account.data_account_type_current_liabilities,pe_chart_template,False
+chart4012,4012,National government - Excise tax,account.data_account_type_current_liabilities,pe_chart_template,False
+chart40151,40151,National government - Customs duties - Customs tariff,account.data_account_type_current_liabilities,pe_chart_template,False
+chart40152,40152,National government - Customs duties - Other customs duties,account.data_account_type_current_liabilities,pe_chart_template,False
+chart40171,40171,National government - Income tax - Third category income,account.data_account_type_current_liabilities,pe_chart_template,False
+chart40172,40172,National government - Income tax - Fourth category rent,account.data_account_type_current_liabilities,pe_chart_template,False
+chart40173,40173,National government - Income tax - Fifth category income,account.data_account_type_current_liabilities,pe_chart_template,False
+chart40174,40174,National government - Income tax - Non-domiciled income,account.data_account_type_current_liabilities,pe_chart_template,False
+chart40175,40175,National government - Income tax - Other retentions,account.data_account_type_current_liabilities,pe_chart_template,False
+chart40181,40181,National government - Other taxes and considerations - Financial transaction tax,account.data_account_type_current_liabilities,pe_chart_template,False
+chart40182,40182,National government - Other taxes and considerations - Tax on casino games and slots,account.data_account_type_current_liabilities,pe_chart_template,False
+chart40183,40183,National government - Other taxes and considerations - Fees for the provision of public services,account.data_account_type_current_liabilities,pe_chart_template,False
+chart40184,40184,National government - Other taxes and considerations - Royalties,account.data_account_type_current_liabilities,pe_chart_template,False
+chart40185,40185,National government - Other taxes and considerations - Dividends tax,account.data_account_type_current_liabilities,pe_chart_template,False
+chart40186,40186,National government - Other taxes and considerations - Temporary tax on net assets,account.data_account_type_current_liabilities,pe_chart_template,False
+chart40189,40189,National government - Other taxes and considerations - Other taxes,account.data_account_type_current_liabilities,pe_chart_template,False
+chart402,402,Tax certificates,account.data_account_type_current_liabilities,pe_chart_template,False
+chart4031,4031,Public institutions - ESSALUD,account.data_account_type_current_liabilities,pe_chart_template,False
+chart4032,4032,Public institutions - ONP,account.data_account_type_current_liabilities,pe_chart_template,False
+chart4033,4033,Public institutions - Contribution to SENATI,account.data_account_type_current_liabilities,pe_chart_template,False
+chart4034,4034,Public institutions - Contribution to SENCICO,account.data_account_type_current_liabilities,pe_chart_template,False
+chart4039,4039,Public institutions - Otras instituciones,account.data_account_type_current_liabilities,pe_chart_template,False
+chart405,405,Regional government,account.data_account_type_current_liabilities,pe_chart_template,False
+chart40611,40611,Local governments - Taxes - Vehicle property tax,account.data_account_type_current_liabilities,pe_chart_template,False
+chart40612,40612,Local governments - Taxes - Gambling tax,account.data_account_type_current_liabilities,pe_chart_template,False
+chart40613,40613,Local governments - Taxes - Gaming taxes,account.data_account_type_current_liabilities,pe_chart_template,False
+chart40614,40614,Local governments - Taxes - Impuesto de alcabala,account.data_account_type_current_liabilities,pe_chart_template,False
+chart40615,40615,Local governments - Taxes - Property tax,account.data_account_type_current_liabilities,pe_chart_template,False
+chart40616,40616,Local governments - Taxes - Tax on non-sporting public shows,account.data_account_type_current_liabilities,pe_chart_template,False
+chart4062,4062,Local governments - Contributions,account.data_account_type_current_liabilities,pe_chart_template,False
+chart40631,40631,Local governments - Fees - Establishment opening license,account.data_account_type_current_liabilities,pe_chart_template,False
+chart40632,40632,Local governments - Fees - Public transportation,account.data_account_type_current_liabilities,pe_chart_template,False
+chart40633,40633,Local governments - Fees - Vehicle parking,account.data_account_type_current_liabilities,pe_chart_template,False
+chart40634,40634,Local governments - Fees - Public or arbitrary services,account.data_account_type_current_liabilities,pe_chart_template,False
+chart40635,40635,Local governments - Fees - Administrative services or rights,account.data_account_type_current_liabilities,pe_chart_template,False
+chart409,409,Other administrative costs and interest,account.data_account_type_current_liabilities,pe_chart_template,False
+chart4111,4111,Remuneration payable - Wages and salaries payable,account.data_account_type_payable,pe_chart_template,True
+chart4112,4112,Remuneration payable - Commissions payable,account.data_account_type_payable,pe_chart_template,True
+chart4113,4113,Remuneration payable - Remuneration in kind payable,account.data_account_type_payable,pe_chart_template,True
+chart4114,4114,Remuneration payable - Gratuities payable,account.data_account_type_payable,pe_chart_template,True
+chart4115,4115,Remuneration payable - Payable vacation,account.data_account_type_payable,pe_chart_template,True
+chart413,413,Employee participations payable,account.data_account_type_payable,pe_chart_template,True
+chart4151,4151,Employee social benefits payable - Compensation for time of services,account.data_account_type_payable,pe_chart_template,True
+chart4152,4152,Employee social benefits payable - Advance compensation for length of service,account.data_account_type_payable,pe_chart_template,True
+chart4153,4153,Employee social benefits payable - Pensions and retirement,account.data_account_type_payable,pe_chart_template,True
+chart417,417,Administrators of pension funds,account.data_account_type_payable,pe_chart_template,True
+chart419,419,Other remuneration and shares payable,account.data_account_type_payable,pe_chart_template,True
+chart4211,4211,"Invoices, tickets and other payable vouchers - Not issued",account.data_account_type_payable,pe_chart_template,True
+chart4212,4212,"Invoices, tickets and other payable vouchers - Not issued",account.data_account_type_payable,pe_chart_template,True
+chart422,422,Advances to suppliers,account.data_account_type_payable,pe_chart_template,True
+chart423,423,Bills to pay,account.data_account_type_payable,pe_chart_template,True
+chart424,424,Honors to be payed,account.data_account_type_payable,pe_chart_template,True
+chart4311,4311,"Invoices, tickets and other payable vouchers - Not issued",account.data_account_type_payable,pe_chart_template,True
+chart4312,4312,"Invoices, tickets and other payable vouchers - Not issued",account.data_account_type_payable,pe_chart_template,True
+chart4321,4321,Advances granted - Advances granted,account.data_account_type_payable,pe_chart_template,True
+chart4331,4331,Bills to pay - Bills to pay,account.data_account_type_payable,pe_chart_template,True
+chart4341,4341,Honors to be payed - Honors to be payed,account.data_account_type_payable,pe_chart_template,True
+chart4411,4411,"Shareholders (partners, participants) - Loans",account.data_account_type_non_current_liabilities,pe_chart_template,False
+chart4412,4412,"Shareholders (partners, participants) - Dividends",account.data_account_type_non_current_liabilities,pe_chart_template,False
+chart4419,4419,"Shareholders (partners, participants) - Other accounts payable",account.data_account_type_non_current_liabilities,pe_chart_template,False
+chart4421,4421,Directors - Subsistence allowance,account.data_account_type_non_current_liabilities,pe_chart_template,False
+chart4429,4429,Directors - Other accounts payable,account.data_account_type_non_current_liabilities,pe_chart_template,False
+chart4511,4511,Loans from financial institutions and other entities - Financial institutions,account.data_account_type_current_liabilities,pe_chart_template,False
+chart4512,4512,Loans from financial institutions and other entities - Other entities,account.data_account_type_current_liabilities,pe_chart_template,False
+chart452,452,Financial lease contracts,account.data_account_type_current_liabilities,pe_chart_template,False
+chart4531,4531,Bonds issued - Issued bonds,account.data_account_type_current_liabilities,pe_chart_template,False
+chart4532,4532,Bonds issued - Bonds securitized,account.data_account_type_current_liabilities,pe_chart_template,False
+chart4533,4533,Bonds issued - Commercial papers,account.data_account_type_current_liabilities,pe_chart_template,False
+chart4539,4539,Bonds issued - Other obligations,account.data_account_type_current_liabilities,pe_chart_template,False
+chart4541,4541,Other financial instruments payable - Bills,account.data_account_type_current_liabilities,pe_chart_template,False
+chart4542,4542,Other financial instruments payable - Commercial papers,account.data_account_type_current_liabilities,pe_chart_template,False
+chart4543,4543,Other financial instruments payable - Bonds,account.data_account_type_current_liabilities,pe_chart_template,False
+chart4544,4544,Other financial instruments payable - Promissory notes,account.data_account_type_current_liabilities,pe_chart_template,False
+chart4545,4545,Other financial instruments payable - Conformed invoices,account.data_account_type_current_liabilities,pe_chart_template,False
+chart4549,4549,Other financial instruments payable - Other financial obligations,account.data_account_type_current_liabilities,pe_chart_template,False
+chart45511,45511,Financing costs payable - Loans from financial institutions and other entities - Financial institutions,account.data_account_type_current_liabilities,pe_chart_template,False
+chart45512,45512,Financing costs payable - Loans from financial institutions and other entities - Other entities,account.data_account_type_current_liabilities,pe_chart_template,False
+chart4552,4552,Financing costs payable - Financial lease contracts,account.data_account_type_current_liabilities,pe_chart_template,False
+chart45531,45531,Financing costs payable - Bonds issued - Issued bonds,account.data_account_type_current_liabilities,pe_chart_template,False
+chart45532,45532,Financing costs payable - Bonds issued - Bonds securitized,account.data_account_type_current_liabilities,pe_chart_template,False
+chart45533,45533,Financing costs payable - Bonds issued - Commercial papers,account.data_account_type_current_liabilities,pe_chart_template,False
+chart45539,45539,Financing costs payable - Bonds issued - Other obligations,account.data_account_type_current_liabilities,pe_chart_template,False
+chart45541,45541,Financing costs payable - Other financial instruments payable - Bills,account.data_account_type_current_liabilities,pe_chart_template,False
+chart45542,45542,Financing costs payable - Other financial instruments payable - Commercial papers,account.data_account_type_current_liabilities,pe_chart_template,False
+chart45543,45543,Financing costs payable - Other financial instruments payable - Bonds,account.data_account_type_current_liabilities,pe_chart_template,False
+chart45544,45544,Financing costs payable - Other financial instruments payable - Promissory notes,account.data_account_type_current_liabilities,pe_chart_template,False
+chart45545,45545,Financing costs payable - Other financial instruments payable - Conformed invoices,account.data_account_type_current_liabilities,pe_chart_template,False
+chart45549,45549,Financing costs payable - Other financial instruments payable - Other financial obligations,account.data_account_type_current_liabilities,pe_chart_template,False
+chart456,456,Loans with repurchase commitments,account.data_account_type_current_liabilities,pe_chart_template,False
+chart461,461,Third Party Claims,account.data_account_type_payable,pe_chart_template,True
+chart4641,4641,Liabilities for financial instruments - Primary financial instruments,account.data_account_type_payable,pe_chart_template,True
+chart46421,46421,Liabilities for financial instruments - Derivative financial instruments - Trading book,account.data_account_type_payable,pe_chart_template,True
+chart46422,46422,Liabilities for financial instruments - Derivative financial instruments - Hedging instruments,account.data_account_type_payable,pe_chart_template,True
+chart4651,4651,Liabilities for purchase of fixed assets - Securities investments,account.data_account_type_payable,pe_chart_template,True
+chart4652,4652,Liabilities for purchase of fixed assets - Investment property,account.data_account_type_payable,pe_chart_template,True
+chart4653,4653,Liabilities for purchase of fixed assets - Assets acquired under finance lease,account.data_account_type_payable,pe_chart_template,True
+chart4654,4654,"Liabilities for purchase of fixed assets - Property, plant and equipment",account.data_account_type_payable,pe_chart_template,True
+chart4655,4655,Liabilities for purchase of fixed assets - Intangibles,account.data_account_type_payable,pe_chart_template,True
+chart4656,4656,Liabilities for purchase of fixed assets - Biological assets,account.data_account_type_payable,pe_chart_template,True
+chart466,466,Participation of third parties in joint agreements,account.data_account_type_payable,pe_chart_template,True
+chart467,467,Deposits received in guarantee,account.data_account_type_payable,pe_chart_template,True
+chart4691,4691,Other sundry accounts payable - Government subsidies,account.data_account_type_payable,pe_chart_template,True
+chart4692,4692,Other sundry accounts payable - Conditional donations,account.data_account_type_payable,pe_chart_template,True
+chart4699,4699,Other sundry accounts payable - Other accounts payable,account.data_account_type_payable,pe_chart_template,True
+chart471,471,Loans,account.data_account_type_payable,pe_chart_template,True
+chart472,472,Financing costs,account.data_account_type_payable,pe_chart_template,True
+chart473,473,Advances received,account.data_account_type_payable,pe_chart_template,True
+chart474,474,Royalties,account.data_account_type_payable,pe_chart_template,True
+chart475,475,Dividends,account.data_account_type_payable,pe_chart_template,True
+chart476,476,Deposits received in guarantee,account.data_account_type_payable,pe_chart_template,True
+chart4771,4771,Liabilities for purchase of fixed assets - Securities investments,account.data_account_type_payable,pe_chart_template,True
+chart4772,4772,Liabilities for purchase of fixed assets - Investment property,account.data_account_type_payable,pe_chart_template,True
+chart4773,4773,Liabilities for purchase of fixed assets - Assets acquired under finance lease,account.data_account_type_payable,pe_chart_template,True
+chart4774,4774,"Liabilities for purchase of fixed assets - Property, plant and equipment",account.data_account_type_payable,pe_chart_template,True
+chart4775,4775,Liabilities for purchase of fixed assets - Intangibles,account.data_account_type_payable,pe_chart_template,True
+chart4776,4776,Liabilities for purchase of fixed assets - Biological assets,account.data_account_type_payable,pe_chart_template,True
+chart4791,4791,Other sundry accounts payable - Other sundry accounts payable,account.data_account_type_payable,pe_chart_template,True
+chart481,481,Provision for litigation,account.data_account_type_non_current_liabilities,pe_chart_template,False
+chart482,482,"Provision for dismantling, removal or rehabilitation of fixed assets",account.data_account_type_non_current_liabilities,pe_chart_template,False
+chart483,483,Provision for restructurings,account.data_account_type_non_current_liabilities,pe_chart_template,False
+chart484,484,Provision for environmental protection and remediation,account.data_account_type_non_current_liabilities,pe_chart_template,False
+chart485,485,Provision for social responsibility expenses,account.data_account_type_non_current_liabilities,pe_chart_template,False
+chart486,486,Provision for guarantees,account.data_account_type_non_current_liabilities,pe_chart_template,False
+chart487,487,Provision for right-of-use assets,account.data_account_type_non_current_liabilities,pe_chart_template,False
+chart489,489,Other provisions,account.data_account_type_non_current_liabilities,pe_chart_template,False
+chart4911,4911,Deferred income tax - Deferred income tax – Heritage,account.data_account_type_non_current_liabilities,pe_chart_template,False
+chart4912,4912,Deferred income tax - Deferred income tax – Results,account.data_account_type_non_current_liabilities,pe_chart_template,False
+chart4921,4921,Deferred employee shares - Deferred employee shares – Heritage,account.data_account_type_current_liabilities,pe_chart_template,False
+chart4922,4922,Deferred employee shares - Deferred employee shares – Results,account.data_account_type_current_liabilities,pe_chart_template,False
+chart4931,4931,Deferred interest - Unearned interest in transactions with third parties,account.data_account_type_current_liabilities,pe_chart_template,False
+chart4932,4932,Deferred interest - Unearned interest on discounted value measurement,account.data_account_type_current_liabilities,pe_chart_template,False
+chart494,494,Profit on sale with parallel financial lease,account.data_account_type_current_liabilities,pe_chart_template,False
+chart495,495,Deferred subsidies received,account.data_account_type_current_liabilities,pe_chart_template,False
+chart496,496,Deferred income,account.data_account_type_current_liabilities,pe_chart_template,False
+chart497,497,Deferred costs,account.data_account_type_current_liabilities,pe_chart_template,False
+chart5011,5011,Capital social - Actions,account.data_account_type_equity,pe_chart_template,False
+chart5012,5012,Capital social - Participations,account.data_account_type_equity,pe_chart_template,False
+chart502,502,Treasury shares,account.data_account_type_equity,pe_chart_template,False
+chart511,511,Investment shares,account.data_account_type_equity,pe_chart_template,False
+chart512,512,Investment shares in treasury,account.data_account_type_equity,pe_chart_template,False
+chart521,521,Premiums (discount) of shares,account.data_account_type_equity,pe_chart_template,False
+chart5221,5221,Capitalizations in process - Contributions,account.data_account_type_equity,pe_chart_template,False
+chart5222,5222,Capitalizations in process - Reserves,account.data_account_type_equity,pe_chart_template,False
+chart5223,5223,Capitalizations in process - Credits,account.data_account_type_equity,pe_chart_template,False
+chart5224,5224,Capitalizations in process - Utilities,account.data_account_type_equity,pe_chart_template,False
+chart523,523,Capital reductions pending formalization,account.data_account_type_equity,pe_chart_template,False
+chart561,561,Exchange difference on permanent investments in foreign entities,account.data_account_type_equity,pe_chart_template,False
+chart562,562,Financial instruments – Hedges,account.data_account_type_equity,pe_chart_template,False
+chart5631,5631,Result on financial assets or liabilities held for trading - Profit,account.data_account_type_equity,pe_chart_template,False
+chart5632,5632,Result on financial assets or liabilities held for trading - Lost,account.data_account_type_equity,pe_chart_template,False
+chart5641,5641,Result in other assets or liabilities for financial investments - Profit,account.data_account_type_equity,pe_chart_template,False
+chart5642,5642,Result in other assets or liabilities for financial investments - Lost,account.data_account_type_equity,pe_chart_template,False
+chart5651,5651,Result on financial assets or liabilities held for trading – Conventional purchase or sale settlement date - Profit,account.data_account_type_equity,pe_chart_template,False
+chart5652,5652,Result on financial assets or liabilities held for trading – Conventional purchase or sale settlement date - Lost,account.data_account_type_equity,pe_chart_template,False
+chart57111,57111,Revaluation surplus - Investment property - Direct acquisition,account.data_account_type_equity,pe_chart_template,False
+chart57112,57112,Revaluation surplus - Investment property - Financial leasing,account.data_account_type_equity,pe_chart_template,False
+chart57121,57121,"Revaluation surplus - Property, plant and equipment - Direct acquisition",account.data_account_type_equity,pe_chart_template,False
+chart57122,57122,"Revaluation surplus - Property, plant and equipment - Financial leasing",account.data_account_type_equity,pe_chart_template,False
+chart5713,5713,Revaluation surplus - Intangibles,account.data_account_type_equity,pe_chart_template,False
+chart5714,5714,Revaluation surplus - Right-of-use assets - Operating lease,account.data_account_type_equity,pe_chart_template,False
+chart572,572,Revaluation surplus – Released shares received,account.data_account_type_equity,pe_chart_template,False
+chart573,573,Participation in revaluation surplus – Investments in related entities,account.data_account_type_equity,pe_chart_template,False
+chart581,581,Reinvestment,account.data_account_type_equity,pe_chart_template,False
 chart582,582,Legal,account.data_account_type_equity,pe_chart_template,False
-chart583,583,Contractuales,account.data_account_type_equity,pe_chart_template,False
-chart584,584,Estatutarias,account.data_account_type_equity,pe_chart_template,False
-chart585,585,Facultativas,account.data_account_type_equity,pe_chart_template,False
-chart589,589,Otras reservas,account.data_account_type_equity,pe_chart_template,False
-chart5911,5911,Utilidades no distribuidas - Utilidades acumuladas,account.data_account_type_equity,pe_chart_template,False
-chart5912,5912,Utilidades no distribuidas - Ingresos de años anteriores,account.data_account_type_equity,pe_chart_template,False
-chart5921,5921,Pérdidas acumuladas - Pérdidas acumuladas,account.data_account_type_equity,pe_chart_template,False
-chart5922,5922,Pérdidas acumuladas - Gastos de años anteriores,account.data_account_type_equity,pe_chart_template,False
-chart6011,6011,Mercaderías - Mercaderías,account.data_account_type_expenses,pe_chart_template,False
-chart602,602,Materias primas,account.data_account_type_expenses,pe_chart_template,False
-chart6031,6031,"Materiales auxiliares, suministros y repuestos - Materiales auxiliares",account.data_account_type_expenses,pe_chart_template,False
-chart6032,6032,"Materiales auxiliares, suministros y repuestos - Suministros",account.data_account_type_expenses,pe_chart_template,False
-chart6033,6033,"Materiales auxiliares, suministros y repuestos - Repuestos",account.data_account_type_expenses,pe_chart_template,False
-chart6041,6041,Envases y embalajes - Envases,account.data_account_type_expenses,pe_chart_template,False
-chart6042,6042,Envases y embalajes - Embalajes,account.data_account_type_expenses,pe_chart_template,False
-chart60911,60911,Costos vinculados con las compras - Costos vinculados con las compras de mercaderías - Transporte,account.data_account_type_expenses,pe_chart_template,False
-chart60912,60912,Costos vinculados con las compras - Costos vinculados con las compras de mercaderías - Seguros,account.data_account_type_expenses,pe_chart_template,False
-chart60913,60913,Costos vinculados con las compras - Costos vinculados con las compras de mercaderías - Derechos aduaneros,account.data_account_type_expenses,pe_chart_template,False
-chart60914,60914,Costos vinculados con las compras - Costos vinculados con las compras de mercaderías - Comisiones,account.data_account_type_expenses,pe_chart_template,False
-chart60919,60919,Costos vinculados con las compras - Costos vinculados con las compras de mercaderías - Otros costos,account.data_account_type_expenses,pe_chart_template,False
-chart60921,60921,Costos vinculados con las compras - Costos vinculados con las compras de materias primas - Transporte,account.data_account_type_expenses,pe_chart_template,False
-chart60922,60922,Costos vinculados con las compras - Costos vinculados con las compras de materias primas - Seguros,account.data_account_type_expenses,pe_chart_template,False
-chart60923,60923,Costos vinculados con las compras - Costos vinculados con las compras de materias primas - Derechos aduaneros,account.data_account_type_expenses,pe_chart_template,False
-chart60924,60924,Costos vinculados con las compras - Costos vinculados con las compras de materias primas - Comisiones,account.data_account_type_expenses,pe_chart_template,False
-chart60925,60925,Costos vinculados con las compras - Costos vinculados con las compras de materias primas - Otros costos,account.data_account_type_expenses,pe_chart_template,False
-chart60931,60931,"Costos vinculados con las compras - Costos vinculados con las compras de materiales, suministros y repuestos - Transporte",account.data_account_type_expenses,pe_chart_template,False
-chart60932,60932,"Costos vinculados con las compras - Costos vinculados con las compras de materiales, suministros y repuestos - Seguros",account.data_account_type_expenses,pe_chart_template,False
-chart60933,60933,"Costos vinculados con las compras - Costos vinculados con las compras de materiales, suministros y repuestos - Derechos aduaneros",account.data_account_type_expenses,pe_chart_template,False
-chart60934,60934,"Costos vinculados con las compras - Costos vinculados con las compras de materiales, suministros y repuestos - Comisiones",account.data_account_type_expenses,pe_chart_template,False
-chart60935,60935,"Costos vinculados con las compras - Costos vinculados con las compras de materiales, suministros y repuestos - Otros costos",account.data_account_type_expenses,pe_chart_template,False
-chart60941,60941,Costos vinculados con las compras - Costos vinculados con las compras de envases y embalajes - Transporte,account.data_account_type_expenses,pe_chart_template,False
-chart60942,60942,Costos vinculados con las compras - Costos vinculados con las compras de envases y embalajes - Seguros,account.data_account_type_expenses,pe_chart_template,False
-chart60943,60943,Costos vinculados con las compras - Costos vinculados con las compras de envases y embalajes - Derechos aduaneros,account.data_account_type_expenses,pe_chart_template,False
-chart60944,60944,Costos vinculados con las compras - Costos vinculados con las compras de envases y embalajes - Comisiones,account.data_account_type_expenses,pe_chart_template,False
-chart60945,60945,Costos vinculados con las compras - Costos vinculados con las compras de envases y embalajes - Otros costos,account.data_account_type_expenses,pe_chart_template,False
-chart6111,6111,Mercaderías - Mercaderías,account.data_account_type_expenses,pe_chart_template,False
-chart6121,6121,Materias primas - Materias primas,account.data_account_type_expenses,pe_chart_template,False
-chart6131,6131,"Materiales auxiliares, suministros y repuestos - Materiales auxiliares",account.data_account_type_expenses,pe_chart_template,False
-chart6132,6132,"Materiales auxiliares, suministros y repuestos - Suministros",account.data_account_type_expenses,pe_chart_template,False
-chart6133,6133,"Materiales auxiliares, suministros y repuestos - Repuestos",account.data_account_type_expenses,pe_chart_template,False
-chart6141,6141,Envases y embalajes - Envases,account.data_account_type_expenses,pe_chart_template,False
-chart6142,6142,Envases y embalajes - Embalajes,account.data_account_type_expenses,pe_chart_template,False
-chart6211,6211,Remuneraciones - Sueldos y salarios,account.data_account_type_expenses,pe_chart_template,False
-chart6212,6212,Remuneraciones - Comisiones,account.data_account_type_expenses,pe_chart_template,False
-chart6213,6213,Remuneraciones - Remuneraciones en especie,account.data_account_type_expenses,pe_chart_template,False
-chart6214,6214,Remuneraciones - Gratificaciones,account.data_account_type_expenses,pe_chart_template,False
-chart6215,6215,Remuneraciones - Vacaciones,account.data_account_type_expenses,pe_chart_template,False
-chart622,622,Otras remuneraciones,account.data_account_type_expenses,pe_chart_template,False
-chart623,623,Indemnizaciones al personal,account.data_account_type_expenses,pe_chart_template,False
-chart624,624,Capacitación,account.data_account_type_expenses,pe_chart_template,False
-chart625,625,Atención al personal,account.data_account_type_expenses,pe_chart_template,False
-chart6271,6271,"Seguridad, previsión social y otras contribuciones - Régimen de prestaciones de salud",account.data_account_type_expenses,pe_chart_template,False
-chart6272,6272,"Seguridad, previsión social y otras contribuciones - Régimen de pensiones - Aporte de empresa",account.data_account_type_expenses,pe_chart_template,False
-chart6273,6273,"Seguridad, previsión social y otras contribuciones - Seguro complementario de trabajo de riesgo, accidentes de trabajo y enfermedades profesionales",account.data_account_type_expenses,pe_chart_template,False
-chart6274,6274,"Seguridad, previsión social y otras contribuciones - Seguro de vida",account.data_account_type_expenses,pe_chart_template,False
-chart6275,6275,"Seguridad, previsión social y otras contribuciones - Seguros particulares de prestaciones de salud – EPS y otros particulares",account.data_account_type_expenses,pe_chart_template,False
-chart6276,6276,"Seguridad, previsión social y otras contribuciones - Caja de beneficios de seguridad social del pescador",account.data_account_type_expenses,pe_chart_template,False
-chart6277,6277,"Seguridad, previsión social y otras contribuciones - Contribuciones al SENATI",account.data_account_type_expenses,pe_chart_template,False
-chart628,628,Retribuciones al directorio,account.data_account_type_expenses,pe_chart_template,False
-chart6291,6291,Beneficios sociales de los trabajadores - Compensación por tiempo de servicio,account.data_account_type_expenses,pe_chart_template,False
-chart6292,6292,Beneficios sociales de los trabajadores - Pensiones y jubilaciones,account.data_account_type_expenses,pe_chart_template,False
-chart6293,6293,Beneficios sociales de los trabajadores - Otros beneficios post-empleo,account.data_account_type_expenses,pe_chart_template,False
-chart62941,62941,Beneficios sociales de los trabajadores - Participación en las utilidades - Participación corriente,account.data_account_type_expenses,pe_chart_template,False
-chart62942,62942,Beneficios sociales de los trabajadores - Participación en las utilidades - Participación diferida,account.data_account_type_expenses,pe_chart_template,False
-chart63111,63111,"Transporte, correos y gastos de viaje - Transporte - De carga",account.data_account_type_expenses,pe_chart_template,False
-chart63112,63112,"Transporte, correos y gastos de viaje - Transporte - De pasajeros",account.data_account_type_expenses,pe_chart_template,False
-chart6312,6312,"Transporte, correos y gastos de viaje - Correos",account.data_account_type_expenses,pe_chart_template,False
-chart6313,6313,"Transporte, correos y gastos de viaje - Alojamiento",account.data_account_type_expenses,pe_chart_template,False
-chart6314,6314,"Transporte, correos y gastos de viaje - Alimentación",account.data_account_type_expenses,pe_chart_template,False
-chart6315,6315,"Transporte, correos y gastos de viaje - Otros gastos de viaje",account.data_account_type_expenses,pe_chart_template,False
-chart6321,6321,Asesoría y consultoría - Administrativa,account.data_account_type_expenses,pe_chart_template,False
-chart6322,6322,Asesoría y consultoría - Legal y tributaria,account.data_account_type_expenses,pe_chart_template,False
-chart6323,6323,Asesoría y consultoría - Auditoría y contable,account.data_account_type_expenses,pe_chart_template,False
-chart6324,6324,Asesoría y consultoría - Mercadotecnia,account.data_account_type_expenses,pe_chart_template,False
-chart6325,6325,Asesoría y consultoría - Medioambiental,account.data_account_type_expenses,pe_chart_template,False
-chart6326,6326,Asesoría y consultoría - Investigación y desarrollo,account.data_account_type_expenses,pe_chart_template,False
-chart6327,6327,Asesoría y consultoría - Producción,account.data_account_type_expenses,pe_chart_template,False
-chart6329,6329,Asesoría y consultoría - Otros,account.data_account_type_expenses,pe_chart_template,False
-chart633,633,Producción encargada a terceros,account.data_account_type_expenses,pe_chart_template,False
-chart6341,6341,Mantenimiento y reparaciones - Propiedad de inversión,account.data_account_type_expenses,pe_chart_template,False
-chart63421,63421,Mantenimiento y reparaciones - Activos por derecho de uso - Financiero,account.data_account_type_expenses,pe_chart_template,False
-chart63432,63432,"Mantenimiento y reparaciones - Propiedad, planta y equipo - Operativo",account.data_account_type_expenses,pe_chart_template,False
-chart6344,6344,Mantenimiento y reparaciones - Intangibles,account.data_account_type_expenses,pe_chart_template,False
-chart6345,6345,Mantenimiento y reparaciones - Activos biológicos,account.data_account_type_expenses,pe_chart_template,False
-chart6351,6351,Alquileres - Terrenos,account.data_account_type_expenses,pe_chart_template,False
-chart6352,6352,Alquileres - Edificaciones,account.data_account_type_expenses,pe_chart_template,False
-chart6353,6353,Alquileres - Maquinarias y equipos de explotación,account.data_account_type_expenses,pe_chart_template,False
-chart6354,6354,Alquileres - Equipo de transporte,account.data_account_type_expenses,pe_chart_template,False
-chart6355,6355,Alquileres - Muebles y enseres,account.data_account_type_expenses,pe_chart_template,False
-chart6356,6356,Alquileres - Equipos diversos,account.data_account_type_expenses,pe_chart_template,False
-chart6361,6361,Servicios básicos - Energía eléctrica,account.data_account_type_expenses,pe_chart_template,False
-chart6362,6362,Servicios básicos - Gas,account.data_account_type_expenses,pe_chart_template,False
-chart6363,6363,Servicios básicos - Agua,account.data_account_type_expenses,pe_chart_template,False
-chart6364,6364,Servicios básicos - Teléfono,account.data_account_type_expenses,pe_chart_template,False
-chart6365,6365,Servicios básicos - Internet,account.data_account_type_expenses,pe_chart_template,False
-chart6366,6366,Servicios básicos - Radio,account.data_account_type_expenses,pe_chart_template,False
-chart6367,6367,Servicios básicos - Cable,account.data_account_type_expenses,pe_chart_template,False
-chart6371,6371,"Publicidad, publicaciones, relaciones públicas - Publicidad",account.data_account_type_expenses,pe_chart_template,False
-chart6372,6372,"Publicidad, publicaciones, relaciones públicas - Publicaciones",account.data_account_type_expenses,pe_chart_template,False
-chart6373,6373,"Publicidad, publicaciones, relaciones públicas - Relaciones públicas",account.data_account_type_expenses,pe_chart_template,False
-chart638,638,Servicios de contratistas,account.data_account_type_expenses,pe_chart_template,False
-chart6391,6391,Otros servicios prestados por terceros - Gastos bancarios,account.data_account_type_expenses,pe_chart_template,False
-chart6392,6392,Otros servicios prestados por terceros - Gastos de laboratorio,account.data_account_type_expenses,pe_chart_template,False
-chart6411,6411,Gobierno nacional - Impuesto general a las ventas y selectivo al consumo,account.data_account_type_expenses,pe_chart_template,False
-chart6412,6412,Gobierno nacional - Impuesto a las transacciones financieras,account.data_account_type_expenses,pe_chart_template,False
-chart6413,6413,Gobierno nacional - Impuesto temporal a los activos netos,account.data_account_type_expenses,pe_chart_template,False
-chart6414,6414,Gobierno nacional - Impuesto a los juegos de casino y máquinas tragamonedas,account.data_account_type_expenses,pe_chart_template,False
-chart6415,6415,Gobierno nacional - Regalías mineras,account.data_account_type_expenses,pe_chart_template,False
-chart6416,6416,Gobierno nacional - Cánones,account.data_account_type_expenses,pe_chart_template,False
-chart6419,6419,Gobierno nacional - Otros,account.data_account_type_expenses,pe_chart_template,False
-chart642,642,Gobierno regional,account.data_account_type_expenses,pe_chart_template,False
-chart6431,6431,Gobierno local - Impuesto predial,account.data_account_type_expenses,pe_chart_template,False
-chart6432,6432,Gobierno local - Arbitrios municipales y seguridad ciudadana,account.data_account_type_expenses,pe_chart_template,False
-chart6433,6433,Gobierno local - Impuesto al patrimonio vehicular,account.data_account_type_expenses,pe_chart_template,False
-chart6434,6434,Gobierno local - Licencia de funcionamiento,account.data_account_type_expenses,pe_chart_template,False
-chart6439,6439,Gobierno local - Otros,account.data_account_type_expenses,pe_chart_template,False
-chart6442,6442,Otros gastos por tributos - Contribución al SENCICO,account.data_account_type_expenses,pe_chart_template,False
-chart6443,6443,Otros gastos por tributos - Otros,account.data_account_type_expenses,pe_chart_template,False
-chart6451,6451,Gastos en deuda tributaria - Intereses,account.data_account_type_expenses,pe_chart_template,False
-chart6452,6452,Gastos en deuda tributaria - intereses - fraccionamiento,account.data_account_type_expenses,pe_chart_template,False
-chart6453,6453,Gastos en deuda tributaria - Multas,account.data_account_type_expenses,pe_chart_template,False
-chart6454,6454,Gastos en deuda tributaria - Costas y otros,account.data_account_type_expenses,pe_chart_template,False
-chart651,651,Seguros,account.data_account_type_expenses,pe_chart_template,False
-chart652,652,Regalías,account.data_account_type_expenses,pe_chart_template,False
-chart653,653,Suscripciones,account.data_account_type_expenses,pe_chart_template,False
-chart654,654,Licencias y derechos de vigencia,account.data_account_type_expenses,pe_chart_template,False
-chart65511,65511,Costo neto de enajenación de activos inmovilizados y operaciones discontinuadas - Costo neto de enajenación de activos inmovilizados - Inversiones mobiliarias,account.data_account_type_expenses,pe_chart_template,False
-chart65512,65512,Costo neto de enajenación de activos inmovilizados y operaciones discontinuadas - Costo neto de enajenación de activos inmovilizados - Propiedades de inversión,account.data_account_type_expenses,pe_chart_template,False
-chart65513,65513,Costo neto de enajenación de activos inmovilizados y operaciones discontinuadas - Costo neto de enajenación de activos inmovilizados - Activos por derecho de uso - arrendamiento financiero,account.data_account_type_expenses,pe_chart_template,False
-chart65514,65514,"Costo neto de enajenación de activos inmovilizados y operaciones discontinuadas - Costo neto de enajenación de activos inmovilizados - Propiedad, planta y equipo",account.data_account_type_expenses,pe_chart_template,False
-chart65515,65515,Costo neto de enajenación de activos inmovilizados y operaciones discontinuadas - Costo neto de enajenación de activos inmovilizados - Intangibles,account.data_account_type_expenses,pe_chart_template,False
-chart65516,65516,Costo neto de enajenación de activos inmovilizados y operaciones discontinuadas - Costo neto de enajenación de activos inmovilizados - Activos biológicos,account.data_account_type_expenses,pe_chart_template,False
-chart65521,65521,Costo neto de enajenación de activos inmovilizados y operaciones discontinuadas - Operaciones discontinuadas – Abandono de activos - Propiedades de inversión,account.data_account_type_expenses,pe_chart_template,False
-chart65522,65522,Costo neto de enajenación de activos inmovilizados y operaciones discontinuadas - Operaciones discontinuadas – Abandono de activos - Activos por derecho de uso - Arrendamiento financiero,account.data_account_type_expenses,pe_chart_template,False
-chart65523,65523,"Costo neto de enajenación de activos inmovilizados y operaciones discontinuadas - Operaciones discontinuadas – Abandono de activos - Propiedad, planta y equipo",account.data_account_type_expenses,pe_chart_template,False
-chart65524,65524,Costo neto de enajenación de activos inmovilizados y operaciones discontinuadas - Operaciones discontinuadas – Abandono de activos - Intangibles,account.data_account_type_expenses,pe_chart_template,False
-chart65525,65525,Costo neto de enajenación de activos inmovilizados y operaciones discontinuadas - Operaciones discontinuadas – Abandono de activos - Activos biológicos,account.data_account_type_expenses,pe_chart_template,False
-chart656,656,Suministros,account.data_account_type_expenses,pe_chart_template,False
-chart658,658,Gestión medioambiental,account.data_account_type_expenses,pe_chart_template,False
-chart6591,6591,Otros gastos de gestión - Donaciones,account.data_account_type_expenses,pe_chart_template,False
-chart6592,6592,Otros gastos de gestión - Sanciones administrativas,account.data_account_type_expenses,pe_chart_template,False
-chart6611,6611,Activo realizable - Mercaderías,account.data_account_type_expenses,pe_chart_template,False
-chart6612,6612,Activo realizable - Productos terminados,account.data_account_type_expenses,pe_chart_template,False
-chart66131,66131,Activo realizable - Activos no corrientes mantenidos para la venta - Propiedades de inversión,account.data_account_type_expenses,pe_chart_template,False
-chart66132,66132,"Activo realizable - Activos no corrientes mantenidos para la venta - Propiedad, planta y equipo",account.data_account_type_expenses,pe_chart_template,False
-chart66133,66133,Activo realizable - Activos no corrientes mantenidos para la venta - Intangibles,account.data_account_type_expenses,pe_chart_template,False
-chart66134,66134,Activo realizable - Activos no corrientes mantenidos para la venta - Activos biológicos,account.data_account_type_expenses,pe_chart_template,False
-chart6621,6621,Activo inmovilizado - Propiedades de inversión,account.data_account_type_expenses,pe_chart_template,False
-chart6622,6622,Activo inmovilizado - Activos biológicos,account.data_account_type_expenses,pe_chart_template,False
-chart6711,6711,Gastos en operaciones de endeudamiento y otros - Préstamos de instituciones financieras y otras entidades,account.data_account_type_expenses,pe_chart_template,False
-chart6712,6712,Gastos en operaciones de endeudamiento y otros - Contratos de arrendamiento financiero,account.data_account_type_expenses,pe_chart_template,False
-chart6713,6713,Gastos en operaciones de endeudamiento y otros - Emisión y colocación de instrumentos representativos de deuda y patrimonio,account.data_account_type_expenses,pe_chart_template,False
-chart6714,6714,Gastos en operaciones de endeudamiento y otros - Documentos vendidos o descontados,account.data_account_type_expenses,pe_chart_template,False
-chart672,672,Pérdida por instrumentos financieros derivados,account.data_account_type_expenses,pe_chart_template,False
-chart67311,67311,Intereses por préstamos y otras obligaciones - Préstamos de instituciones financieras y otras entidades - Instituciones financieras,account.data_account_type_expenses,pe_chart_template,False
-chart67312,67312,Intereses por préstamos y otras obligaciones - Préstamos de instituciones financieras y otras entidades - Otras entidades,account.data_account_type_expenses,pe_chart_template,False
-chart6732,6732,Intereses por préstamos y otras obligaciones - Contratos de arrendamiento financiero,account.data_account_type_expenses,pe_chart_template,False
-chart6733,6733,Intereses por préstamos y otras obligaciones - Otros instrumentos financieros por pagar,account.data_account_type_expenses,pe_chart_template,False
-chart6734,6734,Intereses por préstamos y otras obligaciones - Documentos vendidos o descontados,account.data_account_type_expenses,pe_chart_template,False
-chart6735,6735,Intereses por préstamos y otras obligaciones - Obligaciones emitidas,account.data_account_type_expenses,pe_chart_template,False
-chart6736,6736,Intereses por préstamos y otras obligaciones - Obligaciones comerciales,account.data_account_type_expenses,pe_chart_template,False
-chart6741,6741,Gastos en operaciones de factoraje (factoring) - Pérdida en instrumentos vendidos,account.data_account_type_expenses,pe_chart_template,False
-chart675,675,Descuentos concedidos por pronto pago,account.data_account_type_expenses,pe_chart_template,False
-chart676,676,Diferencia de cambio,account.data_account_type_expenses,pe_chart_template,False
-chart6771,6771,Pérdida por medición de activos y pasivos financieros al valor razonable - Inversiones mantenidas para negociación,account.data_account_type_expenses,pe_chart_template,False
-chart6772,6772,Pérdida por medición de activos y pasivos financieros al valor razonable - Otras inversiones financieras,account.data_account_type_expenses,pe_chart_template,False
-chart6773,6773,Pérdida por medición de activos y pasivos financieros al valor razonable - Otros,account.data_account_type_expenses,pe_chart_template,False
-chart6781,6781,Participación en resultados de entidades relacionadas - Participación en los resultados de subsidiarias y asociadas bajo el método del valor patrimonial,account.data_account_type_expenses,pe_chart_template,False
-chart6782,6782,Participación en resultados de entidades relacionadas - Participaciones en negocios conjuntos,account.data_account_type_expenses,pe_chart_template,False
-chart6791,6791,Otros gastos financieros - Primas por opciones,account.data_account_type_expenses,pe_chart_template,False
-chart6792,6792,Otros gastos financieros - Gastos financieros en medición a valor descontado,account.data_account_type_expenses,pe_chart_template,False
-chart6793,6793,Otros gastos financieros - Gastos financieros en actualización de activos por derecho de uso,account.data_account_type_expenses,pe_chart_template,False
-chart68111,68111,Depreciación de propiedades de inversión - Edificaciones - Costo,account.data_account_type_depreciation,pe_chart_template,False
-chart68112,68112,Depreciación de propiedades de inversión - Edificaciones - Revaluación,account.data_account_type_depreciation,pe_chart_template,False
-chart68113,68113,Depreciación de propiedades de inversión - Edificaciones - Costo de financiación,account.data_account_type_depreciation,pe_chart_template,False
-chart682111,682111,Depreciación de activos por derecho de uso - arrendamiento financiero - Propiedades de inversión - Edificaciones - Costo,account.data_account_type_depreciation,pe_chart_template,False
-chart682112,682112,Depreciación de activos por derecho de uso - arrendamiento financiero - Propiedades de inversión - Edificaciones - Revaluación,account.data_account_type_depreciation,pe_chart_template,False
-chart682113,682113,Depreciación de activos por derecho de uso - arrendamiento financiero - Propiedades de inversión - Edificaciones - Costo de financiación,account.data_account_type_depreciation,pe_chart_template,False
-chart682211,682211,"Depreciación de activos por derecho de uso - arrendamiento financiero - Propiedad, planta y equipo - Edificaciones - Costo",account.data_account_type_depreciation,pe_chart_template,False
-chart682212,682212,"Depreciación de activos por derecho de uso - arrendamiento financiero - Propiedad, planta y equipo - Edificaciones - Revaluación",account.data_account_type_depreciation,pe_chart_template,False
-chart682213,682213,"Depreciación de activos por derecho de uso - arrendamiento financiero - Propiedad, planta y equipo - Edificaciones - Costo de financiación",account.data_account_type_depreciation,pe_chart_template,False
-chart682221,682221,"Depreciación de activos por derecho de uso - arrendamiento financiero - Propiedad, planta y equipo - Maquinarias y equipos de explotación - Costo",account.data_account_type_depreciation,pe_chart_template,False
-chart682222,682222,"Depreciación de activos por derecho de uso - arrendamiento financiero - Propiedad, planta y equipo - Maquinarias y equipos de explotación - Revaluación",account.data_account_type_depreciation,pe_chart_template,False
-chart682223,682223,"Depreciación de activos por derecho de uso - arrendamiento financiero - Propiedad, planta y equipo - Maquinarias y equipos de explotación - Costo de financiación",account.data_account_type_depreciation,pe_chart_template,False
-chart682231,682231,"Depreciación de activos por derecho de uso - arrendamiento financiero - Propiedad, planta y equipo - Unidades de transporte - Costo",account.data_account_type_depreciation,pe_chart_template,False
-chart682232,682232,"Depreciación de activos por derecho de uso - arrendamiento financiero - Propiedad, planta y equipo - Unidades de transporte - Revaluación",account.data_account_type_depreciation,pe_chart_template,False
-chart682251,682251,"Depreciación de activos por derecho de uso - arrendamiento financiero - Propiedad, planta y equipo - Equipos diversos - Costo",account.data_account_type_depreciation,pe_chart_template,False
-chart682252,682252,"Depreciación de activos por derecho de uso - arrendamiento financiero - Propiedad, planta y equipo - Equipos diversos - Revaluación",account.data_account_type_depreciation,pe_chart_template,False
-chart683111,683111,Depreciación de activos por derecho de uso - arrendamiento operativo - Depreciación de activos por derecho de uso - arrendamiento operativo - Edificaciones - Costo,account.data_account_type_depreciation,pe_chart_template,False
-chart683112,683112,Depreciación de activos por derecho de uso - arrendamiento operativo - Depreciación de activos por derecho de uso - arrendamiento operativo - Edificaciones - Revaluación,account.data_account_type_depreciation,pe_chart_template,False
-chart683121,683121,Depreciación de activos por derecho de uso - arrendamiento operativo - Depreciación de activos por derecho de uso - arrendamiento operativo - Maquinarias y equipos de explotación - Costo,account.data_account_type_depreciation,pe_chart_template,False
-chart683122,683122,Depreciación de activos por derecho de uso - arrendamiento operativo - Depreciación de activos por derecho de uso - arrendamiento operativo - Maquinarias y equipos de explotación - Revaluación,account.data_account_type_depreciation,pe_chart_template,False
-chart683131,683131,Depreciación de activos por derecho de uso - arrendamiento operativo - Depreciación de activos por derecho de uso - arrendamiento operativo - Unidades de transporte - Costo,account.data_account_type_depreciation,pe_chart_template,False
-chart683132,683132,Depreciación de activos por derecho de uso - arrendamiento operativo - Depreciación de activos por derecho de uso - arrendamiento operativo - Unidades de transporte - Revaluación,account.data_account_type_depreciation,pe_chart_template,False
-chart683152,683152,Depreciación de activos por derecho de uso - arrendamiento operativo - Depreciación de activos por derecho de uso - arrendamiento operativo - Equipos diversos - Revaluación,account.data_account_type_depreciation,pe_chart_template,False
-chart68410,68410,"Depreciación de propiedad, planta y equipo - Depreciación de propiedad, planta y equipo - Costo - Plantas productoras",account.data_account_type_depreciation,pe_chart_template,False
-chart68411,68411,"Depreciación de propiedad, planta y equipo - Depreciación de propiedad, planta y equipo - Costo - Edificaciones",account.data_account_type_depreciation,pe_chart_template,False
-chart68412,68412,"Depreciación de propiedad, planta y equipo - Depreciación de propiedad, planta y equipo - Costo - Maquinarias y equipos de explotación",account.data_account_type_depreciation,pe_chart_template,False
-chart68413,68413,"Depreciación de propiedad, planta y equipo - Depreciación de propiedad, planta y equipo - Costo - Unidades de transporte",account.data_account_type_depreciation,pe_chart_template,False
-chart68414,68414,"Depreciación de propiedad, planta y equipo - Depreciación de propiedad, planta y equipo - Costo - Muebles y enseres",account.data_account_type_depreciation,pe_chart_template,False
-chart68415,68415,"Depreciación de propiedad, planta y equipo - Depreciación de propiedad, planta y equipo - Costo - Equipos diversos",account.data_account_type_depreciation,pe_chart_template,False
-chart68416,68416,"Depreciación de propiedad, planta y equipo - Depreciación de propiedad, planta y equipo - Costo - Herramientas y unidades de reemplazo",account.data_account_type_depreciation,pe_chart_template,False
-chart68420,68420,"Depreciación de propiedad, planta y equipo - Depreciación de propiedad, planta y equipo - Revaluación - Plantas productoras",account.data_account_type_depreciation,pe_chart_template,False
-chart68421,68421,"Depreciación de propiedad, planta y equipo - Depreciación de propiedad, planta y equipo - Revaluación - Edificaciones",account.data_account_type_depreciation,pe_chart_template,False
-chart68422,68422,"Depreciación de propiedad, planta y equipo - Depreciación de propiedad, planta y equipo - Revaluación - Maquinarias y equipos de explotación",account.data_account_type_depreciation,pe_chart_template,False
-chart68423,68423,"Depreciación de propiedad, planta y equipo - Depreciación de propiedad, planta y equipo - Revaluación - Unidades de transporte",account.data_account_type_depreciation,pe_chart_template,False
-chart68424,68424,"Depreciación de propiedad, planta y equipo - Depreciación de propiedad, planta y equipo - Revaluación - Muebles y enseres",account.data_account_type_depreciation,pe_chart_template,False
-chart68425,68425,"Depreciación de propiedad, planta y equipo - Depreciación de propiedad, planta y equipo - Revaluación - Equipos diversos",account.data_account_type_depreciation,pe_chart_template,False
-chart68426,68426,"Depreciación de propiedad, planta y equipo - Depreciación de propiedad, planta y equipo - Revaluación - Herramientas y unidades de reemplazo",account.data_account_type_depreciation,pe_chart_template,False
-chart68430,68430,"Depreciación de propiedad, planta y equipo - Depreciación de propiedad, planta y equipo - Costos de financiación - Plantas productoras",account.data_account_type_depreciation,pe_chart_template,False
-chart68431,68431,"Depreciación de propiedad, planta y equipo - Depreciación de propiedad, planta y equipo - Costos de financiación - Edificaciones",account.data_account_type_depreciation,pe_chart_template,False
-chart68432,68432,"Depreciación de propiedad, planta y equipo - Depreciación de propiedad, planta y equipo - Costos de financiación - Maquinarias y equipos de explotación",account.data_account_type_depreciation,pe_chart_template,False
-chart68511,68511,Depreciación de activos biológicos en producción - Depreciación de activos biológicos en producción - costo - Activos biológicos de origen animal,account.data_account_type_depreciation,pe_chart_template,False
-chart68512,68512,Depreciación de activos biológicos en producción - Depreciación de activos biológicos en producción - costo - Activos biológicos de origen vegetal,account.data_account_type_depreciation,pe_chart_template,False
-chart68521,68521,Depreciación de activos biológicos en producción - Depreciación de activos biológicos en producción - costo de financiación - Activos biológicos de origen animal,account.data_account_type_depreciation,pe_chart_template,False
-chart68522,68522,Depreciación de activos biológicos en producción - Depreciación de activos biológicos en producción - costo de financiación - Activos biológicos de origen vegetal,account.data_account_type_depreciation,pe_chart_template,False
-chart68611,68611,"Amortización de intangibles - Amortización de intangibles – Costo - Concesiones, licencias y otros derechos",account.data_account_type_depreciation,pe_chart_template,False
-chart68612,68612,Amortización de intangibles - Amortización de intangibles – Costo - Patentes y propiedad industrial,account.data_account_type_depreciation,pe_chart_template,False
-chart68613,68613,Amortización de intangibles - Amortización de intangibles – Costo - Programas de computadora (software),account.data_account_type_depreciation,pe_chart_template,False
-chart68614,68614,Amortización de intangibles - Amortización de intangibles – Costo - Costos de exploración y desarrollo,account.data_account_type_depreciation,pe_chart_template,False
-chart68615,68615,"Amortización de intangibles - Amortización de intangibles – Costo - Fórmulas, diseños y prototipos",account.data_account_type_depreciation,pe_chart_template,False
-chart68619,68619,Amortización de intangibles - Amortización de intangibles – Costo - Otros activos intangibles,account.data_account_type_depreciation,pe_chart_template,False
-chart68621,68621,"Amortización de intangibles - Amortización de intangibles – Revaluación - Concesiones, licencias y otros derechos",account.data_account_type_depreciation,pe_chart_template,False
-chart68622,68622,Amortización de intangibles - Amortización de intangibles – Revaluación - Patentes y propiedad industrial,account.data_account_type_depreciation,pe_chart_template,False
-chart68623,68623,Amortización de intangibles - Amortización de intangibles – Revaluación - Programas de computadora (software),account.data_account_type_depreciation,pe_chart_template,False
-chart68624,68624,Amortización de intangibles - Amortización de intangibles – Revaluación - Costos de exploración y desarrollo,account.data_account_type_depreciation,pe_chart_template,False
-chart68625,68625,"Amortización de intangibles - Amortización de intangibles – Revaluación - Fórmulas, diseños y prototipos",account.data_account_type_depreciation,pe_chart_template,False
-chart68629,68629,Amortización de intangibles - Amortización de intangibles – Revaluación - Otros activos intangibles,account.data_account_type_depreciation,pe_chart_template,False
-chart68711,68711,Valuación de activos - Estimación de cuentas de cobranza dudosa - Cuentas por cobrar comerciales – Terceros,account.data_account_type_depreciation,pe_chart_template,False
-chart68712,68712,Valuación de activos - Estimación de cuentas de cobranza dudosa - Cuentas por cobrar comerciales – Relacionadas,account.data_account_type_depreciation,pe_chart_template,False
-chart68713,68713,"Valuación de activos - Estimación de cuentas de cobranza dudosa - Cuentas por cobrar al personal, a los accionistas (socios) y directores",account.data_account_type_depreciation,pe_chart_template,False
-chart68714,68714,Valuación de activos - Estimación de cuentas de cobranza dudosa - Cuentas por cobrar diversas – Terceros,account.data_account_type_depreciation,pe_chart_template,False
-chart68715,68715,Valuación de activos - Estimación de cuentas de cobranza dudosa - Cuentas por cobrar diversas – Relacionadas,account.data_account_type_depreciation,pe_chart_template,False
-chart68731,68731,Valuación de activos - Desvalorización de inversiones mobiliarias - Inversiones a ser mantenidas hasta el vencimiento,account.data_account_type_depreciation,pe_chart_template,False
-chart68732,68732,Valuación de activos - Desvalorización de inversiones mobiliarias - Instrumentos financieros representativos de derecho patrimonial,account.data_account_type_depreciation,pe_chart_template,False
-chart68812,68812,Deterioro del valor de los activos - Desvalorización de propiedad de inversión - Edificaciones,account.data_account_type_depreciation,pe_chart_template,False
-chart68813,68813,Deterioro del valor de los activos - Desvalorización de propiedad de inversión - Construcciones en curso,account.data_account_type_depreciation,pe_chart_template,False
-chart68820,68820,Deterioro del valor de los activos - Desvalorización de activos por derecho de uso - arrendamiento financiero - Planta productora en producción,account.data_account_type_depreciation,pe_chart_template,False
-chart68821,68821,Deterioro del valor de los activos - Desvalorización de activos por derecho de uso - arrendamiento financiero - Planta productora en desarrollo,account.data_account_type_depreciation,pe_chart_template,False
-chart68822,68822,Deterioro del valor de los activos - Desvalorización de activos por derecho de uso - arrendamiento financiero - Terrenos,account.data_account_type_depreciation,pe_chart_template,False
-chart68823,68823,Deterioro del valor de los activos - Desvalorización de activos por derecho de uso - arrendamiento financiero - Edificaciones,account.data_account_type_depreciation,pe_chart_template,False
-chart68824,68824,Deterioro del valor de los activos - Desvalorización de activos por derecho de uso - arrendamiento financiero - Maquinarias y equipos de explotación,account.data_account_type_depreciation,pe_chart_template,False
-chart68825,68825,Deterioro del valor de los activos - Desvalorización de activos por derecho de uso - arrendamiento financiero - Unidades de transporte,account.data_account_type_depreciation,pe_chart_template,False
-chart68826,68826,Deterioro del valor de los activos - Desvalorización de activos por derecho de uso - arrendamiento financiero - Muebles y enseres,account.data_account_type_depreciation,pe_chart_template,False
-chart68827,68827,Deterioro del valor de los activos - Desvalorización de activos por derecho de uso - arrendamiento financiero - Equipos diversos,account.data_account_type_depreciation,pe_chart_template,False
-chart68828,68828,Deterioro del valor de los activos - Desvalorización de activos por derecho de uso - arrendamiento financiero - Herramientas y unidades de reemplazo,account.data_account_type_depreciation,pe_chart_template,False
-chart68830,68830,"Deterioro del valor de los activos - Desvalorización de propiedad, planta y equipo - Planta productora en producción",account.data_account_type_depreciation,pe_chart_template,False
-chart68831,68831,"Deterioro del valor de los activos - Desvalorización de propiedad, planta y equipo - Planta productora en desarrollo",account.data_account_type_depreciation,pe_chart_template,False
-chart68832,68832,"Deterioro del valor de los activos - Desvalorización de propiedad, planta y equipo - Terrenos",account.data_account_type_depreciation,pe_chart_template,False
-chart68833,68833,"Deterioro del valor de los activos - Desvalorización de propiedad, planta y equipo - Edificaciones",account.data_account_type_depreciation,pe_chart_template,False
-chart68834,68834,"Deterioro del valor de los activos - Desvalorización de propiedad, planta y equipo - Maquinarias y equipos de explotación",account.data_account_type_depreciation,pe_chart_template,False
-chart68835,68835,"Deterioro del valor de los activos - Desvalorización de propiedad, planta y equipo - Unidades de transporte",account.data_account_type_depreciation,pe_chart_template,False
-chart68836,68836,"Deterioro del valor de los activos - Desvalorización de propiedad, planta y equipo - Muebles y enseres",account.data_account_type_depreciation,pe_chart_template,False
-chart68837,68837,"Deterioro del valor de los activos - Desvalorización de propiedad, planta y equipo - Equipos diversos",account.data_account_type_depreciation,pe_chart_template,False
-chart68838,68838,"Deterioro del valor de los activos - Desvalorización de propiedad, planta y equipo - Herramientas y unidades de reemplazo",account.data_account_type_depreciation,pe_chart_template,False
-chart68841,68841,"Deterioro del valor de los activos - Desvalorización de intangibles - Concesiones, licencias y otros derechos",account.data_account_type_depreciation,pe_chart_template,False
-chart68842,68842,Deterioro del valor de los activos - Desvalorización de intangibles - Patentes y propiedad industrial,account.data_account_type_depreciation,pe_chart_template,False
-chart68843,68843,Deterioro del valor de los activos - Desvalorización de intangibles - Programas de computadora (software),account.data_account_type_depreciation,pe_chart_template,False
-chart68844,68844,Deterioro del valor de los activos - Desvalorización de intangibles - Costos de exploración y desarrollo,account.data_account_type_depreciation,pe_chart_template,False
-chart68845,68845,"Deterioro del valor de los activos - Desvalorización de intangibles - Fórmulas, diseños y prototipos",account.data_account_type_depreciation,pe_chart_template,False
-chart68846,68846,Deterioro del valor de los activos - Desvalorización de intangibles - Otros activos intangibles,account.data_account_type_depreciation,pe_chart_template,False
-chart68847,68847,Deterioro del valor de los activos - Desvalorización de intangibles - Plusvalía mercantil,account.data_account_type_depreciation,pe_chart_template,False
-chart68891,68891,Deterioro del valor de los activos - Desvalorización de activos biológicos en producción - Activos biológicos de origen animal,account.data_account_type_depreciation,pe_chart_template,False
-chart68892,68892,Deterioro del valor de los activos - Desvalorización de activos biológicos en producción - Activos biológicos de origen vegetal,account.data_account_type_depreciation,pe_chart_template,False
-chart68911,68911,Provisiones - Provisión para litigios - Provisión para litigios – Costo,account.data_account_type_depreciation,pe_chart_template,False
-chart68912,68912,Provisiones - Provisión para litigios - Provisión para litigios – Actualización financiera,account.data_account_type_depreciation,pe_chart_template,False
-chart68921,68921,"Provisiones - Provisión por desmantelamiento, retiro o rehabilitación del inmovilizado - Provisión por desmantelamiento, retiro o rehabilitación del inmovilizado – Costo",account.data_account_type_depreciation,pe_chart_template,False
-chart68922,68922,"Provisiones - Provisión por desmantelamiento, retiro o rehabilitación del inmovilizado - Provisión por desmantelamiento, retiro o rehabilitación del inmovilizado – Actualización financiera",account.data_account_type_depreciation,pe_chart_template,False
-chart6893,6893,Provisiones - Provisión para reestructuraciones,account.data_account_type_depreciation,pe_chart_template,False
-chart68941,68941,Provisiones - Provisión para protección y remediación del medio ambiente - Provisión para protección y remediación del medio ambiente – Costo,account.data_account_type_depreciation,pe_chart_template,False
-chart68942,68942,Provisiones - Provisión para protección y remediación del medio ambiente - Provisión para protección y remediación del medio ambiente – Actualización financiera,account.data_account_type_depreciation,pe_chart_template,False
-chart68961,68961,Provisiones - Provisión para garantías - Provisión para garantías – Costo,account.data_account_type_depreciation,pe_chart_template,False
-chart68962,68962,Provisiones - Provisión para garantías - Provisión para garantías – Actualización financiera,account.data_account_type_depreciation,pe_chart_template,False
-chart68971,68971,Provisiones - Provisión por activos por derecho de uso - Provisión por activos por derecho de uso arrendamiento operativo,account.data_account_type_depreciation,pe_chart_template,False
-chart68972,68972,Provisiones - Provisión por activos por derecho de uso - Provisión por activos por derecho de uso arrendamiento operativo - actualización financiera,account.data_account_type_depreciation,pe_chart_template,False
-chart6899,6899,Provisiones - Otras provisiones,account.data_account_type_depreciation,pe_chart_template,False
-chart69111,69111,Mercaderías - Mercaderías - exportación - Terceros,account.data_account_type_direct_costs,pe_chart_template,False
-chart69112,69112,Mercaderías - Mercaderías - exportación - Relacionadas,account.data_account_type_direct_costs,pe_chart_template,False
-chart69121,69121,Mercaderías - Mercaderías - venta local - Terceros,account.data_account_type_direct_costs,pe_chart_template,False
-chart69122,69122,Mercaderías - Mercaderías - venta local - Relacionadas,account.data_account_type_direct_costs,pe_chart_template,False
-chart69211,69211,Productos terminados - Productos terminados - Exportación - Terceros,account.data_account_type_direct_costs,pe_chart_template,False
-chart69212,69212,Productos terminados - Productos terminados - Exportación - Relacionadas,account.data_account_type_direct_costs,pe_chart_template,False
-chart69221,69221,Productos terminados - Productos terminados - Venta local - Terceros,account.data_account_type_direct_costs,pe_chart_template,False
-chart69222,69222,Productos terminados - Productos terminados - Venta local - Relacionadas,account.data_account_type_direct_costs,pe_chart_template,False
-chart69231,69231,Productos terminados - Costos de financiación – Productos terminados - Terceros,account.data_account_type_direct_costs,pe_chart_template,False
-chart69232,69232,Productos terminados - Costos de financiación – Productos terminados - Relacionadas,account.data_account_type_direct_costs,pe_chart_template,False
-chart6924,6924,Productos terminados - Costos de producción no absorbido – Productos terminados,account.data_account_type_direct_costs,pe_chart_template,False
-chart6925,6925,Productos terminados - Costo de ineficiencia – Productos terminados,account.data_account_type_direct_costs,pe_chart_template,False
-chart69311,69311,Servicios terminados - Servicios – Exportación - Terceros,account.data_account_type_direct_costs,pe_chart_template,False
-chart69312,69312,Servicios terminados - Servicios – Exportación - Relacionadas,account.data_account_type_direct_costs,pe_chart_template,False
-chart69321,69321,Servicios terminados - Servicios – local - Terceros,account.data_account_type_direct_costs,pe_chart_template,False
-chart69322,69322,Servicios terminados - Servicios – local - Relacionadas,account.data_account_type_direct_costs,pe_chart_template,False
-chart69411,69411,"Subproductos, desechos y desperdicios - Subproductos - Terceros",account.data_account_type_direct_costs,pe_chart_template,False
-chart69412,69412,"Subproductos, desechos y desperdicios - Subproductos - Relacionadas",account.data_account_type_direct_costs,pe_chart_template,False
-chart69421,69421,"Subproductos, desechos y desperdicios - Desechos y desperdicios - Terceros",account.data_account_type_direct_costs,pe_chart_template,False
-chart69422,69422,"Subproductos, desechos y desperdicios - Desechos y desperdicios - Relacionadas",account.data_account_type_direct_costs,pe_chart_template,False
-chart6951,6951,Gastos por desvalorización de inventarios al costo - Mercaderías,account.data_account_type_direct_costs,pe_chart_template,False
-chart6952,6952,Gastos por desvalorización de inventarios al costo - Productos terminados,account.data_account_type_direct_costs,pe_chart_template,False
-chart6953,6953,"Gastos por desvalorización de inventarios al costo - Subproductos, desechos y desperdicios",account.data_account_type_direct_costs,pe_chart_template,False
-chart6954,6954,Gastos por desvalorización de inventarios al costo - Productos en proceso,account.data_account_type_direct_costs,pe_chart_template,False
-chart6955,6955,Gastos por desvalorización de inventarios al costo - Materias primas,account.data_account_type_direct_costs,pe_chart_template,False
-chart6956,6956,"Gastos por desvalorización de inventarios al costo - Materiales auxiliares, suministros y repuestos",account.data_account_type_direct_costs,pe_chart_template,False
-chart6957,6957,Gastos por desvalorización de inventarios al costo - Envases y embalajes,account.data_account_type_direct_costs,pe_chart_template,False
-chart6958,6958,Gastos por desvalorización de inventarios al costo - Inventarios por recibir,account.data_account_type_direct_costs,pe_chart_template,False
-chart70111,70111,Mercaderías - Mercaderías - venta de exportación - Terceros,account.data_account_type_revenue,pe_chart_template,False
-chart70112,70112,Mercaderías - Mercaderías - venta de exportación - Relacionadas,account.data_account_type_revenue,pe_chart_template,False
-chart70121,70121,Mercaderías - Mercaderías - venta local - Terceros,account.data_account_type_revenue,pe_chart_template,False
-chart70122,70122,Mercaderías - Mercaderías - venta local - Relacionadas,account.data_account_type_revenue,pe_chart_template,False
-chart70211,70211,Productos terminados - Productos terminados - venta de exportación - Terceros,account.data_account_type_revenue,pe_chart_template,False
-chart70212,70212,Productos terminados - Productos terminados - venta de exportación - Relacionadas,account.data_account_type_revenue,pe_chart_template,False
-chart70221,70221,Productos terminados - Productos terminados - venta local - Terceros,account.data_account_type_revenue,pe_chart_template,False
-chart70222,70222,Productos terminados - Productos terminados - venta local - Relacionadas,account.data_account_type_revenue,pe_chart_template,False
-chart70311,70311,Servicios terminados - Servicios – exportación - Terceros,account.data_account_type_revenue,pe_chart_template,False
-chart70312,70312,Servicios terminados - Servicios – exportación - Relacionadas,account.data_account_type_revenue,pe_chart_template,False
-chart70321,70321,Servicios terminados - Servicios – local - Terceros,account.data_account_type_revenue,pe_chart_template,False
-chart70322,70322,Servicios terminados - Servicios – local - Relacionadas,account.data_account_type_revenue,pe_chart_template,False
-chart70411,70411,"Subproductos, desechos y desperdicios - Subproductos - Terceros",account.data_account_type_revenue,pe_chart_template,False
-chart70412,70412,"Subproductos, desechos y desperdicios - Subproductos - Relacionadas",account.data_account_type_revenue,pe_chart_template,False
-chart70421,70421,"Subproductos, desechos y desperdicios - Desechos y desperdicios - Terceros",account.data_account_type_revenue,pe_chart_template,False
-chart70422,70422,"Subproductos, desechos y desperdicios - Desechos y desperdicios - Relacionadas",account.data_account_type_revenue,pe_chart_template,False
-chart70911,70911,Devoluciones sobre ventas - Mercaderías - Venta de exportación - Terceros,account.data_account_type_revenue,pe_chart_template,False
-chart70912,70912,Devoluciones sobre ventas - Mercaderías - Venta de exportación - Relacionadas,account.data_account_type_revenue,pe_chart_template,False
-chart70921,70921,Devoluciones sobre ventas - Mercaderías - Venta local - Terceros,account.data_account_type_revenue,pe_chart_template,False
-chart70922,70922,Devoluciones sobre ventas - Mercaderías - Venta local - Relacionadas,account.data_account_type_revenue,pe_chart_template,False
-chart70931,70931,Devoluciones sobre ventas - Productos terminados - Venta de exportación - Terceros,account.data_account_type_revenue,pe_chart_template,False
-chart70932,70932,Devoluciones sobre ventas - Productos terminados - Venta de exportación - Relacionadas,account.data_account_type_revenue,pe_chart_template,False
-chart70941,70941,Devoluciones sobre ventas - Productos terminados - Venta local - Terceros,account.data_account_type_revenue,pe_chart_template,False
-chart70942,70942,Devoluciones sobre ventas - Productos terminados - Venta local - Relacionadas,account.data_account_type_revenue,pe_chart_template,False
-chart70951,70951,Devoluciones sobre ventas - Inventarios de servicios rechazados - Terceros,account.data_account_type_revenue,pe_chart_template,False
-chart70952,70952,Devoluciones sobre ventas - Inventarios de servicios rechazados - Relacionadas,account.data_account_type_revenue,pe_chart_template,False
-chart70961,70961,"Devoluciones sobre ventas - Subproductos, desechos y desperdicios - Terceros",account.data_account_type_revenue,pe_chart_template,False
-chart70962,70962,"Devoluciones sobre ventas - Subproductos, desechos y desperdicios - Relacionadas",account.data_account_type_revenue,pe_chart_template,False
-chart7111,7111,Variación de productos terminados - Productos terminados,account.data_account_type_other_income,pe_chart_template,False
-chart7121,7121,"Variación de subproductos, desechos y desperdicios - Subproductos",account.data_account_type_other_income,pe_chart_template,False
-chart7122,7122,"Variación de subproductos, desechos y desperdicios - Desechos y desperdicios",account.data_account_type_other_income,pe_chart_template,False
-chart7131,7131,Variación de productos en proceso - Productos en proceso de manufactura,account.data_account_type_other_income,pe_chart_template,False
-chart7141,7141,Variación de envases y embalajes - Envases,account.data_account_type_other_income,pe_chart_template,False
-chart7142,7142,Variación de envases y embalajes - Embalajes,account.data_account_type_other_income,pe_chart_template,False
-chart7151,7151,Variación de inventarios de servicios - Inventarios de servicios en proceso,account.data_account_type_other_income,pe_chart_template,False
-chart7211,7211,Propiedades de inversión - Edificaciones,account.data_account_type_other_income,pe_chart_template,False
-chart7220,7220,"Propiedad, planta y equipo - Planta productora",account.data_account_type_other_income,pe_chart_template,False
-chart7221,7221,"Propiedad, planta y equipo - Edificaciones",account.data_account_type_other_income,pe_chart_template,False
-chart7222,7222,"Propiedad, planta y equipo - Maquinarias y otros equipos de explotación",account.data_account_type_other_income,pe_chart_template,False
-chart7223,7223,"Propiedad, planta y equipo - Unidades de transporte",account.data_account_type_other_income,pe_chart_template,False
-chart7224,7224,"Propiedad, planta y equipo - Muebles y enseres",account.data_account_type_other_income,pe_chart_template,False
-chart7225,7225,"Propiedad, planta y equipo - Equipos diversos",account.data_account_type_other_income,pe_chart_template,False
-chart7231,7231,Intangibles - Programas de computadora (software),account.data_account_type_other_income,pe_chart_template,False
-chart7232,7232,Intangibles - Costos de exploración y desarrollo,account.data_account_type_other_income,pe_chart_template,False
-chart7233,7233,"Intangibles - Fórmulas, diseños y prototipos",account.data_account_type_other_income,pe_chart_template,False
-chart7241,7241,Activos biológicos - Activos biológicos en desarrollo de origen animal,account.data_account_type_other_income,pe_chart_template,False
-chart7242,7242,Activos biológicos - Activos biológicos en desarrollo de origen vegetal,account.data_account_type_other_income,pe_chart_template,False
-chart72511,72511,Costos de financiación capitalizados - Costos de financiación – Propiedades de inversión - Plantas productoras en desarrollo,account.data_account_type_other_income,pe_chart_template,False
-chart72512,72512,Costos de financiación capitalizados - Costos de financiación – Propiedades de inversión - Edificaciones,account.data_account_type_other_income,pe_chart_template,False
-chart72521,72521,"Costos de financiación capitalizados - Costos de financiación – Propiedad, planta y equipo - Plantas productoras en desarrollo",account.data_account_type_other_income,pe_chart_template,False
-chart72522,72522,"Costos de financiación capitalizados - Costos de financiación – Propiedad, planta y equipo - Edificaciones",account.data_account_type_other_income,pe_chart_template,False
-chart72523,72523,"Costos de financiación capitalizados - Costos de financiación – Propiedad, planta y equipo - Maquinarias y otros equipos de explotación",account.data_account_type_other_income,pe_chart_template,False
-chart7253,7253,Costos de financiación capitalizados - Costos de financiación – Intangibles,account.data_account_type_other_income,pe_chart_template,False
-chart72541,72541,Costos de financiación capitalizados - Costos de financiación – Activos biológicos en desarrollo - Activos biológicos de origen animal,account.data_account_type_other_income,pe_chart_template,False
-chart72542,72542,Costos de financiación capitalizados - Costos de financiación – Activos biológicos en desarrollo - Activos biológicos de origen vegetal,account.data_account_type_other_income,pe_chart_template,False
-chart7311,7311,"Descuentos, rebajas y bonificaciones obtenidos - Terceros",account.data_account_type_revenue,pe_chart_template,False
-chart7312,7312,"Descuentos, rebajas y bonificaciones obtenidos - Relacionadas",account.data_account_type_revenue,pe_chart_template,False
-chart7411,7411,"Descuentos, rebajas y bonificaciones concedidos - Terceros",account.data_account_type_revenue,pe_chart_template,False
-chart7412,7412,"Descuentos, rebajas y bonificaciones concedidos - Relacionadas",account.data_account_type_revenue,pe_chart_template,False
-chart751,751,Servicios en beneficio del personal,account.data_account_type_other_income,pe_chart_template,False
-chart752,752,Comisiones y corretajes,account.data_account_type_other_income,pe_chart_template,False
-chart753,753,Regalías,account.data_account_type_other_income,pe_chart_template,False
-chart7540,7540,Alquileres - Plantas productoras,account.data_account_type_other_income,pe_chart_template,False
-chart7541,7541,Alquileres - Terrenos,account.data_account_type_other_income,pe_chart_template,False
-chart7542,7542,Alquileres - Edificaciones,account.data_account_type_other_income,pe_chart_template,False
-chart7543,7543,Alquileres - Maquinarias y equipos de explotación,account.data_account_type_other_income,pe_chart_template,False
-chart7544,7544,Alquileres - Unidades de transporte,account.data_account_type_other_income,pe_chart_template,False
-chart7545,7545,Alquileres - Equipos diversos,account.data_account_type_other_income,pe_chart_template,False
-chart7551,7551,Recuperación de cuentas de valuación - Recuperación – Cuentas de cobranza dudosa,account.data_account_type_other_income,pe_chart_template,False
-chart7552,7552,Recuperación de cuentas de valuación - Recuperación – Desvalorización de inventarios,account.data_account_type_other_income,pe_chart_template,False
-chart7553,7553,Recuperación de cuentas de valuación - Recuperación – Desvalorización de inversiones mobiliarias,account.data_account_type_other_income,pe_chart_template,False
-chart7561,7561,Enajenación de activos inmovilizados - Inversiones mobiliarias,account.data_account_type_other_income,pe_chart_template,False
-chart7562,7562,Enajenación de activos inmovilizados - Propiedades de inversión,account.data_account_type_other_income,pe_chart_template,False
-chart7563,7563,Enajenación de activos inmovilizados - Activos adquiridos en arrendamiento financiero,account.data_account_type_other_income,pe_chart_template,False
-chart7564,7564,"Enajenación de activos inmovilizados - Propiedad, planta y equipo",account.data_account_type_other_income,pe_chart_template,False
-chart7565,7565,Enajenación de activos inmovilizados - Intangibles,account.data_account_type_other_income,pe_chart_template,False
-chart7566,7566,Enajenación de activos inmovilizados - Activos biológicos,account.data_account_type_other_income,pe_chart_template,False
-chart7571,7571,Recuperación de deterioro de cuentas de activos inmovilizados - Recuperación de deterioro de propiedades de inversión,account.data_account_type_other_income,pe_chart_template,False
-chart7572,7572,"Recuperación de deterioro de cuentas de activos inmovilizados - Recuperación de deterioro de propiedad, planta y equipo",account.data_account_type_other_income,pe_chart_template,False
-chart7573,7573,Recuperación de deterioro de cuentas de activos inmovilizados - Recuperación de deterioro de intangibles,account.data_account_type_other_income,pe_chart_template,False
-chart7574,7574,Recuperación de deterioro de cuentas de activos inmovilizados - Recuperación de deterioro de activos biológicos,account.data_account_type_other_income,pe_chart_template,False
-chart7591,7591,Otros ingresos de gestión - Subsidios gubernamentales,account.data_account_type_other_income,pe_chart_template,False
-chart7592,7592,Otros ingresos de gestión - Reclamos al seguro,account.data_account_type_other_income,pe_chart_template,False
-chart7593,7593,Otros ingresos de gestión - Donaciones,account.data_account_type_other_income,pe_chart_template,False
-chart7594,7594,Otros ingresos de gestión - Devoluciones tributarias,account.data_account_type_other_income,pe_chart_template,False
-chart7599,7599,Otros ingresos de gestión - Otros ingresos de gestión,account.data_account_type_other_income,pe_chart_template,False
-chart7611,7611,Activo realizable - Mercaderías,account.data_account_type_other_income,pe_chart_template,False
-chart7612,7612,Activo realizable - Productos terminados,account.data_account_type_other_income,pe_chart_template,False
-chart76131,76131,Activo realizable - Activos no corrientes mantenidos para la venta - Propiedades de inversión,account.data_account_type_other_income,pe_chart_template,False
-chart76132,76132,"Activo realizable - Activos no corrientes mantenidos para la venta - Propiedad, planta y equipo",account.data_account_type_other_income,pe_chart_template,False
-chart76133,76133,Activo realizable - Activos no corrientes mantenidos para la venta - Intangibles,account.data_account_type_other_income,pe_chart_template,False
-chart76134,76134,Activo realizable - Activos no corrientes mantenidos para la venta - Activos biológicos,account.data_account_type_other_income,pe_chart_template,False
-chart7621,7621,Activo inmovilizado - Propiedades de inversión,account.data_account_type_other_income,pe_chart_template,False
-chart7622,7622,Activo inmovilizado - Activos biológicos,account.data_account_type_other_income,pe_chart_template,False
-chart771,771,Ganancia por instrumento financiero derivado,account.data_account_type_other_income,pe_chart_template,False
-chart7721,7721,Rendimientos ganados - Depósitos en instituciones financieras,account.data_account_type_other_income,pe_chart_template,False
-chart7722,7722,Rendimientos ganados - Cuentas por cobrar comerciales,account.data_account_type_other_income,pe_chart_template,False
-chart7723,7723,Rendimientos ganados - Préstamos otorgados,account.data_account_type_other_income,pe_chart_template,False
-chart7724,7724,Rendimientos ganados - Inversiones a ser mantenidas hasta el vencimiento,account.data_account_type_other_income,pe_chart_template,False
-chart7725,7725,Rendimientos ganados - Instrumentos financieros representativos de derecho patrimonial,account.data_account_type_other_income,pe_chart_template,False
-chart773,773,Dividendos,account.data_account_type_other_income,pe_chart_template,False
-chart774,774,Ingresos en operaciones de factoraje (factoring),account.data_account_type_other_income,pe_chart_template,False
-chart775,775,Descuentos obtenidos por pronto pago,account.data_account_type_other_income,pe_chart_template,False
-chart776,776,Diferencia en cambio,account.data_account_type_other_income,pe_chart_template,False
-chart7771,7771,Ganancia por medición de activos y pasivos financieros al valor razonable - Inversiones mantenidas para negociación,account.data_account_type_other_income,pe_chart_template,False
-chart7772,7772,Ganancia por medición de activos y pasivos financieros al valor razonable - Otras inversiones,account.data_account_type_other_income,pe_chart_template,False
-chart7773,7773,Ganancia por medición de activos y pasivos financieros al valor razonable - Otras,account.data_account_type_other_income,pe_chart_template,False
-chart7781,7781,Participación en resultados de entidades relacionadas - Participación en los resultados de subsidiarias y asociadas bajo el método del valor patrimonial,account.data_account_type_other_income,pe_chart_template,False
-chart7782,7782,Participación en resultados de entidades relacionadas - Ingresos por participaciones en negocios conjuntos,account.data_account_type_other_income,pe_chart_template,False
-chart7792,7792,Otros ingresos financieros - Ingresos financieros en medición a valor descontado,account.data_account_type_other_income,pe_chart_template,False
-chart781,781,Cargas cubiertas por provisiones,account.data_account_type_other_income,pe_chart_template,False
-chart791,791,Cargas imputables a cuentas de costos y gastos,account.data_account_type_revenue,pe_chart_template,False
-chart792,792,Gastos financieros imputables a cuentas de inventarios,account.data_account_type_revenue,pe_chart_template,False
+chart583,583,Contractual,account.data_account_type_equity,pe_chart_template,False
+chart584,584,By-laws,account.data_account_type_equity,pe_chart_template,False
+chart585,585,Facultative,account.data_account_type_equity,pe_chart_template,False
+chart589,589,Other reserves,account.data_account_type_equity,pe_chart_template,False
+chart5911,5911,Undistributed profits - Acumulated utilities,account.data_account_type_equity,pe_chart_template,False
+chart5912,5912,Undistributed profits - Income from previous years,account.data_account_type_equity,pe_chart_template,False
+chart5921,5921,Accumulated losses - Accumulated losses,account.data_account_type_equity,pe_chart_template,False
+chart5922,5922,Accumulated losses - Expenses from previous years,account.data_account_type_equity,pe_chart_template,False
+chart6011,6011,Merchandise - Merchandise,account.data_account_type_expenses,pe_chart_template,False
+chart602,602,Raw Materials,account.data_account_type_expenses,pe_chart_template,False
+chart6031,6031,"Auxiliary materials, supplies and spare parts - Auxiliary materials",account.data_account_type_expenses,pe_chart_template,False
+chart6032,6032,"Auxiliary materials, supplies and spare parts - Supplies",account.data_account_type_expenses,pe_chart_template,False
+chart6033,6033,"Auxiliary materials, supplies and spare parts - Spare parts",account.data_account_type_expenses,pe_chart_template,False
+chart6041,6041,Containers and packaging - Containers,account.data_account_type_expenses,pe_chart_template,False
+chart6042,6042,Containers and packaging - Packaging,account.data_account_type_expenses,pe_chart_template,False
+chart60911,60911,Costs linked to purchases - Costs associated with purchases of merchandise - Transport,account.data_account_type_expenses,pe_chart_template,False
+chart60912,60912,Costs linked to purchases - Costs associated with purchases of merchandise - Insurance,account.data_account_type_expenses,pe_chart_template,False
+chart60913,60913,Costs linked to purchases - Costs associated with purchases of merchandise - Customs duties,account.data_account_type_expenses,pe_chart_template,False
+chart60914,60914,Costs linked to purchases - Costs associated with purchases of merchandise - Commissions,account.data_account_type_expenses,pe_chart_template,False
+chart60919,60919,Costs linked to purchases - Costs associated with purchases of merchandise - Other costs,account.data_account_type_expenses,pe_chart_template,False
+chart60921,60921,Costs linked to purchases - Costs linked to purchases of raw materials - Transport,account.data_account_type_expenses,pe_chart_template,False
+chart60922,60922,Costs linked to purchases - Costs linked to purchases of raw materials - Insurance,account.data_account_type_expenses,pe_chart_template,False
+chart60923,60923,Costs linked to purchases - Costs linked to purchases of raw materials - Customs duties,account.data_account_type_expenses,pe_chart_template,False
+chart60924,60924,Costs linked to purchases - Costs linked to purchases of raw materials - Commissions,account.data_account_type_expenses,pe_chart_template,False
+chart60925,60925,Costs linked to purchases - Costs linked to purchases of raw materials - Other costs,account.data_account_type_expenses,pe_chart_template,False
+chart60931,60931,"Costos vinculados con las compras - Costs associated with purchases of materials, supplies and spare parts - Transport",account.data_account_type_expenses,pe_chart_template,False
+chart60932,60932,"Costos vinculados con las compras - Costs associated with purchases of materials, supplies and spare parts - Insurance",account.data_account_type_expenses,pe_chart_template,False
+chart60933,60933,"Costos vinculados con las compras - Costs associated with purchases of materials, supplies and spare parts - Customs duties",account.data_account_type_expenses,pe_chart_template,False
+chart60934,60934,"Costos vinculados con las compras - Costs associated with purchases of materials, supplies and spare parts - Commissions",account.data_account_type_expenses,pe_chart_template,False
+chart60935,60935,"Costos vinculados con las compras - Costs associated with purchases of materials, supplies and spare parts - Other costs",account.data_account_type_expenses,pe_chart_template,False
+chart60941,60941,Costos vinculados con las compras - Costs linked to purchases of containers and packaging - Transport,account.data_account_type_expenses,pe_chart_template,False
+chart60942,60942,Costos vinculados con las compras - Costs linked to purchases of containers and packaging - Insurance,account.data_account_type_expenses,pe_chart_template,False
+chart60943,60943,Costos vinculados con las compras - Costs linked to purchases of containers and packaging - Customs duties,account.data_account_type_expenses,pe_chart_template,False
+chart60944,60944,Costos vinculados con las compras - Costs linked to purchases of containers and packaging - Commissions,account.data_account_type_expenses,pe_chart_template,False
+chart60945,60945,Costos vinculados con las compras - Costs linked to purchases of containers and packaging - Other costs,account.data_account_type_expenses,pe_chart_template,False
+chart6111,6111,Merchandise - Merchandise,account.data_account_type_expenses,pe_chart_template,False
+chart6121,6121,Raw Materials - Raw Materials,account.data_account_type_expenses,pe_chart_template,False
+chart6131,6131,"Auxiliary materials, supplies and spare parts - Auxiliary materials",account.data_account_type_expenses,pe_chart_template,False
+chart6132,6132,"Auxiliary materials, supplies and spare parts - Supplies",account.data_account_type_expenses,pe_chart_template,False
+chart6133,6133,"Auxiliary materials, supplies and spare parts - Spare parts",account.data_account_type_expenses,pe_chart_template,False
+chart6141,6141,Containers and packaging - Containers,account.data_account_type_expenses,pe_chart_template,False
+chart6142,6142,Containers and packaging - Packaging,account.data_account_type_expenses,pe_chart_template,False
+chart6211,6211,Remuneration - Wages and salaries,account.data_account_type_expenses,pe_chart_template,False
+chart6212,6212,Remuneration - Commissions,account.data_account_type_expenses,pe_chart_template,False
+chart6213,6213,Remuneration - Remuneration in kind,account.data_account_type_expenses,pe_chart_template,False
+chart6214,6214,Remuneration - Bonuses,account.data_account_type_expenses,pe_chart_template,False
+chart6215,6215,Remuneration - Holidays,account.data_account_type_expenses,pe_chart_template,False
+chart622,622,Other remunerations,account.data_account_type_expenses,pe_chart_template,False
+chart623,623,Staff compensation,account.data_account_type_expenses,pe_chart_template,False
+chart624,624,Training,account.data_account_type_expenses,pe_chart_template,False
+chart625,625,Attentions to staff,account.data_account_type_expenses,pe_chart_template,False
+chart6271,6271,"Security, social security and other contributions - Health benefits scheme",account.data_account_type_expenses,pe_chart_template,False
+chart6272,6272,"Security, social security and other contributions - Pension scheme - Company contribution",account.data_account_type_expenses,pe_chart_template,False
+chart6273,6273,"Security, social security and other contributions - Complementary insurance for risky work, accidents at work and occupational diseases",account.data_account_type_expenses,pe_chart_template,False
+chart6274,6274,"Security, social security and other contributions - Life insurance",account.data_account_type_expenses,pe_chart_template,False
+chart6275,6275,"Security, social security and other contributions - Private insurance for health benefits – EPS and other individuals",account.data_account_type_expenses,pe_chart_template,False
+chart6276,6276,"Security, social security and other contributions - Fisherman's Social Security Benefits Fund",account.data_account_type_expenses,pe_chart_template,False
+chart6277,6277,"Security, social security and other contributions - Contributions to SENATI",account.data_account_type_expenses,pe_chart_template,False
+chart628,628,Board remuneration,account.data_account_type_expenses,pe_chart_template,False
+chart6291,6291,Employee social benefits - Compensation for time of service,account.data_account_type_expenses,pe_chart_template,False
+chart6292,6292,Employee social benefits - Pensions and retirement,account.data_account_type_expenses,pe_chart_template,False
+chart6293,6293,Employee social benefits - Other post-employment benefits,account.data_account_type_expenses,pe_chart_template,False
+chart62941,62941,Employee social benefits - Profit sharing - Current share,account.data_account_type_expenses,pe_chart_template,False
+chart62942,62942,Employee social benefits - Profit sharing - Deferred share,account.data_account_type_expenses,pe_chart_template,False
+chart63111,63111,"Transport, mail and travel expenses - Transport - Charging",account.data_account_type_expenses,pe_chart_template,False
+chart63112,63112,"Transport, mail and travel expenses - Transport - Passengers",account.data_account_type_expenses,pe_chart_template,False
+chart6312,6312,"Transport, mail and travel expenses - Post office",account.data_account_type_expenses,pe_chart_template,False
+chart6313,6313,"Transport, mail and travel expenses - Lodgement",account.data_account_type_expenses,pe_chart_template,False
+chart6314,6314,"Transport, mail and travel expenses - Alimentation",account.data_account_type_expenses,pe_chart_template,False
+chart6315,6315,"Transport, mail and travel expenses - Other travel expenses",account.data_account_type_expenses,pe_chart_template,False
+chart6321,6321,Advice and consultancy - Administrative,account.data_account_type_expenses,pe_chart_template,False
+chart6322,6322,Advice and consultancy - Legal and tax,account.data_account_type_expenses,pe_chart_template,False
+chart6323,6323,Advice and consultancy - Audit and accounting,account.data_account_type_expenses,pe_chart_template,False
+chart6324,6324,Advice and consultancy - Marketing,account.data_account_type_expenses,pe_chart_template,False
+chart6325,6325,Advice and consultancy - Environmental,account.data_account_type_expenses,pe_chart_template,False
+chart6326,6326,Advice and consultancy - Investigation and development,account.data_account_type_expenses,pe_chart_template,False
+chart6327,6327,Advice and consultancy - Production,account.data_account_type_expenses,pe_chart_template,False
+chart6329,6329,Advice and consultancy - Others,account.data_account_type_expenses,pe_chart_template,False
+chart633,633,Production commissioned to third parties,account.data_account_type_expenses,pe_chart_template,False
+chart6341,6341,Maintenance and repairs - Investment property,account.data_account_type_expenses,pe_chart_template,False
+chart63421,63421,Maintenance and repairs - Right-of-use assets - Financial,account.data_account_type_expenses,pe_chart_template,False
+chart63432,63432,"Maintenance and repairs - Property, plant and equipment - Operational",account.data_account_type_expenses,pe_chart_template,False
+chart6344,6344,Maintenance and repairs - Intangibles,account.data_account_type_expenses,pe_chart_template,False
+chart6345,6345,Maintenance and repairs - Biological assets,account.data_account_type_expenses,pe_chart_template,False
+chart6351,6351,Leasings - Land,account.data_account_type_expenses,pe_chart_template,False
+chart6352,6352,Leasings - Buildings,account.data_account_type_expenses,pe_chart_template,False
+chart6353,6353,Leasings - Machinery and exploitation equipment,account.data_account_type_expenses,pe_chart_template,False
+chart6354,6354,Leasings - Transportation equipment,account.data_account_type_expenses,pe_chart_template,False
+chart6355,6355,Leasings - Furniture and fixtures,account.data_account_type_expenses,pe_chart_template,False
+chart6356,6356,Leasings - Miscellaneous equipment,account.data_account_type_expenses,pe_chart_template,False
+chart6361,6361,Basic services - Electric power,account.data_account_type_expenses,pe_chart_template,False
+chart6362,6362,Basic services - Gas,account.data_account_type_expenses,pe_chart_template,False
+chart6363,6363,Basic services - Water,account.data_account_type_expenses,pe_chart_template,False
+chart6364,6364,Basic services - Phone,account.data_account_type_expenses,pe_chart_template,False
+chart6365,6365,Basic services - Internet,account.data_account_type_expenses,pe_chart_template,False
+chart6366,6366,Basic services - Radio,account.data_account_type_expenses,pe_chart_template,False
+chart6367,6367,Basic services - Cable,account.data_account_type_expenses,pe_chart_template,False
+chart6371,6371,"Advertising, publications, public relations - Advertising",account.data_account_type_expenses,pe_chart_template,False
+chart6372,6372,"Advertising, publications, public relations - Publications",account.data_account_type_expenses,pe_chart_template,False
+chart6373,6373,"Advertising, publications, public relations - Public relations",account.data_account_type_expenses,pe_chart_template,False
+chart638,638,Contractor Services,account.data_account_type_expenses,pe_chart_template,False
+chart6391,6391,Other services provided by third parties - Banking expenses,account.data_account_type_expenses,pe_chart_template,False
+chart6392,6392,Other services provided by third parties - Laboratory expenses,account.data_account_type_expenses,pe_chart_template,False
+chart6411,6411,National government - General sales tax and selective consumption,account.data_account_type_expenses,pe_chart_template,False
+chart6412,6412,National government - Financial transaction tax,account.data_account_type_expenses,pe_chart_template,False
+chart6413,6413,National government - Temporary tax on net assets,account.data_account_type_expenses,pe_chart_template,False
+chart6414,6414,National government - Tax on casino games and slot machines,account.data_account_type_expenses,pe_chart_template,False
+chart6415,6415,National government - Mining royalties,account.data_account_type_expenses,pe_chart_template,False
+chart6416,6416,National government - Royalties,account.data_account_type_expenses,pe_chart_template,False
+chart6419,6419,National government - Others,account.data_account_type_expenses,pe_chart_template,False
+chart642,642,Regional government,account.data_account_type_expenses,pe_chart_template,False
+chart6431,6431,Local government - Property tax,account.data_account_type_expenses,pe_chart_template,False
+chart6432,6432,Local government - Municipal taxes and citizen security,account.data_account_type_expenses,pe_chart_template,False
+chart6433,6433,Local government - Vehicle property tax,account.data_account_type_expenses,pe_chart_template,False
+chart6434,6434,Local government - Operating license,account.data_account_type_expenses,pe_chart_template,False
+chart6439,6439,Local government - Others,account.data_account_type_expenses,pe_chart_template,False
+chart6442,6442,Other tax expenses - Contribution to SENCICO,account.data_account_type_expenses,pe_chart_template,False
+chart6443,6443,Other tax expenses - Others,account.data_account_type_expenses,pe_chart_template,False
+chart6451,6451,Tax debt expenses - Interests,account.data_account_type_expenses,pe_chart_template,False
+chart6452,6452,Tax debt expenses - Interests - Subdivision,account.data_account_type_expenses,pe_chart_template,False
+chart6453,6453,Tax debt expenses - Fines,account.data_account_type_expenses,pe_chart_template,False
+chart6454,6454,Tax debt expenses - Costs and others,account.data_account_type_expenses,pe_chart_template,False
+chart651,651,Insurance,account.data_account_type_expenses,pe_chart_template,False
+chart652,652,Royalties,account.data_account_type_expenses,pe_chart_template,False
+chart653,653,Subscriptions,account.data_account_type_expenses,pe_chart_template,False
+chart654,654,Licenses and validity rights,account.data_account_type_expenses,pe_chart_template,False
+chart65511,65511,Net cost of disposal of fixed assets and operations discontinued - Net cost of disposal of fixed assets - Securities investments,account.data_account_type_expenses,pe_chart_template,False
+chart65512,65512,Net cost of disposal of fixed assets and operations discontinued - Net cost of disposal of fixed assets - Investment property,account.data_account_type_expenses,pe_chart_template,False
+chart65513,65513,Net cost of disposal of fixed assets and operations discontinued - Net cost of disposal of fixed assets - Right-of-use assets - Financial leasing,account.data_account_type_expenses,pe_chart_template,False
+chart65514,65514,"Net cost of disposal of fixed assets and operations discontinued - Net cost of disposal of fixed assets - Property, plant and equipment",account.data_account_type_expenses,pe_chart_template,False
+chart65515,65515,Net cost of disposal of fixed assets and operations discontinued - Net cost of disposal of fixed assets - Intangibles,account.data_account_type_expenses,pe_chart_template,False
+chart65516,65516,Net cost of disposal of fixed assets and operations discontinued - Net cost of disposal of fixed assets - Biological assets,account.data_account_type_expenses,pe_chart_template,False
+chart65521,65521,Net cost of disposal of fixed assets and operations discontinued - Discontinued operations – Asset abandonment - Investment property,account.data_account_type_expenses,pe_chart_template,False
+chart65522,65522,Net cost of disposal of fixed assets and operations discontinued - Discontinued operations – Asset abandonment - Right-of-use assets - Financial leasing,account.data_account_type_expenses,pe_chart_template,False
+chart65523,65523,"Net cost of disposal of fixed assets and operations discontinued - Discontinued operations – Asset abandonment - Property, plant and equipment",account.data_account_type_expenses,pe_chart_template,False
+chart65524,65524,Net cost of disposal of fixed assets and operations discontinued - Discontinued operations – Asset abandonment - Intangibles,account.data_account_type_expenses,pe_chart_template,False
+chart65525,65525,Net cost of disposal of fixed assets and operations discontinued - Discontinued operations – Asset abandonment - Biological assets,account.data_account_type_expenses,pe_chart_template,False
+chart656,656,Supplies,account.data_account_type_expenses,pe_chart_template,False
+chart658,658,Environmental management,account.data_account_type_expenses,pe_chart_template,False
+chart6591,6591,Other management fees - Donations,account.data_account_type_expenses,pe_chart_template,False
+chart6592,6592,Other management fees - Administrative sanctions,account.data_account_type_expenses,pe_chart_template,False
+chart6611,6611,Realizable asset - Merchandise,account.data_account_type_expenses,pe_chart_template,False
+chart6612,6612,Realizable asset - Finished products,account.data_account_type_expenses,pe_chart_template,False
+chart66131,66131,Realizable asset - Non-current assets held for sale - Investment property,account.data_account_type_expenses,pe_chart_template,False
+chart66132,66132,"Realizable asset - Non-current assets held for sale - Property, plant and equipment",account.data_account_type_expenses,pe_chart_template,False
+chart66133,66133,Realizable asset - Non-current assets held for sale - Intangibles,account.data_account_type_expenses,pe_chart_template,False
+chart66134,66134,Realizable asset - Non-current assets held for sale - Biological assets,account.data_account_type_expenses,pe_chart_template,False
+chart6621,6621,Fixed asset - Investment property,account.data_account_type_expenses,pe_chart_template,False
+chart6622,6622,Fixed asset - Biological assets,account.data_account_type_expenses,pe_chart_template,False
+chart6711,6711,Expenses in debt operations and others - Loans from financial institutions and other entities,account.data_account_type_expenses,pe_chart_template,False
+chart6712,6712,Expenses in debt operations and others - Financial lease contracts,account.data_account_type_expenses,pe_chart_template,False
+chart6713,6713,Expenses in debt operations and others - Issuance and placement of instruments representing debt and equity,account.data_account_type_expenses,pe_chart_template,False
+chart6714,6714,Expenses in debt operations and others - Documents sold or discounted,account.data_account_type_expenses,pe_chart_template,False
+chart672,672,Loss on derivative financial instruments,account.data_account_type_expenses,pe_chart_template,False
+chart67311,67311,Interest on loans and other obligations - Loans from financial institutions and other entities - Financial institutions,account.data_account_type_expenses,pe_chart_template,False
+chart67312,67312,Interest on loans and other obligations - Loans from financial institutions and other entities - Other entities,account.data_account_type_expenses,pe_chart_template,False
+chart6732,6732,Interest on loans and other obligations - Financial lease contracts,account.data_account_type_expenses,pe_chart_template,False
+chart6733,6733,Interest on loans and other obligations - Other financial instruments payable,account.data_account_type_expenses,pe_chart_template,False
+chart6734,6734,Interest on loans and other obligations - Documents sold or discounted,account.data_account_type_expenses,pe_chart_template,False
+chart6735,6735,Interest on loans and other obligations - Bonds issued,account.data_account_type_expenses,pe_chart_template,False
+chart6736,6736,Interest on loans and other obligations - Commercial obligations,account.data_account_type_expenses,pe_chart_template,False
+chart6741,6741,Expenses in factoring operations - Loss on instruments sold,account.data_account_type_expenses,pe_chart_template,False
+chart675,675,Discounts granted for early payment,account.data_account_type_expenses,pe_chart_template,False
+chart676,676,Exchange rate,account.data_account_type_expenses,pe_chart_template,False
+chart6771,6771,Loss from measurement of financial assets and liabilities at fair value - Investments held for trading,account.data_account_type_expenses,pe_chart_template,False
+chart6772,6772,Loss from measurement of financial assets and liabilities at fair value - Other financial investments,account.data_account_type_expenses,pe_chart_template,False
+chart6773,6773,Loss from measurement of financial assets and liabilities at fair value - Others,account.data_account_type_expenses,pe_chart_template,False
+chart6781,6781,Participation in results of related entities - Participation in the results of subsidiaries and associates under the equity value method,account.data_account_type_expenses,pe_chart_template,False
+chart6782,6782,Participation in results of related entities - Shares in joint ventures,account.data_account_type_expenses,pe_chart_template,False
+chart6791,6791,Other financial expenses - Option premiums,account.data_account_type_expenses,pe_chart_template,False
+chart6792,6792,Other financial expenses - Financial expenses measured at discounted value,account.data_account_type_expenses,pe_chart_template,False
+chart6793,6793,Other financial expenses - Financial expenses in updating assets for right of use,account.data_account_type_expenses,pe_chart_template,False
+chart68111,68111,Depreciation of investment properties - Buildings - Costs,account.data_account_type_depreciation,pe_chart_template,False
+chart68112,68112,Depreciation of investment properties - Buildings - Revaluation,account.data_account_type_depreciation,pe_chart_template,False
+chart68113,68113,Depreciation of investment properties - Buildings - Financing costs,account.data_account_type_depreciation,pe_chart_template,False
+chart682111,682111,Depreciation of assets for right of use - Financial leasing - Investment property - Buildings - Costs,account.data_account_type_depreciation,pe_chart_template,False
+chart682112,682112,Depreciation of assets for right of use - Financial leasing - Investment property - Buildings - Revaluation,account.data_account_type_depreciation,pe_chart_template,False
+chart682113,682113,Depreciation of assets for right of use - Financial leasing - Investment property - Buildings - Financing costs,account.data_account_type_depreciation,pe_chart_template,False
+chart682211,682211,"Depreciation of assets for right of use - Financial leasing - Property, plant and equipment - Buildings - Costs",account.data_account_type_depreciation,pe_chart_template,False
+chart682212,682212,"Depreciation of assets for right of use - Financial leasing - Property, plant and equipment - Buildings - Revaluation",account.data_account_type_depreciation,pe_chart_template,False
+chart682213,682213,"Depreciation of assets for right of use - Financial leasing - Property, plant and equipment - Buildings - Financing costs",account.data_account_type_depreciation,pe_chart_template,False
+chart682221,682221,"Depreciation of assets for right of use - Financial leasing - Property, plant and equipment - Machinery and exploitation equipment - Costs",account.data_account_type_depreciation,pe_chart_template,False
+chart682222,682222,"Depreciation of assets for right of use - Financial leasing - Property, plant and equipment - Machinery and exploitation equipment - Revaluation",account.data_account_type_depreciation,pe_chart_template,False
+chart682223,682223,"Depreciation of assets for right of use - Financial leasing - Property, plant and equipment - Machinery and exploitation equipment - Financing costs",account.data_account_type_depreciation,pe_chart_template,False
+chart682231,682231,"Depreciation of assets for right of use - Financial leasing - Property, plant and equipment - Transport units - Costs",account.data_account_type_depreciation,pe_chart_template,False
+chart682232,682232,"Depreciation of assets for right of use - Financial leasing - Property, plant and equipment - Transport units - Revaluation",account.data_account_type_depreciation,pe_chart_template,False
+chart682251,682251,"Depreciation of assets for right of use - Financial leasing - Property, plant and equipment - Miscellaneous equipment - Costs",account.data_account_type_depreciation,pe_chart_template,False
+chart682252,682252,"Depreciation of assets for right of use - Financial leasing - Property, plant and equipment - Miscellaneous equipment - Revaluation",account.data_account_type_depreciation,pe_chart_template,False
+chart683111,683111,Depreciation of assets for right of use - Operating lease - Depreciation of assets for right of use - Operating lease - Buildings - Costs,account.data_account_type_depreciation,pe_chart_template,False
+chart683112,683112,Depreciation of assets for right of use - Operating lease - Depreciation of assets for right of use - Operating lease - Buildings - Revaluation,account.data_account_type_depreciation,pe_chart_template,False
+chart683121,683121,Depreciation of assets for right of use - Operating lease - Depreciation of assets for right of use - Operating lease - Machinery and exploitation equipment - Costs,account.data_account_type_depreciation,pe_chart_template,False
+chart683122,683122,Depreciation of assets for right of use - Operating lease - Depreciation of assets for right of use - Operating lease - Machinery and exploitation equipment - Revaluation,account.data_account_type_depreciation,pe_chart_template,False
+chart683131,683131,Depreciation of assets for right of use - Operating lease - Depreciation of assets for right of use - Operating lease - Transport units - Costs,account.data_account_type_depreciation,pe_chart_template,False
+chart683132,683132,Depreciation of assets for right of use - Operating lease - Depreciation of assets for right of use - Operating lease - Transport units - Revaluation,account.data_account_type_depreciation,pe_chart_template,False
+chart683152,683152,Depreciation of assets for right of use - Operating lease - Depreciation of assets for right of use - Operating lease - Miscellaneous equipment - Revaluation,account.data_account_type_depreciation,pe_chart_template,False
+chart68410,68410,"Depreciation of property, plant and equipment - Depreciation of property, plant and equipment - Costs - Production plants",account.data_account_type_depreciation,pe_chart_template,False
+chart68411,68411,"Depreciation of property, plant and equipment - Depreciation of property, plant and equipment - Costs - Buildings",account.data_account_type_depreciation,pe_chart_template,False
+chart68412,68412,"Depreciation of property, plant and equipment - Depreciation of property, plant and equipment - Costs - Machinery and exploitation equipment",account.data_account_type_depreciation,pe_chart_template,False
+chart68413,68413,"Depreciation of property, plant and equipment - Depreciation of property, plant and equipment - Costs - Transport units",account.data_account_type_depreciation,pe_chart_template,False
+chart68414,68414,"Depreciation of property, plant and equipment - Depreciation of property, plant and equipment - Costs - Furniture and fixtures",account.data_account_type_depreciation,pe_chart_template,False
+chart68415,68415,"Depreciation of property, plant and equipment - Depreciation of property, plant and equipment - Costs - Miscellaneous equipment",account.data_account_type_depreciation,pe_chart_template,False
+chart68416,68416,"Depreciation of property, plant and equipment - Depreciation of property, plant and equipment - Costs - Replacement tools and units",account.data_account_type_depreciation,pe_chart_template,False
+chart68420,68420,"Depreciation of property, plant and equipment - Depreciation of property, plant and equipment - Revaluation - Production plants",account.data_account_type_depreciation,pe_chart_template,False
+chart68421,68421,"Depreciation of property, plant and equipment - Depreciation of property, plant and equipment - Revaluation - Buildings",account.data_account_type_depreciation,pe_chart_template,False
+chart68422,68422,"Depreciation of property, plant and equipment - Depreciation of property, plant and equipment - Revaluation - Machinery and exploitation equipment",account.data_account_type_depreciation,pe_chart_template,False
+chart68423,68423,"Depreciation of property, plant and equipment - Depreciation of property, plant and equipment - Revaluation - Transport units",account.data_account_type_depreciation,pe_chart_template,False
+chart68424,68424,"Depreciation of property, plant and equipment - Depreciation of property, plant and equipment - Revaluation - Furniture and fixtures",account.data_account_type_depreciation,pe_chart_template,False
+chart68425,68425,"Depreciation of property, plant and equipment - Depreciation of property, plant and equipment - Revaluation - Miscellaneous equipment",account.data_account_type_depreciation,pe_chart_template,False
+chart68426,68426,"Depreciation of property, plant and equipment - Depreciation of property, plant and equipment - Revaluation - Replacement tools and units",account.data_account_type_depreciation,pe_chart_template,False
+chart68430,68430,"Depreciation of property, plant and equipment - Depreciation of property, plant and equipment - Financing costs - Production plants",account.data_account_type_depreciation,pe_chart_template,False
+chart68431,68431,"Depreciation of property, plant and equipment - Depreciation of property, plant and equipment - Financing costs - Buildings",account.data_account_type_depreciation,pe_chart_template,False
+chart68432,68432,"Depreciation of property, plant and equipment - Depreciation of property, plant and equipment - Financing costs - Machinery and exploitation equipment",account.data_account_type_depreciation,pe_chart_template,False
+chart68511,68511,Depreciation of biological assets in production - Depreciation of biological assets in production - Costs - Biological assets of animal origin,account.data_account_type_depreciation,pe_chart_template,False
+chart68512,68512,Depreciation of biological assets in production - Depreciation of biological assets in production - Costs - Biological asset of vegetal origin,account.data_account_type_depreciation,pe_chart_template,False
+chart68521,68521,Depreciation of biological assets in production - Depreciation of biological assets in production - Financing costs - Biological assets of animal origin,account.data_account_type_depreciation,pe_chart_template,False
+chart68522,68522,Depreciation of biological assets in production - Depreciation of biological assets in production - Financing costs - Biological asset of vegetal origin,account.data_account_type_depreciation,pe_chart_template,False
+chart68611,68611,"Amortization of intangibles - Amortization of intangibles – Costs - Concessions, licenses and other rights",account.data_account_type_depreciation,pe_chart_template,False
+chart68612,68612,Amortization of intangibles - Amortization of intangibles – Costs - Patents and industrial property,account.data_account_type_depreciation,pe_chart_template,False
+chart68613,68613,Amortization of intangibles - Amortization of intangibles – Costs - Softwares,account.data_account_type_depreciation,pe_chart_template,False
+chart68614,68614,Amortization of intangibles - Amortization of intangibles – Costs - Exploration and development costs,account.data_account_type_depreciation,pe_chart_template,False
+chart68615,68615,"Amortization of intangibles - Amortization of intangibles – Costs - Formulas, designs and prototypes",account.data_account_type_depreciation,pe_chart_template,False
+chart68619,68619,Amortization of intangibles - Amortization of intangibles – Costs - Other intangible assets,account.data_account_type_depreciation,pe_chart_template,False
+chart68621,68621,"Amortization of intangibles - Amortization of intangibles – Revaluation - Concessions, licenses and other rights",account.data_account_type_depreciation,pe_chart_template,False
+chart68622,68622,Amortization of intangibles - Amortization of intangibles – Revaluation - Patents and industrial property,account.data_account_type_depreciation,pe_chart_template,False
+chart68623,68623,Amortization of intangibles - Amortization of intangibles – Revaluation - Softwares,account.data_account_type_depreciation,pe_chart_template,False
+chart68624,68624,Amortization of intangibles - Amortization of intangibles – Revaluation - Exploration and development costs,account.data_account_type_depreciation,pe_chart_template,False
+chart68625,68625,"Amortization of intangibles - Amortization of intangibles – Revaluation - Formulas, designs and prototypes",account.data_account_type_depreciation,pe_chart_template,False
+chart68629,68629,Amortization of intangibles - Amortization of intangibles – Revaluation - Other intangible assets,account.data_account_type_depreciation,pe_chart_template,False
+chart68711,68711,Asset valuation - Estimation of doubtful accounts receivable - Trade accounts receivable – Third parties,account.data_account_type_depreciation,pe_chart_template,False
+chart68712,68712,Asset valuation - Estimation of doubtful accounts receivable - Trade accounts receivable – Associated,account.data_account_type_depreciation,pe_chart_template,False
+chart68713,68713,"Asset valuation - Estimation of doubtful accounts receivable - Accounts receivable from staff, shareholders (partners) and directors",account.data_account_type_depreciation,pe_chart_template,False
+chart68714,68714,Asset valuation - Estimation of doubtful accounts receivable - Various accounts receivable – Third parties,account.data_account_type_depreciation,pe_chart_template,False
+chart68715,68715,Asset valuation - Estimation of doubtful accounts receivable - Various accounts receivable – Associated,account.data_account_type_depreciation,pe_chart_template,False
+chart68731,68731,Asset valuation - Depreciation of investment property - Investments to be held until maturity,account.data_account_type_depreciation,pe_chart_template,False
+chart68732,68732,Asset valuation - Depreciation of investment property - Financial instruments representative of economic rights,account.data_account_type_depreciation,pe_chart_template,False
+chart68812,68812,Impairment of assets - Impairment of investment property - Buildings,account.data_account_type_depreciation,pe_chart_template,False
+chart68813,68813,Impairment of assets - Impairment of investment property - Constructions in progress,account.data_account_type_depreciation,pe_chart_template,False
+chart68820,68820,Impairment of assets - Impairment of assets for right of use - Financial leasing - Production plant in production,account.data_account_type_depreciation,pe_chart_template,False
+chart68821,68821,Impairment of assets - Impairment of assets for right of use - Financial leasing - Production plant in development,account.data_account_type_depreciation,pe_chart_template,False
+chart68822,68822,Impairment of assets - Impairment of assets for right of use - Financial leasing - Land,account.data_account_type_depreciation,pe_chart_template,False
+chart68823,68823,Impairment of assets - Impairment of assets for right of use - Financial leasing - Buildings,account.data_account_type_depreciation,pe_chart_template,False
+chart68824,68824,Impairment of assets - Impairment of assets for right of use - Financial leasing - Machinery and exploitation equipment,account.data_account_type_depreciation,pe_chart_template,False
+chart68825,68825,Impairment of assets - Impairment of assets for right of use - Financial leasing - Transport units,account.data_account_type_depreciation,pe_chart_template,False
+chart68826,68826,Impairment of assets - Impairment of assets for right of use - Financial leasing - Furniture and fixtures,account.data_account_type_depreciation,pe_chart_template,False
+chart68827,68827,Impairment of assets - Impairment of assets for right of use - Financial leasing - Miscellaneous equipment,account.data_account_type_depreciation,pe_chart_template,False
+chart68828,68828,Impairment of assets - Impairment of assets for right of use - Financial leasing - Replacement tools and units,account.data_account_type_depreciation,pe_chart_template,False
+chart68830,68830,"Impairment of assets - Impairment of property, plant and equipment - Production plant in production",account.data_account_type_depreciation,pe_chart_template,False
+chart68831,68831,"Impairment of assets - Impairment of property, plant and equipment - Production plant in development",account.data_account_type_depreciation,pe_chart_template,False
+chart68832,68832,"Impairment of assets - Impairment of property, plant and equipment - Land",account.data_account_type_depreciation,pe_chart_template,False
+chart68833,68833,"Impairment of assets - Impairment of property, plant and equipment - Buildings",account.data_account_type_depreciation,pe_chart_template,False
+chart68834,68834,"Impairment of assets - Impairment of property, plant and equipment - Machinery and exploitation equipment",account.data_account_type_depreciation,pe_chart_template,False
+chart68835,68835,"Impairment of assets - Impairment of property, plant and equipment - Transport units",account.data_account_type_depreciation,pe_chart_template,False
+chart68836,68836,"Impairment of assets - Impairment of property, plant and equipment - Furniture and fixtures",account.data_account_type_depreciation,pe_chart_template,False
+chart68837,68837,"Impairment of assets - Impairment of property, plant and equipment - Miscellaneous equipment",account.data_account_type_depreciation,pe_chart_template,False
+chart68838,68838,"Impairment of assets - Impairment of property, plant and equipment - Replacement tools and units",account.data_account_type_depreciation,pe_chart_template,False
+chart68841,68841,"Impairment of assets - Impairment of intangibles - Concessions, licenses and other rights",account.data_account_type_depreciation,pe_chart_template,False
+chart68842,68842,Impairment of assets - Impairment of intangibles - Patents and industrial property,account.data_account_type_depreciation,pe_chart_template,False
+chart68843,68843,Impairment of assets - Impairment of intangibles - Softwares,account.data_account_type_depreciation,pe_chart_template,False
+chart68844,68844,Impairment of assets - Impairment of intangibles - Exploration and development costs,account.data_account_type_depreciation,pe_chart_template,False
+chart68845,68845,"Impairment of assets - Impairment of intangibles - Formulas, designs and prototypes",account.data_account_type_depreciation,pe_chart_template,False
+chart68846,68846,Impairment of assets - Impairment of intangibles - Other intangible assets,account.data_account_type_depreciation,pe_chart_template,False
+chart68847,68847,Impairment of assets - Impairment of intangibles - Goodwill,account.data_account_type_depreciation,pe_chart_template,False
+chart68891,68891,Impairment of assets - Impairment of biological assets in production - Biological assets of animal origin,account.data_account_type_depreciation,pe_chart_template,False
+chart68892,68892,Impairment of assets - Impairment of biological assets in production - Biological asset of vegetal origin,account.data_account_type_depreciation,pe_chart_template,False
+chart68911,68911,Provisions - Provision for litigation - Provision for litigation - Costs,account.data_account_type_depreciation,pe_chart_template,False
+chart68912,68912,Provisions - Provision for litigation - Provision for litigation – Financial update,account.data_account_type_depreciation,pe_chart_template,False
+chart68921,68921,"Provisions - Provision for dismantling, removal or rehabilitation of fixed assets - Provision for dismantling, removal or rehabilitation of fixed assets – Costs",account.data_account_type_depreciation,pe_chart_template,False
+chart68922,68922,"Provisions - Provision for dismantling, removal or rehabilitation of fixed assets - Provision for dismantling, removal or rehabilitation of fixed assets – Financial update",account.data_account_type_depreciation,pe_chart_template,False
+chart6893,6893,Provisions - Provision for restructurings,account.data_account_type_depreciation,pe_chart_template,False
+chart68941,68941,Provisions - Provision for environmental protection and remediation - Provision for environmental protection and remediation – Costs,account.data_account_type_depreciation,pe_chart_template,False
+chart68942,68942,Provisions - Provision for environmental protection and remediation - Provision for environmental protection and remediation – Financial update,account.data_account_type_depreciation,pe_chart_template,False
+chart68961,68961,Provisions - Provision for guarantees - Provision for guarantees – Costs,account.data_account_type_depreciation,pe_chart_template,False
+chart68962,68962,Provisions - Provision for guarantees - Provision for guarantees – Financial update,account.data_account_type_depreciation,pe_chart_template,False
+chart68971,68971,Provisions - Provision for right-of-use assets - Provision for right-of-use assets operating lease,account.data_account_type_depreciation,pe_chart_template,False
+chart68972,68972,Provisions - Provision for right-of-use assets - Provision for right-of-use assets operating lease - Financial update,account.data_account_type_depreciation,pe_chart_template,False
+chart6899,6899,Provisions - Other provisions,account.data_account_type_depreciation,pe_chart_template,False
+chart69111,69111,Merchandise - Merchandise - Exportation - Third parties,account.data_account_type_direct_costs,pe_chart_template,False
+chart69112,69112,Merchandise - Merchandise - Exportation - Associated,account.data_account_type_direct_costs,pe_chart_template,False
+chart69121,69121,Merchandise - Merchandise - Local sale - Third parties,account.data_account_type_direct_costs,pe_chart_template,False
+chart69122,69122,Merchandise - Merchandise - Local sale - Associated,account.data_account_type_direct_costs,pe_chart_template,False
+chart69211,69211,Finished products - Finished products - Exportation - Third parties,account.data_account_type_direct_costs,pe_chart_template,False
+chart69212,69212,Finished products - Finished products - Exportation - Associated,account.data_account_type_direct_costs,pe_chart_template,False
+chart69221,69221,Finished products - Finished products - Local sale - Third parties,account.data_account_type_direct_costs,pe_chart_template,False
+chart69222,69222,Finished products - Finished products - Local sale - Associated,account.data_account_type_direct_costs,pe_chart_template,False
+chart69231,69231,Finished products - Financing costs – Finished products - Third parties,account.data_account_type_direct_costs,pe_chart_template,False
+chart69232,69232,Finished products - Financing costs – Finished products - Associated,account.data_account_type_direct_costs,pe_chart_template,False
+chart6924,6924,Finished products - Unabsorbed production costs – Finished products,account.data_account_type_direct_costs,pe_chart_template,False
+chart6925,6925,Finished products - Cost of inefficiency – Finished products,account.data_account_type_direct_costs,pe_chart_template,False
+chart69311,69311,Finished services - Services – Exportation - Third parties,account.data_account_type_direct_costs,pe_chart_template,False
+chart69312,69312,Finished services - Services – Exportation - Associated,account.data_account_type_direct_costs,pe_chart_template,False
+chart69321,69321,Finished services - Services – Local - Third parties,account.data_account_type_direct_costs,pe_chart_template,False
+chart69322,69322,Finished services - Services – Local - Associated,account.data_account_type_direct_costs,pe_chart_template,False
+chart69411,69411,"By-products, waste and scrap - By-products - Third parties",account.data_account_type_direct_costs,pe_chart_template,False
+chart69412,69412,"By-products, waste and scrap - By-products - Associated",account.data_account_type_direct_costs,pe_chart_template,False
+chart69421,69421,"By-products, waste and scrap - Scrap and waste - Third parties",account.data_account_type_direct_costs,pe_chart_template,False
+chart69422,69422,"By-products, waste and scrap - Scrap and waste - Associated",account.data_account_type_direct_costs,pe_chart_template,False
+chart6951,6951,Expenses for impairment of inventories at cost - Merchandise,account.data_account_type_direct_costs,pe_chart_template,False
+chart6952,6952,Expenses for impairment of inventories at cost - Finished products,account.data_account_type_direct_costs,pe_chart_template,False
+chart6953,6953,"Expenses for impairment of inventories at cost - By-products, waste and scrap",account.data_account_type_direct_costs,pe_chart_template,False
+chart6954,6954,Expenses for impairment of inventories at cost - Products in process,account.data_account_type_direct_costs,pe_chart_template,False
+chart6955,6955,Expenses for impairment of inventories at cost - Raw Materials,account.data_account_type_direct_costs,pe_chart_template,False
+chart6956,6956,"Expenses for impairment of inventories at cost - Auxiliary materials, supplies and spare parts",account.data_account_type_direct_costs,pe_chart_template,False
+chart6957,6957,Expenses for impairment of inventories at cost - Containers and packaging,account.data_account_type_direct_costs,pe_chart_template,False
+chart6958,6958,Expenses for impairment of inventories at cost - Inventories to be received,account.data_account_type_direct_costs,pe_chart_template,False
+chart70111,70111,Merchandise - Merchandise - Export sale - Third parties,account.data_account_type_revenue,pe_chart_template,False
+chart70112,70112,Merchandise - Merchandise - Export sale - Associated,account.data_account_type_revenue,pe_chart_template,False
+chart70121,70121,Merchandise - Merchandise - Local sale - Third parties,account.data_account_type_revenue,pe_chart_template,False
+chart70122,70122,Merchandise - Merchandise - Local sale - Associated,account.data_account_type_revenue,pe_chart_template,False
+chart70211,70211,Finished products - Finished products - Export sale - Third parties,account.data_account_type_revenue,pe_chart_template,False
+chart70212,70212,Finished products - Finished products - Export sale - Associated,account.data_account_type_revenue,pe_chart_template,False
+chart70221,70221,Finished products - Finished products - Local sale - Third parties,account.data_account_type_revenue,pe_chart_template,False
+chart70222,70222,Finished products - Finished products - Local sale - Associated,account.data_account_type_revenue,pe_chart_template,False
+chart70311,70311,Finished services - Services – Exportation - Third parties,account.data_account_type_revenue,pe_chart_template,False
+chart70312,70312,Finished services - Services – Exportation - Associated,account.data_account_type_revenue,pe_chart_template,False
+chart70321,70321,Finished services - Services – Local - Third parties,account.data_account_type_revenue,pe_chart_template,False
+chart70322,70322,Finished services - Services – Local - Associated,account.data_account_type_revenue,pe_chart_template,False
+chart70411,70411,"By-products, waste and scrap - By-products - Third parties",account.data_account_type_revenue,pe_chart_template,False
+chart70412,70412,"By-products, waste and scrap - By-products - Associated",account.data_account_type_revenue,pe_chart_template,False
+chart70421,70421,"By-products, waste and scrap - Scrap and waste - Third parties",account.data_account_type_revenue,pe_chart_template,False
+chart70422,70422,"By-products, waste and scrap - Scrap and waste - Associated",account.data_account_type_revenue,pe_chart_template,False
+chart70911,70911,Sales returns - Merchandise - Export sale - Third parties,account.data_account_type_revenue,pe_chart_template,False
+chart70912,70912,Sales returns - Merchandise - Export sale - Associated,account.data_account_type_revenue,pe_chart_template,False
+chart70921,70921,Sales returns - Merchandise - Local sale - Third parties,account.data_account_type_revenue,pe_chart_template,False
+chart70922,70922,Sales returns - Merchandise - Local sale - Associated,account.data_account_type_revenue,pe_chart_template,False
+chart70931,70931,Sales returns - Finished products - Export sale - Third parties,account.data_account_type_revenue,pe_chart_template,False
+chart70932,70932,Sales returns - Finished products - Export sale - Associated,account.data_account_type_revenue,pe_chart_template,False
+chart70941,70941,Sales returns - Finished products - Local sale - Third parties,account.data_account_type_revenue,pe_chart_template,False
+chart70942,70942,Sales returns - Finished products - Local sale - Associated,account.data_account_type_revenue,pe_chart_template,False
+chart70951,70951,Sales returns - Rejected service inventories - Third parties,account.data_account_type_revenue,pe_chart_template,False
+chart70952,70952,Sales returns - Rejected service inventories - Associated,account.data_account_type_revenue,pe_chart_template,False
+chart70961,70961,"Sales returns - By-products, waste and scrap - Third parties",account.data_account_type_revenue,pe_chart_template,False
+chart70962,70962,"Sales returns - By-products, waste and scrap - Associated",account.data_account_type_revenue,pe_chart_template,False
+chart7111,7111,Variation of finished products - Finished products,account.data_account_type_other_income,pe_chart_template,False
+chart7121,7121,"Variation of by-products, waste and scrap - By-products",account.data_account_type_other_income,pe_chart_template,False
+chart7122,7122,"Variation of by-products, waste and scrap - Scrap and waste",account.data_account_type_other_income,pe_chart_template,False
+chart7131,7131,Variation of products in process - Products in manufacturing process,account.data_account_type_other_income,pe_chart_template,False
+chart7141,7141,Variation of containers and packaging - Containers,account.data_account_type_other_income,pe_chart_template,False
+chart7142,7142,Variation of containers and packaging - Packaging,account.data_account_type_other_income,pe_chart_template,False
+chart7151,7151,Variation of services inventories - Inventories of services in process,account.data_account_type_other_income,pe_chart_template,False
+chart7211,7211,Investment property - Buildings,account.data_account_type_other_income,pe_chart_template,False
+chart7220,7220,"Property, plant and equipment- Producing plant",account.data_account_type_other_income,pe_chart_template,False
+chart7221,7221,"Property, plant and equipment- Buildings",account.data_account_type_other_income,pe_chart_template,False
+chart7222,7222,"Property, plant and equipment- Machinery and other operating equipment",account.data_account_type_other_income,pe_chart_template,False
+chart7223,7223,"Property, plant and equipment- Transport units",account.data_account_type_other_income,pe_chart_template,False
+chart7224,7224,"Property, plant and equipment- Furniture and fixtures",account.data_account_type_other_income,pe_chart_template,False
+chart7225,7225,"Property, plant and equipment- Miscellaneous equipment",account.data_account_type_other_income,pe_chart_template,False
+chart7231,7231,Intangibles - Softwares,account.data_account_type_other_income,pe_chart_template,False
+chart7232,7232,Intangibles - Exploration and development costs,account.data_account_type_other_income,pe_chart_template,False
+chart7233,7233,"Intangibles - Formulas, designs and prototypes",account.data_account_type_other_income,pe_chart_template,False
+chart7241,7241,Biological assets - Biological assets in development of animal origin,account.data_account_type_other_income,pe_chart_template,False
+chart7242,7242,Biological assets - Biological assets in development of vegetable origin,account.data_account_type_other_income,pe_chart_template,False
+chart72511,72511,Capitalized financing costs - Financing costs – Investment property - Production plants under development,account.data_account_type_other_income,pe_chart_template,False
+chart72512,72512,Capitalized financing costs - Financing costs – Investment property - Buildings,account.data_account_type_other_income,pe_chart_template,False
+chart72521,72521,"Capitalized financing costs - Financing costs – Property, plant and equipment - Production plants in development",account.data_account_type_other_income,pe_chart_template,False
+chart72522,72522,"Capitalized financing costs - Financing costs – Property, plant and equipment - Buildings",account.data_account_type_other_income,pe_chart_template,False
+chart72523,72523,"Capitalized financing costs - Financing costs – Property, plant and equipment - Machinery and other operating equipment",account.data_account_type_other_income,pe_chart_template,False
+chart7253,7253,Capitalized financing costs - Financing costs – Intangibles,account.data_account_type_other_income,pe_chart_template,False
+chart72541,72541,Capitalized financing costs - Financing costs – Biological assets under development - Biological assets of animal origin,account.data_account_type_other_income,pe_chart_template,False
+chart72542,72542,Capitalized financing costs - Financing costs – Biological assets under development - Biological asset of vegetal origin,account.data_account_type_other_income,pe_chart_template,False
+chart7311,7311,"Discounts, rebates and bonuses obtained - Third parties",account.data_account_type_revenue,pe_chart_template,False
+chart7312,7312,"Discounts, rebates and bonuses obtained - Associated",account.data_account_type_revenue,pe_chart_template,False
+chart7411,7411,"Discounts, rebates and bonuses granted - Third parties",account.data_account_type_revenue,pe_chart_template,False
+chart7412,7412,"Discounts, rebates and bonuses granted - Associated",account.data_account_type_revenue,pe_chart_template,False
+chart751,751,Services for the benefit of staff,account.data_account_type_other_income,pe_chart_template,False
+chart752,752,Commissions and brokerage,account.data_account_type_other_income,pe_chart_template,False
+chart753,753,Royalties,account.data_account_type_other_income,pe_chart_template,False
+chart7540,7540,Leasings - Production plants,account.data_account_type_other_income,pe_chart_template,False
+chart7541,7541,Leasings - Land,account.data_account_type_other_income,pe_chart_template,False
+chart7542,7542,Leasings - Buildings,account.data_account_type_other_income,pe_chart_template,False
+chart7543,7543,Leasings - Machinery and exploitation equipment,account.data_account_type_other_income,pe_chart_template,False
+chart7544,7544,Leasings - Transport units,account.data_account_type_other_income,pe_chart_template,False
+chart7545,7545,Leasings - Miscellaneous equipment,account.data_account_type_other_income,pe_chart_template,False
+chart7551,7551,Recovery of valuation accounts - Recovery – Doubtful accounts,account.data_account_type_other_income,pe_chart_template,False
+chart7552,7552,Recovery of valuation accounts - Recovery – Inventory impairment,account.data_account_type_other_income,pe_chart_template,False
+chart7553,7553,Recovery of valuation accounts - Recovery – Depreciation of investment property,account.data_account_type_other_income,pe_chart_template,False
+chart7561,7561,Disposal of fixed assets - Securities investments,account.data_account_type_other_income,pe_chart_template,False
+chart7562,7562,Disposal of fixed assets - Investment property,account.data_account_type_other_income,pe_chart_template,False
+chart7563,7563,Disposal of fixed assets - Assets acquired under finance lease,account.data_account_type_other_income,pe_chart_template,False
+chart7564,7564,"Disposal of fixed assets - Property, plant and equipment",account.data_account_type_other_income,pe_chart_template,False
+chart7565,7565,Disposal of fixed assets - Intangibles,account.data_account_type_other_income,pe_chart_template,False
+chart7566,7566,Disposal of fixed assets - Biological assets,account.data_account_type_other_income,pe_chart_template,False
+chart7571,7571,Recovery of impairment of fixed asset accounts - Recovery of impairment of investment properties,account.data_account_type_other_income,pe_chart_template,False
+chart7572,7572,"Recovery of impairment of fixed asset accounts - Recovery of impairment of property, plant and equipment",account.data_account_type_other_income,pe_chart_template,False
+chart7573,7573,Recovery of impairment of fixed asset accounts - Recovery of impairment of intangibles,account.data_account_type_other_income,pe_chart_template,False
+chart7574,7574,Recovery of impairment of fixed asset accounts - Recovery of impairment of biological assets,account.data_account_type_other_income,pe_chart_template,False
+chart7591,7591,Other management income - Government subsidies,account.data_account_type_other_income,pe_chart_template,False
+chart7592,7592,Other management income - Insurance claims,account.data_account_type_other_income,pe_chart_template,False
+chart7593,7593,Other management income - Donations,account.data_account_type_other_income,pe_chart_template,False
+chart7594,7594,Other management income - Tax refunds,account.data_account_type_other_income,pe_chart_template,False
+chart7599,7599,Other management income - Other management income,account.data_account_type_other_income,pe_chart_template,False
+chart7611,7611,Realizable asset - Merchandise,account.data_account_type_other_income,pe_chart_template,False
+chart7612,7612,Realizable asset - Finished products,account.data_account_type_other_income,pe_chart_template,False
+chart76131,76131,Realizable asset - Non-current assets held for sale - Investment property,account.data_account_type_other_income,pe_chart_template,False
+chart76132,76132,"Realizable asset - Non-current assets held for sale - Property, plant and equipment",account.data_account_type_other_income,pe_chart_template,False
+chart76133,76133,Realizable asset - Non-current assets held for sale - Intangibles,account.data_account_type_other_income,pe_chart_template,False
+chart76134,76134,Realizable asset - Non-current assets held for sale - Biological assets,account.data_account_type_other_income,pe_chart_template,False
+chart7621,7621,Fixed asset - Investment property,account.data_account_type_other_income,pe_chart_template,False
+chart7622,7622,Fixed asset - Biological assets,account.data_account_type_other_income,pe_chart_template,False
+chart771,771,Gain on derivative financial instrument,account.data_account_type_other_income,pe_chart_template,False
+chart7721,7721,Earned returns - Deposits in financial institutions,account.data_account_type_other_income,pe_chart_template,False
+chart7722,7722,Earned returns - Trade accounts receivable,account.data_account_type_other_income,pe_chart_template,False
+chart7723,7723,Earned returns - Loans granted,account.data_account_type_other_income,pe_chart_template,False
+chart7724,7724,Earned returns - Investments to be held until maturity,account.data_account_type_other_income,pe_chart_template,False
+chart7725,7725,Earned returns - Financial instruments representative of economic rights,account.data_account_type_other_income,pe_chart_template,False
+chart773,773,Dividends,account.data_account_type_other_income,pe_chart_template,False
+chart774,774,Income from factoring operations,account.data_account_type_other_income,pe_chart_template,False
+chart775,775,Discounts obtained for prompt payment,account.data_account_type_other_income,pe_chart_template,False
+chart776,776,Difference in change,account.data_account_type_other_income,pe_chart_template,False
+chart7771,7771,Gain from measuring financial assets and liabilities at fair value - Investments held for trading,account.data_account_type_other_income,pe_chart_template,False
+chart7772,7772,Gain from measuring financial assets and liabilities at fair value - Other investments,account.data_account_type_other_income,pe_chart_template,False
+chart7773,7773,Gain from measuring financial assets and liabilities at fair value - Others,account.data_account_type_other_income,pe_chart_template,False
+chart7781,7781,Participation in results of related entities - Participation in the results of subsidiaries and associates under the equity value method,account.data_account_type_other_income,pe_chart_template,False
+chart7782,7782,Participation in results of related entities - Income from participation in joint ventures,account.data_account_type_other_income,pe_chart_template,False
+chart7792,7792,Other financial income - Financial income measured at discounted value,account.data_account_type_other_income,pe_chart_template,False
+chart781,781,Charges covered by provisions,account.data_account_type_other_income,pe_chart_template,False
+chart791,791,Charges attributable to cost and expense accounts,account.data_account_type_revenue,pe_chart_template,False
+chart792,792,Financial expenses attributable to inventory accounts,account.data_account_type_revenue,pe_chart_template,False
 chart801,801,Margen comercial,account.data_account_type_equity,pe_chart_template,False
-chart811,811,Producción de bienes,account.data_account_type_equity,pe_chart_template,False
-chart812,812,Producción de servicios,account.data_account_type_equity,pe_chart_template,False
-chart813,813,Producción de activo inmovilizado,account.data_account_type_equity,pe_chart_template,False
-chart821,821,Valor agregado,account.data_account_type_equity,pe_chart_template,False
-chart831,831,Excedente bruto (insuficiencia bruta) de explotación,account.data_account_type_equity,pe_chart_template,False
-chart841,841,Resultado de explotación,account.data_account_type_equity,pe_chart_template,False
-chart851,851,Resultado antes del impuesto a las ganancias,account.data_account_type_equity,pe_chart_template,False
-chart881,881,Impuesto a las ganancias – Corriente,account.data_account_type_equity,pe_chart_template,False
-chart882,882,Impuesto a las ganancias – Diferido,account.data_account_type_equity,pe_chart_template,False
-chart891,891,Utilidad,account.data_account_type_equity,pe_chart_template,False
-chart892,892,Pérdida,account.data_account_type_equity,pe_chart_template,False
+chart811,811,Production of goods,account.data_account_type_equity,pe_chart_template,False
+chart812,812,Production of services,account.data_account_type_equity,pe_chart_template,False
+chart813,813,Production of fixed assets,account.data_account_type_equity,pe_chart_template,False
+chart821,821,Value added,account.data_account_type_equity,pe_chart_template,False
+chart831,831,Gross surplus (gross deficiency) of exploitation,account.data_account_type_equity,pe_chart_template,False
+chart841,841,Result of exploitation,account.data_account_type_equity,pe_chart_template,False
+chart851,851,Income before income tax,account.data_account_type_equity,pe_chart_template,False
+chart881,881,Income tax – Current,account.data_account_type_expenses,pe_chart_template,False
+chart882,882,Income tax – Deferred,account.data_account_type_non_current_liabilities,pe_chart_template,False
+chart891,891,Utility,account.data_account_type_equity,pe_chart_template,False
+chart892,892,Lost,account.data_account_type_equity,pe_chart_template,False

--- a/addons/l10n_pe/data/account.group.template.csv
+++ b/addons/l10n_pe/data/account.group.template.csv
@@ -1,84 +1,84 @@
 id,code_prefix_start,name,chart_template_id:id
-group0,0,Cuentas de orden,pe_chart_template
-group1,1,Activo disponible y exigible,pe_chart_template
-group2,2,Activo realizable,pe_chart_template
-group3,3,Activo inmovilizado,pe_chart_template
-group4,4,Pasivo,pe_chart_template
-group5,5,Patrimonio Neto,pe_chart_template
-group6,6,Gastos por naturaleza,pe_chart_template
-group7,7,Ingresos,pe_chart_template
-group8,8,Saldos intrermediarios de gestión y determinación del resultado del ejercicio,pe_chart_template
-group10,10,EFECTIVO Y EQUIVALENTES DE EFECTIVO,pe_chart_template
-group11,11,INVERSIONES FINANCIERAS,pe_chart_template
-group12,12,CUENTAS POR COBRAR COMERCIALES – TERCEROS,pe_chart_template
-group13,13,CUENTAS POR COBRAR COMERCIALES – RELACIONADAS,pe_chart_template
-group14,14,"CUENTAS POR COBRAR AL PERSONAL, A LOS ACCIONISTAS (SOCIOS) y DIRECTORES",pe_chart_template
-group16,16,CUENTAS POR COBRAR DIVERSAS – TERCEROS,pe_chart_template
-group17,17,CUENTAS POR COBRAR DIVERSAS – RELACIONADAS,pe_chart_template
-group18,18,SERVICIOS Y OTROS CONTRATADOS POR ANTICIPADO,pe_chart_template
-group19,19,ESTIMACIÓN DE CUENTAS DE COBRANZA DUDOSA,pe_chart_template
-group20,20,MERCADERÍAS,pe_chart_template
-group21,21,PRODUCTOS TERMINADOS,pe_chart_template
-group22,22,"SUBPRODUCTOS, DESECHOS Y DESPERDICIOS",pe_chart_template
-group23,23,PRODUCTOS EN PROCESO,pe_chart_template
-group24,24,MATERIAS PRIMAS,pe_chart_template
-group25,25,"MATERIALES AUXILIARES, SUMINISTROS Y REPUESTOS",pe_chart_template
-group26,26,ENVASES Y EMBALAJES,pe_chart_template
-group27,27,ACTIVOS NO CORRIENTES MANTENIDOS PARA LA VENTA,pe_chart_template
-group28,28,INVENTARIOS POR RECIBIR,pe_chart_template
-group29,29,DESVALORIZACIÓN DE INVENTARIOS,pe_chart_template
-group30,30,INVERSIONES MOBILIARIAS,pe_chart_template
-group31,31,PROPIEDADES DE INVERSIÓN,pe_chart_template
-group32,32,ACTIVOS POR DERECHO DE USO,pe_chart_template
-group33,33,"PROPIEDAD, PLANTA Y EQUIPO",pe_chart_template
+group0,0,Memorandum accounts,pe_chart_template
+group1,1,Assets available and payable,pe_chart_template
+group2,2,Realizable asset,pe_chart_template
+group3,3,Assets available and payable,pe_chart_template
+group4,4,Liabilities,pe_chart_template
+group5,5,Net Worth,pe_chart_template
+group6,6,Expenses by nature,pe_chart_template
+group7,7,Incomes,pe_chart_template
+group8,8,Intermediate management balances and determination of profit for the year,pe_chart_template
+group10,10,CASH AND CASH EQUIVALENTS,pe_chart_template
+group11,11,FINANCIAL INVESTMENTS,pe_chart_template
+group12,12,TRADE ACCOUNTS RECEIVABLE – THIRD PARTIES,pe_chart_template
+group13,13,TRADE ACCOUNTS RECEIVABLE – ASSOCIATED,pe_chart_template
+group14,14,"ACCOUNTS RECEIVABLE FROM STAFF, SHAREHOLDERS (PARTNERS) AND DIRECTORS",pe_chart_template
+group16,16,MISCELLANEOUS ACCOUNTS RECEIVABLE – THIRD PARTIES,pe_chart_template
+group17,17,MISCELLANEOUS ACCOUNTS RECEIVABLE – ASSOCIATED,pe_chart_template
+group18,18,SERVICES AND OTHER CONTRACTED IN ADVANCE,pe_chart_template
+group19,19,ESTIMATION OF DOUBTFUL ACCOUNTS,pe_chart_template
+group20,20,MERCHANDISE,pe_chart_template
+group21,21,FINISHED PRODUCTS,pe_chart_template
+group22,22,"BY-PRODUCTS, WASTE AND WASTE",pe_chart_template
+group23,23,PRODUCTS IN PROCESS,pe_chart_template
+group24,24,RAW MATERIALS,pe_chart_template
+group25,25,"AUXILIARY MATERIALS, SUPPLIES AND SPARE PARTS",pe_chart_template
+group26,26,CONTAINERS AND PACKAGING,pe_chart_template
+group27,27,NON-CURRENT ASSETS HELD FOR SALE,pe_chart_template
+group28,28,INVENTORIES TO RECEIVE,pe_chart_template
+group29,29,DEVALUATION OF INVENTORIES,pe_chart_template
+group30,30,PROPERTY INVESTMENTS,pe_chart_template
+group31,31,INVESTMENT PROPERTIES,pe_chart_template
+group32,32,ASSETS BY RIGHT OF USE,pe_chart_template
+group33,33,"PROPERTY, PLANT AND EQUIPMENT",pe_chart_template
 group34,34,INTANGIBLES,pe_chart_template
-group35,35,ACTIVOS BIOLÓGICOS,pe_chart_template
-group36,36,DESVALORIZACIÓN DE ACTIVO INMOVILIZADO,pe_chart_template
-group37,37,ACTIVO DIFERIDO,pe_chart_template
-group38,38,OTROS ACTIVOS,pe_chart_template
-group39,39,DEPRECIACIÓN y AMORTIZACIÓN ACUMULADOS,pe_chart_template
-group40,40,"TRIBUTOS, CONTRAPRESTACIONES Y APORTES AL SISTEMA PÚBLICO DE PENSIONES Y DE SALUD POR PAGAR",pe_chart_template
-group41,41,REMUNERACIONES Y PARTICIPACIONES POR PAGAR,pe_chart_template
-group42,42,CUENTAS POR PAGAR COMERCIALES TERCEROS,pe_chart_template
-group43,43,CUENTAS POR PAGAR COMERCIALES RELACIONADAS,pe_chart_template
-group44,44,"CUENTAS POR PAGAR A LOS ACCIONISTAS (SOCIOS, PARTÍCIPES) Y DIRECTORES",pe_chart_template
-group45,45,OBLIGACIONES FINANCIERAS,pe_chart_template
-group46,46,CUENTAS POR PAGAR DIVERSAS – TERCEROS,pe_chart_template
-group47,47,CUENTAS POR PAGAR DIVERSAS – RELACIONADAS,pe_chart_template
-group48,48,PROVISIONES,pe_chart_template
-group49,49,PASIVO DIFERIDO,pe_chart_template
+group35,35,BIOLOGICAL ASSETS,pe_chart_template
+group36,36,DEVALUATION OF FIXED ASSETS,pe_chart_template
+group37,37,DEFERRED ASSETS,pe_chart_template
+group38,38,OTHER ASSETS,pe_chart_template
+group39,39,ACCUMULATED DEPRECIATION AND AMORTIZATION,pe_chart_template
+group40,40,"TAXES, CONSIDERATIONS AND CONTRIBUTIONS TO THE PUBLIC PENSION AND HEALTH SYSTEM PAYABLE",pe_chart_template
+group41,41,REMUNERATIONS AND PARTICIPATIONS PAYABLE,pe_chart_template
+group42,42,THIRD-PARTY TRADE ACCOUNTS PAYABLE,pe_chart_template
+group43,43,RELATED TRADE ACCOUNTS PAYABLE,pe_chart_template
+group44,44,"ACCOUNTS PAYABLE TO SHAREHOLDERS (PARTNERS, PARTICIPANTS) AND DIRECTORS",pe_chart_template
+group45,45,FINANCIAL OBLIGATIONS,pe_chart_template
+group46,46,OTHER ACCOUNTS PAYABLE – THIRD PARTIES,pe_chart_template
+group47,47,OTHER ACCOUNTS PAYABLE – ASSOCIATED,pe_chart_template
+group48,48,PROVISIONS,pe_chart_template
+group49,49,DEFERRED LIABILITIES,pe_chart_template
 group50,50,CAPITAL,pe_chart_template
-group51,51,ACCIONES DE INVERSIÓN,pe_chart_template
-group52,52,CAPITAL ADICIONAL,pe_chart_template
-group56,56,RESULTADOS NO REALIZADOS,pe_chart_template
-group57,57,EXCEDENTE DE REVALUACIÓN,pe_chart_template
-group58,58,RESERVAS,pe_chart_template
-group59,59,RESULTADOS ACUMULADOS,pe_chart_template
-group60,60,COMPRAS,pe_chart_template
-group61,61,VARIACIÓN DE INVENTARIOS,pe_chart_template
-group62,62,GASTOS DE PERSONAL Y DIRECTORES,pe_chart_template
-group63,63,GASTOS DE SERVICIOS PRESTADOS POR TERCEROS,pe_chart_template
-group64,64,GASTOS POR TRIBUTOS,pe_chart_template
-group65,65,OTROS GASTOS DE GESTION,pe_chart_template
-group66,66,PERDIDA POR MEDICIÓN DE ACTIVOS NO FINANCIEROS AL VALOR RAZONABLE,pe_chart_template
-group67,67,GASTOS FINANCIEROS,pe_chart_template
-group68,68,VALUACIÓN Y DETERIORO DE ACTIVOS Y PROVISIONES,pe_chart_template
-group69,69,COSTO DE VENTAS,pe_chart_template
-group70,70,VENTAS,pe_chart_template
-group71,71,VARIACIÓN DE LA PRODUCCIÓN ALMACENADA,pe_chart_template
-group72,72,PRODUCCIÓN DE ACTIVO INMOVILIZADO,pe_chart_template
-group73,73,"DESCUENTOS, REBAJAS Y BONIFICACIONES OBTENIDOS",pe_chart_template
-group74,74,"DESCUENTOS, REBAJAS y BONIFICACIONES CONCEDIDOS",pe_chart_template
-group75,75,OTROS INGRESOS DE GESTIÓN,pe_chart_template
-group76,76,GANANCIA POR MEDICIÓN DE ACTIVOS NO FINANCIEROS AL VALOR RAZONABLE,pe_chart_template
-group77,77,INGRESOS FINANCIEROS,pe_chart_template
-group78,78,CARGAS CUBIERTAS POR PROVISIONES,pe_chart_template
-group79,79,CARGAS IMPUTABLES A CUENTAS DE COSTOS Y GASTOS,pe_chart_template
-group80,80,MARGEN COMERCIAL,pe_chart_template
-group81,81,PRODUCCIÓN DEL EJERCICIO,pe_chart_template
-group82,82,VALOR AGREGADO,pe_chart_template
-group83,83,EXCEDENTE BRUTO (INSUFICIENCIA BRUTA) DE EXPLOTACIÓN,pe_chart_template
-group84,84,RESULTADO DE EXPLOTACIÓN,pe_chart_template
-group85,85,RESULTADO ANTES DE PARTICIPACIONES E IMPUESTOS,pe_chart_template
-group88,88,IMPUESTO A LA RENTA,pe_chart_template
-group89,89,DETERMINACIÓN DEL RESULTADO DEL EJERCICIO,pe_chart_template
+group51,51,INVESTMENT STOCKS,pe_chart_template
+group52,52,ADDITIONAL CAPITAL,pe_chart_template
+group56,56,UNREALIZED RESULTS,pe_chart_template
+group57,57,REVALUATION SURPLUS,pe_chart_template
+group58,58,RESERVES,pe_chart_template
+group59,59,ACUMULATED RESULTS,pe_chart_template
+group60,60,PURCHASES,pe_chart_template
+group61,61,VARIATION IN INVENTORIES,pe_chart_template
+group62,62,STAFF AND DIRECTORS EXPENSES,pe_chart_template
+group63,63,EXPENSES FOR SERVICES RENDERED BY THIRD PARTIES,pe_chart_template
+group64,64,TAX EXPENSES,pe_chart_template
+group65,65,OTHER MANAGEMENT EXPENSES,pe_chart_template
+group66,66,LOSS DUE TO MEASUREMENT OF NON-FINANCIAL ASSETS AT FAIR VALUE,pe_chart_template
+group67,67,FINANCIAL EXPENSES,pe_chart_template
+group68,68,VALUATION AND IMPAIRMENT OF ASSETS AND PROVISIONS,pe_chart_template
+group69,69,SALES COST,pe_chart_template
+group70,70,SALES,pe_chart_template
+group71,71,VARIATION IN STORED PRODUCTION,pe_chart_template
+group72,72,PRODUCTION OF FIXED ASSETS,pe_chart_template
+group73,73,"DISCOUNTS, REBATES AND BONUSES OBTAINED",pe_chart_template
+group74,74,"DISCOUNTS, DISCOUNTS AND BONUSES GRANTED",pe_chart_template
+group75,75,OTHER MANAGEMENT INCOME,pe_chart_template
+group76,76,PROFIT FROM MEASUREMENT OF NON-FINANCIAL ASSETS AT FAIR VALUE,pe_chart_template
+group77,77,FINANCIAL INCOME,pe_chart_template
+group78,78,CHARGES COVERED BY PROVISIONS,pe_chart_template
+group79,79,CHARGES ATTRIBUTABLE TO COST AND EXPENSE ACCOUNTS,pe_chart_template
+group80,80,COMMERCIAL MARGIN,pe_chart_template
+group81,81,PRODUCTION OF THE YEAR,pe_chart_template
+group82,82,VALUE ADDED,pe_chart_template
+group83,83,GROSS SURPLUS (GROSS LACK) FROM OPERATING,pe_chart_template
+group84,84,RESULT OF EXPLOITATION,pe_chart_template
+group85,85,RESULT BEFORE PARTICIPATIONS AND TAXES,pe_chart_template
+group88,88,INCOME TAX,pe_chart_template
+group89,89,DETERMINATION OF THE RESULT OF THE YEAR,pe_chart_template

--- a/addons/l10n_pe/data/account_tax_group_data.xml
+++ b/addons/l10n_pe/data/account_tax_group_data.xml
@@ -36,7 +36,7 @@
             <field name="country_id" ref="base.pe"/>
         </record>
         <record id="tax_group_other" model="account.tax.group">
-            <field name="name">OTROS</field>
+            <field name="name">OTHERS</field>
             <field name="sequence">0</field>
             <field name="country_id" ref="base.pe"/>
         </record>

--- a/addons/l10n_pe/data/fiscal_position_data.xml
+++ b/addons/l10n_pe/data/fiscal_position_data.xml
@@ -7,7 +7,7 @@
         <field name="sequence">15</field>
     </record>
     <record id="exportation" model="account.fiscal.position.template">
-        <field name="name">EXTRANJERO - EXPORTACIÓN</field>
+        <field name="name">FOREIGN - EXPORT</field>
         <field name="chart_template_id" ref="pe_chart_template"/>
         <field name="auto_apply">1</field>
         <field name="sequence">10</field>

--- a/addons/l10n_pe/data/menuitem_data.xml
+++ b/addons/l10n_pe/data/menuitem_data.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <menuitem id="account_reports_pe_statements_menu" name="Peru" parent="account.menu_finance_reports" sequence="0"
+              groups="account.group_account_readonly"/>
+</odoo>

--- a/addons/l10n_pe/i18n/es.po
+++ b/addons/l10n_pe/i18n/es.po
@@ -4,10 +4,10 @@
 #
 msgid ""
 msgstr ""
-"Project-Id-Version: Odoo Server 14.0+e\n"
+"Project-Id-Version: Odoo Server 15.0+e\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2021-02-26 17:44+0000\n"
-"PO-Revision-Date: 2021-02-26 17:44+0000\n"
+"POT-Creation-Date: 2022-08-09 12:57+0000\n"
+"PO-Revision-Date: 2022-08-09 12:57+0000\n"
 "Last-Translator: \n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"
@@ -16,10 +16,4805 @@ msgstr ""
 "Plural-Forms: \n"
 
 #. module: l10n_pe
+#: model:account.tax,name:l10n_pe.1_sale_tax_exp
+#: model:account.tax,name:l10n_pe.2_sale_tax_exp
+#: model:account.tax.template,name:l10n_pe.sale_tax_exp
+msgid "0% EXP"
+msgstr "0% EXP"
+
+#. module: l10n_pe
+#: model:account.tax,name:l10n_pe.1_purchase_tax_exo
+#: model:account.tax,name:l10n_pe.1_sale_tax_exo
+#: model:account.tax,name:l10n_pe.2_purchase_tax_exo
+#: model:account.tax,name:l10n_pe.2_sale_tax_exo
+#: model:account.tax.template,name:l10n_pe.purchase_tax_exo
+#: model:account.tax.template,name:l10n_pe.sale_tax_exo
+msgid "0% Exonerated"
+msgstr "0% Exonerado"
+
+#. module: l10n_pe
+#: model:account.tax,name:l10n_pe.1_purchase_tax_gra
+#: model:account.tax,name:l10n_pe.1_sale_tax_gra
+#: model:account.tax,name:l10n_pe.2_purchase_tax_gra
+#: model:account.tax,name:l10n_pe.2_sale_tax_gra
+#: model:account.tax.template,name:l10n_pe.purchase_tax_gra
+#: model:account.tax.template,name:l10n_pe.sale_tax_gra
+msgid "0% Free"
+msgstr "0% Gratis"
+
+#. module: l10n_pe
+#: model:account.tax,name:l10n_pe.1_purchase_tax_ina
+#: model:account.tax,name:l10n_pe.1_sale_tax_ina
+#: model:account.tax,name:l10n_pe.2_purchase_tax_ina
+#: model:account.tax,name:l10n_pe.2_sale_tax_ina
+#: model:account.tax.template,name:l10n_pe.purchase_tax_ina
+#: model:account.tax.template,name:l10n_pe.sale_tax_ina
+msgid "0% Unaffected"
+msgstr "0% Inafectado"
+
+#. module: l10n_pe
+#: model:account.tax,name:l10n_pe.1_purchase_tax_igv_18
+#: model:account.tax,name:l10n_pe.1_sale_tax_igv_18
+#: model:account.tax,name:l10n_pe.2_purchase_tax_igv_18
+#: model:account.tax,name:l10n_pe.2_sale_tax_igv_18
+#: model:account.tax.template,name:l10n_pe.purchase_tax_igv_18
+#: model:account.tax.template,name:l10n_pe.sale_tax_igv_18
+msgid "18%"
+msgstr "18%"
+
+#. module: l10n_pe
+#: model:account.tax,name:l10n_pe.1_purchase_tax_igv_18_included
+#: model:account.tax,name:l10n_pe.1_sale_tax_igv_18_included
+#: model:account.tax,name:l10n_pe.2_purchase_tax_igv_18_included
+#: model:account.tax,name:l10n_pe.2_sale_tax_igv_18_included
+#: model:account.tax.template,name:l10n_pe.purchase_tax_igv_18_included
+#: model:account.tax.template,name:l10n_pe.sale_tax_igv_18_included
+msgid "18% (Included in price)"
+msgstr "18% (Incluido en precio)"
+
+#. module: l10n_pe
+#: model:account.group,name:l10n_pe.1_group44
+#: model:account.group,name:l10n_pe.2_group44
+#: model:account.group.template,name:l10n_pe.group44
+msgid ""
+"ACCOUNTS PAYABLE TO SHAREHOLDERS (PARTNERS, PARTICIPANTS) AND DIRECTORS"
+msgstr "CUENTAS POR PAGAR A LOS ACCIONISTAS (SOCIOS, PARTÍCIPES) Y DIRECTORES"
+
+#. module: l10n_pe
+#: model:account.group,name:l10n_pe.1_group14
+#: model:account.group,name:l10n_pe.2_group14
+#: model:account.group.template,name:l10n_pe.group14
+msgid "ACCOUNTS RECEIVABLE FROM STAFF, SHAREHOLDERS (PARTNERS) AND DIRECTORS"
+msgstr ""
+"CUENTAS POR COBRAR AL PERSONAL, A LOS ACCIONISTAS (SOCIOS) y DIRECTORES"
+
+#. module: l10n_pe
+#: model:account.group,name:l10n_pe.1_group39
+#: model:account.group,name:l10n_pe.2_group39
+#: model:account.group.template,name:l10n_pe.group39
+msgid "ACCUMULATED DEPRECIATION AND AMORTIZATION"
+msgstr "DEPRECIACIÓN y AMORTIZACIÓN ACUMULADOS"
+
+#. module: l10n_pe
+#: model:account.group,name:l10n_pe.1_group59
+#: model:account.group,name:l10n_pe.2_group59
+#: model:account.group.template,name:l10n_pe.group59
+msgid "ACUMULATED RESULTS"
+msgstr "RESULTADOS ACUMULADOS"
+
+#. module: l10n_pe
+#: model:account.group,name:l10n_pe.1_group52
+#: model:account.group,name:l10n_pe.2_group52
+#: model:account.group.template,name:l10n_pe.group52
+msgid "ADDITIONAL CAPITAL"
+msgstr "CAPITAL ADICIONAL"
+
+#. module: l10n_pe
+#: model:account.group,name:l10n_pe.1_group32
+#: model:account.group,name:l10n_pe.2_group32
+#: model:account.group.template,name:l10n_pe.group32
+msgid "ASSETS BY RIGHT OF USE"
+msgstr "ACTIVOS POR DERECHO DE USO"
+
+#. module: l10n_pe
+#: model:account.group,name:l10n_pe.1_group25
+#: model:account.group,name:l10n_pe.2_group25
+#: model:account.group.template,name:l10n_pe.group25
+msgid "AUXILIARY MATERIALS, SUPPLIES AND SPARE PARTS"
+msgstr "MATERIALES AUXILIARES, SUMINISTROS Y REPUESTOS"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_030101
+#: model:res.city,name:l10n_pe.city_pe_0301
+msgid "Abancay"
+msgstr "Abancay"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_020502
+msgid "Abelardo Pardo Lezameta"
+msgstr "Abelardo Pardo Lezameta"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_040302
+msgid "Acarí"
+msgstr "Acarí"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_021402
+msgid "Acas"
+msgstr "Acas"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_081002
+msgid "Accha"
+msgstr "Accha"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_051102
+msgid "Accomarca"
+msgstr "Accomarca"
+
+#. module: l10n_pe
+#: model:ir.model,name:l10n_pe.model_account_chart_template
+msgid "Account Chart Template"
+msgstr "Plantilla de Plan de Cuentas"
+
+#. module: l10n_pe
+#: model:ir.model.fields,help:l10n_pe.field_account_move_line__l10n_pe_group_id
+msgid "Account prefixes can determine account groups."
+msgstr "Prefijos de cuentas pueden determinar grupos de cuentas."
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart1215
+#: model:account.account,name:l10n_pe.2_chart1215
+#: model:account.account.template,name:l10n_pe.chart1215
+msgid ""
+"Accounts receivable ... - Invoices, tickets and other receipts receivable "
+"not issued (PoS)"
+msgstr ""
+"Cuentas por cobrar ... - Facturas, boletas y otros comprobantes por cobrar /"
+" no emitidas (PoS)"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart1933
+#: model:account.account,name:l10n_pe.2_chart1933
+#: model:account.account.template,name:l10n_pe.chart1933
+msgid ""
+"Accounts receivable from staff, shareholders (partners) and directors - "
+"Directors"
+msgstr ""
+"Cuentas por cobrar al personal, a los accionistas (socios) y directores - "
+"Directors"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart1931
+#: model:account.account,name:l10n_pe.2_chart1931
+#: model:account.account.template,name:l10n_pe.chart1931
+msgid ""
+"Accounts receivable from staff, shareholders (partners) and directors - "
+"Personal"
+msgstr ""
+"Cuentas por cobrar al personal, a los accionistas (socios) y directores - "
+"Personal"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart1932
+#: model:account.account,name:l10n_pe.2_chart1932
+#: model:account.account.template,name:l10n_pe.chart1932
+msgid ""
+"Accounts receivable from staff, shareholders (partners) and directors - "
+"Shareholders (or partners)"
+msgstr ""
+"Cuentas por cobrar al personal, a los accionistas (socios) y directores - "
+"Shareholders (or partners)"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart1939
+#: model:account.account,name:l10n_pe.2_chart1939
+#: model:account.account.template,name:l10n_pe.chart1939
+msgid ""
+"Accounts receivable from staff, shareholders (partners) and directors - "
+"Various"
+msgstr ""
+"Cuentas por cobrar al personal, a los accionistas (socios) y directores - "
+"Diversas"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart39611
+#: model:account.account,name:l10n_pe.2_chart39611
+#: model:account.account.template,name:l10n_pe.chart39611
+msgid ""
+"Accumulated amortization - Intangibles – Costs - Concessions, licenses and "
+"other rights"
+msgstr ""
+"Amortización acumulada - Intangibles – Costo - Concesiones, licencias y "
+"otros derechos"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart39614
+#: model:account.account,name:l10n_pe.2_chart39614
+#: model:account.account.template,name:l10n_pe.chart39614
+msgid ""
+"Accumulated amortization - Intangibles – Costs - Exploration and development"
+" costs"
+msgstr ""
+"Amortización acumulada - Intangibles – Costo - Costos de exploración y "
+"desarrollo"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart39615
+#: model:account.account,name:l10n_pe.2_chart39615
+#: model:account.account.template,name:l10n_pe.chart39615
+msgid ""
+"Accumulated amortization - Intangibles – Costs - Formulas, designs and "
+"prototypes"
+msgstr ""
+"Amortización acumulada - Intangibles – Costo - Fórmulas, diseños y "
+"prototipos"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart39619
+#: model:account.account,name:l10n_pe.2_chart39619
+#: model:account.account.template,name:l10n_pe.chart39619
+msgid ""
+"Accumulated amortization - Intangibles – Costs - Other intangible assets"
+msgstr ""
+"Amortización acumulada - Intangibles – Costo - Otros activos intangibles"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart39612
+#: model:account.account,name:l10n_pe.2_chart39612
+#: model:account.account.template,name:l10n_pe.chart39612
+msgid ""
+"Accumulated amortization - Intangibles – Costs - Patents and industrial "
+"property"
+msgstr ""
+"Amortización acumulada - Intangibles – Costo - Patentes y propiedad "
+"industrial"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart39613
+#: model:account.account,name:l10n_pe.2_chart39613
+#: model:account.account.template,name:l10n_pe.chart39613
+msgid "Accumulated amortization - Intangibles – Costs - Softwares"
+msgstr ""
+"Amortización acumulada - Intangibles – Costo - Programas de computadora "
+"(software)"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart39635
+#: model:account.account,name:l10n_pe.2_chart39635
+#: model:account.account.template,name:l10n_pe.chart39635
+msgid ""
+"Accumulated amortization - Intangibles – Financing costs - Development costs"
+msgstr ""
+"Amortización acumulada - Intangibles – Costos de financiación - Costos de "
+"desarrollo"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart39634
+#: model:account.account,name:l10n_pe.2_chart39634
+#: model:account.account.template,name:l10n_pe.chart39634
+msgid ""
+"Accumulated amortization - Intangibles – Financing costs - Exploration costs"
+msgstr ""
+"Amortización acumulada - Intangibles – Costos de financiación - Costos de "
+"exploración"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart39633
+#: model:account.account,name:l10n_pe.2_chart39633
+#: model:account.account.template,name:l10n_pe.chart39633
+msgid "Accumulated amortization - Intangibles – Financing costs - Softwares"
+msgstr ""
+"Amortización acumulada - Intangibles – Costos de financiación - Programas de"
+" computadora"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart39621
+#: model:account.account,name:l10n_pe.2_chart39621
+#: model:account.account.template,name:l10n_pe.chart39621
+msgid ""
+"Accumulated amortization - Intangibles – Revaluation - Concessions, licenses"
+" and other rights"
+msgstr ""
+"Amortización acumulada - Intangibles – Revaluación - Concesiones, licencias "
+"y otros derechos"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart39624
+#: model:account.account,name:l10n_pe.2_chart39624
+#: model:account.account.template,name:l10n_pe.chart39624
+msgid ""
+"Accumulated amortization - Intangibles – Revaluation - Exploration and "
+"development costs"
+msgstr ""
+"Amortización acumulada - Intangibles – Revaluación - Costos de exploración y"
+" desarrollo"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart39625
+#: model:account.account,name:l10n_pe.2_chart39625
+#: model:account.account.template,name:l10n_pe.chart39625
+msgid ""
+"Accumulated amortization - Intangibles – Revaluation - Formulas, designs and"
+" prototypes"
+msgstr ""
+"Amortización acumulada - Intangibles – Revaluación - Fórmulas, diseños y "
+"prototipos"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart39629
+#: model:account.account,name:l10n_pe.2_chart39629
+#: model:account.account.template,name:l10n_pe.chart39629
+msgid ""
+"Accumulated amortization - Intangibles – Revaluation - Other intangible "
+"assets"
+msgstr ""
+"Amortización acumulada - Intangibles – Revaluación - Otros activos "
+"intangibles"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart39622
+#: model:account.account,name:l10n_pe.2_chart39622
+#: model:account.account.template,name:l10n_pe.chart39622
+msgid ""
+"Accumulated amortization - Intangibles – Revaluation - Patents and "
+"industrial property"
+msgstr ""
+"Amortización acumulada - Intangibles – Revaluación - Patentes y propiedad "
+"industrial"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart39623
+#: model:account.account,name:l10n_pe.2_chart39623
+#: model:account.account.template,name:l10n_pe.chart39623
+msgid "Accumulated amortization - Intangibles – Revaluation - Softwares"
+msgstr ""
+"Amortización acumulada - Intangibles – Revaluación - Programas de "
+"computadora (software)"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart27711
+#: model:account.account,name:l10n_pe.2_chart27711
+#: model:account.account.template,name:l10n_pe.chart27711
+msgid ""
+"Accumulated amortization – Intangibles - Concessions, licenses and rights - "
+"Costs"
+msgstr ""
+"Amortización acumulada – Intangibles - Concesiones, licencias y derechos - "
+"Costo"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart27712
+#: model:account.account,name:l10n_pe.2_chart27712
+#: model:account.account.template,name:l10n_pe.chart27712
+msgid ""
+"Accumulated amortization – Intangibles - Concessions, licenses and rights - "
+"Revaluation"
+msgstr ""
+"Amortización acumulada – Intangibles - Concesiones, licencias y derechos - "
+"Revaluación"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart27741
+#: model:account.account,name:l10n_pe.2_chart27741
+#: model:account.account.template,name:l10n_pe.chart27741
+msgid ""
+"Accumulated amortization – Intangibles - Exploration and development costs -"
+" Costs"
+msgstr ""
+"Amortización acumulada – Intangibles - Costos de exploración y desarrollo - "
+"Costo"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart27742
+#: model:account.account,name:l10n_pe.2_chart27742
+#: model:account.account.template,name:l10n_pe.chart27742
+msgid ""
+"Accumulated amortization – Intangibles - Exploration and development costs -"
+" Revaluation"
+msgstr ""
+"Amortización acumulada – Intangibles - Costos de exploración y desarrollo - "
+"Revaluación"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart27751
+#: model:account.account,name:l10n_pe.2_chart27751
+#: model:account.account.template,name:l10n_pe.chart27751
+msgid ""
+"Accumulated amortization – Intangibles - Formulas, designs and prototypes - "
+"Costs"
+msgstr ""
+"Amortización acumulada – Intangibles - Fórmulas, diseños y prototipos - "
+"Costo"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart27752
+#: model:account.account,name:l10n_pe.2_chart27752
+#: model:account.account.template,name:l10n_pe.chart27752
+msgid ""
+"Accumulated amortization – Intangibles - Formulas, designs and prototypes - "
+"Revaluation"
+msgstr ""
+"Amortización acumulada – Intangibles - Fórmulas, diseños y prototipos - "
+"Revaluación"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart27791
+#: model:account.account,name:l10n_pe.2_chart27791
+#: model:account.account.template,name:l10n_pe.chart27791
+msgid ""
+"Accumulated amortization – Intangibles - Other intangible assets - Costs"
+msgstr ""
+"Amortización acumulada – Intangibles - Otros activos intangibles - Costo"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart27792
+#: model:account.account,name:l10n_pe.2_chart27792
+#: model:account.account.template,name:l10n_pe.chart27792
+msgid ""
+"Accumulated amortization – Intangibles - Other intangible assets - "
+"Revaluation"
+msgstr ""
+"Amortización acumulada – Intangibles - Otros activos intangibles - "
+"Revaluación"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart27721
+#: model:account.account,name:l10n_pe.2_chart27721
+#: model:account.account.template,name:l10n_pe.chart27721
+msgid ""
+"Accumulated amortization – Intangibles - Patents and industrial property - "
+"Costs"
+msgstr ""
+"Amortización acumulada – Intangibles - Patentes y propiedad industrial - "
+"Costo"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart27722
+#: model:account.account,name:l10n_pe.2_chart27722
+#: model:account.account.template,name:l10n_pe.chart27722
+msgid ""
+"Accumulated amortization – Intangibles - Patents and industrial property - "
+"Revaluation"
+msgstr ""
+"Amortización acumulada – Intangibles - Patentes y propiedad industrial - "
+"Revaluación"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart27731
+#: model:account.account,name:l10n_pe.2_chart27731
+#: model:account.account.template,name:l10n_pe.chart27731
+msgid "Accumulated amortization – Intangibles - Softwares - Costs"
+msgstr ""
+"Amortización acumulada – Intangibles - Programas de computadora (software) -"
+" Costo"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart27732
+#: model:account.account,name:l10n_pe.2_chart27732
+#: model:account.account.template,name:l10n_pe.chart27732
+msgid "Accumulated amortization – Intangibles - Softwares - Revaluation"
+msgstr ""
+"Amortización acumulada – Intangibles - Programas de computadora (software) -"
+" Revaluación"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart39811
+#: model:account.account,name:l10n_pe.2_chart39811
+#: model:account.account.template,name:l10n_pe.chart39811
+msgid ""
+"Accumulated depreciation - Biological assets in production - Biological "
+"assets in production - Costs - Biological assets in production"
+msgstr ""
+"Depreciación acumulada - Activos biológicos en producción - Activos "
+"biológicos en producción - Costo - Activos biológicos en producción"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart39412
+#: model:account.account,name:l10n_pe.2_chart39412
+#: model:account.account.template,name:l10n_pe.chart39412
+msgid ""
+"Accumulated depreciation - Operating lease - Right-of-use assets - Operating"
+" lease - Buildings"
+msgstr ""
+"Depreciación acumulada - Arrendamiento operativo - Activos por derecho de "
+"uso - Arrendamiento operativo - Edificaciones"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart39411
+#: model:account.account,name:l10n_pe.2_chart39411
+#: model:account.account.template,name:l10n_pe.chart39411
+msgid ""
+"Accumulated depreciation - Operating lease - Right-of-use assets - Operating"
+" lease - Land"
+msgstr ""
+"Depreciación acumulada - Arrendamiento operativo - Activos por derecho de "
+"uso - Arrendamiento operativo - Terrenos"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart39413
+#: model:account.account,name:l10n_pe.2_chart39413
+#: model:account.account.template,name:l10n_pe.chart39413
+msgid ""
+"Accumulated depreciation - Operating lease - Right-of-use assets - Operating"
+" lease - Machinery and exploitation equipment"
+msgstr ""
+"Depreciación acumulada - Arrendamiento operativo - Activos por derecho de "
+"uso - Arrendamiento operativo - Maquinarias y equipos de explotación"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart39415
+#: model:account.account,name:l10n_pe.2_chart39415
+#: model:account.account.template,name:l10n_pe.chart39415
+msgid ""
+"Accumulated depreciation - Operating lease - Right-of-use assets - Operating"
+" lease - Miscellaneous equipment"
+msgstr ""
+"Depreciación acumulada - Arrendamiento operativo - Activos por derecho de "
+"uso - Arrendamiento operativo - Equipos diversos"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart39410
+#: model:account.account,name:l10n_pe.2_chart39410
+#: model:account.account.template,name:l10n_pe.chart39410
+msgid ""
+"Accumulated depreciation - Operating lease - Right-of-use assets - Operating"
+" lease - Production plants"
+msgstr ""
+"Depreciación acumulada - Arrendamiento operativo - Activos por derecho de "
+"uso - Arrendamiento operativo - Plantas productoras"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart39414
+#: model:account.account,name:l10n_pe.2_chart39414
+#: model:account.account.template,name:l10n_pe.chart39414
+msgid ""
+"Accumulated depreciation - Operating lease - Right-of-use assets - Operating"
+" lease - Transport units"
+msgstr ""
+"Depreciación acumulada - Arrendamiento operativo - Activos por derecho de "
+"uso - Arrendamiento operativo - Unidades de transporte"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart39111
+#: model:account.account,name:l10n_pe.2_chart39111
+#: model:account.account.template,name:l10n_pe.chart39111
+msgid "Accumulated depreciation investment properties - Buildings - Costs"
+msgstr ""
+"Depreciación acumulada propiedades de inversión - Edificaciones - Costo"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart39113
+#: model:account.account,name:l10n_pe.2_chart39113
+#: model:account.account.template,name:l10n_pe.chart39113
+msgid ""
+"Accumulated depreciation investment properties - Buildings - Financing costs"
+msgstr ""
+"Depreciación acumulada propiedades de inversión - Edificaciones - Costos de "
+"financiación"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart39112
+#: model:account.account,name:l10n_pe.2_chart39112
+#: model:account.account.template,name:l10n_pe.chart39112
+msgid ""
+"Accumulated depreciation investment properties - Buildings - Revaluation"
+msgstr ""
+"Depreciación acumulada propiedades de inversión - Edificaciones - "
+"Revaluación"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart39211
+#: model:account.account,name:l10n_pe.2_chart39211
+#: model:account.account.template,name:l10n_pe.chart39211
+msgid ""
+"Accumulated depreciation investment properties - Financial leasing - "
+"Buildings - Costs"
+msgstr ""
+"Depreciación acumulada propiedades de inversión - Arrendamiento financiero -"
+" Edificaciones - Costo"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart39213
+#: model:account.account,name:l10n_pe.2_chart39213
+#: model:account.account.template,name:l10n_pe.chart39213
+msgid ""
+"Accumulated depreciation investment properties - Financial leasing - "
+"Buildings - Financing costs"
+msgstr ""
+"Depreciación acumulada propiedades de inversión - Arrendamiento financiero -"
+" Edificaciones - Costos de financiación"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart39212
+#: model:account.account,name:l10n_pe.2_chart39212
+#: model:account.account.template,name:l10n_pe.chart39212
+msgid ""
+"Accumulated depreciation investment properties - Financial leasing - "
+"Buildings - Revaluation"
+msgstr ""
+"Depreciación acumulada propiedades de inversión - Arrendamiento financiero -"
+" Edificaciones - Revaluación"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart39521
+#: model:account.account,name:l10n_pe.2_chart39521
+#: model:account.account.template,name:l10n_pe.chart39521
+msgid ""
+"Accumulated depreciation of property, plant and equipment - Accumulated "
+"depreciation - Costs - Buildings"
+msgstr ""
+"Depreciación acumulada de propiedad, planta y equipo - Depreciación "
+"acumulada - Costo - Edificaciones"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart39526
+#: model:account.account,name:l10n_pe.2_chart39526
+#: model:account.account.template,name:l10n_pe.chart39526
+msgid ""
+"Accumulated depreciation of property, plant and equipment - Accumulated "
+"depreciation - Costs - Furniture and fixtures"
+msgstr ""
+"Depreciación acumulada de propiedad, planta y equipo - Depreciación "
+"acumulada - Costo - Muebles y enseres"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart39523
+#: model:account.account,name:l10n_pe.2_chart39523
+#: model:account.account.template,name:l10n_pe.chart39523
+msgid ""
+"Accumulated depreciation of property, plant and equipment - Accumulated "
+"depreciation - Costs - Improvements in leased premises"
+msgstr ""
+"Depreciación acumulada de propiedad, planta y equipo - Depreciación "
+"acumulada - Costo - Mejoras en locales arrendados"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart39522
+#: model:account.account,name:l10n_pe.2_chart39522
+#: model:account.account.template,name:l10n_pe.chart39522
+msgid ""
+"Accumulated depreciation of property, plant and equipment - Accumulated "
+"depreciation - Costs - Installations"
+msgstr ""
+"Depreciación acumulada de propiedad, planta y equipo - Depreciación "
+"acumulada - Costo - Instalaciones"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart39524
+#: model:account.account,name:l10n_pe.2_chart39524
+#: model:account.account.template,name:l10n_pe.chart39524
+msgid ""
+"Accumulated depreciation of property, plant and equipment - Accumulated "
+"depreciation - Costs - Machinery and exploitation equipment"
+msgstr ""
+"Depreciación acumulada de propiedad, planta y equipo - Depreciación "
+"acumulada - Costo - Maquinarias y equipos de explotación"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart39527
+#: model:account.account,name:l10n_pe.2_chart39527
+#: model:account.account.template,name:l10n_pe.chart39527
+msgid ""
+"Accumulated depreciation of property, plant and equipment - Accumulated "
+"depreciation - Costs - Miscellaneous equipment"
+msgstr ""
+"Depreciación acumulada de propiedad, planta y equipo - Depreciación "
+"acumulada - Costo - Equipos diversos"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart39520
+#: model:account.account,name:l10n_pe.2_chart39520
+#: model:account.account.template,name:l10n_pe.chart39520
+msgid ""
+"Accumulated depreciation of property, plant and equipment - Accumulated "
+"depreciation - Costs - Production plants"
+msgstr ""
+"Depreciación acumulada de propiedad, planta y equipo - Depreciación "
+"acumulada - Costo - Plantas productoras"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart39529
+#: model:account.account,name:l10n_pe.2_chart39529
+#: model:account.account.template,name:l10n_pe.chart39529
+msgid ""
+"Accumulated depreciation of property, plant and equipment - Accumulated "
+"depreciation - Costs - Replacement units"
+msgstr ""
+"Depreciación acumulada de propiedad, planta y equipo - Depreciación "
+"acumulada - Costo - Unidades de reemplazo"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart39528
+#: model:account.account,name:l10n_pe.2_chart39528
+#: model:account.account.template,name:l10n_pe.chart39528
+msgid ""
+"Accumulated depreciation of property, plant and equipment - Accumulated "
+"depreciation - Costs - Tools"
+msgstr ""
+"Depreciación acumulada de propiedad, planta y equipo - Depreciación "
+"acumulada - Costo - Herramientas"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart39525
+#: model:account.account,name:l10n_pe.2_chart39525
+#: model:account.account.template,name:l10n_pe.chart39525
+msgid ""
+"Accumulated depreciation of property, plant and equipment - Accumulated "
+"depreciation - Costs - Transport units"
+msgstr ""
+"Depreciación acumulada de propiedad, planta y equipo - Depreciación "
+"acumulada - Costo - Unidades de transporte"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart39550
+#: model:account.account,name:l10n_pe.2_chart39550
+#: model:account.account.template,name:l10n_pe.chart39550
+msgid ""
+"Accumulated depreciation of property, plant and equipment - Property, plant "
+"and equipment - Fair value - Production plants"
+msgstr ""
+"Depreciación acumulada de propiedad, planta y equipo - Propiedad, planta y "
+"equipo - Valor razonable - Plantas productoras"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart39541
+#: model:account.account,name:l10n_pe.2_chart39541
+#: model:account.account.template,name:l10n_pe.chart39541
+msgid ""
+"Accumulated depreciation of property, plant and equipment - Property, plant "
+"and equipment - Financing costs - Buildings"
+msgstr ""
+"Depreciación acumulada de propiedad, planta y equipo - Propiedad, planta y "
+"equipo - Costos de financiación - Edificaciones"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart39542
+#: model:account.account,name:l10n_pe.2_chart39542
+#: model:account.account.template,name:l10n_pe.chart39542
+msgid ""
+"Accumulated depreciation of property, plant and equipment - Property, plant "
+"and equipment - Financing costs - Machinery and exploitation equipment"
+msgstr ""
+"Depreciación acumulada de propiedad, planta y equipo - Propiedad, planta y "
+"equipo - Costos de financiación - Maquinarias y equipos de explotación"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart39540
+#: model:account.account,name:l10n_pe.2_chart39540
+#: model:account.account.template,name:l10n_pe.chart39540
+msgid ""
+"Accumulated depreciation of property, plant and equipment - Property, plant "
+"and equipment - Financing costs - Production plants"
+msgstr ""
+"Depreciación acumulada de propiedad, planta y equipo - Propiedad, planta y "
+"equipo - Costos de financiación - Plantas productoras"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart39531
+#: model:account.account,name:l10n_pe.2_chart39531
+#: model:account.account.template,name:l10n_pe.chart39531
+msgid ""
+"Accumulated depreciation of property, plant and equipment - Property, plant "
+"and equipment - Revaluation - Buildings"
+msgstr ""
+"Depreciación acumulada de propiedad, planta y equipo - Propiedad, planta y "
+"equipo - Revaluación - Edificaciones"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart39536
+#: model:account.account,name:l10n_pe.2_chart39536
+#: model:account.account.template,name:l10n_pe.chart39536
+msgid ""
+"Accumulated depreciation of property, plant and equipment - Property, plant "
+"and equipment - Revaluation - Furniture and fixtures"
+msgstr ""
+"Depreciación acumulada de propiedad, planta y equipo - Propiedad, planta y "
+"equipo - Revaluación - Muebles y enseres"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart39533
+#: model:account.account,name:l10n_pe.2_chart39533
+#: model:account.account.template,name:l10n_pe.chart39533
+msgid ""
+"Accumulated depreciation of property, plant and equipment - Property, plant "
+"and equipment - Revaluation - Improvements in leased premises"
+msgstr ""
+"Depreciación acumulada de propiedad, planta y equipo - Propiedad, planta y "
+"equipo - Revaluación - Mejoras en locales arrendados"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart39532
+#: model:account.account,name:l10n_pe.2_chart39532
+#: model:account.account.template,name:l10n_pe.chart39532
+msgid ""
+"Accumulated depreciation of property, plant and equipment - Property, plant "
+"and equipment - Revaluation - Installations"
+msgstr ""
+"Depreciación acumulada de propiedad, planta y equipo - Propiedad, planta y "
+"equipo - Revaluación - Instalaciones"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart39534
+#: model:account.account,name:l10n_pe.2_chart39534
+#: model:account.account.template,name:l10n_pe.chart39534
+msgid ""
+"Accumulated depreciation of property, plant and equipment - Property, plant "
+"and equipment - Revaluation - Machinery and exploitation equipment"
+msgstr ""
+"Depreciación acumulada de propiedad, planta y equipo - Propiedad, planta y "
+"equipo - Revaluación - Maquinarias y equipos de explotación"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart39537
+#: model:account.account,name:l10n_pe.2_chart39537
+#: model:account.account.template,name:l10n_pe.chart39537
+msgid ""
+"Accumulated depreciation of property, plant and equipment - Property, plant "
+"and equipment - Revaluation - Miscellaneous equipment"
+msgstr ""
+"Depreciación acumulada de propiedad, planta y equipo - Propiedad, planta y "
+"equipo - Revaluación - Equipos diversos"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart39530
+#: model:account.account,name:l10n_pe.2_chart39530
+#: model:account.account.template,name:l10n_pe.chart39530
+msgid ""
+"Accumulated depreciation of property, plant and equipment - Property, plant "
+"and equipment - Revaluation - Production plants"
+msgstr ""
+"Depreciación acumulada de propiedad, planta y equipo - Propiedad, planta y "
+"equipo - Revaluación - Plantas productoras"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart39538
+#: model:account.account,name:l10n_pe.2_chart39538
+#: model:account.account.template,name:l10n_pe.chart39538
+msgid ""
+"Accumulated depreciation of property, plant and equipment - Property, plant "
+"and equipment - Revaluation - Replacement tools and units"
+msgstr ""
+"Depreciación acumulada de propiedad, planta y equipo - Propiedad, planta y "
+"equipo - Revaluación - Herramientas y unidades de reemplazo"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart39535
+#: model:account.account,name:l10n_pe.2_chart39535
+#: model:account.account.template,name:l10n_pe.chart39535
+msgid ""
+"Accumulated depreciation of property, plant and equipment - Property, plant "
+"and equipment - Revaluation - Transport units"
+msgstr ""
+"Depreciación acumulada de propiedad, planta y equipo - Propiedad, planta y "
+"equipo - Revaluación - Unidades de transporte"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart39321
+#: model:account.account,name:l10n_pe.2_chart39321
+#: model:account.account.template,name:l10n_pe.chart39321
+msgid ""
+"Accumulated depreciation property, plant and equipment - Financial leasing -"
+" Buildings - Costs"
+msgstr ""
+"Depreciación acumulada propiedad, planta y equipo - Financial leasing - "
+"Edificaciones - Costo"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart39323
+#: model:account.account,name:l10n_pe.2_chart39323
+#: model:account.account.template,name:l10n_pe.chart39323
+msgid ""
+"Accumulated depreciation property, plant and equipment - Financial leasing -"
+" Buildings - Financing costs"
+msgstr ""
+"Depreciación acumulada propiedad, planta y equipo - Financial leasing - "
+"Edificaciones - Costos de financiación"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart39322
+#: model:account.account,name:l10n_pe.2_chart39322
+#: model:account.account.template,name:l10n_pe.chart39322
+msgid ""
+"Accumulated depreciation property, plant and equipment - Financial leasing -"
+" Buildings - Revaluation"
+msgstr ""
+"Depreciación acumulada propiedad, planta y equipo - Financial leasing - "
+"Edificaciones - Revaluación"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart39351
+#: model:account.account,name:l10n_pe.2_chart39351
+#: model:account.account.template,name:l10n_pe.chart39351
+msgid ""
+"Accumulated depreciation property, plant and equipment - Financial leasing -"
+" Furniture and fixtures - Costs"
+msgstr ""
+"Depreciación acumulada propiedad, planta y equipo - Financial leasing - "
+"Muebles y enseres - Costo"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart39331
+#: model:account.account,name:l10n_pe.2_chart39331
+#: model:account.account.template,name:l10n_pe.chart39331
+msgid ""
+"Accumulated depreciation property, plant and equipment - Financial leasing -"
+" Machinery and exploitation equipment - Costs"
+msgstr ""
+"Depreciación acumulada propiedad, planta y equipo - Financial leasing - "
+"Maquinarias y equipos de explotación - Costo"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart39333
+#: model:account.account,name:l10n_pe.2_chart39333
+#: model:account.account.template,name:l10n_pe.chart39333
+msgid ""
+"Accumulated depreciation property, plant and equipment - Financial leasing -"
+" Machinery and exploitation equipment - Financing costs"
+msgstr ""
+"Depreciación acumulada propiedad, planta y equipo - Financial leasing - "
+"Maquinarias y equipos de explotación - Costos de financiación"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart39332
+#: model:account.account,name:l10n_pe.2_chart39332
+#: model:account.account.template,name:l10n_pe.chart39332
+msgid ""
+"Accumulated depreciation property, plant and equipment - Financial leasing -"
+" Machinery and exploitation equipment - Revaluation"
+msgstr ""
+"Depreciación acumulada propiedad, planta y equipo - Financial leasing - "
+"Maquinarias y equipos de explotación - Revaluación"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart39361
+#: model:account.account,name:l10n_pe.2_chart39361
+#: model:account.account.template,name:l10n_pe.chart39361
+msgid ""
+"Accumulated depreciation property, plant and equipment - Financial leasing -"
+" Miscellaneous equipment - Costs"
+msgstr ""
+"Depreciación acumulada propiedad, planta y equipo - Financial leasing - "
+"Equipos diversos - Costo"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart39362
+#: model:account.account,name:l10n_pe.2_chart39362
+#: model:account.account.template,name:l10n_pe.chart39362
+msgid ""
+"Accumulated depreciation property, plant and equipment - Financial leasing -"
+" Miscellaneous equipment - Revaluation"
+msgstr ""
+"Depreciación acumulada propiedad, planta y equipo - Financial leasing - "
+"Equipos diversos - Revaluación"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart39341
+#: model:account.account,name:l10n_pe.2_chart39341
+#: model:account.account.template,name:l10n_pe.chart39341
+msgid ""
+"Accumulated depreciation property, plant and equipment - Financial leasing -"
+" Transport units - Costs"
+msgstr ""
+"Depreciación acumulada propiedad, planta y equipo - Financial leasing - "
+"Unidades de transporte - Costo"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart39342
+#: model:account.account,name:l10n_pe.2_chart39342
+#: model:account.account.template,name:l10n_pe.chart39342
+msgid ""
+"Accumulated depreciation property, plant and equipment - Financial leasing -"
+" Transport units - Revaluation"
+msgstr ""
+"Depreciación acumulada propiedad, planta y equipo - Financial leasing - "
+"Unidades de transporte - Revaluación"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart27811
+#: model:account.account,name:l10n_pe.2_chart27811
+#: model:account.account.template,name:l10n_pe.chart27811
+msgid ""
+"Accumulated depreciation – Biological assets - Biological assets in "
+"production - Costs"
+msgstr ""
+"Depreciación acumulada – Activos biológicos - Activos biológicos en "
+"producción - Costo"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart27813
+#: model:account.account,name:l10n_pe.2_chart27813
+#: model:account.account.template,name:l10n_pe.chart27813
+msgid ""
+"Accumulated depreciation – Biological assets - Biological assets in "
+"production - Financing costs"
+msgstr ""
+"Depreciación acumulada – Activos biológicos - Activos biológicos en "
+"producción - Costos de financiación"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart27821
+#: model:account.account,name:l10n_pe.2_chart27821
+#: model:account.account.template,name:l10n_pe.chart27821
+msgid ""
+"Accumulated depreciation – Biological assets - Biological assets under "
+"development - Costs"
+msgstr ""
+"Depreciación acumulada – Activos biológicos - Activos biológicos en "
+"desarrollo - Costo"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart27823
+#: model:account.account,name:l10n_pe.2_chart27823
+#: model:account.account.template,name:l10n_pe.chart27823
+msgid ""
+"Accumulated depreciation – Biological assets - Biological assets under "
+"development - Financing costs"
+msgstr ""
+"Depreciación acumulada – Activos biológicos - Activos biológicos en "
+"desarrollo - Costos de financiación"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart27521
+#: model:account.account,name:l10n_pe.2_chart27521
+#: model:account.account.template,name:l10n_pe.chart27521
+msgid "Accumulated depreciation – Investment property - Buildings - Costs"
+msgstr ""
+"Depreciación acumulada – Propiedades de inversión - Edificaciones - Costo"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart27523
+#: model:account.account,name:l10n_pe.2_chart27523
+#: model:account.account.template,name:l10n_pe.chart27523
+msgid ""
+"Accumulated depreciation – Investment property - Buildings - Financing costs"
+msgstr ""
+"Depreciación acumulada – Propiedades de inversión - Edificaciones - Costo de"
+" financiación"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart27522
+#: model:account.account,name:l10n_pe.2_chart27522
+#: model:account.account.template,name:l10n_pe.chart27522
+msgid ""
+"Accumulated depreciation – Investment property - Buildings - Revaluation"
+msgstr ""
+"Depreciación acumulada – Propiedades de inversión - Edificaciones - "
+"Revaluación"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart27621
+#: model:account.account,name:l10n_pe.2_chart27621
+#: model:account.account.template,name:l10n_pe.chart27621
+msgid ""
+"Accumulated depreciation – Property, plant and equipment - Buildings - Costs"
+msgstr ""
+"Depreciación acumulada – Propiedades, planta y equipo - Edificaciones - "
+"Costo"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart27623
+#: model:account.account,name:l10n_pe.2_chart27623
+#: model:account.account.template,name:l10n_pe.chart27623
+msgid ""
+"Accumulated depreciation – Property, plant and equipment - Buildings - "
+"Financing costs"
+msgstr ""
+"Depreciación acumulada – Propiedades, planta y equipo - Edificaciones - "
+"Costo de financiación"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart27622
+#: model:account.account,name:l10n_pe.2_chart27622
+#: model:account.account.template,name:l10n_pe.chart27622
+msgid ""
+"Accumulated depreciation – Property, plant and equipment - Buildings - "
+"Revaluation"
+msgstr ""
+"Depreciación acumulada – Propiedades, planta y equipo - Edificaciones - "
+"Revaluación"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart27651
+#: model:account.account,name:l10n_pe.2_chart27651
+#: model:account.account.template,name:l10n_pe.chart27651
+msgid ""
+"Accumulated depreciation – Property, plant and equipment - Furniture and "
+"fixtures - Costs"
+msgstr ""
+"Depreciación acumulada – Propiedades, planta y equipo - Muebles y enseres - "
+"Costo"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart27652
+#: model:account.account,name:l10n_pe.2_chart27652
+#: model:account.account.template,name:l10n_pe.chart27652
+msgid ""
+"Accumulated depreciation – Property, plant and equipment - Furniture and "
+"fixtures - Revaluation"
+msgstr ""
+"Depreciación acumulada – Propiedades, planta y equipo - Muebles y enseres - "
+"Revaluación"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart27631
+#: model:account.account,name:l10n_pe.2_chart27631
+#: model:account.account.template,name:l10n_pe.chart27631
+msgid ""
+"Accumulated depreciation – Property, plant and equipment - Machinery and "
+"operating equipment - Costs"
+msgstr ""
+"Depreciación acumulada – Propiedades, planta y equipo - Maquinarias y equipo"
+" de explotación - Costo"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart27633
+#: model:account.account,name:l10n_pe.2_chart27633
+#: model:account.account.template,name:l10n_pe.chart27633
+msgid ""
+"Accumulated depreciation – Property, plant and equipment - Machinery and "
+"operating equipment - Financing costs"
+msgstr ""
+"Depreciación acumulada – Propiedades, planta y equipo - Maquinarias y equipo"
+" de explotación - Costos de financiación"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart27632
+#: model:account.account,name:l10n_pe.2_chart27632
+#: model:account.account.template,name:l10n_pe.chart27632
+msgid ""
+"Accumulated depreciation – Property, plant and equipment - Machinery and "
+"operating equipment - Revaluation"
+msgstr ""
+"Depreciación acumulada – Propiedades, planta y equipo - Maquinarias y equipo"
+" de explotación - Revaluación"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart27661
+#: model:account.account,name:l10n_pe.2_chart27661
+#: model:account.account.template,name:l10n_pe.chart27661
+msgid ""
+"Accumulated depreciation – Property, plant and equipment - Miscellaneous "
+"equipment - Costs"
+msgstr ""
+"Depreciación acumulada – Propiedades, planta y equipo - Equipos diversos - "
+"Costo"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart27662
+#: model:account.account,name:l10n_pe.2_chart27662
+#: model:account.account.template,name:l10n_pe.chart27662
+msgid ""
+"Accumulated depreciation – Property, plant and equipment - Miscellaneous "
+"equipment - Revaluation"
+msgstr ""
+"Depreciación acumulada – Propiedades, planta y equipo - Equipos diversos - "
+"Revaluación"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart27601
+#: model:account.account,name:l10n_pe.2_chart27601
+#: model:account.account.template,name:l10n_pe.chart27601
+msgid ""
+"Accumulated depreciation – Property, plant and equipment - Production plant "
+"in production - Costs"
+msgstr ""
+"Depreciación acumulada – Propiedades, planta y equipo - Planta productora en"
+" producción - Costo"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart27604
+#: model:account.account,name:l10n_pe.2_chart27604
+#: model:account.account.template,name:l10n_pe.chart27604
+msgid ""
+"Accumulated depreciation – Property, plant and equipment - Production plant "
+"in production - Fair value"
+msgstr ""
+"Depreciación acumulada – Propiedades, planta y equipo - Planta productora en"
+" producción - Valor razonable"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart27603
+#: model:account.account,name:l10n_pe.2_chart27603
+#: model:account.account.template,name:l10n_pe.chart27603
+msgid ""
+"Accumulated depreciation – Property, plant and equipment - Production plant "
+"in production - Financing costs"
+msgstr ""
+"Depreciación acumulada – Propiedades, planta y equipo - Planta productora en"
+" producción - Costos de financiación"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart27602
+#: model:account.account,name:l10n_pe.2_chart27602
+#: model:account.account.template,name:l10n_pe.chart27602
+msgid ""
+"Accumulated depreciation – Property, plant and equipment - Production plant "
+"in production - Revaluation"
+msgstr ""
+"Depreciación acumulada – Propiedades, planta y equipo - Planta productora en"
+" producción - Revaluación"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart27671
+#: model:account.account,name:l10n_pe.2_chart27671
+#: model:account.account.template,name:l10n_pe.chart27671
+msgid ""
+"Accumulated depreciation – Property, plant and equipment - Replacement tools"
+" and units - Costs"
+msgstr ""
+"Depreciación acumulada – Propiedades, planta y equipo - Herramientas y "
+"unidades de reemplazo - Costo"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart27672
+#: model:account.account,name:l10n_pe.2_chart27672
+#: model:account.account.template,name:l10n_pe.chart27672
+msgid ""
+"Accumulated depreciation – Property, plant and equipment - Replacement tools"
+" and units - Revaluation"
+msgstr ""
+"Depreciación acumulada – Propiedades, planta y equipo - Herramientas y "
+"unidades de reemplazo - Revaluación"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart27641
+#: model:account.account,name:l10n_pe.2_chart27641
+#: model:account.account.template,name:l10n_pe.chart27641
+msgid ""
+"Accumulated depreciation – Property, plant and equipment - Transport units -"
+" Costs"
+msgstr ""
+"Depreciación acumulada – Propiedades, planta y equipo - Unidades de "
+"transporte - Costo"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart27642
+#: model:account.account,name:l10n_pe.2_chart27642
+#: model:account.account.template,name:l10n_pe.chart27642
+msgid ""
+"Accumulated depreciation – Property, plant and equipment - Transport units -"
+" Revaluation"
+msgstr ""
+"Depreciación acumulada – Propiedades, planta y equipo - Unidades de "
+"transporte - Revaluación"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart27951
+#: model:account.account,name:l10n_pe.2_chart27951
+#: model:account.account.template,name:l10n_pe.chart27951
+msgid ""
+"Accumulated impairment - Biological assets - Biological assets in production"
+msgstr ""
+"Desvalorización acumulada - Activos biológicos - Activos biológicos en "
+"producción"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart27952
+#: model:account.account,name:l10n_pe.2_chart27952
+#: model:account.account.template,name:l10n_pe.chart27952
+msgid ""
+"Accumulated impairment - Biological assets - Biological assets under "
+"development"
+msgstr ""
+"Desvalorización acumulada - Activos biológicos - Activos biológicos en "
+"desarrollo"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart27941
+#: model:account.account,name:l10n_pe.2_chart27941
+#: model:account.account.template,name:l10n_pe.chart27941
+msgid ""
+"Accumulated impairment - Intangibles - Concessions, licenses and other "
+"rights"
+msgstr ""
+"Desvalorización acumulada - Intangibles - Concesiones, licencias y otros "
+"derechos"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart27944
+#: model:account.account,name:l10n_pe.2_chart27944
+#: model:account.account.template,name:l10n_pe.chart27944
+msgid ""
+"Accumulated impairment - Intangibles - Exploration and development costs"
+msgstr ""
+"Desvalorización acumulada - Intangibles - Costos de exploración y desarrollo"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart27945
+#: model:account.account,name:l10n_pe.2_chart27945
+#: model:account.account.template,name:l10n_pe.chart27945
+msgid ""
+"Accumulated impairment - Intangibles - Formulas, designs and prototypes"
+msgstr ""
+"Desvalorización acumulada - Intangibles - Fórmulas, diseños y prototipos"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart27949
+#: model:account.account,name:l10n_pe.2_chart27949
+#: model:account.account.template,name:l10n_pe.chart27949
+msgid "Accumulated impairment - Intangibles - Other intangible assets"
+msgstr "Desvalorización acumulada - Intangibles - Otros activos intangibles"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart27942
+#: model:account.account,name:l10n_pe.2_chart27942
+#: model:account.account.template,name:l10n_pe.chart27942
+msgid "Accumulated impairment - Intangibles - Patents and industrial property"
+msgstr ""
+"Desvalorización acumulada - Intangibles - Patentes y propiedad industrial"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart27943
+#: model:account.account,name:l10n_pe.2_chart27943
+#: model:account.account.template,name:l10n_pe.chart27943
+msgid "Accumulated impairment - Intangibles - Softwares"
+msgstr ""
+"Desvalorización acumulada - Intangibles - Programas de computadora "
+"(software)"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart27913
+#: model:account.account,name:l10n_pe.2_chart27913
+#: model:account.account.template,name:l10n_pe.chart27913
+msgid "Accumulated impairment - Investment property - Buildings"
+msgstr "Desvalorización acumulada - Propiedad de inversión - Edificaciones"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart27912
+#: model:account.account,name:l10n_pe.2_chart27912
+#: model:account.account.template,name:l10n_pe.chart27912
+msgid "Accumulated impairment - Investment property - Land"
+msgstr "Desvalorización acumulada - Propiedad de inversión - Terrenos"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart27911
+#: model:account.account,name:l10n_pe.2_chart27911
+#: model:account.account.template,name:l10n_pe.chart27911
+msgid ""
+"Accumulated impairment - Investment property - Production plant in "
+"development"
+msgstr ""
+"Desvalorización acumulada - Propiedad de inversión - Planta productora en "
+"desarrollo"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart27910
+#: model:account.account,name:l10n_pe.2_chart27910
+#: model:account.account.template,name:l10n_pe.chart27910
+msgid ""
+"Accumulated impairment - Investment property - Production plant in "
+"production"
+msgstr ""
+"Desvalorización acumulada - Propiedad de inversión - Planta productora en "
+"producción"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart27933
+#: model:account.account,name:l10n_pe.2_chart27933
+#: model:account.account.template,name:l10n_pe.chart27933
+msgid "Accumulated impairment - Property, plant and equipment - Buildings"
+msgstr ""
+"Desvalorización acumulada - Propiedades, planta y equipo - Edificaciones"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart27936
+#: model:account.account,name:l10n_pe.2_chart27936
+#: model:account.account.template,name:l10n_pe.chart27936
+msgid ""
+"Accumulated impairment - Property, plant and equipment - Furniture and "
+"fixtures"
+msgstr ""
+"Desvalorización acumulada - Propiedades, planta y equipo - Muebles y enseres"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart27932
+#: model:account.account,name:l10n_pe.2_chart27932
+#: model:account.account.template,name:l10n_pe.chart27932
+msgid "Accumulated impairment - Property, plant and equipment - Land"
+msgstr "Desvalorización acumulada - Propiedades, planta y equipo - Terrenos"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart27934
+#: model:account.account,name:l10n_pe.2_chart27934
+#: model:account.account.template,name:l10n_pe.chart27934
+msgid ""
+"Accumulated impairment - Property, plant and equipment - Machinery and "
+"exploitation equipment"
+msgstr ""
+"Desvalorización acumulada - Propiedades, planta y equipo - Maquinarias y "
+"equipos de explotación"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart27937
+#: model:account.account,name:l10n_pe.2_chart27937
+#: model:account.account.template,name:l10n_pe.chart27937
+msgid ""
+"Accumulated impairment - Property, plant and equipment - Miscellaneous "
+"equipment"
+msgstr ""
+"Desvalorización acumulada - Propiedades, planta y equipo - Equipos diversos"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart27931
+#: model:account.account,name:l10n_pe.2_chart27931
+#: model:account.account.template,name:l10n_pe.chart27931
+msgid ""
+"Accumulated impairment - Property, plant and equipment - Production plant in"
+" development"
+msgstr ""
+"Desvalorización acumulada - Propiedades, planta y equipo - Planta productora"
+" en desarrollo"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart27930
+#: model:account.account,name:l10n_pe.2_chart27930
+#: model:account.account.template,name:l10n_pe.chart27930
+msgid ""
+"Accumulated impairment - Property, plant and equipment - Production plants "
+"in production"
+msgstr ""
+"Desvalorización acumulada - Propiedades, planta y equipo - Plantas "
+"productoras en producción"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart27938
+#: model:account.account,name:l10n_pe.2_chart27938
+#: model:account.account.template,name:l10n_pe.chart27938
+msgid ""
+"Accumulated impairment - Property, plant and equipment - Replacement tools "
+"and units"
+msgstr ""
+"Desvalorización acumulada - Propiedades, planta y equipo - Herramientas y "
+"unidades de reemplazo"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart27935
+#: model:account.account,name:l10n_pe.2_chart27935
+#: model:account.account.template,name:l10n_pe.chart27935
+msgid ""
+"Accumulated impairment - Property, plant and equipment - Transport units"
+msgstr ""
+"Desvalorización acumulada - Propiedades, planta y equipo - Unidades de "
+"transporte"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart5921
+#: model:account.account,name:l10n_pe.2_chart5921
+#: model:account.account.template,name:l10n_pe.chart5921
+msgid "Accumulated losses - Accumulated losses"
+msgstr "Pérdidas acumuladas - Pérdidas acumuladas"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart5922
+#: model:account.account,name:l10n_pe.2_chart5922
+#: model:account.account.template,name:l10n_pe.chart5922
+msgid "Accumulated losses - Expenses from previous years"
+msgstr "Pérdidas acumuladas - Gastos de años anteriores"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_210202
+msgid "Achaya"
+msgstr "Achaya"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_040502
+msgid "Achoma"
+msgstr "Achoma"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_020902
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_120202
+msgid "Aco"
+msgstr "Aco"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_021902
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_090201
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_120702
+#: model:res.city,name:l10n_pe.city_pe_0902
+msgid "Acobamba"
+msgstr "Acobamba"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_090102
+msgid "Acobambilla"
+msgstr "Acobambilla"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_020402
+msgid "Acochaca"
+msgstr "Acochaca"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_050102
+msgid "Acocro"
+msgstr "Acocro"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_120402
+msgid "Acolla"
+msgstr "Acolla"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_080201
+#: model:res.city,name:l10n_pe.city_pe_0802
+msgid "Acomayo"
+msgstr "Acomayo"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_020602
+msgid "Acopampa"
+msgstr "Acopampa"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_080202
+msgid "Acopia"
+msgstr "Acopia"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_210102
+msgid "Acora"
+msgstr "Acora"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_090103
+msgid "Acoria"
+msgstr "Acoria"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_080203
+msgid "Acos"
+msgstr "Acos"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_050103
+msgid "Acos Vinchos"
+msgstr "Acos Vinchos"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_090702
+msgid "Acostambo"
+msgstr "Acostambo"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_090703
+msgid "Acraquia"
+msgstr "Acraquia"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_020302
+msgid "Aczo"
+msgstr "Aczo"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart417
+#: model:account.account,name:l10n_pe.2_chart417
+#: model:account.account.template,name:l10n_pe.chart417
+msgid "Administrators of pension funds"
+msgstr "Administradoras de fondos de pensiones"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart122
+#: model:account.account,name:l10n_pe.2_chart122
+#: model:account.account.template,name:l10n_pe.chart122
+msgid "Advances from customers"
+msgstr "Anticipos de clientes"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart4321
+#: model:account.account,name:l10n_pe.2_chart4321
+#: model:account.account.template,name:l10n_pe.chart4321
+msgid "Advances granted - Advances granted"
+msgstr "Anticipos otorgados - Anticipos otorgados"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart473
+#: model:account.account,name:l10n_pe.2_chart473
+#: model:account.account.template,name:l10n_pe.chart473
+msgid "Advances received"
+msgstr "Anticipos recibidos"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart1321
+#: model:account.account,name:l10n_pe.2_chart1321
+#: model:account.account.template,name:l10n_pe.chart1321
+msgid "Advances received - Advances received"
+msgstr "Anticipos recibidos - Anticipos recibidos"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart422
+#: model:account.account,name:l10n_pe.2_chart422
+#: model:account.account.template,name:l10n_pe.chart422
+msgid "Advances to suppliers"
+msgstr "Anticipos a proveedores"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart6371
+#: model:account.account,name:l10n_pe.2_chart6371
+#: model:account.account.template,name:l10n_pe.chart6371
+msgid "Advertising, publications, public relations - Advertising"
+msgstr "Publicidad, publicaciones, relaciones públicas - Publicidad"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart6373
+#: model:account.account,name:l10n_pe.2_chart6373
+#: model:account.account.template,name:l10n_pe.chart6373
+msgid "Advertising, publications, public relations - Public relations"
+msgstr "Publicidad, publicaciones, relaciones públicas - Relaciones públicas"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart6372
+#: model:account.account,name:l10n_pe.2_chart6372
+#: model:account.account.template,name:l10n_pe.chart6372
+msgid "Advertising, publications, public relations - Publications"
+msgstr "Publicidad, publicaciones, relaciones públicas - Publicaciones"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart6321
+#: model:account.account,name:l10n_pe.2_chart6321
+#: model:account.account.template,name:l10n_pe.chart6321
+msgid "Advice and consultancy - Administrative"
+msgstr "Asesoría y consultoría - Administrativa"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart6323
+#: model:account.account,name:l10n_pe.2_chart6323
+#: model:account.account.template,name:l10n_pe.chart6323
+msgid "Advice and consultancy - Audit and accounting"
+msgstr "Asesoría y consultoría - Auditoría y contable"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart6325
+#: model:account.account,name:l10n_pe.2_chart6325
+#: model:account.account.template,name:l10n_pe.chart6325
+msgid "Advice and consultancy - Environmental"
+msgstr "Asesoría y consultoría - Medioambiental"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart6326
+#: model:account.account,name:l10n_pe.2_chart6326
+#: model:account.account.template,name:l10n_pe.chart6326
+msgid "Advice and consultancy - Investigation and development"
+msgstr "Asesoría y consultoría - Investigación y desarrollo"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart6322
+#: model:account.account,name:l10n_pe.2_chart6322
+#: model:account.account.template,name:l10n_pe.chart6322
+msgid "Advice and consultancy - Legal and tax"
+msgstr "Asesoría y consultoría - Legal y tributaria"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart6324
+#: model:account.account,name:l10n_pe.2_chart6324
+#: model:account.account.template,name:l10n_pe.chart6324
+msgid "Advice and consultancy - Marketing"
+msgstr "Asesoría y consultoría - Mercadotecnia"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart6329
+#: model:account.account,name:l10n_pe.2_chart6329
+#: model:account.account.template,name:l10n_pe.chart6329
+msgid "Advice and consultancy - Others"
+msgstr "Asesoría y consultoría - Otros"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart6327
+#: model:account.account,name:l10n_pe.2_chart6327
+#: model:account.account.template,name:l10n_pe.chart6327
+msgid "Advice and consultancy - Production"
+msgstr "Asesoría y consultoría - Producción"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_130602
+msgid "Agallpampa"
+msgstr "Agallpampa"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_220302
+msgid "Agua Blanca"
+msgstr "Agua Blanca"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_240302
+msgid "Aguas Verdes"
+msgstr "Aguas Verdes"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_120902
+msgid "Ahuac"
+msgstr "Ahuac"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_090704
+msgid "Ahuaycha"
+msgstr "Ahuaycha"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_020201
+#: model:res.city,name:l10n_pe.city_pe_0202
+msgid "Aija"
+msgstr "Aija"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_210302
+msgid "Ajoyani"
+msgstr "Ajoyani"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_220902
+msgid "Alberto Leveau"
+msgstr "Alberto Leveau"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_040802
+msgid "Alca"
+msgstr "Alca"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_051002
+msgid "Alcamenca"
+msgstr "Alcamenca"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_250305
+msgid "Alexander Von Humboldt"
+msgstr "Alexander Von Humboldt"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_021903
+msgid "Alfonso Ugarte"
+msgstr "Alfonso Ugarte"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_151002
+msgid "Alis"
+msgstr "Alis"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_151003
+msgid "Allauca"
+msgstr "Allauca"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_220502
+msgid "Alonso de Alvarado"
+msgstr "Alonso de Alvarado"
+
+#. module: l10n_pe
+#: model:res.city,name:l10n_pe.city_pe_1602
+msgid "Alto Amazonas"
+msgstr "Alto Amazonas"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_220202
+msgid "Alto Biavo"
+msgstr "Alto Biavo"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_211209
+msgid "Alto Inambari"
+msgstr "Alto Inambari"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_110202
+msgid "Alto Laran"
+msgstr "Alto Laran"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_160102
+msgid "Alto Nanay"
+msgstr "Alto Nanay"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_080808
+msgid "Alto Pichigua"
+msgstr "Alto Pichigua"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_220402
+msgid "Alto Saposoa"
+msgstr "Alto Saposoa"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_040102
+msgid "Alto Selva Alegre"
+msgstr "Alto Selva Alegre"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_160502
+msgid "Alto Tapiche"
+msgstr "Alto Tapiche"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_230102
+msgid "Alto de la Alianza"
+msgstr "Alto de la Alianza"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_210103
+msgid "Amantani"
+msgstr "Amantani"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_100102
+msgid "Amarilis"
+msgstr "Amarilis"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_020603
+msgid "Amashca"
+msgstr "Amashca"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_150802
+msgid "Ambar"
+msgstr "Ambar"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_100201
+#: model:res.city,name:l10n_pe.city_pe_1002
+msgid "Ambo"
+msgstr "Ambo"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart68611
+#: model:account.account,name:l10n_pe.2_chart68611
+#: model:account.account.template,name:l10n_pe.chart68611
+msgid ""
+"Amortization of intangibles - Amortization of intangibles – Costs - "
+"Concessions, licenses and other rights"
+msgstr ""
+"Amortización de intangibles - Amortización de intangibles – Costo - "
+"Concesiones, licencias y otros derechos"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart68614
+#: model:account.account,name:l10n_pe.2_chart68614
+#: model:account.account.template,name:l10n_pe.chart68614
+msgid ""
+"Amortization of intangibles - Amortization of intangibles – Costs - "
+"Exploration and development costs"
+msgstr ""
+"Amortización de intangibles - Amortización de intangibles – Costo - Costo de"
+" exploración y desarrollo"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart68615
+#: model:account.account,name:l10n_pe.2_chart68615
+#: model:account.account.template,name:l10n_pe.chart68615
+msgid ""
+"Amortization of intangibles - Amortization of intangibles – Costs - "
+"Formulas, designs and prototypes"
+msgstr ""
+"Amortización de intangibles - Amortización de intangibles – Costo - "
+"Fórmulas, diseños y prototipos"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart68619
+#: model:account.account,name:l10n_pe.2_chart68619
+#: model:account.account.template,name:l10n_pe.chart68619
+msgid ""
+"Amortization of intangibles - Amortization of intangibles – Costs - Other "
+"intangible assets"
+msgstr ""
+"Amortización de intangibles - Amortización de intangibles – Costo - Otros "
+"activos intangibles"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart68612
+#: model:account.account,name:l10n_pe.2_chart68612
+#: model:account.account.template,name:l10n_pe.chart68612
+msgid ""
+"Amortization of intangibles - Amortization of intangibles – Costs - Patents "
+"and industrial property"
+msgstr ""
+"Amortización de intangibles - Amortización de intangibles – Costo - Patentes"
+" y propiedad industrial"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart68613
+#: model:account.account,name:l10n_pe.2_chart68613
+#: model:account.account.template,name:l10n_pe.chart68613
+msgid ""
+"Amortization of intangibles - Amortization of intangibles – Costs - "
+"Softwares"
+msgstr ""
+"Amortización de intangibles - Amortización de intangibles – Costo - "
+"Programas de computadora (software)"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart68621
+#: model:account.account,name:l10n_pe.2_chart68621
+#: model:account.account.template,name:l10n_pe.chart68621
+msgid ""
+"Amortization of intangibles - Amortization of intangibles – Revaluation - "
+"Concessions, licenses and other rights"
+msgstr ""
+"Amortización de intangibles - Amortización de intangibles – Revaluación - "
+"Concesiones, licencias y otros derechos"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart68624
+#: model:account.account,name:l10n_pe.2_chart68624
+#: model:account.account.template,name:l10n_pe.chart68624
+msgid ""
+"Amortization of intangibles - Amortization of intangibles – Revaluation - "
+"Exploration and development costs"
+msgstr ""
+"Amortización de intangibles - Amortización de intangibles – Revaluación - "
+"Costos de exploración y desarrollo"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart68625
+#: model:account.account,name:l10n_pe.2_chart68625
+#: model:account.account.template,name:l10n_pe.chart68625
+msgid ""
+"Amortization of intangibles - Amortization of intangibles – Revaluation - "
+"Formulas, designs and prototypes"
+msgstr ""
+"Amortización de intangibles - Amortización de intangibles – Revaluación - "
+"Fórmulas, diseños y prototipos"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart68629
+#: model:account.account,name:l10n_pe.2_chart68629
+#: model:account.account.template,name:l10n_pe.chart68629
+msgid ""
+"Amortization of intangibles - Amortization of intangibles – Revaluation - "
+"Other intangible assets"
+msgstr ""
+"Amortización de intangibles - Amortización de intangibles – Revaluación - "
+"Otros activos intangibles"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart68622
+#: model:account.account,name:l10n_pe.2_chart68622
+#: model:account.account.template,name:l10n_pe.chart68622
+msgid ""
+"Amortization of intangibles - Amortization of intangibles – Revaluation - "
+"Patents and industrial property"
+msgstr ""
+"Amortización de intangibles - Amortización de intangibles – Revaluación - "
+"Patentes y propiedad industrial"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart68623
+#: model:account.account,name:l10n_pe.2_chart68623
+#: model:account.account.template,name:l10n_pe.chart68623
+msgid ""
+"Amortization of intangibles - Amortization of intangibles – Revaluation - "
+"Softwares"
+msgstr ""
+"Amortización de intangibles - Amortización de intangibles – Revaluación - "
+"Programas de computadora (software)"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_200502
+msgid "Amotape"
+msgstr "Amotape"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_211002
+msgid "Ananea"
+msgstr "Ananea"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_211302
+msgid "Anapia"
+msgstr "Anapia"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_080302
+msgid "Ancahuasi"
+msgstr "Ancahuasi"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_050510
+msgid "Anchihuay"
+msgstr "Anchihuay"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_090302
+msgid "Anchonga"
+msgstr "Anchonga"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_050502
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_090502
+msgid "Anco"
+msgstr "Anco"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_030602
+msgid "Anco_huallo"
+msgstr "Anco_huallo"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_150102
+msgid "Ancón"
+msgstr "Ancón"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_061302
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_090202
+msgid "Andabamba"
+msgstr "Andabamba"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_040402
+msgid "Andagua"
+msgstr "Andagua"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_030201
+#: model:res.city,name:l10n_pe.city_pe_0302
+msgid "Andahuaylas"
+msgstr "Andahuaylas"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_081202
+msgid "Andahuaylillas"
+msgstr "Andahuaylillas"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_150902
+msgid "Andajes"
+msgstr "Andajes"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_120203
+msgid "Andamarca"
+msgstr "Andamarca"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_030202
+msgid "Andarapa"
+msgstr "Andarapa"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_040602
+msgid "Andaray"
+msgstr "Andaray"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_090720
+msgid "Andaymarca"
+msgstr "Andaymarca"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_160706
+msgid "Andoas"
+msgstr "Andoas"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_050116
+msgid "Andrés Avelino Cáceres Dorregaray"
+msgstr "Andrés Avelino Cáceres Dorregaray"
+
+#. module: l10n_pe
+#: model:res.city,name:l10n_pe.city_pe_0903
+msgid "Angaraes"
+msgstr "Angaraes"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_131002
+msgid "Angasmarca"
+msgstr "Angasmarca"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_060402
+msgid "Anguia"
+msgstr "Anguia"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_021002
+msgid "Anra"
+msgstr "Anra"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_020604
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_080301
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_090203
+#: model:res.city,name:l10n_pe.city_pe_0803
+msgid "Anta"
+msgstr "Anta"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_030301
+#: model:res.city,name:l10n_pe.city_pe_0303
+msgid "Antabamba"
+msgstr "Antabamba"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_210802
+msgid "Antauta"
+msgstr "Antauta"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_150702
+msgid "Antioquia"
+msgstr "Antioquia"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_020503
+#: model:res.city,name:l10n_pe.city_pe_0203
+msgid "Antonio Raymondi"
+msgstr "Antonio Raymondi"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_101104
+msgid "Aparicio Pomares"
+msgstr "Aparicio Pomares"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_120403
+msgid "Apata"
+msgstr "Apata"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_040401
+msgid "Aplao"
+msgstr "Aplao"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_051003
+msgid "Apongo"
+msgstr "Apongo"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_020504
+msgid "Aquia"
+msgstr "Aquia"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_150402
+msgid "Arahuay"
+msgstr "Arahuay"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_010202
+msgid "Aramango"
+msgstr "Aramango"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_100502
+msgid "Arancay"
+msgstr "Arancay"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_210203
+msgid "Arapa"
+msgstr "Arapa"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_200503
+msgid "Arenal"
+msgstr "Arenal"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_040101
+#: model:res.city,name:l10n_pe.city_pe_0401
+msgid "Arequipa"
+msgstr "Arequipa"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_090402
+msgid "Arma"
+msgstr "Arma"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart3812
+#: model:account.account,name:l10n_pe.2_chart3812
+#: model:account.account.template,name:l10n_pe.chart3812
+msgid "Art and culture goods - Library"
+msgstr "Bienes de arte y cultura - Biblioteca"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart3813
+#: model:account.account,name:l10n_pe.2_chart3813
+#: model:account.account.template,name:l10n_pe.chart3813
+msgid "Art and culture goods - Others"
+msgstr "Bienes de arte y cultura - Otros"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart3811
+#: model:account.account,name:l10n_pe.2_chart3811
+#: model:account.account.template,name:l10n_pe.chart3811
+msgid "Art and culture goods - Works of art"
+msgstr "Bienes de arte y cultura - Obras de arte"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_090118
+msgid "Ascensión"
+msgstr "Ascensión"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_130201
+#: model:res.city,name:l10n_pe.city_pe_1302
+msgid "Ascope"
+msgstr "Ascope"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_150502
+msgid "Asia"
+msgstr "Asia"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_210204
+msgid "Asillo"
+msgstr "Asillo"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_051004
+msgid "Asquipata"
+msgstr "Asquipata"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart68732
+#: model:account.account,name:l10n_pe.2_chart68732
+#: model:account.account.template,name:l10n_pe.chart68732
+msgid ""
+"Asset valuation - Depreciation of investment property - Financial "
+"instruments representative of economic rights"
+msgstr ""
+"Valuación de activos - Desvalorización de inversiones mobiliarias - "
+"Instrumentos financieros representativos de derecho patrimonial"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart68731
+#: model:account.account,name:l10n_pe.2_chart68731
+#: model:account.account.template,name:l10n_pe.chart68731
+msgid ""
+"Asset valuation - Depreciation of investment property - Investments to be "
+"held until maturity"
+msgstr ""
+"Valuación de activos - Desvalorización de inversiones mobiliarias - "
+"Inversiones a ser mantenidas hasta el vencimiento"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart68713
+#: model:account.account,name:l10n_pe.2_chart68713
+#: model:account.account.template,name:l10n_pe.chart68713
+msgid ""
+"Asset valuation - Estimation of doubtful accounts receivable - Accounts "
+"receivable from staff, shareholders (partners) and directors"
+msgstr ""
+"Valuación de activos - Estimación de cuentas de cobranza dudosa - Cuentas "
+"por cobrar al personal, a los accionistas (socios) y directores"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart68712
+#: model:account.account,name:l10n_pe.2_chart68712
+#: model:account.account.template,name:l10n_pe.chart68712
+msgid ""
+"Asset valuation - Estimation of doubtful accounts receivable - Trade "
+"accounts receivable – Associated"
+msgstr ""
+"Valuación de activos - Estimación de cuentas de cobranza dudosa - Cuentas "
+"por cobrar comerciales – Relacionadas"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart68711
+#: model:account.account,name:l10n_pe.2_chart68711
+#: model:account.account.template,name:l10n_pe.chart68711
+msgid ""
+"Asset valuation - Estimation of doubtful accounts receivable - Trade "
+"accounts receivable – Third parties"
+msgstr ""
+"Valuación de activos - Estimación de cuentas de cobranza dudosa - Cuentas "
+"por cobrar comerciales – Terceros"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart68715
+#: model:account.account,name:l10n_pe.2_chart68715
+#: model:account.account.template,name:l10n_pe.chart68715
+msgid ""
+"Asset valuation - Estimation of doubtful accounts receivable - Various "
+"accounts receivable – Associated"
+msgstr ""
+"Valuación de activos - Estimación de cuentas de cobranza dudosa - Cuentas "
+"por cobrar diversas – Relacionadas"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart68714
+#: model:account.account,name:l10n_pe.2_chart68714
+#: model:account.account.template,name:l10n_pe.chart68714
+msgid ""
+"Asset valuation - Estimation of doubtful accounts receivable - Various "
+"accounts receivable – Third parties"
+msgstr ""
+"Valuación de activos - Estimación de cuentas de cobranza dudosa - Cuentas "
+"por cobrar diversas – Terceros"
+
+#. module: l10n_pe
+#: model:account.group,name:l10n_pe.1_group1
+#: model:account.group,name:l10n_pe.1_group3
+#: model:account.group,name:l10n_pe.2_group1
+#: model:account.group,name:l10n_pe.2_group3
+#: model:account.group.template,name:l10n_pe.group1
+#: model:account.group.template,name:l10n_pe.group3
+msgid "Assets available and payable"
+msgstr "Activo disponible y exigible"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart16621
+#: model:account.account,name:l10n_pe.1_chart17621
+#: model:account.account,name:l10n_pe.2_chart16621
+#: model:account.account,name:l10n_pe.2_chart17621
+#: model:account.account.template,name:l10n_pe.chart16621
+#: model:account.account.template,name:l10n_pe.chart17621
+msgid ""
+"Assets for financial instruments - Derivative financial instruments - Costs"
+msgstr ""
+"Activos por instrumentos financieros - Instrumentos financieros derivados - "
+"Costo"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart16622
+#: model:account.account,name:l10n_pe.1_chart17622
+#: model:account.account,name:l10n_pe.2_chart16622
+#: model:account.account,name:l10n_pe.2_chart17622
+#: model:account.account.template,name:l10n_pe.chart16622
+#: model:account.account.template,name:l10n_pe.chart17622
+msgid ""
+"Assets for financial instruments - Derivative financial instruments - Fair "
+"value"
+msgstr ""
+"Activos por instrumentos financieros - Instrumentos financieros derivados - "
+"Valor razonable"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart16611
+#: model:account.account,name:l10n_pe.1_chart17611
+#: model:account.account,name:l10n_pe.2_chart16611
+#: model:account.account,name:l10n_pe.2_chart17611
+#: model:account.account.template,name:l10n_pe.chart16611
+#: model:account.account.template,name:l10n_pe.chart17611
+msgid ""
+"Assets for financial instruments - Primary financial instruments - Costs"
+msgstr ""
+"Activos por instrumentos financieros - Instrumentos financieros primarios - "
+"Costos"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart16612
+#: model:account.account,name:l10n_pe.1_chart17612
+#: model:account.account,name:l10n_pe.2_chart16612
+#: model:account.account,name:l10n_pe.2_chart17612
+#: model:account.account.template,name:l10n_pe.chart16612
+#: model:account.account.template,name:l10n_pe.chart17612
+msgid ""
+"Assets for financial instruments - Primary financial instruments - Fair "
+"value"
+msgstr ""
+"Activos por instrumentos financieros - Instrumentos financieros primarios - "
+"Valor razonable"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_010102
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_060102
+#: model:res.city,name:l10n_pe.city_pe_0204
+msgid "Asunción"
+msgstr "Asunción"
+
+#. module: l10n_pe
+#: model:res.city,name:l10n_pe.city_pe_2502
+msgid "Atalaya"
+msgstr "Atalaya"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_020605
+msgid "Ataquero"
+msgstr "Ataquero"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_120404
+msgid "Ataura"
+msgstr "Ataura"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_150602
+msgid "Atavillos Alto"
+msgstr "Atavillos Alto"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_150603
+msgid "Atavillos Bajo"
+msgstr "Atavillos Bajo"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_150103
+msgid "Ate"
+msgstr "Ate"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_040303
+msgid "Atico"
+msgstr "Atico"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_040304
+msgid "Atiquipa"
+msgstr "Atiquipa"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart625
+#: model:account.account,name:l10n_pe.2_chart625
+#: model:account.account.template,name:l10n_pe.chart625
+msgid "Attentions to staff"
+msgstr "Atención al personal"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_210104
+msgid "Atuncolla"
+msgstr "Atuncolla"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_150604
+msgid "Aucallama"
+msgstr "Aucallama"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_050602
+msgid "Aucara"
+msgstr "Aucara"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_090403
+msgid "Aurahua"
+msgstr "Aurahua"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart251
+#: model:account.account,name:l10n_pe.2_chart251
+#: model:account.account.template,name:l10n_pe.chart251
+msgid "Auxiliary materials"
+msgstr "Materiales auxiliares"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart285
+#: model:account.account,name:l10n_pe.2_chart285
+#: model:account.account.template,name:l10n_pe.chart285
+msgid "Auxiliary materials, supplies and spare parts"
+msgstr "Materiales auxiliares, suministros y repuestos"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart2961
+#: model:account.account,name:l10n_pe.1_chart6031
+#: model:account.account,name:l10n_pe.1_chart6131
+#: model:account.account,name:l10n_pe.2_chart2961
+#: model:account.account,name:l10n_pe.2_chart6031
+#: model:account.account,name:l10n_pe.2_chart6131
+#: model:account.account.template,name:l10n_pe.chart2961
+#: model:account.account.template,name:l10n_pe.chart6031
+#: model:account.account.template,name:l10n_pe.chart6131
+msgid "Auxiliary materials, supplies and spare parts - Auxiliary materials"
+msgstr ""
+"Materiales auxiliares, suministros y repuestos - Materiales auxiliares"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart2963
+#: model:account.account,name:l10n_pe.1_chart6033
+#: model:account.account,name:l10n_pe.1_chart6133
+#: model:account.account,name:l10n_pe.2_chart2963
+#: model:account.account,name:l10n_pe.2_chart6033
+#: model:account.account,name:l10n_pe.2_chart6133
+#: model:account.account.template,name:l10n_pe.chart2963
+#: model:account.account.template,name:l10n_pe.chart6033
+#: model:account.account.template,name:l10n_pe.chart6133
+msgid "Auxiliary materials, supplies and spare parts - Spare parts"
+msgstr "Materiales auxiliares, suministros y repuestos - Repuestos"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart2962
+#: model:account.account,name:l10n_pe.1_chart6032
+#: model:account.account,name:l10n_pe.1_chart6132
+#: model:account.account,name:l10n_pe.2_chart2962
+#: model:account.account,name:l10n_pe.2_chart6032
+#: model:account.account,name:l10n_pe.2_chart6132
+#: model:account.account.template,name:l10n_pe.chart2962
+#: model:account.account.template,name:l10n_pe.chart6032
+#: model:account.account.template,name:l10n_pe.chart6132
+msgid "Auxiliary materials, supplies and spare parts - Supplies"
+msgstr "Materiales auxiliares, suministros y repuestos - Suministros"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_220802
+msgid "Awajun"
+msgstr "Awajun"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_200201
+#: model:res.city,name:l10n_pe.city_pe_2002
+msgid "Ayabaca"
+msgstr "Ayabaca"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_050101
+msgid "Ayacucho"
+msgstr "Ayacucho"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_050402
+msgid "Ayahuanco"
+msgstr "Ayahuanco"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_210303
+msgid "Ayapata"
+msgstr "Ayapata"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_090602
+msgid "Ayavi"
+msgstr "Ayavi"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_151004
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_210801
+msgid "Ayaviri"
+msgstr "Ayaviri"
+
+#. module: l10n_pe
+#: model:res.city,name:l10n_pe.city_pe_0304
+msgid "Aymaraes"
+msgstr "Aymaraes"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_050503
+msgid "Ayna"
+msgstr "Ayna"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_040403
+msgid "Ayo"
+msgstr "Ayo"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_151005
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_210201
+#: model:res.city,name:l10n_pe.city_pe_2102
+msgid "Azángaro"
+msgstr "Azángaro"
+
+#. module: l10n_pe
+#: model:account.group,name:l10n_pe.1_group35
+#: model:account.group,name:l10n_pe.2_group35
+#: model:account.group.template,name:l10n_pe.group35
+msgid "BIOLOGICAL ASSETS"
+msgstr "ACTIVOS BIOLÓGICOS"
+
+#. module: l10n_pe
+#: model:account.group,name:l10n_pe.1_group22
+#: model:account.group,name:l10n_pe.2_group22
+#: model:account.group.template,name:l10n_pe.group22
+msgid "BY-PRODUCTS, WASTE AND WASTE"
+msgstr "SUBPRODUCTOS, DESECHOS Y DESPERDICIOS"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_010201
+#: model:res.city,name:l10n_pe.city_pe_0102
+msgid "Bagua"
+msgstr "Bagua"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_010701
+msgid "Bagua Grande"
+msgstr "Bagua Grande"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_220203
+msgid "Bajo Biavo"
+msgstr "Bajo Biavo"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_160202
+msgid "Balsapuerto"
+msgstr "Balsapuerto"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_010103
+msgid "Balsas"
+msgstr "Balsas"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_060701
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_130302
+msgid "Bambamarca"
+msgstr "Bambamarca"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_020903
+msgid "Bambas"
+msgstr "Bambas"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_150201
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_160701
+#: model:res.city,name:l10n_pe.city_pe_1502
+msgid "Barranca"
+msgstr "Barranca"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_150104
+msgid "Barranco"
+msgstr "Barranco"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_220503
+msgid "Barranquita"
+msgstr "Barranquita"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart6367
+#: model:account.account,name:l10n_pe.2_chart6367
+#: model:account.account.template,name:l10n_pe.chart6367
+msgid "Basic services - Cable"
+msgstr "Servicios básicos - Cable"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart6361
+#: model:account.account,name:l10n_pe.2_chart6361
+#: model:account.account.template,name:l10n_pe.chart6361
+msgid "Basic services - Electric power"
+msgstr "Servicios básicos - Energía eléctrica"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart6362
+#: model:account.account,name:l10n_pe.2_chart6362
+#: model:account.account.template,name:l10n_pe.chart6362
+msgid "Basic services - Gas"
+msgstr "Servicios básicos - Gas"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart6365
+#: model:account.account,name:l10n_pe.2_chart6365
+#: model:account.account.template,name:l10n_pe.chart6365
+msgid "Basic services - Internet"
+msgstr "Servicios básicos - Internet"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart6364
+#: model:account.account,name:l10n_pe.2_chart6364
+#: model:account.account.template,name:l10n_pe.chart6364
+msgid "Basic services - Phone"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart6366
+#: model:account.account,name:l10n_pe.2_chart6366
+#: model:account.account.template,name:l10n_pe.chart6366
+msgid "Basic services - Radio"
+msgstr "Servicios básicos - Radio"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart6363
+#: model:account.account,name:l10n_pe.2_chart6363
+#: model:account.account.template,name:l10n_pe.chart6363
+msgid "Basic services - Water"
+msgstr "Servicios básicos - Agua"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_101002
+msgid "Baños"
+msgstr "Baños"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_040305
+msgid "Bella Unión"
+msgstr "Bella Unión"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_060802
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_070102
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_200602
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_220201
+#: model:res.city,name:l10n_pe.city_pe_2202
+msgid "Bellavista"
+msgstr "Bellavista"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_200802
+msgid "Bellavista de la Unión"
+msgstr "Bellavista de la Unión"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_050902
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_160112
+msgid "Belén"
+msgstr "Belén"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_200803
+msgid "Bernal"
+msgstr "Bernal"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart1233
+#: model:account.account,name:l10n_pe.1_chart1332
+#: model:account.account,name:l10n_pe.2_chart1233
+#: model:account.account,name:l10n_pe.2_chart1332
+#: model:account.account.template,name:l10n_pe.chart1233
+#: model:account.account.template,name:l10n_pe.chart1332
+msgid "Bills to be collected - In collection"
+msgstr "Letras por cobrar - En cobranza"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart1232
+#: model:account.account,name:l10n_pe.1_chart1331
+#: model:account.account,name:l10n_pe.2_chart1232
+#: model:account.account,name:l10n_pe.2_chart1331
+#: model:account.account.template,name:l10n_pe.chart1232
+#: model:account.account.template,name:l10n_pe.chart1331
+msgid "Bills to be collected - In portfolio"
+msgstr "Letras por cobrar - En cartera"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart1234
+#: model:account.account,name:l10n_pe.1_chart1333
+#: model:account.account,name:l10n_pe.2_chart1234
+#: model:account.account,name:l10n_pe.2_chart1333
+#: model:account.account.template,name:l10n_pe.chart1234
+#: model:account.account.template,name:l10n_pe.chart1333
+msgid "Bills to be collected - Off sale"
+msgstr "Letras por cobrar - En descuento"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart423
+#: model:account.account,name:l10n_pe.2_chart423
+#: model:account.account.template,name:l10n_pe.chart423
+msgid "Bills to pay"
+msgstr "Letras por pagar"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart4331
+#: model:account.account,name:l10n_pe.2_chart4331
+#: model:account.account.template,name:l10n_pe.chart4331
+msgid "Bills to pay - Bills to pay"
+msgstr "Letras por pagar - Letras por pagar"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart7241
+#: model:account.account,name:l10n_pe.2_chart7241
+#: model:account.account.template,name:l10n_pe.chart7241
+msgid "Biological assets - Biological assets in development of animal origin"
+msgstr ""
+"Activos biológicos - Activos biológicos en desarrollo de origen animal"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart7242
+#: model:account.account,name:l10n_pe.2_chart7242
+#: model:account.account.template,name:l10n_pe.chart7242
+msgid ""
+"Biological assets - Biological assets in development of vegetable origin"
+msgstr ""
+"Activos biológicos - Activos biológicos en desarrollo de origen vegetal"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart27411
+#: model:account.account,name:l10n_pe.2_chart27411
+#: model:account.account.template,name:l10n_pe.chart27411
+msgid "Biological assets - Biological assets in production - Costs"
+msgstr "Activos biológicos - Activos biológicos en producción - Costo"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart27414
+#: model:account.account,name:l10n_pe.2_chart27414
+#: model:account.account.template,name:l10n_pe.chart27414
+msgid "Biological assets - Biological assets in production - Fair value"
+msgstr ""
+"Activos biológicos - Activos biológicos en producción - Valor razonable"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart27413
+#: model:account.account,name:l10n_pe.2_chart27413
+#: model:account.account.template,name:l10n_pe.chart27413
+msgid "Biological assets - Biological assets in production - Financing costs"
+msgstr ""
+"Activos biológicos - Activos biológicos en producción - Costos de "
+"financiación"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart27421
+#: model:account.account,name:l10n_pe.2_chart27421
+#: model:account.account.template,name:l10n_pe.chart27421
+msgid "Biological assets - Biological assets under development - Costs"
+msgstr "Activos biológicos - Activos biológicos en desarrollo - Costo"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart27424
+#: model:account.account,name:l10n_pe.2_chart27424
+#: model:account.account.template,name:l10n_pe.chart27424
+msgid "Biological assets - Biological assets under development - Fair value"
+msgstr ""
+"Activos biológicos - Activos biológicos en desarrollo - Valor razonable"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart27423
+#: model:account.account,name:l10n_pe.2_chart27423
+#: model:account.account.template,name:l10n_pe.chart27423
+msgid ""
+"Biological assets - Biological assets under development - Financing costs"
+msgstr ""
+"Activos biológicos - Activos biológicos en desarrollo - Costos de "
+"financiación"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart35111
+#: model:account.account,name:l10n_pe.2_chart35111
+#: model:account.account.template,name:l10n_pe.chart35111
+msgid "Biological assets in production - Animal origin - Costs"
+msgstr "Activos biológicos en producción - De origen animal - Costo"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart35114
+#: model:account.account,name:l10n_pe.2_chart35114
+#: model:account.account.template,name:l10n_pe.chart35114
+msgid "Biological assets in production - Animal origin - Fair value"
+msgstr "Activos biológicos en producción - De origen animal - Valor razonable"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart35113
+#: model:account.account,name:l10n_pe.2_chart35113
+#: model:account.account.template,name:l10n_pe.chart35113
+msgid "Biological assets in production - Animal origin - Financing costs"
+msgstr ""
+"Activos biológicos en producción - Animal origin - Costos de financiación"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart36611
+#: model:account.account,name:l10n_pe.2_chart36611
+#: model:account.account.template,name:l10n_pe.chart36611
+msgid "Biological assets in production - Costs"
+msgstr "Activos biológicos en producción - Costo"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart36613
+#: model:account.account,name:l10n_pe.2_chart36613
+#: model:account.account.template,name:l10n_pe.chart36613
+msgid "Biological assets in production - Financing costs"
+msgstr "Activos biológicos en producción - Costos de financiación"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart35121
+#: model:account.account,name:l10n_pe.2_chart35121
+#: model:account.account.template,name:l10n_pe.chart35121
+msgid "Biological assets in production - Vegetal origin - Costs"
+msgstr "Activos biológicos en producción - De origen vegetal - Costo"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart35124
+#: model:account.account,name:l10n_pe.2_chart35124
+#: model:account.account.template,name:l10n_pe.chart35124
+msgid "Biological assets in production - Vegetal origin - Fair value"
+msgstr ""
+"Activos biológicos en producción - De origen vegetal - Valor razonable"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart35123
+#: model:account.account,name:l10n_pe.2_chart35123
+#: model:account.account.template,name:l10n_pe.chart35123
+msgid "Biological assets in production - Vegetal origin - Financing costs"
+msgstr ""
+"Activos biológicos en producción - De origen vegetal - Costos de "
+"financiación"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart35211
+#: model:account.account,name:l10n_pe.2_chart35211
+#: model:account.account.template,name:l10n_pe.chart35211
+msgid "Biological assets under development - Animal origin - Costs"
+msgstr "Activos biológicos en desarrollo - De origen animal - Costo"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart35214
+#: model:account.account,name:l10n_pe.2_chart35214
+#: model:account.account.template,name:l10n_pe.chart35214
+msgid "Biological assets under development - Animal origin - Fair value"
+msgstr "Activos biológicos en desarrollo - De origen animal - Valor razonable"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart35213
+#: model:account.account,name:l10n_pe.2_chart35213
+#: model:account.account.template,name:l10n_pe.chart35213
+msgid "Biological assets under development - Animal origin - Financing costs"
+msgstr ""
+"Activos biológicos en desarrollo - De origen animal - Costos de financiación"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart36621
+#: model:account.account,name:l10n_pe.2_chart36621
+#: model:account.account.template,name:l10n_pe.chart36621
+msgid "Biological assets under development - Costs"
+msgstr "Activos biológicos en desarrollo - Costo"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart36622
+#: model:account.account,name:l10n_pe.2_chart36622
+#: model:account.account.template,name:l10n_pe.chart36622
+msgid "Biological assets under development - Financing costs"
+msgstr "Activos biológicos en desarrollo - Costos de financiación"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart35221
+#: model:account.account,name:l10n_pe.2_chart35221
+#: model:account.account.template,name:l10n_pe.chart35221
+msgid "Biological assets under development - Vegetal origin - Costs"
+msgstr "Activos biológicos en desarrollo - De origen animal - Costo"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart35224
+#: model:account.account,name:l10n_pe.2_chart35224
+#: model:account.account.template,name:l10n_pe.chart35224
+msgid "Biological assets under development - Vegetal origin - Fair value"
+msgstr ""
+"Activos biológicos en desarrollo - De origen vegetal - Valor razonable"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart35223
+#: model:account.account,name:l10n_pe.2_chart35223
+#: model:account.account.template,name:l10n_pe.chart35223
+msgid "Biological assets under development - Vegetal origin - Financing costs"
+msgstr ""
+"Activos biológicos under development - Vegetal origin - Costos de "
+"financiación"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart628
+#: model:account.account,name:l10n_pe.2_chart628
+#: model:account.account.template,name:l10n_pe.chart628
+msgid "Board remuneration"
+msgstr "Retribuciones al directorio"
+
+#. module: l10n_pe
+#: model:res.city,name:l10n_pe.city_pe_1303
+msgid "Bolivar"
+msgstr "Bolivar"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_021502
+#: model:res.city,name:l10n_pe.city_pe_0205
+msgid "Bolognesi"
+msgstr "Bolognesi"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_061102
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_130301
+msgid "Bolívar"
+msgstr "Bolívar"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart4532
+#: model:account.account,name:l10n_pe.2_chart4532
+#: model:account.account.template,name:l10n_pe.chart4532
+msgid "Bonds issued - Bonds securitized"
+msgstr "Obligaciones emitidas - Bonos titulizados"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart4533
+#: model:account.account,name:l10n_pe.2_chart4533
+#: model:account.account.template,name:l10n_pe.chart4533
+msgid "Bonds issued - Commercial papers"
+msgstr "Obligaciones emitidas - Papeles comerciales"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart4531
+#: model:account.account,name:l10n_pe.2_chart4531
+#: model:account.account.template,name:l10n_pe.chart4531
+msgid "Bonds issued - Issued bonds"
+msgstr "Obligaciones emitidas - Bonos emitidos"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart4539
+#: model:account.account,name:l10n_pe.2_chart4539
+#: model:account.account.template,name:l10n_pe.chart4539
+msgid "Bonds issued - Other obligations"
+msgstr "Obligaciones emitidas - Otras obligaciones"
+
+#. module: l10n_pe
+#: model:res.city,name:l10n_pe.city_pe_0103
+msgid "Bongara"
+msgstr "Bongara"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_150105
+msgid "Breña"
+msgstr "Breña"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_020802
+msgid "Buena Vista Alta"
+msgstr "Buena Vista Alta"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_200402
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_220702
+msgid "Buenos Aires"
+msgstr "Buenos Aires"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart31211
+#: model:account.account,name:l10n_pe.1_chart33211
+#: model:account.account,name:l10n_pe.1_chart36421
+#: model:account.account,name:l10n_pe.2_chart31211
+#: model:account.account,name:l10n_pe.2_chart33211
+#: model:account.account,name:l10n_pe.2_chart36421
+#: model:account.account.template,name:l10n_pe.chart31211
+#: model:account.account.template,name:l10n_pe.chart33211
+#: model:account.account.template,name:l10n_pe.chart36421
+msgid "Buildings - Buildings - Costs"
+msgstr "Edificaciones - Edificaciones - Costo"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart31214
+#: model:account.account,name:l10n_pe.2_chart31214
+#: model:account.account.template,name:l10n_pe.chart31214
+msgid "Buildings - Buildings - Fair value"
+msgstr "Edificaciones - Edificaciones - Valor razonable"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart31213
+#: model:account.account,name:l10n_pe.1_chart33213
+#: model:account.account,name:l10n_pe.1_chart36423
+#: model:account.account,name:l10n_pe.2_chart31213
+#: model:account.account,name:l10n_pe.2_chart33213
+#: model:account.account,name:l10n_pe.2_chart36423
+#: model:account.account.template,name:l10n_pe.chart31213
+#: model:account.account.template,name:l10n_pe.chart33213
+#: model:account.account.template,name:l10n_pe.chart36423
+msgid "Buildings - Buildings - Financing costs"
+msgstr "Edificaciones - Edificaciones - Costos de financiación"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart31212
+#: model:account.account,name:l10n_pe.1_chart33212
+#: model:account.account,name:l10n_pe.1_chart36422
+#: model:account.account,name:l10n_pe.2_chart31212
+#: model:account.account,name:l10n_pe.2_chart33212
+#: model:account.account,name:l10n_pe.2_chart36422
+#: model:account.account.template,name:l10n_pe.chart31212
+#: model:account.account.template,name:l10n_pe.chart33212
+#: model:account.account.template,name:l10n_pe.chart36422
+msgid "Buildings - Buildings - Revaluation"
+msgstr "Edificaciones - Edificaciones - Revaluación"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart36121
+#: model:account.account,name:l10n_pe.2_chart36121
+#: model:account.account.template,name:l10n_pe.chart36121
+msgid "Buildings - Costs"
+msgstr "Edificaciones - Costo"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart36123
+#: model:account.account,name:l10n_pe.2_chart36123
+#: model:account.account.template,name:l10n_pe.chart36123
+msgid "Buildings - Financing costs"
+msgstr "Edificaciones - Costos de financiación"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart36427
+#: model:account.account,name:l10n_pe.2_chart36427
+#: model:account.account.template,name:l10n_pe.chart36427
+msgid "Buildings - Improvements in leased premises - Costs"
+msgstr "Edificaciones - Mejoras en locales arrendados - Costo"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart36429
+#: model:account.account,name:l10n_pe.2_chart36429
+#: model:account.account.template,name:l10n_pe.chart36429
+msgid "Buildings - Improvements in leased premises - Financing costs"
+msgstr ""
+"Edificaciones - Mejoras en locales arrendados - Costos de financiación"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart36428
+#: model:account.account,name:l10n_pe.2_chart36428
+#: model:account.account.template,name:l10n_pe.chart36428
+msgid "Buildings - Improvements in leased premises - Revaluation"
+msgstr "Edificaciones - Mejoras en locales arrendados - Revaluación"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart33251
+#: model:account.account,name:l10n_pe.2_chart33251
+#: model:account.account.template,name:l10n_pe.chart33251
+msgid "Buildings - Improvements in leased premises. - Costs"
+msgstr "Edificaciones - Mejoras en locales arrendados. - Costo"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart33253
+#: model:account.account,name:l10n_pe.2_chart33253
+#: model:account.account.template,name:l10n_pe.chart33253
+msgid "Buildings - Improvements in leased premises. - Financing costs"
+msgstr ""
+"Edificaciones - Mejoras en locales arrendados. - Costo de Financiación"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart33252
+#: model:account.account,name:l10n_pe.2_chart33252
+#: model:account.account.template,name:l10n_pe.chart33252
+msgid "Buildings - Improvements in leased premises. - Revaluation"
+msgstr "Edificaciones - Mejoras en locales arrendados. - Revaluación"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart33241
+#: model:account.account,name:l10n_pe.1_chart36424
+#: model:account.account,name:l10n_pe.2_chart33241
+#: model:account.account,name:l10n_pe.2_chart36424
+#: model:account.account.template,name:l10n_pe.chart33241
+#: model:account.account.template,name:l10n_pe.chart36424
+msgid "Buildings - Installations - Costs"
+msgstr "Edificaciones - Instalaciones - Costo"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart33243
+#: model:account.account,name:l10n_pe.1_chart36426
+#: model:account.account,name:l10n_pe.2_chart33243
+#: model:account.account,name:l10n_pe.2_chart36426
+#: model:account.account.template,name:l10n_pe.chart33243
+#: model:account.account.template,name:l10n_pe.chart36426
+msgid "Buildings - Installations - Financing costs"
+msgstr "Edificaciones - Instalaciones - Costos de financiación"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart33242
+#: model:account.account,name:l10n_pe.1_chart36425
+#: model:account.account,name:l10n_pe.2_chart33242
+#: model:account.account,name:l10n_pe.2_chart36425
+#: model:account.account.template,name:l10n_pe.chart33242
+#: model:account.account.template,name:l10n_pe.chart36425
+msgid "Buildings - Installations - Revaluation"
+msgstr "Edificaciones - Instalaciones - Revaluación"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart36122
+#: model:account.account,name:l10n_pe.2_chart36122
+#: model:account.account.template,name:l10n_pe.chart36122
+msgid "Buildings - Revaluation"
+msgstr "Edificaciones - Revaluación"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_130802
+msgid "Buldibuyo"
+msgstr "Buldibuyo"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart584
+#: model:account.account,name:l10n_pe.2_chart584
+#: model:account.account.template,name:l10n_pe.chart584
+msgid "By-laws"
+msgstr "Estatutarias"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart221
+#: model:account.account,name:l10n_pe.2_chart221
+#: model:account.account.template,name:l10n_pe.chart221
+msgid "By-products"
+msgstr "Subproductos"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart2931
+#: model:account.account,name:l10n_pe.2_chart2931
+#: model:account.account.template,name:l10n_pe.chart2931
+msgid "By-products, waste and scrap - By-products"
+msgstr "Subproductos, desechos y desperdicios - Subproductos"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart69412
+#: model:account.account,name:l10n_pe.1_chart70412
+#: model:account.account,name:l10n_pe.2_chart69412
+#: model:account.account,name:l10n_pe.2_chart70412
+#: model:account.account.template,name:l10n_pe.chart69412
+#: model:account.account.template,name:l10n_pe.chart70412
+msgid "By-products, waste and scrap - By-products - Associated"
+msgstr "Subproductos, desechos y desperdicios - Subproductos - Relacionadas"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart69411
+#: model:account.account,name:l10n_pe.1_chart70411
+#: model:account.account,name:l10n_pe.2_chart69411
+#: model:account.account,name:l10n_pe.2_chart70411
+#: model:account.account.template,name:l10n_pe.chart69411
+#: model:account.account.template,name:l10n_pe.chart70411
+msgid "By-products, waste and scrap - By-products - Third parties"
+msgstr "Subproductos, desechos y desperdicios - Subproductos - Terceros"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart2932
+#: model:account.account,name:l10n_pe.2_chart2932
+#: model:account.account.template,name:l10n_pe.chart2932
+msgid "By-products, waste and scrap - Scrap and waste"
+msgstr "Subproductos, desechos y desperdicios - Desechos y desperdicios"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart69422
+#: model:account.account,name:l10n_pe.1_chart70422
+#: model:account.account,name:l10n_pe.2_chart69422
+#: model:account.account,name:l10n_pe.2_chart70422
+#: model:account.account.template,name:l10n_pe.chart69422
+#: model:account.account.template,name:l10n_pe.chart70422
+msgid "By-products, waste and scrap - Scrap and waste - Associated"
+msgstr ""
+"Subproductos, desechos y desperdicios - Desechos y desperdicios - "
+"Relacionadas"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart69421
+#: model:account.account,name:l10n_pe.1_chart70421
+#: model:account.account,name:l10n_pe.2_chart69421
+#: model:account.account,name:l10n_pe.2_chart70421
+#: model:account.account.template,name:l10n_pe.chart69421
+#: model:account.account.template,name:l10n_pe.chart70421
+msgid "By-products, waste and scrap - Scrap and waste - Third parties"
+msgstr ""
+"Subproductos, desechos y desperdicios - Desechos y desperdicios - Terceros"
+
+#. module: l10n_pe
+#: model:account.group,name:l10n_pe.1_group50
+#: model:account.group,name:l10n_pe.2_group50
+#: model:account.group.template,name:l10n_pe.group50
+msgid "CAPITAL"
+msgstr "CAPITAL"
+
+#. module: l10n_pe
+#: model:account.group,name:l10n_pe.1_group10
+#: model:account.group,name:l10n_pe.2_group10
+#: model:account.group.template,name:l10n_pe.group10
+msgid "CASH AND CASH EQUIVALENTS"
+msgstr "EFECTIVO Y EQUIVALENTES DE EFECTIVO"
+
+#. module: l10n_pe
+#: model:account.group,name:l10n_pe.1_group79
+#: model:account.group,name:l10n_pe.2_group79
+#: model:account.group.template,name:l10n_pe.group79
+msgid "CHARGES ATTRIBUTABLE TO COST AND EXPENSE ACCOUNTS"
+msgstr "CARGAS IMPUTABLES A CUENTAS DE COSTOS Y GASTOS"
+
+#. module: l10n_pe
+#: model:account.group,name:l10n_pe.1_group78
+#: model:account.group,name:l10n_pe.2_group78
+#: model:account.group.template,name:l10n_pe.group78
+msgid "CHARGES COVERED BY PROVISIONS"
+msgstr "CARGAS CUBIERTAS POR PROVISIONES"
+
+#. module: l10n_pe
+#: model:account.group,name:l10n_pe.1_group80
+#: model:account.group,name:l10n_pe.2_group80
+#: model:account.group.template,name:l10n_pe.group80
+msgid "COMMERCIAL MARGIN"
+msgstr "MARGEN COMERCIAL"
+
+#. module: l10n_pe
+#: model:account.group,name:l10n_pe.1_group26
+#: model:account.group,name:l10n_pe.2_group26
+#: model:account.group.template,name:l10n_pe.group26
+msgid "CONTAINERS AND PACKAGING"
+msgstr "ENVASES Y EMBALAJES"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_021501
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_050603
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_211102
+msgid "Cabana"
+msgstr "Cabana"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_040503
+msgid "Cabanaconde"
+msgstr "Cabanaconde"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_210702
+msgid "Cabanilla"
+msgstr "Cabanilla"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_211103
+msgid "Cabanillas"
+msgstr "Cabanillas"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_220903
+msgid "Cacatachi"
+msgstr "Cacatachi"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_060202
+msgid "Cachachi"
+msgstr "Cachachi"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_131003
+msgid "Cachicadan"
+msgstr "Cachicadan"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_080303
+msgid "Cachimayo"
+msgstr "Cachimayo"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_151006
+msgid "Cacra"
+msgstr "Cacra"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_101102
+msgid "Cahuac"
+msgstr "Cahuac"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_040306
+msgid "Cahuacho"
+msgstr "Cahuacho"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_160702
+msgid "Cahuapanas"
+msgstr "Cahuapanas"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_081102
+msgid "Caicay"
+msgstr "Caicay"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_230202
+msgid "Cairani"
+msgstr "Cairani"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_090204
+msgid "Caja"
+msgstr "Caja"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_060201
+#: model:res.city,name:l10n_pe.city_pe_0602
+msgid "Cajabamba"
+msgstr "Cajabamba"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_020505
+msgid "Cajacay"
+msgstr "Cajacay"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_060101
+#: model:res.city,name:l10n_pe.city_pe_0601
+msgid "Cajamarca"
+msgstr "Cajamarca"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_021403
+msgid "Cajamarquilla"
+msgstr "Cajamarquilla"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_010702
+msgid "Cajaruro"
+msgstr "Cajaruro"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_150301
+#: model:res.city,name:l10n_pe.city_pe_1503
+msgid "Cajatambo"
+msgstr "Cajatambo"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_021003
+msgid "Cajay"
+msgstr "Cajay"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_130502
+msgid "Calamarca"
+msgstr "Calamarca"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_230103
+msgid "Calana"
+msgstr "Calana"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_150503
+msgid "Calango"
+msgstr "Calango"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_210703
+msgid "Calapuja"
+msgstr "Calapuja"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_080401
+#: model:res.city,name:l10n_pe.city_pe_0804
+msgid "Calca"
+msgstr "Calca"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_150803
+msgid "Caleta de Carquin"
+msgstr "Caleta de Carquin"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_150703
+msgid "Callahuanca"
+msgstr "Callahuanca"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_040504
+msgid "Callalli"
+msgstr "Callalli"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_090303
+msgid "Callanmarca"
+msgstr "Callanmarca"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_070101
+#: model:res.city,name:l10n_pe.city_pe_0701
+msgid "Callao"
+msgstr "Callao"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_060602
+msgid "Callayuc"
+msgstr "Callayuc"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_250101
+msgid "Calleria"
+msgstr "Calleria"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_061103
+msgid "Calquis"
+msgstr "Calquis"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_220102
+msgid "Calzada"
+msgstr "Calzada"
+
+#. module: l10n_pe
+#: model:res.city,name:l10n_pe.city_pe_0402
+msgid "Camana"
+msgstr "Camana"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_081203
+msgid "Camanti"
+msgstr "Camanti"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_040201
+msgid "Camaná"
+msgstr "Camaná"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_230203
+msgid "Camilaca"
+msgstr "Camilaca"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_210205
+msgid "Caminaca"
+msgstr "Caminaca"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_220602
+msgid "Campanilla"
+msgstr "Campanilla"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_010502
+msgid "Camporredondo"
+msgstr "Camporredondo"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_250102
+msgid "Campoverde"
+msgstr "Campoverde"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_051005
+msgid "Canaria"
+msgstr "Canaria"
+
+#. module: l10n_pe
+#: model:res.city,name:l10n_pe.city_pe_0805
+msgid "Canas"
+msgstr "Canas"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_050409
+msgid "Canayre"
+msgstr "Canayre"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_100402
+msgid "Canchabamba"
+msgstr "Canchabamba"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_200330
+msgid "Canchaque"
+msgstr "Canchaque"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_120405
+msgid "Canchayllo"
+msgstr "Canchayllo"
+
+#. module: l10n_pe
+#: model:res.city,name:l10n_pe.city_pe_0806
+msgid "Canchis"
+msgstr "Canchis"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_230201
+#: model:res.city,name:l10n_pe.city_pe_2302
+msgid "Candarave"
+msgstr "Candarave"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_050201
+#: model:res.city,name:l10n_pe.city_pe_0502
+msgid "Cangallo"
+msgstr "Cangallo"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_020506
+msgid "Canis"
+msgstr "Canis"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_240203
+msgid "Canoas de Punta Sal"
+msgstr "Canoas de Punta Sal"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_150401
+#: model:res.city,name:l10n_pe.city_pe_1504
+msgid "Canta"
+msgstr "Canta"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_210105
+msgid "Capachica"
+msgstr "Capachica"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_080702
+msgid "Capacmarca"
+msgstr "Capacmarca"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_030402
+msgid "Capaya"
+msgstr "Capaya"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_210502
+msgid "Capazo"
+msgstr "Capazo"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_160503
+msgid "Capelo"
+msgstr "Capelo"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_090404
+msgid "Capillas"
+msgstr "Capillas"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart523
+#: model:account.account,name:l10n_pe.2_chart523
+#: model:account.account.template,name:l10n_pe.chart523
+msgid "Capital reductions pending formalization"
+msgstr "Reducciones de capital pendientes de formalización"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart5011
+#: model:account.account,name:l10n_pe.2_chart5011
+#: model:account.account.template,name:l10n_pe.chart5011
+msgid "Capital social - Actions"
+msgstr "Capital social - Acciones"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart5012
+#: model:account.account,name:l10n_pe.2_chart5012
+#: model:account.account.template,name:l10n_pe.chart5012
+msgid "Capital social - Participations"
+msgstr "Capital social - Participaciones"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart5221
+#: model:account.account,name:l10n_pe.2_chart5221
+#: model:account.account.template,name:l10n_pe.chart5221
+msgid "Capitalizations in process - Contributions"
+msgstr "Capitalizaciones en trámite - Aportes"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart5223
+#: model:account.account,name:l10n_pe.2_chart5223
+#: model:account.account.template,name:l10n_pe.chart5223
+msgid "Capitalizations in process - Credits"
+msgstr "Capitalizaciones en trámite - Acreencias"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart5222
+#: model:account.account,name:l10n_pe.2_chart5222
+#: model:account.account.template,name:l10n_pe.chart5222
+msgid "Capitalizations in process - Reserves"
+msgstr "Capitalizaciones en trámite - Reservas"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart5224
+#: model:account.account,name:l10n_pe.2_chart5224
+#: model:account.account.template,name:l10n_pe.chart5224
+msgid "Capitalizations in process - Utilities"
+msgstr "Capitalizaciones en trámite - Utilidades"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart72542
+#: model:account.account,name:l10n_pe.2_chart72542
+#: model:account.account.template,name:l10n_pe.chart72542
+msgid ""
+"Capitalized financing costs - Financing costs – Biological assets under "
+"development - Biological asset of vegetal origin"
+msgstr ""
+"Costos de financiación capitalizados - Costos de financiación – Activos "
+"biológicos en desarrollo - Activos biológicos de origen vegetal"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart72541
+#: model:account.account,name:l10n_pe.2_chart72541
+#: model:account.account.template,name:l10n_pe.chart72541
+msgid ""
+"Capitalized financing costs - Financing costs – Biological assets under "
+"development - Biological assets of animal origin"
+msgstr ""
+"Costos de financiación capitalizados - Costos de financiación – Activos "
+"biológicos en desarrollo - Activos biológicos de origen animal"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart7253
+#: model:account.account,name:l10n_pe.2_chart7253
+#: model:account.account.template,name:l10n_pe.chart7253
+msgid "Capitalized financing costs - Financing costs – Intangibles"
+msgstr ""
+"Costos de financiación capitalizados - Costos de financiación – Intangibles"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart72512
+#: model:account.account,name:l10n_pe.2_chart72512
+#: model:account.account.template,name:l10n_pe.chart72512
+msgid ""
+"Capitalized financing costs - Financing costs – Investment property - "
+"Buildings"
+msgstr ""
+"Costos de financiación capitalizados - Costos de financiación – Propiedades "
+"de inversión - Edificaciones"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart72511
+#: model:account.account,name:l10n_pe.2_chart72511
+#: model:account.account.template,name:l10n_pe.chart72511
+msgid ""
+"Capitalized financing costs - Financing costs – Investment property - "
+"Production plants under development"
+msgstr ""
+"Costos de financiación capitalizados - Costos de financiación – Propiedades "
+"de inversión - Plantas productoras en desarrollo"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart72522
+#: model:account.account,name:l10n_pe.2_chart72522
+#: model:account.account.template,name:l10n_pe.chart72522
+msgid ""
+"Capitalized financing costs - Financing costs – Property, plant and "
+"equipment - Buildings"
+msgstr ""
+"Costos de financiación capitalizados - Costos de financiación – Propiedad, "
+"planta y equipo - Edificaciones"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart72523
+#: model:account.account,name:l10n_pe.2_chart72523
+#: model:account.account.template,name:l10n_pe.chart72523
+msgid ""
+"Capitalized financing costs - Financing costs – Property, plant and "
+"equipment - Machinery and other operating equipment"
+msgstr ""
+"Costos de financiación capitalizados - Costos de financiación – Propiedad, "
+"planta y equipo - Maquinarias y otros equipos de explotación"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart72521
+#: model:account.account,name:l10n_pe.2_chart72521
+#: model:account.account.template,name:l10n_pe.chart72521
+msgid ""
+"Capitalized financing costs - Financing costs – Property, plant and "
+"equipment - Production plants in development"
+msgstr ""
+"Costos de financiación capitalizados - Costos de financiación – Propiedad, "
+"planta y equipo - Plantas productoras en desarrollo"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_130503
+msgid "Carabamba"
+msgstr "Carabamba"
+
+#. module: l10n_pe
+#: model:res.city,name:l10n_pe.city_pe_2103
+msgid "Carabaya"
+msgstr "Carabaya"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_150106
+msgid "Carabayllo"
+msgstr "Carabayllo"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_211104
+msgid "Caracoto"
+msgstr "Caracoto"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_150704
+msgid "Carampoma"
+msgstr "Carampoma"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_151007
+msgid "Carania"
+msgstr "Carania"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_050302
+msgid "Carapo"
+msgstr "Carapo"
+
+#. module: l10n_pe
+#: model:res.city,name:l10n_pe.city_pe_0403
+msgid "Caraveli"
+msgstr "Caraveli"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_040301
+msgid "Caravelí"
+msgstr "Caravelí"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_030403
+msgid "Caraybamba"
+msgstr "Caraybamba"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_021201
+msgid "Caraz"
+msgstr "Caraz"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_120104
+msgid "Carhuacallanga"
+msgstr "Carhuacallanga"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_120502
+msgid "Carhuamayo"
+msgstr "Carhuamayo"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_051103
+msgid "Carhuanca"
+msgstr "Carhuanca"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_021404
+msgid "Carhuapampa"
+msgstr "Carhuapampa"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_020601
+#: model:res.city,name:l10n_pe.city_pe_0206
+msgid "Carhuaz"
+msgstr "Carhuaz"
+
+#. module: l10n_pe
+#: model:res.city,name:l10n_pe.city_pe_0207
+msgid "Carlos Fermin Fitzcarrald"
+msgstr "Carlos Fermin Fitzcarrald"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_050104
+msgid "Carmen Alto"
+msgstr "Carmen Alto"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_050604
+msgid "Carmen Salcedo"
+msgstr "Carmen Salcedo"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_070103
+msgid "Carmen de la Legua Reynoso"
+msgstr "Carmen de la Legua Reynoso"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_180102
+msgid "Carumas"
+msgstr "Carumas"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_130208
+msgid "Casa Grande"
+msgstr "Casa Grande"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_021302
+msgid "Casca"
+msgstr "Casca"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_022002
+msgid "Cascapara"
+msgstr "Cascapara"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_131101
+msgid "Cascas"
+msgstr "Cascas"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart101
+#: model:account.account,name:l10n_pe.2_chart101
+#: model:account.account.template,name:l10n_pe.chart101
+msgid "Cash"
+msgstr "Caja"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_021904
+msgid "Cashapampa"
+msgstr "Cashapampa"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_240202
+msgid "Casitas"
+msgstr "Casitas"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_020801
+#: model:res.city,name:l10n_pe.city_pe_0208
+msgid "Casma"
+msgstr "Casma"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_220703
+msgid "Caspisapa"
+msgstr "Caspisapa"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_200104
+#: model:res.city,name:l10n_pe.city_pe_0404
+msgid "Castilla"
+msgstr "Castilla"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_100608
+msgid "Castillo Grande"
+msgstr "Castillo Grande"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_090401
+#: model:res.city,name:l10n_pe.city_pe_0904
+msgid "Castrovirreyna"
+msgstr "Castrovirreyna"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_021702
+msgid "Catac"
+msgstr "Catac"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_200105
+msgid "Catacaos"
+msgstr "Catacaos"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_061303
+msgid "Catache"
+msgstr "Catache"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_151008
+msgid "Catahuasi"
+msgstr "Catahuasi"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_061104
+msgid "Catilluc"
+msgstr "Catilluc"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_150903
+msgid "Caujul"
+msgstr "Caujul"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_140116
+msgid "Cayalti"
+msgstr "Cayalti"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_051006
+msgid "Cayara"
+msgstr "Cayara"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_040603
+msgid "Cayarani"
+msgstr "Cayarani"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_040505
+#: model:res.city,name:l10n_pe.city_pe_0405
+msgid "Caylloma"
+msgstr "Caylloma"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_040103
+msgid "Cayma"
+msgstr "Cayma"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_100202
+msgid "Cayna"
+msgstr "Cayna"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_220504
+msgid "Caynarachi"
+msgstr "Caynarachi"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_140202
+msgid "Cañaris"
+msgstr "Cañaris"
+
+#. module: l10n_pe
+#: model:res.city,name:l10n_pe.city_pe_1505
+msgid "Cañete"
+msgstr "Cañete"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_081003
+msgid "Ccapi"
+msgstr "Ccapi"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_081204
+msgid "Ccarhuayo"
+msgstr "Ccarhuayo"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_081205
+msgid "Ccatca"
+msgstr "Ccatca"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_090304
+msgid "Ccochaccasa"
+msgstr "Ccochaccasa"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_080102
+msgid "Ccorca"
+msgstr "Ccorca"
+
+#. module: l10n_pe
+#: model:res.city,name:l10n_pe.city_pe_0603
+msgid "Celendin"
+msgstr "Celendin"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_060301
+msgid "Celendín"
+msgstr "Celendín"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_150504
+msgid "Cerro Azul"
+msgstr "Cerro Azul"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_040104
+msgid "Cerro colorado"
+msgstr "Cerro colorado"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart30311
+#: model:account.account,name:l10n_pe.2_chart30311
+#: model:account.account.template,name:l10n_pe.chart30311
+msgid ""
+"Certificates of participation in funds - Dues - Investment funds - Costs"
+msgstr ""
+"Certificados de participación en fondos - Cuotas - Fondos de inversión - "
+"Costo"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart30314
+#: model:account.account,name:l10n_pe.2_chart30314
+#: model:account.account.template,name:l10n_pe.chart30314
+msgid ""
+"Certificates of participation in funds - Dues - Investment funds - Fair "
+"value"
+msgstr ""
+"Certificados de participación en fondos - Cuotas - Fondos de inversión - "
+"Fair value"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart30321
+#: model:account.account,name:l10n_pe.2_chart30321
+#: model:account.account.template,name:l10n_pe.chart30321
+msgid "Certificates of participation in funds - Dues - Mutual funds - Costs"
+msgstr ""
+"Certificados de participación en fondos - Cuotas - Fondos mutuos - Costo"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart30324
+#: model:account.account,name:l10n_pe.2_chart30324
+#: model:account.account.template,name:l10n_pe.chart30324
+msgid ""
+"Certificates of participation in funds - Dues - Mutual funds - Fair value"
+msgstr ""
+"Certificados de participación en fondos - Cuotas - Fondos mutuos - Valor "
+"razonable"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_050412
+msgid "Chaca"
+msgstr "Chaca"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_101103
+msgid "Chacabamba"
+msgstr "Chacabamba"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_120802
+msgid "Chacapalpa"
+msgstr "Chacapalpa"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_120105
+msgid "Chacapampa"
+msgstr "Chacapampa"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_020401
+msgid "Chacas"
+msgstr "Chacas"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_190202
+msgid "Chacayan"
+msgstr "Chacayan"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_020303
+msgid "Chaccho"
+msgstr "Chaccho"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_010101
+#: model:res.city,name:l10n_pe.city_pe_0101
+msgid "Chachapoyas"
+msgstr "Chachapoyas"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_040404
+msgid "Chachas"
+msgstr "Chachas"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_150107
+msgid "Chaclacayo"
+msgstr "Chaclacayo"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_030102
+msgid "Chacoche"
+msgstr "Chacoche"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_060403
+msgid "Chadin"
+msgstr "Chadin"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_100802
+msgid "Chaglla"
+msgstr "Chaglla"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_040307
+msgid "Chala"
+msgstr "Chala"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_200403
+msgid "Chalaco"
+msgstr "Chalaco"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_060419
+msgid "Chalamarca"
+msgstr "Chalamarca"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_050903
+msgid "Chalcos"
+msgstr "Chalcos"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_030401
+msgid "Chalhuanca"
+msgstr "Chalhuanca"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_081103
+msgid "Challabamba"
+msgstr "Challabamba"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_030506
+msgid "Challhuahuacho"
+msgstr "Challhuahuacho"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_080703
+msgid "Chamaca"
+msgstr "Chamaca"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_120204
+msgid "Chambara"
+msgstr "Chambara"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_061002
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_150605
+msgid "Chancay"
+msgstr "Chancay"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_061304
+msgid "Chancaybaños"
+msgstr "Chancaybaños"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_120301
+#: model:res.city,name:l10n_pe.city_pe_1203
+msgid "Chanchamayo"
+msgstr "Chanchamayo"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_110302
+msgid "Changuillo"
+msgstr "Changuillo"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_131202
+msgid "Chao"
+msgstr "Chao"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_040308
+msgid "Chaparra"
+msgstr "Chaparra"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_030404
+msgid "Chapimarca"
+msgstr "Chapimarca"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_040105
+msgid "Characato"
+msgstr "Characato"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_130604
+msgid "Charat"
+msgstr "Charat"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_040803
+msgid "Charcana"
+msgstr "Charcana"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart791
+#: model:account.account,name:l10n_pe.2_chart791
+#: model:account.account.template,name:l10n_pe.chart791
+msgid "Charges attributable to cost and expense accounts"
+msgstr "Cargas imputables a cuentas de costos y gastos"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart781
+#: model:account.account,name:l10n_pe.2_chart781
+#: model:account.account.template,name:l10n_pe.chart781
+msgid "Charges covered by provisions"
+msgstr "Cargas cubiertas por provisiones"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_190101
+msgid "Chaupimarca"
+msgstr "Chaupimarca"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_050605
+msgid "Chaviña"
+msgstr "Chaviña"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_110203
+msgid "Chavín"
+msgstr "Chavín"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_021004
+msgid "Chavín de Huantar"
+msgstr "Chavín de Huantar"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_100503
+msgid "Chavín de Pariarca"
+msgstr "Chavín de Pariarca"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_101101
+msgid "Chavínillo"
+msgstr "Chavínillo"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_220904
+msgid "Chazuta"
+msgstr "Chazuta"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_080602
+msgid "Checacupe"
+msgstr "Checacupe"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_080502
+msgid "Checca"
+msgstr "Checca"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_150804
+msgid "Checras"
+msgstr "Checras"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_130401
+msgid "Chepen"
+msgstr "Chepen"
+
+#. module: l10n_pe
+#: model:res.city,name:l10n_pe.city_pe_1304
+msgid "Chepén"
+msgstr "Chepén"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_060103
+msgid "Chetilla"
+msgstr "Chetilla"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_010104
+msgid "Cheto"
+msgstr "Cheto"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_030203
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_050105
+msgid "Chiara"
+msgstr "Chiara"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_130202
+msgid "Chicama"
+msgstr "Chicama"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_120106
+msgid "Chicche"
+msgstr "Chicche"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_040604
+msgid "Chichas"
+msgstr "Chichas"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_150705
+msgid "Chicla"
+msgstr "Chicla"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_140101
+#: model:res.city,name:l10n_pe.city_pe_1401
+msgid "Chiclayo"
+msgstr "Chiclayo"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_040106
+msgid "Chiguata"
+msgstr "Chiguata"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_060404
+msgid "Chiguirip"
+msgstr "Chiguirip"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_120107
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_150505
+msgid "Chilca"
+msgstr "Chilca"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_050504
+msgid "Chilcas"
+msgstr "Chilcas"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_040405
+msgid "Chilcaymarca"
+msgstr "Chilcaymarca"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_050904
+msgid "Chilcayoc"
+msgstr "Chilcayoc"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_060502
+msgid "Chilete"
+msgstr "Chilete"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_010105
+msgid "Chiliquin"
+msgstr "Chiliquin"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_130803
+msgid "Chillia"
+msgstr "Chillia"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_060405
+msgid "Chimban"
+msgstr "Chimban"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_021801
+msgid "Chimbote"
+msgstr "Chimbote"
+
+#. module: l10n_pe
+#: model:res.city,name:l10n_pe.city_pe_1102
+msgid "Chincha"
+msgstr "Chincha"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_110201
+msgid "Chincha Alta"
+msgstr "Chincha Alta"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_110204
+msgid "Chincha Baja"
+msgstr "Chincha Baja"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_100103
+msgid "Chinchao"
+msgstr "Chinchao"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_080304
+msgid "Chinchaypujio"
+msgstr "Chinchaypujio"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_081302
+msgid "Chinchero"
+msgstr "Chinchero"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_030601
+#: model:res.city,name:l10n_pe.city_pe_0306
+msgid "Chincheros"
+msgstr "Chincheros"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_090503
+msgid "Chinchihuasi"
+msgstr "Chinchihuasi"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_090305
+msgid "Chincho"
+msgstr "Chincho"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_021905
+msgid "Chingalpo"
+msgstr "Chingalpo"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_020304
+msgid "Chingas"
+msgstr "Chingas"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_050606
+msgid "Chipao"
+msgstr "Chipao"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_220905
+msgid "Chipurana"
+msgstr "Chipurana"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_020501
+msgid "Chiquian"
+msgstr "Chiquian"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_010602
+msgid "Chirimoto"
+msgstr "Chirimoto"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_060902
+msgid "Chirinos"
+msgstr "Chirinos"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_010302
+msgid "Chisquilla"
+msgstr "Chisquilla"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_040501
+msgid "Chivay"
+msgstr "Chivay"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_140302
+msgid "Chochope"
+msgstr "Chochope"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_040406
+msgid "Choco"
+msgstr "Choco"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_130203
+msgid "Chocope"
+msgstr "Chocope"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_151009
+msgid "Chocos"
+msgstr "Chocos"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_180202
+msgid "Chojata"
+msgstr "Chojata"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_100702
+msgid "Cholon"
+msgstr "Cholon"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_120108
+msgid "Chongos Alto"
+msgstr "Chongos Alto"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_120903
+msgid "Chongos Bajo"
+msgstr "Chongos Bajo"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_140102
+msgid "Chongoyape"
+msgstr "Chongoyape"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_190302
+msgid "Chontabamba"
+msgstr "Chontabamba"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_060803
+msgid "Chontali"
+msgstr "Chontali"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_101108
+msgid "Choras"
+msgstr "Choras"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_060406
+msgid "Choropampa"
+msgstr "Choropampa"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_060603
+msgid "Choros"
+msgstr "Choros"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_150108
+msgid "Chorrillos"
+msgstr "Chorrillos"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_060401
+#: model:res.city,name:l10n_pe.city_pe_0604
+msgid "Chota"
+msgstr "Chota"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_210106
+#: model:res.city,name:l10n_pe.city_pe_2104
+msgid "Chucuito"
+msgstr "Chucuito"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_130902
+msgid "Chugay"
+msgstr "Chugay"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_060702
+msgid "Chugur"
+msgstr "Chugur"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_200401
+msgid "Chulucanas"
+msgstr "Chulucanas"
+
+#. module: l10n_pe
+#: model:res.city,name:l10n_pe.city_pe_0807
+msgid "Chumbivilcas"
+msgstr "Chumbivilcas"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_050702
+msgid "Chumpi"
+msgstr "Chumpi"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_060302
+msgid "Chumuch"
+msgstr "Chumuch"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_050505
+msgid "Chungui"
+msgstr "Chungui"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_210206
+msgid "Chupa"
+msgstr "Chupa"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_120901
+#: model:res.city,name:l10n_pe.city_pe_1209
+msgid "Chupaca"
+msgstr "Chupaca"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_090405
+msgid "Chupamarca"
+msgstr "Chupamarca"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_120111
+msgid "Chupuro"
+msgstr "Chupuro"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_010106
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_040601
+msgid "Chuquibamba"
+msgstr "Chuquibamba"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_030701
+msgid "Chuquibambilla"
+msgstr "Chuquibambilla"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_100307
+msgid "Chuquis"
+msgstr "Chuquis"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_090501
+#: model:res.city,name:l10n_pe.city_pe_0905
+msgid "Churcampa"
+msgstr "Churcampa"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_100104
+msgid "Churubamba"
+msgstr "Churubamba"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_010303
+msgid "Churuja"
+msgstr "Churuja"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_050202
+msgid "Chuschi"
+msgstr "Chuschi"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_150109
+msgid "Cieneguilla"
+msgstr "Cieneguilla"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_030103
+msgid "Circa"
+msgstr "Circa"
+
+#. module: l10n_pe
 #: model:ir.model,name:l10n_pe.model_res_city
 #: model:ir.model.fields,field_description:l10n_pe.field_l10n_pe_res_city_district__city_id
 msgid "City"
 msgstr "Ciudad"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_230104
+msgid "Ciudad Nueva"
+msgstr "Ciudad Nueva"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart1621
+#: model:account.account,name:l10n_pe.2_chart1621
+#: model:account.account.template,name:l10n_pe.chart1621
+msgid "Claims to third parties - Insurance companies"
+msgstr "Reclamaciones a terceros - Compañías aseguradoras"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart1629
+#: model:account.account,name:l10n_pe.2_chart1629
+#: model:account.account.template,name:l10n_pe.chart1629
+msgid "Claims to third parties - Others"
+msgstr "Reclamaciones a terceros - Otras"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart1623
+#: model:account.account,name:l10n_pe.2_chart1623
+#: model:account.account.template,name:l10n_pe.chart1623
+msgid "Claims to third parties - Public services"
+msgstr "Reclamaciones a terceros - Servicios públicos"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart1624
+#: model:account.account,name:l10n_pe.2_chart1624
+#: model:account.account.template,name:l10n_pe.chart1624
+msgid "Claims to third parties - Taxes"
+msgstr "Reclamaciones a terceros - Tributos"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart1622
+#: model:account.account,name:l10n_pe.2_chart1622
+#: model:account.account.template,name:l10n_pe.chart1622
+msgid "Claims to third parties - Transportation"
+msgstr "Reclamaciones a terceros - Transportadoras"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_180203
+msgid "Coalaque"
+msgstr "Coalaque"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_210304
+msgid "Coasa"
+msgstr "Coasa"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_210107
+msgid "Coata"
+msgstr "Coata"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_150506
+msgid "Coayllo"
+msgstr "Coayllo"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_010503
+msgid "Cocabamba"
+msgstr "Cocabamba"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_040702
+msgid "Cocachacra"
+msgstr "Cocachacra"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_090406
+msgid "Cocas"
+msgstr "Cocas"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_020102
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_060407
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_100403
+msgid "Cochabamba"
+msgstr "Cochabamba"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_010603
+msgid "Cochamal"
+msgstr "Cochamal"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_150904
+msgid "Cochamarca"
+msgstr "Cochamarca"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_021102
+msgid "Cochapeti"
+msgstr "Cochapeti"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_030603
+msgid "Cocharcas"
+msgstr "Cocharcas"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_021405
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_120205
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_151010
+msgid "Cochas"
+msgstr "Cochas"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_130903
+msgid "Cochorco"
+msgstr "Cochorco"
 
 #. module: l10n_pe
 #: model:ir.model.fields,field_description:l10n_pe.field_l10n_pe_res_city_district__code
@@ -28,20 +4823,1797 @@ msgid "Code"
 msgstr "Código"
 
 #. module: l10n_pe
-#: model:l10n_latam.identification.type,name:l10n_pe.it_DIC
-msgid "Diplomatic Identity Card"
-msgstr "Cédula Diplomática de identidad"
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_100902
+msgid "Codo del Pozuzo"
+msgstr "Codo del Pozuzo"
 
 #. module: l10n_pe
-#: model:ir.model.fields,field_description:l10n_pe.field_account_move_line__display_name
-#: model:ir.model.fields,field_description:l10n_pe.field_account_tax__display_name
-#: model:ir.model.fields,field_description:l10n_pe.field_account_tax_template__display_name
-#: model:ir.model.fields,field_description:l10n_pe.field_l10n_latam_identification_type__display_name
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_021803
+msgid "Coishco"
+msgstr "Coishco"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_210602
+msgid "Cojata"
+msgstr "Cojata"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_200504
+msgid "Colan"
+msgstr "Colan"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_060804
+msgid "Colasay"
+msgstr "Colasay"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_051007
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_120112
+msgid "Colca"
+msgstr "Colca"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_020103
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_030405
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_090705
+msgid "Colcabamba"
+msgstr "Colcabamba"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_010504
+msgid "Colcamar"
+msgstr "Colcamar"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_081004
+msgid "Colcha"
+msgstr "Colcha"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_151011
+msgid "Colonia"
+msgstr "Colonia"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_100203
+msgid "Colpas"
+msgstr "Colpas"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_080704
+msgid "Colquemarca"
+msgstr "Colquemarca"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_081104
+msgid "Colquepata"
+msgstr "Colquepata"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_020507
+msgid "Colquioc"
+msgstr "Colquioc"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_050802
+msgid "Colta"
+msgstr "Colta"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_020803
+msgid "Comandante Noel"
+msgstr "Comandante Noel"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_120206
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_150110
+msgid "Comas"
+msgstr "Comas"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_080603
+msgid "Combapata"
+msgstr "Combapata"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart752
+#: model:account.account,name:l10n_pe.2_chart752
+#: model:account.account.template,name:l10n_pe.chart752
+msgid "Commissions and brokerage"
+msgstr "Comisiones y corretajes"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart0127
+#: model:account.account,name:l10n_pe.1_chart0227
+#: model:account.account,name:l10n_pe.2_chart0127
+#: model:account.account,name:l10n_pe.2_chart0227
+#: model:account.account.template,name:l10n_pe.chart0127
+#: model:account.account.template,name:l10n_pe.chart0227
+msgid "Commitments on financial instruments"
+msgstr "Compromisos sobre instrumentos financieros"
+
+#. module: l10n_pe
+#: model:ir.model,name:l10n_pe.model_res_company
+msgid "Companies"
+msgstr "Compañías"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_090104
+msgid "Conayca"
+msgstr "Conayca"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_051104
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_120201
+#: model:res.city,name:l10n_pe.city_pe_1202
+msgid "Concepción"
+msgstr "Concepción"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart36511
+#: model:account.account,name:l10n_pe.2_chart36511
+#: model:account.account.template,name:l10n_pe.chart36511
+msgid "Concessions, licenses and other rights - Costs"
+msgstr "Concesiones, licencias y otros derechos - Costo"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart34121
+#: model:account.account,name:l10n_pe.2_chart34121
+#: model:account.account.template,name:l10n_pe.chart34121
+msgid "Concessions, licenses and other rights - License - Costs"
+msgstr "Concesiones, licencias y otros derechos - Licencias - Costo"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart34122
+#: model:account.account,name:l10n_pe.2_chart34122
+#: model:account.account.template,name:l10n_pe.chart34122
+msgid "Concessions, licenses and other rights - License - Revaluation"
+msgstr "Concesiones, licencias y otros derechos - Licencias - Revaluación"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart34191
+#: model:account.account,name:l10n_pe.2_chart34191
+#: model:account.account.template,name:l10n_pe.chart34191
+msgid "Concessions, licenses and other rights - Other rights - Costs"
+msgstr "Concesiones, licencias y otros derechos - Otros derechos - Costo"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart34192
+#: model:account.account,name:l10n_pe.2_chart34192
+#: model:account.account.template,name:l10n_pe.chart34192
+msgid "Concessions, licenses and other rights - Other rights - Revaluation"
+msgstr ""
+"Concesiones, licencias y otros derechos - Otros derechos - Revaluación"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart36512
+#: model:account.account,name:l10n_pe.2_chart36512
+#: model:account.account.template,name:l10n_pe.chart36512
+msgid "Concessions, licenses and other rights - Revaluation"
+msgstr "Concesiones, licencias y otros derechos - Revaluación"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart34111
+#: model:account.account,name:l10n_pe.2_chart34111
+#: model:account.account.template,name:l10n_pe.chart34111
+msgid ""
+"Concessions, licenses and other rights - Rights for concessions - Costs"
+msgstr ""
+"Concesiones, licencias y otros derechos - Derechos por concesiones - Costo"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart34112
+#: model:account.account,name:l10n_pe.2_chart34112
+#: model:account.account.template,name:l10n_pe.chart34112
+msgid ""
+"Concessions, licenses and other rights - Rights for concessions - "
+"Revaluation"
+msgstr ""
+"Concesiones, licencias y otros derechos - Derechos por concesiones - "
+"Revaluación"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_100204
+msgid "Conchamarca"
+msgstr "Conchamarca"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_060408
+msgid "Conchan"
+msgstr "Conchan"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_021503
+msgid "Conchucos"
+msgstr "Conchucos"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_060203
+msgid "Condebamba"
+msgstr "Condebamba"
+
+#. module: l10n_pe
+#: model:res.city,name:l10n_pe.city_pe_0406
+msgid "Condesuyos"
+msgstr "Condesuyos"
+
+#. module: l10n_pe
+#: model:res.city,name:l10n_pe.city_pe_0104
+msgid "Condorcanqui"
+msgstr "Condorcanqui"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_130303
+msgid "Condormarca"
+msgstr "Condormarca"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_080802
+msgid "Condoroma"
+msgstr "Condoroma"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_210505
+msgid "Conduriri"
+msgstr "Conduriri"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_090306
+msgid "Congalla"
+msgstr "Congalla"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_021406
+msgid "Congas"
+msgstr "Congas"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_010505
+msgid "Conila"
+msgstr "Conila"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_210902
+msgid "Conima"
+msgstr "Conima"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_190308
+msgid "Constitución"
+msgstr "Constitución"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart31311
+#: model:account.account,name:l10n_pe.1_chart36131
+#: model:account.account,name:l10n_pe.2_chart31311
+#: model:account.account,name:l10n_pe.2_chart36131
+#: model:account.account.template,name:l10n_pe.chart31311
+#: model:account.account.template,name:l10n_pe.chart36131
+msgid "Constructions in progress - Buildings - Costs"
+msgstr "Construcciones en curso - Edificaciones - Costo"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart31314
+#: model:account.account,name:l10n_pe.2_chart31314
+#: model:account.account.template,name:l10n_pe.chart31314
+msgid "Constructions in progress - Buildings - Fair value"
+msgstr "Construcciones en curso - Edificaciones - Valor razonable"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart31313
+#: model:account.account,name:l10n_pe.1_chart36133
+#: model:account.account,name:l10n_pe.2_chart31313
+#: model:account.account,name:l10n_pe.2_chart36133
+#: model:account.account.template,name:l10n_pe.chart31313
+#: model:account.account.template,name:l10n_pe.chart36133
+msgid "Constructions in progress - Buildings - Financing costs"
+msgstr "Construcciones en curso - Edificaciones - Costos de financiación"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart31312
+#: model:account.account,name:l10n_pe.1_chart36132
+#: model:account.account,name:l10n_pe.2_chart31312
+#: model:account.account,name:l10n_pe.2_chart36132
+#: model:account.account.template,name:l10n_pe.chart31312
+#: model:account.account.template,name:l10n_pe.chart36132
+msgid "Constructions in progress - Buildings - Revaluation"
+msgstr "Construcciones en curso - Edificaciones - Revaluación"
+
+#. module: l10n_pe
+#: model:ir.model,name:l10n_pe.model_res_partner
+msgid "Contact"
+msgstr "Contacto"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart261
+#: model:account.account,name:l10n_pe.2_chart261
+#: model:account.account.template,name:l10n_pe.chart261
+msgid "Containers"
+msgstr "Envases"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart286
+#: model:account.account,name:l10n_pe.2_chart286
+#: model:account.account.template,name:l10n_pe.chart286
+msgid "Containers and packaging"
+msgstr "Envases y embalajes"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart2971
+#: model:account.account,name:l10n_pe.1_chart6041
+#: model:account.account,name:l10n_pe.1_chart6141
+#: model:account.account,name:l10n_pe.2_chart2971
+#: model:account.account,name:l10n_pe.2_chart6041
+#: model:account.account,name:l10n_pe.2_chart6141
+#: model:account.account.template,name:l10n_pe.chart2971
+#: model:account.account.template,name:l10n_pe.chart6041
+#: model:account.account.template,name:l10n_pe.chart6141
+msgid "Containers and packaging - Containers"
+msgstr "Envases y embalajes - Envases"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart2972
+#: model:account.account,name:l10n_pe.1_chart6042
+#: model:account.account,name:l10n_pe.1_chart6142
+#: model:account.account,name:l10n_pe.2_chart2972
+#: model:account.account,name:l10n_pe.2_chart6042
+#: model:account.account,name:l10n_pe.2_chart6142
+#: model:account.account.template,name:l10n_pe.chart2972
+#: model:account.account.template,name:l10n_pe.chart6042
+#: model:account.account.template,name:l10n_pe.chart6142
+msgid "Containers and packaging - Packaging"
+msgstr "Envases y embalajes - Embalajes"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_160601
+msgid "Contamana"
+msgstr "Contamana"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart638
+#: model:account.account,name:l10n_pe.2_chart638
+#: model:account.account.template,name:l10n_pe.chart638
+msgid "Contractor Services"
+msgstr "Servicios de contratistas"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart583
+#: model:account.account,name:l10n_pe.2_chart583
+#: model:account.account.template,name:l10n_pe.chart583
+msgid "Contractual"
+msgstr "Contractuales"
+
+#. module: l10n_pe
+#: model:res.city,name:l10n_pe.city_pe_2402
+msgid "Contralmirante Villar"
+msgstr "Contralmirante Villar"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_060501
+msgid "Contumaza"
+msgstr "Contumaza"
+
+#. module: l10n_pe
+#: model:res.city,name:l10n_pe.city_pe_0605
+msgid "Contumazá"
+msgstr "Contumazá"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_150302
+msgid "Copa"
+msgstr "Copa"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_010203
+msgid "Copallin"
+msgstr "Copallin"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_211303
+msgid "Copani"
+msgstr "Copani"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_040506
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_080803
+msgid "Coporaque"
+msgstr "Coporaque"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_050701
+msgid "Coracora"
+msgstr "Coracora"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_210305
+msgid "Corani"
+msgstr "Corani"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_050803
+msgid "Corculla"
+msgstr "Corculla"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_020202
+msgid "Coris"
+msgstr "Coris"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_050703
+msgid "Coronel Castañeda"
+msgstr "Coronel Castañeda"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_230110
+msgid "Coronel Gregorio Albarracín Lanchipa"
+msgstr "Coronel Gregorio Albarracín Lanchipa"
+
+#. module: l10n_pe
+#: model:res.city,name:l10n_pe.city_pe_2501
+msgid "Coronel Portillo"
+msgstr "Coronel Portillo"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_020901
+#: model:res.city,name:l10n_pe.city_pe_0209
+msgid "Corongo"
+msgstr "Corongo"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_010304
+msgid "Corosha"
+msgstr "Corosha"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_240102
+msgid "Corrales"
+msgstr "Corrales"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_060303
+msgid "Cortegana"
+msgstr "Cortegana"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_090511
+msgid "Cosme"
+msgstr "Cosme"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_060104
+msgid "Cospan"
+msgstr "Cospan"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart60934
+#: model:account.account,name:l10n_pe.2_chart60934
+#: model:account.account.template,name:l10n_pe.chart60934
+msgid ""
+"Costos vinculados con las compras - Costs associated with purchases of "
+"materials, supplies and spare parts - Commissions"
+msgstr ""
+"Costos vinculados con las compras - Costos vinculados con las compras de "
+"materiales, suministros y repuestos - Comisiones"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart60933
+#: model:account.account,name:l10n_pe.2_chart60933
+#: model:account.account.template,name:l10n_pe.chart60933
+msgid ""
+"Costos vinculados con las compras - Costs associated with purchases of "
+"materials, supplies and spare parts - Customs duties"
+msgstr ""
+"Costos vinculados con las compras - Costos vinculados con las compras de "
+"materiales, suministros y repuestos - Derechos aduaneros"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart60932
+#: model:account.account,name:l10n_pe.2_chart60932
+#: model:account.account.template,name:l10n_pe.chart60932
+msgid ""
+"Costos vinculados con las compras - Costs associated with purchases of "
+"materials, supplies and spare parts - Insurance"
+msgstr ""
+"Costos vinculados con las compras - Costos vinculados con las compras de "
+"materiales, suministros y repuestos - Seguros"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart60935
+#: model:account.account,name:l10n_pe.2_chart60935
+#: model:account.account.template,name:l10n_pe.chart60935
+msgid ""
+"Costos vinculados con las compras - Costs associated with purchases of "
+"materials, supplies and spare parts - Other costs"
+msgstr ""
+"Costos vinculados con las compras - Costos vinculados con las compras de "
+"materiales, suministros y repuestos - Otros costos"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart60931
+#: model:account.account,name:l10n_pe.2_chart60931
+#: model:account.account.template,name:l10n_pe.chart60931
+msgid ""
+"Costos vinculados con las compras - Costs associated with purchases of "
+"materials, supplies and spare parts - Transport"
+msgstr ""
+"Costos vinculados con las compras - Costos vinculados con las compras de "
+"materiales, suministros y repuestos - Transporte"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart60944
+#: model:account.account,name:l10n_pe.2_chart60944
+#: model:account.account.template,name:l10n_pe.chart60944
+msgid ""
+"Costos vinculados con las compras - Costs linked to purchases of containers "
+"and packaging - Commissions"
+msgstr ""
+"Costos vinculados con las compras - Costos vinculados con las compras de "
+"envases y embalajes - Comisiones"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart60943
+#: model:account.account,name:l10n_pe.2_chart60943
+#: model:account.account.template,name:l10n_pe.chart60943
+msgid ""
+"Costos vinculados con las compras - Costs linked to purchases of containers "
+"and packaging - Customs duties"
+msgstr ""
+"Costos vinculados con las compras - Costos vinculados con las compras de "
+"envases y embalajes - Derechos aduaneros"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart60942
+#: model:account.account,name:l10n_pe.2_chart60942
+#: model:account.account.template,name:l10n_pe.chart60942
+msgid ""
+"Costos vinculados con las compras - Costs linked to purchases of containers "
+"and packaging - Insurance"
+msgstr ""
+"Costos vinculados con las compras - Costos vinculados con las compras de "
+"envases y embalajes - Seguros"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart60945
+#: model:account.account,name:l10n_pe.2_chart60945
+#: model:account.account.template,name:l10n_pe.chart60945
+msgid ""
+"Costos vinculados con las compras - Costs linked to purchases of containers "
+"and packaging - Other costs"
+msgstr ""
+"Costos vinculados con las compras - Costos vinculados con las compras de "
+"envases y embalajes - Otros costos"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart60941
+#: model:account.account,name:l10n_pe.2_chart60941
+#: model:account.account.template,name:l10n_pe.chart60941
+msgid ""
+"Costos vinculados con las compras - Costs linked to purchases of containers "
+"and packaging - Transport"
+msgstr ""
+"Costos vinculados con las compras - Costos vinculados con las compras de "
+"envases y embalajes - Transporte"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart60914
+#: model:account.account,name:l10n_pe.2_chart60914
+#: model:account.account.template,name:l10n_pe.chart60914
+msgid ""
+"Costs linked to purchases - Costs associated with purchases of merchandise -"
+" Commissions"
+msgstr ""
+"Costos vinculados con las compras - Costs associated with purchases of "
+"merchandise - Comisiones"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart60913
+#: model:account.account,name:l10n_pe.2_chart60913
+#: model:account.account.template,name:l10n_pe.chart60913
+msgid ""
+"Costs linked to purchases - Costs associated with purchases of merchandise -"
+" Customs duties"
+msgstr ""
+"Costos vinculados con las compras - Costos vinculados con las compras de "
+"mercaderías - Derechos aduaneros"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart60912
+#: model:account.account,name:l10n_pe.2_chart60912
+#: model:account.account.template,name:l10n_pe.chart60912
+msgid ""
+"Costs linked to purchases - Costs associated with purchases of merchandise -"
+" Insurance"
+msgstr ""
+"Costos vinculados con las compras - Costos vinculados con las compras de "
+"mercaderías - Seguros"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart60919
+#: model:account.account,name:l10n_pe.2_chart60919
+#: model:account.account.template,name:l10n_pe.chart60919
+msgid ""
+"Costs linked to purchases - Costs associated with purchases of merchandise -"
+" Other costs"
+msgstr ""
+"Costos vinculados con las compras - Costos vinculados con las compras de "
+"mercaderías - Otros costos"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart60911
+#: model:account.account,name:l10n_pe.2_chart60911
+#: model:account.account.template,name:l10n_pe.chart60911
+msgid ""
+"Costs linked to purchases - Costs associated with purchases of merchandise -"
+" Transport"
+msgstr ""
+"Costos vinculados con las compras - Costos vinculados con las compras de "
+"mercaderías - Transporte"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart60924
+#: model:account.account,name:l10n_pe.2_chart60924
+#: model:account.account.template,name:l10n_pe.chart60924
+msgid ""
+"Costs linked to purchases - Costs linked to purchases of raw materials - "
+"Commissions"
+msgstr ""
+"Costos vinculados con las compras - Costos vinculados con las compras de "
+"materias primas - Comisiones"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart60923
+#: model:account.account,name:l10n_pe.2_chart60923
+#: model:account.account.template,name:l10n_pe.chart60923
+msgid ""
+"Costs linked to purchases - Costs linked to purchases of raw materials - "
+"Customs duties"
+msgstr ""
+"Costos vinculados con las compras - Costos vinculados con las compras de "
+"materias primas - Derechos aduaneros"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart60922
+#: model:account.account,name:l10n_pe.2_chart60922
+#: model:account.account.template,name:l10n_pe.chart60922
+msgid ""
+"Costs linked to purchases - Costs linked to purchases of raw materials - "
+"Insurance"
+msgstr ""
+"Costos vinculados con las compras - Costos vinculados con las compras de "
+"materias primas - Seguros"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart60925
+#: model:account.account,name:l10n_pe.2_chart60925
+#: model:account.account.template,name:l10n_pe.chart60925
+msgid ""
+"Costs linked to purchases - Costs linked to purchases of raw materials - "
+"Other costs"
+msgstr ""
+"Costos vinculados con las compras - Costos vinculados con las compras de "
+"materias primas - Otros costos"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart60921
+#: model:account.account,name:l10n_pe.2_chart60921
+#: model:account.account.template,name:l10n_pe.chart60921
+msgid ""
+"Costs linked to purchases - Costs linked to purchases of raw materials - "
+"Transport"
+msgstr ""
+"Costos vinculados con las compras - Costos vinculados con las compras de "
+"materias primas - Transporte"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_030502
+#: model:res.city,name:l10n_pe.city_pe_0305
+msgid "Cotabambas"
+msgstr "Cotabambas"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_040801
+msgid "Cotahuasi"
+msgstr "Cotahuasi"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_021703
+msgid "Cotaparaco"
+msgstr "Cotaparaco"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_030406
+msgid "Cotaruse"
+msgstr "Cotaruse"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart0229
+#: model:account.account,name:l10n_pe.2_chart0229
+#: model:account.account.template,name:l10n_pe.chart0229
+msgid "Counterpart creditor memorandum accounts"
+msgstr "Contrapartidacuentas de orden acreedoras"
+
+#. module: l10n_pe
+#: model_terms:ir.ui.view,arch_db:l10n_pe.pe_partner_address_form
+msgid "Country"
+msgstr "País"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_120602
+msgid "Coviriali"
+msgstr "Coviriali"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_080402
+msgid "Coya"
+msgstr "Coya"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_030503
+msgid "Coyllurqui"
+msgstr "Coyllurqui"
+
+#. module: l10n_pe
+#: model:ir.model.fields,field_description:l10n_pe.field_l10n_pe_res_city_district__create_uid
+msgid "Created by"
+msgstr "Creado por"
+
+#. module: l10n_pe
+#: model:ir.model.fields,field_description:l10n_pe.field_l10n_pe_res_city_district__create_date
+msgid "Created on"
+msgstr "Creado el"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart0129
+#: model:account.account,name:l10n_pe.2_chart0129
+#: model:account.account.template,name:l10n_pe.chart0129
+msgid "Creditors offset"
+msgstr "Acreedoras por contra"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_200804
+msgid "Cristo Nos Valga"
+msgstr "Cristo Nos Valga"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_210306
+msgid "Crucero"
+msgstr "Crucero"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_180103
+msgid "Cuchumbaya"
+msgstr "Cuchumbaya"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_090105
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_150706
+msgid "Cuenca"
+msgstr "Cuenca"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_010305
+msgid "Cuispes"
+msgstr "Cuispes"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_060604
+msgid "Cujillo"
+msgstr "Cujillo"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_021103
+msgid "Culebras"
+msgstr "Culebras"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_120113
+msgid "Cullhuas"
+msgstr "Cullhuas"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_010703
+msgid "Cumba"
+msgstr "Cumba"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_210803
+msgid "Cupi"
+msgstr "Cupi"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_060503
+msgid "Cupisnique"
+msgstr "Cupisnique"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_200107
+msgid "Cura Mori"
+msgstr "Cura Mori"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_030104
+msgid "Curahuasi"
+msgstr "Curahuasi"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_030714
+msgid "Curasco"
+msgstr "Curasco"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_130904
+msgid "Curgos"
+msgstr "Curgos"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_230204
+msgid "Curibaya"
+msgstr "Curibaya"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_120406
+msgid "Curicaca"
+msgstr "Curicaca"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_250303
+msgid "Curimana"
+msgstr "Curimana"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_030702
+msgid "Curpahuasi"
+msgstr "Curpahuasi"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart1042
+#: model:account.account,name:l10n_pe.2_chart1042
+#: model:account.account.template,name:l10n_pe.chart1042
+msgid ""
+"Current accounts in financial institutions - Current accounts for specific "
+"purposes"
+msgstr ""
+"Cuentas corrientes en instituciones financieras - Cuentas corrientes para "
+"fines específicos"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart1041
+#: model:account.account,name:l10n_pe.2_chart1041
+#: model:account.account.template,name:l10n_pe.chart1041
+msgid ""
+"Current accounts in financial institutions - Operating checking accounts"
+msgstr ""
+"Cuentas corrientes en instituciones financieras - Cuentas corrientes "
+"operativas"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_020904
+msgid "Cusca"
+msgstr "Cusca"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_080101
+#: model:res.city,name:l10n_pe.city_pe_0801
+msgid "Cusco"
+msgstr "Cusco"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_081206
+msgid "Cusipata"
+msgstr "Cusipata"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_060601
+#: model:res.city,name:l10n_pe.city_pe_0606
+msgid "Cutervo"
+msgstr "Cutervo"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_211304
+msgid "Cuturapi"
+msgstr "Cuturapi"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_211202
+msgid "Cuyocuyo"
+msgstr "Cuyocuyo"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_220505
+msgid "Cuñumbuqui"
+msgstr "Cuñumbuqui"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_021802
+msgid "Cáceres del Perú"
+msgstr "Cáceres del Perú"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_090603
+msgid "Córdova"
+msgstr "Córdova"
+
+#. module: l10n_pe
+#: model:account.group,name:l10n_pe.1_group37
+#: model:account.group,name:l10n_pe.2_group37
+#: model:account.group.template,name:l10n_pe.group37
+msgid "DEFERRED ASSETS"
+msgstr "ACTIVO DIFERIDO"
+
+#. module: l10n_pe
+#: model:account.group,name:l10n_pe.1_group49
+#: model:account.group,name:l10n_pe.2_group49
+#: model:account.group.template,name:l10n_pe.group49
+msgid "DEFERRED LIABILITIES"
+msgstr "PASIVO DIFERIDO"
+
+#. module: l10n_pe
+#: model:account.tax.group,name:l10n_pe.tax_group_det
+msgid "DET"
+msgstr "DET"
+
+#. module: l10n_pe
+#: model:account.group,name:l10n_pe.1_group89
+#: model:account.group,name:l10n_pe.2_group89
+#: model:account.group.template,name:l10n_pe.group89
+msgid "DETERMINATION OF THE RESULT OF THE YEAR"
+msgstr "DETERMINACIÓN DEL RESULTADO DEL EJERCICIO"
+
+#. module: l10n_pe
+#: model:account.group,name:l10n_pe.1_group36
+#: model:account.group,name:l10n_pe.2_group36
+#: model:account.group.template,name:l10n_pe.group36
+msgid "DEVALUATION OF FIXED ASSETS"
+msgstr "DESVALORIZACIÓN DE ACTIVO INMOVILIZADO"
+
+#. module: l10n_pe
+#: model:account.group,name:l10n_pe.1_group29
+#: model:account.group,name:l10n_pe.2_group29
+#: model:account.group.template,name:l10n_pe.group29
+msgid "DEVALUATION OF INVENTORIES"
+msgstr "DESVALORIZACIÓN DE INVENTARIOS"
+
+#. module: l10n_pe
+#: model:account.group,name:l10n_pe.1_group74
+#: model:account.group,name:l10n_pe.2_group74
+#: model:account.group.template,name:l10n_pe.group74
+msgid "DISCOUNTS, DISCOUNTS AND BONUSES GRANTED"
+msgstr "DESCUENTOS, REBAJAS y BONIFICACIONES CONCEDIDOS"
+
+#. module: l10n_pe
+#: model:account.group,name:l10n_pe.1_group73
+#: model:account.group,name:l10n_pe.2_group73
+#: model:account.group.template,name:l10n_pe.group73
+msgid "DISCOUNTS, REBATES AND BONUSES OBTAINED"
+msgstr "DESCUENTOS, REBAJAS Y BONIFICACIONES OBTENIDOS"
+
+#. module: l10n_pe
+#: model:l10n_latam.identification.type,name:l10n_pe.it_DNI
+msgid "DNI"
+msgstr "DNI"
+
+#. module: l10n_pe
+#: model:res.city,name:l10n_pe.city_pe_1902
+msgid "Daniel Alcides Carrión"
+msgstr "Daniel Alcides Carrión"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_100602
+msgid "Daniel Alomía Robles"
+msgstr "Daniel Alomía Robles"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_090706
+msgid "Daniel Hernández"
+msgstr "Daniel Hernández"
+
+#. module: l10n_pe
+#: model:res.city,name:l10n_pe.city_pe_1607
+msgid "Datem del Marañón"
+msgstr "Datem del Marañón"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_040703
+msgid "Dean Valdivia"
+msgstr "Dean Valdivia"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart0114
+#: model:account.account,name:l10n_pe.2_chart0114
+#: model:account.account.template,name:l10n_pe.chart0114
+msgid "Debitors offset"
+msgstr "Deudoras por contra"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart497
+#: model:account.account,name:l10n_pe.2_chart497
+#: model:account.account.template,name:l10n_pe.chart497
+msgid "Deferred costs"
+msgstr "Costos diferidos"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart3721
+#: model:account.account,name:l10n_pe.1_chart4921
+#: model:account.account,name:l10n_pe.2_chart3721
+#: model:account.account,name:l10n_pe.2_chart4921
+#: model:account.account.template,name:l10n_pe.chart3721
+#: model:account.account.template,name:l10n_pe.chart4921
+msgid "Deferred employee shares - Deferred employee shares – Heritage"
+msgstr ""
+"Participaciones de los trabajadores diferidas - Participaciones de los "
+"trabajadores diferidas – Patrimonio"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart3722
+#: model:account.account,name:l10n_pe.1_chart4922
+#: model:account.account,name:l10n_pe.2_chart3722
+#: model:account.account,name:l10n_pe.2_chart4922
+#: model:account.account.template,name:l10n_pe.chart3722
+#: model:account.account.template,name:l10n_pe.chart4922
+msgid "Deferred employee shares - Deferred employee shares – Results"
+msgstr ""
+"Participaciones de los trabajadores diferidas - Participaciones de los "
+"trabajadores diferidas – Resultados"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart496
+#: model:account.account,name:l10n_pe.2_chart496
+#: model:account.account.template,name:l10n_pe.chart496
+msgid "Deferred income"
+msgstr "Ingresos diferidos"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart3711
+#: model:account.account,name:l10n_pe.1_chart4911
+#: model:account.account,name:l10n_pe.2_chart3711
+#: model:account.account,name:l10n_pe.2_chart4911
+#: model:account.account.template,name:l10n_pe.chart3711
+#: model:account.account.template,name:l10n_pe.chart4911
+msgid "Deferred income tax - Deferred income tax – Heritage"
+msgstr ""
+"Impuesto a la renta diferido - Impuesto a la renta diferido – Patrimonio"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart3712
+#: model:account.account,name:l10n_pe.1_chart4912
+#: model:account.account,name:l10n_pe.2_chart3712
+#: model:account.account,name:l10n_pe.2_chart4912
+#: model:account.account.template,name:l10n_pe.chart3712
+#: model:account.account.template,name:l10n_pe.chart4912
+msgid "Deferred income tax - Deferred income tax – Results"
+msgstr ""
+"Impuesto a la renta diferido - Impuesto a la renta diferido – Resultados"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart3731
+#: model:account.account,name:l10n_pe.1_chart4931
+#: model:account.account,name:l10n_pe.2_chart3731
+#: model:account.account,name:l10n_pe.2_chart4931
+#: model:account.account.template,name:l10n_pe.chart3731
+#: model:account.account.template,name:l10n_pe.chart4931
+msgid ""
+"Deferred interest - Unearned interest in transactions with third parties"
+msgstr ""
+"Intereses diferidos - Intereses no devengados en transacciones con terceros"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart3732
+#: model:account.account,name:l10n_pe.1_chart4932
+#: model:account.account,name:l10n_pe.2_chart3732
+#: model:account.account,name:l10n_pe.2_chart4932
+#: model:account.account.template,name:l10n_pe.chart3732
+#: model:account.account.template,name:l10n_pe.chart4932
+msgid "Deferred interest - Unearned interest on discounted value measurement"
+msgstr ""
+"Intereses diferidos - Intereses no devengados en medición a valor descontado"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart495
+#: model:account.account,name:l10n_pe.2_chart495
+#: model:account.account.template,name:l10n_pe.chart495
+msgid "Deferred subsidies received"
+msgstr "Subsidios recibidos diferidos"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart1641
+#: model:account.account,name:l10n_pe.1_chart1741
+#: model:account.account,name:l10n_pe.2_chart1641
+#: model:account.account,name:l10n_pe.2_chart1741
+#: model:account.account.template,name:l10n_pe.chart1641
+#: model:account.account.template,name:l10n_pe.chart1741
+msgid "Deposits granted in guarantee - Loans from financial institutions"
+msgstr ""
+"Depósitos otorgados en garantía - Préstamos de instituciones financieras"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart1642
+#: model:account.account,name:l10n_pe.1_chart1742
+#: model:account.account,name:l10n_pe.2_chart1642
+#: model:account.account,name:l10n_pe.2_chart1742
+#: model:account.account.template,name:l10n_pe.chart1642
+#: model:account.account.template,name:l10n_pe.chart1742
+msgid "Deposits granted in guarantee - Loans from non-financial institutions"
+msgstr ""
+"Depósitos otorgados en garantía - Préstamos de instituciones no financieras"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart1649
+#: model:account.account,name:l10n_pe.1_chart1749
+#: model:account.account,name:l10n_pe.2_chart1649
+#: model:account.account,name:l10n_pe.2_chart1749
+#: model:account.account.template,name:l10n_pe.chart1649
+#: model:account.account.template,name:l10n_pe.chart1749
+msgid "Deposits granted in guarantee - Other security deposits"
+msgstr "Depósitos otorgados en garantía - Otros depósitos en garantía"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart1643
+#: model:account.account,name:l10n_pe.1_chart1743
+#: model:account.account,name:l10n_pe.2_chart1643
+#: model:account.account,name:l10n_pe.2_chart1743
+#: model:account.account.template,name:l10n_pe.chart1643
+#: model:account.account.template,name:l10n_pe.chart1743
+msgid "Deposits granted in guarantee - Security deposits for rentals"
+msgstr ""
+"Depósitos otorgados en garantía - Depósitos en garantía por alquileres"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart1061
+#: model:account.account,name:l10n_pe.2_chart1061
+#: model:account.account.template,name:l10n_pe.chart1061
+msgid "Deposits in financial institutions - Savings deposits"
+msgstr "Depósitos en instituciones financieras - Depósitos de ahorro"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart1062
+#: model:account.account,name:l10n_pe.2_chart1062
+#: model:account.account.template,name:l10n_pe.chart1062
+msgid "Deposits in financial institutions - Time deposits"
+msgstr "Depósitos en instituciones financieras - Depósitos a plazo"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart467
+#: model:account.account,name:l10n_pe.1_chart476
+#: model:account.account,name:l10n_pe.2_chart467
+#: model:account.account,name:l10n_pe.2_chart476
+#: model:account.account.template,name:l10n_pe.chart467
+#: model:account.account.template,name:l10n_pe.chart476
+msgid "Deposits received in guarantee"
+msgstr "Depósitos recibidos en garantía"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart682111
+#: model:account.account,name:l10n_pe.2_chart682111
+#: model:account.account.template,name:l10n_pe.chart682111
+msgid ""
+"Depreciation of assets for right of use - Financial leasing - Investment "
+"property - Buildings - Costs"
+msgstr ""
+"Depreciación de activos por derecho de uso - Arrendamiento financiero - "
+"Propiedades de inversión - Edificaciones - Costo"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart682113
+#: model:account.account,name:l10n_pe.2_chart682113
+#: model:account.account.template,name:l10n_pe.chart682113
+msgid ""
+"Depreciation of assets for right of use - Financial leasing - Investment "
+"property - Buildings - Financing costs"
+msgstr ""
+"Depreciación de activos por derecho de uso - Arrendamiento financiero - "
+"Propiedades de inversión - Edificaciones - Costos de financiación"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart682112
+#: model:account.account,name:l10n_pe.2_chart682112
+#: model:account.account.template,name:l10n_pe.chart682112
+msgid ""
+"Depreciation of assets for right of use - Financial leasing - Investment "
+"property - Buildings - Revaluation"
+msgstr ""
+"Depreciación de activos por derecho de uso - Arrendamiento financiero - "
+"Propiedades de inversión - Edificaciones - Revaluación"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart682211
+#: model:account.account,name:l10n_pe.2_chart682211
+#: model:account.account.template,name:l10n_pe.chart682211
+msgid ""
+"Depreciation of assets for right of use - Financial leasing - Property, "
+"plant and equipment - Buildings - Costs"
+msgstr ""
+"Depreciación de activos por derecho de uso - Arrendamiento financiero - "
+"Propiedades, planta y equipo - Edificaciones - Costo"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart682213
+#: model:account.account,name:l10n_pe.2_chart682213
+#: model:account.account.template,name:l10n_pe.chart682213
+msgid ""
+"Depreciation of assets for right of use - Financial leasing - Property, "
+"plant and equipment - Buildings - Financing costs"
+msgstr ""
+"Depreciación de activos por derecho de uso - Arrendamiento financiero - "
+"Propiedades, planta y equipo - Edificaciones - Costos de financiación"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart682212
+#: model:account.account,name:l10n_pe.2_chart682212
+#: model:account.account.template,name:l10n_pe.chart682212
+msgid ""
+"Depreciation of assets for right of use - Financial leasing - Property, "
+"plant and equipment - Buildings - Revaluation"
+msgstr ""
+"Depreciación de activos por derecho de uso - Arrendamiento financiero - "
+"Propiedades, planta y equipo - Edificaciones - Revaluación"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart682221
+#: model:account.account,name:l10n_pe.2_chart682221
+#: model:account.account.template,name:l10n_pe.chart682221
+msgid ""
+"Depreciation of assets for right of use - Financial leasing - Property, "
+"plant and equipment - Machinery and exploitation equipment - Costs"
+msgstr ""
+"Depreciación de activos por derecho de uso - Arrendamiento financiero - "
+"Propiedades, planta y equipo - Maquinarias y equipos de explotación - Costo"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart682223
+#: model:account.account,name:l10n_pe.2_chart682223
+#: model:account.account.template,name:l10n_pe.chart682223
+msgid ""
+"Depreciation of assets for right of use - Financial leasing - Property, "
+"plant and equipment - Machinery and exploitation equipment - Financing costs"
+msgstr ""
+"Depreciación de activos por derecho de uso - Arrendamiento financiero - "
+"Propiedades, planta y equipo - Maquinarias y equipos de explotación - Costo "
+"de financiación"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart682222
+#: model:account.account,name:l10n_pe.2_chart682222
+#: model:account.account.template,name:l10n_pe.chart682222
+msgid ""
+"Depreciation of assets for right of use - Financial leasing - Property, "
+"plant and equipment - Machinery and exploitation equipment - Revaluation"
+msgstr ""
+"Depreciación de activos por derecho de uso - Arrendamiento financiero - "
+"Propiedades, planta y equipo - Maquinarias y equipos de explotación - "
+"Revaluación"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart682251
+#: model:account.account,name:l10n_pe.2_chart682251
+#: model:account.account.template,name:l10n_pe.chart682251
+msgid ""
+"Depreciation of assets for right of use - Financial leasing - Property, "
+"plant and equipment - Miscellaneous equipment - Costs"
+msgstr ""
+"Depreciación de activos por derecho de uso - Arrendamiento financiero - "
+"Propiedades, planta y equipo - Equipos diversos - Costo"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart682252
+#: model:account.account,name:l10n_pe.2_chart682252
+#: model:account.account.template,name:l10n_pe.chart682252
+msgid ""
+"Depreciation of assets for right of use - Financial leasing - Property, "
+"plant and equipment - Miscellaneous equipment - Revaluation"
+msgstr ""
+"Depreciación de activos por derecho de uso - Arrendamiento financiero - "
+"Propiedades, planta y equipo - Equipos diversos - Revaluación"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart682231
+#: model:account.account,name:l10n_pe.2_chart682231
+#: model:account.account.template,name:l10n_pe.chart682231
+msgid ""
+"Depreciation of assets for right of use - Financial leasing - Property, "
+"plant and equipment - Transport units - Costs"
+msgstr ""
+"Depreciación de activos por derecho de uso - Arrendamiento financiero - "
+"Propiedades, planta y equipo - Unidades de transporte - Costo"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart682232
+#: model:account.account,name:l10n_pe.2_chart682232
+#: model:account.account.template,name:l10n_pe.chart682232
+msgid ""
+"Depreciation of assets for right of use - Financial leasing - Property, "
+"plant and equipment - Transport units - Revaluation"
+msgstr ""
+"Depreciación de activos por derecho de uso - Arrendamiento financiero - "
+"Propiedades, planta y equipo - Unidades de transporte - Revaluación"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart683111
+#: model:account.account,name:l10n_pe.2_chart683111
+#: model:account.account.template,name:l10n_pe.chart683111
+msgid ""
+"Depreciation of assets for right of use - Operating lease - Depreciation of "
+"assets for right of use - Operating lease - Buildings - Costs"
+msgstr ""
+"Depreciación de activos por derecho de uso - Arrendamiento operativo - "
+"Depreciación de activos por derecho de uso - Arrendamiento operativo - "
+"Edificaciones - Costo"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart683112
+#: model:account.account,name:l10n_pe.2_chart683112
+#: model:account.account.template,name:l10n_pe.chart683112
+msgid ""
+"Depreciation of assets for right of use - Operating lease - Depreciation of "
+"assets for right of use - Operating lease - Buildings - Revaluation"
+msgstr ""
+"Depreciación de activos por derecho de uso - Arrendamiento operativo - "
+"Depreciación de activos por derecho de uso - Arrendamiento operativo - "
+"Edificaciones - Revaluación"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart683121
+#: model:account.account,name:l10n_pe.2_chart683121
+#: model:account.account.template,name:l10n_pe.chart683121
+msgid ""
+"Depreciation of assets for right of use - Operating lease - Depreciation of "
+"assets for right of use - Operating lease - Machinery and exploitation "
+"equipment - Costs"
+msgstr ""
+"Depreciación de activos por derecho de uso - Arrendamiento operativo - "
+"Depreciación de activos por derecho de uso - Arrendamiento operativo - "
+"Maquinarias y equipos de explotación - Costo"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart683122
+#: model:account.account,name:l10n_pe.2_chart683122
+#: model:account.account.template,name:l10n_pe.chart683122
+msgid ""
+"Depreciation of assets for right of use - Operating lease - Depreciation of "
+"assets for right of use - Operating lease - Machinery and exploitation "
+"equipment - Revaluation"
+msgstr ""
+"Depreciación de activos por derecho de uso - Arrendamiento operativo - "
+"Depreciación de activos por derecho de uso - Arrendamiento operativo - "
+"Maquinarias y equipos de explotación - Revaluación"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart683152
+#: model:account.account,name:l10n_pe.2_chart683152
+#: model:account.account.template,name:l10n_pe.chart683152
+msgid ""
+"Depreciation of assets for right of use - Operating lease - Depreciation of "
+"assets for right of use - Operating lease - Miscellaneous equipment - "
+"Revaluation"
+msgstr ""
+"Depreciación de activos por derecho de uso - Arrendamiento operativo - "
+"Equipos diversos - Revaluación"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart683131
+#: model:account.account,name:l10n_pe.2_chart683131
+#: model:account.account.template,name:l10n_pe.chart683131
+msgid ""
+"Depreciation of assets for right of use - Operating lease - Depreciation of "
+"assets for right of use - Operating lease - Transport units - Costs"
+msgstr ""
+"Depreciación de activos por derecho de uso - Arrendamiento operativo - "
+"Depreciación de activos por derecho de uso - Arrendamiento operativo - "
+"Unidades de transporte - Costo"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart683132
+#: model:account.account,name:l10n_pe.2_chart683132
+#: model:account.account.template,name:l10n_pe.chart683132
+msgid ""
+"Depreciation of assets for right of use - Operating lease - Depreciation of "
+"assets for right of use - Operating lease - Transport units - Revaluation"
+msgstr ""
+"Depreciación de activos por derecho de uso - Arrendamiento operativo - "
+"Depreciación de activos por derecho de uso - Arrendamiento operativo - "
+"Unidades de transporte - Revaluación"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart68512
+#: model:account.account,name:l10n_pe.2_chart68512
+#: model:account.account.template,name:l10n_pe.chart68512
+msgid ""
+"Depreciation of biological assets in production - Depreciation of biological"
+" assets in production - Costs - Biological asset of vegetal origin"
+msgstr ""
+"Depreciación de activos biológicos en producción - Depreciación de activos "
+"biológicos en producción - Costo - Activos biológicos de origen vegetal"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart68511
+#: model:account.account,name:l10n_pe.2_chart68511
+#: model:account.account.template,name:l10n_pe.chart68511
+msgid ""
+"Depreciation of biological assets in production - Depreciation of biological"
+" assets in production - Costs - Biological assets of animal origin"
+msgstr ""
+"Depreciación de activos biológicos en producción - Depreciación de activos "
+"biológicos en producción - Costo - Activos biológicos de origen animal"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart68522
+#: model:account.account,name:l10n_pe.2_chart68522
+#: model:account.account.template,name:l10n_pe.chart68522
+msgid ""
+"Depreciation of biological assets in production - Depreciation of biological"
+" assets in production - Financing costs - Biological asset of vegetal origin"
+msgstr ""
+"Depreciación de activos biológicos en producción - Depreciación de activos "
+"biológicos en producción - Costo de financiación - Activos biológicos de "
+"origen vegetal"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart68521
+#: model:account.account,name:l10n_pe.2_chart68521
+#: model:account.account.template,name:l10n_pe.chart68521
+msgid ""
+"Depreciation of biological assets in production - Depreciation of biological"
+" assets in production - Financing costs - Biological assets of animal origin"
+msgstr ""
+"Depreciación de activos biológicos en producción - Depreciación de activos "
+"biológicos en producción - Costo de financiación - Activos biológicos de "
+"origen animal"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart68111
+#: model:account.account,name:l10n_pe.2_chart68111
+#: model:account.account.template,name:l10n_pe.chart68111
+msgid "Depreciation of investment properties - Buildings - Costs"
+msgstr "Depreciación de propiedades de inversión - Edificaciones - Costo"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart68113
+#: model:account.account,name:l10n_pe.2_chart68113
+#: model:account.account.template,name:l10n_pe.chart68113
+msgid "Depreciation of investment properties - Buildings - Financing costs"
+msgstr ""
+"Depreciación de propiedades de inversión - Edificaciones - Costos de "
+"financiación"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart68112
+#: model:account.account,name:l10n_pe.2_chart68112
+#: model:account.account.template,name:l10n_pe.chart68112
+msgid "Depreciation of investment properties - Buildings - Revaluation"
+msgstr ""
+"Depreciación de propiedades de inversión - Edificaciones - Revaluación"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart68411
+#: model:account.account,name:l10n_pe.2_chart68411
+#: model:account.account.template,name:l10n_pe.chart68411
+msgid ""
+"Depreciation of property, plant and equipment - Depreciation of property, "
+"plant and equipment - Costs - Buildings"
+msgstr ""
+"Depreciación de propiedad, planta y equipo - Depreciación de propiedad, "
+"planta y equipo - Costo - Edificaciones"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart68414
+#: model:account.account,name:l10n_pe.2_chart68414
+#: model:account.account.template,name:l10n_pe.chart68414
+msgid ""
+"Depreciation of property, plant and equipment - Depreciation of property, "
+"plant and equipment - Costs - Furniture and fixtures"
+msgstr ""
+"Depreciación de propiedad, planta y equipo - Depreciación de propiedad, "
+"planta y equipo - Costo - Muebles y enseres"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart68412
+#: model:account.account,name:l10n_pe.2_chart68412
+#: model:account.account.template,name:l10n_pe.chart68412
+msgid ""
+"Depreciation of property, plant and equipment - Depreciation of property, "
+"plant and equipment - Costs - Machinery and exploitation equipment"
+msgstr ""
+"Depreciación de propiedad, planta y equipo - Depreciación de propiedad, "
+"planta y equipo - Costo - Maquinarias y equipos de explotación"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart68415
+#: model:account.account,name:l10n_pe.2_chart68415
+#: model:account.account.template,name:l10n_pe.chart68415
+msgid ""
+"Depreciation of property, plant and equipment - Depreciation of property, "
+"plant and equipment - Costs - Miscellaneous equipment"
+msgstr ""
+"Depreciación de propiedad, planta y equipo - Depreciación de propiedad, "
+"planta y equipo - Costo - Equipos diversos"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart68410
+#: model:account.account,name:l10n_pe.2_chart68410
+#: model:account.account.template,name:l10n_pe.chart68410
+msgid ""
+"Depreciation of property, plant and equipment - Depreciation of property, "
+"plant and equipment - Costs - Production plants"
+msgstr ""
+"Depreciación de propiedad, planta y equipo - Depreciación de propiedad, "
+"planta y equipo - Costo - Plantas productoras"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart68416
+#: model:account.account,name:l10n_pe.2_chart68416
+#: model:account.account.template,name:l10n_pe.chart68416
+msgid ""
+"Depreciation of property, plant and equipment - Depreciation of property, "
+"plant and equipment - Costs - Replacement tools and units"
+msgstr ""
+"Depreciación de propiedad, planta y equipo - Depreciación de propiedad, "
+"planta y equipo - Costo - Herramientas y unidades de reemplazo"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart68413
+#: model:account.account,name:l10n_pe.2_chart68413
+#: model:account.account.template,name:l10n_pe.chart68413
+msgid ""
+"Depreciation of property, plant and equipment - Depreciation of property, "
+"plant and equipment - Costs - Transport units"
+msgstr ""
+"Depreciación de propiedad, planta y equipo - Depreciación de propiedad, "
+"planta y equipo - Costo - Unidades de transporte"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart68431
+#: model:account.account,name:l10n_pe.2_chart68431
+#: model:account.account.template,name:l10n_pe.chart68431
+msgid ""
+"Depreciation of property, plant and equipment - Depreciation of property, "
+"plant and equipment - Financing costs - Buildings"
+msgstr ""
+"Depreciación de propiedad, planta y equipo - Depreciación de propiedad, "
+"planta y equipo - Costos de financiación - Edificaciones"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart68432
+#: model:account.account,name:l10n_pe.2_chart68432
+#: model:account.account.template,name:l10n_pe.chart68432
+msgid ""
+"Depreciation of property, plant and equipment - Depreciation of property, "
+"plant and equipment - Financing costs - Machinery and exploitation equipment"
+msgstr ""
+"Depreciación de propiedad, planta y equipo - Depreciación de propiedad, "
+"planta y equipo - Costos de financiación - Maquinarias y equipos de "
+"explotación"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart68430
+#: model:account.account,name:l10n_pe.2_chart68430
+#: model:account.account.template,name:l10n_pe.chart68430
+msgid ""
+"Depreciation of property, plant and equipment - Depreciation of property, "
+"plant and equipment - Financing costs - Production plants"
+msgstr ""
+"Depreciación de propiedad, planta y equipo - Depreciación de propiedad, "
+"planta y equipo - Costos de financiación - Plantas productoras"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart68421
+#: model:account.account,name:l10n_pe.2_chart68421
+#: model:account.account.template,name:l10n_pe.chart68421
+msgid ""
+"Depreciation of property, plant and equipment - Depreciation of property, "
+"plant and equipment - Revaluation - Buildings"
+msgstr ""
+"Depreciación de propiedad, planta y equipo - Depreciación de propiedad, "
+"planta y equipo - Revaluación - Edificaciones"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart68424
+#: model:account.account,name:l10n_pe.2_chart68424
+#: model:account.account.template,name:l10n_pe.chart68424
+msgid ""
+"Depreciation of property, plant and equipment - Depreciation of property, "
+"plant and equipment - Revaluation - Furniture and fixtures"
+msgstr ""
+"Depreciación de propiedad, planta y equipo - Depreciación de propiedad, "
+"planta y equipo - Revaluación - Muebles y enseres"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart68422
+#: model:account.account,name:l10n_pe.2_chart68422
+#: model:account.account.template,name:l10n_pe.chart68422
+msgid ""
+"Depreciation of property, plant and equipment - Depreciation of property, "
+"plant and equipment - Revaluation - Machinery and exploitation equipment"
+msgstr ""
+"Depreciación de propiedad, planta y equipo - Depreciación de propiedad, "
+"planta y equipo - Revaluación - Maquinarias y equipos de explotación"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart68425
+#: model:account.account,name:l10n_pe.2_chart68425
+#: model:account.account.template,name:l10n_pe.chart68425
+msgid ""
+"Depreciation of property, plant and equipment - Depreciation of property, "
+"plant and equipment - Revaluation - Miscellaneous equipment"
+msgstr ""
+"Depreciación de propiedad, planta y equipo - Depreciación de propiedad, "
+"planta y equipo - Revaluación - Equipos diversos"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart68420
+#: model:account.account,name:l10n_pe.2_chart68420
+#: model:account.account.template,name:l10n_pe.chart68420
+msgid ""
+"Depreciation of property, plant and equipment - Depreciation of property, "
+"plant and equipment - Revaluation - Production plants"
+msgstr ""
+"Depreciación de propiedad, planta y equipo - Depreciación de propiedad, "
+"planta y equipo - Revaluación - Plantas productoras"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart68426
+#: model:account.account,name:l10n_pe.2_chart68426
+#: model:account.account.template,name:l10n_pe.chart68426
+msgid ""
+"Depreciation of property, plant and equipment - Depreciation of property, "
+"plant and equipment - Revaluation - Replacement tools and units"
+msgstr ""
+"Depreciación de propiedad, planta y equipo - Depreciación de propiedad, "
+"planta y equipo - Revaluación - Herramientas y unidades de reemplazo"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart68423
+#: model:account.account,name:l10n_pe.2_chart68423
+#: model:account.account.template,name:l10n_pe.chart68423
+msgid ""
+"Depreciation of property, plant and equipment - Depreciation of property, "
+"plant and equipment - Revaluation - Transport units"
+msgstr ""
+"Depreciación de propiedad, planta y equipo - Depreciación de propiedad, "
+"planta y equipo - Revaluación - Unidades de transporte"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_210402
+msgid "Desaguadero"
+msgstr "Desaguadero"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart776
+#: model:account.account,name:l10n_pe.2_chart776
+#: model:account.account.template,name:l10n_pe.chart776
+msgid "Difference in change"
+msgstr "Diferencia en cambio"
+
+#. module: l10n_pe
+#: model:l10n_latam.identification.type,name:l10n_pe.it_DIC
+msgid "Diplomatic Identity Card"
+msgstr "Cédula de Identidad Diplomática"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart1432
+#: model:account.account,name:l10n_pe.2_chart1432
+#: model:account.account.template,name:l10n_pe.chart1432
+msgid "Directors - Advance of daily subsistence allowance"
+msgstr "Directores - Adelanto de dietas"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart1433
+#: model:account.account,name:l10n_pe.2_chart1433
+#: model:account.account.template,name:l10n_pe.chart1433
+msgid "Directors - Deliveries to account"
+msgstr "Directores - Entregas a rendir cuenta"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart1431
+#: model:account.account,name:l10n_pe.2_chart1431
+#: model:account.account.template,name:l10n_pe.chart1431
+msgid "Directors - Loans"
+msgstr "Directores - Préstamos"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart4429
+#: model:account.account,name:l10n_pe.2_chart4429
+#: model:account.account.template,name:l10n_pe.chart4429
+msgid "Directors - Other accounts payable"
+msgstr "Directores - Other accounts payable"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart4421
+#: model:account.account,name:l10n_pe.2_chart4421
+#: model:account.account.template,name:l10n_pe.chart4421
+msgid "Directors - Subsistence allowance"
+msgstr "Directores - Dietas"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart675
+#: model:account.account,name:l10n_pe.2_chart675
+#: model:account.account.template,name:l10n_pe.chart675
+msgid "Discounts granted for early payment"
+msgstr "Descuentos concedidos por pronto pago"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart775
+#: model:account.account,name:l10n_pe.2_chart775
+#: model:account.account.template,name:l10n_pe.chart775
+msgid "Discounts obtained for prompt payment"
+msgstr "Descuentos obtenidos por pronto pago"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart7412
+#: model:account.account,name:l10n_pe.2_chart7412
+#: model:account.account.template,name:l10n_pe.chart7412
+msgid "Discounts, rebates and bonuses granted - Associated"
+msgstr "Descuentos, rebajas y bonificaciones concedidos - Relacionadas"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart7411
+#: model:account.account,name:l10n_pe.2_chart7411
+#: model:account.account.template,name:l10n_pe.chart7411
+msgid "Discounts, rebates and bonuses granted - Third parties"
+msgstr "Descuentos, rebajas y bonificaciones concedidos - Terceros"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart7312
+#: model:account.account,name:l10n_pe.2_chart7312
+#: model:account.account.template,name:l10n_pe.chart7312
+msgid "Discounts, rebates and bonuses obtained - Associated"
+msgstr "Descuentos, rebajas y bonificaciones obtenidos - Relacionadas"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart7311
+#: model:account.account,name:l10n_pe.2_chart7311
+#: model:account.account.template,name:l10n_pe.chart7311
+msgid "Discounts, rebates and bonuses obtained - Third parties"
+msgstr "Descuentos, rebajas y bonificaciones obtenidos - Terceros"
+
+#. module: l10n_pe
 #: model:ir.model.fields,field_description:l10n_pe.field_l10n_pe_res_city_district__display_name
-#: model:ir.model.fields,field_description:l10n_pe.field_res_city__display_name
-#: model:ir.model.fields,field_description:l10n_pe.field_res_partner__display_name
 msgid "Display Name"
-msgstr "Nombre Mostrado"
+msgstr "Nombre para mostrar"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart7563
+#: model:account.account,name:l10n_pe.2_chart7563
+#: model:account.account.template,name:l10n_pe.chart7563
+msgid "Disposal of fixed assets - Assets acquired under finance lease"
+msgstr ""
+"Enajenación de activos inmovilizados - Activos adquiridos en arrendamiento "
+"financiero"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart7566
+#: model:account.account,name:l10n_pe.2_chart7566
+#: model:account.account.template,name:l10n_pe.chart7566
+msgid "Disposal of fixed assets - Biological assets"
+msgstr "Enajenación de activos inmovilizados - Activos biológicos"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart7565
+#: model:account.account,name:l10n_pe.2_chart7565
+#: model:account.account.template,name:l10n_pe.chart7565
+msgid "Disposal of fixed assets - Intangibles"
+msgstr "Enajenación de activos inmovilizados - Intangibles"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart7562
+#: model:account.account,name:l10n_pe.2_chart7562
+#: model:account.account.template,name:l10n_pe.chart7562
+msgid "Disposal of fixed assets - Investment property"
+msgstr "Enajenación de activos inmovilizados - Propiedades de inversión"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart7564
+#: model:account.account,name:l10n_pe.2_chart7564
+#: model:account.account.template,name:l10n_pe.chart7564
+msgid "Disposal of fixed assets - Property, plant and equipment"
+msgstr "Enajenación de activos inmovilizados - Propiedades, planta y equipo"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart7561
+#: model:account.account,name:l10n_pe.2_chart7561
+#: model:account.account.template,name:l10n_pe.chart7561
+msgid "Disposal of fixed assets - Securities investments"
+msgstr "Enajenación de activos inmovilizados - Inversiones mobiliarias"
 
 #. module: l10n_pe
 #: model:ir.model,name:l10n_pe.model_l10n_pe_res_city_district
@@ -59,19 +6631,52 @@ msgstr "Distrito..."
 #: model:ir.model.fields,help:l10n_pe.field_res_partner__l10n_pe_district
 #: model:ir.model.fields,help:l10n_pe.field_res_users__l10n_pe_district
 msgid "Districts are part of a province or city."
-msgstr "Los distritos forman parte de una ciudad o provincia"
+msgstr "Los distritos son parte de una provincia o ciudad."
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart475
+#: model:account.account,name:l10n_pe.1_chart773
+#: model:account.account,name:l10n_pe.2_chart475
+#: model:account.account,name:l10n_pe.2_chart773
+#: model:account.account.template,name:l10n_pe.chart475
+#: model:account.account.template,name:l10n_pe.chart773
+msgid "Dividends"
+msgstr "Dividendos"
+
+#. module: l10n_pe
+#: model:res.city,name:l10n_pe.city_pe_1003
+msgid "Dos de mayo"
+msgstr "Dos de mayo"
 
 #. module: l10n_pe
 #: model:ir.model.fields,field_description:l10n_pe.field_account_tax__l10n_pe_edi_unece_category
 #: model:ir.model.fields,field_description:l10n_pe.field_account_tax_template__l10n_pe_edi_unece_category
 msgid "EDI UNECE code"
-msgstr "Código UNECE"
+msgstr "Código EDI UNECE"
 
 #. module: l10n_pe
 #: model:ir.model.fields,field_description:l10n_pe.field_account_tax__l10n_pe_edi_tax_code
 #: model:ir.model.fields,field_description:l10n_pe.field_account_tax_template__l10n_pe_edi_tax_code
 msgid "EDI peruvian code"
-msgstr "Código de Tributo"
+msgstr "Código EDI peruano"
+
+#. module: l10n_pe
+#: model:account.group,name:l10n_pe.1_group19
+#: model:account.group,name:l10n_pe.2_group19
+#: model:account.group.template,name:l10n_pe.group19
+msgid "ESTIMATION OF DOUBTFUL ACCOUNTS"
+msgstr "ESTIMACIÓN DE CUENTAS DE COBRANZA DUDOSA"
+
+#. module: l10n_pe
+#: model:account.tax,description:l10n_pe.1_purchase_tax_exo
+#: model:account.tax,description:l10n_pe.1_sale_tax_exo
+#: model:account.tax,description:l10n_pe.2_purchase_tax_exo
+#: model:account.tax,description:l10n_pe.2_sale_tax_exo
+#: model:account.tax.group,name:l10n_pe.tax_group_exo
+#: model:account.tax.template,description:l10n_pe.purchase_tax_exo
+#: model:account.tax.template,description:l10n_pe.sale_tax_exo
+msgid "EXO"
+msgstr "EXO"
 
 #. module: l10n_pe
 #: model:ir.model.fields.selection,name:l10n_pe.selection__account_tax__l10n_pe_edi_tax_code__9997
@@ -80,10 +6685,312 @@ msgid "EXO - Exonerated"
 msgstr "EXO - Exonerado"
 
 #. module: l10n_pe
+#: model:account.tax,description:l10n_pe.1_sale_tax_exp
+#: model:account.tax,description:l10n_pe.2_sale_tax_exp
+#: model:account.tax.group,name:l10n_pe.tax_group_exp
+#: model:account.tax.template,description:l10n_pe.sale_tax_exp
+msgid "EXP"
+msgstr "EXP"
+
+#. module: l10n_pe
 #: model:ir.model.fields.selection,name:l10n_pe.selection__account_tax__l10n_pe_edi_tax_code__9995
 #: model:ir.model.fields.selection,name:l10n_pe.selection__account_tax_template__l10n_pe_edi_tax_code__9995
 msgid "EXP - Exportation"
 msgstr "EXP - Exportación"
+
+#. module: l10n_pe
+#: model:account.group,name:l10n_pe.1_group63
+#: model:account.group,name:l10n_pe.2_group63
+#: model:account.group.template,name:l10n_pe.group63
+msgid "EXPENSES FOR SERVICES RENDERED BY THIRD PARTIES"
+msgstr "GASTOS DE SERVICIOS PRESTADOS POR TERCEROS"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart7721
+#: model:account.account,name:l10n_pe.2_chart7721
+#: model:account.account.template,name:l10n_pe.chart7721
+msgid "Earned returns - Deposits in financial institutions"
+msgstr "Rendimientos ganados - Depósitos en instituciones financieras"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart7725
+#: model:account.account,name:l10n_pe.2_chart7725
+#: model:account.account.template,name:l10n_pe.chart7725
+msgid ""
+"Earned returns - Financial instruments representative of economic rights"
+msgstr ""
+"Rendimientos ganados - Instrumentos financieros representativos de derecho "
+"patrimonial"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart7724
+#: model:account.account,name:l10n_pe.2_chart7724
+#: model:account.account.template,name:l10n_pe.chart7724
+msgid "Earned returns - Investments to be held until maturity"
+msgstr ""
+"Rendimientos ganados - Inversiones a ser mantenidas hasta el vencimiento"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart7723
+#: model:account.account,name:l10n_pe.2_chart7723
+#: model:account.account.template,name:l10n_pe.chart7723
+msgid "Earned returns - Loans granted"
+msgstr "Rendimientos ganados - Préstamos otorgados"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart7722
+#: model:account.account,name:l10n_pe.2_chart7722
+#: model:account.account.template,name:l10n_pe.chart7722
+msgid "Earned returns - Trade accounts receivable"
+msgstr "Rendimientos ganados - Cuentas por cobrar comerciales"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_080902
+msgid "Echarate"
+msgstr "Echarate"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_061003
+msgid "Eduardo Villanueva"
+msgstr "Eduardo Villanueva"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_150111
+msgid "El Agustíno"
+msgstr "El Agustíno"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_180302
+msgid "El Algarrobal"
+msgstr "El Algarrobal"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_200702
+msgid "El Alto"
+msgstr "El Alto"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_090504
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_110205
+msgid "El Carmen"
+msgstr "El Carmen"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_200303
+msgid "El Carmen de la Frontera"
+msgstr "El Carmen de la Frontera"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_010402
+msgid "El Cenepa"
+msgstr "El Cenepa"
+
+#. module: l10n_pe
+#: model:res.city,name:l10n_pe.city_pe_2105
+msgid "El Collao"
+msgstr "El Collao"
+
+#. module: l10n_pe
+#: model:res.city,name:l10n_pe.city_pe_2203
+msgid "El Dorado"
+msgstr "El Dorado"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_220403
+msgid "El Eslabón"
+msgstr "El Eslabón"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_110303
+msgid "El Ingenio"
+msgstr "El Ingenio"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_120407
+msgid "El Mantaro"
+msgstr "El Mantaro"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_010704
+msgid "El Milagro"
+msgstr "El Milagro"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_030302
+msgid "El Oro"
+msgstr "El Oro"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_010204
+msgid "El Parco"
+msgstr "El Parco"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_030610
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_130102
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_220906
+msgid "El Porvenir"
+msgstr "El Porvenir"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_061105
+msgid "El Prado"
+msgstr "El Prado"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_200108
+msgid "El Tallan"
+msgstr "El Tallan"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_120114
+msgid "El Tambo"
+msgstr "El Tambo"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_021303
+msgid "Eleazar Guzmán Barron"
+msgstr "Eleazar Guzmán Barron"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_220803
+msgid "Elias Soplin Vargas"
+msgstr "Elias Soplin Vargas"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_160504
+msgid "Emilio San Martín"
+msgstr "Emilio San Martín"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart413
+#: model:account.account,name:l10n_pe.2_chart413
+#: model:account.account.template,name:l10n_pe.chart413
+msgid "Employee participations payable"
+msgstr "Participaciones de los trabajadores por pagar"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart6291
+#: model:account.account,name:l10n_pe.2_chart6291
+#: model:account.account.template,name:l10n_pe.chart6291
+msgid "Employee social benefits - Compensation for time of service"
+msgstr ""
+"Beneficios sociales de los trabajadores - Compensación por tiempo de "
+"servicio"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart6293
+#: model:account.account,name:l10n_pe.2_chart6293
+#: model:account.account.template,name:l10n_pe.chart6293
+msgid "Employee social benefits - Other post-employment benefits"
+msgstr ""
+"Beneficios sociales de los trabajadores - Otros beneficios post-empleo"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart6292
+#: model:account.account,name:l10n_pe.2_chart6292
+#: model:account.account.template,name:l10n_pe.chart6292
+msgid "Employee social benefits - Pensions and retirement"
+msgstr "Beneficios sociales de los trabajadores - Pensiones y jubilaciones"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart62941
+#: model:account.account,name:l10n_pe.2_chart62941
+#: model:account.account.template,name:l10n_pe.chart62941
+msgid "Employee social benefits - Profit sharing - Current share"
+msgstr ""
+"Beneficios sociales de los trabajadores - Participación en las utilidades - "
+"Participación corriente"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart62942
+#: model:account.account,name:l10n_pe.2_chart62942
+#: model:account.account.template,name:l10n_pe.chart62942
+msgid "Employee social benefits - Profit sharing - Deferred share"
+msgstr ""
+"Beneficios sociales de los trabajadores - Participación en las utilidades - "
+"Participación diferida"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart4152
+#: model:account.account,name:l10n_pe.2_chart4152
+#: model:account.account.template,name:l10n_pe.chart4152
+msgid ""
+"Employee social benefits payable - Advance compensation for length of "
+"service"
+msgstr ""
+"Beneficios sociales de los trabajadores por pagar - Adelanto de compensación"
+" por tiempo de servicios"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart4151
+#: model:account.account,name:l10n_pe.2_chart4151
+#: model:account.account.template,name:l10n_pe.chart4151
+msgid "Employee social benefits payable - Compensation for time of services"
+msgstr ""
+"Beneficios sociales de los trabajadores por pagar - Compensación por tiempo "
+"de servicios"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart4153
+#: model:account.account,name:l10n_pe.2_chart4153
+#: model:account.account.template,name:l10n_pe.chart4153
+msgid "Employee social benefits payable - Pensions and retirement"
+msgstr ""
+"Beneficios sociales de los trabajadores por pagar - Pensiones y jubilaciones"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_060105
+msgid "Encañada"
+msgstr "Encañada"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart658
+#: model:account.account,name:l10n_pe.2_chart658
+#: model:account.account.template,name:l10n_pe.chart658
+msgid "Environmental management"
+msgstr "Gestión medioambiental"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_080801
+#: model:res.city,name:l10n_pe.city_pe_0808
+msgid "Espinar"
+msgstr "Espinar"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_230403
+msgid "Estique"
+msgstr "Estique"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_230404
+msgid "Estique-Pampa"
+msgstr "Estique-Pampa"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_140103
+msgid "Eten"
+msgstr "Eten"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_140104
+msgid "Eten Puerto"
+msgstr "Eten Puerto"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart561
+#: model:account.account,name:l10n_pe.2_chart561
+#: model:account.account.template,name:l10n_pe.chart561
+msgid "Exchange difference on permanent investments in foreign entities"
+msgstr ""
+"Diferencia en cambio de inversiones permanentes en entidades extranjeras"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart676
+#: model:account.account,name:l10n_pe.2_chart676
+#: model:account.account.template,name:l10n_pe.chart676
+msgid "Exchange rate"
+msgstr "Diferencia de cambio"
 
 #. module: l10n_pe
 #: model:ir.model.fields.selection,name:l10n_pe.selection__account_tax__l10n_pe_edi_unece_category__e
@@ -92,15 +6999,968 @@ msgid "Exempt from tax"
 msgstr "Exento de impuestos"
 
 #. module: l10n_pe
+#: model:account.group,name:l10n_pe.1_group6
+#: model:account.group,name:l10n_pe.2_group6
+#: model:account.group.template,name:l10n_pe.group6
+msgid "Expenses by nature"
+msgstr "Gastos por naturaleza"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart6956
+#: model:account.account,name:l10n_pe.2_chart6956
+#: model:account.account.template,name:l10n_pe.chart6956
+msgid ""
+"Expenses for impairment of inventories at cost - Auxiliary materials, "
+"supplies and spare parts"
+msgstr ""
+"Gastos por desvalorización de inventarios al costo - Materiales auxiliares, "
+"suministros y repuestos"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart6953
+#: model:account.account,name:l10n_pe.2_chart6953
+#: model:account.account.template,name:l10n_pe.chart6953
+msgid ""
+"Expenses for impairment of inventories at cost - By-products, waste and "
+"scrap"
+msgstr ""
+"Gastos por desvalorización de inventarios al costo - Subproductos, desechos "
+"y desperdicios"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart6957
+#: model:account.account,name:l10n_pe.2_chart6957
+#: model:account.account.template,name:l10n_pe.chart6957
+msgid ""
+"Expenses for impairment of inventories at cost - Containers and packaging"
+msgstr ""
+"Gastos por desvalorización de inventarios al costo - Envases y embalajes"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart6952
+#: model:account.account,name:l10n_pe.2_chart6952
+#: model:account.account.template,name:l10n_pe.chart6952
+msgid "Expenses for impairment of inventories at cost - Finished products"
+msgstr ""
+"Gastos por desvalorización de inventarios al costo - Productos terminados"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart6958
+#: model:account.account,name:l10n_pe.2_chart6958
+#: model:account.account.template,name:l10n_pe.chart6958
+msgid ""
+"Expenses for impairment of inventories at cost - Inventories to be received"
+msgstr ""
+"Gastos por desvalorización de inventarios al costo - Inventarios por recibir"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart6951
+#: model:account.account,name:l10n_pe.2_chart6951
+#: model:account.account.template,name:l10n_pe.chart6951
+msgid "Expenses for impairment of inventories at cost - Merchandise"
+msgstr "Gastos por desvalorización de inventarios al costo - Mercaderías"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart6954
+#: model:account.account,name:l10n_pe.2_chart6954
+#: model:account.account.template,name:l10n_pe.chart6954
+msgid "Expenses for impairment of inventories at cost - Products in process"
+msgstr ""
+"Gastos por desvalorización de inventarios al costo - Productos en proceso"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart6955
+#: model:account.account,name:l10n_pe.2_chart6955
+#: model:account.account.template,name:l10n_pe.chart6955
+msgid "Expenses for impairment of inventories at cost - Raw Materials"
+msgstr "Gastos por desvalorización de inventarios al costo - Materias primas"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart6714
+#: model:account.account,name:l10n_pe.2_chart6714
+#: model:account.account.template,name:l10n_pe.chart6714
+msgid "Expenses in debt operations and others - Documents sold or discounted"
+msgstr ""
+"Gastos en operaciones de endeudamiento y otros - Documentos vendidos o "
+"descontados"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart6712
+#: model:account.account,name:l10n_pe.2_chart6712
+#: model:account.account.template,name:l10n_pe.chart6712
+msgid "Expenses in debt operations and others - Financial lease contracts"
+msgstr ""
+"Gastos en operaciones de endeudamiento y otros - Contratos de arrendamiento "
+"financiero"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart6713
+#: model:account.account,name:l10n_pe.2_chart6713
+#: model:account.account.template,name:l10n_pe.chart6713
+msgid ""
+"Expenses in debt operations and others - Issuance and placement of "
+"instruments representing debt and equity"
+msgstr ""
+"Gastos en operaciones de endeudamiento y otros - Emisión y colocación de "
+"instrumentos representativos de deuda y patrimonio"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart6711
+#: model:account.account,name:l10n_pe.2_chart6711
+#: model:account.account.template,name:l10n_pe.chart6711
+msgid ""
+"Expenses in debt operations and others - Loans from financial institutions "
+"and other entities"
+msgstr ""
+"Gastos en operaciones de endeudamiento y otros - Préstamos de instituciones "
+"financieras y otras entidades"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart6741
+#: model:account.account,name:l10n_pe.2_chart6741
+#: model:account.account.template,name:l10n_pe.chart6741
+msgid "Expenses in factoring operations - Loss on instruments sold"
+msgstr ""
+"Gastos en operaciones de factoraje (factoring) - Pérdida en instrumentos "
+"vendidos"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart36541
+#: model:account.account,name:l10n_pe.2_chart36541
+#: model:account.account.template,name:l10n_pe.chart36541
+msgid "Exploration and development costs - Costs"
+msgstr "Costos de exploración y desarrollo - Costo"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart34421
+#: model:account.account,name:l10n_pe.2_chart34421
+#: model:account.account.template,name:l10n_pe.chart34421
+msgid "Exploration and development costs - Development costs - Costs"
+msgstr "Costos de exploración y desarrollo - Costos de desarrollo - Costo"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart34423
+#: model:account.account,name:l10n_pe.2_chart34423
+#: model:account.account.template,name:l10n_pe.chart34423
+msgid ""
+"Exploration and development costs - Development costs - Financing costs"
+msgstr ""
+"Costos de exploración y desarrollo - Costos de desarrollo - Costos de "
+"financiación"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart34422
+#: model:account.account,name:l10n_pe.2_chart34422
+#: model:account.account.template,name:l10n_pe.chart34422
+msgid "Exploration and development costs - Development costs - Revaluation"
+msgstr ""
+"Costos de exploración y desarrollo - Costos de desarrollo - Revaluación"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart34411
+#: model:account.account,name:l10n_pe.2_chart34411
+#: model:account.account.template,name:l10n_pe.chart34411
+msgid "Exploration and development costs - Exploration costs - Costs"
+msgstr "Costos de exploración y desarrollo - Costos de exploración - Costo"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart34413
+#: model:account.account,name:l10n_pe.2_chart34413
+#: model:account.account.template,name:l10n_pe.chart34413
+msgid ""
+"Exploration and development costs - Exploration costs - Financing costs"
+msgstr ""
+"Costos de exploración y desarrollo - Costos de exploración - Costos de "
+"financiación"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart34412
+#: model:account.account,name:l10n_pe.2_chart34412
+#: model:account.account.template,name:l10n_pe.chart34412
+msgid "Exploration and development costs - Exploration costs - Revaluation"
+msgstr ""
+"Costos de exploración y desarrollo - Costos de exploración - Revaluación"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart36543
+#: model:account.account,name:l10n_pe.2_chart36543
+#: model:account.account.template,name:l10n_pe.chart36543
+msgid "Exploration and development costs - Financing costs"
+msgstr "Costos de exploración y desarrollo - Costos de financiación"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart36542
+#: model:account.account,name:l10n_pe.2_chart36542
+#: model:account.account.template,name:l10n_pe.chart36542
+msgid "Exploration and development costs - Revaluation"
+msgstr "Costos de exploración y desarrollo - Revaluación"
+
+#. module: l10n_pe
+#: model:account.group,name:l10n_pe.1_group67
+#: model:account.group,name:l10n_pe.2_group67
+#: model:account.group.template,name:l10n_pe.group67
+msgid "FINANCIAL EXPENSES"
+msgstr "GASTOS FINANCIEROS"
+
+#. module: l10n_pe
+#: model:account.group,name:l10n_pe.1_group77
+#: model:account.group,name:l10n_pe.2_group77
+#: model:account.group.template,name:l10n_pe.group77
+msgid "FINANCIAL INCOME"
+msgstr "INGRESOS FINANCIEROS"
+
+#. module: l10n_pe
+#: model:account.group,name:l10n_pe.1_group11
+#: model:account.group,name:l10n_pe.2_group11
+#: model:account.group.template,name:l10n_pe.group11
+msgid "FINANCIAL INVESTMENTS"
+msgstr "INVERSIONES FINANCIERAS"
+
+#. module: l10n_pe
+#: model:account.group,name:l10n_pe.1_group45
+#: model:account.group,name:l10n_pe.2_group45
+#: model:account.group.template,name:l10n_pe.group45
+msgid "FINANCIAL OBLIGATIONS"
+msgstr "OBLIGACIONES FINANCIERAS"
+
+#. module: l10n_pe
+#: model:account.group,name:l10n_pe.1_group21
+#: model:account.group,name:l10n_pe.2_group21
+#: model:account.group.template,name:l10n_pe.group21
+msgid "FINISHED PRODUCTS"
+msgstr "PRODUCTOS TERMINADOS"
+
+#. module: l10n_pe
+#: model:account.fiscal.position,name:l10n_pe.1_exportation
+#: model:account.fiscal.position,name:l10n_pe.2_exportation
+#: model:account.fiscal.position.template,name:l10n_pe.exportation
+msgid "FOREIGN - EXPORT"
+msgstr "EXTRANJERO - EXPORTACIÓN"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart585
+#: model:account.account,name:l10n_pe.2_chart585
+#: model:account.account.template,name:l10n_pe.chart585
+msgid "Facultative"
+msgstr "Facultativas"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_160103
+msgid "Fernando Lores"
+msgstr "Fernando Lores"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_140201
+#: model:res.city,name:l10n_pe.city_pe_1402
+msgid "Ferreñafe"
+msgstr "Ferreñafe"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_021304
+msgid "Fidel Olivas Escudero"
+msgstr "Fidel Olivas Escudero"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart11311
+#: model:account.account,name:l10n_pe.2_chart11311
+#: model:account.account.template,name:l10n_pe.chart11311
+msgid ""
+"Financial assets – Purchase agreements - Investments held for trading – "
+"Purchase agreements - Costs"
+msgstr ""
+"Activos financieros – Acuerdo de compra - Inversiones mantenidas para "
+"negociación – Acuerdo de compra - Costo"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart11312
+#: model:account.account,name:l10n_pe.2_chart11312
+#: model:account.account.template,name:l10n_pe.chart11312
+msgid ""
+"Financial assets – Purchase agreements - Investments held for trading – "
+"Purchase agreements - Fair value"
+msgstr ""
+"Activos financieros – Acuerdo de compra - Inversiones mantenidas para "
+"negociación – Acuerdo de compra - Valor Razonable"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart11321
+#: model:account.account,name:l10n_pe.2_chart11321
+#: model:account.account.template,name:l10n_pe.chart11321
+msgid ""
+"Financial assets – Purchase agreements - Other financial investments - Costs"
+msgstr ""
+"Activos financieros – Acuerdo de compra - Otras inversiones financieras - "
+"Costo"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart11322
+#: model:account.account,name:l10n_pe.2_chart11322
+#: model:account.account.template,name:l10n_pe.chart11322
+msgid ""
+"Financial assets – Purchase agreements - Other financial investments - Fair "
+"value"
+msgstr ""
+"Activos financieros – Acuerdo de compra - Otras inversiones financieras - "
+"Valor Razonable"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart181
+#: model:account.account,name:l10n_pe.2_chart181
+#: model:account.account.template,name:l10n_pe.chart181
+msgid "Financial costs"
+msgstr "Costos financieros"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart792
+#: model:account.account,name:l10n_pe.2_chart792
+#: model:account.account.template,name:l10n_pe.chart792
+msgid "Financial expenses attributable to inventory accounts"
+msgstr "Gastos financieros imputables a cuentas de inventarios"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart30241
+#: model:account.account,name:l10n_pe.2_chart30241
+#: model:account.account.template,name:l10n_pe.chart30241
+msgid ""
+"Financial instruments representative of economic rights - Investment shares "
+"- Costs"
+msgstr ""
+"Financial instruments representative of economic rights - Acciones de "
+"inversión - Costo"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart30245
+#: model:account.account,name:l10n_pe.2_chart30245
+#: model:account.account.template,name:l10n_pe.chart30245
+msgid ""
+"Financial instruments representative of economic rights - Investment shares "
+"- Equity participation"
+msgstr ""
+"Instrumentos financieros representativos de derecho patrimonial - Acciones "
+"de inversión - Participación patrimonial"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart30244
+#: model:account.account,name:l10n_pe.2_chart30244
+#: model:account.account.template,name:l10n_pe.chart30244
+msgid ""
+"Financial instruments representative of economic rights - Investment shares "
+"- Fair value"
+msgstr ""
+"Instrumentos financieros representativos de derecho patrimonial - Acciones "
+"de inversión - Valor razonable"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart30281
+#: model:account.account,name:l10n_pe.2_chart30281
+#: model:account.account.template,name:l10n_pe.chart30281
+msgid ""
+"Financial instruments representative of economic rights - Other titles "
+"representing equity - Costs"
+msgstr ""
+"Instrumentos financieros representativos de derecho patrimonial - Otros "
+"títulos representativos de patrimonio - Costo"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart30285
+#: model:account.account,name:l10n_pe.2_chart30285
+#: model:account.account.template,name:l10n_pe.chart30285
+msgid ""
+"Financial instruments representative of economic rights - Other titles "
+"representing equity - Equity participation"
+msgstr ""
+"Instrumentos financieros representativos de derecho patrimonial - Otros "
+"títulos representativos de patrimonio - Participación patrimonial"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart30284
+#: model:account.account,name:l10n_pe.2_chart30284
+#: model:account.account.template,name:l10n_pe.chart30284
+msgid ""
+"Financial instruments representative of economic rights - Other titles "
+"representing equity - Fair value"
+msgstr ""
+"Instrumentos financieros representativos de derecho patrimonial - Otros "
+"títulos representativos de patrimonio - Valor razonable"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart3021
+#: model:account.account,name:l10n_pe.2_chart3021
+#: model:account.account.template,name:l10n_pe.chart3021
+msgid ""
+"Financial instruments representative of economic rights - Preferred "
+"Subscription Certificates"
+msgstr ""
+"Instrumentos financieros representativos de derecho patrimonial - "
+"Certificados de suscripción preferente"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart30221
+#: model:account.account,name:l10n_pe.2_chart30221
+#: model:account.account.template,name:l10n_pe.chart30221
+msgid ""
+"Financial instruments representative of economic rights - Shares "
+"representing capital stock – Common - Costs"
+msgstr ""
+"Instrumentos financieros representativos de derecho patrimonial - Acciones "
+"representativas de capital social – Comunes - Costo"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart30225
+#: model:account.account,name:l10n_pe.2_chart30225
+#: model:account.account.template,name:l10n_pe.chart30225
+msgid ""
+"Financial instruments representative of economic rights - Shares "
+"representing capital stock – Common - Equity participation"
+msgstr ""
+"Instrumentos financieros representativos de derecho patrimonial - Acciones "
+"representativas de capital social – Comunes - Participación patrimonial"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart30224
+#: model:account.account,name:l10n_pe.2_chart30224
+#: model:account.account.template,name:l10n_pe.chart30224
+msgid ""
+"Financial instruments representative of economic rights - Shares "
+"representing capital stock – Common - Fair value"
+msgstr ""
+"Instrumentos financieros representativos de derecho patrimonial - Acciones "
+"representativas de capital social – Comunes - Valor razonable"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart30231
+#: model:account.account,name:l10n_pe.2_chart30231
+#: model:account.account.template,name:l10n_pe.chart30231
+msgid ""
+"Financial instruments representative of economic rights - Shares "
+"representing capital stock – Preferences - Costs"
+msgstr ""
+"Instrumentos financieros representativos de derecho patrimonial - Acciones "
+"representativas de capital social – Preferentes - Costo"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart30235
+#: model:account.account,name:l10n_pe.2_chart30235
+#: model:account.account.template,name:l10n_pe.chart30235
+msgid ""
+"Financial instruments representative of economic rights - Shares "
+"representing capital stock – Preferences - Equity participation"
+msgstr ""
+"Instrumentos financieros representativos de derecho patrimonial - Acciones "
+"representativas de capital social – Preferentes - Participación patrimonial"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart30234
+#: model:account.account,name:l10n_pe.2_chart30234
+#: model:account.account.template,name:l10n_pe.chart30234
+msgid ""
+"Financial instruments representative of economic rights - Shares "
+"representing capital stock – Preferences - Fair value"
+msgstr ""
+"Instrumentos financieros representativos de derecho patrimonial - Acciones "
+"representativas de capital social – Preferentes - Valor razonable"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart562
+#: model:account.account,name:l10n_pe.2_chart562
+#: model:account.account.template,name:l10n_pe.chart562
+msgid "Financial instruments – Hedges"
+msgstr "Instrumentos financieros – Coberturas"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart36721
+#: model:account.account,name:l10n_pe.2_chart36721
+#: model:account.account.template,name:l10n_pe.chart36721
+msgid "Financial investments representative of patrimonial right - Costs"
+msgstr ""
+"Inversiones financieras representativas de derecho patrimonial - Costo"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart452
+#: model:account.account,name:l10n_pe.2_chart452
+#: model:account.account.template,name:l10n_pe.chart452
+msgid "Financial lease contracts"
+msgstr "Contratos de arrendamiento financiero"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart36221
+#: model:account.account,name:l10n_pe.1_chart36321
+#: model:account.account,name:l10n_pe.2_chart36221
+#: model:account.account,name:l10n_pe.2_chart36321
+#: model:account.account.template,name:l10n_pe.chart36221
+#: model:account.account.template,name:l10n_pe.chart36321
+msgid "Financial leasing - Buildings - Costs"
+msgstr "Arrendamiento financiero - Edificaciones - Costo"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart36223
+#: model:account.account,name:l10n_pe.1_chart36323
+#: model:account.account,name:l10n_pe.2_chart36223
+#: model:account.account,name:l10n_pe.2_chart36323
+#: model:account.account.template,name:l10n_pe.chart36223
+#: model:account.account.template,name:l10n_pe.chart36323
+msgid "Financial leasing - Buildings - Financing costs"
+msgstr "Arrendamiento financiero - Edificaciones - Costos de financiación"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart36222
+#: model:account.account,name:l10n_pe.1_chart36322
+#: model:account.account,name:l10n_pe.2_chart36222
+#: model:account.account,name:l10n_pe.2_chart36322
+#: model:account.account.template,name:l10n_pe.chart36222
+#: model:account.account.template,name:l10n_pe.chart36322
+msgid "Financial leasing - Buildings - Revaluation"
+msgstr "Arrendamiento financiero - Edificaciones - Revaluación"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart36351
+#: model:account.account,name:l10n_pe.2_chart36351
+#: model:account.account.template,name:l10n_pe.chart36351
+msgid "Financial leasing - Furniture and fixtures - Costs"
+msgstr "Arrendamiento financiero - Muebles y enseres - Costo"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart36352
+#: model:account.account,name:l10n_pe.2_chart36352
+#: model:account.account.template,name:l10n_pe.chart36352
+msgid "Financial leasing - Furniture and fixtures - Revaluation"
+msgstr "Arrendamiento financiero - Muebles y enseres - Revaluación"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart36211
+#: model:account.account,name:l10n_pe.1_chart36311
+#: model:account.account,name:l10n_pe.2_chart36211
+#: model:account.account,name:l10n_pe.2_chart36311
+#: model:account.account.template,name:l10n_pe.chart36211
+#: model:account.account.template,name:l10n_pe.chart36311
+msgid "Financial leasing - Land - Costs"
+msgstr "Arrendamiento financiero - Terrenos - Costo"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart36212
+#: model:account.account,name:l10n_pe.1_chart36312
+#: model:account.account,name:l10n_pe.2_chart36212
+#: model:account.account,name:l10n_pe.2_chart36312
+#: model:account.account.template,name:l10n_pe.chart36212
+#: model:account.account.template,name:l10n_pe.chart36312
+msgid "Financial leasing - Land - Revaluation"
+msgstr "Arrendamiento financiero - Terrenos - Revaluación"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart36331
+#: model:account.account,name:l10n_pe.2_chart36331
+#: model:account.account.template,name:l10n_pe.chart36331
+msgid "Financial leasing - Machinery and exploitation equipment - Costs"
+msgstr "Arrendamiento financiero - Maquinaria y equipo de explotación - Costo"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart36333
+#: model:account.account,name:l10n_pe.2_chart36333
+#: model:account.account.template,name:l10n_pe.chart36333
+msgid ""
+"Financial leasing - Machinery and exploitation equipment - Financing costs"
+msgstr ""
+"Arrendamiento financiero - Maquinaria y equipo de explotación - Costo de "
+"financiación"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart36332
+#: model:account.account,name:l10n_pe.2_chart36332
+#: model:account.account.template,name:l10n_pe.chart36332
+msgid "Financial leasing - Machinery and exploitation equipment - Revaluation"
+msgstr ""
+"Arrendamiento financiero - Maquinaria y equipo de explotación - Revaluación"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart36361
+#: model:account.account,name:l10n_pe.2_chart36361
+#: model:account.account.template,name:l10n_pe.chart36361
+msgid "Financial leasing - Miscellaneous equipment - Costs"
+msgstr "Arrendamiento financiero - Equipos diversos - Costo"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart36362
+#: model:account.account,name:l10n_pe.2_chart36362
+#: model:account.account.template,name:l10n_pe.chart36362
+msgid "Financial leasing - Miscellaneous equipment - Revaluation"
+msgstr "Arrendamiento financiero - Equipos diversos - Revaluación"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart36341
+#: model:account.account,name:l10n_pe.2_chart36341
+#: model:account.account.template,name:l10n_pe.chart36341
+msgid "Financial leasing - Transport units - Costs"
+msgstr "Arrendamiento financiero - Unidades de transporte - Costo"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart36342
+#: model:account.account,name:l10n_pe.2_chart36342
+#: model:account.account.template,name:l10n_pe.chart36342
+msgid "Financial leasing - Transport units - Revaluation"
+msgstr "Arrendamiento financiero - Unidades de transporte - Revaluación"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart472
+#: model:account.account,name:l10n_pe.2_chart472
+#: model:account.account.template,name:l10n_pe.chart472
+msgid "Financing costs"
+msgstr "Costos de financiación"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart45532
+#: model:account.account,name:l10n_pe.2_chart45532
+#: model:account.account.template,name:l10n_pe.chart45532
+msgid "Financing costs payable - Bonds issued - Bonds securitized"
+msgstr ""
+"Costos de financiación por pagar - Obligaciones emitidas - Bonos titulizados"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart45533
+#: model:account.account,name:l10n_pe.2_chart45533
+#: model:account.account.template,name:l10n_pe.chart45533
+msgid "Financing costs payable - Bonds issued - Commercial papers"
+msgstr ""
+"Costos de financiación por pagar - Obligaciones emitidas - Papeles "
+"comerciales"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart45531
+#: model:account.account,name:l10n_pe.2_chart45531
+#: model:account.account.template,name:l10n_pe.chart45531
+msgid "Financing costs payable - Bonds issued - Issued bonds"
+msgstr ""
+"Costos de financiación por pagar - Obligaciones emitidas - Bonos emitidos"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart45539
+#: model:account.account,name:l10n_pe.2_chart45539
+#: model:account.account.template,name:l10n_pe.chart45539
+msgid "Financing costs payable - Bonds issued - Other obligations"
+msgstr ""
+"Costos de financiación por pagar - Obligaciones emitidas - Otras "
+"obligaciones"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart4552
+#: model:account.account,name:l10n_pe.2_chart4552
+#: model:account.account.template,name:l10n_pe.chart4552
+msgid "Financing costs payable - Financial lease contracts"
+msgstr ""
+"Costos de financiación por pagar - Contratos de arrendamiento financiero"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart45511
+#: model:account.account,name:l10n_pe.2_chart45511
+#: model:account.account.template,name:l10n_pe.chart45511
+msgid ""
+"Financing costs payable - Loans from financial institutions and other "
+"entities - Financial institutions"
+msgstr ""
+"Costos de financiación por pagar - Préstamos de instituciones financieras y "
+"otras entidades - Instituciones financieras"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart45512
+#: model:account.account,name:l10n_pe.2_chart45512
+#: model:account.account.template,name:l10n_pe.chart45512
+msgid ""
+"Financing costs payable - Loans from financial institutions and other "
+"entities - Other entities"
+msgstr ""
+"Costos de financiación por pagar - Préstamos de instituciones financieras y "
+"otras entidades - Otras entidades"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart45541
+#: model:account.account,name:l10n_pe.2_chart45541
+#: model:account.account.template,name:l10n_pe.chart45541
+msgid "Financing costs payable - Other financial instruments payable - Bills"
+msgstr ""
+"Costos de financiación por pagar - Otros instrumentos financieros por pagar "
+"- Letras"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart45543
+#: model:account.account,name:l10n_pe.2_chart45543
+#: model:account.account.template,name:l10n_pe.chart45543
+msgid "Financing costs payable - Other financial instruments payable - Bonds"
+msgstr ""
+"Costos de financiación por pagar - Otros instrumentos financieros por pagar "
+"- Bonos"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart45542
+#: model:account.account,name:l10n_pe.2_chart45542
+#: model:account.account.template,name:l10n_pe.chart45542
+msgid ""
+"Financing costs payable - Other financial instruments payable - Commercial "
+"papers"
+msgstr ""
+"Costos de financiación por pagar - Otros instrumentos financieros por pagar "
+"- Papeles comerciales"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart45545
+#: model:account.account,name:l10n_pe.2_chart45545
+#: model:account.account.template,name:l10n_pe.chart45545
+msgid ""
+"Financing costs payable - Other financial instruments payable - Conformed "
+"invoices"
+msgstr ""
+"Costos de financiación por pagar - Otros instrumentos financieros por pagar "
+"- Facturas conformadas"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart45549
+#: model:account.account,name:l10n_pe.2_chart45549
+#: model:account.account.template,name:l10n_pe.chart45549
+msgid ""
+"Financing costs payable - Other financial instruments payable - Other "
+"financial obligations"
+msgstr ""
+"Costos de financiación por pagar - Otros instrumentos financieros por pagar "
+"- Otras obligaciones financieras"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart45544
+#: model:account.account,name:l10n_pe.2_chart45544
+#: model:account.account.template,name:l10n_pe.chart45544
+msgid ""
+"Financing costs payable - Other financial instruments payable - Promissory "
+"notes"
+msgstr ""
+"Costos de financiación por pagar - Otros instrumentos financieros por pagar "
+"- Pagarés"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart6925
+#: model:account.account,name:l10n_pe.2_chart6925
+#: model:account.account.template,name:l10n_pe.chart6925
+msgid "Finished products - Cost of inefficiency – Finished products"
+msgstr "Productos terminados - Costo de ineficiencia – Finished products"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart69232
+#: model:account.account,name:l10n_pe.2_chart69232
+#: model:account.account.template,name:l10n_pe.chart69232
+msgid "Finished products - Financing costs – Finished products - Associated"
+msgstr ""
+"Productos terminados - Costos de financiación - Productos terminados - "
+"Relacionadas"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart69231
+#: model:account.account,name:l10n_pe.2_chart69231
+#: model:account.account.template,name:l10n_pe.chart69231
+msgid ""
+"Finished products - Financing costs – Finished products - Third parties"
+msgstr ""
+"Productos terminados - Costos de financiación - Productos terminados - "
+"Terceros"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart21111
+#: model:account.account,name:l10n_pe.1_chart29211
+#: model:account.account,name:l10n_pe.2_chart21111
+#: model:account.account,name:l10n_pe.2_chart29211
+#: model:account.account.template,name:l10n_pe.chart21111
+#: model:account.account.template,name:l10n_pe.chart29211
+msgid "Finished products - Finished products - Costs"
+msgstr "Productos terminados - Productos terminados - Costo"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart70212
+#: model:account.account,name:l10n_pe.2_chart70212
+#: model:account.account.template,name:l10n_pe.chart70212
+msgid "Finished products - Finished products - Export sale - Associated"
+msgstr ""
+"Productos terminados - Productos terminados - Venta de exportación - "
+"Relacionadas"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart70211
+#: model:account.account,name:l10n_pe.2_chart70211
+#: model:account.account.template,name:l10n_pe.chart70211
+msgid "Finished products - Finished products - Export sale - Third parties"
+msgstr ""
+"Productos terminados - Productos terminados - Venta de exportación - "
+"Terceros"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart69212
+#: model:account.account,name:l10n_pe.2_chart69212
+#: model:account.account.template,name:l10n_pe.chart69212
+msgid "Finished products - Finished products - Exportation - Associated"
+msgstr ""
+"Productos terminados - Productos terminados - Exportación - Relacionadas"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart69211
+#: model:account.account,name:l10n_pe.2_chart69211
+#: model:account.account.template,name:l10n_pe.chart69211
+msgid "Finished products - Finished products - Exportation - Third parties"
+msgstr "Productos terminados - Productos terminados - Exportación - Terceros"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart21114
+#: model:account.account,name:l10n_pe.2_chart21114
+#: model:account.account.template,name:l10n_pe.chart21114
+msgid "Finished products - Finished products - Fair value"
+msgstr "Productos terminados - Productos terminados - Fair value"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart21113
+#: model:account.account,name:l10n_pe.1_chart29213
+#: model:account.account,name:l10n_pe.2_chart21113
+#: model:account.account,name:l10n_pe.2_chart29213
+#: model:account.account.template,name:l10n_pe.chart21113
+#: model:account.account.template,name:l10n_pe.chart29213
+msgid "Finished products - Finished products - Financing costs"
+msgstr "Productos terminados - Productos terminados - Costos de financiación"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart69222
+#: model:account.account,name:l10n_pe.1_chart70222
+#: model:account.account,name:l10n_pe.2_chart69222
+#: model:account.account,name:l10n_pe.2_chart70222
+#: model:account.account.template,name:l10n_pe.chart69222
+#: model:account.account.template,name:l10n_pe.chart70222
+msgid "Finished products - Finished products - Local sale - Associated"
+msgstr ""
+"Productos terminados - Productos terminados - Venta local - Relacionadas"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart69221
+#: model:account.account,name:l10n_pe.1_chart70221
+#: model:account.account,name:l10n_pe.2_chart69221
+#: model:account.account,name:l10n_pe.2_chart70221
+#: model:account.account.template,name:l10n_pe.chart69221
+#: model:account.account.template,name:l10n_pe.chart70221
+msgid "Finished products - Finished products - Local sale - Third parties"
+msgstr "Productos terminados - Productos terminados - Venta local - Terceros"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart29251
+#: model:account.account,name:l10n_pe.2_chart29251
+#: model:account.account.template,name:l10n_pe.chart29251
+msgid "Finished products - Inventory of finished services - Costs"
+msgstr "Productos terminados - Inventario de servicios terminados - Costo"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart6924
+#: model:account.account,name:l10n_pe.2_chart6924
+#: model:account.account.template,name:l10n_pe.chart6924
+msgid "Finished products - Unabsorbed production costs – Finished products"
+msgstr ""
+"Productos terminados - Costos de producción no absorbido – Productos "
+"terminados"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart69312
+#: model:account.account,name:l10n_pe.1_chart70312
+#: model:account.account,name:l10n_pe.2_chart69312
+#: model:account.account,name:l10n_pe.2_chart70312
+#: model:account.account.template,name:l10n_pe.chart69312
+#: model:account.account.template,name:l10n_pe.chart70312
+msgid "Finished services - Services – Exportation - Associated"
+msgstr "Servicios terminados - Servicios – Exportación - Relacionadas"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart69311
+#: model:account.account,name:l10n_pe.1_chart70311
+#: model:account.account,name:l10n_pe.2_chart69311
+#: model:account.account,name:l10n_pe.2_chart70311
+#: model:account.account.template,name:l10n_pe.chart69311
+#: model:account.account.template,name:l10n_pe.chart70311
+msgid "Finished services - Services – Exportation - Third parties"
+msgstr "Servicios terminados - Servicios – exportación - Terceros"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart69322
+#: model:account.account,name:l10n_pe.1_chart70322
+#: model:account.account,name:l10n_pe.2_chart69322
+#: model:account.account,name:l10n_pe.2_chart70322
+#: model:account.account.template,name:l10n_pe.chart69322
+#: model:account.account.template,name:l10n_pe.chart70322
+msgid "Finished services - Services – Local - Associated"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart69321
+#: model:account.account,name:l10n_pe.1_chart70321
+#: model:account.account,name:l10n_pe.2_chart69321
+#: model:account.account,name:l10n_pe.2_chart70321
+#: model:account.account.template,name:l10n_pe.chart69321
+#: model:account.account.template,name:l10n_pe.chart70321
+msgid "Finished services - Services – Local - Third parties"
+msgstr "Servicios terminados - Servicios – Local - Terceros"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_170202
+msgid "Fitzcarrald"
+msgstr "Fitzcarrald"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart6622
+#: model:account.account,name:l10n_pe.1_chart7622
+#: model:account.account,name:l10n_pe.2_chart6622
+#: model:account.account,name:l10n_pe.2_chart7622
+#: model:account.account.template,name:l10n_pe.chart6622
+#: model:account.account.template,name:l10n_pe.chart7622
+msgid "Fixed asset - Biological assets"
+msgstr "Activo inmovilizado - Activos biológicos"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart6621
+#: model:account.account,name:l10n_pe.1_chart7621
+#: model:account.account,name:l10n_pe.2_chart6621
+#: model:account.account,name:l10n_pe.2_chart7621
+#: model:account.account.template,name:l10n_pe.chart6621
+#: model:account.account.template,name:l10n_pe.chart7621
+msgid "Fixed asset - Investment property"
+msgstr "Activo inmovilizado - Propiedades de inversión"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart102
+#: model:account.account,name:l10n_pe.2_chart102
+#: model:account.account.template,name:l10n_pe.chart102
+msgid "Fixed funds"
+msgstr "Fondos fijos"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart1031
+#: model:account.account,name:l10n_pe.2_chart1031
+#: model:account.account.template,name:l10n_pe.chart1031
+msgid "Fixed funds - Cash in transit"
+msgstr "Fondos fijos - Efectivo en tránsito"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart1032
+#: model:account.account,name:l10n_pe.2_chart1032
+#: model:account.account.template,name:l10n_pe.chart1032
+msgid "Fixed funds - Checks in transit"
+msgstr "Fondos fijos - Cheques en tránsito"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_130103
+msgid "Florencia de Mora"
+msgstr "Florencia de Mora"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_010306
+msgid "Florida"
+msgstr "Florida"
+
+#. module: l10n_pe
 #: model:ir.model.fields,help:l10n_pe.field_account_tax_template__l10n_pe_edi_unece_category
 msgid ""
 "Follow the UN/ECE 5305 standard from the United Nations Economic Commission "
 "for Europe for more information  "
 "http://www.unece.org/trade/untdid/d08a/tred/tred5305.htm"
 msgstr ""
-"Estandard UN/ECE 5305 de las Comisión Económica de las Naciones Unidas para Europa"
-"para mas información consulta este enlace"
-"http://www.unece.org/trade/untdid/d08a/tred/tred5305.htm"
+"Siga el estándar UNECE 5305 de la Comisión Económica de las Naciones Unidas "
+"para Europa para más información "
+"http:www.unece.orgtradeuntdidd08atredtred5305.htm"
 
 #. module: l10n_pe
 #: model:ir.model.fields,help:l10n_pe.field_account_tax__l10n_pe_edi_unece_category
@@ -109,15 +7969,116 @@ msgid ""
 "for Europe for more information "
 "http://www.unece.org/trade/untdid/d08a/tred/tred5305.htm"
 msgstr ""
-"Estándar UN/ECE 5305 de las Comisión Económica de las Naciones Unidas para Europa"
-"para mas información consulta este enlace"
-"http://www.unece.org/trade/untdid/d08a/tred/tred5305.htm"
+"Siga el estándar UNECE 5305 de la Comisión Económica de las Naciones Unidas "
+"para Europa para más información "
+"http:www.unece.orgtradeuntdidd08atredtred5305.htm"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart36551
+#: model:account.account,name:l10n_pe.2_chart36551
+#: model:account.account.template,name:l10n_pe.chart36551
+msgid "Formulas, designs and prototypes - Costs"
+msgstr "Fórmulas, diseños y prototipos - Costo"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart34521
+#: model:account.account,name:l10n_pe.2_chart34521
+#: model:account.account.template,name:l10n_pe.chart34521
+msgid "Formulas, designs and prototypes - Designs and prototypes - Costs"
+msgstr "Fórmulas, diseños y prototipos - Diseños y prototipos - Costo"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart34522
+#: model:account.account,name:l10n_pe.2_chart34522
+#: model:account.account.template,name:l10n_pe.chart34522
+msgid ""
+"Formulas, designs and prototypes - Designs and prototypes - Revaluation"
+msgstr "Fórmulas, diseños y prototipos - Diseños y prototipos - Revaluación"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart34511
+#: model:account.account,name:l10n_pe.2_chart34511
+#: model:account.account.template,name:l10n_pe.chart34511
+msgid "Formulas, designs and prototypes - Formulas - Costs"
+msgstr "Fórmulas, diseños y prototipos - Fórmulas - Costo"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart34512
+#: model:account.account,name:l10n_pe.2_chart34512
+#: model:account.account.template,name:l10n_pe.chart34512
+msgid "Formulas, designs and prototypes - Formulas - Revaluation"
+msgstr "Fórmulas, diseños y prototipos - Fórmulas - Revaluación"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart36552
+#: model:account.account,name:l10n_pe.2_chart36552
+#: model:account.account.template,name:l10n_pe.chart36552
+msgid "Formulas, designs and prototypes - Revaluation"
+msgstr "Fórmulas, diseños y prototipos - Revaluación"
 
 #. module: l10n_pe
 #: model:ir.model.fields.selection,name:l10n_pe.selection__account_tax__l10n_pe_edi_unece_category__g
 #: model:ir.model.fields.selection,name:l10n_pe.selection__account_tax_template__l10n_pe_edi_unece_category__g
 msgid "Free export item, tax not charged"
-msgstr "Articulo de exportación, libre de impuestos."
+msgstr "Artículo de exportación gratuita, impuesto no cobrado"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_200202
+msgid "Frias"
+msgstr "Frias"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart36451
+#: model:account.account,name:l10n_pe.2_chart36451
+#: model:account.account.template,name:l10n_pe.chart36451
+msgid "Furniture and fixtures - Costs"
+msgstr "Muebles y enseres - Costo"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart33521
+#: model:account.account,name:l10n_pe.2_chart33521
+#: model:account.account.template,name:l10n_pe.chart33521
+msgid "Furniture and fixtures - Equipment - Costs"
+msgstr "Muebles y enseres - Enseres - Costo"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart33522
+#: model:account.account,name:l10n_pe.2_chart33522
+#: model:account.account.template,name:l10n_pe.chart33522
+msgid "Furniture and fixtures - Equipment - Revaluation"
+msgstr "Muebles y enseres - Enseres - Revaluación"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart33511
+#: model:account.account,name:l10n_pe.2_chart33511
+#: model:account.account.template,name:l10n_pe.chart33511
+msgid "Furniture and fixtures - Furnitures - Costs"
+msgstr "Muebles y enseres - Muebles - Costo"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart33512
+#: model:account.account,name:l10n_pe.2_chart33512
+#: model:account.account.template,name:l10n_pe.chart33512
+msgid "Furniture and fixtures - Furnitures - Revaluation"
+msgstr "Muebles y enseres - Muebles - Revaluación"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart36452
+#: model:account.account,name:l10n_pe.2_chart36452
+#: model:account.account.template,name:l10n_pe.chart36452
+msgid "Furniture and fixtures - Revaluation"
+msgstr "Muebles y enseres - Revaluación"
+
+#. module: l10n_pe
+#: model:account.tax,description:l10n_pe.1_purchase_tax_gra
+#: model:account.tax,description:l10n_pe.1_sale_tax_gra
+#: model:account.tax,description:l10n_pe.2_purchase_tax_gra
+#: model:account.tax,description:l10n_pe.2_sale_tax_gra
+#: model:account.tax.group,name:l10n_pe.tax_group_gra
+#: model:account.tax.template,description:l10n_pe.purchase_tax_gra
+#: model:account.tax.template,description:l10n_pe.sale_tax_gra
+msgid "GRA"
+msgstr "GRA"
 
 #. module: l10n_pe
 #: model:ir.model.fields.selection,name:l10n_pe.selection__account_tax__l10n_pe_edi_tax_code__9996
@@ -126,16 +8087,899 @@ msgid "GRA - Free"
 msgstr "GRA - Gratuito"
 
 #. module: l10n_pe
+#: model:account.group,name:l10n_pe.1_group83
+#: model:account.group,name:l10n_pe.2_group83
+#: model:account.group.template,name:l10n_pe.group83
+msgid "GROSS SURPLUS (GROSS LACK) FROM OPERATING"
+msgstr "EXCEDENTE BRUTO (INSUFICIENCIA BRUTA) DE EXPLOTACIÓN"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart7771
+#: model:account.account,name:l10n_pe.2_chart7771
+#: model:account.account.template,name:l10n_pe.chart7771
+msgid ""
+"Gain from measuring financial assets and liabilities at fair value - "
+"Investments held for trading"
+msgstr ""
+"Ganancia por medición de activos y pasivos financieros al valor razonable - "
+"Inversiones mantenidas para negociación"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart7772
+#: model:account.account,name:l10n_pe.2_chart7772
+#: model:account.account.template,name:l10n_pe.chart7772
+msgid ""
+"Gain from measuring financial assets and liabilities at fair value - Other "
+"investments"
+msgstr ""
+"Ganancia por medición de activos y pasivos financieros al valor razonable - "
+"Otras inversiones"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart7773
+#: model:account.account,name:l10n_pe.2_chart7773
+#: model:account.account.template,name:l10n_pe.chart7773
+msgid ""
+"Gain from measuring financial assets and liabilities at fair value - Others"
+msgstr ""
+"Ganancia por medición de activos y pasivos financieros al valor razonable - "
+"Others"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart771
+#: model:account.account,name:l10n_pe.2_chart771
+#: model:account.account.template,name:l10n_pe.chart771
+msgid "Gain on derivative financial instrument"
+msgstr "Ganancia por instrumento financiero derivado"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_030703
+msgid "Gamarra"
+msgstr "Gamarra"
+
+#. module: l10n_pe
+#: model:res.city,name:l10n_pe.city_pe_1802
+msgid "General Sánchez Cerro"
+msgstr "General Sánchez Cerro"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart0111
+#: model:account.account,name:l10n_pe.1_chart0211
+#: model:account.account,name:l10n_pe.2_chart0111
+#: model:account.account,name:l10n_pe.2_chart0211
+#: model:account.account.template,name:l10n_pe.chart0111
+#: model:account.account.template,name:l10n_pe.chart0211
+msgid "Goods and securities delivered"
+msgstr "Bienes y valores entregados"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart0126
+#: model:account.account,name:l10n_pe.1_chart0226
+#: model:account.account,name:l10n_pe.2_chart0126
+#: model:account.account,name:l10n_pe.2_chart0226
+#: model:account.account.template,name:l10n_pe.chart0126
+#: model:account.account.template,name:l10n_pe.chart0226
+msgid "Goods and values received"
+msgstr "Bienes y valores recibidos"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart3657
+#: model:account.account,name:l10n_pe.2_chart3657
+#: model:account.account.template,name:l10n_pe.chart3657
+msgid "Goodwill"
+msgstr "Plusvalía mercantil"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart3471
+#: model:account.account,name:l10n_pe.2_chart3471
+#: model:account.account.template,name:l10n_pe.chart3471
+msgid "Goodwill - Goodwill"
+msgstr "Plusvalía mercantil - Plusvalía mercantil"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_150303
+msgid "Gorgor"
+msgstr "Gorgor"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_190203
+msgid "Goyllarisquizga"
+msgstr "Goyllarisquizga"
+
+#. module: l10n_pe
+#: model:res.city,name:l10n_pe.city_pe_1311
+msgid "Gran Chimú"
+msgstr "Gran Chimú"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_010107
+msgid "Granada"
+msgstr "Granada"
+
+#. module: l10n_pe
+#: model:res.city,name:l10n_pe.city_pe_0307
+msgid "Grau"
+msgstr "Grau"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_061004
+msgid "Gregorio Pita"
+msgstr "Gregorio Pita"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_110206
+msgid "Grocio Prado"
+msgstr "Grocio Prado"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart831
+#: model:account.account,name:l10n_pe.2_chart831
+#: model:account.account.template,name:l10n_pe.chart831
+msgid "Gross surplus (gross deficiency) of exploitation"
+msgstr "Excedente bruto (insuficiencia bruta) de explotación"
+
+#. module: l10n_pe
+#: model:ir.model.fields,field_description:l10n_pe.field_account_move_line__l10n_pe_group_id
+msgid "Group"
+msgstr "Grupo"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_130702
+msgid "Guadalupe"
+msgstr "Guadalupe"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_131203
+msgid "Guadalupito"
+msgstr "Guadalupito"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_060504
+msgid "Guzmángo"
+msgstr "Guzmángo"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_220103
+msgid "Habana"
+msgstr "Habana"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_030504
+msgid "Haquira"
+msgstr "Haquira"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_100603
+msgid "Hermílio Valdizan"
+msgstr "Hermílio Valdizan"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_230402
+msgid "Heroes Albarracín"
+msgstr "Heroes Albarracín"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_120207
+msgid "Heroínas Toledo"
+msgstr "Heroínas Toledo"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_151012
+msgid "Hongos"
+msgstr "Hongos"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_100903
+msgid "Honoria"
+msgstr "Honoria"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart424
+#: model:account.account,name:l10n_pe.2_chart424
+#: model:account.account.template,name:l10n_pe.chart424
+msgid "Honors to be payed"
+msgstr "Honorarios por pagar"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart4341
+#: model:account.account,name:l10n_pe.2_chart4341
+#: model:account.account.template,name:l10n_pe.chart4341
+msgid "Honors to be payed - Honors to be payed"
+msgstr "Honorarios por pagar - Honorarios por pagar"
+
+#. module: l10n_pe
+#: model:res.city,name:l10n_pe.city_pe_1201
+msgid "Hua ncayo"
+msgstr "Hua ncayo"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_060805
+msgid "Huabal"
+msgstr "Huabal"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_050607
+msgid "Huac-Huas"
+msgstr "Huac-Huas"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_021005
+msgid "Huacachi"
+msgstr "Huacachi"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_100205
+msgid "Huacar"
+msgstr "Huacar"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_021504
+msgid "Huacaschuque"
+msgstr "Huacaschuque"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_100401
+#: model:res.city,name:l10n_pe.city_pe_1004
+msgid "Huacaybamba"
+msgstr "Huacaybamba"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_050905
+msgid "Huacaña"
+msgstr "Huacaña"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_030604
+msgid "Huaccana"
+msgstr "Huaccana"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_021006
+msgid "Huacchis"
+msgstr "Huacchis"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_120904
+msgid "Huachac"
+msgstr "Huachac"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_021007
+msgid "Huachis"
+msgstr "Huachis"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_150801
+msgid "Huacho"
+msgstr "Huacho"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_090106
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_090707
+msgid "Huachocolpa"
+msgstr "Huachocolpa"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_190102
+msgid "Huachon"
+msgstr "Huachon"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_090407
+msgid "Huachos"
+msgstr "Huachos"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_150707
+msgid "Huachupampa"
+msgstr "Huachupampa"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_020203
+msgid "Huacllan"
+msgstr "Huacllan"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_100701
+msgid "Huacrachuco"
+msgstr "Huacrachuco"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_120116
+msgid "Huacrapuquio"
+msgstr "Huacrapuquio"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_210403
+msgid "Huacullani"
+msgstr "Huacullani"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_060703
+#: model:res.city,name:l10n_pe.city_pe_0607
+msgid "Hualgayoc"
+msgstr "Hualgayoc"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_120117
+msgid "Hualhuas"
+msgstr "Hualhuas"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_220204
+#: model:res.city,name:l10n_pe.city_pe_2204
+msgid "Huallaga"
+msgstr "Huallaga"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_020508
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_021202
+msgid "Huallanca"
+msgstr "Huallanca"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_150805
+msgid "Hualmay"
+msgstr "Hualmay"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_130901
+msgid "Huamachuco"
+msgstr "Huamachuco"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_120408
+msgid "Huamali"
+msgstr "Huamali"
+
+#. module: l10n_pe
+#: model:res.city,name:l10n_pe.city_pe_1005
+msgid "Huamalies"
+msgstr "Huamalies"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_120905
+msgid "Huamancaca Chico"
+msgstr "Huamancaca Chico"
+
+#. module: l10n_pe
+#: model:res.city,name:l10n_pe.city_pe_0501
+msgid "Huamanga"
+msgstr "Huamanga"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_050403
+msgid "Huamanguilla"
+msgstr "Huamanguilla"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_051008
+msgid "Huamanquiquia"
+msgstr "Huamanquiquia"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_150403
+msgid "Huamantanga"
+msgstr "Huamantanga"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_090408
+msgid "Huamatambo"
+msgstr "Huamatambo"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_051105
+msgid "Huambalpa"
+msgstr "Huambalpa"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_010604
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_040507
+msgid "Huambo"
+msgstr "Huambo"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_060409
+msgid "Huambos"
+msgstr "Huambos"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_151013
+msgid "Huampara"
+msgstr "Huampara"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_040508
+msgid "Huanca"
+msgstr "Huanca"
+
+#. module: l10n_pe
+#: model:res.city,name:l10n_pe.city_pe_0503
+msgid "Huanca Sancos"
+msgstr "Huanca Sancos"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_090307
+msgid "Huanca-Huanca"
+msgstr "Huanca-Huanca"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_190303
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_200301
+#: model:res.city,name:l10n_pe.city_pe_2003
+msgid "Huancabamba"
+msgstr "Huancabamba"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_120119
+msgid "Huancan"
+msgstr "Huancan"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_210601
+msgid "Huancane"
+msgstr "Huancane"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_110502
+msgid "Huancano"
+msgstr "Huancano"
+
+#. module: l10n_pe
+#: model:res.city,name:l10n_pe.city_pe_2106
+msgid "Huancané"
+msgstr "Huancané"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_051001
+msgid "Huancapi"
+msgstr "Huancapi"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_150304
+msgid "Huancapon"
+msgstr "Huancapon"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_030204
+msgid "Huancarama"
+msgstr "Huancarama"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_081105
+msgid "Huancarani"
+msgstr "Huancarani"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_030205
+msgid "Huancaray"
+msgstr "Huancaray"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_051009
+msgid "Huancaraylla"
+msgstr "Huancaraylla"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_040407
+msgid "Huancarqui"
+msgstr "Huancarqui"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_010108
+msgid "Huancas"
+msgstr "Huancas"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_130804
+msgid "Huancaspata"
+msgstr "Huancaspata"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_090101
+#: model:res.city,name:l10n_pe.city_pe_0901
+msgid "Huancavelica"
+msgstr "Huancavelica"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_151014
+msgid "Huancaya"
+msgstr "Huancaya"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_120101
+msgid "Huancayo"
+msgstr "Huancayo"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_130104
+msgid "Huanchaco"
+msgstr "Huanchaco"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_020104
+msgid "Huanchay"
+msgstr "Huanchay"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_090119
+msgid "Huando"
+msgstr "Huando"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_021505
+msgid "Huandoval"
+msgstr "Huandoval"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_151015
+msgid "Huangascar"
+msgstr "Huangascar"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_030105
+msgid "Huanipaca"
+msgstr "Huanipaca"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_081005
+msgid "Huanoquite"
+msgstr "Huanoquite"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_050401
+#: model:res.city,name:l10n_pe.city_pe_0504
+msgid "Huanta"
+msgstr "Huanta"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_151016
+msgid "Huantan"
+msgstr "Huantan"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_021008
+msgid "Huantar"
+msgstr "Huantar"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_230205
+msgid "Huanuara"
+msgstr "Huanuara"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_100101
+msgid "Huanuco"
+msgstr "Huanuco"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_040309
+msgid "Huanuhuanu"
+msgstr "Huanuhuanu"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_150708
+msgid "Huanza"
+msgstr "Huanza"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_030303
+msgid "Huaquirca"
+msgstr "Huaquirca"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_150601
+#: model:res.city,name:l10n_pe.city_pe_1506
+msgid "Huaral"
+msgstr "Huaral"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_130605
+msgid "Huaranchal"
+msgstr "Huaranchal"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_060903
+msgid "Huarango"
+msgstr "Huarango"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_020101
+#: model:res.city,name:l10n_pe.city_pe_0201
+msgid "Huaraz"
+msgstr "Huaraz"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_021001
+#: model:res.city,name:l10n_pe.city_pe_0210
+msgid "Huari"
+msgstr "Huari"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_190103
+msgid "Huariaca"
+msgstr "Huariaca"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_090709
+msgid "Huaribamba"
+msgstr "Huaribamba"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_120703
+msgid "Huaricolca"
+msgstr "Huaricolca"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_120409
+msgid "Huaripampa"
+msgstr "Huaripampa"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_021101
+#: model:res.city,name:l10n_pe.city_pe_0211
+msgid "Huarmey"
+msgstr "Huarmey"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_081207
+msgid "Huaro"
+msgstr "Huaro"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_150709
+#: model:res.city,name:l10n_pe.city_pe_1507
+msgid "Huarochiri"
+msgstr "Huarochiri"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_080305
+msgid "Huarocondo"
+msgstr "Huarocondo"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_150404
+msgid "Huaros"
+msgstr "Huaros"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_120704
+msgid "Huasahuasi"
+msgstr "Huasahuasi"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_120120
+msgid "Huasicancha"
+msgstr "Huasicancha"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_060304
+msgid "Huasmin"
+msgstr "Huasmin"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_130504
+msgid "Huaso"
+msgstr "Huaso"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_020509
+msgid "Huasta"
+msgstr "Huasta"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_021203
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_210108
+msgid "Huata"
+msgstr "Huata"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_210603
+msgid "Huatasani"
+msgstr "Huatasani"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_150806
+#: model:res.city,name:l10n_pe.city_pe_1508
+msgid "Huaura"
+msgstr "Huaura"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_120803
+msgid "Huay-Huay"
+msgstr "Huay-Huay"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_051010
+msgid "Huaya"
+msgstr "Huaya"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_090604
+msgid "Huayacundo Arma"
+msgstr "Huayacundo Arma"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_021104
+msgid "Huayan"
+msgstr "Huayan"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_030206
+msgid "Huayana"
+msgstr "Huayana"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_021204
+#: model:res.city,name:l10n_pe.city_pe_0212
+msgid "Huaylas"
+msgstr "Huaylas"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_130805
+msgid "Huaylillas"
+msgstr "Huaylillas"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_021906
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_081303
+msgid "Huayllabamba"
+msgstr "Huayllabamba"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_020510
+msgid "Huayllacayan"
+msgstr "Huayllacayan"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_090107
+msgid "Huayllahuara"
+msgstr "Huayllahuara"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_021602
+msgid "Huayllan"
+msgstr "Huayllan"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_021704
+msgid "Huayllapampa"
+msgstr "Huayllapampa"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_030704
+msgid "Huayllati"
+msgstr "Huayllati"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_190104
+msgid "Huayllay"
+msgstr "Huayllay"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_090308
+msgid "Huayllay Grande"
+msgstr "Huayllay Grande"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_030407
+msgid "Huayllo"
+msgstr "Huayllo"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_040804
+msgid "Huaynacotas"
+msgstr "Huaynacotas"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_130806
+msgid "Huayo"
+msgstr "Huayo"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_080903
+msgid "Huayopata"
+msgstr "Huayopata"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_210903
+msgid "Huayrapata"
+msgstr "Huayrapata"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_090601
+msgid "Huaytara"
+msgstr "Huaytara"
+
+#. module: l10n_pe
+#: model:res.city,name:l10n_pe.city_pe_0906
+msgid "Huaytará"
+msgstr "Huaytará"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_120121
+msgid "Huayucachi"
+msgstr "Huayucachi"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_151017
+msgid "Huañec"
+msgstr "Huañec"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_170204
+msgid "Huepetuhe"
+msgstr "Huepetuhe"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_120410
+msgid "Huertas"
+msgstr "Huertas"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_220603
+msgid "Huicungo"
+msgstr "Huicungo"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_220907
+msgid "Huimbayoc"
+msgstr "Huimbayoc"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_110503
+msgid "Humay"
+msgstr "Humay"
+
+#. module: l10n_pe
+#: model:res.city,name:l10n_pe.city_pe_1001
+msgid "Huánuco"
+msgstr "Huánuco"
+
+#. module: l10n_pe
 #: model:ir.model.fields.selection,name:l10n_pe.selection__account_tax__l10n_pe_edi_tax_code__7152
 #: model:ir.model.fields.selection,name:l10n_pe.selection__account_tax_template__l10n_pe_edi_tax_code__7152
 msgid "ICBPER - Plastic bag tax"
-msgstr "ICBPER - Impuesto a la bolsa plastica"
+msgstr "ICBPER - Impuesto a las bolsas de plástico"
+
+#. module: l10n_pe
+#: model:ir.model.fields,field_description:l10n_pe.field_l10n_pe_res_city_district__id
+msgid "ID"
+msgstr "ID"
+
+#. module: l10n_pe
+#: model:account.tax,description:l10n_pe.1_purchase_tax_igv_18
+#: model:account.tax,description:l10n_pe.1_purchase_tax_igv_18_included
+#: model:account.tax,description:l10n_pe.1_sale_tax_igv_18
+#: model:account.tax,description:l10n_pe.1_sale_tax_igv_18_included
+#: model:account.tax,description:l10n_pe.2_purchase_tax_igv_18
+#: model:account.tax,description:l10n_pe.2_purchase_tax_igv_18_included
+#: model:account.tax,description:l10n_pe.2_sale_tax_igv_18
+#: model:account.tax,description:l10n_pe.2_sale_tax_igv_18_included
+#: model:account.tax.group,name:l10n_pe.tax_group_igv
+#: model:account.tax.template,description:l10n_pe.purchase_tax_igv_18
+#: model:account.tax.template,description:l10n_pe.purchase_tax_igv_18_included
+#: model:account.tax.template,description:l10n_pe.sale_tax_igv_18
+#: model:account.tax.template,description:l10n_pe.sale_tax_igv_18_included
+msgid "IGV"
+msgstr "IGV"
 
 #. module: l10n_pe
 #: model:ir.model.fields.selection,name:l10n_pe.selection__account_tax__l10n_pe_edi_tax_code__1000
 #: model:ir.model.fields.selection,name:l10n_pe.selection__account_tax_template__l10n_pe_edi_tax_code__1000
 msgid "IGV - General Sales Tax"
-msgstr "IGV - IGV Impuesto General a las Ventas"
+msgstr "IGV - Impuesto general a las ventas"
+
+#. module: l10n_pe
+#: model:account.tax,description:l10n_pe.1_purchase_tax_ina
+#: model:account.tax,description:l10n_pe.1_sale_tax_ina
+#: model:account.tax,description:l10n_pe.2_purchase_tax_ina
+#: model:account.tax,description:l10n_pe.2_sale_tax_ina
+#: model:account.tax.group,name:l10n_pe.tax_group_ina
+#: model:account.tax.template,description:l10n_pe.purchase_tax_ina
+#: model:account.tax.template,description:l10n_pe.sale_tax_ina
+msgid "INA"
+msgstr "INA"
 
 #. module: l10n_pe
 #: model:ir.model.fields.selection,name:l10n_pe.selection__account_tax__l10n_pe_edi_tax_code__9998
@@ -144,16 +8988,97 @@ msgid "INA - Unaffected"
 msgstr "INA - Inafecto"
 
 #. module: l10n_pe
+#: model:account.group,name:l10n_pe.1_group88
+#: model:account.group,name:l10n_pe.2_group88
+#: model:account.group.template,name:l10n_pe.group88
+msgid "INCOME TAX"
+msgstr "IMPUESTO A LA RENTA"
+
+#. module: l10n_pe
+#: model:account.group,name:l10n_pe.1_group34
+#: model:account.group,name:l10n_pe.2_group34
+#: model:account.group.template,name:l10n_pe.group34
+msgid "INTANGIBLES"
+msgstr "INTANGIBLES"
+
+#. module: l10n_pe
+#: model:account.group,name:l10n_pe.1_group28
+#: model:account.group,name:l10n_pe.2_group28
+#: model:account.group.template,name:l10n_pe.group28
+msgid "INVENTORIES TO RECEIVE"
+msgstr "INVENTARIOS POR RECIBIR"
+
+#. module: l10n_pe
+#: model:account.group,name:l10n_pe.1_group31
+#: model:account.group,name:l10n_pe.2_group31
+#: model:account.group.template,name:l10n_pe.group31
+msgid "INVESTMENT PROPERTIES"
+msgstr "PROPIEDADES DE INVERSIÓN"
+
+#. module: l10n_pe
+#: model:account.group,name:l10n_pe.1_group51
+#: model:account.group,name:l10n_pe.2_group51
+#: model:account.group.template,name:l10n_pe.group51
+msgid "INVESTMENT STOCKS"
+msgstr "ACCIONES DE INVERSIÓN"
+
+#. module: l10n_pe
+#: model:account.tax.group,name:l10n_pe.tax_group_isc
+msgid "ISC"
+msgstr "ISC"
+
+#. module: l10n_pe
 #: model:ir.model.fields.selection,name:l10n_pe.selection__account_tax__l10n_pe_edi_tax_code__2000
 #: model:ir.model.fields.selection,name:l10n_pe.selection__account_tax_template__l10n_pe_edi_tax_code__2000
 msgid "ISC - Selective Excise Tax"
-msgstr "ISC - Impuesto Selectivo al Consumo"
+msgstr "ISC - Impuesto selectivo"
+
+#. module: l10n_pe
+#: model:account.tax.group,name:l10n_pe.tax_group_ivap
+msgid "IVAP"
+msgstr "IVAP"
 
 #. module: l10n_pe
 #: model:ir.model.fields.selection,name:l10n_pe.selection__account_tax__l10n_pe_edi_tax_code__1016
 #: model:ir.model.fields.selection,name:l10n_pe.selection__account_tax_template__l10n_pe_edi_tax_code__1016
 msgid "IVAP - Tax on Sale Paddy Rice"
-msgstr "IVAP - Impuesto a la Venta Arroz Pilado"
+msgstr "IVAP - Impuesto sobre la venta de trigo"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_170302
+msgid "Iberia"
+msgstr "Iberia"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_110101
+#: model:res.city,name:l10n_pe.city_pe_1101
+msgid "Ica"
+msgstr "Ica"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_061005
+msgid "Ichocan"
+msgstr "Ichocan"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_040509
+msgid "Ichupampa"
+msgstr "Ichupampa"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_180204
+msgid "Ichuña"
+msgstr "Ichuña"
+
+#. module: l10n_pe
+#: model:l10n_latam.identification.type,name:l10n_pe.it_IN
+msgid "Identification Number"
+msgstr "Número de identificación"
+
+#. module: l10n_pe
+#: model:ir.model,name:l10n_pe.model_l10n_latam_identification_type
+msgid "Identification Types"
+msgstr "Tipos de Identificación"
 
 #. module: l10n_pe
 #: model:l10n_latam.identification.type,name:l10n_pe.it_IDCR
@@ -161,52 +9086,9284 @@ msgid "Identity document of the country of residence"
 msgstr "Documento de identidad del país de residencia"
 
 #. module: l10n_pe
-#: model:l10n_latam.identification.type,name:l10n_pe.it_SP
-msgid "Safe Passage"
-msgstr "Salvoconducto"
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_200603
+msgid "Ignacio Escudero"
+msgstr "Ignacio Escudero"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_050404
+msgid "Iguain"
+msgstr "Iguain"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_150606
+msgid "Ihuari"
+msgstr "Ihuari"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_230302
+msgid "Ilabaya"
+msgstr "Ilabaya"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_210501
+msgid "Ilave"
+msgstr "Ilave"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_140303
+msgid "Illimo"
+msgstr "Illimo"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_180301
+#: model:res.city,name:l10n_pe.city_pe_1803
+msgid "Ilo"
+msgstr "Ilo"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_010205
+msgid "Imaza"
+msgstr "Imaza"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart68823
+#: model:account.account,name:l10n_pe.2_chart68823
+#: model:account.account.template,name:l10n_pe.chart68823
+msgid ""
+"Impairment of assets - Impairment of assets for right of use - Financial "
+"leasing - Buildings"
+msgstr ""
+"Deterioro del valor de los activos - Desvalorización de activos por derecho "
+"de uso - Arrendamiento financiero - Edificaciones"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart68826
+#: model:account.account,name:l10n_pe.2_chart68826
+#: model:account.account.template,name:l10n_pe.chart68826
+msgid ""
+"Impairment of assets - Impairment of assets for right of use - Financial "
+"leasing - Furniture and fixtures"
+msgstr ""
+"Deterioro del valor de los activos - Desvalorización de activos por derecho "
+"de uso - Arrendamiento financiero - Muebles y enseres"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart68822
+#: model:account.account,name:l10n_pe.2_chart68822
+#: model:account.account.template,name:l10n_pe.chart68822
+msgid ""
+"Impairment of assets - Impairment of assets for right of use - Financial "
+"leasing - Land"
+msgstr ""
+"Deterioro del valor de los activos - Desvalorización de activos por derecho "
+"de uso - Arrendamiento financiero - Terrenos"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart68824
+#: model:account.account,name:l10n_pe.2_chart68824
+#: model:account.account.template,name:l10n_pe.chart68824
+msgid ""
+"Impairment of assets - Impairment of assets for right of use - Financial "
+"leasing - Machinery and exploitation equipment"
+msgstr ""
+"Deterioro del valor de los activos - Desvalorización de activos por derecho "
+"de uso - Arrendamiento financiero - Maquinarias y equipos de explotación"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart68827
+#: model:account.account,name:l10n_pe.2_chart68827
+#: model:account.account.template,name:l10n_pe.chart68827
+msgid ""
+"Impairment of assets - Impairment of assets for right of use - Financial "
+"leasing - Miscellaneous equipment"
+msgstr ""
+"Deterioro del valor de los activos - Desvalorización de activos por derecho "
+"de uso - Arrendamiento financiero - Equipos diversos"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart68821
+#: model:account.account,name:l10n_pe.2_chart68821
+#: model:account.account.template,name:l10n_pe.chart68821
+msgid ""
+"Impairment of assets - Impairment of assets for right of use - Financial "
+"leasing - Production plant in development"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart68820
+#: model:account.account,name:l10n_pe.2_chart68820
+#: model:account.account.template,name:l10n_pe.chart68820
+msgid ""
+"Impairment of assets - Impairment of assets for right of use - Financial "
+"leasing - Production plant in production"
+msgstr ""
+"Deterioro del valor de los activos - Desvalorización de activos por derecho "
+"de uso - Arrendamiento financiero - Planta productora en producción"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart68828
+#: model:account.account,name:l10n_pe.2_chart68828
+#: model:account.account.template,name:l10n_pe.chart68828
+msgid ""
+"Impairment of assets - Impairment of assets for right of use - Financial "
+"leasing - Replacement tools and units"
+msgstr ""
+"Deterioro del valor de los activos - Desvalorización de activos por derecho "
+"de uso - Arrendamiento financiero - Herramientas y unidades de reemplazo"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart68825
+#: model:account.account,name:l10n_pe.2_chart68825
+#: model:account.account.template,name:l10n_pe.chart68825
+msgid ""
+"Impairment of assets - Impairment of assets for right of use - Financial "
+"leasing - Transport units"
+msgstr ""
+"Deterioro del valor de los activos - Desvalorización de activos por derecho "
+"de uso - Arrendamiento financiero - Unidades de transporte"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart68892
+#: model:account.account,name:l10n_pe.2_chart68892
+#: model:account.account.template,name:l10n_pe.chart68892
+msgid ""
+"Impairment of assets - Impairment of biological assets in production - "
+"Biological asset of vegetal origin"
+msgstr ""
+"Deterioro del valor de los activos - Desvalorización de activos biológicos "
+"en producción - Activos biológicos de origen vegetal"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart68891
+#: model:account.account,name:l10n_pe.2_chart68891
+#: model:account.account.template,name:l10n_pe.chart68891
+msgid ""
+"Impairment of assets - Impairment of biological assets in production - "
+"Biological assets of animal origin"
+msgstr ""
+"Deterioro del valor de los activos - Desvalorización de activos biológicos "
+"en producción - Activos biológicos de origen animal"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart68841
+#: model:account.account,name:l10n_pe.2_chart68841
+#: model:account.account.template,name:l10n_pe.chart68841
+msgid ""
+"Impairment of assets - Impairment of intangibles - Concessions, licenses and"
+" other rights"
+msgstr ""
+"Deterioro del valor de los activos - Desvalorización de intangibles - "
+"Concesiones, licencias y otros derechos"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart68844
+#: model:account.account,name:l10n_pe.2_chart68844
+#: model:account.account.template,name:l10n_pe.chart68844
+msgid ""
+"Impairment of assets - Impairment of intangibles - Exploration and "
+"development costs"
+msgstr ""
+"Deterioro del valor de los activos - Desvalorización de intangibles - Costo "
+"de exploración y desarrollo"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart68845
+#: model:account.account,name:l10n_pe.2_chart68845
+#: model:account.account.template,name:l10n_pe.chart68845
+msgid ""
+"Impairment of assets - Impairment of intangibles - Formulas, designs and "
+"prototypes"
+msgstr ""
+"Deterioro del valor de los activos - Desvalorización de intangibles - "
+"Fórmulas, diseños y prototipos"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart68847
+#: model:account.account,name:l10n_pe.2_chart68847
+#: model:account.account.template,name:l10n_pe.chart68847
+msgid "Impairment of assets - Impairment of intangibles - Goodwill"
+msgstr ""
+"Deterioro del valor de los activos - Desvalorización de intangibles - "
+"Plusvalía mercantil"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart68846
+#: model:account.account,name:l10n_pe.2_chart68846
+#: model:account.account.template,name:l10n_pe.chart68846
+msgid ""
+"Impairment of assets - Impairment of intangibles - Other intangible assets"
+msgstr ""
+"Deterioro del valor de los activos - Desvalorización de intangibles - Otros "
+"activos intangibles"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart68842
+#: model:account.account,name:l10n_pe.2_chart68842
+#: model:account.account.template,name:l10n_pe.chart68842
+msgid ""
+"Impairment of assets - Impairment of intangibles - Patents and industrial "
+"property"
+msgstr ""
+"Deterioro del valor de los activos - Desvalorización de intangibles - "
+"Patentes y propiedad industrial"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart68843
+#: model:account.account,name:l10n_pe.2_chart68843
+#: model:account.account.template,name:l10n_pe.chart68843
+msgid "Impairment of assets - Impairment of intangibles - Softwares"
+msgstr ""
+"Deterioro del valor de los activos - Desvalorización de intangibles - "
+"Programas de computadora (software)"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart68812
+#: model:account.account,name:l10n_pe.2_chart68812
+#: model:account.account.template,name:l10n_pe.chart68812
+msgid "Impairment of assets - Impairment of investment property - Buildings"
+msgstr ""
+"Deterioro del valor de los activos - Desvalorización de propiedad de "
+"inversión - Edificaciones"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart68813
+#: model:account.account,name:l10n_pe.2_chart68813
+#: model:account.account.template,name:l10n_pe.chart68813
+msgid ""
+"Impairment of assets - Impairment of investment property - Constructions in "
+"progress"
+msgstr ""
+"Deterioro del valor de los activos - Desvalorización de propiedad de "
+"inversión - Construcciones en curso"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart68833
+#: model:account.account,name:l10n_pe.2_chart68833
+#: model:account.account.template,name:l10n_pe.chart68833
+msgid ""
+"Impairment of assets - Impairment of property, plant and equipment - "
+"Buildings"
+msgstr ""
+"Deterioro del valor de los activos - Desvalorización de propiedad, planta y "
+"equipo - Edificaciones"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart68836
+#: model:account.account,name:l10n_pe.2_chart68836
+#: model:account.account.template,name:l10n_pe.chart68836
+msgid ""
+"Impairment of assets - Impairment of property, plant and equipment - "
+"Furniture and fixtures"
+msgstr ""
+"Deterioro del valor de los activos - Desvalorización de propiedad, planta y "
+"equipo - Muebles y enseres"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart68832
+#: model:account.account,name:l10n_pe.2_chart68832
+#: model:account.account.template,name:l10n_pe.chart68832
+msgid ""
+"Impairment of assets - Impairment of property, plant and equipment - Land"
+msgstr ""
+"Deterioro del valor de los activos - Desvalorización de propiedad, planta y "
+"equipo - Terrenos"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart68834
+#: model:account.account,name:l10n_pe.2_chart68834
+#: model:account.account.template,name:l10n_pe.chart68834
+msgid ""
+"Impairment of assets - Impairment of property, plant and equipment - "
+"Machinery and exploitation equipment"
+msgstr ""
+"Deterioro del valor de los activos - Desvalorización de propiedad, planta y "
+"equipo - Maquinarias y equipos de explotación"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart68837
+#: model:account.account,name:l10n_pe.2_chart68837
+#: model:account.account.template,name:l10n_pe.chart68837
+msgid ""
+"Impairment of assets - Impairment of property, plant and equipment - "
+"Miscellaneous equipment"
+msgstr ""
+"Deterioro del valor de los activos - Desvalorización de propiedad, planta y "
+"equipo - Equipos diversos"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart68831
+#: model:account.account,name:l10n_pe.2_chart68831
+#: model:account.account.template,name:l10n_pe.chart68831
+msgid ""
+"Impairment of assets - Impairment of property, plant and equipment - "
+"Production plant in development"
+msgstr ""
+"Deterioro del valor de los activos - Desvalorización de propiedad, planta y "
+"equipo - Planta productora en desarrollo"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart68830
+#: model:account.account,name:l10n_pe.2_chart68830
+#: model:account.account.template,name:l10n_pe.chart68830
+msgid ""
+"Impairment of assets - Impairment of property, plant and equipment - "
+"Production plant in production"
+msgstr ""
+"Deterioro del valor de los activos - Desvalorización de propiedad, planta y "
+"equipo - Planta productora en producción"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart68838
+#: model:account.account,name:l10n_pe.2_chart68838
+#: model:account.account.template,name:l10n_pe.chart68838
+msgid ""
+"Impairment of assets - Impairment of property, plant and equipment - "
+"Replacement tools and units"
+msgstr ""
+"Deterioro del valor de los activos - Desvalorización de propiedad, planta y "
+"equipo - Herramientas y unidades de reemplazo"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart68835
+#: model:account.account,name:l10n_pe.2_chart68835
+#: model:account.account.template,name:l10n_pe.chart68835
+msgid ""
+"Impairment of assets - Impairment of property, plant and equipment - "
+"Transport units"
+msgstr ""
+"Deterioro del valor de los activos - Desvalorización de propiedad, planta y "
+"equipo - Unidades de transporte"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_150507
+msgid "Imperial"
+msgstr "Imperial"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_160602
+msgid "Inahuaya"
+msgstr "Inahuaya"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_170102
+msgid "Inambari"
+msgstr "Inambari"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_140203
+msgid "Incahuasi"
+msgstr "Incahuasi"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_210604
+msgid "Inchupalla"
+msgstr "Inchupalla"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_230105
+msgid "Inclan"
+msgstr "Inclan"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart851
+#: model:account.account,name:l10n_pe.2_chart851
+#: model:account.account.template,name:l10n_pe.chart851
+msgid "Income before income tax"
+msgstr "Resultado antes del impuesto a las ganancias"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart774
+#: model:account.account,name:l10n_pe.2_chart774
+#: model:account.account.template,name:l10n_pe.chart774
+msgid "Income from factoring operations"
+msgstr "Ingresos en operaciones de factoraje (factoring)"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart881
+#: model:account.account,name:l10n_pe.2_chart881
+#: model:account.account.template,name:l10n_pe.chart881
+msgid "Income tax – Current"
+msgstr "Impuesto a las ganancias – Corriente"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart882
+#: model:account.account,name:l10n_pe.2_chart882
+#: model:account.account.template,name:l10n_pe.chart882
+msgid "Income tax – Deferred"
+msgstr "Impuesto a las ganancias – Diferido"
+
+#. module: l10n_pe
+#: model:account.group,name:l10n_pe.1_group7
+#: model:account.group,name:l10n_pe.2_group7
+#: model:account.group.template,name:l10n_pe.group7
+msgid "Incomes"
+msgstr "Ingresos"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_020105
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_051106
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_110504
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_150112
+msgid "Independencia"
+msgstr "Independencia"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_160104
+msgid "Indiana"
+msgstr "Indiana"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_120122
+msgid "Ingenio"
+msgstr "Ingenio"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_010506
+msgid "Inguilpata"
+msgstr "Inguilpata"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_080911
+msgid "Inkawasi"
+msgstr "Inkawasi"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart182
+#: model:account.account,name:l10n_pe.1_chart651
+#: model:account.account,name:l10n_pe.2_chart182
+#: model:account.account,name:l10n_pe.2_chart651
+#: model:account.account.template,name:l10n_pe.chart182
+#: model:account.account.template,name:l10n_pe.chart651
+msgid "Insurance"
+msgstr "Seguros"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart27311
+#: model:account.account,name:l10n_pe.2_chart27311
+#: model:account.account.template,name:l10n_pe.chart27311
+msgid "Intangibles - Concessions, licenses and rights - Costs"
+msgstr "Intangibles - Concesiones, licencias y derechos - Costo"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart27312
+#: model:account.account,name:l10n_pe.2_chart27312
+#: model:account.account.template,name:l10n_pe.chart27312
+msgid "Intangibles - Concessions, licenses and rights - Revaluation"
+msgstr "Intangibles - Concesiones, licencias y derechos - Revaluación"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart7232
+#: model:account.account,name:l10n_pe.2_chart7232
+#: model:account.account.template,name:l10n_pe.chart7232
+msgid "Intangibles - Exploration and development costs"
+msgstr "Intangibles - Costos de exploración y desarrollo"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart27341
+#: model:account.account,name:l10n_pe.2_chart27341
+#: model:account.account.template,name:l10n_pe.chart27341
+msgid "Intangibles - Exploration and development costs - Costs"
+msgstr "Intangibles - Costos de exploración y desarrollo - Costo"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart27342
+#: model:account.account,name:l10n_pe.2_chart27342
+#: model:account.account.template,name:l10n_pe.chart27342
+msgid "Intangibles - Exploration and development costs - Revaluation"
+msgstr "Intangibles - Costos de exploración y desarrollo - Revaluación"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart7233
+#: model:account.account,name:l10n_pe.2_chart7233
+#: model:account.account.template,name:l10n_pe.chart7233
+msgid "Intangibles - Formulas, designs and prototypes"
+msgstr "Intangibles - Fórmulas, diseños y prototipos"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart27351
+#: model:account.account,name:l10n_pe.2_chart27351
+#: model:account.account.template,name:l10n_pe.chart27351
+msgid "Intangibles - Formulas, designs and prototypes - Costs"
+msgstr "Intangibles - Fórmulas, diseños y prototipos - Costo"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart27352
+#: model:account.account,name:l10n_pe.2_chart27352
+#: model:account.account.template,name:l10n_pe.chart27352
+msgid "Intangibles - Formulas, designs and prototypes - Revaluation"
+msgstr "Intangibles - Fórmulas, diseños y prototipos - Revaluación"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart27391
+#: model:account.account,name:l10n_pe.2_chart27391
+#: model:account.account.template,name:l10n_pe.chart27391
+msgid "Intangibles - Other intangible assets - Costs"
+msgstr "Intangibles - Otros activos intangibles - Costo"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart27392
+#: model:account.account,name:l10n_pe.2_chart27392
+#: model:account.account.template,name:l10n_pe.chart27392
+msgid "Intangibles - Other intangible assets - Revaluation"
+msgstr "Intangibles - Otros activos intangibles - Revaluación"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart27321
+#: model:account.account,name:l10n_pe.2_chart27321
+#: model:account.account.template,name:l10n_pe.chart27321
+msgid "Intangibles - Patents and industrial property - Costs"
+msgstr "Intangibles - Patentes y propiedad industrial - Costo"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart27322
+#: model:account.account,name:l10n_pe.2_chart27322
+#: model:account.account.template,name:l10n_pe.chart27322
+msgid "Intangibles - Patents and industrial property - Revaluation"
+msgstr "Intangibles - Patentes y propiedad industrial - Revaluación"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart7231
+#: model:account.account,name:l10n_pe.2_chart7231
+#: model:account.account.template,name:l10n_pe.chart7231
+msgid "Intangibles - Softwares"
+msgstr "Intangibles - Programas de computadora (software)"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart27331
+#: model:account.account,name:l10n_pe.2_chart27331
+#: model:account.account.template,name:l10n_pe.chart27331
+msgid "Intangibles - Softwares - Costs"
+msgstr "Intangibles - Programas de computadora (software) - Costo"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart27332
+#: model:account.account,name:l10n_pe.2_chart27332
+#: model:account.account.template,name:l10n_pe.chart27332
+msgid "Intangibles - Softwares - Revaluation"
+msgstr "Intangibles - Programas de computadora (software) - Revaluación"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart6735
+#: model:account.account,name:l10n_pe.2_chart6735
+#: model:account.account.template,name:l10n_pe.chart6735
+msgid "Interest on loans and other obligations - Bonds issued"
+msgstr "Intereses por préstamos y otras obligaciones - Obligaciones emitidas"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart6736
+#: model:account.account,name:l10n_pe.2_chart6736
+#: model:account.account.template,name:l10n_pe.chart6736
+msgid "Interest on loans and other obligations - Commercial obligations"
+msgstr ""
+"Intereses por préstamos y otras obligaciones - Obligaciones comerciales"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart6734
+#: model:account.account,name:l10n_pe.2_chart6734
+#: model:account.account.template,name:l10n_pe.chart6734
+msgid "Interest on loans and other obligations - Documents sold or discounted"
+msgstr ""
+"Intereses por préstamos y otras obligaciones - Documentos vendidos o "
+"descontados"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart6732
+#: model:account.account,name:l10n_pe.2_chart6732
+#: model:account.account.template,name:l10n_pe.chart6732
+msgid "Interest on loans and other obligations - Financial lease contracts"
+msgstr ""
+"Intereses por préstamos y otras obligaciones - Contratos de arrendamiento "
+"financiero"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart67311
+#: model:account.account,name:l10n_pe.2_chart67311
+#: model:account.account.template,name:l10n_pe.chart67311
+msgid ""
+"Interest on loans and other obligations - Loans from financial institutions "
+"and other entities - Financial institutions"
+msgstr ""
+"Intereses por préstamos y otras obligaciones - Préstamos de instituciones "
+"financieras y otras entidades - Instituciones financieras"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart67312
+#: model:account.account,name:l10n_pe.2_chart67312
+#: model:account.account.template,name:l10n_pe.chart67312
+msgid ""
+"Interest on loans and other obligations - Loans from financial institutions "
+"and other entities - Other entities"
+msgstr ""
+"Intereses por préstamos y otras obligaciones - Préstamos de instituciones "
+"financieras y otras entidades - Otras entidades"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart6733
+#: model:account.account,name:l10n_pe.2_chart6733
+#: model:account.account.template,name:l10n_pe.chart6733
+msgid ""
+"Interest on loans and other obligations - Other financial instruments "
+"payable"
+msgstr ""
+"Intereses por préstamos y otras obligaciones - Otros instrumentos "
+"financieros por pagar"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart1633
+#: model:account.account,name:l10n_pe.1_chart1733
+#: model:account.account,name:l10n_pe.2_chart1633
+#: model:account.account,name:l10n_pe.2_chart1733
+#: model:account.account.template,name:l10n_pe.chart1633
+#: model:account.account.template,name:l10n_pe.chart1733
+msgid "Interest, royalties and dividends - Dividends"
+msgstr "Intereses, regalías y dividendos - Dividendos"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart1631
+#: model:account.account,name:l10n_pe.1_chart1731
+#: model:account.account,name:l10n_pe.2_chart1631
+#: model:account.account,name:l10n_pe.2_chart1731
+#: model:account.account.template,name:l10n_pe.chart1631
+#: model:account.account.template,name:l10n_pe.chart1731
+msgid "Interest, royalties and dividends - Interests"
+msgstr "Intereses, regalías y dividendos - Intereses"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart1632
+#: model:account.account,name:l10n_pe.1_chart1732
+#: model:account.account,name:l10n_pe.2_chart1632
+#: model:account.account,name:l10n_pe.2_chart1732
+#: model:account.account.template,name:l10n_pe.chart1632
+#: model:account.account.template,name:l10n_pe.chart1732
+msgid "Interest, royalties and dividends - Royalties"
+msgstr "Intereses, regalías y dividendos - Regalías"
+
+#. module: l10n_pe
+#: model:account.group,name:l10n_pe.1_group8
+#: model:account.group,name:l10n_pe.2_group8
+#: model:account.group.template,name:l10n_pe.group8
+msgid ""
+"Intermediate management balances and determination of profit for the year"
+msgstr ""
+"Saldos intrermediarios de gestión y determinación del resultado del "
+"ejercicio"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart21511
+#: model:account.account,name:l10n_pe.2_chart21511
+#: model:account.account.template,name:l10n_pe.chart21511
+msgid "Inventory of finished services - Finished services - Costs"
+msgstr "Inventario de servicios terminados - Servicios terminados - Costo"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart23511
+#: model:account.account,name:l10n_pe.2_chart23511
+#: model:account.account.template,name:l10n_pe.chart23511
+msgid "Inventory of services in process - Services in process - Costs"
+msgstr "Inventario de servicios en proceso - Servicios en proceso - Costo"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart7211
+#: model:account.account,name:l10n_pe.2_chart7211
+#: model:account.account.template,name:l10n_pe.chart7211
+msgid "Investment property - Buildings"
+msgstr "Propiedades de inversión - Edificaciones"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart27121
+#: model:account.account,name:l10n_pe.2_chart27121
+#: model:account.account.template,name:l10n_pe.chart27121
+msgid "Investment property - Buildings - Costs"
+msgstr "Propiedades de inversión - Edificaciones - Costo"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart27124
+#: model:account.account,name:l10n_pe.2_chart27124
+#: model:account.account.template,name:l10n_pe.chart27124
+msgid "Investment property - Buildings - Fair value"
+msgstr "Propiedades de inversión - Edificaciones - Fair value"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart27123
+#: model:account.account,name:l10n_pe.2_chart27123
+#: model:account.account.template,name:l10n_pe.chart27123
+msgid "Investment property - Buildings - Financing costs"
+msgstr "Propiedades de inversión - Edificaciones - Costos de financiación"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart27122
+#: model:account.account,name:l10n_pe.2_chart27122
+#: model:account.account.template,name:l10n_pe.chart27122
+msgid "Investment property - Buildings - Revaluation"
+msgstr "Propiedades de inversión - Edificaciones - Revaluación"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart32121
+#: model:account.account,name:l10n_pe.2_chart32121
+#: model:account.account.template,name:l10n_pe.chart32121
+msgid "Investment property - Financial leasing - Buildings - Costs"
+msgstr ""
+"Propiedades de inversión - Arrendamiento financiero - Edificaciones - Costo"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart32124
+#: model:account.account,name:l10n_pe.2_chart32124
+#: model:account.account.template,name:l10n_pe.chart32124
+msgid "Investment property - Financial leasing - Buildings - Fair value"
+msgstr ""
+"Propiedades de inversión - Arrendamiento financiero - Edificaciones - Valor "
+"razonable"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart32123
+#: model:account.account,name:l10n_pe.2_chart32123
+#: model:account.account.template,name:l10n_pe.chart32123
+msgid "Investment property - Financial leasing - Buildings - Financing costs"
+msgstr ""
+"Propiedades de inversión - Arrendamiento financiero - Edificaciones - Costo "
+"de financiación"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart32122
+#: model:account.account,name:l10n_pe.2_chart32122
+#: model:account.account.template,name:l10n_pe.chart32122
+msgid "Investment property - Financial leasing - Buildings - Revaluation"
+msgstr ""
+"Propiedades de inversión - Arrendamiento financiero - Edificaciones - "
+"Revaluación"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart32111
+#: model:account.account,name:l10n_pe.2_chart32111
+#: model:account.account.template,name:l10n_pe.chart32111
+msgid "Investment property - Financial leasing - Land - Costs"
+msgstr ""
+"Propiedades de inversión - Arrendamiento financiero - Terrenos - Costo"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart32114
+#: model:account.account,name:l10n_pe.2_chart32114
+#: model:account.account.template,name:l10n_pe.chart32114
+msgid "Investment property - Financial leasing - Land - Fair value"
+msgstr ""
+"Propiedades de inversión - Arrendamiento financiero - Terrenos - Valor "
+"razonable"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart32112
+#: model:account.account,name:l10n_pe.2_chart32112
+#: model:account.account.template,name:l10n_pe.chart32112
+msgid "Investment property - Financial leasing - Land - Revaluation"
+msgstr ""
+"Propiedades de inversión - Arrendamiento financiero - Terrenos - Revaluación"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart27111
+#: model:account.account,name:l10n_pe.2_chart27111
+#: model:account.account.template,name:l10n_pe.chart27111
+msgid "Investment property - Land - Costs"
+msgstr "Propiedades de inversión - Terrenos - Costo"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart27114
+#: model:account.account,name:l10n_pe.2_chart27114
+#: model:account.account.template,name:l10n_pe.chart27114
+msgid "Investment property - Land - Fair value"
+msgstr "Propiedades de inversión - Terrenos - Fair value"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart27112
+#: model:account.account,name:l10n_pe.2_chart27112
+#: model:account.account.template,name:l10n_pe.chart27112
+msgid "Investment property - Land - Revaluation"
+msgstr "Propiedades de inversión - Terrenos - Revaluación"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart511
+#: model:account.account,name:l10n_pe.2_chart511
+#: model:account.account.template,name:l10n_pe.chart511
+msgid "Investment shares"
+msgstr "Acciones de inversión"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart512
+#: model:account.account,name:l10n_pe.2_chart512
+#: model:account.account.template,name:l10n_pe.chart512
+msgid "Investment shares in treasury"
+msgstr "Acciones de inversión en tesorería"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart11151
+#: model:account.account,name:l10n_pe.2_chart11151
+#: model:account.account.template,name:l10n_pe.chart11151
+msgid "Investments held for trading - Holdings in entities - Costs"
+msgstr ""
+"Inversiones mantenidas para negociación - Participaciones en entidades - "
+"Costo"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart11152
+#: model:account.account,name:l10n_pe.2_chart11152
+#: model:account.account.template,name:l10n_pe.chart11152
+msgid "Investments held for trading - Holdings in entities - Fair value"
+msgstr ""
+"Inversiones mantenidas para negociación - Participaciones en entidades - "
+"Valor razonable"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart11141
+#: model:account.account,name:l10n_pe.2_chart11141
+#: model:account.account.template,name:l10n_pe.chart11141
+msgid "Investments held for trading - Other debt instruments - Costs"
+msgstr ""
+"Inversiones mantenidas para negociación - Otros títulos representativos de "
+"deuda - Costo"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart11142
+#: model:account.account,name:l10n_pe.2_chart11142
+#: model:account.account.template,name:l10n_pe.chart11142
+msgid "Investments held for trading - Other debt instruments - Fair value"
+msgstr ""
+"Inversiones mantenidas para negociación - Otros títulos representativos de "
+"deuda - Valor razonable"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart11131
+#: model:account.account,name:l10n_pe.2_chart11131
+#: model:account.account.template,name:l10n_pe.chart11131
+msgid "Investments held for trading - Securities issued by entities - Costs"
+msgstr ""
+"Inversiones mantenidas para negociación - Valores emitidos por entidades - "
+"Costo"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart11132
+#: model:account.account,name:l10n_pe.2_chart11132
+#: model:account.account.template,name:l10n_pe.chart11132
+msgid ""
+"Investments held for trading - Securities issued by entities - Fair value"
+msgstr ""
+"Inversiones mantenidas para negociación - Valores emitidos por entidades - "
+"Valor razonable"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart11121
+#: model:account.account,name:l10n_pe.2_chart11121
+#: model:account.account.template,name:l10n_pe.chart11121
+msgid ""
+"Investments held for trading - Securities issued by the financial system - "
+"Costs"
+msgstr ""
+"Inversiones mantenidas para negociación - Valores emitidos por el sistema "
+"financiero - Costo"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart11122
+#: model:account.account,name:l10n_pe.2_chart11122
+#: model:account.account.template,name:l10n_pe.chart11122
+msgid ""
+"Investments held for trading - Securities issued by the financial system - "
+"Fair value"
+msgstr ""
+"Inversiones mantenidas para negociación - Valores emitidos por el sistema "
+"financiero - Valor razonable"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart11111
+#: model:account.account,name:l10n_pe.2_chart11111
+#: model:account.account.template,name:l10n_pe.chart11111
+msgid ""
+"Investments held for trading - Securities issued or guaranteed by the State "
+"- Costs"
+msgstr ""
+"Inversiones mantenidas para negociación - Valores emitidos o garantizados "
+"por el Estado - Costo"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart11112
+#: model:account.account,name:l10n_pe.2_chart11112
+#: model:account.account.template,name:l10n_pe.chart11112
+msgid ""
+"Investments held for trading - Securities issued or guaranteed by the State "
+"- Fair value"
+msgstr ""
+"Inversiones mantenidas para negociación - Valores emitidos o garantizados "
+"por el Estado - Valor razonable"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart36711
+#: model:account.account,name:l10n_pe.2_chart36711
+#: model:account.account.template,name:l10n_pe.chart36711
+msgid "Investments to be held until maturity - Costs"
+msgstr "Inversiones a ser mantenidas hasta el vencimiento - Costo"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart30111
+#: model:account.account,name:l10n_pe.2_chart30111
+#: model:account.account.template,name:l10n_pe.chart30111
+msgid ""
+"Investments to be held until maturity - Debt financial instruments - Costs"
+msgstr ""
+"Inversiones a ser mantenidas hasta el vencimiento - Instrumentos financieros"
+" representativos de deuda - Costo"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart30114
+#: model:account.account,name:l10n_pe.2_chart30114
+#: model:account.account.template,name:l10n_pe.chart30114
+msgid ""
+"Investments to be held until maturity - Debt financial instruments - Fair "
+"value"
+msgstr ""
+"Inversiones a ser mantenidas hasta el vencimiento - Instrumentos financieros"
+" representativos de deuda - Valor razonable"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart4211
+#: model:account.account,name:l10n_pe.1_chart4212
+#: model:account.account,name:l10n_pe.1_chart4311
+#: model:account.account,name:l10n_pe.1_chart4312
+#: model:account.account,name:l10n_pe.2_chart4211
+#: model:account.account,name:l10n_pe.2_chart4212
+#: model:account.account,name:l10n_pe.2_chart4311
+#: model:account.account,name:l10n_pe.2_chart4312
+#: model:account.account.template,name:l10n_pe.chart4211
+#: model:account.account.template,name:l10n_pe.chart4212
+#: model:account.account.template,name:l10n_pe.chart4311
+#: model:account.account.template,name:l10n_pe.chart4312
+msgid "Invoices, tickets and other payable vouchers - Not issued"
+msgstr "Facturas, boletas y otros comprobantes por pagar - No emitidas"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart1213
+#: model:account.account,name:l10n_pe.1_chart1313
+#: model:account.account,name:l10n_pe.2_chart1213
+#: model:account.account,name:l10n_pe.2_chart1313
+#: model:account.account.template,name:l10n_pe.chart1213
+#: model:account.account.template,name:l10n_pe.chart1313
+msgid "Invoices, tickets and other receipts receivable - In collection"
+msgstr "Facturas, boletas y otros comprobantes por cobrar - En cobranza"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart1312
+#: model:account.account,name:l10n_pe.2_chart1312
+#: model:account.account.template,name:l10n_pe.chart1312
+msgid "Invoices, tickets and other receipts receivable - In portfolio"
+msgstr "Facturas, boletas y otros comprobantes por cobrar - En cartera"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart1212
+#: model:account.account,name:l10n_pe.2_chart1212
+#: model:account.account.template,name:l10n_pe.chart1212
+msgid "Invoices, tickets and other receipts receivable - Issued in portfolio"
+msgstr ""
+"Facturas, boletas y otros comprobantes por cobrar - Emitidas en cartera"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart1211
+#: model:account.account,name:l10n_pe.1_chart1311
+#: model:account.account,name:l10n_pe.2_chart1211
+#: model:account.account,name:l10n_pe.2_chart1311
+#: model:account.account.template,name:l10n_pe.chart1211
+#: model:account.account.template,name:l10n_pe.chart1311
+msgid "Invoices, tickets and other receipts receivable - Not issued"
+msgstr "Facturas, boletas y otros comprobantes por cobrar - No emitidas"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart1214
+#: model:account.account,name:l10n_pe.1_chart1314
+#: model:account.account,name:l10n_pe.2_chart1214
+#: model:account.account,name:l10n_pe.2_chart1314
+#: model:account.account.template,name:l10n_pe.chart1214
+#: model:account.account.template,name:l10n_pe.chart1314
+msgid "Invoices, tickets and other receipts receivable - Off sale"
+msgstr "Facturas, boletas y otros comprobantes por cobrar - En descuento"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_250103
+msgid "Iparia"
+msgstr "Iparia"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_160101
+msgid "Iquitos"
+msgstr "Iquitos"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_040605
+msgid "Iray"
+msgstr "Iray"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_250302
+msgid "Irazola"
+msgstr "Irazola"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_040704
+#: model:res.city,name:l10n_pe.city_pe_0407
+msgid "Islay"
+msgstr "Islay"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_230303
+msgid "Ite"
+msgstr "Ite"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_210307
+msgid "Ituata"
+msgstr "Ituata"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_090108
+msgid "Izcuchaca"
+msgstr "Izcuchaca"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_170301
+msgid "Iñapari"
+msgstr "Iñapari"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_101105
+msgid "Jacas Chico"
+msgstr "Jacas Chico"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_100504
+msgid "Jacas Grande"
+msgstr "Jacas Grande"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_040107
+msgid "Jacobo Hunter"
+msgstr "Jacobo Hunter"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_010705
+msgid "Jamalca"
+msgstr "Jamalca"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_020106
+msgid "Jangas"
+msgstr "Jangas"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_120411
+msgid "Janjaillo"
+msgstr "Janjaillo"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_040310
+msgid "Jaqui"
+msgstr "Jaqui"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_120401
+#: model:res.city,name:l10n_pe.city_pe_1204
+msgid "Jauja"
+msgstr "Jauja"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_140304
+msgid "Jayanca"
+msgstr "Jayanca"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_010307
+msgid "Jazan"
+msgstr "Jazan"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_060801
+#: model:res.city,name:l10n_pe.city_pe_0608
+msgid "Jaén"
+msgstr "Jaén"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_160205
+msgid "Jeberos"
+msgstr "Jeberos"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_160510
+msgid "Jenaro Herrera"
+msgstr "Jenaro Herrera"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_220104
+msgid "Jepelacio"
+msgstr "Jepelacio"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_130703
+msgid "Jequetepeque"
+msgstr "Jequetepeque"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_060106
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_101001
+msgid "Jesús"
+msgstr "Jesús"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_150113
+msgid "Jesús María"
+msgstr "Jesús María"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_050115
+msgid "Jesús Nazareno"
+msgstr "Jesús Nazareno"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_200203
+msgid "Jilili"
+msgstr "Jilili"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_100505
+msgid "Jircan"
+msgstr "Jircan"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_101003
+msgid "Jivia"
+msgstr "Jivia"
+
+#. module: l10n_pe
+#: model:res.city,name:l10n_pe.city_pe_2303
+msgid "Jorge Basadre"
+msgstr "Jorge Basadre"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_060305
+msgid "Jorge Chávez"
+msgstr "Jorge Chávez"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_100604
+msgid "José Crespo y Castillo"
+msgstr "José Crespo y Castillo"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_210207
+msgid "José Domingo Choquehuanca"
+msgstr "José Domingo Choquehuanca"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_060306
+msgid "José Gálvez"
+msgstr "José Gálvez"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_140105
+msgid "José Leonardo Ortiz"
+msgstr "José Leonardo Ortiz"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_040129
+msgid "José Luis Bustamante Y Rivero"
+msgstr "José Luis Bustamante Y Rivero"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_061006
+msgid "José Manuel Quiroz"
+msgstr "José Manuel Quiroz"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_030220
+msgid "José María Arguedas"
+msgstr "José María Arguedas"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_040202
+msgid "José María Quimper"
+msgstr "José María Quimper"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_061007
+msgid "José Sabogal"
+msgstr "José Sabogal"
+
+#. module: l10n_pe
+#: model:ir.model,name:l10n_pe.model_account_move_line
+msgid "Journal Item"
+msgstr "Apunte contable"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_030304
+msgid "Juan Espinoza Medrano"
+msgstr "Juan Espinoza Medrano"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_220908
+msgid "Juan Guerra"
+msgstr "Juan Guerra"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_220601
+msgid "Juanjuí"
+msgstr "Juanjuí"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_090309
+msgid "Julcamarca"
+msgstr "Julcamarca"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_120412
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_130501
+#: model:res.city,name:l10n_pe.city_pe_1305
+msgid "Julcán"
+msgstr "Julcán"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_210401
+msgid "Juli"
+msgstr "Juli"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_211101
+msgid "Juliaca"
+msgstr "Juliaca"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_010301
+msgid "Jumbilla"
+msgstr "Jumbilla"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_120501
+#: model:res.city,name:l10n_pe.city_pe_1205
+msgid "Junin"
+msgstr "Junin"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_030408
+msgid "Justo Apu Sahuaraura"
+msgstr "Justo Apu Sahuaraura"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_030219
+msgid "Kaquiabamba"
+msgstr "Kaquiabamba"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_210404
+msgid "Kelluyo"
+msgstr "Kelluyo"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_080907
+msgid "Kimbiri"
+msgstr "Kimbiri"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_030207
+msgid "Kishuara"
+msgstr "Kishuara"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_081106
+msgid "Kosñipata"
+msgstr "Kosñipata"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_080503
+msgid "Kunturkanki"
+msgstr "Kunturkanki"
 
 #. module: l10n_pe
 #: model:ir.model.fields,field_description:l10n_pe.field_l10n_latam_identification_type__l10n_pe_vat_code
 msgid "L10N Pe Vat Code"
-msgstr "Código de tipo de documento de identidad"
+msgstr "Código de IVA"
 
 #. module: l10n_pe
-#: model:ir.model.fields,field_description:l10n_pe.field_account_move_line____last_update
-#: model:ir.model.fields,field_description:l10n_pe.field_account_tax____last_update
-#: model:ir.model.fields,field_description:l10n_pe.field_account_tax_template____last_update
-#: model:ir.model.fields,field_description:l10n_pe.field_l10n_latam_identification_type____last_update
+#: model:account.fiscal.position,name:l10n_pe.1_local_peru
+#: model:account.fiscal.position,name:l10n_pe.2_local_peru
+#: model:account.fiscal.position.template,name:l10n_pe.local_peru
+msgid "LOCAL PERU"
+msgstr "LOCAL PERÚ"
+
+#. module: l10n_pe
+#: model:account.group,name:l10n_pe.1_group66
+#: model:account.group,name:l10n_pe.2_group66
+#: model:account.group.template,name:l10n_pe.group66
+msgid "LOSS DUE TO MEASUREMENT OF NON-FINANCIAL ASSETS AT FAIR VALUE"
+msgstr "PERDIDA POR MEDICIÓN DE ACTIVOS NO FINANCIEROS AL VALOR RAZONABLE"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_200109
+msgid "La Arena"
+msgstr "La Arena"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_220909
+msgid "La Banda de Shilcayo"
+msgstr "La Banda de Shilcayo"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_200703
+msgid "La Brea"
+msgstr "La Brea"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_180205
+msgid "La Capilla"
+msgstr "La Capilla"
+
+#. module: l10n_pe
+#: model:res.city,name:l10n_pe.city_pe_0809
+msgid "La Convención"
+msgstr "La Convención"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_240103
+msgid "La Cruz"
+msgstr "La Cruz"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_130606
+msgid "La Cuesta"
+msgstr "La Cuesta"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_061305
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_130105
+msgid "La Esperanza"
+msgstr "La Esperanza"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_061106
+msgid "La Florida"
+msgstr "La Florida"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_200505
+msgid "La Huaca"
+msgstr "La Huaca"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_010109
+msgid "La Jalca"
+msgstr "La Jalca"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_040108
+msgid "La Joya"
+msgstr "La Joya"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_020107
+msgid "La Libertad"
+msgstr "La Libertad"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_060312
+msgid "La Libertad de Pallan"
+msgstr "La Libertad de Pallan"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_200404
+msgid "La Matanza"
+msgstr "La Matanza"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_020204
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_090505
+msgid "La Merced"
+msgstr "La Merced"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_150114
+msgid "La Molina"
+msgstr "La Molina"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_100704
+msgid "La Morada"
+msgstr "La Morada"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_120801
+msgid "La Oroya"
+msgstr "La Oroya"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_020905
+msgid "La Pampa"
+msgstr "La Pampa"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_010206
+msgid "La Peca"
+msgstr "La Peca"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_070104
+msgid "La Perla"
+msgstr "La Perla"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_020511
+msgid "La Primavera"
+msgstr "La Primavera"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_070105
+msgid "La Punta"
+msgstr "La Punta"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_060605
+msgid "La Ramada"
+msgstr "La Ramada"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_110102
+msgid "La Tinguiña"
+msgstr "La Tinguiña"
+
+#. module: l10n_pe
+#: model:res.city,name:l10n_pe.city_pe_0408
+msgid "La Union"
+msgstr "La Union"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_100301
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_120705
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_200110
+msgid "La Unión"
+msgstr "La Unión"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_140106
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_150115
+msgid "La Victoria"
+msgstr "La Victoria"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_230111
+msgid "La Yarada los Palos"
+msgstr "La Yarada los Palos"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_060904
+msgid "La coipa"
+msgstr "La coipa"
+
+#. module: l10n_pe
+#: model:res.city,name:l10n_pe.city_pe_0505
+msgid "La mar"
+msgstr "La mar"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_170104
+msgid "Laberinto"
+msgstr "Laberinto"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_021506
+msgid "Lacabamba"
+msgstr "Lacabamba"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_150405
+msgid "Lachaqui"
+msgstr "Lachaqui"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_140107
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_160206
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_200204
+msgid "Lagunas"
+msgstr "Lagunas"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_150710
+msgid "Lahuaytambo"
+msgstr "Lahuaytambo"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_060410
+msgid "Lajas"
+msgstr "Lajas"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_200305
+msgid "Lalaquiz"
+msgstr "Lalaquiz"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_220501
+#: model:res.city,name:l10n_pe.city_pe_2205
+msgid "Lamas"
+msgstr "Lamas"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_080403
+msgid "Lamay"
+msgstr "Lamay"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_140301
+#: model:res.city,name:l10n_pe.city_pe_1403
+msgid "Lambayeque"
+msgstr "Lambayeque"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_030106
+msgid "Lambrama"
+msgstr "Lambrama"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_050804
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_210701
+#: model:res.city,name:l10n_pe.city_pe_2107
+msgid "Lampa"
+msgstr "Lampa"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_150607
+msgid "Lampian"
+msgstr "Lampian"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_010501
+msgid "Lamud"
+msgstr "Lamud"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_200604
+msgid "Lancones"
+msgstr "Lancones"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart36111
+#: model:account.account,name:l10n_pe.1_chart36411
+#: model:account.account,name:l10n_pe.2_chart36111
+#: model:account.account,name:l10n_pe.2_chart36411
+#: model:account.account.template,name:l10n_pe.chart36111
+#: model:account.account.template,name:l10n_pe.chart36411
+msgid "Land - Costs"
+msgstr "Terrenos - Costo"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart33111
+#: model:account.account,name:l10n_pe.2_chart33111
+#: model:account.account.template,name:l10n_pe.chart33111
+msgid "Land - Land - Costs"
+msgstr "Terrenos - Terrenos - Costo"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart33112
+#: model:account.account,name:l10n_pe.2_chart33112
+#: model:account.account.template,name:l10n_pe.chart33112
+msgid "Land - Land - Revaluation"
+msgstr "Terrenos - Terrenos - Revaluación"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart36112
+#: model:account.account,name:l10n_pe.1_chart36412
+#: model:account.account,name:l10n_pe.2_chart36112
+#: model:account.account,name:l10n_pe.2_chart36412
+#: model:account.account.template,name:l10n_pe.chart36112
+#: model:account.account.template,name:l10n_pe.chart36412
+msgid "Land - Revaluation"
+msgstr "Terrenos - Revaluación"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart31121
+#: model:account.account,name:l10n_pe.2_chart31121
+#: model:account.account.template,name:l10n_pe.chart31121
+msgid "Land - Rural - Costs"
+msgstr "Terrenos - Rurales - Costo"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart31124
+#: model:account.account,name:l10n_pe.2_chart31124
+#: model:account.account.template,name:l10n_pe.chart31124
+msgid "Land - Rural - Fair value"
+msgstr "Terrenos - Rurales - Fair value"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart31122
+#: model:account.account,name:l10n_pe.2_chart31122
+#: model:account.account.template,name:l10n_pe.chart31122
+msgid "Land - Rural - Revaluation"
+msgstr "Terrenos - Rurales - Revaluación"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart31111
+#: model:account.account,name:l10n_pe.2_chart31111
+#: model:account.account.template,name:l10n_pe.chart31111
+msgid "Land - Urban - Costs"
+msgstr "Terrenos - Urbanos - Costo"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart31114
+#: model:account.account,name:l10n_pe.2_chart31114
+#: model:account.account.template,name:l10n_pe.chart31114
+msgid "Land - Urban - Fair value"
+msgstr "Terrenos - Urbanos - Fair value"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart31112
+#: model:account.account,name:l10n_pe.2_chart31112
+#: model:account.account.template,name:l10n_pe.chart31112
+msgid "Land - Urban - Revaluation"
+msgstr "Terrenos - Urbanos - Revaluación"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_150711
+msgid "Langa"
+msgstr "Langa"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_080504
+msgid "Langui"
+msgstr "Langui"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_090605
+msgid "Laramarca"
+msgstr "Laramarca"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_050608
+msgid "Laramate"
+msgstr "Laramate"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_150712
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_151018
+msgid "Laraos"
+msgstr "Laraos"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_130106
+msgid "Laredo"
+msgstr "Laredo"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_080404
+msgid "Lares"
+msgstr "Lares"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_040510
+msgid "Lari"
+msgstr "Lari"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_090109
+msgid "Laria"
+msgstr "Laria"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_160105
+msgid "Las Amazonas"
+msgstr "Las Amazonas"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_200111
+msgid "Las Lomas"
+msgstr "Las Lomas"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_170103
+msgid "Las Piedras"
+msgstr "Las Piedras"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_060806
+msgid "Las Pirias"
+msgstr "Las Pirias"
+
+#. module: l10n_pe
 #: model:ir.model.fields,field_description:l10n_pe.field_l10n_pe_res_city_district____last_update
-#: model:ir.model.fields,field_description:l10n_pe.field_res_city____last_update
-#: model:ir.model.fields,field_description:l10n_pe.field_res_partner____last_update
 msgid "Last Modified on"
-msgstr "Última modificación el"
+msgstr "Última Modificación en"
 
 #. module: l10n_pe
 #: model:ir.model.fields,field_description:l10n_pe.field_l10n_pe_res_city_district__write_uid
 msgid "Last Updated by"
-msgstr "Última actualización por"
+msgstr "Última Actualización por"
 
 #. module: l10n_pe
 #: model:ir.model.fields,field_description:l10n_pe.field_l10n_pe_res_city_district__write_date
 msgid "Last Updated on"
-msgstr "Última actualización el"
+msgstr "Última Actualización en"
+
+#. module: l10n_pe
+#: model:res.city,name:l10n_pe.city_pe_1010
+msgid "Lauricocha"
+msgstr "Lauricocha"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_080505
+msgid "Layo"
+msgstr "Layo"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart183
+#: model:account.account,name:l10n_pe.2_chart183
+#: model:account.account.template,name:l10n_pe.chart183
+msgid "Leasings"
+msgstr "Alquileres"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart6352
+#: model:account.account,name:l10n_pe.1_chart7542
+#: model:account.account,name:l10n_pe.2_chart6352
+#: model:account.account,name:l10n_pe.2_chart7542
+#: model:account.account.template,name:l10n_pe.chart6352
+#: model:account.account.template,name:l10n_pe.chart7542
+msgid "Leasings - Buildings"
+msgstr "Alquileres - Edificaciones"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart6355
+#: model:account.account,name:l10n_pe.2_chart6355
+#: model:account.account.template,name:l10n_pe.chart6355
+msgid "Leasings - Furniture and fixtures"
+msgstr "Alquileres - Muebles y enseres"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart6351
+#: model:account.account,name:l10n_pe.1_chart7541
+#: model:account.account,name:l10n_pe.2_chart6351
+#: model:account.account,name:l10n_pe.2_chart7541
+#: model:account.account.template,name:l10n_pe.chart6351
+#: model:account.account.template,name:l10n_pe.chart7541
+msgid "Leasings - Land"
+msgstr "Alquileres - Terrenos"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart6353
+#: model:account.account,name:l10n_pe.1_chart7543
+#: model:account.account,name:l10n_pe.2_chart6353
+#: model:account.account,name:l10n_pe.2_chart7543
+#: model:account.account.template,name:l10n_pe.chart6353
+#: model:account.account.template,name:l10n_pe.chart7543
+msgid "Leasings - Machinery and exploitation equipment"
+msgstr "Alquileres - Maquinarias y equipos de explotación"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart6356
+#: model:account.account,name:l10n_pe.1_chart7545
+#: model:account.account,name:l10n_pe.2_chart6356
+#: model:account.account,name:l10n_pe.2_chart7545
+#: model:account.account.template,name:l10n_pe.chart6356
+#: model:account.account.template,name:l10n_pe.chart7545
+msgid "Leasings - Miscellaneous equipment"
+msgstr "Alquileres - Equipos diversos"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart7540
+#: model:account.account,name:l10n_pe.2_chart7540
+#: model:account.account.template,name:l10n_pe.chart7540
+msgid "Leasings - Production plants"
+msgstr "Alquileres - Plantas productoras"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart7544
+#: model:account.account,name:l10n_pe.2_chart7544
+#: model:account.account.template,name:l10n_pe.chart7544
+msgid "Leasings - Transport units"
+msgstr "Alquileres - Unidades de transporte"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart6354
+#: model:account.account,name:l10n_pe.2_chart6354
+#: model:account.account.template,name:l10n_pe.chart6354
+msgid "Leasings - Transportation equipment"
+msgstr "Alquileres - Equipo de transporte"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart582
+#: model:account.account,name:l10n_pe.2_chart582
+#: model:account.account.template,name:l10n_pe.chart582
+msgid "Legal"
+msgstr "Legal"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_010110
+msgid "Leimebamba"
+msgstr "Leimebamba"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_050609
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_150807
+#: model:res.city,name:l10n_pe.city_pe_1006
+msgid "Leoncio Prado"
+msgstr "Leoncio Prado"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_120413
+msgid "Leonor Ordoñez"
+msgstr "Leonor Ordoñez"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_010111
+msgid "Levanto"
+msgstr "Levanto"
+
+#. module: l10n_pe
+#: model:account.group,name:l10n_pe.1_group4
+#: model:account.group,name:l10n_pe.2_group4
+#: model:account.group.template,name:l10n_pe.group4
+msgid "Liabilities"
+msgstr "Pasivo"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart46422
+#: model:account.account,name:l10n_pe.2_chart46422
+#: model:account.account.template,name:l10n_pe.chart46422
+msgid ""
+"Liabilities for financial instruments - Derivative financial instruments - "
+"Hedging instruments"
+msgstr ""
+"Pasivos por instrumentos financieros - Derivative financial instruments - "
+"Instrumentos de cobertura"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart46421
+#: model:account.account,name:l10n_pe.2_chart46421
+#: model:account.account.template,name:l10n_pe.chart46421
+msgid ""
+"Liabilities for financial instruments - Derivative financial instruments - "
+"Trading book"
+msgstr ""
+"Pasivos por instrumentos financieros - Derivative financial instruments - "
+"Cartera de negociación"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart4641
+#: model:account.account,name:l10n_pe.2_chart4641
+#: model:account.account.template,name:l10n_pe.chart4641
+msgid "Liabilities for financial instruments - Primary financial instruments"
+msgstr ""
+"Pasivos por instrumentos financieros - Instrumentos financieros primarios"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart4653
+#: model:account.account,name:l10n_pe.1_chart4773
+#: model:account.account,name:l10n_pe.2_chart4653
+#: model:account.account,name:l10n_pe.2_chart4773
+#: model:account.account.template,name:l10n_pe.chart4653
+#: model:account.account.template,name:l10n_pe.chart4773
+msgid ""
+"Liabilities for purchase of fixed assets - Assets acquired under finance "
+"lease"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart4656
+#: model:account.account,name:l10n_pe.1_chart4776
+#: model:account.account,name:l10n_pe.2_chart4656
+#: model:account.account,name:l10n_pe.2_chart4776
+#: model:account.account.template,name:l10n_pe.chart4656
+#: model:account.account.template,name:l10n_pe.chart4776
+msgid "Liabilities for purchase of fixed assets - Biological assets"
+msgstr "Pasivo por compra de activo inmovilizado - Activos biológicos"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart4655
+#: model:account.account,name:l10n_pe.1_chart4775
+#: model:account.account,name:l10n_pe.2_chart4655
+#: model:account.account,name:l10n_pe.2_chart4775
+#: model:account.account.template,name:l10n_pe.chart4655
+#: model:account.account.template,name:l10n_pe.chart4775
+msgid "Liabilities for purchase of fixed assets - Intangibles"
+msgstr "Pasivos por compra de activo inmovilizado - Intangibles"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart4652
+#: model:account.account,name:l10n_pe.1_chart4772
+#: model:account.account,name:l10n_pe.2_chart4652
+#: model:account.account,name:l10n_pe.2_chart4772
+#: model:account.account.template,name:l10n_pe.chart4652
+#: model:account.account.template,name:l10n_pe.chart4772
+msgid "Liabilities for purchase of fixed assets - Investment property"
+msgstr "Pasivos por compra de activo inmovilizado - Propiedades de inversión"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart4654
+#: model:account.account,name:l10n_pe.1_chart4774
+#: model:account.account,name:l10n_pe.2_chart4654
+#: model:account.account,name:l10n_pe.2_chart4774
+#: model:account.account.template,name:l10n_pe.chart4654
+#: model:account.account.template,name:l10n_pe.chart4774
+msgid ""
+"Liabilities for purchase of fixed assets - Property, plant and equipment"
+msgstr ""
+"Pasivo por compra de activo inmovilizado - Propiedades, planta y equipo"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart4651
+#: model:account.account,name:l10n_pe.1_chart4771
+#: model:account.account,name:l10n_pe.2_chart4651
+#: model:account.account,name:l10n_pe.2_chart4771
+#: model:account.account.template,name:l10n_pe.chart4651
+#: model:account.account.template,name:l10n_pe.chart4771
+msgid "Liabilities for purchase of fixed assets - Securities investments"
+msgstr "Pasivo por compra de activo inmovilizado - Inversiones mobiliarias"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart654
+#: model:account.account,name:l10n_pe.2_chart654
+#: model:account.account.template,name:l10n_pe.chart654
+msgid "Licenses and validity rights"
+msgstr "Licencias y derechos de vigencia"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_150101
+#: model:res.city,name:l10n_pe.city_pe_1501
+msgid "Lima"
+msgstr "Lima"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_010605
+msgid "Limabamba"
+msgstr "Limabamba"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_080306
+msgid "Limatambo"
+msgstr "Limatambo"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_211203
+msgid "Limbani"
+msgstr "Limbani"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_150116
+msgid "Lince"
+msgstr "Lince"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_151019
+msgid "Lincha"
+msgstr "Lincha"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_pe_chart_template_liquidity_transfer
+#: model:account.account,name:l10n_pe.2_pe_chart_template_liquidity_transfer
+#: model:account.account.template,name:l10n_pe.pe_chart_template_liquidity_transfer
+msgid "Liquidity Transfer"
+msgstr "Transferencia de Liquidez"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_090301
+msgid "Lircay"
+msgstr "Lircay"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_080705
+msgid "Livitaca"
+msgstr "Livitaca"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_060107
+msgid "Llacanora"
+msgstr "Llacanora"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_021705
+msgid "Llacllin"
+msgstr "Llacllin"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_210804
+msgid "Llalli"
+msgstr "Llalli"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_021305
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_060411
+msgid "Llama"
+msgstr "Llama"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_020301
+msgid "Llamellin"
+msgstr "Llamellin"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_061107
+msgid "Llapa"
+msgstr "Llapa"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_021507
+msgid "Llapo"
+msgstr "Llapo"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_100501
+msgid "Llata"
+msgstr "Llata"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_050610
+msgid "Llauta"
+msgstr "Llauta"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_120603
+msgid "Llaylla"
+msgstr "Llaylla"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_021407
+msgid "Llipa"
+msgstr "Llipa"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_110402
+msgid "Llipata"
+msgstr "Llipata"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_050408
+msgid "Llochegua"
+msgstr "Llochegua"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_120414
+msgid "Llocllapampa"
+msgstr "Llocllapampa"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_180206
+msgid "Lloque"
+msgstr "Lloque"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_021306
+msgid "Llumpa"
+msgstr "Llumpa"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_080706
+msgid "Llusco"
+msgstr "Llusco"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_040511
+msgid "Lluta"
+msgstr "Lluta"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart471
+#: model:account.account,name:l10n_pe.2_chart471
+#: model:account.account.template,name:l10n_pe.chart471
+msgid "Loans"
+msgstr "Préstamos"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart1612
+#: model:account.account,name:l10n_pe.1_chart1712
+#: model:account.account,name:l10n_pe.2_chart1612
+#: model:account.account,name:l10n_pe.2_chart1712
+#: model:account.account.template,name:l10n_pe.chart1612
+#: model:account.account.template,name:l10n_pe.chart1712
+msgid "Loans - Whithout garantee"
+msgstr "Préstamos - Sin garantía"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart1611
+#: model:account.account,name:l10n_pe.1_chart1711
+#: model:account.account,name:l10n_pe.2_chart1611
+#: model:account.account,name:l10n_pe.2_chart1711
+#: model:account.account.template,name:l10n_pe.chart1611
+#: model:account.account.template,name:l10n_pe.chart1711
+msgid "Loans - With guarantee"
+msgstr "Préstamos - Con garantía"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart4511
+#: model:account.account,name:l10n_pe.2_chart4511
+#: model:account.account.template,name:l10n_pe.chart4511
+msgid ""
+"Loans from financial institutions and other entities - Financial "
+"institutions"
+msgstr ""
+"Préstamos de instituciones financieras y otras entidades - Instituciones "
+"financieras"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart4512
+#: model:account.account,name:l10n_pe.2_chart4512
+#: model:account.account.template,name:l10n_pe.chart4512
+msgid "Loans from financial institutions and other entities - Other entities"
+msgstr ""
+"Préstamos de instituciones financieras y otras entidades - Otras entidades"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart456
+#: model:account.account,name:l10n_pe.2_chart456
+#: model:account.account.template,name:l10n_pe.chart456
+msgid "Loans with repurchase commitments"
+msgstr "Préstamos con compromisos de recompra"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_200704
+msgid "Lobitos"
+msgstr "Lobitos"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart6432
+#: model:account.account,name:l10n_pe.2_chart6432
+#: model:account.account.template,name:l10n_pe.chart6432
+msgid "Local government - Municipal taxes and citizen security"
+msgstr "Gobierno local - Arbitrios municipales y seguridad ciudadana"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart6434
+#: model:account.account,name:l10n_pe.2_chart6434
+#: model:account.account.template,name:l10n_pe.chart6434
+msgid "Local government - Operating license"
+msgstr "Gobierno local - Licencia de funcionamiento"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart6439
+#: model:account.account,name:l10n_pe.2_chart6439
+#: model:account.account.template,name:l10n_pe.chart6439
+msgid "Local government - Others"
+msgstr "Gobierno local - Otros"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart6431
+#: model:account.account,name:l10n_pe.2_chart6431
+#: model:account.account.template,name:l10n_pe.chart6431
+msgid "Local government - Property tax"
+msgstr "Gobierno local - Impuesto predial"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart6433
+#: model:account.account,name:l10n_pe.2_chart6433
+#: model:account.account.template,name:l10n_pe.chart6433
+msgid "Local government - Vehicle property tax"
+msgstr "Gobierno local - Impuesto al patrimonio vehicular"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart4062
+#: model:account.account,name:l10n_pe.2_chart4062
+#: model:account.account.template,name:l10n_pe.chart4062
+msgid "Local governments - Contributions"
+msgstr "Gobiernos locales - Contribuciones"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart40635
+#: model:account.account,name:l10n_pe.2_chart40635
+#: model:account.account.template,name:l10n_pe.chart40635
+msgid "Local governments - Fees - Administrative services or rights"
+msgstr "Gobiernos locales - Tasas - Servicios administrativos o derechos"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart40631
+#: model:account.account,name:l10n_pe.2_chart40631
+#: model:account.account.template,name:l10n_pe.chart40631
+msgid "Local governments - Fees - Establishment opening license"
+msgstr "Gobiernos locales - Tasas - Licencia de apertura de establecimientos"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart40634
+#: model:account.account,name:l10n_pe.2_chart40634
+#: model:account.account.template,name:l10n_pe.chart40634
+msgid "Local governments - Fees - Public or arbitrary services"
+msgstr "Gobiernos locales - Tasas - Servicios públicos o arbitrios"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart40632
+#: model:account.account,name:l10n_pe.2_chart40632
+#: model:account.account.template,name:l10n_pe.chart40632
+msgid "Local governments - Fees - Public transportation"
+msgstr "Gobiernos locales - Tasas - Transporte público"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart40633
+#: model:account.account,name:l10n_pe.2_chart40633
+#: model:account.account.template,name:l10n_pe.chart40633
+msgid "Local governments - Fees - Vehicle parking"
+msgstr "Gobiernos locales - Tasas - Estacionamiento de vehículos"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart40612
+#: model:account.account,name:l10n_pe.2_chart40612
+#: model:account.account.template,name:l10n_pe.chart40612
+msgid "Local governments - Taxes - Gambling tax"
+msgstr "Gobiernos locales - Impuestos - Impuesto a las apuestas"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart40613
+#: model:account.account,name:l10n_pe.2_chart40613
+#: model:account.account.template,name:l10n_pe.chart40613
+msgid "Local governments - Taxes - Gaming taxes"
+msgstr "Gobiernos locales - Impuestos - Impuesto a los juegos"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart40614
+#: model:account.account,name:l10n_pe.2_chart40614
+#: model:account.account.template,name:l10n_pe.chart40614
+msgid "Local governments - Taxes - Impuesto de alcabala"
+msgstr "Gobiernos locales - Impuestos - Impuesto de alcabala"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart40615
+#: model:account.account,name:l10n_pe.2_chart40615
+#: model:account.account.template,name:l10n_pe.chart40615
+msgid "Local governments - Taxes - Property tax"
+msgstr "Gobiernos locales - Impuestos - Impuesto predial"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart40616
+#: model:account.account,name:l10n_pe.2_chart40616
+#: model:account.account.template,name:l10n_pe.chart40616
+msgid "Local governments - Taxes - Tax on non-sporting public shows"
+msgstr ""
+"Gobiernos locales - Impuestos - Impuesto a los espectáculos públicos no "
+"deportivos"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart40611
+#: model:account.account,name:l10n_pe.2_chart40611
+#: model:account.account.template,name:l10n_pe.chart40611
+msgid "Local governments - Taxes - Vehicle property tax"
+msgstr "Gobiernos locales - Impuestos - Impuesto al patrimonio vehicular"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_090506
+msgid "Locroja"
+msgstr "Locroja"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_230301
+msgid "Locumba"
+msgstr "Locumba"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_040311
+msgid "Lomas"
+msgstr "Lomas"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_010606
+msgid "Longar"
+msgstr "Longar"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_130304
+msgid "Longotea"
+msgstr "Longotea"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_010507
+msgid "Longuita"
+msgstr "Longuita"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_010508
+msgid "Lonya Chico"
+msgstr "Lonya Chico"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_010706
+msgid "Lonya Grande"
+msgstr "Lonya Grande"
+
+#. module: l10n_pe
+#: model:res.city,name:l10n_pe.city_pe_1603
+msgid "Loreto"
+msgstr "Loreto"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_110103
+msgid "Los Aquijes"
+msgstr "Los Aquijes"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_060108
+msgid "Los Baños del Inca"
+msgstr "Los Baños del Inca"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_030611
+msgid "Los Chankas"
+msgstr "Los Chankas"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_050203
+msgid "Los Morochucos"
+msgstr "Los Morochucos"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_150117
+msgid "Los Olivos"
+msgstr "Los Olivos"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_200705
+msgid "Los Organos"
+msgstr "Los Organos"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart6771
+#: model:account.account,name:l10n_pe.2_chart6771
+#: model:account.account.template,name:l10n_pe.chart6771
+msgid ""
+"Loss from measurement of financial assets and liabilities at fair value - "
+"Investments held for trading"
+msgstr ""
+"Pérdida por medición de activos y pasivos financieros al valor razonable - "
+"Inversiones mantenidas para negociación"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart6772
+#: model:account.account,name:l10n_pe.2_chart6772
+#: model:account.account.template,name:l10n_pe.chart6772
+msgid ""
+"Loss from measurement of financial assets and liabilities at fair value - "
+"Other financial investments"
+msgstr ""
+"Pérdida por medición de activos y pasivos financieros al valor razonable - "
+"Otras inversiones financieras"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart6773
+#: model:account.account,name:l10n_pe.2_chart6773
+#: model:account.account.template,name:l10n_pe.chart6773
+msgid ""
+"Loss from measurement of financial assets and liabilities at fair value - "
+"Others"
+msgstr ""
+"Pérdida por medición de activos y pasivos financieros al valor razonable - "
+"Otros"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart672
+#: model:account.account,name:l10n_pe.2_chart672
+#: model:account.account.template,name:l10n_pe.chart672
+msgid "Loss on derivative financial instruments"
+msgstr "Pérdida por instrumentos financieros derivados"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart892
+#: model:account.account,name:l10n_pe.2_chart892
+#: model:account.account.template,name:l10n_pe.chart892
+msgid "Lost"
+msgstr "Pérdida"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_050611
+#: model:res.city,name:l10n_pe.city_pe_0506
+msgid "Lucanas"
+msgstr "Lucanas"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_021307
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_131102
+msgid "Lucma"
+msgstr "Lucma"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_030409
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_081208
+msgid "Lucre"
+msgstr "Lucre"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_050506
+msgid "Luis Carranza"
+msgstr "Luis Carranza"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_150508
+msgid "Lunahuana"
+msgstr "Lunahuana"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_050405
+msgid "Luricocha"
+msgstr "Luricocha"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_150118
+msgid "Lurigancho"
+msgstr "Lurigancho"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_150119
+msgid "Lurin"
+msgstr "Lurin"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_010509
+#: model:res.city,name:l10n_pe.city_pe_0105
+msgid "Luya"
+msgstr "Luya"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_010510
+msgid "Luya Viejo"
+msgstr "Luya Viejo"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_100605
+msgid "Luyando"
+msgstr "Luyando"
+
+#. module: l10n_pe
+#: model:account.group,name:l10n_pe.1_group20
+#: model:account.group,name:l10n_pe.2_group20
+#: model:account.group.template,name:l10n_pe.group20
+msgid "MERCHANDISE"
+msgstr "MERCADERÍAS"
+
+#. module: l10n_pe
+#: model:account.group,name:l10n_pe.1_group17
+#: model:account.group,name:l10n_pe.2_group17
+#: model:account.group.template,name:l10n_pe.group17
+msgid "MISCELLANEOUS ACCOUNTS RECEIVABLE – ASSOCIATED"
+msgstr "CUENTAS POR COBRAR DIVERSAS – RELACIONADAS"
+
+#. module: l10n_pe
+#: model:account.group,name:l10n_pe.1_group16
+#: model:account.group,name:l10n_pe.2_group16
+#: model:account.group.template,name:l10n_pe.group16
+msgid "MISCELLANEOUS ACCOUNTS RECEIVABLE – THIRD PARTIES"
+msgstr "CUENTAS POR COBRAR DIVERSAS – TERCEROS"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_040512
+msgid "Maca"
+msgstr "Maca"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_210805
+msgid "Macari"
+msgstr "Macari"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_021804
+msgid "Macate"
+msgstr "Macate"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_040408
+msgid "Machaguay"
+msgstr "Machaguay"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_130608
+msgid "Mache"
+msgstr "Mache"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart36431
+#: model:account.account,name:l10n_pe.2_chart36431
+#: model:account.account.template,name:l10n_pe.chart36431
+msgid "Machinery and exploitation equipment - Costs"
+msgstr "Maquinarias y equipos de explotación - Costo"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart36433
+#: model:account.account,name:l10n_pe.2_chart36433
+#: model:account.account.template,name:l10n_pe.chart36433
+msgid "Machinery and exploitation equipment - Financing costs"
+msgstr "Maquinarias y equipos de explotación - Costos de financiación"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart33311
+#: model:account.account,name:l10n_pe.2_chart33311
+#: model:account.account.template,name:l10n_pe.chart33311
+msgid ""
+"Machinery and exploitation equipment - Machinery and exploitation equipment "
+"- Costs"
+msgstr ""
+"Maquinarias y equipos de explotación - Maquinarias y equipos de explotación "
+"- Costo"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart33313
+#: model:account.account,name:l10n_pe.2_chart33313
+#: model:account.account.template,name:l10n_pe.chart33313
+msgid ""
+"Machinery and exploitation equipment - Machinery and exploitation equipment "
+"- Financing costs"
+msgstr ""
+"Maquinarias y equipos de explotación - Maquinarias y equipos de explotación "
+"- Costos de financiación"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart33312
+#: model:account.account,name:l10n_pe.2_chart33312
+#: model:account.account.template,name:l10n_pe.chart33312
+msgid ""
+"Machinery and exploitation equipment - Machinery and exploitation equipment "
+"- Revaluation"
+msgstr ""
+"Maquinarias y equipos de explotación - Maquinarias y equipos de explotación "
+"- Revaluación"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart36432
+#: model:account.account,name:l10n_pe.2_chart36432
+#: model:account.account.template,name:l10n_pe.chart36432
+msgid "Machinery and exploitation equipment - Revaluation"
+msgstr "Maquinarias y equipos de explotación - Revaluación"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_081304
+msgid "Machupicchu"
+msgstr "Machupicchu"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_210301
+msgid "Macusani"
+msgstr "Macusani"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_151020
+msgid "Madean"
+msgstr "Madean"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_170203
+msgid "Madre de Dios"
+msgstr "Madre de Dios"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_040513
+msgid "Madrigal"
+msgstr "Madrigal"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_010112
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_060109
+msgid "Magdalena"
+msgstr "Magdalena"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_130204
+msgid "Magdalena de Cao"
+msgstr "Magdalena de Cao"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_150120
+msgid "Magdalena del Mar"
+msgstr "Magdalena del Mar"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart6345
+#: model:account.account,name:l10n_pe.2_chart6345
+#: model:account.account.template,name:l10n_pe.chart6345
+msgid "Maintenance and repairs - Biological assets"
+msgstr "Mantenimiento y reparaciones - Activos biológicos"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart6344
+#: model:account.account,name:l10n_pe.2_chart6344
+#: model:account.account.template,name:l10n_pe.chart6344
+msgid "Maintenance and repairs - Intangibles"
+msgstr "Mantenimiento y reparaciones - Intangibles"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart6341
+#: model:account.account,name:l10n_pe.2_chart6341
+#: model:account.account.template,name:l10n_pe.chart6341
+msgid "Maintenance and repairs - Investment property"
+msgstr "Mantenimiento y reparaciones - Propiedad de inversión"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart63432
+#: model:account.account,name:l10n_pe.2_chart63432
+#: model:account.account.template,name:l10n_pe.chart63432
+msgid "Maintenance and repairs - Property, plant and equipment - Operational"
+msgstr ""
+"Mantenimiento y reparaciones - Propiedades, planta y equipo - Operativo"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart63421
+#: model:account.account,name:l10n_pe.2_chart63421
+#: model:account.account.template,name:l10n_pe.chart63421
+msgid "Maintenance and repairs - Right-of-use assets - Financial"
+msgstr ""
+"Mantenimiento y reparaciones - Activos por derecho de uso - Financiero"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart185
+#: model:account.account,name:l10n_pe.2_chart185
+#: model:account.account.template,name:l10n_pe.chart185
+msgid "Maintenance of fixed assets"
+msgstr "Mantenimiento de activos inmovilizados"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_040520
+msgid "Majes"
+msgstr "Majes"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_150509
+msgid "Mala"
+msgstr "Mala"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_021105
+msgid "Malvas"
+msgstr "Malvas"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_030705
+msgid "Mamara"
+msgstr "Mamara"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_250107
+msgid "Manantay"
+msgstr "Manantay"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_150305
+msgid "Manas"
+msgstr "Manas"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_200706
+msgid "Mancora"
+msgstr "Mancora"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_022003
+msgid "Mancos"
+msgstr "Mancos"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_020512
+msgid "Mangas"
+msgstr "Mangas"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_160703
+msgid "Manseriche"
+msgstr "Manseriche"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_090110
+msgid "Manta"
+msgstr "Manta"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_170201
+#: model:res.city,name:l10n_pe.city_pe_1702
+msgid "Manu"
+msgstr "Manu"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_140204
+msgid "Manuel Antonio Mesones Muro"
+msgstr "Manuel Antonio Mesones Muro"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_120208
+msgid "Manzanares"
+msgstr "Manzanares"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_160505
+msgid "Maquia"
+msgstr "Maquia"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_030505
+msgid "Mara"
+msgstr "Mara"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_080604
+msgid "Marangani"
+msgstr "Marangani"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_080904
+msgid "Maranura"
+msgstr "Maranura"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_081305
+msgid "Maras"
+msgstr "Maras"
+
+#. module: l10n_pe
+#: model:res.city,name:l10n_pe.city_pe_1007
+msgid "Marañón"
+msgstr "Marañón"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_021706
+msgid "Marca"
+msgstr "Marca"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_130905
+msgid "Marcabal"
+msgstr "Marcabal"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_050805
+msgid "Marcabamba"
+msgstr "Marcabamba"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_081209
+msgid "Marcapata"
+msgstr "Marcapata"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_120804
+msgid "Marcapomacocha"
+msgstr "Marcapomacocha"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_020606
+msgid "Marcara"
+msgstr "Marcara"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_090205
+msgid "Marcas"
+msgstr "Marcas"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_200605
+msgid "Marcavelica"
+msgstr "Marcavelica"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_120415
+msgid "Marco"
+msgstr "Marco"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_110304
+msgid "Marcona"
+msgstr "Marcona"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart801
+#: model:account.account,name:l10n_pe.2_chart801
+#: model:account.account.template,name:l10n_pe.chart801
+msgid "Margen comercial"
+msgstr "Margen comercial"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_100105
+msgid "Margos"
+msgstr "Margos"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_100606
+msgid "Mariano Damaso Beraun"
+msgstr "Mariano Damaso Beraun"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_010607
+msgid "Mariscal Benavides"
+msgstr "Mariscal Benavides"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_010113
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_120209
+msgid "Mariscal Castilla"
+msgstr "Mariscal Castilla"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_040204
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_090111
+#: model:res.city,name:l10n_pe.city_pe_2206
+msgid "Mariscal Cáceres"
+msgstr "Mariscal Cáceres"
+
+#. module: l10n_pe
+#: model:res.city,name:l10n_pe.city_pe_0213
+msgid "Mariscal Luzuriaga"
+msgstr "Mariscal Luzuriaga"
+
+#. module: l10n_pe
+#: model:res.city,name:l10n_pe.city_pe_1801
+msgid "Mariscal Nieto"
+msgstr "Mariscal Nieto"
+
+#. module: l10n_pe
+#: model:res.city,name:l10n_pe.city_pe_1604
+msgid "Mariscal Ramón Castilla"
+msgstr "Mariscal Ramón Castilla"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_131103
+msgid "Marmot"
+msgstr "Marmot"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_010511
+msgid "María"
+msgstr "María"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_050204
+msgid "María Parado de Bellido"
+msgstr "María Parado de Bellido"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_040109
+msgid "Maríano Melgar"
+msgstr "Maríano Melgar"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_040203
+msgid "Maríano Nicolás Valcárcel"
+msgstr "Maríano Nicolás Valcárcel"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_100311
+msgid "Marías"
+msgstr "Marías"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_150713
+msgid "Maríatana"
+msgstr "Maríatana"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_021009
+msgid "Masin"
+msgstr "Masin"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_250104
+msgid "Masisea"
+msgstr "Masisea"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_120416
+msgid "Masma"
+msgstr "Masma"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_120417
+msgid "Masma Chicche"
+msgstr "Masma Chicche"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_022004
+msgid "Matacoto"
+msgstr "Matacoto"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_120210
+msgid "Matahuasi"
+msgstr "Matahuasi"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_180207
+msgid "Matalaque"
+msgstr "Matalaque"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_240303
+msgid "Matapalo"
+msgstr "Matapalo"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_060110
+msgid "Matara"
+msgstr "Matara"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_021205
+msgid "Mato"
+msgstr "Mato"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_150701
+msgid "Matucana"
+msgstr "Matucana"
+
+#. module: l10n_pe
+#: model:res.city,name:l10n_pe.city_pe_1601
+msgid "Maynas"
+msgstr "Maynas"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_120604
+msgid "Mazamari"
+msgstr "Mazamari"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_160106
+msgid "Mazan"
+msgstr "Mazan"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_210109
+msgid "Mañazo"
+msgstr "Mañazo"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_080914
+msgid "Megantoni"
+msgstr "Megantoni"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_040705
+msgid "Mejia"
+msgstr "Mejia"
+
+#. module: l10n_pe
+#: model:res.city,name:l10n_pe.city_pe_2108
+msgid "Melgar"
+msgstr "Melgar"
+
+#. module: l10n_pe
+#: model:account.group,name:l10n_pe.1_group0
+#: model:account.group,name:l10n_pe.2_group0
+#: model:account.group.template,name:l10n_pe.group0
+msgid "Memorandum accounts"
+msgstr "Cuentas de orden"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart281
+#: model:account.account,name:l10n_pe.2_chart281
+#: model:account.account.template,name:l10n_pe.chart281
+msgid "Merchandise"
+msgstr "Mercaderías"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart6011
+#: model:account.account,name:l10n_pe.1_chart6111
+#: model:account.account,name:l10n_pe.2_chart6011
+#: model:account.account,name:l10n_pe.2_chart6111
+#: model:account.account.template,name:l10n_pe.chart6011
+#: model:account.account.template,name:l10n_pe.chart6111
+msgid "Merchandise - Merchandise"
+msgstr "Mercaderías - Mercaderías"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart20111
+#: model:account.account,name:l10n_pe.1_chart29111
+#: model:account.account,name:l10n_pe.2_chart20111
+#: model:account.account,name:l10n_pe.2_chart29111
+#: model:account.account.template,name:l10n_pe.chart20111
+#: model:account.account.template,name:l10n_pe.chart29111
+msgid "Merchandise - Merchandise - Costs"
+msgstr "Mercaderías - Mercaderías - Costo"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart70112
+#: model:account.account,name:l10n_pe.2_chart70112
+#: model:account.account.template,name:l10n_pe.chart70112
+msgid "Merchandise - Merchandise - Export sale - Associated"
+msgstr "Mercaderías - Mercaderías - Venta de exportación - Relacionadas"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart70111
+#: model:account.account,name:l10n_pe.2_chart70111
+#: model:account.account.template,name:l10n_pe.chart70111
+msgid "Merchandise - Merchandise - Export sale - Third parties"
+msgstr "Mercaderías - Mercaderías - Venta de exportación - Terceros"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart69112
+#: model:account.account,name:l10n_pe.2_chart69112
+#: model:account.account.template,name:l10n_pe.chart69112
+msgid "Merchandise - Merchandise - Exportation - Associated"
+msgstr "Mercaderías - Mercaderías - Exportación - Relacionadas"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart69111
+#: model:account.account,name:l10n_pe.2_chart69111
+#: model:account.account.template,name:l10n_pe.chart69111
+msgid "Merchandise - Merchandise - Exportation - Third parties"
+msgstr "Mercaderías - Mercaderías - Exportación - Terceros"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart20114
+#: model:account.account,name:l10n_pe.2_chart20114
+#: model:account.account.template,name:l10n_pe.chart20114
+msgid "Merchandise - Merchandise - Fair value"
+msgstr "Mercaderías - Mercaderías - Valor razonable"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart69122
+#: model:account.account,name:l10n_pe.1_chart70122
+#: model:account.account,name:l10n_pe.2_chart69122
+#: model:account.account,name:l10n_pe.2_chart70122
+#: model:account.account.template,name:l10n_pe.chart69122
+#: model:account.account.template,name:l10n_pe.chart70122
+msgid "Merchandise - Merchandise - Local sale - Associated"
+msgstr "Mercaderías - Mercaderías - Venta local - Relacionadas"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart69121
+#: model:account.account,name:l10n_pe.1_chart70121
+#: model:account.account,name:l10n_pe.2_chart69121
+#: model:account.account,name:l10n_pe.2_chart70121
+#: model:account.account.template,name:l10n_pe.chart69121
+#: model:account.account.template,name:l10n_pe.chart70121
+msgid "Merchandise - Merchandise - Local sale - Third parties"
+msgstr "Mercaderías - Mercaderías - Venta local - Terceros"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_070107
+msgid "Mi Perú"
+msgstr "Mi Perú"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_030706
+msgid "Micaela Bastidas"
+msgstr "Micaela Bastidas"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_200606
+msgid "Miguel Checa"
+msgstr "Miguel Checa"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_060307
+msgid "Miguel Iglesias"
+msgstr "Miguel Iglesias"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_010608
+msgid "Milpuc"
+msgstr "Milpuc"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_060412
+msgid "Miracosta"
+msgstr "Miracosta"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_040110
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_100506
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_150122
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_151021
+msgid "Miraflores"
+msgstr "Miraflores"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_020305
+msgid "Mirgas"
+msgstr "Mirgas"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart3823
+#: model:account.account,name:l10n_pe.2_chart3823
+#: model:account.account.template,name:l10n_pe.chart3823
+msgid "Misc. - Assets received in payment (awarded and realizable)"
+msgstr "Diversos - Bienes recibidos en pago (adjudicados y realizables)"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart3821
+#: model:account.account,name:l10n_pe.2_chart3821
+#: model:account.account.template,name:l10n_pe.chart3821
+msgid "Misc. - Coins and jewelry"
+msgstr "Diversos - Monedas y joyas"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart3822
+#: model:account.account,name:l10n_pe.2_chart3822
+#: model:account.account.template,name:l10n_pe.chart3822
+msgid "Misc. - Goods delivered on loan"
+msgstr "Diversos - Bienes entregados en comodato"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart3829
+#: model:account.account,name:l10n_pe.2_chart3829
+#: model:account.account.template,name:l10n_pe.chart3829
+msgid "Misc. - Others"
+msgstr "Diversos - Otros"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart33621
+#: model:account.account,name:l10n_pe.2_chart33621
+#: model:account.account.template,name:l10n_pe.chart33621
+msgid "Miscellaneous equipment - Communication equipment - Costs"
+msgstr "Equipos diversos - Equipo de comunicación - Costo"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart33622
+#: model:account.account,name:l10n_pe.2_chart33622
+#: model:account.account.template,name:l10n_pe.chart33622
+msgid "Miscellaneous equipment - Communication equipment - Revaluation"
+msgstr "Equipos diversos - Equipo de comunicación - Revaluación"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart36461
+#: model:account.account,name:l10n_pe.2_chart36461
+#: model:account.account.template,name:l10n_pe.chart36461
+msgid "Miscellaneous equipment - Costs"
+msgstr "Equipos diversos - Costo"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart33641
+#: model:account.account,name:l10n_pe.2_chart33641
+#: model:account.account.template,name:l10n_pe.chart33641
+msgid "Miscellaneous equipment - Environmental equipment - Costs"
+msgstr "Equipos diversos - Equipo de medio ambiente - Costo"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart33642
+#: model:account.account,name:l10n_pe.2_chart33642
+#: model:account.account.template,name:l10n_pe.chart33642
+msgid "Miscellaneous equipment - Environmental equipment - Revaluation"
+msgstr "Equipos diversos - Equipo de medio ambiente - Revaluación"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart33611
+#: model:account.account,name:l10n_pe.2_chart33611
+#: model:account.account.template,name:l10n_pe.chart33611
+msgid "Miscellaneous equipment - Information processing equipment - Costs"
+msgstr "Equipos diversos - Equipo para procesamiento de información - Costo"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart33612
+#: model:account.account,name:l10n_pe.2_chart33612
+#: model:account.account.template,name:l10n_pe.chart33612
+msgid ""
+"Miscellaneous equipment - Information processing equipment - Revaluation"
+msgstr ""
+"Equipos diversos - Equipo para procesamiento de información - Revaluación"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart33691
+#: model:account.account,name:l10n_pe.2_chart33691
+#: model:account.account.template,name:l10n_pe.chart33691
+msgid "Miscellaneous equipment - Other equipments - Costs"
+msgstr "Equipos diversos - Otros equipos - Costo"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart33692
+#: model:account.account,name:l10n_pe.2_chart33692
+#: model:account.account.template,name:l10n_pe.chart33692
+msgid "Miscellaneous equipment - Other equipments - Revaluation"
+msgstr "Equipos diversos - Otros equipos - Revaluación"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart36462
+#: model:account.account,name:l10n_pe.2_chart36462
+#: model:account.account.template,name:l10n_pe.chart36462
+msgid "Miscellaneous equipment - Revaluation"
+msgstr "Equipos diversos - Revaluación"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart33631
+#: model:account.account,name:l10n_pe.2_chart33631
+#: model:account.account.template,name:l10n_pe.chart33631
+msgid "Miscellaneous equipment - Security equipment - Costs"
+msgstr "Equipos diversos - Equipo de seguridad - Costo"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart33632
+#: model:account.account,name:l10n_pe.2_chart33632
+#: model:account.account.template,name:l10n_pe.chart33632
+msgid "Miscellaneous equipment - Security equipment - Revaluation"
+msgstr "Equipos diversos - Revaluación"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_120211
+msgid "Mito"
+msgstr "Mito"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_130107
+msgid "Moche"
+msgstr "Moche"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_140305
+msgid "Mochumi"
+msgstr "Mochumi"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_210901
+#: model:res.city,name:l10n_pe.city_pe_2109
+msgid "Moho"
+msgstr "Moho"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_100803
+msgid "Molino"
+msgstr "Molino"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_010114
+msgid "Molinopampa"
+msgstr "Molinopampa"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_120418
+msgid "Molinos"
+msgstr "Molinos"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_131004
+msgid "Mollebamba"
+msgstr "Mollebamba"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_040111
+msgid "Mollebaya"
+msgstr "Mollebaya"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_040701
+msgid "Mollendo"
+msgstr "Mollendo"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_090409
+msgid "Mollepampa"
+msgstr "Mollepampa"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_080307
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_131005
+msgid "Mollepata"
+msgstr "Mollepata"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_120419
+msgid "Monobamba"
+msgstr "Monobamba"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_140108
+msgid "Monsefu"
+msgstr "Monsefu"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_200205
+msgid "Montero"
+msgstr "Montero"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_010115
+msgid "Montevideo"
+msgstr "Montevideo"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_100507
+msgid "Monzón"
+msgstr "Monzón"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_180101
+msgid "Moquegua"
+msgstr "Moquegua"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_220910
+msgid "Morales"
+msgstr "Morales"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_050906
+msgid "Morcolla"
+msgstr "Morcolla"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_021805
+msgid "Moro"
+msgstr "Moro"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_120805
+msgid "Morococha"
+msgstr "Morococha"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_160704
+msgid "Morona"
+msgstr "Morona"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_140306
+msgid "Morrope"
+msgstr "Morrope"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_200405
+msgid "Morropon"
+msgstr "Morropon"
+
+#. module: l10n_pe
+#: model:res.city,name:l10n_pe.city_pe_2004
+msgid "Morropón"
+msgstr "Morropón"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_080204
+msgid "Mosoc Llacta"
+msgstr "Mosoc Llacta"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_140307
+msgid "Motupe"
+msgstr "Motupe"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_090112
+msgid "Moya"
+msgstr "Moya"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_220101
+#: model:res.city,name:l10n_pe.city_pe_2201
+msgid "Moyobamba"
+msgstr "Moyobamba"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_120420
+msgid "Muqui"
+msgstr "Muqui"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_120421
+msgid "Muquiyauyo"
+msgstr "Muquiyauyo"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_021308
+msgid "Musga"
+msgstr "Musga"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_210208
+msgid "Muñani"
+msgstr "Muñani"
+
+#. module: l10n_pe
+#: model:account.group,name:l10n_pe.1_group27
+#: model:account.group,name:l10n_pe.2_group27
+#: model:account.group.template,name:l10n_pe.group27
+msgid "NON-CURRENT ASSETS HELD FOR SALE"
+msgstr "ACTIVOS NO CORRIENTES MANTENIDOS PARA LA VENTA"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_060905
+msgid "Namballe"
+msgstr "Namballe"
+
+#. module: l10n_pe
+#: model:ir.model.fields,field_description:l10n_pe.field_l10n_pe_res_city_district__name
+msgid "Name"
+msgstr "Nombre"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_060111
+msgid "Namora"
+msgstr "Namora"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_061108
+msgid "Nanchoc"
+msgstr "Nanchoc"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_160107
+msgid "Napo"
+msgstr "Napo"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart40151
+#: model:account.account,name:l10n_pe.2_chart40151
+#: model:account.account.template,name:l10n_pe.chart40151
+msgid "National government - Customs duties - Customs tariff"
+msgstr "Gobierno nacional - Derechos aduaneros - Derechos arancelarios"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart40152
+#: model:account.account,name:l10n_pe.2_chart40152
+#: model:account.account.template,name:l10n_pe.chart40152
+msgid "National government - Customs duties - Other customs duties"
+msgstr "Gobierno nacional - Derechos aduaneros - Otros derechos arancelarios"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart4012
+#: model:account.account,name:l10n_pe.2_chart4012
+#: model:account.account.template,name:l10n_pe.chart4012
+msgid "National government - Excise tax"
+msgstr "Gobierno nacional - Impuesto selectivo al consumo"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart6412
+#: model:account.account,name:l10n_pe.2_chart6412
+#: model:account.account.template,name:l10n_pe.chart6412
+msgid "National government - Financial transaction tax"
+msgstr "Gobierno nacional - Impuesto a las transacciones financieras"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart40117
+#: model:account.account,name:l10n_pe.2_chart40117
+#: model:account.account.template,name:l10n_pe.chart40117
+msgid ""
+"National government - General sales tax - IGV - Intended for common "
+"operations"
+msgstr ""
+"Gobierno nacional - Impuesto general a las ventas - IGV - Destinado a "
+"operaciones comunes"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart40115
+#: model:account.account,name:l10n_pe.2_chart40115
+#: model:account.account.template,name:l10n_pe.chart40115
+msgid "National government - General sales tax - IGV – Imports"
+msgstr ""
+"Gobierno nacional - Impuesto general a las ventas - IGV – Importaciones"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart40116
+#: model:account.account,name:l10n_pe.2_chart40116
+#: model:account.account.template,name:l10n_pe.chart40116
+msgid ""
+"National government - General sales tax - IGV – Intended for taxed "
+"operations"
+msgstr ""
+"Gobierno nacional - Impuesto general a las ventas - IGV – Destinado a "
+"operaciones gravadas"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart40111
+#: model:account.account,name:l10n_pe.2_chart40111
+#: model:account.account.template,name:l10n_pe.chart40111
+msgid "National government - General sales tax - IGV – Own account"
+msgstr ""
+"Gobierno nacional - Impuesto general a las ventas - IGV – Cuenta propia"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart40113
+#: model:account.account,name:l10n_pe.2_chart40113
+#: model:account.account.template,name:l10n_pe.chart40113
+msgid "National government - General sales tax - IGV – Perception regime"
+msgstr ""
+"Gobierno nacional - Impuesto general a las ventas - IGV – Régimen de "
+"percepciones"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart40112
+#: model:account.account,name:l10n_pe.2_chart40112
+#: model:account.account.template,name:l10n_pe.chart40112
+msgid ""
+"National government - General sales tax - IGV – Services provided by non-"
+"residents"
+msgstr ""
+"Gobierno nacional - Impuesto general a las ventas - IGV – Servicios "
+"prestados por no domiciliados"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart40114
+#: model:account.account,name:l10n_pe.2_chart40114
+#: model:account.account.template,name:l10n_pe.chart40114
+msgid "National government - General sales tax - IGV – Withholding regime"
+msgstr ""
+"Gobierno nacional - Impuesto general a las ventas - IGV – Régimen de "
+"retenciones"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart6411
+#: model:account.account,name:l10n_pe.2_chart6411
+#: model:account.account.template,name:l10n_pe.chart6411
+msgid "National government - General sales tax and selective consumption"
+msgstr ""
+"Gobierno nacional - Impuesto general a las ventas y selectivo al consumo"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart40173
+#: model:account.account,name:l10n_pe.2_chart40173
+#: model:account.account.template,name:l10n_pe.chart40173
+msgid "National government - Income tax - Fifth category income"
+msgstr "Gobierno nacional - Impuesto a la renta - Renta de quinta categoría"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart40172
+#: model:account.account,name:l10n_pe.2_chart40172
+#: model:account.account.template,name:l10n_pe.chart40172
+msgid "National government - Income tax - Fourth category rent"
+msgstr "Gobierno nacional - Impuesto a la renta - Renta de cuarta categoría"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart40174
+#: model:account.account,name:l10n_pe.2_chart40174
+#: model:account.account.template,name:l10n_pe.chart40174
+msgid "National government - Income tax - Non-domiciled income"
+msgstr "Gobierno nacional - Impuesto a la renta - Renta de no domiciliados"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart40175
+#: model:account.account,name:l10n_pe.2_chart40175
+#: model:account.account.template,name:l10n_pe.chart40175
+msgid "National government - Income tax - Other retentions"
+msgstr "Gobierno nacional - Impuesto a la renta - Otras retenciones"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart40171
+#: model:account.account,name:l10n_pe.2_chart40171
+#: model:account.account.template,name:l10n_pe.chart40171
+msgid "National government - Income tax - Third category income"
+msgstr "Gobierno nacional - Impuesto a la renta - Renta de tercera categoría"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart6415
+#: model:account.account,name:l10n_pe.2_chart6415
+#: model:account.account.template,name:l10n_pe.chart6415
+msgid "National government - Mining royalties"
+msgstr "Gobierno nacional - Regalías mineras"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart40185
+#: model:account.account,name:l10n_pe.2_chart40185
+#: model:account.account.template,name:l10n_pe.chart40185
+msgid "National government - Other taxes and considerations - Dividends tax"
+msgstr ""
+"Gobierno nacional - Otros impuestos y contraprestaciones - Impuesto a los "
+"dividendos"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart40183
+#: model:account.account,name:l10n_pe.2_chart40183
+#: model:account.account.template,name:l10n_pe.chart40183
+msgid ""
+"National government - Other taxes and considerations - Fees for the "
+"provision of public services"
+msgstr ""
+"Gobierno nacional - Otros impuestos y contraprestaciones - Tasas por la "
+"prestación de servicios públicos"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart40181
+#: model:account.account,name:l10n_pe.2_chart40181
+#: model:account.account.template,name:l10n_pe.chart40181
+msgid ""
+"National government - Other taxes and considerations - Financial transaction"
+" tax"
+msgstr ""
+"Gobierno nacional - Otros impuestos y contraprestaciones - Impuesto a las "
+"transacciones financieras"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart40189
+#: model:account.account,name:l10n_pe.2_chart40189
+#: model:account.account.template,name:l10n_pe.chart40189
+msgid "National government - Other taxes and considerations - Other taxes"
+msgstr ""
+"Gobierno nacional - Otros impuestos y contraprestaciones - Otros impuestos"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart40184
+#: model:account.account,name:l10n_pe.2_chart40184
+#: model:account.account.template,name:l10n_pe.chart40184
+msgid "National government - Other taxes and considerations - Royalties"
+msgstr "Gobierno nacional - Otros impuestos y contraprestaciones - Regalías"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart40182
+#: model:account.account,name:l10n_pe.2_chart40182
+#: model:account.account.template,name:l10n_pe.chart40182
+msgid ""
+"National government - Other taxes and considerations - Tax on casino games "
+"and slots"
+msgstr ""
+"Gobierno nacional - Otros impuestos y contraprestaciones - Impuesto a los "
+"juegos de casino y tragamonedas"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart40186
+#: model:account.account,name:l10n_pe.2_chart40186
+#: model:account.account.template,name:l10n_pe.chart40186
+msgid ""
+"National government - Other taxes and considerations - Temporary tax on net "
+"assets"
+msgstr ""
+"Gobierno nacional - Otros impuestos y contraprestaciones - Impuesto temporal"
+" a los activos netos"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart6419
+#: model:account.account,name:l10n_pe.2_chart6419
+#: model:account.account.template,name:l10n_pe.chart6419
+msgid "National government - Others"
+msgstr "Gobierno nacional - Otros"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart6416
+#: model:account.account,name:l10n_pe.2_chart6416
+#: model:account.account.template,name:l10n_pe.chart6416
+msgid "National government - Royalties"
+msgstr "Gobierno nacional - Cánones"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart6414
+#: model:account.account,name:l10n_pe.2_chart6414
+#: model:account.account.template,name:l10n_pe.chart6414
+msgid "National government - Tax on casino games and slot machines"
+msgstr ""
+"Gobierno nacional - Impuesto a los juegos de casino y máquinas tragamonedas"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart6413
+#: model:account.account,name:l10n_pe.2_chart6413
+#: model:account.account.template,name:l10n_pe.chart6413
+msgid "National government - Temporary tax on net assets"
+msgstr "Gobierno nacional - Impuesto temporal a los activos netos"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_160301
+msgid "Nauta"
+msgstr "Nauta"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_150905
+msgid "Navan"
+msgstr "Navan"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_110301
+#: model:res.city,name:l10n_pe.city_pe_1103
+msgid "Nazca"
+msgstr "Nazca"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_021806
+msgid "Nepeña"
+msgstr "Nepeña"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_250304
+msgid "Neshuya"
+msgstr "Neshuya"
+
+#. module: l10n_pe
+#: model:account.group,name:l10n_pe.1_group5
+#: model:account.group,name:l10n_pe.2_group5
+#: model:account.group.template,name:l10n_pe.group5
+msgid "Net Worth"
+msgstr "Patrimonio Neto"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart65525
+#: model:account.account,name:l10n_pe.2_chart65525
+#: model:account.account.template,name:l10n_pe.chart65525
+msgid ""
+"Net cost of disposal of fixed assets and operations discontinued - "
+"Discontinued operations – Asset abandonment - Biological assets"
+msgstr ""
+"Costo neto de enajenación de activos inmovilizados y operaciones "
+"discontinuadas - Operaciones discontinuadas – Abandono de activos - Activos "
+"biológicos"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart65524
+#: model:account.account,name:l10n_pe.2_chart65524
+#: model:account.account.template,name:l10n_pe.chart65524
+msgid ""
+"Net cost of disposal of fixed assets and operations discontinued - "
+"Discontinued operations – Asset abandonment - Intangibles"
+msgstr ""
+"Costo neto de enajenación de activos inmovilizados y operaciones "
+"discontinuadas - Operaciones discontinuadas – Abandono de activos - "
+"Intangibles"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart65521
+#: model:account.account,name:l10n_pe.2_chart65521
+#: model:account.account.template,name:l10n_pe.chart65521
+msgid ""
+"Net cost of disposal of fixed assets and operations discontinued - "
+"Discontinued operations – Asset abandonment - Investment property"
+msgstr ""
+"Costo neto de enajenación de activos inmovilizados y operaciones "
+"discontinuadas - Operaciones discontinuadas – Abandono de activos - "
+"Propiedades de inversión"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart65523
+#: model:account.account,name:l10n_pe.2_chart65523
+#: model:account.account.template,name:l10n_pe.chart65523
+msgid ""
+"Net cost of disposal of fixed assets and operations discontinued - "
+"Discontinued operations – Asset abandonment - Property, plant and equipment"
+msgstr ""
+"Costo neto de enajenación de activos inmovilizados y operaciones "
+"discontinuadas - Operaciones discontinuadas – Abandono de activos - "
+"Propiedades, planta y equipo"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart65522
+#: model:account.account,name:l10n_pe.2_chart65522
+#: model:account.account.template,name:l10n_pe.chart65522
+msgid ""
+"Net cost of disposal of fixed assets and operations discontinued - "
+"Discontinued operations – Asset abandonment - Right-of-use assets - "
+"Financial leasing"
+msgstr ""
+"Costo neto de enajenación de activos inmovilizados y operaciones "
+"discontinuadas - Operaciones discontinuadas – Abandono de activos - Activos "
+"por derecho de uso - Financial leasing"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart65516
+#: model:account.account,name:l10n_pe.2_chart65516
+#: model:account.account.template,name:l10n_pe.chart65516
+msgid ""
+"Net cost of disposal of fixed assets and operations discontinued - Net cost "
+"of disposal of fixed assets - Biological assets"
+msgstr ""
+"Costo neto de enajenación de activos inmovilizados y operaciones "
+"discontinuadas - Costo neto de enajenación de activos inmovilizados - "
+"Activos biológicos"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart65515
+#: model:account.account,name:l10n_pe.2_chart65515
+#: model:account.account.template,name:l10n_pe.chart65515
+msgid ""
+"Net cost of disposal of fixed assets and operations discontinued - Net cost "
+"of disposal of fixed assets - Intangibles"
+msgstr ""
+"Costo neto de enajenación de activos inmovilizados y operaciones "
+"discontinuadas - Costo neto de enajenación de activos inmovilizados - "
+"Intangibles"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart65512
+#: model:account.account,name:l10n_pe.2_chart65512
+#: model:account.account.template,name:l10n_pe.chart65512
+msgid ""
+"Net cost of disposal of fixed assets and operations discontinued - Net cost "
+"of disposal of fixed assets - Investment property"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart65514
+#: model:account.account,name:l10n_pe.2_chart65514
+#: model:account.account.template,name:l10n_pe.chart65514
+msgid ""
+"Net cost of disposal of fixed assets and operations discontinued - Net cost "
+"of disposal of fixed assets - Property, plant and equipment"
+msgstr ""
+"Costo neto de enajenación de activos inmovilizados y operaciones "
+"discontinuadas - Costo neto de enajenación de activos inmovilizados - "
+"Propiedades, planta y equipo"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart65513
+#: model:account.account,name:l10n_pe.2_chart65513
+#: model:account.account.template,name:l10n_pe.chart65513
+msgid ""
+"Net cost of disposal of fixed assets and operations discontinued - Net cost "
+"of disposal of fixed assets - Right-of-use assets - Financial leasing"
+msgstr ""
+"Costo neto de enajenación de activos inmovilizados y operaciones "
+"discontinuadas - Costo neto de enajenación de activos inmovilizados - "
+"Activos por derecho de uso - Arrendamiento financiero"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart65511
+#: model:account.account,name:l10n_pe.2_chart65511
+#: model:account.account.template,name:l10n_pe.chart65511
+msgid ""
+"Net cost of disposal of fixed assets and operations discontinued - Net cost "
+"of disposal of fixed assets - Securities investments"
+msgstr ""
+"Costo neto de enajenación de activos inmovilizados y operaciones "
+"discontinuadas - Costo neto de enajenación de activos inmovilizados - "
+"Inversiones mobiliarias"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_210704
+msgid "Nicasio"
+msgstr "Nicasio"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_040205
+msgid "Nicolás de Pierola"
+msgstr "Nicolás de Pierola"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_061109
+msgid "Niepos"
+msgstr "Niepos"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_010401
+msgid "Nieva"
+msgstr "Nieva"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_061306
+msgid "Ninabamba"
+msgstr "Ninabamba"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_190105
+msgid "Ninacaca"
+msgstr "Ninacaca"
 
 #. module: l10n_pe
 #: model:l10n_latam.identification.type,name:l10n_pe.it_NDTD
 msgid "Non-Domiciled Tax Document"
-msgstr "Documento tributario no domiciliado, sin RUC"
+msgstr "Documento de Impuesto No Domiciliado"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_140109
+msgid "Nueva Arica"
+msgstr "Nueva Arica"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_220804
+msgid "Nueva Cajamarca"
+msgstr "Nueva Cajamarca"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_250106
+msgid "Nueva Requena"
+msgstr "Nueva Requena"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_120212
+msgid "Nueve de Julio"
+msgstr "Nueve de Julio"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_150510
+msgid "Nuevo Imperial"
+msgstr "Nuevo Imperial"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_090113
+msgid "Nuevo Occoro"
+msgstr "Nuevo Occoro"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_221002
+msgid "Nuevo Progreso"
+msgstr "Nuevo Progreso"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_021809
+msgid "Nuevo chimbote"
+msgstr "Nuevo chimbote"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_210806
+msgid "Nuñoa"
+msgstr "Nuñoa"
+
+#. module: l10n_pe
+#: model:account.group,name:l10n_pe.1_group47
+#: model:account.group,name:l10n_pe.2_group47
+#: model:account.group.template,name:l10n_pe.group47
+msgid "OTHER ACCOUNTS PAYABLE – ASSOCIATED"
+msgstr "CUENTAS POR PAGAR DIVERSAS – RELACIONADAS"
+
+#. module: l10n_pe
+#: model:account.group,name:l10n_pe.1_group46
+#: model:account.group,name:l10n_pe.2_group46
+#: model:account.group.template,name:l10n_pe.group46
+msgid "OTHER ACCOUNTS PAYABLE – THIRD PARTIES"
+msgstr "CUENTAS POR PAGAR DIVERSAS – TERCEROS"
+
+#. module: l10n_pe
+#: model:account.group,name:l10n_pe.1_group38
+#: model:account.group,name:l10n_pe.2_group38
+#: model:account.group.template,name:l10n_pe.group38
+msgid "OTHER ASSETS"
+msgstr "OTROS ACTIVOS"
+
+#. module: l10n_pe
+#: model:account.group,name:l10n_pe.1_group65
+#: model:account.group,name:l10n_pe.2_group65
+#: model:account.group.template,name:l10n_pe.group65
+msgid "OTHER MANAGEMENT EXPENSES"
+msgstr "OTROS GASTOS DE GESTION"
+
+#. module: l10n_pe
+#: model:account.group,name:l10n_pe.1_group75
+#: model:account.group,name:l10n_pe.2_group75
+#: model:account.group.template,name:l10n_pe.group75
+msgid "OTHER MANAGEMENT INCOME"
+msgstr "OTROS INGRESOS DE GESTIÓN"
+
+#. module: l10n_pe
+#: model:account.tax.group,name:l10n_pe.tax_group_other
+msgid "OTHERS"
+msgstr "OTROS"
 
 #. module: l10n_pe
 #: model:ir.model.fields.selection,name:l10n_pe.selection__account_tax__l10n_pe_edi_tax_code__9999
 #: model:ir.model.fields.selection,name:l10n_pe.selection__account_tax_template__l10n_pe_edi_tax_code__9999
-msgid "OTROS - Other taxes"
-msgstr "OTROS - Otros tributos"
+msgid "OTHERS - Other taxes"
+msgstr "OTROS - Otros impuestos"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_101106
+msgid "Obas"
+msgstr "Obas"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_010512
+msgid "Ocalli"
+msgstr "Ocalli"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_050612
+msgid "Ocaña"
+msgstr "Ocaña"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_030605
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_080905
+msgid "Ocobamba"
+msgstr "Ocobamba"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_081210
+msgid "Ocongate"
+msgstr "Ocongate"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_080804
+msgid "Ocoruro"
+msgstr "Ocoruro"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_090606
+msgid "Ocoyo"
+msgstr "Ocoyo"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_040206
+msgid "Ocoña"
+msgstr "Ocoña"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_021401
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_050106
+#: model:res.city,name:l10n_pe.city_pe_0214
+msgid "Ocros"
+msgstr "Ocros"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_110104
+msgid "Ocucaje"
+msgstr "Ocucaje"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_010513
+msgid "Ocumal"
+msgstr "Ocumal"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_210705
+msgid "Ocuviri"
+msgstr "Ocuviri"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart0215
+#: model:account.account,name:l10n_pe.2_chart0215
+#: model:account.account.template,name:l10n_pe.chart0215
+msgid "Offsetting accounts debit memorandum"
+msgstr "Contrapartida cuentas de orden deudora"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_210308
+msgid "Ollachea"
+msgstr "Ollachea"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_081306
+msgid "Ollantaytambo"
+msgstr "Ollantaytambo"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_211305
+msgid "Ollaraya"
+msgstr "Ollaraya"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_010116
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_020108
+msgid "Olleros"
+msgstr "Olleros"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_140308
+msgid "Olmos"
+msgstr "Olmos"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_081006
+msgid "Omacha"
+msgstr "Omacha"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_151022
+msgid "Omas"
+msgstr "Omas"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_180201
+msgid "Omate"
+msgstr "Omate"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_010609
+msgid "Omia"
+msgstr "Omia"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_120503
+msgid "Ondores"
+msgstr "Ondores"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_130807
+msgid "Ongon"
+msgstr "Ongon"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_030606
+msgid "Ongoy"
+msgstr "Ongoy"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_040409
+msgid "Orcopampa"
+msgstr "Orcopampa"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_120213
+msgid "Orcotuna"
+msgstr "Orcotuna"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_050511
+msgid "Oronccoy"
+msgstr "Oronccoy"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_030305
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_081211
+msgid "Oropesa"
+msgstr "Oropesa"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_210807
+msgid "Orurillo"
+msgstr "Orurillo"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart409
+#: model:account.account,name:l10n_pe.2_chart409
+#: model:account.account.template,name:l10n_pe.chart409
+msgid "Other administrative costs and interest"
+msgstr "Otros costos administrativos e intereses"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart1051
+#: model:account.account,name:l10n_pe.2_chart1051
+#: model:account.account.template,name:l10n_pe.chart1051
+msgid "Other cash equivalents - Other cash equivalents"
+msgstr "Otros equivalentes de efectivo - Otro equivalentes de efectivo"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart0128
+#: model:account.account,name:l10n_pe.1_chart0228
+#: model:account.account,name:l10n_pe.2_chart0128
+#: model:account.account,name:l10n_pe.2_chart0228
+#: model:account.account.template,name:l10n_pe.chart0128
+#: model:account.account.template,name:l10n_pe.chart0228
+msgid "Other credit memorandum accounts"
+msgstr "Otras cuentas de orden acreedoras"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart0113
+#: model:account.account,name:l10n_pe.1_chart0214
+#: model:account.account,name:l10n_pe.2_chart0113
+#: model:account.account,name:l10n_pe.2_chart0214
+#: model:account.account.template,name:l10n_pe.chart0113
+#: model:account.account.template,name:l10n_pe.chart0214
+msgid "Other debit memorandum accounts"
+msgstr "Otras cuentas de orden deudoras"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart189
+#: model:account.account,name:l10n_pe.2_chart189
+#: model:account.account.template,name:l10n_pe.chart189
+msgid "Other expenses contracted in advance"
+msgstr "Otros gastos contratados por anticipado"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart6793
+#: model:account.account,name:l10n_pe.2_chart6793
+#: model:account.account.template,name:l10n_pe.chart6793
+msgid ""
+"Other financial expenses - Financial expenses in updating assets for right "
+"of use"
+msgstr ""
+"Otros gastos financieros - Gastos financieros en actualización de activos "
+"por derecho de uso"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart6792
+#: model:account.account,name:l10n_pe.2_chart6792
+#: model:account.account.template,name:l10n_pe.chart6792
+msgid ""
+"Other financial expenses - Financial expenses measured at discounted value"
+msgstr ""
+"Otros gastos financieros - Gastos financieros en medición a valor descontado"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart6791
+#: model:account.account,name:l10n_pe.2_chart6791
+#: model:account.account.template,name:l10n_pe.chart6791
+msgid "Other financial expenses - Option premiums"
+msgstr "Otros gastos financieros - Primas por opciones"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart7792
+#: model:account.account,name:l10n_pe.2_chart7792
+#: model:account.account.template,name:l10n_pe.chart7792
+msgid "Other financial income - Financial income measured at discounted value"
+msgstr ""
+"Otros ingresos financieros - Ingresos financieros en medición a valor "
+"descontado"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart4541
+#: model:account.account,name:l10n_pe.2_chart4541
+#: model:account.account.template,name:l10n_pe.chart4541
+msgid "Other financial instruments payable - Bills"
+msgstr "Otros Instrumentos financieros por pagar - Letras"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart4543
+#: model:account.account,name:l10n_pe.2_chart4543
+#: model:account.account.template,name:l10n_pe.chart4543
+msgid "Other financial instruments payable - Bonds"
+msgstr "Otros Instrumentos financieros por pagar - Bonos"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart4542
+#: model:account.account,name:l10n_pe.2_chart4542
+#: model:account.account.template,name:l10n_pe.chart4542
+msgid "Other financial instruments payable - Commercial papers"
+msgstr "Otros Instrumentos financieros por pagar - Papeles comerciales"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart4545
+#: model:account.account,name:l10n_pe.2_chart4545
+#: model:account.account.template,name:l10n_pe.chart4545
+msgid "Other financial instruments payable - Conformed invoices"
+msgstr "Otros Instrumentos financieros por pagar - Facturas conformadas"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart4549
+#: model:account.account,name:l10n_pe.2_chart4549
+#: model:account.account.template,name:l10n_pe.chart4549
+msgid "Other financial instruments payable - Other financial obligations"
+msgstr ""
+"Otros Instrumentos financieros por pagar - Otras obligaciones financieras"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart4544
+#: model:account.account,name:l10n_pe.2_chart4544
+#: model:account.account.template,name:l10n_pe.chart4544
+msgid "Other financial instruments payable - Promissory notes"
+msgstr "Otros Instrumentos financieros por pagar - Pagarés"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart36731
+#: model:account.account,name:l10n_pe.2_chart36731
+#: model:account.account.template,name:l10n_pe.chart36731
+msgid "Other financial investments - Costs"
+msgstr "Otras inversiones financieras - Costo"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart11211
+#: model:account.account,name:l10n_pe.2_chart11211
+#: model:account.account.template,name:l10n_pe.chart11211
+msgid "Other financial investments - Other financial investments - Costs"
+msgstr "Otras inversiones financieras - Otras inversiones financieras - Costo"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart11212
+#: model:account.account,name:l10n_pe.2_chart11212
+#: model:account.account.template,name:l10n_pe.chart11212
+msgid "Other financial investments - Other financial investments - Fair value"
+msgstr ""
+"Otras inversiones financieras - Otras inversiones financieras - Valor "
+"Razonable"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart36591
+#: model:account.account,name:l10n_pe.2_chart36591
+#: model:account.account.template,name:l10n_pe.chart36591
+msgid "Other intangible assets - Costs"
+msgstr "Otros activos intangibles - Costo"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart34911
+#: model:account.account,name:l10n_pe.2_chart34911
+#: model:account.account.template,name:l10n_pe.chart34911
+msgid "Other intangible assets - Other intangible assets - Costs"
+msgstr "Otros activos intangibles - Otros activos intangibles - Costo"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart34912
+#: model:account.account,name:l10n_pe.2_chart34912
+#: model:account.account.template,name:l10n_pe.chart34912
+msgid "Other intangible assets - Other intangible assets - Revaluation"
+msgstr "Otros activos intangibles - Otros activos intangibles - Revaluación"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart36592
+#: model:account.account,name:l10n_pe.2_chart36592
+#: model:account.account.template,name:l10n_pe.chart36592
+msgid "Other intangible assets - Revaluation"
+msgstr "Otros activos intangibles - Revaluación"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart6592
+#: model:account.account,name:l10n_pe.2_chart6592
+#: model:account.account.template,name:l10n_pe.chart6592
+msgid "Other management fees - Administrative sanctions"
+msgstr "Otros gastos de gestión - Sanciones administrativas"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart6591
+#: model:account.account,name:l10n_pe.2_chart6591
+#: model:account.account.template,name:l10n_pe.chart6591
+msgid "Other management fees - Donations"
+msgstr "Otros gastos de gestión - Donaciones"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart7593
+#: model:account.account,name:l10n_pe.2_chart7593
+#: model:account.account.template,name:l10n_pe.chart7593
+msgid "Other management income - Donations"
+msgstr "Otros ingresos de gestión - Donaciones"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart7591
+#: model:account.account,name:l10n_pe.2_chart7591
+#: model:account.account.template,name:l10n_pe.chart7591
+msgid "Other management income - Government subsidies"
+msgstr "Otros ingresos de gestión - Subsidios gubernamentales"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart7592
+#: model:account.account,name:l10n_pe.2_chart7592
+#: model:account.account.template,name:l10n_pe.chart7592
+msgid "Other management income - Insurance claims"
+msgstr "Otros ingresos de gestión - Reclamos al seguro"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart7599
+#: model:account.account,name:l10n_pe.2_chart7599
+#: model:account.account.template,name:l10n_pe.chart7599
+msgid "Other management income - Other management income"
+msgstr "Otros ingresos de gestión - Otros ingresos de gestión"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart7594
+#: model:account.account,name:l10n_pe.2_chart7594
+#: model:account.account.template,name:l10n_pe.chart7594
+msgid "Other management income - Tax refunds"
+msgstr "Otros ingresos de gestión - Devoluciones tributarias"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart489
+#: model:account.account,name:l10n_pe.2_chart489
+#: model:account.account.template,name:l10n_pe.chart489
+msgid "Other provisions"
+msgstr "Otras provisiones"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart419
+#: model:account.account,name:l10n_pe.2_chart419
+#: model:account.account.template,name:l10n_pe.chart419
+msgid "Other remuneration and shares payable"
+msgstr "Otras remuneraciones y participaciones por pagar"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart622
+#: model:account.account,name:l10n_pe.2_chart622
+#: model:account.account.template,name:l10n_pe.chart622
+msgid "Other remunerations"
+msgstr "Otras remuneraciones"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart589
+#: model:account.account,name:l10n_pe.2_chart589
+#: model:account.account.template,name:l10n_pe.chart589
+msgid "Other reserves"
+msgstr "Otras reservas"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart6391
+#: model:account.account,name:l10n_pe.2_chart6391
+#: model:account.account.template,name:l10n_pe.chart6391
+msgid "Other services provided by third parties - Banking expenses"
+msgstr "Otros servicios prestados por terceros - Gastos bancarios"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart6392
+#: model:account.account,name:l10n_pe.2_chart6392
+#: model:account.account.template,name:l10n_pe.chart6392
+msgid "Other services provided by third parties - Laboratory expenses"
+msgstr "Otros servicios prestados por terceros - Gastos de laboratorio"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart4692
+#: model:account.account,name:l10n_pe.2_chart4692
+#: model:account.account.template,name:l10n_pe.chart4692
+msgid "Other sundry accounts payable - Conditional donations"
+msgstr "Otras cuentas por pagar diversas - Donaciones condicionadas"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart4691
+#: model:account.account,name:l10n_pe.2_chart4691
+#: model:account.account.template,name:l10n_pe.chart4691
+msgid "Other sundry accounts payable - Government subsidies"
+msgstr "Otras cuentas por pagar diversas - Subsidios gubernamentales"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart4699
+#: model:account.account,name:l10n_pe.2_chart4699
+#: model:account.account.template,name:l10n_pe.chart4699
+msgid "Other sundry accounts payable - Other accounts payable"
+msgstr "Otras cuentas por pagar diversas - Other accounts payable"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart4791
+#: model:account.account,name:l10n_pe.2_chart4791
+#: model:account.account.template,name:l10n_pe.chart4791
+msgid "Other sundry accounts payable - Other sundry accounts payable"
+msgstr "Otras cuentas por pagar diversas - Otras cuentas por pagar diversas"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart179
+#: model:account.account,name:l10n_pe.2_chart179
+#: model:account.account.template,name:l10n_pe.chart179
+msgid "Other sundry accounts receivable"
+msgstr "Otras cuentas por cobrar diversas"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart1691
+#: model:account.account,name:l10n_pe.2_chart1691
+#: model:account.account.template,name:l10n_pe.chart1691
+msgid ""
+"Other sundry accounts receivable - Deliveries to account to third parties"
+msgstr ""
+"Otras cuentas por cobrar diversas - Entregas a rendir cuenta a terceros"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart1699
+#: model:account.account,name:l10n_pe.2_chart1699
+#: model:account.account.template,name:l10n_pe.chart1699
+msgid "Other sundry accounts receivable - Other sundry accounts receivable"
+msgstr "Otras cuentas por cobrar diversas - Otras cuentas por cobrar diversas"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart6442
+#: model:account.account,name:l10n_pe.2_chart6442
+#: model:account.account.template,name:l10n_pe.chart6442
+msgid "Other tax expenses - Contribution to SENCICO"
+msgstr "Otros gastos por tributos - Contribución al SENCICO"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart6443
+#: model:account.account,name:l10n_pe.2_chart6443
+#: model:account.account.template,name:l10n_pe.chart6443
+msgid "Other tax expenses - Others"
+msgstr "Otros gastos por tributos - Otros"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_050613
+msgid "Otoca"
+msgstr "Otoca"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_130601
+#: model:res.city,name:l10n_pe.city_pe_1306
+msgid "Otuzco"
+msgstr "Otuzco"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_060308
+msgid "Oxamarca"
+msgstr "Oxamarca"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_190301
+#: model:res.city,name:l10n_pe.city_pe_1903
+msgid "Oxapampa"
+msgstr "Oxapampa"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_050806
+msgid "Oyolo"
+msgstr "Oyolo"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_150901
+msgid "Oyon"
+msgstr "Oyon"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_140110
+msgid "Oyotun"
+msgstr "Oyotun"
+
+#. module: l10n_pe
+#: model:res.city,name:l10n_pe.city_pe_1509
+msgid "Oyón"
+msgstr "Oyón"
+
+#. module: l10n_pe
+#: model:account.group,name:l10n_pe.1_group72
+#: model:account.group,name:l10n_pe.2_group72
+#: model:account.group.template,name:l10n_pe.group72
+msgid "PRODUCTION OF FIXED ASSETS"
+msgstr "PRODUCCIÓN DE ACTIVO INMOVILIZADO"
+
+#. module: l10n_pe
+#: model:account.group,name:l10n_pe.1_group81
+#: model:account.group,name:l10n_pe.2_group81
+#: model:account.group.template,name:l10n_pe.group81
+msgid "PRODUCTION OF THE YEAR"
+msgstr "PRODUCCIÓN DEL EJERCICIO"
+
+#. module: l10n_pe
+#: model:account.group,name:l10n_pe.1_group23
+#: model:account.group,name:l10n_pe.2_group23
+#: model:account.group.template,name:l10n_pe.group23
+msgid "PRODUCTS IN PROCESS"
+msgstr "PRODUCTOS EN PROCESO"
+
+#. module: l10n_pe
+#: model:account.group,name:l10n_pe.1_group76
+#: model:account.group,name:l10n_pe.2_group76
+#: model:account.group.template,name:l10n_pe.group76
+msgid "PROFIT FROM MEASUREMENT OF NON-FINANCIAL ASSETS AT FAIR VALUE"
+msgstr "GANANCIA POR MEDICIÓN DE ACTIVOS NO FINANCIEROS AL VALOR RAZONABLE"
+
+#. module: l10n_pe
+#: model:account.group,name:l10n_pe.1_group30
+#: model:account.group,name:l10n_pe.2_group30
+#: model:account.group.template,name:l10n_pe.group30
+msgid "PROPERTY INVESTMENTS"
+msgstr "INVERSIONES MOBILIARIAS"
+
+#. module: l10n_pe
+#: model:account.group,name:l10n_pe.1_group33
+#: model:account.group,name:l10n_pe.2_group33
+#: model:account.group.template,name:l10n_pe.group33
+msgid "PROPERTY, PLANT AND EQUIPMENT"
+msgstr "PROPIEDAD, PLANTA Y EQUIPO"
+
+#. module: l10n_pe
+#: model:account.group,name:l10n_pe.1_group48
+#: model:account.group,name:l10n_pe.2_group48
+#: model:account.group.template,name:l10n_pe.group48
+msgid "PROVISIONS"
+msgstr "PROVISIONES"
+
+#. module: l10n_pe
+#: model:l10n_latam.identification.type,name:l10n_pe.it_PTP
+msgid "PTP"
+msgstr "PTP"
+
+#. module: l10n_pe
+#: model:account.group,name:l10n_pe.1_group60
+#: model:account.group,name:l10n_pe.2_group60
+#: model:account.group.template,name:l10n_pe.group60
+msgid "PURCHASES"
+msgstr "COMPRAS"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_120422
+msgid "Paca"
+msgstr "Paca"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_200206
+msgid "Pacaipampa"
+msgstr "Pacaipampa"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_130402
+msgid "Pacanga"
+msgstr "Pacanga"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_050704
+msgid "Pacapausa"
+msgstr "Pacapausa"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_150511
+msgid "Pacaran"
+msgstr "Pacaran"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_150608
+msgid "Pacaraos"
+msgstr "Pacaraos"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_130704
+#: model:res.city,name:l10n_pe.city_pe_1307
+msgid "Pacasmayo"
+msgstr "Pacasmayo"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_050107
+msgid "Pacaycasa"
+msgstr "Pacaycasa"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_081007
+msgid "Paccaritambo"
+msgstr "Paccaritambo"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_060413
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_120423
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_120806
+msgid "Paccha"
+msgstr "Paccha"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_150808
+msgid "Paccho"
+msgstr "Paccho"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_150123
+msgid "Pachacamac"
+msgstr "Pachacamac"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_030306
+msgid "Pachaconas"
+msgstr "Pachaconas"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_110105
+msgid "Pachacutec"
+msgstr "Pachacutec"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_090510
+msgid "Pachamarca"
+msgstr "Pachamarca"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_150906
+msgid "Pachangara"
+msgstr "Pachangara"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_100313
+msgid "Pachas"
+msgstr "Pachas"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_230106
+msgid "Pachia"
+msgstr "Pachia"
+
+#. module: l10n_pe
+#: model:res.city,name:l10n_pe.city_pe_1008
+msgid "Pachitea"
+msgstr "Pachitea"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_220604
+msgid "Pachiza"
+msgstr "Pachiza"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart262
+#: model:account.account,name:l10n_pe.2_chart262
+#: model:account.account.template,name:l10n_pe.chart262
+msgid "Packaging"
+msgstr "Embalajes"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_020513
+msgid "Pacllon"
+msgstr "Pacllon"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_030208
+msgid "Pacobamba"
+msgstr "Pacobamba"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_180303
+msgid "Pacocha"
+msgstr "Pacocha"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_140309
+msgid "Pacora"
+msgstr "Pacora"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_030209
+msgid "Pacucha"
+msgstr "Pacucha"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_250301
+#: model:res.city,name:l10n_pe.city_pe_2503
+msgid "Padre Abad"
+msgstr "Padre Abad"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_160603
+msgid "Padre Márquez"
+msgstr "Padre Márquez"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_050907
+msgid "Paico"
+msgstr "Paico"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_130205
+msgid "Paijan"
+msgstr "Paijan"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_200207
+msgid "Paimas"
+msgstr "Paimas"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_200501
+#: model:res.city,name:l10n_pe.city_pe_2005
+msgid "Paita"
+msgstr "Paita"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_220605
+msgid "Pajarillo"
+msgstr "Pajarillo"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_090114
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_120706
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_210706
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_230107
+msgid "Palca"
+msgstr "Palca"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_120707
+msgid "Palcamayo"
+msgstr "Palcamayo"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_190304
+msgid "Palcazu"
+msgstr "Palcazu"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_190106
+msgid "Pallanchacra"
+msgstr "Pallanchacra"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_021508
+#: model:res.city,name:l10n_pe.city_pe_0215
+msgid "Pallasca"
+msgstr "Pallasca"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_080805
+msgid "Pallpata"
+msgstr "Pallpata"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_110401
+#: model:res.city,name:l10n_pe.city_pe_1104
+msgid "Palpa"
+msgstr "Palpa"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_120605
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_160604
+msgid "Pampa Hermosa"
+msgstr "Pampa Hermosa"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_030210
+msgid "Pampachiri"
+msgstr "Pampachiri"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_040410
+msgid "Pampacolca"
+msgstr "Pampacolca"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_040805
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_080506
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_101107
+msgid "Pampamarca"
+msgstr "Pampamarca"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_021206
+msgid "Pamparomas"
+msgstr "Pamparomas"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_020109
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_021509
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_090701
+msgid "Pampas"
+msgstr "Pampas"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_021707
+msgid "Pampas chico"
+msgstr "Pampas chico"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_240104
+msgid "Pampas de Hospital"
+msgstr "Pampas de Hospital"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_100801
+msgid "Panao"
+msgstr "Panao"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_120424
+msgid "Pancan"
+msgstr "Pancan"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_120606
+msgid "Pangoa"
+msgstr "Pangoa"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_220911
+msgid "Papaplaya"
+msgstr "Papaplaya"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_240304
+msgid "Papayal"
+msgstr "Papayal"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_110505
+msgid "Paracas"
+msgstr "Paracas"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_150202
+msgid "Paramonga"
+msgstr "Paramonga"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_130610
+msgid "Paranday"
+msgstr "Paranday"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_050807
+msgid "Pararca"
+msgstr "Pararca"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_021708
+msgid "Pararin"
+msgstr "Pararin"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_050205
+msgid "Paras"
+msgstr "Paras"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_210707
+msgid "Paratia"
+msgstr "Paratia"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_120425
+msgid "Parco"
+msgstr "Parco"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_110106
+msgid "Parcona"
+msgstr "Parcona"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_130808
+msgid "Parcoy"
+msgstr "Parcoy"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_220805
+msgid "Pardo Miguel"
+msgstr "Pardo Miguel"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_020110
+msgid "Pariacoto"
+msgstr "Pariacoto"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_020607
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_120124
+msgid "Pariahuanca"
+msgstr "Pariahuanca"
+
+#. module: l10n_pe
+#: model:res.city,name:l10n_pe.city_pe_0507
+msgid "Parinacochas"
+msgstr "Parinacochas"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_160302
+msgid "Parinari"
+msgstr "Parinari"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_200701
+msgid "Pariñas"
+msgstr "Pariñas"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_021603
+msgid "Parobamba"
+msgstr "Parobamba"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart7782
+#: model:account.account,name:l10n_pe.2_chart7782
+#: model:account.account.template,name:l10n_pe.chart7782
+msgid ""
+"Participation in results of related entities - Income from participation in "
+"joint ventures"
+msgstr ""
+"Participación en resultados de entidades relacionadas - Participaciones en "
+"negocios conjuntos"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart6781
+#: model:account.account,name:l10n_pe.1_chart7781
+#: model:account.account,name:l10n_pe.2_chart6781
+#: model:account.account,name:l10n_pe.2_chart7781
+#: model:account.account.template,name:l10n_pe.chart6781
+#: model:account.account.template,name:l10n_pe.chart7781
+msgid ""
+"Participation in results of related entities - Participation in the results "
+"of subsidiaries and associates under the equity value method"
+msgstr ""
+"Participación en resultados de entidades relacionadas - Participación en los"
+" resultados de subsidiarias y asociadas bajo el método del valor patrimonial"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart6782
+#: model:account.account,name:l10n_pe.2_chart6782
+#: model:account.account.template,name:l10n_pe.chart6782
+msgid ""
+"Participation in results of related entities - Shares in joint ventures"
+msgstr ""
+"Participación en resultados de entidades relacionadas - Participaciones en "
+"negocios conjuntos"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart573
+#: model:account.account,name:l10n_pe.2_chart573
+#: model:account.account.template,name:l10n_pe.chart573
+msgid "Participation in revaluation surplus – Investments in related entities"
+msgstr ""
+"Participación en excedente de revaluación – Inversiones en entidades "
+"relacionadas"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart466
+#: model:account.account,name:l10n_pe.2_chart466
+#: model:account.account.template,name:l10n_pe.chart466
+msgid "Participation of third parties in joint agreements"
+msgstr "Participación de terceros en acuerdos conjuntos"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart30411
+#: model:account.account,name:l10n_pe.2_chart30411
+#: model:account.account.template,name:l10n_pe.chart30411
+msgid "Participations in joint agreements - Joint operations - Costs"
+msgstr "Participaciones en acuerdos conjuntos - Operaciones conjuntas - Costo"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart30415
+#: model:account.account,name:l10n_pe.2_chart30415
+#: model:account.account.template,name:l10n_pe.chart30415
+msgid ""
+"Participations in joint agreements - Joint operations - Equity participation"
+msgstr ""
+"Participaciones en acuerdos conjuntos - Operaciones conjuntas - "
+"Participación patrimonial"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart30414
+#: model:account.account,name:l10n_pe.2_chart30414
+#: model:account.account.template,name:l10n_pe.chart30414
+msgid "Participations in joint agreements - Joint operations - Fair value"
+msgstr ""
+"Participaciones en acuerdos conjuntos - Operaciones conjuntas - Valor "
+"razonable"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart30421
+#: model:account.account,name:l10n_pe.2_chart30421
+#: model:account.account.template,name:l10n_pe.chart30421
+msgid "Participations in joint agreements - Joint ventures - Costs"
+msgstr "Participaciones en acuerdos conjuntos - Negocios conjuntos - Costo"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart30425
+#: model:account.account,name:l10n_pe.2_chart30425
+#: model:account.account.template,name:l10n_pe.chart30425
+msgid ""
+"Participations in joint agreements - Joint ventures - Equity participation"
+msgstr ""
+"Participaciones en acuerdos conjuntos - Negocios conjuntos - Participación "
+"patrimonial"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart30424
+#: model:account.account,name:l10n_pe.2_chart30424
+#: model:account.account.template,name:l10n_pe.chart30424
+msgid "Participations in joint agreements - Joint ventures - Fair value"
+msgstr ""
+"Participaciones en acuerdos conjuntos - Negocios conjuntos - Valor razonable"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_081001
+#: model:res.city,name:l10n_pe.city_pe_0810
+msgid "Paruro"
+msgstr "Paruro"
+
+#. module: l10n_pe
+#: model:res.city,name:l10n_pe.city_pe_1901
+msgid "Pasco"
+msgstr "Pasco"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_160705
+msgid "Pastaza"
+msgstr "Pastaza"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_211204
+msgid "Patambuco"
+msgstr "Patambuco"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_140117
+msgid "Patapo"
+msgstr "Patapo"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_030707
+msgid "Pataypampa"
+msgstr "Pataypampa"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_130809
+#: model:res.city,name:l10n_pe.city_pe_1308
+msgid "Pataz"
+msgstr "Pataz"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart34221
+#: model:account.account,name:l10n_pe.2_chart34221
+#: model:account.account.template,name:l10n_pe.chart34221
+msgid "Patents and industrial property - Brands - Costs"
+msgstr "Patentes y propiedad industrial - Marcas - Costo"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart34222
+#: model:account.account,name:l10n_pe.2_chart34222
+#: model:account.account.template,name:l10n_pe.chart34222
+msgid "Patents and industrial property - Brands - Revaluation"
+msgstr "Patentes y propiedad industrial - Marcas - Revaluación"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart36521
+#: model:account.account,name:l10n_pe.2_chart36521
+#: model:account.account.template,name:l10n_pe.chart36521
+msgid "Patents and industrial property - Costs"
+msgstr "Patentes y propiedad industrial - Costo"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart34211
+#: model:account.account,name:l10n_pe.2_chart34211
+#: model:account.account.template,name:l10n_pe.chart34211
+msgid "Patents and industrial property - Patents - Costs"
+msgstr "Patentes y propiedad industrial - Patentes - Costo"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart34212
+#: model:account.account,name:l10n_pe.2_chart34212
+#: model:account.account.template,name:l10n_pe.chart34212
+msgid "Patents and industrial property - Patents - Revaluation"
+msgstr "Patentes y propiedad industrial - Patentes - Revaluación"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart36522
+#: model:account.account,name:l10n_pe.2_chart36522
+#: model:account.account.template,name:l10n_pe.chart36522
+msgid "Patents and industrial property - Revaluation"
+msgstr "Patentes y propiedad industrial - Revaluación"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_150203
+msgid "Pativilca"
+msgstr "Pativilca"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_190204
+msgid "Paucar"
+msgstr "Paucar"
+
+#. module: l10n_pe
+#: model:res.city,name:l10n_pe.city_pe_0508
+msgid "Paucar del Sara Sara"
+msgstr "Paucar del Sara Sara"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_090206
+msgid "Paucara"
+msgstr "Paucara"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_090507
+msgid "Paucarbamba"
+msgstr "Paucarbamba"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_210110
+msgid "Paucarcolla"
+msgstr "Paucarcolla"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_040112
+msgid "Paucarpata"
+msgstr "Paucarpata"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_081101
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_190107
+#: model:res.city,name:l10n_pe.city_pe_0811
+msgid "Paucartambo"
+msgstr "Paucartambo"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_021010
+msgid "Paucas"
+msgstr "Paucas"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_050801
+msgid "Pausa"
+msgstr "Pausa"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_090711
+msgid "Pazos"
+msgstr "Pazos"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_160402
+msgid "Pebas"
+msgstr "Pebas"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_061001
+msgid "Pedro Gálvez"
+msgstr "Pedro Gálvez"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_211003
+msgid "Pedro Vilca Apaza"
+msgstr "Pedro Vilca Apaza"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_120302
+msgid "Perene"
+msgstr "Perene"
+
+#. module: l10n_pe
+#: model:ir.ui.menu,name:l10n_pe.account_reports_pe_statements_menu
+msgid "Peru"
+msgstr "Perú"
+
+#. module: l10n_pe
+#: model:account.chart.template,name:l10n_pe.pe_chart_template
+msgid "Peru - PCGE 2019"
+msgstr "Perú - PCGE 2019"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_211205
+msgid "Phara"
+msgstr "Phara"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_130810
+msgid "Pias"
+msgstr "Pias"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_210111
+msgid "Pichacani"
+msgstr "Pichacani"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_120303
+msgid "Pichanaqui"
+msgstr "Pichanaqui"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_080910
+msgid "Pichari"
+msgstr "Pichari"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_080806
+msgid "Pichigua"
+msgstr "Pichigua"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_030107
+msgid "Pichirhua"
+msgstr "Pichirhua"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_090722
+msgid "Pichos"
+msgstr "Pichos"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_220701
+#: model:res.city,name:l10n_pe.city_pe_2207
+msgid "Picota"
+msgstr "Picota"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_140111
+msgid "Picsi"
+msgstr "Picsi"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_090115
+msgid "Pilchaca"
+msgstr "Pilchaca"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_120125
+msgid "Pilcomayo"
+msgstr "Pilcomayo"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_210503
+msgid "Pilcuyo"
+msgstr "Pilcuyo"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_100111
+msgid "Pillco Marca"
+msgstr "Pillco Marca"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_081008
+msgid "Pillpinto"
+msgstr "Pillpinto"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_220704
+msgid "Pilluana"
+msgstr "Pilluana"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_090607
+msgid "Pilpichaca"
+msgstr "Pilpichaca"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_140112
+msgid "Pimentel"
+msgstr "Pimentel"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_060606
+msgid "Pimpingos"
+msgstr "Pimpingos"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_100404
+msgid "Pinra"
+msgstr "Pinra"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_220506
+msgid "Pinto Recodo"
+msgstr "Pinto Recodo"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_060414
+msgid "Pion"
+msgstr "Pion"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_020111
+msgid "Pira"
+msgstr "Pira"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_080405
+msgid "Pisac"
+msgstr "Pisac"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_210405
+msgid "Pisacoma"
+msgstr "Pisacoma"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_110501
+#: model:res.city,name:l10n_pe.city_pe_1105
+msgid "Pisco"
+msgstr "Pisco"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_021301
+msgid "Piscobamba"
+msgstr "Piscobamba"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_220404
+msgid "Piscoyacu"
+msgstr "Piscoyacu"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_010514
+msgid "Pisuquia"
+msgstr "Pisuquia"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_140205
+msgid "Pitipo"
+msgstr "Pitipo"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_080605
+msgid "Pitumarca"
+msgstr "Pitumarca"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_200101
+#: model:res.city,name:l10n_pe.city_pe_2001
+msgid "Piura"
+msgstr "Piura"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_210112
+msgid "Plateria"
+msgstr "Plateria"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_030410
+msgid "Pocohuanca"
+msgstr "Pocohuanca"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_230108
+msgid "Pocollay"
+msgstr "Pocollay"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_040113
+msgid "Pocsi"
+msgstr "Pocsi"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_040114
+msgid "Polobaya"
+msgstr "Polobaya"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_221003
+msgid "Polvora"
+msgstr "Polvora"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_021601
+#: model:res.city,name:l10n_pe.city_pe_0216
+msgid "Pomabamba"
+msgstr "Pomabamba"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_120426
+msgid "Pomacancha"
+msgstr "Pomacancha"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_080205
+msgid "Pomacanchi"
+msgstr "Pomacanchi"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_030211
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_090207
+msgid "Pomacocha"
+msgstr "Pomacocha"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_060807
+msgid "Pomahuaca"
+msgstr "Pomahuaca"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_140118
+msgid "Pomalca"
+msgstr "Pomalca"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_210406
+msgid "Pomata"
+msgstr "Pomata"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_021011
+msgid "Ponto"
+msgstr "Ponto"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_130108
+msgid "Poroto"
+msgstr "Poroto"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_080103
+msgid "Poroy"
+msgstr "Poroy"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_220806
+msgid "Posic"
+msgstr "Posic"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_210209
+msgid "Potoni"
+msgstr "Potoni"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_190305
+msgid "Pozuzo"
+msgstr "Pozuzo"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart521
+#: model:account.account,name:l10n_pe.2_chart521
+#: model:account.account.template,name:l10n_pe.chart521
+msgid "Premiums (discount) of shares"
+msgstr "Primas (descuento) de acciones"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart184
+#: model:account.account,name:l10n_pe.2_chart184
+#: model:account.account.template,name:l10n_pe.chart184
+msgid "Premiums paid for options"
+msgstr "Primas pagadas por opciones"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart33021
+#: model:account.account,name:l10n_pe.2_chart33021
+#: model:account.account.template,name:l10n_pe.chart33021
+msgid "Producing plant - Production plant in development - Costs"
+msgstr "Planta productora - Planta productora en desarrollo - Costo"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart33024
+#: model:account.account,name:l10n_pe.2_chart33024
+#: model:account.account.template,name:l10n_pe.chart33024
+msgid "Producing plant - Production plant in development - Fair value"
+msgstr "Planta productora - Planta productora en desarrollo - Valor razonable"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart33023
+#: model:account.account,name:l10n_pe.2_chart33023
+#: model:account.account.template,name:l10n_pe.chart33023
+msgid "Producing plant - Production plant in development - Financing costs"
+msgstr ""
+"Planta productora - Planta productora en desarrollo - Costos de financiación"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart33022
+#: model:account.account,name:l10n_pe.2_chart33022
+#: model:account.account.template,name:l10n_pe.chart33022
+msgid "Producing plant - Production plant in development - Revaluation"
+msgstr "Planta productora - Planta productora en desarrollo - Revaluación"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart33011
+#: model:account.account,name:l10n_pe.2_chart33011
+#: model:account.account.template,name:l10n_pe.chart33011
+msgid "Producing plant - Production plant in production - Costs"
+msgstr "Planta productora - Planta productora en producción - Costo"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart33014
+#: model:account.account,name:l10n_pe.2_chart33014
+#: model:account.account.template,name:l10n_pe.chart33014
+msgid "Producing plant - Production plant in production - Fair value"
+msgstr "Planta productora - Planta productora en producción - Valor razonable"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart33013
+#: model:account.account,name:l10n_pe.2_chart33013
+#: model:account.account.template,name:l10n_pe.chart33013
+msgid "Producing plant - Production plant in production - Financing costs"
+msgstr ""
+"Planta productora - Planta productora en producción - Costos de financiación"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart33012
+#: model:account.account,name:l10n_pe.2_chart33012
+#: model:account.account.template,name:l10n_pe.chart33012
+msgid "Producing plant - Production plant in production - Revaluation"
+msgstr "Planta productora - Planta productora en producción - Revaluación"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart633
+#: model:account.account,name:l10n_pe.2_chart633
+#: model:account.account.template,name:l10n_pe.chart633
+msgid "Production commissioned to third parties"
+msgstr "Producción encargada a terceros"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart813
+#: model:account.account,name:l10n_pe.2_chart813
+#: model:account.account.template,name:l10n_pe.chart813
+msgid "Production of fixed assets"
+msgstr "Producción de activo inmovilizado"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart811
+#: model:account.account,name:l10n_pe.2_chart811
+#: model:account.account.template,name:l10n_pe.chart811
+msgid "Production of goods"
+msgstr "Producción de bienes"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart812
+#: model:account.account,name:l10n_pe.2_chart812
+#: model:account.account.template,name:l10n_pe.chart812
+msgid "Production of services"
+msgstr "Producción de servicios"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart36401
+#: model:account.account,name:l10n_pe.2_chart36401
+#: model:account.account.template,name:l10n_pe.chart36401
+msgid "Production plant in production - Costs"
+msgstr "Planta productora en producción - Costo"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart36405
+#: model:account.account,name:l10n_pe.2_chart36405
+#: model:account.account.template,name:l10n_pe.chart36405
+msgid ""
+"Production plant in production - Production plant in development - Costs"
+msgstr ""
+"Planta productora en producción - Planta productora en desarrollo - Costo"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart36408
+#: model:account.account,name:l10n_pe.2_chart36408
+#: model:account.account.template,name:l10n_pe.chart36408
+msgid ""
+"Production plant in production - Production plant in development - Fair "
+"value"
+msgstr ""
+"Planta productora en producción - Planta productora en desarrollo - Valor "
+"razonable"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart36407
+#: model:account.account,name:l10n_pe.2_chart36407
+#: model:account.account.template,name:l10n_pe.chart36407
+msgid ""
+"Production plant in production - Production plant in development - Financing"
+" costs"
+msgstr ""
+"Planta productora en producción - Planta productora en desarrollo - Costo de"
+" financiación"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart36406
+#: model:account.account,name:l10n_pe.2_chart36406
+#: model:account.account.template,name:l10n_pe.chart36406
+msgid ""
+"Production plant in production - Production plant in development - "
+"Revaluation"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart36403
+#: model:account.account,name:l10n_pe.2_chart36403
+#: model:account.account.template,name:l10n_pe.chart36403
+msgid ""
+"Production plant in production - Production plant in production - Financing "
+"costs"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart36402
+#: model:account.account,name:l10n_pe.2_chart36402
+#: model:account.account.template,name:l10n_pe.chart36402
+msgid ""
+"Production plant in production - Production plant in production - "
+"Revaluation"
+msgstr ""
+"Planta productora en producción - Planta productora en desarrollo - "
+"Revaluación"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart2945
+#: model:account.account,name:l10n_pe.2_chart2945
+#: model:account.account.template,name:l10n_pe.chart2945
+msgid "Products in process - Inventory of services in process"
+msgstr "Productos en proceso - Inventario de servicios en proceso"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart23111
+#: model:account.account,name:l10n_pe.1_chart29411
+#: model:account.account,name:l10n_pe.2_chart23111
+#: model:account.account,name:l10n_pe.2_chart29411
+#: model:account.account.template,name:l10n_pe.chart23111
+#: model:account.account.template,name:l10n_pe.chart29411
+msgid "Products in process - Products in process - Costs"
+msgstr "Productos en proceso - Productos en proceso - Costo"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart23113
+#: model:account.account,name:l10n_pe.1_chart29413
+#: model:account.account,name:l10n_pe.2_chart23113
+#: model:account.account,name:l10n_pe.2_chart29413
+#: model:account.account.template,name:l10n_pe.chart23113
+#: model:account.account.template,name:l10n_pe.chart29413
+msgid "Products in process - Products in process - Financing costs"
+msgstr "Productos en proceso - Productos en proceso - Costos de financiación"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart494
+#: model:account.account,name:l10n_pe.2_chart494
+#: model:account.account.template,name:l10n_pe.chart494
+msgid "Profit on sale with parallel financial lease"
+msgstr "Ganancia en venta con arrendamiento financiero paralelo"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_030708
+msgid "Progreso"
+msgstr "Progreso"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart27231
+#: model:account.account,name:l10n_pe.2_chart27231
+#: model:account.account.template,name:l10n_pe.chart27231
+msgid "Property, plant and equipment - Buildings - Costs"
+msgstr "Propiedad, planta y equipo - Edificaciones - Costo"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart27233
+#: model:account.account,name:l10n_pe.2_chart27233
+#: model:account.account.template,name:l10n_pe.chart27233
+msgid "Property, plant and equipment - Buildings - Financing costs"
+msgstr "Propiedad, planta y equipo - Edificaciones - Costos de financiación"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart27232
+#: model:account.account,name:l10n_pe.2_chart27232
+#: model:account.account.template,name:l10n_pe.chart27232
+msgid "Property, plant and equipment - Buildings - Revaluation"
+msgstr "Propiedad, planta y equipo - Edificaciones - Revaluación"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart32231
+#: model:account.account,name:l10n_pe.2_chart32231
+#: model:account.account.template,name:l10n_pe.chart32231
+msgid "Property, plant and equipment - Financial leasing - Buildings - Costs"
+msgstr ""
+"Propiedades, planta y equipo - Arrendamiento financiero - Edificaciones - "
+"Costo"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart32233
+#: model:account.account,name:l10n_pe.2_chart32233
+#: model:account.account.template,name:l10n_pe.chart32233
+msgid ""
+"Property, plant and equipment - Financial leasing - Buildings - Financing "
+"costs"
+msgstr ""
+"Propiedades, planta y equipo - Arrendamiento financiero - Edificaciones - "
+"Costos de financiación"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart32232
+#: model:account.account,name:l10n_pe.2_chart32232
+#: model:account.account.template,name:l10n_pe.chart32232
+msgid ""
+"Property, plant and equipment - Financial leasing - Buildings - Revaluation"
+msgstr ""
+"Propiedades, planta y equipo - Arrendamiento financiero - Edificaciones - "
+"Revaluación"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart32261
+#: model:account.account,name:l10n_pe.2_chart32261
+#: model:account.account.template,name:l10n_pe.chart32261
+msgid ""
+"Property, plant and equipment - Financial leasing - Furniture and fixtures -"
+" Costs"
+msgstr ""
+"Propiedad, planta y equipo - Arrendamiento financiero - Muebles y enseres - "
+"Costo"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart32262
+#: model:account.account,name:l10n_pe.2_chart32262
+#: model:account.account.template,name:l10n_pe.chart32262
+msgid ""
+"Property, plant and equipment - Financial leasing - Furniture and fixtures -"
+" Revaluation"
+msgstr ""
+"Propiedad, planta y equipo - Arrendamiento financiero - Muebles y enseres - "
+"Revaluación"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart32221
+#: model:account.account,name:l10n_pe.2_chart32221
+#: model:account.account.template,name:l10n_pe.chart32221
+msgid "Property, plant and equipment - Financial leasing - Land - Costs"
+msgstr ""
+"Propiedad, planta y equipo - Arrendamiento financiero - Planta productora en"
+" desarrollo - Costo"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart32222
+#: model:account.account,name:l10n_pe.2_chart32222
+#: model:account.account.template,name:l10n_pe.chart32222
+msgid "Property, plant and equipment - Financial leasing - Land - Revaluation"
+msgstr ""
+"Propiedad, planta y equipo - Arrendamiento financiero - Terrenos - "
+"Revaluación"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart32241
+#: model:account.account,name:l10n_pe.2_chart32241
+#: model:account.account.template,name:l10n_pe.chart32241
+msgid ""
+"Property, plant and equipment - Financial leasing - Machinery and "
+"exploitation equipment - Costs"
+msgstr ""
+"Propiedad, planta y equipo - Arrendamiento financiero - Maquinaria y equipo "
+"de explotación - Costo"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart32243
+#: model:account.account,name:l10n_pe.2_chart32243
+#: model:account.account.template,name:l10n_pe.chart32243
+msgid ""
+"Property, plant and equipment - Financial leasing - Machinery and "
+"exploitation equipment - Financing costs"
+msgstr ""
+"Propiedad, planta y equipo - Arrendamiento financiero - Maquinaria y equipo "
+"de explotación - Costos de financiación"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart32242
+#: model:account.account,name:l10n_pe.2_chart32242
+#: model:account.account.template,name:l10n_pe.chart32242
+msgid ""
+"Property, plant and equipment - Financial leasing - Machinery and "
+"exploitation equipment - Revaluation"
+msgstr ""
+"Propiedad, planta y equipo - Arrendamiento financiero - Maquinaria y equipo "
+"de explotación - Revaluación"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart32271
+#: model:account.account,name:l10n_pe.2_chart32271
+#: model:account.account.template,name:l10n_pe.chart32271
+msgid ""
+"Property, plant and equipment - Financial leasing - Miscellaneous equipment "
+"- Costs"
+msgstr ""
+"Propiedades, planta y equipo - Arrendamiento financiero - Equipos diversos -"
+" Costo"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart32272
+#: model:account.account,name:l10n_pe.2_chart32272
+#: model:account.account.template,name:l10n_pe.chart32272
+msgid ""
+"Property, plant and equipment - Financial leasing - Miscellaneous equipment "
+"- Revaluation"
+msgstr ""
+"Propiedades, planta y equipo - Arrendamiento financiero - Equipos diversos -"
+" Revaluación"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart32211
+#: model:account.account,name:l10n_pe.2_chart32211
+#: model:account.account.template,name:l10n_pe.chart32211
+msgid ""
+"Property, plant and equipment - Financial leasing - Production plant in "
+"development - Costs"
+msgstr ""
+"Propiedad, planta y equipo - Arrendamiento financiero - Planta productora en"
+" desarrollo - Costo"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart32213
+#: model:account.account,name:l10n_pe.2_chart32213
+#: model:account.account.template,name:l10n_pe.chart32213
+msgid ""
+"Property, plant and equipment - Financial leasing - Production plant in "
+"development - Financing costs"
+msgstr ""
+"Propiedad, planta y equipo - Arrendamiento financiero - Planta productora en"
+" desarrollo - Costos de financiación"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart32212
+#: model:account.account,name:l10n_pe.2_chart32212
+#: model:account.account.template,name:l10n_pe.chart32212
+msgid ""
+"Property, plant and equipment - Financial leasing - Production plant in "
+"development - Revaluation"
+msgstr ""
+"Propiedad, planta y equipo - Arrendamiento financiero - Planta productora en"
+" desarrollo - Revaluación"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart32201
+#: model:account.account,name:l10n_pe.2_chart32201
+#: model:account.account.template,name:l10n_pe.chart32201
+msgid ""
+"Property, plant and equipment - Financial leasing - Production plant in "
+"production - Costs"
+msgstr ""
+"Propiedad, planta y equipo - Arrendamiento financiero - Planta productora en"
+" producción - Costo"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart32203
+#: model:account.account,name:l10n_pe.2_chart32203
+#: model:account.account.template,name:l10n_pe.chart32203
+msgid ""
+"Property, plant and equipment - Financial leasing - Production plant in "
+"production - Financing costs"
+msgstr ""
+"Propiedad, planta y equipo - Arrendamiento financiero - Planta productora en"
+" producción - Costos de financiación"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart32202
+#: model:account.account,name:l10n_pe.2_chart32202
+#: model:account.account.template,name:l10n_pe.chart32202
+msgid ""
+"Property, plant and equipment - Financial leasing - Production plant in "
+"production - Revaluation"
+msgstr ""
+"Propiedad, planta y equipo - Arrendamiento financiero - Planta productora en"
+" producción - Revaluación"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart32281
+#: model:account.account,name:l10n_pe.2_chart32281
+#: model:account.account.template,name:l10n_pe.chart32281
+msgid ""
+"Property, plant and equipment - Financial leasing - Replacement tools and "
+"units - Costs"
+msgstr ""
+"Propiedades, planta y equipo - Arrendamiento financiero - Herramientas y "
+"unidades de reemplazo - Costo"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart32282
+#: model:account.account,name:l10n_pe.2_chart32282
+#: model:account.account.template,name:l10n_pe.chart32282
+msgid ""
+"Property, plant and equipment - Financial leasing - Replacement tools and "
+"units - Revaluation"
+msgstr ""
+"Propiedad, planta y equipo - Arrendamiento financiero - Herramientas y "
+"unidades de reemplazo - Revaluación"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart32251
+#: model:account.account,name:l10n_pe.2_chart32251
+#: model:account.account.template,name:l10n_pe.chart32251
+msgid ""
+"Property, plant and equipment - Financial leasing - Transport units - Costs"
+msgstr ""
+"Propiedad, planta y equipo - Arrendamiento financiero - Unidades de "
+"transporte - Costo"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart32252
+#: model:account.account,name:l10n_pe.2_chart32252
+#: model:account.account.template,name:l10n_pe.chart32252
+msgid ""
+"Property, plant and equipment - Financial leasing - Transport units - "
+"Revaluation"
+msgstr ""
+"Propiedad, planta y equipo - Arrendamiento financiero - Unidades de "
+"transporte - Revaluación"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart27261
+#: model:account.account,name:l10n_pe.2_chart27261
+#: model:account.account.template,name:l10n_pe.chart27261
+msgid "Property, plant and equipment - Furniture and fixtures - Costs"
+msgstr "Propiedad, planta y equipo - Muebles y enseres - Costo"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart27262
+#: model:account.account,name:l10n_pe.2_chart27262
+#: model:account.account.template,name:l10n_pe.chart27262
+msgid "Property, plant and equipment - Furniture and fixtures - Revaluation"
+msgstr "Propiedad, planta y equipo - Muebles y enseres - Revaluación"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart27221
+#: model:account.account,name:l10n_pe.2_chart27221
+#: model:account.account.template,name:l10n_pe.chart27221
+msgid "Property, plant and equipment - Land - Costs"
+msgstr "Propiedad, planta y equipo - Obras en curso - Costo"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart27222
+#: model:account.account,name:l10n_pe.2_chart27222
+#: model:account.account.template,name:l10n_pe.chart27222
+msgid "Property, plant and equipment - Land - Revaluation"
+msgstr "Propiedad, planta y equipo - Obras en curso - Revaluación"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart27241
+#: model:account.account,name:l10n_pe.2_chart27241
+#: model:account.account.template,name:l10n_pe.chart27241
+msgid ""
+"Property, plant and equipment - Machinery and exploitation equipment - Costs"
+msgstr ""
+"Propiedad, planta y equipo - Maquinarias y equipos de explotación - Costo"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart27243
+#: model:account.account,name:l10n_pe.2_chart27243
+#: model:account.account.template,name:l10n_pe.chart27243
+msgid ""
+"Property, plant and equipment - Machinery and exploitation equipment - "
+"Financing costs"
+msgstr ""
+"Propiedad, planta y equipo - Maquinarias y equipos de explotación - Costo de"
+" financiación"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart27242
+#: model:account.account,name:l10n_pe.2_chart27242
+#: model:account.account.template,name:l10n_pe.chart27242
+msgid ""
+"Property, plant and equipment - Machinery and exploitation equipment - "
+"Revaluation"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart27271
+#: model:account.account,name:l10n_pe.2_chart27271
+#: model:account.account.template,name:l10n_pe.chart27271
+msgid "Property, plant and equipment - Miscellaneous equipment - Costs"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart27272
+#: model:account.account,name:l10n_pe.2_chart27272
+#: model:account.account.template,name:l10n_pe.chart27272
+msgid "Property, plant and equipment - Miscellaneous equipment - Revaluation"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart32331
+#: model:account.account,name:l10n_pe.2_chart32331
+#: model:account.account.template,name:l10n_pe.chart32331
+msgid "Property, plant and equipment - Operating lease - Buildings - Costs"
+msgstr ""
+"Propiedad, planta y equipo - Arrendamiento operativo - Edificaciones - Costo"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart32332
+#: model:account.account,name:l10n_pe.2_chart32332
+#: model:account.account.template,name:l10n_pe.chart32332
+msgid ""
+"Property, plant and equipment - Operating lease - Buildings - Revaluation"
+msgstr ""
+"Propiedad, planta y equipo - Arrendamiento operativo - Edificaciones - "
+"Revaluación"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart32321
+#: model:account.account,name:l10n_pe.2_chart32321
+#: model:account.account.template,name:l10n_pe.chart32321
+msgid "Property, plant and equipment - Operating lease - Land - Costs"
+msgstr ""
+"Propiedad, planta y equipo - Arrendamiento operativo - Terrenos - Costo"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart32341
+#: model:account.account,name:l10n_pe.2_chart32341
+#: model:account.account.template,name:l10n_pe.chart32341
+msgid ""
+"Property, plant and equipment - Operating lease - Machinery and exploitation"
+" equipment - Costs"
+msgstr ""
+"Propiedad, planta y equipo - Arrendamiento operativo - Maquinaria y equipo "
+"de explotación - Costo"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart32342
+#: model:account.account,name:l10n_pe.2_chart32342
+#: model:account.account.template,name:l10n_pe.chart32342
+msgid ""
+"Property, plant and equipment - Operating lease - Machinery and exploitation"
+" equipment - Revaluation"
+msgstr ""
+"Propiedad, planta y equipo - Arrendamiento operativo - Maquinaria y equipo "
+"de explotación - Revaluación"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart32361
+#: model:account.account,name:l10n_pe.2_chart32361
+#: model:account.account.template,name:l10n_pe.chart32361
+msgid ""
+"Property, plant and equipment - Operating lease - Miscellaneous equipment - "
+"Costs"
+msgstr ""
+"Propiedad, planta y equipo - Arrendamiento operativo - Equipos diversos - "
+"Costo"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart32362
+#: model:account.account,name:l10n_pe.2_chart32362
+#: model:account.account.template,name:l10n_pe.chart32362
+msgid ""
+"Property, plant and equipment - Operating lease - Miscellaneous equipment - "
+"Revaluation"
+msgstr ""
+"Propiedad, planta y equipo - Arrendamiento operativo - Equipos diversos - "
+"Revaluación"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart32301
+#: model:account.account,name:l10n_pe.2_chart32301
+#: model:account.account.template,name:l10n_pe.chart32301
+msgid ""
+"Property, plant and equipment - Operating lease - Production plant in "
+"production - Costs"
+msgstr ""
+"Propiedad, planta y equipo - Arrendamiento operativo - Planta productora en "
+"producción - Costo"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart32302
+#: model:account.account,name:l10n_pe.2_chart32302
+#: model:account.account.template,name:l10n_pe.chart32302
+msgid ""
+"Property, plant and equipment - Operating lease - Production plant in "
+"production - Revaluation"
+msgstr ""
+"Propiedad, planta y equipo - Arrendamiento operativo - Planta productora en "
+"producción - Revaluación"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart32351
+#: model:account.account,name:l10n_pe.2_chart32351
+#: model:account.account.template,name:l10n_pe.chart32351
+msgid ""
+"Property, plant and equipment - Operating lease - Transport units - Costs"
+msgstr ""
+"Propiedad, planta y equipo - Arrendamiento operativo - Unidades de "
+"transporte - Costo"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart32352
+#: model:account.account,name:l10n_pe.2_chart32352
+#: model:account.account.template,name:l10n_pe.chart32352
+msgid ""
+"Property, plant and equipment - Operating lease - Transport units - "
+"Revaluation"
+msgstr ""
+"Propiedad, planta y equipo - Arrendamiento operativo - Unidades de "
+"transporte - Revaluación"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart27211
+#: model:account.account,name:l10n_pe.2_chart27211
+#: model:account.account.template,name:l10n_pe.chart27211
+msgid ""
+"Property, plant and equipment - Production plant in development - Costs"
+msgstr "Propiedad, planta y equipo - Planta productora en desarrollo - Costo"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart27214
+#: model:account.account,name:l10n_pe.2_chart27214
+#: model:account.account.template,name:l10n_pe.chart27214
+msgid ""
+"Property, plant and equipment - Production plant in development - Fair value"
+msgstr ""
+"Propiedad, planta y equipo - Planta productora en desarrollo - Valor "
+"razonable"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart27213
+#: model:account.account,name:l10n_pe.2_chart27213
+#: model:account.account.template,name:l10n_pe.chart27213
+msgid ""
+"Property, plant and equipment - Production plant in development - Financing "
+"costs"
+msgstr ""
+"Propiedad, planta y equipo - Planta productora en desarrollo - Costos de "
+"financiación"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart27212
+#: model:account.account,name:l10n_pe.2_chart27212
+#: model:account.account.template,name:l10n_pe.chart27212
+msgid ""
+"Property, plant and equipment - Production plant in development - "
+"Revaluation"
+msgstr ""
+"Propiedad, planta y equipo - Planta productora en desarrollo - Revaluación"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart27201
+#: model:account.account,name:l10n_pe.2_chart27201
+#: model:account.account.template,name:l10n_pe.chart27201
+msgid "Property, plant and equipment - Production plant in production - Costs"
+msgstr "Propiedad, planta y equipo - Planta productora en producción - Costo"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart27204
+#: model:account.account,name:l10n_pe.2_chart27204
+#: model:account.account.template,name:l10n_pe.chart27204
+msgid ""
+"Property, plant and equipment - Production plant in production - Fair value"
+msgstr ""
+"Propiedad, planta y equipo - Planta productora en producción - Valor "
+"razonable"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart27203
+#: model:account.account,name:l10n_pe.2_chart27203
+#: model:account.account.template,name:l10n_pe.chart27203
+msgid ""
+"Property, plant and equipment - Production plant in production - Financing "
+"costs"
+msgstr ""
+"Propiedad, planta y equipo - Planta productora en producción - Costos de "
+"financiación"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart27202
+#: model:account.account,name:l10n_pe.2_chart27202
+#: model:account.account.template,name:l10n_pe.chart27202
+msgid ""
+"Property, plant and equipment - Production plant in production - Revaluation"
+msgstr ""
+"Propiedad, planta y equipo - Planta productora en producción - Revaluación"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart27281
+#: model:account.account,name:l10n_pe.2_chart27281
+#: model:account.account.template,name:l10n_pe.chart27281
+msgid "Property, plant and equipment - Replacement tools and units - Costs"
+msgstr ""
+"Propiedad, planta y equipo - Herramientas y unidades de reemplazo - Costo"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart27282
+#: model:account.account,name:l10n_pe.2_chart27282
+#: model:account.account.template,name:l10n_pe.chart27282
+msgid ""
+"Property, plant and equipment - Replacement tools and units - Revaluation"
+msgstr ""
+"Propiedad, planta y equipo - Herramientas y unidades de reemplazo - "
+"Revaluación"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart27251
+#: model:account.account,name:l10n_pe.2_chart27251
+#: model:account.account.template,name:l10n_pe.chart27251
+msgid "Property, plant and equipment - Transport units - Costs"
+msgstr "Propiedad, planta y equipo - Unidades de transporte - Costo"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart27252
+#: model:account.account,name:l10n_pe.2_chart27252
+#: model:account.account.template,name:l10n_pe.chart27252
+msgid "Property, plant and equipment - Transport units - Revaluation"
+msgstr "Propiedad, planta y equipo - Unidades de transporte - Revaluación"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart27291
+#: model:account.account,name:l10n_pe.2_chart27291
+#: model:account.account.template,name:l10n_pe.chart27291
+msgid "Property, plant and equipment - Work in progress - Costs"
+msgstr "Propiedad, planta y equipo - Obras en curso - Costo"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart27292
+#: model:account.account,name:l10n_pe.2_chart27292
+#: model:account.account.template,name:l10n_pe.chart27292
+msgid "Property, plant and equipment - Work in progress - Revaluation"
+msgstr "Propiedad, planta y equipo - Obras en curso - Revaluación"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart7221
+#: model:account.account,name:l10n_pe.2_chart7221
+#: model:account.account.template,name:l10n_pe.chart7221
+msgid "Property, plant and equipment- Buildings"
+msgstr "Propiedad, planta y equipo - Edificaciones"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart7224
+#: model:account.account,name:l10n_pe.2_chart7224
+#: model:account.account.template,name:l10n_pe.chart7224
+msgid "Property, plant and equipment- Furniture and fixtures"
+msgstr "Propiedad, planta y equipo - Muebles y enseres"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart7222
+#: model:account.account,name:l10n_pe.2_chart7222
+#: model:account.account.template,name:l10n_pe.chart7222
+msgid "Property, plant and equipment- Machinery and other operating equipment"
+msgstr ""
+"Propiedad, planta y equipo - Maquinarias y otros equipos de explotación"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart7225
+#: model:account.account,name:l10n_pe.2_chart7225
+#: model:account.account.template,name:l10n_pe.chart7225
+msgid "Property, plant and equipment- Miscellaneous equipment"
+msgstr "Propiedad, planta y equipo - Equipos diversos"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart7220
+#: model:account.account,name:l10n_pe.2_chart7220
+#: model:account.account.template,name:l10n_pe.chart7220
+msgid "Property, plant and equipment- Producing plant"
+msgstr "Propiedad, planta y equipo - Planta productora"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart7223
+#: model:account.account,name:l10n_pe.2_chart7223
+#: model:account.account.template,name:l10n_pe.chart7223
+msgid "Property, plant and equipment- Transport units"
+msgstr "Propiedad, planta y equipo - Unidades de transporte"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_010515
+msgid "Providencia"
+msgstr "Providencia"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart482
+#: model:account.account,name:l10n_pe.2_chart482
+#: model:account.account.template,name:l10n_pe.chart482
+msgid "Provision for dismantling, removal or rehabilitation of fixed assets"
+msgstr ""
+"Provisión por desmantelamiento, retiro o rehabilitación del inmovilizado"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart484
+#: model:account.account,name:l10n_pe.2_chart484
+#: model:account.account.template,name:l10n_pe.chart484
+msgid "Provision for environmental protection and remediation"
+msgstr "Provisión para protección y remediación del medio ambiente"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart486
+#: model:account.account,name:l10n_pe.2_chart486
+#: model:account.account.template,name:l10n_pe.chart486
+msgid "Provision for guarantees"
+msgstr "Provisión para garantías"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart481
+#: model:account.account,name:l10n_pe.2_chart481
+#: model:account.account.template,name:l10n_pe.chart481
+msgid "Provision for litigation"
+msgstr "Provisión para litigios"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart483
+#: model:account.account,name:l10n_pe.2_chart483
+#: model:account.account.template,name:l10n_pe.chart483
+msgid "Provision for restructurings"
+msgstr "Provisión para reestructuraciones"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart487
+#: model:account.account,name:l10n_pe.2_chart487
+#: model:account.account.template,name:l10n_pe.chart487
+msgid "Provision for right-of-use assets"
+msgstr "Provisión por activos por derecho de uso"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart485
+#: model:account.account,name:l10n_pe.2_chart485
+#: model:account.account.template,name:l10n_pe.chart485
+msgid "Provision for social responsibility expenses"
+msgstr "Provisión para gastos de responsabilidad social"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart6899
+#: model:account.account,name:l10n_pe.2_chart6899
+#: model:account.account.template,name:l10n_pe.chart6899
+msgid "Provisions - Other provisions"
+msgstr "Provisiones - Otras provisiones"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart68921
+#: model:account.account,name:l10n_pe.2_chart68921
+#: model:account.account.template,name:l10n_pe.chart68921
+msgid ""
+"Provisions - Provision for dismantling, removal or rehabilitation of fixed "
+"assets - Provision for dismantling, removal or rehabilitation of fixed "
+"assets – Costs"
+msgstr ""
+"Provisiones - Provisión por desmantelamiento, retiro o rehabilitación del "
+"inmovilizado - Provisión por desmantelamiento, retiro o rehabilitación del "
+"inmovilizado – Costo"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart68922
+#: model:account.account,name:l10n_pe.2_chart68922
+#: model:account.account.template,name:l10n_pe.chart68922
+msgid ""
+"Provisions - Provision for dismantling, removal or rehabilitation of fixed "
+"assets - Provision for dismantling, removal or rehabilitation of fixed "
+"assets – Financial update"
+msgstr ""
+"Provisiones - Provisión por desmantelamiento, retiro o rehabilitación del "
+"inmovilizado - Provisión por desmantelamiento, retiro o rehabilitación del "
+"inmovilizado – Actualización financiera"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart68941
+#: model:account.account,name:l10n_pe.2_chart68941
+#: model:account.account.template,name:l10n_pe.chart68941
+msgid ""
+"Provisions - Provision for environmental protection and remediation - "
+"Provision for environmental protection and remediation – Costs"
+msgstr ""
+"Provisiones - Provisión para protección y remediación del medio ambiente - "
+"Provisión para protección y remediación del medio ambiente – Costo"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart68942
+#: model:account.account,name:l10n_pe.2_chart68942
+#: model:account.account.template,name:l10n_pe.chart68942
+msgid ""
+"Provisions - Provision for environmental protection and remediation - "
+"Provision for environmental protection and remediation – Financial update"
+msgstr ""
+"Provisiones - Provisión para protección y remediación del medio ambiente - "
+"Provisión para protección y remediación del medio ambiente – Actualización "
+"financiera"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart68961
+#: model:account.account,name:l10n_pe.2_chart68961
+#: model:account.account.template,name:l10n_pe.chart68961
+msgid ""
+"Provisions - Provision for guarantees - Provision for guarantees – Costs"
+msgstr ""
+"Provisiones - Provisión para garantías - Provisión para garantías – Costo"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart68962
+#: model:account.account,name:l10n_pe.2_chart68962
+#: model:account.account.template,name:l10n_pe.chart68962
+msgid ""
+"Provisions - Provision for guarantees - Provision for guarantees – Financial"
+" update"
+msgstr ""
+"Provisiones - Provisión para garantías - Provisión para garantías – "
+"Actualización financiera"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart68911
+#: model:account.account,name:l10n_pe.2_chart68911
+#: model:account.account.template,name:l10n_pe.chart68911
+msgid ""
+"Provisions - Provision for litigation - Provision for litigation - Costs"
+msgstr ""
+"Provisiones - Provisión para litigios - Provisión para litigios – Costo"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart68912
+#: model:account.account,name:l10n_pe.2_chart68912
+#: model:account.account.template,name:l10n_pe.chart68912
+msgid ""
+"Provisions - Provision for litigation - Provision for litigation – Financial"
+" update"
+msgstr ""
+"Provisiones - Provisión para litigios - Provisión para litigios – "
+"Actualización financiera"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart6893
+#: model:account.account,name:l10n_pe.2_chart6893
+#: model:account.account.template,name:l10n_pe.chart6893
+msgid "Provisions - Provision for restructurings"
+msgstr "Provisiones - Provisión para reestructuraciones"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart68971
+#: model:account.account,name:l10n_pe.2_chart68971
+#: model:account.account.template,name:l10n_pe.chart68971
+msgid ""
+"Provisions - Provision for right-of-use assets - Provision for right-of-use "
+"assets operating lease"
+msgstr ""
+"Provisiones - Provisión por activos por derecho de uso - Provisión por "
+"activos por derecho de uso arrendamiento operativo"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart68972
+#: model:account.account,name:l10n_pe.2_chart68972
+#: model:account.account.template,name:l10n_pe.chart68972
+msgid ""
+"Provisions - Provision for right-of-use assets - Provision for right-of-use "
+"assets operating lease - Financial update"
+msgstr ""
+"Provisiones - Provisión por activos por derecho de uso - Provisión por "
+"activos por derecho de uso arrendamiento operativo - Actualización "
+"financiera"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart4033
+#: model:account.account,name:l10n_pe.2_chart4033
+#: model:account.account.template,name:l10n_pe.chart4033
+msgid "Public institutions - Contribution to SENATI"
+msgstr "Instituciones públicas - Contribución al SENATI"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart4034
+#: model:account.account,name:l10n_pe.2_chart4034
+#: model:account.account.template,name:l10n_pe.chart4034
+msgid "Public institutions - Contribution to SENCICO"
+msgstr "Instituciones públicas - Contribución al SENCICO"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart4031
+#: model:account.account,name:l10n_pe.2_chart4031
+#: model:account.account.template,name:l10n_pe.chart4031
+msgid "Public institutions - ESSALUD"
+msgstr "Instituciones públicas - ESSALUD"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart4032
+#: model:account.account,name:l10n_pe.2_chart4032
+#: model:account.account.template,name:l10n_pe.chart4032
+msgid "Public institutions - ONP"
+msgstr "Instituciones públicas - ONP"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart4039
+#: model:account.account,name:l10n_pe.2_chart4039
+#: model:account.account.template,name:l10n_pe.chart4039
+msgid "Public institutions - Otras instituciones"
+msgstr "Instituciones públicas - Other institutions"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_220705
+msgid "Pucacaca"
+msgstr "Pucacaca"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_050411
+msgid "Pucacolpa"
+msgstr "Pucacolpa"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_140119
+msgid "Pucala"
+msgstr "Pucala"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_060808
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_120126
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_210708
+msgid "Pucara"
+msgstr "Pucara"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_100607
+msgid "Pucayacu"
+msgstr "Pucayacu"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_150124
+msgid "Pucusana"
+msgstr "Pucusana"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_080308
+msgid "Pucyura"
+msgstr "Pucyura"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_021207
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_150121
+msgid "Pueblo Libre"
+msgstr "Pueblo Libre"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_100609
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_110107
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_110207
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_130403
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_140206
+msgid "Pueblo Nuevo"
+msgstr "Pueblo Nuevo"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_150125
+msgid "Puente Piedra"
+msgstr "Puente Piedra"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_190306
+msgid "Puerto Bermúdez"
+msgstr "Puerto Bermúdez"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_100901
+msgid "Puerto Inca"
+msgstr "Puerto Inca"
+
+#. module: l10n_pe
+#: model:res.city,name:l10n_pe.city_pe_1009
+msgid "Puerto inca"
+msgstr "Puerto inca"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_160506
+msgid "Puinahua"
+msgstr "Puinahua"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_061307
+msgid "Pulan"
+msgstr "Pulan"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_050705
+msgid "Pullo"
+msgstr "Pullo"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_160108
+msgid "Punchana"
+msgstr "Punchana"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_100508
+msgid "Punchao"
+msgstr "Punchao"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_210101
+#: model:res.city,name:l10n_pe.city_pe_2101
+msgid "Puno"
+msgstr "Puno"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_150126
+msgid "Punta Hermosa"
+msgstr "Punta Hermosa"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_150127
+msgid "Punta Negra"
+msgstr "Punta Negra"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_040706
+msgid "Punta de Bombón"
+msgstr "Punta de Bombón"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_180208
+msgid "Puquina"
+msgstr "Puquina"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_050601
+msgid "Puquio"
+msgstr "Puquio"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_250401
+msgid "Purus"
+msgstr "Purus"
+
+#. module: l10n_pe
+#: model:res.city,name:l10n_pe.city_pe_2504
+msgid "Purús"
+msgstr "Purús"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_210605
+msgid "Pusi"
+msgstr "Pusi"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_211001
+msgid "Putina"
+msgstr "Putina"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_151023
+msgid "Putinza"
+msgstr "Putinza"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_160109
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_160801
+#: model:res.city,name:l10n_pe.city_pe_1608
+msgid "Putumayo"
+msgstr "Putumayo"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_040806
+msgid "Puyca"
+msgstr "Puyca"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_050706
+msgid "Puyusca"
+msgstr "Puyusca"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_100509
+msgid "Puños"
+msgstr "Puños"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_040807
+msgid "Quechualla"
+msgstr "Quechualla"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_080507
+msgid "Quehue"
+msgstr "Quehue"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_080906
+msgid "Quellouno"
+msgstr "Quellouno"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_040115
+msgid "Quequeña"
+msgstr "Quequeña"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_090608
+msgid "Querco"
+msgstr "Querco"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_200607
+msgid "Querecotillo"
+msgstr "Querecotillo"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_050901
+msgid "Querobamba"
+msgstr "Querobamba"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_060607
+msgid "Querocotillo"
+msgstr "Querocotillo"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_101004
+msgid "Queropalca"
+msgstr "Queropalca"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_211206
+msgid "Quiaca"
+msgstr "Quiaca"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_040312
+msgid "Quicacha"
+msgstr "Quicacha"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_021907
+msgid "Quiches"
+msgstr "Quiches"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_090719
+msgid "Quichuas"
+msgstr "Quichuas"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_120127
+msgid "Quichuay"
+msgstr "Quichuay"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_230206
+msgid "Quilahuani"
+msgstr "Quilahuani"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_040207
+msgid "Quilca"
+msgstr "Quilca"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_211004
+msgid "Quilcapuncu"
+msgstr "Quilcapuncu"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_120128
+msgid "Quilcas"
+msgstr "Quilcas"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_022005
+msgid "Quillo"
+msgstr "Quillo"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_150512
+msgid "Quilmana"
+msgstr "Quilmana"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_151024
+msgid "Quinches"
+msgstr "Quinches"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_180209
+msgid "Quinistaquillas"
+msgstr "Quinistaquillas"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_010117
+msgid "Quinjalca"
+msgstr "Quinjalca"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_151025
+msgid "Quinocay"
+msgstr "Quinocay"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_050108
+msgid "Quinua"
+msgstr "Quinua"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_021604
+msgid "Quinuabamba"
+msgstr "Quinuabamba"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_081212
+msgid "Quiquijana"
+msgstr "Quiquijana"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_131006
+msgid "Quiruvilca"
+msgstr "Quiruvilca"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_090713
+msgid "Quishuar"
+msgstr "Quishuar"
+
+#. module: l10n_pe
+#: model:res.city,name:l10n_pe.city_pe_0812
+msgid "Quispicanchi"
+msgstr "Quispicanchi"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_100106
+msgid "Quisqui (Kichki)"
+msgstr "Quisqui (Kichki)"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_090609
+msgid "Quito-Arma"
+msgstr "Quito-Arma"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_100316
+msgid "Quivilla"
+msgstr "Quivilla"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_080707
+msgid "Quiñota"
+msgstr "Quiñota"
+
+#. module: l10n_pe
+#: model:account.group,name:l10n_pe.1_group24
+#: model:account.group,name:l10n_pe.2_group24
+#: model:account.group.template,name:l10n_pe.group24
+msgid "RAW MATERIALS"
+msgstr "MATERIAS PRIMAS"
+
+#. module: l10n_pe
+#: model:account.group,name:l10n_pe.1_group43
+#: model:account.group,name:l10n_pe.2_group43
+#: model:account.group.template,name:l10n_pe.group43
+msgid "RELATED TRADE ACCOUNTS PAYABLE"
+msgstr "CUENTAS POR PAGAR COMERCIALES RELACIONADAS"
+
+#. module: l10n_pe
+#: model:account.group,name:l10n_pe.1_group41
+#: model:account.group,name:l10n_pe.2_group41
+#: model:account.group.template,name:l10n_pe.group41
+msgid "REMUNERATIONS AND PARTICIPATIONS PAYABLE"
+msgstr "REMUNERACIONES Y PARTICIPACIONES POR PAGAR"
+
+#. module: l10n_pe
+#: model:account.group,name:l10n_pe.1_group58
+#: model:account.group,name:l10n_pe.2_group58
+#: model:account.group.template,name:l10n_pe.group58
+msgid "RESERVES"
+msgstr "RESERVAS"
+
+#. module: l10n_pe
+#: model:account.group,name:l10n_pe.1_group85
+#: model:account.group,name:l10n_pe.2_group85
+#: model:account.group.template,name:l10n_pe.group85
+msgid "RESULT BEFORE PARTICIPATIONS AND TAXES"
+msgstr "RESULTADO ANTES DE PARTICIPACIONES E IMPUESTOS"
+
+#. module: l10n_pe
+#: model:account.group,name:l10n_pe.1_group84
+#: model:account.group,name:l10n_pe.2_group84
+#: model:account.group.template,name:l10n_pe.group84
+msgid "RESULT OF EXPLOITATION"
+msgstr "RESULTADO DE EXPLOTACIÓN"
+
+#. module: l10n_pe
+#: model:account.group,name:l10n_pe.1_group57
+#: model:account.group,name:l10n_pe.2_group57
+#: model:account.group.template,name:l10n_pe.group57
+msgid "REVALUATION SURPLUS"
+msgstr "EXCEDENTE DE REVALUACIÓN"
+
+#. module: l10n_pe
+#: model:l10n_latam.identification.type,name:l10n_pe.it_RUC
+msgid "RUC"
+msgstr "RUC"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_021908
+msgid "Ragash"
+msgstr "Ragash"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_021012
+msgid "Rahuapampa"
+msgstr "Rahuapampa"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_160401
+msgid "Ramón Castilla"
+msgstr "Ramón Castilla"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_030608
+msgid "Ranracancha"
+msgstr "Ranracancha"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_022006
+msgid "Ranrahirca"
+msgstr "Ranrahirca"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_021013
+msgid "Rapayan"
+msgstr "Rapayan"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart284
+#: model:account.account,name:l10n_pe.1_chart602
+#: model:account.account,name:l10n_pe.2_chart284
+#: model:account.account,name:l10n_pe.2_chart602
+#: model:account.account.template,name:l10n_pe.chart284
+#: model:account.account.template,name:l10n_pe.chart602
+msgid "Raw Materials"
+msgstr "Materias primas"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart6121
+#: model:account.account,name:l10n_pe.2_chart6121
+#: model:account.account.template,name:l10n_pe.chart6121
+msgid "Raw Materials - Raw Materials"
+msgstr "Materias primas - Materias primas"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart24111
+#: model:account.account,name:l10n_pe.1_chart29511
+#: model:account.account,name:l10n_pe.2_chart24111
+#: model:account.account,name:l10n_pe.2_chart29511
+#: model:account.account.template,name:l10n_pe.chart24111
+#: model:account.account.template,name:l10n_pe.chart29511
+msgid "Raw Materials - Raw Materials - Costs"
+msgstr "Materias primas - Materias primas - Costo"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart24114
+#: model:account.account,name:l10n_pe.2_chart24114
+#: model:account.account.template,name:l10n_pe.chart24114
+msgid "Raw Materials - Raw Materials - Fair value"
+msgstr "Materias primas - Materias primas - Valor razonable"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_250201
+msgid "Raymondi"
+msgstr "Raymondi"
+
+#. module: l10n_pe
+#: model:account.group,name:l10n_pe.1_group2
+#: model:account.group,name:l10n_pe.2_group2
+#: model:account.group.template,name:l10n_pe.group2
+msgid "Realizable asset"
+msgstr "Activo realizable"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart6612
+#: model:account.account,name:l10n_pe.1_chart7612
+#: model:account.account,name:l10n_pe.2_chart6612
+#: model:account.account,name:l10n_pe.2_chart7612
+#: model:account.account.template,name:l10n_pe.chart6612
+#: model:account.account.template,name:l10n_pe.chart7612
+msgid "Realizable asset - Finished products"
+msgstr "Activo realizable - Productos terminados"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart6611
+#: model:account.account,name:l10n_pe.1_chart7611
+#: model:account.account,name:l10n_pe.2_chart6611
+#: model:account.account,name:l10n_pe.2_chart7611
+#: model:account.account.template,name:l10n_pe.chart6611
+#: model:account.account.template,name:l10n_pe.chart7611
+msgid "Realizable asset - Merchandise"
+msgstr "Activo realizable - Mercaderías"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart66134
+#: model:account.account,name:l10n_pe.1_chart76134
+#: model:account.account,name:l10n_pe.2_chart66134
+#: model:account.account,name:l10n_pe.2_chart76134
+#: model:account.account.template,name:l10n_pe.chart66134
+#: model:account.account.template,name:l10n_pe.chart76134
+msgid ""
+"Realizable asset - Non-current assets held for sale - Biological assets"
+msgstr ""
+"Activo realizable - Non-current assets held for sale - Activos biológicos"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart66133
+#: model:account.account,name:l10n_pe.1_chart76133
+#: model:account.account,name:l10n_pe.2_chart66133
+#: model:account.account,name:l10n_pe.2_chart76133
+#: model:account.account.template,name:l10n_pe.chart66133
+#: model:account.account.template,name:l10n_pe.chart76133
+msgid "Realizable asset - Non-current assets held for sale - Intangibles"
+msgstr ""
+"Activo realizable - Activos no corrientes mantenidos para la venta - "
+"Intangibles"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart66131
+#: model:account.account,name:l10n_pe.1_chart76131
+#: model:account.account,name:l10n_pe.2_chart66131
+#: model:account.account,name:l10n_pe.2_chart76131
+#: model:account.account.template,name:l10n_pe.chart66131
+#: model:account.account.template,name:l10n_pe.chart76131
+msgid ""
+"Realizable asset - Non-current assets held for sale - Investment property"
+msgstr ""
+"Recuperación de cuentas de valuación - Recuperación – Desvalorización de "
+"inversiones mobiliarias"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart66132
+#: model:account.account,name:l10n_pe.1_chart76132
+#: model:account.account,name:l10n_pe.2_chart66132
+#: model:account.account,name:l10n_pe.2_chart76132
+#: model:account.account.template,name:l10n_pe.chart66132
+#: model:account.account.template,name:l10n_pe.chart76132
+msgid ""
+"Realizable asset - Non-current assets held for sale - Property, plant and "
+"equipment"
+msgstr ""
+"Activo realizable - Activos no corrientes mantenidos para la venta - "
+"Propiedades, planta y equipo"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart7574
+#: model:account.account,name:l10n_pe.2_chart7574
+#: model:account.account.template,name:l10n_pe.chart7574
+msgid ""
+"Recovery of impairment of fixed asset accounts - Recovery of impairment of "
+"biological assets"
+msgstr ""
+"Recuperación de deterioro de cuentas de activos inmovilizados - Recuperación"
+" de deterioro de activos biológicos"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart7573
+#: model:account.account,name:l10n_pe.2_chart7573
+#: model:account.account.template,name:l10n_pe.chart7573
+msgid ""
+"Recovery of impairment of fixed asset accounts - Recovery of impairment of "
+"intangibles"
+msgstr ""
+"Recuperación de deterioro de cuentas de activos inmovilizados - Recuperación"
+" de deterioro de intangibles"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart7571
+#: model:account.account,name:l10n_pe.2_chart7571
+#: model:account.account.template,name:l10n_pe.chart7571
+msgid ""
+"Recovery of impairment of fixed asset accounts - Recovery of impairment of "
+"investment properties"
+msgstr ""
+"Recuperación de deterioro de cuentas de activos inmovilizados - Recuperación"
+" de deterioro de propiedades de inversión"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart7572
+#: model:account.account,name:l10n_pe.2_chart7572
+#: model:account.account.template,name:l10n_pe.chart7572
+msgid ""
+"Recovery of impairment of fixed asset accounts - Recovery of impairment of "
+"property, plant and equipment"
+msgstr ""
+"Recuperación de deterioro de cuentas de activos inmovilizados - Recuperación"
+" de deterioro de propiedad, planta y equipo"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart7553
+#: model:account.account,name:l10n_pe.2_chart7553
+#: model:account.account.template,name:l10n_pe.chart7553
+msgid ""
+"Recovery of valuation accounts - Recovery – Depreciation of investment "
+"property"
+msgstr ""
+"Recuperación de cuentas de valuación - Recuperación – Desvalorización de "
+"inversiones mobiliarias"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart7551
+#: model:account.account,name:l10n_pe.2_chart7551
+#: model:account.account.template,name:l10n_pe.chart7551
+msgid "Recovery of valuation accounts - Recovery – Doubtful accounts"
+msgstr ""
+"Recuperación de cuentas de valuación - Recuperación – Cuentas de cobranza "
+"dudosa"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart7552
+#: model:account.account,name:l10n_pe.2_chart7552
+#: model:account.account.template,name:l10n_pe.chart7552
+msgid "Recovery of valuation accounts - Recovery – Inventory impairment"
+msgstr ""
+"Recuperación de cuentas de valuación - Recuperación – Desvalorización de "
+"inventarios"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_010308
+msgid "Recta"
+msgstr "Recta"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_021701
+#: model:res.city,name:l10n_pe.city_pe_0217
+msgid "Recuay"
+msgstr "Recuay"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart405
+#: model:account.account,name:l10n_pe.1_chart642
+#: model:account.account,name:l10n_pe.2_chart405
+#: model:account.account,name:l10n_pe.2_chart642
+#: model:account.account.template,name:l10n_pe.chart405
+#: model:account.account.template,name:l10n_pe.chart642
+msgid "Regional government"
+msgstr "Gobierno regional"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart581
+#: model:account.account,name:l10n_pe.2_chart581
+#: model:account.account.template,name:l10n_pe.chart581
+msgid "Reinvestment"
+msgstr "Reinversión"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart6214
+#: model:account.account,name:l10n_pe.2_chart6214
+#: model:account.account.template,name:l10n_pe.chart6214
+msgid "Remuneration - Bonuses"
+msgstr "Remuneraciones - Gratificaciones"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart6212
+#: model:account.account,name:l10n_pe.2_chart6212
+#: model:account.account.template,name:l10n_pe.chart6212
+msgid "Remuneration - Commissions"
+msgstr "Remuneraciones - Comisiones"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart6215
+#: model:account.account,name:l10n_pe.2_chart6215
+#: model:account.account.template,name:l10n_pe.chart6215
+msgid "Remuneration - Holidays"
+msgstr "Remuneraciones - Vacaciones"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart6213
+#: model:account.account,name:l10n_pe.2_chart6213
+#: model:account.account.template,name:l10n_pe.chart6213
+msgid "Remuneration - Remuneration in kind"
+msgstr "Remuneraciones - Remuneraciones en especie"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart6211
+#: model:account.account,name:l10n_pe.2_chart6211
+#: model:account.account.template,name:l10n_pe.chart6211
+msgid "Remuneration - Wages and salaries"
+msgstr "Remuneraciones - Sueldos y salarios"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart4112
+#: model:account.account,name:l10n_pe.2_chart4112
+#: model:account.account.template,name:l10n_pe.chart4112
+msgid "Remuneration payable - Commissions payable"
+msgstr "Remuneraciones por pagar - Comisiones por pagar"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart4114
+#: model:account.account,name:l10n_pe.2_chart4114
+#: model:account.account.template,name:l10n_pe.chart4114
+msgid "Remuneration payable - Gratuities payable"
+msgstr "Remuneraciones por pagar - Gratificaciones por pagar"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart4115
+#: model:account.account,name:l10n_pe.2_chart4115
+#: model:account.account.template,name:l10n_pe.chart4115
+msgid "Remuneration payable - Payable vacation"
+msgstr "Remuneraciones por pagar - Vacaciones por pagar"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart4113
+#: model:account.account,name:l10n_pe.2_chart4113
+#: model:account.account.template,name:l10n_pe.chart4113
+msgid "Remuneration payable - Remuneration in kind payable"
+msgstr "Remuneraciones por pagar - Remuneraciones en especie por pagar"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart4111
+#: model:account.account,name:l10n_pe.2_chart4111
+#: model:account.account.template,name:l10n_pe.chart4111
+msgid "Remuneration payable - Wages and salaries payable"
+msgstr "Remuneraciones por pagar - Sueldos y salarios por pagar"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart33721
+#: model:account.account,name:l10n_pe.2_chart33721
+#: model:account.account.template,name:l10n_pe.chart33721
+msgid "Replacement tools and units - Replacement units - Costs"
+msgstr "Herramientas y unidades de reemplazo - Unidades de reemplazo - Costo"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart33722
+#: model:account.account,name:l10n_pe.2_chart33722
+#: model:account.account.template,name:l10n_pe.chart33722
+msgid "Replacement tools and units - Replacement units - Revaluation"
+msgstr ""
+"Herramientas y unidades de reemplazo - Unidades de reemplazo - Revaluación"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart33711
+#: model:account.account,name:l10n_pe.1_chart36471
+#: model:account.account,name:l10n_pe.2_chart33711
+#: model:account.account,name:l10n_pe.2_chart36471
+#: model:account.account.template,name:l10n_pe.chart33711
+#: model:account.account.template,name:l10n_pe.chart36471
+msgid "Replacement tools and units - Tools - Costs"
+msgstr "Herramientas y unidades de reemplazo - Herramientas - Costo"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart33712
+#: model:account.account,name:l10n_pe.2_chart33712
+#: model:account.account.template,name:l10n_pe.chart33712
+msgid "Replacement tools and units - Tools - Revaluation"
+msgstr "Herramientas y unidades de reemplazo - Herramientas - Revaluación"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_140113
+msgid "Reque"
+msgstr "Reque"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_160501
+#: model:res.city,name:l10n_pe.city_pe_1605
+msgid "Requena"
+msgstr "Requena"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart1071
+#: model:account.account,name:l10n_pe.2_chart1071
+#: model:account.account.template,name:l10n_pe.chart1071
+msgid "Restricted Funds - Funds in guarantee"
+msgstr "Fondos sujetos a restricción - Fondos en garantía"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart1072
+#: model:account.account,name:l10n_pe.2_chart1072
+#: model:account.account.template,name:l10n_pe.chart1072
+msgid "Restricted Funds - Funds withheld by mandate of the authority"
+msgstr ""
+"Fondos sujetos a restricción - Fondos retenidos por mandato de la autoridad"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart1073
+#: model:account.account,name:l10n_pe.2_chart1073
+#: model:account.account.template,name:l10n_pe.chart1073
+msgid "Restricted Funds - Other restricted funds"
+msgstr "Fondos sujetos a restricción - Otros fondos sujetos a restricción"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart5642
+#: model:account.account,name:l10n_pe.2_chart5642
+#: model:account.account.template,name:l10n_pe.chart5642
+msgid "Result in other assets or liabilities for financial investments - Lost"
+msgstr ""
+"Resultado en otros activos o pasivos por inversiones financieras - Pérdida"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart5641
+#: model:account.account,name:l10n_pe.2_chart5641
+#: model:account.account.template,name:l10n_pe.chart5641
+msgid ""
+"Result in other assets or liabilities for financial investments - Profit"
+msgstr ""
+"Resultado en otros activos o pasivos por inversiones financieras - Ganancia"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart841
+#: model:account.account,name:l10n_pe.2_chart841
+#: model:account.account.template,name:l10n_pe.chart841
+msgid "Result of exploitation"
+msgstr "Resultado de explotación"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart5632
+#: model:account.account,name:l10n_pe.2_chart5632
+#: model:account.account.template,name:l10n_pe.chart5632
+msgid "Result on financial assets or liabilities held for trading - Lost"
+msgstr ""
+"Resultado en activos o pasivos financieros mantenidos para negociación - "
+"Pérdida"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart5631
+#: model:account.account,name:l10n_pe.2_chart5631
+#: model:account.account.template,name:l10n_pe.chart5631
+msgid "Result on financial assets or liabilities held for trading - Profit"
+msgstr ""
+"Resultado en activos o pasivos financieros mantenidos para negociación - "
+"Ganancia"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart5652
+#: model:account.account,name:l10n_pe.2_chart5652
+#: model:account.account.template,name:l10n_pe.chart5652
+msgid ""
+"Result on financial assets or liabilities held for trading – Conventional "
+"purchase or sale settlement date - Lost"
+msgstr ""
+"Resultado en activos o pasivos financieros mantenidos para negociación - "
+"Pérdida"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart5651
+#: model:account.account,name:l10n_pe.2_chart5651
+#: model:account.account.template,name:l10n_pe.chart5651
+msgid ""
+"Result on financial assets or liabilities held for trading – Conventional "
+"purchase or sale settlement date - Profit"
+msgstr ""
+"Resultado en activos o pasivos financieros mantenidos para negociación – "
+"Compra o venta convencional fecha de liquidación - Ganancia"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart5713
+#: model:account.account,name:l10n_pe.2_chart5713
+#: model:account.account.template,name:l10n_pe.chart5713
+msgid "Revaluation surplus - Intangibles"
+msgstr "Excedente de revaluación - Intangibles"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart57111
+#: model:account.account,name:l10n_pe.2_chart57111
+#: model:account.account.template,name:l10n_pe.chart57111
+msgid "Revaluation surplus - Investment property - Direct acquisition"
+msgstr ""
+"Excedente de revaluación - Propiedad de inversión - Adquisición directa"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart57112
+#: model:account.account,name:l10n_pe.2_chart57112
+#: model:account.account.template,name:l10n_pe.chart57112
+msgid "Revaluation surplus - Investment property - Financial leasing"
+msgstr "Excedente de revaluación - Propiedad de inversión - Financial leasing"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart57121
+#: model:account.account,name:l10n_pe.2_chart57121
+#: model:account.account.template,name:l10n_pe.chart57121
+msgid ""
+"Revaluation surplus - Property, plant and equipment - Direct acquisition"
+msgstr ""
+"Excedente de revaluación - Propiedades, planta y equipo - Adquisición "
+"directa"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart57122
+#: model:account.account,name:l10n_pe.2_chart57122
+#: model:account.account.template,name:l10n_pe.chart57122
+msgid ""
+"Revaluation surplus - Property, plant and equipment - Financial leasing"
+msgstr ""
+"Excedente de revaluación - Propiedades, planta y equipo - Arrendamiento "
+"financiero"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart5714
+#: model:account.account,name:l10n_pe.2_chart5714
+#: model:account.account.template,name:l10n_pe.chart5714
+msgid "Revaluation surplus - Right-of-use assets - Operating lease"
+msgstr ""
+"Excedente de revaluación - Activos por derecho de uso - Arrendamiento "
+"operativo"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart572
+#: model:account.account,name:l10n_pe.2_chart572
+#: model:account.account.template,name:l10n_pe.chart572
+msgid "Revaluation surplus – Released shares received"
+msgstr "Excedente de revaluación – Acciones liberadas recibidas"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_150714
+msgid "Ricardo Palma"
+msgstr "Ricardo Palma"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_120427
+msgid "Ricran"
+msgstr "Ricran"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart0112
+#: model:account.account,name:l10n_pe.1_chart0213
+#: model:account.account,name:l10n_pe.2_chart0112
+#: model:account.account,name:l10n_pe.2_chart0213
+#: model:account.account.template,name:l10n_pe.chart0112
+#: model:account.account.template,name:l10n_pe.chart0213
+msgid "Rights on financial instruments"
+msgstr "Derechos sobre instrumentos financiero"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_150128
+msgid "Rimac"
+msgstr "Rimac"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_200806
+msgid "Rinconada Llicuar"
+msgstr "Rinconada Llicuar"
+
+#. module: l10n_pe
+#: model:res.city,name:l10n_pe.city_pe_2208
+msgid "Rioja"
+msgstr "Rioja"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_100317
+msgid "Ripan"
+msgstr "Ripan"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_090721
+msgid "Roble"
+msgstr "Roble"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_030609
+msgid "Rocchacc"
+msgstr "Rocchacc"
+
+#. module: l10n_pe
+#: model:res.city,name:l10n_pe.city_pe_0106
+msgid "Rodriguez de Mendoza"
+msgstr "Rodriguez de Mendoza"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_080206
+msgid "Rondocan"
+msgstr "Rondocan"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_101005
+msgid "Rondos"
+msgstr "Rondos"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_160802
+msgid "Rosa Panduro"
+msgstr "Rosa Panduro"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_090208
+msgid "Rosario"
+msgstr "Rosario"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_210606
+msgid "Rosaspata"
+msgstr "Rosaspata"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart474
+#: model:account.account,name:l10n_pe.1_chart652
+#: model:account.account,name:l10n_pe.1_chart753
+#: model:account.account,name:l10n_pe.2_chart474
+#: model:account.account,name:l10n_pe.2_chart652
+#: model:account.account,name:l10n_pe.2_chart753
+#: model:account.account.template,name:l10n_pe.chart474
+#: model:account.account.template,name:l10n_pe.chart652
+#: model:account.account.template,name:l10n_pe.chart753
+msgid "Royalties"
+msgstr "Regalías"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_220507
+msgid "Rumisapa"
+msgstr "Rumisapa"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_100601
+msgid "Rupa-Rupa"
+msgstr "Rupa-Rupa"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_130206
+msgid "Rázuri"
+msgstr "Rázuri"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_040606
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_110403
+msgid "Río Grande"
+msgstr "Río Grande"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_120607
+msgid "Río Negro"
+msgstr "Río Negro"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_010403
+msgid "Río Santiago"
+msgstr "Río Santiago"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_120608
+msgid "Río Tambo"
+msgstr "Río Tambo"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_220801
+msgid "Ríoja"
+msgstr "Ríoja"
+
+#. module: l10n_pe
+#: model:account.group,name:l10n_pe.1_group70
+#: model:account.group,name:l10n_pe.2_group70
+#: model:account.group.template,name:l10n_pe.group70
+msgid "SALES"
+msgstr "VENTAS"
+
+#. module: l10n_pe
+#: model:account.group,name:l10n_pe.1_group69
+#: model:account.group,name:l10n_pe.2_group69
+#: model:account.group.template,name:l10n_pe.group69
+msgid "SALES COST"
+msgstr "COSTO DE VENTAS"
+
+#. module: l10n_pe
+#: model:account.group,name:l10n_pe.1_group18
+#: model:account.group,name:l10n_pe.2_group18
+#: model:account.group.template,name:l10n_pe.group18
+msgid "SERVICES AND OTHER CONTRACTED IN ADVANCE"
+msgstr "SERVICIOS Y OTROS CONTRATADOS POR ANTICIPADO"
+
+#. module: l10n_pe
+#: model:account.group,name:l10n_pe.1_group62
+#: model:account.group,name:l10n_pe.2_group62
+#: model:account.group.template,name:l10n_pe.group62
+msgid "STAFF AND DIRECTORS EXPENSES"
+msgstr "GASTOS DE PERSONAL Y DIRECTORES"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_030307
+msgid "Sabaino"
+msgstr "Sabaino"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_040116
+msgid "Sabandia"
+msgstr "Sabandia"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_220405
+msgid "Sacanche"
+msgstr "Sacanche"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_040117
+msgid "Sachaca"
+msgstr "Sachaca"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_050303
+msgid "Sacsamarca"
+msgstr "Sacsamarca"
+
+#. module: l10n_pe
+#: model:l10n_latam.identification.type,name:l10n_pe.it_SP
+msgid "Safe Passage"
+msgstr "Paso seguro"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_050614
+msgid "Saisa"
+msgstr "Saisa"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_040607
+msgid "Salamanca"
+msgstr "Salamanca"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_110108
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_140310
+msgid "Salas"
+msgstr "Salas"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_130109
+msgid "Salaverry"
+msgstr "Salaverry"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_090714
+msgid "Salcabamba"
+msgstr "Salcabamba"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_090715
+msgid "Salcahuasi"
+msgstr "Salcahuasi"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart1655
+#: model:account.account,name:l10n_pe.1_chart1755
+#: model:account.account,name:l10n_pe.2_chart1655
+#: model:account.account,name:l10n_pe.2_chart1755
+#: model:account.account.template,name:l10n_pe.chart1655
+#: model:account.account.template,name:l10n_pe.chart1755
+msgid "Sale of fixed assets - Biological assets"
+msgstr "Venta de activo inmovilizado - Activos biológicos"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart1654
+#: model:account.account,name:l10n_pe.1_chart1754
+#: model:account.account,name:l10n_pe.2_chart1654
+#: model:account.account,name:l10n_pe.2_chart1754
+#: model:account.account.template,name:l10n_pe.chart1654
+#: model:account.account.template,name:l10n_pe.chart1754
+msgid "Sale of fixed assets - Intangibles"
+msgstr "Venta de activo inmovilizado - Intangibles"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart1652
+#: model:account.account,name:l10n_pe.1_chart1752
+#: model:account.account,name:l10n_pe.2_chart1652
+#: model:account.account,name:l10n_pe.2_chart1752
+#: model:account.account.template,name:l10n_pe.chart1652
+#: model:account.account.template,name:l10n_pe.chart1752
+msgid "Sale of fixed assets - Investment property"
+msgstr "Venta de activo inmovilizado - Propiedades de inversión"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart1659
+#: model:account.account,name:l10n_pe.1_chart1759
+#: model:account.account,name:l10n_pe.2_chart1659
+#: model:account.account,name:l10n_pe.2_chart1759
+#: model:account.account.template,name:l10n_pe.chart1659
+#: model:account.account.template,name:l10n_pe.chart1759
+msgid "Sale of fixed assets - Otros activos inmovilizados"
+msgstr "Venta de activo inmovilizado - Otros activos inmovilizados"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart1651
+#: model:account.account,name:l10n_pe.1_chart1751
+#: model:account.account,name:l10n_pe.2_chart1651
+#: model:account.account,name:l10n_pe.2_chart1751
+#: model:account.account.template,name:l10n_pe.chart1651
+#: model:account.account.template,name:l10n_pe.chart1751
+msgid "Sale of fixed assets - Property investment"
+msgstr "Venta de activo inmovilizado - Inversión mobiliaria"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart1653
+#: model:account.account,name:l10n_pe.1_chart1753
+#: model:account.account,name:l10n_pe.2_chart1653
+#: model:account.account,name:l10n_pe.2_chart1753
+#: model:account.account.template,name:l10n_pe.chart1653
+#: model:account.account.template,name:l10n_pe.chart1753
+msgid "Sale of fixed assets - Property, plant and equipment"
+msgstr "Venta de activo inmovilizado - Propiedad, planta y equipo"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart70962
+#: model:account.account,name:l10n_pe.2_chart70962
+#: model:account.account.template,name:l10n_pe.chart70962
+msgid "Sales returns - By-products, waste and scrap - Associated"
+msgstr ""
+"Devoluciones sobre ventas - Subproductos, desechos y desperdicios - "
+"Relacionadas"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart70961
+#: model:account.account,name:l10n_pe.2_chart70961
+#: model:account.account.template,name:l10n_pe.chart70961
+msgid "Sales returns - By-products, waste and scrap - Third parties"
+msgstr ""
+"Devoluciones sobre ventas - Subproductos, desechos y desperdicios - Terceros"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart70932
+#: model:account.account,name:l10n_pe.2_chart70932
+#: model:account.account.template,name:l10n_pe.chart70932
+msgid "Sales returns - Finished products - Export sale - Associated"
+msgstr ""
+"Devoluciones sobre ventas - Productos terminados - Venta de exportación - "
+"Relacionadas"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart70931
+#: model:account.account,name:l10n_pe.2_chart70931
+#: model:account.account.template,name:l10n_pe.chart70931
+msgid "Sales returns - Finished products - Export sale - Third parties"
+msgstr ""
+"Devoluciones sobre ventas - Productos terminados - Venta de exportación - "
+"Terceros"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart70942
+#: model:account.account,name:l10n_pe.2_chart70942
+#: model:account.account.template,name:l10n_pe.chart70942
+msgid "Sales returns - Finished products - Local sale - Associated"
+msgstr ""
+"Devoluciones sobre ventas - Productos terminados - Venta local - "
+"Relacionadas"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart70941
+#: model:account.account,name:l10n_pe.2_chart70941
+#: model:account.account.template,name:l10n_pe.chart70941
+msgid "Sales returns - Finished products - Local sale - Third parties"
+msgstr ""
+"Devoluciones sobre ventas - Productos terminados - Venta local - Terceros"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart70912
+#: model:account.account,name:l10n_pe.2_chart70912
+#: model:account.account.template,name:l10n_pe.chart70912
+msgid "Sales returns - Merchandise - Export sale - Associated"
+msgstr ""
+"Devoluciones sobre ventas - Mercaderías - Venta de exportación - "
+"Relacionadas"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart70911
+#: model:account.account,name:l10n_pe.2_chart70911
+#: model:account.account.template,name:l10n_pe.chart70911
+msgid "Sales returns - Merchandise - Export sale - Third parties"
+msgstr ""
+"Devoluciones sobre ventas - Mercaderías - Venta de exportación - Terceros"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart70922
+#: model:account.account,name:l10n_pe.2_chart70922
+#: model:account.account.template,name:l10n_pe.chart70922
+msgid "Sales returns - Merchandise - Local sale - Associated"
+msgstr "Devoluciones sobre ventas - Mercaderías - Venta local - Relacionadas"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart70921
+#: model:account.account,name:l10n_pe.2_chart70921
+#: model:account.account.template,name:l10n_pe.chart70921
+msgid "Sales returns - Merchandise - Local sale - Third parties"
+msgstr "Devoluciones sobre ventas - Mercaderías - Venta local - Terceros"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart70952
+#: model:account.account,name:l10n_pe.2_chart70952
+#: model:account.account.template,name:l10n_pe.chart70952
+msgid "Sales returns - Rejected service inventories - Associated"
+msgstr ""
+"Devoluciones sobre ventas - Inventarios de servicios rechazados - "
+"Relacionadas"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart70951
+#: model:account.account,name:l10n_pe.2_chart70951
+#: model:account.account.template,name:l10n_pe.chart70951
+msgid "Sales returns - Rejected service inventories - Third parties"
+msgstr ""
+"Devoluciones sobre ventas - Inventarios de servicios rechazados - Terceros"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_200406
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_200608
+msgid "Salitral"
+msgstr "Salitral"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_060809
+msgid "Sallique"
+msgstr "Sallique"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_130611
+msgid "Salpo"
+msgstr "Salpo"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_230109
+msgid "Sama"
+msgstr "Sama"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_210210
+msgid "Saman"
+msgstr "Saman"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_021807
+msgid "Samanco"
+msgstr "Samanco"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_180104
+msgid "Samegua"
+msgstr "Samegua"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_040208
+msgid "Samuel Pastor"
+msgstr "Samuel Pastor"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_050509
+msgid "Samugari"
+msgstr "Samugari"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_120129
+msgid "San Agustín"
+msgstr "San Agustín"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_110506
+msgid "San Andrés"
+msgstr "San Andrés"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_060608
+msgid "San Andrés de Cutervo"
+msgstr "San Andrés de Cutervo"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_150715
+msgid "San Andrés de Tupicocha"
+msgstr "San Andrés de Tupicocha"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_210211
+msgid "San Anton"
+msgstr "San Anton"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_030709
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_150513
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_150716
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_210113
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_220912
+msgid "San Antonio"
+msgstr "San Antonio"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_040514
+msgid "San Antonio de Ahuca"
+msgstr "San Antonio de Ahuca"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_090310
+msgid "San Antonio de Antaparco"
+msgstr "San Antonio de Antaparco"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_030212
+msgid "San Antonio de Cachi"
+msgstr "San Antonio de Cachi"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_090610
+msgid "San Antonio de Cusicancha"
+msgstr "San Antonio de Cusicancha"
+
+#. module: l10n_pe
+#: model:res.city,name:l10n_pe.city_pe_2110
+msgid "San Antonio de Putina"
+msgstr "San Antonio de Putina"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_150129
+msgid "San Bartolo"
+msgstr "San Bartolo"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_150717
+msgid "San Bartolome"
+msgstr "San Bartolome"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_060505
+msgid "San Benito"
+msgstr "San Benito"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_061202
+msgid "San Bernardino"
+msgstr "San Bernardino"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_150130
+msgid "San Borja"
+msgstr "San Borja"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_100703
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_150406
+msgid "San Buenaventura"
+msgstr "San Buenaventura"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_010309
+msgid "San Carlos"
+msgstr "San Carlos"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_110507
+msgid "San Clemente"
+msgstr "San Clemente"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_010516
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_050615
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_180105
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_220706
+msgid "San Cristóbal"
+msgstr "San Cristóbal"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_021408
+msgid "San Cristóbal de Rajan"
+msgstr "San Cristóbal de Rajan"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_150718
+msgid "San Damian"
+msgstr "San Damian"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_060810
+msgid "San Felipe"
+msgstr "San Felipe"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_220807
+msgid "San Fernando"
+msgstr "San Fernando"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_100206
+msgid "San Francisco"
+msgstr "San Francisco"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_101006
+msgid "San Francisco de Asís"
+msgstr "San Francisco de Asís"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_190108
+msgid "San Francisco de Asís de Yarusyacan"
+msgstr "San Francisco de Asís de Yarusyacan"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_100107
+msgid "San Francisco de Cayran"
+msgstr "San Francisco de Cayran"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_010118
+msgid "San Francisco de Daguas"
+msgstr "San Francisco de Daguas"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_050707
+msgid "San Francisco de Ravacayco"
+msgstr "San Francisco de Ravacayco"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_090611
+msgid "San Francisco de Sangayaico"
+msgstr "San Francisco de Sangayaico"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_010517
+msgid "San Francisco del Yeso"
+msgstr "San Francisco del Yeso"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_210309
+msgid "San Gaban"
+msgstr "San Gaban"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_061110
+msgid "San Gregorio"
+msgstr "San Gregorio"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_220707
+msgid "San Hilarión"
+msgstr "San Hilarión"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_060901
+#: model:res.city,name:l10n_pe.city_pe_0609
+msgid "San Ignacio"
+msgstr "San Ignacio"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_090612
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_150131
+msgid "San Isidro"
+msgstr "San Isidro"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_010119
+msgid "San Isidro de Maino"
+msgstr "San Isidro de Maino"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_240105
+msgid "San Jacinto"
+msgstr "San Jacinto"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_050808
+msgid "San Javier de Alpabamba"
+msgstr "San Javier de Alpabamba"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_010518
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_030213
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_080104
+msgid "San Jerónimo"
+msgstr "San Jerónimo"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_120130
+msgid "San Jerónimo de Tunan"
+msgstr "San Jerónimo de Tunan"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_151026
+msgid "San Joaquin"
+msgstr "San Joaquin"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_130705
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_140311
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_210212
+msgid "San José"
+msgstr "San José"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_110109
+msgid "San José de Los Molinos"
+msgstr "San José de Los Molinos"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_060906
+msgid "San José de Lourdes"
+msgstr "San José de Lourdes"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_120214
+msgid "San José de Quero"
+msgstr "San José de Quero"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_220301
+msgid "San José de Sisa"
+msgstr "San José de Sisa"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_050109
+msgid "San José de Ticllas"
+msgstr "San José de Ticllas"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_050809
+msgid "San José de ushua"
+msgstr "San José de ushua"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_060811
+msgid "San José del Alto"
+msgstr "San José del Alto"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_021909
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_050616
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_060112
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_090410
+msgid "San Juan"
+msgstr "San Juan"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_050110
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_110110
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_160113
+msgid "San Juan Bautista"
+msgstr "San Juan Bautista"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_200407
+msgid "San Juan de Bigote"
+msgstr "San Juan de Bigote"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_030411
+msgid "San Juan de Chacña"
+msgstr "San Juan de Chacña"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_060609
+msgid "San Juan de Cutervo"
+msgstr "San Juan de Cutervo"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_150719
+msgid "San Juan de Iris"
+msgstr "San Juan de Iris"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_120906
+msgid "San Juan de Iscos"
+msgstr "San Juan de Iscos"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_120907
+msgid "San Juan de Jarpa"
+msgstr "San Juan de Jarpa"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_060416
+msgid "San Juan de Licupis"
+msgstr "San Juan de Licupis"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_010519
+msgid "San Juan de Lopecancha"
+msgstr "San Juan de Lopecancha"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_150132
+msgid "San Juan de Lurigancho"
+msgstr "San Juan de Lurigancho"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_150133
+msgid "San Juan de Miraflores"
+msgstr "San Juan de Miraflores"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_020306
+msgid "San Juan de Rontoy"
+msgstr "San Juan de Rontoy"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_210213
+msgid "San Juan de Salinas"
+msgstr "San Juan de Salinas"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_040118
+msgid "San Juan de Siguas"
+msgstr "San Juan de Siguas"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_150720
+msgid "San Juan de Tantaranche"
+msgstr "San Juan de Tantaranche"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_040119
+msgid "San Juan de Tarucani"
+msgstr "San Juan de Tarucani"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_110208
+msgid "San Juan de Yanac"
+msgstr "San Juan de Yanac"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_240106
+msgid "San Juan de la Virgen"
+msgstr "San Juan de la Virgen"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_211207
+msgid "San Juan del Oro"
+msgstr "San Juan del Oro"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_120428
+msgid "San Lorenzo"
+msgstr "San Lorenzo"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_150721
+msgid "San Lorenzo de Quinti"
+msgstr "San Lorenzo de Quinti"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_020701
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_061203
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_150134
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_150514
+msgid "San Luis"
+msgstr "San Luis"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_060610
+msgid "San Luis de Lucma"
+msgstr "San Luis de Lucma"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_120304
+msgid "San Luis de Shuaro"
+msgstr "San Luis de Shuaro"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_021014
+#: model:res.city,name:l10n_pe.city_pe_0610
+msgid "San Marcos"
+msgstr "San Marcos"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_090716
+msgid "San Marcos de Rocchac"
+msgstr "San Marcos de Rocchac"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_220303
+#: model:res.city,name:l10n_pe.city_pe_2209
+msgid "San Martín"
+msgstr "San Martín"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_150135
+msgid "San Martín de Porres"
+msgstr "San Martín de Porres"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_150722
+msgid "San Mateo"
+msgstr "San Mateo"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_150723
+msgid "San Mateo de Otao"
+msgstr "San Mateo de Otao"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_050501
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_061101
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_150136
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_211105
+#: model:res.city,name:l10n_pe.city_pe_0611
+msgid "San Miguel"
+msgstr "San Miguel"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_020608
+msgid "San Miguel de Aco"
+msgstr "San Miguel de Aco"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_150609
+msgid "San Miguel de Acos"
+msgstr "San Miguel de Acos"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_101007
+msgid "San Miguel de Cauri"
+msgstr "San Miguel de Cauri"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_030214
+msgid "San Miguel de Chaccrampa"
+msgstr "San Miguel de Chaccrampa"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_020514
+msgid "San Miguel de Corpanqui"
+msgstr "San Miguel de Corpanqui"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_200306
+msgid "San Miguel de El Faique"
+msgstr "San Miguel de El Faique"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_090508
+msgid "San Miguel de Mayocc"
+msgstr "San Miguel de Mayocc"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_010601
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_020702
+msgid "San Nicolás"
+msgstr "San Nicolás"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_061201
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_080606
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_160404
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_220205
+#: model:res.city,name:l10n_pe.city_pe_0612
+msgid "San Pablo"
+msgstr "San Pablo"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_100113
+msgid "San Pablo de Pillao"
+msgstr "San Pablo de Pillao"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_021409
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_050617
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_080607
+msgid "San Pedro"
+msgstr "San Pedro"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_030108
+msgid "San Pedro de Cachora"
+msgstr "San Pedro de Cachora"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_120708
+msgid "San Pedro de Cajas"
+msgstr "San Pedro de Cajas"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_150724
+msgid "San Pedro de Casta"
+msgstr "San Pedro de Casta"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_100108
+msgid "San Pedro de Chaulan"
+msgstr "San Pedro de Chaulan"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_120429
+msgid "San Pedro de Chunan"
+msgstr "San Pedro de Chunan"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_090509
+msgid "San Pedro de Coris"
+msgstr "San Pedro de Coris"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_110209
+msgid "San Pedro de Huacarpana"
+msgstr "San Pedro de Huacarpana"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_150725
+msgid "San Pedro de Huancayre"
+msgstr "San Pedro de Huancayre"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_050908
+msgid "San Pedro de Larcay"
+msgstr "San Pedro de Larcay"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_130701
+msgid "San Pedro de Lloc"
+msgstr "San Pedro de Lloc"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_050618
+msgid "San Pedro de Palco"
+msgstr "San Pedro de Palco"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_151027
+msgid "San Pedro de Pilas"
+msgstr "San Pedro de Pilas"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_190205
+msgid "San Pedro de Pillao"
+msgstr "San Pedro de Pillao"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_211210
+msgid "San Pedro de Putina Punco"
+msgstr "San Pedro de Putina Punco"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_021015
+msgid "San Pedro de chana"
+msgstr "San Pedro de chana"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_100207
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_220206
+msgid "San Rafael"
+msgstr "San Rafael"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_120305
+msgid "San Ramón"
+msgstr "San Ramón"
+
+#. module: l10n_pe
+#: model:res.city,name:l10n_pe.city_pe_2111
+msgid "San Román"
+msgstr "San Román"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_220508
+msgid "San Roque de Cumbaza"
+msgstr "San Roque de Cumbaza"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_080406
+msgid "San Salvador"
+msgstr "San Salvador"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_050909
+msgid "San Salvador de Quije"
+msgstr "San Salvador de Quije"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_080105
+msgid "San Sebastian"
+msgstr "San Sebastian"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_061111
+msgid "San Silvestre de Cochan"
+msgstr "San Silvestre de Cochan"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_150501
+msgid "San Vicente de Cañete"
+msgstr "San Vicente de Cañete"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_130906
+msgid "Sanagoran"
+msgstr "Sanagoran"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_050301
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_050619
+msgid "Sancos"
+msgstr "Sancos"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_211201
+#: model:res.city,name:l10n_pe.city_pe_2112
+msgid "Sandia"
+msgstr "Sandia"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_150726
+msgid "Sangallaya"
+msgstr "Sangallaya"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_080207
+msgid "Sangarara"
+msgstr "Sangarara"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_021808
+#: model:res.city,name:l10n_pe.city_pe_0218
+msgid "Santa"
+msgstr "Santa"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_080901
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_090411
+msgid "Santa Ana"
+msgstr "Santa Ana"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_050620
+msgid "Santa Ana de Huaycahuacho"
+msgstr "Santa Ana de Huaycahuacho"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_190206
+msgid "Santa Ana de Tusi"
+msgstr "Santa Ana de Tusi"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_150137
+msgid "Santa Anita"
+msgstr "Santa Anita"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_120807
+msgid "Santa Bárbara de Carhuacayan"
+msgstr "Santa Bárbara de Carhuacayan"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_010520
+msgid "Santa Catalina"
+msgstr "Santa Catalina"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_200408
+msgid "Santa Catalina de Mossa"
+msgstr "Santa Catalina de Mossa"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_021208
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_060611
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_061301
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_110404
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_160210
+#: model:res.city,name:l10n_pe.city_pe_0613
+msgid "Santa Cruz"
+msgstr "Santa Cruz"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_150610
+msgid "Santa Cruz de Andamarca"
+msgstr "Santa Cruz de Andamarca"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_131007
+msgid "Santa Cruz de Chuca"
+msgstr "Santa Cruz de Chuca"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_150727
+msgid "Santa Cruz de Cocachacra"
+msgstr "Santa Cruz de Cocachacra"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_150515
+msgid "Santa Cruz de Flores"
+msgstr "Santa Cruz de Flores"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_060506
+msgid "Santa Cruz de Toledo"
+msgstr "Santa Cruz de Toledo"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_150728
+msgid "Santa Eulalia"
+msgstr "Santa Eulalia"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_040120
+msgid "Santa Isabel de Siguas"
+msgstr "Santa Isabel de Siguas"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_150809
+msgid "Santa Leonor"
+msgstr "Santa Leonor"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_050621
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_210709
+msgid "Santa Lucia"
+msgstr "Santa Lucia"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_150810
+msgid "Santa María"
+msgstr "Santa María"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_030215
+msgid "Santa María de Chicmo"
+msgstr "Santa María de Chicmo"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_150138
+msgid "Santa María del Mar"
+msgstr "Santa María del Mar"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_100109
+msgid "Santa María del Valle"
+msgstr "Santa María del Valle"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_040121
+msgid "Santa Rita de Siguas"
+msgstr "Santa Rita de Siguas"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_010610
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_021510
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_030710
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_050507
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_060812
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_140114
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_150139
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_210504
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_210808
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_220304
+msgid "Santa Rosa"
+msgstr "Santa Rosa"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_100705
+msgid "Santa Rosa de Alto Yanajanca"
+msgstr "Santa Rosa de Alto Yanajanca"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_120215
+msgid "Santa Rosa de Ocopa"
+msgstr "Santa Rosa de Ocopa"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_150407
+msgid "Santa Rosa de Quives"
+msgstr "Santa Rosa de Quives"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_120808
+msgid "Santa Rosa de Sacco"
+msgstr "Santa Rosa de Sacco"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_080908
+msgid "Santa Teresa"
+msgstr "Santa Teresa"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_080106
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_110111
+msgid "Santiago"
+msgstr "Santiago"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_150729
+msgid "Santiago de Anchucaya"
+msgstr "Santiago de Anchucaya"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_130207
+msgid "Santiago de Cao"
+msgstr "Santiago de Cao"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_130811
+msgid "Santiago de Challas"
+msgstr "Santiago de Challas"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_090613
+msgid "Santiago de Chocorvos"
+msgstr "Santiago de Chocorvos"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_131001
+#: model:res.city,name:l10n_pe.city_pe_1310
+msgid "Santiago de Chuco"
+msgstr "Santiago de Chuco"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_050304
+msgid "Santiago de Lucanamarca"
+msgstr "Santiago de Lucanamarca"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_050910
+msgid "Santiago de Paucaray"
+msgstr "Santiago de Paucaray"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_050111
+msgid "Santiago de Pischa"
+msgstr "Santiago de Pischa"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_210214
+msgid "Santiago de Pupuja"
+msgstr "Santiago de Pupuja"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_090614
+msgid "Santiago de Quirahuara"
+msgstr "Santiago de Quirahuara"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_150140
+msgid "Santiago de Surco"
+msgstr "Santiago de Surco"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_090723
+msgid "Santiago de Tucuma"
+msgstr "Santiago de Tucuma"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_150730
+msgid "Santiago de Tuna"
+msgstr "Santiago de Tuna"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_021410
+msgid "Santiago de chilcas"
+msgstr "Santiago de chilcas"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_050406
+msgid "Santillana"
+msgstr "Santillana"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_200409
+msgid "Santo Domingo"
+msgstr "Santo Domingo"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_120135
+msgid "Santo Domingo de Acobamba"
+msgstr "Santo Domingo de Acobamba"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_100610
+msgid "Santo Domingo de Anda"
+msgstr "Santo Domingo de Anda"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_090615
+msgid "Santo Domingo de Capillas"
+msgstr "Santo Domingo de Capillas"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_060612
+msgid "Santo Domingo de la Capilla"
+msgstr "Santo Domingo de la Capilla"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_150731
+msgid "Santo Domingo de los Olleros"
+msgstr "Santo Domingo de los Olleros"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_010521
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_060613
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_080701
+msgid "Santo Tomas"
+msgstr "Santo Tomas"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_090311
+msgid "Santo Tomas de Pata"
+msgstr "Santo Tomas de Pata"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_021209
+msgid "Santo Toribio"
+msgstr "Santo Toribio"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_120133
+msgid "Sapallanga"
+msgstr "Sapallanga"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_200208
+msgid "Sapillica"
+msgstr "Sapillica"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_220401
+msgid "Saposoa"
+msgstr "Saposoa"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_160507
+msgid "Saquena"
+msgstr "Saquena"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_050810
+msgid "Sara Sara"
+msgstr "Sara Sara"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_160605
+msgid "Sarayacu"
+msgstr "Sarayacu"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_051011
+msgid "Sarhua"
+msgstr "Sarhua"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_130907
+msgid "Sarin"
+msgstr "Sarin"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_130908
+msgid "Sartimbamba"
+msgstr "Sartimbamba"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_120601
+#: model:res.city,name:l10n_pe.city_pe_1206
+msgid "Satipo"
+msgstr "Satipo"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_220913
+msgid "Sauce"
+msgstr "Sauce"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_061308
+msgid "Saucepampa"
+msgstr "Saucepampa"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_051107
+msgid "Saurama"
+msgstr "Saurama"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_120430
+msgid "Sausa"
+msgstr "Sausa"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_150811
+msgid "Sayan"
+msgstr "Sayan"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_131104
+msgid "Sayapullo"
+msgstr "Sayapullo"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_040808
+msgid "Sayla"
+msgstr "Sayla"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_080107
+msgid "Saylla"
+msgstr "Saylla"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_140115
+msgid "Saña"
+msgstr "Saña"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_030412
+msgid "Sañayca"
+msgstr "Sañayca"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_120132
+msgid "Saño"
+msgstr "Saño"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart222
+#: model:account.account,name:l10n_pe.2_chart222
+#: model:account.account.template,name:l10n_pe.chart222
+msgid "Scrap and waste"
+msgstr "Desechos y desperdicios"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_090312
+msgid "Secclla"
+msgstr "Secclla"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_200801
+#: model:res.city,name:l10n_pe.city_pe_2008
+msgid "Sechura"
+msgstr "Sechura"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart30811
+#: model:account.account,name:l10n_pe.2_chart30811
+#: model:account.account.template,name:l10n_pe.chart30811
+msgid ""
+"Securities investments – Purchase agreements - Debt financial instruments – "
+"Purchase agreements - Costs"
+msgstr ""
+"Inversiones mobiliarias – Acuerdos de compra - Instrumentos financieros "
+"representativos de deuda – Acuerdos de compra - Costo"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart30814
+#: model:account.account,name:l10n_pe.2_chart30814
+#: model:account.account.template,name:l10n_pe.chart30814
+msgid ""
+"Securities investments – Purchase agreements - Debt financial instruments – "
+"Purchase agreements - Fair value"
+msgstr ""
+"Inversiones mobiliarias – Acuerdos de compra - Instrumentos financieros "
+"representativos de deuda – Acuerdos de compra - Valor razonable"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart30821
+#: model:account.account,name:l10n_pe.2_chart30821
+#: model:account.account.template,name:l10n_pe.chart30821
+msgid ""
+"Securities investments – Purchase agreements - Financial instruments "
+"representative of economic rights – Purchase agreements - Costs"
+msgstr ""
+"Inversiones mobiliarias – Acuerdos de compra - Instrumentos financieros "
+"representativos de derecho patrimonial – Acuerdos de compra - Costo"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart30824
+#: model:account.account,name:l10n_pe.2_chart30824
+#: model:account.account.template,name:l10n_pe.chart30824
+msgid ""
+"Securities investments – Purchase agreements - Financial instruments "
+"representative of economic rights – Purchase agreements - Fair value"
+msgstr ""
+"Inversiones mobiliarias – Acuerdos de compra - Instrumentos financieros "
+"representativos de derecho patrimonial – Acuerdos de compra - Valor "
+"razonable"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart6273
+#: model:account.account,name:l10n_pe.2_chart6273
+#: model:account.account.template,name:l10n_pe.chart6273
+msgid ""
+"Security, social security and other contributions - Complementary insurance "
+"for risky work, accidents at work and occupational diseases"
+msgstr ""
+"Seguridad, previsión social y otras contribuciones - Seguro complementario "
+"de trabajo de riesgo, accidentes de trabajo y enfermedades profesionales"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart6277
+#: model:account.account,name:l10n_pe.2_chart6277
+#: model:account.account.template,name:l10n_pe.chart6277
+msgid ""
+"Security, social security and other contributions - Contributions to SENATI"
+msgstr ""
+"Seguridad, previsión social y otras contribuciones - Contribuciones al "
+"SENATI"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart6276
+#: model:account.account,name:l10n_pe.2_chart6276
+#: model:account.account.template,name:l10n_pe.chart6276
+msgid ""
+"Security, social security and other contributions - Fisherman's Social "
+"Security Benefits Fund"
+msgstr ""
+"Seguridad, previsión social y otras contribuciones - Caja de beneficios de "
+"seguridad social del pescador"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart6271
+#: model:account.account,name:l10n_pe.2_chart6271
+#: model:account.account.template,name:l10n_pe.chart6271
+msgid ""
+"Security, social security and other contributions - Health benefits scheme"
+msgstr ""
+"Seguridad, previsión social y otras contribuciones - Régimen de prestaciones"
+" de salud"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart6274
+#: model:account.account,name:l10n_pe.2_chart6274
+#: model:account.account.template,name:l10n_pe.chart6274
+msgid "Security, social security and other contributions - Life insurance"
+msgstr "Seguridad, previsión social y otras contribuciones - Seguro de vida"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart6272
+#: model:account.account,name:l10n_pe.2_chart6272
+#: model:account.account.template,name:l10n_pe.chart6272
+msgid ""
+"Security, social security and other contributions - Pension scheme - Company"
+" contribution"
+msgstr ""
+"Seguridad, previsión social y otras contribuciones - Régimen de pensiones - "
+"Aporte de empresa"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart6275
+#: model:account.account,name:l10n_pe.2_chart6275
+#: model:account.account.template,name:l10n_pe.chart6275
+msgid ""
+"Security, social security and other contributions - Private insurance for "
+"health benefits – EPS and other individuals"
+msgstr ""
+"Seguridad, previsión social y otras contribuciones - Seguros particulares de"
+" prestaciones de salud – EPS y otros particulares"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_250202
+msgid "Sepahua"
+msgstr "Sepahua"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart751
+#: model:account.account,name:l10n_pe.2_chart751
+#: model:account.account.template,name:l10n_pe.chart751
+msgid "Services for the benefit of staff"
+msgstr "Servicios en beneficio del personal"
 
 #. module: l10n_pe
 #: model:ir.model.fields.selection,name:l10n_pe.selection__account_tax__l10n_pe_edi_unece_category__o
 #: model:ir.model.fields.selection,name:l10n_pe.selection__account_tax_template__l10n_pe_edi_unece_category__o
 msgid "Services outside scope of tax"
-msgstr "Servicios fuera del ámbito fiscal"
+msgstr "Servicios fuera de la gama de impuestos"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_061309
+msgid "Sexi"
+msgstr "Sexi"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_220708
+msgid "Shamboyacu"
+msgstr "Shamboyacu"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_220509
+msgid "Shanao"
+msgstr "Shanao"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_220914
+msgid "Shapaja"
+msgstr "Shapaja"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart1422
+#: model:account.account,name:l10n_pe.2_chart1422
+#: model:account.account.template,name:l10n_pe.chart1422
+msgid "Shareholders (or partners) - Loans"
+msgstr "Accionistas (o socios) - Préstamos"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart1421
+#: model:account.account,name:l10n_pe.2_chart1421
+#: model:account.account.template,name:l10n_pe.chart1421
+msgid ""
+"Shareholders (or partners) - Subscriptions receivable from partners or "
+"shareholders"
+msgstr ""
+"Accionistas (o socios) - Suscripciones por cobrar a socios o accionistas"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart4412
+#: model:account.account,name:l10n_pe.2_chart4412
+#: model:account.account.template,name:l10n_pe.chart4412
+msgid "Shareholders (partners, participants) - Dividends"
+msgstr "Accionistas (socios, partícipes) - Dividendos"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart4411
+#: model:account.account,name:l10n_pe.2_chart4411
+#: model:account.account.template,name:l10n_pe.chart4411
+msgid "Shareholders (partners, participants) - Loans"
+msgstr "Accionistas (socios, partícipes) - Préstamos"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart4419
+#: model:account.account,name:l10n_pe.2_chart4419
+#: model:account.account.template,name:l10n_pe.chart4419
+msgid "Shareholders (partners, participants) - Other accounts payable"
+msgstr "Accionistas (socios, partícipes) - Otras cuentas por pagar"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_220305
+msgid "Shatoja"
+msgstr "Shatoja"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_020609
+msgid "Shilla"
+msgstr "Shilla"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_010310
+msgid "Shipasbamba"
+msgstr "Shipasbamba"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_100321
+msgid "Shunqui"
+msgstr "Shunqui"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_221004
+msgid "Shunte"
+msgstr "Shunte"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_022007
+msgid "Shupluy"
+msgstr "Shupluy"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_040515
+msgid "Sibayo"
+msgstr "Sibayo"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_120134
+msgid "Sicaya"
+msgstr "Sicaya"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_200209
+msgid "Sicchez"
+msgstr "Sicchez"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_021910
+msgid "Sicsibamba"
+msgstr "Sicsibamba"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_080601
+msgid "Sicuani"
+msgstr "Sicuani"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_021901
+#: model:res.city,name:l10n_pe.city_pe_0219
+msgid "Sihuas"
+msgstr "Sihuas"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_100322
+msgid "Sillapata"
+msgstr "Sillapata"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_130110
+msgid "Simbal"
+msgstr "Simbal"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_190109
+msgid "Simon Bolívar"
+msgstr "Simon Bolívar"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_211005
+msgid "Sina"
+msgstr "Sina"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_120431
+msgid "Sincos"
+msgstr "Sincos"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_100510
+msgid "Singa"
+msgstr "Singa"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_130613
+msgid "Sinsicap"
+msgstr "Sinsicap"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_131008
+msgid "Sitabamba"
+msgstr "Sitabamba"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_060204
+msgid "Sitacocha"
+msgstr "Sitacocha"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_230405
+msgid "Sitajara"
+msgstr "Sitajara"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_050407
+msgid "Sivia"
+msgstr "Sivia"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_040122
+msgid "Socabaya"
+msgstr "Socabaya"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_050112
+msgid "Socos"
+msgstr "Socos"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_060614
+msgid "Socota"
+msgstr "Socota"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart34311
+#: model:account.account,name:l10n_pe.2_chart34311
+#: model:account.account.template,name:l10n_pe.chart34311
+msgid "Softwares - Computer applications - Costs"
+msgstr ""
+"Programas de computadora (software) - Aplicaciones informáticas - Costo"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart34312
+#: model:account.account,name:l10n_pe.2_chart34312
+#: model:account.account.template,name:l10n_pe.chart34312
+msgid "Softwares - Computer applications - Revaluation"
+msgstr ""
+"Programas de computadora (software) - Aplicaciones informáticas - "
+"Revaluación"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart36531
+#: model:account.account,name:l10n_pe.2_chart36531
+#: model:account.account.template,name:l10n_pe.chart36531
+msgid "Softwares - Costs"
+msgstr "Programas de computadora (software) - Costo"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart36532
+#: model:account.account,name:l10n_pe.2_chart36532
+#: model:account.account.template,name:l10n_pe.chart36532
+msgid "Softwares - Revaluation"
+msgstr "Programas de computadora (software) - Revaluación"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_010120
+msgid "Soloco"
+msgstr "Soloco"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_010121
+msgid "Sonche"
+msgstr "Sonche"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_200307
+msgid "Sondor"
+msgstr "Sondor"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_200308
+msgid "Sondorillo"
+msgstr "Sondorillo"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_160508
+msgid "Soplin"
+msgstr "Soplin"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_050911
+msgid "Soras"
+msgstr "Soras"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_030413
+msgid "Soraya"
+msgstr "Soraya"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_220105
+msgid "Soritor"
+msgstr "Soritor"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_060309
+msgid "Sorochuco"
+msgstr "Sorochuco"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart253
+#: model:account.account,name:l10n_pe.2_chart253
+#: model:account.account.template,name:l10n_pe.chart253
+msgid "Spare parts"
+msgstr "Repuestos"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart1413
+#: model:account.account,name:l10n_pe.2_chart1413
+#: model:account.account.template,name:l10n_pe.chart1413
+msgid "Staff - Deliveries to account"
+msgstr "Personal - Entregas a rendir cuenta"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart1411
+#: model:account.account,name:l10n_pe.2_chart1411
+#: model:account.account.template,name:l10n_pe.chart1411
+msgid "Staff - Loans"
+msgstr "Personal - Préstamos"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart1419
+#: model:account.account,name:l10n_pe.2_chart1419
+#: model:account.account.template,name:l10n_pe.chart1419
+msgid "Staff - Other accounts receivable from staff"
+msgstr "Personal - Otras cuentas por cobrar al personal"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart1412
+#: model:account.account,name:l10n_pe.2_chart1412
+#: model:account.account.template,name:l10n_pe.chart1412
+msgid "Staff - Salary advance"
+msgstr "Personal - Adelanto de remuneraciones"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart623
+#: model:account.account,name:l10n_pe.2_chart623
+#: model:account.account.template,name:l10n_pe.chart623
+msgid "Staff compensation"
+msgstr "Indemnizaciones al personal"
 
 #. module: l10n_pe
 #: model:ir.model.fields.selection,name:l10n_pe.selection__account_tax__l10n_pe_edi_unece_category__s
@@ -220,14 +18377,402 @@ msgid "State..."
 msgstr "Estado..."
 
 #. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart2983
+#: model:account.account,name:l10n_pe.2_chart2983
+#: model:account.account.template,name:l10n_pe.chart2983
+msgid "Stock to be received - Auxiliary materials, supplies and spare parts"
+msgstr ""
+"Existencias por recibir - Materiales auxiliares, suministros y repuestos"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart2984
+#: model:account.account,name:l10n_pe.2_chart2984
+#: model:account.account.template,name:l10n_pe.chart2984
+msgid "Stock to be received - Containers and packaging"
+msgstr "Existencias por recibir - Materias primas"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart2981
+#: model:account.account,name:l10n_pe.2_chart2981
+#: model:account.account.template,name:l10n_pe.chart2981
+msgid "Stock to be received - Merchandise"
+msgstr "Existencias por recibir - Mercaderías"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart2982
+#: model:account.account,name:l10n_pe.2_chart2982
+#: model:account.account.template,name:l10n_pe.chart2982
+msgid "Stock to be received - Raw Materials"
+msgstr "Existencias por recibir - Materias primas"
+
+#. module: l10n_pe
 #: model_terms:ir.ui.view,arch_db:l10n_pe.pe_partner_address_form
 msgid "Street"
 msgstr "Calle"
 
 #. module: l10n_pe
-#: model_terms:ir.ui.view,arch_db:l10n_pe.pe_partner_address_form
-msgid "Street Name..."
-msgstr "Nombre de la calle..."
+#: model:account.account,name:l10n_pe.1_chart653
+#: model:account.account,name:l10n_pe.2_chart653
+#: model:account.account.template,name:l10n_pe.chart653
+msgid "Subscriptions"
+msgstr "Suscripciones"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_110112
+msgid "Subtanjalla"
+msgstr "Subtanjalla"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_020205
+msgid "Succha"
+msgstr "Succha"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_060310
+#: model:res.city,name:l10n_pe.city_pe_0509
+msgid "Sucre"
+msgstr "Sucre"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_120809
+msgid "Suitucancha"
+msgstr "Suitucancha"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_200601
+#: model:res.city,name:l10n_pe.city_pe_2006
+msgid "Sullana"
+msgstr "Sullana"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_150611
+msgid "Sumbilca"
+msgstr "Sumbilca"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_110210
+msgid "Sunampe"
+msgstr "Sunampe"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_150204
+msgid "Supe"
+msgstr "Supe"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_150205
+msgid "Supe Puerto"
+msgstr "Supe Puerto"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart656
+#: model:account.account,name:l10n_pe.2_chart656
+#: model:account.account.template,name:l10n_pe.chart656
+msgid "Supplies"
+msgstr "Suministros"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart2523
+#: model:account.account,name:l10n_pe.2_chart2523
+#: model:account.account.template,name:l10n_pe.chart2523
+msgid "Supplies - Energy"
+msgstr "Suministros - Energía"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart2521
+#: model:account.account,name:l10n_pe.2_chart2521
+#: model:account.account.template,name:l10n_pe.chart2521
+msgid "Supplies - Fuels"
+msgstr "Suministros - Combustibles"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart2522
+#: model:account.account,name:l10n_pe.2_chart2522
+#: model:account.account.template,name:l10n_pe.chart2522
+msgid "Supplies - Lubricants"
+msgstr "Suministros - Lubricantes"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart2524
+#: model:account.account,name:l10n_pe.2_chart2524
+#: model:account.account.template,name:l10n_pe.chart2524
+msgid "Supplies - Other supplies"
+msgstr "Suministros - Otros suministros"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_150732
+msgid "Surco"
+msgstr "Surco"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_090717
+msgid "Surcubamba"
+msgstr "Surcubamba"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_150141
+msgid "Surquillo"
+msgstr "Surquillo"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_230406
+msgid "Susapaya"
+msgstr "Susapaya"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_080807
+msgid "Suyckutambo"
+msgstr "Suyckutambo"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_200210
+msgid "Suyo"
+msgstr "Suyo"
+
+#. module: l10n_pe
+#: model:res.city,name:l10n_pe.city_pe_1309
+msgid "Sánchez Carrión"
+msgstr "Sánchez Carrión"
+
+#. module: l10n_pe
+#: model:l10n_latam.identification.type,name:l10n_pe.it_TAM
+msgid "TAM"
+msgstr "TAM"
+
+#. module: l10n_pe
+#: model:account.group,name:l10n_pe.1_group64
+#: model:account.group,name:l10n_pe.2_group64
+#: model:account.group.template,name:l10n_pe.group64
+msgid "TAX EXPENSES"
+msgstr "GASTOS POR TRIBUTOS"
+
+#. module: l10n_pe
+#: model:account.group,name:l10n_pe.1_group40
+#: model:account.group,name:l10n_pe.2_group40
+#: model:account.group.template,name:l10n_pe.group40
+msgid ""
+"TAXES, CONSIDERATIONS AND CONTRIBUTIONS TO THE PUBLIC PENSION AND HEALTH "
+"SYSTEM PAYABLE"
+msgstr ""
+"TRIBUTOS, CONTRAPRESTACIONES Y APORTES AL SISTEMA PÚBLICO DE PENSIONES Y DE "
+"SALUD POR PAGAR"
+
+#. module: l10n_pe
+#: model:account.group,name:l10n_pe.1_group42
+#: model:account.group,name:l10n_pe.2_group42
+#: model:account.group.template,name:l10n_pe.group42
+msgid "THIRD-PARTY TRADE ACCOUNTS PAYABLE"
+msgstr "CUENTAS POR PAGAR COMERCIALES TERCEROS"
+
+#. module: l10n_pe
+#: model:account.group,name:l10n_pe.1_group13
+#: model:account.group,name:l10n_pe.2_group13
+#: model:account.group.template,name:l10n_pe.group13
+msgid "TRADE ACCOUNTS RECEIVABLE – ASSOCIATED"
+msgstr "CUENTAS POR COBRAR COMERCIALES – RELACIONADAS"
+
+#. module: l10n_pe
+#: model:account.group,name:l10n_pe.1_group12
+#: model:account.group,name:l10n_pe.2_group12
+#: model:account.group.template,name:l10n_pe.group12
+msgid "TRADE ACCOUNTS RECEIVABLE – THIRD PARTIES"
+msgstr "CUENTAS POR COBRAR COMERCIALES – TERCEROS"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_060907
+msgid "Tabaconas"
+msgstr "Tabaconas"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_220510
+msgid "Tabalosos"
+msgstr "Tabalosos"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_060417
+msgid "Tacabamba"
+msgstr "Tacabamba"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_230101
+#: model:res.city,name:l10n_pe.city_pe_2301
+msgid "Tacna"
+msgstr "Tacna"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_170303
+#: model:res.city,name:l10n_pe.city_pe_1703
+msgid "Tahuamanu"
+msgstr "Tahuamanu"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_250203
+msgid "Tahuania"
+msgstr "Tahuania"
+
+#. module: l10n_pe
+#: model:res.city,name:l10n_pe.city_pe_2007
+msgid "Talara"
+msgstr "Talara"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_030216
+msgid "Talavera"
+msgstr "Talavera"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_200506
+msgid "Tamarindo"
+msgstr "Tamarindo"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_050113
+msgid "Tambillo"
+msgstr "Tambillo"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_050508
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_090616
+msgid "Tambo"
+msgstr "Tambo"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_200114
+msgid "Tambo Grande"
+msgstr "Tambo Grande"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_110211
+msgid "Tambo de Mora"
+msgstr "Tambo de Mora"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_030501
+msgid "Tambobamba"
+msgstr "Tambobamba"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_170101
+#: model:res.city,name:l10n_pe.city_pe_1701
+msgid "Tambopata"
+msgstr "Tambopata"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_030109
+msgid "Tamburco"
+msgstr "Tamburco"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_151028
+msgid "Tanta"
+msgstr "Tanta"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_100511
+msgid "Tantamayo"
+msgstr "Tantamayo"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_090412
+msgid "Tantara"
+msgstr "Tantara"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_060507
+msgid "Tantarica"
+msgstr "Tantarica"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_021709
+msgid "Tapacocha"
+msgstr "Tapacocha"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_030414
+msgid "Tapairihua"
+msgstr "Tapairihua"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_040516
+msgid "Tapay"
+msgstr "Tapay"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_160509
+msgid "Tapiche"
+msgstr "Tapiche"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_120709
+msgid "Tapo"
+msgstr "Tapo"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_190207
+msgid "Tapuc"
+msgstr "Tapuc"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_210607
+msgid "Taraco"
+msgstr "Taraco"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_220901
+msgid "Tarapoto"
+msgstr "Tarapoto"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_230401
+#: model:res.city,name:l10n_pe.city_pe_2304
+msgid "Tarata"
+msgstr "Tarata"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_080407
+msgid "Taray"
+msgstr "Taray"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_020112
+msgid "Tarica"
+msgstr "Tarica"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_120701
+#: model:res.city,name:l10n_pe.city_pe_1207
+msgid "Tarma"
+msgstr "Tarma"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_230407
+msgid "Tarucachi"
+msgstr "Tarucachi"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_110113
+msgid "Tate"
+msgstr "Tate"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_021511
+msgid "Tauca"
+msgstr "Tauca"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_040809
+msgid "Tauria"
+msgstr "Tauria"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_130812
+msgid "Taurija"
+msgstr "Taurija"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_151029
+msgid "Tauripampa"
+msgstr "Tauripampa"
 
 #. module: l10n_pe
 #: model:ir.model,name:l10n_pe.model_account_tax
@@ -235,18 +18780,1460 @@ msgid "Tax"
 msgstr "Impuesto"
 
 #. module: l10n_pe
+#: model:l10n_latam.identification.type,name:l10n_pe.it_TIN
+msgid "Tax Identification Number"
+msgstr "Numero de Identificacion Fiscal"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart402
+#: model:account.account,name:l10n_pe.2_chart402
+#: model:account.account.template,name:l10n_pe.chart402
+msgid "Tax certificates"
+msgstr "Certificados tributarios"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart6454
+#: model:account.account,name:l10n_pe.2_chart6454
+#: model:account.account.template,name:l10n_pe.chart6454
+msgid "Tax debt expenses - Costs and others"
+msgstr "Gastos en deuda tributaria - Costas y otros"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart6453
+#: model:account.account,name:l10n_pe.2_chart6453
+#: model:account.account.template,name:l10n_pe.chart6453
+msgid "Tax debt expenses - Fines"
+msgstr "Gastos en deuda tributaria - Multas"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart6451
+#: model:account.account,name:l10n_pe.2_chart6451
+#: model:account.account.template,name:l10n_pe.chart6451
+msgid "Tax debt expenses - Interests"
+msgstr "Gastos en deuda tributaria - Intereses"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart6452
+#: model:account.account,name:l10n_pe.2_chart6452
+#: model:account.account.template,name:l10n_pe.chart6452
+msgid "Tax debt expenses - Interests - Subdivision"
+msgstr "Gastos en deuda tributaria - Intereses - Fraccionamiento"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart1673
+#: model:account.account,name:l10n_pe.2_chart1673
+#: model:account.account.template,name:l10n_pe.chart1673
+msgid "Taxes to be credited - IGV to be credited on purchases"
+msgstr "Tributos por acreditar - IGV por acreditar en compras"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart1674
+#: model:account.account,name:l10n_pe.2_chart1674
+#: model:account.account.template,name:l10n_pe.chart1674
+msgid "Taxes to be credited - IGV to credit non-residents"
+msgstr "Tributos por acreditar - IGV por acreditar no domiciliados"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart1672
+#: model:account.account,name:l10n_pe.2_chart1672
+#: model:account.account.template,name:l10n_pe.chart1672
+msgid "Taxes to be credited - ITAN account payments"
+msgstr "Tributos por acreditar - Pagos a cuenta de ITAN"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart1671
+#: model:account.account,name:l10n_pe.2_chart1671
+#: model:account.account.template,name:l10n_pe.chart1671
+msgid "Taxes to be credited - Payments on account of income tax"
+msgstr "Tributos por acreditar - Pagos a cuenta del impuesto a la renta"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart1675
+#: model:account.account,name:l10n_pe.2_chart1675
+#: model:account.account.template,name:l10n_pe.chart1675
+msgid "Taxes to be credited - Works for taxes"
+msgstr "Tributos por acreditar - Obras por impuestos"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_130801
+msgid "Tayabamba"
+msgstr "Tayabamba"
+
+#. module: l10n_pe
+#: model:res.city,name:l10n_pe.city_pe_0907
+msgid "Tayacaja"
+msgstr "Tayacaja"
+
+#. module: l10n_pe
+#: model:ir.model,name:l10n_pe.model_account_tax_template
+msgid "Templates for Taxes"
+msgstr "Plantilla de impuestos"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_160211
+msgid "Teniente Cesar López Rojas"
+msgstr "Teniente Cesar López Rojas"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_160803
+msgid "Teniente Manuel Clavero"
+msgstr "Teniente Manuel Clavero"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart461
+#: model:account.account,name:l10n_pe.2_chart461
+#: model:account.account.template,name:l10n_pe.chart461
+msgid "Third Party Claims"
+msgstr "Reclamaciones de terceros"
+
+#. module: l10n_pe
 #: model:ir.model.fields,help:l10n_pe.field_res_city__l10n_pe_code
 msgid "This code will help with the identification of each city in Peru."
-msgstr "Este código ayudará con la identificación de cada ciudad en Perú."
+msgstr "Este código ayudará a identificar cada ciudad en Perú."
 
 #. module: l10n_pe
 #: model:ir.model.fields,help:l10n_pe.field_l10n_pe_res_city_district__code
 msgid "This code will help with the identification of each district in Peru."
-msgstr "Este código ayudará con la identificación de cada distrito en Perú."
+msgstr "Este código ayudará a identificar cada distrito en Perú."
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_040123
+msgid "Tiabaya"
+msgstr "Tiabaya"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_110405
+msgid "Tibillo"
+msgstr "Tibillo"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_230408
+msgid "Ticaco"
+msgstr "Ticaco"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_021710
+msgid "Ticapampa"
+msgstr "Ticapampa"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_190110
+msgid "Ticlacayan"
+msgstr "Ticlacayan"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_020515
+msgid "Ticllos"
+msgstr "Ticllos"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_090413
+msgid "Ticrapo"
+msgstr "Ticrapo"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_160303
+msgid "Tigre"
+msgstr "Tigre"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_210904
+msgid "Tilali"
+msgstr "Tilali"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_020610
+msgid "Tinco"
+msgstr "Tinco"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_010522
+msgid "Tingo"
+msgstr "Tingo"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_220709
+msgid "Tingo de Ponasa"
+msgstr "Tingo de Ponasa"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_220406
+msgid "Tingo de Saposoa"
+msgstr "Tingo de Saposoa"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_211306
+msgid "Tinicachi"
+msgstr "Tinicachi"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_080608
+msgid "Tinta"
+msgstr "Tinta"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_030415
+msgid "Tintay"
+msgstr "Tintay"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_090718
+msgid "Tintay Puncu"
+msgstr "Tintay Puncu"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_190111
+msgid "Tinyahuarco"
+msgstr "Tinyahuarco"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_040411
+msgid "Tipan"
+msgstr "Tipan"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_210114
+msgid "Tiquillaca"
+msgstr "Tiquillaca"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_210215
+msgid "Tirapata"
+msgstr "Tirapata"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_040517
+msgid "Tisco"
+msgstr "Tisco"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_221001
+#: model:res.city,name:l10n_pe.city_pe_2210
+msgid "Tocache"
+msgstr "Tocache"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_060418
+msgid "Tocmoche"
+msgstr "Tocmoche"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_151030
+msgid "Tomas"
+msgstr "Tomas"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_100208
+msgid "Tomay Kichwa"
+msgstr "Tomay Kichwa"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_040810
+msgid "Tomepampa"
+msgstr "Tomepampa"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_061112
+msgid "Tongod"
+msgstr "Tongod"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_180106
+msgid "Torata"
+msgstr "Torata"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_030416
+msgid "Toraya"
+msgstr "Toraya"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_060615
+msgid "Toribio Casanova"
+msgstr "Toribio Casanova"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_040811
+msgid "Toro"
+msgstr "Toro"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_160110
+msgid "Torres Causana"
+msgstr "Torres Causana"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_010611
+msgid "Totora"
+msgstr "Totora"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_050206
+msgid "Totos"
+msgstr "Totos"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_100904
+msgid "Tournavista"
+msgstr "Tournavista"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart1923
+#: model:account.account,name:l10n_pe.2_chart1923
+#: model:account.account.template,name:l10n_pe.chart1923
+msgid "Trade accounts receivable – Associated - Bills to be collected"
+msgstr "Cuentas por cobrar comerciales – Relacionadas - Letras por cobrar"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart1921
+#: model:account.account,name:l10n_pe.2_chart1921
+#: model:account.account.template,name:l10n_pe.chart1921
+msgid ""
+"Trade accounts receivable – Associated - Invoices, tickets and other "
+"receipts receivable"
+msgstr ""
+"Cuentas por cobrar comerciales – Relacionadas - Facturas, boletas y otros "
+"comprobantes por cobrar"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart1913
+#: model:account.account,name:l10n_pe.2_chart1913
+#: model:account.account.template,name:l10n_pe.chart1913
+msgid "Trade accounts receivable – Third parties - Bills to be collected"
+msgstr "Cuentas por cobrar comerciales – Terceros - Letras por cobrar"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart1911
+#: model:account.account,name:l10n_pe.2_chart1911
+#: model:account.account.template,name:l10n_pe.chart1911
+msgid ""
+"Trade accounts receivable – Third parties - Invoices, tickets and other "
+"receipts receivable"
+msgstr ""
+"Cuentas por cobrar comerciales – Terceros - Facturas, boletas y otros "
+"comprobantes por cobrar"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart624
+#: model:account.account,name:l10n_pe.2_chart624
+#: model:account.account.template,name:l10n_pe.chart624
+msgid "Training"
+msgstr "Capacitación"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart36441
+#: model:account.account,name:l10n_pe.2_chart36441
+#: model:account.account.template,name:l10n_pe.chart36441
+msgid "Transport units - Costs"
+msgstr "Unidades de transporte - Costo"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart33411
+#: model:account.account,name:l10n_pe.2_chart33411
+#: model:account.account.template,name:l10n_pe.chart33411
+msgid "Transport units - Motor vehicles - Costs"
+msgstr "Unidades de transporte - Vehículos motorizados - Costo"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart33412
+#: model:account.account,name:l10n_pe.2_chart33412
+#: model:account.account.template,name:l10n_pe.chart33412
+msgid "Transport units - Motor vehicles - Revaluation"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart33421
+#: model:account.account,name:l10n_pe.2_chart33421
+#: model:account.account.template,name:l10n_pe.chart33421
+msgid "Transport units - Non-motorized vehicles - Costs"
+msgstr "Unidades de transporte - Vehículos no motorizados - Costo"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart33422
+#: model:account.account,name:l10n_pe.2_chart33422
+#: model:account.account.template,name:l10n_pe.chart33422
+msgid "Transport units - Non-motorized vehicles - Revaluation"
+msgstr "Unidades de transporte - Vehículos no motorizados - Revaluación"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart36442
+#: model:account.account,name:l10n_pe.2_chart36442
+#: model:account.account.template,name:l10n_pe.chart36442
+msgid "Transport units - Revaluation"
+msgstr "Unidades de transporte - Revaluación"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart6314
+#: model:account.account,name:l10n_pe.2_chart6314
+#: model:account.account.template,name:l10n_pe.chart6314
+msgid "Transport, mail and travel expenses - Alimentation"
+msgstr "Transporte, correos y gastos de viaje - Alimentación"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart6313
+#: model:account.account,name:l10n_pe.2_chart6313
+#: model:account.account.template,name:l10n_pe.chart6313
+msgid "Transport, mail and travel expenses - Lodgement"
+msgstr "Transporte, correos y gastos de viaje - Alojamiento"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart6315
+#: model:account.account,name:l10n_pe.2_chart6315
+#: model:account.account.template,name:l10n_pe.chart6315
+msgid "Transport, mail and travel expenses - Other travel expenses"
+msgstr "Transporte, correos y gastos de viaje - Otros gastos de viaje"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart6312
+#: model:account.account,name:l10n_pe.2_chart6312
+#: model:account.account.template,name:l10n_pe.chart6312
+msgid "Transport, mail and travel expenses - Post office"
+msgstr "Transporte, correos y gastos de viaje - Correos"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart63111
+#: model:account.account,name:l10n_pe.2_chart63111
+#: model:account.account.template,name:l10n_pe.chart63111
+msgid "Transport, mail and travel expenses - Transport - Charging"
+msgstr "Transporte, correos y gastos de viaje - Transporte - De carga"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart63112
+#: model:account.account,name:l10n_pe.2_chart63112
+#: model:account.account.template,name:l10n_pe.chart63112
+msgid "Transport, mail and travel expenses - Transport - Passengers"
+msgstr "Transporte, correos y gastos de viaje - Transporte - De pasajeros"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart502
+#: model:account.account,name:l10n_pe.2_chart502
+#: model:account.account.template,name:l10n_pe.chart502
+msgid "Treasury shares"
+msgstr "Acciones en tesorería"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_220710
+msgid "Tres Unidos"
+msgstr "Tres Unidos"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_120908
+msgid "Tres de Diciembre"
+msgstr "Tres de Diciembre"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_010523
+msgid "Trita"
+msgstr "Trita"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_160304
+msgid "Trompeteros"
+msgstr "Trompeteros"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_130101
+#: model:res.city,name:l10n_pe.city_pe_1301
+msgid "Trujillo"
+msgstr "Trujillo"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_140312
+msgid "Tucume"
+msgstr "Tucume"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_140120
+msgid "Tuman"
+msgstr "Tuman"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_030217
+msgid "Tumay Huaraca"
+msgstr "Tumay Huaraca"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_061204
+msgid "Tumbaden"
+msgstr "Tumbaden"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_240101
+#: model:res.city,name:l10n_pe.city_pe_2401
+msgid "Tumbes"
+msgstr "Tumbes"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_120432
+msgid "Tunan Marca"
+msgstr "Tunan Marca"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_080508
+msgid "Tupac Amaru"
+msgstr "Tupac Amaru"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_110508
+msgid "Tupac Amaru Inca"
+msgstr "Tupac Amaru Inca"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_151031
+msgid "Tupe"
+msgstr "Tupe"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_030711
+msgid "Turpay"
+msgstr "Turpay"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_030218
+msgid "Turpo"
+msgstr "Turpo"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_040518
+msgid "Tuti"
+msgstr "Tuti"
+
+#. module: l10n_pe
+#: model:account.group,name:l10n_pe.1_group56
+#: model:account.group,name:l10n_pe.2_group56
+#: model:account.group.template,name:l10n_pe.group56
+msgid "UNREALIZED RESULTS"
+msgstr "RESULTADOS NO REALIZADOS"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_180210
+msgid "Ubinas"
+msgstr "Ubinas"
+
+#. module: l10n_pe
+#: model:res.city,name:l10n_pe.city_pe_1606
+msgid "Ucayali"
+msgstr "Ucayali"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_221005
+msgid "Uchiza"
+msgstr "Uchiza"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_130305
+msgid "Uchumarca"
+msgstr "Uchumarca"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_040124
+msgid "Uchumayo"
+msgstr "Uchumayo"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_050410
+msgid "Uchuraccay"
+msgstr "Uchuraccay"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_021016
+msgid "Uco"
+msgstr "Uco"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_130306
+msgid "Ucuncha"
+msgstr "Ucuncha"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_120504
+msgid "Ulcumayo"
+msgstr "Ulcumayo"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_210809
+msgid "Umachiri"
+msgstr "Umachiri"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_100804
+msgid "Umari"
+msgstr "Umari"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart5911
+#: model:account.account,name:l10n_pe.2_chart5911
+#: model:account.account.template,name:l10n_pe.chart5911
+msgid "Undistributed profits - Acumulated utilities"
+msgstr "Utilidades no distribuidas - Utilidades acumuladas"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart5912
+#: model:account.account,name:l10n_pe.2_chart5912
+#: model:account.account.template,name:l10n_pe.chart5912
+msgid "Undistributed profits - Income from previous years"
+msgstr "Utilidades no distribuidas - Ingresos de años anteriores"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_211307
+msgid "Unicachi"
+msgstr "Unicachi"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart3383
+#: model:account.account,name:l10n_pe.2_chart3383
+#: model:account.account.template,name:l10n_pe.chart3383
+msgid "Units to receive - Furniture and fixtures"
+msgstr "Unidades por recibir - Muebles y enseres"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart3381
+#: model:account.account,name:l10n_pe.2_chart3381
+#: model:account.account.template,name:l10n_pe.chart3381
+msgid "Units to receive - Machinery and exploitation equipment"
+msgstr "Unidades por recibir - Maquinarias y equipos de explotación"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart3386
+#: model:account.account,name:l10n_pe.2_chart3386
+#: model:account.account.template,name:l10n_pe.chart3386
+msgid "Units to receive - Miscellaneous equipment"
+msgstr "Unidades por recibir - Equipos diversos"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart3387
+#: model:account.account,name:l10n_pe.2_chart3387
+#: model:account.account.template,name:l10n_pe.chart3387
+msgid "Units to receive - Replacement tools and units"
+msgstr "Unidades por recibir - Herramientas y unidades de reemplazo"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart3382
+#: model:account.account,name:l10n_pe.2_chart3382
+#: model:account.account.template,name:l10n_pe.chart3382
+msgid "Units to receive - Transportation equipment"
+msgstr "Unidades por recibir - Equipo de transporte"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_061113
+msgid "Unión Agua Blanca"
+msgstr "Unión Agua Blanca"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_050708
+msgid "Upahuacho"
+msgstr "Upahuacho"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_040413
+msgid "Uraca"
+msgstr "Uraca"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_030607
+msgid "Uranmarca"
+msgstr "Uranmarca"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_160305
+msgid "Urarinas"
+msgstr "Urarinas"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_081201
+msgid "Urcos"
+msgstr "Urcos"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_130813
+msgid "Urpay"
+msgstr "Urpay"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_081301
+#: model:res.city,name:l10n_pe.city_pe_0813
+msgid "Urubamba"
+msgstr "Urubamba"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_210310
+msgid "Usicayos"
+msgstr "Usicayos"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_130614
+msgid "Usquil"
+msgstr "Usquil"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_060311
+msgid "Utco"
+msgstr "Utco"
+
+#. module: l10n_pe
+#: model:res.city,name:l10n_pe.city_pe_0107
+msgid "Utcubamba"
+msgstr "Utcubamba"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_061310
+msgid "Uticyacu"
+msgstr "Uticyacu"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart891
+#: model:account.account,name:l10n_pe.2_chart891
+#: model:account.account.template,name:l10n_pe.chart891
+msgid "Utility"
+msgstr "Utilidad"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_040412
+msgid "Uñon"
+msgstr "Uñon"
+
+#. module: l10n_pe
+#: model:account.group,name:l10n_pe.1_group68
+#: model:account.group,name:l10n_pe.2_group68
+#: model:account.group.template,name:l10n_pe.group68
+msgid "VALUATION AND IMPAIRMENT OF ASSETS AND PROVISIONS"
+msgstr "VALUACIÓN Y DETERIORO DE ACTIVOS Y PROVISIONES"
+
+#. module: l10n_pe
+#: model:account.group,name:l10n_pe.1_group82
+#: model:account.group,name:l10n_pe.2_group82
+#: model:account.group.template,name:l10n_pe.group82
+msgid "VALUE ADDED"
+msgstr "VALOR AGREGADO"
+
+#. module: l10n_pe
+#: model:account.group,name:l10n_pe.1_group61
+#: model:account.group,name:l10n_pe.2_group61
+#: model:account.group.template,name:l10n_pe.group61
+msgid "VARIATION IN INVENTORIES"
+msgstr "VARIACIÓN DE INVENTARIOS"
+
+#. module: l10n_pe
+#: model:account.group,name:l10n_pe.1_group71
+#: model:account.group,name:l10n_pe.2_group71
+#: model:account.group.template,name:l10n_pe.group71
+msgid "VARIATION IN STORED PRODUCTION"
+msgstr "VARIACIÓN DE LA PRODUCCIÓN ALMACENADA"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_010311
+msgid "Valera"
+msgstr "Valera"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart821
+#: model:account.account,name:l10n_pe.2_chart821
+#: model:account.account.template,name:l10n_pe.chart821
+msgid "Value added"
+msgstr "Valor agregado"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_160606
+msgid "Vargas Guerra"
+msgstr "Vargas Guerra"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart7121
+#: model:account.account,name:l10n_pe.2_chart7121
+#: model:account.account.template,name:l10n_pe.chart7121
+msgid "Variation of by-products, waste and scrap - By-products"
+msgstr "Variación de subproductos, desechos y desperdicios - Subproductos"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart7122
+#: model:account.account,name:l10n_pe.2_chart7122
+#: model:account.account.template,name:l10n_pe.chart7122
+msgid "Variation of by-products, waste and scrap - Scrap and waste"
+msgstr ""
+"Variación de subproductos, desechos y desperdicios - Desechos y desperdicios"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart7141
+#: model:account.account,name:l10n_pe.2_chart7141
+#: model:account.account.template,name:l10n_pe.chart7141
+msgid "Variation of containers and packaging - Containers"
+msgstr "Variación de envases y embalajes - Envases"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart7142
+#: model:account.account,name:l10n_pe.2_chart7142
+#: model:account.account.template,name:l10n_pe.chart7142
+msgid "Variation of containers and packaging - Packaging"
+msgstr "Variación de envases y embalajes - Embalajes"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart7111
+#: model:account.account,name:l10n_pe.2_chart7111
+#: model:account.account.template,name:l10n_pe.chart7111
+msgid "Variation of finished products - Finished products"
+msgstr "Variación de productos terminados - Productos terminados"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart7131
+#: model:account.account,name:l10n_pe.2_chart7131
+#: model:account.account.template,name:l10n_pe.chart7131
+msgid "Variation of products in process - Products in manufacturing process"
+msgstr ""
+"Variación de productos en proceso - Productos en proceso de manufactura"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart7151
+#: model:account.account,name:l10n_pe.2_chart7151
+#: model:account.account.template,name:l10n_pe.chart7151
+msgid "Variation of services inventories - Inventories of services in process"
+msgstr ""
+"Variación de inventarios de servicios - Inventarios de servicios en proceso"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart149
+#: model:account.account,name:l10n_pe.2_chart149
+#: model:account.account.template,name:l10n_pe.chart149
+msgid "Various"
+msgstr "Diversas"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart1956
+#: model:account.account,name:l10n_pe.2_chart1956
+#: model:account.account.template,name:l10n_pe.chart1956
+msgid ""
+"Various accounts receivable – Associated - Assets for financial instruments"
+msgstr ""
+"Cuentas por cobrar diversas – Relacionadas - Activos por instrumentos "
+"financieros"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart1954
+#: model:account.account,name:l10n_pe.2_chart1954
+#: model:account.account.template,name:l10n_pe.chart1954
+msgid ""
+"Various accounts receivable – Associated - Deposits granted in guarantee"
+msgstr ""
+"Cuentas por cobrar diversas – Relacionadas - Depósitos otorgados en garantía"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart1953
+#: model:account.account,name:l10n_pe.2_chart1953
+#: model:account.account.template,name:l10n_pe.chart1953
+msgid ""
+"Various accounts receivable – Associated - Interest, royalties and dividends"
+msgstr ""
+"Cuentas por cobrar diversas – Relacionadas - Intereses, regalías y "
+"dividendos"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart1951
+#: model:account.account,name:l10n_pe.2_chart1951
+#: model:account.account.template,name:l10n_pe.chart1951
+msgid "Various accounts receivable – Associated - Loans"
+msgstr "Cuentas por cobrar diversas – Relacionadas - Préstamos"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart1959
+#: model:account.account,name:l10n_pe.2_chart1959
+#: model:account.account.template,name:l10n_pe.chart1959
+msgid ""
+"Various accounts receivable – Associated - Other sundry accounts receivable"
+msgstr ""
+"Cuentas por cobrar diversas – Relacionadas - Otras cuentas por cobrar "
+"diversas"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart1955
+#: model:account.account,name:l10n_pe.2_chart1955
+#: model:account.account.template,name:l10n_pe.chart1955
+msgid "Various accounts receivable – Associated - Sale of fixed assets"
+msgstr ""
+"Cuentas por cobrar diversas – Relacionadas - Venta de activo inmovilizado"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart1946
+#: model:account.account,name:l10n_pe.2_chart1946
+#: model:account.account.template,name:l10n_pe.chart1946
+msgid ""
+"Various accounts receivable – Third parties - Assets for financial "
+"instruments"
+msgstr ""
+"Cuentas por cobrar diversas – Terceros - Activos por instrumentos "
+"financieros"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart1942
+#: model:account.account,name:l10n_pe.2_chart1942
+#: model:account.account.template,name:l10n_pe.chart1942
+msgid "Various accounts receivable – Third parties - Claims to third parties"
+msgstr "Cuentas por cobrar diversas – Terceros - Reclamaciones a terceros"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart1944
+#: model:account.account,name:l10n_pe.2_chart1944
+#: model:account.account.template,name:l10n_pe.chart1944
+msgid ""
+"Various accounts receivable – Third parties - Deposits granted in guarantee"
+msgstr ""
+"Cuentas por cobrar diversas – Terceros - Depósitos otorgados en garantía"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart1943
+#: model:account.account,name:l10n_pe.2_chart1943
+#: model:account.account.template,name:l10n_pe.chart1943
+msgid ""
+"Various accounts receivable – Third parties - Interest, royalties and "
+"dividends"
+msgstr ""
+"Cuentas por cobrar diversas – Terceros - Intereses, regalías y dividendos"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart1941
+#: model:account.account,name:l10n_pe.2_chart1941
+#: model:account.account.template,name:l10n_pe.chart1941
+msgid "Various accounts receivable – Third parties - Loans"
+msgstr "Cuentas por cobrar diversas – Terceros - Préstamos"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart1949
+#: model:account.account,name:l10n_pe.2_chart1949
+#: model:account.account.template,name:l10n_pe.chart1949
+msgid ""
+"Various accounts receivable – Third parties - Other sundry accounts "
+"receivable"
+msgstr ""
+"Cuentas por cobrar diversas – Terceros - Otras cuentas por cobrar diversas"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart1945
+#: model:account.account,name:l10n_pe.2_chart1945
+#: model:account.account.template,name:l10n_pe.chart1945
+msgid "Various accounts receivable – Third parties - Sale of fixed assets"
+msgstr "Cuentas por cobrar diversas – Terceros - Venta de activo inmovilizado"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_150812
+msgid "Vegueta"
+msgstr "Vegueta"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_200115
+msgid "Veintiseis de Octubre"
+msgstr "Veintiseis de Octubre"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_150612
+msgid "Veintisiete de Noviembre"
+msgstr "Veintisiete de Noviembre"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_080708
+msgid "Velille"
+msgstr "Velille"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_070106
+msgid "Ventanilla"
+msgstr "Ventanilla"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_190112
+msgid "Vicco"
+msgstr "Vicco"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_200805
+msgid "Vice"
+msgstr "Vice"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_200507
+msgid "Vichayal"
+msgstr "Vichayal"
+
+#. module: l10n_pe
+#: model:res.city,name:l10n_pe.city_pe_0510
+msgid "Victor Fajardo"
+msgstr "Victor Fajardo"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_130111
+msgid "Victor Larco Herrera"
+msgstr "Victor Larco Herrera"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_210710
+msgid "Vilavila"
+msgstr "Vilavila"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_090116
+msgid "Vilca"
+msgstr "Vilca"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_030712
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_080909
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_190208
+msgid "Vilcabamba"
+msgstr "Vilcabamba"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_051012
+msgid "Vilcanchos"
+msgstr "Vilcanchos"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_051101
+msgid "Vilcas Huaman"
+msgstr "Vilcas Huaman"
+
+#. module: l10n_pe
+#: model:res.city,name:l10n_pe.city_pe_0511
+msgid "Vilcas Huamán"
+msgstr "Vilcas Huamán"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_080913
+msgid "Villa Kintiarina"
+msgstr "Villa Kintiarina"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_150143
+msgid "Villa María del Triunfo"
+msgstr "Villa María del Triunfo"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_190307
+msgid "Villa Rica"
+msgstr "Villa Rica"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_080912
+msgid "Villa Virgen"
+msgstr "Villa Virgen"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_150142
+msgid "Villa el Salvador"
+msgstr "Villa el Salvador"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_210115
+msgid "Vilque"
+msgstr "Vilque"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_210608
+msgid "Vilque Chico"
+msgstr "Vilque Chico"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_050114
+msgid "Vinchos"
+msgstr "Vinchos"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_120136
+msgid "Viques"
+msgstr "Viques"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_040414
+msgid "Viraco"
+msgstr "Viraco"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_131201
+msgid "Viru"
+msgstr "Viru"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_030713
+msgid "Virundo"
+msgstr "Virundo"
+
+#. module: l10n_pe
+#: model:res.city,name:l10n_pe.city_pe_1312
+msgid "Virú"
+msgstr "Virú"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_051108
+msgid "Vischongo"
+msgstr "Vischongo"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_010612
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_110305
+msgid "Vista Alegre"
+msgstr "Vista Alegre"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_151033
+msgid "Vitis"
+msgstr "Vitis"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_120306
+msgid "Vitoc"
+msgstr "Vitoc"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_040125
+msgid "Vitor"
+msgstr "Vitor"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_120609
+msgid "Vizcatan del Enengoa"
+msgstr "Vizcatan del Enengoa"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_151032
+msgid "Viñac"
+msgstr "Viñac"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_080108
+msgid "Wanchaq"
+msgstr "Wanchaq"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart33931
+#: model:account.account,name:l10n_pe.2_chart33931
+#: model:account.account.template,name:l10n_pe.chart33931
+msgid "Work in progress - Assembly machinery - Costs"
+msgstr "Obras en curso - Maquinaria en montaje - Costo"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart33932
+#: model:account.account,name:l10n_pe.2_chart33932
+#: model:account.account.template,name:l10n_pe.chart33932
+msgid "Work in progress - Assembly machinery - Financing costs"
+msgstr "Obras en curso - Maquinaria en montaje - Costos de financiación"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart33921
+#: model:account.account,name:l10n_pe.2_chart33921
+#: model:account.account.template,name:l10n_pe.chart33921
+msgid "Work in progress - Buildings in progress - Costs"
+msgstr "Obras en curso - Edificaciones en curso - Costo"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart33922
+#: model:account.account,name:l10n_pe.2_chart33922
+#: model:account.account.template,name:l10n_pe.chart33922
+msgid "Work in progress - Buildings in progress - Financing costs"
+msgstr "Obras en curso - Edificaciones en curso - Costos de financiación"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart36491
+#: model:account.account,name:l10n_pe.2_chart36491
+#: model:account.account.template,name:l10n_pe.chart36491
+msgid "Work in progress - Costs"
+msgstr "Obras en curso - Costo"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart3391
+#: model:account.account,name:l10n_pe.2_chart3391
+#: model:account.account.template,name:l10n_pe.chart3391
+msgid "Work in progress - Landscaping"
+msgstr "Obras en curso - Adecuación de terrenos"
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart36492
+#: model:account.account,name:l10n_pe.2_chart36492
+#: model:account.account.template,name:l10n_pe.chart36492
+msgid "Work in progress - Revaluation"
+msgstr "Obras en curso - Revaluación"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_100112
+msgid "Yacus"
+msgstr "Yacus"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_160804
+msgid "Yaguas"
+msgstr "Yaguas"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_200410
+msgid "Yamango"
+msgstr "Yamango"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_010312
+msgid "Yambrasbamba"
+msgstr "Yambrasbamba"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_010707
+msgid "Yamon"
+msgstr "Yamon"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_020906
+msgid "Yanac"
+msgstr "Yanac"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_030417
+msgid "Yanaca"
+msgstr "Yanaca"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_120909
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_190113
+msgid "Yanacancha"
+msgstr "Yanacancha"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_190201
+msgid "Yanahuanca"
+msgstr "Yanahuanca"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_040126
+msgid "Yanahuara"
+msgstr "Yanahuara"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_211208
+msgid "Yanahuaya"
+msgstr "Yanahuaya"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_022008
+msgid "Yanama"
+msgstr "Yanama"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_080501
+msgid "Yanaoca"
+msgstr "Yanaoca"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_040608
+msgid "Yanaquihua"
+msgstr "Yanaquihua"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_100323
+msgid "Yanas"
+msgstr "Yanas"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_080408
+msgid "Yanatile"
+msgstr "Yanatile"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_040519
+msgid "Yanque"
+msgstr "Yanque"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_220106
+msgid "Yantalo"
+msgstr "Yantalo"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_160511
+msgid "Yaquerana"
+msgstr "Yaquerana"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_040127
+msgid "Yarabamba"
+msgstr "Yarabamba"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_250105
+msgid "Yarinacocha"
+msgstr "Yarinacocha"
+
+#. module: l10n_pe
+#: model:res.city,name:l10n_pe.city_pe_1011
+msgid "Yarowilca"
+msgstr "Yarowilca"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_100110
+msgid "Yarumayo"
+msgstr "Yarumayo"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_040313
+msgid "Yauca"
+msgstr "Yauca"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_110114
+msgid "Yauca del Rosario"
+msgstr "Yauca del Rosario"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_090117
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_120433
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_120810
+#: model:res.city,name:l10n_pe.city_pe_1208
+msgid "Yauli"
+msgstr "Yauli"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_081009
+msgid "Yaurisque"
+msgstr "Yaurisque"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_020804
+msgid "Yautan"
+msgstr "Yautan"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_020703
+msgid "Yauya"
+msgstr "Yauya"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_120434
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_151001
+#: model:res.city,name:l10n_pe.city_pe_1510
+msgid "Yauyos"
+msgstr "Yauyos"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_061311
+msgid "Yauyucan"
+msgstr "Yauyucan"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_160403
+msgid "Yavari"
+msgstr "Yavari"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_060508
+msgid "Yonan"
+msgstr "Yonan"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_220808
+msgid "Yorongos"
+msgstr "Yorongos"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_081307
+msgid "Yucay"
+msgstr "Yucay"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_180211
+msgid "Yunga"
+msgstr "Yunga"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_020611
+msgid "Yungar"
+msgstr "Yungar"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_022001
+#: model:res.city,name:l10n_pe.city_pe_0220
+msgid "Yungay"
+msgstr "Yungay"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_211301
+#: model:res.city,name:l10n_pe.city_pe_2113
+msgid "Yunguyo"
+msgstr "Yunguyo"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_020907
+msgid "Yupan"
+msgstr "Yupan"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_040128
+msgid "Yura"
+msgstr "Yura"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_021210
+msgid "Yuracmarca"
+msgstr "Yuracmarca"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_220809
+msgid "Yuracyacu"
+msgstr "Yuracyacu"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_160201
+msgid "Yurimaguas"
+msgstr "Yurimaguas"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_250204
+msgid "Yurua"
+msgstr "Yurua"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_100905
+msgid "Yuyapichis"
+msgstr "Yuyapichis"
+
+#. module: l10n_pe
+#: model_terms:ir.ui.view,arch_db:l10n_pe.pe_partner_address_form
+msgid "ZIP"
+msgstr "ZIP"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_220511
+msgid "Zapatero"
+msgstr "Zapatero"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_240301
+#: model:res.city,name:l10n_pe.city_pe_2403
+msgid "Zarumilla"
+msgstr "Zarumilla"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_210407
+msgid "Zepita"
+msgstr "Zepita"
 
 #. module: l10n_pe
 #: model:ir.model.fields.selection,name:l10n_pe.selection__account_tax__l10n_pe_edi_unece_category__z
 #: model:ir.model.fields.selection,name:l10n_pe.selection__account_tax_template__l10n_pe_edi_unece_category__z
 msgid "Zero rated goods"
-msgstr "Bienes libres de impuestos"
+msgstr "Mercancías con calificación cero"
 
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_240201
+msgid "Zorritos"
+msgstr "Zorritos"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_080309
+msgid "Zurite"
+msgstr "Zurite"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_150516
+msgid "Zuñiga"
+msgstr "Zuñiga"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_060415
+msgid "querocoto"
+msgstr "querocoto"
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_090710
+msgid "Ñahuimpuquio"
+msgstr "Ñahuimpuquio"

--- a/addons/l10n_pe/i18n/l10n_pe.pot
+++ b/addons/l10n_pe/i18n/l10n_pe.pot
@@ -4,10 +4,10 @@
 #
 msgid ""
 msgstr ""
-"Project-Id-Version: Odoo Server 14.0+e\n"
+"Project-Id-Version: Odoo Server 15.0+e\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2021-02-26 17:44+0000\n"
-"PO-Revision-Date: 2021-02-26 17:44+0000\n"
+"POT-Creation-Date: 2022-08-09 12:56+0000\n"
+"PO-Revision-Date: 2022-08-09 12:56+0000\n"
 "Last-Translator: \n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"
@@ -16,9 +16,4481 @@ msgstr ""
 "Plural-Forms: \n"
 
 #. module: l10n_pe
+#: model:account.tax,name:l10n_pe.1_sale_tax_exp
+#: model:account.tax,name:l10n_pe.2_sale_tax_exp
+#: model:account.tax.template,name:l10n_pe.sale_tax_exp
+msgid "0% EXP"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.tax,name:l10n_pe.1_purchase_tax_exo
+#: model:account.tax,name:l10n_pe.1_sale_tax_exo
+#: model:account.tax,name:l10n_pe.2_purchase_tax_exo
+#: model:account.tax,name:l10n_pe.2_sale_tax_exo
+#: model:account.tax.template,name:l10n_pe.purchase_tax_exo
+#: model:account.tax.template,name:l10n_pe.sale_tax_exo
+msgid "0% Exonerated"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.tax,name:l10n_pe.1_purchase_tax_gra
+#: model:account.tax,name:l10n_pe.1_sale_tax_gra
+#: model:account.tax,name:l10n_pe.2_purchase_tax_gra
+#: model:account.tax,name:l10n_pe.2_sale_tax_gra
+#: model:account.tax.template,name:l10n_pe.purchase_tax_gra
+#: model:account.tax.template,name:l10n_pe.sale_tax_gra
+msgid "0% Free"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.tax,name:l10n_pe.1_purchase_tax_ina
+#: model:account.tax,name:l10n_pe.1_sale_tax_ina
+#: model:account.tax,name:l10n_pe.2_purchase_tax_ina
+#: model:account.tax,name:l10n_pe.2_sale_tax_ina
+#: model:account.tax.template,name:l10n_pe.purchase_tax_ina
+#: model:account.tax.template,name:l10n_pe.sale_tax_ina
+msgid "0% Unaffected"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.tax,name:l10n_pe.1_purchase_tax_igv_18
+#: model:account.tax,name:l10n_pe.1_sale_tax_igv_18
+#: model:account.tax,name:l10n_pe.2_purchase_tax_igv_18
+#: model:account.tax,name:l10n_pe.2_sale_tax_igv_18
+#: model:account.tax.template,name:l10n_pe.purchase_tax_igv_18
+#: model:account.tax.template,name:l10n_pe.sale_tax_igv_18
+msgid "18%"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.tax,name:l10n_pe.1_purchase_tax_igv_18_included
+#: model:account.tax,name:l10n_pe.1_sale_tax_igv_18_included
+#: model:account.tax,name:l10n_pe.2_purchase_tax_igv_18_included
+#: model:account.tax,name:l10n_pe.2_sale_tax_igv_18_included
+#: model:account.tax.template,name:l10n_pe.purchase_tax_igv_18_included
+#: model:account.tax.template,name:l10n_pe.sale_tax_igv_18_included
+msgid "18% (Included in price)"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.group,name:l10n_pe.1_group44
+#: model:account.group,name:l10n_pe.2_group44
+#: model:account.group.template,name:l10n_pe.group44
+msgid ""
+"ACCOUNTS PAYABLE TO SHAREHOLDERS (PARTNERS, PARTICIPANTS) AND DIRECTORS"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.group,name:l10n_pe.1_group14
+#: model:account.group,name:l10n_pe.2_group14
+#: model:account.group.template,name:l10n_pe.group14
+msgid "ACCOUNTS RECEIVABLE FROM STAFF, SHAREHOLDERS (PARTNERS) AND DIRECTORS"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.group,name:l10n_pe.1_group39
+#: model:account.group,name:l10n_pe.2_group39
+#: model:account.group.template,name:l10n_pe.group39
+msgid "ACCUMULATED DEPRECIATION AND AMORTIZATION"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.group,name:l10n_pe.1_group59
+#: model:account.group,name:l10n_pe.2_group59
+#: model:account.group.template,name:l10n_pe.group59
+msgid "ACUMULATED RESULTS"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.group,name:l10n_pe.1_group52
+#: model:account.group,name:l10n_pe.2_group52
+#: model:account.group.template,name:l10n_pe.group52
+msgid "ADDITIONAL CAPITAL"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.group,name:l10n_pe.1_group32
+#: model:account.group,name:l10n_pe.2_group32
+#: model:account.group.template,name:l10n_pe.group32
+msgid "ASSETS BY RIGHT OF USE"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.group,name:l10n_pe.1_group25
+#: model:account.group,name:l10n_pe.2_group25
+#: model:account.group.template,name:l10n_pe.group25
+msgid "AUXILIARY MATERIALS, SUPPLIES AND SPARE PARTS"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_030101
+#: model:res.city,name:l10n_pe.city_pe_0301
+msgid "Abancay"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_020502
+msgid "Abelardo Pardo Lezameta"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_040302
+msgid "Acarí"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_021402
+msgid "Acas"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_081002
+msgid "Accha"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_051102
+msgid "Accomarca"
+msgstr ""
+
+#. module: l10n_pe
+#: model:ir.model,name:l10n_pe.model_account_chart_template
+msgid "Account Chart Template"
+msgstr ""
+
+#. module: l10n_pe
+#: model:ir.model.fields,help:l10n_pe.field_account_move_line__l10n_pe_group_id
+msgid "Account prefixes can determine account groups."
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart1215
+#: model:account.account,name:l10n_pe.2_chart1215
+#: model:account.account.template,name:l10n_pe.chart1215
+msgid ""
+"Accounts receivable ... - Invoices, tickets and other receipts receivable "
+"not issued (PoS)"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart1933
+#: model:account.account,name:l10n_pe.2_chart1933
+#: model:account.account.template,name:l10n_pe.chart1933
+msgid ""
+"Accounts receivable from staff, shareholders (partners) and directors - "
+"Directors"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart1931
+#: model:account.account,name:l10n_pe.2_chart1931
+#: model:account.account.template,name:l10n_pe.chart1931
+msgid ""
+"Accounts receivable from staff, shareholders (partners) and directors - "
+"Personal"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart1932
+#: model:account.account,name:l10n_pe.2_chart1932
+#: model:account.account.template,name:l10n_pe.chart1932
+msgid ""
+"Accounts receivable from staff, shareholders (partners) and directors - "
+"Shareholders (or partners)"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart1939
+#: model:account.account,name:l10n_pe.2_chart1939
+#: model:account.account.template,name:l10n_pe.chart1939
+msgid ""
+"Accounts receivable from staff, shareholders (partners) and directors - "
+"Various"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart39611
+#: model:account.account,name:l10n_pe.2_chart39611
+#: model:account.account.template,name:l10n_pe.chart39611
+msgid ""
+"Accumulated amortization - Intangibles – Costs - Concessions, licenses and "
+"other rights"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart39614
+#: model:account.account,name:l10n_pe.2_chart39614
+#: model:account.account.template,name:l10n_pe.chart39614
+msgid ""
+"Accumulated amortization - Intangibles – Costs - Exploration and development"
+" costs"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart39615
+#: model:account.account,name:l10n_pe.2_chart39615
+#: model:account.account.template,name:l10n_pe.chart39615
+msgid ""
+"Accumulated amortization - Intangibles – Costs - Formulas, designs and "
+"prototypes"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart39619
+#: model:account.account,name:l10n_pe.2_chart39619
+#: model:account.account.template,name:l10n_pe.chart39619
+msgid ""
+"Accumulated amortization - Intangibles – Costs - Other intangible assets"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart39612
+#: model:account.account,name:l10n_pe.2_chart39612
+#: model:account.account.template,name:l10n_pe.chart39612
+msgid ""
+"Accumulated amortization - Intangibles – Costs - Patents and industrial "
+"property"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart39613
+#: model:account.account,name:l10n_pe.2_chart39613
+#: model:account.account.template,name:l10n_pe.chart39613
+msgid "Accumulated amortization - Intangibles – Costs - Softwares"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart39635
+#: model:account.account,name:l10n_pe.2_chart39635
+#: model:account.account.template,name:l10n_pe.chart39635
+msgid ""
+"Accumulated amortization - Intangibles – Financing costs - Development costs"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart39634
+#: model:account.account,name:l10n_pe.2_chart39634
+#: model:account.account.template,name:l10n_pe.chart39634
+msgid ""
+"Accumulated amortization - Intangibles – Financing costs - Exploration costs"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart39633
+#: model:account.account,name:l10n_pe.2_chart39633
+#: model:account.account.template,name:l10n_pe.chart39633
+msgid "Accumulated amortization - Intangibles – Financing costs - Softwares"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart39621
+#: model:account.account,name:l10n_pe.2_chart39621
+#: model:account.account.template,name:l10n_pe.chart39621
+msgid ""
+"Accumulated amortization - Intangibles – Revaluation - Concessions, licenses"
+" and other rights"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart39624
+#: model:account.account,name:l10n_pe.2_chart39624
+#: model:account.account.template,name:l10n_pe.chart39624
+msgid ""
+"Accumulated amortization - Intangibles – Revaluation - Exploration and "
+"development costs"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart39625
+#: model:account.account,name:l10n_pe.2_chart39625
+#: model:account.account.template,name:l10n_pe.chart39625
+msgid ""
+"Accumulated amortization - Intangibles – Revaluation - Formulas, designs and"
+" prototypes"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart39629
+#: model:account.account,name:l10n_pe.2_chart39629
+#: model:account.account.template,name:l10n_pe.chart39629
+msgid ""
+"Accumulated amortization - Intangibles – Revaluation - Other intangible "
+"assets"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart39622
+#: model:account.account,name:l10n_pe.2_chart39622
+#: model:account.account.template,name:l10n_pe.chart39622
+msgid ""
+"Accumulated amortization - Intangibles – Revaluation - Patents and "
+"industrial property"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart39623
+#: model:account.account,name:l10n_pe.2_chart39623
+#: model:account.account.template,name:l10n_pe.chart39623
+msgid "Accumulated amortization - Intangibles – Revaluation - Softwares"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart27711
+#: model:account.account,name:l10n_pe.2_chart27711
+#: model:account.account.template,name:l10n_pe.chart27711
+msgid ""
+"Accumulated amortization – Intangibles - Concessions, licenses and rights - "
+"Costs"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart27712
+#: model:account.account,name:l10n_pe.2_chart27712
+#: model:account.account.template,name:l10n_pe.chart27712
+msgid ""
+"Accumulated amortization – Intangibles - Concessions, licenses and rights - "
+"Revaluation"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart27741
+#: model:account.account,name:l10n_pe.2_chart27741
+#: model:account.account.template,name:l10n_pe.chart27741
+msgid ""
+"Accumulated amortization – Intangibles - Exploration and development costs -"
+" Costs"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart27742
+#: model:account.account,name:l10n_pe.2_chart27742
+#: model:account.account.template,name:l10n_pe.chart27742
+msgid ""
+"Accumulated amortization – Intangibles - Exploration and development costs -"
+" Revaluation"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart27751
+#: model:account.account,name:l10n_pe.2_chart27751
+#: model:account.account.template,name:l10n_pe.chart27751
+msgid ""
+"Accumulated amortization – Intangibles - Formulas, designs and prototypes - "
+"Costs"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart27752
+#: model:account.account,name:l10n_pe.2_chart27752
+#: model:account.account.template,name:l10n_pe.chart27752
+msgid ""
+"Accumulated amortization – Intangibles - Formulas, designs and prototypes - "
+"Revaluation"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart27791
+#: model:account.account,name:l10n_pe.2_chart27791
+#: model:account.account.template,name:l10n_pe.chart27791
+msgid ""
+"Accumulated amortization – Intangibles - Other intangible assets - Costs"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart27792
+#: model:account.account,name:l10n_pe.2_chart27792
+#: model:account.account.template,name:l10n_pe.chart27792
+msgid ""
+"Accumulated amortization – Intangibles - Other intangible assets - "
+"Revaluation"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart27721
+#: model:account.account,name:l10n_pe.2_chart27721
+#: model:account.account.template,name:l10n_pe.chart27721
+msgid ""
+"Accumulated amortization – Intangibles - Patents and industrial property - "
+"Costs"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart27722
+#: model:account.account,name:l10n_pe.2_chart27722
+#: model:account.account.template,name:l10n_pe.chart27722
+msgid ""
+"Accumulated amortization – Intangibles - Patents and industrial property - "
+"Revaluation"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart27731
+#: model:account.account,name:l10n_pe.2_chart27731
+#: model:account.account.template,name:l10n_pe.chart27731
+msgid "Accumulated amortization – Intangibles - Softwares - Costs"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart27732
+#: model:account.account,name:l10n_pe.2_chart27732
+#: model:account.account.template,name:l10n_pe.chart27732
+msgid "Accumulated amortization – Intangibles - Softwares - Revaluation"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart39811
+#: model:account.account,name:l10n_pe.2_chart39811
+#: model:account.account.template,name:l10n_pe.chart39811
+msgid ""
+"Accumulated depreciation - Biological assets in production - Biological "
+"assets in production - Costs - Biological assets in production"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart39412
+#: model:account.account,name:l10n_pe.2_chart39412
+#: model:account.account.template,name:l10n_pe.chart39412
+msgid ""
+"Accumulated depreciation - Operating lease - Right-of-use assets - Operating"
+" lease - Buildings"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart39411
+#: model:account.account,name:l10n_pe.2_chart39411
+#: model:account.account.template,name:l10n_pe.chart39411
+msgid ""
+"Accumulated depreciation - Operating lease - Right-of-use assets - Operating"
+" lease - Land"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart39413
+#: model:account.account,name:l10n_pe.2_chart39413
+#: model:account.account.template,name:l10n_pe.chart39413
+msgid ""
+"Accumulated depreciation - Operating lease - Right-of-use assets - Operating"
+" lease - Machinery and exploitation equipment"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart39415
+#: model:account.account,name:l10n_pe.2_chart39415
+#: model:account.account.template,name:l10n_pe.chart39415
+msgid ""
+"Accumulated depreciation - Operating lease - Right-of-use assets - Operating"
+" lease - Miscellaneous equipment"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart39410
+#: model:account.account,name:l10n_pe.2_chart39410
+#: model:account.account.template,name:l10n_pe.chart39410
+msgid ""
+"Accumulated depreciation - Operating lease - Right-of-use assets - Operating"
+" lease - Production plants"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart39414
+#: model:account.account,name:l10n_pe.2_chart39414
+#: model:account.account.template,name:l10n_pe.chart39414
+msgid ""
+"Accumulated depreciation - Operating lease - Right-of-use assets - Operating"
+" lease - Transport units"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart39111
+#: model:account.account,name:l10n_pe.2_chart39111
+#: model:account.account.template,name:l10n_pe.chart39111
+msgid "Accumulated depreciation investment properties - Buildings - Costs"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart39113
+#: model:account.account,name:l10n_pe.2_chart39113
+#: model:account.account.template,name:l10n_pe.chart39113
+msgid ""
+"Accumulated depreciation investment properties - Buildings - Financing costs"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart39112
+#: model:account.account,name:l10n_pe.2_chart39112
+#: model:account.account.template,name:l10n_pe.chart39112
+msgid ""
+"Accumulated depreciation investment properties - Buildings - Revaluation"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart39211
+#: model:account.account,name:l10n_pe.2_chart39211
+#: model:account.account.template,name:l10n_pe.chart39211
+msgid ""
+"Accumulated depreciation investment properties - Financial leasing - "
+"Buildings - Costs"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart39213
+#: model:account.account,name:l10n_pe.2_chart39213
+#: model:account.account.template,name:l10n_pe.chart39213
+msgid ""
+"Accumulated depreciation investment properties - Financial leasing - "
+"Buildings - Financing costs"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart39212
+#: model:account.account,name:l10n_pe.2_chart39212
+#: model:account.account.template,name:l10n_pe.chart39212
+msgid ""
+"Accumulated depreciation investment properties - Financial leasing - "
+"Buildings - Revaluation"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart39521
+#: model:account.account,name:l10n_pe.2_chart39521
+#: model:account.account.template,name:l10n_pe.chart39521
+msgid ""
+"Accumulated depreciation of property, plant and equipment - Accumulated "
+"depreciation - Costs - Buildings"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart39526
+#: model:account.account,name:l10n_pe.2_chart39526
+#: model:account.account.template,name:l10n_pe.chart39526
+msgid ""
+"Accumulated depreciation of property, plant and equipment - Accumulated "
+"depreciation - Costs - Furniture and fixtures"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart39523
+#: model:account.account,name:l10n_pe.2_chart39523
+#: model:account.account.template,name:l10n_pe.chart39523
+msgid ""
+"Accumulated depreciation of property, plant and equipment - Accumulated "
+"depreciation - Costs - Improvements in leased premises"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart39522
+#: model:account.account,name:l10n_pe.2_chart39522
+#: model:account.account.template,name:l10n_pe.chart39522
+msgid ""
+"Accumulated depreciation of property, plant and equipment - Accumulated "
+"depreciation - Costs - Installations"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart39524
+#: model:account.account,name:l10n_pe.2_chart39524
+#: model:account.account.template,name:l10n_pe.chart39524
+msgid ""
+"Accumulated depreciation of property, plant and equipment - Accumulated "
+"depreciation - Costs - Machinery and exploitation equipment"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart39527
+#: model:account.account,name:l10n_pe.2_chart39527
+#: model:account.account.template,name:l10n_pe.chart39527
+msgid ""
+"Accumulated depreciation of property, plant and equipment - Accumulated "
+"depreciation - Costs - Miscellaneous equipment"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart39520
+#: model:account.account,name:l10n_pe.2_chart39520
+#: model:account.account.template,name:l10n_pe.chart39520
+msgid ""
+"Accumulated depreciation of property, plant and equipment - Accumulated "
+"depreciation - Costs - Production plants"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart39529
+#: model:account.account,name:l10n_pe.2_chart39529
+#: model:account.account.template,name:l10n_pe.chart39529
+msgid ""
+"Accumulated depreciation of property, plant and equipment - Accumulated "
+"depreciation - Costs - Replacement units"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart39528
+#: model:account.account,name:l10n_pe.2_chart39528
+#: model:account.account.template,name:l10n_pe.chart39528
+msgid ""
+"Accumulated depreciation of property, plant and equipment - Accumulated "
+"depreciation - Costs - Tools"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart39525
+#: model:account.account,name:l10n_pe.2_chart39525
+#: model:account.account.template,name:l10n_pe.chart39525
+msgid ""
+"Accumulated depreciation of property, plant and equipment - Accumulated "
+"depreciation - Costs - Transport units"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart39550
+#: model:account.account,name:l10n_pe.2_chart39550
+#: model:account.account.template,name:l10n_pe.chart39550
+msgid ""
+"Accumulated depreciation of property, plant and equipment - Property, plant "
+"and equipment - Fair value - Production plants"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart39541
+#: model:account.account,name:l10n_pe.2_chart39541
+#: model:account.account.template,name:l10n_pe.chart39541
+msgid ""
+"Accumulated depreciation of property, plant and equipment - Property, plant "
+"and equipment - Financing costs - Buildings"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart39542
+#: model:account.account,name:l10n_pe.2_chart39542
+#: model:account.account.template,name:l10n_pe.chart39542
+msgid ""
+"Accumulated depreciation of property, plant and equipment - Property, plant "
+"and equipment - Financing costs - Machinery and exploitation equipment"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart39540
+#: model:account.account,name:l10n_pe.2_chart39540
+#: model:account.account.template,name:l10n_pe.chart39540
+msgid ""
+"Accumulated depreciation of property, plant and equipment - Property, plant "
+"and equipment - Financing costs - Production plants"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart39531
+#: model:account.account,name:l10n_pe.2_chart39531
+#: model:account.account.template,name:l10n_pe.chart39531
+msgid ""
+"Accumulated depreciation of property, plant and equipment - Property, plant "
+"and equipment - Revaluation - Buildings"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart39536
+#: model:account.account,name:l10n_pe.2_chart39536
+#: model:account.account.template,name:l10n_pe.chart39536
+msgid ""
+"Accumulated depreciation of property, plant and equipment - Property, plant "
+"and equipment - Revaluation - Furniture and fixtures"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart39533
+#: model:account.account,name:l10n_pe.2_chart39533
+#: model:account.account.template,name:l10n_pe.chart39533
+msgid ""
+"Accumulated depreciation of property, plant and equipment - Property, plant "
+"and equipment - Revaluation - Improvements in leased premises"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart39532
+#: model:account.account,name:l10n_pe.2_chart39532
+#: model:account.account.template,name:l10n_pe.chart39532
+msgid ""
+"Accumulated depreciation of property, plant and equipment - Property, plant "
+"and equipment - Revaluation - Installations"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart39534
+#: model:account.account,name:l10n_pe.2_chart39534
+#: model:account.account.template,name:l10n_pe.chart39534
+msgid ""
+"Accumulated depreciation of property, plant and equipment - Property, plant "
+"and equipment - Revaluation - Machinery and exploitation equipment"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart39537
+#: model:account.account,name:l10n_pe.2_chart39537
+#: model:account.account.template,name:l10n_pe.chart39537
+msgid ""
+"Accumulated depreciation of property, plant and equipment - Property, plant "
+"and equipment - Revaluation - Miscellaneous equipment"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart39530
+#: model:account.account,name:l10n_pe.2_chart39530
+#: model:account.account.template,name:l10n_pe.chart39530
+msgid ""
+"Accumulated depreciation of property, plant and equipment - Property, plant "
+"and equipment - Revaluation - Production plants"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart39538
+#: model:account.account,name:l10n_pe.2_chart39538
+#: model:account.account.template,name:l10n_pe.chart39538
+msgid ""
+"Accumulated depreciation of property, plant and equipment - Property, plant "
+"and equipment - Revaluation - Replacement tools and units"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart39535
+#: model:account.account,name:l10n_pe.2_chart39535
+#: model:account.account.template,name:l10n_pe.chart39535
+msgid ""
+"Accumulated depreciation of property, plant and equipment - Property, plant "
+"and equipment - Revaluation - Transport units"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart39321
+#: model:account.account,name:l10n_pe.2_chart39321
+#: model:account.account.template,name:l10n_pe.chart39321
+msgid ""
+"Accumulated depreciation property, plant and equipment - Financial leasing -"
+" Buildings - Costs"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart39323
+#: model:account.account,name:l10n_pe.2_chart39323
+#: model:account.account.template,name:l10n_pe.chart39323
+msgid ""
+"Accumulated depreciation property, plant and equipment - Financial leasing -"
+" Buildings - Financing costs"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart39322
+#: model:account.account,name:l10n_pe.2_chart39322
+#: model:account.account.template,name:l10n_pe.chart39322
+msgid ""
+"Accumulated depreciation property, plant and equipment - Financial leasing -"
+" Buildings - Revaluation"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart39351
+#: model:account.account,name:l10n_pe.2_chart39351
+#: model:account.account.template,name:l10n_pe.chart39351
+msgid ""
+"Accumulated depreciation property, plant and equipment - Financial leasing -"
+" Furniture and fixtures - Costs"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart39331
+#: model:account.account,name:l10n_pe.2_chart39331
+#: model:account.account.template,name:l10n_pe.chart39331
+msgid ""
+"Accumulated depreciation property, plant and equipment - Financial leasing -"
+" Machinery and exploitation equipment - Costs"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart39333
+#: model:account.account,name:l10n_pe.2_chart39333
+#: model:account.account.template,name:l10n_pe.chart39333
+msgid ""
+"Accumulated depreciation property, plant and equipment - Financial leasing -"
+" Machinery and exploitation equipment - Financing costs"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart39332
+#: model:account.account,name:l10n_pe.2_chart39332
+#: model:account.account.template,name:l10n_pe.chart39332
+msgid ""
+"Accumulated depreciation property, plant and equipment - Financial leasing -"
+" Machinery and exploitation equipment - Revaluation"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart39361
+#: model:account.account,name:l10n_pe.2_chart39361
+#: model:account.account.template,name:l10n_pe.chart39361
+msgid ""
+"Accumulated depreciation property, plant and equipment - Financial leasing -"
+" Miscellaneous equipment - Costs"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart39362
+#: model:account.account,name:l10n_pe.2_chart39362
+#: model:account.account.template,name:l10n_pe.chart39362
+msgid ""
+"Accumulated depreciation property, plant and equipment - Financial leasing -"
+" Miscellaneous equipment - Revaluation"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart39341
+#: model:account.account,name:l10n_pe.2_chart39341
+#: model:account.account.template,name:l10n_pe.chart39341
+msgid ""
+"Accumulated depreciation property, plant and equipment - Financial leasing -"
+" Transport units - Costs"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart39342
+#: model:account.account,name:l10n_pe.2_chart39342
+#: model:account.account.template,name:l10n_pe.chart39342
+msgid ""
+"Accumulated depreciation property, plant and equipment - Financial leasing -"
+" Transport units - Revaluation"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart27811
+#: model:account.account,name:l10n_pe.2_chart27811
+#: model:account.account.template,name:l10n_pe.chart27811
+msgid ""
+"Accumulated depreciation – Biological assets - Biological assets in "
+"production - Costs"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart27813
+#: model:account.account,name:l10n_pe.2_chart27813
+#: model:account.account.template,name:l10n_pe.chart27813
+msgid ""
+"Accumulated depreciation – Biological assets - Biological assets in "
+"production - Financing costs"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart27821
+#: model:account.account,name:l10n_pe.2_chart27821
+#: model:account.account.template,name:l10n_pe.chart27821
+msgid ""
+"Accumulated depreciation – Biological assets - Biological assets under "
+"development - Costs"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart27823
+#: model:account.account,name:l10n_pe.2_chart27823
+#: model:account.account.template,name:l10n_pe.chart27823
+msgid ""
+"Accumulated depreciation – Biological assets - Biological assets under "
+"development - Financing costs"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart27521
+#: model:account.account,name:l10n_pe.2_chart27521
+#: model:account.account.template,name:l10n_pe.chart27521
+msgid "Accumulated depreciation – Investment property - Buildings - Costs"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart27523
+#: model:account.account,name:l10n_pe.2_chart27523
+#: model:account.account.template,name:l10n_pe.chart27523
+msgid ""
+"Accumulated depreciation – Investment property - Buildings - Financing costs"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart27522
+#: model:account.account,name:l10n_pe.2_chart27522
+#: model:account.account.template,name:l10n_pe.chart27522
+msgid ""
+"Accumulated depreciation – Investment property - Buildings - Revaluation"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart27621
+#: model:account.account,name:l10n_pe.2_chart27621
+#: model:account.account.template,name:l10n_pe.chart27621
+msgid ""
+"Accumulated depreciation – Property, plant and equipment - Buildings - Costs"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart27623
+#: model:account.account,name:l10n_pe.2_chart27623
+#: model:account.account.template,name:l10n_pe.chart27623
+msgid ""
+"Accumulated depreciation – Property, plant and equipment - Buildings - "
+"Financing costs"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart27622
+#: model:account.account,name:l10n_pe.2_chart27622
+#: model:account.account.template,name:l10n_pe.chart27622
+msgid ""
+"Accumulated depreciation – Property, plant and equipment - Buildings - "
+"Revaluation"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart27651
+#: model:account.account,name:l10n_pe.2_chart27651
+#: model:account.account.template,name:l10n_pe.chart27651
+msgid ""
+"Accumulated depreciation – Property, plant and equipment - Furniture and "
+"fixtures - Costs"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart27652
+#: model:account.account,name:l10n_pe.2_chart27652
+#: model:account.account.template,name:l10n_pe.chart27652
+msgid ""
+"Accumulated depreciation – Property, plant and equipment - Furniture and "
+"fixtures - Revaluation"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart27631
+#: model:account.account,name:l10n_pe.2_chart27631
+#: model:account.account.template,name:l10n_pe.chart27631
+msgid ""
+"Accumulated depreciation – Property, plant and equipment - Machinery and "
+"operating equipment - Costs"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart27633
+#: model:account.account,name:l10n_pe.2_chart27633
+#: model:account.account.template,name:l10n_pe.chart27633
+msgid ""
+"Accumulated depreciation – Property, plant and equipment - Machinery and "
+"operating equipment - Financing costs"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart27632
+#: model:account.account,name:l10n_pe.2_chart27632
+#: model:account.account.template,name:l10n_pe.chart27632
+msgid ""
+"Accumulated depreciation – Property, plant and equipment - Machinery and "
+"operating equipment - Revaluation"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart27661
+#: model:account.account,name:l10n_pe.2_chart27661
+#: model:account.account.template,name:l10n_pe.chart27661
+msgid ""
+"Accumulated depreciation – Property, plant and equipment - Miscellaneous "
+"equipment - Costs"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart27662
+#: model:account.account,name:l10n_pe.2_chart27662
+#: model:account.account.template,name:l10n_pe.chart27662
+msgid ""
+"Accumulated depreciation – Property, plant and equipment - Miscellaneous "
+"equipment - Revaluation"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart27601
+#: model:account.account,name:l10n_pe.2_chart27601
+#: model:account.account.template,name:l10n_pe.chart27601
+msgid ""
+"Accumulated depreciation – Property, plant and equipment - Production plant "
+"in production - Costs"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart27604
+#: model:account.account,name:l10n_pe.2_chart27604
+#: model:account.account.template,name:l10n_pe.chart27604
+msgid ""
+"Accumulated depreciation – Property, plant and equipment - Production plant "
+"in production - Fair value"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart27603
+#: model:account.account,name:l10n_pe.2_chart27603
+#: model:account.account.template,name:l10n_pe.chart27603
+msgid ""
+"Accumulated depreciation – Property, plant and equipment - Production plant "
+"in production - Financing costs"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart27602
+#: model:account.account,name:l10n_pe.2_chart27602
+#: model:account.account.template,name:l10n_pe.chart27602
+msgid ""
+"Accumulated depreciation – Property, plant and equipment - Production plant "
+"in production - Revaluation"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart27671
+#: model:account.account,name:l10n_pe.2_chart27671
+#: model:account.account.template,name:l10n_pe.chart27671
+msgid ""
+"Accumulated depreciation – Property, plant and equipment - Replacement tools"
+" and units - Costs"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart27672
+#: model:account.account,name:l10n_pe.2_chart27672
+#: model:account.account.template,name:l10n_pe.chart27672
+msgid ""
+"Accumulated depreciation – Property, plant and equipment - Replacement tools"
+" and units - Revaluation"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart27641
+#: model:account.account,name:l10n_pe.2_chart27641
+#: model:account.account.template,name:l10n_pe.chart27641
+msgid ""
+"Accumulated depreciation – Property, plant and equipment - Transport units -"
+" Costs"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart27642
+#: model:account.account,name:l10n_pe.2_chart27642
+#: model:account.account.template,name:l10n_pe.chart27642
+msgid ""
+"Accumulated depreciation – Property, plant and equipment - Transport units -"
+" Revaluation"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart27951
+#: model:account.account,name:l10n_pe.2_chart27951
+#: model:account.account.template,name:l10n_pe.chart27951
+msgid ""
+"Accumulated impairment - Biological assets - Biological assets in production"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart27952
+#: model:account.account,name:l10n_pe.2_chart27952
+#: model:account.account.template,name:l10n_pe.chart27952
+msgid ""
+"Accumulated impairment - Biological assets - Biological assets under "
+"development"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart27941
+#: model:account.account,name:l10n_pe.2_chart27941
+#: model:account.account.template,name:l10n_pe.chart27941
+msgid ""
+"Accumulated impairment - Intangibles - Concessions, licenses and other "
+"rights"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart27944
+#: model:account.account,name:l10n_pe.2_chart27944
+#: model:account.account.template,name:l10n_pe.chart27944
+msgid ""
+"Accumulated impairment - Intangibles - Exploration and development costs"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart27945
+#: model:account.account,name:l10n_pe.2_chart27945
+#: model:account.account.template,name:l10n_pe.chart27945
+msgid ""
+"Accumulated impairment - Intangibles - Formulas, designs and prototypes"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart27949
+#: model:account.account,name:l10n_pe.2_chart27949
+#: model:account.account.template,name:l10n_pe.chart27949
+msgid "Accumulated impairment - Intangibles - Other intangible assets"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart27942
+#: model:account.account,name:l10n_pe.2_chart27942
+#: model:account.account.template,name:l10n_pe.chart27942
+msgid "Accumulated impairment - Intangibles - Patents and industrial property"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart27943
+#: model:account.account,name:l10n_pe.2_chart27943
+#: model:account.account.template,name:l10n_pe.chart27943
+msgid "Accumulated impairment - Intangibles - Softwares"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart27913
+#: model:account.account,name:l10n_pe.2_chart27913
+#: model:account.account.template,name:l10n_pe.chart27913
+msgid "Accumulated impairment - Investment property - Buildings"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart27912
+#: model:account.account,name:l10n_pe.2_chart27912
+#: model:account.account.template,name:l10n_pe.chart27912
+msgid "Accumulated impairment - Investment property - Land"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart27911
+#: model:account.account,name:l10n_pe.2_chart27911
+#: model:account.account.template,name:l10n_pe.chart27911
+msgid ""
+"Accumulated impairment - Investment property - Production plant in "
+"development"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart27910
+#: model:account.account,name:l10n_pe.2_chart27910
+#: model:account.account.template,name:l10n_pe.chart27910
+msgid ""
+"Accumulated impairment - Investment property - Production plant in "
+"production"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart27933
+#: model:account.account,name:l10n_pe.2_chart27933
+#: model:account.account.template,name:l10n_pe.chart27933
+msgid "Accumulated impairment - Property, plant and equipment - Buildings"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart27936
+#: model:account.account,name:l10n_pe.2_chart27936
+#: model:account.account.template,name:l10n_pe.chart27936
+msgid ""
+"Accumulated impairment - Property, plant and equipment - Furniture and "
+"fixtures"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart27932
+#: model:account.account,name:l10n_pe.2_chart27932
+#: model:account.account.template,name:l10n_pe.chart27932
+msgid "Accumulated impairment - Property, plant and equipment - Land"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart27934
+#: model:account.account,name:l10n_pe.2_chart27934
+#: model:account.account.template,name:l10n_pe.chart27934
+msgid ""
+"Accumulated impairment - Property, plant and equipment - Machinery and "
+"exploitation equipment"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart27937
+#: model:account.account,name:l10n_pe.2_chart27937
+#: model:account.account.template,name:l10n_pe.chart27937
+msgid ""
+"Accumulated impairment - Property, plant and equipment - Miscellaneous "
+"equipment"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart27931
+#: model:account.account,name:l10n_pe.2_chart27931
+#: model:account.account.template,name:l10n_pe.chart27931
+msgid ""
+"Accumulated impairment - Property, plant and equipment - Production plant in"
+" development"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart27930
+#: model:account.account,name:l10n_pe.2_chart27930
+#: model:account.account.template,name:l10n_pe.chart27930
+msgid ""
+"Accumulated impairment - Property, plant and equipment - Production plants "
+"in production"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart27938
+#: model:account.account,name:l10n_pe.2_chart27938
+#: model:account.account.template,name:l10n_pe.chart27938
+msgid ""
+"Accumulated impairment - Property, plant and equipment - Replacement tools "
+"and units"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart27935
+#: model:account.account,name:l10n_pe.2_chart27935
+#: model:account.account.template,name:l10n_pe.chart27935
+msgid ""
+"Accumulated impairment - Property, plant and equipment - Transport units"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart5921
+#: model:account.account,name:l10n_pe.2_chart5921
+#: model:account.account.template,name:l10n_pe.chart5921
+msgid "Accumulated losses - Accumulated losses"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart5922
+#: model:account.account,name:l10n_pe.2_chart5922
+#: model:account.account.template,name:l10n_pe.chart5922
+msgid "Accumulated losses - Expenses from previous years"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_210202
+msgid "Achaya"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_040502
+msgid "Achoma"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_020902
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_120202
+msgid "Aco"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_021902
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_090201
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_120702
+#: model:res.city,name:l10n_pe.city_pe_0902
+msgid "Acobamba"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_090102
+msgid "Acobambilla"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_020402
+msgid "Acochaca"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_050102
+msgid "Acocro"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_120402
+msgid "Acolla"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_080201
+#: model:res.city,name:l10n_pe.city_pe_0802
+msgid "Acomayo"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_020602
+msgid "Acopampa"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_080202
+msgid "Acopia"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_210102
+msgid "Acora"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_090103
+msgid "Acoria"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_080203
+msgid "Acos"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_050103
+msgid "Acos Vinchos"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_090702
+msgid "Acostambo"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_090703
+msgid "Acraquia"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_020302
+msgid "Aczo"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart417
+#: model:account.account,name:l10n_pe.2_chart417
+#: model:account.account.template,name:l10n_pe.chart417
+msgid "Administrators of pension funds"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart122
+#: model:account.account,name:l10n_pe.2_chart122
+#: model:account.account.template,name:l10n_pe.chart122
+msgid "Advances from customers"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart4321
+#: model:account.account,name:l10n_pe.2_chart4321
+#: model:account.account.template,name:l10n_pe.chart4321
+msgid "Advances granted - Advances granted"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart473
+#: model:account.account,name:l10n_pe.2_chart473
+#: model:account.account.template,name:l10n_pe.chart473
+msgid "Advances received"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart1321
+#: model:account.account,name:l10n_pe.2_chart1321
+#: model:account.account.template,name:l10n_pe.chart1321
+msgid "Advances received - Advances received"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart422
+#: model:account.account,name:l10n_pe.2_chart422
+#: model:account.account.template,name:l10n_pe.chart422
+msgid "Advances to suppliers"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart6371
+#: model:account.account,name:l10n_pe.2_chart6371
+#: model:account.account.template,name:l10n_pe.chart6371
+msgid "Advertising, publications, public relations - Advertising"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart6373
+#: model:account.account,name:l10n_pe.2_chart6373
+#: model:account.account.template,name:l10n_pe.chart6373
+msgid "Advertising, publications, public relations - Public relations"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart6372
+#: model:account.account,name:l10n_pe.2_chart6372
+#: model:account.account.template,name:l10n_pe.chart6372
+msgid "Advertising, publications, public relations - Publications"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart6321
+#: model:account.account,name:l10n_pe.2_chart6321
+#: model:account.account.template,name:l10n_pe.chart6321
+msgid "Advice and consultancy - Administrative"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart6323
+#: model:account.account,name:l10n_pe.2_chart6323
+#: model:account.account.template,name:l10n_pe.chart6323
+msgid "Advice and consultancy - Audit and accounting"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart6325
+#: model:account.account,name:l10n_pe.2_chart6325
+#: model:account.account.template,name:l10n_pe.chart6325
+msgid "Advice and consultancy - Environmental"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart6326
+#: model:account.account,name:l10n_pe.2_chart6326
+#: model:account.account.template,name:l10n_pe.chart6326
+msgid "Advice and consultancy - Investigation and development"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart6322
+#: model:account.account,name:l10n_pe.2_chart6322
+#: model:account.account.template,name:l10n_pe.chart6322
+msgid "Advice and consultancy - Legal and tax"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart6324
+#: model:account.account,name:l10n_pe.2_chart6324
+#: model:account.account.template,name:l10n_pe.chart6324
+msgid "Advice and consultancy - Marketing"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart6329
+#: model:account.account,name:l10n_pe.2_chart6329
+#: model:account.account.template,name:l10n_pe.chart6329
+msgid "Advice and consultancy - Others"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart6327
+#: model:account.account,name:l10n_pe.2_chart6327
+#: model:account.account.template,name:l10n_pe.chart6327
+msgid "Advice and consultancy - Production"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_130602
+msgid "Agallpampa"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_220302
+msgid "Agua Blanca"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_240302
+msgid "Aguas Verdes"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_120902
+msgid "Ahuac"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_090704
+msgid "Ahuaycha"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_020201
+#: model:res.city,name:l10n_pe.city_pe_0202
+msgid "Aija"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_210302
+msgid "Ajoyani"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_220902
+msgid "Alberto Leveau"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_040802
+msgid "Alca"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_051002
+msgid "Alcamenca"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_250305
+msgid "Alexander Von Humboldt"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_021903
+msgid "Alfonso Ugarte"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_151002
+msgid "Alis"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_151003
+msgid "Allauca"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_220502
+msgid "Alonso de Alvarado"
+msgstr ""
+
+#. module: l10n_pe
+#: model:res.city,name:l10n_pe.city_pe_1602
+msgid "Alto Amazonas"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_220202
+msgid "Alto Biavo"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_211209
+msgid "Alto Inambari"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_110202
+msgid "Alto Laran"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_160102
+msgid "Alto Nanay"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_080808
+msgid "Alto Pichigua"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_220402
+msgid "Alto Saposoa"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_040102
+msgid "Alto Selva Alegre"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_160502
+msgid "Alto Tapiche"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_230102
+msgid "Alto de la Alianza"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_210103
+msgid "Amantani"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_100102
+msgid "Amarilis"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_020603
+msgid "Amashca"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_150802
+msgid "Ambar"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_100201
+#: model:res.city,name:l10n_pe.city_pe_1002
+msgid "Ambo"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart68611
+#: model:account.account,name:l10n_pe.2_chart68611
+#: model:account.account.template,name:l10n_pe.chart68611
+msgid ""
+"Amortization of intangibles - Amortization of intangibles – Costs - "
+"Concessions, licenses and other rights"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart68614
+#: model:account.account,name:l10n_pe.2_chart68614
+#: model:account.account.template,name:l10n_pe.chart68614
+msgid ""
+"Amortization of intangibles - Amortization of intangibles – Costs - "
+"Exploration and development costs"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart68615
+#: model:account.account,name:l10n_pe.2_chart68615
+#: model:account.account.template,name:l10n_pe.chart68615
+msgid ""
+"Amortization of intangibles - Amortization of intangibles – Costs - "
+"Formulas, designs and prototypes"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart68619
+#: model:account.account,name:l10n_pe.2_chart68619
+#: model:account.account.template,name:l10n_pe.chart68619
+msgid ""
+"Amortization of intangibles - Amortization of intangibles – Costs - Other "
+"intangible assets"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart68612
+#: model:account.account,name:l10n_pe.2_chart68612
+#: model:account.account.template,name:l10n_pe.chart68612
+msgid ""
+"Amortization of intangibles - Amortization of intangibles – Costs - Patents "
+"and industrial property"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart68613
+#: model:account.account,name:l10n_pe.2_chart68613
+#: model:account.account.template,name:l10n_pe.chart68613
+msgid ""
+"Amortization of intangibles - Amortization of intangibles – Costs - "
+"Softwares"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart68621
+#: model:account.account,name:l10n_pe.2_chart68621
+#: model:account.account.template,name:l10n_pe.chart68621
+msgid ""
+"Amortization of intangibles - Amortization of intangibles – Revaluation - "
+"Concessions, licenses and other rights"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart68624
+#: model:account.account,name:l10n_pe.2_chart68624
+#: model:account.account.template,name:l10n_pe.chart68624
+msgid ""
+"Amortization of intangibles - Amortization of intangibles – Revaluation - "
+"Exploration and development costs"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart68625
+#: model:account.account,name:l10n_pe.2_chart68625
+#: model:account.account.template,name:l10n_pe.chart68625
+msgid ""
+"Amortization of intangibles - Amortization of intangibles – Revaluation - "
+"Formulas, designs and prototypes"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart68629
+#: model:account.account,name:l10n_pe.2_chart68629
+#: model:account.account.template,name:l10n_pe.chart68629
+msgid ""
+"Amortization of intangibles - Amortization of intangibles – Revaluation - "
+"Other intangible assets"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart68622
+#: model:account.account,name:l10n_pe.2_chart68622
+#: model:account.account.template,name:l10n_pe.chart68622
+msgid ""
+"Amortization of intangibles - Amortization of intangibles – Revaluation - "
+"Patents and industrial property"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart68623
+#: model:account.account,name:l10n_pe.2_chart68623
+#: model:account.account.template,name:l10n_pe.chart68623
+msgid ""
+"Amortization of intangibles - Amortization of intangibles – Revaluation - "
+"Softwares"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_200502
+msgid "Amotape"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_211002
+msgid "Ananea"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_211302
+msgid "Anapia"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_080302
+msgid "Ancahuasi"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_050510
+msgid "Anchihuay"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_090302
+msgid "Anchonga"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_050502
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_090502
+msgid "Anco"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_030602
+msgid "Anco_huallo"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_150102
+msgid "Ancón"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_061302
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_090202
+msgid "Andabamba"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_040402
+msgid "Andagua"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_030201
+#: model:res.city,name:l10n_pe.city_pe_0302
+msgid "Andahuaylas"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_081202
+msgid "Andahuaylillas"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_150902
+msgid "Andajes"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_120203
+msgid "Andamarca"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_030202
+msgid "Andarapa"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_040602
+msgid "Andaray"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_090720
+msgid "Andaymarca"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_160706
+msgid "Andoas"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_050116
+msgid "Andrés Avelino Cáceres Dorregaray"
+msgstr ""
+
+#. module: l10n_pe
+#: model:res.city,name:l10n_pe.city_pe_0903
+msgid "Angaraes"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_131002
+msgid "Angasmarca"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_060402
+msgid "Anguia"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_021002
+msgid "Anra"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_020604
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_080301
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_090203
+#: model:res.city,name:l10n_pe.city_pe_0803
+msgid "Anta"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_030301
+#: model:res.city,name:l10n_pe.city_pe_0303
+msgid "Antabamba"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_210802
+msgid "Antauta"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_150702
+msgid "Antioquia"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_020503
+#: model:res.city,name:l10n_pe.city_pe_0203
+msgid "Antonio Raymondi"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_101104
+msgid "Aparicio Pomares"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_120403
+msgid "Apata"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_040401
+msgid "Aplao"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_051003
+msgid "Apongo"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_020504
+msgid "Aquia"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_150402
+msgid "Arahuay"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_010202
+msgid "Aramango"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_100502
+msgid "Arancay"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_210203
+msgid "Arapa"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_200503
+msgid "Arenal"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_040101
+#: model:res.city,name:l10n_pe.city_pe_0401
+msgid "Arequipa"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_090402
+msgid "Arma"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart3812
+#: model:account.account,name:l10n_pe.2_chart3812
+#: model:account.account.template,name:l10n_pe.chart3812
+msgid "Art and culture goods - Library"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart3813
+#: model:account.account,name:l10n_pe.2_chart3813
+#: model:account.account.template,name:l10n_pe.chart3813
+msgid "Art and culture goods - Others"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart3811
+#: model:account.account,name:l10n_pe.2_chart3811
+#: model:account.account.template,name:l10n_pe.chart3811
+msgid "Art and culture goods - Works of art"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_090118
+msgid "Ascensión"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_130201
+#: model:res.city,name:l10n_pe.city_pe_1302
+msgid "Ascope"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_150502
+msgid "Asia"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_210204
+msgid "Asillo"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_051004
+msgid "Asquipata"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart68732
+#: model:account.account,name:l10n_pe.2_chart68732
+#: model:account.account.template,name:l10n_pe.chart68732
+msgid ""
+"Asset valuation - Depreciation of investment property - Financial "
+"instruments representative of economic rights"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart68731
+#: model:account.account,name:l10n_pe.2_chart68731
+#: model:account.account.template,name:l10n_pe.chart68731
+msgid ""
+"Asset valuation - Depreciation of investment property - Investments to be "
+"held until maturity"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart68713
+#: model:account.account,name:l10n_pe.2_chart68713
+#: model:account.account.template,name:l10n_pe.chart68713
+msgid ""
+"Asset valuation - Estimation of doubtful accounts receivable - Accounts "
+"receivable from staff, shareholders (partners) and directors"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart68712
+#: model:account.account,name:l10n_pe.2_chart68712
+#: model:account.account.template,name:l10n_pe.chart68712
+msgid ""
+"Asset valuation - Estimation of doubtful accounts receivable - Trade "
+"accounts receivable – Associated"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart68711
+#: model:account.account,name:l10n_pe.2_chart68711
+#: model:account.account.template,name:l10n_pe.chart68711
+msgid ""
+"Asset valuation - Estimation of doubtful accounts receivable - Trade "
+"accounts receivable – Third parties"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart68715
+#: model:account.account,name:l10n_pe.2_chart68715
+#: model:account.account.template,name:l10n_pe.chart68715
+msgid ""
+"Asset valuation - Estimation of doubtful accounts receivable - Various "
+"accounts receivable – Associated"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart68714
+#: model:account.account,name:l10n_pe.2_chart68714
+#: model:account.account.template,name:l10n_pe.chart68714
+msgid ""
+"Asset valuation - Estimation of doubtful accounts receivable - Various "
+"accounts receivable – Third parties"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.group,name:l10n_pe.1_group1
+#: model:account.group,name:l10n_pe.1_group3
+#: model:account.group,name:l10n_pe.2_group1
+#: model:account.group,name:l10n_pe.2_group3
+#: model:account.group.template,name:l10n_pe.group1
+#: model:account.group.template,name:l10n_pe.group3
+msgid "Assets available and payable"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart16621
+#: model:account.account,name:l10n_pe.1_chart17621
+#: model:account.account,name:l10n_pe.2_chart16621
+#: model:account.account,name:l10n_pe.2_chart17621
+#: model:account.account.template,name:l10n_pe.chart16621
+#: model:account.account.template,name:l10n_pe.chart17621
+msgid ""
+"Assets for financial instruments - Derivative financial instruments - Costs"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart16622
+#: model:account.account,name:l10n_pe.1_chart17622
+#: model:account.account,name:l10n_pe.2_chart16622
+#: model:account.account,name:l10n_pe.2_chart17622
+#: model:account.account.template,name:l10n_pe.chart16622
+#: model:account.account.template,name:l10n_pe.chart17622
+msgid ""
+"Assets for financial instruments - Derivative financial instruments - Fair "
+"value"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart16611
+#: model:account.account,name:l10n_pe.1_chart17611
+#: model:account.account,name:l10n_pe.2_chart16611
+#: model:account.account,name:l10n_pe.2_chart17611
+#: model:account.account.template,name:l10n_pe.chart16611
+#: model:account.account.template,name:l10n_pe.chart17611
+msgid ""
+"Assets for financial instruments - Primary financial instruments - Costs"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart16612
+#: model:account.account,name:l10n_pe.1_chart17612
+#: model:account.account,name:l10n_pe.2_chart16612
+#: model:account.account,name:l10n_pe.2_chart17612
+#: model:account.account.template,name:l10n_pe.chart16612
+#: model:account.account.template,name:l10n_pe.chart17612
+msgid ""
+"Assets for financial instruments - Primary financial instruments - Fair "
+"value"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_010102
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_060102
+#: model:res.city,name:l10n_pe.city_pe_0204
+msgid "Asunción"
+msgstr ""
+
+#. module: l10n_pe
+#: model:res.city,name:l10n_pe.city_pe_2502
+msgid "Atalaya"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_020605
+msgid "Ataquero"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_120404
+msgid "Ataura"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_150602
+msgid "Atavillos Alto"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_150603
+msgid "Atavillos Bajo"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_150103
+msgid "Ate"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_040303
+msgid "Atico"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_040304
+msgid "Atiquipa"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart625
+#: model:account.account,name:l10n_pe.2_chart625
+#: model:account.account.template,name:l10n_pe.chart625
+msgid "Attentions to staff"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_210104
+msgid "Atuncolla"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_150604
+msgid "Aucallama"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_050602
+msgid "Aucara"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_090403
+msgid "Aurahua"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart251
+#: model:account.account,name:l10n_pe.2_chart251
+#: model:account.account.template,name:l10n_pe.chart251
+msgid "Auxiliary materials"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart285
+#: model:account.account,name:l10n_pe.2_chart285
+#: model:account.account.template,name:l10n_pe.chart285
+msgid "Auxiliary materials, supplies and spare parts"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart2961
+#: model:account.account,name:l10n_pe.1_chart6031
+#: model:account.account,name:l10n_pe.1_chart6131
+#: model:account.account,name:l10n_pe.2_chart2961
+#: model:account.account,name:l10n_pe.2_chart6031
+#: model:account.account,name:l10n_pe.2_chart6131
+#: model:account.account.template,name:l10n_pe.chart2961
+#: model:account.account.template,name:l10n_pe.chart6031
+#: model:account.account.template,name:l10n_pe.chart6131
+msgid "Auxiliary materials, supplies and spare parts - Auxiliary materials"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart2963
+#: model:account.account,name:l10n_pe.1_chart6033
+#: model:account.account,name:l10n_pe.1_chart6133
+#: model:account.account,name:l10n_pe.2_chart2963
+#: model:account.account,name:l10n_pe.2_chart6033
+#: model:account.account,name:l10n_pe.2_chart6133
+#: model:account.account.template,name:l10n_pe.chart2963
+#: model:account.account.template,name:l10n_pe.chart6033
+#: model:account.account.template,name:l10n_pe.chart6133
+msgid "Auxiliary materials, supplies and spare parts - Spare parts"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart2962
+#: model:account.account,name:l10n_pe.1_chart6032
+#: model:account.account,name:l10n_pe.1_chart6132
+#: model:account.account,name:l10n_pe.2_chart2962
+#: model:account.account,name:l10n_pe.2_chart6032
+#: model:account.account,name:l10n_pe.2_chart6132
+#: model:account.account.template,name:l10n_pe.chart2962
+#: model:account.account.template,name:l10n_pe.chart6032
+#: model:account.account.template,name:l10n_pe.chart6132
+msgid "Auxiliary materials, supplies and spare parts - Supplies"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_220802
+msgid "Awajun"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_200201
+#: model:res.city,name:l10n_pe.city_pe_2002
+msgid "Ayabaca"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_050101
+msgid "Ayacucho"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_050402
+msgid "Ayahuanco"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_210303
+msgid "Ayapata"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_090602
+msgid "Ayavi"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_151004
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_210801
+msgid "Ayaviri"
+msgstr ""
+
+#. module: l10n_pe
+#: model:res.city,name:l10n_pe.city_pe_0304
+msgid "Aymaraes"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_050503
+msgid "Ayna"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_040403
+msgid "Ayo"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_151005
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_210201
+#: model:res.city,name:l10n_pe.city_pe_2102
+msgid "Azángaro"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.group,name:l10n_pe.1_group35
+#: model:account.group,name:l10n_pe.2_group35
+#: model:account.group.template,name:l10n_pe.group35
+msgid "BIOLOGICAL ASSETS"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.group,name:l10n_pe.1_group22
+#: model:account.group,name:l10n_pe.2_group22
+#: model:account.group.template,name:l10n_pe.group22
+msgid "BY-PRODUCTS, WASTE AND WASTE"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_010201
+#: model:res.city,name:l10n_pe.city_pe_0102
+msgid "Bagua"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_010701
+msgid "Bagua Grande"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_220203
+msgid "Bajo Biavo"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_160202
+msgid "Balsapuerto"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_010103
+msgid "Balsas"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_060701
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_130302
+msgid "Bambamarca"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_020903
+msgid "Bambas"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_150201
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_160701
+#: model:res.city,name:l10n_pe.city_pe_1502
+msgid "Barranca"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_150104
+msgid "Barranco"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_220503
+msgid "Barranquita"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart6367
+#: model:account.account,name:l10n_pe.2_chart6367
+#: model:account.account.template,name:l10n_pe.chart6367
+msgid "Basic services - Cable"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart6361
+#: model:account.account,name:l10n_pe.2_chart6361
+#: model:account.account.template,name:l10n_pe.chart6361
+msgid "Basic services - Electric power"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart6362
+#: model:account.account,name:l10n_pe.2_chart6362
+#: model:account.account.template,name:l10n_pe.chart6362
+msgid "Basic services - Gas"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart6365
+#: model:account.account,name:l10n_pe.2_chart6365
+#: model:account.account.template,name:l10n_pe.chart6365
+msgid "Basic services - Internet"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart6364
+#: model:account.account,name:l10n_pe.2_chart6364
+#: model:account.account.template,name:l10n_pe.chart6364
+msgid "Basic services - Phone"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart6366
+#: model:account.account,name:l10n_pe.2_chart6366
+#: model:account.account.template,name:l10n_pe.chart6366
+msgid "Basic services - Radio"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart6363
+#: model:account.account,name:l10n_pe.2_chart6363
+#: model:account.account.template,name:l10n_pe.chart6363
+msgid "Basic services - Water"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_101002
+msgid "Baños"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_040305
+msgid "Bella Unión"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_060802
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_070102
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_200602
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_220201
+#: model:res.city,name:l10n_pe.city_pe_2202
+msgid "Bellavista"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_200802
+msgid "Bellavista de la Unión"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_050902
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_160112
+msgid "Belén"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_200803
+msgid "Bernal"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart1233
+#: model:account.account,name:l10n_pe.1_chart1332
+#: model:account.account,name:l10n_pe.2_chart1233
+#: model:account.account,name:l10n_pe.2_chart1332
+#: model:account.account.template,name:l10n_pe.chart1233
+#: model:account.account.template,name:l10n_pe.chart1332
+msgid "Bills to be collected - In collection"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart1232
+#: model:account.account,name:l10n_pe.1_chart1331
+#: model:account.account,name:l10n_pe.2_chart1232
+#: model:account.account,name:l10n_pe.2_chart1331
+#: model:account.account.template,name:l10n_pe.chart1232
+#: model:account.account.template,name:l10n_pe.chart1331
+msgid "Bills to be collected - In portfolio"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart1234
+#: model:account.account,name:l10n_pe.1_chart1333
+#: model:account.account,name:l10n_pe.2_chart1234
+#: model:account.account,name:l10n_pe.2_chart1333
+#: model:account.account.template,name:l10n_pe.chart1234
+#: model:account.account.template,name:l10n_pe.chart1333
+msgid "Bills to be collected - Off sale"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart423
+#: model:account.account,name:l10n_pe.2_chart423
+#: model:account.account.template,name:l10n_pe.chart423
+msgid "Bills to pay"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart4331
+#: model:account.account,name:l10n_pe.2_chart4331
+#: model:account.account.template,name:l10n_pe.chart4331
+msgid "Bills to pay - Bills to pay"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart7241
+#: model:account.account,name:l10n_pe.2_chart7241
+#: model:account.account.template,name:l10n_pe.chart7241
+msgid "Biological assets - Biological assets in development of animal origin"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart7242
+#: model:account.account,name:l10n_pe.2_chart7242
+#: model:account.account.template,name:l10n_pe.chart7242
+msgid ""
+"Biological assets - Biological assets in development of vegetable origin"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart27411
+#: model:account.account,name:l10n_pe.2_chart27411
+#: model:account.account.template,name:l10n_pe.chart27411
+msgid "Biological assets - Biological assets in production - Costs"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart27414
+#: model:account.account,name:l10n_pe.2_chart27414
+#: model:account.account.template,name:l10n_pe.chart27414
+msgid "Biological assets - Biological assets in production - Fair value"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart27413
+#: model:account.account,name:l10n_pe.2_chart27413
+#: model:account.account.template,name:l10n_pe.chart27413
+msgid "Biological assets - Biological assets in production - Financing costs"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart27421
+#: model:account.account,name:l10n_pe.2_chart27421
+#: model:account.account.template,name:l10n_pe.chart27421
+msgid "Biological assets - Biological assets under development - Costs"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart27424
+#: model:account.account,name:l10n_pe.2_chart27424
+#: model:account.account.template,name:l10n_pe.chart27424
+msgid "Biological assets - Biological assets under development - Fair value"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart27423
+#: model:account.account,name:l10n_pe.2_chart27423
+#: model:account.account.template,name:l10n_pe.chart27423
+msgid ""
+"Biological assets - Biological assets under development - Financing costs"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart35111
+#: model:account.account,name:l10n_pe.2_chart35111
+#: model:account.account.template,name:l10n_pe.chart35111
+msgid "Biological assets in production - Animal origin - Costs"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart35114
+#: model:account.account,name:l10n_pe.2_chart35114
+#: model:account.account.template,name:l10n_pe.chart35114
+msgid "Biological assets in production - Animal origin - Fair value"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart35113
+#: model:account.account,name:l10n_pe.2_chart35113
+#: model:account.account.template,name:l10n_pe.chart35113
+msgid "Biological assets in production - Animal origin - Financing costs"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart36611
+#: model:account.account,name:l10n_pe.2_chart36611
+#: model:account.account.template,name:l10n_pe.chart36611
+msgid "Biological assets in production - Costs"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart36613
+#: model:account.account,name:l10n_pe.2_chart36613
+#: model:account.account.template,name:l10n_pe.chart36613
+msgid "Biological assets in production - Financing costs"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart35121
+#: model:account.account,name:l10n_pe.2_chart35121
+#: model:account.account.template,name:l10n_pe.chart35121
+msgid "Biological assets in production - Vegetal origin - Costs"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart35124
+#: model:account.account,name:l10n_pe.2_chart35124
+#: model:account.account.template,name:l10n_pe.chart35124
+msgid "Biological assets in production - Vegetal origin - Fair value"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart35123
+#: model:account.account,name:l10n_pe.2_chart35123
+#: model:account.account.template,name:l10n_pe.chart35123
+msgid "Biological assets in production - Vegetal origin - Financing costs"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart35211
+#: model:account.account,name:l10n_pe.2_chart35211
+#: model:account.account.template,name:l10n_pe.chart35211
+msgid "Biological assets under development - Animal origin - Costs"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart35214
+#: model:account.account,name:l10n_pe.2_chart35214
+#: model:account.account.template,name:l10n_pe.chart35214
+msgid "Biological assets under development - Animal origin - Fair value"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart35213
+#: model:account.account,name:l10n_pe.2_chart35213
+#: model:account.account.template,name:l10n_pe.chart35213
+msgid "Biological assets under development - Animal origin - Financing costs"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart36621
+#: model:account.account,name:l10n_pe.2_chart36621
+#: model:account.account.template,name:l10n_pe.chart36621
+msgid "Biological assets under development - Costs"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart36622
+#: model:account.account,name:l10n_pe.2_chart36622
+#: model:account.account.template,name:l10n_pe.chart36622
+msgid "Biological assets under development - Financing costs"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart35221
+#: model:account.account,name:l10n_pe.2_chart35221
+#: model:account.account.template,name:l10n_pe.chart35221
+msgid "Biological assets under development - Vegetal origin - Costs"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart35224
+#: model:account.account,name:l10n_pe.2_chart35224
+#: model:account.account.template,name:l10n_pe.chart35224
+msgid "Biological assets under development - Vegetal origin - Fair value"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart35223
+#: model:account.account,name:l10n_pe.2_chart35223
+#: model:account.account.template,name:l10n_pe.chart35223
+msgid "Biological assets under development - Vegetal origin - Financing costs"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart628
+#: model:account.account,name:l10n_pe.2_chart628
+#: model:account.account.template,name:l10n_pe.chart628
+msgid "Board remuneration"
+msgstr ""
+
+#. module: l10n_pe
+#: model:res.city,name:l10n_pe.city_pe_1303
+msgid "Bolivar"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_021502
+#: model:res.city,name:l10n_pe.city_pe_0205
+msgid "Bolognesi"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_061102
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_130301
+msgid "Bolívar"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart4532
+#: model:account.account,name:l10n_pe.2_chart4532
+#: model:account.account.template,name:l10n_pe.chart4532
+msgid "Bonds issued - Bonds securitized"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart4533
+#: model:account.account,name:l10n_pe.2_chart4533
+#: model:account.account.template,name:l10n_pe.chart4533
+msgid "Bonds issued - Commercial papers"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart4531
+#: model:account.account,name:l10n_pe.2_chart4531
+#: model:account.account.template,name:l10n_pe.chart4531
+msgid "Bonds issued - Issued bonds"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart4539
+#: model:account.account,name:l10n_pe.2_chart4539
+#: model:account.account.template,name:l10n_pe.chart4539
+msgid "Bonds issued - Other obligations"
+msgstr ""
+
+#. module: l10n_pe
+#: model:res.city,name:l10n_pe.city_pe_0103
+msgid "Bongara"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_150105
+msgid "Breña"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_020802
+msgid "Buena Vista Alta"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_200402
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_220702
+msgid "Buenos Aires"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart31211
+#: model:account.account,name:l10n_pe.1_chart33211
+#: model:account.account,name:l10n_pe.1_chart36421
+#: model:account.account,name:l10n_pe.2_chart31211
+#: model:account.account,name:l10n_pe.2_chart33211
+#: model:account.account,name:l10n_pe.2_chart36421
+#: model:account.account.template,name:l10n_pe.chart31211
+#: model:account.account.template,name:l10n_pe.chart33211
+#: model:account.account.template,name:l10n_pe.chart36421
+msgid "Buildings - Buildings - Costs"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart31214
+#: model:account.account,name:l10n_pe.2_chart31214
+#: model:account.account.template,name:l10n_pe.chart31214
+msgid "Buildings - Buildings - Fair value"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart31213
+#: model:account.account,name:l10n_pe.1_chart33213
+#: model:account.account,name:l10n_pe.1_chart36423
+#: model:account.account,name:l10n_pe.2_chart31213
+#: model:account.account,name:l10n_pe.2_chart33213
+#: model:account.account,name:l10n_pe.2_chart36423
+#: model:account.account.template,name:l10n_pe.chart31213
+#: model:account.account.template,name:l10n_pe.chart33213
+#: model:account.account.template,name:l10n_pe.chart36423
+msgid "Buildings - Buildings - Financing costs"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart31212
+#: model:account.account,name:l10n_pe.1_chart33212
+#: model:account.account,name:l10n_pe.1_chart36422
+#: model:account.account,name:l10n_pe.2_chart31212
+#: model:account.account,name:l10n_pe.2_chart33212
+#: model:account.account,name:l10n_pe.2_chart36422
+#: model:account.account.template,name:l10n_pe.chart31212
+#: model:account.account.template,name:l10n_pe.chart33212
+#: model:account.account.template,name:l10n_pe.chart36422
+msgid "Buildings - Buildings - Revaluation"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart36121
+#: model:account.account,name:l10n_pe.2_chart36121
+#: model:account.account.template,name:l10n_pe.chart36121
+msgid "Buildings - Costs"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart36123
+#: model:account.account,name:l10n_pe.2_chart36123
+#: model:account.account.template,name:l10n_pe.chart36123
+msgid "Buildings - Financing costs"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart36427
+#: model:account.account,name:l10n_pe.2_chart36427
+#: model:account.account.template,name:l10n_pe.chart36427
+msgid "Buildings - Improvements in leased premises - Costs"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart36429
+#: model:account.account,name:l10n_pe.2_chart36429
+#: model:account.account.template,name:l10n_pe.chart36429
+msgid "Buildings - Improvements in leased premises - Financing costs"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart36428
+#: model:account.account,name:l10n_pe.2_chart36428
+#: model:account.account.template,name:l10n_pe.chart36428
+msgid "Buildings - Improvements in leased premises - Revaluation"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart33251
+#: model:account.account,name:l10n_pe.2_chart33251
+#: model:account.account.template,name:l10n_pe.chart33251
+msgid "Buildings - Improvements in leased premises. - Costs"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart33253
+#: model:account.account,name:l10n_pe.2_chart33253
+#: model:account.account.template,name:l10n_pe.chart33253
+msgid "Buildings - Improvements in leased premises. - Financing costs"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart33252
+#: model:account.account,name:l10n_pe.2_chart33252
+#: model:account.account.template,name:l10n_pe.chart33252
+msgid "Buildings - Improvements in leased premises. - Revaluation"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart33241
+#: model:account.account,name:l10n_pe.1_chart36424
+#: model:account.account,name:l10n_pe.2_chart33241
+#: model:account.account,name:l10n_pe.2_chart36424
+#: model:account.account.template,name:l10n_pe.chart33241
+#: model:account.account.template,name:l10n_pe.chart36424
+msgid "Buildings - Installations - Costs"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart33243
+#: model:account.account,name:l10n_pe.1_chart36426
+#: model:account.account,name:l10n_pe.2_chart33243
+#: model:account.account,name:l10n_pe.2_chart36426
+#: model:account.account.template,name:l10n_pe.chart33243
+#: model:account.account.template,name:l10n_pe.chart36426
+msgid "Buildings - Installations - Financing costs"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart33242
+#: model:account.account,name:l10n_pe.1_chart36425
+#: model:account.account,name:l10n_pe.2_chart33242
+#: model:account.account,name:l10n_pe.2_chart36425
+#: model:account.account.template,name:l10n_pe.chart33242
+#: model:account.account.template,name:l10n_pe.chart36425
+msgid "Buildings - Installations - Revaluation"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart36122
+#: model:account.account,name:l10n_pe.2_chart36122
+#: model:account.account.template,name:l10n_pe.chart36122
+msgid "Buildings - Revaluation"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_130802
+msgid "Buldibuyo"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart584
+#: model:account.account,name:l10n_pe.2_chart584
+#: model:account.account.template,name:l10n_pe.chart584
+msgid "By-laws"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart221
+#: model:account.account,name:l10n_pe.2_chart221
+#: model:account.account.template,name:l10n_pe.chart221
+msgid "By-products"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart2931
+#: model:account.account,name:l10n_pe.2_chart2931
+#: model:account.account.template,name:l10n_pe.chart2931
+msgid "By-products, waste and scrap - By-products"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart69412
+#: model:account.account,name:l10n_pe.1_chart70412
+#: model:account.account,name:l10n_pe.2_chart69412
+#: model:account.account,name:l10n_pe.2_chart70412
+#: model:account.account.template,name:l10n_pe.chart69412
+#: model:account.account.template,name:l10n_pe.chart70412
+msgid "By-products, waste and scrap - By-products - Associated"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart69411
+#: model:account.account,name:l10n_pe.1_chart70411
+#: model:account.account,name:l10n_pe.2_chart69411
+#: model:account.account,name:l10n_pe.2_chart70411
+#: model:account.account.template,name:l10n_pe.chart69411
+#: model:account.account.template,name:l10n_pe.chart70411
+msgid "By-products, waste and scrap - By-products - Third parties"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart2932
+#: model:account.account,name:l10n_pe.2_chart2932
+#: model:account.account.template,name:l10n_pe.chart2932
+msgid "By-products, waste and scrap - Scrap and waste"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart69422
+#: model:account.account,name:l10n_pe.1_chart70422
+#: model:account.account,name:l10n_pe.2_chart69422
+#: model:account.account,name:l10n_pe.2_chart70422
+#: model:account.account.template,name:l10n_pe.chart69422
+#: model:account.account.template,name:l10n_pe.chart70422
+msgid "By-products, waste and scrap - Scrap and waste - Associated"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart69421
+#: model:account.account,name:l10n_pe.1_chart70421
+#: model:account.account,name:l10n_pe.2_chart69421
+#: model:account.account,name:l10n_pe.2_chart70421
+#: model:account.account.template,name:l10n_pe.chart69421
+#: model:account.account.template,name:l10n_pe.chart70421
+msgid "By-products, waste and scrap - Scrap and waste - Third parties"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.group,name:l10n_pe.1_group50
+#: model:account.group,name:l10n_pe.2_group50
+#: model:account.group.template,name:l10n_pe.group50
+msgid "CAPITAL"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.group,name:l10n_pe.1_group10
+#: model:account.group,name:l10n_pe.2_group10
+#: model:account.group.template,name:l10n_pe.group10
+msgid "CASH AND CASH EQUIVALENTS"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.group,name:l10n_pe.1_group79
+#: model:account.group,name:l10n_pe.2_group79
+#: model:account.group.template,name:l10n_pe.group79
+msgid "CHARGES ATTRIBUTABLE TO COST AND EXPENSE ACCOUNTS"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.group,name:l10n_pe.1_group78
+#: model:account.group,name:l10n_pe.2_group78
+#: model:account.group.template,name:l10n_pe.group78
+msgid "CHARGES COVERED BY PROVISIONS"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.group,name:l10n_pe.1_group80
+#: model:account.group,name:l10n_pe.2_group80
+#: model:account.group.template,name:l10n_pe.group80
+msgid "COMMERCIAL MARGIN"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.group,name:l10n_pe.1_group26
+#: model:account.group,name:l10n_pe.2_group26
+#: model:account.group.template,name:l10n_pe.group26
+msgid "CONTAINERS AND PACKAGING"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_021501
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_050603
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_211102
+msgid "Cabana"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_040503
+msgid "Cabanaconde"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_210702
+msgid "Cabanilla"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_211103
+msgid "Cabanillas"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_220903
+msgid "Cacatachi"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_060202
+msgid "Cachachi"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_131003
+msgid "Cachicadan"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_080303
+msgid "Cachimayo"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_151006
+msgid "Cacra"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_101102
+msgid "Cahuac"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_040306
+msgid "Cahuacho"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_160702
+msgid "Cahuapanas"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_081102
+msgid "Caicay"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_230202
+msgid "Cairani"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_090204
+msgid "Caja"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_060201
+#: model:res.city,name:l10n_pe.city_pe_0602
+msgid "Cajabamba"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_020505
+msgid "Cajacay"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_060101
+#: model:res.city,name:l10n_pe.city_pe_0601
+msgid "Cajamarca"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_021403
+msgid "Cajamarquilla"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_010702
+msgid "Cajaruro"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_150301
+#: model:res.city,name:l10n_pe.city_pe_1503
+msgid "Cajatambo"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_021003
+msgid "Cajay"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_130502
+msgid "Calamarca"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_230103
+msgid "Calana"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_150503
+msgid "Calango"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_210703
+msgid "Calapuja"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_080401
+#: model:res.city,name:l10n_pe.city_pe_0804
+msgid "Calca"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_150803
+msgid "Caleta de Carquin"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_150703
+msgid "Callahuanca"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_040504
+msgid "Callalli"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_090303
+msgid "Callanmarca"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_070101
+#: model:res.city,name:l10n_pe.city_pe_0701
+msgid "Callao"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_060602
+msgid "Callayuc"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_250101
+msgid "Calleria"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_061103
+msgid "Calquis"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_220102
+msgid "Calzada"
+msgstr ""
+
+#. module: l10n_pe
+#: model:res.city,name:l10n_pe.city_pe_0402
+msgid "Camana"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_081203
+msgid "Camanti"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_040201
+msgid "Camaná"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_230203
+msgid "Camilaca"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_210205
+msgid "Caminaca"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_220602
+msgid "Campanilla"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_010502
+msgid "Camporredondo"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_250102
+msgid "Campoverde"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_051005
+msgid "Canaria"
+msgstr ""
+
+#. module: l10n_pe
+#: model:res.city,name:l10n_pe.city_pe_0805
+msgid "Canas"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_050409
+msgid "Canayre"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_100402
+msgid "Canchabamba"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_200330
+msgid "Canchaque"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_120405
+msgid "Canchayllo"
+msgstr ""
+
+#. module: l10n_pe
+#: model:res.city,name:l10n_pe.city_pe_0806
+msgid "Canchis"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_230201
+#: model:res.city,name:l10n_pe.city_pe_2302
+msgid "Candarave"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_050201
+#: model:res.city,name:l10n_pe.city_pe_0502
+msgid "Cangallo"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_020506
+msgid "Canis"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_240203
+msgid "Canoas de Punta Sal"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_150401
+#: model:res.city,name:l10n_pe.city_pe_1504
+msgid "Canta"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_210105
+msgid "Capachica"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_080702
+msgid "Capacmarca"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_030402
+msgid "Capaya"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_210502
+msgid "Capazo"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_160503
+msgid "Capelo"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_090404
+msgid "Capillas"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart523
+#: model:account.account,name:l10n_pe.2_chart523
+#: model:account.account.template,name:l10n_pe.chart523
+msgid "Capital reductions pending formalization"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart5011
+#: model:account.account,name:l10n_pe.2_chart5011
+#: model:account.account.template,name:l10n_pe.chart5011
+msgid "Capital social - Actions"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart5012
+#: model:account.account,name:l10n_pe.2_chart5012
+#: model:account.account.template,name:l10n_pe.chart5012
+msgid "Capital social - Participations"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart5221
+#: model:account.account,name:l10n_pe.2_chart5221
+#: model:account.account.template,name:l10n_pe.chart5221
+msgid "Capitalizations in process - Contributions"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart5223
+#: model:account.account,name:l10n_pe.2_chart5223
+#: model:account.account.template,name:l10n_pe.chart5223
+msgid "Capitalizations in process - Credits"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart5222
+#: model:account.account,name:l10n_pe.2_chart5222
+#: model:account.account.template,name:l10n_pe.chart5222
+msgid "Capitalizations in process - Reserves"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart5224
+#: model:account.account,name:l10n_pe.2_chart5224
+#: model:account.account.template,name:l10n_pe.chart5224
+msgid "Capitalizations in process - Utilities"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart72542
+#: model:account.account,name:l10n_pe.2_chart72542
+#: model:account.account.template,name:l10n_pe.chart72542
+msgid ""
+"Capitalized financing costs - Financing costs – Biological assets under "
+"development - Biological asset of vegetal origin"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart72541
+#: model:account.account,name:l10n_pe.2_chart72541
+#: model:account.account.template,name:l10n_pe.chart72541
+msgid ""
+"Capitalized financing costs - Financing costs – Biological assets under "
+"development - Biological assets of animal origin"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart7253
+#: model:account.account,name:l10n_pe.2_chart7253
+#: model:account.account.template,name:l10n_pe.chart7253
+msgid "Capitalized financing costs - Financing costs – Intangibles"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart72512
+#: model:account.account,name:l10n_pe.2_chart72512
+#: model:account.account.template,name:l10n_pe.chart72512
+msgid ""
+"Capitalized financing costs - Financing costs – Investment property - "
+"Buildings"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart72511
+#: model:account.account,name:l10n_pe.2_chart72511
+#: model:account.account.template,name:l10n_pe.chart72511
+msgid ""
+"Capitalized financing costs - Financing costs – Investment property - "
+"Production plants under development"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart72522
+#: model:account.account,name:l10n_pe.2_chart72522
+#: model:account.account.template,name:l10n_pe.chart72522
+msgid ""
+"Capitalized financing costs - Financing costs – Property, plant and "
+"equipment - Buildings"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart72523
+#: model:account.account,name:l10n_pe.2_chart72523
+#: model:account.account.template,name:l10n_pe.chart72523
+msgid ""
+"Capitalized financing costs - Financing costs – Property, plant and "
+"equipment - Machinery and other operating equipment"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart72521
+#: model:account.account,name:l10n_pe.2_chart72521
+#: model:account.account.template,name:l10n_pe.chart72521
+msgid ""
+"Capitalized financing costs - Financing costs – Property, plant and "
+"equipment - Production plants in development"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_130503
+msgid "Carabamba"
+msgstr ""
+
+#. module: l10n_pe
+#: model:res.city,name:l10n_pe.city_pe_2103
+msgid "Carabaya"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_150106
+msgid "Carabayllo"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_211104
+msgid "Caracoto"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_150704
+msgid "Carampoma"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_151007
+msgid "Carania"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_050302
+msgid "Carapo"
+msgstr ""
+
+#. module: l10n_pe
+#: model:res.city,name:l10n_pe.city_pe_0403
+msgid "Caraveli"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_040301
+msgid "Caravelí"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_030403
+msgid "Caraybamba"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_021201
+msgid "Caraz"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_120104
+msgid "Carhuacallanga"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_120502
+msgid "Carhuamayo"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_051103
+msgid "Carhuanca"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_021404
+msgid "Carhuapampa"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_020601
+#: model:res.city,name:l10n_pe.city_pe_0206
+msgid "Carhuaz"
+msgstr ""
+
+#. module: l10n_pe
+#: model:res.city,name:l10n_pe.city_pe_0207
+msgid "Carlos Fermin Fitzcarrald"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_050104
+msgid "Carmen Alto"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_050604
+msgid "Carmen Salcedo"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_070103
+msgid "Carmen de la Legua Reynoso"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_180102
+msgid "Carumas"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_130208
+msgid "Casa Grande"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_021302
+msgid "Casca"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_022002
+msgid "Cascapara"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_131101
+msgid "Cascas"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart101
+#: model:account.account,name:l10n_pe.2_chart101
+#: model:account.account.template,name:l10n_pe.chart101
+msgid "Cash"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_021904
+msgid "Cashapampa"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_240202
+msgid "Casitas"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_020801
+#: model:res.city,name:l10n_pe.city_pe_0208
+msgid "Casma"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_220703
+msgid "Caspisapa"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_200104
+#: model:res.city,name:l10n_pe.city_pe_0404
+msgid "Castilla"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_100608
+msgid "Castillo Grande"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_090401
+#: model:res.city,name:l10n_pe.city_pe_0904
+msgid "Castrovirreyna"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_021702
+msgid "Catac"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_200105
+msgid "Catacaos"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_061303
+msgid "Catache"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_151008
+msgid "Catahuasi"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_061104
+msgid "Catilluc"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_150903
+msgid "Caujul"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_140116
+msgid "Cayalti"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_051006
+msgid "Cayara"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_040603
+msgid "Cayarani"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_040505
+#: model:res.city,name:l10n_pe.city_pe_0405
+msgid "Caylloma"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_040103
+msgid "Cayma"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_100202
+msgid "Cayna"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_220504
+msgid "Caynarachi"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_140202
+msgid "Cañaris"
+msgstr ""
+
+#. module: l10n_pe
+#: model:res.city,name:l10n_pe.city_pe_1505
+msgid "Cañete"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_081003
+msgid "Ccapi"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_081204
+msgid "Ccarhuayo"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_081205
+msgid "Ccatca"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_090304
+msgid "Ccochaccasa"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_080102
+msgid "Ccorca"
+msgstr ""
+
+#. module: l10n_pe
+#: model:res.city,name:l10n_pe.city_pe_0603
+msgid "Celendin"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_060301
+msgid "Celendín"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_150504
+msgid "Cerro Azul"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_040104
+msgid "Cerro colorado"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart30311
+#: model:account.account,name:l10n_pe.2_chart30311
+#: model:account.account.template,name:l10n_pe.chart30311
+msgid ""
+"Certificates of participation in funds - Dues - Investment funds - Costs"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart30314
+#: model:account.account,name:l10n_pe.2_chart30314
+#: model:account.account.template,name:l10n_pe.chart30314
+msgid ""
+"Certificates of participation in funds - Dues - Investment funds - Fair "
+"value"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart30321
+#: model:account.account,name:l10n_pe.2_chart30321
+#: model:account.account.template,name:l10n_pe.chart30321
+msgid "Certificates of participation in funds - Dues - Mutual funds - Costs"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart30324
+#: model:account.account,name:l10n_pe.2_chart30324
+#: model:account.account.template,name:l10n_pe.chart30324
+msgid ""
+"Certificates of participation in funds - Dues - Mutual funds - Fair value"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_050412
+msgid "Chaca"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_101103
+msgid "Chacabamba"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_120802
+msgid "Chacapalpa"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_120105
+msgid "Chacapampa"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_020401
+msgid "Chacas"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_190202
+msgid "Chacayan"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_020303
+msgid "Chaccho"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_010101
+#: model:res.city,name:l10n_pe.city_pe_0101
+msgid "Chachapoyas"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_040404
+msgid "Chachas"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_150107
+msgid "Chaclacayo"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_030102
+msgid "Chacoche"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_060403
+msgid "Chadin"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_100802
+msgid "Chaglla"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_040307
+msgid "Chala"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_200403
+msgid "Chalaco"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_060419
+msgid "Chalamarca"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_050903
+msgid "Chalcos"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_030401
+msgid "Chalhuanca"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_081103
+msgid "Challabamba"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_030506
+msgid "Challhuahuacho"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_080703
+msgid "Chamaca"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_120204
+msgid "Chambara"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_061002
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_150605
+msgid "Chancay"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_061304
+msgid "Chancaybaños"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_120301
+#: model:res.city,name:l10n_pe.city_pe_1203
+msgid "Chanchamayo"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_110302
+msgid "Changuillo"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_131202
+msgid "Chao"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_040308
+msgid "Chaparra"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_030404
+msgid "Chapimarca"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_040105
+msgid "Characato"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_130604
+msgid "Charat"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_040803
+msgid "Charcana"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart791
+#: model:account.account,name:l10n_pe.2_chart791
+#: model:account.account.template,name:l10n_pe.chart791
+msgid "Charges attributable to cost and expense accounts"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart781
+#: model:account.account,name:l10n_pe.2_chart781
+#: model:account.account.template,name:l10n_pe.chart781
+msgid "Charges covered by provisions"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_190101
+msgid "Chaupimarca"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_050605
+msgid "Chaviña"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_110203
+msgid "Chavín"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_021004
+msgid "Chavín de Huantar"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_100503
+msgid "Chavín de Pariarca"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_101101
+msgid "Chavínillo"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_220904
+msgid "Chazuta"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_080602
+msgid "Checacupe"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_080502
+msgid "Checca"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_150804
+msgid "Checras"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_130401
+msgid "Chepen"
+msgstr ""
+
+#. module: l10n_pe
+#: model:res.city,name:l10n_pe.city_pe_1304
+msgid "Chepén"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_060103
+msgid "Chetilla"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_010104
+msgid "Cheto"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_030203
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_050105
+msgid "Chiara"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_130202
+msgid "Chicama"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_120106
+msgid "Chicche"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_040604
+msgid "Chichas"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_150705
+msgid "Chicla"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_140101
+#: model:res.city,name:l10n_pe.city_pe_1401
+msgid "Chiclayo"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_040106
+msgid "Chiguata"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_060404
+msgid "Chiguirip"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_120107
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_150505
+msgid "Chilca"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_050504
+msgid "Chilcas"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_040405
+msgid "Chilcaymarca"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_050904
+msgid "Chilcayoc"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_060502
+msgid "Chilete"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_010105
+msgid "Chiliquin"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_130803
+msgid "Chillia"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_060405
+msgid "Chimban"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_021801
+msgid "Chimbote"
+msgstr ""
+
+#. module: l10n_pe
+#: model:res.city,name:l10n_pe.city_pe_1102
+msgid "Chincha"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_110201
+msgid "Chincha Alta"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_110204
+msgid "Chincha Baja"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_100103
+msgid "Chinchao"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_080304
+msgid "Chinchaypujio"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_081302
+msgid "Chinchero"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_030601
+#: model:res.city,name:l10n_pe.city_pe_0306
+msgid "Chincheros"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_090503
+msgid "Chinchihuasi"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_090305
+msgid "Chincho"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_021905
+msgid "Chingalpo"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_020304
+msgid "Chingas"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_050606
+msgid "Chipao"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_220905
+msgid "Chipurana"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_020501
+msgid "Chiquian"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_010602
+msgid "Chirimoto"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_060902
+msgid "Chirinos"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_010302
+msgid "Chisquilla"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_040501
+msgid "Chivay"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_140302
+msgid "Chochope"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_040406
+msgid "Choco"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_130203
+msgid "Chocope"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_151009
+msgid "Chocos"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_180202
+msgid "Chojata"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_100702
+msgid "Cholon"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_120108
+msgid "Chongos Alto"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_120903
+msgid "Chongos Bajo"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_140102
+msgid "Chongoyape"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_190302
+msgid "Chontabamba"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_060803
+msgid "Chontali"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_101108
+msgid "Choras"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_060406
+msgid "Choropampa"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_060603
+msgid "Choros"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_150108
+msgid "Chorrillos"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_060401
+#: model:res.city,name:l10n_pe.city_pe_0604
+msgid "Chota"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_210106
+#: model:res.city,name:l10n_pe.city_pe_2104
+msgid "Chucuito"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_130902
+msgid "Chugay"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_060702
+msgid "Chugur"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_200401
+msgid "Chulucanas"
+msgstr ""
+
+#. module: l10n_pe
+#: model:res.city,name:l10n_pe.city_pe_0807
+msgid "Chumbivilcas"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_050702
+msgid "Chumpi"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_060302
+msgid "Chumuch"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_050505
+msgid "Chungui"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_210206
+msgid "Chupa"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_120901
+#: model:res.city,name:l10n_pe.city_pe_1209
+msgid "Chupaca"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_090405
+msgid "Chupamarca"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_120111
+msgid "Chupuro"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_010106
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_040601
+msgid "Chuquibamba"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_030701
+msgid "Chuquibambilla"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_100307
+msgid "Chuquis"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_090501
+#: model:res.city,name:l10n_pe.city_pe_0905
+msgid "Churcampa"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_100104
+msgid "Churubamba"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_010303
+msgid "Churuja"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_050202
+msgid "Chuschi"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_150109
+msgid "Cieneguilla"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_030103
+msgid "Circa"
+msgstr ""
+
+#. module: l10n_pe
 #: model:ir.model,name:l10n_pe.model_res_city
 #: model:ir.model.fields,field_description:l10n_pe.field_l10n_pe_res_city_district__city_id
 msgid "City"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_230104
+msgid "Ciudad Nueva"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart1621
+#: model:account.account,name:l10n_pe.2_chart1621
+#: model:account.account.template,name:l10n_pe.chart1621
+msgid "Claims to third parties - Insurance companies"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart1629
+#: model:account.account,name:l10n_pe.2_chart1629
+#: model:account.account.template,name:l10n_pe.chart1629
+msgid "Claims to third parties - Others"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart1623
+#: model:account.account,name:l10n_pe.2_chart1623
+#: model:account.account.template,name:l10n_pe.chart1623
+msgid "Claims to third parties - Public services"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart1624
+#: model:account.account,name:l10n_pe.2_chart1624
+#: model:account.account.template,name:l10n_pe.chart1624
+msgid "Claims to third parties - Taxes"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart1622
+#: model:account.account,name:l10n_pe.2_chart1622
+#: model:account.account.template,name:l10n_pe.chart1622
+msgid "Claims to third parties - Transportation"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_180203
+msgid "Coalaque"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_210304
+msgid "Coasa"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_210107
+msgid "Coata"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_150506
+msgid "Coayllo"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_010503
+msgid "Cocabamba"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_040702
+msgid "Cocachacra"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_090406
+msgid "Cocas"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_020102
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_060407
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_100403
+msgid "Cochabamba"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_010603
+msgid "Cochamal"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_150904
+msgid "Cochamarca"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_021102
+msgid "Cochapeti"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_030603
+msgid "Cocharcas"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_021405
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_120205
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_151010
+msgid "Cochas"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_130903
+msgid "Cochorco"
 msgstr ""
 
 #. module: l10n_pe
@@ -28,19 +4500,1639 @@ msgid "Code"
 msgstr ""
 
 #. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_100902
+msgid "Codo del Pozuzo"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_021803
+msgid "Coishco"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_210602
+msgid "Cojata"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_200504
+msgid "Colan"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_060804
+msgid "Colasay"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_051007
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_120112
+msgid "Colca"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_020103
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_030405
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_090705
+msgid "Colcabamba"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_010504
+msgid "Colcamar"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_081004
+msgid "Colcha"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_151011
+msgid "Colonia"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_100203
+msgid "Colpas"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_080704
+msgid "Colquemarca"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_081104
+msgid "Colquepata"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_020507
+msgid "Colquioc"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_050802
+msgid "Colta"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_020803
+msgid "Comandante Noel"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_120206
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_150110
+msgid "Comas"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_080603
+msgid "Combapata"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart752
+#: model:account.account,name:l10n_pe.2_chart752
+#: model:account.account.template,name:l10n_pe.chart752
+msgid "Commissions and brokerage"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart0127
+#: model:account.account,name:l10n_pe.1_chart0227
+#: model:account.account,name:l10n_pe.2_chart0127
+#: model:account.account,name:l10n_pe.2_chart0227
+#: model:account.account.template,name:l10n_pe.chart0127
+#: model:account.account.template,name:l10n_pe.chart0227
+msgid "Commitments on financial instruments"
+msgstr ""
+
+#. module: l10n_pe
+#: model:ir.model,name:l10n_pe.model_res_company
+msgid "Companies"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_090104
+msgid "Conayca"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_051104
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_120201
+#: model:res.city,name:l10n_pe.city_pe_1202
+msgid "Concepción"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart36511
+#: model:account.account,name:l10n_pe.2_chart36511
+#: model:account.account.template,name:l10n_pe.chart36511
+msgid "Concessions, licenses and other rights - Costs"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart34121
+#: model:account.account,name:l10n_pe.2_chart34121
+#: model:account.account.template,name:l10n_pe.chart34121
+msgid "Concessions, licenses and other rights - License - Costs"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart34122
+#: model:account.account,name:l10n_pe.2_chart34122
+#: model:account.account.template,name:l10n_pe.chart34122
+msgid "Concessions, licenses and other rights - License - Revaluation"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart34191
+#: model:account.account,name:l10n_pe.2_chart34191
+#: model:account.account.template,name:l10n_pe.chart34191
+msgid "Concessions, licenses and other rights - Other rights - Costs"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart34192
+#: model:account.account,name:l10n_pe.2_chart34192
+#: model:account.account.template,name:l10n_pe.chart34192
+msgid "Concessions, licenses and other rights - Other rights - Revaluation"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart36512
+#: model:account.account,name:l10n_pe.2_chart36512
+#: model:account.account.template,name:l10n_pe.chart36512
+msgid "Concessions, licenses and other rights - Revaluation"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart34111
+#: model:account.account,name:l10n_pe.2_chart34111
+#: model:account.account.template,name:l10n_pe.chart34111
+msgid ""
+"Concessions, licenses and other rights - Rights for concessions - Costs"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart34112
+#: model:account.account,name:l10n_pe.2_chart34112
+#: model:account.account.template,name:l10n_pe.chart34112
+msgid ""
+"Concessions, licenses and other rights - Rights for concessions - "
+"Revaluation"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_100204
+msgid "Conchamarca"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_060408
+msgid "Conchan"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_021503
+msgid "Conchucos"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_060203
+msgid "Condebamba"
+msgstr ""
+
+#. module: l10n_pe
+#: model:res.city,name:l10n_pe.city_pe_0406
+msgid "Condesuyos"
+msgstr ""
+
+#. module: l10n_pe
+#: model:res.city,name:l10n_pe.city_pe_0104
+msgid "Condorcanqui"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_130303
+msgid "Condormarca"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_080802
+msgid "Condoroma"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_210505
+msgid "Conduriri"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_090306
+msgid "Congalla"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_021406
+msgid "Congas"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_010505
+msgid "Conila"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_210902
+msgid "Conima"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_190308
+msgid "Constitución"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart31311
+#: model:account.account,name:l10n_pe.1_chart36131
+#: model:account.account,name:l10n_pe.2_chart31311
+#: model:account.account,name:l10n_pe.2_chart36131
+#: model:account.account.template,name:l10n_pe.chart31311
+#: model:account.account.template,name:l10n_pe.chart36131
+msgid "Constructions in progress - Buildings - Costs"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart31314
+#: model:account.account,name:l10n_pe.2_chart31314
+#: model:account.account.template,name:l10n_pe.chart31314
+msgid "Constructions in progress - Buildings - Fair value"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart31313
+#: model:account.account,name:l10n_pe.1_chart36133
+#: model:account.account,name:l10n_pe.2_chart31313
+#: model:account.account,name:l10n_pe.2_chart36133
+#: model:account.account.template,name:l10n_pe.chart31313
+#: model:account.account.template,name:l10n_pe.chart36133
+msgid "Constructions in progress - Buildings - Financing costs"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart31312
+#: model:account.account,name:l10n_pe.1_chart36132
+#: model:account.account,name:l10n_pe.2_chart31312
+#: model:account.account,name:l10n_pe.2_chart36132
+#: model:account.account.template,name:l10n_pe.chart31312
+#: model:account.account.template,name:l10n_pe.chart36132
+msgid "Constructions in progress - Buildings - Revaluation"
+msgstr ""
+
+#. module: l10n_pe
+#: model:ir.model,name:l10n_pe.model_res_partner
+msgid "Contact"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart261
+#: model:account.account,name:l10n_pe.2_chart261
+#: model:account.account.template,name:l10n_pe.chart261
+msgid "Containers"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart286
+#: model:account.account,name:l10n_pe.2_chart286
+#: model:account.account.template,name:l10n_pe.chart286
+msgid "Containers and packaging"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart2971
+#: model:account.account,name:l10n_pe.1_chart6041
+#: model:account.account,name:l10n_pe.1_chart6141
+#: model:account.account,name:l10n_pe.2_chart2971
+#: model:account.account,name:l10n_pe.2_chart6041
+#: model:account.account,name:l10n_pe.2_chart6141
+#: model:account.account.template,name:l10n_pe.chart2971
+#: model:account.account.template,name:l10n_pe.chart6041
+#: model:account.account.template,name:l10n_pe.chart6141
+msgid "Containers and packaging - Containers"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart2972
+#: model:account.account,name:l10n_pe.1_chart6042
+#: model:account.account,name:l10n_pe.1_chart6142
+#: model:account.account,name:l10n_pe.2_chart2972
+#: model:account.account,name:l10n_pe.2_chart6042
+#: model:account.account,name:l10n_pe.2_chart6142
+#: model:account.account.template,name:l10n_pe.chart2972
+#: model:account.account.template,name:l10n_pe.chart6042
+#: model:account.account.template,name:l10n_pe.chart6142
+msgid "Containers and packaging - Packaging"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_160601
+msgid "Contamana"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart638
+#: model:account.account,name:l10n_pe.2_chart638
+#: model:account.account.template,name:l10n_pe.chart638
+msgid "Contractor Services"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart583
+#: model:account.account,name:l10n_pe.2_chart583
+#: model:account.account.template,name:l10n_pe.chart583
+msgid "Contractual"
+msgstr ""
+
+#. module: l10n_pe
+#: model:res.city,name:l10n_pe.city_pe_2402
+msgid "Contralmirante Villar"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_060501
+msgid "Contumaza"
+msgstr ""
+
+#. module: l10n_pe
+#: model:res.city,name:l10n_pe.city_pe_0605
+msgid "Contumazá"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_150302
+msgid "Copa"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_010203
+msgid "Copallin"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_211303
+msgid "Copani"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_040506
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_080803
+msgid "Coporaque"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_050701
+msgid "Coracora"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_210305
+msgid "Corani"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_050803
+msgid "Corculla"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_020202
+msgid "Coris"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_050703
+msgid "Coronel Castañeda"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_230110
+msgid "Coronel Gregorio Albarracín Lanchipa"
+msgstr ""
+
+#. module: l10n_pe
+#: model:res.city,name:l10n_pe.city_pe_2501
+msgid "Coronel Portillo"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_020901
+#: model:res.city,name:l10n_pe.city_pe_0209
+msgid "Corongo"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_010304
+msgid "Corosha"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_240102
+msgid "Corrales"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_060303
+msgid "Cortegana"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_090511
+msgid "Cosme"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_060104
+msgid "Cospan"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart60934
+#: model:account.account,name:l10n_pe.2_chart60934
+#: model:account.account.template,name:l10n_pe.chart60934
+msgid ""
+"Costos vinculados con las compras - Costs associated with purchases of "
+"materials, supplies and spare parts - Commissions"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart60933
+#: model:account.account,name:l10n_pe.2_chart60933
+#: model:account.account.template,name:l10n_pe.chart60933
+msgid ""
+"Costos vinculados con las compras - Costs associated with purchases of "
+"materials, supplies and spare parts - Customs duties"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart60932
+#: model:account.account,name:l10n_pe.2_chart60932
+#: model:account.account.template,name:l10n_pe.chart60932
+msgid ""
+"Costos vinculados con las compras - Costs associated with purchases of "
+"materials, supplies and spare parts - Insurance"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart60935
+#: model:account.account,name:l10n_pe.2_chart60935
+#: model:account.account.template,name:l10n_pe.chart60935
+msgid ""
+"Costos vinculados con las compras - Costs associated with purchases of "
+"materials, supplies and spare parts - Other costs"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart60931
+#: model:account.account,name:l10n_pe.2_chart60931
+#: model:account.account.template,name:l10n_pe.chart60931
+msgid ""
+"Costos vinculados con las compras - Costs associated with purchases of "
+"materials, supplies and spare parts - Transport"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart60944
+#: model:account.account,name:l10n_pe.2_chart60944
+#: model:account.account.template,name:l10n_pe.chart60944
+msgid ""
+"Costos vinculados con las compras - Costs linked to purchases of containers "
+"and packaging - Commissions"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart60943
+#: model:account.account,name:l10n_pe.2_chart60943
+#: model:account.account.template,name:l10n_pe.chart60943
+msgid ""
+"Costos vinculados con las compras - Costs linked to purchases of containers "
+"and packaging - Customs duties"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart60942
+#: model:account.account,name:l10n_pe.2_chart60942
+#: model:account.account.template,name:l10n_pe.chart60942
+msgid ""
+"Costos vinculados con las compras - Costs linked to purchases of containers "
+"and packaging - Insurance"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart60945
+#: model:account.account,name:l10n_pe.2_chart60945
+#: model:account.account.template,name:l10n_pe.chart60945
+msgid ""
+"Costos vinculados con las compras - Costs linked to purchases of containers "
+"and packaging - Other costs"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart60941
+#: model:account.account,name:l10n_pe.2_chart60941
+#: model:account.account.template,name:l10n_pe.chart60941
+msgid ""
+"Costos vinculados con las compras - Costs linked to purchases of containers "
+"and packaging - Transport"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart60914
+#: model:account.account,name:l10n_pe.2_chart60914
+#: model:account.account.template,name:l10n_pe.chart60914
+msgid ""
+"Costs linked to purchases - Costs associated with purchases of merchandise -"
+" Commissions"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart60913
+#: model:account.account,name:l10n_pe.2_chart60913
+#: model:account.account.template,name:l10n_pe.chart60913
+msgid ""
+"Costs linked to purchases - Costs associated with purchases of merchandise -"
+" Customs duties"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart60912
+#: model:account.account,name:l10n_pe.2_chart60912
+#: model:account.account.template,name:l10n_pe.chart60912
+msgid ""
+"Costs linked to purchases - Costs associated with purchases of merchandise -"
+" Insurance"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart60919
+#: model:account.account,name:l10n_pe.2_chart60919
+#: model:account.account.template,name:l10n_pe.chart60919
+msgid ""
+"Costs linked to purchases - Costs associated with purchases of merchandise -"
+" Other costs"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart60911
+#: model:account.account,name:l10n_pe.2_chart60911
+#: model:account.account.template,name:l10n_pe.chart60911
+msgid ""
+"Costs linked to purchases - Costs associated with purchases of merchandise -"
+" Transport"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart60924
+#: model:account.account,name:l10n_pe.2_chart60924
+#: model:account.account.template,name:l10n_pe.chart60924
+msgid ""
+"Costs linked to purchases - Costs linked to purchases of raw materials - "
+"Commissions"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart60923
+#: model:account.account,name:l10n_pe.2_chart60923
+#: model:account.account.template,name:l10n_pe.chart60923
+msgid ""
+"Costs linked to purchases - Costs linked to purchases of raw materials - "
+"Customs duties"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart60922
+#: model:account.account,name:l10n_pe.2_chart60922
+#: model:account.account.template,name:l10n_pe.chart60922
+msgid ""
+"Costs linked to purchases - Costs linked to purchases of raw materials - "
+"Insurance"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart60925
+#: model:account.account,name:l10n_pe.2_chart60925
+#: model:account.account.template,name:l10n_pe.chart60925
+msgid ""
+"Costs linked to purchases - Costs linked to purchases of raw materials - "
+"Other costs"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart60921
+#: model:account.account,name:l10n_pe.2_chart60921
+#: model:account.account.template,name:l10n_pe.chart60921
+msgid ""
+"Costs linked to purchases - Costs linked to purchases of raw materials - "
+"Transport"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_030502
+#: model:res.city,name:l10n_pe.city_pe_0305
+msgid "Cotabambas"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_040801
+msgid "Cotahuasi"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_021703
+msgid "Cotaparaco"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_030406
+msgid "Cotaruse"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart0229
+#: model:account.account,name:l10n_pe.2_chart0229
+#: model:account.account.template,name:l10n_pe.chart0229
+msgid "Counterpart creditor memorandum accounts"
+msgstr ""
+
+#. module: l10n_pe
+#: model_terms:ir.ui.view,arch_db:l10n_pe.pe_partner_address_form
+msgid "Country"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_120602
+msgid "Coviriali"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_080402
+msgid "Coya"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_030503
+msgid "Coyllurqui"
+msgstr ""
+
+#. module: l10n_pe
+#: model:ir.model.fields,field_description:l10n_pe.field_l10n_pe_res_city_district__create_uid
+msgid "Created by"
+msgstr ""
+
+#. module: l10n_pe
+#: model:ir.model.fields,field_description:l10n_pe.field_l10n_pe_res_city_district__create_date
+msgid "Created on"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart0129
+#: model:account.account,name:l10n_pe.2_chart0129
+#: model:account.account.template,name:l10n_pe.chart0129
+msgid "Creditors offset"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_200804
+msgid "Cristo Nos Valga"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_210306
+msgid "Crucero"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_180103
+msgid "Cuchumbaya"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_090105
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_150706
+msgid "Cuenca"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_010305
+msgid "Cuispes"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_060604
+msgid "Cujillo"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_021103
+msgid "Culebras"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_120113
+msgid "Cullhuas"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_010703
+msgid "Cumba"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_210803
+msgid "Cupi"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_060503
+msgid "Cupisnique"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_200107
+msgid "Cura Mori"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_030104
+msgid "Curahuasi"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_030714
+msgid "Curasco"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_130904
+msgid "Curgos"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_230204
+msgid "Curibaya"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_120406
+msgid "Curicaca"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_250303
+msgid "Curimana"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_030702
+msgid "Curpahuasi"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart1042
+#: model:account.account,name:l10n_pe.2_chart1042
+#: model:account.account.template,name:l10n_pe.chart1042
+msgid ""
+"Current accounts in financial institutions - Current accounts for specific "
+"purposes"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart1041
+#: model:account.account,name:l10n_pe.2_chart1041
+#: model:account.account.template,name:l10n_pe.chart1041
+msgid ""
+"Current accounts in financial institutions - Operating checking accounts"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_020904
+msgid "Cusca"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_080101
+#: model:res.city,name:l10n_pe.city_pe_0801
+msgid "Cusco"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_081206
+msgid "Cusipata"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_060601
+#: model:res.city,name:l10n_pe.city_pe_0606
+msgid "Cutervo"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_211304
+msgid "Cuturapi"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_211202
+msgid "Cuyocuyo"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_220505
+msgid "Cuñumbuqui"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_021802
+msgid "Cáceres del Perú"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_090603
+msgid "Córdova"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.group,name:l10n_pe.1_group37
+#: model:account.group,name:l10n_pe.2_group37
+#: model:account.group.template,name:l10n_pe.group37
+msgid "DEFERRED ASSETS"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.group,name:l10n_pe.1_group49
+#: model:account.group,name:l10n_pe.2_group49
+#: model:account.group.template,name:l10n_pe.group49
+msgid "DEFERRED LIABILITIES"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.tax.group,name:l10n_pe.tax_group_det
+msgid "DET"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.group,name:l10n_pe.1_group89
+#: model:account.group,name:l10n_pe.2_group89
+#: model:account.group.template,name:l10n_pe.group89
+msgid "DETERMINATION OF THE RESULT OF THE YEAR"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.group,name:l10n_pe.1_group36
+#: model:account.group,name:l10n_pe.2_group36
+#: model:account.group.template,name:l10n_pe.group36
+msgid "DEVALUATION OF FIXED ASSETS"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.group,name:l10n_pe.1_group29
+#: model:account.group,name:l10n_pe.2_group29
+#: model:account.group.template,name:l10n_pe.group29
+msgid "DEVALUATION OF INVENTORIES"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.group,name:l10n_pe.1_group74
+#: model:account.group,name:l10n_pe.2_group74
+#: model:account.group.template,name:l10n_pe.group74
+msgid "DISCOUNTS, DISCOUNTS AND BONUSES GRANTED"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.group,name:l10n_pe.1_group73
+#: model:account.group,name:l10n_pe.2_group73
+#: model:account.group.template,name:l10n_pe.group73
+msgid "DISCOUNTS, REBATES AND BONUSES OBTAINED"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_latam.identification.type,name:l10n_pe.it_DNI
+msgid "DNI"
+msgstr ""
+
+#. module: l10n_pe
+#: model:res.city,name:l10n_pe.city_pe_1902
+msgid "Daniel Alcides Carrión"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_100602
+msgid "Daniel Alomía Robles"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_090706
+msgid "Daniel Hernández"
+msgstr ""
+
+#. module: l10n_pe
+#: model:res.city,name:l10n_pe.city_pe_1607
+msgid "Datem del Marañón"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_040703
+msgid "Dean Valdivia"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart0114
+#: model:account.account,name:l10n_pe.2_chart0114
+#: model:account.account.template,name:l10n_pe.chart0114
+msgid "Debitors offset"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart497
+#: model:account.account,name:l10n_pe.2_chart497
+#: model:account.account.template,name:l10n_pe.chart497
+msgid "Deferred costs"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart3721
+#: model:account.account,name:l10n_pe.1_chart4921
+#: model:account.account,name:l10n_pe.2_chart3721
+#: model:account.account,name:l10n_pe.2_chart4921
+#: model:account.account.template,name:l10n_pe.chart3721
+#: model:account.account.template,name:l10n_pe.chart4921
+msgid "Deferred employee shares - Deferred employee shares – Heritage"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart3722
+#: model:account.account,name:l10n_pe.1_chart4922
+#: model:account.account,name:l10n_pe.2_chart3722
+#: model:account.account,name:l10n_pe.2_chart4922
+#: model:account.account.template,name:l10n_pe.chart3722
+#: model:account.account.template,name:l10n_pe.chart4922
+msgid "Deferred employee shares - Deferred employee shares – Results"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart496
+#: model:account.account,name:l10n_pe.2_chart496
+#: model:account.account.template,name:l10n_pe.chart496
+msgid "Deferred income"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart3711
+#: model:account.account,name:l10n_pe.1_chart4911
+#: model:account.account,name:l10n_pe.2_chart3711
+#: model:account.account,name:l10n_pe.2_chart4911
+#: model:account.account.template,name:l10n_pe.chart3711
+#: model:account.account.template,name:l10n_pe.chart4911
+msgid "Deferred income tax - Deferred income tax – Heritage"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart3712
+#: model:account.account,name:l10n_pe.1_chart4912
+#: model:account.account,name:l10n_pe.2_chart3712
+#: model:account.account,name:l10n_pe.2_chart4912
+#: model:account.account.template,name:l10n_pe.chart3712
+#: model:account.account.template,name:l10n_pe.chart4912
+msgid "Deferred income tax - Deferred income tax – Results"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart3731
+#: model:account.account,name:l10n_pe.1_chart4931
+#: model:account.account,name:l10n_pe.2_chart3731
+#: model:account.account,name:l10n_pe.2_chart4931
+#: model:account.account.template,name:l10n_pe.chart3731
+#: model:account.account.template,name:l10n_pe.chart4931
+msgid ""
+"Deferred interest - Unearned interest in transactions with third parties"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart3732
+#: model:account.account,name:l10n_pe.1_chart4932
+#: model:account.account,name:l10n_pe.2_chart3732
+#: model:account.account,name:l10n_pe.2_chart4932
+#: model:account.account.template,name:l10n_pe.chart3732
+#: model:account.account.template,name:l10n_pe.chart4932
+msgid "Deferred interest - Unearned interest on discounted value measurement"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart495
+#: model:account.account,name:l10n_pe.2_chart495
+#: model:account.account.template,name:l10n_pe.chart495
+msgid "Deferred subsidies received"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart1641
+#: model:account.account,name:l10n_pe.1_chart1741
+#: model:account.account,name:l10n_pe.2_chart1641
+#: model:account.account,name:l10n_pe.2_chart1741
+#: model:account.account.template,name:l10n_pe.chart1641
+#: model:account.account.template,name:l10n_pe.chart1741
+msgid "Deposits granted in guarantee - Loans from financial institutions"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart1642
+#: model:account.account,name:l10n_pe.1_chart1742
+#: model:account.account,name:l10n_pe.2_chart1642
+#: model:account.account,name:l10n_pe.2_chart1742
+#: model:account.account.template,name:l10n_pe.chart1642
+#: model:account.account.template,name:l10n_pe.chart1742
+msgid "Deposits granted in guarantee - Loans from non-financial institutions"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart1649
+#: model:account.account,name:l10n_pe.1_chart1749
+#: model:account.account,name:l10n_pe.2_chart1649
+#: model:account.account,name:l10n_pe.2_chart1749
+#: model:account.account.template,name:l10n_pe.chart1649
+#: model:account.account.template,name:l10n_pe.chart1749
+msgid "Deposits granted in guarantee - Other security deposits"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart1643
+#: model:account.account,name:l10n_pe.1_chart1743
+#: model:account.account,name:l10n_pe.2_chart1643
+#: model:account.account,name:l10n_pe.2_chart1743
+#: model:account.account.template,name:l10n_pe.chart1643
+#: model:account.account.template,name:l10n_pe.chart1743
+msgid "Deposits granted in guarantee - Security deposits for rentals"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart1061
+#: model:account.account,name:l10n_pe.2_chart1061
+#: model:account.account.template,name:l10n_pe.chart1061
+msgid "Deposits in financial institutions - Savings deposits"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart1062
+#: model:account.account,name:l10n_pe.2_chart1062
+#: model:account.account.template,name:l10n_pe.chart1062
+msgid "Deposits in financial institutions - Time deposits"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart467
+#: model:account.account,name:l10n_pe.1_chart476
+#: model:account.account,name:l10n_pe.2_chart467
+#: model:account.account,name:l10n_pe.2_chart476
+#: model:account.account.template,name:l10n_pe.chart467
+#: model:account.account.template,name:l10n_pe.chart476
+msgid "Deposits received in guarantee"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart682111
+#: model:account.account,name:l10n_pe.2_chart682111
+#: model:account.account.template,name:l10n_pe.chart682111
+msgid ""
+"Depreciation of assets for right of use - Financial leasing - Investment "
+"property - Buildings - Costs"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart682113
+#: model:account.account,name:l10n_pe.2_chart682113
+#: model:account.account.template,name:l10n_pe.chart682113
+msgid ""
+"Depreciation of assets for right of use - Financial leasing - Investment "
+"property - Buildings - Financing costs"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart682112
+#: model:account.account,name:l10n_pe.2_chart682112
+#: model:account.account.template,name:l10n_pe.chart682112
+msgid ""
+"Depreciation of assets for right of use - Financial leasing - Investment "
+"property - Buildings - Revaluation"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart682211
+#: model:account.account,name:l10n_pe.2_chart682211
+#: model:account.account.template,name:l10n_pe.chart682211
+msgid ""
+"Depreciation of assets for right of use - Financial leasing - Property, "
+"plant and equipment - Buildings - Costs"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart682213
+#: model:account.account,name:l10n_pe.2_chart682213
+#: model:account.account.template,name:l10n_pe.chart682213
+msgid ""
+"Depreciation of assets for right of use - Financial leasing - Property, "
+"plant and equipment - Buildings - Financing costs"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart682212
+#: model:account.account,name:l10n_pe.2_chart682212
+#: model:account.account.template,name:l10n_pe.chart682212
+msgid ""
+"Depreciation of assets for right of use - Financial leasing - Property, "
+"plant and equipment - Buildings - Revaluation"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart682221
+#: model:account.account,name:l10n_pe.2_chart682221
+#: model:account.account.template,name:l10n_pe.chart682221
+msgid ""
+"Depreciation of assets for right of use - Financial leasing - Property, "
+"plant and equipment - Machinery and exploitation equipment - Costs"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart682223
+#: model:account.account,name:l10n_pe.2_chart682223
+#: model:account.account.template,name:l10n_pe.chart682223
+msgid ""
+"Depreciation of assets for right of use - Financial leasing - Property, "
+"plant and equipment - Machinery and exploitation equipment - Financing costs"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart682222
+#: model:account.account,name:l10n_pe.2_chart682222
+#: model:account.account.template,name:l10n_pe.chart682222
+msgid ""
+"Depreciation of assets for right of use - Financial leasing - Property, "
+"plant and equipment - Machinery and exploitation equipment - Revaluation"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart682251
+#: model:account.account,name:l10n_pe.2_chart682251
+#: model:account.account.template,name:l10n_pe.chart682251
+msgid ""
+"Depreciation of assets for right of use - Financial leasing - Property, "
+"plant and equipment - Miscellaneous equipment - Costs"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart682252
+#: model:account.account,name:l10n_pe.2_chart682252
+#: model:account.account.template,name:l10n_pe.chart682252
+msgid ""
+"Depreciation of assets for right of use - Financial leasing - Property, "
+"plant and equipment - Miscellaneous equipment - Revaluation"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart682231
+#: model:account.account,name:l10n_pe.2_chart682231
+#: model:account.account.template,name:l10n_pe.chart682231
+msgid ""
+"Depreciation of assets for right of use - Financial leasing - Property, "
+"plant and equipment - Transport units - Costs"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart682232
+#: model:account.account,name:l10n_pe.2_chart682232
+#: model:account.account.template,name:l10n_pe.chart682232
+msgid ""
+"Depreciation of assets for right of use - Financial leasing - Property, "
+"plant and equipment - Transport units - Revaluation"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart683111
+#: model:account.account,name:l10n_pe.2_chart683111
+#: model:account.account.template,name:l10n_pe.chart683111
+msgid ""
+"Depreciation of assets for right of use - Operating lease - Depreciation of "
+"assets for right of use - Operating lease - Buildings - Costs"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart683112
+#: model:account.account,name:l10n_pe.2_chart683112
+#: model:account.account.template,name:l10n_pe.chart683112
+msgid ""
+"Depreciation of assets for right of use - Operating lease - Depreciation of "
+"assets for right of use - Operating lease - Buildings - Revaluation"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart683121
+#: model:account.account,name:l10n_pe.2_chart683121
+#: model:account.account.template,name:l10n_pe.chart683121
+msgid ""
+"Depreciation of assets for right of use - Operating lease - Depreciation of "
+"assets for right of use - Operating lease - Machinery and exploitation "
+"equipment - Costs"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart683122
+#: model:account.account,name:l10n_pe.2_chart683122
+#: model:account.account.template,name:l10n_pe.chart683122
+msgid ""
+"Depreciation of assets for right of use - Operating lease - Depreciation of "
+"assets for right of use - Operating lease - Machinery and exploitation "
+"equipment - Revaluation"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart683152
+#: model:account.account,name:l10n_pe.2_chart683152
+#: model:account.account.template,name:l10n_pe.chart683152
+msgid ""
+"Depreciation of assets for right of use - Operating lease - Depreciation of "
+"assets for right of use - Operating lease - Miscellaneous equipment - "
+"Revaluation"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart683131
+#: model:account.account,name:l10n_pe.2_chart683131
+#: model:account.account.template,name:l10n_pe.chart683131
+msgid ""
+"Depreciation of assets for right of use - Operating lease - Depreciation of "
+"assets for right of use - Operating lease - Transport units - Costs"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart683132
+#: model:account.account,name:l10n_pe.2_chart683132
+#: model:account.account.template,name:l10n_pe.chart683132
+msgid ""
+"Depreciation of assets for right of use - Operating lease - Depreciation of "
+"assets for right of use - Operating lease - Transport units - Revaluation"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart68512
+#: model:account.account,name:l10n_pe.2_chart68512
+#: model:account.account.template,name:l10n_pe.chart68512
+msgid ""
+"Depreciation of biological assets in production - Depreciation of biological"
+" assets in production - Costs - Biological asset of vegetal origin"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart68511
+#: model:account.account,name:l10n_pe.2_chart68511
+#: model:account.account.template,name:l10n_pe.chart68511
+msgid ""
+"Depreciation of biological assets in production - Depreciation of biological"
+" assets in production - Costs - Biological assets of animal origin"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart68522
+#: model:account.account,name:l10n_pe.2_chart68522
+#: model:account.account.template,name:l10n_pe.chart68522
+msgid ""
+"Depreciation of biological assets in production - Depreciation of biological"
+" assets in production - Financing costs - Biological asset of vegetal origin"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart68521
+#: model:account.account,name:l10n_pe.2_chart68521
+#: model:account.account.template,name:l10n_pe.chart68521
+msgid ""
+"Depreciation of biological assets in production - Depreciation of biological"
+" assets in production - Financing costs - Biological assets of animal origin"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart68111
+#: model:account.account,name:l10n_pe.2_chart68111
+#: model:account.account.template,name:l10n_pe.chart68111
+msgid "Depreciation of investment properties - Buildings - Costs"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart68113
+#: model:account.account,name:l10n_pe.2_chart68113
+#: model:account.account.template,name:l10n_pe.chart68113
+msgid "Depreciation of investment properties - Buildings - Financing costs"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart68112
+#: model:account.account,name:l10n_pe.2_chart68112
+#: model:account.account.template,name:l10n_pe.chart68112
+msgid "Depreciation of investment properties - Buildings - Revaluation"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart68411
+#: model:account.account,name:l10n_pe.2_chart68411
+#: model:account.account.template,name:l10n_pe.chart68411
+msgid ""
+"Depreciation of property, plant and equipment - Depreciation of property, "
+"plant and equipment - Costs - Buildings"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart68414
+#: model:account.account,name:l10n_pe.2_chart68414
+#: model:account.account.template,name:l10n_pe.chart68414
+msgid ""
+"Depreciation of property, plant and equipment - Depreciation of property, "
+"plant and equipment - Costs - Furniture and fixtures"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart68412
+#: model:account.account,name:l10n_pe.2_chart68412
+#: model:account.account.template,name:l10n_pe.chart68412
+msgid ""
+"Depreciation of property, plant and equipment - Depreciation of property, "
+"plant and equipment - Costs - Machinery and exploitation equipment"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart68415
+#: model:account.account,name:l10n_pe.2_chart68415
+#: model:account.account.template,name:l10n_pe.chart68415
+msgid ""
+"Depreciation of property, plant and equipment - Depreciation of property, "
+"plant and equipment - Costs - Miscellaneous equipment"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart68410
+#: model:account.account,name:l10n_pe.2_chart68410
+#: model:account.account.template,name:l10n_pe.chart68410
+msgid ""
+"Depreciation of property, plant and equipment - Depreciation of property, "
+"plant and equipment - Costs - Production plants"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart68416
+#: model:account.account,name:l10n_pe.2_chart68416
+#: model:account.account.template,name:l10n_pe.chart68416
+msgid ""
+"Depreciation of property, plant and equipment - Depreciation of property, "
+"plant and equipment - Costs - Replacement tools and units"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart68413
+#: model:account.account,name:l10n_pe.2_chart68413
+#: model:account.account.template,name:l10n_pe.chart68413
+msgid ""
+"Depreciation of property, plant and equipment - Depreciation of property, "
+"plant and equipment - Costs - Transport units"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart68431
+#: model:account.account,name:l10n_pe.2_chart68431
+#: model:account.account.template,name:l10n_pe.chart68431
+msgid ""
+"Depreciation of property, plant and equipment - Depreciation of property, "
+"plant and equipment - Financing costs - Buildings"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart68432
+#: model:account.account,name:l10n_pe.2_chart68432
+#: model:account.account.template,name:l10n_pe.chart68432
+msgid ""
+"Depreciation of property, plant and equipment - Depreciation of property, "
+"plant and equipment - Financing costs - Machinery and exploitation equipment"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart68430
+#: model:account.account,name:l10n_pe.2_chart68430
+#: model:account.account.template,name:l10n_pe.chart68430
+msgid ""
+"Depreciation of property, plant and equipment - Depreciation of property, "
+"plant and equipment - Financing costs - Production plants"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart68421
+#: model:account.account,name:l10n_pe.2_chart68421
+#: model:account.account.template,name:l10n_pe.chart68421
+msgid ""
+"Depreciation of property, plant and equipment - Depreciation of property, "
+"plant and equipment - Revaluation - Buildings"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart68424
+#: model:account.account,name:l10n_pe.2_chart68424
+#: model:account.account.template,name:l10n_pe.chart68424
+msgid ""
+"Depreciation of property, plant and equipment - Depreciation of property, "
+"plant and equipment - Revaluation - Furniture and fixtures"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart68422
+#: model:account.account,name:l10n_pe.2_chart68422
+#: model:account.account.template,name:l10n_pe.chart68422
+msgid ""
+"Depreciation of property, plant and equipment - Depreciation of property, "
+"plant and equipment - Revaluation - Machinery and exploitation equipment"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart68425
+#: model:account.account,name:l10n_pe.2_chart68425
+#: model:account.account.template,name:l10n_pe.chart68425
+msgid ""
+"Depreciation of property, plant and equipment - Depreciation of property, "
+"plant and equipment - Revaluation - Miscellaneous equipment"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart68420
+#: model:account.account,name:l10n_pe.2_chart68420
+#: model:account.account.template,name:l10n_pe.chart68420
+msgid ""
+"Depreciation of property, plant and equipment - Depreciation of property, "
+"plant and equipment - Revaluation - Production plants"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart68426
+#: model:account.account,name:l10n_pe.2_chart68426
+#: model:account.account.template,name:l10n_pe.chart68426
+msgid ""
+"Depreciation of property, plant and equipment - Depreciation of property, "
+"plant and equipment - Revaluation - Replacement tools and units"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart68423
+#: model:account.account,name:l10n_pe.2_chart68423
+#: model:account.account.template,name:l10n_pe.chart68423
+msgid ""
+"Depreciation of property, plant and equipment - Depreciation of property, "
+"plant and equipment - Revaluation - Transport units"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_210402
+msgid "Desaguadero"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart776
+#: model:account.account,name:l10n_pe.2_chart776
+#: model:account.account.template,name:l10n_pe.chart776
+msgid "Difference in change"
+msgstr ""
+
+#. module: l10n_pe
 #: model:l10n_latam.identification.type,name:l10n_pe.it_DIC
 msgid "Diplomatic Identity Card"
 msgstr ""
 
 #. module: l10n_pe
-#: model:ir.model.fields,field_description:l10n_pe.field_account_move_line__display_name
-#: model:ir.model.fields,field_description:l10n_pe.field_account_tax__display_name
-#: model:ir.model.fields,field_description:l10n_pe.field_account_tax_template__display_name
-#: model:ir.model.fields,field_description:l10n_pe.field_l10n_latam_identification_type__display_name
+#: model:account.account,name:l10n_pe.1_chart1432
+#: model:account.account,name:l10n_pe.2_chart1432
+#: model:account.account.template,name:l10n_pe.chart1432
+msgid "Directors - Advance of daily subsistence allowance"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart1433
+#: model:account.account,name:l10n_pe.2_chart1433
+#: model:account.account.template,name:l10n_pe.chart1433
+msgid "Directors - Deliveries to account"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart1431
+#: model:account.account,name:l10n_pe.2_chart1431
+#: model:account.account.template,name:l10n_pe.chart1431
+msgid "Directors - Loans"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart4429
+#: model:account.account,name:l10n_pe.2_chart4429
+#: model:account.account.template,name:l10n_pe.chart4429
+msgid "Directors - Other accounts payable"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart4421
+#: model:account.account,name:l10n_pe.2_chart4421
+#: model:account.account.template,name:l10n_pe.chart4421
+msgid "Directors - Subsistence allowance"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart675
+#: model:account.account,name:l10n_pe.2_chart675
+#: model:account.account.template,name:l10n_pe.chart675
+msgid "Discounts granted for early payment"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart775
+#: model:account.account,name:l10n_pe.2_chart775
+#: model:account.account.template,name:l10n_pe.chart775
+msgid "Discounts obtained for prompt payment"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart7412
+#: model:account.account,name:l10n_pe.2_chart7412
+#: model:account.account.template,name:l10n_pe.chart7412
+msgid "Discounts, rebates and bonuses granted - Associated"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart7411
+#: model:account.account,name:l10n_pe.2_chart7411
+#: model:account.account.template,name:l10n_pe.chart7411
+msgid "Discounts, rebates and bonuses granted - Third parties"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart7312
+#: model:account.account,name:l10n_pe.2_chart7312
+#: model:account.account.template,name:l10n_pe.chart7312
+msgid "Discounts, rebates and bonuses obtained - Associated"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart7311
+#: model:account.account,name:l10n_pe.2_chart7311
+#: model:account.account.template,name:l10n_pe.chart7311
+msgid "Discounts, rebates and bonuses obtained - Third parties"
+msgstr ""
+
+#. module: l10n_pe
 #: model:ir.model.fields,field_description:l10n_pe.field_l10n_pe_res_city_district__display_name
-#: model:ir.model.fields,field_description:l10n_pe.field_res_city__display_name
-#: model:ir.model.fields,field_description:l10n_pe.field_res_partner__display_name
 msgid "Display Name"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart7563
+#: model:account.account,name:l10n_pe.2_chart7563
+#: model:account.account.template,name:l10n_pe.chart7563
+msgid "Disposal of fixed assets - Assets acquired under finance lease"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart7566
+#: model:account.account,name:l10n_pe.2_chart7566
+#: model:account.account.template,name:l10n_pe.chart7566
+msgid "Disposal of fixed assets - Biological assets"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart7565
+#: model:account.account,name:l10n_pe.2_chart7565
+#: model:account.account.template,name:l10n_pe.chart7565
+msgid "Disposal of fixed assets - Intangibles"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart7562
+#: model:account.account,name:l10n_pe.2_chart7562
+#: model:account.account.template,name:l10n_pe.chart7562
+msgid "Disposal of fixed assets - Investment property"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart7564
+#: model:account.account,name:l10n_pe.2_chart7564
+#: model:account.account.template,name:l10n_pe.chart7564
+msgid "Disposal of fixed assets - Property, plant and equipment"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart7561
+#: model:account.account,name:l10n_pe.2_chart7561
+#: model:account.account.template,name:l10n_pe.chart7561
+msgid "Disposal of fixed assets - Securities investments"
 msgstr ""
 
 #. module: l10n_pe
@@ -62,6 +6154,21 @@ msgid "Districts are part of a province or city."
 msgstr ""
 
 #. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart475
+#: model:account.account,name:l10n_pe.1_chart773
+#: model:account.account,name:l10n_pe.2_chart475
+#: model:account.account,name:l10n_pe.2_chart773
+#: model:account.account.template,name:l10n_pe.chart475
+#: model:account.account.template,name:l10n_pe.chart773
+msgid "Dividends"
+msgstr ""
+
+#. module: l10n_pe
+#: model:res.city,name:l10n_pe.city_pe_1003
+msgid "Dos de mayo"
+msgstr ""
+
+#. module: l10n_pe
 #: model:ir.model.fields,field_description:l10n_pe.field_account_tax__l10n_pe_edi_unece_category
 #: model:ir.model.fields,field_description:l10n_pe.field_account_tax_template__l10n_pe_edi_unece_category
 msgid "EDI UNECE code"
@@ -74,9 +6181,35 @@ msgid "EDI peruvian code"
 msgstr ""
 
 #. module: l10n_pe
+#: model:account.group,name:l10n_pe.1_group19
+#: model:account.group,name:l10n_pe.2_group19
+#: model:account.group.template,name:l10n_pe.group19
+msgid "ESTIMATION OF DOUBTFUL ACCOUNTS"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.tax,description:l10n_pe.1_purchase_tax_exo
+#: model:account.tax,description:l10n_pe.1_sale_tax_exo
+#: model:account.tax,description:l10n_pe.2_purchase_tax_exo
+#: model:account.tax,description:l10n_pe.2_sale_tax_exo
+#: model:account.tax.group,name:l10n_pe.tax_group_exo
+#: model:account.tax.template,description:l10n_pe.purchase_tax_exo
+#: model:account.tax.template,description:l10n_pe.sale_tax_exo
+msgid "EXO"
+msgstr ""
+
+#. module: l10n_pe
 #: model:ir.model.fields.selection,name:l10n_pe.selection__account_tax__l10n_pe_edi_tax_code__9997
 #: model:ir.model.fields.selection,name:l10n_pe.selection__account_tax_template__l10n_pe_edi_tax_code__9997
 msgid "EXO - Exonerated"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.tax,description:l10n_pe.1_sale_tax_exp
+#: model:account.tax,description:l10n_pe.2_sale_tax_exp
+#: model:account.tax.group,name:l10n_pe.tax_group_exp
+#: model:account.tax.template,description:l10n_pe.sale_tax_exp
+msgid "EXP"
 msgstr ""
 
 #. module: l10n_pe
@@ -86,9 +6219,1143 @@ msgid "EXP - Exportation"
 msgstr ""
 
 #. module: l10n_pe
+#: model:account.group,name:l10n_pe.1_group63
+#: model:account.group,name:l10n_pe.2_group63
+#: model:account.group.template,name:l10n_pe.group63
+msgid "EXPENSES FOR SERVICES RENDERED BY THIRD PARTIES"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart7721
+#: model:account.account,name:l10n_pe.2_chart7721
+#: model:account.account.template,name:l10n_pe.chart7721
+msgid "Earned returns - Deposits in financial institutions"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart7725
+#: model:account.account,name:l10n_pe.2_chart7725
+#: model:account.account.template,name:l10n_pe.chart7725
+msgid ""
+"Earned returns - Financial instruments representative of economic rights"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart7724
+#: model:account.account,name:l10n_pe.2_chart7724
+#: model:account.account.template,name:l10n_pe.chart7724
+msgid "Earned returns - Investments to be held until maturity"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart7723
+#: model:account.account,name:l10n_pe.2_chart7723
+#: model:account.account.template,name:l10n_pe.chart7723
+msgid "Earned returns - Loans granted"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart7722
+#: model:account.account,name:l10n_pe.2_chart7722
+#: model:account.account.template,name:l10n_pe.chart7722
+msgid "Earned returns - Trade accounts receivable"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_080902
+msgid "Echarate"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_061003
+msgid "Eduardo Villanueva"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_150111
+msgid "El Agustíno"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_180302
+msgid "El Algarrobal"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_200702
+msgid "El Alto"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_090504
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_110205
+msgid "El Carmen"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_200303
+msgid "El Carmen de la Frontera"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_010402
+msgid "El Cenepa"
+msgstr ""
+
+#. module: l10n_pe
+#: model:res.city,name:l10n_pe.city_pe_2105
+msgid "El Collao"
+msgstr ""
+
+#. module: l10n_pe
+#: model:res.city,name:l10n_pe.city_pe_2203
+msgid "El Dorado"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_220403
+msgid "El Eslabón"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_110303
+msgid "El Ingenio"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_120407
+msgid "El Mantaro"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_010704
+msgid "El Milagro"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_030302
+msgid "El Oro"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_010204
+msgid "El Parco"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_030610
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_130102
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_220906
+msgid "El Porvenir"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_061105
+msgid "El Prado"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_200108
+msgid "El Tallan"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_120114
+msgid "El Tambo"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_021303
+msgid "Eleazar Guzmán Barron"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_220803
+msgid "Elias Soplin Vargas"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_160504
+msgid "Emilio San Martín"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart413
+#: model:account.account,name:l10n_pe.2_chart413
+#: model:account.account.template,name:l10n_pe.chart413
+msgid "Employee participations payable"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart6291
+#: model:account.account,name:l10n_pe.2_chart6291
+#: model:account.account.template,name:l10n_pe.chart6291
+msgid "Employee social benefits - Compensation for time of service"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart6293
+#: model:account.account,name:l10n_pe.2_chart6293
+#: model:account.account.template,name:l10n_pe.chart6293
+msgid "Employee social benefits - Other post-employment benefits"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart6292
+#: model:account.account,name:l10n_pe.2_chart6292
+#: model:account.account.template,name:l10n_pe.chart6292
+msgid "Employee social benefits - Pensions and retirement"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart62941
+#: model:account.account,name:l10n_pe.2_chart62941
+#: model:account.account.template,name:l10n_pe.chart62941
+msgid "Employee social benefits - Profit sharing - Current share"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart62942
+#: model:account.account,name:l10n_pe.2_chart62942
+#: model:account.account.template,name:l10n_pe.chart62942
+msgid "Employee social benefits - Profit sharing - Deferred share"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart4152
+#: model:account.account,name:l10n_pe.2_chart4152
+#: model:account.account.template,name:l10n_pe.chart4152
+msgid ""
+"Employee social benefits payable - Advance compensation for length of "
+"service"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart4151
+#: model:account.account,name:l10n_pe.2_chart4151
+#: model:account.account.template,name:l10n_pe.chart4151
+msgid "Employee social benefits payable - Compensation for time of services"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart4153
+#: model:account.account,name:l10n_pe.2_chart4153
+#: model:account.account.template,name:l10n_pe.chart4153
+msgid "Employee social benefits payable - Pensions and retirement"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_060105
+msgid "Encañada"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart658
+#: model:account.account,name:l10n_pe.2_chart658
+#: model:account.account.template,name:l10n_pe.chart658
+msgid "Environmental management"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_080801
+#: model:res.city,name:l10n_pe.city_pe_0808
+msgid "Espinar"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_230403
+msgid "Estique"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_230404
+msgid "Estique-Pampa"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_140103
+msgid "Eten"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_140104
+msgid "Eten Puerto"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart561
+#: model:account.account,name:l10n_pe.2_chart561
+#: model:account.account.template,name:l10n_pe.chart561
+msgid "Exchange difference on permanent investments in foreign entities"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart676
+#: model:account.account,name:l10n_pe.2_chart676
+#: model:account.account.template,name:l10n_pe.chart676
+msgid "Exchange rate"
+msgstr ""
+
+#. module: l10n_pe
 #: model:ir.model.fields.selection,name:l10n_pe.selection__account_tax__l10n_pe_edi_unece_category__e
 #: model:ir.model.fields.selection,name:l10n_pe.selection__account_tax_template__l10n_pe_edi_unece_category__e
 msgid "Exempt from tax"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.group,name:l10n_pe.1_group6
+#: model:account.group,name:l10n_pe.2_group6
+#: model:account.group.template,name:l10n_pe.group6
+msgid "Expenses by nature"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart6956
+#: model:account.account,name:l10n_pe.2_chart6956
+#: model:account.account.template,name:l10n_pe.chart6956
+msgid ""
+"Expenses for impairment of inventories at cost - Auxiliary materials, "
+"supplies and spare parts"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart6953
+#: model:account.account,name:l10n_pe.2_chart6953
+#: model:account.account.template,name:l10n_pe.chart6953
+msgid ""
+"Expenses for impairment of inventories at cost - By-products, waste and "
+"scrap"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart6957
+#: model:account.account,name:l10n_pe.2_chart6957
+#: model:account.account.template,name:l10n_pe.chart6957
+msgid ""
+"Expenses for impairment of inventories at cost - Containers and packaging"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart6952
+#: model:account.account,name:l10n_pe.2_chart6952
+#: model:account.account.template,name:l10n_pe.chart6952
+msgid "Expenses for impairment of inventories at cost - Finished products"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart6958
+#: model:account.account,name:l10n_pe.2_chart6958
+#: model:account.account.template,name:l10n_pe.chart6958
+msgid ""
+"Expenses for impairment of inventories at cost - Inventories to be received"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart6951
+#: model:account.account,name:l10n_pe.2_chart6951
+#: model:account.account.template,name:l10n_pe.chart6951
+msgid "Expenses for impairment of inventories at cost - Merchandise"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart6954
+#: model:account.account,name:l10n_pe.2_chart6954
+#: model:account.account.template,name:l10n_pe.chart6954
+msgid "Expenses for impairment of inventories at cost - Products in process"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart6955
+#: model:account.account,name:l10n_pe.2_chart6955
+#: model:account.account.template,name:l10n_pe.chart6955
+msgid "Expenses for impairment of inventories at cost - Raw Materials"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart6714
+#: model:account.account,name:l10n_pe.2_chart6714
+#: model:account.account.template,name:l10n_pe.chart6714
+msgid "Expenses in debt operations and others - Documents sold or discounted"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart6712
+#: model:account.account,name:l10n_pe.2_chart6712
+#: model:account.account.template,name:l10n_pe.chart6712
+msgid "Expenses in debt operations and others - Financial lease contracts"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart6713
+#: model:account.account,name:l10n_pe.2_chart6713
+#: model:account.account.template,name:l10n_pe.chart6713
+msgid ""
+"Expenses in debt operations and others - Issuance and placement of "
+"instruments representing debt and equity"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart6711
+#: model:account.account,name:l10n_pe.2_chart6711
+#: model:account.account.template,name:l10n_pe.chart6711
+msgid ""
+"Expenses in debt operations and others - Loans from financial institutions "
+"and other entities"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart6741
+#: model:account.account,name:l10n_pe.2_chart6741
+#: model:account.account.template,name:l10n_pe.chart6741
+msgid "Expenses in factoring operations - Loss on instruments sold"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart36541
+#: model:account.account,name:l10n_pe.2_chart36541
+#: model:account.account.template,name:l10n_pe.chart36541
+msgid "Exploration and development costs - Costs"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart34421
+#: model:account.account,name:l10n_pe.2_chart34421
+#: model:account.account.template,name:l10n_pe.chart34421
+msgid "Exploration and development costs - Development costs - Costs"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart34423
+#: model:account.account,name:l10n_pe.2_chart34423
+#: model:account.account.template,name:l10n_pe.chart34423
+msgid ""
+"Exploration and development costs - Development costs - Financing costs"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart34422
+#: model:account.account,name:l10n_pe.2_chart34422
+#: model:account.account.template,name:l10n_pe.chart34422
+msgid "Exploration and development costs - Development costs - Revaluation"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart34411
+#: model:account.account,name:l10n_pe.2_chart34411
+#: model:account.account.template,name:l10n_pe.chart34411
+msgid "Exploration and development costs - Exploration costs - Costs"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart34413
+#: model:account.account,name:l10n_pe.2_chart34413
+#: model:account.account.template,name:l10n_pe.chart34413
+msgid ""
+"Exploration and development costs - Exploration costs - Financing costs"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart34412
+#: model:account.account,name:l10n_pe.2_chart34412
+#: model:account.account.template,name:l10n_pe.chart34412
+msgid "Exploration and development costs - Exploration costs - Revaluation"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart36543
+#: model:account.account,name:l10n_pe.2_chart36543
+#: model:account.account.template,name:l10n_pe.chart36543
+msgid "Exploration and development costs - Financing costs"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart36542
+#: model:account.account,name:l10n_pe.2_chart36542
+#: model:account.account.template,name:l10n_pe.chart36542
+msgid "Exploration and development costs - Revaluation"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.group,name:l10n_pe.1_group67
+#: model:account.group,name:l10n_pe.2_group67
+#: model:account.group.template,name:l10n_pe.group67
+msgid "FINANCIAL EXPENSES"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.group,name:l10n_pe.1_group77
+#: model:account.group,name:l10n_pe.2_group77
+#: model:account.group.template,name:l10n_pe.group77
+msgid "FINANCIAL INCOME"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.group,name:l10n_pe.1_group11
+#: model:account.group,name:l10n_pe.2_group11
+#: model:account.group.template,name:l10n_pe.group11
+msgid "FINANCIAL INVESTMENTS"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.group,name:l10n_pe.1_group45
+#: model:account.group,name:l10n_pe.2_group45
+#: model:account.group.template,name:l10n_pe.group45
+msgid "FINANCIAL OBLIGATIONS"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.group,name:l10n_pe.1_group21
+#: model:account.group,name:l10n_pe.2_group21
+#: model:account.group.template,name:l10n_pe.group21
+msgid "FINISHED PRODUCTS"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.fiscal.position,name:l10n_pe.1_exportation
+#: model:account.fiscal.position,name:l10n_pe.2_exportation
+#: model:account.fiscal.position.template,name:l10n_pe.exportation
+msgid "FOREIGN - EXPORT"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart585
+#: model:account.account,name:l10n_pe.2_chart585
+#: model:account.account.template,name:l10n_pe.chart585
+msgid "Facultative"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_160103
+msgid "Fernando Lores"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_140201
+#: model:res.city,name:l10n_pe.city_pe_1402
+msgid "Ferreñafe"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_021304
+msgid "Fidel Olivas Escudero"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart11311
+#: model:account.account,name:l10n_pe.2_chart11311
+#: model:account.account.template,name:l10n_pe.chart11311
+msgid ""
+"Financial assets – Purchase agreements - Investments held for trading – "
+"Purchase agreements - Costs"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart11312
+#: model:account.account,name:l10n_pe.2_chart11312
+#: model:account.account.template,name:l10n_pe.chart11312
+msgid ""
+"Financial assets – Purchase agreements - Investments held for trading – "
+"Purchase agreements - Fair value"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart11321
+#: model:account.account,name:l10n_pe.2_chart11321
+#: model:account.account.template,name:l10n_pe.chart11321
+msgid ""
+"Financial assets – Purchase agreements - Other financial investments - Costs"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart11322
+#: model:account.account,name:l10n_pe.2_chart11322
+#: model:account.account.template,name:l10n_pe.chart11322
+msgid ""
+"Financial assets – Purchase agreements - Other financial investments - Fair "
+"value"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart181
+#: model:account.account,name:l10n_pe.2_chart181
+#: model:account.account.template,name:l10n_pe.chart181
+msgid "Financial costs"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart792
+#: model:account.account,name:l10n_pe.2_chart792
+#: model:account.account.template,name:l10n_pe.chart792
+msgid "Financial expenses attributable to inventory accounts"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart30241
+#: model:account.account,name:l10n_pe.2_chart30241
+#: model:account.account.template,name:l10n_pe.chart30241
+msgid ""
+"Financial instruments representative of economic rights - Investment shares "
+"- Costs"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart30245
+#: model:account.account,name:l10n_pe.2_chart30245
+#: model:account.account.template,name:l10n_pe.chart30245
+msgid ""
+"Financial instruments representative of economic rights - Investment shares "
+"- Equity participation"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart30244
+#: model:account.account,name:l10n_pe.2_chart30244
+#: model:account.account.template,name:l10n_pe.chart30244
+msgid ""
+"Financial instruments representative of economic rights - Investment shares "
+"- Fair value"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart30281
+#: model:account.account,name:l10n_pe.2_chart30281
+#: model:account.account.template,name:l10n_pe.chart30281
+msgid ""
+"Financial instruments representative of economic rights - Other titles "
+"representing equity - Costs"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart30285
+#: model:account.account,name:l10n_pe.2_chart30285
+#: model:account.account.template,name:l10n_pe.chart30285
+msgid ""
+"Financial instruments representative of economic rights - Other titles "
+"representing equity - Equity participation"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart30284
+#: model:account.account,name:l10n_pe.2_chart30284
+#: model:account.account.template,name:l10n_pe.chart30284
+msgid ""
+"Financial instruments representative of economic rights - Other titles "
+"representing equity - Fair value"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart3021
+#: model:account.account,name:l10n_pe.2_chart3021
+#: model:account.account.template,name:l10n_pe.chart3021
+msgid ""
+"Financial instruments representative of economic rights - Preferred "
+"Subscription Certificates"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart30221
+#: model:account.account,name:l10n_pe.2_chart30221
+#: model:account.account.template,name:l10n_pe.chart30221
+msgid ""
+"Financial instruments representative of economic rights - Shares "
+"representing capital stock – Common - Costs"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart30225
+#: model:account.account,name:l10n_pe.2_chart30225
+#: model:account.account.template,name:l10n_pe.chart30225
+msgid ""
+"Financial instruments representative of economic rights - Shares "
+"representing capital stock – Common - Equity participation"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart30224
+#: model:account.account,name:l10n_pe.2_chart30224
+#: model:account.account.template,name:l10n_pe.chart30224
+msgid ""
+"Financial instruments representative of economic rights - Shares "
+"representing capital stock – Common - Fair value"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart30231
+#: model:account.account,name:l10n_pe.2_chart30231
+#: model:account.account.template,name:l10n_pe.chart30231
+msgid ""
+"Financial instruments representative of economic rights - Shares "
+"representing capital stock – Preferences - Costs"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart30235
+#: model:account.account,name:l10n_pe.2_chart30235
+#: model:account.account.template,name:l10n_pe.chart30235
+msgid ""
+"Financial instruments representative of economic rights - Shares "
+"representing capital stock – Preferences - Equity participation"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart30234
+#: model:account.account,name:l10n_pe.2_chart30234
+#: model:account.account.template,name:l10n_pe.chart30234
+msgid ""
+"Financial instruments representative of economic rights - Shares "
+"representing capital stock – Preferences - Fair value"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart562
+#: model:account.account,name:l10n_pe.2_chart562
+#: model:account.account.template,name:l10n_pe.chart562
+msgid "Financial instruments – Hedges"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart36721
+#: model:account.account,name:l10n_pe.2_chart36721
+#: model:account.account.template,name:l10n_pe.chart36721
+msgid "Financial investments representative of patrimonial right - Costs"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart452
+#: model:account.account,name:l10n_pe.2_chart452
+#: model:account.account.template,name:l10n_pe.chart452
+msgid "Financial lease contracts"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart36221
+#: model:account.account,name:l10n_pe.1_chart36321
+#: model:account.account,name:l10n_pe.2_chart36221
+#: model:account.account,name:l10n_pe.2_chart36321
+#: model:account.account.template,name:l10n_pe.chart36221
+#: model:account.account.template,name:l10n_pe.chart36321
+msgid "Financial leasing - Buildings - Costs"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart36223
+#: model:account.account,name:l10n_pe.1_chart36323
+#: model:account.account,name:l10n_pe.2_chart36223
+#: model:account.account,name:l10n_pe.2_chart36323
+#: model:account.account.template,name:l10n_pe.chart36223
+#: model:account.account.template,name:l10n_pe.chart36323
+msgid "Financial leasing - Buildings - Financing costs"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart36222
+#: model:account.account,name:l10n_pe.1_chart36322
+#: model:account.account,name:l10n_pe.2_chart36222
+#: model:account.account,name:l10n_pe.2_chart36322
+#: model:account.account.template,name:l10n_pe.chart36222
+#: model:account.account.template,name:l10n_pe.chart36322
+msgid "Financial leasing - Buildings - Revaluation"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart36351
+#: model:account.account,name:l10n_pe.2_chart36351
+#: model:account.account.template,name:l10n_pe.chart36351
+msgid "Financial leasing - Furniture and fixtures - Costs"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart36352
+#: model:account.account,name:l10n_pe.2_chart36352
+#: model:account.account.template,name:l10n_pe.chart36352
+msgid "Financial leasing - Furniture and fixtures - Revaluation"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart36211
+#: model:account.account,name:l10n_pe.1_chart36311
+#: model:account.account,name:l10n_pe.2_chart36211
+#: model:account.account,name:l10n_pe.2_chart36311
+#: model:account.account.template,name:l10n_pe.chart36211
+#: model:account.account.template,name:l10n_pe.chart36311
+msgid "Financial leasing - Land - Costs"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart36212
+#: model:account.account,name:l10n_pe.1_chart36312
+#: model:account.account,name:l10n_pe.2_chart36212
+#: model:account.account,name:l10n_pe.2_chart36312
+#: model:account.account.template,name:l10n_pe.chart36212
+#: model:account.account.template,name:l10n_pe.chart36312
+msgid "Financial leasing - Land - Revaluation"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart36331
+#: model:account.account,name:l10n_pe.2_chart36331
+#: model:account.account.template,name:l10n_pe.chart36331
+msgid "Financial leasing - Machinery and exploitation equipment - Costs"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart36333
+#: model:account.account,name:l10n_pe.2_chart36333
+#: model:account.account.template,name:l10n_pe.chart36333
+msgid ""
+"Financial leasing - Machinery and exploitation equipment - Financing costs"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart36332
+#: model:account.account,name:l10n_pe.2_chart36332
+#: model:account.account.template,name:l10n_pe.chart36332
+msgid "Financial leasing - Machinery and exploitation equipment - Revaluation"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart36361
+#: model:account.account,name:l10n_pe.2_chart36361
+#: model:account.account.template,name:l10n_pe.chart36361
+msgid "Financial leasing - Miscellaneous equipment - Costs"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart36362
+#: model:account.account,name:l10n_pe.2_chart36362
+#: model:account.account.template,name:l10n_pe.chart36362
+msgid "Financial leasing - Miscellaneous equipment - Revaluation"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart36341
+#: model:account.account,name:l10n_pe.2_chart36341
+#: model:account.account.template,name:l10n_pe.chart36341
+msgid "Financial leasing - Transport units - Costs"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart36342
+#: model:account.account,name:l10n_pe.2_chart36342
+#: model:account.account.template,name:l10n_pe.chart36342
+msgid "Financial leasing - Transport units - Revaluation"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart472
+#: model:account.account,name:l10n_pe.2_chart472
+#: model:account.account.template,name:l10n_pe.chart472
+msgid "Financing costs"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart45532
+#: model:account.account,name:l10n_pe.2_chart45532
+#: model:account.account.template,name:l10n_pe.chart45532
+msgid "Financing costs payable - Bonds issued - Bonds securitized"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart45533
+#: model:account.account,name:l10n_pe.2_chart45533
+#: model:account.account.template,name:l10n_pe.chart45533
+msgid "Financing costs payable - Bonds issued - Commercial papers"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart45531
+#: model:account.account,name:l10n_pe.2_chart45531
+#: model:account.account.template,name:l10n_pe.chart45531
+msgid "Financing costs payable - Bonds issued - Issued bonds"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart45539
+#: model:account.account,name:l10n_pe.2_chart45539
+#: model:account.account.template,name:l10n_pe.chart45539
+msgid "Financing costs payable - Bonds issued - Other obligations"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart4552
+#: model:account.account,name:l10n_pe.2_chart4552
+#: model:account.account.template,name:l10n_pe.chart4552
+msgid "Financing costs payable - Financial lease contracts"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart45511
+#: model:account.account,name:l10n_pe.2_chart45511
+#: model:account.account.template,name:l10n_pe.chart45511
+msgid ""
+"Financing costs payable - Loans from financial institutions and other "
+"entities - Financial institutions"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart45512
+#: model:account.account,name:l10n_pe.2_chart45512
+#: model:account.account.template,name:l10n_pe.chart45512
+msgid ""
+"Financing costs payable - Loans from financial institutions and other "
+"entities - Other entities"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart45541
+#: model:account.account,name:l10n_pe.2_chart45541
+#: model:account.account.template,name:l10n_pe.chart45541
+msgid "Financing costs payable - Other financial instruments payable - Bills"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart45543
+#: model:account.account,name:l10n_pe.2_chart45543
+#: model:account.account.template,name:l10n_pe.chart45543
+msgid "Financing costs payable - Other financial instruments payable - Bonds"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart45542
+#: model:account.account,name:l10n_pe.2_chart45542
+#: model:account.account.template,name:l10n_pe.chart45542
+msgid ""
+"Financing costs payable - Other financial instruments payable - Commercial "
+"papers"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart45545
+#: model:account.account,name:l10n_pe.2_chart45545
+#: model:account.account.template,name:l10n_pe.chart45545
+msgid ""
+"Financing costs payable - Other financial instruments payable - Conformed "
+"invoices"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart45549
+#: model:account.account,name:l10n_pe.2_chart45549
+#: model:account.account.template,name:l10n_pe.chart45549
+msgid ""
+"Financing costs payable - Other financial instruments payable - Other "
+"financial obligations"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart45544
+#: model:account.account,name:l10n_pe.2_chart45544
+#: model:account.account.template,name:l10n_pe.chart45544
+msgid ""
+"Financing costs payable - Other financial instruments payable - Promissory "
+"notes"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart6925
+#: model:account.account,name:l10n_pe.2_chart6925
+#: model:account.account.template,name:l10n_pe.chart6925
+msgid "Finished products - Cost of inefficiency – Finished products"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart69232
+#: model:account.account,name:l10n_pe.2_chart69232
+#: model:account.account.template,name:l10n_pe.chart69232
+msgid "Finished products - Financing costs – Finished products - Associated"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart69231
+#: model:account.account,name:l10n_pe.2_chart69231
+#: model:account.account.template,name:l10n_pe.chart69231
+msgid ""
+"Finished products - Financing costs – Finished products - Third parties"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart21111
+#: model:account.account,name:l10n_pe.1_chart29211
+#: model:account.account,name:l10n_pe.2_chart21111
+#: model:account.account,name:l10n_pe.2_chart29211
+#: model:account.account.template,name:l10n_pe.chart21111
+#: model:account.account.template,name:l10n_pe.chart29211
+msgid "Finished products - Finished products - Costs"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart70212
+#: model:account.account,name:l10n_pe.2_chart70212
+#: model:account.account.template,name:l10n_pe.chart70212
+msgid "Finished products - Finished products - Export sale - Associated"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart70211
+#: model:account.account,name:l10n_pe.2_chart70211
+#: model:account.account.template,name:l10n_pe.chart70211
+msgid "Finished products - Finished products - Export sale - Third parties"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart69212
+#: model:account.account,name:l10n_pe.2_chart69212
+#: model:account.account.template,name:l10n_pe.chart69212
+msgid "Finished products - Finished products - Exportation - Associated"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart69211
+#: model:account.account,name:l10n_pe.2_chart69211
+#: model:account.account.template,name:l10n_pe.chart69211
+msgid "Finished products - Finished products - Exportation - Third parties"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart21114
+#: model:account.account,name:l10n_pe.2_chart21114
+#: model:account.account.template,name:l10n_pe.chart21114
+msgid "Finished products - Finished products - Fair value"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart21113
+#: model:account.account,name:l10n_pe.1_chart29213
+#: model:account.account,name:l10n_pe.2_chart21113
+#: model:account.account,name:l10n_pe.2_chart29213
+#: model:account.account.template,name:l10n_pe.chart21113
+#: model:account.account.template,name:l10n_pe.chart29213
+msgid "Finished products - Finished products - Financing costs"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart69222
+#: model:account.account,name:l10n_pe.1_chart70222
+#: model:account.account,name:l10n_pe.2_chart69222
+#: model:account.account,name:l10n_pe.2_chart70222
+#: model:account.account.template,name:l10n_pe.chart69222
+#: model:account.account.template,name:l10n_pe.chart70222
+msgid "Finished products - Finished products - Local sale - Associated"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart69221
+#: model:account.account,name:l10n_pe.1_chart70221
+#: model:account.account,name:l10n_pe.2_chart69221
+#: model:account.account,name:l10n_pe.2_chart70221
+#: model:account.account.template,name:l10n_pe.chart69221
+#: model:account.account.template,name:l10n_pe.chart70221
+msgid "Finished products - Finished products - Local sale - Third parties"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart29251
+#: model:account.account,name:l10n_pe.2_chart29251
+#: model:account.account.template,name:l10n_pe.chart29251
+msgid "Finished products - Inventory of finished services - Costs"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart6924
+#: model:account.account,name:l10n_pe.2_chart6924
+#: model:account.account.template,name:l10n_pe.chart6924
+msgid "Finished products - Unabsorbed production costs – Finished products"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart69312
+#: model:account.account,name:l10n_pe.1_chart70312
+#: model:account.account,name:l10n_pe.2_chart69312
+#: model:account.account,name:l10n_pe.2_chart70312
+#: model:account.account.template,name:l10n_pe.chart69312
+#: model:account.account.template,name:l10n_pe.chart70312
+msgid "Finished services - Services – Exportation - Associated"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart69311
+#: model:account.account,name:l10n_pe.1_chart70311
+#: model:account.account,name:l10n_pe.2_chart69311
+#: model:account.account,name:l10n_pe.2_chart70311
+#: model:account.account.template,name:l10n_pe.chart69311
+#: model:account.account.template,name:l10n_pe.chart70311
+msgid "Finished services - Services – Exportation - Third parties"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart69322
+#: model:account.account,name:l10n_pe.1_chart70322
+#: model:account.account,name:l10n_pe.2_chart69322
+#: model:account.account,name:l10n_pe.2_chart70322
+#: model:account.account.template,name:l10n_pe.chart69322
+#: model:account.account.template,name:l10n_pe.chart70322
+msgid "Finished services - Services – Local - Associated"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart69321
+#: model:account.account,name:l10n_pe.1_chart70321
+#: model:account.account,name:l10n_pe.2_chart69321
+#: model:account.account,name:l10n_pe.2_chart70321
+#: model:account.account.template,name:l10n_pe.chart69321
+#: model:account.account.template,name:l10n_pe.chart70321
+msgid "Finished services - Services – Local - Third parties"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_170202
+msgid "Fitzcarrald"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart6622
+#: model:account.account,name:l10n_pe.1_chart7622
+#: model:account.account,name:l10n_pe.2_chart6622
+#: model:account.account,name:l10n_pe.2_chart7622
+#: model:account.account.template,name:l10n_pe.chart6622
+#: model:account.account.template,name:l10n_pe.chart7622
+msgid "Fixed asset - Biological assets"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart6621
+#: model:account.account,name:l10n_pe.1_chart7621
+#: model:account.account,name:l10n_pe.2_chart6621
+#: model:account.account,name:l10n_pe.2_chart7621
+#: model:account.account.template,name:l10n_pe.chart6621
+#: model:account.account.template,name:l10n_pe.chart7621
+msgid "Fixed asset - Investment property"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart102
+#: model:account.account,name:l10n_pe.2_chart102
+#: model:account.account.template,name:l10n_pe.chart102
+msgid "Fixed funds"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart1031
+#: model:account.account,name:l10n_pe.2_chart1031
+#: model:account.account.template,name:l10n_pe.chart1031
+msgid "Fixed funds - Cash in transit"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart1032
+#: model:account.account,name:l10n_pe.2_chart1032
+#: model:account.account.template,name:l10n_pe.chart1032
+msgid "Fixed funds - Checks in transit"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_130103
+msgid "Florencia de Mora"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_010306
+msgid "Florida"
 msgstr ""
 
 #. module: l10n_pe
@@ -98,9 +7365,6 @@ msgid ""
 "for Europe for more information  "
 "http://www.unece.org/trade/untdid/d08a/tred/tred5305.htm"
 msgstr ""
-"Estandard UN/ECE 5305 de las Comisión Económica de las Naciones Unidas para Europa"
-"para mas información consulta este enlace"
-"http://www.unece.org/trade/untdid/d08a/tred/tred5305.htm"
 
 #. module: l10n_pe
 #: model:ir.model.fields,help:l10n_pe.field_account_tax__l10n_pe_edi_unece_category
@@ -111,9 +7375,110 @@ msgid ""
 msgstr ""
 
 #. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart36551
+#: model:account.account,name:l10n_pe.2_chart36551
+#: model:account.account.template,name:l10n_pe.chart36551
+msgid "Formulas, designs and prototypes - Costs"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart34521
+#: model:account.account,name:l10n_pe.2_chart34521
+#: model:account.account.template,name:l10n_pe.chart34521
+msgid "Formulas, designs and prototypes - Designs and prototypes - Costs"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart34522
+#: model:account.account,name:l10n_pe.2_chart34522
+#: model:account.account.template,name:l10n_pe.chart34522
+msgid ""
+"Formulas, designs and prototypes - Designs and prototypes - Revaluation"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart34511
+#: model:account.account,name:l10n_pe.2_chart34511
+#: model:account.account.template,name:l10n_pe.chart34511
+msgid "Formulas, designs and prototypes - Formulas - Costs"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart34512
+#: model:account.account,name:l10n_pe.2_chart34512
+#: model:account.account.template,name:l10n_pe.chart34512
+msgid "Formulas, designs and prototypes - Formulas - Revaluation"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart36552
+#: model:account.account,name:l10n_pe.2_chart36552
+#: model:account.account.template,name:l10n_pe.chart36552
+msgid "Formulas, designs and prototypes - Revaluation"
+msgstr ""
+
+#. module: l10n_pe
 #: model:ir.model.fields.selection,name:l10n_pe.selection__account_tax__l10n_pe_edi_unece_category__g
 #: model:ir.model.fields.selection,name:l10n_pe.selection__account_tax_template__l10n_pe_edi_unece_category__g
 msgid "Free export item, tax not charged"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_200202
+msgid "Frias"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart36451
+#: model:account.account,name:l10n_pe.2_chart36451
+#: model:account.account.template,name:l10n_pe.chart36451
+msgid "Furniture and fixtures - Costs"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart33521
+#: model:account.account,name:l10n_pe.2_chart33521
+#: model:account.account.template,name:l10n_pe.chart33521
+msgid "Furniture and fixtures - Equipment - Costs"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart33522
+#: model:account.account,name:l10n_pe.2_chart33522
+#: model:account.account.template,name:l10n_pe.chart33522
+msgid "Furniture and fixtures - Equipment - Revaluation"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart33511
+#: model:account.account,name:l10n_pe.2_chart33511
+#: model:account.account.template,name:l10n_pe.chart33511
+msgid "Furniture and fixtures - Furnitures - Costs"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart33512
+#: model:account.account,name:l10n_pe.2_chart33512
+#: model:account.account.template,name:l10n_pe.chart33512
+msgid "Furniture and fixtures - Furnitures - Revaluation"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart36452
+#: model:account.account,name:l10n_pe.2_chart36452
+#: model:account.account.template,name:l10n_pe.chart36452
+msgid "Furniture and fixtures - Revaluation"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.tax,description:l10n_pe.1_purchase_tax_gra
+#: model:account.tax,description:l10n_pe.1_sale_tax_gra
+#: model:account.tax,description:l10n_pe.2_purchase_tax_gra
+#: model:account.tax,description:l10n_pe.2_sale_tax_gra
+#: model:account.tax.group,name:l10n_pe.tax_group_gra
+#: model:account.tax.template,description:l10n_pe.purchase_tax_gra
+#: model:account.tax.template,description:l10n_pe.sale_tax_gra
+msgid "GRA"
 msgstr ""
 
 #. module: l10n_pe
@@ -123,13 +7488,874 @@ msgid "GRA - Free"
 msgstr ""
 
 #. module: l10n_pe
+#: model:account.group,name:l10n_pe.1_group83
+#: model:account.group,name:l10n_pe.2_group83
+#: model:account.group.template,name:l10n_pe.group83
+msgid "GROSS SURPLUS (GROSS LACK) FROM OPERATING"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart7771
+#: model:account.account,name:l10n_pe.2_chart7771
+#: model:account.account.template,name:l10n_pe.chart7771
+msgid ""
+"Gain from measuring financial assets and liabilities at fair value - "
+"Investments held for trading"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart7772
+#: model:account.account,name:l10n_pe.2_chart7772
+#: model:account.account.template,name:l10n_pe.chart7772
+msgid ""
+"Gain from measuring financial assets and liabilities at fair value - Other "
+"investments"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart7773
+#: model:account.account,name:l10n_pe.2_chart7773
+#: model:account.account.template,name:l10n_pe.chart7773
+msgid ""
+"Gain from measuring financial assets and liabilities at fair value - Others"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart771
+#: model:account.account,name:l10n_pe.2_chart771
+#: model:account.account.template,name:l10n_pe.chart771
+msgid "Gain on derivative financial instrument"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_030703
+msgid "Gamarra"
+msgstr ""
+
+#. module: l10n_pe
+#: model:res.city,name:l10n_pe.city_pe_1802
+msgid "General Sánchez Cerro"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart0111
+#: model:account.account,name:l10n_pe.1_chart0211
+#: model:account.account,name:l10n_pe.2_chart0111
+#: model:account.account,name:l10n_pe.2_chart0211
+#: model:account.account.template,name:l10n_pe.chart0111
+#: model:account.account.template,name:l10n_pe.chart0211
+msgid "Goods and securities delivered"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart0126
+#: model:account.account,name:l10n_pe.1_chart0226
+#: model:account.account,name:l10n_pe.2_chart0126
+#: model:account.account,name:l10n_pe.2_chart0226
+#: model:account.account.template,name:l10n_pe.chart0126
+#: model:account.account.template,name:l10n_pe.chart0226
+msgid "Goods and values received"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart3657
+#: model:account.account,name:l10n_pe.2_chart3657
+#: model:account.account.template,name:l10n_pe.chart3657
+msgid "Goodwill"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart3471
+#: model:account.account,name:l10n_pe.2_chart3471
+#: model:account.account.template,name:l10n_pe.chart3471
+msgid "Goodwill - Goodwill"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_150303
+msgid "Gorgor"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_190203
+msgid "Goyllarisquizga"
+msgstr ""
+
+#. module: l10n_pe
+#: model:res.city,name:l10n_pe.city_pe_1311
+msgid "Gran Chimú"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_010107
+msgid "Granada"
+msgstr ""
+
+#. module: l10n_pe
+#: model:res.city,name:l10n_pe.city_pe_0307
+msgid "Grau"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_061004
+msgid "Gregorio Pita"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_110206
+msgid "Grocio Prado"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart831
+#: model:account.account,name:l10n_pe.2_chart831
+#: model:account.account.template,name:l10n_pe.chart831
+msgid "Gross surplus (gross deficiency) of exploitation"
+msgstr ""
+
+#. module: l10n_pe
+#: model:ir.model.fields,field_description:l10n_pe.field_account_move_line__l10n_pe_group_id
+msgid "Group"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_130702
+msgid "Guadalupe"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_131203
+msgid "Guadalupito"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_060504
+msgid "Guzmángo"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_220103
+msgid "Habana"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_030504
+msgid "Haquira"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_100603
+msgid "Hermílio Valdizan"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_230402
+msgid "Heroes Albarracín"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_120207
+msgid "Heroínas Toledo"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_151012
+msgid "Hongos"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_100903
+msgid "Honoria"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart424
+#: model:account.account,name:l10n_pe.2_chart424
+#: model:account.account.template,name:l10n_pe.chart424
+msgid "Honors to be payed"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart4341
+#: model:account.account,name:l10n_pe.2_chart4341
+#: model:account.account.template,name:l10n_pe.chart4341
+msgid "Honors to be payed - Honors to be payed"
+msgstr ""
+
+#. module: l10n_pe
+#: model:res.city,name:l10n_pe.city_pe_1201
+msgid "Hua ncayo"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_060805
+msgid "Huabal"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_050607
+msgid "Huac-Huas"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_021005
+msgid "Huacachi"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_100205
+msgid "Huacar"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_021504
+msgid "Huacaschuque"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_100401
+#: model:res.city,name:l10n_pe.city_pe_1004
+msgid "Huacaybamba"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_050905
+msgid "Huacaña"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_030604
+msgid "Huaccana"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_021006
+msgid "Huacchis"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_120904
+msgid "Huachac"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_021007
+msgid "Huachis"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_150801
+msgid "Huacho"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_090106
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_090707
+msgid "Huachocolpa"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_190102
+msgid "Huachon"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_090407
+msgid "Huachos"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_150707
+msgid "Huachupampa"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_020203
+msgid "Huacllan"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_100701
+msgid "Huacrachuco"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_120116
+msgid "Huacrapuquio"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_210403
+msgid "Huacullani"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_060703
+#: model:res.city,name:l10n_pe.city_pe_0607
+msgid "Hualgayoc"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_120117
+msgid "Hualhuas"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_220204
+#: model:res.city,name:l10n_pe.city_pe_2204
+msgid "Huallaga"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_020508
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_021202
+msgid "Huallanca"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_150805
+msgid "Hualmay"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_130901
+msgid "Huamachuco"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_120408
+msgid "Huamali"
+msgstr ""
+
+#. module: l10n_pe
+#: model:res.city,name:l10n_pe.city_pe_1005
+msgid "Huamalies"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_120905
+msgid "Huamancaca Chico"
+msgstr ""
+
+#. module: l10n_pe
+#: model:res.city,name:l10n_pe.city_pe_0501
+msgid "Huamanga"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_050403
+msgid "Huamanguilla"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_051008
+msgid "Huamanquiquia"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_150403
+msgid "Huamantanga"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_090408
+msgid "Huamatambo"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_051105
+msgid "Huambalpa"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_010604
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_040507
+msgid "Huambo"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_060409
+msgid "Huambos"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_151013
+msgid "Huampara"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_040508
+msgid "Huanca"
+msgstr ""
+
+#. module: l10n_pe
+#: model:res.city,name:l10n_pe.city_pe_0503
+msgid "Huanca Sancos"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_090307
+msgid "Huanca-Huanca"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_190303
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_200301
+#: model:res.city,name:l10n_pe.city_pe_2003
+msgid "Huancabamba"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_120119
+msgid "Huancan"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_210601
+msgid "Huancane"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_110502
+msgid "Huancano"
+msgstr ""
+
+#. module: l10n_pe
+#: model:res.city,name:l10n_pe.city_pe_2106
+msgid "Huancané"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_051001
+msgid "Huancapi"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_150304
+msgid "Huancapon"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_030204
+msgid "Huancarama"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_081105
+msgid "Huancarani"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_030205
+msgid "Huancaray"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_051009
+msgid "Huancaraylla"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_040407
+msgid "Huancarqui"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_010108
+msgid "Huancas"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_130804
+msgid "Huancaspata"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_090101
+#: model:res.city,name:l10n_pe.city_pe_0901
+msgid "Huancavelica"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_151014
+msgid "Huancaya"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_120101
+msgid "Huancayo"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_130104
+msgid "Huanchaco"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_020104
+msgid "Huanchay"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_090119
+msgid "Huando"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_021505
+msgid "Huandoval"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_151015
+msgid "Huangascar"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_030105
+msgid "Huanipaca"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_081005
+msgid "Huanoquite"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_050401
+#: model:res.city,name:l10n_pe.city_pe_0504
+msgid "Huanta"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_151016
+msgid "Huantan"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_021008
+msgid "Huantar"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_230205
+msgid "Huanuara"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_100101
+msgid "Huanuco"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_040309
+msgid "Huanuhuanu"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_150708
+msgid "Huanza"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_030303
+msgid "Huaquirca"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_150601
+#: model:res.city,name:l10n_pe.city_pe_1506
+msgid "Huaral"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_130605
+msgid "Huaranchal"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_060903
+msgid "Huarango"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_020101
+#: model:res.city,name:l10n_pe.city_pe_0201
+msgid "Huaraz"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_021001
+#: model:res.city,name:l10n_pe.city_pe_0210
+msgid "Huari"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_190103
+msgid "Huariaca"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_090709
+msgid "Huaribamba"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_120703
+msgid "Huaricolca"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_120409
+msgid "Huaripampa"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_021101
+#: model:res.city,name:l10n_pe.city_pe_0211
+msgid "Huarmey"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_081207
+msgid "Huaro"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_150709
+#: model:res.city,name:l10n_pe.city_pe_1507
+msgid "Huarochiri"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_080305
+msgid "Huarocondo"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_150404
+msgid "Huaros"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_120704
+msgid "Huasahuasi"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_120120
+msgid "Huasicancha"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_060304
+msgid "Huasmin"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_130504
+msgid "Huaso"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_020509
+msgid "Huasta"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_021203
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_210108
+msgid "Huata"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_210603
+msgid "Huatasani"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_150806
+#: model:res.city,name:l10n_pe.city_pe_1508
+msgid "Huaura"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_120803
+msgid "Huay-Huay"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_051010
+msgid "Huaya"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_090604
+msgid "Huayacundo Arma"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_021104
+msgid "Huayan"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_030206
+msgid "Huayana"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_021204
+#: model:res.city,name:l10n_pe.city_pe_0212
+msgid "Huaylas"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_130805
+msgid "Huaylillas"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_021906
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_081303
+msgid "Huayllabamba"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_020510
+msgid "Huayllacayan"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_090107
+msgid "Huayllahuara"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_021602
+msgid "Huayllan"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_021704
+msgid "Huayllapampa"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_030704
+msgid "Huayllati"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_190104
+msgid "Huayllay"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_090308
+msgid "Huayllay Grande"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_030407
+msgid "Huayllo"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_040804
+msgid "Huaynacotas"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_130806
+msgid "Huayo"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_080903
+msgid "Huayopata"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_210903
+msgid "Huayrapata"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_090601
+msgid "Huaytara"
+msgstr ""
+
+#. module: l10n_pe
+#: model:res.city,name:l10n_pe.city_pe_0906
+msgid "Huaytará"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_120121
+msgid "Huayucachi"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_151017
+msgid "Huañec"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_170204
+msgid "Huepetuhe"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_120410
+msgid "Huertas"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_220603
+msgid "Huicungo"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_220907
+msgid "Huimbayoc"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_110503
+msgid "Humay"
+msgstr ""
+
+#. module: l10n_pe
+#: model:res.city,name:l10n_pe.city_pe_1001
+msgid "Huánuco"
+msgstr ""
+
+#. module: l10n_pe
 #: model:ir.model.fields.selection,name:l10n_pe.selection__account_tax__l10n_pe_edi_tax_code__7152
 #: model:ir.model.fields.selection,name:l10n_pe.selection__account_tax_template__l10n_pe_edi_tax_code__7152
 msgid "ICBPER - Plastic bag tax"
 msgstr ""
 
 #. module: l10n_pe
+#: model:ir.model.fields,field_description:l10n_pe.field_l10n_pe_res_city_district__id
+msgid "ID"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.tax,description:l10n_pe.1_purchase_tax_igv_18
+#: model:account.tax,description:l10n_pe.1_purchase_tax_igv_18_included
+#: model:account.tax,description:l10n_pe.1_sale_tax_igv_18
+#: model:account.tax,description:l10n_pe.1_sale_tax_igv_18_included
+#: model:account.tax,description:l10n_pe.2_purchase_tax_igv_18
+#: model:account.tax,description:l10n_pe.2_purchase_tax_igv_18_included
+#: model:account.tax,description:l10n_pe.2_sale_tax_igv_18
+#: model:account.tax,description:l10n_pe.2_sale_tax_igv_18_included
 #: model:account.tax.group,name:l10n_pe.tax_group_igv
+#: model:account.tax.template,description:l10n_pe.purchase_tax_igv_18
+#: model:account.tax.template,description:l10n_pe.purchase_tax_igv_18_included
+#: model:account.tax.template,description:l10n_pe.sale_tax_igv_18
+#: model:account.tax.template,description:l10n_pe.sale_tax_igv_18_included
 msgid "IGV"
 msgstr ""
 
@@ -140,9 +8366,60 @@ msgid "IGV - General Sales Tax"
 msgstr ""
 
 #. module: l10n_pe
+#: model:account.tax,description:l10n_pe.1_purchase_tax_ina
+#: model:account.tax,description:l10n_pe.1_sale_tax_ina
+#: model:account.tax,description:l10n_pe.2_purchase_tax_ina
+#: model:account.tax,description:l10n_pe.2_sale_tax_ina
+#: model:account.tax.group,name:l10n_pe.tax_group_ina
+#: model:account.tax.template,description:l10n_pe.purchase_tax_ina
+#: model:account.tax.template,description:l10n_pe.sale_tax_ina
+msgid "INA"
+msgstr ""
+
+#. module: l10n_pe
 #: model:ir.model.fields.selection,name:l10n_pe.selection__account_tax__l10n_pe_edi_tax_code__9998
 #: model:ir.model.fields.selection,name:l10n_pe.selection__account_tax_template__l10n_pe_edi_tax_code__9998
 msgid "INA - Unaffected"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.group,name:l10n_pe.1_group88
+#: model:account.group,name:l10n_pe.2_group88
+#: model:account.group.template,name:l10n_pe.group88
+msgid "INCOME TAX"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.group,name:l10n_pe.1_group34
+#: model:account.group,name:l10n_pe.2_group34
+#: model:account.group.template,name:l10n_pe.group34
+msgid "INTANGIBLES"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.group,name:l10n_pe.1_group28
+#: model:account.group,name:l10n_pe.2_group28
+#: model:account.group.template,name:l10n_pe.group28
+msgid "INVENTORIES TO RECEIVE"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.group,name:l10n_pe.1_group31
+#: model:account.group,name:l10n_pe.2_group31
+#: model:account.group.template,name:l10n_pe.group31
+msgid "INVESTMENT PROPERTIES"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.group,name:l10n_pe.1_group51
+#: model:account.group,name:l10n_pe.2_group51
+#: model:account.group.template,name:l10n_pe.group51
+msgid "INVESTMENT STOCKS"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.tax.group,name:l10n_pe.tax_group_isc
+msgid "ISC"
 msgstr ""
 
 #. module: l10n_pe
@@ -152,9 +8429,50 @@ msgid "ISC - Selective Excise Tax"
 msgstr ""
 
 #. module: l10n_pe
+#: model:account.tax.group,name:l10n_pe.tax_group_ivap
+msgid "IVAP"
+msgstr ""
+
+#. module: l10n_pe
 #: model:ir.model.fields.selection,name:l10n_pe.selection__account_tax__l10n_pe_edi_tax_code__1016
 #: model:ir.model.fields.selection,name:l10n_pe.selection__account_tax_template__l10n_pe_edi_tax_code__1016
 msgid "IVAP - Tax on Sale Paddy Rice"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_170302
+msgid "Iberia"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_110101
+#: model:res.city,name:l10n_pe.city_pe_1101
+msgid "Ica"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_061005
+msgid "Ichocan"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_040509
+msgid "Ichupampa"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_180204
+msgid "Ichuña"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_latam.identification.type,name:l10n_pe.it_IN
+msgid "Identification Number"
+msgstr ""
+
+#. module: l10n_pe
+#: model:ir.model,name:l10n_pe.model_l10n_latam_identification_type
+msgid "Identification Types"
 msgstr ""
 
 #. module: l10n_pe
@@ -163,8 +8481,1191 @@ msgid "Identity document of the country of residence"
 msgstr ""
 
 #. module: l10n_pe
-#: model:l10n_latam.identification.type,name:l10n_pe.it_SP
-msgid "Safe Passage"
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_200603
+msgid "Ignacio Escudero"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_050404
+msgid "Iguain"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_150606
+msgid "Ihuari"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_230302
+msgid "Ilabaya"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_210501
+msgid "Ilave"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_140303
+msgid "Illimo"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_180301
+#: model:res.city,name:l10n_pe.city_pe_1803
+msgid "Ilo"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_010205
+msgid "Imaza"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart68823
+#: model:account.account,name:l10n_pe.2_chart68823
+#: model:account.account.template,name:l10n_pe.chart68823
+msgid ""
+"Impairment of assets - Impairment of assets for right of use - Financial "
+"leasing - Buildings"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart68826
+#: model:account.account,name:l10n_pe.2_chart68826
+#: model:account.account.template,name:l10n_pe.chart68826
+msgid ""
+"Impairment of assets - Impairment of assets for right of use - Financial "
+"leasing - Furniture and fixtures"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart68822
+#: model:account.account,name:l10n_pe.2_chart68822
+#: model:account.account.template,name:l10n_pe.chart68822
+msgid ""
+"Impairment of assets - Impairment of assets for right of use - Financial "
+"leasing - Land"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart68824
+#: model:account.account,name:l10n_pe.2_chart68824
+#: model:account.account.template,name:l10n_pe.chart68824
+msgid ""
+"Impairment of assets - Impairment of assets for right of use - Financial "
+"leasing - Machinery and exploitation equipment"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart68827
+#: model:account.account,name:l10n_pe.2_chart68827
+#: model:account.account.template,name:l10n_pe.chart68827
+msgid ""
+"Impairment of assets - Impairment of assets for right of use - Financial "
+"leasing - Miscellaneous equipment"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart68821
+#: model:account.account,name:l10n_pe.2_chart68821
+#: model:account.account.template,name:l10n_pe.chart68821
+msgid ""
+"Impairment of assets - Impairment of assets for right of use - Financial "
+"leasing - Production plant in development"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart68820
+#: model:account.account,name:l10n_pe.2_chart68820
+#: model:account.account.template,name:l10n_pe.chart68820
+msgid ""
+"Impairment of assets - Impairment of assets for right of use - Financial "
+"leasing - Production plant in production"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart68828
+#: model:account.account,name:l10n_pe.2_chart68828
+#: model:account.account.template,name:l10n_pe.chart68828
+msgid ""
+"Impairment of assets - Impairment of assets for right of use - Financial "
+"leasing - Replacement tools and units"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart68825
+#: model:account.account,name:l10n_pe.2_chart68825
+#: model:account.account.template,name:l10n_pe.chart68825
+msgid ""
+"Impairment of assets - Impairment of assets for right of use - Financial "
+"leasing - Transport units"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart68892
+#: model:account.account,name:l10n_pe.2_chart68892
+#: model:account.account.template,name:l10n_pe.chart68892
+msgid ""
+"Impairment of assets - Impairment of biological assets in production - "
+"Biological asset of vegetal origin"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart68891
+#: model:account.account,name:l10n_pe.2_chart68891
+#: model:account.account.template,name:l10n_pe.chart68891
+msgid ""
+"Impairment of assets - Impairment of biological assets in production - "
+"Biological assets of animal origin"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart68841
+#: model:account.account,name:l10n_pe.2_chart68841
+#: model:account.account.template,name:l10n_pe.chart68841
+msgid ""
+"Impairment of assets - Impairment of intangibles - Concessions, licenses and"
+" other rights"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart68844
+#: model:account.account,name:l10n_pe.2_chart68844
+#: model:account.account.template,name:l10n_pe.chart68844
+msgid ""
+"Impairment of assets - Impairment of intangibles - Exploration and "
+"development costs"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart68845
+#: model:account.account,name:l10n_pe.2_chart68845
+#: model:account.account.template,name:l10n_pe.chart68845
+msgid ""
+"Impairment of assets - Impairment of intangibles - Formulas, designs and "
+"prototypes"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart68847
+#: model:account.account,name:l10n_pe.2_chart68847
+#: model:account.account.template,name:l10n_pe.chart68847
+msgid "Impairment of assets - Impairment of intangibles - Goodwill"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart68846
+#: model:account.account,name:l10n_pe.2_chart68846
+#: model:account.account.template,name:l10n_pe.chart68846
+msgid ""
+"Impairment of assets - Impairment of intangibles - Other intangible assets"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart68842
+#: model:account.account,name:l10n_pe.2_chart68842
+#: model:account.account.template,name:l10n_pe.chart68842
+msgid ""
+"Impairment of assets - Impairment of intangibles - Patents and industrial "
+"property"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart68843
+#: model:account.account,name:l10n_pe.2_chart68843
+#: model:account.account.template,name:l10n_pe.chart68843
+msgid "Impairment of assets - Impairment of intangibles - Softwares"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart68812
+#: model:account.account,name:l10n_pe.2_chart68812
+#: model:account.account.template,name:l10n_pe.chart68812
+msgid "Impairment of assets - Impairment of investment property - Buildings"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart68813
+#: model:account.account,name:l10n_pe.2_chart68813
+#: model:account.account.template,name:l10n_pe.chart68813
+msgid ""
+"Impairment of assets - Impairment of investment property - Constructions in "
+"progress"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart68833
+#: model:account.account,name:l10n_pe.2_chart68833
+#: model:account.account.template,name:l10n_pe.chart68833
+msgid ""
+"Impairment of assets - Impairment of property, plant and equipment - "
+"Buildings"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart68836
+#: model:account.account,name:l10n_pe.2_chart68836
+#: model:account.account.template,name:l10n_pe.chart68836
+msgid ""
+"Impairment of assets - Impairment of property, plant and equipment - "
+"Furniture and fixtures"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart68832
+#: model:account.account,name:l10n_pe.2_chart68832
+#: model:account.account.template,name:l10n_pe.chart68832
+msgid ""
+"Impairment of assets - Impairment of property, plant and equipment - Land"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart68834
+#: model:account.account,name:l10n_pe.2_chart68834
+#: model:account.account.template,name:l10n_pe.chart68834
+msgid ""
+"Impairment of assets - Impairment of property, plant and equipment - "
+"Machinery and exploitation equipment"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart68837
+#: model:account.account,name:l10n_pe.2_chart68837
+#: model:account.account.template,name:l10n_pe.chart68837
+msgid ""
+"Impairment of assets - Impairment of property, plant and equipment - "
+"Miscellaneous equipment"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart68831
+#: model:account.account,name:l10n_pe.2_chart68831
+#: model:account.account.template,name:l10n_pe.chart68831
+msgid ""
+"Impairment of assets - Impairment of property, plant and equipment - "
+"Production plant in development"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart68830
+#: model:account.account,name:l10n_pe.2_chart68830
+#: model:account.account.template,name:l10n_pe.chart68830
+msgid ""
+"Impairment of assets - Impairment of property, plant and equipment - "
+"Production plant in production"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart68838
+#: model:account.account,name:l10n_pe.2_chart68838
+#: model:account.account.template,name:l10n_pe.chart68838
+msgid ""
+"Impairment of assets - Impairment of property, plant and equipment - "
+"Replacement tools and units"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart68835
+#: model:account.account,name:l10n_pe.2_chart68835
+#: model:account.account.template,name:l10n_pe.chart68835
+msgid ""
+"Impairment of assets - Impairment of property, plant and equipment - "
+"Transport units"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_150507
+msgid "Imperial"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_160602
+msgid "Inahuaya"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_170102
+msgid "Inambari"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_140203
+msgid "Incahuasi"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_210604
+msgid "Inchupalla"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_230105
+msgid "Inclan"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart851
+#: model:account.account,name:l10n_pe.2_chart851
+#: model:account.account.template,name:l10n_pe.chart851
+msgid "Income before income tax"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart774
+#: model:account.account,name:l10n_pe.2_chart774
+#: model:account.account.template,name:l10n_pe.chart774
+msgid "Income from factoring operations"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart881
+#: model:account.account,name:l10n_pe.2_chart881
+#: model:account.account.template,name:l10n_pe.chart881
+msgid "Income tax – Current"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart882
+#: model:account.account,name:l10n_pe.2_chart882
+#: model:account.account.template,name:l10n_pe.chart882
+msgid "Income tax – Deferred"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.group,name:l10n_pe.1_group7
+#: model:account.group,name:l10n_pe.2_group7
+#: model:account.group.template,name:l10n_pe.group7
+msgid "Incomes"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_020105
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_051106
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_110504
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_150112
+msgid "Independencia"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_160104
+msgid "Indiana"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_120122
+msgid "Ingenio"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_010506
+msgid "Inguilpata"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_080911
+msgid "Inkawasi"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart182
+#: model:account.account,name:l10n_pe.1_chart651
+#: model:account.account,name:l10n_pe.2_chart182
+#: model:account.account,name:l10n_pe.2_chart651
+#: model:account.account.template,name:l10n_pe.chart182
+#: model:account.account.template,name:l10n_pe.chart651
+msgid "Insurance"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart27311
+#: model:account.account,name:l10n_pe.2_chart27311
+#: model:account.account.template,name:l10n_pe.chart27311
+msgid "Intangibles - Concessions, licenses and rights - Costs"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart27312
+#: model:account.account,name:l10n_pe.2_chart27312
+#: model:account.account.template,name:l10n_pe.chart27312
+msgid "Intangibles - Concessions, licenses and rights - Revaluation"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart7232
+#: model:account.account,name:l10n_pe.2_chart7232
+#: model:account.account.template,name:l10n_pe.chart7232
+msgid "Intangibles - Exploration and development costs"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart27341
+#: model:account.account,name:l10n_pe.2_chart27341
+#: model:account.account.template,name:l10n_pe.chart27341
+msgid "Intangibles - Exploration and development costs - Costs"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart27342
+#: model:account.account,name:l10n_pe.2_chart27342
+#: model:account.account.template,name:l10n_pe.chart27342
+msgid "Intangibles - Exploration and development costs - Revaluation"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart7233
+#: model:account.account,name:l10n_pe.2_chart7233
+#: model:account.account.template,name:l10n_pe.chart7233
+msgid "Intangibles - Formulas, designs and prototypes"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart27351
+#: model:account.account,name:l10n_pe.2_chart27351
+#: model:account.account.template,name:l10n_pe.chart27351
+msgid "Intangibles - Formulas, designs and prototypes - Costs"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart27352
+#: model:account.account,name:l10n_pe.2_chart27352
+#: model:account.account.template,name:l10n_pe.chart27352
+msgid "Intangibles - Formulas, designs and prototypes - Revaluation"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart27391
+#: model:account.account,name:l10n_pe.2_chart27391
+#: model:account.account.template,name:l10n_pe.chart27391
+msgid "Intangibles - Other intangible assets - Costs"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart27392
+#: model:account.account,name:l10n_pe.2_chart27392
+#: model:account.account.template,name:l10n_pe.chart27392
+msgid "Intangibles - Other intangible assets - Revaluation"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart27321
+#: model:account.account,name:l10n_pe.2_chart27321
+#: model:account.account.template,name:l10n_pe.chart27321
+msgid "Intangibles - Patents and industrial property - Costs"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart27322
+#: model:account.account,name:l10n_pe.2_chart27322
+#: model:account.account.template,name:l10n_pe.chart27322
+msgid "Intangibles - Patents and industrial property - Revaluation"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart7231
+#: model:account.account,name:l10n_pe.2_chart7231
+#: model:account.account.template,name:l10n_pe.chart7231
+msgid "Intangibles - Softwares"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart27331
+#: model:account.account,name:l10n_pe.2_chart27331
+#: model:account.account.template,name:l10n_pe.chart27331
+msgid "Intangibles - Softwares - Costs"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart27332
+#: model:account.account,name:l10n_pe.2_chart27332
+#: model:account.account.template,name:l10n_pe.chart27332
+msgid "Intangibles - Softwares - Revaluation"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart6735
+#: model:account.account,name:l10n_pe.2_chart6735
+#: model:account.account.template,name:l10n_pe.chart6735
+msgid "Interest on loans and other obligations - Bonds issued"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart6736
+#: model:account.account,name:l10n_pe.2_chart6736
+#: model:account.account.template,name:l10n_pe.chart6736
+msgid "Interest on loans and other obligations - Commercial obligations"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart6734
+#: model:account.account,name:l10n_pe.2_chart6734
+#: model:account.account.template,name:l10n_pe.chart6734
+msgid "Interest on loans and other obligations - Documents sold or discounted"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart6732
+#: model:account.account,name:l10n_pe.2_chart6732
+#: model:account.account.template,name:l10n_pe.chart6732
+msgid "Interest on loans and other obligations - Financial lease contracts"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart67311
+#: model:account.account,name:l10n_pe.2_chart67311
+#: model:account.account.template,name:l10n_pe.chart67311
+msgid ""
+"Interest on loans and other obligations - Loans from financial institutions "
+"and other entities - Financial institutions"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart67312
+#: model:account.account,name:l10n_pe.2_chart67312
+#: model:account.account.template,name:l10n_pe.chart67312
+msgid ""
+"Interest on loans and other obligations - Loans from financial institutions "
+"and other entities - Other entities"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart6733
+#: model:account.account,name:l10n_pe.2_chart6733
+#: model:account.account.template,name:l10n_pe.chart6733
+msgid ""
+"Interest on loans and other obligations - Other financial instruments "
+"payable"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart1633
+#: model:account.account,name:l10n_pe.1_chart1733
+#: model:account.account,name:l10n_pe.2_chart1633
+#: model:account.account,name:l10n_pe.2_chart1733
+#: model:account.account.template,name:l10n_pe.chart1633
+#: model:account.account.template,name:l10n_pe.chart1733
+msgid "Interest, royalties and dividends - Dividends"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart1631
+#: model:account.account,name:l10n_pe.1_chart1731
+#: model:account.account,name:l10n_pe.2_chart1631
+#: model:account.account,name:l10n_pe.2_chart1731
+#: model:account.account.template,name:l10n_pe.chart1631
+#: model:account.account.template,name:l10n_pe.chart1731
+msgid "Interest, royalties and dividends - Interests"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart1632
+#: model:account.account,name:l10n_pe.1_chart1732
+#: model:account.account,name:l10n_pe.2_chart1632
+#: model:account.account,name:l10n_pe.2_chart1732
+#: model:account.account.template,name:l10n_pe.chart1632
+#: model:account.account.template,name:l10n_pe.chart1732
+msgid "Interest, royalties and dividends - Royalties"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.group,name:l10n_pe.1_group8
+#: model:account.group,name:l10n_pe.2_group8
+#: model:account.group.template,name:l10n_pe.group8
+msgid ""
+"Intermediate management balances and determination of profit for the year"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart21511
+#: model:account.account,name:l10n_pe.2_chart21511
+#: model:account.account.template,name:l10n_pe.chart21511
+msgid "Inventory of finished services - Finished services - Costs"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart23511
+#: model:account.account,name:l10n_pe.2_chart23511
+#: model:account.account.template,name:l10n_pe.chart23511
+msgid "Inventory of services in process - Services in process - Costs"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart7211
+#: model:account.account,name:l10n_pe.2_chart7211
+#: model:account.account.template,name:l10n_pe.chart7211
+msgid "Investment property - Buildings"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart27121
+#: model:account.account,name:l10n_pe.2_chart27121
+#: model:account.account.template,name:l10n_pe.chart27121
+msgid "Investment property - Buildings - Costs"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart27124
+#: model:account.account,name:l10n_pe.2_chart27124
+#: model:account.account.template,name:l10n_pe.chart27124
+msgid "Investment property - Buildings - Fair value"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart27123
+#: model:account.account,name:l10n_pe.2_chart27123
+#: model:account.account.template,name:l10n_pe.chart27123
+msgid "Investment property - Buildings - Financing costs"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart27122
+#: model:account.account,name:l10n_pe.2_chart27122
+#: model:account.account.template,name:l10n_pe.chart27122
+msgid "Investment property - Buildings - Revaluation"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart32121
+#: model:account.account,name:l10n_pe.2_chart32121
+#: model:account.account.template,name:l10n_pe.chart32121
+msgid "Investment property - Financial leasing - Buildings - Costs"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart32124
+#: model:account.account,name:l10n_pe.2_chart32124
+#: model:account.account.template,name:l10n_pe.chart32124
+msgid "Investment property - Financial leasing - Buildings - Fair value"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart32123
+#: model:account.account,name:l10n_pe.2_chart32123
+#: model:account.account.template,name:l10n_pe.chart32123
+msgid "Investment property - Financial leasing - Buildings - Financing costs"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart32122
+#: model:account.account,name:l10n_pe.2_chart32122
+#: model:account.account.template,name:l10n_pe.chart32122
+msgid "Investment property - Financial leasing - Buildings - Revaluation"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart32111
+#: model:account.account,name:l10n_pe.2_chart32111
+#: model:account.account.template,name:l10n_pe.chart32111
+msgid "Investment property - Financial leasing - Land - Costs"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart32114
+#: model:account.account,name:l10n_pe.2_chart32114
+#: model:account.account.template,name:l10n_pe.chart32114
+msgid "Investment property - Financial leasing - Land - Fair value"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart32112
+#: model:account.account,name:l10n_pe.2_chart32112
+#: model:account.account.template,name:l10n_pe.chart32112
+msgid "Investment property - Financial leasing - Land - Revaluation"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart27111
+#: model:account.account,name:l10n_pe.2_chart27111
+#: model:account.account.template,name:l10n_pe.chart27111
+msgid "Investment property - Land - Costs"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart27114
+#: model:account.account,name:l10n_pe.2_chart27114
+#: model:account.account.template,name:l10n_pe.chart27114
+msgid "Investment property - Land - Fair value"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart27112
+#: model:account.account,name:l10n_pe.2_chart27112
+#: model:account.account.template,name:l10n_pe.chart27112
+msgid "Investment property - Land - Revaluation"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart511
+#: model:account.account,name:l10n_pe.2_chart511
+#: model:account.account.template,name:l10n_pe.chart511
+msgid "Investment shares"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart512
+#: model:account.account,name:l10n_pe.2_chart512
+#: model:account.account.template,name:l10n_pe.chart512
+msgid "Investment shares in treasury"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart11151
+#: model:account.account,name:l10n_pe.2_chart11151
+#: model:account.account.template,name:l10n_pe.chart11151
+msgid "Investments held for trading - Holdings in entities - Costs"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart11152
+#: model:account.account,name:l10n_pe.2_chart11152
+#: model:account.account.template,name:l10n_pe.chart11152
+msgid "Investments held for trading - Holdings in entities - Fair value"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart11141
+#: model:account.account,name:l10n_pe.2_chart11141
+#: model:account.account.template,name:l10n_pe.chart11141
+msgid "Investments held for trading - Other debt instruments - Costs"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart11142
+#: model:account.account,name:l10n_pe.2_chart11142
+#: model:account.account.template,name:l10n_pe.chart11142
+msgid "Investments held for trading - Other debt instruments - Fair value"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart11131
+#: model:account.account,name:l10n_pe.2_chart11131
+#: model:account.account.template,name:l10n_pe.chart11131
+msgid "Investments held for trading - Securities issued by entities - Costs"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart11132
+#: model:account.account,name:l10n_pe.2_chart11132
+#: model:account.account.template,name:l10n_pe.chart11132
+msgid ""
+"Investments held for trading - Securities issued by entities - Fair value"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart11121
+#: model:account.account,name:l10n_pe.2_chart11121
+#: model:account.account.template,name:l10n_pe.chart11121
+msgid ""
+"Investments held for trading - Securities issued by the financial system - "
+"Costs"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart11122
+#: model:account.account,name:l10n_pe.2_chart11122
+#: model:account.account.template,name:l10n_pe.chart11122
+msgid ""
+"Investments held for trading - Securities issued by the financial system - "
+"Fair value"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart11111
+#: model:account.account,name:l10n_pe.2_chart11111
+#: model:account.account.template,name:l10n_pe.chart11111
+msgid ""
+"Investments held for trading - Securities issued or guaranteed by the State "
+"- Costs"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart11112
+#: model:account.account,name:l10n_pe.2_chart11112
+#: model:account.account.template,name:l10n_pe.chart11112
+msgid ""
+"Investments held for trading - Securities issued or guaranteed by the State "
+"- Fair value"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart36711
+#: model:account.account,name:l10n_pe.2_chart36711
+#: model:account.account.template,name:l10n_pe.chart36711
+msgid "Investments to be held until maturity - Costs"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart30111
+#: model:account.account,name:l10n_pe.2_chart30111
+#: model:account.account.template,name:l10n_pe.chart30111
+msgid ""
+"Investments to be held until maturity - Debt financial instruments - Costs"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart30114
+#: model:account.account,name:l10n_pe.2_chart30114
+#: model:account.account.template,name:l10n_pe.chart30114
+msgid ""
+"Investments to be held until maturity - Debt financial instruments - Fair "
+"value"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart4211
+#: model:account.account,name:l10n_pe.1_chart4212
+#: model:account.account,name:l10n_pe.1_chart4311
+#: model:account.account,name:l10n_pe.1_chart4312
+#: model:account.account,name:l10n_pe.2_chart4211
+#: model:account.account,name:l10n_pe.2_chart4212
+#: model:account.account,name:l10n_pe.2_chart4311
+#: model:account.account,name:l10n_pe.2_chart4312
+#: model:account.account.template,name:l10n_pe.chart4211
+#: model:account.account.template,name:l10n_pe.chart4212
+#: model:account.account.template,name:l10n_pe.chart4311
+#: model:account.account.template,name:l10n_pe.chart4312
+msgid "Invoices, tickets and other payable vouchers - Not issued"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart1213
+#: model:account.account,name:l10n_pe.1_chart1313
+#: model:account.account,name:l10n_pe.2_chart1213
+#: model:account.account,name:l10n_pe.2_chart1313
+#: model:account.account.template,name:l10n_pe.chart1213
+#: model:account.account.template,name:l10n_pe.chart1313
+msgid "Invoices, tickets and other receipts receivable - In collection"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart1312
+#: model:account.account,name:l10n_pe.2_chart1312
+#: model:account.account.template,name:l10n_pe.chart1312
+msgid "Invoices, tickets and other receipts receivable - In portfolio"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart1212
+#: model:account.account,name:l10n_pe.2_chart1212
+#: model:account.account.template,name:l10n_pe.chart1212
+msgid "Invoices, tickets and other receipts receivable - Issued in portfolio"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart1211
+#: model:account.account,name:l10n_pe.1_chart1311
+#: model:account.account,name:l10n_pe.2_chart1211
+#: model:account.account,name:l10n_pe.2_chart1311
+#: model:account.account.template,name:l10n_pe.chart1211
+#: model:account.account.template,name:l10n_pe.chart1311
+msgid "Invoices, tickets and other receipts receivable - Not issued"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart1214
+#: model:account.account,name:l10n_pe.1_chart1314
+#: model:account.account,name:l10n_pe.2_chart1214
+#: model:account.account,name:l10n_pe.2_chart1314
+#: model:account.account.template,name:l10n_pe.chart1214
+#: model:account.account.template,name:l10n_pe.chart1314
+msgid "Invoices, tickets and other receipts receivable - Off sale"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_250103
+msgid "Iparia"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_160101
+msgid "Iquitos"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_040605
+msgid "Iray"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_250302
+msgid "Irazola"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_040704
+#: model:res.city,name:l10n_pe.city_pe_0407
+msgid "Islay"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_230303
+msgid "Ite"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_210307
+msgid "Ituata"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_090108
+msgid "Izcuchaca"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_170301
+msgid "Iñapari"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_101105
+msgid "Jacas Chico"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_100504
+msgid "Jacas Grande"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_040107
+msgid "Jacobo Hunter"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_010705
+msgid "Jamalca"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_020106
+msgid "Jangas"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_120411
+msgid "Janjaillo"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_040310
+msgid "Jaqui"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_120401
+#: model:res.city,name:l10n_pe.city_pe_1204
+msgid "Jauja"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_140304
+msgid "Jayanca"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_010307
+msgid "Jazan"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_060801
+#: model:res.city,name:l10n_pe.city_pe_0608
+msgid "Jaén"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_160205
+msgid "Jeberos"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_160510
+msgid "Jenaro Herrera"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_220104
+msgid "Jepelacio"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_130703
+msgid "Jequetepeque"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_060106
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_101001
+msgid "Jesús"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_150113
+msgid "Jesús María"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_050115
+msgid "Jesús Nazareno"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_200203
+msgid "Jilili"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_100505
+msgid "Jircan"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_101003
+msgid "Jivia"
+msgstr ""
+
+#. module: l10n_pe
+#: model:res.city,name:l10n_pe.city_pe_2303
+msgid "Jorge Basadre"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_060305
+msgid "Jorge Chávez"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_100604
+msgid "José Crespo y Castillo"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_210207
+msgid "José Domingo Choquehuanca"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_060306
+msgid "José Gálvez"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_140105
+msgid "José Leonardo Ortiz"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_040129
+msgid "José Luis Bustamante Y Rivero"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_061006
+msgid "José Manuel Quiroz"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_030220
+msgid "José María Arguedas"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_040202
+msgid "José María Quimper"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_061007
+msgid "José Sabogal"
+msgstr ""
+
+#. module: l10n_pe
+#: model:ir.model,name:l10n_pe.model_account_move_line
+msgid "Journal Item"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_030304
+msgid "Juan Espinoza Medrano"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_220908
+msgid "Juan Guerra"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_220601
+msgid "Juanjuí"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_090309
+msgid "Julcamarca"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_120412
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_130501
+#: model:res.city,name:l10n_pe.city_pe_1305
+msgid "Julcán"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_210401
+msgid "Juli"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_211101
+msgid "Juliaca"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_010301
+msgid "Jumbilla"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_120501
+#: model:res.city,name:l10n_pe.city_pe_1205
+msgid "Junin"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_030408
+msgid "Justo Apu Sahuaraura"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_030219
+msgid "Kaquiabamba"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_210404
+msgid "Kelluyo"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_080907
+msgid "Kimbiri"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_030207
+msgid "Kishuara"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_081106
+msgid "Kosñipata"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_080503
+msgid "Kunturkanki"
 msgstr ""
 
 #. module: l10n_pe
@@ -173,13 +9674,409 @@ msgid "L10N Pe Vat Code"
 msgstr ""
 
 #. module: l10n_pe
-#: model:ir.model.fields,field_description:l10n_pe.field_account_move_line____last_update
-#: model:ir.model.fields,field_description:l10n_pe.field_account_tax____last_update
-#: model:ir.model.fields,field_description:l10n_pe.field_account_tax_template____last_update
-#: model:ir.model.fields,field_description:l10n_pe.field_l10n_latam_identification_type____last_update
+#: model:account.fiscal.position,name:l10n_pe.1_local_peru
+#: model:account.fiscal.position,name:l10n_pe.2_local_peru
+#: model:account.fiscal.position.template,name:l10n_pe.local_peru
+msgid "LOCAL PERU"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.group,name:l10n_pe.1_group66
+#: model:account.group,name:l10n_pe.2_group66
+#: model:account.group.template,name:l10n_pe.group66
+msgid "LOSS DUE TO MEASUREMENT OF NON-FINANCIAL ASSETS AT FAIR VALUE"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_200109
+msgid "La Arena"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_220909
+msgid "La Banda de Shilcayo"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_200703
+msgid "La Brea"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_180205
+msgid "La Capilla"
+msgstr ""
+
+#. module: l10n_pe
+#: model:res.city,name:l10n_pe.city_pe_0809
+msgid "La Convención"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_240103
+msgid "La Cruz"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_130606
+msgid "La Cuesta"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_061305
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_130105
+msgid "La Esperanza"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_061106
+msgid "La Florida"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_200505
+msgid "La Huaca"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_010109
+msgid "La Jalca"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_040108
+msgid "La Joya"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_020107
+msgid "La Libertad"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_060312
+msgid "La Libertad de Pallan"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_200404
+msgid "La Matanza"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_020204
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_090505
+msgid "La Merced"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_150114
+msgid "La Molina"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_100704
+msgid "La Morada"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_120801
+msgid "La Oroya"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_020905
+msgid "La Pampa"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_010206
+msgid "La Peca"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_070104
+msgid "La Perla"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_020511
+msgid "La Primavera"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_070105
+msgid "La Punta"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_060605
+msgid "La Ramada"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_110102
+msgid "La Tinguiña"
+msgstr ""
+
+#. module: l10n_pe
+#: model:res.city,name:l10n_pe.city_pe_0408
+msgid "La Union"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_100301
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_120705
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_200110
+msgid "La Unión"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_140106
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_150115
+msgid "La Victoria"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_230111
+msgid "La Yarada los Palos"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_060904
+msgid "La coipa"
+msgstr ""
+
+#. module: l10n_pe
+#: model:res.city,name:l10n_pe.city_pe_0505
+msgid "La mar"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_170104
+msgid "Laberinto"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_021506
+msgid "Lacabamba"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_150405
+msgid "Lachaqui"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_140107
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_160206
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_200204
+msgid "Lagunas"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_150710
+msgid "Lahuaytambo"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_060410
+msgid "Lajas"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_200305
+msgid "Lalaquiz"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_220501
+#: model:res.city,name:l10n_pe.city_pe_2205
+msgid "Lamas"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_080403
+msgid "Lamay"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_140301
+#: model:res.city,name:l10n_pe.city_pe_1403
+msgid "Lambayeque"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_030106
+msgid "Lambrama"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_050804
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_210701
+#: model:res.city,name:l10n_pe.city_pe_2107
+msgid "Lampa"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_150607
+msgid "Lampian"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_010501
+msgid "Lamud"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_200604
+msgid "Lancones"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart36111
+#: model:account.account,name:l10n_pe.1_chart36411
+#: model:account.account,name:l10n_pe.2_chart36111
+#: model:account.account,name:l10n_pe.2_chart36411
+#: model:account.account.template,name:l10n_pe.chart36111
+#: model:account.account.template,name:l10n_pe.chart36411
+msgid "Land - Costs"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart33111
+#: model:account.account,name:l10n_pe.2_chart33111
+#: model:account.account.template,name:l10n_pe.chart33111
+msgid "Land - Land - Costs"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart33112
+#: model:account.account,name:l10n_pe.2_chart33112
+#: model:account.account.template,name:l10n_pe.chart33112
+msgid "Land - Land - Revaluation"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart36112
+#: model:account.account,name:l10n_pe.1_chart36412
+#: model:account.account,name:l10n_pe.2_chart36112
+#: model:account.account,name:l10n_pe.2_chart36412
+#: model:account.account.template,name:l10n_pe.chart36112
+#: model:account.account.template,name:l10n_pe.chart36412
+msgid "Land - Revaluation"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart31121
+#: model:account.account,name:l10n_pe.2_chart31121
+#: model:account.account.template,name:l10n_pe.chart31121
+msgid "Land - Rural - Costs"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart31124
+#: model:account.account,name:l10n_pe.2_chart31124
+#: model:account.account.template,name:l10n_pe.chart31124
+msgid "Land - Rural - Fair value"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart31122
+#: model:account.account,name:l10n_pe.2_chart31122
+#: model:account.account.template,name:l10n_pe.chart31122
+msgid "Land - Rural - Revaluation"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart31111
+#: model:account.account,name:l10n_pe.2_chart31111
+#: model:account.account.template,name:l10n_pe.chart31111
+msgid "Land - Urban - Costs"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart31114
+#: model:account.account,name:l10n_pe.2_chart31114
+#: model:account.account.template,name:l10n_pe.chart31114
+msgid "Land - Urban - Fair value"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart31112
+#: model:account.account,name:l10n_pe.2_chart31112
+#: model:account.account.template,name:l10n_pe.chart31112
+msgid "Land - Urban - Revaluation"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_150711
+msgid "Langa"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_080504
+msgid "Langui"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_090605
+msgid "Laramarca"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_050608
+msgid "Laramate"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_150712
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_151018
+msgid "Laraos"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_130106
+msgid "Laredo"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_080404
+msgid "Lares"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_040510
+msgid "Lari"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_090109
+msgid "Laria"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_160105
+msgid "Las Amazonas"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_200111
+msgid "Las Lomas"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_170103
+msgid "Las Piedras"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_060806
+msgid "Las Pirias"
+msgstr ""
+
+#. module: l10n_pe
 #: model:ir.model.fields,field_description:l10n_pe.field_l10n_pe_res_city_district____last_update
-#: model:ir.model.fields,field_description:l10n_pe.field_res_city____last_update
-#: model:ir.model.fields,field_description:l10n_pe.field_res_partner____last_update
 msgid "Last Modified on"
 msgstr ""
 
@@ -194,20 +10091,7269 @@ msgid "Last Updated on"
 msgstr ""
 
 #. module: l10n_pe
+#: model:res.city,name:l10n_pe.city_pe_1010
+msgid "Lauricocha"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_080505
+msgid "Layo"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart183
+#: model:account.account,name:l10n_pe.2_chart183
+#: model:account.account.template,name:l10n_pe.chart183
+msgid "Leasings"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart6352
+#: model:account.account,name:l10n_pe.1_chart7542
+#: model:account.account,name:l10n_pe.2_chart6352
+#: model:account.account,name:l10n_pe.2_chart7542
+#: model:account.account.template,name:l10n_pe.chart6352
+#: model:account.account.template,name:l10n_pe.chart7542
+msgid "Leasings - Buildings"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart6355
+#: model:account.account,name:l10n_pe.2_chart6355
+#: model:account.account.template,name:l10n_pe.chart6355
+msgid "Leasings - Furniture and fixtures"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart6351
+#: model:account.account,name:l10n_pe.1_chart7541
+#: model:account.account,name:l10n_pe.2_chart6351
+#: model:account.account,name:l10n_pe.2_chart7541
+#: model:account.account.template,name:l10n_pe.chart6351
+#: model:account.account.template,name:l10n_pe.chart7541
+msgid "Leasings - Land"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart6353
+#: model:account.account,name:l10n_pe.1_chart7543
+#: model:account.account,name:l10n_pe.2_chart6353
+#: model:account.account,name:l10n_pe.2_chart7543
+#: model:account.account.template,name:l10n_pe.chart6353
+#: model:account.account.template,name:l10n_pe.chart7543
+msgid "Leasings - Machinery and exploitation equipment"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart6356
+#: model:account.account,name:l10n_pe.1_chart7545
+#: model:account.account,name:l10n_pe.2_chart6356
+#: model:account.account,name:l10n_pe.2_chart7545
+#: model:account.account.template,name:l10n_pe.chart6356
+#: model:account.account.template,name:l10n_pe.chart7545
+msgid "Leasings - Miscellaneous equipment"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart7540
+#: model:account.account,name:l10n_pe.2_chart7540
+#: model:account.account.template,name:l10n_pe.chart7540
+msgid "Leasings - Production plants"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart7544
+#: model:account.account,name:l10n_pe.2_chart7544
+#: model:account.account.template,name:l10n_pe.chart7544
+msgid "Leasings - Transport units"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart6354
+#: model:account.account,name:l10n_pe.2_chart6354
+#: model:account.account.template,name:l10n_pe.chart6354
+msgid "Leasings - Transportation equipment"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart582
+#: model:account.account,name:l10n_pe.2_chart582
+#: model:account.account.template,name:l10n_pe.chart582
+msgid "Legal"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_010110
+msgid "Leimebamba"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_050609
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_150807
+#: model:res.city,name:l10n_pe.city_pe_1006
+msgid "Leoncio Prado"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_120413
+msgid "Leonor Ordoñez"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_010111
+msgid "Levanto"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.group,name:l10n_pe.1_group4
+#: model:account.group,name:l10n_pe.2_group4
+#: model:account.group.template,name:l10n_pe.group4
+msgid "Liabilities"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart46422
+#: model:account.account,name:l10n_pe.2_chart46422
+#: model:account.account.template,name:l10n_pe.chart46422
+msgid ""
+"Liabilities for financial instruments - Derivative financial instruments - "
+"Hedging instruments"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart46421
+#: model:account.account,name:l10n_pe.2_chart46421
+#: model:account.account.template,name:l10n_pe.chart46421
+msgid ""
+"Liabilities for financial instruments - Derivative financial instruments - "
+"Trading book"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart4641
+#: model:account.account,name:l10n_pe.2_chart4641
+#: model:account.account.template,name:l10n_pe.chart4641
+msgid "Liabilities for financial instruments - Primary financial instruments"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart4653
+#: model:account.account,name:l10n_pe.1_chart4773
+#: model:account.account,name:l10n_pe.2_chart4653
+#: model:account.account,name:l10n_pe.2_chart4773
+#: model:account.account.template,name:l10n_pe.chart4653
+#: model:account.account.template,name:l10n_pe.chart4773
+msgid ""
+"Liabilities for purchase of fixed assets - Assets acquired under finance "
+"lease"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart4656
+#: model:account.account,name:l10n_pe.1_chart4776
+#: model:account.account,name:l10n_pe.2_chart4656
+#: model:account.account,name:l10n_pe.2_chart4776
+#: model:account.account.template,name:l10n_pe.chart4656
+#: model:account.account.template,name:l10n_pe.chart4776
+msgid "Liabilities for purchase of fixed assets - Biological assets"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart4655
+#: model:account.account,name:l10n_pe.1_chart4775
+#: model:account.account,name:l10n_pe.2_chart4655
+#: model:account.account,name:l10n_pe.2_chart4775
+#: model:account.account.template,name:l10n_pe.chart4655
+#: model:account.account.template,name:l10n_pe.chart4775
+msgid "Liabilities for purchase of fixed assets - Intangibles"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart4652
+#: model:account.account,name:l10n_pe.1_chart4772
+#: model:account.account,name:l10n_pe.2_chart4652
+#: model:account.account,name:l10n_pe.2_chart4772
+#: model:account.account.template,name:l10n_pe.chart4652
+#: model:account.account.template,name:l10n_pe.chart4772
+msgid "Liabilities for purchase of fixed assets - Investment property"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart4654
+#: model:account.account,name:l10n_pe.1_chart4774
+#: model:account.account,name:l10n_pe.2_chart4654
+#: model:account.account,name:l10n_pe.2_chart4774
+#: model:account.account.template,name:l10n_pe.chart4654
+#: model:account.account.template,name:l10n_pe.chart4774
+msgid ""
+"Liabilities for purchase of fixed assets - Property, plant and equipment"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart4651
+#: model:account.account,name:l10n_pe.1_chart4771
+#: model:account.account,name:l10n_pe.2_chart4651
+#: model:account.account,name:l10n_pe.2_chart4771
+#: model:account.account.template,name:l10n_pe.chart4651
+#: model:account.account.template,name:l10n_pe.chart4771
+msgid "Liabilities for purchase of fixed assets - Securities investments"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart654
+#: model:account.account,name:l10n_pe.2_chart654
+#: model:account.account.template,name:l10n_pe.chart654
+msgid "Licenses and validity rights"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_150101
+#: model:res.city,name:l10n_pe.city_pe_1501
+msgid "Lima"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_010605
+msgid "Limabamba"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_080306
+msgid "Limatambo"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_211203
+msgid "Limbani"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_150116
+msgid "Lince"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_151019
+msgid "Lincha"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_pe_chart_template_liquidity_transfer
+#: model:account.account,name:l10n_pe.2_pe_chart_template_liquidity_transfer
+#: model:account.account.template,name:l10n_pe.pe_chart_template_liquidity_transfer
+msgid "Liquidity Transfer"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_090301
+msgid "Lircay"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_080705
+msgid "Livitaca"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_060107
+msgid "Llacanora"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_021705
+msgid "Llacllin"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_210804
+msgid "Llalli"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_021305
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_060411
+msgid "Llama"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_020301
+msgid "Llamellin"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_061107
+msgid "Llapa"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_021507
+msgid "Llapo"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_100501
+msgid "Llata"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_050610
+msgid "Llauta"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_120603
+msgid "Llaylla"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_021407
+msgid "Llipa"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_110402
+msgid "Llipata"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_050408
+msgid "Llochegua"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_120414
+msgid "Llocllapampa"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_180206
+msgid "Lloque"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_021306
+msgid "Llumpa"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_080706
+msgid "Llusco"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_040511
+msgid "Lluta"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart471
+#: model:account.account,name:l10n_pe.2_chart471
+#: model:account.account.template,name:l10n_pe.chart471
+msgid "Loans"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart1612
+#: model:account.account,name:l10n_pe.1_chart1712
+#: model:account.account,name:l10n_pe.2_chart1612
+#: model:account.account,name:l10n_pe.2_chart1712
+#: model:account.account.template,name:l10n_pe.chart1612
+#: model:account.account.template,name:l10n_pe.chart1712
+msgid "Loans - Whithout garantee"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart1611
+#: model:account.account,name:l10n_pe.1_chart1711
+#: model:account.account,name:l10n_pe.2_chart1611
+#: model:account.account,name:l10n_pe.2_chart1711
+#: model:account.account.template,name:l10n_pe.chart1611
+#: model:account.account.template,name:l10n_pe.chart1711
+msgid "Loans - With guarantee"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart4511
+#: model:account.account,name:l10n_pe.2_chart4511
+#: model:account.account.template,name:l10n_pe.chart4511
+msgid ""
+"Loans from financial institutions and other entities - Financial "
+"institutions"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart4512
+#: model:account.account,name:l10n_pe.2_chart4512
+#: model:account.account.template,name:l10n_pe.chart4512
+msgid "Loans from financial institutions and other entities - Other entities"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart456
+#: model:account.account,name:l10n_pe.2_chart456
+#: model:account.account.template,name:l10n_pe.chart456
+msgid "Loans with repurchase commitments"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_200704
+msgid "Lobitos"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart6432
+#: model:account.account,name:l10n_pe.2_chart6432
+#: model:account.account.template,name:l10n_pe.chart6432
+msgid "Local government - Municipal taxes and citizen security"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart6434
+#: model:account.account,name:l10n_pe.2_chart6434
+#: model:account.account.template,name:l10n_pe.chart6434
+msgid "Local government - Operating license"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart6439
+#: model:account.account,name:l10n_pe.2_chart6439
+#: model:account.account.template,name:l10n_pe.chart6439
+msgid "Local government - Others"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart6431
+#: model:account.account,name:l10n_pe.2_chart6431
+#: model:account.account.template,name:l10n_pe.chart6431
+msgid "Local government - Property tax"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart6433
+#: model:account.account,name:l10n_pe.2_chart6433
+#: model:account.account.template,name:l10n_pe.chart6433
+msgid "Local government - Vehicle property tax"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart4062
+#: model:account.account,name:l10n_pe.2_chart4062
+#: model:account.account.template,name:l10n_pe.chart4062
+msgid "Local governments - Contributions"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart40635
+#: model:account.account,name:l10n_pe.2_chart40635
+#: model:account.account.template,name:l10n_pe.chart40635
+msgid "Local governments - Fees - Administrative services or rights"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart40631
+#: model:account.account,name:l10n_pe.2_chart40631
+#: model:account.account.template,name:l10n_pe.chart40631
+msgid "Local governments - Fees - Establishment opening license"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart40634
+#: model:account.account,name:l10n_pe.2_chart40634
+#: model:account.account.template,name:l10n_pe.chart40634
+msgid "Local governments - Fees - Public or arbitrary services"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart40632
+#: model:account.account,name:l10n_pe.2_chart40632
+#: model:account.account.template,name:l10n_pe.chart40632
+msgid "Local governments - Fees - Public transportation"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart40633
+#: model:account.account,name:l10n_pe.2_chart40633
+#: model:account.account.template,name:l10n_pe.chart40633
+msgid "Local governments - Fees - Vehicle parking"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart40612
+#: model:account.account,name:l10n_pe.2_chart40612
+#: model:account.account.template,name:l10n_pe.chart40612
+msgid "Local governments - Taxes - Gambling tax"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart40613
+#: model:account.account,name:l10n_pe.2_chart40613
+#: model:account.account.template,name:l10n_pe.chart40613
+msgid "Local governments - Taxes - Gaming taxes"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart40614
+#: model:account.account,name:l10n_pe.2_chart40614
+#: model:account.account.template,name:l10n_pe.chart40614
+msgid "Local governments - Taxes - Impuesto de alcabala"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart40615
+#: model:account.account,name:l10n_pe.2_chart40615
+#: model:account.account.template,name:l10n_pe.chart40615
+msgid "Local governments - Taxes - Property tax"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart40616
+#: model:account.account,name:l10n_pe.2_chart40616
+#: model:account.account.template,name:l10n_pe.chart40616
+msgid "Local governments - Taxes - Tax on non-sporting public shows"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart40611
+#: model:account.account,name:l10n_pe.2_chart40611
+#: model:account.account.template,name:l10n_pe.chart40611
+msgid "Local governments - Taxes - Vehicle property tax"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_090506
+msgid "Locroja"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_230301
+msgid "Locumba"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_040311
+msgid "Lomas"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_010606
+msgid "Longar"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_130304
+msgid "Longotea"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_010507
+msgid "Longuita"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_010508
+msgid "Lonya Chico"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_010706
+msgid "Lonya Grande"
+msgstr ""
+
+#. module: l10n_pe
+#: model:res.city,name:l10n_pe.city_pe_1603
+msgid "Loreto"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_110103
+msgid "Los Aquijes"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_060108
+msgid "Los Baños del Inca"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_030611
+msgid "Los Chankas"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_050203
+msgid "Los Morochucos"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_150117
+msgid "Los Olivos"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_200705
+msgid "Los Organos"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart6771
+#: model:account.account,name:l10n_pe.2_chart6771
+#: model:account.account.template,name:l10n_pe.chart6771
+msgid ""
+"Loss from measurement of financial assets and liabilities at fair value - "
+"Investments held for trading"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart6772
+#: model:account.account,name:l10n_pe.2_chart6772
+#: model:account.account.template,name:l10n_pe.chart6772
+msgid ""
+"Loss from measurement of financial assets and liabilities at fair value - "
+"Other financial investments"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart6773
+#: model:account.account,name:l10n_pe.2_chart6773
+#: model:account.account.template,name:l10n_pe.chart6773
+msgid ""
+"Loss from measurement of financial assets and liabilities at fair value - "
+"Others"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart672
+#: model:account.account,name:l10n_pe.2_chart672
+#: model:account.account.template,name:l10n_pe.chart672
+msgid "Loss on derivative financial instruments"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart892
+#: model:account.account,name:l10n_pe.2_chart892
+#: model:account.account.template,name:l10n_pe.chart892
+msgid "Lost"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_050611
+#: model:res.city,name:l10n_pe.city_pe_0506
+msgid "Lucanas"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_021307
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_131102
+msgid "Lucma"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_030409
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_081208
+msgid "Lucre"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_050506
+msgid "Luis Carranza"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_150508
+msgid "Lunahuana"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_050405
+msgid "Luricocha"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_150118
+msgid "Lurigancho"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_150119
+msgid "Lurin"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_010509
+#: model:res.city,name:l10n_pe.city_pe_0105
+msgid "Luya"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_010510
+msgid "Luya Viejo"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_100605
+msgid "Luyando"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.group,name:l10n_pe.1_group20
+#: model:account.group,name:l10n_pe.2_group20
+#: model:account.group.template,name:l10n_pe.group20
+msgid "MERCHANDISE"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.group,name:l10n_pe.1_group17
+#: model:account.group,name:l10n_pe.2_group17
+#: model:account.group.template,name:l10n_pe.group17
+msgid "MISCELLANEOUS ACCOUNTS RECEIVABLE – ASSOCIATED"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.group,name:l10n_pe.1_group16
+#: model:account.group,name:l10n_pe.2_group16
+#: model:account.group.template,name:l10n_pe.group16
+msgid "MISCELLANEOUS ACCOUNTS RECEIVABLE – THIRD PARTIES"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_040512
+msgid "Maca"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_210805
+msgid "Macari"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_021804
+msgid "Macate"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_040408
+msgid "Machaguay"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_130608
+msgid "Mache"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart36431
+#: model:account.account,name:l10n_pe.2_chart36431
+#: model:account.account.template,name:l10n_pe.chart36431
+msgid "Machinery and exploitation equipment - Costs"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart36433
+#: model:account.account,name:l10n_pe.2_chart36433
+#: model:account.account.template,name:l10n_pe.chart36433
+msgid "Machinery and exploitation equipment - Financing costs"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart33311
+#: model:account.account,name:l10n_pe.2_chart33311
+#: model:account.account.template,name:l10n_pe.chart33311
+msgid ""
+"Machinery and exploitation equipment - Machinery and exploitation equipment "
+"- Costs"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart33313
+#: model:account.account,name:l10n_pe.2_chart33313
+#: model:account.account.template,name:l10n_pe.chart33313
+msgid ""
+"Machinery and exploitation equipment - Machinery and exploitation equipment "
+"- Financing costs"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart33312
+#: model:account.account,name:l10n_pe.2_chart33312
+#: model:account.account.template,name:l10n_pe.chart33312
+msgid ""
+"Machinery and exploitation equipment - Machinery and exploitation equipment "
+"- Revaluation"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart36432
+#: model:account.account,name:l10n_pe.2_chart36432
+#: model:account.account.template,name:l10n_pe.chart36432
+msgid "Machinery and exploitation equipment - Revaluation"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_081304
+msgid "Machupicchu"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_210301
+msgid "Macusani"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_151020
+msgid "Madean"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_170203
+msgid "Madre de Dios"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_040513
+msgid "Madrigal"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_010112
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_060109
+msgid "Magdalena"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_130204
+msgid "Magdalena de Cao"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_150120
+msgid "Magdalena del Mar"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart6345
+#: model:account.account,name:l10n_pe.2_chart6345
+#: model:account.account.template,name:l10n_pe.chart6345
+msgid "Maintenance and repairs - Biological assets"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart6344
+#: model:account.account,name:l10n_pe.2_chart6344
+#: model:account.account.template,name:l10n_pe.chart6344
+msgid "Maintenance and repairs - Intangibles"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart6341
+#: model:account.account,name:l10n_pe.2_chart6341
+#: model:account.account.template,name:l10n_pe.chart6341
+msgid "Maintenance and repairs - Investment property"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart63432
+#: model:account.account,name:l10n_pe.2_chart63432
+#: model:account.account.template,name:l10n_pe.chart63432
+msgid "Maintenance and repairs - Property, plant and equipment - Operational"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart63421
+#: model:account.account,name:l10n_pe.2_chart63421
+#: model:account.account.template,name:l10n_pe.chart63421
+msgid "Maintenance and repairs - Right-of-use assets - Financial"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart185
+#: model:account.account,name:l10n_pe.2_chart185
+#: model:account.account.template,name:l10n_pe.chart185
+msgid "Maintenance of fixed assets"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_040520
+msgid "Majes"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_150509
+msgid "Mala"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_021105
+msgid "Malvas"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_030705
+msgid "Mamara"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_250107
+msgid "Manantay"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_150305
+msgid "Manas"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_200706
+msgid "Mancora"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_022003
+msgid "Mancos"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_020512
+msgid "Mangas"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_160703
+msgid "Manseriche"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_090110
+msgid "Manta"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_170201
+#: model:res.city,name:l10n_pe.city_pe_1702
+msgid "Manu"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_140204
+msgid "Manuel Antonio Mesones Muro"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_120208
+msgid "Manzanares"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_160505
+msgid "Maquia"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_030505
+msgid "Mara"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_080604
+msgid "Marangani"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_080904
+msgid "Maranura"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_081305
+msgid "Maras"
+msgstr ""
+
+#. module: l10n_pe
+#: model:res.city,name:l10n_pe.city_pe_1007
+msgid "Marañón"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_021706
+msgid "Marca"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_130905
+msgid "Marcabal"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_050805
+msgid "Marcabamba"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_081209
+msgid "Marcapata"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_120804
+msgid "Marcapomacocha"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_020606
+msgid "Marcara"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_090205
+msgid "Marcas"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_200605
+msgid "Marcavelica"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_120415
+msgid "Marco"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_110304
+msgid "Marcona"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart801
+#: model:account.account,name:l10n_pe.2_chart801
+#: model:account.account.template,name:l10n_pe.chart801
+msgid "Margen comercial"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_100105
+msgid "Margos"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_100606
+msgid "Mariano Damaso Beraun"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_010607
+msgid "Mariscal Benavides"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_010113
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_120209
+msgid "Mariscal Castilla"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_040204
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_090111
+#: model:res.city,name:l10n_pe.city_pe_2206
+msgid "Mariscal Cáceres"
+msgstr ""
+
+#. module: l10n_pe
+#: model:res.city,name:l10n_pe.city_pe_0213
+msgid "Mariscal Luzuriaga"
+msgstr ""
+
+#. module: l10n_pe
+#: model:res.city,name:l10n_pe.city_pe_1801
+msgid "Mariscal Nieto"
+msgstr ""
+
+#. module: l10n_pe
+#: model:res.city,name:l10n_pe.city_pe_1604
+msgid "Mariscal Ramón Castilla"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_131103
+msgid "Marmot"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_010511
+msgid "María"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_050204
+msgid "María Parado de Bellido"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_040109
+msgid "Maríano Melgar"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_040203
+msgid "Maríano Nicolás Valcárcel"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_100311
+msgid "Marías"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_150713
+msgid "Maríatana"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_021009
+msgid "Masin"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_250104
+msgid "Masisea"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_120416
+msgid "Masma"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_120417
+msgid "Masma Chicche"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_022004
+msgid "Matacoto"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_120210
+msgid "Matahuasi"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_180207
+msgid "Matalaque"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_240303
+msgid "Matapalo"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_060110
+msgid "Matara"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_021205
+msgid "Mato"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_150701
+msgid "Matucana"
+msgstr ""
+
+#. module: l10n_pe
+#: model:res.city,name:l10n_pe.city_pe_1601
+msgid "Maynas"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_120604
+msgid "Mazamari"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_160106
+msgid "Mazan"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_210109
+msgid "Mañazo"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_080914
+msgid "Megantoni"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_040705
+msgid "Mejia"
+msgstr ""
+
+#. module: l10n_pe
+#: model:res.city,name:l10n_pe.city_pe_2108
+msgid "Melgar"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.group,name:l10n_pe.1_group0
+#: model:account.group,name:l10n_pe.2_group0
+#: model:account.group.template,name:l10n_pe.group0
+msgid "Memorandum accounts"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart281
+#: model:account.account,name:l10n_pe.2_chart281
+#: model:account.account.template,name:l10n_pe.chart281
+msgid "Merchandise"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart6011
+#: model:account.account,name:l10n_pe.1_chart6111
+#: model:account.account,name:l10n_pe.2_chart6011
+#: model:account.account,name:l10n_pe.2_chart6111
+#: model:account.account.template,name:l10n_pe.chart6011
+#: model:account.account.template,name:l10n_pe.chart6111
+msgid "Merchandise - Merchandise"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart20111
+#: model:account.account,name:l10n_pe.1_chart29111
+#: model:account.account,name:l10n_pe.2_chart20111
+#: model:account.account,name:l10n_pe.2_chart29111
+#: model:account.account.template,name:l10n_pe.chart20111
+#: model:account.account.template,name:l10n_pe.chart29111
+msgid "Merchandise - Merchandise - Costs"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart70112
+#: model:account.account,name:l10n_pe.2_chart70112
+#: model:account.account.template,name:l10n_pe.chart70112
+msgid "Merchandise - Merchandise - Export sale - Associated"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart70111
+#: model:account.account,name:l10n_pe.2_chart70111
+#: model:account.account.template,name:l10n_pe.chart70111
+msgid "Merchandise - Merchandise - Export sale - Third parties"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart69112
+#: model:account.account,name:l10n_pe.2_chart69112
+#: model:account.account.template,name:l10n_pe.chart69112
+msgid "Merchandise - Merchandise - Exportation - Associated"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart69111
+#: model:account.account,name:l10n_pe.2_chart69111
+#: model:account.account.template,name:l10n_pe.chart69111
+msgid "Merchandise - Merchandise - Exportation - Third parties"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart20114
+#: model:account.account,name:l10n_pe.2_chart20114
+#: model:account.account.template,name:l10n_pe.chart20114
+msgid "Merchandise - Merchandise - Fair value"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart69122
+#: model:account.account,name:l10n_pe.1_chart70122
+#: model:account.account,name:l10n_pe.2_chart69122
+#: model:account.account,name:l10n_pe.2_chart70122
+#: model:account.account.template,name:l10n_pe.chart69122
+#: model:account.account.template,name:l10n_pe.chart70122
+msgid "Merchandise - Merchandise - Local sale - Associated"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart69121
+#: model:account.account,name:l10n_pe.1_chart70121
+#: model:account.account,name:l10n_pe.2_chart69121
+#: model:account.account,name:l10n_pe.2_chart70121
+#: model:account.account.template,name:l10n_pe.chart69121
+#: model:account.account.template,name:l10n_pe.chart70121
+msgid "Merchandise - Merchandise - Local sale - Third parties"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_070107
+msgid "Mi Perú"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_030706
+msgid "Micaela Bastidas"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_200606
+msgid "Miguel Checa"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_060307
+msgid "Miguel Iglesias"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_010608
+msgid "Milpuc"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_060412
+msgid "Miracosta"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_040110
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_100506
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_150122
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_151021
+msgid "Miraflores"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_020305
+msgid "Mirgas"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart3823
+#: model:account.account,name:l10n_pe.2_chart3823
+#: model:account.account.template,name:l10n_pe.chart3823
+msgid "Misc. - Assets received in payment (awarded and realizable)"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart3821
+#: model:account.account,name:l10n_pe.2_chart3821
+#: model:account.account.template,name:l10n_pe.chart3821
+msgid "Misc. - Coins and jewelry"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart3822
+#: model:account.account,name:l10n_pe.2_chart3822
+#: model:account.account.template,name:l10n_pe.chart3822
+msgid "Misc. - Goods delivered on loan"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart3829
+#: model:account.account,name:l10n_pe.2_chart3829
+#: model:account.account.template,name:l10n_pe.chart3829
+msgid "Misc. - Others"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart33621
+#: model:account.account,name:l10n_pe.2_chart33621
+#: model:account.account.template,name:l10n_pe.chart33621
+msgid "Miscellaneous equipment - Communication equipment - Costs"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart33622
+#: model:account.account,name:l10n_pe.2_chart33622
+#: model:account.account.template,name:l10n_pe.chart33622
+msgid "Miscellaneous equipment - Communication equipment - Revaluation"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart36461
+#: model:account.account,name:l10n_pe.2_chart36461
+#: model:account.account.template,name:l10n_pe.chart36461
+msgid "Miscellaneous equipment - Costs"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart33641
+#: model:account.account,name:l10n_pe.2_chart33641
+#: model:account.account.template,name:l10n_pe.chart33641
+msgid "Miscellaneous equipment - Environmental equipment - Costs"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart33642
+#: model:account.account,name:l10n_pe.2_chart33642
+#: model:account.account.template,name:l10n_pe.chart33642
+msgid "Miscellaneous equipment - Environmental equipment - Revaluation"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart33611
+#: model:account.account,name:l10n_pe.2_chart33611
+#: model:account.account.template,name:l10n_pe.chart33611
+msgid "Miscellaneous equipment - Information processing equipment - Costs"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart33612
+#: model:account.account,name:l10n_pe.2_chart33612
+#: model:account.account.template,name:l10n_pe.chart33612
+msgid ""
+"Miscellaneous equipment - Information processing equipment - Revaluation"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart33691
+#: model:account.account,name:l10n_pe.2_chart33691
+#: model:account.account.template,name:l10n_pe.chart33691
+msgid "Miscellaneous equipment - Other equipments - Costs"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart33692
+#: model:account.account,name:l10n_pe.2_chart33692
+#: model:account.account.template,name:l10n_pe.chart33692
+msgid "Miscellaneous equipment - Other equipments - Revaluation"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart36462
+#: model:account.account,name:l10n_pe.2_chart36462
+#: model:account.account.template,name:l10n_pe.chart36462
+msgid "Miscellaneous equipment - Revaluation"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart33631
+#: model:account.account,name:l10n_pe.2_chart33631
+#: model:account.account.template,name:l10n_pe.chart33631
+msgid "Miscellaneous equipment - Security equipment - Costs"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart33632
+#: model:account.account,name:l10n_pe.2_chart33632
+#: model:account.account.template,name:l10n_pe.chart33632
+msgid "Miscellaneous equipment - Security equipment - Revaluation"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_120211
+msgid "Mito"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_130107
+msgid "Moche"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_140305
+msgid "Mochumi"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_210901
+#: model:res.city,name:l10n_pe.city_pe_2109
+msgid "Moho"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_100803
+msgid "Molino"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_010114
+msgid "Molinopampa"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_120418
+msgid "Molinos"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_131004
+msgid "Mollebamba"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_040111
+msgid "Mollebaya"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_040701
+msgid "Mollendo"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_090409
+msgid "Mollepampa"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_080307
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_131005
+msgid "Mollepata"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_120419
+msgid "Monobamba"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_140108
+msgid "Monsefu"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_200205
+msgid "Montero"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_010115
+msgid "Montevideo"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_100507
+msgid "Monzón"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_180101
+msgid "Moquegua"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_220910
+msgid "Morales"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_050906
+msgid "Morcolla"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_021805
+msgid "Moro"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_120805
+msgid "Morococha"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_160704
+msgid "Morona"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_140306
+msgid "Morrope"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_200405
+msgid "Morropon"
+msgstr ""
+
+#. module: l10n_pe
+#: model:res.city,name:l10n_pe.city_pe_2004
+msgid "Morropón"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_080204
+msgid "Mosoc Llacta"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_140307
+msgid "Motupe"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_090112
+msgid "Moya"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_220101
+#: model:res.city,name:l10n_pe.city_pe_2201
+msgid "Moyobamba"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_120420
+msgid "Muqui"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_120421
+msgid "Muquiyauyo"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_021308
+msgid "Musga"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_210208
+msgid "Muñani"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.group,name:l10n_pe.1_group27
+#: model:account.group,name:l10n_pe.2_group27
+#: model:account.group.template,name:l10n_pe.group27
+msgid "NON-CURRENT ASSETS HELD FOR SALE"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_060905
+msgid "Namballe"
+msgstr ""
+
+#. module: l10n_pe
+#: model:ir.model.fields,field_description:l10n_pe.field_l10n_pe_res_city_district__name
+msgid "Name"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_060111
+msgid "Namora"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_061108
+msgid "Nanchoc"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_160107
+msgid "Napo"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart40151
+#: model:account.account,name:l10n_pe.2_chart40151
+#: model:account.account.template,name:l10n_pe.chart40151
+msgid "National government - Customs duties - Customs tariff"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart40152
+#: model:account.account,name:l10n_pe.2_chart40152
+#: model:account.account.template,name:l10n_pe.chart40152
+msgid "National government - Customs duties - Other customs duties"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart4012
+#: model:account.account,name:l10n_pe.2_chart4012
+#: model:account.account.template,name:l10n_pe.chart4012
+msgid "National government - Excise tax"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart6412
+#: model:account.account,name:l10n_pe.2_chart6412
+#: model:account.account.template,name:l10n_pe.chart6412
+msgid "National government - Financial transaction tax"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart40117
+#: model:account.account,name:l10n_pe.2_chart40117
+#: model:account.account.template,name:l10n_pe.chart40117
+msgid ""
+"National government - General sales tax - IGV - Intended for common "
+"operations"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart40115
+#: model:account.account,name:l10n_pe.2_chart40115
+#: model:account.account.template,name:l10n_pe.chart40115
+msgid "National government - General sales tax - IGV – Imports"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart40116
+#: model:account.account,name:l10n_pe.2_chart40116
+#: model:account.account.template,name:l10n_pe.chart40116
+msgid ""
+"National government - General sales tax - IGV – Intended for taxed "
+"operations"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart40111
+#: model:account.account,name:l10n_pe.2_chart40111
+#: model:account.account.template,name:l10n_pe.chart40111
+msgid "National government - General sales tax - IGV – Own account"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart40113
+#: model:account.account,name:l10n_pe.2_chart40113
+#: model:account.account.template,name:l10n_pe.chart40113
+msgid "National government - General sales tax - IGV – Perception regime"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart40112
+#: model:account.account,name:l10n_pe.2_chart40112
+#: model:account.account.template,name:l10n_pe.chart40112
+msgid ""
+"National government - General sales tax - IGV – Services provided by non-"
+"residents"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart40114
+#: model:account.account,name:l10n_pe.2_chart40114
+#: model:account.account.template,name:l10n_pe.chart40114
+msgid "National government - General sales tax - IGV – Withholding regime"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart6411
+#: model:account.account,name:l10n_pe.2_chart6411
+#: model:account.account.template,name:l10n_pe.chart6411
+msgid "National government - General sales tax and selective consumption"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart40173
+#: model:account.account,name:l10n_pe.2_chart40173
+#: model:account.account.template,name:l10n_pe.chart40173
+msgid "National government - Income tax - Fifth category income"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart40172
+#: model:account.account,name:l10n_pe.2_chart40172
+#: model:account.account.template,name:l10n_pe.chart40172
+msgid "National government - Income tax - Fourth category rent"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart40174
+#: model:account.account,name:l10n_pe.2_chart40174
+#: model:account.account.template,name:l10n_pe.chart40174
+msgid "National government - Income tax - Non-domiciled income"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart40175
+#: model:account.account,name:l10n_pe.2_chart40175
+#: model:account.account.template,name:l10n_pe.chart40175
+msgid "National government - Income tax - Other retentions"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart40171
+#: model:account.account,name:l10n_pe.2_chart40171
+#: model:account.account.template,name:l10n_pe.chart40171
+msgid "National government - Income tax - Third category income"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart6415
+#: model:account.account,name:l10n_pe.2_chart6415
+#: model:account.account.template,name:l10n_pe.chart6415
+msgid "National government - Mining royalties"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart40185
+#: model:account.account,name:l10n_pe.2_chart40185
+#: model:account.account.template,name:l10n_pe.chart40185
+msgid "National government - Other taxes and considerations - Dividends tax"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart40183
+#: model:account.account,name:l10n_pe.2_chart40183
+#: model:account.account.template,name:l10n_pe.chart40183
+msgid ""
+"National government - Other taxes and considerations - Fees for the "
+"provision of public services"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart40181
+#: model:account.account,name:l10n_pe.2_chart40181
+#: model:account.account.template,name:l10n_pe.chart40181
+msgid ""
+"National government - Other taxes and considerations - Financial transaction"
+" tax"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart40189
+#: model:account.account,name:l10n_pe.2_chart40189
+#: model:account.account.template,name:l10n_pe.chart40189
+msgid "National government - Other taxes and considerations - Other taxes"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart40184
+#: model:account.account,name:l10n_pe.2_chart40184
+#: model:account.account.template,name:l10n_pe.chart40184
+msgid "National government - Other taxes and considerations - Royalties"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart40182
+#: model:account.account,name:l10n_pe.2_chart40182
+#: model:account.account.template,name:l10n_pe.chart40182
+msgid ""
+"National government - Other taxes and considerations - Tax on casino games "
+"and slots"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart40186
+#: model:account.account,name:l10n_pe.2_chart40186
+#: model:account.account.template,name:l10n_pe.chart40186
+msgid ""
+"National government - Other taxes and considerations - Temporary tax on net "
+"assets"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart6419
+#: model:account.account,name:l10n_pe.2_chart6419
+#: model:account.account.template,name:l10n_pe.chart6419
+msgid "National government - Others"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart6416
+#: model:account.account,name:l10n_pe.2_chart6416
+#: model:account.account.template,name:l10n_pe.chart6416
+msgid "National government - Royalties"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart6414
+#: model:account.account,name:l10n_pe.2_chart6414
+#: model:account.account.template,name:l10n_pe.chart6414
+msgid "National government - Tax on casino games and slot machines"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart6413
+#: model:account.account,name:l10n_pe.2_chart6413
+#: model:account.account.template,name:l10n_pe.chart6413
+msgid "National government - Temporary tax on net assets"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_160301
+msgid "Nauta"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_150905
+msgid "Navan"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_110301
+#: model:res.city,name:l10n_pe.city_pe_1103
+msgid "Nazca"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_021806
+msgid "Nepeña"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_250304
+msgid "Neshuya"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.group,name:l10n_pe.1_group5
+#: model:account.group,name:l10n_pe.2_group5
+#: model:account.group.template,name:l10n_pe.group5
+msgid "Net Worth"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart65525
+#: model:account.account,name:l10n_pe.2_chart65525
+#: model:account.account.template,name:l10n_pe.chart65525
+msgid ""
+"Net cost of disposal of fixed assets and operations discontinued - "
+"Discontinued operations – Asset abandonment - Biological assets"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart65524
+#: model:account.account,name:l10n_pe.2_chart65524
+#: model:account.account.template,name:l10n_pe.chart65524
+msgid ""
+"Net cost of disposal of fixed assets and operations discontinued - "
+"Discontinued operations – Asset abandonment - Intangibles"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart65521
+#: model:account.account,name:l10n_pe.2_chart65521
+#: model:account.account.template,name:l10n_pe.chart65521
+msgid ""
+"Net cost of disposal of fixed assets and operations discontinued - "
+"Discontinued operations – Asset abandonment - Investment property"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart65523
+#: model:account.account,name:l10n_pe.2_chart65523
+#: model:account.account.template,name:l10n_pe.chart65523
+msgid ""
+"Net cost of disposal of fixed assets and operations discontinued - "
+"Discontinued operations – Asset abandonment - Property, plant and equipment"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart65522
+#: model:account.account,name:l10n_pe.2_chart65522
+#: model:account.account.template,name:l10n_pe.chart65522
+msgid ""
+"Net cost of disposal of fixed assets and operations discontinued - "
+"Discontinued operations – Asset abandonment - Right-of-use assets - "
+"Financial leasing"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart65516
+#: model:account.account,name:l10n_pe.2_chart65516
+#: model:account.account.template,name:l10n_pe.chart65516
+msgid ""
+"Net cost of disposal of fixed assets and operations discontinued - Net cost "
+"of disposal of fixed assets - Biological assets"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart65515
+#: model:account.account,name:l10n_pe.2_chart65515
+#: model:account.account.template,name:l10n_pe.chart65515
+msgid ""
+"Net cost of disposal of fixed assets and operations discontinued - Net cost "
+"of disposal of fixed assets - Intangibles"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart65512
+#: model:account.account,name:l10n_pe.2_chart65512
+#: model:account.account.template,name:l10n_pe.chart65512
+msgid ""
+"Net cost of disposal of fixed assets and operations discontinued - Net cost "
+"of disposal of fixed assets - Investment property"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart65514
+#: model:account.account,name:l10n_pe.2_chart65514
+#: model:account.account.template,name:l10n_pe.chart65514
+msgid ""
+"Net cost of disposal of fixed assets and operations discontinued - Net cost "
+"of disposal of fixed assets - Property, plant and equipment"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart65513
+#: model:account.account,name:l10n_pe.2_chart65513
+#: model:account.account.template,name:l10n_pe.chart65513
+msgid ""
+"Net cost of disposal of fixed assets and operations discontinued - Net cost "
+"of disposal of fixed assets - Right-of-use assets - Financial leasing"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart65511
+#: model:account.account,name:l10n_pe.2_chart65511
+#: model:account.account.template,name:l10n_pe.chart65511
+msgid ""
+"Net cost of disposal of fixed assets and operations discontinued - Net cost "
+"of disposal of fixed assets - Securities investments"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_210704
+msgid "Nicasio"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_040205
+msgid "Nicolás de Pierola"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_061109
+msgid "Niepos"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_010401
+msgid "Nieva"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_061306
+msgid "Ninabamba"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_190105
+msgid "Ninacaca"
+msgstr ""
+
+#. module: l10n_pe
 #: model:l10n_latam.identification.type,name:l10n_pe.it_NDTD
 msgid "Non-Domiciled Tax Document"
 msgstr ""
 
 #. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_140109
+msgid "Nueva Arica"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_220804
+msgid "Nueva Cajamarca"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_250106
+msgid "Nueva Requena"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_120212
+msgid "Nueve de Julio"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_150510
+msgid "Nuevo Imperial"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_090113
+msgid "Nuevo Occoro"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_221002
+msgid "Nuevo Progreso"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_021809
+msgid "Nuevo chimbote"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_210806
+msgid "Nuñoa"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.group,name:l10n_pe.1_group47
+#: model:account.group,name:l10n_pe.2_group47
+#: model:account.group.template,name:l10n_pe.group47
+msgid "OTHER ACCOUNTS PAYABLE – ASSOCIATED"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.group,name:l10n_pe.1_group46
+#: model:account.group,name:l10n_pe.2_group46
+#: model:account.group.template,name:l10n_pe.group46
+msgid "OTHER ACCOUNTS PAYABLE – THIRD PARTIES"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.group,name:l10n_pe.1_group38
+#: model:account.group,name:l10n_pe.2_group38
+#: model:account.group.template,name:l10n_pe.group38
+msgid "OTHER ASSETS"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.group,name:l10n_pe.1_group65
+#: model:account.group,name:l10n_pe.2_group65
+#: model:account.group.template,name:l10n_pe.group65
+msgid "OTHER MANAGEMENT EXPENSES"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.group,name:l10n_pe.1_group75
+#: model:account.group,name:l10n_pe.2_group75
+#: model:account.group.template,name:l10n_pe.group75
+msgid "OTHER MANAGEMENT INCOME"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.tax.group,name:l10n_pe.tax_group_other
+msgid "OTHERS"
+msgstr ""
+
+#. module: l10n_pe
 #: model:ir.model.fields.selection,name:l10n_pe.selection__account_tax__l10n_pe_edi_tax_code__9999
 #: model:ir.model.fields.selection,name:l10n_pe.selection__account_tax_template__l10n_pe_edi_tax_code__9999
-msgid "OTROS - Other taxes"
+msgid "OTHERS - Other taxes"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_101106
+msgid "Obas"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_010512
+msgid "Ocalli"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_050612
+msgid "Ocaña"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_030605
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_080905
+msgid "Ocobamba"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_081210
+msgid "Ocongate"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_080804
+msgid "Ocoruro"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_090606
+msgid "Ocoyo"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_040206
+msgid "Ocoña"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_021401
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_050106
+#: model:res.city,name:l10n_pe.city_pe_0214
+msgid "Ocros"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_110104
+msgid "Ocucaje"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_010513
+msgid "Ocumal"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_210705
+msgid "Ocuviri"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart0215
+#: model:account.account,name:l10n_pe.2_chart0215
+#: model:account.account.template,name:l10n_pe.chart0215
+msgid "Offsetting accounts debit memorandum"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_210308
+msgid "Ollachea"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_081306
+msgid "Ollantaytambo"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_211305
+msgid "Ollaraya"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_010116
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_020108
+msgid "Olleros"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_140308
+msgid "Olmos"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_081006
+msgid "Omacha"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_151022
+msgid "Omas"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_180201
+msgid "Omate"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_010609
+msgid "Omia"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_120503
+msgid "Ondores"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_130807
+msgid "Ongon"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_030606
+msgid "Ongoy"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_040409
+msgid "Orcopampa"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_120213
+msgid "Orcotuna"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_050511
+msgid "Oronccoy"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_030305
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_081211
+msgid "Oropesa"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_210807
+msgid "Orurillo"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart409
+#: model:account.account,name:l10n_pe.2_chart409
+#: model:account.account.template,name:l10n_pe.chart409
+msgid "Other administrative costs and interest"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart1051
+#: model:account.account,name:l10n_pe.2_chart1051
+#: model:account.account.template,name:l10n_pe.chart1051
+msgid "Other cash equivalents - Other cash equivalents"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart0128
+#: model:account.account,name:l10n_pe.1_chart0228
+#: model:account.account,name:l10n_pe.2_chart0128
+#: model:account.account,name:l10n_pe.2_chart0228
+#: model:account.account.template,name:l10n_pe.chart0128
+#: model:account.account.template,name:l10n_pe.chart0228
+msgid "Other credit memorandum accounts"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart0113
+#: model:account.account,name:l10n_pe.1_chart0214
+#: model:account.account,name:l10n_pe.2_chart0113
+#: model:account.account,name:l10n_pe.2_chart0214
+#: model:account.account.template,name:l10n_pe.chart0113
+#: model:account.account.template,name:l10n_pe.chart0214
+msgid "Other debit memorandum accounts"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart189
+#: model:account.account,name:l10n_pe.2_chart189
+#: model:account.account.template,name:l10n_pe.chart189
+msgid "Other expenses contracted in advance"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart6793
+#: model:account.account,name:l10n_pe.2_chart6793
+#: model:account.account.template,name:l10n_pe.chart6793
+msgid ""
+"Other financial expenses - Financial expenses in updating assets for right "
+"of use"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart6792
+#: model:account.account,name:l10n_pe.2_chart6792
+#: model:account.account.template,name:l10n_pe.chart6792
+msgid ""
+"Other financial expenses - Financial expenses measured at discounted value"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart6791
+#: model:account.account,name:l10n_pe.2_chart6791
+#: model:account.account.template,name:l10n_pe.chart6791
+msgid "Other financial expenses - Option premiums"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart7792
+#: model:account.account,name:l10n_pe.2_chart7792
+#: model:account.account.template,name:l10n_pe.chart7792
+msgid "Other financial income - Financial income measured at discounted value"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart4541
+#: model:account.account,name:l10n_pe.2_chart4541
+#: model:account.account.template,name:l10n_pe.chart4541
+msgid "Other financial instruments payable - Bills"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart4543
+#: model:account.account,name:l10n_pe.2_chart4543
+#: model:account.account.template,name:l10n_pe.chart4543
+msgid "Other financial instruments payable - Bonds"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart4542
+#: model:account.account,name:l10n_pe.2_chart4542
+#: model:account.account.template,name:l10n_pe.chart4542
+msgid "Other financial instruments payable - Commercial papers"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart4545
+#: model:account.account,name:l10n_pe.2_chart4545
+#: model:account.account.template,name:l10n_pe.chart4545
+msgid "Other financial instruments payable - Conformed invoices"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart4549
+#: model:account.account,name:l10n_pe.2_chart4549
+#: model:account.account.template,name:l10n_pe.chart4549
+msgid "Other financial instruments payable - Other financial obligations"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart4544
+#: model:account.account,name:l10n_pe.2_chart4544
+#: model:account.account.template,name:l10n_pe.chart4544
+msgid "Other financial instruments payable - Promissory notes"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart36731
+#: model:account.account,name:l10n_pe.2_chart36731
+#: model:account.account.template,name:l10n_pe.chart36731
+msgid "Other financial investments - Costs"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart11211
+#: model:account.account,name:l10n_pe.2_chart11211
+#: model:account.account.template,name:l10n_pe.chart11211
+msgid "Other financial investments - Other financial investments - Costs"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart11212
+#: model:account.account,name:l10n_pe.2_chart11212
+#: model:account.account.template,name:l10n_pe.chart11212
+msgid "Other financial investments - Other financial investments - Fair value"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart36591
+#: model:account.account,name:l10n_pe.2_chart36591
+#: model:account.account.template,name:l10n_pe.chart36591
+msgid "Other intangible assets - Costs"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart34911
+#: model:account.account,name:l10n_pe.2_chart34911
+#: model:account.account.template,name:l10n_pe.chart34911
+msgid "Other intangible assets - Other intangible assets - Costs"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart34912
+#: model:account.account,name:l10n_pe.2_chart34912
+#: model:account.account.template,name:l10n_pe.chart34912
+msgid "Other intangible assets - Other intangible assets - Revaluation"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart36592
+#: model:account.account,name:l10n_pe.2_chart36592
+#: model:account.account.template,name:l10n_pe.chart36592
+msgid "Other intangible assets - Revaluation"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart6592
+#: model:account.account,name:l10n_pe.2_chart6592
+#: model:account.account.template,name:l10n_pe.chart6592
+msgid "Other management fees - Administrative sanctions"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart6591
+#: model:account.account,name:l10n_pe.2_chart6591
+#: model:account.account.template,name:l10n_pe.chart6591
+msgid "Other management fees - Donations"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart7593
+#: model:account.account,name:l10n_pe.2_chart7593
+#: model:account.account.template,name:l10n_pe.chart7593
+msgid "Other management income - Donations"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart7591
+#: model:account.account,name:l10n_pe.2_chart7591
+#: model:account.account.template,name:l10n_pe.chart7591
+msgid "Other management income - Government subsidies"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart7592
+#: model:account.account,name:l10n_pe.2_chart7592
+#: model:account.account.template,name:l10n_pe.chart7592
+msgid "Other management income - Insurance claims"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart7599
+#: model:account.account,name:l10n_pe.2_chart7599
+#: model:account.account.template,name:l10n_pe.chart7599
+msgid "Other management income - Other management income"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart7594
+#: model:account.account,name:l10n_pe.2_chart7594
+#: model:account.account.template,name:l10n_pe.chart7594
+msgid "Other management income - Tax refunds"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart489
+#: model:account.account,name:l10n_pe.2_chart489
+#: model:account.account.template,name:l10n_pe.chart489
+msgid "Other provisions"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart419
+#: model:account.account,name:l10n_pe.2_chart419
+#: model:account.account.template,name:l10n_pe.chart419
+msgid "Other remuneration and shares payable"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart622
+#: model:account.account,name:l10n_pe.2_chart622
+#: model:account.account.template,name:l10n_pe.chart622
+msgid "Other remunerations"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart589
+#: model:account.account,name:l10n_pe.2_chart589
+#: model:account.account.template,name:l10n_pe.chart589
+msgid "Other reserves"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart6391
+#: model:account.account,name:l10n_pe.2_chart6391
+#: model:account.account.template,name:l10n_pe.chart6391
+msgid "Other services provided by third parties - Banking expenses"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart6392
+#: model:account.account,name:l10n_pe.2_chart6392
+#: model:account.account.template,name:l10n_pe.chart6392
+msgid "Other services provided by third parties - Laboratory expenses"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart4692
+#: model:account.account,name:l10n_pe.2_chart4692
+#: model:account.account.template,name:l10n_pe.chart4692
+msgid "Other sundry accounts payable - Conditional donations"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart4691
+#: model:account.account,name:l10n_pe.2_chart4691
+#: model:account.account.template,name:l10n_pe.chart4691
+msgid "Other sundry accounts payable - Government subsidies"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart4699
+#: model:account.account,name:l10n_pe.2_chart4699
+#: model:account.account.template,name:l10n_pe.chart4699
+msgid "Other sundry accounts payable - Other accounts payable"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart4791
+#: model:account.account,name:l10n_pe.2_chart4791
+#: model:account.account.template,name:l10n_pe.chart4791
+msgid "Other sundry accounts payable - Other sundry accounts payable"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart179
+#: model:account.account,name:l10n_pe.2_chart179
+#: model:account.account.template,name:l10n_pe.chart179
+msgid "Other sundry accounts receivable"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart1691
+#: model:account.account,name:l10n_pe.2_chart1691
+#: model:account.account.template,name:l10n_pe.chart1691
+msgid ""
+"Other sundry accounts receivable - Deliveries to account to third parties"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart1699
+#: model:account.account,name:l10n_pe.2_chart1699
+#: model:account.account.template,name:l10n_pe.chart1699
+msgid "Other sundry accounts receivable - Other sundry accounts receivable"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart6442
+#: model:account.account,name:l10n_pe.2_chart6442
+#: model:account.account.template,name:l10n_pe.chart6442
+msgid "Other tax expenses - Contribution to SENCICO"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart6443
+#: model:account.account,name:l10n_pe.2_chart6443
+#: model:account.account.template,name:l10n_pe.chart6443
+msgid "Other tax expenses - Others"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_050613
+msgid "Otoca"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_130601
+#: model:res.city,name:l10n_pe.city_pe_1306
+msgid "Otuzco"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_060308
+msgid "Oxamarca"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_190301
+#: model:res.city,name:l10n_pe.city_pe_1903
+msgid "Oxapampa"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_050806
+msgid "Oyolo"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_150901
+msgid "Oyon"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_140110
+msgid "Oyotun"
+msgstr ""
+
+#. module: l10n_pe
+#: model:res.city,name:l10n_pe.city_pe_1509
+msgid "Oyón"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.group,name:l10n_pe.1_group72
+#: model:account.group,name:l10n_pe.2_group72
+#: model:account.group.template,name:l10n_pe.group72
+msgid "PRODUCTION OF FIXED ASSETS"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.group,name:l10n_pe.1_group81
+#: model:account.group,name:l10n_pe.2_group81
+#: model:account.group.template,name:l10n_pe.group81
+msgid "PRODUCTION OF THE YEAR"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.group,name:l10n_pe.1_group23
+#: model:account.group,name:l10n_pe.2_group23
+#: model:account.group.template,name:l10n_pe.group23
+msgid "PRODUCTS IN PROCESS"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.group,name:l10n_pe.1_group76
+#: model:account.group,name:l10n_pe.2_group76
+#: model:account.group.template,name:l10n_pe.group76
+msgid "PROFIT FROM MEASUREMENT OF NON-FINANCIAL ASSETS AT FAIR VALUE"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.group,name:l10n_pe.1_group30
+#: model:account.group,name:l10n_pe.2_group30
+#: model:account.group.template,name:l10n_pe.group30
+msgid "PROPERTY INVESTMENTS"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.group,name:l10n_pe.1_group33
+#: model:account.group,name:l10n_pe.2_group33
+#: model:account.group.template,name:l10n_pe.group33
+msgid "PROPERTY, PLANT AND EQUIPMENT"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.group,name:l10n_pe.1_group48
+#: model:account.group,name:l10n_pe.2_group48
+#: model:account.group.template,name:l10n_pe.group48
+msgid "PROVISIONS"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_latam.identification.type,name:l10n_pe.it_PTP
+msgid "PTP"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.group,name:l10n_pe.1_group60
+#: model:account.group,name:l10n_pe.2_group60
+#: model:account.group.template,name:l10n_pe.group60
+msgid "PURCHASES"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_120422
+msgid "Paca"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_200206
+msgid "Pacaipampa"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_130402
+msgid "Pacanga"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_050704
+msgid "Pacapausa"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_150511
+msgid "Pacaran"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_150608
+msgid "Pacaraos"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_130704
+#: model:res.city,name:l10n_pe.city_pe_1307
+msgid "Pacasmayo"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_050107
+msgid "Pacaycasa"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_081007
+msgid "Paccaritambo"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_060413
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_120423
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_120806
+msgid "Paccha"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_150808
+msgid "Paccho"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_150123
+msgid "Pachacamac"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_030306
+msgid "Pachaconas"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_110105
+msgid "Pachacutec"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_090510
+msgid "Pachamarca"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_150906
+msgid "Pachangara"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_100313
+msgid "Pachas"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_230106
+msgid "Pachia"
+msgstr ""
+
+#. module: l10n_pe
+#: model:res.city,name:l10n_pe.city_pe_1008
+msgid "Pachitea"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_220604
+msgid "Pachiza"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart262
+#: model:account.account,name:l10n_pe.2_chart262
+#: model:account.account.template,name:l10n_pe.chart262
+msgid "Packaging"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_020513
+msgid "Pacllon"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_030208
+msgid "Pacobamba"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_180303
+msgid "Pacocha"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_140309
+msgid "Pacora"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_030209
+msgid "Pacucha"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_250301
+#: model:res.city,name:l10n_pe.city_pe_2503
+msgid "Padre Abad"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_160603
+msgid "Padre Márquez"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_050907
+msgid "Paico"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_130205
+msgid "Paijan"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_200207
+msgid "Paimas"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_200501
+#: model:res.city,name:l10n_pe.city_pe_2005
+msgid "Paita"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_220605
+msgid "Pajarillo"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_090114
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_120706
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_210706
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_230107
+msgid "Palca"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_120707
+msgid "Palcamayo"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_190304
+msgid "Palcazu"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_190106
+msgid "Pallanchacra"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_021508
+#: model:res.city,name:l10n_pe.city_pe_0215
+msgid "Pallasca"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_080805
+msgid "Pallpata"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_110401
+#: model:res.city,name:l10n_pe.city_pe_1104
+msgid "Palpa"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_120605
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_160604
+msgid "Pampa Hermosa"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_030210
+msgid "Pampachiri"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_040410
+msgid "Pampacolca"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_040805
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_080506
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_101107
+msgid "Pampamarca"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_021206
+msgid "Pamparomas"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_020109
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_021509
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_090701
+msgid "Pampas"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_021707
+msgid "Pampas chico"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_240104
+msgid "Pampas de Hospital"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_100801
+msgid "Panao"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_120424
+msgid "Pancan"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_120606
+msgid "Pangoa"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_220911
+msgid "Papaplaya"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_240304
+msgid "Papayal"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_110505
+msgid "Paracas"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_150202
+msgid "Paramonga"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_130610
+msgid "Paranday"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_050807
+msgid "Pararca"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_021708
+msgid "Pararin"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_050205
+msgid "Paras"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_210707
+msgid "Paratia"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_120425
+msgid "Parco"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_110106
+msgid "Parcona"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_130808
+msgid "Parcoy"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_220805
+msgid "Pardo Miguel"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_020110
+msgid "Pariacoto"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_020607
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_120124
+msgid "Pariahuanca"
+msgstr ""
+
+#. module: l10n_pe
+#: model:res.city,name:l10n_pe.city_pe_0507
+msgid "Parinacochas"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_160302
+msgid "Parinari"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_200701
+msgid "Pariñas"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_021603
+msgid "Parobamba"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart7782
+#: model:account.account,name:l10n_pe.2_chart7782
+#: model:account.account.template,name:l10n_pe.chart7782
+msgid ""
+"Participation in results of related entities - Income from participation in "
+"joint ventures"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart6781
+#: model:account.account,name:l10n_pe.1_chart7781
+#: model:account.account,name:l10n_pe.2_chart6781
+#: model:account.account,name:l10n_pe.2_chart7781
+#: model:account.account.template,name:l10n_pe.chart6781
+#: model:account.account.template,name:l10n_pe.chart7781
+msgid ""
+"Participation in results of related entities - Participation in the results "
+"of subsidiaries and associates under the equity value method"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart6782
+#: model:account.account,name:l10n_pe.2_chart6782
+#: model:account.account.template,name:l10n_pe.chart6782
+msgid ""
+"Participation in results of related entities - Shares in joint ventures"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart573
+#: model:account.account,name:l10n_pe.2_chart573
+#: model:account.account.template,name:l10n_pe.chart573
+msgid "Participation in revaluation surplus – Investments in related entities"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart466
+#: model:account.account,name:l10n_pe.2_chart466
+#: model:account.account.template,name:l10n_pe.chart466
+msgid "Participation of third parties in joint agreements"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart30411
+#: model:account.account,name:l10n_pe.2_chart30411
+#: model:account.account.template,name:l10n_pe.chart30411
+msgid "Participations in joint agreements - Joint operations - Costs"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart30415
+#: model:account.account,name:l10n_pe.2_chart30415
+#: model:account.account.template,name:l10n_pe.chart30415
+msgid ""
+"Participations in joint agreements - Joint operations - Equity participation"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart30414
+#: model:account.account,name:l10n_pe.2_chart30414
+#: model:account.account.template,name:l10n_pe.chart30414
+msgid "Participations in joint agreements - Joint operations - Fair value"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart30421
+#: model:account.account,name:l10n_pe.2_chart30421
+#: model:account.account.template,name:l10n_pe.chart30421
+msgid "Participations in joint agreements - Joint ventures - Costs"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart30425
+#: model:account.account,name:l10n_pe.2_chart30425
+#: model:account.account.template,name:l10n_pe.chart30425
+msgid ""
+"Participations in joint agreements - Joint ventures - Equity participation"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart30424
+#: model:account.account,name:l10n_pe.2_chart30424
+#: model:account.account.template,name:l10n_pe.chart30424
+msgid "Participations in joint agreements - Joint ventures - Fair value"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_081001
+#: model:res.city,name:l10n_pe.city_pe_0810
+msgid "Paruro"
+msgstr ""
+
+#. module: l10n_pe
+#: model:res.city,name:l10n_pe.city_pe_1901
+msgid "Pasco"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_160705
+msgid "Pastaza"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_211204
+msgid "Patambuco"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_140117
+msgid "Patapo"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_030707
+msgid "Pataypampa"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_130809
+#: model:res.city,name:l10n_pe.city_pe_1308
+msgid "Pataz"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart34221
+#: model:account.account,name:l10n_pe.2_chart34221
+#: model:account.account.template,name:l10n_pe.chart34221
+msgid "Patents and industrial property - Brands - Costs"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart34222
+#: model:account.account,name:l10n_pe.2_chart34222
+#: model:account.account.template,name:l10n_pe.chart34222
+msgid "Patents and industrial property - Brands - Revaluation"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart36521
+#: model:account.account,name:l10n_pe.2_chart36521
+#: model:account.account.template,name:l10n_pe.chart36521
+msgid "Patents and industrial property - Costs"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart34211
+#: model:account.account,name:l10n_pe.2_chart34211
+#: model:account.account.template,name:l10n_pe.chart34211
+msgid "Patents and industrial property - Patents - Costs"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart34212
+#: model:account.account,name:l10n_pe.2_chart34212
+#: model:account.account.template,name:l10n_pe.chart34212
+msgid "Patents and industrial property - Patents - Revaluation"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart36522
+#: model:account.account,name:l10n_pe.2_chart36522
+#: model:account.account.template,name:l10n_pe.chart36522
+msgid "Patents and industrial property - Revaluation"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_150203
+msgid "Pativilca"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_190204
+msgid "Paucar"
+msgstr ""
+
+#. module: l10n_pe
+#: model:res.city,name:l10n_pe.city_pe_0508
+msgid "Paucar del Sara Sara"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_090206
+msgid "Paucara"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_090507
+msgid "Paucarbamba"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_210110
+msgid "Paucarcolla"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_040112
+msgid "Paucarpata"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_081101
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_190107
+#: model:res.city,name:l10n_pe.city_pe_0811
+msgid "Paucartambo"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_021010
+msgid "Paucas"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_050801
+msgid "Pausa"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_090711
+msgid "Pazos"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_160402
+msgid "Pebas"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_061001
+msgid "Pedro Gálvez"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_211003
+msgid "Pedro Vilca Apaza"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_120302
+msgid "Perene"
+msgstr ""
+
+#. module: l10n_pe
+#: model:ir.ui.menu,name:l10n_pe.account_reports_pe_statements_menu
+msgid "Peru"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.chart.template,name:l10n_pe.pe_chart_template
+msgid "Peru - PCGE 2019"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_211205
+msgid "Phara"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_130810
+msgid "Pias"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_210111
+msgid "Pichacani"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_120303
+msgid "Pichanaqui"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_080910
+msgid "Pichari"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_080806
+msgid "Pichigua"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_030107
+msgid "Pichirhua"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_090722
+msgid "Pichos"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_220701
+#: model:res.city,name:l10n_pe.city_pe_2207
+msgid "Picota"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_140111
+msgid "Picsi"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_090115
+msgid "Pilchaca"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_120125
+msgid "Pilcomayo"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_210503
+msgid "Pilcuyo"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_100111
+msgid "Pillco Marca"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_081008
+msgid "Pillpinto"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_220704
+msgid "Pilluana"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_090607
+msgid "Pilpichaca"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_140112
+msgid "Pimentel"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_060606
+msgid "Pimpingos"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_100404
+msgid "Pinra"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_220506
+msgid "Pinto Recodo"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_060414
+msgid "Pion"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_020111
+msgid "Pira"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_080405
+msgid "Pisac"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_210405
+msgid "Pisacoma"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_110501
+#: model:res.city,name:l10n_pe.city_pe_1105
+msgid "Pisco"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_021301
+msgid "Piscobamba"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_220404
+msgid "Piscoyacu"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_010514
+msgid "Pisuquia"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_140205
+msgid "Pitipo"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_080605
+msgid "Pitumarca"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_200101
+#: model:res.city,name:l10n_pe.city_pe_2001
+msgid "Piura"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_210112
+msgid "Plateria"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_030410
+msgid "Pocohuanca"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_230108
+msgid "Pocollay"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_040113
+msgid "Pocsi"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_040114
+msgid "Polobaya"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_221003
+msgid "Polvora"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_021601
+#: model:res.city,name:l10n_pe.city_pe_0216
+msgid "Pomabamba"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_120426
+msgid "Pomacancha"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_080205
+msgid "Pomacanchi"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_030211
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_090207
+msgid "Pomacocha"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_060807
+msgid "Pomahuaca"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_140118
+msgid "Pomalca"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_210406
+msgid "Pomata"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_021011
+msgid "Ponto"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_130108
+msgid "Poroto"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_080103
+msgid "Poroy"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_220806
+msgid "Posic"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_210209
+msgid "Potoni"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_190305
+msgid "Pozuzo"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart521
+#: model:account.account,name:l10n_pe.2_chart521
+#: model:account.account.template,name:l10n_pe.chart521
+msgid "Premiums (discount) of shares"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart184
+#: model:account.account,name:l10n_pe.2_chart184
+#: model:account.account.template,name:l10n_pe.chart184
+msgid "Premiums paid for options"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart33021
+#: model:account.account,name:l10n_pe.2_chart33021
+#: model:account.account.template,name:l10n_pe.chart33021
+msgid "Producing plant - Production plant in development - Costs"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart33024
+#: model:account.account,name:l10n_pe.2_chart33024
+#: model:account.account.template,name:l10n_pe.chart33024
+msgid "Producing plant - Production plant in development - Fair value"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart33023
+#: model:account.account,name:l10n_pe.2_chart33023
+#: model:account.account.template,name:l10n_pe.chart33023
+msgid "Producing plant - Production plant in development - Financing costs"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart33022
+#: model:account.account,name:l10n_pe.2_chart33022
+#: model:account.account.template,name:l10n_pe.chart33022
+msgid "Producing plant - Production plant in development - Revaluation"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart33011
+#: model:account.account,name:l10n_pe.2_chart33011
+#: model:account.account.template,name:l10n_pe.chart33011
+msgid "Producing plant - Production plant in production - Costs"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart33014
+#: model:account.account,name:l10n_pe.2_chart33014
+#: model:account.account.template,name:l10n_pe.chart33014
+msgid "Producing plant - Production plant in production - Fair value"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart33013
+#: model:account.account,name:l10n_pe.2_chart33013
+#: model:account.account.template,name:l10n_pe.chart33013
+msgid "Producing plant - Production plant in production - Financing costs"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart33012
+#: model:account.account,name:l10n_pe.2_chart33012
+#: model:account.account.template,name:l10n_pe.chart33012
+msgid "Producing plant - Production plant in production - Revaluation"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart633
+#: model:account.account,name:l10n_pe.2_chart633
+#: model:account.account.template,name:l10n_pe.chart633
+msgid "Production commissioned to third parties"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart813
+#: model:account.account,name:l10n_pe.2_chart813
+#: model:account.account.template,name:l10n_pe.chart813
+msgid "Production of fixed assets"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart811
+#: model:account.account,name:l10n_pe.2_chart811
+#: model:account.account.template,name:l10n_pe.chart811
+msgid "Production of goods"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart812
+#: model:account.account,name:l10n_pe.2_chart812
+#: model:account.account.template,name:l10n_pe.chart812
+msgid "Production of services"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart36401
+#: model:account.account,name:l10n_pe.2_chart36401
+#: model:account.account.template,name:l10n_pe.chart36401
+msgid "Production plant in production - Costs"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart36405
+#: model:account.account,name:l10n_pe.2_chart36405
+#: model:account.account.template,name:l10n_pe.chart36405
+msgid ""
+"Production plant in production - Production plant in development - Costs"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart36408
+#: model:account.account,name:l10n_pe.2_chart36408
+#: model:account.account.template,name:l10n_pe.chart36408
+msgid ""
+"Production plant in production - Production plant in development - Fair "
+"value"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart36407
+#: model:account.account,name:l10n_pe.2_chart36407
+#: model:account.account.template,name:l10n_pe.chart36407
+msgid ""
+"Production plant in production - Production plant in development - Financing"
+" costs"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart36406
+#: model:account.account,name:l10n_pe.2_chart36406
+#: model:account.account.template,name:l10n_pe.chart36406
+msgid ""
+"Production plant in production - Production plant in development - "
+"Revaluation"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart36403
+#: model:account.account,name:l10n_pe.2_chart36403
+#: model:account.account.template,name:l10n_pe.chart36403
+msgid ""
+"Production plant in production - Production plant in production - Financing "
+"costs"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart36402
+#: model:account.account,name:l10n_pe.2_chart36402
+#: model:account.account.template,name:l10n_pe.chart36402
+msgid ""
+"Production plant in production - Production plant in production - "
+"Revaluation"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart2945
+#: model:account.account,name:l10n_pe.2_chart2945
+#: model:account.account.template,name:l10n_pe.chart2945
+msgid "Products in process - Inventory of services in process"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart23111
+#: model:account.account,name:l10n_pe.1_chart29411
+#: model:account.account,name:l10n_pe.2_chart23111
+#: model:account.account,name:l10n_pe.2_chart29411
+#: model:account.account.template,name:l10n_pe.chart23111
+#: model:account.account.template,name:l10n_pe.chart29411
+msgid "Products in process - Products in process - Costs"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart23113
+#: model:account.account,name:l10n_pe.1_chart29413
+#: model:account.account,name:l10n_pe.2_chart23113
+#: model:account.account,name:l10n_pe.2_chart29413
+#: model:account.account.template,name:l10n_pe.chart23113
+#: model:account.account.template,name:l10n_pe.chart29413
+msgid "Products in process - Products in process - Financing costs"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart494
+#: model:account.account,name:l10n_pe.2_chart494
+#: model:account.account.template,name:l10n_pe.chart494
+msgid "Profit on sale with parallel financial lease"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_030708
+msgid "Progreso"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart27231
+#: model:account.account,name:l10n_pe.2_chart27231
+#: model:account.account.template,name:l10n_pe.chart27231
+msgid "Property, plant and equipment - Buildings - Costs"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart27233
+#: model:account.account,name:l10n_pe.2_chart27233
+#: model:account.account.template,name:l10n_pe.chart27233
+msgid "Property, plant and equipment - Buildings - Financing costs"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart27232
+#: model:account.account,name:l10n_pe.2_chart27232
+#: model:account.account.template,name:l10n_pe.chart27232
+msgid "Property, plant and equipment - Buildings - Revaluation"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart32231
+#: model:account.account,name:l10n_pe.2_chart32231
+#: model:account.account.template,name:l10n_pe.chart32231
+msgid "Property, plant and equipment - Financial leasing - Buildings - Costs"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart32233
+#: model:account.account,name:l10n_pe.2_chart32233
+#: model:account.account.template,name:l10n_pe.chart32233
+msgid ""
+"Property, plant and equipment - Financial leasing - Buildings - Financing "
+"costs"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart32232
+#: model:account.account,name:l10n_pe.2_chart32232
+#: model:account.account.template,name:l10n_pe.chart32232
+msgid ""
+"Property, plant and equipment - Financial leasing - Buildings - Revaluation"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart32261
+#: model:account.account,name:l10n_pe.2_chart32261
+#: model:account.account.template,name:l10n_pe.chart32261
+msgid ""
+"Property, plant and equipment - Financial leasing - Furniture and fixtures -"
+" Costs"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart32262
+#: model:account.account,name:l10n_pe.2_chart32262
+#: model:account.account.template,name:l10n_pe.chart32262
+msgid ""
+"Property, plant and equipment - Financial leasing - Furniture and fixtures -"
+" Revaluation"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart32221
+#: model:account.account,name:l10n_pe.2_chart32221
+#: model:account.account.template,name:l10n_pe.chart32221
+msgid "Property, plant and equipment - Financial leasing - Land - Costs"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart32222
+#: model:account.account,name:l10n_pe.2_chart32222
+#: model:account.account.template,name:l10n_pe.chart32222
+msgid "Property, plant and equipment - Financial leasing - Land - Revaluation"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart32241
+#: model:account.account,name:l10n_pe.2_chart32241
+#: model:account.account.template,name:l10n_pe.chart32241
+msgid ""
+"Property, plant and equipment - Financial leasing - Machinery and "
+"exploitation equipment - Costs"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart32243
+#: model:account.account,name:l10n_pe.2_chart32243
+#: model:account.account.template,name:l10n_pe.chart32243
+msgid ""
+"Property, plant and equipment - Financial leasing - Machinery and "
+"exploitation equipment - Financing costs"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart32242
+#: model:account.account,name:l10n_pe.2_chart32242
+#: model:account.account.template,name:l10n_pe.chart32242
+msgid ""
+"Property, plant and equipment - Financial leasing - Machinery and "
+"exploitation equipment - Revaluation"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart32271
+#: model:account.account,name:l10n_pe.2_chart32271
+#: model:account.account.template,name:l10n_pe.chart32271
+msgid ""
+"Property, plant and equipment - Financial leasing - Miscellaneous equipment "
+"- Costs"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart32272
+#: model:account.account,name:l10n_pe.2_chart32272
+#: model:account.account.template,name:l10n_pe.chart32272
+msgid ""
+"Property, plant and equipment - Financial leasing - Miscellaneous equipment "
+"- Revaluation"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart32211
+#: model:account.account,name:l10n_pe.2_chart32211
+#: model:account.account.template,name:l10n_pe.chart32211
+msgid ""
+"Property, plant and equipment - Financial leasing - Production plant in "
+"development - Costs"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart32213
+#: model:account.account,name:l10n_pe.2_chart32213
+#: model:account.account.template,name:l10n_pe.chart32213
+msgid ""
+"Property, plant and equipment - Financial leasing - Production plant in "
+"development - Financing costs"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart32212
+#: model:account.account,name:l10n_pe.2_chart32212
+#: model:account.account.template,name:l10n_pe.chart32212
+msgid ""
+"Property, plant and equipment - Financial leasing - Production plant in "
+"development - Revaluation"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart32201
+#: model:account.account,name:l10n_pe.2_chart32201
+#: model:account.account.template,name:l10n_pe.chart32201
+msgid ""
+"Property, plant and equipment - Financial leasing - Production plant in "
+"production - Costs"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart32203
+#: model:account.account,name:l10n_pe.2_chart32203
+#: model:account.account.template,name:l10n_pe.chart32203
+msgid ""
+"Property, plant and equipment - Financial leasing - Production plant in "
+"production - Financing costs"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart32202
+#: model:account.account,name:l10n_pe.2_chart32202
+#: model:account.account.template,name:l10n_pe.chart32202
+msgid ""
+"Property, plant and equipment - Financial leasing - Production plant in "
+"production - Revaluation"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart32281
+#: model:account.account,name:l10n_pe.2_chart32281
+#: model:account.account.template,name:l10n_pe.chart32281
+msgid ""
+"Property, plant and equipment - Financial leasing - Replacement tools and "
+"units - Costs"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart32282
+#: model:account.account,name:l10n_pe.2_chart32282
+#: model:account.account.template,name:l10n_pe.chart32282
+msgid ""
+"Property, plant and equipment - Financial leasing - Replacement tools and "
+"units - Revaluation"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart32251
+#: model:account.account,name:l10n_pe.2_chart32251
+#: model:account.account.template,name:l10n_pe.chart32251
+msgid ""
+"Property, plant and equipment - Financial leasing - Transport units - Costs"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart32252
+#: model:account.account,name:l10n_pe.2_chart32252
+#: model:account.account.template,name:l10n_pe.chart32252
+msgid ""
+"Property, plant and equipment - Financial leasing - Transport units - "
+"Revaluation"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart27261
+#: model:account.account,name:l10n_pe.2_chart27261
+#: model:account.account.template,name:l10n_pe.chart27261
+msgid "Property, plant and equipment - Furniture and fixtures - Costs"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart27262
+#: model:account.account,name:l10n_pe.2_chart27262
+#: model:account.account.template,name:l10n_pe.chart27262
+msgid "Property, plant and equipment - Furniture and fixtures - Revaluation"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart27221
+#: model:account.account,name:l10n_pe.2_chart27221
+#: model:account.account.template,name:l10n_pe.chart27221
+msgid "Property, plant and equipment - Land - Costs"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart27222
+#: model:account.account,name:l10n_pe.2_chart27222
+#: model:account.account.template,name:l10n_pe.chart27222
+msgid "Property, plant and equipment - Land - Revaluation"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart27241
+#: model:account.account,name:l10n_pe.2_chart27241
+#: model:account.account.template,name:l10n_pe.chart27241
+msgid ""
+"Property, plant and equipment - Machinery and exploitation equipment - Costs"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart27243
+#: model:account.account,name:l10n_pe.2_chart27243
+#: model:account.account.template,name:l10n_pe.chart27243
+msgid ""
+"Property, plant and equipment - Machinery and exploitation equipment - "
+"Financing costs"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart27242
+#: model:account.account,name:l10n_pe.2_chart27242
+#: model:account.account.template,name:l10n_pe.chart27242
+msgid ""
+"Property, plant and equipment - Machinery and exploitation equipment - "
+"Revaluation"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart27271
+#: model:account.account,name:l10n_pe.2_chart27271
+#: model:account.account.template,name:l10n_pe.chart27271
+msgid "Property, plant and equipment - Miscellaneous equipment - Costs"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart27272
+#: model:account.account,name:l10n_pe.2_chart27272
+#: model:account.account.template,name:l10n_pe.chart27272
+msgid "Property, plant and equipment - Miscellaneous equipment - Revaluation"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart32331
+#: model:account.account,name:l10n_pe.2_chart32331
+#: model:account.account.template,name:l10n_pe.chart32331
+msgid "Property, plant and equipment - Operating lease - Buildings - Costs"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart32332
+#: model:account.account,name:l10n_pe.2_chart32332
+#: model:account.account.template,name:l10n_pe.chart32332
+msgid ""
+"Property, plant and equipment - Operating lease - Buildings - Revaluation"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart32321
+#: model:account.account,name:l10n_pe.2_chart32321
+#: model:account.account.template,name:l10n_pe.chart32321
+msgid "Property, plant and equipment - Operating lease - Land - Costs"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart32341
+#: model:account.account,name:l10n_pe.2_chart32341
+#: model:account.account.template,name:l10n_pe.chart32341
+msgid ""
+"Property, plant and equipment - Operating lease - Machinery and exploitation"
+" equipment - Costs"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart32342
+#: model:account.account,name:l10n_pe.2_chart32342
+#: model:account.account.template,name:l10n_pe.chart32342
+msgid ""
+"Property, plant and equipment - Operating lease - Machinery and exploitation"
+" equipment - Revaluation"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart32361
+#: model:account.account,name:l10n_pe.2_chart32361
+#: model:account.account.template,name:l10n_pe.chart32361
+msgid ""
+"Property, plant and equipment - Operating lease - Miscellaneous equipment - "
+"Costs"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart32362
+#: model:account.account,name:l10n_pe.2_chart32362
+#: model:account.account.template,name:l10n_pe.chart32362
+msgid ""
+"Property, plant and equipment - Operating lease - Miscellaneous equipment - "
+"Revaluation"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart32301
+#: model:account.account,name:l10n_pe.2_chart32301
+#: model:account.account.template,name:l10n_pe.chart32301
+msgid ""
+"Property, plant and equipment - Operating lease - Production plant in "
+"production - Costs"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart32302
+#: model:account.account,name:l10n_pe.2_chart32302
+#: model:account.account.template,name:l10n_pe.chart32302
+msgid ""
+"Property, plant and equipment - Operating lease - Production plant in "
+"production - Revaluation"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart32351
+#: model:account.account,name:l10n_pe.2_chart32351
+#: model:account.account.template,name:l10n_pe.chart32351
+msgid ""
+"Property, plant and equipment - Operating lease - Transport units - Costs"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart32352
+#: model:account.account,name:l10n_pe.2_chart32352
+#: model:account.account.template,name:l10n_pe.chart32352
+msgid ""
+"Property, plant and equipment - Operating lease - Transport units - "
+"Revaluation"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart27211
+#: model:account.account,name:l10n_pe.2_chart27211
+#: model:account.account.template,name:l10n_pe.chart27211
+msgid ""
+"Property, plant and equipment - Production plant in development - Costs"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart27214
+#: model:account.account,name:l10n_pe.2_chart27214
+#: model:account.account.template,name:l10n_pe.chart27214
+msgid ""
+"Property, plant and equipment - Production plant in development - Fair value"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart27213
+#: model:account.account,name:l10n_pe.2_chart27213
+#: model:account.account.template,name:l10n_pe.chart27213
+msgid ""
+"Property, plant and equipment - Production plant in development - Financing "
+"costs"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart27212
+#: model:account.account,name:l10n_pe.2_chart27212
+#: model:account.account.template,name:l10n_pe.chart27212
+msgid ""
+"Property, plant and equipment - Production plant in development - "
+"Revaluation"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart27201
+#: model:account.account,name:l10n_pe.2_chart27201
+#: model:account.account.template,name:l10n_pe.chart27201
+msgid "Property, plant and equipment - Production plant in production - Costs"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart27204
+#: model:account.account,name:l10n_pe.2_chart27204
+#: model:account.account.template,name:l10n_pe.chart27204
+msgid ""
+"Property, plant and equipment - Production plant in production - Fair value"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart27203
+#: model:account.account,name:l10n_pe.2_chart27203
+#: model:account.account.template,name:l10n_pe.chart27203
+msgid ""
+"Property, plant and equipment - Production plant in production - Financing "
+"costs"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart27202
+#: model:account.account,name:l10n_pe.2_chart27202
+#: model:account.account.template,name:l10n_pe.chart27202
+msgid ""
+"Property, plant and equipment - Production plant in production - Revaluation"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart27281
+#: model:account.account,name:l10n_pe.2_chart27281
+#: model:account.account.template,name:l10n_pe.chart27281
+msgid "Property, plant and equipment - Replacement tools and units - Costs"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart27282
+#: model:account.account,name:l10n_pe.2_chart27282
+#: model:account.account.template,name:l10n_pe.chart27282
+msgid ""
+"Property, plant and equipment - Replacement tools and units - Revaluation"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart27251
+#: model:account.account,name:l10n_pe.2_chart27251
+#: model:account.account.template,name:l10n_pe.chart27251
+msgid "Property, plant and equipment - Transport units - Costs"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart27252
+#: model:account.account,name:l10n_pe.2_chart27252
+#: model:account.account.template,name:l10n_pe.chart27252
+msgid "Property, plant and equipment - Transport units - Revaluation"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart27291
+#: model:account.account,name:l10n_pe.2_chart27291
+#: model:account.account.template,name:l10n_pe.chart27291
+msgid "Property, plant and equipment - Work in progress - Costs"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart27292
+#: model:account.account,name:l10n_pe.2_chart27292
+#: model:account.account.template,name:l10n_pe.chart27292
+msgid "Property, plant and equipment - Work in progress - Revaluation"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart7221
+#: model:account.account,name:l10n_pe.2_chart7221
+#: model:account.account.template,name:l10n_pe.chart7221
+msgid "Property, plant and equipment- Buildings"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart7224
+#: model:account.account,name:l10n_pe.2_chart7224
+#: model:account.account.template,name:l10n_pe.chart7224
+msgid "Property, plant and equipment- Furniture and fixtures"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart7222
+#: model:account.account,name:l10n_pe.2_chart7222
+#: model:account.account.template,name:l10n_pe.chart7222
+msgid "Property, plant and equipment- Machinery and other operating equipment"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart7225
+#: model:account.account,name:l10n_pe.2_chart7225
+#: model:account.account.template,name:l10n_pe.chart7225
+msgid "Property, plant and equipment- Miscellaneous equipment"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart7220
+#: model:account.account,name:l10n_pe.2_chart7220
+#: model:account.account.template,name:l10n_pe.chart7220
+msgid "Property, plant and equipment- Producing plant"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart7223
+#: model:account.account,name:l10n_pe.2_chart7223
+#: model:account.account.template,name:l10n_pe.chart7223
+msgid "Property, plant and equipment- Transport units"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_010515
+msgid "Providencia"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart482
+#: model:account.account,name:l10n_pe.2_chart482
+#: model:account.account.template,name:l10n_pe.chart482
+msgid "Provision for dismantling, removal or rehabilitation of fixed assets"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart484
+#: model:account.account,name:l10n_pe.2_chart484
+#: model:account.account.template,name:l10n_pe.chart484
+msgid "Provision for environmental protection and remediation"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart486
+#: model:account.account,name:l10n_pe.2_chart486
+#: model:account.account.template,name:l10n_pe.chart486
+msgid "Provision for guarantees"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart481
+#: model:account.account,name:l10n_pe.2_chart481
+#: model:account.account.template,name:l10n_pe.chart481
+msgid "Provision for litigation"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart483
+#: model:account.account,name:l10n_pe.2_chart483
+#: model:account.account.template,name:l10n_pe.chart483
+msgid "Provision for restructurings"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart487
+#: model:account.account,name:l10n_pe.2_chart487
+#: model:account.account.template,name:l10n_pe.chart487
+msgid "Provision for right-of-use assets"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart485
+#: model:account.account,name:l10n_pe.2_chart485
+#: model:account.account.template,name:l10n_pe.chart485
+msgid "Provision for social responsibility expenses"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart6899
+#: model:account.account,name:l10n_pe.2_chart6899
+#: model:account.account.template,name:l10n_pe.chart6899
+msgid "Provisions - Other provisions"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart68921
+#: model:account.account,name:l10n_pe.2_chart68921
+#: model:account.account.template,name:l10n_pe.chart68921
+msgid ""
+"Provisions - Provision for dismantling, removal or rehabilitation of fixed "
+"assets - Provision for dismantling, removal or rehabilitation of fixed "
+"assets – Costs"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart68922
+#: model:account.account,name:l10n_pe.2_chart68922
+#: model:account.account.template,name:l10n_pe.chart68922
+msgid ""
+"Provisions - Provision for dismantling, removal or rehabilitation of fixed "
+"assets - Provision for dismantling, removal or rehabilitation of fixed "
+"assets – Financial update"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart68941
+#: model:account.account,name:l10n_pe.2_chart68941
+#: model:account.account.template,name:l10n_pe.chart68941
+msgid ""
+"Provisions - Provision for environmental protection and remediation - "
+"Provision for environmental protection and remediation – Costs"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart68942
+#: model:account.account,name:l10n_pe.2_chart68942
+#: model:account.account.template,name:l10n_pe.chart68942
+msgid ""
+"Provisions - Provision for environmental protection and remediation - "
+"Provision for environmental protection and remediation – Financial update"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart68961
+#: model:account.account,name:l10n_pe.2_chart68961
+#: model:account.account.template,name:l10n_pe.chart68961
+msgid ""
+"Provisions - Provision for guarantees - Provision for guarantees – Costs"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart68962
+#: model:account.account,name:l10n_pe.2_chart68962
+#: model:account.account.template,name:l10n_pe.chart68962
+msgid ""
+"Provisions - Provision for guarantees - Provision for guarantees – Financial"
+" update"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart68911
+#: model:account.account,name:l10n_pe.2_chart68911
+#: model:account.account.template,name:l10n_pe.chart68911
+msgid ""
+"Provisions - Provision for litigation - Provision for litigation - Costs"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart68912
+#: model:account.account,name:l10n_pe.2_chart68912
+#: model:account.account.template,name:l10n_pe.chart68912
+msgid ""
+"Provisions - Provision for litigation - Provision for litigation – Financial"
+" update"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart6893
+#: model:account.account,name:l10n_pe.2_chart6893
+#: model:account.account.template,name:l10n_pe.chart6893
+msgid "Provisions - Provision for restructurings"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart68971
+#: model:account.account,name:l10n_pe.2_chart68971
+#: model:account.account.template,name:l10n_pe.chart68971
+msgid ""
+"Provisions - Provision for right-of-use assets - Provision for right-of-use "
+"assets operating lease"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart68972
+#: model:account.account,name:l10n_pe.2_chart68972
+#: model:account.account.template,name:l10n_pe.chart68972
+msgid ""
+"Provisions - Provision for right-of-use assets - Provision for right-of-use "
+"assets operating lease - Financial update"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart4033
+#: model:account.account,name:l10n_pe.2_chart4033
+#: model:account.account.template,name:l10n_pe.chart4033
+msgid "Public institutions - Contribution to SENATI"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart4034
+#: model:account.account,name:l10n_pe.2_chart4034
+#: model:account.account.template,name:l10n_pe.chart4034
+msgid "Public institutions - Contribution to SENCICO"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart4031
+#: model:account.account,name:l10n_pe.2_chart4031
+#: model:account.account.template,name:l10n_pe.chart4031
+msgid "Public institutions - ESSALUD"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart4032
+#: model:account.account,name:l10n_pe.2_chart4032
+#: model:account.account.template,name:l10n_pe.chart4032
+msgid "Public institutions - ONP"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart4039
+#: model:account.account,name:l10n_pe.2_chart4039
+#: model:account.account.template,name:l10n_pe.chart4039
+msgid "Public institutions - Otras instituciones"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_220705
+msgid "Pucacaca"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_050411
+msgid "Pucacolpa"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_140119
+msgid "Pucala"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_060808
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_120126
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_210708
+msgid "Pucara"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_100607
+msgid "Pucayacu"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_150124
+msgid "Pucusana"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_080308
+msgid "Pucyura"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_021207
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_150121
+msgid "Pueblo Libre"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_100609
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_110107
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_110207
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_130403
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_140206
+msgid "Pueblo Nuevo"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_150125
+msgid "Puente Piedra"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_190306
+msgid "Puerto Bermúdez"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_100901
+msgid "Puerto Inca"
+msgstr ""
+
+#. module: l10n_pe
+#: model:res.city,name:l10n_pe.city_pe_1009
+msgid "Puerto inca"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_160506
+msgid "Puinahua"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_061307
+msgid "Pulan"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_050705
+msgid "Pullo"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_160108
+msgid "Punchana"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_100508
+msgid "Punchao"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_210101
+#: model:res.city,name:l10n_pe.city_pe_2101
+msgid "Puno"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_150126
+msgid "Punta Hermosa"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_150127
+msgid "Punta Negra"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_040706
+msgid "Punta de Bombón"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_180208
+msgid "Puquina"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_050601
+msgid "Puquio"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_250401
+msgid "Purus"
+msgstr ""
+
+#. module: l10n_pe
+#: model:res.city,name:l10n_pe.city_pe_2504
+msgid "Purús"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_210605
+msgid "Pusi"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_211001
+msgid "Putina"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_151023
+msgid "Putinza"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_160109
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_160801
+#: model:res.city,name:l10n_pe.city_pe_1608
+msgid "Putumayo"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_040806
+msgid "Puyca"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_050706
+msgid "Puyusca"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_100509
+msgid "Puños"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_040807
+msgid "Quechualla"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_080507
+msgid "Quehue"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_080906
+msgid "Quellouno"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_040115
+msgid "Quequeña"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_090608
+msgid "Querco"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_200607
+msgid "Querecotillo"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_050901
+msgid "Querobamba"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_060607
+msgid "Querocotillo"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_101004
+msgid "Queropalca"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_211206
+msgid "Quiaca"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_040312
+msgid "Quicacha"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_021907
+msgid "Quiches"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_090719
+msgid "Quichuas"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_120127
+msgid "Quichuay"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_230206
+msgid "Quilahuani"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_040207
+msgid "Quilca"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_211004
+msgid "Quilcapuncu"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_120128
+msgid "Quilcas"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_022005
+msgid "Quillo"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_150512
+msgid "Quilmana"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_151024
+msgid "Quinches"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_180209
+msgid "Quinistaquillas"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_010117
+msgid "Quinjalca"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_151025
+msgid "Quinocay"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_050108
+msgid "Quinua"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_021604
+msgid "Quinuabamba"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_081212
+msgid "Quiquijana"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_131006
+msgid "Quiruvilca"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_090713
+msgid "Quishuar"
+msgstr ""
+
+#. module: l10n_pe
+#: model:res.city,name:l10n_pe.city_pe_0812
+msgid "Quispicanchi"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_100106
+msgid "Quisqui (Kichki)"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_090609
+msgid "Quito-Arma"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_100316
+msgid "Quivilla"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_080707
+msgid "Quiñota"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.group,name:l10n_pe.1_group24
+#: model:account.group,name:l10n_pe.2_group24
+#: model:account.group.template,name:l10n_pe.group24
+msgid "RAW MATERIALS"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.group,name:l10n_pe.1_group43
+#: model:account.group,name:l10n_pe.2_group43
+#: model:account.group.template,name:l10n_pe.group43
+msgid "RELATED TRADE ACCOUNTS PAYABLE"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.group,name:l10n_pe.1_group41
+#: model:account.group,name:l10n_pe.2_group41
+#: model:account.group.template,name:l10n_pe.group41
+msgid "REMUNERATIONS AND PARTICIPATIONS PAYABLE"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.group,name:l10n_pe.1_group58
+#: model:account.group,name:l10n_pe.2_group58
+#: model:account.group.template,name:l10n_pe.group58
+msgid "RESERVES"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.group,name:l10n_pe.1_group85
+#: model:account.group,name:l10n_pe.2_group85
+#: model:account.group.template,name:l10n_pe.group85
+msgid "RESULT BEFORE PARTICIPATIONS AND TAXES"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.group,name:l10n_pe.1_group84
+#: model:account.group,name:l10n_pe.2_group84
+#: model:account.group.template,name:l10n_pe.group84
+msgid "RESULT OF EXPLOITATION"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.group,name:l10n_pe.1_group57
+#: model:account.group,name:l10n_pe.2_group57
+#: model:account.group.template,name:l10n_pe.group57
+msgid "REVALUATION SURPLUS"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_latam.identification.type,name:l10n_pe.it_RUC
+msgid "RUC"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_021908
+msgid "Ragash"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_021012
+msgid "Rahuapampa"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_160401
+msgid "Ramón Castilla"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_030608
+msgid "Ranracancha"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_022006
+msgid "Ranrahirca"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_021013
+msgid "Rapayan"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart284
+#: model:account.account,name:l10n_pe.1_chart602
+#: model:account.account,name:l10n_pe.2_chart284
+#: model:account.account,name:l10n_pe.2_chart602
+#: model:account.account.template,name:l10n_pe.chart284
+#: model:account.account.template,name:l10n_pe.chart602
+msgid "Raw Materials"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart6121
+#: model:account.account,name:l10n_pe.2_chart6121
+#: model:account.account.template,name:l10n_pe.chart6121
+msgid "Raw Materials - Raw Materials"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart24111
+#: model:account.account,name:l10n_pe.1_chart29511
+#: model:account.account,name:l10n_pe.2_chart24111
+#: model:account.account,name:l10n_pe.2_chart29511
+#: model:account.account.template,name:l10n_pe.chart24111
+#: model:account.account.template,name:l10n_pe.chart29511
+msgid "Raw Materials - Raw Materials - Costs"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart24114
+#: model:account.account,name:l10n_pe.2_chart24114
+#: model:account.account.template,name:l10n_pe.chart24114
+msgid "Raw Materials - Raw Materials - Fair value"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_250201
+msgid "Raymondi"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.group,name:l10n_pe.1_group2
+#: model:account.group,name:l10n_pe.2_group2
+#: model:account.group.template,name:l10n_pe.group2
+msgid "Realizable asset"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart6612
+#: model:account.account,name:l10n_pe.1_chart7612
+#: model:account.account,name:l10n_pe.2_chart6612
+#: model:account.account,name:l10n_pe.2_chart7612
+#: model:account.account.template,name:l10n_pe.chart6612
+#: model:account.account.template,name:l10n_pe.chart7612
+msgid "Realizable asset - Finished products"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart6611
+#: model:account.account,name:l10n_pe.1_chart7611
+#: model:account.account,name:l10n_pe.2_chart6611
+#: model:account.account,name:l10n_pe.2_chart7611
+#: model:account.account.template,name:l10n_pe.chart6611
+#: model:account.account.template,name:l10n_pe.chart7611
+msgid "Realizable asset - Merchandise"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart66134
+#: model:account.account,name:l10n_pe.1_chart76134
+#: model:account.account,name:l10n_pe.2_chart66134
+#: model:account.account,name:l10n_pe.2_chart76134
+#: model:account.account.template,name:l10n_pe.chart66134
+#: model:account.account.template,name:l10n_pe.chart76134
+msgid ""
+"Realizable asset - Non-current assets held for sale - Biological assets"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart66133
+#: model:account.account,name:l10n_pe.1_chart76133
+#: model:account.account,name:l10n_pe.2_chart66133
+#: model:account.account,name:l10n_pe.2_chart76133
+#: model:account.account.template,name:l10n_pe.chart66133
+#: model:account.account.template,name:l10n_pe.chart76133
+msgid "Realizable asset - Non-current assets held for sale - Intangibles"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart66131
+#: model:account.account,name:l10n_pe.1_chart76131
+#: model:account.account,name:l10n_pe.2_chart66131
+#: model:account.account,name:l10n_pe.2_chart76131
+#: model:account.account.template,name:l10n_pe.chart66131
+#: model:account.account.template,name:l10n_pe.chart76131
+msgid ""
+"Realizable asset - Non-current assets held for sale - Investment property"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart66132
+#: model:account.account,name:l10n_pe.1_chart76132
+#: model:account.account,name:l10n_pe.2_chart66132
+#: model:account.account,name:l10n_pe.2_chart76132
+#: model:account.account.template,name:l10n_pe.chart66132
+#: model:account.account.template,name:l10n_pe.chart76132
+msgid ""
+"Realizable asset - Non-current assets held for sale - Property, plant and "
+"equipment"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart7574
+#: model:account.account,name:l10n_pe.2_chart7574
+#: model:account.account.template,name:l10n_pe.chart7574
+msgid ""
+"Recovery of impairment of fixed asset accounts - Recovery of impairment of "
+"biological assets"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart7573
+#: model:account.account,name:l10n_pe.2_chart7573
+#: model:account.account.template,name:l10n_pe.chart7573
+msgid ""
+"Recovery of impairment of fixed asset accounts - Recovery of impairment of "
+"intangibles"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart7571
+#: model:account.account,name:l10n_pe.2_chart7571
+#: model:account.account.template,name:l10n_pe.chart7571
+msgid ""
+"Recovery of impairment of fixed asset accounts - Recovery of impairment of "
+"investment properties"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart7572
+#: model:account.account,name:l10n_pe.2_chart7572
+#: model:account.account.template,name:l10n_pe.chart7572
+msgid ""
+"Recovery of impairment of fixed asset accounts - Recovery of impairment of "
+"property, plant and equipment"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart7553
+#: model:account.account,name:l10n_pe.2_chart7553
+#: model:account.account.template,name:l10n_pe.chart7553
+msgid ""
+"Recovery of valuation accounts - Recovery – Depreciation of investment "
+"property"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart7551
+#: model:account.account,name:l10n_pe.2_chart7551
+#: model:account.account.template,name:l10n_pe.chart7551
+msgid "Recovery of valuation accounts - Recovery – Doubtful accounts"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart7552
+#: model:account.account,name:l10n_pe.2_chart7552
+#: model:account.account.template,name:l10n_pe.chart7552
+msgid "Recovery of valuation accounts - Recovery – Inventory impairment"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_010308
+msgid "Recta"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_021701
+#: model:res.city,name:l10n_pe.city_pe_0217
+msgid "Recuay"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart405
+#: model:account.account,name:l10n_pe.1_chart642
+#: model:account.account,name:l10n_pe.2_chart405
+#: model:account.account,name:l10n_pe.2_chart642
+#: model:account.account.template,name:l10n_pe.chart405
+#: model:account.account.template,name:l10n_pe.chart642
+msgid "Regional government"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart581
+#: model:account.account,name:l10n_pe.2_chart581
+#: model:account.account.template,name:l10n_pe.chart581
+msgid "Reinvestment"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart6214
+#: model:account.account,name:l10n_pe.2_chart6214
+#: model:account.account.template,name:l10n_pe.chart6214
+msgid "Remuneration - Bonuses"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart6212
+#: model:account.account,name:l10n_pe.2_chart6212
+#: model:account.account.template,name:l10n_pe.chart6212
+msgid "Remuneration - Commissions"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart6215
+#: model:account.account,name:l10n_pe.2_chart6215
+#: model:account.account.template,name:l10n_pe.chart6215
+msgid "Remuneration - Holidays"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart6213
+#: model:account.account,name:l10n_pe.2_chart6213
+#: model:account.account.template,name:l10n_pe.chart6213
+msgid "Remuneration - Remuneration in kind"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart6211
+#: model:account.account,name:l10n_pe.2_chart6211
+#: model:account.account.template,name:l10n_pe.chart6211
+msgid "Remuneration - Wages and salaries"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart4112
+#: model:account.account,name:l10n_pe.2_chart4112
+#: model:account.account.template,name:l10n_pe.chart4112
+msgid "Remuneration payable - Commissions payable"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart4114
+#: model:account.account,name:l10n_pe.2_chart4114
+#: model:account.account.template,name:l10n_pe.chart4114
+msgid "Remuneration payable - Gratuities payable"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart4115
+#: model:account.account,name:l10n_pe.2_chart4115
+#: model:account.account.template,name:l10n_pe.chart4115
+msgid "Remuneration payable - Payable vacation"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart4113
+#: model:account.account,name:l10n_pe.2_chart4113
+#: model:account.account.template,name:l10n_pe.chart4113
+msgid "Remuneration payable - Remuneration in kind payable"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart4111
+#: model:account.account,name:l10n_pe.2_chart4111
+#: model:account.account.template,name:l10n_pe.chart4111
+msgid "Remuneration payable - Wages and salaries payable"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart33721
+#: model:account.account,name:l10n_pe.2_chart33721
+#: model:account.account.template,name:l10n_pe.chart33721
+msgid "Replacement tools and units - Replacement units - Costs"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart33722
+#: model:account.account,name:l10n_pe.2_chart33722
+#: model:account.account.template,name:l10n_pe.chart33722
+msgid "Replacement tools and units - Replacement units - Revaluation"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart33711
+#: model:account.account,name:l10n_pe.1_chart36471
+#: model:account.account,name:l10n_pe.2_chart33711
+#: model:account.account,name:l10n_pe.2_chart36471
+#: model:account.account.template,name:l10n_pe.chart33711
+#: model:account.account.template,name:l10n_pe.chart36471
+msgid "Replacement tools and units - Tools - Costs"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart33712
+#: model:account.account,name:l10n_pe.2_chart33712
+#: model:account.account.template,name:l10n_pe.chart33712
+msgid "Replacement tools and units - Tools - Revaluation"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_140113
+msgid "Reque"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_160501
+#: model:res.city,name:l10n_pe.city_pe_1605
+msgid "Requena"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart1071
+#: model:account.account,name:l10n_pe.2_chart1071
+#: model:account.account.template,name:l10n_pe.chart1071
+msgid "Restricted Funds - Funds in guarantee"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart1072
+#: model:account.account,name:l10n_pe.2_chart1072
+#: model:account.account.template,name:l10n_pe.chart1072
+msgid "Restricted Funds - Funds withheld by mandate of the authority"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart1073
+#: model:account.account,name:l10n_pe.2_chart1073
+#: model:account.account.template,name:l10n_pe.chart1073
+msgid "Restricted Funds - Other restricted funds"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart5642
+#: model:account.account,name:l10n_pe.2_chart5642
+#: model:account.account.template,name:l10n_pe.chart5642
+msgid "Result in other assets or liabilities for financial investments - Lost"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart5641
+#: model:account.account,name:l10n_pe.2_chart5641
+#: model:account.account.template,name:l10n_pe.chart5641
+msgid ""
+"Result in other assets or liabilities for financial investments - Profit"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart841
+#: model:account.account,name:l10n_pe.2_chart841
+#: model:account.account.template,name:l10n_pe.chart841
+msgid "Result of exploitation"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart5632
+#: model:account.account,name:l10n_pe.2_chart5632
+#: model:account.account.template,name:l10n_pe.chart5632
+msgid "Result on financial assets or liabilities held for trading - Lost"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart5631
+#: model:account.account,name:l10n_pe.2_chart5631
+#: model:account.account.template,name:l10n_pe.chart5631
+msgid "Result on financial assets or liabilities held for trading - Profit"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart5652
+#: model:account.account,name:l10n_pe.2_chart5652
+#: model:account.account.template,name:l10n_pe.chart5652
+msgid ""
+"Result on financial assets or liabilities held for trading – Conventional "
+"purchase or sale settlement date - Lost"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart5651
+#: model:account.account,name:l10n_pe.2_chart5651
+#: model:account.account.template,name:l10n_pe.chart5651
+msgid ""
+"Result on financial assets or liabilities held for trading – Conventional "
+"purchase or sale settlement date - Profit"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart5713
+#: model:account.account,name:l10n_pe.2_chart5713
+#: model:account.account.template,name:l10n_pe.chart5713
+msgid "Revaluation surplus - Intangibles"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart57111
+#: model:account.account,name:l10n_pe.2_chart57111
+#: model:account.account.template,name:l10n_pe.chart57111
+msgid "Revaluation surplus - Investment property - Direct acquisition"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart57112
+#: model:account.account,name:l10n_pe.2_chart57112
+#: model:account.account.template,name:l10n_pe.chart57112
+msgid "Revaluation surplus - Investment property - Financial leasing"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart57121
+#: model:account.account,name:l10n_pe.2_chart57121
+#: model:account.account.template,name:l10n_pe.chart57121
+msgid ""
+"Revaluation surplus - Property, plant and equipment - Direct acquisition"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart57122
+#: model:account.account,name:l10n_pe.2_chart57122
+#: model:account.account.template,name:l10n_pe.chart57122
+msgid ""
+"Revaluation surplus - Property, plant and equipment - Financial leasing"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart5714
+#: model:account.account,name:l10n_pe.2_chart5714
+#: model:account.account.template,name:l10n_pe.chart5714
+msgid "Revaluation surplus - Right-of-use assets - Operating lease"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart572
+#: model:account.account,name:l10n_pe.2_chart572
+#: model:account.account.template,name:l10n_pe.chart572
+msgid "Revaluation surplus – Released shares received"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_150714
+msgid "Ricardo Palma"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_120427
+msgid "Ricran"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart0112
+#: model:account.account,name:l10n_pe.1_chart0213
+#: model:account.account,name:l10n_pe.2_chart0112
+#: model:account.account,name:l10n_pe.2_chart0213
+#: model:account.account.template,name:l10n_pe.chart0112
+#: model:account.account.template,name:l10n_pe.chart0213
+msgid "Rights on financial instruments"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_150128
+msgid "Rimac"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_200806
+msgid "Rinconada Llicuar"
+msgstr ""
+
+#. module: l10n_pe
+#: model:res.city,name:l10n_pe.city_pe_2208
+msgid "Rioja"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_100317
+msgid "Ripan"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_090721
+msgid "Roble"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_030609
+msgid "Rocchacc"
+msgstr ""
+
+#. module: l10n_pe
+#: model:res.city,name:l10n_pe.city_pe_0106
+msgid "Rodriguez de Mendoza"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_080206
+msgid "Rondocan"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_101005
+msgid "Rondos"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_160802
+msgid "Rosa Panduro"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_090208
+msgid "Rosario"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_210606
+msgid "Rosaspata"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart474
+#: model:account.account,name:l10n_pe.1_chart652
+#: model:account.account,name:l10n_pe.1_chart753
+#: model:account.account,name:l10n_pe.2_chart474
+#: model:account.account,name:l10n_pe.2_chart652
+#: model:account.account,name:l10n_pe.2_chart753
+#: model:account.account.template,name:l10n_pe.chart474
+#: model:account.account.template,name:l10n_pe.chart652
+#: model:account.account.template,name:l10n_pe.chart753
+msgid "Royalties"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_220507
+msgid "Rumisapa"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_100601
+msgid "Rupa-Rupa"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_130206
+msgid "Rázuri"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_040606
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_110403
+msgid "Río Grande"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_120607
+msgid "Río Negro"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_010403
+msgid "Río Santiago"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_120608
+msgid "Río Tambo"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_220801
+msgid "Ríoja"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.group,name:l10n_pe.1_group70
+#: model:account.group,name:l10n_pe.2_group70
+#: model:account.group.template,name:l10n_pe.group70
+msgid "SALES"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.group,name:l10n_pe.1_group69
+#: model:account.group,name:l10n_pe.2_group69
+#: model:account.group.template,name:l10n_pe.group69
+msgid "SALES COST"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.group,name:l10n_pe.1_group18
+#: model:account.group,name:l10n_pe.2_group18
+#: model:account.group.template,name:l10n_pe.group18
+msgid "SERVICES AND OTHER CONTRACTED IN ADVANCE"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.group,name:l10n_pe.1_group62
+#: model:account.group,name:l10n_pe.2_group62
+#: model:account.group.template,name:l10n_pe.group62
+msgid "STAFF AND DIRECTORS EXPENSES"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_030307
+msgid "Sabaino"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_040116
+msgid "Sabandia"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_220405
+msgid "Sacanche"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_040117
+msgid "Sachaca"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_050303
+msgid "Sacsamarca"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_latam.identification.type,name:l10n_pe.it_SP
+msgid "Safe Passage"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_050614
+msgid "Saisa"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_040607
+msgid "Salamanca"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_110108
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_140310
+msgid "Salas"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_130109
+msgid "Salaverry"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_090714
+msgid "Salcabamba"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_090715
+msgid "Salcahuasi"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart1655
+#: model:account.account,name:l10n_pe.1_chart1755
+#: model:account.account,name:l10n_pe.2_chart1655
+#: model:account.account,name:l10n_pe.2_chart1755
+#: model:account.account.template,name:l10n_pe.chart1655
+#: model:account.account.template,name:l10n_pe.chart1755
+msgid "Sale of fixed assets - Biological assets"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart1654
+#: model:account.account,name:l10n_pe.1_chart1754
+#: model:account.account,name:l10n_pe.2_chart1654
+#: model:account.account,name:l10n_pe.2_chart1754
+#: model:account.account.template,name:l10n_pe.chart1654
+#: model:account.account.template,name:l10n_pe.chart1754
+msgid "Sale of fixed assets - Intangibles"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart1652
+#: model:account.account,name:l10n_pe.1_chart1752
+#: model:account.account,name:l10n_pe.2_chart1652
+#: model:account.account,name:l10n_pe.2_chart1752
+#: model:account.account.template,name:l10n_pe.chart1652
+#: model:account.account.template,name:l10n_pe.chart1752
+msgid "Sale of fixed assets - Investment property"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart1659
+#: model:account.account,name:l10n_pe.1_chart1759
+#: model:account.account,name:l10n_pe.2_chart1659
+#: model:account.account,name:l10n_pe.2_chart1759
+#: model:account.account.template,name:l10n_pe.chart1659
+#: model:account.account.template,name:l10n_pe.chart1759
+msgid "Sale of fixed assets - Otros activos inmovilizados"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart1651
+#: model:account.account,name:l10n_pe.1_chart1751
+#: model:account.account,name:l10n_pe.2_chart1651
+#: model:account.account,name:l10n_pe.2_chart1751
+#: model:account.account.template,name:l10n_pe.chart1651
+#: model:account.account.template,name:l10n_pe.chart1751
+msgid "Sale of fixed assets - Property investment"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart1653
+#: model:account.account,name:l10n_pe.1_chart1753
+#: model:account.account,name:l10n_pe.2_chart1653
+#: model:account.account,name:l10n_pe.2_chart1753
+#: model:account.account.template,name:l10n_pe.chart1653
+#: model:account.account.template,name:l10n_pe.chart1753
+msgid "Sale of fixed assets - Property, plant and equipment"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart70962
+#: model:account.account,name:l10n_pe.2_chart70962
+#: model:account.account.template,name:l10n_pe.chart70962
+msgid "Sales returns - By-products, waste and scrap - Associated"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart70961
+#: model:account.account,name:l10n_pe.2_chart70961
+#: model:account.account.template,name:l10n_pe.chart70961
+msgid "Sales returns - By-products, waste and scrap - Third parties"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart70932
+#: model:account.account,name:l10n_pe.2_chart70932
+#: model:account.account.template,name:l10n_pe.chart70932
+msgid "Sales returns - Finished products - Export sale - Associated"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart70931
+#: model:account.account,name:l10n_pe.2_chart70931
+#: model:account.account.template,name:l10n_pe.chart70931
+msgid "Sales returns - Finished products - Export sale - Third parties"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart70942
+#: model:account.account,name:l10n_pe.2_chart70942
+#: model:account.account.template,name:l10n_pe.chart70942
+msgid "Sales returns - Finished products - Local sale - Associated"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart70941
+#: model:account.account,name:l10n_pe.2_chart70941
+#: model:account.account.template,name:l10n_pe.chart70941
+msgid "Sales returns - Finished products - Local sale - Third parties"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart70912
+#: model:account.account,name:l10n_pe.2_chart70912
+#: model:account.account.template,name:l10n_pe.chart70912
+msgid "Sales returns - Merchandise - Export sale - Associated"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart70911
+#: model:account.account,name:l10n_pe.2_chart70911
+#: model:account.account.template,name:l10n_pe.chart70911
+msgid "Sales returns - Merchandise - Export sale - Third parties"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart70922
+#: model:account.account,name:l10n_pe.2_chart70922
+#: model:account.account.template,name:l10n_pe.chart70922
+msgid "Sales returns - Merchandise - Local sale - Associated"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart70921
+#: model:account.account,name:l10n_pe.2_chart70921
+#: model:account.account.template,name:l10n_pe.chart70921
+msgid "Sales returns - Merchandise - Local sale - Third parties"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart70952
+#: model:account.account,name:l10n_pe.2_chart70952
+#: model:account.account.template,name:l10n_pe.chart70952
+msgid "Sales returns - Rejected service inventories - Associated"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart70951
+#: model:account.account,name:l10n_pe.2_chart70951
+#: model:account.account.template,name:l10n_pe.chart70951
+msgid "Sales returns - Rejected service inventories - Third parties"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_200406
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_200608
+msgid "Salitral"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_060809
+msgid "Sallique"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_130611
+msgid "Salpo"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_230109
+msgid "Sama"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_210210
+msgid "Saman"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_021807
+msgid "Samanco"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_180104
+msgid "Samegua"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_040208
+msgid "Samuel Pastor"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_050509
+msgid "Samugari"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_120129
+msgid "San Agustín"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_110506
+msgid "San Andrés"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_060608
+msgid "San Andrés de Cutervo"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_150715
+msgid "San Andrés de Tupicocha"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_210211
+msgid "San Anton"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_030709
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_150513
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_150716
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_210113
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_220912
+msgid "San Antonio"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_040514
+msgid "San Antonio de Ahuca"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_090310
+msgid "San Antonio de Antaparco"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_030212
+msgid "San Antonio de Cachi"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_090610
+msgid "San Antonio de Cusicancha"
+msgstr ""
+
+#. module: l10n_pe
+#: model:res.city,name:l10n_pe.city_pe_2110
+msgid "San Antonio de Putina"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_150129
+msgid "San Bartolo"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_150717
+msgid "San Bartolome"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_060505
+msgid "San Benito"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_061202
+msgid "San Bernardino"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_150130
+msgid "San Borja"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_100703
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_150406
+msgid "San Buenaventura"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_010309
+msgid "San Carlos"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_110507
+msgid "San Clemente"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_010516
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_050615
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_180105
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_220706
+msgid "San Cristóbal"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_021408
+msgid "San Cristóbal de Rajan"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_150718
+msgid "San Damian"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_060810
+msgid "San Felipe"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_220807
+msgid "San Fernando"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_100206
+msgid "San Francisco"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_101006
+msgid "San Francisco de Asís"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_190108
+msgid "San Francisco de Asís de Yarusyacan"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_100107
+msgid "San Francisco de Cayran"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_010118
+msgid "San Francisco de Daguas"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_050707
+msgid "San Francisco de Ravacayco"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_090611
+msgid "San Francisco de Sangayaico"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_010517
+msgid "San Francisco del Yeso"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_210309
+msgid "San Gaban"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_061110
+msgid "San Gregorio"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_220707
+msgid "San Hilarión"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_060901
+#: model:res.city,name:l10n_pe.city_pe_0609
+msgid "San Ignacio"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_090612
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_150131
+msgid "San Isidro"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_010119
+msgid "San Isidro de Maino"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_240105
+msgid "San Jacinto"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_050808
+msgid "San Javier de Alpabamba"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_010518
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_030213
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_080104
+msgid "San Jerónimo"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_120130
+msgid "San Jerónimo de Tunan"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_151026
+msgid "San Joaquin"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_130705
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_140311
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_210212
+msgid "San José"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_110109
+msgid "San José de Los Molinos"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_060906
+msgid "San José de Lourdes"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_120214
+msgid "San José de Quero"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_220301
+msgid "San José de Sisa"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_050109
+msgid "San José de Ticllas"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_050809
+msgid "San José de ushua"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_060811
+msgid "San José del Alto"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_021909
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_050616
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_060112
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_090410
+msgid "San Juan"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_050110
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_110110
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_160113
+msgid "San Juan Bautista"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_200407
+msgid "San Juan de Bigote"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_030411
+msgid "San Juan de Chacña"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_060609
+msgid "San Juan de Cutervo"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_150719
+msgid "San Juan de Iris"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_120906
+msgid "San Juan de Iscos"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_120907
+msgid "San Juan de Jarpa"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_060416
+msgid "San Juan de Licupis"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_010519
+msgid "San Juan de Lopecancha"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_150132
+msgid "San Juan de Lurigancho"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_150133
+msgid "San Juan de Miraflores"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_020306
+msgid "San Juan de Rontoy"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_210213
+msgid "San Juan de Salinas"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_040118
+msgid "San Juan de Siguas"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_150720
+msgid "San Juan de Tantaranche"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_040119
+msgid "San Juan de Tarucani"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_110208
+msgid "San Juan de Yanac"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_240106
+msgid "San Juan de la Virgen"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_211207
+msgid "San Juan del Oro"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_120428
+msgid "San Lorenzo"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_150721
+msgid "San Lorenzo de Quinti"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_020701
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_061203
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_150134
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_150514
+msgid "San Luis"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_060610
+msgid "San Luis de Lucma"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_120304
+msgid "San Luis de Shuaro"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_021014
+#: model:res.city,name:l10n_pe.city_pe_0610
+msgid "San Marcos"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_090716
+msgid "San Marcos de Rocchac"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_220303
+#: model:res.city,name:l10n_pe.city_pe_2209
+msgid "San Martín"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_150135
+msgid "San Martín de Porres"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_150722
+msgid "San Mateo"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_150723
+msgid "San Mateo de Otao"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_050501
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_061101
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_150136
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_211105
+#: model:res.city,name:l10n_pe.city_pe_0611
+msgid "San Miguel"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_020608
+msgid "San Miguel de Aco"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_150609
+msgid "San Miguel de Acos"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_101007
+msgid "San Miguel de Cauri"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_030214
+msgid "San Miguel de Chaccrampa"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_020514
+msgid "San Miguel de Corpanqui"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_200306
+msgid "San Miguel de El Faique"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_090508
+msgid "San Miguel de Mayocc"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_010601
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_020702
+msgid "San Nicolás"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_061201
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_080606
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_160404
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_220205
+#: model:res.city,name:l10n_pe.city_pe_0612
+msgid "San Pablo"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_100113
+msgid "San Pablo de Pillao"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_021409
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_050617
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_080607
+msgid "San Pedro"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_030108
+msgid "San Pedro de Cachora"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_120708
+msgid "San Pedro de Cajas"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_150724
+msgid "San Pedro de Casta"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_100108
+msgid "San Pedro de Chaulan"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_120429
+msgid "San Pedro de Chunan"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_090509
+msgid "San Pedro de Coris"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_110209
+msgid "San Pedro de Huacarpana"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_150725
+msgid "San Pedro de Huancayre"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_050908
+msgid "San Pedro de Larcay"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_130701
+msgid "San Pedro de Lloc"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_050618
+msgid "San Pedro de Palco"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_151027
+msgid "San Pedro de Pilas"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_190205
+msgid "San Pedro de Pillao"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_211210
+msgid "San Pedro de Putina Punco"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_021015
+msgid "San Pedro de chana"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_100207
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_220206
+msgid "San Rafael"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_120305
+msgid "San Ramón"
+msgstr ""
+
+#. module: l10n_pe
+#: model:res.city,name:l10n_pe.city_pe_2111
+msgid "San Román"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_220508
+msgid "San Roque de Cumbaza"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_080406
+msgid "San Salvador"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_050909
+msgid "San Salvador de Quije"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_080105
+msgid "San Sebastian"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_061111
+msgid "San Silvestre de Cochan"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_150501
+msgid "San Vicente de Cañete"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_130906
+msgid "Sanagoran"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_050301
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_050619
+msgid "Sancos"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_211201
+#: model:res.city,name:l10n_pe.city_pe_2112
+msgid "Sandia"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_150726
+msgid "Sangallaya"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_080207
+msgid "Sangarara"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_021808
+#: model:res.city,name:l10n_pe.city_pe_0218
+msgid "Santa"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_080901
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_090411
+msgid "Santa Ana"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_050620
+msgid "Santa Ana de Huaycahuacho"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_190206
+msgid "Santa Ana de Tusi"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_150137
+msgid "Santa Anita"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_120807
+msgid "Santa Bárbara de Carhuacayan"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_010520
+msgid "Santa Catalina"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_200408
+msgid "Santa Catalina de Mossa"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_021208
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_060611
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_061301
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_110404
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_160210
+#: model:res.city,name:l10n_pe.city_pe_0613
+msgid "Santa Cruz"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_150610
+msgid "Santa Cruz de Andamarca"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_131007
+msgid "Santa Cruz de Chuca"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_150727
+msgid "Santa Cruz de Cocachacra"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_150515
+msgid "Santa Cruz de Flores"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_060506
+msgid "Santa Cruz de Toledo"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_150728
+msgid "Santa Eulalia"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_040120
+msgid "Santa Isabel de Siguas"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_150809
+msgid "Santa Leonor"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_050621
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_210709
+msgid "Santa Lucia"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_150810
+msgid "Santa María"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_030215
+msgid "Santa María de Chicmo"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_150138
+msgid "Santa María del Mar"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_100109
+msgid "Santa María del Valle"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_040121
+msgid "Santa Rita de Siguas"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_010610
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_021510
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_030710
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_050507
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_060812
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_140114
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_150139
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_210504
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_210808
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_220304
+msgid "Santa Rosa"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_100705
+msgid "Santa Rosa de Alto Yanajanca"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_120215
+msgid "Santa Rosa de Ocopa"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_150407
+msgid "Santa Rosa de Quives"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_120808
+msgid "Santa Rosa de Sacco"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_080908
+msgid "Santa Teresa"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_080106
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_110111
+msgid "Santiago"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_150729
+msgid "Santiago de Anchucaya"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_130207
+msgid "Santiago de Cao"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_130811
+msgid "Santiago de Challas"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_090613
+msgid "Santiago de Chocorvos"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_131001
+#: model:res.city,name:l10n_pe.city_pe_1310
+msgid "Santiago de Chuco"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_050304
+msgid "Santiago de Lucanamarca"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_050910
+msgid "Santiago de Paucaray"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_050111
+msgid "Santiago de Pischa"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_210214
+msgid "Santiago de Pupuja"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_090614
+msgid "Santiago de Quirahuara"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_150140
+msgid "Santiago de Surco"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_090723
+msgid "Santiago de Tucuma"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_150730
+msgid "Santiago de Tuna"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_021410
+msgid "Santiago de chilcas"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_050406
+msgid "Santillana"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_200409
+msgid "Santo Domingo"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_120135
+msgid "Santo Domingo de Acobamba"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_100610
+msgid "Santo Domingo de Anda"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_090615
+msgid "Santo Domingo de Capillas"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_060612
+msgid "Santo Domingo de la Capilla"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_150731
+msgid "Santo Domingo de los Olleros"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_010521
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_060613
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_080701
+msgid "Santo Tomas"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_090311
+msgid "Santo Tomas de Pata"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_021209
+msgid "Santo Toribio"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_120133
+msgid "Sapallanga"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_200208
+msgid "Sapillica"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_220401
+msgid "Saposoa"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_160507
+msgid "Saquena"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_050810
+msgid "Sara Sara"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_160605
+msgid "Sarayacu"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_051011
+msgid "Sarhua"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_130907
+msgid "Sarin"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_130908
+msgid "Sartimbamba"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_120601
+#: model:res.city,name:l10n_pe.city_pe_1206
+msgid "Satipo"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_220913
+msgid "Sauce"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_061308
+msgid "Saucepampa"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_051107
+msgid "Saurama"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_120430
+msgid "Sausa"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_150811
+msgid "Sayan"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_131104
+msgid "Sayapullo"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_040808
+msgid "Sayla"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_080107
+msgid "Saylla"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_140115
+msgid "Saña"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_030412
+msgid "Sañayca"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_120132
+msgid "Saño"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart222
+#: model:account.account,name:l10n_pe.2_chart222
+#: model:account.account.template,name:l10n_pe.chart222
+msgid "Scrap and waste"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_090312
+msgid "Secclla"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_200801
+#: model:res.city,name:l10n_pe.city_pe_2008
+msgid "Sechura"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart30811
+#: model:account.account,name:l10n_pe.2_chart30811
+#: model:account.account.template,name:l10n_pe.chart30811
+msgid ""
+"Securities investments – Purchase agreements - Debt financial instruments – "
+"Purchase agreements - Costs"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart30814
+#: model:account.account,name:l10n_pe.2_chart30814
+#: model:account.account.template,name:l10n_pe.chart30814
+msgid ""
+"Securities investments – Purchase agreements - Debt financial instruments – "
+"Purchase agreements - Fair value"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart30821
+#: model:account.account,name:l10n_pe.2_chart30821
+#: model:account.account.template,name:l10n_pe.chart30821
+msgid ""
+"Securities investments – Purchase agreements - Financial instruments "
+"representative of economic rights – Purchase agreements - Costs"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart30824
+#: model:account.account,name:l10n_pe.2_chart30824
+#: model:account.account.template,name:l10n_pe.chart30824
+msgid ""
+"Securities investments – Purchase agreements - Financial instruments "
+"representative of economic rights – Purchase agreements - Fair value"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart6273
+#: model:account.account,name:l10n_pe.2_chart6273
+#: model:account.account.template,name:l10n_pe.chart6273
+msgid ""
+"Security, social security and other contributions - Complementary insurance "
+"for risky work, accidents at work and occupational diseases"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart6277
+#: model:account.account,name:l10n_pe.2_chart6277
+#: model:account.account.template,name:l10n_pe.chart6277
+msgid ""
+"Security, social security and other contributions - Contributions to SENATI"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart6276
+#: model:account.account,name:l10n_pe.2_chart6276
+#: model:account.account.template,name:l10n_pe.chart6276
+msgid ""
+"Security, social security and other contributions - Fisherman's Social "
+"Security Benefits Fund"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart6271
+#: model:account.account,name:l10n_pe.2_chart6271
+#: model:account.account.template,name:l10n_pe.chart6271
+msgid ""
+"Security, social security and other contributions - Health benefits scheme"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart6274
+#: model:account.account,name:l10n_pe.2_chart6274
+#: model:account.account.template,name:l10n_pe.chart6274
+msgid "Security, social security and other contributions - Life insurance"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart6272
+#: model:account.account,name:l10n_pe.2_chart6272
+#: model:account.account.template,name:l10n_pe.chart6272
+msgid ""
+"Security, social security and other contributions - Pension scheme - Company"
+" contribution"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart6275
+#: model:account.account,name:l10n_pe.2_chart6275
+#: model:account.account.template,name:l10n_pe.chart6275
+msgid ""
+"Security, social security and other contributions - Private insurance for "
+"health benefits – EPS and other individuals"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_250202
+msgid "Sepahua"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart751
+#: model:account.account,name:l10n_pe.2_chart751
+#: model:account.account.template,name:l10n_pe.chart751
+msgid "Services for the benefit of staff"
 msgstr ""
 
 #. module: l10n_pe
 #: model:ir.model.fields.selection,name:l10n_pe.selection__account_tax__l10n_pe_edi_unece_category__o
 #: model:ir.model.fields.selection,name:l10n_pe.selection__account_tax_template__l10n_pe_edi_unece_category__o
 msgid "Services outside scope of tax"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_061309
+msgid "Sexi"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_220708
+msgid "Shamboyacu"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_220509
+msgid "Shanao"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_220914
+msgid "Shapaja"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart1422
+#: model:account.account,name:l10n_pe.2_chart1422
+#: model:account.account.template,name:l10n_pe.chart1422
+msgid "Shareholders (or partners) - Loans"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart1421
+#: model:account.account,name:l10n_pe.2_chart1421
+#: model:account.account.template,name:l10n_pe.chart1421
+msgid ""
+"Shareholders (or partners) - Subscriptions receivable from partners or "
+"shareholders"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart4412
+#: model:account.account,name:l10n_pe.2_chart4412
+#: model:account.account.template,name:l10n_pe.chart4412
+msgid "Shareholders (partners, participants) - Dividends"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart4411
+#: model:account.account,name:l10n_pe.2_chart4411
+#: model:account.account.template,name:l10n_pe.chart4411
+msgid "Shareholders (partners, participants) - Loans"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart4419
+#: model:account.account,name:l10n_pe.2_chart4419
+#: model:account.account.template,name:l10n_pe.chart4419
+msgid "Shareholders (partners, participants) - Other accounts payable"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_220305
+msgid "Shatoja"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_020609
+msgid "Shilla"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_010310
+msgid "Shipasbamba"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_100321
+msgid "Shunqui"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_221004
+msgid "Shunte"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_022007
+msgid "Shupluy"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_040515
+msgid "Sibayo"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_120134
+msgid "Sicaya"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_200209
+msgid "Sicchez"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_021910
+msgid "Sicsibamba"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_080601
+msgid "Sicuani"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_021901
+#: model:res.city,name:l10n_pe.city_pe_0219
+msgid "Sihuas"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_100322
+msgid "Sillapata"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_130110
+msgid "Simbal"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_190109
+msgid "Simon Bolívar"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_211005
+msgid "Sina"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_120431
+msgid "Sincos"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_100510
+msgid "Singa"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_130613
+msgid "Sinsicap"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_131008
+msgid "Sitabamba"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_060204
+msgid "Sitacocha"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_230405
+msgid "Sitajara"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_050407
+msgid "Sivia"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_040122
+msgid "Socabaya"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_050112
+msgid "Socos"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_060614
+msgid "Socota"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart34311
+#: model:account.account,name:l10n_pe.2_chart34311
+#: model:account.account.template,name:l10n_pe.chart34311
+msgid "Softwares - Computer applications - Costs"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart34312
+#: model:account.account,name:l10n_pe.2_chart34312
+#: model:account.account.template,name:l10n_pe.chart34312
+msgid "Softwares - Computer applications - Revaluation"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart36531
+#: model:account.account,name:l10n_pe.2_chart36531
+#: model:account.account.template,name:l10n_pe.chart36531
+msgid "Softwares - Costs"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart36532
+#: model:account.account,name:l10n_pe.2_chart36532
+#: model:account.account.template,name:l10n_pe.chart36532
+msgid "Softwares - Revaluation"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_010120
+msgid "Soloco"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_010121
+msgid "Sonche"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_200307
+msgid "Sondor"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_200308
+msgid "Sondorillo"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_160508
+msgid "Soplin"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_050911
+msgid "Soras"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_030413
+msgid "Soraya"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_220105
+msgid "Soritor"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_060309
+msgid "Sorochuco"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart253
+#: model:account.account,name:l10n_pe.2_chart253
+#: model:account.account.template,name:l10n_pe.chart253
+msgid "Spare parts"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart1413
+#: model:account.account,name:l10n_pe.2_chart1413
+#: model:account.account.template,name:l10n_pe.chart1413
+msgid "Staff - Deliveries to account"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart1411
+#: model:account.account,name:l10n_pe.2_chart1411
+#: model:account.account.template,name:l10n_pe.chart1411
+msgid "Staff - Loans"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart1419
+#: model:account.account,name:l10n_pe.2_chart1419
+#: model:account.account.template,name:l10n_pe.chart1419
+msgid "Staff - Other accounts receivable from staff"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart1412
+#: model:account.account,name:l10n_pe.2_chart1412
+#: model:account.account.template,name:l10n_pe.chart1412
+msgid "Staff - Salary advance"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart623
+#: model:account.account,name:l10n_pe.2_chart623
+#: model:account.account.template,name:l10n_pe.chart623
+msgid "Staff compensation"
 msgstr ""
 
 #. module: l10n_pe
@@ -222,18 +17368,510 @@ msgid "State..."
 msgstr ""
 
 #. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart2983
+#: model:account.account,name:l10n_pe.2_chart2983
+#: model:account.account.template,name:l10n_pe.chart2983
+msgid "Stock to be received - Auxiliary materials, supplies and spare parts"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart2984
+#: model:account.account,name:l10n_pe.2_chart2984
+#: model:account.account.template,name:l10n_pe.chart2984
+msgid "Stock to be received - Containers and packaging"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart2981
+#: model:account.account,name:l10n_pe.2_chart2981
+#: model:account.account.template,name:l10n_pe.chart2981
+msgid "Stock to be received - Merchandise"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart2982
+#: model:account.account,name:l10n_pe.2_chart2982
+#: model:account.account.template,name:l10n_pe.chart2982
+msgid "Stock to be received - Raw Materials"
+msgstr ""
+
+#. module: l10n_pe
 #: model_terms:ir.ui.view,arch_db:l10n_pe.pe_partner_address_form
 msgid "Street"
 msgstr ""
 
 #. module: l10n_pe
-#: model_terms:ir.ui.view,arch_db:l10n_pe.pe_partner_address_form
-msgid "Street Name..."
+#: model:account.account,name:l10n_pe.1_chart653
+#: model:account.account,name:l10n_pe.2_chart653
+#: model:account.account.template,name:l10n_pe.chart653
+msgid "Subscriptions"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_110112
+msgid "Subtanjalla"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_020205
+msgid "Succha"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_060310
+#: model:res.city,name:l10n_pe.city_pe_0509
+msgid "Sucre"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_120809
+msgid "Suitucancha"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_200601
+#: model:res.city,name:l10n_pe.city_pe_2006
+msgid "Sullana"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_150611
+msgid "Sumbilca"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_110210
+msgid "Sunampe"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_150204
+msgid "Supe"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_150205
+msgid "Supe Puerto"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart656
+#: model:account.account,name:l10n_pe.2_chart656
+#: model:account.account.template,name:l10n_pe.chart656
+msgid "Supplies"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart2523
+#: model:account.account,name:l10n_pe.2_chart2523
+#: model:account.account.template,name:l10n_pe.chart2523
+msgid "Supplies - Energy"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart2521
+#: model:account.account,name:l10n_pe.2_chart2521
+#: model:account.account.template,name:l10n_pe.chart2521
+msgid "Supplies - Fuels"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart2522
+#: model:account.account,name:l10n_pe.2_chart2522
+#: model:account.account.template,name:l10n_pe.chart2522
+msgid "Supplies - Lubricants"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart2524
+#: model:account.account,name:l10n_pe.2_chart2524
+#: model:account.account.template,name:l10n_pe.chart2524
+msgid "Supplies - Other supplies"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_150732
+msgid "Surco"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_090717
+msgid "Surcubamba"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_150141
+msgid "Surquillo"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_230406
+msgid "Susapaya"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_080807
+msgid "Suyckutambo"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_200210
+msgid "Suyo"
+msgstr ""
+
+#. module: l10n_pe
+#: model:res.city,name:l10n_pe.city_pe_1309
+msgid "Sánchez Carrión"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_latam.identification.type,name:l10n_pe.it_TAM
+msgid "TAM"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.group,name:l10n_pe.1_group64
+#: model:account.group,name:l10n_pe.2_group64
+#: model:account.group.template,name:l10n_pe.group64
+msgid "TAX EXPENSES"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.group,name:l10n_pe.1_group40
+#: model:account.group,name:l10n_pe.2_group40
+#: model:account.group.template,name:l10n_pe.group40
+msgid ""
+"TAXES, CONSIDERATIONS AND CONTRIBUTIONS TO THE PUBLIC PENSION AND HEALTH "
+"SYSTEM PAYABLE"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.group,name:l10n_pe.1_group42
+#: model:account.group,name:l10n_pe.2_group42
+#: model:account.group.template,name:l10n_pe.group42
+msgid "THIRD-PARTY TRADE ACCOUNTS PAYABLE"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.group,name:l10n_pe.1_group13
+#: model:account.group,name:l10n_pe.2_group13
+#: model:account.group.template,name:l10n_pe.group13
+msgid "TRADE ACCOUNTS RECEIVABLE – ASSOCIATED"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.group,name:l10n_pe.1_group12
+#: model:account.group,name:l10n_pe.2_group12
+#: model:account.group.template,name:l10n_pe.group12
+msgid "TRADE ACCOUNTS RECEIVABLE – THIRD PARTIES"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_060907
+msgid "Tabaconas"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_220510
+msgid "Tabalosos"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_060417
+msgid "Tacabamba"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_230101
+#: model:res.city,name:l10n_pe.city_pe_2301
+msgid "Tacna"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_170303
+#: model:res.city,name:l10n_pe.city_pe_1703
+msgid "Tahuamanu"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_250203
+msgid "Tahuania"
+msgstr ""
+
+#. module: l10n_pe
+#: model:res.city,name:l10n_pe.city_pe_2007
+msgid "Talara"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_030216
+msgid "Talavera"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_200506
+msgid "Tamarindo"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_050113
+msgid "Tambillo"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_050508
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_090616
+msgid "Tambo"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_200114
+msgid "Tambo Grande"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_110211
+msgid "Tambo de Mora"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_030501
+msgid "Tambobamba"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_170101
+#: model:res.city,name:l10n_pe.city_pe_1701
+msgid "Tambopata"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_030109
+msgid "Tamburco"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_151028
+msgid "Tanta"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_100511
+msgid "Tantamayo"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_090412
+msgid "Tantara"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_060507
+msgid "Tantarica"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_021709
+msgid "Tapacocha"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_030414
+msgid "Tapairihua"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_040516
+msgid "Tapay"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_160509
+msgid "Tapiche"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_120709
+msgid "Tapo"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_190207
+msgid "Tapuc"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_210607
+msgid "Taraco"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_220901
+msgid "Tarapoto"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_230401
+#: model:res.city,name:l10n_pe.city_pe_2304
+msgid "Tarata"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_080407
+msgid "Taray"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_020112
+msgid "Tarica"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_120701
+#: model:res.city,name:l10n_pe.city_pe_1207
+msgid "Tarma"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_230407
+msgid "Tarucachi"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_110113
+msgid "Tate"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_021511
+msgid "Tauca"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_040809
+msgid "Tauria"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_130812
+msgid "Taurija"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_151029
+msgid "Tauripampa"
 msgstr ""
 
 #. module: l10n_pe
 #: model:ir.model,name:l10n_pe.model_account_tax
 msgid "Tax"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_latam.identification.type,name:l10n_pe.it_TIN
+msgid "Tax Identification Number"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart402
+#: model:account.account,name:l10n_pe.2_chart402
+#: model:account.account.template,name:l10n_pe.chart402
+msgid "Tax certificates"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart6454
+#: model:account.account,name:l10n_pe.2_chart6454
+#: model:account.account.template,name:l10n_pe.chart6454
+msgid "Tax debt expenses - Costs and others"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart6453
+#: model:account.account,name:l10n_pe.2_chart6453
+#: model:account.account.template,name:l10n_pe.chart6453
+msgid "Tax debt expenses - Fines"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart6451
+#: model:account.account,name:l10n_pe.2_chart6451
+#: model:account.account.template,name:l10n_pe.chart6451
+msgid "Tax debt expenses - Interests"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart6452
+#: model:account.account,name:l10n_pe.2_chart6452
+#: model:account.account.template,name:l10n_pe.chart6452
+msgid "Tax debt expenses - Interests - Subdivision"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart1673
+#: model:account.account,name:l10n_pe.2_chart1673
+#: model:account.account.template,name:l10n_pe.chart1673
+msgid "Taxes to be credited - IGV to be credited on purchases"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart1674
+#: model:account.account,name:l10n_pe.2_chart1674
+#: model:account.account.template,name:l10n_pe.chart1674
+msgid "Taxes to be credited - IGV to credit non-residents"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart1672
+#: model:account.account,name:l10n_pe.2_chart1672
+#: model:account.account.template,name:l10n_pe.chart1672
+msgid "Taxes to be credited - ITAN account payments"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart1671
+#: model:account.account,name:l10n_pe.2_chart1671
+#: model:account.account.template,name:l10n_pe.chart1671
+msgid "Taxes to be credited - Payments on account of income tax"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart1675
+#: model:account.account,name:l10n_pe.2_chart1675
+#: model:account.account.template,name:l10n_pe.chart1675
+msgid "Taxes to be credited - Works for taxes"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_130801
+msgid "Tayabamba"
+msgstr ""
+
+#. module: l10n_pe
+#: model:res.city,name:l10n_pe.city_pe_0907
+msgid "Tayacaja"
+msgstr ""
+
+#. module: l10n_pe
+#: model:ir.model,name:l10n_pe.model_account_tax_template
+msgid "Templates for Taxes"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_160211
+msgid "Teniente Cesar López Rojas"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_160803
+msgid "Teniente Manuel Clavero"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart461
+#: model:account.account,name:l10n_pe.2_chart461
+#: model:account.account.template,name:l10n_pe.chart461
+msgid "Third Party Claims"
 msgstr ""
 
 #. module: l10n_pe
@@ -247,8 +17885,1323 @@ msgid "This code will help with the identification of each district in Peru."
 msgstr ""
 
 #. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_040123
+msgid "Tiabaya"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_110405
+msgid "Tibillo"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_230408
+msgid "Ticaco"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_021710
+msgid "Ticapampa"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_190110
+msgid "Ticlacayan"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_020515
+msgid "Ticllos"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_090413
+msgid "Ticrapo"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_160303
+msgid "Tigre"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_210904
+msgid "Tilali"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_020610
+msgid "Tinco"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_010522
+msgid "Tingo"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_220709
+msgid "Tingo de Ponasa"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_220406
+msgid "Tingo de Saposoa"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_211306
+msgid "Tinicachi"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_080608
+msgid "Tinta"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_030415
+msgid "Tintay"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_090718
+msgid "Tintay Puncu"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_190111
+msgid "Tinyahuarco"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_040411
+msgid "Tipan"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_210114
+msgid "Tiquillaca"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_210215
+msgid "Tirapata"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_040517
+msgid "Tisco"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_221001
+#: model:res.city,name:l10n_pe.city_pe_2210
+msgid "Tocache"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_060418
+msgid "Tocmoche"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_151030
+msgid "Tomas"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_100208
+msgid "Tomay Kichwa"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_040810
+msgid "Tomepampa"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_061112
+msgid "Tongod"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_180106
+msgid "Torata"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_030416
+msgid "Toraya"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_060615
+msgid "Toribio Casanova"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_040811
+msgid "Toro"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_160110
+msgid "Torres Causana"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_010611
+msgid "Totora"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_050206
+msgid "Totos"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_100904
+msgid "Tournavista"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart1923
+#: model:account.account,name:l10n_pe.2_chart1923
+#: model:account.account.template,name:l10n_pe.chart1923
+msgid "Trade accounts receivable – Associated - Bills to be collected"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart1921
+#: model:account.account,name:l10n_pe.2_chart1921
+#: model:account.account.template,name:l10n_pe.chart1921
+msgid ""
+"Trade accounts receivable – Associated - Invoices, tickets and other "
+"receipts receivable"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart1913
+#: model:account.account,name:l10n_pe.2_chart1913
+#: model:account.account.template,name:l10n_pe.chart1913
+msgid "Trade accounts receivable – Third parties - Bills to be collected"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart1911
+#: model:account.account,name:l10n_pe.2_chart1911
+#: model:account.account.template,name:l10n_pe.chart1911
+msgid ""
+"Trade accounts receivable – Third parties - Invoices, tickets and other "
+"receipts receivable"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart624
+#: model:account.account,name:l10n_pe.2_chart624
+#: model:account.account.template,name:l10n_pe.chart624
+msgid "Training"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart36441
+#: model:account.account,name:l10n_pe.2_chart36441
+#: model:account.account.template,name:l10n_pe.chart36441
+msgid "Transport units - Costs"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart33411
+#: model:account.account,name:l10n_pe.2_chart33411
+#: model:account.account.template,name:l10n_pe.chart33411
+msgid "Transport units - Motor vehicles - Costs"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart33412
+#: model:account.account,name:l10n_pe.2_chart33412
+#: model:account.account.template,name:l10n_pe.chart33412
+msgid "Transport units - Motor vehicles - Revaluation"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart33421
+#: model:account.account,name:l10n_pe.2_chart33421
+#: model:account.account.template,name:l10n_pe.chart33421
+msgid "Transport units - Non-motorized vehicles - Costs"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart33422
+#: model:account.account,name:l10n_pe.2_chart33422
+#: model:account.account.template,name:l10n_pe.chart33422
+msgid "Transport units - Non-motorized vehicles - Revaluation"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart36442
+#: model:account.account,name:l10n_pe.2_chart36442
+#: model:account.account.template,name:l10n_pe.chart36442
+msgid "Transport units - Revaluation"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart6314
+#: model:account.account,name:l10n_pe.2_chart6314
+#: model:account.account.template,name:l10n_pe.chart6314
+msgid "Transport, mail and travel expenses - Alimentation"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart6313
+#: model:account.account,name:l10n_pe.2_chart6313
+#: model:account.account.template,name:l10n_pe.chart6313
+msgid "Transport, mail and travel expenses - Lodgement"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart6315
+#: model:account.account,name:l10n_pe.2_chart6315
+#: model:account.account.template,name:l10n_pe.chart6315
+msgid "Transport, mail and travel expenses - Other travel expenses"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart6312
+#: model:account.account,name:l10n_pe.2_chart6312
+#: model:account.account.template,name:l10n_pe.chart6312
+msgid "Transport, mail and travel expenses - Post office"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart63111
+#: model:account.account,name:l10n_pe.2_chart63111
+#: model:account.account.template,name:l10n_pe.chart63111
+msgid "Transport, mail and travel expenses - Transport - Charging"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart63112
+#: model:account.account,name:l10n_pe.2_chart63112
+#: model:account.account.template,name:l10n_pe.chart63112
+msgid "Transport, mail and travel expenses - Transport - Passengers"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart502
+#: model:account.account,name:l10n_pe.2_chart502
+#: model:account.account.template,name:l10n_pe.chart502
+msgid "Treasury shares"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_220710
+msgid "Tres Unidos"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_120908
+msgid "Tres de Diciembre"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_010523
+msgid "Trita"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_160304
+msgid "Trompeteros"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_130101
+#: model:res.city,name:l10n_pe.city_pe_1301
+msgid "Trujillo"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_140312
+msgid "Tucume"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_140120
+msgid "Tuman"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_030217
+msgid "Tumay Huaraca"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_061204
+msgid "Tumbaden"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_240101
+#: model:res.city,name:l10n_pe.city_pe_2401
+msgid "Tumbes"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_120432
+msgid "Tunan Marca"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_080508
+msgid "Tupac Amaru"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_110508
+msgid "Tupac Amaru Inca"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_151031
+msgid "Tupe"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_030711
+msgid "Turpay"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_030218
+msgid "Turpo"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_040518
+msgid "Tuti"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.group,name:l10n_pe.1_group56
+#: model:account.group,name:l10n_pe.2_group56
+#: model:account.group.template,name:l10n_pe.group56
+msgid "UNREALIZED RESULTS"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_180210
+msgid "Ubinas"
+msgstr ""
+
+#. module: l10n_pe
+#: model:res.city,name:l10n_pe.city_pe_1606
+msgid "Ucayali"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_221005
+msgid "Uchiza"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_130305
+msgid "Uchumarca"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_040124
+msgid "Uchumayo"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_050410
+msgid "Uchuraccay"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_021016
+msgid "Uco"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_130306
+msgid "Ucuncha"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_120504
+msgid "Ulcumayo"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_210809
+msgid "Umachiri"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_100804
+msgid "Umari"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart5911
+#: model:account.account,name:l10n_pe.2_chart5911
+#: model:account.account.template,name:l10n_pe.chart5911
+msgid "Undistributed profits - Acumulated utilities"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart5912
+#: model:account.account,name:l10n_pe.2_chart5912
+#: model:account.account.template,name:l10n_pe.chart5912
+msgid "Undistributed profits - Income from previous years"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_211307
+msgid "Unicachi"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart3383
+#: model:account.account,name:l10n_pe.2_chart3383
+#: model:account.account.template,name:l10n_pe.chart3383
+msgid "Units to receive - Furniture and fixtures"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart3381
+#: model:account.account,name:l10n_pe.2_chart3381
+#: model:account.account.template,name:l10n_pe.chart3381
+msgid "Units to receive - Machinery and exploitation equipment"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart3386
+#: model:account.account,name:l10n_pe.2_chart3386
+#: model:account.account.template,name:l10n_pe.chart3386
+msgid "Units to receive - Miscellaneous equipment"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart3387
+#: model:account.account,name:l10n_pe.2_chart3387
+#: model:account.account.template,name:l10n_pe.chart3387
+msgid "Units to receive - Replacement tools and units"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart3382
+#: model:account.account,name:l10n_pe.2_chart3382
+#: model:account.account.template,name:l10n_pe.chart3382
+msgid "Units to receive - Transportation equipment"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_061113
+msgid "Unión Agua Blanca"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_050708
+msgid "Upahuacho"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_040413
+msgid "Uraca"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_030607
+msgid "Uranmarca"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_160305
+msgid "Urarinas"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_081201
+msgid "Urcos"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_130813
+msgid "Urpay"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_081301
+#: model:res.city,name:l10n_pe.city_pe_0813
+msgid "Urubamba"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_210310
+msgid "Usicayos"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_130614
+msgid "Usquil"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_060311
+msgid "Utco"
+msgstr ""
+
+#. module: l10n_pe
+#: model:res.city,name:l10n_pe.city_pe_0107
+msgid "Utcubamba"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_061310
+msgid "Uticyacu"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart891
+#: model:account.account,name:l10n_pe.2_chart891
+#: model:account.account.template,name:l10n_pe.chart891
+msgid "Utility"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_040412
+msgid "Uñon"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.group,name:l10n_pe.1_group68
+#: model:account.group,name:l10n_pe.2_group68
+#: model:account.group.template,name:l10n_pe.group68
+msgid "VALUATION AND IMPAIRMENT OF ASSETS AND PROVISIONS"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.group,name:l10n_pe.1_group82
+#: model:account.group,name:l10n_pe.2_group82
+#: model:account.group.template,name:l10n_pe.group82
+msgid "VALUE ADDED"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.group,name:l10n_pe.1_group61
+#: model:account.group,name:l10n_pe.2_group61
+#: model:account.group.template,name:l10n_pe.group61
+msgid "VARIATION IN INVENTORIES"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.group,name:l10n_pe.1_group71
+#: model:account.group,name:l10n_pe.2_group71
+#: model:account.group.template,name:l10n_pe.group71
+msgid "VARIATION IN STORED PRODUCTION"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_010311
+msgid "Valera"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart821
+#: model:account.account,name:l10n_pe.2_chart821
+#: model:account.account.template,name:l10n_pe.chart821
+msgid "Value added"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_160606
+msgid "Vargas Guerra"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart7121
+#: model:account.account,name:l10n_pe.2_chart7121
+#: model:account.account.template,name:l10n_pe.chart7121
+msgid "Variation of by-products, waste and scrap - By-products"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart7122
+#: model:account.account,name:l10n_pe.2_chart7122
+#: model:account.account.template,name:l10n_pe.chart7122
+msgid "Variation of by-products, waste and scrap - Scrap and waste"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart7141
+#: model:account.account,name:l10n_pe.2_chart7141
+#: model:account.account.template,name:l10n_pe.chart7141
+msgid "Variation of containers and packaging - Containers"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart7142
+#: model:account.account,name:l10n_pe.2_chart7142
+#: model:account.account.template,name:l10n_pe.chart7142
+msgid "Variation of containers and packaging - Packaging"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart7111
+#: model:account.account,name:l10n_pe.2_chart7111
+#: model:account.account.template,name:l10n_pe.chart7111
+msgid "Variation of finished products - Finished products"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart7131
+#: model:account.account,name:l10n_pe.2_chart7131
+#: model:account.account.template,name:l10n_pe.chart7131
+msgid "Variation of products in process - Products in manufacturing process"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart7151
+#: model:account.account,name:l10n_pe.2_chart7151
+#: model:account.account.template,name:l10n_pe.chart7151
+msgid "Variation of services inventories - Inventories of services in process"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart149
+#: model:account.account,name:l10n_pe.2_chart149
+#: model:account.account.template,name:l10n_pe.chart149
+msgid "Various"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart1956
+#: model:account.account,name:l10n_pe.2_chart1956
+#: model:account.account.template,name:l10n_pe.chart1956
+msgid ""
+"Various accounts receivable – Associated - Assets for financial instruments"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart1954
+#: model:account.account,name:l10n_pe.2_chart1954
+#: model:account.account.template,name:l10n_pe.chart1954
+msgid ""
+"Various accounts receivable – Associated - Deposits granted in guarantee"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart1953
+#: model:account.account,name:l10n_pe.2_chart1953
+#: model:account.account.template,name:l10n_pe.chart1953
+msgid ""
+"Various accounts receivable – Associated - Interest, royalties and dividends"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart1951
+#: model:account.account,name:l10n_pe.2_chart1951
+#: model:account.account.template,name:l10n_pe.chart1951
+msgid "Various accounts receivable – Associated - Loans"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart1959
+#: model:account.account,name:l10n_pe.2_chart1959
+#: model:account.account.template,name:l10n_pe.chart1959
+msgid ""
+"Various accounts receivable – Associated - Other sundry accounts receivable"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart1955
+#: model:account.account,name:l10n_pe.2_chart1955
+#: model:account.account.template,name:l10n_pe.chart1955
+msgid "Various accounts receivable – Associated - Sale of fixed assets"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart1946
+#: model:account.account,name:l10n_pe.2_chart1946
+#: model:account.account.template,name:l10n_pe.chart1946
+msgid ""
+"Various accounts receivable – Third parties - Assets for financial "
+"instruments"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart1942
+#: model:account.account,name:l10n_pe.2_chart1942
+#: model:account.account.template,name:l10n_pe.chart1942
+msgid "Various accounts receivable – Third parties - Claims to third parties"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart1944
+#: model:account.account,name:l10n_pe.2_chart1944
+#: model:account.account.template,name:l10n_pe.chart1944
+msgid ""
+"Various accounts receivable – Third parties - Deposits granted in guarantee"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart1943
+#: model:account.account,name:l10n_pe.2_chart1943
+#: model:account.account.template,name:l10n_pe.chart1943
+msgid ""
+"Various accounts receivable – Third parties - Interest, royalties and "
+"dividends"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart1941
+#: model:account.account,name:l10n_pe.2_chart1941
+#: model:account.account.template,name:l10n_pe.chart1941
+msgid "Various accounts receivable – Third parties - Loans"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart1949
+#: model:account.account,name:l10n_pe.2_chart1949
+#: model:account.account.template,name:l10n_pe.chart1949
+msgid ""
+"Various accounts receivable – Third parties - Other sundry accounts "
+"receivable"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart1945
+#: model:account.account,name:l10n_pe.2_chart1945
+#: model:account.account.template,name:l10n_pe.chart1945
+msgid "Various accounts receivable – Third parties - Sale of fixed assets"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_150812
+msgid "Vegueta"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_200115
+msgid "Veintiseis de Octubre"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_150612
+msgid "Veintisiete de Noviembre"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_080708
+msgid "Velille"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_070106
+msgid "Ventanilla"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_190112
+msgid "Vicco"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_200805
+msgid "Vice"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_200507
+msgid "Vichayal"
+msgstr ""
+
+#. module: l10n_pe
+#: model:res.city,name:l10n_pe.city_pe_0510
+msgid "Victor Fajardo"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_130111
+msgid "Victor Larco Herrera"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_210710
+msgid "Vilavila"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_090116
+msgid "Vilca"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_030712
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_080909
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_190208
+msgid "Vilcabamba"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_051012
+msgid "Vilcanchos"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_051101
+msgid "Vilcas Huaman"
+msgstr ""
+
+#. module: l10n_pe
+#: model:res.city,name:l10n_pe.city_pe_0511
+msgid "Vilcas Huamán"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_080913
+msgid "Villa Kintiarina"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_150143
+msgid "Villa María del Triunfo"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_190307
+msgid "Villa Rica"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_080912
+msgid "Villa Virgen"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_150142
+msgid "Villa el Salvador"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_210115
+msgid "Vilque"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_210608
+msgid "Vilque Chico"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_050114
+msgid "Vinchos"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_120136
+msgid "Viques"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_040414
+msgid "Viraco"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_131201
+msgid "Viru"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_030713
+msgid "Virundo"
+msgstr ""
+
+#. module: l10n_pe
+#: model:res.city,name:l10n_pe.city_pe_1312
+msgid "Virú"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_051108
+msgid "Vischongo"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_010612
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_110305
+msgid "Vista Alegre"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_151033
+msgid "Vitis"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_120306
+msgid "Vitoc"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_040125
+msgid "Vitor"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_120609
+msgid "Vizcatan del Enengoa"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_151032
+msgid "Viñac"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_080108
+msgid "Wanchaq"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart33931
+#: model:account.account,name:l10n_pe.2_chart33931
+#: model:account.account.template,name:l10n_pe.chart33931
+msgid "Work in progress - Assembly machinery - Costs"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart33932
+#: model:account.account,name:l10n_pe.2_chart33932
+#: model:account.account.template,name:l10n_pe.chart33932
+msgid "Work in progress - Assembly machinery - Financing costs"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart33921
+#: model:account.account,name:l10n_pe.2_chart33921
+#: model:account.account.template,name:l10n_pe.chart33921
+msgid "Work in progress - Buildings in progress - Costs"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart33922
+#: model:account.account,name:l10n_pe.2_chart33922
+#: model:account.account.template,name:l10n_pe.chart33922
+msgid "Work in progress - Buildings in progress - Financing costs"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart36491
+#: model:account.account,name:l10n_pe.2_chart36491
+#: model:account.account.template,name:l10n_pe.chart36491
+msgid "Work in progress - Costs"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart3391
+#: model:account.account,name:l10n_pe.2_chart3391
+#: model:account.account.template,name:l10n_pe.chart3391
+msgid "Work in progress - Landscaping"
+msgstr ""
+
+#. module: l10n_pe
+#: model:account.account,name:l10n_pe.1_chart36492
+#: model:account.account,name:l10n_pe.2_chart36492
+#: model:account.account.template,name:l10n_pe.chart36492
+msgid "Work in progress - Revaluation"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_100112
+msgid "Yacus"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_160804
+msgid "Yaguas"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_200410
+msgid "Yamango"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_010312
+msgid "Yambrasbamba"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_010707
+msgid "Yamon"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_020906
+msgid "Yanac"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_030417
+msgid "Yanaca"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_120909
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_190113
+msgid "Yanacancha"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_190201
+msgid "Yanahuanca"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_040126
+msgid "Yanahuara"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_211208
+msgid "Yanahuaya"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_022008
+msgid "Yanama"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_080501
+msgid "Yanaoca"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_040608
+msgid "Yanaquihua"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_100323
+msgid "Yanas"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_080408
+msgid "Yanatile"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_040519
+msgid "Yanque"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_220106
+msgid "Yantalo"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_160511
+msgid "Yaquerana"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_040127
+msgid "Yarabamba"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_250105
+msgid "Yarinacocha"
+msgstr ""
+
+#. module: l10n_pe
+#: model:res.city,name:l10n_pe.city_pe_1011
+msgid "Yarowilca"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_100110
+msgid "Yarumayo"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_040313
+msgid "Yauca"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_110114
+msgid "Yauca del Rosario"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_090117
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_120433
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_120810
+#: model:res.city,name:l10n_pe.city_pe_1208
+msgid "Yauli"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_081009
+msgid "Yaurisque"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_020804
+msgid "Yautan"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_020703
+msgid "Yauya"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_120434
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_151001
+#: model:res.city,name:l10n_pe.city_pe_1510
+msgid "Yauyos"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_061311
+msgid "Yauyucan"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_160403
+msgid "Yavari"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_060508
+msgid "Yonan"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_220808
+msgid "Yorongos"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_081307
+msgid "Yucay"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_180211
+msgid "Yunga"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_020611
+msgid "Yungar"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_022001
+#: model:res.city,name:l10n_pe.city_pe_0220
+msgid "Yungay"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_211301
+#: model:res.city,name:l10n_pe.city_pe_2113
+msgid "Yunguyo"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_020907
+msgid "Yupan"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_040128
+msgid "Yura"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_021210
+msgid "Yuracmarca"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_220809
+msgid "Yuracyacu"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_160201
+msgid "Yurimaguas"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_250204
+msgid "Yurua"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_100905
+msgid "Yuyapichis"
+msgstr ""
+
+#. module: l10n_pe
+#: model_terms:ir.ui.view,arch_db:l10n_pe.pe_partner_address_form
+msgid "ZIP"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_220511
+msgid "Zapatero"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_240301
+#: model:res.city,name:l10n_pe.city_pe_2403
+msgid "Zarumilla"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_210407
+msgid "Zepita"
+msgstr ""
+
+#. module: l10n_pe
 #: model:ir.model.fields.selection,name:l10n_pe.selection__account_tax__l10n_pe_edi_unece_category__z
 #: model:ir.model.fields.selection,name:l10n_pe.selection__account_tax_template__l10n_pe_edi_unece_category__z
 msgid "Zero rated goods"
 msgstr ""
 
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_240201
+msgid "Zorritos"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_080309
+msgid "Zurite"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_150516
+msgid "Zuñiga"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_060415
+msgid "querocoto"
+msgstr ""
+
+#. module: l10n_pe
+#: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_090710
+msgid "Ñahuimpuquio"
+msgstr ""

--- a/addons/l10n_pe/models/account_tax.py
+++ b/addons/l10n_pe/models/account_tax.py
@@ -14,7 +14,7 @@ class AccountTax(models.Model):
         ('9996', 'GRA - Free'),
         ('9997', 'EXO - Exonerated'),
         ('9998', 'INA - Unaffected'),
-        ('9999', 'OTROS - Other taxes')
+        ('9999', 'OTHERS - Other taxes')
     ], 'EDI peruvian code')
 
     l10n_pe_edi_unece_category = fields.Selection([
@@ -40,7 +40,7 @@ class AccountTaxTemplate(models.Model):
         ('9996', 'GRA - Free'),
         ('9997', 'EXO - Exonerated'),
         ('9998', 'INA - Unaffected'),
-        ('9999', 'OTROS - Other taxes')
+        ('9999', 'OTHERS - Other taxes')
     ], 'EDI peruvian code')
 
     l10n_pe_edi_unece_category = fields.Selection([


### PR DESCRIPTION
Add balance sheet and profit and loss reports menu items that are
missing

As there are currently no menu for the implementation of Peruvian
localisation Balance sheet and Profit and Loss reports.
This aims to solve that.

Task: task-2774275
Signed-off-by: Julien Alardot (jual) <jual@odoo.com>

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
