### PR TITLE
[IMP] base: add server action id in test_expr

### DIFF
--- a/odoo/addons/base/models/ir_actions.py
+++ b/odoo/addons/base/models/ir_actions.py
@@ -503,7 +503,7 @@ class IrActionsServer(models.Model):
         return True
 
     def _run_action_code_multi(self, eval_context):
-        safe_eval(self.code.strip(), eval_context, mode="exec", nocopy=True)  # nocopy allows to return 'action'
+        safe_eval(self.code.strip(), eval_context, mode="exec", nocopy=True, filename=str(self))  # nocopy allows to return 'action'
         return eval_context.get('action')
 
     def _run_action_multi(self, eval_context=None):

--- a/odoo/tools/safe_eval.py
+++ b/odoo/tools/safe_eval.py
@@ -169,19 +169,23 @@ def assert_valid_codeobj(allowed_codes, code_obj, expr):
         if isinstance(const, CodeType):
             assert_valid_codeobj(allowed_codes, const, 'lambda')
 
-def test_expr(expr, allowed_codes, mode="eval"):
-    """test_expr(expression, allowed_codes[, mode]) -> code_object
+def test_expr(expr, allowed_codes, mode="eval", filename=None):
+    """test_expr(expression, allowed_codes[, mode[, filename]]) -> code_object
 
     Test that the expression contains only the allowed opcodes.
     If the expression is valid and contains only allowed codes,
     return the compiled code object.
     Otherwise raise a ValueError, a Syntax Error or TypeError accordingly.
+
+    :param filename: optional pseudo-filename for the compiled expression,
+                 displayed for example in traceback frames
+    :type filename: string
     """
     try:
         if mode == 'eval':
             # eval() does not like leading/trailing whitespace
             expr = expr.strip()
-        code_obj = compile(expr, "", mode)
+        code_obj = compile(expr, filename or "", mode)
     except (SyntaxError, TypeError, ValueError):
         raise
     except Exception as e:
@@ -280,7 +284,7 @@ _BUILTINS = {
     'zip': zip,
     'Exception': Exception,
 }
-def safe_eval(expr, globals_dict=None, locals_dict=None, mode="eval", nocopy=False, locals_builtins=False):
+def safe_eval(expr, globals_dict=None, locals_dict=None, mode="eval", nocopy=False, locals_builtins=False, filename=None):
     """safe_eval(expression[, globals[, locals[, mode[, nocopy]]]]) -> result
 
     System-restricted Python expression evaluation
@@ -292,6 +296,9 @@ def safe_eval(expr, globals_dict=None, locals_dict=None, mode="eval", nocopy=Fal
     This can be used to e.g. evaluate
     an OpenERP domain expression from an untrusted source.
 
+    :param filename: optional pseudo-filename for the compiled expression,
+                     displayed for example in traceback frames
+    :type filename: string
     :throws TypeError: If the expression provided is a code object
     :throws SyntaxError: If the expression provided is not valid Python
     :throws NameError: If the expression provided accesses forbidden names
@@ -325,7 +332,7 @@ def safe_eval(expr, globals_dict=None, locals_dict=None, mode="eval", nocopy=Fal
         if locals_dict is None:
             locals_dict = {}
         locals_dict.update(_BUILTINS)
-    c = test_expr(expr, _SAFE_OPCODES, mode=mode)
+    c = test_expr(expr, _SAFE_OPCODES, mode=mode, filename=filename)
     try:
         return unsafe_eval(c, globals_dict, locals_dict)
     except odoo.exceptions.UserError:


### PR DESCRIPTION
When we had a traceback because of a server action, we used to have no
information in the traceback about which server action it was.

With this commit, we will be able to see the server action id in the
traceback. This will help the investigation as we will be able to check
the server action that causes the issue.

Example:

Previous traceback for a server action that executes bad python code:

```
Traceback (most recent call last):
  File "/home/odoo/src/version/15.0/odoo/odoo/tools/safe_eval.py", line 330, in safe_eval
    return unsafe_eval(c, globals_dict, locals_dict)
  File "", line 1, in <module>
NameError: name 'i' is not defined
```

Now:

```
Traceback (most recent call last):
  File "/home/odoo/src/version/15.0/odoo/odoo/tools/safe_eval.py", line 330, in safe_eval
    return unsafe_eval(c, globals_dict, locals_dict)
  File "ir.actions.server(152,)", line 1, in <module>
NameError: name 'i' is not defined
```

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
