### PR TITLE
[FIX] survey: refined the IF conditions in the controller

### DIFF
--- a/addons/survey/controllers/main.py
+++ b/addons/survey/controllers/main.py
@@ -84,7 +84,7 @@ class Survey(http.Controller):
             return 'survey_void'
 
         if answer_sudo and check_partner:
-            if request.env.user._is_public() and answer_sudo.partner_id:
+            if request.env.user._is_public() and answer_sudo.partner_id and not answer_token:
                 # answers from public user should not have any partner_id; this indicates probably a cookie issue
                 return 'answer_wrong_user'
             if not request.env.user._is_public() and answer_sudo.partner_id != request.env.user.partner_id:


### PR DESCRIPTION
Reproduction:
1. Create a survey or use an existing one
2. Share it via mail
3. Try to open a link provided in the mail

Reason: the conditions for public users in _check_validity() are not
refined enough. The link in the email has answer_token, while the
general Survey URL is a direct link to the survey. However, the
condition ”request.env.user._is_public() ” is true for both cases. This
leads to redirection to the homepage for survey links in the email.
Tested locally that sending two different recipients same survey by
email will assign two different answer tokens

Fix: add the answer_token to the condition. If there is an answer_token
part, it means this link is specific for a partner, and no user check is
needed. Because ideally, only this partner received the link. If there’s
a leakage, it’s probably his/her problem

Original commit: https://github.com/odoo/odoo/commit/3c71f66bb541fcf31f31e75b60f7825d26109bc4
First fix: https://github.com/odoo/odoo/commit/cffc732e58c14541abcf06bb0d58add224396b7c

opw-2795134


I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
