### PR TITLE
[FIX] mail: reintroduce scroll to top on posting message in chatter

### DIFF
--- a/addons/mail/static/src/components/message_list/message_list.js
+++ b/addons/mail/static/src/components/message_list/message_list.js
@@ -109,6 +109,7 @@ export class MessageList extends Component {
                     // saved position if it exists or scroll to the end
                     this._adjustScrollFromModel();
                     break;
+                case 'message-posted':
                 case 'message-received':
                 case 'messages-loaded':
                 case 'new-messages-loaded':

--- a/addons/mail/static/src/models/composer_view/composer_view.js
+++ b/addons/mail/static/src/models/composer_view/composer_view.js
@@ -327,12 +327,15 @@ function factory(dependencies) {
                 for (const threadView of message.originThread.threadViews) {
                     // Reset auto scroll to be able to see the newly posted message.
                     threadView.update({ hasAutoScrollOnMessageReceived: true });
+                    threadView.addComponentHint('message-posted', { message });
                 }
                 if (chatterThread) {
                     if (this.exists()) {
                         this.delete();
                     }
                     if (chatterThread.exists()) {
+                        // Load new messages to fetch potential new messages from other users (useful due to lack of auto-sync in chatter).
+                        chatterThread.loadNewMessages();
                         chatterThread.refreshFollowers();
                         chatterThread.fetchAndUpdateSuggestedRecipients();
                     }

--- a/addons/mail/static/src/models/thread_cache/thread_cache.js
+++ b/addons/mail/static/src/models/thread_cache/thread_cache.js
@@ -59,7 +59,7 @@ function factory(dependencies) {
             }
             const messageIds = this.fetchedMessages.map(message => message.id);
             const fetchedMessages = this._loadMessages({ minId: Math.max(...messageIds) });
-            if (!fetchedMessages) {
+            if (!fetchedMessages || fetchedMessages.length === 0) {
                 return;
             }
             for (const threadView of this.threadViews) {


### PR DESCRIPTION
The feature was broken in https://github.com/odoo/odoo/commit/80d74e7ee0eab83dc5100e0776df09d04b882fec#diff-14904a101d1c0589d79515df7065aeeaaf0d4cdeaff9a4748ff0331c481efe8eL275
where `loadNewMessages` was mistakenly removed.

But this call is useful to make sure newly posted messages (from other users)
are fetched, as well as having the side-effect to scroll to the newly posted
message of the current user in particular.