### PR TITLE
[FIX] hr: hide create employee from res_users form view

### DIFF
--- a/addons/hr/views/res_users.xml
+++ b/addons/hr/views/res_users.xml
@@ -205,7 +205,7 @@
             <field name="inherit_id" ref="base.view_users_simple_form"/>
             <field name="arch" type="xml">
                 <xpath expr="//field[@name='mobile']" position="after">
-                    <field name="create_employee" force_save="1" string="Create Employee"/>
+                    <field name="create_employee" force_save="1" string="Create Employee" attrs="{'invisible': [('id', '>', 0)]}"/>
                     <field name="create_employee_id" force_save="1" invisible="1"/>
                 </xpath>
             </field>


### PR DESCRIPTION
Prior to this commit the create_employee check box was always shown when
using the view_users_simple_form, it will now only show when the record
does not exist yet.

TaskId-2797251
