### PR TITLE
[FIX] mail: correct res fake model

### DIFF
--- a/addons/mail/static/tests/helpers/mock_models.js
+++ b/addons/mail/static/tests/helpers/mock_models.js
@@ -242,7 +242,7 @@ class MockModels {
                     email_cc: { type: 'char' },
                     partner_ids: {
                         string: "Related partners",
-                        type: 'many2one',
+                        type: 'one2many',
                         relation: 'res.partner'
                     },
                 },


### PR DESCRIPTION
The res.fake model has a partner_ids fields which is a many2one but is used as a one2many.