### PR TITLE
[FIX] website_{profile,slides}: fix the rank layout

### DIFF
--- a/addons/website_profile/views/website_profile.xml
+++ b/addons/website_profile/views/website_profile.xml
@@ -251,7 +251,7 @@
                             <t t-set="next_rank_id" t-value="user._get_next_rank()"/>
                             <small t-if="next_rank_id" class="font-weight-bold mt-1">Next rank:</small>
                             <t t-if="next_rank_id or user.rank_id" t-call="website_profile.profile_next_rank_card">
-                                <t t-set="img_max_width" t-valuef="40%"/>
+                                <t t-set="img_max_width" t-value="'40%'"/>
                             </t>
 
                             <table class="table table-sm w-100" id="o_wprofile_sidebar_table">

--- a/addons/website_slides/views/website_slides_templates_homepage.xml
+++ b/addons/website_slides/views/website_slides_templates_homepage.xml
@@ -462,7 +462,7 @@
         <div t-if="next_rank_id" class="font-weight-bold text-muted mt-1">Next rank:</div>
         <t t-if="next_rank_id or user.rank_id" t-call="website_profile.profile_next_rank_card">
             <t t-set="bg_class" t-valuef="bg-200"/>
-            <t t-set="img_max_width" t-valuef="50%"/>
+            <t t-set="img_max_width" t-value="'50%'"/>
         </t>
         <div t-if="next_rank_id" t-field="next_rank_id.description_motivational"/>
         <div t-else="">Congratulations, you have reached the last rank!</div>


### PR DESCRIPTION
In the current layout that displays user rank in the website profile,
the image overlaps content so the information is not fully readable.

This happens due to wrong value being set as a variable with q-web
directive.

With a recent refactoring (see commit[1]), the `_compile_format`
method replaces % into %%. So in our case, we are trying to set the
width in % (for ex 50%) which is parsed by qweb and converted into
50%%, and thus the CSS property is not applied correctly.

This commit fixes the issue by using `t-value` instead of `t-valuef to
avoid the string formatting related parsing, and thus making sure
that the proper css property is applied.

commit[1] - https://github.com/odoo/odoo/commit/e830953570d5f28aee9bdcdf97af18d3e3246030
task-2792149

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
