### PR TITLE
[FIX] mail: allow sending multiple mails doc-based

### DIFF
--- a/addons/mail/wizard/mail_compose_message.py
+++ b/addons/mail/wizard/mail_compose_message.py
@@ -473,6 +473,9 @@ class MailComposer(models.TransientModel):
         blacklist_ids = self._get_blacklist_record_ids(mail_values_dict)
         optout_emails = self._get_optout_emails(mail_values_dict)
         done_emails = self._get_done_emails(mail_values_dict)
+        mailing_contact_based = False
+        if 'mass_mailing_id' in self._fields and self.mass_mailing_id:
+            mailing_contact_based = True
 
         for record_id, mail_values in mail_values_dict.items():
             recipients = recipients_info[record_id]
@@ -495,7 +498,7 @@ class MailComposer(models.TransientModel):
             elif optout_emails and mail_to in optout_emails:
                 mail_values['state'] = 'cancel'
                 mail_values['failure_type'] = 'mail_optout'
-            elif done_emails and mail_to in done_emails:
+            elif mailing_contact_based and done_emails and mail_to in done_emails:
                 mail_values['state'] = 'cancel'
                 mail_values['failure_type'] = 'mail_dup'
             # void of falsy values -> error
@@ -505,7 +508,7 @@ class MailComposer(models.TransientModel):
             elif not mail_to_normalized or not email_re.findall(mail_to):
                 mail_values['state'] = 'cancel'
                 mail_values['failure_type'] = 'mail_email_invalid'
-            elif done_emails is not None:
+            elif mailing_contact_based and done_emails is not None:
                 done_emails.append(mail_to)
 
         return mail_values_dict

--- a/addons/test_mail/tests/test_mail_composer.py
+++ b/addons/test_mail/tests/test_mail_composer.py
@@ -702,6 +702,32 @@ class TestComposerResultsComment(TestMailComposer):
     notification and emails generated during this process. """
 
     @users('employee')
+    def test_mail_composer_document_based(self):
+        """ Tests a document-based mass mailing with the same address mails
+        This should be allowed and not considered as duplicate in this context
+
+        document-based: that is, not from `mass_mailing` (contact-based)
+        """
+        attachment_data = self._generate_attachments_data(2)
+        email_to_1 = self.test_record.customer_id.email
+        self.template.write({
+            'auto_delete': False,  # keep sent emails to check content
+            'attachment_ids': [(0, 0, a) for a in attachment_data],
+            'email_to': '%s, %s' % (email_to_1, email_to_1),
+            'report_name': 'TestReport for {{ object.name }}',  # test cursor forces html
+            'report_template': self.test_report.id,
+        })
+        # launch composer in mass mode
+        composer_form = Form(self.env['mail.compose.message'].with_context(
+            self._get_web_context(self.test_record, add_web=True,
+                                  default_template_id=self.template.id)
+        ))
+        composer = composer_form.save()
+        with self.mock_mail_gateway(mail_unlink_sent=False), self.mock_mail_app():
+            composer._action_send_mail()
+        self.assertEqual(len(self._mails), 2, 'Should have sent 2 emails.')
+
+    @users('employee')
     @mute_logger('odoo.tests', 'odoo.addons.mail.models.mail_mail', 'odoo.models.unlink')
     def test_mail_composer_notifications_delete(self):
         """ Notifications are correctly deleted once sent """


### PR DESCRIPTION
Steps to repoduce:
- Accounting > Customers > Invoices:
	 select several invoices to send
- Action > Send & Print > (deselect Print) > Send & Print

Issue:
- It sends only one invoice per company

Cause:
- the mail_compose_message sets the status of an email as `cancel` when a mail has already been sent to a specific adress mail in the batch

Solution:
- If the use of mass mailing is not contact-based (e.g.: sending multiple invoices) it will allow to send multiple emails to the same adress

opw-2775121

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
