### PR TITLE
[FIX] product: pricelist not using currency in prices

### DIFF
--- a/addons/product/models/product_pricelist.py
+++ b/addons/product/models/product_pricelist.py
@@ -221,7 +221,9 @@ class Pricelist(models.Model):
                     price = product.price_compute(rule.base)[product.id]
 
                 if price is not False:
-                    price = rule._compute_price(price, price_uom, product, quantity=qty, partner=partner)
+                    # pass the date through the context for further currency conversions
+                    rule_with_date_context = rule.with_context(date=date)
+                    price = rule_with_date_context._compute_price(price, price_uom, product, quantity=qty, partner=partner)
                     suitable_rule = rule
                 break
             # Final price conversion into pricelist currency
@@ -583,6 +585,7 @@ class PricelistItem(models.Model):
            The unused parameters are there to make the full context available for overrides.
         """
         self.ensure_one()
+        date = self.env.context.get('date') or fields.Date.today()
         convert_to_price_uom = (lambda price: product.uom_id._compute_price(price, price_uom))
         if self.compute_price == 'fixed':
             price = convert_to_price_uom(self.fixed_price)
@@ -592,18 +595,30 @@ class PricelistItem(models.Model):
             # complete formula
             price_limit = price
             price = (price - (price * (self.price_discount / 100))) or 0.0
+            if self.base == 'standard_price':
+                price_currency = product.cost_currency_id
+            elif self.base == 'pricelist':
+                price_currency = self.currency_id  # Already converted before to the pricelist currency
+            else:
+                price_currency = product.currency_id
             if self.price_round:
                 price = tools.float_round(price, precision_rounding=self.price_round)
 
+            def convert_to_base_price_currency(amount):
+                return self.currency_id._convert(amount, price_currency, self.env.company, date, round=False)
+
             if self.price_surcharge:
-                price_surcharge = convert_to_price_uom(self.price_surcharge)
+                price_surcharge = convert_to_base_price_currency(self.price_surcharge)
+                price_surcharge = convert_to_price_uom(price_surcharge)
                 price += price_surcharge
 
             if self.price_min_margin:
-                price_min_margin = convert_to_price_uom(self.price_min_margin)
+                price_min_margin = convert_to_base_price_currency(self.price_min_margin)
+                price_min_margin = convert_to_price_uom(price_min_margin)
                 price = max(price, price_limit + price_min_margin)
 
             if self.price_max_margin:
-                price_max_margin = convert_to_price_uom(self.price_max_margin)
+                price_max_margin = convert_to_base_price_currency(self.price_max_margin)
+                price_max_margin = convert_to_price_uom(price_max_margin)
                 price = min(price, price_limit + price_max_margin)
         return price


### PR DESCRIPTION
When using a pricelist with a currency different than the one
of the product, the prices used in the pricelist (surcharge, min_margin,
& max_margin) are using the default currency of the company which is invalid.

To reproduce the issue:
1. Enable multiple currency and enable a second one with an exagerated rate for the sake of clarity.
2. Create a formula pricelist with the newly activated currency using either surcharge or the margin.
3. Create a SO with a standard product. By switching between pricelist, you will see an invalid price.
E.G.:
        EUR_rates = 2 compared to USD        PRICELIST = surcharge of 10€ on any product
        PRODUCT_price = 300$      PRODUCT_price_euros = 150€
        CURRENT_SO_price = (300 + 10)/rate_EUR = (300 + 10)/2 = 155€
        EXPECTED_SO_price = (300 + 10*rate_EUR)/rate_EUR = (300 + 10*2)/2 = 160€

Solution: Adapt the computation of a pricelist_item to take into account the currency.
Could not embed everything in the PricelistItem._compute_price method as it would imply
changing its signature (to include the date of the transaction). Consequently,
using a context to pass the adapted prices.

opw-2760720