### PR TITLE
[REF] base: Load country states only once

### DIFF
--- a/odoo/addons/base/__init__.py
+++ b/odoo/addons/base/__init__.py
@@ -6,11 +6,15 @@ from . import models
 from . import populate
 from . import report
 from . import wizard
+from odoo import tools
 
 
 def post_init(cr, registry):
-    """Rewrite ICP's to force groups"""
+    """Rewrite ICP's to force groups
+    Load states only once"""
     from odoo import api, SUPERUSER_ID
 
     env = api.Environment(cr, SUPERUSER_ID, {})
     env['ir.config_parameter'].init(force=True)
+
+    tools.convert.convert_file(cr, 'base', 'data/res.country.state.csv', noupdate=True)

--- a/odoo/addons/base/__manifest__.py
+++ b/odoo/addons/base/__manifest__.py
@@ -26,7 +26,6 @@ The kernel of Odoo, needed for all installation.
         'views/base_menus.xml',
         'views/decimal_precision_views.xml',
         'views/res_config_views.xml',
-        'data/res.country.state.csv',
         'views/ir_actions_views.xml',
         'views/ir_config_parameter_views.xml',
         'views/ir_cron_views.xml',

--- a/odoo/addons/base/models/ir_model.py
+++ b/odoo/addons/base/models/ir_model.py
@@ -2238,6 +2238,11 @@ class IrModelData(models.Model):
         self = self.with_context({MODULE_UNINSTALL_FLAG: True})
         loaded_xmlids = self.pool.loaded_xmlids
 
+        # Load all xmlids of state that were changed to be loaded in a hook but they were noupdate=False
+        cr.execute("SELECT module, name FROM ir_model_data WHERE module='base' AND model='res.country.state'")
+        rows = cr.dictfetchall()
+        self.pool.loaded_xmlids.update("%(module)s.%(name)s" % row for row in rows)
+
         query = """ SELECT id, module || '.' || name, model, res_id FROM ir_model_data
                     WHERE module IN %s AND res_id IS NOT NULL AND COALESCE(noupdate, false) != %s ORDER BY id DESC
                 """


### PR DESCRIPTION
Running '-u base' odoo will reload the 'data/res.country.state.csv' file
and it will trigger all the computed, constraint and extra process
for your custom modules in production database
spending extra time ~10m

So loading it only once it will be loaded only when the module is installed

We have the following logs for production database running `-u base`:

```log
2022-03-15 18:58:29,123 14 INFO DB odoo.modules.loading: loading base/data/res.country.state.csv
2022-03-15 19:09:57,228 14 INFO DB odoo.modules.loading: loading base/views/ir_actions_views.xml 
```

The diff of time is ~12m

I didn't find the real reason since that it is not reproduced in demo data or populated using only base module

For now, I think it is better if we avoid loading this file each time better only once

The profilers only loading this file:
 - ![2022-03-18 09 26 13](https://user-images.githubusercontent.com/6644187/159032335-59b9ce01-c9e1-4717-b008-c9e0f57c140b.jpg)

 - ![2022-03-18 09 26 09](https://user-images.githubusercontent.com/6644187/159032339-21ce3ab2-b15d-4b92-9439-a726864e48bc.jpg)

The database has ~700k partners and custom modules installed