### PR TITLE
[IMP] survey: hide Answer page if no scoring

### DIFF
--- a/addons/survey/views/survey_question_views.xml
+++ b/addons/survey/views/survey_question_views.xml
@@ -109,7 +109,10 @@
                         </group>
                     </group>
                     <notebook>
-                        <page string="Answers" name="answers" attrs="{'invisible': ['|', ('is_page', '=', True), ('question_type', '=', 'text_box')]}">
+                        <page string="Answers" name="answers" attrs="{'invisible': ['|', '|',
+                            ('is_page', '=', True), ('question_type', '=', 'text_box'),
+                            '&amp;', ('scoring_type', '=', 'no_scoring'), ('question_type', 'in', ['numerical_box', 'date', 'datetime']),
+                        ]}">
                             <group>
                                 <group attrs="{'invisible': [('question_type', 'not in', ['char_box', 'numerical_box', 'date', 'datetime'])]}">
                                     <field name="answer_numerical_box" string="Correct Answer"


### PR DESCRIPTION
Purpose
=======
Avoid showing the "Correct Answer" field if the survey is not scored
(for question type numerical, date or datetime). Since it is the only
field on this page, hide the page completely.

Task-2795296
