### PR TITLE
[FIX] hr_work_entry: fix multi calendar issue with global time off

### DIFF
--- a/addons/hr_work_entry_contract/tests/__init__.py
+++ b/addons/hr_work_entry_contract/tests/__init__.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
+from . import test_global_time_off
 from . import test_work_entry
 from . import test_work_intervals

--- a/addons/hr_work_entry_contract/tests/test_global_time_off.py
+++ b/addons/hr_work_entry_contract/tests/test_global_time_off.py
@@ -1,0 +1,38 @@
+# # -*- coding: utf-8 -*-
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from .common import TestWorkEntryBase
+
+from datetime import datetime
+
+from odoo.tests import tagged
+
+@tagged('-at_install', 'post_install')
+class TestGlobalTimeOff(TestWorkEntryBase):
+
+    def test_gto_other_calendar(self):
+        # Tests that a global time off in another calendar does not affect work entry generation
+        #  for other calendars
+        other_calendar = self.env['resource.calendar'].create({
+            'name': 'other calendar',
+        })
+        start = datetime(2018, 1, 1, 0, 0, 0)
+        end = datetime(2018, 1, 1, 23, 59, 59)
+        leave = self.env['resource.calendar.leaves'].create({
+            'date_from': start,
+            'date_to': end,
+            'calendar_id': other_calendar.id,
+            'work_entry_type_id': self.work_entry_type_leave.id,
+        })
+        contract = self.richard_emp.contract_ids
+        contract.state = 'open'
+        contract.date_generated_from = start
+        contract.date_generated_to = start
+        work_entries = contract._generate_work_entries(start, end)
+        self.assertEqual(work_entries.work_entry_type_id, contract._get_default_work_entry_type())
+        work_entries.unlink()
+        contract.date_generated_from = start
+        contract.date_generated_to = start
+        leave.calendar_id = contract.resource_calendar_id
+        work_entries = contract._generate_work_entries(start, end)
+        self.assertEqual(work_entries.work_entry_type_id, leave.work_entry_type_id)

--- a/addons/hr_work_entry_holidays/models/hr_contract.py
+++ b/addons/hr_work_entry_holidays/models/hr_contract.py
@@ -71,3 +71,16 @@ class HrContract(models.Model):
         if rc_leave:
             return self._get_leave_work_entry_type_dates(rc_leave, interval_start, interval_stop, self.employee_id)
         return self.env.ref('hr_work_entry_contract.work_entry_type_leave')
+
+    def _get_leave_domain(self, start_dt, end_dt):
+        self.ensure_one()
+        # Complete override, compare over holiday_id.employee_id instead of calendar_id
+        return [
+            ('time_type', '=', 'leave'),
+            '|', ('calendar_id', 'in', [False, self.resource_calendar_id.id]),
+                 ('holiday_id.employee_id', '=', self.employee_id.id), # see https://github.com/odoo/enterprise/pull/15091
+            ('resource_id', 'in', [False, self.employee_id.resource_id.id]),
+            ('date_from', '<=', end_dt),
+            ('date_to', '>=', start_dt),
+            ('company_id', 'in', [False, self.company_id.id]),
+        ]


### PR DESCRIPTION
When creating a global time off in one resource.calendar A , it will be
propagated on any new resource.calendar B.
However the reverse is not true, if I delete the global time off in
calendar A it will not be deleted in calendar B.
During the work entry generation this is not taken into account, a
contract using calendar A will generate leave work entries because of
the global time off in calendar B.
This is due to a change in PR odoo/enterprise#15091.

The domain is now correct and will only fetch the right leaves.

TaskId-2627378