### PR TITLE
[FIX] mrp_account: add user group check

### DIFF
--- a/addons/mrp_account/views/analytic_account_views.xml
+++ b/addons/mrp_account/views/analytic_account_views.xml
@@ -5,6 +5,7 @@
         <field name="model">account.analytic.account</field>
         <field name="inherit_id" ref="analytic.view_account_analytic_account_form"/>
         <field eval="14" name="priority"/>
+        <field name="groups_id" eval="[(4, ref('mrp.group_mrp_user'))]"/>
         <field name="arch" type="xml">
             <div name="button_box" position="inside">
                 <button class="oe_stat_button" type="object" name="action_view_mrp_production"

--- a/addons/mrp_account/views/product_views.xml
+++ b/addons/mrp_account/views/product_views.xml
@@ -5,7 +5,7 @@
             <field name="model">product.template</field>
             <field name="priority">3</field>
             <field name="inherit_id" ref="product.product_template_only_form_view" />
-            <field name="groups_id" eval="[(4, ref('mrp.group_mrp_user'))]"/>
+            <field name="groups_id" eval="[(4, ref('mrp.group_mrp_manager'))]"/>
             <field name="arch" type="xml">
                 <xpath expr="//div[@name='standard_price_uom']" position="inside">
                     <field name="cost_method" invisible="1"/>
@@ -24,7 +24,7 @@
             <field name="model">product.product</field>
             <field name="priority">4</field>
             <field name="inherit_id" ref="product.product_normal_form_view"/>
-            <field name="groups_id" eval="[(4, ref('mrp.group_mrp_user'))]"/>
+            <field name="groups_id" eval="[(4, ref('mrp.group_mrp_manager'))]"/>
             <field name="arch" type="xml">
                 <xpath expr="//div[@name='standard_price_uom']" position="inside">
                     <field name="cost_method" invisible="1"/>
@@ -43,6 +43,7 @@
             <field name="name">product.product.product.view.form.easy.bom.inherit</field>
             <field name="model">product.product</field>
             <field name="inherit_id" ref="product.product_variant_easy_edit_view"/>
+            <field name="groups_id" eval="[(4, ref('mrp.group_mrp_manager'))]"/>
             <field name="arch" type="xml">
                 <data>
                 <xpath expr="//field[@name='standard_price']" position="replace">


### PR DESCRIPTION
Steps to reproduce the bug:

- Install mrp_account and accounting

1:/
- remove MRP access to Marc Demo
- connect with Marc
- Go to any product with variant > variants > then open any variant

Problem:
Access error is triggered, we try to calculate the bom_count of this product, but the user does not have manager access to MRP

2:/
- now Give accountant access to Marc
- Go to any analytic account with bom or production

Problem:
Marc can see the number of boms or productions, while he does not have access to MRP

opw-2794179




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
