### PR TITLE
[FIX] web_editor: use strict equal instead of =like in shape controller

### DIFF
--- a/addons/web_editor/controllers/main.py
+++ b/addons/web_editor/controllers/main.py
@@ -527,7 +527,7 @@ class Web_Editor(http.Controller):
         """
         svg = None
         if module == 'illustration':
-            attachment = request.env['ir.attachment'].sudo().search([('url', '=like', request.httprequest.path), ('public', '=', True)], limit=1)
+            attachment = request.env['ir.attachment'].sudo().search([('url', '=', request.httprequest.path), ('public', '=', True)], limit=1)
             if not attachment:
                 raise werkzeug.exceptions.NotFound()
             svg = b64decode(attachment.datas).decode('utf-8')


### PR DESCRIPTION
Currently, the shape controller uses =like when looking for an
attachment with a matching URL, but what is compared against is the
request's path. While this is not a security issue as we know the path
starts with the controller's route and only look for public attachments,
it's still undesirable as the end of the url may contain underscores or
percent and we do not want those to be interpreted as a pattern.
