### PR TITLE
[ADD] mass_mailing: add a design tab to apply global styles to mailing

### DIFF
--- a/addons/mass_mailing/static/src/js/mass_mailing_snippets.js
+++ b/addons/mass_mailing/static/src/js/mass_mailing_snippets.js
@@ -1,9 +1,110 @@
 odoo.define('mass_mailing.snippets.options', function (require) {
 "use strict";
 
-var options = require('web_editor.snippets.options');
+const options = require('web_editor.snippets.options');
 const {ColorpickerWidget} = require('web.Colorpicker');
+const SelectUserValueWidget = options.userValueWidgetsRegistry['we-select'];
+const weUtils = require('web_editor.utils');
 const {_t} = require('web.core');
+
+//--------------------------------------------------------------------------
+// Constants
+//--------------------------------------------------------------------------
+
+const _getFontName = fontFamily => fontFamily.split(',')[0].replace(/"/g, '').replace(/([a-z])([A-Z])/g, (v, a, b) => `${a} ${b}`).trim();
+const _normalizeFontFamily = fontFamily => fontFamily.replace(/"/g, '').replace(/, /g, ',');
+const FONT_FAMILIES = [
+    'Arial, "Helvetica Neue", Helvetica, sans-serif', // name: "Arial"
+    '"Courier New", Courier, "Lucida Sans Typewriter", "Lucida Typewriter", monospace', // name: "Courier New"
+    'Georgia, Times, "Times New Roman", serif', // name: "Georgia"
+    '"Helvetica Neue", Helvetica, Arial, sans-serif', // name: "Helvetica Neue"
+    '"Lucida Grande", "Lucida Sans Unicode", "Lucida Sans", Geneva, Verdana, sans-serif', // name: "Lucida Grande"
+    'Tahoma, Verdana, Segoe, sans-serif', // name: "Tahoma"
+    'TimesNewRoman, "Times New Roman", Times, Baskerville, Georgia, serif', // name: "Times New Roman"
+    '"Trebuchet MS", "Lucida Grande", "Lucida Sans Unicode", "Lucida Sans", Tahoma, sans-serif', // name: "Trebuchet MS"
+    'Verdana, Geneva, sans-serif', // name: "Verdana"
+].map(fontFamily => _normalizeFontFamily(fontFamily));
+const CSS_PREFIX = '.o_mail_wrapper';
+const DEFAULT_CSS = `
+    ${CSS_PREFIX} h1 {
+        font-size: 35px;
+        color: #212529;
+        font-family: Arial,Helvetica Neue,Helvetica,sans-serif;
+    }
+    ${CSS_PREFIX} h2 {
+        font-size: 28px;
+        color: #212529;
+        font-family: Arial,Helvetica Neue,Helvetica,sans-serif;
+    }
+    ${CSS_PREFIX} h3 {
+        font-size: 24.5px;
+        color: #212529;
+        font-family: Arial,Helvetica Neue,Helvetica,sans-serif;
+    }
+    ${CSS_PREFIX} p {
+        font-size: 14px;
+        color: #212529;
+        font-family: Arial,Helvetica Neue,Helvetica,sans-serif;
+    }
+    ${CSS_PREFIX} a:not(.btn) {
+        text-decoration-line: none;
+        color: #276e72
+    }
+    ${CSS_PREFIX} a[href].btn-primary {
+        font-size: 14px;
+        color: #FFFFFF;
+        background-color: #35979c;
+        border-color: #35979c;
+        border-style: solid;
+        border-width: 1px;
+    }
+    ${CSS_PREFIX} a[href].btn-secondary {
+        font-size: 14px;
+        color: #FFFFFF;
+        background-color: #685563;
+        border-color: #685563;
+        border-style: solid;
+        border-width: 1px;
+    }
+    ${CSS_PREFIX} hr {
+        border-top-color: #212529;
+        border-top-style: solid;
+        border-top-width: 1px;
+        width: 100%;
+    }
+`;
+const BTN_SIZE_STYLES = {
+    'btn-sm': {
+        'padding': '0.25rem 0.5rem',
+        'font-size': '0.875rem',
+        'line-height': '1.5rem',
+    },
+    'btn-lg': {
+        'padding': '0.5rem 1rem',
+        'font-size': '1.25rem',
+        'line-height': '1.5rem',
+    },
+    'btn-md': {
+        'padding': false, // Property must be removed.
+        'font-size': '14px',
+        'line-height': false, // Property must be removed.
+    },
+};
+const DEFAULT_BUTTON_SIZE = 'btn-md';
+const PRIORITY_STYLES = {
+    'h1': ['font-family'],
+    'h2': ['font-family'],
+    'h3': ['font-family'],
+    'p': ['font-family'],
+    'a:not(.btn)': [],
+    'a[href].btn-primary': [],
+    'a[href].btn-secondary': [],
+    'hr': [],
+};
+
+//--------------------------------------------------------------------------
+// Options
+//--------------------------------------------------------------------------
 
 // Snippet option for resizing  image and column width inline like excel
 options.registry.mass_mailing_sizing_x = options.Class.extend({
@@ -148,6 +249,226 @@ options.registry.ImageTools.include({
             warningEl.title = _t("Be aware that this option may not work on many mail clients");
             imgShapeTitleEl.appendChild(warningEl);
         }
+    },
+});
+
+options.userValueWidgetsRegistry['we-fontfamilypicker'] = SelectUserValueWidget.extend({
+    /**
+     * @override
+     * @see FONT_FAMILIES
+     */
+    start: async function () {
+        const res = await this._super(...arguments);
+        // Populate the `we-select` with the font family buttons
+        for (const fontFamily of FONT_FAMILIES) {
+            const button = document.createElement('we-button');
+            button.style.setProperty('font-family', fontFamily);
+            button.dataset.customizeCssProperty = fontFamily;
+            button.dataset.cssProperty = 'font-family';
+            button.dataset.selectorText = this.el.dataset.selectorText;
+            button.textContent = _getFontName(fontFamily);
+            this.menuEl.appendChild(button);
+        };
+        return res;
+    },
+});
+
+options.registry.DesignTab = options.Class.extend({
+    /**
+     * @override
+     */
+    async start() {
+        const res = await this._super(...arguments);
+        const $editable = this.options.wysiwyg.getEditable();
+        this.styleElement = $editable[0].ownerDocument.querySelector('#design-element');
+        if (!this.styleElement) {
+            // If a style element can't be found, create one and initialize it.
+            this.styleElement = document.createElement('style');
+            this.styleElement.setAttribute('id', 'design-element');
+            // The style element needs to be within the layout of the email in
+            // order to be saved along with it.
+            $editable.find('.o_layout').prepend(this.styleElement);
+            this.styleElement.textContent = DEFAULT_CSS;
+        }
+        // When editing a stylesheet, its content is not updated so it won't be
+        // saved along with the mailing. Therefore we need to write its cssText
+        // into it. However, when doing that we lose its reference. So we need
+        // two separate style elements: one that will be saved and one to hold
+        // the stylesheet. Both need to be synchronized, which will be done via
+        // `_commitCss`.
+        let sheetOwner = $editable[0].ownerDocument.querySelector('#sheet-owner');
+        if (!sheetOwner) {
+            sheetOwner = document.createElement('style');
+            sheetOwner.setAttribute('id', 'sheet-owner');
+            $editable[0].ownerDocument.head.appendChild(sheetOwner);
+        }
+        sheetOwner.disabled = true;
+        sheetOwner.textContent = this.styleElement.textContent;
+        this.styleSheet = sheetOwner.sheet;
+        return res;
+    },
+
+    //--------------------------------------------------------------------------
+    // Public
+    //--------------------------------------------------------------------------
+
+    /**
+     * Option method to set a css property in the mailing's custom stylesheet.
+     * Note: marks all the styles as important to make sure they take precedence
+     * on other stylesheets.
+     *
+     * @param {boolean|string} previewMode
+     * @param {string} widgetValue
+     * @param {Object} params
+     * @param {string} params.selectorText the css selector for which to apply
+     *                                     the css
+     * @param {string} params.cssProperty the name of the property to edit
+     *                                    (camel cased)
+     * @param {string} [params.toggle] if 'true', will remove the property if
+     *                                 its value is already the one it's being
+     *                                 set to
+     * @param {string} [params.activeValue] the value to set, if `widgetValue`
+     *                                      is not defined.
+     * @returns {Promise|undefined}
+     */
+    customizeCssProperty(previewMode, widgetValue, params) {
+        if (!params.selectorText || !params.cssProperty) {
+            return;
+        }
+        let value = widgetValue || params.activeValue;
+        if (params.cssProperty.includes('color')) {
+            value = weUtils.normalizeColor(value);
+        }
+        const selectors = this._getSelectors(params.selectorText);
+        if (params.cssProperty === 'font-family') {
+            // Ensure font-family gets passed to all descendants.
+            selectors.push(...selectors.map(selector => selector + ' *'));
+        }
+        const firstSelector = selectors[0].replace(CSS_PREFIX, '').trim();
+        for (const selector of selectors) {
+            const priority = PRIORITY_STYLES[firstSelector].includes(params.cssProperty) ? ' !important' : '';
+            const rule = this._getRule(selector);
+            if (rule) {
+                // The rule exists: update it.
+                if (params.toggle === 'true' && rule.style.getPropertyValue(params.cssProperty) === value) {
+                    rule.style.removeProperty(params.cssProperty);
+                } else {
+                    // Convert the style to css text and add the new style (the
+                    // `style` property is readonly, we can only edit
+                    // `cssText`).
+                    const cssTexts = [];
+                    for (const style of rule.style) {
+                        const ownPriority = rule.style.getPropertyPriority(style) ? ' !important' : '';
+                        if (style !== params.cssProperty) {
+                            cssTexts.push(`${style}: ${rule.style[style]}${priority || ownPriority};`);
+                        }
+                    }
+                    cssTexts.push(`${params.cssProperty}: ${value}${priority};`);
+                    rule.style.cssText = cssTexts.join('\n'); // Apply the new css text.
+                }
+            } else {
+                // The rule doesn't exist: create it.
+                this.styleSheet.insertRule(`${selector} {
+                    ${params.cssProperty}: ${value}${priority};
+                }`);
+            }
+        }
+        this._commitCss();
+    },
+    /**
+     * Option method to change the size of buttons.
+     *
+     * @see BTN_SIZE_STYLES
+     * @param {boolean|string} previewMode
+     * @param {string} widgetValue ('btn-sm'|'btn-md'|'btn-lg'|''|undefined)
+     * @param {Object} params
+     * @returns {Promise|undefined}
+     */
+     applyButtonSize(previewMode, widgetValue, params) {
+        for (const [styleName, styleValue] of Object.entries(BTN_SIZE_STYLES[widgetValue || params.activeValue || DEFAULT_BUTTON_SIZE])) {
+            if (styleValue) {
+                this.customizeCssProperty(previewMode, styleValue, Object.assign({}, params, { cssProperty: styleName }));
+            } else {
+                // If the value is falsy, remove the property.
+                for (const selector of this._getSelectors(params.selectorText)) {
+                    const rule = this._getRule(selector);
+                    if (rule) {
+                        rule.style.removeProperty(styleName);
+                    }
+                }
+            }
+        }
+        this._commitCss();
+    },
+
+    //--------------------------------------------------------------------------
+    // Private
+    //--------------------------------------------------------------------------
+
+    /**
+     * Apply the stylesheet's css text to the style element that will be saved.
+     */
+    _commitCss() {
+        const cssTexts = [];
+        for (const rule of this.styleSheet.cssRules || this.styleSheet.rules) {
+            cssTexts.push(rule.cssText);
+        }
+        this.styleElement.textContent = cssTexts.join('\n');
+    },
+    /**
+     * @override
+     */
+    async _computeWidgetState(methodName, params) {
+        const res = await this._super(...arguments);
+        if (res === undefined) {
+            switch (methodName) {
+                case 'customizeCssProperty': {
+                    if (!params.selectorText) {
+                        return;
+                    }
+                    const rule = this._getRule(this._getSelectors(params.selectorText)[0]);
+                    if (params.possibleValues && params.possibleValues[1] === FONT_FAMILIES[0]) {
+                        // For font-family, we need to normalize it so it
+                        // matches an option value.
+                        return rule && _normalizeFontFamily(rule.style.getPropertyValue('font-family'));
+                    } else {
+                        return rule && rule.style.getPropertyValue(params.cssProperty);
+                    }
+                }
+                case 'applyButtonSize':
+                    // Match a button size by its padding value.
+                    const rule = this._getRule(this._getSelectors(params.selectorText)[0]);
+                    if (rule) {
+                        const classIndex = Object.values(BTN_SIZE_STYLES).findIndex(style => style.padding === rule.style.padding);
+                        return classIndex >= 0 ? Object.keys(BTN_SIZE_STYLES)[classIndex] : DEFAULT_BUTTON_SIZE;
+                    } else {
+                        return DEFAULT_BUTTON_SIZE;
+                    }
+            }
+        } else {
+            return res;
+        }
+    },
+    /**
+     * Take a CSS selector and split it into separate selectors, all prefixed
+     * with the `CSS_PREFIX`. Return them as an array.
+     *
+     * @see CSS_PREFIX
+     * @param {string} selectorText
+     * @returns {string[]}
+     */
+    _getSelectors(selectorText) {
+        return selectorText.split(',').map(t => `${t.startsWith(CSS_PREFIX) ? '' : CSS_PREFIX + ' '}${t.trim()}`.trim());;
+    },
+    /**
+     * Take a CSS selector and find its matching rule in the mailing's custom
+     * stylesheet, if it exists.
+     *
+     * @param {string} selectorText
+     * @returns {CSSStyleRule|undefined}
+     */
+    _getRule(selectorText) {
+        return [...(this.styleSheet.cssRules || this.styleSheet.rules)].find(rule => rule.selectorText === selectorText);
     },
 });
 

--- a/addons/mass_mailing/static/src/js/mass_mailing_widget.js
+++ b/addons/mass_mailing/static/src/js/mass_mailing_widget.js
@@ -402,8 +402,6 @@ var MassMailingFieldHtml = FieldHtml.extend({
         var selectorToKeep = '.o_we_external_history_buttons, .email_designer_top_actions';
         // Overide `d-flex` class which style is `!important`
         $snippetsSideBar.find(`.o_we_website_top_actions > *:not(${selectorToKeep})`).attr('style', 'display: none!important');
-        var $snippets_menu = $snippetsSideBar.find("#snippets_menu");
-        var $selectTemplateBtn = $snippets_menu.find('.o_we_select_template');
 
         if (config.device.isMobile) {
             $snippetsSideBar.hide();
@@ -460,9 +458,6 @@ var MassMailingFieldHtml = FieldHtml.extend({
          * Create theme selection screen and check if it must be forced opened.
          * Reforce it opened if the last snippet is removed.
          */
-        const $themeSelector = $(core.qweb.render("mass_mailing.theme_selector", {
-            themes: themesParams
-        }));
         const $themeSelectorNew = $(core.qweb.render("mass_mailing.theme_selector_new", {
             themes: themesParams,
             templates: templatesParams,
@@ -475,74 +470,15 @@ var MassMailingFieldHtml = FieldHtml.extend({
             $themeSelectorNew.appendTo(this.wysiwyg.$iframeBody);
         }
 
-        /**
-         * Add proposition to install enterprise themes if not installed.
-         */
-        var $mail_themes_upgrade = $themeSelector.find(".o_mass_mailing_themes_upgrade");
-        $mail_themes_upgrade.on("click", function (e) {
-            e.stopImmediatePropagation();
-            e.preventDefault();
-            self.do_action("mass_mailing.action_mass_mailing_configuration");
-        });
-
-        $selectTemplateBtn.on('click', () => {
-            $snippetsSideBar.data('snippetMenu').activateCustomTab($themeSelector);
-            /**
-             * Ensure the parent of the theme selector is not used as parent for a
-             * tooltip as it is overflow auto and would result in the tooltip being
-             * hidden by the body of the mail.
-             */
-            $themeSelector.parent().addClass('o_forbidden_tooltip_parent');
-            $selectTemplateBtn.addClass('active');
-        });
-
-        /**
-         * Switch theme when a theme button is hovered. Confirm change if the theme button
-         * is pressed.
-         */
-        var selectedTheme = false;
-        $themeSelector.on("mouseenter", ".dropdown-item", function (e) {
-            e.preventDefault();
-            var themeParams = themesParams[$(e.currentTarget).index()];
-            self.wysiwyg.odooEditor.automaticStepSkipStack();
-            self._switchThemes(themeParams);
-        });
-        $themeSelector.on("mouseleave", ".dropdown-item", function (e) {
-            if (self.$lastContent) {
-                self._switchThemes(Object.assign({}, selectedTheme, {template: self.$lastContent}));
-            } else {
-                self._switchThemes(selectedTheme);
-            }
-        });
-        $themeSelector.on("click", '[data-toggle="dropdown"]', function (e) {
-            var $menu = $themeSelector.find('.dropdown-menu');
-            var isVisible = $menu.hasClass('show');
-            if (isVisible) {
-                e.preventDefault();
-                e.stopImmediatePropagation();
-                $menu.removeClass('show');
-            }
-        });
-
-        const selectTheme = (themeParams) => {
+        let selectedTheme = false;
+        const selectTheme = themeParams => {
             self._switchImages(themeParams, $snippets);
-
             selectedTheme = themeParams;
-
-            // Notify form view
-            $themeSelector.find('.dropdown-item.selected').removeClass('selected');
-            $themeSelector.find('.dropdown-item:eq(' + themesParams.indexOf(selectedTheme) + ')').addClass('selected');
 
             // Invalidate previous content.
             self.$lastContent = undefined;
         };
 
-        $themeSelector.on('click', '.dropdown-item', (e) => {
-            e.preventDefault();
-            e.stopImmediatePropagation();
-            const themeParams = themesParams[$(e.currentTarget).index()];
-            selectTheme(themeParams);
-        });
         $themeSelectorNew.on('click', '.dropdown-item', async (e) => {
             e.preventDefault();
             e.stopImmediatePropagation();
@@ -558,10 +494,6 @@ var MassMailingFieldHtml = FieldHtml.extend({
             this.$content.closest('body').removeClass("o_force_mail_theme_choice");
 
             $themeSelectorNew.remove();
-
-            if ($mail_themes_upgrade.length) {
-                $snippets_menu.empty();
-            }
 
             selectTheme(themeParams);
             this._addEditorMessages();
@@ -598,7 +530,6 @@ var MassMailingFieldHtml = FieldHtml.extend({
         selectedTheme = this._getSelectedTheme(themesParams);
         if (selectedTheme) {
             this.$content.closest('body').addClass(selectedTheme.className);
-            $themeSelector.find('.dropdown-item:eq(' + themesParams.indexOf(selectedTheme) + ')').addClass('selected');
             this._switchImages(selectedTheme, $snippets);
         } else if (this.$content.find('.o_layout').length) {
             themesParams.push({

--- a/addons/mass_mailing/static/src/js/snippets.editor.js
+++ b/addons/mass_mailing/static/src/js/snippets.editor.js
@@ -1,15 +1,25 @@
 odoo.define('mass_mailing.snippets.editor', function (require) {
 'use strict';
 
+const {_lt} = require('web.core');
 const snippetsEditor = require('web_editor.snippet.editor');
 
 const MassMailingSnippetsMenu = snippetsEditor.SnippetsMenu.extend({
+    events: _.extend({}, snippetsEditor.SnippetsMenu.prototype.events, {
+        'click .o_we_customize_design_btn': '_onDesignTabClick',
+    }),
     custom_events: _.extend({}, snippetsEditor.SnippetsMenu.prototype.custom_events, {
         drop_zone_over: '_onDropZoneOver',
         drop_zone_out: '_onDropZoneOut',
         drop_zone_start: '_onDropZoneStart',
         drop_zone_stop: '_onDropZoneStop',
     }),
+    tabs: _.extend({}, snippetsEditor.SnippetsMenu.prototype.tabs, {
+        DESIGN: 'design',
+    }),
+    optionsTabStructure: [
+        ['design-options', _lt("Design Options")],
+    ],
 
     //--------------------------------------------------------------------------
     // Public
@@ -37,6 +47,13 @@ const MassMailingSnippetsMenu = snippetsEditor.SnippetsMenu.extend({
         $dropzone.attr('data-editor-message', $hookParent.attr('data-editor-message'));
         $dropzone.attr('data-editor-sub-message', $hookParent.attr('data-editor-sub-message'));
         return $dropzone;
+    },
+    /**
+     * @override
+     */
+    _updateRightPanelContent: function ({content, tab}) {
+        this._super(...arguments);
+        this.$('.o_we_customize_design_btn').toggleClass('active', tab === this.tabs.DESIGN);
     },
 
     //--------------------------------------------------------------------------
@@ -86,6 +103,62 @@ const MassMailingSnippetsMenu = snippetsEditor.SnippetsMenu.extend({
         if (!$oEditable.children().length) {
             $oEditable.empty(); // remove any superfluous whitespace
             $oEditable.attr('contenteditable', false);
+        }
+    },
+    /**
+     * @private
+     */
+    async _onDesignTabClick() {
+        // Note: nothing async here but start the loading effect asap
+        let releaseLoader;
+        try {
+            const promise = new Promise(resolve => releaseLoader = resolve);
+            this._execWithLoadingEffect(() => promise, false, 0);
+            // loader is added to the DOM synchronously
+            await new Promise(resolve => requestAnimationFrame(() => requestAnimationFrame(resolve)));
+            // ensure loader is rendered: first call asks for the (already done) DOM update,
+            // second call happens only after rendering the first "updates"
+
+            if (!this.topFakeOptionEl) {
+                let el;
+                for (const [elementName, title] of this.optionsTabStructure) {
+                    const newEl = document.createElement(elementName);
+                    newEl.dataset.name = title;
+                    if (el) {
+                        el.appendChild(newEl);
+                    } else {
+                        this.topFakeOptionEl = newEl;
+                    }
+                    el = newEl;
+                }
+                this.bottomFakeOptionEl = el;
+                this.el.appendChild(this.topFakeOptionEl);
+            }
+
+            // Need all of this in that order so that:
+            // - the element is visible and can be enabled and the onFocus method is
+            //   called each time.
+            // - the element is hidden afterwards so it does not take space in the
+            //   DOM, same as the overlay which may make a scrollbar appear.
+            this.topFakeOptionEl.classList.remove('d-none');
+            const editorPromise = this._activateSnippet($(this.bottomFakeOptionEl));
+            releaseLoader(); // because _activateSnippet uses the same mutex as the loader
+            releaseLoader = undefined;
+            const editor = await editorPromise;
+            this.topFakeOptionEl.classList.add('d-none');
+            editor.toggleOverlay(false);
+
+            this._updateRightPanelContent({
+                tab: this.tabs.DESIGN,
+            });
+        } catch (e) {
+            // Normally the loading effect is removed in case of error during the action but here
+            // the actual activity is happening outside of the action, the effect must therefore
+            // be cleared in case of error as well
+            if (releaseLoader) {
+                releaseLoader();
+            }
+            throw e;
         }
     },
 });

--- a/addons/mass_mailing/static/src/scss/themes/theme_default.scss
+++ b/addons/mass_mailing/static/src/scss/themes/theme_default.scss
@@ -92,7 +92,7 @@ div.col:not([align]) {
 
     a:not(.btn), .btn.btn-link {
         font-weight: bold;
-        text-decoration: none !important;
+        text-decoration: none;
         padding-left: 0 !important;
         padding-right: 0 !important;
         border: none!important;

--- a/addons/mass_mailing/views/assets.xml
+++ b/addons/mass_mailing/views/assets.xml
@@ -23,7 +23,7 @@
                 box-sizing: border-box !important;
             }
             .o_layout :not(.fa) {
-                font-family: Arial, sans-serif !important;
+                font-family: Arial,Helvetica Neue,Helvetica,sans-serif;
             }
             /* Remove space around the email design. */
                 html,

--- a/addons/mass_mailing/views/snippets_themes.xml
+++ b/addons/mass_mailing/views/snippets_themes.xml
@@ -411,19 +411,6 @@
         </we-button-group>
     </div>
 
-    <div data-js="BodyWidth" data-selector=".o_layout" data-target=".o_mail_wrapper" data-no-check="true">
-        <we-button-group string="Body Width">
-            <we-button data-select-class="o_mail_small"
-                        data-img="/mass_mailing/static/src/img/snippets_options/content_width_small.svg"
-                        title="Small"/>
-            <we-button data-select-class="o_mail_regular"
-                        data-img="/mass_mailing/static/src/img/snippets_options/content_width_normal.svg"
-                        title="Regular"/>
-            <we-button data-select-class=""
-                        data-img="/mass_mailing/static/src/img/snippets_options/content_width_full.svg"
-                        title="Full"/>
-        </we-button-group>
-    </div>
     <div data-option-name="minHeight" data-selector=".o_mail_snippet_general" data-exclude=".o_mail_snippet_general .row > div *">
         <we-button-group string="Height">
             <we-button data-name="minheight_auto_opt" data-select-class="" title="Fit content">Auto</we-button>
@@ -477,12 +464,10 @@
         data-drop-near=".row:not(.s_col_no_resize) > div"
         data-exclude=".o_mail_no_resize, .o_mail_no_options"/>
 
-    <div data-selector=".o_layout, .note-editable > div:not(.o_layout),
-        .note-editable .oe_structure > div:not(:has(> .o_mail_snippet_general)),
+    <div data-selector=".note-editable .oe_structure > div:not(:has(> .o_mail_snippet_general)),
         .note-editable .oe_structure > div.o_mail_snippet_general,
         .note-editable .oe_structure > div.o_mail_snippet_general .o_cc,
-        .note-editable .oe_structure > div.o_mail_snippet_general .btn:not(.btn-link),
-        td, td.o_mail_no_colorpicker div:first-child, th"
+        .note-editable .oe_structure > div.o_mail_snippet_general .btn:not(.btn-link)"
         data-exclude=".o_mail_no_colorpicker, .o_mail_no_options">
         <we-colorpicker string="Background Color"
             data-select-style="true"
@@ -537,6 +522,277 @@
 
     <!-- DESIGN OPTIONS -->
     <div data-js="DesignTab" data-selector="design-options" data-no-check="true">
+        <!-- BODY WIDTH -->
+        <we-row string="Body Width">
+            <we-button-group data-target=".o_mail_wrapper" data-no-preview="true">
+                <we-button data-select-class="o_mail_small"
+                            data-img="/mass_mailing/static/src/img/snippets_options/content_width_small.svg"
+                            title="Small"/>
+                <we-button data-select-class="o_mail_regular"
+                            data-img="/mass_mailing/static/src/img/snippets_options/content_width_normal.svg"
+                            title="Regular"/>
+                <we-button data-select-class=""
+                            data-img="/mass_mailing/static/src/img/snippets_options/content_width_full.svg"
+                            title="Full"/>
+            </we-button-group>
+        </we-row>
+        <we-row string="Background Color">
+            <we-colorpicker data-target=".o_layout, .note-editable > div:not(.o_layout)"
+                            data-select-style="true"
+                            data-no-transparency="true"
+                            data-css-property="background-color"
+                            data-color-prefix="bg-"/>
+        </we-row>
+        <!-- HEADING 1 -->
+        <we-row string="Heading 1" class="o_design_tab_title">
+            <we-input data-customize-css-property=""
+                        data-css-property="font-size"
+                        data-selector-text="h1"
+                        data-unit="px"/>
+            <we-colorpicker data-customize-css-property=""
+                            data-css-property="color"
+                            data-selector-text="h1"
+                            data-no-transparency="true"
+                            data-color-prefix="text-"/>
+        </we-row>
+        <we-row string="⌙ " class="o_short_title">
+            <we-fontfamilypicker data-selector-text="h1"/>
+            <span>​</span> <!-- Separate the select from the buttons (styling) -->
+            <we-button title="Bold" class="fa fa-fw fa-bold" data-no-preview="true" data-toggle="true"
+                        data-customize-css-property="bolder"
+                        data-selector-text="h1"
+                        data-css-property="font-weight"/>
+            <we-button title="Italic" class="fa fa-fw fa-italic" data-no-preview="true" data-toggle="true"
+                        data-customize-css-property="italic"
+                        data-selector-text="h1"
+                        data-css-property="font-style"/>
+            <we-button title="Underline" class="fa fa-fw fa-underline" data-no-preview="true" data-toggle="true"
+                        data-customize-css-property="underline"
+                        data-selector-text="h1"
+                        data-css-property="text-decoration-line"/>
+        </we-row>
+        <!-- HEADING 2 -->
+        <we-row string="Heading 2" class="o_design_tab_title">
+            <we-input data-customize-css-property=""
+                        data-css-property="font-size"
+                        data-selector-text="h2"
+                        data-unit="px"/>
+            <we-colorpicker data-customize-css-property=""
+                            data-css-property="color"
+                            data-selector-text="h2"
+                            data-no-transparency="true"
+                            data-color-prefix="text-"/>
+        </we-row>
+        <we-row string="⌙ " class="o_short_title">
+            <we-fontfamilypicker data-selector-text="h2"/>
+            <span>​</span> <!-- Separate the select from the buttons (styling) -->
+            <we-button title="Bold" class="fa fa-fw fa-bold" data-no-preview="true" data-toggle="true"
+                        data-customize-css-property="bolder"
+                        data-selector-text="h2"
+                        data-css-property="font-weight"/>
+            <we-button title="Italic" class="fa fa-fw fa-italic" data-no-preview="true" data-toggle="true"
+                        data-customize-css-property="italic"
+                        data-selector-text="h2"
+                        data-css-property="font-style"/>
+            <we-button title="Underline" class="fa fa-fw fa-underline" data-no-preview="true" data-toggle="true"
+                        data-customize-css-property="underline"
+                        data-selector-text="h2"
+                        data-css-property="text-decoration-line"/>
+        </we-row>
+        <!-- HEADING 3 -->
+        <we-row string="Heading 3" class="o_design_tab_title">
+            <we-input data-customize-css-property=""
+                        data-css-property="font-size"
+                        data-selector-text="h3"
+                        data-unit="px"/>
+            <we-colorpicker data-customize-css-property=""
+                            data-css-property="color"
+                            data-selector-text="h3"
+                            data-no-transparency="true"
+                            data-color-prefix="text-"/>
+        </we-row>
+        <we-row string="⌙ " class="o_short_title">
+            <we-fontfamilypicker data-selector-text="h3"/>
+            <span>​</span> <!-- Separate the select from the buttons (styling) -->
+            <we-button title="Bold" class="fa fa-fw fa-bold" data-no-preview="true" data-toggle="true"
+                        data-customize-css-property="bolder"
+                        data-selector-text="h3"
+                        data-css-property="font-weight"/>
+            <we-button title="Italic" class="fa fa-fw fa-italic" data-no-preview="true" data-toggle="true"
+                        data-customize-css-property="italic"
+                        data-selector-text="h3"
+                        data-css-property="font-style"/>
+            <we-button title="Underline" class="fa fa-fw fa-underline" data-no-preview="true" data-toggle="true"
+                        data-customize-css-property="underline"
+                        data-selector-text="h3"
+                        data-css-property="text-decoration-line"/>
+        </we-row>
+        <!-- TEXT -->
+        <we-row string="Text" class="o_design_tab_title">
+            <we-input data-customize-css-property=""
+                        data-css-property="font-size"
+                        data-selector-text="p, p *, li, li *"
+                        data-unit="px"/>
+            <we-colorpicker data-customize-css-property=""
+                            data-css-property="color"
+                            data-selector-text="p, p *, li, li *"
+                            data-no-transparency="true"
+                            data-color-prefix="text-"/>
+        </we-row>
+        <we-row string="⌙ " class="o_short_title">
+            <we-fontfamilypicker data-selector-text="p, p *, li, li *"/>
+            <span>​</span> <!-- Separate the select from the buttons (styling) -->
+            <we-button title="Bold" class="fa fa-fw fa-bold" data-no-preview="true" data-toggle="true"
+                        data-customize-css-property="bolder"
+                        data-selector-text="p, p *, li, li *"
+                        data-css-property="font-weight"/>
+            <we-button title="Italic" class="fa fa-fw fa-italic" data-no-preview="true" data-toggle="true"
+                        data-customize-css-property="italic"
+                        data-selector-text="p, p *, li, li *"
+                        data-css-property="font-style"/>
+            <we-button title="Underline" class="fa fa-fw fa-underline" data-no-preview="true" data-toggle="true"
+                        data-customize-css-property="underline"
+                        data-selector-text="p, p *, li, li *"
+                        data-css-property="text-decoration-line"/>
+        </we-row>
+        <!-- LINKS -->
+        <we-row string="Links" class="o_design_tab_title">
+            <we-colorpicker data-customize-css-property=""
+                            data-css-property="color"
+                            data-selector-text="a:not(.btn), a.btn-link"
+                            data-no-transparency="true"
+                            data-color-prefix="text-"/>
+            <we-button title="Underline" class="fa fa-fw fa-underline" data-no-preview="true" data-toggle="true"
+                        data-customize-css-property="underline"
+                        data-selector-text="a:not(.btn), a.btn-link"
+                        data-css-property="text-decoration-line"/>
+        </we-row>
+        <!-- PRIMARY BUTTONS -->
+        <we-row string="Primary Buttons" class="o_design_tab_title">
+            <we-input data-customize-css-property=""
+                        data-css-property="font-size"
+                        data-selector-text="a[href].btn-primary, a[href].btn-outline-primary, a[href].btn-fill-primary"
+                        data-unit="px"/>
+            <we-colorpicker data-customize-css-property=""
+                            data-css-property="color"
+                            data-selector-text="a[href].btn-primary, a[href].btn-outline-primary, a[href].btn-fill-primary"
+                            data-no-transparency="true"
+                            data-color-prefix="text-"/>
+            <we-colorpicker data-customize-css-property=""
+                            data-css-property="background-color"
+                            data-selector-text="a[href].btn-primary, a[href].btn-outline-primary, a[href].btn-fill-primary"
+                            data-no-transparency="true"
+                            data-color-prefix="bg-"/>
+        </we-row>
+        <we-select string="⌙ Size" data-selector-text="a[href].btn-primary, a[href].btn-outline-primary, a[href].btn-fill-primary">
+            <we-button data-apply-button-size="btn-sm">Small</we-button>
+            <we-button data-apply-button-size="btn-md">Medium</we-button>
+            <we-button data-apply-button-size="btn-lg">Large</we-button>
+        </we-select>
+        <we-row string="⌙ Border">
+            <we-input data-customize-css-property=""
+                        data-css-property="border-width"
+                        data-selector-text="a[href].btn-primary, a[href].btn-outline-primary, a[href].btn-fill-primary"
+                        data-unit="px"/>
+            <we-select data-selector-text="a[href].btn-primary, a[href].btn-outline-primary, a[href].btn-fill-primary" data-css-property="border-style">
+                <we-button title="Solid" data-customize-css-property="solid">
+                    <div class="o_we_fake_img_item o_we_border_preview" style="border-style: solid;"/>
+                </we-button>
+                <we-button title="Dashed" data-customize-css-property="dashed">
+                    <div class="o_we_fake_img_item o_we_border_preview" style="border-style: dashed;"/>
+                </we-button>
+                <we-button title="Dotted" data-customize-css-property="dotted">
+                    <div class="o_we_fake_img_item o_we_border_preview" style="border-style: dotted;"/>
+                </we-button>
+                <we-button title="Double" data-customize-css-property="double">
+                    <div class="o_we_fake_img_item o_we_border_preview" style="border-style: double; border-left: none; border-right: none;"/>
+                </we-button>
+            </we-select>
+            <we-colorpicker data-customize-css-property=""
+                            data-css-property="border-color"
+                            data-selector-text="a[href].btn-primary, a[href].btn-outline-primary, a[href].btn-fill-primary"
+                            data-no-transparency="true"
+                            data-color-prefix="border-"/>
+        </we-row>
+        <!-- SECONDARY BUTTONS -->
+        <we-row string="Secondary Buttons" class="o_design_tab_title">
+            <we-input data-customize-css-property=""
+                        data-css-property="font-size"
+                        data-selector-text="a[href].btn-secondary, a[href].btn-outline-secondary, a[href].btn-fill-secondary"
+                        data-unit="px"/>
+            <we-colorpicker data-customize-css-property=""
+                            data-css-property="color"
+                            data-selector-text="a[href].btn-secondary, a[href].btn-outline-secondary, a[href].btn-fill-secondary"
+                            data-no-transparency="true"
+                            data-color-prefix="text-"/>
+            <we-colorpicker data-customize-css-property=""
+                            data-css-property="background-color"
+                            data-selector-text="a[href].btn-secondary, a[href].btn-outline-secondary, a[href].btn-fill-secondary"
+                            data-no-transparency="true"
+                            data-color-prefix="bg-"/>
+        </we-row>
+        <we-select string="⌙ Size" data-selector-text="a[href].btn-secondary, a[href].btn-outline-secondary, a[href].btn-fill-secondary">
+            <we-button data-apply-button-size="btn-sm">Small</we-button>
+            <we-button data-apply-button-size="btn-md">Medium</we-button>
+            <we-button data-apply-button-size="btn-lg">Large</we-button>
+        </we-select>
+        <we-row string="⌙ Border">
+            <we-input data-customize-css-property=""
+                        data-css-property="border-width"
+                        data-selector-text="a[href].btn-secondary, a[href].btn-outline-secondary, a[href].btn-fill-secondary"
+                        data-unit="px"/>
+            <we-select data-selector-text="a[href].btn-secondary, a[href].btn-outline-secondary, a[href].btn-fill-secondary" data-css-property="border-style">
+                <we-button title="Solid" data-customize-css-property="solid">
+                    <div class="o_we_fake_img_item o_we_border_preview" style="border-style: solid;"/>
+                </we-button>
+                <we-button title="Dashed" data-customize-css-property="dashed">
+                    <div class="o_we_fake_img_item o_we_border_preview" style="border-style: dashed;"/>
+                </we-button>
+                <we-button title="Dotted" data-customize-css-property="dotted">
+                    <div class="o_we_fake_img_item o_we_border_preview" style="border-style: dotted;"/>
+                </we-button>
+                <we-button title="Double" data-customize-css-property="double">
+                    <div class="o_we_fake_img_item o_we_border_preview" style="border-style: double; border-left: none; border-right: none;"/>
+                </we-button>
+            </we-select>
+            <we-colorpicker data-customize-css-property=""
+                            data-css-property="border-color"
+                            data-selector-text="a[href].btn-secondary, a[href].btn-outline-secondary, a[href].btn-fill-secondary"
+                            data-no-transparency="true"
+                            data-color-prefix="border-"/>
+        </we-row>
+        <!-- SEPARATORS -->
+        <we-row string="Separators" class="o_design_tab_title">
+            <we-input data-customize-css-property=""
+                    data-css-property="border-top-width"
+                    data-selector-text="hr"
+                    data-unit="px"/>
+            <we-select data-selector-text="hr" data-css-property="border-top-style">
+                <we-button title="Solid" data-customize-css-property="solid">
+                    <div class="o_we_fake_img_item o_we_border_preview" style="border-style: solid;"/>
+                </we-button>
+                <we-button title="Dashed" data-customize-css-property="dashed">
+                    <div class="o_we_fake_img_item o_we_border_preview" style="border-style: dashed;"/>
+                </we-button>
+                <we-button title="Dotted" data-customize-css-property="dotted">
+                    <div class="o_we_fake_img_item o_we_border_preview" style="border-style: dotted;"/>
+                </we-button>
+                <we-button title="Double" data-customize-css-property="double">
+                    <div class="o_we_fake_img_item o_we_border_preview" style="border-style: double; border-left: none; border-right: none;"/>
+                </we-button>
+            </we-select>
+            <we-colorpicker data-customize-css-property=""
+                            data-css-property="border-top-color"
+                            data-selector-text="hr"
+                            data-no-transparency="true"
+                            data-color-prefix="border-"/>
+        </we-row>
+        <we-select string="⌙ Width" data-selector-text="hr" data-css-property="width">
+            <we-button data-customize-css-property="25%">25%</we-button>
+            <we-button data-customize-css-property="50%">50%</we-button>
+            <we-button data-customize-css-property="75%">75%</we-button>
+            <we-button data-customize-css-property="100%">100%</we-button>
+        </we-select>
     </div>
 </template>
 </odoo>

--- a/addons/mass_mailing/views/snippets_themes.xml
+++ b/addons/mass_mailing/views/snippets_themes.xml
@@ -13,7 +13,9 @@
         </div>
     </xpath>
     <xpath expr="//div[@id='snippets_menu']" position="inside">
-        <button type="button" class="o_we_select_template text-uppercase"><span>Select a template</span></button>
+        <button type="button" tabindex="3" class="o_we_customize_design_btn text-uppercase" accesskey="2">
+            <span>Design</span>
+        </button>
     </xpath>
     <xpath expr="//t[@id='default_snippets']" position="replace">
         <t id="default_snippets">
@@ -531,6 +533,10 @@
                        data-select-class="align-items-stretch"
                        data-img="/mass_mailing/static/src/img/snippets_options/align_stretch.svg"/>
         </we-button-group>
+    </div>
+
+    <!-- DESIGN OPTIONS -->
+    <div data-js="DesignTab" data-selector="design-options" data-no-check="true">
     </div>
 </template>
 </odoo>

--- a/addons/web_editor/static/src/js/backend/convert_inline.js
+++ b/addons/web_editor/static/src/js/backend/convert_inline.js
@@ -336,10 +336,6 @@ function classToStyle($editable, cssRules) {
                 writes.push(() => { node.style[styleName] = ''; });
             }
         }
-        // Ignore font-family (mail-safe font declared in <head>)
-        if ('font-family' in css) {
-            delete css['font-family'];
-        }
 
         // Do not apply css that would override inline styles (which are prioritary).
         let style = node.getAttribute('style') || '';
@@ -444,6 +440,9 @@ function toInline($editable, cssRules, $iframe) {
     const rootFontSizeProperty = getComputedStyle(editable.ownerDocument.documentElement).fontSize;
     const rootFontSize = parseFloat(rootFontSizeProperty.replace(/[^\d\.]/g, ''));
     normalizeRem($editable, rootFontSize);
+
+    // Styles were applied inline, we don't need a style element anymore.
+    $editable.find('style').remove();
 
     for (const [node, displayValue] of displaysToRestore) {
         node.style.setProperty('display', displayValue);

--- a/addons/web_editor/static/src/scss/wysiwyg_snippets.scss
+++ b/addons/web_editor/static/src/scss/wysiwyg_snippets.scss
@@ -1555,6 +1555,8 @@ body.editor_enable.editor_has_snippets {
                 padding-right: 10px !important;
             }
             &.o_design_tab_title {
+                margin-top: 15px;
+
                 we-title {
                     font-weight: 600;
                 }

--- a/addons/web_editor/static/src/scss/wysiwyg_snippets.scss
+++ b/addons/web_editor/static/src/scss/wysiwyg_snippets.scss
@@ -1545,6 +1545,20 @@ body.editor_enable.editor_has_snippets {
             &.o_we_full_row > div {
                 flex: 1 1 auto;
             }
+
+            &.o_short_title we-title, .o_short_title we-title {
+                width: unset !important;
+                padding-right: 0 !important;
+            }
+            &.o_long_title we-title, .o_long_title we-title {
+                width: fit-content !important;
+                padding-right: 10px !important;
+            }
+            &.o_design_tab_title {
+                we-title {
+                    font-weight: 600;
+                }
+            }
         }
 
         %o-we-inline {


### PR DESCRIPTION
This adds a design tab to mass_mailing, allowing the user to apply global styles to their mailing such as colors and fonts to headings for instance. This tab replaces the "select a template" tab.

task-2789287

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
