### PR TITLE
[FIX] web: trim search bar input

### DIFF
--- a/addons/web/static/src/legacy/js/control_panel/search_bar.js
+++ b/addons/web/static/src/legacy/js/control_panel/search_bar.js
@@ -276,7 +276,7 @@ odoo.define('web.SearchBar', function (require) {
             // - Selection sources
             // - "no result" items
             if (source.active) {
-                const labelValue = source.label || this.state.inputValue;
+                const labelValue = source.label || (this.state.inputValue || '').trim();
                 this.model.dispatch('addAutoCompletionValues', {
                     filterId: source.filterId,
                     value: "value" in source ? source.value : this._parseWithSource(labelValue, source),


### PR DESCRIPTION
user input should be trimmed to avoid annoying manual removing the spaces that
happens because copy-pasting the search value (e.g. sale order number)

---

opw-2796868

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
