### PR TITLE
[FIX] website: Don't override form value if already set

### DIFF
--- a/addons/website/static/src/snippets/s_website_form/000.js
+++ b/addons/website/static/src/snippets/s_website_form/000.js
@@ -137,7 +137,6 @@ odoo.define('website.s_website_form', function (require) {
                     } else if (!$field.val() && $field.data('fill-with')) {
                         $field.val(self.preFillValues[$field.data('fill-with')] || '');
                     }
-                    $field.data('website_form_original_default_value', $field.val());
                 });
             }
 

--- a/addons/website/static/src/snippets/s_website_form/options.js
+++ b/addons/website/static/src/snippets/s_website_form/options.js
@@ -385,14 +385,6 @@ options.registry.WebsiteFormEditor = FormEditor.extend({
             this.$target.removeClass('d-none');
             this.$message.addClass("d-none");
         }
-
-        // Clear default values coming from data-for/data-values attributes
-        this.$target.find('input[name],textarea[name]').each(function () {
-            var original = $(this).data('website_form_original_default_value');
-            if (original !== undefined && $(this).val() === original) {
-                $(this).val('').removeAttr('value');
-            }
-        });
     },
     /**
      * @override


### PR DESCRIPTION
Steps to Reproduce:

  - Install website_form_project
  - Edit homepage
  - Add a form
  - Switch action to `Create a Task`
  - Select any project then save
  - Edit homepage again
  - Click on form and directly save
  - Edit homepage again and click on form

Issue:

  Project is not set.

Cause:

  Conflict with new feature `fill-with` and the fix
  https://github.com/odoo/odoo/pull/68634 .

Solution:

  Revert https://github.com/odoo/odoo/pull/68634 .

opw-2746377