### PR TITLE
[13.0] fix sender configurability

### DIFF
--- a/addons/event/models/event_mail.py
+++ b/addons/event/models/event_mail.py
@@ -190,21 +190,7 @@ class EventMailRegistration(models.Model):
     def execute(self):
         for mail in self:
             if mail.registration_id.state in ['open', 'done'] and not mail.mail_sent and mail.scheduler_id.notification_type == 'mail':
-                organizer = mail.scheduler_id.event_id.organizer_id
-                company = self.env.company
-                author = self.env.ref('base.user_root')
-                if organizer.email:
-                    author = organizer
-                elif company.email:
-                    author = company.partner_id
-                elif self.env.user.email:
-                    author = self.env.user
-                
-                email_values = {
-                    'email_from': author.email_formatted,
-                    'author_id': author.id,
-                }
-                mail.scheduler_id.template_id.send_mail(mail.registration_id.id, email_values=email_values)
+                mail.scheduler_id.template_id.send_mail(mail.registration_id.id)
                 mail.write({'mail_sent': True})
 
     @api.depends('registration_id', 'scheduler_id.interval_unit', 'scheduler_id.interval_type')

--- a/doc/cla/individual/petrus-v.md
+++ b/doc/cla/individual/petrus-v.md
@@ -1,0 +1,11 @@
+France, 2021-03-22
+
+I hereby agree to the terms of the Odoo Individual Contributor License
+Agreement v1.0.
+
+I declare that I am authorized and able to make this agreement and sign this
+declaration.
+
+Signed,
+
+Pierre Verkest pierreverkest84@gmail.com https://github.com/petrus-v


### PR DESCRIPTION
This reverts commit 7f0ec1f164be6745494d72dc6cf2a67b10ec1486.

I've tested this issue on odoo v15.0 but as reading the code of v13 i think it's here as well  

Description of the issue/feature this PR addresses:

Email template used by event module ignore `email_from` configuration. 

## To reproduce:
* change `From` `Event: Registration` email template for instance forcing value : `test@test.fr`
* configure an event that you can register online with an email send once the sale if paid
* register to the event online
 

### Current behavior before PR:

Email is still send with the organizer linked


### Desired behavior after PR is merged:

Email template configuration should be applied.


I believe the desired behaviour introduce by the reverted commit should respect the promise of configurability of the mail template. Which is probably hard to manage actually to get the company or odoobot user from mako template ?


@fbarbe00 @tde-banana-odoo  what do you think about ? if you are ok with such change should the reverted behaviour implement in an other way through the same PR or in a different PR ?

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
