### PR TITLE
[FIX] purchase: removed header on subsequent pages of RFQ

### DIFF
--- a/addons/purchase/report/purchase_quotation_templates.xml
+++ b/addons/purchase/report/purchase_quotation_templates.xml
@@ -21,7 +21,7 @@
             <h2>Request for Quotation <span t-field="o.name"/></h2>
 
             <table class="table table-sm">
-                <thead>
+                <thead style="display: table-row-group">
                     <tr>
                         <th name="th_description"><strong>Description</strong></th>
                         <th name="th_expected_date" class="text-center"><strong>Expected Date</strong></th>


### PR DESCRIPTION
Reproduction:
1. Change Document layout style to "Boxed"
2. Creating a PO with long descriptions for each product, make sure the
report is at least 2 pages
3. Send By Email (use default RFQ template)
4. In chatter, open the RFQ pdf file-> go to second page -> the
descriptions overlap the header

Reason: like a fix from previous bug in sale order report, the header is
removed in subsequent pages to avoid overlapping

Fix: set the header to row group

opw-2779427

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
