### PR TITLE
[FIX] base: allow the codeview on users signature

### DIFF
--- a/odoo/addons/base/views/res_users_views.xml
+++ b/odoo/addons/base/views/res_users_views.xml
@@ -256,7 +256,7 @@
                                     </group>
                                 </group>
                                 <group name="messaging">
-                                    <field name="signature" options="{'style-inline': true}"/>
+                                    <field name="signature" options="{'style-inline': true, 'codeview': true}"/>
                                 </group>
                             </page>
                         </notebook>


### PR DESCRIPTION
Since v15 and the owl improvment, the signatures of other users
could not be modified in HTML (as v14 and previous) as the
codeview button was missing.

In order to modify the signature with this commit in v15:
1/ Access a user
2/ Edit
3/ Click on the codeview button (Odoo Green button with </> inside)
4/ Copy/paste your html code
5/ (/!\) Click again on the codeview button
> You should see your HTML signature
6/ Save

opw-2728194
follow-up of https://github.com/odoo/odoo/pull/80788