### PR TITLE
[REV] mass_mailing, website: simplify s_numbers snippet

### DIFF
--- a/addons/mass_mailing/views/snippets/s_numbers.xml
+++ b/addons/mass_mailing/views/snippets/s_numbers.xml
@@ -5,15 +5,15 @@
             <div class="container">
                 <div class="row">
                     <div class="text-center pt24 pb24 col-lg-4" valign="top">
-                        <span class="s_number display-4 o_default_snippet_text">12</span><br/>
+                        <span class="s_number display-4 o_default_snippet_text">12</span>
                         <h6 class="o_default_snippet_text">Useful options</h6>
                     </div>
                     <div class="text-center pt24 pb24 col-lg-4" valign="top">
-                        <span class="s_number display-4 o_default_snippet_text">45</span><br/>
+                        <span class="s_number display-4 o_default_snippet_text">45</span>
                         <h6 class="">Beautiful snippets</h6>
                     </div>
                     <div class="text-center pt24 pb24 col-lg-4" valign="top">
-                        <span class="s_number display-4 o_default_snippet_text">8</span><br/>
+                        <span class="s_number display-4 o_default_snippet_text">8</span>
                         <h6 class="o_default_snippet_text">Amazing pages</h6>
                     </div>
                 </div>

--- a/addons/website/views/snippets/s_numbers.xml
+++ b/addons/website/views/snippets/s_numbers.xml
@@ -6,19 +6,19 @@
         <div class="container">
             <div class="row">
                 <div class="col-lg-3 text-center pt24 pb24">
-                    <span class="s_number display-4">12</span><br/>
+                    <span class="s_number display-4">12</span>
                     <h6>Useful options</h6>
                 </div>
                 <div class="col-lg-3 text-center pt24 pb24">
-                    <span class="s_number display-4">45</span><br/>
+                    <span class="s_number display-4">45</span>
                     <h6>Beautiful snippets</h6>
                 </div>
                 <div class="col-lg-3 text-center pt24 pb24">
-                    <span class="s_number display-4">8</span><br/>
+                    <span class="s_number display-4">8</span>
                     <h6>Amazing pages</h6>
                 </div>
                 <div class="col-lg-3 text-center pt24 pb24">
-                    <span class="s_number display-4">37</span><br/>
+                    <span class="s_number display-4">37</span>
                     <h6>Outstanding images</h6>
                 </div>
             </div>


### PR DESCRIPTION
This reverts commit [1] (in master only since XML change) which was a
temporary fix. Indeed, the proper fix was merged at [2] since then.

[1]: https://github.com/odoo/odoo/commit/886af1f328a9f1664b0d3e204bf984bfee28b215
[2]: https://github.com/odoo/odoo/commit/5e3c466e1b6a23a76807ab4f4d81bcf70105eedb
