### PR TITLE
[FIX] website_sale: cannot search products by reference

### DIFF
--- a/addons/website_sale/models/product_template.py
+++ b/addons/website_sale/models/product_template.py
@@ -362,7 +362,7 @@ class ProductTemplate(models.Model):
                     ids = [value[1]]
             if attrib:
                 domains.append([('attribute_line_ids.value_ids', 'in', ids)])
-        search_fields = ['name']
+        search_fields = ['name', 'default_code']
         fetch_fields = ['id', 'name', 'website_url']
         mapping = {
             'name': {'name': 'name', 'type': 'text', 'match': True},

--- a/addons/website_sale/tests/__init__.py
+++ b/addons/website_sale/tests/__init__.py
@@ -12,3 +12,4 @@ from . import test_website_sale_product_attribute_value_config
 from . import test_website_sale_image
 from . import test_website_sequence
 from . import test_website_sale_visitor
+from . import test_website_product_search

--- a/addons/website_sale/tests/test_website_product_search.py
+++ b/addons/website_sale/tests/test_website_product_search.py
@@ -1,0 +1,51 @@
+# -*- coding: utf-8 -*-
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from odoo.tests import tagged
+from odoo.addons.base.tests.common import TransactionCase
+
+
+@tagged('post_install', '-at_install')
+class TestWebsiteProductSearch(TransactionCase):
+
+    def _search_products(self, search):
+        current_website = self.env['website'].get_current_website()
+        options = {
+            'displayDescription': False,
+            'displayDetail': False,
+            'displayExtraLink': False,
+            'displayImage': False,
+            'display_currency': current_website.get_current_pricelist().currency_id,
+        }
+        product_count, details, _ = current_website._search_with_fuzzy("products_only", search,
+            limit=None, order='', options=options)
+        return product_count, details[0].get('results')
+
+    def setUp(self):
+        super(TestWebsiteProductSearch, self).setUp()
+
+        self.env['product.product'].create({
+            'name': 'My Wonderful MAC - M1',
+            'default_code': 'MAC0001',
+            'list_price': 1400.0,
+            'website_published': True,
+        })
+        self.env['product.product'].create({
+            'name': 'My Wonderful MAC - Vanilla',
+            'default_code': 'MAC0002',
+            'list_price': 1000.0,
+            'website_published': True,
+        })
+
+    def test_01_search_by_reference(self):
+        """Test to make sure that search works with references"""
+        product_count, products = self._search_products('MAC0001')
+        self.assertEqual(product_count, 1)
+        self.assertEqual(products[0].name, 'My Wonderful MAC - M1')
+
+    def test_02_search_by_name(self):
+        """Test to make sure that search works with name"""
+        product_count, products = self._search_products('My Wonderful MAC -')
+        self.assertEqual(product_count, 2)
+        self.assertEqual(products[0].name, 'My Wonderful MAC - M1')
+        self.assertEqual(products[1].name, 'My Wonderful MAC - Vanilla')


### PR DESCRIPTION
Clients of the SHOP website cannot search products by their references.
This feature existed in previous releases.

To reproduce the issue:
1. Create a product with an internal reference number
2. Publish the product on the website
3. Search for the internal reference number of the product on the search page
4. The product cannot be found while it should be.

Solution: The engine did no longer checked on the 'default_code' field.
We just need to enable it again.

OPW-2790788