### PR TITLE
[FIX] mail: disable mail notif when merging contact

### DIFF
--- a/addons/mail/models/mail_thread.py
+++ b/addons/mail/models/mail_thread.py
@@ -2442,6 +2442,8 @@ class MailThread(models.AbstractModel):
         for pid, cid, active, pshare, ctype, notif, groups in res:
             if pid and pid == author_id and not self.env.context.get('mail_notify_author'):  # do not notify the author of its own messages
                 continue
+            if pid and self.env.context.get("do_not_send_mail"):
+                continue
             if pid:
                 if active is False:
                     continue


### PR DESCRIPTION
Steps to reproduce:
- Duplicate a contact
- Send a message/mail in the chatter to the contact (or add it as a follower)
- in Data Cleaning, merge the two contacts

Issue:
- A mail is sent to the customer

Solution:
Prevent the email to be sent
