### PR TITLE
[IMP] models.py: speed-up fields_get translated attributes

### DIFF
--- a/addons/account/models/account_journal.py
+++ b/addons/account/models/account_journal.py
@@ -560,7 +560,7 @@ class AccountJournal(models.Model):
             if 'restrict_mode_hash_table' in vals and not vals.get('restrict_mode_hash_table'):
                 journal_entry = self.env['account.move'].search([('journal_id', '=', self.id), ('state', '=', 'posted'), ('secure_sequence_number', '!=', 0)], limit=1)
                 if len(journal_entry) > 0:
-                    field_string = self._fields['restrict_mode_hash_table'].get_description(self.env)['string']
+                    field_string = self.fields_get(allfields=['restrict_mode_hash_table'], attributes=['string'])['restrict_mode_hash_table']['string']
                     raise UserError(_("You cannot modify the field %s of a journal that already has accounting entries.", field_string))
         result = super(AccountJournal, self).write(vals)
 

--- a/addons/point_of_sale/models/pos_config.py
+++ b/addons/point_of_sale/models/pos_config.py
@@ -463,9 +463,10 @@ class PosConfig(models.Model):
         opened_session = self.mapped('session_ids').filtered(lambda s: s.state != 'closed')
         if opened_session:
             forbidden_fields = []
-            for key in self._get_forbidden_change_fields():
-                if key in vals.keys():
-                    field_name = self._fields[key].get_description(self.env)["string"]
+            field_names = self.fields_get(allfields=self._get_forbidden_change_fields(), attributes=["string"])
+            for fname, info in field_names.items():
+                if fname in vals.keys():
+                    field_name = info["string"]
                     forbidden_fields.append(field_name)
             if len(forbidden_fields) > 0:
                 raise UserError(_(

--- a/addons/web_editor/models/ir_qweb_fields.py
+++ b/addons/web_editor/models/ir_qweb_fields.py
@@ -352,7 +352,7 @@ class Selection(models.AbstractModel):
     @api.model
     def from_html(self, model, field, element):
         value = element.text_content().strip()
-        selection = field.get_description(self.env)['selection']
+        selection = self.env[field.model_name].fields_get(allfields=[field.name], attributes=['selection'])[field.name]['selection']
         for k, v in selection:
             if isinstance(v, str):
                 v = ustr(v)

--- a/odoo/addons/base/models/ir_fields.py
+++ b/odoo/addons/base/models/ir_fields.py
@@ -313,7 +313,7 @@ class IrFieldsConverter(models.AbstractModel):
     def _str_to_selection(self, model, field, value):
         # get untranslated values
         env = self.with_context(lang=None).env
-        selection = field.get_description(env)['selection']
+        selection = model.fields_get(allfields=[field.name], attributes=['selection'])[field.name]['selection']
 
         for item, label in selection:
             label = ustr(label)

--- a/odoo/addons/base/models/ir_qweb_fields.py
+++ b/odoo/addons/base/models/ir_qweb_fields.py
@@ -310,7 +310,8 @@ class SelectionConverter(models.AbstractModel):
     @api.model
     def record_to_html(self, record, field_name, options):
         if 'selection' not in options:
-            options = dict(options, selection=dict(record._fields[field_name].get_description(self.env)['selection']))
+            selection = record.fields_get(allfields=[field_name], attributes=['selection'])[field_name]['selection']
+            options = dict(options, selection=dict(selection))
         return super(SelectionConverter, self).record_to_html(record, field_name, options)
 
 

--- a/odoo/addons/test_new_api/tests/test_schema.py
+++ b/odoo/addons/test_new_api/tests/test_schema.py
@@ -84,7 +84,7 @@ class TestReflection(common.TransactionCase):
                             for sel in ir_field.selection_ids:
                                 self.assertSelectionXID(sel)
 
-                field_description = field.get_description(self.env)
+                field_description = self.env[field.model_name].fields_get(allfields=[field.name], attributes=['sortable'])[field.name]
                 if field.type in ('many2many', 'one2many'):
                     self.assertFalse(field_description['sortable'])
                 elif field.store and field.column_type:

--- a/odoo/fields.py
+++ b/odoo/fields.py
@@ -793,19 +793,7 @@ class Field(MetaField('DummyField', (object,), {})):
     # Field description
     #
 
-    def get_description(self, env):
-        """ Return a dictionary that describes the field ``self``. """
-        desc = {'type': self.type}
-        for attr, prop in self.description_attrs:
-            value = getattr(self, prop)
-            if callable(value):
-                value = value(env)
-            if value is not None:
-                desc[attr] = value
-
-        return desc
-
-    # properties used by get_description()
+    # properties used by fields_get()
     _description_store = property(attrgetter('store'))
     _description_manual = property(attrgetter('manual'))
     _description_related = property(attrgetter('related'))


### PR DESCRIPTION
Speed-up fields_get by avoiding looking up a tremendous
number of time in the ormcache.

When loading 10.000 times `fields_get` of `res.partner`
a significant time was spent looking up the ormcache LRU
for the translation of the field strings and helps.
And by significant, I mean most of the time.

By getting these translations in batch for all fields
at once rather than field by field,
loading 10.000 times `res.partner.fields_get()`
goes from 26 seconds to 15 seconds on my laptop.

See the speedscope profiler screenshots in the PR description.

Before revision:
![screenshot-localhost_8069-2022 03 18-10_08_13](https://user-images.githubusercontent.com/5822488/158974465-4f07fc6f-3f80-4cfa-92c2-e5483a6f2f28.png)

After revision:
![screenshot-localhost_8069-2022 03 18-10_07_52](https://user-images.githubusercontent.com/5822488/158974510-9f6d53cb-ecf4-417b-b366-91605b419e4f.png)


