### PR TITLE
[FIX] account: wrong destination account id in internal transfer

### DIFF
--- a/addons/account/models/account_payment.py
+++ b/addons/account/models/account_payment.py
@@ -380,11 +380,13 @@ class AccountPayment(models.Model):
             else:
                 payment.amount_signed = payment.amount
 
-    @api.depends('partner_id', 'company_id', 'payment_type')
+    @api.depends('partner_id', 'company_id', 'payment_type', 'destination_journal_id', 'is_internal_transfer')
     def _compute_available_partner_bank_ids(self):
         for pay in self:
             if pay.payment_type == 'inbound':
                 pay.available_partner_bank_ids = pay.journal_id.bank_account_id
+            elif pay.is_internal_transfer:
+                pay.available_partner_bank_ids = pay.destination_journal_id.bank_account_id
             else:
                 pay.available_partner_bank_ids = pay.partner_id.bank_ids\
                         .filtered(lambda x: x.company_id.id in (False, pay.company_id.id))._origin


### PR DESCRIPTION
Setup at least 2 bank accounts [ACC1] and [ACC2]
Setup a Journal [BNK1] with [ACC1]
Setup a second journal [BNK2] with [ACC2]
Create an Internal Transfer from [BNK1] to [BNK2]
Save and confirm

partner_bank_id will be choosen from the Journal, for inbound
payment, ([ACC1]) or it from one of the company bank accounts in
outbound payment, so either [ACC1] or [ACC2]
This is wrong as [ACC2] should be used because defined on [BNK2]

opw-2794081

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
