### PR TITLE
[FIX] web_editor: prevent opening linktool on uneditable links

### DIFF
--- a/addons/web_editor/static/src/js/wysiwyg/wysiwyg.js
+++ b/addons/web_editor/static/src/js/wysiwyg/wysiwyg.js
@@ -276,6 +276,7 @@ const Wysiwyg = Widget.extend({
 
             if ($target.is(this.customizableLinksSelector)
                     && $target.is('a')
+                    && $target[0].isContentEditable
                     && !$target.attr('data-oe-model')
                     && !$target.find('> [data-oe-model]').length
                     && !$target[0].closest('.o_extra_menu_items')) {


### PR DESCRIPTION
Before this commit
When trying to open the linktool on link that are not
`isContentEditable`, the linktool was initialized and not
showed in the sidebar.

After this commit
As it does not make sense to edit a link that is not editable,
prevent the linktool from being initialized in the first place.

task-2802592



--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
