### PR TITLE
[FIX] barcodes: don't ignore CTRL and ALT keys

### DIFF
--- a/addons/barcodes/static/src/js/barcode_events.js
+++ b/addons/barcodes/static/src/js/barcode_events.js
@@ -167,8 +167,8 @@ var BarcodeEvents = core.Class.extend(mixins.PropertiesMixin, {
         // Don't catch non-printable keys for which Firefox triggers a keypress
         if (this.is_special_key(e))
             return;
-        // Don't catch keypresses which could have a UX purpose (like shortcuts)
-        if (e.ctrlKey || e.metaKey || e.altKey)
+        // Don't catch keypresses which could have a UX purpose
+        if (e.metaKey)
             return;
         // Don't catch Return when nothing is buffered. This way users
         // can still use Return to 'click' on focused buttons or links.

--- a/addons/barcodes/static/src/js/barcode_events.js
+++ b/addons/barcodes/static/src/js/barcode_events.js
@@ -165,11 +165,11 @@ var BarcodeEvents = core.Class.extend(mixins.PropertiesMixin, {
         if (e.dispatched_by_barcode_reader)
             return;
         // Don't catch non-printable keys for which Firefox triggers a keypress
-        if (this.is_special_key(e))
-            return;
+        // if (this.is_special_key(e))
+        //     return;
         // Don't catch keypresses which could have a UX purpose
-        if (e.metaKey)
-            return;
+        // if (e.metaKey)
+        //     return;
         // Don't catch Return when nothing is buffered. This way users
         // can still use Return to 'click' on focused buttons or links.
         if (e.which === 13 && this.buffered_key_events.length === 0)


### PR DESCRIPTION
When a barcode scanner scan barcodes by mimicing a keyboard, we ignore
CTRL and ALT keys so that we can support UX's shortcut. This makes us
can't interpret code like FNC1(by default CTRL+]).

In this commit, we removed the code to ignore CTRL and ALT keys. No
tests broken and shortcut functionalty remains to be completed in both
chrome and firefox. We didn't test IE:)

Task-2657043





--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
