### PR TITLE
[FIX][stock]: Fix aggregated quantity ordered in delivery slip report

### DIFF
--- a/addons/stock/models/stock_move_line.py
+++ b/addons/stock/models/stock_move_line.py
@@ -762,6 +762,7 @@ class StockMoveLine(models.Model):
                                                    'product_uom_rec': uom,
                                                    'product': move_line.product_id}
             else:
+                aggregated_move_lines[line_key]['qty_ordered'] += move_line.move_id.product_uom_qty
                 aggregated_move_lines[line_key]['qty_done'] += move_line.qty_done
 
         # Does the same for empty move line to retrieve the ordered qty. for partially done moves


### PR DESCRIPTION
Description of the issue/feature this PR addresses:

When the same product with different quantity ordered has a transfer
as confirmed state, the aggregated quantity_done is surplused but
the quantity_ordered(product_uom_qty) does not get summed up in
delivery slip report.

Current behavior before PR:

- Aggregated quantity ordered(product_uom_qty) is not surplussed in delivery slip report

Desired behavior after PR is merged:

- Aggregated quantity ordered(product_uom_qty) is summed up