### PR TITLE
[FIX][14.0] hr_holidays: raise warning different timezone

### DIFF
--- a/addons/hr_holidays/__manifest__.py
+++ b/addons/hr_holidays/__manifest__.py
@@ -3,7 +3,7 @@
 
 {
     'name': 'Time Off',
-    'version': '1.5',
+    'version': '1.6',
     'category': 'Human Resources/Time Off',
     'sequence': 85,
     'summary': 'Allocate time off and follow time off requests',

--- a/addons/hr_holidays/migrations/14.0.1.6/pre-migration.py
+++ b/addons/hr_holidays/migrations/14.0.1.6/pre-migration.py
@@ -1,0 +1,7 @@
+def migrate(cr, version):
+    cr.execute("""
+        UPDATE hr_leave
+        SET request_unit_custom = FALSE
+        WHERE request_unit_custom = TRUE
+        AND (holiday_status_id IS NOT NULL OR request_unit_half OR request_unit_hours);
+    """)

--- a/addons/hr_holidays/models/hr_leave.py
+++ b/addons/hr_holidays/models/hr_leave.py
@@ -78,9 +78,9 @@ class HolidaysRequest(models.Model):
 
             if lt:
                 defaults['holiday_status_id'] = lt.id
+                defaults['request_unit_custom'] = False
 
         if 'state' in fields_list and not defaults.get('state'):
-            lt = self.env['hr.leave.type'].browse(defaults.get('holiday_status_id'))
             defaults['state'] = 'confirm'
 
         now = fields.Datetime.now()


### PR DESCRIPTION
Description of the issue/feature this PR addresses: 
- The warning appears when you hit the create a leave schedule button on the interface:  "The employee has a different timezone than yours! Here dates and times are displayed in the employee's timezone (UTC)." Despite the fact that timezones are the same

![timeoff](https://user-images.githubusercontent.com/41574005/159890367-107f3332-09fa-45b3-b695-623893cf4ac3.png)


Current behavior before PR:

- A warning message appears:
"The employee has a different timezone than yours! Here dates and times are displayed in the employee's timezone (UTC)." 

Desired behavior after PR is merged:

- When the timezones are the same, the alert does not show.




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
