### PR TITLE
[FIX] account: allow invoicing internal user/customer

### DIFF
--- a/addons/account/models/account_payment.py
+++ b/addons/account/models/account_payment.py
@@ -395,10 +395,12 @@ class AccountPayment(models.Model):
         for pay in self:
             pay.partner_bank_id = pay.available_partner_bank_ids[:1]._origin
 
-    @api.depends('partner_id', 'destination_account_id', 'journal_id')
+    @api.depends('partner_id', 'journal_id', 'destination_journal_id')
     def _compute_is_internal_transfer(self):
         for payment in self:
-            payment.is_internal_transfer = payment.partner_id and payment.partner_id == payment.journal_id.company_id.partner_id
+            payment.is_internal_transfer = payment.partner_id \
+                                           and payment.partner_id == payment.journal_id.company_id.partner_id \
+                                           and payment.destination_journal_id
 
     @api.depends('payment_type', 'journal_id')
     def _compute_payment_method_line_id(self):


### PR DESCRIPTION
Steps to reproduce:
1. Install sales
2. Change Mitchell Admin contacts so that he is set in the "YourCompany" company
3. Create a quotation with Michell Admin as the customer
4. Put any item and confirm the quote
5. Receive the product and create the invoice
6. Go to the invoice, confirm the payment and register it

Issue:
-> Error with the journal id

Cause:
The payment is considered as internal payment and in https://github.com/odoo/odoo/blob/6d129783b53115927f664499207c8c800d40bca2/addons/account/models/account_payment.py#L886-L895
There is no destination_journal which violates not-null constraint

Solution:
Be sure that there is a destination journal when `is_internal_transfer` is computed.

opw-2753819
