### PR TITLE
[FIX] mrp_plm: mrp document not displayed on product

### DIFF
--- a/addons/mrp/models/mrp_document.py
+++ b/addons/mrp/models/mrp_document.py
@@ -15,6 +15,14 @@ class MrpDocument(models.Model):
     }
     _order = "priority desc, id desc"
 
+    def copy(self, default=None):
+        ir_default = default
+        if ir_default:
+            ir_fields = list(self.env['ir.attachment']._fields)
+            ir_default = {field : default[field] for field in default.keys() if field in ir_fields}
+        new_attach = self.ir_attachment_id.copy(ir_default)
+        return super().copy(dict(default, ir_attachment_id=new_attach.id))
+
     ir_attachment_id = fields.Many2one('ir.attachment', string='Related attachment', required=True, ondelete='cascade')
     active = fields.Boolean('Active', default=True)
     priority = fields.Selection([


### PR DESCRIPTION
Steps to reproduce the issue:

- create product P
- create a Engineering Change ders ECO in PLM app
- attach documents to ECO and apply changements

Bug:
- go to the product, try to open uploaded documents. they are not found

This bug happened since odoo/odoo@114b71f

opw:2762448
Co-authored-by: mart-e <mat@odoo.com>