### PR TITLE
[FIX] web_editor: load odooEditor base style

### DIFF
--- a/addons/web_editor/__manifest__.py
+++ b/addons/web_editor/__manifest__.py
@@ -85,6 +85,7 @@ Odoo Web Editor widget.
             'web_editor/static/src/js/wysiwyg/wysiwyg_iframe.js',
         ],
         'web.assets_common': [
+            'web_editor/static/lib/odoo-editor/src/base_style.css',
             'web_editor/static/lib/vkbeautify/**/*',
             'web_editor/static/src/js/common/**/*',
             'web_editor/static/lib/odoo-editor/src/utils/utils.js',

--- a/addons/web_editor/static/lib/odoo-editor/demo/index.html
+++ b/addons/web_editor/static/lib/odoo-editor/demo/index.html
@@ -14,6 +14,8 @@
         <script src="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/js/bootstrap.bundle.min.js" integrity="sha384-ho+j7jyWK8fNQe+A12Hb8AhRq26LrZ/JpcUGGOn+Y7RsweNrtN/tE3MoK7ZeZDyx" crossorigin="anonymous"></script>
         <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.15.1/css/all.min.css" integrity="sha512-+4zCK9k+qNFUR5X+cKL9EIR+ZOhtIloNl9GIKS57V1MyNsYpYcUrUeQc9vNfzsWfV28IaLL3i96P9sdNyeRssA==" crossorigin="anonymous"/>
 
+        <!-- Base style to be loaded without the editor -->
+        <link rel="stylesheet" href="../src/base_style.css"/>
         <!-- custom style -->
         <link rel="stylesheet" href="../src/style.css"/>
         <!-- Checklists are styled separately in Odoo -->

--- a/addons/web_editor/static/lib/odoo-editor/src/base_style.css
+++ b/addons/web_editor/static/lib/odoo-editor/src/base_style.css
@@ -1,0 +1,3 @@
+li.oe-nested {
+    display: block;
+}

--- a/addons/web_editor/static/lib/odoo-editor/src/style.css
+++ b/addons/web_editor/static/lib/odoo-editor/src/style.css
@@ -194,9 +194,6 @@
 }
 /* Content styling */
 
-li.oe-nested {
-    display: block;
-}
 .oe-commandbar-wrapper {
     position: absolute;
     z-index: 1051;

--- a/addons/web_editor/static/lib/odoo-editor/test/editor-test.html
+++ b/addons/web_editor/static/lib/odoo-editor/test/editor-test.html
@@ -7,6 +7,7 @@
 
         <title>Odoo Editor tests</title>
 
+        <link rel="stylesheet" href="../src/base_style.css"/>
         <link rel="stylesheet" href="../src/checklist.css"/>
         <link rel="stylesheet" href="lib/mocha.css" />
         <style type="text/css">


### PR DESCRIPTION
Before this commit
The style for `li.oe-nested` was loaded only when the editor loaded.
The problem is that the style needs to be visible even when the editor
has never been loaded.

After this commit
The style for `li.oe-nested` is always loaded in the backend and in
the frontend.

Task-2793528





--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
