### PR TITLE
[IMP] web, base, http: Add X-Accel-Redirect to content routes

### DIFF
--- a/odoo/addons/test_http/data.xml
+++ b/odoo/addons/test_http/data.xml
@@ -1,5 +1,14 @@
 <odoo>
     <data>
+        <record id="one_pixel_png" model="ir.attachment">
+            <field name="name">one_pixel.png</field>
+            <field name="type">binary</field>
+            <field name="url">/test_http/static/src/img/one_pixel.png</field>
+            <field name="datas">iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVQIW2Own7D9PwAFHgKGNgmXYwAAAABJRU5ErkJggg==</field>
+            <field name="public">True</field>
+        </record>
+
+
         <record id="milky_way" model="test_http.galaxy">
             <field name="name">Milky Way</field>
         </record>

--- a/odoo/http.py
+++ b/odoo/http.py
@@ -422,10 +422,12 @@ def set_safe_image_headers(headers, content):
     file is of an unsafe type, it is not interpreted as that type if the
     `Content-type` header was already set to a different mimetype
     """
+    xaccel_header = [header for header in headers if 'X-Accel-Redirect' in header]
     headers = werkzeug.datastructures.Headers(headers)
-    content_type = guess_mimetype(content)
-    if content_type in SAFE_IMAGE_MIMETYPES:
-        headers['Content-Type'] = content_type
+    if not xaccel_header:
+        content_type = guess_mimetype(content)
+        if content_type in SAFE_IMAGE_MIMETYPES:
+            headers['Content-Type'] = content_type
     headers['X-Content-Type-Options'] = 'nosniff'
     headers['Content-Length'] = len(content)
     return list(headers)

--- a/odoo/tools/config.py
+++ b/odoo/tools/config.py
@@ -307,6 +307,10 @@ class configmanager(object):
                          help="Try to enable the unaccent extension when creating new databases.")
         group.add_option("--geoip-db", dest="geoip_database", my_default='/usr/share/GeoIP/GeoLite2-City.mmdb',
                          help="Absolute path to the GeoIP database file.")
+        group.add_option("--xaccel", dest="xaccel", my_default=False,
+                         help="Enable X-Accel-Redirect content serving from NGINX instead of from Odoo workers."
+                              "Using X-Accel requires security precautions, see X-Accel documentation.")
+
         parser.add_option_group(group)
 
         if os.name == 'posix':
@@ -446,7 +450,7 @@ class configmanager(object):
                 'db_maxconn', 'import_partial', 'addons_path', 'upgrade_path',
                 'syslog', 'without_demo', 'screencasts', 'screenshots',
                 'dbfilter', 'log_level', 'log_db',
-                'log_db_level', 'geoip_database', 'dev_mode', 'shell_interface'
+                'log_db_level', 'geoip_database', 'dev_mode', 'shell_interface', 'xaccel'
         ]
 
         for arg in keys:


### PR DESCRIPTION
As per FP and AL's suggestion, X-Accel-Redirect headers can improve
media serving performance significantly.

This commit implements an --xaccel option for the Odoo CLI, which,
when enabled, does not use the Odoo server process to serve binary
content. Instead, it ignores the loading of the content and serves
a response with an X-Accel-Redirect header that is intercepted by
NGINX. NGINX then uses a configured location to serve the binary
data directly from the location. This is done by adding something
similar to this in the NGINX configuration file:
location /xaccel
{
internal;
alias /home/odoo/.local/share/Odoo/filestore/my_odoo_database;
}

task-2801675