### PR TITLE
[FIX] stock: avoid internal SM for inter-warehouses transfers

### DIFF
--- a/addons/stock/i18n/stock.pot
+++ b/addons/stock/i18n/stock.pot
@@ -7158,6 +7158,15 @@ msgid "You need to supply a Lot/Serial number for product %s."
 msgstr ""
 
 #. module: stock
+#: code:addons/stock/models/stock_picking.py:0
+#, python-format
+msgid ""
+"You should not use an internal transfer to move some products between two "
+"warehouses. Instead, use two pickings: a delivery from %s and a receipt to "
+"%s"
+msgstr ""
+
+#. module: stock
 #: code:addons/stock/models/stock_warehouse.py:0
 #, python-format
 msgid ""

--- a/addons/stock/models/stock_picking.py
+++ b/addons/stock/models/stock_picking.py
@@ -572,6 +572,17 @@ class Picking(models.Model):
                     'message': partner.picking_warn_msg
                 }}
 
+    @api.onchange('location_id', 'location_dest_id', 'picking_type_id')
+    def onchange_locations(self):
+        from_wh = self.location_id.get_warehouse()
+        to_wh = self.location_dest_id.get_warehouse()
+        if self.picking_type_id.code == 'internal' and from_wh and to_wh and from_wh != to_wh:
+            return {'warning': {
+                'title': _("Warning"),
+                'message': _("You should not use an internal transfer to move some products between two warehouses. "
+                             "Instead, use two pickings: a delivery from %s and a receipt to %s") % (from_wh.display_name, to_wh.display_name),
+            }}
+
     @api.model
     def create(self, vals):
         defaults = self.default_get(['name', 'picking_type_id'])


### PR DESCRIPTION
When using an internal transfer to move some products between two
warehouses, the forecasted inventory becomes incorrect

To reproduce the issue:
(Let WH01 be the existing warehouse)
1. In Settings, enable "Multi-Warehouses"
2. Create a second warehouse WH02
3. Create a storable product P
4. Update its quantity: 1 x P at WH01/Stock
5. Create a planned internal transfer (the warehouse does not matter):
    - Source: WH01/Stock
    - Destination: WH02/Stock
    - Operations:
        - 1 x P
6. Mark the transfer as Todo
7. Consult the Forecasted Inventory report:
    - Filters:
        - Forecasted Stock
        - Product: P
    - Group By:
        - Warehouse

Error: The line for WH02 is missing and the line for WH01 is incorrect
(qty is 1 for next days while it should be 0)

The report used (`report_stock_quantity`) does not handle this transfer.
Because both locations (source and destination) are defined, the SM is
not considered as an in-move or out-move:
https://github.com/odoo/odoo/blob/07f0ffad6ecc08f4165902db45ae96e4b41199e8/addons/stock/report/report_stock_quantity.py#L38-L43
Moreover, it would be hard to change the SQL view to generate two lines
(one 'in' and one 'out') from the same SM (the internal move).

The graph on the forecasted report of product P is also incorrect (it
uses `report_stock_quantity` to get the data, so if the user selects a
specific warehouse in the filters, the result will be incorrect)

To easy all computations, the user should rather use two pickings
(delivery+receipt) when moving some products between two warehouses.

OPW-2752017