### PR TITLE
[FIX] sale_order, l10n_de: fix the pro forma invoice report

### DIFF
--- a/addons/l10n_de/report/din5008_report.xml
+++ b/addons/l10n_de/report/din5008_report.xml
@@ -100,7 +100,8 @@
                         </tr>
                     </table>
                     <h2>
-                        <span t-if="not o and not docs"><t t-esc="company.l10n_de_document_title"/></span>
+                        <span t-if="env.context.get('proforma', False) or is_pro_forma">Pro-Forma Invoice #<span t-field="docs[0].name"/></span>
+                        <span t-elif="not o and not docs"><t t-esc="company.l10n_de_document_title"/></span>
                         <span t-else="">
                             <t t-set="o" t-value="docs[0]" t-if="not o" />
                             <span t-if="'l10n_de_document_title' in o"><t t-esc="o.l10n_de_document_title"/></span>


### PR DESCRIPTION
This fix should solve the issue with the pro forma invoice not having the right title in the document file

Current behavior before PR:
- In the pro-forma invoice, the document title is either quotation or sale order depending on the state of the record

Desired behavior after PR is merged:
- display the pro-forma invoice in the document title to indicate that it's a pro-forma invoice

opw-2790124

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
