### PR TITLE
[FIX] website: properly stop widgets before removing snippets

### DIFF
--- a/addons/web_editor/static/src/js/editor/snippets.editor.js
+++ b/addons/web_editor/static/src/js/editor/snippets.editor.js
@@ -199,6 +199,7 @@ var SnippetEditor = Widget.extend({
      */
     removeSnippet: async function () {
         this.toggleFocus(false);
+        this.trigger_up('will_remove_snippet', {$target: this.$target});
 
         await new Promise(resolve => {
             this.trigger_up('call_for_each_child_snippet', {

--- a/addons/website/static/src/js/content/website_root.js
+++ b/addons/website/static/src/js/content/website_root.js
@@ -19,6 +19,7 @@ var WebsiteRoot = publicRootData.PublicRoot.extend({
     }),
     custom_events: _.extend({}, publicRootData.PublicRoot.prototype.custom_events || {}, {
         'ready_to_clean_for_save': '_onWidgetsStopRequest',
+        'will_remove_snippet': '_onWidgetsStopRequest',
         seo_object_request: '_onSeoObjectRequest',
     }),
 


### PR DESCRIPTION
__About__
This fixes the slow dynamic snippet removal but an underlying issue still exists:
Should `_callForEachChildSnippet` enable editors for snippets inside
a [contenteditable=false] element?

_Commit Message_
```
Prior to this commit, removing a snippet while its widget was still
active could lead to slow removal as editors would be created for its
inner content.

Stopping a widget before removing it is good practice as it will clear
the DOM from any content it may leave behind and will prevent snippet
editor to be created for its dynamic inner content.

task-2781418

```