### PR TITLE
[IMP] mail: `ChatterTopbar` remove inconsistent style

### DIFF
--- a/addons/mail/static/src/components/chatter_topbar/chatter_topbar.scss
+++ b/addons/mail/static/src/components/chatter_topbar/chatter_topbar.scss
@@ -26,6 +26,7 @@
 
     &.o-active {
         @include o-hover-text-color($o-brand-odoo, $link-hover-color);
+        border-radius: $nav-tabs-border-radius $nav-tabs-border-radius 0 0;
         background-color: $gray-100;
 
         &:focus {

--- a/addons/mail/static/src/components/chatter_topbar/chatter_topbar.xml
+++ b/addons/mail/static/src/components/chatter_topbar/chatter_topbar.xml
@@ -55,15 +55,17 @@
                             <t t-if="chatter.hasFollowers and chatter.thread">
                                 <t t-if="chatter.thread.channel_type !== 'chat'">
                                     <FollowButton
-                                        className="'o_ChatterTopbar_button o_ChatterTopbar_followButton'"
+                                        className="'o_ChatterTopbar_followButton'"
                                         isDisabled="chatter.isDisabled"
                                         threadLocalId="chatter.thread.localId"
+                                        isChatterButton="true"
                                     />
                                 </t>
                                 <FollowerListMenu
-                                    className="'o_ChatterTopbar_button o_ChatterTopbar_followerListMenu'"
+                                    className="'o_ChatterTopbar_followerListMenu'"
                                     isDisabled="chatter.isDisabled"
                                     threadLocalId="chatter.thread.localId"
+                                    isChatterButton="true"
                                 />
                             </t>
                         </div>

--- a/addons/mail/static/src/components/follow_button/follow_button.js
+++ b/addons/mail/static/src/components/follow_button/follow_button.js
@@ -71,10 +71,12 @@ export class FollowButton extends Component {
 Object.assign(FollowButton, {
     defaultProps: {
         isDisabled: false,
+        isChatterButton: false,
     },
     props: {
         isDisabled: { type: Boolean, optional: true },
         threadLocalId: String,
+        isChatterButton: { type: Boolean, optional: true },
     },
     template: 'mail.FollowButton',
 });

--- a/addons/mail/static/src/components/follow_button/follow_button.xml
+++ b/addons/mail/static/src/components/follow_button/follow_button.xml
@@ -5,7 +5,7 @@
         <t t-if="thread">
             <div class="o_FollowButton" t-attf-class="{{ className }}" t-ref="root">
                 <t t-if="thread.isCurrentPartnerFollowing">
-                    <button class="o_FollowButton_unfollow btn btn-link" t-att-class="{ 'o-following': !state.isUnfollowButtonHighlighted, 'o-unfollow': state.isUnfollowButtonHighlighted }" t-att-disabled="props.isDisabled" t-on-click="_onClickUnfollow" t-on-mouseenter="_onMouseEnterUnfollow" t-on-mouseleave="_onMouseLeaveUnfollow">
+                    <button class="o_FollowButton_unfollow btn btn-link" t-att-class="{ 'o_ChatterTopbar_button': props.isChatterButton, 'o-following': !state.isUnfollowButtonHighlighted, 'o-unfollow': state.isUnfollowButtonHighlighted }" t-att-disabled="props.isDisabled" t-on-click="_onClickUnfollow" t-on-mouseenter="_onMouseEnterUnfollow" t-on-mouseleave="_onMouseLeaveUnfollow">
                         <t t-if="state.isUnfollowButtonHighlighted">
                             <i class="fa fa-times"/> Unfollow
                         </t>
@@ -15,7 +15,7 @@
                     </button>
                 </t>
                 <t t-else="">
-                    <button class="o_FollowButton_follow btn btn-link" t-att-disabled="props.isDisabled" t-on-click="_onClickFollow">
+                    <button class="o_FollowButton_follow btn btn-link" t-att-disabled="props.isDisabled" t-on-click="_onClickFollow" t-att-class="{ 'o_ChatterTopbar_button': props.isChatterButton }">
                         Follow
                     </button>
                 </t>

--- a/addons/mail/static/src/components/follower_list_menu/follower_list_menu.js
+++ b/addons/mail/static/src/components/follower_list_menu/follower_list_menu.js
@@ -115,10 +115,12 @@ export class FollowerListMenu extends Component {
 Object.assign(FollowerListMenu, {
     defaultProps: {
         isDisabled: false,
+        isChatterButton: false,
     },
     props: {
         isDisabled: { type: Boolean, optional: true },
         threadLocalId: String,
+        isChatterButton: { type: Boolean, optional: true },
     },
     template: 'mail.FollowerListMenu',
 });

--- a/addons/mail/static/src/components/follower_list_menu/follower_list_menu.xml
+++ b/addons/mail/static/src/components/follower_list_menu/follower_list_menu.xml
@@ -5,7 +5,7 @@
         <t t-if="thread">
             <div class="o_FollowerListMenu position-relative d-flex" t-attf-class="{{ className }}" t-on-keydown="_onKeydown" t-ref="root">
                 <div class="o_FollowerListMenu_followers d-flex" t-ref="dropdown">
-                    <button class="o_FollowerListMenu_buttonFollowers btn btn-link" t-att-disabled="props.isDisabled" t-on-click="_onClickFollowersButton" title="Show Followers">
+                    <button class="o_FollowerListMenu_buttonFollowers btn btn-link" t-att-disabled="props.isDisabled" t-on-click="_onClickFollowersButton" title="Show Followers" t-att-class="{ 'o_ChatterTopbar_button': props.isChatterButton }">
                         <i class="fa fa-user"/>
                         <span class="o_FollowerListMenu_buttonFollowersCount pl-1" t-esc="thread.followers.length"/>
                     </button>


### PR DESCRIPTION
Prior this commit, there were several inconsistencies with the corners
of `ChatterTopbar` buttons. Some of them had rounded corners, others did
not.

After this commit, the `ChatterTopbar` buttons have the same consistent
style: rounded in Community and square in Enterprise.

task-2781992

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
