### PR TITLE
[FIX] project: correct display_project_id on duplicate

### DIFF
--- a/addons/project/models/project.py
+++ b/addons/project/models/project.py
@@ -440,6 +440,7 @@ class Project(models.Model):
 
     def map_tasks(self, new_project_id):
         """ copy and map tasks from old to new project """
+        self.ensure_one()
         project = self.browse(new_project_id)
         tasks = self.env['project.task']
         # We want to copy archived task, but do not propagate an active_test context key
@@ -451,6 +452,9 @@ class Project(models.Model):
             if task.parent_id:
                 # set the parent to the duplicated task
                 defaults['parent_id'] = old_to_new_tasks.get(task.parent_id.id, False)
+            elif task.display_project_id == self:
+                defaults['project_id'] = project.id
+                defaults['display_project_id'] = project.id
             new_task = task.copy(defaults)
             # If child are created before parent (ex sub_sub_tasks)
             new_child_ids = [old_to_new_tasks[child.id] for child in task.child_ids if child.id in old_to_new_tasks]

--- a/addons/project/tests/test_project_subtasks.py
+++ b/addons/project/tests/test_project_subtasks.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 
+from odoo import Command
 from odoo.addons.project.tests.test_project_base import TestProjectCommon
 from odoo.tests import tagged
 from odoo.tests.common import Form
@@ -191,3 +192,38 @@ class TestProjectSubtasks(TestProjectCommon):
                 subtask_form.display_project_id = self.project_goats
 
         self.assertEqual(self.task_1.child_ids.stage_id.name, "New", "The stage of the child task should be the default one of the display project id, once set.")
+
+    def test_copy_project_with_subtasks(self):
+        self.env['project.task'].with_context({'mail_create_nolog': True}).create({
+
+            'name': 'Parent Task',
+
+            'project_id': self.project_goats.id,
+
+            'child_ids': [
+                Command.create({'name': 'child 1'}),
+                Command.create({'name': 'child 2', 'display_project_id': self.project_goats.id}),
+                Command.create({'name': 'child 3 with subtask', 'child_ids': [Command.create({'name': 'child 4'})]}),
+                Command.create({'name': 'child archived', 'active': False}),
+            ],
+
+        })
+
+        task_count_with_subtasks_including_archived_in_project_goats = self.project_goats.with_context(
+            active_test=False).task_count_with_subtasks
+
+        self.project_goats._compute_task_count()  # recompute without archived tasks and subtasks
+
+        task_count_in_project_goats = self.project_goats.task_count
+
+        project_goats_duplicated = self.project_goats.copy()
+
+        self.project_pigs._compute_task_count()  # retrigger since a new task should be added in the project after the duplication of Project Goats
+
+        self.assertEqual(
+            project_goats_duplicated.with_context(active_test=False).task_count_with_subtasks,
+            task_count_with_subtasks_including_archived_in_project_goats,
+            'The number of duplicated tasks (subtasks included) should be equal to the number of all task of both projects')
+
+        self.assertEqual(self.project_goats.task_count, task_count_in_project_goats,
+                         'The number of tasks should be the same before and after the duplication of this project.')


### PR DESCRIPTION
Step to reproduce :
- Create a project with a subtask
- Assign the project to the subtask's `display_project_id`
- Duplicate the project

Current behaviour :
- Duplicate project subtask has no `display_project_id`

Behaviour after PR:
- Duplicate project subtask `display_project_id` is the project copy

opw-2799614

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
