### PR TITLE
[FIX] l10n_fr_fec: allows exporting FEC without TVA number.

### DIFF
--- a/addons/l10n_fr_fec/wizard/account_fr_fec.py
+++ b/addons/l10n_fr_fec/wizard/account_fr_fec.py
@@ -90,18 +90,12 @@ class AccountFrFec(models.TransientModel):
         """
         dom_tom_group = self.env.ref('l10n_fr.dom-tom')
         is_dom_tom = company.country_id.code in dom_tom_group.country_ids.mapped('code')
-        if is_dom_tom:
+        if not company.vat or is_dom_tom:
             return ''
-        elif company.country_id.code == 'FR':
-            if not company.vat:
-                raise UserError(_("Missing VAT number for company %s") % company.display_name)
-            elif len(company.vat) < 13 or not siren.is_valid(company.vat[4:13]):
-                raise UserError(_("Invalid VAT number for company %s") % company.display_name)
-            else:
-                return company.vat[4:13]
+        elif company.country_id.code == 'FR' and len(company.vat) >= 13 and siren.is_valid(company.vat[4:13]):
+            return company.vat[4:13]
         else:
-            return '' if not company.vat else company.vat
-
+            return company.vat
 
     def generate_fec(self):
         self.ensure_one()


### PR DESCRIPTION
Not all company needs a French TVA number but still needs to provide
FEC file.
Improve that by making the TVA number optional, allowing to export the
FEC file without it. The only difference is that in such case, the vat
number won't be appended to the file name.

Task id #2801629

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
