### PR TITLE
[FIX] [14.0] Mail: error when adding attachments

### DIFF
--- a/addons/mail/static/src/components/file_uploader/file_uploader.js
+++ b/addons/mail/static/src/components/file_uploader/file_uploader.js
@@ -172,14 +172,6 @@ class FileUploader extends Component {
                     type: 'danger',
                     message: owl.utils.escape(error),
                 });
-                const relatedTemporaryAttachments = this.env.models['mail.attachment']
-                    .find(attachment =>
-                        attachment.filename === filename &&
-                        attachment.isTemporary
-                    );
-                for (const attachment of relatedTemporaryAttachments) {
-                    attachment.delete();
-                }
                 return;
             }
             // FIXME : needed to avoid problems on uploading

--- a/addons/web/controllers/main.py
+++ b/addons/web/controllers/main.py
@@ -1612,6 +1612,8 @@ class Binary(http.Controller):
                     'res_id': int(id)
                 })
                 attachment._post_add_create()
+            except AccessError:
+                args.append({'error': _("You are not allowed to upload an attachment here.")})
             except Exception:
                 args.append({'error': _("Something horrible happened")})
                 _logger.exception("Fail to upload attachment %s" % ufile.filename)

--- a/addons/web/i18n/web.pot
+++ b/addons/web/i18n/web.pot
@@ -4562,6 +4562,12 @@ msgid "Yesterday"
 msgstr ""
 
 #. module: web
+#: code:addons/web/controllers/main.py:0
+#, python-format
+msgid "You are not allowed to upload an attachment here."
+msgstr ""
+
+#. module: web
 #. openerp-web
 #: code:addons/web/static/src/js/widgets/model_field_selector.js:0
 #, python-format


### PR DESCRIPTION
Description of the issue/feature this PR addresses: Fix errors when adding attachment to records with read only permission.

Current behavior before PR: 

- [x] Error adding attachment to records with read only permission. 
- [x] The message is not as clear as version 13.0

![Screenshot from 2022-03-21 14-07-10](https://user-images.githubusercontent.com/65994959/159217637-3f12b250-e7d0-4a5e-9895-5ca43b9bc8da.png)


Desired behavior after PR is merged:
- [x] Only display the message "You are not allowed to upload an attachment here." if you do not have permission to upload files

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
