### PR TITLE
IMP mass_mailing_event: exclude cancelled attendees by default

### DIFF
--- a/addons/mass_mailing_event/models/event_event.py
+++ b/addons/mass_mailing_event/models/event_event.py
@@ -16,7 +16,7 @@ class Event(models.Model):
             'target': 'current',
             'context': {
                 'default_mailing_model_id': self.env.ref('event.model_event_registration').id,
-                'default_mailing_domain': repr([('event_id', 'in', self.ids)])
+                'default_mailing_domain': repr([('event_id', 'in', self.ids), ('state', '!=', 'cancel')])
             },
         }
 


### PR DESCRIPTION
When contacting attendees of an event, exclude cancelled attendees by default
as chances are they do not have any interest in what you are going to
communicate.

Task-2796152

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
