### PR TITLE
[FIX] base: record count on ir.model defined by query

### DIFF
--- a/odoo/addons/base/models/ir_model.py
+++ b/odoo/addons/base/models/ir_model.py
@@ -201,7 +201,7 @@ class IrModel(models.Model):
         self.count = 0
         for model in self:
             records = self.env[model.model]
-            if not records._abstract:
+            if not records._abstract and records._auto:
                 cr.execute(sql.SQL('SELECT COUNT(*) FROM {}').format(sql.Identifier(records._table)))
                 model.count = cr.fetchone()[0]
 


### PR DESCRIPTION
Models can be defined by an SQL table, an SQL view or an SQL query (with attribute `_table_query`).  Counting records makes little sense when the model does not correspond to a table, and actually fails when it is defined by an SQL query.

We fix the compute method by counting records only for models where `_auto=True`.