### PR TITLE
[FIX] qweb: reset the attributes dictionary

### DIFF
--- a/odoo/addons/base/models/ir_qweb.py
+++ b/odoo/addons/base/models/ir_qweb.py
@@ -1204,11 +1204,7 @@ class IrQWeb(models.AbstractModel):
                 if directive in el.attrib:
                     code.extend(self._compile_directive(el, options, directive, level))
             elif directive == 'att':
-                if any(name.startswith('t-att-') or
-                        name.startswith('t-attf-') or
-                        not name.startswith('t-')
-                        for name in el.attrib):
-                    code.extend(self._compile_directive(el, options, directive, level))
+                code.extend(self._compile_directive(el, options, directive, level))
             elif directive == 'options':
                 if any(name.startswith('t-options-') for name in el.attrib):
                     code.extend(self._compile_directive(el, options, directive, level))
@@ -1509,6 +1505,7 @@ class IrQWeb(models.AbstractModel):
 
         if el.text is not None:
             self._append_text(el.text, options)
+
         body = []
         for item in el:
             if isinstance(item, etree._Comment):

--- a/odoo/addons/base/tests/test_qweb.py
+++ b/odoo/addons/base/tests/test_qweb.py
@@ -849,6 +849,57 @@ class TestQWebBasic(TransactionCase):
         rendered = self.env['ir.qweb']._render(t.id, values)
         self.assertEqual(rendered.strip(), result.strip())
 
+    def test_att_no_propagation_1(self):
+        t = self.env['ir.ui.view'].create({
+            'name': 'test',
+            'type': 'qweb',
+            'arch_db': '''<t t-name="bibi">
+                <div t-foreach="[1, 2]" t-as="v" class="toto"/>
+                <t class="remove_me" t-set="data">a</t>
+                <div t-out="data"/>
+            </t>'''
+        })
+        result = """
+                <div class="toto"></div><div class="toto"></div>
+                <div>a</div>
+            """
+        rendered = self.env['ir.qweb']._render(t.id)
+        self.assertEqual(rendered.strip(), result.strip())
+
+    def test_att_no_propagation_2(self):
+        t = self.env['ir.ui.view'].create({
+            'name': 'test',
+            'type': 'qweb',
+            'arch_db': '''<t t-name="bibi">
+                <section>
+                    <div t-foreach="[1, 2]" t-as="v">
+                        <span t-att-test="v" t-esc="v_index"/>
+                    </div>
+                    <div t-foreach="[1, 2]" t-as="v" class="o">
+                        <span t-att-test="v" t-esc="v_index"/>
+                    </div>
+                </section>
+            </t>'''
+        })
+        result = """
+                <section>
+                    <div>
+                        <span test="1">0</span>
+                    </div>
+                    <div>
+                        <span test="2">1</span>
+                    </div>
+                    <div class="o">
+                        <span test="1">0</span>
+                    </div>
+                    <div class="o">
+                        <span test="2">1</span>
+                    </div>
+                </section>
+            """
+        rendered = self.env['ir.qweb']._render(t.id)
+        self.assertEqual(etree.fromstring(rendered), etree.fromstring(result))
+
     def test_set_1(self):
         t = self.env['ir.ui.view'].create({
             'name': 'test',

--- a/odoo/tools/profiler.py
+++ b/odoo/tools/profiler.py
@@ -316,7 +316,7 @@ class QwebTracker():
             if not options.get('profile') or directive in ('inner-content', 'tag-open', 'tag-close'):
                 return method_compile_directive(self, el, options, directive, level)
             enter = f"{' ' * 4 * level}self.env.context['qweb_tracker'].enter_directive({directive!r}, {el.attrib!r}, {options['last_path_node']!r})"
-            leave = f"{' ' * 4 * level}self.env.context['qweb_tracker'].leave_directive()"
+            leave = f"{' ' * 4 * level}self.env.context['qweb_tracker'].leave_directive({directive!r}, {el.attrib!r}, {options['last_path_node']!r})"
             code_directive = method_compile_directive(self, el, options, directive, level)
             return [enter, *code_directive, leave] if code_directive else []
         return _tracked_compile_directive
@@ -366,12 +366,12 @@ class QwebTracker():
         for hook in self.qweb_hooks:
             hook('enter', self.cr.sql_log_count, view_id=self.view_id, xpath=xpath, directive=directive, attrib=attrib)
 
-    def leave_directive(self):
+    def leave_directive(self, directive, attrib, xpath):
         if self.execution_context_enabled:
             self.context_stack.pop().__exit__()
 
         for hook in self.qweb_hooks:
-            hook('leave', self.cr.sql_log_count)
+            hook('leave', self.cr.sql_log_count, view_id=self.view_id, xpath=xpath, directive=directive, attrib=attrib)
 
 
 class QwebCollector(Collector):
@@ -451,19 +451,21 @@ class QwebCollector(Collector):
             last_event_time = time
             last_event_query = sql_count
 
-            if event == 'enter':
-                data = {
-                    'view_id': kwargs['view_id'],
-                    'xpath': kwargs['xpath'],
-                    'directive': self._get_directive_profiling_name(kwargs['directive'], kwargs['attrib']),
-                    'delay': 0,
-                    'query': 0,
-                }
-                results.append(data)
-                stack.append(data)
-            else:
-                assert event == "leave"
-                data = stack.pop()
+            directive = self._get_directive_profiling_name(kwargs['directive'], kwargs['attrib'])
+            if directive:
+                if event == 'enter':
+                    data = {
+                        'view_id': kwargs['view_id'],
+                        'xpath': kwargs['xpath'],
+                        'directive': directive,
+                        'delay': 0,
+                        'query': 0,
+                    }
+                    results.append(data)
+                    stack.append(data)
+                else:
+                    assert event == "leave"
+                    data = stack.pop()
 
         self.add({'results': {'archs': archs, 'data': results}})
         super().post_process()


### PR DESCRIPTION
Issue: attributes could be generated by directives and not be used (for
example on <t>). These attributes could end up unwittingly on the next
node.
