### PR TITLE
[FIX] web_editor: prevent traceback on remove highlight color

### DIFF
--- a/addons/web_editor/static/lib/odoo-editor/src/utils/sanitize.js
+++ b/addons/web_editor/static/lib/odoo-editor/src/utils/sanitize.js
@@ -78,15 +78,20 @@ export function areSimilarElements(node, node2) {
 class Sanitize {
     constructor(root) {
         this.root = root;
-        // Remove unique ids from checklists and stars. These will be renewed
-        // afterwards.
-        for (const node of closestBlock(root).querySelectorAll('[id^=checkId-]')) {
-            node.removeAttribute('id');
+        const rootClosestBlock = closestBlock(root);
+        if (rootClosestBlock) {
+            // Remove unique ids from checklists and stars. These will be
+            // renewed afterwards.
+            for (const node of rootClosestBlock.querySelectorAll('[id^=checkId-]')) {
+                node.removeAttribute('id');
+            }
         }
         this.parse(root);
-        // Ensure unique ids on checklists and stars.
-        for (const node of closestBlock(root).querySelectorAll('.o_checklist > li, .o_stars')) {
-            node.setAttribute('id', `checkId-${Math.floor(new Date() * Math.random())}`);
+        if (rootClosestBlock) {
+            // Ensure unique ids on checklists and stars.
+            for (const node of rootClosestBlock.querySelectorAll('.o_checklist > li, .o_stars')) {
+                node.setAttribute('id', `checkId-${Math.floor(new Date() * Math.random())}`);
+            }
         }
     }
 


### PR DESCRIPTION
This prevents a traceback when no closest block to the root node can be found in the sanitizer.

task-2796371

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
