### PR TITLE
[FIX] website_slides: correct model definitions setup

### DIFF
--- a/addons/website_slides/static/tests/helpers/model_definitions_setup.js
+++ b/addons/website_slides/static/tests/helpers/model_definitions_setup.js
@@ -2,4 +2,4 @@
 
 import { addModelNamesToFetch } from '@mail/../tests/helpers/model_definitions_helpers';
 
-addModelNamesToFetch(['slide.channel', 'note.note']);
+addModelNamesToFetch(['slide.channel']);


### PR DESCRIPTION
website_slides was relying on a model that belongs to a module it does not depend on. This makes the single module builds fail. Moreover, it appears this model was not even used during tests.
