### PR TITLE
[FIX] website_event_*exhibitor,(q)web: don't crash sponsor if no name

### DIFF
--- a/addons/web/models/ir_qweb.py
+++ b/addons/web/models/ir_qweb.py
@@ -45,7 +45,7 @@ class Image(models.AbstractModel):
             filename = options['filename']
         else:
             filename = record.display_name
-        filename = filename.replace('/', '-').replace('\\', '-').replace('..', '--')
+        filename = (filename or 'name').replace('/', '-').replace('\\', '-').replace('..', '--')
 
         src = '/web/image/%s/%s/%s%s/%s?unique=%s' % (record._name, record.id, options.get('preview_image', field_name), max_size, url_quote(filename), sha)
 

--- a/addons/website_event_booth_exhibitor/models/event_booth.py
+++ b/addons/website_event_booth_exhibitor/models/event_booth.py
@@ -40,6 +40,9 @@ class EventBooth(models.Model):
                 'partner_id': self.partner_id.id,
                 **{key.partition('sponsor_')[2]: value for key, value in vals.items() if key.startswith('sponsor_')},
             }
+            # If confirmed from backend, we don't have _prepare_booth_registration_values
+            if not values.get('name'):
+                values['name'] = self.partner_id.name
             if self.booth_category_id.exhibitor_type == 'online':
                 values.update({
                     'room_name': 'odoo-exhibitor-%s' % self.partner_id.name,

--- a/addons/website_event_exhibitor/views/event_exhibitor_templates_page.xml
+++ b/addons/website_event_exhibitor/views/event_exhibitor_templates_page.xml
@@ -100,10 +100,10 @@
         <hr class="my-0"/>
         <div class="ml-3 clearfix">
             <div class="float-left pt-3">
-                <span t-if="sponsor.image_512" t-field="sponsor.image_512" class="o_wevent_online_page_avatar"
-                    t-options="{'widget': 'image', 'max-width': '96'}"/>
-                <span t-elif="sponsor.partner_id.image_512" t-field="sponsor.partner_id.image_512" class="o_wevent_online_page_avatar"
-                    t-options="{'widget': 'image', 'max-width': '96'}"/>
+                <span t-if="sponsor.image_128" t-field="sponsor.image_128" class="o_wevent_online_page_avatar"
+                    t-options="{'widget': 'image', 'filename-field': 'partner_name'}"/>
+                <span t-elif="sponsor.partner_id.image_128" t-field="sponsor.partner_id.image_128" class="o_wevent_online_page_avatar"
+                    t-options="{'widget': 'image', 'filename-field': 'partner_name'}"/>
             </div>
             <div class="o_wevent_sponsor px-3 pt-3 d-flex flex-row justify-content-between position-relative">
                 <div class="d-flex flex-column">

--- a/addons/website_event_exhibitor/views/event_templates_sponsor.xml
+++ b/addons/website_event_exhibitor/views/event_templates_sponsor.xml
@@ -28,7 +28,7 @@
 <template id="event_sponsor_thumb_details">
     <div class="h-100 shadow-sm p-2">
         <span t-field="sponsor.image_128"
-            t-options='{"widget": "image", "class": "img img-fluid"}'/>
+            t-options='{"widget": "image", "class": "img img-fluid", "filename-field": "partner_name"}'/>
         <span t-if="sponsor.sponsor_type_id.display_ribbon_style and sponsor.sponsor_type_id.display_ribbon_style != 'no_ribbon'"
             t-field="sponsor.sponsor_type_id" t-attf-class="o_ribbon o_ribbon_right ribbon_#{sponsor.sponsor_type_id.display_ribbon_style}"/>
     </div>


### PR DESCRIPTION
Field name on sponsor are not required. So when we display the image of a
sponsor without field-name it will use the rec_name 'name' that is not set
and so False.
It will crash during rendering of the widget image that use it.

Now we force to use a field required 'partner_name' to avoid the crash.
By default, when you confirm the sale_order from the backend, we copy
the partner name in field name.

Because we use a class avatar to have a max-width of 96, we don't need
to use a image_512, image_128 is enough in most of case.
The max-width option on widget image has no effect on rendering.

In other case where the rec_name is Falsy and we don't provide other name to
the widget, we now use a default 'name' value to avoid a crash:
AttributeError: 'bool' object has no attribute 'replace'


--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
