### PR TITLE
[FIX] mass_mailing: fixes save filter glitch

### DIFF
--- a/addons/mass_mailing/static/src/js/mailing_filter_widget.js
+++ b/addons/mass_mailing/static/src/js/mailing_filter_widget.js
@@ -103,7 +103,7 @@ const FieldMailingFilter = FieldMany2One.extend({
     _onFavoriteFilterDropdownShown(ev) {
         const filterInput = ev.target.querySelector('input.o_mass_mailing_filter_name');
         filterInput.value = '';
-        filterInput.focus();
+        filterInput.focus({ preventScroll: true });
     },
 
     /**

--- a/addons/mass_mailing/static/tests/mass_mailing_favourite_filter_tests.js
+++ b/addons/mass_mailing/static/tests/mass_mailing_favourite_filter_tests.js
@@ -151,6 +151,8 @@ QUnit.module('favorite filter widget', {
             "should have option to remove filter if filter is already set");
         assert.isNotVisible(form.$('.o_mass_mailing_save_filter_container'),
             "should not have option to save filter if filter is already set");
+        // Ensures input is not focussed otherwise clicking on it will just close the dropdown instead of opening it
+        form.$('.o_field_many2one[name="mailing_filter_id"] .o_input_dropdown input').blur();
         await testUtils.dom.click('.o_field_many2one[name="mailing_filter_id"] input');
         assert.containsN($dropdown, 'li.ui-menu-item', 2,
             "there should be two existing filters");


### PR DESCRIPTION
In the mass mailing form, when clicking on the filter save button, the screen
was unexpectedly scrolling down. This fixes this problem.

Task-2793090

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
