### PR TITLE
[FIX] account_edi: don’t remove edi attachment when cancelling invoice

### DIFF
--- a/addons/account_edi/models/account_edi_document.py
+++ b/addons/account_edi/models/account_edi_document.py
@@ -181,16 +181,13 @@ class AccountEdiDocument(models.Model):
 
         def _postprocess_cancel_edi_results(documents, edi_result):
             invoice_ids_to_cancel = set()  # Avoid duplicates
-            attachments_to_unlink = self.env['ir.attachment']
             for document in documents:
                 move = document.move_id
                 move_result = edi_result.get(move, {})
                 if move_result.get('success') is True:
-                    old_attachment = document.attachment_id
                     document.write({
                         'state': 'cancelled',
                         'error': False,
-                        'attachment_id': False,
                         'blocking_level': False,
                     })
 
@@ -198,9 +195,6 @@ class AccountEdiDocument(models.Model):
                         # The user requested a cancellation of the EDI and it has been approved. Then, the invoice
                         # can be safely cancelled.
                         invoice_ids_to_cancel.add(move.id)
-
-                    if not old_attachment.res_model or not old_attachment.res_id:
-                        attachments_to_unlink |= old_attachment
 
                 elif not move_result.get('success'):
                     document.write({
@@ -212,10 +206,6 @@ class AccountEdiDocument(models.Model):
                 invoices = self.env['account.move'].browse(list(invoice_ids_to_cancel))
                 invoices.button_draft()
                 invoices.button_cancel()
-
-            # Attachments that are not explicitly linked to a business model could be removed because they are not
-            # supposed to have any traceability from the user.
-            attachments_to_unlink.unlink()
 
         test_mode = self._context.get('edi_test_mode', False)
 


### PR DESCRIPTION
#### The issue
At the moment, when we successfully request the cancellation of an
invoice in Mexico, the cfdi attachment is deleted.
However, several stored computed fields depend on this attachment,
notably the Fiscal Folio uuid.  Without this uuid, we can't query
the invoice’s status from the SAT. As a result, the invoice’s
status is ‘Not Found’ when it really should be ‘Canceled’.

See this video by @vbe-odoo demonstrating the problem functionally:
https://us02web.zoom.us/rec/play/7kRPfbcM1YixbiezgtHV0C9KAP6AwAmEzf05WtBJO2j3cLMpvSXznOad0qT2u0NoJsisH5ICFLfcxrNN.NjyNJHvBxfK2TNf3?continueMode=true&_x_zm_rtaid=xzBnPaTGTZiTv53zobKqqg.1646836564724.d211a63c07c388cdef9dfb832d780831&_x_zm_rhtaid=552
password: ?wgK1c$N

See this explanation of where the issue occurs in the source code:
https://drive.google.com/file/d/1z8GhsSk6nphmhB46C0wiDHMZjV7_QSZ8/view?usp=sharing

#### The solution
Don’t delete the attachment when the invoice is successfully canceled.

#### Does it work?

Yes. (See this video where I do the testing):
https://drive.google.com/file/d/1IIV7_kntYaUlXF5IarE5FEJaRwTW83qq/view?usp=sharing

#### Does it break any other EDIs?

No.
- only Colombia and Peru use the cancellation workflow
- in Colombia, the attachment isn’t used to populate fields
- in Peru, the only time the attachment is used is in `_l10n_pe_edi_get_extra_report_values` (see https://github.com/odoo/enterprise/blob/28554d66478a8d884e618e35406c1ad9ac2dd646/l10n_pe_edi/models/account_move.py#L213-L214 ) which is used to create the invoice PDF. It’s not a problem if the values are correctly populated for a cancelled invoice.

See this video:
https://drive.google.com/file/d/1GUoQ-4HAVf1fNRWlNNkRxYWP538Jc230/view?usp=sharing

#### Related support tickets

opw-2790491 opw-2716731
