### PR TITLE
[FIX] sale_project : create on order when type updated to service

### DIFF
--- a/addons/sale_timesheet/models/sale_order.py
+++ b/addons/sale_timesheet/models/sale_order.py
@@ -180,12 +180,12 @@ class SaleOrderLine(models.Model):
         """ Hook for validated timesheet in addionnal module """
         return [('project_id', '!=', False)]
 
-    @api.depends('product_id')
+    @api.depends('product_id.type')
     def _compute_is_service(self):
         for so_line in self:
             so_line.is_service = so_line.product_id.type == 'service'
 
-    @api.depends('product_id')
+    @api.depends('product_id.type')
     def _compute_product_updatable(self):
         for line in self:
             if line.product_id.type == 'service' and line.state == 'sale':

--- a/addons/sale_timesheet/tests/test_sale_service.py
+++ b/addons/sale_timesheet/tests/test_sale_service.py
@@ -599,3 +599,18 @@ class TestSaleService(TestCommonSaleTimesheetNoChart):
         # copy the task
         task_copy = task.copy()
         self.assertEqual(task.sale_line_id, task_copy.sale_line_id, "Duplicatinga task should keep its Sale line")
+
+    def test_sol_product_type_update(self):
+        self.product_delivery_timesheet3.type = 'consu'
+        sale_order_line = self.env['sale.order.line'].create({
+            'order_id': self.sale_order.id,
+            'name': self.product_delivery_timesheet3.name,
+            'product_id': self.product_delivery_timesheet3.id,
+            'product_uom_qty': 5,
+            'product_uom': self.product_delivery_timesheet3.uom_id.id,
+            'price_unit': self.product_delivery_timesheet3.list_price
+        })
+        self.assertFalse(sale_order_line.is_service, "As the product is consumable, the SOL should not be a service")
+
+        self.product_delivery_timesheet3.type = 'service'
+        self.assertTrue(sale_order_line.is_service, "As the product is a service, the SOL should be a service")


### PR DESCRIPTION
Steps :
Install Sales, Project and Inventory.
Create a Storable Product.
Create a SO with this product, but do not confirm it.
Change this product :
	> Type : Service
	> Sales > Service Tracking : Create a task in SO's project
Confirm the SO.

Issue :
Neither a delivery or a task is created.

Cause :
Confirming the SO calls SO._timesheet_service_generation(),
which filtered its SOLs based on is_service to 'create on order'.
As this field is not updated when changing the type of the product,
the SOL with the service is filtered out.

Fix :
Update SOL_.is_service when changing SOL.product_id.type.

opw-2786655

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
