### PR TITLE
[FIX] sale_project: use is_closed in domains instead of stage_id.fold

### DIFF
--- a/addons/sale_project/models/project.py
+++ b/addons/sale_project/models/project.py
@@ -75,11 +75,11 @@ class Project(models.Model):
 
     def _get_all_sales_orders(self):
         self.ensure_one()
-        return self._fetch_sale_order_items({'project.task': ['|', ('stage_id.fold', '=', False), ('stage_id', '=', False)]}).order_id
+        return self._fetch_sale_order_items({'project.task': [('is_closed', '=', False)]}).order_id
 
     @api.depends('sale_order_id', 'task_ids.sale_order_id')
     def _compute_sale_order_count(self):
-        sale_order_items_per_project_id = self._fetch_sale_order_items_per_project_id({'project.task': ['|', ('stage_id.fold', '=', False), ('stage_id', '=', False)]})
+        sale_order_items_per_project_id = self._fetch_sale_order_items_per_project_id({'project.task': [('is_closed', '=', False)]})
         for project in self:
             project.sale_order_count = len(sale_order_items_per_project_id.get(project.id, self.env['sale.order.line']).order_id)
 


### PR DESCRIPTION
Before this commit:
- Two uses of `stage_id.fold` were remaining in the code of sale_project
  although `is_closed` is directly available in the model and is an
  indexed field.

After this commit:
- The use of `is_closed` will improve the code performance as the field
  is in the model and indexed.

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
