### PR TITLE
[FIX] hw_drivers: Allow the IoT to run without data base

### DIFF
--- a/addons/hw_drivers/http.py
+++ b/addons/hw_drivers/http.py
@@ -1,34 +1,10 @@
 # -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
-from odoo import http
+import odoo
 
 
-class IoTBoxHttpRequest(http.HttpRequest):
-    def dispatch(self):
-        if self._is_cors_preflight(http.request.endpoint):
-            # Using the PoS in debug mode in v12, the call to '/hw_proxy/handshake' contains the
-            # 'X-Debug-Mode' header, which was removed from 'Access-Control-Allow-Headers' in v13.
-            # When the code of http.py is not checked out to v12 (i.e. in Community), the connection
-            # fails as the header is rejected and none of the devices can be used.
-            headers = {
-                'Access-Control-Max-Age': 60 * 60 * 24,
-                'Access-Control-Allow-Headers': 'Origin, X-Requested-With, Content-Type, Accept, Authorization, X-Debug-Mode'
-            }
-            return http.Response(status=200, headers=headers)
-        return super(IoTBoxHttpRequest, self).dispatch()
+def db_list(force=False, host=None):
+    return []
 
-
-class IoTBoxRoot(http.Root):
-    def setup_db(self, httprequest):
-        # No database on the IoT Box
-        pass
-
-    def get_request(self, httprequest):
-        # Override HttpRequestwith IoTBoxHttpRequest
-        if httprequest.mimetype not in ("application/json", "application/json-rpc"):
-            return IoTBoxHttpRequest(httprequest)
-        return super(IoTBoxRoot, self).get_request(httprequest)
-
-http.Root = IoTBoxRoot
-http.root = IoTBoxRoot()
+odoo.http.db_list = db_list

--- a/addons/hw_drivers/tools/helpers.py
+++ b/addons/hw_drivers/tools/helpers.py
@@ -17,6 +17,7 @@ from threading import Thread
 import time
 
 from odoo import _, http
+from odoo.tools.func import lazy_property
 from odoo.modules.module import get_resource_path
 
 _logger = logging.getLogger(__name__)
@@ -266,7 +267,7 @@ def load_iot_handlers():
             if spec:
                 module = util.module_from_spec(spec)
                 spec.loader.exec_module(module)
-    http.root = http.Root()
+    lazy_property.reset_all(http.root)
 
 def odoo_restart(delay):
     IR = IoTRestart(delay)


### PR DESCRIPTION
From the last refactoring [#78857](https://github.com/odoo/odoo/pull/78857) it was no longer possible to run the odoo server on an iot

With this commit we change the override of the `db_list` function
And reload the driver controllers

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
