### PR TITLE
[IMP] website_slides: improve the design of the start learning card

### DIFF
--- a/addons/website_sale_slides/views/website_sale_templates.xml
+++ b/addons/website_sale_slides/views/website_sale_templates.xml
@@ -16,23 +16,25 @@
     </div>
     <div class="mt-2">
         <t t-foreach="order.order_line" t-as="line">
-            <t t-foreach="line.product_id.channel_ids" t-as="course">
-                <table class="table pb-32 border">
-                    <tr>
-                        <td class="w-50">
-                            <span t-if="course.image_1920" class="w-75" t-field="course.image_1920" t-options="{'widget': 'image'}"/>
-                            <img t-else="" class="img img-responsive w-75" src="/website_slides/static/src/img/channel-training-default.jpg"/>
-                        </td>
-                        <td>
-                            <h3 t-esc="course.name" class="m-2"/>
-                            <div t-field="course.description_short" class="font-weight-light o_wslides_desc_truncate_3 pb-2 ml-2"/>
-                            <a role="button" class="btn btn-primary ml-2" t-attf-href="/slides/#{slug(course)}">
-                                Start Learning
-                            </a>
-                        </td>
-                    </tr>
-                </table>
-            </t>
+            <div t-foreach="line.product_id.channel_ids" t-as="course" class="row mx-0 my-2 border">
+                <div class="col-5 d-flex justify-content-center my-auto">
+                    <span t-if="course.image_1920" t-field="course.image_1920" t-options="{'widget': 'image', 'class': 'my-2'}"/>
+                    <img t-else="" class="img img-fluid my-2" src="/website_slides/static/src/img/channel-training-default.jpg"/>
+                </div>
+                <div class="col-7">
+                    <a t-attf-href="/slides/#{slug(course)}"><h3 t-out="course.name" class="m-2"/></a>
+                    <div t-out="course.description_short" class="font-weight-light o_wslides_desc_truncate_2 ml-2"/>
+                    <div class="font-weight-light ml-2 mt-2">
+                        <t t-out="course.total_time" t-options="{'widget': 'duration', 'unit': 'hour', 'round': 'minute'}"/>
+                        <t t-if="course.total_slides">
+                           <t t-if="course.total_time"> - </t><t t-out="course.total_slides"/> step(s)
+                        </t>
+                    </div>
+                    <a role="button" class="btn btn-primary ml-2 my-2" t-attf-href="/slides/#{slug(course)}">
+                        Start Learning
+                    </a>
+                </div>
+            </div>
         </t>
     </div>
 </template>


### PR DESCRIPTION
PURPOSE

Improve the layout of the card and make it look more similar to the one in /slides

SPECIFICATIONS

Current:

currently when we see the name of course are not clickable, we have not course step and duration
of course are not mention.

To Be:

After this commit the card layout will look more similar to the one in slides.
I have added course steps, duration of course and the name of
the course is clickable.

TaskId-2790996