### PR TITLE
[FIX] website: correct page properties groups behavior

### DIFF
--- a/addons/website/static/src/xml/website.pageProperties.xml
+++ b/addons/website/static/src/xml/website.pageProperties.xml
@@ -173,7 +173,7 @@
                             </t>
                             <t t-else="">
                                 <t t-set='groups_tooltip'>More than one group has been set on the view.</t>
-                                <a class="show_group_id btn btn-link mx-auto" href="/web#model=ir.ui.view&amp;id=681" t-att-title='groups_tooltip'>Discard &amp; Edit in backend</a>
+                                <a class="show_group_id btn btn-link mx-auto" t-attf-href="/web#id=#{widget.page.view_id[0]}&amp;view_type=form&amp;model=ir.ui.view" t-att-title='groups_tooltip'>Discard &amp; Edit in backend</a>
                             </t>
                         </div>
                     </div>


### PR DESCRIPTION
Before this commit and since [1], there was an issue regarding the
group feature on the page properties dialog.
When a page visibility is set to restricted groups, and that more then
one group is required, a link would be displayed to edit the page's
view in the backend. That link was hardcoded, always pointing to the
same view.

[1]: https://github.com/odoo/odoo/commit/e239934abe456257c9dc285d1ad9829c0353900c

task-2800685
