### PR TITLE
[FIX] hr : fixing access rule to be able to update its own res_users

### DIFF
--- a/addons/hr/security/hr_security.xml
+++ b/addons/hr/security/hr_security.xml
@@ -41,7 +41,7 @@
     <record id="hr_employee_public_comp_rule" model="ir.rule">
         <field name="name">Employee multi company rule</field>
         <field name="model_id" ref="model_hr_employee_public"/>
-        <field name="domain_force">['|',('company_id','=',False),('company_id', 'in', company_ids)]</field>
+        <field name="domain_force">['|','|',('user_id', '=', user.id),('company_id', '=',False),('company_id', 'in', company_ids)]</field>
     </record>
 
     <record id="hr_job_comp_rule" model="ir.rule">


### PR DESCRIPTION
To reproduce
============

- Connect with Mitchell Admin

- Go to Employee -> Settings and uncheck "Skills Management"

- Go to Settings -> Users, create a user "Test" and give him access to 2 companies (e.g. My Company [San Fransisco] and My Company [Chicago])

- Set current company to My Company [San Fransisco], go to Employees, create an employee record and associate it with your test user (in HR Settings tab)

- Set current company to My Company [Chicago] and create another employee and associate it with your test user too

- Connect as "test" user and go to my profile

- Try to change your langage (From English US to French) ==> Access rights error

Purpose
=======

When the `OnChange` is triggred we try to read the two employees linked to this user, but one of this employees is in unslected company
which leads to Access rights error.

Specification
=============

To solve the issue the domain in the security rule **Employee multi company rule** has been updated, where we added the condition
`('user_id', '=', user.id)` which gives the user the ability to read the needed data.

opw-2793123
