### PR TITLE
[FIX] event_track_quiz : fix quiz validation error

### DIFF
--- a/addons/website_event_track_quiz/controllers/event_track_quiz.py
+++ b/addons/website_event_track_quiz/controllers/event_track_quiz.py
@@ -66,7 +66,7 @@ class WebsiteEventTrackQuiz(EventTrackController):
         })
 
     def _get_quiz_answers_details(self, track, answer_ids):
-        questions_count = len(track.quiz_ids)
+        questions_count = track.quiz_questions_count
         user_answers = request.env['event.quiz.answer'].sudo().search([('id', 'in', answer_ids)])
 
         if len(user_answers.mapped('question_id')) != questions_count:


### PR DESCRIPTION
- before this commit:
 always return an error when submitting answers

- after theis commit:
 return the awarded_points according to the answers




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
