### PR TITLE
[FIX] mail: html tags visible for a split second at channel creation

### DIFF
--- a/addons/mail/static/src/models/discuss/discuss.js
+++ b/addons/mail/static/src/models/discuss/discuss.js
@@ -49,6 +49,7 @@ function factory(dependencies) {
          * @param {integer} ui.item.id
          */
         async handleAddChannelAutocompleteSelect(ev, ui) {
+            ev.preventDefault();
             const name = this.addingChannelValue;
             this.clearIsAddingItem();
             if (ui.item.special) {


### PR DESCRIPTION
**Current behavior before PR:**

When you create a new channel HTML tags are visible in Autocomplete text area
for a split second

**Desired behavior after PR is merged:**

No HTML tags are visible in Autocomplete text area

Task-2792365



--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
