### PR TITLE
[FIX] web: add the globals

### DIFF
--- a/addons/web/tooling/_eslintrc.json
+++ b/addons/web/tooling/_eslintrc.json
@@ -22,8 +22,21 @@
     "no-unused-vars": ["error", { "vars": "all", "args": "none", "ignoreRestSiblings": false, "caughtErrors": "all", "caughtErrorsIgnorePattern": "^_" }]
   },
   "globals": {
-    "odoo": "writable",
     "owl": "readonly",
-    "luxon": "readonly"
+    "odoo": "readonly",
+    "$": "readonly",
+    "jQuery": "readonly",
+    "_": "readonly",
+    "Chart": "readonly",
+    "fuzzy": "readonly",
+    "QWeb2": "readonly",
+    "Popover": "readonly",
+    "StackTrace": "readonly",
+    "QUnit": "readonly",
+    "luxon": "readonly",
+    "moment": "readonly",
+    "py": "readonly",
+    "ClipboardJS": "readonly",
+    "globalThis": "readonly"
   }
 }


### PR DESCRIPTION
On 19e775b3cc94235cd8ddb5a841c7231d72907131 we added the same rules that
exists in test_lint on the tooling, but we didn't add the globals.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
