### PR TITLE
[FIX] l10n_cl: unable to issue credit note

### DIFF
--- a/addons/l10n_cl/models/account_move.py
+++ b/addons/l10n_cl/models/account_move.py
@@ -21,7 +21,11 @@ class AccountMove(models.Model):
                 self.journal_id.l10n_latam_use_documents:
             return super()._get_l10n_latam_documents_domain()
         if self.journal_id.type == 'sale':
-            domain = [('country_id.code', '=', "CL"), ('internal_type', '!=', 'invoice_in')]
+            if self.move_type == 'out_refund':
+                internal_types_domain = ('internal_type', '=', 'credit_note')
+            else:
+                internal_types_domain = ('internal_type', 'not in', ['invoice_in', 'credit_note'])
+            domain = [('country_id.code', '=', 'CL'), internal_types_domain]
             if self.company_id.partner_id.l10n_cl_sii_taxpayer_type == '1':
                 domain += [('code', '!=', '71')]  # Companies with VAT Affected doesn't have "Boleta de honorarios Electrónica"
             return domain


### PR DESCRIPTION
Have a CL company setup
Issue an invoice
Then generate the credit note via 'Add Credit Note' wizard
Add a reason (credit method is locked to 'partial refund') and confirm
Error will raise “You can not use a invoice document type with a refund
invoice”

This occur after
https://github.com/odoo/enterprise/commit/9e049b833b23809e4287ef61ddf7482413debefd

We now fall back to the logic of l10n_latam_invoice_document
which, in turns, fall back to the l10n_cl, ignoring the 'credit_note'
case.

opw-2794515

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
