### PR TITLE
[FIX] sale_management: do not reset lines on company change

### DIFF
--- a/addons/sale_management/models/sale_order.py
+++ b/addons/sale_management/models/sale_order.py
@@ -31,10 +31,12 @@ class SaleOrder(models.Model):
     @api.depends('company_id')
     def _compute_sale_order_template_id(self):
         for order in self:
-            if order.state != 'draft':
-                # Do NOT update existing SO's template and dependent fields
+            if order._origin.id:  # If record has already been saved
+                # 1) Do NOT update existing SO's template and dependent fields
                 # Especially when installing sale_management in a db
                 # already containing SO records
+                # 2) Only apply the company default if the company is modified before the record is saved
+                # to make sure the lines are not magically reset when the company is modified (internal odoo issue)
                 continue
             company_template = order.company_id.sale_order_template_id
             if company_template and order.sale_order_template_id != company_template:


### PR DESCRIPTION
Finetuning of 970904b06f6872aadf69d64c7bc82072a16f1596

Only update the template (& reset the lines if change done through UX) if
the SO wasn't saved already to make sure existing setup is not reset.

This commit restores even more of the previous behavior when the template
was only defaulted to the current company one.  Now the default is only
modified if you change the company before saving the record.

In all other cases, the template can only be modified manually/programmatically,
but won't be reset/updated by the compute method.

Task ID - 2798588


--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
