### PR TITLE
[FIX] web: Empty cache when editing favorites

### DIFF
--- a/addons/web/static/src/legacy/js/services/data_manager.js
+++ b/addons/web/static/src/legacy/js/services/data_manager.js
@@ -22,10 +22,15 @@ return core.Class.extend({
     },
 
     /**
-     * Invalidates the whole cache
+     * Invalidates the whole cache. Only works when not triggered by itself.
      * Suggestion: could be refined to invalidate some part of the cache
+     *
+     * @param {Object} [dataManager]
      */
-    invalidate: function () {
+    invalidate: function (dataManager) {
+        if (dataManager === this) {
+            return;
+        }
         session.invalidateCacheKey('load_menus');
         this._init_cache();
     },
@@ -203,6 +208,7 @@ return core.Class.extend({
      * @param {string} key
      */
     _invalidate(section, key) {
+        core.bus.trigger("clear_cache", this);
         if (key) {
             delete this._cache[section][key];
         } else {

--- a/addons/web/static/src/search/favorite_menu/custom_favorite_item.js
+++ b/addons/web/static/src/search/favorite_menu/custom_favorite_item.js
@@ -14,7 +14,7 @@ export class CustomFavoriteItem extends Component {
         this.descriptionRef = useRef("description");
         useAutofocus();
         this.state = useState({
-            description: this.env.config.displayName,
+            description: this.env.config.displayName || "",
             isDefault: false,
             isShared: false,
         });
@@ -46,7 +46,7 @@ export class CustomFavoriteItem extends Component {
         this.env.searchModel.createNewFavorite({ description, isDefault, isShared });
 
         Object.assign(this.state, {
-            description: this.env.config.displayName,
+            description: this.env.config.displayName || "",
             isDefault: false,
             isShared: false,
         });

--- a/addons/web/static/src/search/search_model.js
+++ b/addons/web/static/src/search/search_model.js
@@ -549,6 +549,7 @@ export class SearchModel extends EventBus {
     async createNewFavorite(params) {
         const { preFavorite, irFilter } = this._getIrFilterDescription(params);
         const serverSideId = await this.orm.call("ir.filters", "create_or_replace", [irFilter]);
+        this.env.bus.trigger("CLEAR-CACHES");
 
         // before the filter cache was cleared!
         this.blockNotification = true;
@@ -658,9 +659,8 @@ export class SearchModel extends EventBus {
             return;
         }
         const { serverSideId } = searchItem;
-        await this.orm.unlink("ir.filters", [
-            serverSideId,
-        ]); /** @todo we should maybe expose some method in view_manager: before, the filter cache was invalidated */
+        await this.orm.unlink("ir.filters", [serverSideId]);
+        this.env.bus.trigger("CLEAR-CACHES");
         const index = this.query.findIndex((queryElem) => queryElem.searchItemId === favoriteId);
         delete this.searchItems[favoriteId];
         if (index >= 0) {

--- a/addons/web/static/src/views/view_service.js
+++ b/addons/web/static/src/views/view_service.js
@@ -79,7 +79,7 @@ export const viewService = {
                         const viewDescriptions = {
                             __legacy__: result,
                         }; // for legacy purpose, keys in result are left in viewDescriptions
-                        for (const [_, viewType] of params.views) {
+                        for (const [, viewType] of params.views) {
                             const viewDescription = JSON.parse(
                                 JSON.stringify(result.fields_views[viewType])
                             );

--- a/addons/web/static/tests/search/custom_favorite_item_tests.js
+++ b/addons/web/static/tests/search/custom_favorite_item_tests.js
@@ -157,7 +157,7 @@ QUnit.module("Search", (hooks) => {
     });
 
     QUnit.test("save filter", async function (assert) {
-        assert.expect(1);
+        assert.expect(4);
 
         class TestComponent extends owl.Component {
             setup() {
@@ -185,11 +185,16 @@ QUnit.module("Search", (hooks) => {
             Component: TestComponent,
             searchViewId: false,
         });
+        comp.env.bus.on("CLEAR-CACHES", comp, () => assert.step("CLEAR-CACHES"));
+
+        assert.verifySteps([]);
 
         await toggleFavoriteMenu(comp);
         await toggleSaveFavorite(comp);
         await editFavoriteName(comp, "aaa");
         await saveFavorite(comp);
+
+        assert.verifySteps(["CLEAR-CACHES"]);
     });
 
     QUnit.test("dynamic filters are saved dynamic", async function (assert) {

--- a/addons/web/static/tests/search/favorite_menu_tests.js
+++ b/addons/web/static/tests/search/favorite_menu_tests.js
@@ -1,12 +1,6 @@
 /** @odoo-module **/
 
 import { click, patchDate } from "@web/../tests/helpers/utils";
-import { createWebClient, doAction } from "@web/../tests/webclient/helpers";
-import { dialogService } from "@web/core/dialog/dialog_service";
-import { registry } from "@web/core/registry";
-import { ControlPanel } from "@web/search/control_panel/control_panel";
-import { FavoriteMenu } from "@web/search/favorite_menu/favorite_menu";
-import { SearchBar } from "@web/search/search_bar/search_bar";
 import {
     deleteFavorite,
     getFacetTexts,
@@ -17,7 +11,13 @@ import {
     toggleComparisonMenu,
     toggleFavoriteMenu,
     toggleMenuItem,
-} from "./helpers";
+} from "@web/../tests/search/helpers";
+import { createWebClient, doAction } from "@web/../tests/webclient/helpers";
+import { dialogService } from "@web/core/dialog/dialog_service";
+import { registry } from "@web/core/registry";
+import { ControlPanel } from "@web/search/control_panel/control_panel";
+import { FavoriteMenu } from "@web/search/favorite_menu/favorite_menu";
+import { SearchBar } from "@web/search/search_bar/search_bar";
 
 const serviceRegistry = registry.category("services");
 const viewRegistry = registry.category("views");
@@ -124,77 +124,75 @@ QUnit.module("Search", (hooks) => {
         assert.containsOnce(controlPanel, ".dropdown-menu .o_add_favorite");
     });
 
-    QUnit.test(
-        "delete an active favorite remove it both in list of favorite and in search bar",
-        async function (assert) {
-            assert.expect(7);
+    QUnit.test("delete an active favorite", async function (assert) {
+        assert.expect(11);
 
-            class ToyView extends owl.Component {
-                setup() {
-                    assert.deepEqual(this.props.domain, [["foo", "=", "qsdf"]]);
-                }
-                willUpdateProps(nextProps) {
-                    assert.deepEqual(nextProps.domain, []);
-                }
+        class ToyView extends owl.Component {
+            setup() {
+                assert.deepEqual(this.props.domain, [["foo", "=", "qsdf"]]);
             }
-            ToyView.components = { FavoriteMenu, SearchBar };
-            ToyView.template = owl.tags.xml`
+            willUpdateProps(nextProps) {
+                assert.deepEqual(nextProps.domain, []);
+            }
+        }
+        ToyView.components = { FavoriteMenu, SearchBar };
+        ToyView.template = owl.tags.xml`
                 <div>
                     <SearchBar/>
                     <FavoriteMenu/>
                 </div>
             `;
-            ToyView.type = "toy";
-            ToyView.display_name = "";
+        ToyView.type = "toy";
+        ToyView.display_name = "Toy";
 
-            viewRegistry.add("toy", ToyView);
+        viewRegistry.add("toy", ToyView);
 
-            serverData.views["foo,false,toy"] = `<toy/>`;
+        serverData.views["foo,false,toy"] = `<toy />`;
+        serverData.models.foo.filters = [
+            {
+                context: "{}",
+                domain: "[['foo', '=', 'qsdf']]",
+                id: 7,
+                is_default: true,
+                name: "My favorite",
+                sort: "[]",
+                user_id: [2, "Mitchell Admin"],
+            },
+        ];
 
-            serverData.models.foo.filters = [
-                {
-                    context: "{}",
-                    domain: "[['foo', '=', 'qsdf']]",
-                    id: 7,
-                    is_default: true,
-                    name: "My favorite",
-                    sort: "[]",
-                    user_id: [2, "Mitchell Admin"],
-                },
-            ];
+        const webClient = await createWebClient({
+            serverData,
+            mockRPC: async (_, args) => {
+                if (args.model === "ir.filters" && args.method === "unlink") {
+                    assert.step("deleteFavorite");
+                    return { result: true }; // mocked unlink result
+                }
+            },
+        });
+        webClient.env.bus.on("CLEAR-CACHES", webClient, () => assert.step("CLEAR-CACHES"));
+        await doAction(webClient, {
+            name: "Action",
+            res_model: "foo",
+            type: "ir.actions.act_window",
+            views: [[false, "toy"]],
+        });
 
-            const webClient = await createWebClient({
-                serverData,
-                mockRPC: async (_, args) => {
-                    if (args.model === "ir.filters" && args.method === "unlink") {
-                        return { result: true }; // mocked unlink result
-                    }
-                },
-            });
-            await doAction(webClient, {
-                name: "Action",
-                res_model: "foo",
-                type: "ir.actions.act_window",
-                views: [[false, "toy"]],
-            });
+        await toggleFavoriteMenu(webClient);
 
-            await toggleFavoriteMenu(webClient);
+        assert.deepEqual(getFacetTexts(webClient), ["My favorite"]);
+        assert.hasClass(webClient.el.querySelector(".o_favorite_menu .o_menu_item"), "selected");
 
-            assert.deepEqual(getFacetTexts(webClient), ["My favorite"]);
-            assert.hasClass(
-                webClient.el.querySelector(".o_favorite_menu .o_menu_item"),
-                "selected"
-            );
+        await deleteFavorite(webClient, 0);
 
-            await deleteFavorite(webClient, 0);
+        assert.verifySteps([]);
 
-            await click(document.querySelector("div.o_dialog footer button"));
+        await click(document.querySelector("div.o_dialog footer button"));
 
-            assert.deepEqual(getFacetTexts(webClient), []);
-            assert.containsNone(webClient, ".o_favorite_menu .o_menu_item");
-            assert.containsOnce(webClient, ".o_favorite_menu .o_add_favorite");
-        }
-    );
+        assert.deepEqual(getFacetTexts(webClient), []);
+        assert.containsNone(webClient, ".o_favorite_menu .o_menu_item");
+        assert.containsOnce(webClient, ".o_favorite_menu .o_add_favorite");
+        assert.verifySteps(["deleteFavorite", "CLEAR-CACHES"]);
+    });
 
     QUnit.test(
         "default favorite is not activated if activateFavorite is set to false",


### PR DESCRIPTION
Before this commit, the view service kept the same cache information
even thought favorite filters would be created or deleted. This caused
inconsistencies when the interface tried to reload views that would
access the cache and display outdated information.

Now the related views cache keys are invalidated when favorite filters
are created or deleted.

closes odoo/odoo#76507

Signed-off-by: Aaron Bohy (aab) <aab@odoo.com>

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
