### PR TITLE
FIX Translation error in Japanese language

### DIFF
--- a/addons/point_of_sale/i18n/ja.po
+++ b/addons/point_of_sale/i18n/ja.po
@@ -124,7 +124,7 @@ msgstr ""
 #: code:addons/point_of_sale/models/pos_order.py:0
 #, python-format
 msgid "<p>Dear %s,<br/>Here is your electronic ticket for the %s. </p>"
-msgstr "<p>親愛なる%s、<br/>これが％sの電子チケットです。</p>"
+msgstr "<p>親愛なる%s、<br/>これが%sの電子チケットです。</p>"
 
 #. module: point_of_sale
 #. openerp-web


### PR DESCRIPTION
python can not convert  Japanese "％s" to string

Current behavior before PR:
when print receipt error will occur.


--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
