### PR TITLE
[FIX] website: make `theme.website.menu` working

### DIFF
--- a/addons/website/models/theme_models.py
+++ b/addons/website/models/theme_models.py
@@ -110,7 +110,7 @@ class ThemeMenu(models.Model):
     def _convert_to_base_model(self, website, **kwargs):
         self.ensure_one()
         page_id = self.page_id.copy_ids.filtered(lambda x: x.website_id == website)
-        parent_id = self.copy_ids.filtered(lambda x: x.website_id == website)
+        parent_id = self.parent_id.copy_ids.filtered(lambda x: x.website_id == website)
         new_menu = {
             'name': self.name,
             'url': self.url,
@@ -118,6 +118,7 @@ class ThemeMenu(models.Model):
             'new_window': self.new_window,
             'sequence': self.sequence,
             'parent_id': parent_id and parent_id.id or False,
+            'website_id': website.id,
             'theme_template_id': self.id,
         }
         return new_menu
@@ -143,6 +144,7 @@ class ThemePage(models.Model):
             'url': self.url,
             'view_id': view_id.id,
             'website_indexed': self.website_indexed,
+            'website_id': website.id,
             'theme_template_id': self.id,
         }
         return new_page


### PR DESCRIPTION
Before this commit, there were multiple issues related to the creation
of `theme.website.menu` records in a theme.

Indeed, the point of creating a menu is to add in to the existing
website's navbar, whose records are `website.menu`.
To do so, one should specify it by refering to the generic menu from
the XML file data.

The system then needs to understand that and find the corresponding
record for the given website. Note that there is no way to identify a
generic menu's website copies. Neither through a direct DB field,
neither through a persistent info like we do with the `key` attribute
of views.

Before this commit, when one would try to create a `theme.website.menu`
that menu would be created for every website when instaling the theme
on a particular website, which is terribly wrong as it goes against the
multi-website holy grail rule: when editing a website, do not impact
other websites.

Also, it was impossible to create a `theme.website.menu` having a
`website.menu` record as parent, which seems to be the main use case.

Issue 85630 (waiting before direct reference)