### PR TITLE
[FIX] account: add onchange warning when setting a contact's company

### DIFF
--- a/addons/account/models/partner.py
+++ b/addons/account/models/partner.py
@@ -489,6 +489,18 @@ class ResPartner(models.Model):
             company = self.env.company
         return {'domain': {'property_account_position_id': [('company_id', 'in', [company.id, False])]}}
 
+    @api.onchange('parent_id')
+    def onchange_parent_id(self):
+        result = super().onchange_parent_id()
+        if self.sudo()._origin.journal_item_count:
+            result['warning'] = {
+                'title': _('Warning'),
+                'message': _('Setting a company for a contact who has some moves '
+                             'could lead to unintended behaviour, you should '
+                             'create a new contact under the company instead. '
+                             'You can use the "Discard" button to abandon this change.')}
+        return result
+
     def can_edit_vat(self):
         ''' Can't edit `vat` if there is (non draft) issued invoices. '''
         can_edit_vat = super(ResPartner, self).can_edit_vat()


### PR DESCRIPTION
If a partner has already some journal items, we display a warning
when setting the partner's company.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
