### PR TITLE
[FIX] hr_expense: added force_save to untaxed_amount

### DIFF
--- a/addons/hr_expense/views/hr_expense_views.xml
+++ b/addons/hr_expense/views/hr_expense_views.xml
@@ -144,6 +144,7 @@
                             <field name="sheet_is_editable" invisible="1"/>
                             <field name="product_id" required="1" attrs="{'readonly': [('sheet_is_editable', '=', False)]}" context="{'default_can_be_expensed': 1, 'tree_view_ref': 'hr_expense.product_product_expense_tree_view', 'form_view_ref': 'hr_expense.product_product_expense_form_view'}"/>
                             <field name="unit_amount" required="1" widget="monetary" options="{'currency_field': 'currency_id', 'field_digits': True}" attrs="{'invisible': [('product_has_cost', '=', False)], 'readonly': [('sheet_is_editable', '=', False)]}"/>
+                            <field name="untaxed_amount" invisible="1" force_save="1"/>
                             <field name="product_uom_category_id" invisible="1"/>
                             <label for="quantity" attrs="{'invisible': [('product_has_cost', '=', False)]}"/>
                             <div class="o_row" attrs="{'invisible': [('product_has_cost', '=', False)]}">


### PR DESCRIPTION
Reproduction:
1. Add the subtotal field (untaxed_amount) to either the list or form
view in hr.expense
2. Create an expense that uses a unit price/quantity, set the fields and
save
3. The subtotal field is not updated

Reason: the field untaxed_amount is not saved, as its value is not
passed to the write function even with attribute store=True

Fix: Added an invisible field for untaxed_amount and set force_save=”1”

opw-2725901





--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
