### PR TITLE
[FIX] website_sale_coupon_delivery : update amount with free delivery

### DIFF
--- a/addons/website_sale_coupon_delivery/controllers/main.py
+++ b/addons/website_sale_coupon_delivery/controllers/main.py
@@ -27,6 +27,7 @@ class WebsiteSaleCouponDelivery(WebsiteSaleDelivery):
                 'new_amount_tax': Monetary.value_to_html(order.amount_tax, {'display_currency': currency}),
                 'new_amount_total': Monetary.value_to_html(order.amount_total, {'display_currency': currency}),
                 'new_amount_order_discounted': Monetary.value_to_html(order.reward_amount - amount_free_shipping, {'display_currency': currency}),
+                'new_amount_total_raw': order.amount_total,
             })
         return result
 


### PR DESCRIPTION
Steps:
Create a promotion program which applies to all sales and gives free shipping.
Ensure there is a free delivery method and a normal delivery method
with price based on formula (that resolves to non-zero cost).
Sort the normal delivery method to appear before the free method (easier to test).
Enable Stripe in test mode with test credentials.
Follow eCommerce flow up to payment with Stripe,
and switch from normal delivery method to free delivery method. Then pay with Stripe.

Issue :
There is a different cost in Stripe than what the order is for.

Cause :
The amount set in the transaction is the 'new_amount_total_raw'.
Its value is not updated when changing the delivery method.

Fix :
Put it in the result of update_eshop_carrier.

Note :
This is following what was done at https://github.com/odoo-dev/odoo/commit/349c3710ae42617cb7a195b3eb83532778be8384,
which was done to fix https://github.com/odoo-dev/odoo/commit/573ed74c121c1572b3fab6f9553ed7f93f7b3f99.

opw-2794156


--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
