### PR TITLE
[FIX] hr_holidays: Check manager for approved by manager's leave

### DIFF
--- a/addons/hr_holidays/i18n/hr_holidays.pot
+++ b/addons/hr_holidays/i18n/hr_holidays.pot
@@ -3899,6 +3899,13 @@ msgstr ""
 #: code:addons/hr_holidays/models/hr_leave.py:0
 #, python-format
 msgid ""
+"You must be %s\'s Manager to approve this leave"
+msgstr ""
+
+#. module: hr_holidays
+#: code:addons/hr_holidays/models/hr_leave.py:0
+#, python-format
+msgid ""
 "You must be either %s's manager or Time off Manager to approve this leave"
 msgstr ""
 

--- a/addons/hr_holidays/models/hr_leave.py
+++ b/addons/hr_holidays/models/hr_leave.py
@@ -1282,9 +1282,12 @@ class HolidaysRequest(models.Model):
                     if holiday.employee_id == current_employee:
                         raise UserError(_('Only a Time Off Manager can approve/refuse its own requests.'))
 
-                    if (state == 'validate1' and val_type == 'both') or (state == 'validate' and val_type == 'manager') and holiday.holiday_type == 'employee':
+                    if (state == 'validate1' and val_type == 'both') and holiday.holiday_type == 'employee':
                         if not is_officer and self.env.user != holiday.employee_id.leave_manager_id:
                             raise UserError(_('You must be either %s\'s manager or Time off Manager to approve this leave') % (holiday.employee_id.name))
+
+                    if (state == 'validate' and val_type == 'manager') and self.env.user != holiday.employee_id.leave_manager_id:
+                        raise UserError(_('You must be %s\'s Manager to approve this leave', holiday.employee_id.name))
 
                     if not is_officer and (state == 'validate' and val_type == 'hr') and holiday.holiday_type == 'employee':
                         raise UserError(_('You must either be a Time off Officer or Time off Manager to approve this leave'))


### PR DESCRIPTION
Step to reproduce:
- Create leave type approved by the employee manager (and no limit
 allocation)
- Set User A with user B as his manager
- Set User C as a time off Officer
- As user A request leaves of the before-mentionned type
- As user C, try to approve A's leave request

Current behaviour:
- Leave is accepted
 Since V15, the groups have change and `is_officer` no longer
 represent time_off all approver but time_off officer.
 All approver are now timeoff Administrator and so the right
 of time off officer should be limited.

Behaviour after PR:
- Error is shown to the current user explaining that he need to
 be the current employee manager.

opw-2753845

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
