### PR TITLE
[FIX] hr_contract: fix traceback when searching on first_contract_date

### DIFF
--- a/addons/hr_contract/models/hr_employee_public.py
+++ b/addons/hr_contract/models/hr_employee_public.py
@@ -1,10 +1,21 @@
 # -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
-from odoo import fields, models
+from odoo import api, fields, models
 
 
 class HrEmployeePublic(models.Model):
     _inherit = "hr.employee.public"
 
     first_contract_date = fields.Date(related='employee_id.first_contract_date', groups="base.group_user")
+
+    @api.model
+    def _setup_fields(self):
+        res = super()._setup_fields()
+        self._fields['first_contract_date'].search = '_search_first_contract_date'
+        return res
+
+    def _search_first_contract_date(self, operator, value):
+        return [('id', 'in', [res['id'] for res in self.env['hr.employee'].sudo().search_read([
+                ('first_contract_date', operator, value)
+            ])])]


### PR DESCRIPTION
This commit fixes a traceback when filtering on `first_contract_date` on
`hr.employee.public` (RecursionError).

TaskId-2781421

NOTE: I am aware this is very hackish, in master we can simply remove the related and make it a regular field as `hr.employee.public` IS a view on `hr.employee`.
Related PR: https://github.com/odoo/odoo/pull/85740