### PR TITLE
[FIX] mail: change "on" to "for" in message_activity_assigned

### DIFF
--- a/addons/mail/data/mail_data.xml
+++ b/addons/mail/data/mail_data.xml
@@ -345,7 +345,7 @@
 <div style="margin: 0px; padding: 0px; font-size: 13px;">
     <span t-field="activity.create_uid.name"/> assigned you an activity <span t-field="activity.activity_type_id.name"/>
     <t t-if="activity.summary">(<span t-field="activity.summary"/>)</t>
-    on <span t-field="activity.res_name"/>
+    for <span t-field="activity.res_name"/>
     to close for <span t-field="activity.date_deadline"/>.<br />
     <p style="margin: 16px 0px 16px 0px;">
         <a t-att-href="access_link" t-att-data-oe-model="activity.res_model" t-att-data-oe-id="activity.res_id"


### PR DESCRIPTION
### Observed Behaviour
When asking for a new time-off, he approbation message seems not perfectly translated in french, giving the sentence
"_XXX vous a assigné une activité Approbation d'Allocation le Allocation de Congés payés ..._",
while, in English, it gives us
"_XXX assigned you an activity Allocation Approval on Allocation of Paid Time Off ..._"

### Reproducibility
This issue can be reproduced following these steps:
1. Log in as M. Admin
2. Change the DB language to any french variant
3. Make sure you correctly have configured Odoo so that you'll be able to get the notification as mail sent to M. Admin
4. Log in as M. Demo
5. Go to time Off and ask for a new time-off approbation
6. Check the mail sent to M. Admin about this time-off

### Problem Root Cause
The strange look of the translated sentence comes from the "on" word being translated to "le".

### Fix Description
Unfortunately, we can't change the translation directly as it's also used by another sentence in the same module -> We decided to change the word "on" to "for" giving us the following sentences :
- EN: "_XXX assigned you an activity Allocation Approval for Allocation of Paid Time Off ..._"
- FR: "_XXX vous a assigné une activité Approbation d'Allocation pour Allocation de Congés payés ..._"

Ideally, we should use something like "for the task", but this should be done for the master version as it will need a brand new translation.

### Related Issues/PR
- opw-2706384

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
