### PR TITLE
[IMP] im_livechat: remove unused _channel_get_livechat_partner_name

### DIFF
--- a/addons/im_livechat/models/mail_channel.py
+++ b/addons/im_livechat/models/mail_channel.py
@@ -107,23 +107,6 @@ class MailChannel(models.Model):
             'name': self.anonymous_name or _("Visitor"),
         }
 
-    def _channel_get_livechat_partner_name(self):
-        if self.livechat_operator_id in self.channel_partner_ids:
-            partners = self.channel_partner_ids - self.livechat_operator_id
-            if partners:
-                partner_name = False
-                for partner in partners:
-                    if not partner_name:
-                        partner_name = partner.name
-                    else:
-                        partner_name += ', %s' % partner.name
-                    if partner.country_id:
-                        partner_name += ' (%s)' % partner.country_id.name
-                return partner_name
-        if self.anonymous_name:
-            return self.anonymous_name
-        return _("Visitor")
-
     @api.autovacuum
     def _gc_empty_livechat_sessions(self):
         hours = 1  # never remove empty session created within the last hour


### PR DESCRIPTION
**Current behavior before PR:**

There is an unused method _channel_get_livechat_partner_name

**Desired behavior after PR is merged:**

Removed unused method

Task-2801010



--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
