### PR TITLE
[IMP] account: add 'Product' filter in account moves

### DIFF
--- a/addons/account/views/account_move_views.xml
+++ b/addons/account/views/account_move_views.xml
@@ -1338,6 +1338,7 @@
                     <field name="partner_id" operator="child_of"/>
                     <field name="invoice_user_id" string="Salesperson" domain="[('share', '=', False)]"/>
                     <field name="date" string="Period"/>
+                    <field name="line_ids" string="Invoice Line"/>
                     <filter domain="[('invoice_user_id', '=', uid)]" name="myinvoices" help="My Invoices"/>
                     <separator/>
                     <filter name="draft" string="Draft" domain="[('state','=','draft')]"/>


### PR DESCRIPTION
**Description of the issue/feature this PR addresses:**

Searching for the product field of account move lines is something expected to be used frequently.

**Current behavior before PR:**

Cannot be searched by product in account moves.

**Desired behavior after PR is merged:**

A search by product can be done in account moves.

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr