### PR TITLE
[FIX] mrp: don't show reserved column for byproducts

### DIFF
--- a/addons/mrp/models/stock_move.py
+++ b/addons/mrp/models/stock_move.py
@@ -308,6 +308,7 @@ class StockMove(models.Model):
         elif self.production_id:
             action['views'] = [(self.env.ref('mrp.view_stock_move_operations_finished').id, 'form')]
             action['context']['show_source_location'] = False
+            action['context']['show_reserved_quantity'] = False
         return action
 
     def _action_cancel(self):


### PR DESCRIPTION
No longer show the reserved column from by-products production registration on an MO.

Task ID: 2797692

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr