### PR TITLE
[FIX] google_calendar : fix default reminder

### DIFF
--- a/addons/google_calendar/models/calendar.py
+++ b/addons/google_calendar/models/calendar.py
@@ -57,7 +57,13 @@ class Meeting(models.Model):
         if google_event.is_cancelled():
             return {'active': False}
 
-        alarm_commands = self._odoo_reminders_commands(google_event.reminders.get('overrides') or default_reminders)
+        # default_reminders is never () it is set to google's default reminder (30 min before)
+        # we need to check 'useDefault' for the event to determine if we have to use google's
+        # default reminder or not
+        reminder_command = google_event.reminders.get('overrides')
+        if not reminder_command:
+            reminder_command = google_event.reminders.get('useDefault') and default_reminders or ()
+        alarm_commands = self._odoo_reminders_commands(reminder_command)
         attendee_commands, partner_commands = self._odoo_attendee_commands(google_event)
         values = {
             'name': google_event.summary or _("(No title)"),


### PR DESCRIPTION
To reproduce
============

- Sync Google Calendar to Odoo
- Create an event in GCaledar without setting a notification
In Odoo Notification reminder is set

Purpose
=======

we use default reminder given by Google which is notification 30 minutes before even if the event
doesn't have a reminder.

Specification
=============

To solve the issue we use empty reminder instead of the default given by google if no reminder is set.

opw-2792364
