### PR TITLE
[FIX] base: config setting search contains '&amp;'

### DIFF
--- a/odoo/addons/base/static/src/js/res_config_settings.js
+++ b/odoo/addons/base/static/src/js/res_config_settings.js
@@ -320,17 +320,20 @@ var BaseSettingRenderer = FormRenderer.extend({
             module.settingView.find('h2').addClass('o_hidden');
             module.settingView.find('.settingSearchHeader').addClass('o_hidden');
             module.settingView.find('.o_settings_container').removeClass('mt16');
-            var resultSetting = module.settingView.find(".o_form_label:containsTextLike('" + self.searchText + "')");
-            if (resultSetting.length > 0) {
-                resultSetting.each(function () {
-                    var settingBox = $(this).closest('.o_setting_box');
+
+            const upperCasedSearchText = self.searchText.toUpperCase();
+            const resultSetting = module.settingView.find(".o_form_label")
+                .filter((_, e) => e.textContent.toUpperCase().includes(upperCasedSearchText));
+            if (resultSetting.length) {
+                for (let result of resultSetting) {
+                    const settingBox = $(result).closest('.o_setting_box');
                     if (!settingBox.hasClass('o_invisible_modifier')) {
                         settingBox.removeClass('o_hidden');
-                        $(this).html(self._wordHighlighter($(this).html(), self.searchText));
+                        self._wordHighlighter(result, upperCasedSearchText);
                     } else {
                         self.inVisibleCount++;
                     }
-                });
+                }
                 if (self.inVisibleCount !== resultSetting.length) {
                     module.settingView.find('.settingSearchHeader').removeClass('o_hidden');
                     module.settingView.removeClass('o_hidden');
@@ -344,22 +347,23 @@ var BaseSettingRenderer = FormRenderer.extend({
             this._resetSearch();
         }
     },
+
     /**
      * highlight search word
      *
      * @private
-     * @param {string} text
-     * @param {string} word
+     * @param {HTMLElement} node
+     * @param {string} upperCasedSearchText
      */
-    _wordHighlighter: function (text, word) {
-        if (text.indexOf('highlighter') !== -1) {
-            text = text.replace('<span class="highlighter">', "");
-            text = text.replace("</span>", "");
-        }
-        var match = text.search(new RegExp(word, "i"));
-        word = text.substring(match, match + word.length);
-        var highlightedWord = "<span class='highlighter'>" + word + '</span>';
-        return text.replace(word, highlightedWord);
+    _wordHighlighter: function (node, upperCasedSearchText) {
+        const text = node.textContent;
+        const startIndex = text.toUpperCase().indexOf(upperCasedSearchText);
+        const endIndex = startIndex + upperCasedSearchText.length;
+        $(node).empty().append(
+            document.createTextNode(text.substring(0, startIndex)),
+            $('<span class="highlighter">').text(text.substring(startIndex, endIndex)),
+            document.createTextNode(text.substring(endIndex))
+        );
     },
 });
 

--- a/odoo/addons/base/static/src/js/res_config_settings.js
+++ b/odoo/addons/base/static/src/js/res_config_settings.js
@@ -322,10 +322,10 @@ var BaseSettingRenderer = FormRenderer.extend({
             module.settingView.find('.o_settings_container').removeClass('mt16');
 
             const upperCasedSearchText = self.searchText.toUpperCase();
-            const resultSetting = module.settingView.find(".o_form_label")
-                .filter((_, e) => e.textContent.toUpperCase().includes(upperCasedSearchText));
-            if (resultSetting.length) {
-                for (let result of resultSetting) {
+            const [matches, others] = _.partition(module.settingView.find(".o_form_label"),
+                (e) => e.textContent.toUpperCase().includes(upperCasedSearchText));
+            if (matches.length) {
+                for (let result of matches) {
                     const settingBox = $(result).closest('.o_setting_box');
                     if (!settingBox.hasClass('o_invisible_modifier')) {
                         settingBox.removeClass('o_hidden');
@@ -334,13 +334,14 @@ var BaseSettingRenderer = FormRenderer.extend({
                         self.inVisibleCount++;
                     }
                 }
-                if (self.inVisibleCount !== resultSetting.length) {
+                if (self.inVisibleCount !== matches.length) {
                     module.settingView.find('.settingSearchHeader').removeClass('o_hidden');
                     module.settingView.removeClass('o_hidden');
                 }
             } else {
                 ++self.count;
             }
+            others.filter(e => e.firstElementChild).forEach(e => self._removeHighlight(e));
         });
         this.count === _.size(this.modules) ? this.$('.notFound').removeClass('o_hidden') : this.$('.notFound').addClass('o_hidden');
         if (this.searchText.length === 0) {
@@ -364,6 +365,14 @@ var BaseSettingRenderer = FormRenderer.extend({
             $('<span class="highlighter">').text(text.substring(startIndex, endIndex)),
             document.createTextNode(text.substring(endIndex))
         );
+    },
+
+    /**
+     * @param {HTMLElement} node
+     * @private
+     */
+    _removeHighlight: function(node) {
+        node.textContent = node.textContent;
     },
 });
 


### PR DESCRIPTION
**Steps to follow**

  - Go to Settings
  - Type 'Import' in the search bar
  -> 'Import &amp; Export' is displayed

**Cause of the issue**

  `_wordHighlighter` works on the HTML as a string

**Solution**

  - Use innerText to get the correct text value
  - Replace the content of the highlighted element by
    * a textnode with the text before the matched substring
    * a `span.highlighter` with the search word
    * a textnode with the text after the matcher substring

**Other issues**

  A string concatanated css rule was used to filter the matching elements
  This could cause an invalid selector
  An error can be triggered by simply entering a closing parenthesis in the search field
  -> Filter nodes by their innerText instead.

opw-2778304