### PR TITLE
[IMP] account: improve display of invoices/bills in list view

### DIFF
--- a/addons/account/models/account_move.py
+++ b/addons/account/models/account_move.py
@@ -1430,7 +1430,7 @@ class AccountMove(models.Model):
                         total_tax_currency += line.amount_currency
                         total += line.balance
                         total_currency += line.amount_currency
-                    elif line.account_id.user_type_id.type in ('receivable', 'payable'):
+                    elif line.account_id.user_type_id.type in ('receivable', 'payable') and move.state not in ('draft', 'cancel'):
                         # Residual amount.
                         total_to_pay += line.balance
                         total_residual += line.amount_residual

--- a/addons/account/views/account_move_views.xml
+++ b/addons/account/views/account_move_views.xml
@@ -420,6 +420,7 @@
                 <tree string="Invoices"
                       js_class="account_tree"
                       decoration-info="state == 'draft'"
+                      decoration-muted="state == 'cancel'"
                       sample="1">
                     <header>
                         <button name="action_register_payment" type="object" string="Register Payment"

--- a/addons/stock_account/tests/test_account_move.py
+++ b/addons/stock_account/tests/test_account_move.py
@@ -57,7 +57,7 @@ class TestAccountMove(AccountTestInvoicingCommon):
         invoice = move_form.save()
 
         self.assertAlmostEqual(self.product_A.lst_price * rate, invoice.amount_total)
-        self.assertAlmostEqual(self.product_A.lst_price * rate, invoice.amount_residual)
+        self.assertAlmostEqual(0, invoice.amount_residual)
         self.assertEqual(len(invoice.mapped("line_ids")), 2)
         self.assertEqual(len(invoice.mapped("line_ids.currency_id")), 1)
 
@@ -82,7 +82,7 @@ class TestAccountMove(AccountTestInvoicingCommon):
         invoice = move_form.save()
 
         self.assertAlmostEqual(self.product_A.lst_price * rate, invoice.amount_total)
-        self.assertAlmostEqual(self.product_A.lst_price * rate, invoice.amount_residual)
+        self.assertAlmostEqual(0, invoice.amount_residual)
         self.assertEqual(len(invoice.mapped("line_ids")), 2)
         self.assertEqual(len(invoice.mapped("line_ids.currency_id")), 1)
 
@@ -107,7 +107,7 @@ class TestAccountMove(AccountTestInvoicingCommon):
         invoice = move_form.save()
 
         self.assertAlmostEqual(self.product_A.lst_price * rate, invoice.amount_total)
-        self.assertAlmostEqual(self.product_A.lst_price * rate, invoice.amount_residual)
+        self.assertAlmostEqual(0, invoice.amount_residual)
         self.assertEqual(len(invoice.mapped("line_ids")), 2)
         self.assertEqual(len(invoice.mapped("line_ids.currency_id")), 1)
 


### PR DESCRIPTION
Two problems seem to have emerged in the list view of invoices and vendor bills since 12.0:
- Amount Due is not 0 for draft and canceled entries. It should be 0 since they haven't been posted yet.
- Canceled entries are not greyed out. They should be in order to be distinguished from other invoices.

A few tests have to be adapted to reflect this change in spec.

task id=2801521

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
