### PR TITLE
[FIX][14.0] mail_thread: fix error unlink mail.message

### DIFF
--- a/addons/mail/models/mail_thread.py
+++ b/addons/mail/models/mail_thread.py
@@ -333,7 +333,7 @@ class MailThread(models.AbstractModel):
             return True
         # discard pending tracking
         self._discard_tracking()
-        self.env['mail.message'].search([('model', '=', self._name), ('res_id', 'in', self.ids)]).sudo().unlink()
+        self.env['mail.message'].sudo().search([('model', '=', self._name), ('res_id', 'in', self.ids)]).unlink()
         res = super(MailThread, self).unlink()
         self.env['mail.followers'].sudo().search(
             [('res_model', '=', self._name), ('res_id', 'in', self.ids)]


### PR DESCRIPTION
Description of the issue/feature this PR addresses:


https://user-images.githubusercontent.com/55737816/159888248-ef011441-9c15-4337-9275-8b4315c7b480.mov


Current behavior before PR:
If a mail.message was created by odoo boot, search can't found that

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
