### PR TITLE
[IMP] sale_management: only use SUPERUSER when needed

### DIFF
--- a/addons/sale_management/models/sale_order.py
+++ b/addons/sale_management/models/sale_order.py
@@ -150,9 +150,12 @@ class SaleOrder(models.Model):
 
     def action_confirm(self):
         res = super(SaleOrder, self).action_confirm()
+        if self.env.su:
+            self = self.with_user(SUPERUSER_ID)
+
         for order in self:
             if order.sale_order_template_id and order.sale_order_template_id.mail_template_id:
-                order.sale_order_template_id.mail_template_id.with_user(SUPERUSER_ID).send_mail(order.id)
+                order.sale_order_template_id.mail_template_id.send_mail(order.id)
         return res
 
     def get_access_action(self, access_uid=None):


### PR DESCRIPTION
improve the behaviour introduced in https://github.com/odoo/odoo/pull/85186 to only use
 SUPERUSER_ID when in sudo.

Do not force the sale order confirmation mail to be always sent as superuser.
When the user is not superuser, keeping the information related to the
original sender of the mail was current behaviour before SUDO changes
and should be kept as is.
That way, only confirmation mails triggered by portal confirmation should
be sent as "OdooBot" (Superuser) instead of "Public User/logged user",
avoiding security problems & confusing mail authorship.

Backport of https://github.com/odoo/odoo/commit/e6800845cd8af6e190871c9b2853b5d4b7d286ce

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
