### PR TITLE
FIX event: fix event description edition (leak from one to another)

### DIFF
--- a/addons/event/models/event_event.py
+++ b/addons/event/models/event_event.py
@@ -91,7 +91,9 @@ class EventEvent(models.Model):
         return self.env['event.stage'].search([], limit=1)
 
     def _default_description(self):
-        return self.env['ir.ui.view']._render_template('event.event_default_descripton')
+        # avoid template branding by setting rendering_bundle=True in the context
+        return self.env['ir.ui.view'].with_context(rendering_bundle=True) \
+            ._render_template('event.event_default_descripton')
 
     def _default_event_mail_ids(self):
         return self.env['event.type']._default_event_mail_type_ids()


### PR DESCRIPTION
When saving a description the one edited doesn't appear but the one edited
previously instead. This fixes this problem.

Technical note: the default description for a new event was the rendering of
a template. That template was shared between all the events and overridden each
time.
The solution was to strip the identity of the template while rendering
it using the attribute "t-ignore" on the template making it a constant and
preventing it from being shared between events.

Task-2781443

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
