### PR TITLE
[FIX] account: add missing _name_search for account.move.line

### DIFF
--- a/addons/account/models/account_move.py
+++ b/addons/account/models/account_move.py
@@ -3740,6 +3740,18 @@ class AccountMoveLine(models.Model):
         return result
 
     @api.model
+    def _name_search(self, name, args=None, operator='ilike', limit=100, name_get_uid=None):
+        if operator == 'ilike':
+            args = ['|', '|',
+                    ('name', 'ilike', name),
+                    ('move_id', 'ilike', name),
+                    ('product_id', 'ilike', name)]
+            result = self._search(args, limit=limit, access_rights_uid=name_get_uid)
+            return models.lazy_name_get(self.browse(result).with_user(name_get_uid))
+
+        return super()._name_search(name, args=args, operator=operator, limit=limit, name_get_uid=name_get_uid)
+
+    @api.model
     def invalidate_cache(self, fnames=None, ids=None):
         # Invalidate cache of related moves
         if fnames is None or 'move_id' in fnames:


### PR DESCRIPTION
The model had name_get, but not _name_search, which leads to difference between
display names and expected results.

This patch doesn't fix the issue completly, but adds more search results on
searching just by account move (e.g. invoice) name.

STEPS:

* open menu Analytic Items (account.analytic.line)
* make custom filter *Journal items contains "INV/"* (
`[["move_id","ilike","INV"]]` )

BEFORE: no items found even if you see such analytic items

---

opw-2691495

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
