### PR TITLE
[FIX] point_of_sale: preserve unpaid orders with a payment

### DIFF
--- a/addons/point_of_sale/static/src/js/models.js
+++ b/addons/point_of_sale/static/src/js/models.js
@@ -792,7 +792,7 @@ exports.PosModel = Backbone.Model.extend({
         }
         for (var i = 0; i < jsons.length; i++) {
             var json = jsons[i];
-            if (json.pos_session_id !== this.pos_session.id && json.lines.length > 0) {
+            if (json.pos_session_id !== this.pos_session.id && (json.lines.length > 0 || json.statement_ids.length > 0)) {
                 orders.push(new exports.Order({},{
                     pos:  this,
                     json: json,


### PR DESCRIPTION
Unpaid orders are preserved in the local storage and can be recovered
even if you close the session and open a new one. But they would be
removed if they didn't contain any lines (articles).

On the other hand, it's possible to remove all of the order's lines
after receiving payment. So it's essential to preserve an order which
contains a payment.

Steps to reproduce the issue:
 1. Open a PoS session and create a new order
 2. Add some articles and proceed with the payment
 3. Select one of the payment methods to make the payment
 4. Do not validate the session and click on the "Back" button
 6. Remove all of the order's article and close the session
 7. Open a new session from the same PoS
=> The order with the received payment is removed

The solution is to preserve the orders with a payment line.

It is meant to replace this one that was a prototype:
https://github.com/odoo/odoo/pull/85832

opw-2766658


--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
