### PR TITLE
[IMP] digest: ease the way people can unsubscribe from a digest

### DIFF
--- a/addons/digest/controllers/portal.py
+++ b/addons/digest/controllers/portal.py
@@ -11,8 +11,25 @@ from odoo.tools import consteq
 
 class DigestController(Controller):
 
-    @route('/digest/<int:digest_id>/unsubscribe', type='http', website=True, auth='public')
-    def digest_unsubscribe(self, digest_id, token=None, user_id=None):
+    # csrf is disabled here because it will be called by the MUA with unpredictable session at that time
+    @route('/digest/<int:digest_id>/unsubscribe', type='http', website=True, auth='public', methods=['GET', 'POST'],
+           csrf=False)
+    def digest_unsubscribe(self, digest_id, token=None, user_id=None, one_click=None):
+        """ Unsubscribe a given user from a given digest
+
+        :param int digest_id: id of digest to unsubscribe from
+        :param str token: token preventing URL forgery
+        :param user_id: id of user to unsubscribe
+        :param int one_click: set it to 1 when using the URL in the header of
+          the email to allow mail user agent to propose a one click button to the
+          user to unsubscribe as defined in rfc8058. When set to True, only POST
+          method is allowed preventing the risk that anti-spam trigger unwanted
+          unsubscribe (scenario explained in the same rfc). Note: this method
+          must support encoding method 'multipart/form-data' and 'application/x-www-form-urlencoded'.
+        """
+        if one_click and int(one_click) and request.httprequest.method != "POST":
+            raise Forbidden()
+
         digest_sudo = request.env['digest.digest'].sudo().browse(digest_id).exists()
 
         # new route parameters

--- a/addons/digest/views/digest_views.xml
+++ b/addons/digest/views/digest_views.xml
@@ -20,7 +20,7 @@
             <form string="KPI Digest">
                 <field name="is_subscribed" invisible="1"/>
                 <header>
-                    <button type="object" name="action_send" string="Send Now"
+                    <button type="object" name="action_send_manual" string="Send Now"
                         class="oe_highlight"
                         attrs="{'invisible': [('state','=','deactivated')]}" groups="base.group_system"/>
                     <button type="object" name="action_deactivate" string="Deactivate"


### PR DESCRIPTION
Ease the way people can unsubscribe from a digest by adding information
to the email enabling a user agent to present a button to the user that
automate the unsubscription.

Technical notes:
To ease the way people can unsubscribe from a digest, we have followed the
advice of rfc8058 by adding the following header to the email:
- List-Unsubscribe: https_URL_to_unsubscribe
- List-Unsubscribe-Post: List-Unsubscribe=One-Click

The https_URL_to_unsubscribe
- must work with the POST method but not the GET. The GET version is disabled
to avoid unintended unsubscription that could be triggered by an anti-spam
accessing the URLs in the headers.
- must unsubscribe the user without any additional steps (one click)
- should contain an opaque identifier hard-to-forge to identify the list and
the user (our token fulfills that goal). The goal is to avoid that someone
could unregister someone else easily.
- must fulfill other conditions like no cookie, no redirection, ...

It requires also that List-Unsubscribe and List-Unsubscribe-Post be covered by
a DKIM signature.

Task-2800499

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
