### PR TITLE
[FIX] web_editor: fix scrolling the page while dragging a snippet

### DIFF
--- a/addons/web_editor/static/src/js/editor/snippets.editor.js
+++ b/addons/web_editor/static/src/js/editor/snippets.editor.js
@@ -2396,7 +2396,7 @@ var SnippetsMenu = Widget.extend({
 
         let dragAndDropResolve;
         let $scrollingElement = $().getScrollingElement(this.ownerDocument);
-        if (!$scrollingElement[0] || $scrollingElement.find('body.o_in_iframe')) {
+        if (!$scrollingElement[0] || $scrollingElement.find('body.o_in_iframe').length) {
             $scrollingElement = $(this.ownerDocument).find('.o_editable');
         }
 


### PR DESCRIPTION
Since the commit [1], it's no longer possible to scroll the page while
dragging a snippet thanks to its thumbnail.

This is because for mass mailing the scroll element is not the same and
to check it we were looking for a class in the DOM. For that we did a
jQuery 'find' but without a 'length', the jQuery 'find' is always
truthy.

[1]: https://github.com/odoo/odoo/commit/29c6c80ac7009aa5068c763778342f7c6b115fad

task-2798872

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
