### PR TITLE
[FIX] web_editor: prevent loading toolbar twice in translate mode

### DIFF
--- a/addons/web_editor/static/src/js/editor/snippets.editor.js
+++ b/addons/web_editor/static/src/js/editor/snippets.editor.js
@@ -1260,7 +1260,7 @@ var SnippetsMenu = Widget.extend({
             this.$('.o_we_customize_snippet_btn').addClass('active').prop('disabled', false);
             this.$('o_we_ui_loading').addClass('d-none');
             $(this.customizePanel).removeClass('d-none');
-            return Promise.all(defs).then(this._addToolbar.bind(this));
+            return Promise.all(defs);
         }
         this.invisibleDOMPanelEl = document.createElement('div');
         this.invisibleDOMPanelEl.classList.add('o_we_invisible_el_panel');


### PR DESCRIPTION
[FIX] web_editor: prevent loading toolbar twice in translate mode

task-2802733

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
