### PR TITLE
[IMP] web_editor: improve commandbar design

### DIFF
--- a/addons/web_editor/static/lib/odoo-editor/src/powerbox/Powerbox.js
+++ b/addons/web_editor/static/lib/odoo-editor/src/powerbox/Powerbox.js
@@ -42,14 +42,8 @@ export class Powerbox {
         clearTimeout(this._renderingTimeout);
         this._hoverActive = false;
 
+        this._mainWrapperElement.classList.toggle('oe-commandbar-noResult', commands.length === 0);
         if (commands.length === 0) {
-            const groupWrapperEl = document.createElement('div');
-            groupWrapperEl.className = 'oe-commandbar-groupWrapper';
-            const groupNameEl = document.createElement('div');
-            groupNameEl.className = 'oe-commandbar-noResult';
-            groupWrapperEl.append(groupNameEl);
-            this._mainWrapperElement.append(groupWrapperEl);
-            groupNameEl.innerText = this.options._t('No results');
             return;
         }
 

--- a/addons/web_editor/static/lib/odoo-editor/src/powerbox/Powerbox.js
+++ b/addons/web_editor/static/lib/odoo-editor/src/powerbox/Powerbox.js
@@ -156,6 +156,7 @@ export class Powerbox {
     open(openOptions) {
         this.options.onActivate && this.options.onActivate();
         this._currentOpenOptions = openOptions;
+        this._currentOpenOptions.commands = this._orderCommandsByGroup(openOptions.commands);
 
         const openOnKeyupTarget =
             this._currentOpenOptions.openOnKeyupTarget || this.options.editable;
@@ -283,6 +284,7 @@ export class Powerbox {
 
     nextOpenOptions(openOptions) {
         this._currentOpenOptions = openOptions;
+        this._currentOpenOptions.commands = this._orderCommandsByGroup(openOptions.commands);
         this._initialValue = (
             this._currentOpenOptions.openOnKeyupTarget || this.options.editable
         ).textContent;
@@ -302,11 +304,11 @@ export class Powerbox {
     }
 
     // -------------------------------------------------------------------------
-    // private
+    // Private
     // -------------------------------------------------------------------------
 
     _filter(term, commands) {
-        const initalCommands = commands;
+        const initialCommands = commands;
         term = term.toLowerCase();
         term = term.replaceAll(/\s/g, '\\s');
         const regex = new RegExp(
@@ -316,14 +318,25 @@ export class Powerbox {
                 .join('.*'),
         );
         if (term.length) {
-            commands = initalCommands.filter(command => {
+            commands = initialCommands.filter(command => {
                 const commandText = (command.groupName + ' ' + command.title).toLowerCase();
                 return commandText.match(regex);
             });
         }
         return commands;
     }
-
+    _orderCommandsByGroup(commands) {
+        const groups = {};
+        for (const command of commands) {
+            groups[command.groupName] = groups[command.groupName] || [];
+            groups[command.groupName].push(command);
+        }
+        const reorderedCommands = [];
+        for (const groupCommands of Object.values(groups)) {
+            reorderedCommands.push(...groupCommands);
+        }
+        return reorderedCommands;
+    }
     _resetPosition() {
         const position = getRangePosition(this.el, this.options.document);
         if (!position) {

--- a/addons/web_editor/static/lib/odoo-editor/src/powerbox/Powerbox.js
+++ b/addons/web_editor/static/lib/odoo-editor/src/powerbox/Powerbox.js
@@ -13,13 +13,14 @@ function cycle(num, max) {
 export class Powerbox {
     constructor(options = {}) {
         this.options = options;
-        this.options.width = this.options.width || 340;
         if (!this.options._t) this.options._t = string => string;
 
         this.el = document.createElement('div');
         this.el.className = 'oe-commandbar-wrapper';
         this.el.style.display = 'none';
-        this.el.style.width = `${this.options.width}px`;
+        if (this.options.width !== undefined) {
+            this.el.style.width = `${this.options.width}px`;
+        }
         document.body.append(this.el);
 
         this.addKeydownTrigger('/', { commands: this.options.commands });

--- a/addons/web_editor/static/lib/odoo-editor/src/style.css
+++ b/addons/web_editor/static/lib/odoo-editor/src/style.css
@@ -221,6 +221,7 @@
 }
 .oe-commandbar-groupName {
     text-transform: uppercase;
+    margin: 5px 12px;
 }
 .oe-commandbar-noResult {
     font-size: 15px;
@@ -228,7 +229,7 @@
 
 .oe-commandbar-commandWrapper {
     display: flex;
-    padding: 3px 10px;
+    padding: 6px 12px;
     cursor: pointer;
 }
 
@@ -238,26 +239,24 @@
 
 i.oe-commandbar-commandImg {
     display: flex;
-    height: 50px;
-    width: 50px;
+    height: 30px;
+    width: 30px;
     align-items: center;
     justify-content: center;
     background: white;
     color: rgba(0, 0, 0, 0.6);
     border: 1px solid rgba(0, 0, 0, 0.1);
-    border-radius: 4px;
-    font-size: 25px;
+    border-radius: 7px;
+    font-size: 15px;
 }
 
 .oe-commandbar-commandTitle {
-    margin-top: 6px;
-    font-size: 14px;
+    font-size: 13px;
 }
 
 .oe-commandbar-commandDescription {
     color: rgba(0, 0, 0, 0.5);
     font-size: 12px;
-    margin: 4px 0;
 }
 
 .oe-commandbar-commandRightCol {

--- a/addons/web_editor/static/lib/odoo-editor/src/style.css
+++ b/addons/web_editor/static/lib/odoo-editor/src/style.css
@@ -224,7 +224,7 @@
     margin: 5px 12px;
 }
 .oe-commandbar-noResult {
-    font-size: 15px;
+    display: none;
 }
 
 .oe-commandbar-commandWrapper {


### PR DESCRIPTION
- When no command is found in the Powerbox, the text "No results" is shown, which is annoying. Instead, this hides the Powerbox, and restores it if needed (on backspace for instance).
- This is a general design upgrade for the Powerbox.


task-2802749

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
