### PR TITLE
[FIX] auth_totp_portal: revoke trusted device selector and model

### DIFF
--- a/addons/auth_totp_portal/static/src/js/totp_frontend.js
+++ b/addons/auth_totp_portal/static/src/js/totp_frontend.js
@@ -266,7 +266,7 @@ publicWidget.registry.DisableTOTPButton = publicWidget.Widget.extend({
     }
 });
 publicWidget.registry.RevokeTrustedDeviceButton = publicWidget.Widget.extend({
-    selector: '.fa.fa-trash.text-danger',
+    selector: '#totp_wizard_view + * .fa.fa-trash.text-danger',
     events: {
         click: '_onClick'
     },
@@ -276,7 +276,7 @@ publicWidget.registry.RevokeTrustedDeviceButton = publicWidget.Widget.extend({
         await handleCheckIdentity(
             this.proxy('_rpc'),
             this._rpc({
-                model: 'res.users.apikeys',
+                model: 'auth_totp.device',
                 method: 'remove',
                 args: [parseInt(this.target.id)]
             })


### PR DESCRIPTION
The selector `.fa.fa-trash.text-danger` is not enough precise,
it could select another element using the same classes,
as it's the case in #85682,
and at the binding the event `RevokeTrustedDeviceButton` `_onClick`
event on that other element.
I would have used a dedicated class directly on the element,
such as `o_auth_totp_remove_trusted_device`,
but since we are in stable and cannot rely on the template
being updated, there is no other choice than using what we
currently have without the update.

In addition, the `remove` method must be called on the model
`auth_totp.device`, as since the revision
https://github.com/odoo/odoo/commit/2dee29a7dc6db5cd1f9cc62989b905cff5466f3b#diff-6ea780b2956bc89552a57dd3e711fdd7191d1599c246cc9c887bcc38fa7eabacR11-R12
`auth_totp.device` has been added,
inheriting from `res.users.apikeys` but with a different `_name`
and they therefore do not share the same IDs.
Meaning you would end asking the deletion of the `res.users.apikeys`
record using the same ID than trusted device record.