### PR TITLE
Update server.py

### DIFF
--- a/odoo/service/server.py
+++ b/odoo/service/server.py
@@ -1205,7 +1205,7 @@ Maybe you forgot to add those addons in your addons_path configuration."""
 def _reexec(updated_modules=None):
     """reexecute openerp-server process with (nearly) the same arguments"""
     if odoo.tools.osutil.is_running_as_nt_service():
-        subprocess.call('net stop {0} && net start {0}'.format(nt_service_name), shell=True)
+        subprocess.call(['net stop {0} && net start {0}'.format(nt_service_name)])
     exe = os.path.basename(sys.executable)
     args = stripped_sys_argv()
     if updated_modules:


### PR DESCRIPTION
**Hi vulnerability**

Description of the issue/feature this PR addresses:

use of "shell=True" is insecure in "subprocess" module
This linter searches for use of the subprocess module with shell=True. This module commonly allows for arbitrary code execution bugs when combined with user input.Unlike some other popen functions, this implementation will never implicitly call a system shell. This means that all characters, including shell metacharacters, can safely be passed to child processes. If the shell is invoked explicitly, via shell=True, it is the application's responsibility to ensure that all whitespace and metacharacters are quoted appropriately to avoid shell injection vulnerabilities.

When using shell=True, the shlex.quote() function can be used to properly escape whitespace and shell metacharacters in strings that are going to be used to construct shell commands.

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
