### PR TITLE
[IMP] hr_timesheet:  add some test case in timesheet application 

### DIFF
--- a/addons/hr_timesheet/tests/test_timesheet.py
+++ b/addons/hr_timesheet/tests/test_timesheet.py
@@ -394,3 +394,22 @@ class TestTimesheet(TestCommonTimesheet):
             'company_id': company_3.id,
         })
         self.assertFalse(timesheet.employee_id, 'As there are several employees for this user, but none of them in this company, none must be found')
+
+    def test_create_timesheet_with_multi_company(self):
+        """ Always set the current company in the timesheet, not the employee company """
+        company_4 = self.env['res.company'].create({'name': 'Company 4'})
+        empl_employee = self.env['hr.employee'].with_company(company_4).create({
+            'name': 'Employee 3',
+        })
+
+        Timesheet = self.env['account.analytic.line'].with_context(allowed_company_ids=[company_4.id, self.env.company.id])
+
+        timesheet = Timesheet.create({
+            'project_id': self.project_customer.id,
+            'task_id': self.task1.id,
+            'name': 'my first timesheet',
+            'unit_amount': 4,
+            'employee_id': empl_employee.id,
+        })
+
+        self.assertEqual(timesheet.company_id.id, self.env.company.id)

--- a/addons/hr_timesheet_attendance/tests/__init__.py
+++ b/addons/hr_timesheet_attendance/tests/__init__.py
@@ -1,0 +1,4 @@
+# -*- coding: utf-8 -*-
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from . import test_timesheet_attendance

--- a/addons/hr_timesheet_attendance/tests/test_timesheet_attendance.py
+++ b/addons/hr_timesheet_attendance/tests/test_timesheet_attendance.py
@@ -1,0 +1,35 @@
+# -*- coding: utf-8 -*-
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from datetime import datetime
+
+from odoo.tests import tagged
+from odoo.addons.hr_timesheet.tests.test_timesheet import TestCommonTimesheet
+
+@tagged('post_install', '-at_install')
+class TestTimesheetAttendance(TestCommonTimesheet):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.env['hr.attendance'].create({
+            'employee_id': cls.empl_employee.id,
+            'check_in': datetime(2022, 2, 9, 8, 0), # Wednesday
+            'check_out': datetime(2022, 2, 9, 16, 0),
+        })
+
+    def test_timesheet_attendance_report(self):
+        self.env['account.analytic.line'].with_user(self.user_employee).create({
+            'name': 'Test timesheet 1',
+            'project_id': self.project_customer.id,
+            'unit_amount': 6.0,
+            'date': datetime(2022, 2, 9),
+        })
+        report_data = self.env['hr.timesheet.attendance.report']._read_group(
+            [('user_id', '=', self.user_employee.id),
+            ('date', '>=', datetime(2022, 2, 9, 8, 0)), ('date', '<=', datetime(2022, 2, 9, 16, 0))],
+            ['total_timesheet', 'total_attendance', 'total_difference'],
+            ['user_id'],
+        )[0]
+        self.assertEqual(report_data['total_timesheet'], 6.0, "Total timesheet in report should be 4.0")
+        self.assertEqual(report_data['total_attendance'], 8.0, "Total attendance in report should be 8.0")
+        self.assertEqual(report_data['total_attendance'] - report_data['total_timesheet'], 2)

--- a/addons/project_timesheet_holidays/tests/test_timesheet_holidays.py
+++ b/addons/project_timesheet_holidays/tests/test_timesheet_holidays.py
@@ -104,6 +104,11 @@ class TestTimesheetHolidays(TestCommonTimesheet):
             'number_of_days': number_of_days,
         })
         holiday.with_user(SUPERUSER_ID).action_validate()
+
+        # The leave type and timesheet are linked to the same project and task'
+        self.assertEqual(holiday.timesheet_ids.project_id.id, self.internal_project.id)
+        self.assertEqual(holiday.timesheet_ids.task_id.id, self.internal_task_leaves.id)
+
         self.assertEqual(len(holiday.timesheet_ids), number_of_days, 'Number of generated timesheets should be the same as the leave duration (1 per day between %s and %s)' % (fields.Datetime.to_string(self.leave_start_datetime), fields.Datetime.to_string(self.leave_end_datetime)))
 
         # manager refuse the leave


### PR DESCRIPTION

Reminders-
- employee reminder: an email should be sent when the employee has timesheet less hours than he should have
- manager reminder: an email should be sent when the manager has not validated timesheets within the corresponding timeframe.

Timesheet / attendance report 

Time off

- public holidays should not generate an entry if the employee is already on time off
- the project and task set on the time off type should be set on the generated timesheets

task-2727561
