### PR TITLE
[FIX] website, website_payment: exclude Donation snippet from cache

### DIFF
--- a/addons/website/models/website_page.py
+++ b/addons/website/models/website_page.py
@@ -221,8 +221,8 @@ class Page(models.Model):
         self.ensure_one()
         return self.view_id.get_website_meta()
 
-    @staticmethod
-    def _get_cached_blacklist():
+    @classmethod
+    def _get_cached_blacklist(cls):
         return ('data-snippet="s_website_form"', 'data-no-page-cache=', )
 
     def _can_be_cached(self, response):

--- a/addons/website_payment/models/__init__.py
+++ b/addons/website_payment/models/__init__.py
@@ -4,3 +4,4 @@
 from . import account_payment
 from . import payment_acquirer
 from . import payment_transaction
+from . import website_page

--- a/addons/website_payment/models/website_page.py
+++ b/addons/website_payment/models/website_page.py
@@ -1,0 +1,15 @@
+# -*- coding: utf-8 -*-
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from odoo import models
+
+
+class Page(models.Model):
+    _inherit = 'website.page'
+
+    @classmethod
+    def _get_cached_blacklist(cls):
+        return super()._get_cached_blacklist() + (
+            # Contains a form with a dynamically added CSRF token
+            'data-snippet="s_donation"',
+        )


### PR DESCRIPTION
Since [1] the CSRF token used by the donation snippet's form did end up
being cached for new visitors that did not have a session id yet.
This made the validation of the token fail when using the form because
the token from the very first new visitor on the worker was reused.

After this commit pages that contain a Donation snippet are not cached
anymore in order to always get a fresh CSRF token - similarly to what is
done for the form snippet.

When using incognito mode the csrf token is sometimes not recognized
during navigation to the donation payment page.
Simple sequence to reproduce it:
- drop a Donation snippet on the Home page
- use Firefox and do not log in
- in normal browser, select 25 then press Donate Now
- open an incognito browser, select 50 then press Donate Now
=> 400 Bad Request
Alternative (any browser):
- open page with Donation snippet in incognito window
- remove session id from cookies using developer tools
- close window
- reopen page in a new incognito window
- try to donate
=> 400 Bad Request

[1]: https://github.com/odoo/odoo/commit/7fccbac004628093da49016f75370a84bba49465

opw-2774065

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
