### PR TITLE
[IMP] mail: improve active style on mentions dropdown

### DIFF
--- a/addons/mail/static/src/components/composer_suggestion/composer_suggestion.scss
+++ b/addons/mail/static/src/components/composer_suggestion/composer_suggestion.scss
@@ -6,6 +6,10 @@
     display: flex;
     width: map-get($sizes, 100);
     padding: map-get($spacers, 2) map-get($spacers, 4);
+
+    &:active {
+        background-color: $gray-300;
+     }
 }
 
 .o_ComposerSuggestion_part1 {

--- a/addons/mail/static/src/components/composer_suggestion/composer_suggestion.xml
+++ b/addons/mail/static/src/components/composer_suggestion/composer_suggestion.xml
@@ -2,7 +2,7 @@
 <templates xml:space="preserve">
 
     <t t-name="mail.ComposerSuggestion" owl="1">
-        <a class="o_ComposerSuggestion dropdown-item" t-att-class="{ 'active': props.isActive }" href="#" t-att-title="record and title()" role="menuitem" t-on-click="_onClick">
+        <a class="o_ComposerSuggestion dropdown-item" t-att-class="{ 'active bg-300': props.isActive }" href="#" t-att-title="record and title()" role="menuitem" t-on-click="_onClick">
             <t t-if="record">
                 <t t-if="isCannedResponse">
                     <span class="o_ComposerSuggestion_part1 text-truncate"><t t-esc="record.source"/></span>


### PR DESCRIPTION
**Current behavior before PR:** 

The current 'active' class on the @mentions dropdown is not clear enough.
The purpose of this task is to add a grey hover background when the item is
active.

**Desired behavior after PR is merged:**

Add the grey hover background when the item is active

Task-2786679



--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
