### PR TITLE
2022 03 ac fix account withoold 100

### DIFF
--- a/addons/l10n_ec/data/account_tax_template_withhold_vat_data.xml
+++ b/addons/l10n_ec/data/account_tax_template_withhold_vat_data.xml
@@ -187,7 +187,7 @@
                 (0,0, {
                     'factor_percent': 12,
                     'repartition_type': 'tax',
-                    'account_id': ref('l10n_ec.ec_vat_withhold_70'),
+                    'account_id': ref('l10n_ec.ec_vat_withhold_100'),
                     'plus_report_line_ids': [ref('tax_report_line_104_731')],
                 }),]"/>
             <field name="refund_repartition_line_ids" eval="[(5, 0, 0),
@@ -198,7 +198,7 @@
                 (0,0, {
                     'factor_percent': 12,
                     'repartition_type': 'tax',
-                    'account_id': ref('l10n_ec.ec_vat_withhold_70'),
+                    'account_id': ref('l10n_ec.ec_vat_withhold_100'),
                     'minus_report_line_ids': [ref('tax_report_line_104_731')],
                 }),]"/>
         </record>


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
When installing new companies the account configured on tax "Vat Withhold 100%" is mistakenly setup with the account for vat withhold 70%.

Desired behavior after PR is merged:
The accounts will be properly set for tax "Vat withhold 100%"


--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
