### PR TITLE
[IMP] mail: prevent useless render of message view

### DIFF
--- a/addons/mail/static/src/models/message_view.js
+++ b/addons/mail/static/src/models/message_view.js
@@ -40,7 +40,7 @@ registerModel({
                 this.highlight();
                 this.update({ doHighlight: clear() });
             }
-            if (this.threadView && this.threadView.lastMessageView === this && this.component && this.component.isPartiallyVisible()) {
+            if (this.threadViewOwnerAsLastMessageView && this.component && this.component.isPartiallyVisible()) {
                 this.threadView.handleVisibleMessage(this.message);
             }
         },
@@ -266,6 +266,14 @@ registerModel({
          */
         threadView: one('ThreadView', {
             inverse: 'messageViews',
+            readonly: true,
+        }),
+        /**
+         * States whether this message view is the last one of its thread view.
+         * Computed from inverse relation.
+         */
+        threadViewOwnerAsLastMessageView: one('ThreadView', {
+            inverse: 'lastMessageView',
             readonly: true,
         }),
     },

--- a/addons/mail/static/src/models/thread_view.js
+++ b/addons/mail/static/src/models/thread_view.js
@@ -438,6 +438,8 @@ registerModel({
         }),
         lastMessageView: one('MessageView', {
             compute: '_computeLastMessageView',
+            inverse: 'threadViewOwnerAsLastMessageView',
+            readonly: true,
         }),
         /**
          * Most recent message in this ThreadView that has been shown to the


### PR DESCRIPTION
Avoid observing the last message view just for checking the state of self.

task-2800990