### PR TITLE
[FIX] hr_recruitment : send interview to duplicated applicant

### DIFF
--- a/addons/hr_recruitment_survey/models/hr_applicant.py
+++ b/addons/hr_recruitment_survey/models/hr_applicant.py
@@ -8,7 +8,7 @@ class Applicant(models.Model):
     _inherit = "hr.applicant"
 
     survey_id = fields.Many2one('survey.survey', related='job_id.survey_id', string="Survey", readonly=True)
-    response_id = fields.Many2one('survey.user_input', "Response", ondelete="set null")
+    response_id = fields.Many2one('survey.user_input', "Response", ondelete="set null", copy=False)
     response_state = fields.Selection(related='response_id.state', readonly=True)
 
     def action_print_survey(self):


### PR DESCRIPTION
Steps :
Install Recruitment and Surveys.
Recruitment > Settings > Enable Send Interview Survey.
Recruitment > Any Position > Create an Application,
click on Send Interview and then on Send.
Duplicate it, click on Send Interview end then on Send.

Issue :
ValueError: Wrong value for survey.user_input.applicant_id.

Fix :
This is initially caused by the fact that the applicant's response
is also duplicated. As it shouldn't be, copy=False.

opw-2751975

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
