### PR TITLE
[FIX] web: action service: concurrency issue

### DIFF
--- a/addons/web/static/src/webclient/actions/action_service.js
+++ b/addons/web/static/src/webclient/actions/action_service.js
@@ -1219,6 +1219,7 @@ function makeActionManager(env) {
      * @returns {Promise<Number>}
      */
     async function switchView(viewType, props = {}) {
+        await keepLast.add(Promise.resolve());
         const controller = controllerStack[controllerStack.length - 1];
         const view = _getView(viewType);
         if (!view) {
@@ -1278,6 +1279,7 @@ function makeActionManager(env) {
      * @param {string} jsId
      */
     async function restore(jsId) {
+        await keepLast.add(Promise.resolve());
         let index;
         if (!jsId) {
             index = controllerStack.length - 2;

--- a/addons/web/static/tests/webclient/actions/concurrency_tests.js
+++ b/addons/web/static/tests/webclient/actions/concurrency_tests.js
@@ -506,6 +506,84 @@ QUnit.module("ActionManager", (hooks) => {
         }
     );
 
+    QUnit.test("restoring a controller when doing an action -- load_action slow", async function (assert) {
+        assert.expect(14);
+        let def;
+        const mockRPC = async (route, args) => {
+            assert.step((args && args.method) || route);
+            if (route === "/web/action/load") {
+                return Promise.resolve(def);
+            }
+        };
+        const webClient = await createWebClient({ serverData, mockRPC });
+        await doAction(webClient, 3);
+        assert.containsOnce(webClient, ".o_list_view");
+        await click(webClient.el.querySelector(".o_list_view .o_data_cell"));
+        await legacyExtraNextTick();
+        assert.containsOnce(webClient, ".o_form_view");
+        def = makeDeferred();
+        doAction(webClient, 4, { clearBreadcrumbs: true });
+        await nextTick();
+        await legacyExtraNextTick();
+        assert.containsOnce(webClient, ".o_form_view", "should still contain the form view");
+        await click(webClient.el.querySelector(".o_control_panel .breadcrumb-item a"));
+        def.resolve();
+        await nextTick();
+        await legacyExtraNextTick();
+        assert.containsOnce(webClient, ".o_list_view");
+        assert.strictEqual(
+            webClient.el.querySelector(".o_control_panel .breadcrumb-item").textContent,
+            "Partners"
+        );
+        assert.containsNone(webClient, ".o_form_view");
+        assert.verifySteps([
+            "/web/webclient/load_menus",
+            "/web/action/load",
+            "load_views",
+            "/web/dataset/search_read",
+            "read",
+            "/web/action/load",
+            "/web/dataset/search_read",
+        ]);
+    });
+
+    QUnit.test("switching when doing an action -- load_action slow", async function (assert) {
+        assert.expect(12);
+        let def;
+        const mockRPC = async (route, args) => {
+            assert.step((args && args.method) || route);
+            if (route === "/web/action/load") {
+                return Promise.resolve(def);
+            }
+        };
+        const webClient = await createWebClient({ serverData, mockRPC });
+        await doAction(webClient, 3);
+        assert.containsOnce(webClient, ".o_list_view");
+        def = makeDeferred();
+        doAction(webClient, 4, { clearBreadcrumbs: true });
+        await nextTick();
+        await legacyExtraNextTick();
+        assert.containsOnce(webClient, ".o_list_view", "should still contain the list view");
+        await cpHelpers.switchView(webClient, "kanban");
+        def.resolve();
+        await nextTick();
+        await legacyExtraNextTick();
+        assert.containsOnce(webClient, ".o_kanban_view");
+        assert.strictEqual(
+            webClient.el.querySelector(".o_control_panel .breadcrumb-item").textContent,
+            "Partners"
+        );
+        assert.containsNone(webClient, ".o_list_view");
+        assert.verifySteps([
+            "/web/webclient/load_menus",
+            "/web/action/load",
+            "load_views",
+            "/web/dataset/search_read",
+            "/web/action/load",
+            "/web/dataset/search_read",
+        ]);
+    });
+
     QUnit.test("switching when doing an action -- load_views slow", async function (assert) {
         assert.expect(13);
         let def;


### PR DESCRIPTION
There is a concurrency issue in the action service:
 1) be in an action with several views
 2) click on a menu to execute another action
  -> [calls the route "/web/action/load", and it takes a while]
 3) meanwhile, click on another view in the view switcher

If the call to "/web/action/load" is long enough, it may happen
that the view requested in step 3 is briefly shown before the
action associated with the menu clicked in step 2.

In this scenario, the action of step 2 should never be displayed,
because the user requested something else afterwards (in this
case a switch view).

One can produce a similar issue when restoring a previous action
of the breadcrumbs instead of switching view.

This commit fixes those two issues by registering a resolved
promise in the keepLast (concurrency utils), s.t. it "cancels"
the potential current operation (in this case, the call to
"/web/load/action").
