### PR TITLE
[FIX] project: make custom fields copiable again

### DIFF
--- a/addons/project/models/project.py
+++ b/addons/project/models/project.py
@@ -944,7 +944,7 @@ class Task(models.Model):
     # Second Many2many containing the actual personal stage for the current user
     # See project_task_stage_personal.py for the model defininition
     personal_stage_type_ids = fields.Many2many('project.task.type', 'project_task_user_rel', column1='task_id', column2='stage_id',
-        ondelete='restrict', group_expand='_read_group_personal_stage_type_ids',
+        ondelete='restrict', group_expand='_read_group_personal_stage_type_ids', copy=False,
         domain="[('user_id', '=', user.id)]", depends=['user_ids'], string='Personal Stage')
     # Personal Stage computed from the user
     personal_stage_id = fields.Many2one('project.task.stage.personal', string='Personal Stage State', compute_sudo=False,
@@ -1604,6 +1604,8 @@ class Task(models.Model):
 
     def copy_data(self, default=None):
         defaults = super().copy_data(default=default)
+        if self.env.user.has_group('project.group_project_user'):
+            return defaults
         return [{k: v for k, v in default.items() if k in self.SELF_READABLE_FIELDS} for default in defaults]
 
     @api.model


### PR DESCRIPTION
Since https://github.com/odoo/odoo/pull/73341 copy_data is filtered to avoid leaking information to portal user.
Partically, it makes custom field not copiable.

Fix it by disabling the filter for internal users. This may lead to a problem
with hacky field `personal_stage_type_ids`. To avoid extra complexity in the
code, just mark it as `copy=False`. The latter change is kind of an improvement
from functional point of view, since using default personal stage seems to be a
better idea rather than copying the stage.

---

opw-2746922