### PR TITLE
[FIX] point_of_sale: fix quantity decrease popup

### DIFF
--- a/addons/point_of_sale/static/src/js/Screens/ProductScreen/ProductScreen.js
+++ b/addons/point_of_sale/static/src/js/Screens/ProductScreen/ProductScreen.js
@@ -317,7 +317,7 @@ odoo.define('point_of_sale.ProductScreen', function(require) {
                 startingValue: 0,
                 title: this.env._t('Set the new quantity'),
             });
-            let newQuantity = inputNumber !== "" ? parse.float(inputNumber) : null;
+            let newQuantity = inputNumber && inputNumber !== "" ? parse.float(inputNumber) : null;
             if (confirmed && newQuantity !== null) {
                 let order = this.env.pos.get_order();
                 let selectedLine = this.env.pos.get_order().get_selected_orderline();


### PR DESCRIPTION
When the popup was canceled, the input value was null and it lead to an error.

Now we add a check to ensure the value exist.

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
