### PR TITLE
[FIX] hr_holidays : ignore inactive leaves for IM status

### DIFF
--- a/addons/hr_holidays/models/res_users.py
+++ b/addons/hr_holidays/models/res_users.py
@@ -50,6 +50,7 @@ class User(models.Model):
         self.env.cr.execute('''SELECT res_users.%s FROM res_users
                             JOIN hr_leave ON hr_leave.user_id = res_users.id
                             AND state not in ('cancel', 'refuse')
+                            AND hr_leave.active = 't'
                             AND res_users.active = 't'
                             AND date_from <= %%s AND date_to >= %%s''' % field, (now, now))
         return [r[0] for r in self.env.cr.fetchall()]


### PR DESCRIPTION
To reproduce
============

- In a belgian company, set legal time type as no need approval

- as admin, take a day in the future with this time off

- in the time off form, a cancel appears (near refuse)

- Cancel the time off

The day of the time off, the flight icon is set on the employee

Purpose
=======

When cancelling a time off, we set it's `active` field to False, but its state remains `validate`,
but when fetching for users on leave, there is no check on the `active` field.

Specification
=============

To solve the issue a check on `active` field was added to the query.

opw-2784173
