### PR TITLE
[FIX] sale,*: post mig issues in sale scope

### DIFF
--- a/addons/sale_management/models/sale_order.py
+++ b/addons/sale_management/models/sale_order.py
@@ -36,7 +36,9 @@ class SaleOrder(models.Model):
                 # Especially when installing sale_management in a db
                 # already containing SO records
                 continue
-            order.sale_order_template_id = order.company_id.sale_order_template_id.id
+            company_template = order.company_id.sale_order_template_id
+            if company_template and order.sale_order_template_id != company_template:
+                order.sale_order_template_id = order.company_id.sale_order_template_id.id
 
     @api.depends('partner_id', 'sale_order_template_id')
     def _compute_note(self):

--- a/addons/website_sale/models/website.py
+++ b/addons/website_sale/models/website.py
@@ -343,7 +343,7 @@ class Website(models.Model):
 
             # if fiscal position, update the order lines taxes
             if sale_order.fiscal_position_id:
-                sale_order._compute_tax_id()
+                sale_order.order_line._compute_tax_id()
 
             # if values, then make the SO update
             if values:


### PR DESCRIPTION
1) website_sale: tax application:

The method `_compute_tax_id` doesn't exist anymore on the sale.order model.
It has to be called manually on the sale.order.line instead.

2) sale_management: SO company change should not reset all lines

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
