### PR TITLE
[FIX] point_of_sale: no fiscal position in refund

### DIFF
--- a/addons/point_of_sale/static/src/js/Screens/TicketScreen/TicketScreen.js
+++ b/addons/point_of_sale/static/src/js/Screens/TicketScreen/TicketScreen.js
@@ -247,6 +247,7 @@ odoo.define('point_of_sale.TicketScreen', function (require) {
             // Set the customer to the destinationOrder.
             if (customer && !destinationOrder.get_client()) {
                 destinationOrder.set_client(customer);
+                destinationOrder.updatePricelist(customer);
             }
 
             this._onCloseScreen();


### PR DESCRIPTION
- Create a fiscal position [FPOS]
- Assign [FPOS] to a customer [DEMO]
- Add [FPOS] to the available fiscal positions of POS
- Open pos session, add a product, select [DEMO], [FPOS] will be
automatically selected. Confirm order and pay
- Click on refund button and select the previous order

[FPOS] will not be automatically selected for the refund order

opw-2799179

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
