### PR TITLE
[FIX] mail: fix mock server's mail channel write method

### DIFF
--- a/addons/mail/static/tests/helpers/mock_server.js
+++ b/addons/mail/static/tests/helpers/mock_server.js
@@ -1117,7 +1117,7 @@ MockServer.include({
         this._widget.call('bus_service', 'trigger', 'notification', [{
             type: 'mail.channel/insert',
             payload: {
-                id: 20,
+                id,
                 avatarCacheKey: avatarCacheKey,
             },
         }]);


### PR DESCRIPTION
Mock server's mail channel write method is incorrect. It assumes the id of the channel will always be 20 while it could be anything.