### PR TITLE
[FIX] base: Allow users read_group with reified field inside the view

### DIFF
--- a/odoo/addons/base/models/res_users.py
+++ b/odoo/addons/base/models/res_users.py
@@ -1311,6 +1311,13 @@ class UsersView(models.Model):
                     values.pop('groups_id', None)
         return res
 
+    @api.model
+    def read_group(self, domain, fields, groupby, offset=0, limit=None, orderby=False, lazy=True):
+        if fields:
+            # ignore reified fields
+            fields = [fname for fname in fields if not is_reified_group(fname)]
+        return super().read_group(domain, fields, groupby, offset=offset, limit=limit, orderby=orderby, lazy=lazy)
+
     def _add_reified_groups(self, fields, values):
         """ add the given reified group fields into `values` """
         gids = set(parse_m2m(values.get('groups_id') or []))

--- a/odoo/addons/base/tests/test_res_users.py
+++ b/odoo/addons/base/tests/test_res_users.py
@@ -114,3 +114,24 @@ class TestUsers(TransactionCase):
             "On user company change, if its partner_id has already a company_id,"
             "the company_id of the partner_id shall be updated"
         )
+
+    def test_read_group_with_reified_field(self):
+        """ Check that read_group gets rid of reified fields"""
+        User = self.env['res.users']
+        fnames = ['name', 'email', 'login']
+
+        # find some reified field name
+        reified_fname = next(
+            fname
+            for fname in User.fields_get()
+            if fname.startswith(('in_group_', 'sel_groups_'))
+        )
+
+        # check that the reified field name has no effect in fields
+        res_with_reified = User.read_group([], fnames + [reified_fname], ['company_id'])
+        res_without_reified = User.read_group([], fnames, ['company_id'])
+        self.assertEqual(res_with_reified, res_without_reified, "Reified fields should be ignored")
+
+        # Verify that the read_group is raising an error if reified field is used as groupby
+        with self.assertRaises(ValueError):
+            User.read_group([], fnames + [reified_fname], [reified_fname])


### PR DESCRIPTION
Until now using a groupby on a view containing a reified field added
with studio was not possible.

Because `read_group` uses these pseudofields as simple fields when they
are not actually columns in the table.

With `read`, `write`, `create` and `fields_get` it was already
supported.

This commit solves this problem by ignoring reified fields in an
override of `read_group`

opw-2793148