### PR TITLE
[FIX] google_calendar: prevent responsible modification

### DIFF
--- a/addons/google_calendar/views/google_calendar_views.xml
+++ b/addons/google_calendar/views/google_calendar_views.xml
@@ -10,4 +10,19 @@
             </field>
         </field>
     </record>
+    <record id="view_google_calendar_form" model="ir.ui.view">
+        <field name="name">google_calendar.event.calendar.form</field>
+        <field name="model">calendar.event</field>
+        <field name="inherit_id" ref="calendar.view_calendar_event_form"/>
+        <field name="arch" type="xml">
+            <xpath expr="//field[@name='active']" position="after">
+                <field name="google_id" invisible="1"/>
+            </xpath>
+            <xpath expr="//field[@name='user_id']" position="attributes">
+                <attribute name="attrs">
+                    {'readonly': [('google_id', '!=', False)]}
+                </attribute>
+            </xpath>
+        </field>
+    </record>
 </odoo>


### PR DESCRIPTION
Before this commit: it was possible to modify the responsible person of
a synced event on the Odoo, but it wouldn't reflect on Google because
the "move" method is not implemented in Odoo.
https://developers.google.com/calendar/api/v3/reference/events/move

Steps to reproduce the issue:
 1. Create two Odoo users, and sync a Google account for each.
 2. Log in with one user, create an event with the current user as
the responsible
 3. Modify the event and change the responsible person to
the second user
	=> event organizer in the google calendar is the first user,
but it's the second user in Odoo

This inconsistency would cause several issues for the customers.

The solution is to make the event's responsible field read-only in the
form view whenever it's synced with Google.

opw-2761908

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
