### PR TITLE
[FIX] mail: Properly set socket timeout

### DIFF
--- a/addons/fetchmail/models/fetchmail.py
+++ b/addons/fetchmail/models/fetchmail.py
@@ -3,6 +3,7 @@
 
 import logging
 import poplib
+import socket
 from imaplib import IMAP4, IMAP4_SSL
 from poplib import POP3, POP3_SSL
 
@@ -16,6 +17,11 @@ MAIL_TIMEOUT = 60
 
 # Workaround for Python 2.7.8 bug https://bugs.python.org/issue23906
 poplib._MAXLINE = 65536
+
+# Add timeout to IMAP connections
+# HACK https://bugs.python.org/issue38615
+# TODO: clean in Python 3.9
+IMAP4._create_socket = lambda self, timeout=MAIL_TIMEOUT: socket.create_connection((self.host or None, self.port), timeout)
 
 
 class FetchmailServer(models.Model):
@@ -106,15 +112,13 @@ odoo_mailgate: "|/path/to/odoo-mailgate.py --host=localhost -u %(uid)d -p PASSWO
             self._imap_login(connection)
         elif self.server_type == 'pop':
             if self.is_ssl:
-                connection = POP3_SSL(self.server, int(self.port))
+                connection = POP3_SSL(self.server, int(self.port), timeout=MAIL_TIMEOUT)
             else:
-                connection = POP3(self.server, int(self.port))
+                connection = POP3(self.server, int(self.port), timeout=MAIL_TIMEOUT)
             #TODO: use this to remove only unread messages
             #connection.user("recent:"+server.user)
             connection.user(self.user)
             connection.pass_(self.password)
-        # Add timeout on socket
-        connection.sock.settimeout(MAIL_TIMEOUT)
         return connection
 
     def _imap_login(self, connection):


### PR DESCRIPTION
Superseeding #39451 targeted to `13.0`.

Let's hope it gets merged now so users don't stumble upon this bug from version to version :pray: ping @yelizariev 

Original PR message from @Yajo 

The connection socket is initialized before actually creating the connection object. This means that setting the socket timeout after connecting to server could still lead to an endless connection if a timeout is produced while connecting.

I actually faced this in a production server where this dump was extracted after 2 days waiting for the fetchmail to be completed:

```log
# Thread: <Thread(Worker WorkerCron (63) workthread, started daemon 140366248367872)> (db:prod) (uid:n/a) (url:n/a)
File: "/usr/local/lib/python3.5/threading.py", line 882, in _bootstrap
  self._bootstrap_inner()
File: "/usr/local/lib/python3.5/threading.py", line 914, in _bootstrap_inner
  self.run()
File: "/usr/local/lib/python3.5/threading.py", line 862, in run
  self._target(*self._args, **self._kwargs)
File: "/opt/odoo/custom/src/odoo/odoo/service/server.py", line 827, in _runloop
  self.process_work()
File: "/opt/odoo/custom/src/odoo/odoo/service/server.py", line 911, in process_work
  base.ir.ir_cron.ir_cron._acquire_job(db_name)
File: "/opt/odoo/custom/src/odoo/odoo/addons/base/ir/ir_cron.py", line 259, in _acquire_job
  cls._process_jobs(db_name)
File: "/opt/odoo/custom/src/odoo/odoo/addons/base/ir/ir_cron.py", line 223, in _process_jobs
  registry[cls._name]._process_job(job_cr, job, lock_cr)
File: "/opt/odoo/custom/src/odoo/odoo/addons/base/ir/ir_cron.py", line 138, in _process_job
  cron._callback(job['cron_name'], job['ir_actions_server_id'], job['id'])
File: "/opt/odoo/custom/src/odoo/odoo/addons/base/ir/ir_cron.py", line 102, in _callback
  self.env['ir.actions.server'].browse(server_action_id).run()
File: "/opt/odoo/custom/src/odoo/odoo/addons/base/ir/ir_actions.py", line 557, in run
  res = func(action, eval_context=eval_context)
File: "/opt/odoo/auto/addons/website/models/ir_actions.py", line 57, in run_action_code_multi
  res = super(ServerAction, self).run_action_code_multi(action, eval_context)
File: "/opt/odoo/custom/src/odoo/odoo/addons/base/ir/ir_actions.py", line 433, in run_action_code_multi
  safe_eval(action.sudo().code.strip(), eval_context, mode="exec", nocopy=True)  # nocopy allows to return 'action'
File: "/opt/odoo/custom/src/odoo/odoo/tools/safe_eval.py", line 350, in safe_eval
  return unsafe_eval(c, globals_dict, locals_dict)
File: "", line 1, in <module>
File: "/opt/odoo/auto/addons/fetchmail/models/fetchmail.py", line 153, in _fetch_mails
  return self.search([('state', '=', 'done'), ('type', 'in', ['pop', 'imap'])]).fetch_mail()
File: "/opt/odoo/auto/addons/fetchmail/models/fetchmail.py", line 171, in fetch_mail
  imap_server = server.connect()
File: "/opt/odoo/auto/addons/fetchmail/models/fetchmail.py", line 112, in connect
  connection = IMAP4_SSL(self.server, int(self.port))
File: "/usr/local/lib/python3.5/imaplib.py", line 1272, in __init__
  IMAP4.__init__(self, host, port)
File: "/usr/local/lib/python3.5/imaplib.py", line 189, in __init__
  self.open(host, port)
File: "/usr/local/lib/python3.5/imaplib.py", line 1285, in open
  IMAP4.open(self, host, port)
File: "/usr/local/lib/python3.5/imaplib.py", line 286, in open
  self.sock = self._create_socket()
File: "/usr/local/lib/python3.5/imaplib.py", line 1277, in _create_socket
  server_hostname=self.host)
File: "/usr/local/lib/python3.5/ssl.py", line 385, in wrap_socket
  _context=self)
File: "/usr/local/lib/python3.5/ssl.py", line 760, in __init__
  self.do_handshake()
File: "/usr/local/lib/python3.5/ssl.py", line 996, in do_handshake
  self._sslobj.do_handshake()
File: "/usr/local/lib/python3.5/ssl.py", line 641, in do_handshake
  self._sslobj.do_handshake()
```

To fix this problem, I opened https://bugs.python.org/issue38615 (which explains the problem in `imaplib` itself) and I publish here the workaround.

`poplib` supports setting the timeout before initializing the connection, so it's used instead of the workaround.

@Tecnativa TT20364

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
