### PR TITLE
[FIX] web: fields _onClick triggered twice

### DIFF
--- a/addons/web/static/src/legacy/js/fields/basic_fields.js
+++ b/addons/web/static/src/legacy/js/fields/basic_fields.js
@@ -1683,7 +1683,7 @@ var FieldEmail = InputField.extend({
     description: _lt("Email"),
     className: 'o_field_email',
     events: _.extend({}, InputField.prototype.events, {
-        'click': '_onClick',
+        'click': '_onClickLink',
     }),
     prefix: 'mailto',
     supportedFieldTypes: ['char'],
@@ -1758,8 +1758,10 @@ var FieldEmail = InputField.extend({
      * @private
      * @param {MouseEvent} ev
      */
-    _onClick: function (ev) {
-        ev.stopPropagation();
+    _onClickLink: function (ev) {
+        if (ev.target.matches("a")) {
+            ev.stopImmediatePropagation();
+        }
     },
 });
 

--- a/addons/web/static/tests/legacy/fields/basic_fields_tests.js
+++ b/addons/web/static/tests/legacy/fields/basic_fields_tests.js
@@ -1300,6 +1300,38 @@ QUnit.module('basic_fields', {
         form.destroy();
     });
 
+    QUnit.test("click on email field link don't switch to edit mode", async function (assert) {
+        testUtils.mock.patch(field_registry.map.email, {
+            _onClickLink: function (ev) {
+                assert.step(ev.target.nodeName + " clicked");
+                this._super.apply(this, arguments);
+            },
+        });
+        var form = await createView({
+            View: FormView,
+            model: 'partner',
+            data: this.data,
+            arch: '<form string="Partners">' +
+                    '<sheet>' +
+                        '<group>' +
+                            '<field name="foo" widget="email"/>' +
+                        '</group>' +
+                    '</sheet>' +
+                '</form>',
+            res_id: 1,
+        });
+
+        await testUtils.dom.click(form.el.querySelector('.o_field_email a'));
+        assert.containsOnce(form.el, ".o_form_readonly", "form view is not in edit mode");
+
+        await testUtils.dom.click(form.el.querySelector('.o_field_email'));
+        assert.verifySteps(["A clicked", "DIV clicked"]);
+        assert.containsOnce(form.el, ".o_form_editable", "form view is in edit mode");
+
+        form.destroy();
+        testUtils.mock.unpatch(field_registry.map.email);
+    });
+
     QUnit.module('FieldChar');
 
     QUnit.test('char widget isValid method works', async function (assert) {


### PR DESCRIPTION
This commit fixes a bug present in FieldEmail and
FieldPhone where the handler on the click event was
triggered twice and was not preventing the field to
turn into quick edit mode appropriately.
A test has been added for EmailField to ensure the
correct behavior

PR enterprise: https://github.com/odoo/enterprise/pull/25506
