### PR TITLE
[FIX] l10n_it_edi: traceback when line has 0 qty (anyway wrong)

### DIFF
--- a/addons/l10n_it_edi/data/invoice_it_template.xml
+++ b/addons/l10n_it_edi/data/invoice_it_template.xml
@@ -20,7 +20,7 @@
                 </Descrizione>
                 <Quantita t-esc="format_numbers(line.quantity)"/>
                 <UnitaMisura t-if="line.product_uom_id.category_id != env.ref('uom.product_uom_categ_unit')" t-esc="line.product_uom_id.name"/>
-                <PrezzoUnitario t-esc="'%.06f' % (line.price_subtotal / (( 1 - (line.discount or 0.0) / 100.0) * line.quantity) if line.discount != 100.0 else line.price_unit)"/>
+                <PrezzoUnitario t-esc="'%.06f' % (line.price_subtotal / (( 1 - (line.discount or 0.0) / 100.0) * line.quantity) if line.quantity and line.discount != 100.0 else line.price_unit)"/>
                 <ScontoMaggiorazione t-if="line.discount != 0">
                     <!-- [2.2.1.10] -->
                     <Tipo t-esc="discount_type(line.discount)"/>


### PR DESCRIPTION
In case there is an AML with 0 qty, the generation of the FatturaPA e-invoice
tracebacked. Even if it's a functional error on the invoice, this also impeded
the EDI cron to run, and this is solved by avoiding the case in the
computation.