### PR TITLE
[FIX] web: Avoid showing bootstrap error

### DIFF
--- a/addons/web/static/src/legacy/js/libs/bootstrap.js
+++ b/addons/web/static/src/legacy/js/libs/bootstrap.js
@@ -78,8 +78,15 @@ $.fn.tooltip.Constructor.prototype.show = function () {
     // Overwrite bootstrap tooltip method to prevent showing 2 tooltip at the
     // same time
     $('.tooltip').remove();
-
-    return bootstrapShowFunction.call(this);
+    const errorsToIgnore = ["Please use show on visible elements"];
+    try {
+        return bootstrapShowFunction.call(this);
+    } catch (error) {
+        if (errorsToIgnore.includes(error.message)) {
+            return 0;
+        }
+        throw error;
+    }
 };
 
 /* Bootstrap scrollspy fix for non-body to spy */


### PR DESCRIPTION
Current behavior:
In some particular cases bootstrap was throwing an error "Uncaught Error: Please use show on visible elements"
wich appeared on the users screens.

Steps to reproduce:
- Could only reproduce on copy of clients Db
- Go in CRM and go in any lead
- Create a new activity
- Swap to an activity with less fields
- Then quickly put your mouse on the top of a field that just disappeared
- The "Please use show on visible elements" error appears.

Here's a video where I reproduce it on clients Db : https://watch.screencastify.com/v/gksBwwF0McirZzSFwaAP

opw-2720853
--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
