### PR TITLE
[FIX] product: Wrong variants filtering

### DIFF
--- a/addons/product/i18n/product.pot
+++ b/addons/product/i18n/product.pot
@@ -2282,6 +2282,12 @@ msgid "The product template is archived so no combination is possible."
 msgstr ""
 
 #. module: product
+#: code:addons/product/models/product.py:0
+#, python-format
+msgid "The product variant must be a variant of the product template."
+msgstr ""
+
+#. module: product
 #: model:ir.model.fields,help:product.field_product_supplierinfo__min_qty
 msgid ""
 "The quantity to purchase from this vendor to benefit from the price, "

--- a/addons/product/models/product.py
+++ b/addons/product/models/product.py
@@ -777,3 +777,9 @@ class SupplierInfo(models.Model):
             'label': _('Import Template for Vendor Pricelists'),
             'template': '/product/static/xls/product_supplierinfo.xls'
         }]
+
+    @api.constrains('product_id', 'product_tmpl_id')
+    def _check_product_variant(self):
+        for supplier in self:
+            if supplier.product_id and supplier.product_tmpl_id and supplier.product_id.product_tmpl_id != supplier.product_tmpl_id:
+                raise ValidationError(_('The product variant must be a variant of the product template.'))

--- a/addons/product/views/product_views.xml
+++ b/addons/product/views/product_views.xml
@@ -660,7 +660,9 @@
                     <field name="name" readonly="1"/>
                     <field name="product_id" readonly="1" optional="hide"
                         invisible="context.get('product_template_invisible_variant', False)"
-                        groups="product.group_product_variant"/>
+                        groups="product.group_product_variant"
+                        domain="[('product_tmpl_id', '=?', context.get('default_product_tmpl_id', False))]"
+                        options="{'no_quick_create': True, 'no_create_edit' : True}"/>
                     <field name="product_tmpl_id" string="Product" readonly="1"
                         invisible="context.get('visible_product_tmpl_id', True)"/>
                     <field name="product_name" optional="hide"/>


### PR DESCRIPTION
Supplier pricelists doesn't restrict the choice of the variant to the
variants of the current product template (in the view).

To reproduce the issue:
1. Create a product with different variant
2. Install 'purchase' and go to the 'purchase' page on a product form.
3. Create a new Supplier Pricelist (a new line).
4. In the 'product_variant' the user can select any product of the company.
We should only see the variants of the current product.

Solution: Since 14.0, the Supplier Pricelist can be edited directly from the
tree view (while in 13.0 a form was used). In this tree view, there are no filtering/domain
on the 'product_tmpl_id'. This filtering is however present in the form in 13.0
which is why the problem is present only as from 14.0. Similarly to the 13.0 form,
the 'product_variant' field doesn't allow the quick creation.

opw-2792060