### PR TITLE
[IMP] mail: show footer separator correctly

### DIFF
--- a/addons/mail/data/mail_templates_email_layouts.xml
+++ b/addons/mail/data/mail_templates_email_layouts.xml
@@ -110,14 +110,10 @@
             <b t-esc="company.name"/><br/>
             <div style="color: #999999;">
                 <t t-esc="company.phone"/>
-                <t t-if="company.email"> |
-                    <a t-att-href="'mailto:%s' % company.email" style="text-decoration:none; color: #999999;"><t t-esc="company.email"/></a>
-                </t>
-                <t t-if="company.website"> |
-                    <a t-att-href="'%s' % company.website" style="text-decoration:none; color: #999999;">
-                        <t t-esc="company.website"/>
-                    </a>
-                </t>
+                <t t-if="company.email and company.phone"> |</t>
+                <a t-if="company.email" t-att-href="'mailto:%s' % company.email" style="text-decoration:none; color: #999999;" t-esc="company.email"/>
+                <t t-if="company.website and (company.phone or company.email)"> |</t>
+                <a t-if="company.website" t-att-href="'%s' % company.website" style="text-decoration:none; color: #999999;" t-esc="company.website"/>
             </div>
         </td>
     </tr>
@@ -211,14 +207,10 @@
             <b t-esc="company.name"/><br/>
             <div style="color: #999999; padding-top:2px">
                 <t t-esc="company.phone"/>
-                <t t-if="company.email"> |
-                    <a t-att-href="'mailto:%s' % company.email" style="text-decoration:none; color: #999999;"><t t-esc="company.email"/></a>
-                </t>
-                <t t-if="company.website"> |
-                    <a t-att-href="'%s' % company.website" style="text-decoration:none; color: #999999;">
-                        <t t-esc="company.website"/>
-                    </a>
-                </t>
+                <t t-if="company.email and company.phone"> |</t>
+                <a t-if="company.email" t-att-href="'mailto:%s' % company.email" style="text-decoration:none; color: #999999;" t-esc="company.email"/>
+                <t t-if="company.website and (company.phone or company.email)"> |</t>
+                <a t-if="company.website" t-att-href="'%s' % company.website" style="text-decoration:none; color: #999999;" t-esc="company.website"/>
             </div>
         </td>
     </tr>

--- a/addons/mail/data/mail_templates_email_layouts.xml
+++ b/addons/mail/data/mail_templates_email_layouts.xml
@@ -18,13 +18,13 @@
         <a t-if="has_button_access"
                 t-att-href="button_access['url']"
                 style="padding: 8px 12px; font-size: 12px; color: #FFFFFF; text-decoration: none !important; font-weight: 400; background-color: #875A7B; border: 0px solid #875A7B; border-radius:3px">
-            <t t-esc="button_access['title']"/>
+            <t t-out="button_access['title']"/>
         </a>
         <t t-if="actions">
             <t t-foreach="actions" t-as="action">
                 |
                 <a t-att-href="action['url']" style="color: #875A7B; text-decoration:none !important;">
-                    <t t-esc="action['title']"/>
+                    <t t-out="action['title']"/>
                 </a>
             </t>
         </t>
@@ -46,7 +46,7 @@
 <div t-out="message.body"/>
 <ul t-if="tracking_values">
     <t t-foreach="tracking_values" t-as="tracking">
-        <li><t t-esc="tracking[0]"/>: <t t-esc="tracking[1]"/> -&gt; <t t-esc="tracking[2]"/></li>
+        <li><t t-out="tracking[0]"/>: <t t-out="tracking[1]"/> -&gt; <t t-out="tracking[2]"/></li>
     </t>
 </ul>
 <div t-if="email_add_signature and not is_html_empty(signature)" t-out="signature" style="font-size: 13px;"/>
@@ -55,9 +55,9 @@
     <span t-if="company.name">
     by
     <a t-if="website_url" t-att-href="website_url" style="text-decoration:none; color: #875A7B;">
-        <span t-esc="company.name"/>
+        <span t-out="company.name"/>
     </a>
-    <span t-if="not website_url" t-esc="company.name"/>
+    <span t-if="not website_url" t-out="company.name"/>
     </span>
     using
     <a target="_blank" href="https://www.odoo.com?utm_source=db&amp;utm_medium=email" style="text-decoration:none; color: #875A7B;">Odoo</a>.
@@ -74,18 +74,18 @@
         <td align="center" style="min-width: 590px;">
             <table border="0" cellpadding="0" cellspacing="0" width="100%" style="background-color: white; padding: 0; border-collapse:separate;">
                 <tr><td valign="middle">
-                    <span style="font-size: 10px;">Your <t t-esc="model_description or 'document'"/></span>
+                    <span style="font-size: 10px;">Your <t t-out="model_description or 'document'"/></span>
                     <br/>
                     <t t-if="has_button_access">
                         <a t-att-href="button_access['url']">
                             <span style="font-size: 20px; font-weight: bold;">
-                                <t t-esc="message.record_name and message.record_name.replace('/','-') or ''"/>
+                                <t t-out="message.record_name and message.record_name.replace('/','-') or ''"/>
                             </span>
                         </a>
                     </t>
                     <t t-else="">
                         <span style="font-size: 20px; font-weight: bold;">
-                            <t t-esc="message.record_name and message.record_name.replace('/','-') or ''"/>
+                            <t t-out="message.record_name and message.record_name.replace('/','-') or ''"/>
                         </span>
                     </t>
                 </td><td valign="middle" align="right">
@@ -107,13 +107,13 @@
     <tr>
         <td align="center" style="min-width: 590px; padding: 0 8px 0 8px; font-size:11px;">
             <hr width="100%" style="background-color:rgb(204,204,204);border:medium none;clear:both;display:block;font-size:0px;min-height:1px;line-height:0; margin: 16px 0px 4px 0px;"/>
-            <b t-esc="company.name"/><br/>
+            <b t-out="company.name"/><br/>
             <div style="color: #999999;">
-                <t t-esc="company.phone"/>
+                <t t-out="company.phone"/>
                 <t t-if="company.email and company.phone"> |</t>
-                <a t-if="company.email" t-att-href="'mailto:%s' % company.email" style="text-decoration:none; color: #999999;" t-esc="company.email"/>
+                <a t-if="company.email" t-att-href="'mailto:%s' % company.email" style="text-decoration:none; color: #999999;" t-out="company.email"/>
                 <t t-if="company.website and (company.phone or company.email)"> |</t>
-                <a t-if="company.website" t-att-href="'%s' % company.website" style="text-decoration:none; color: #999999;" t-esc="company.website"/>
+                <a t-if="company.website" t-att-href="'%s' % company.website" style="text-decoration:none; color: #999999;" t-out="company.website"/>
             </div>
         </td>
     </tr>
@@ -148,17 +148,17 @@
                             <tr><td style="border-radius: 3px; background: #875A7B; text-align: center; padding: 8px 12px;">
                                 <a t-att-href="button_access['url']"
                                    style="border: 0; font-size: 12px; text-decoration: none !important; text-decoration: none; font-weight: 400; text-align: center; display: block;">
-                                    <span style="white-space:nowrap; color:#FFFFFF;" t-esc="button_access['title']"></span>
+                                    <span style="white-space:nowrap; color:#FFFFFF;" t-out="button_access['title']"></span>
                                 </a>
                             </td></tr>
                         </table></td><td width="7"></td><!--only inner cellspacing-->
                     </t>
                     <t t-if="not has_button_access and is_html_empty(subtitle)">
                         <td>
-                            <span style="font-size: 10px;">Your <t t-esc="model_description or 'document'"/></span>
+                            <span style="font-size: 10px;">Your <t t-out="model_description or 'document'"/></span>
                             <br />
                             <span style="font-size: 20px; font-weight: bold;">
-                                <t t-esc="message.record_name and message.record_name.replace('/','-') or ''"/>
+                                <t t-out="message.record_name and message.record_name.replace('/','-') or ''"/>
                             </span>
                         </td><td width="7"></td>
                     </t>
@@ -167,7 +167,7 @@
                             <t t-foreach="actions" t-as="action">
                                 |
                                 <a t-att-href="action['url']" style="color: #875A7B; text-decoration:none !important; text-decoration: none;">
-                                    <t t-esc="action['title']"/>
+                                    <t t-out="action['title']"/>
                                 </a>
                             </t>
                         </td><td width="7"></td>
@@ -204,13 +204,13 @@
     <tr>
         <td style="padding-left: 5px; font-size:11px;">
             <hr width="100%" style="background-color:rgb(204,204,204);border:medium none;clear:both;display:block;font-size:0px;min-height:1px;line-height:0; margin: 16px 0px 4px 0px;"/>
-            <b t-esc="company.name"/><br/>
+            <b t-out="company.name"/><br/>
             <div style="color: #999999; padding-top:2px">
-                <t t-esc="company.phone"/>
+                <t t-out="company.phone"/>
                 <t t-if="company.email and company.phone"> |</t>
-                <a t-if="company.email" t-att-href="'mailto:%s' % company.email" style="text-decoration:none; color: #999999;" t-esc="company.email"/>
+                <a t-if="company.email" t-att-href="'mailto:%s' % company.email" style="text-decoration:none; color: #999999;" t-out="company.email"/>
                 <t t-if="company.website and (company.phone or company.email)"> |</t>
-                <a t-if="company.website" t-att-href="'%s' % company.website" style="text-decoration:none; color: #999999;" t-esc="company.website"/>
+                <a t-if="company.website" t-att-href="'%s' % company.website" style="text-decoration:none; color: #999999;" t-out="company.website"/>
             </div>
         </td>
     </tr>


### PR DESCRIPTION
Purpose
=======
Avoid displaying "|" if there is nothing to separate in footer of email
template for sale order.

Task-2798501