### PR TITLE
[FIX] base: Fix flaky action label

### DIFF
--- a/odoo/addons/base/models/res_config.py
+++ b/odoo/addons/base/models/res_config.py
@@ -668,7 +668,7 @@ class ResConfigSettings(models.TransientModel, ResConfigModuleInstallationMixin)
     def name_get(self):
         """ Override name_get method to return an appropriate configuration wizard
         name, and not the generated name."""
-        action = self.env['ir.actions.act_window'].search([('res_model', '=', self._name)], limit=1)
+        action = self.env['ir.actions.act_window'].search([('res_model', '=', self._name)], limit=1, order='id')
         name = action.name or self._name
         return [(record.id, name) for record in self]
 


### PR DESCRIPTION
The following line of code:
  - `self.env["ir.actions.act_window"].search([("res_model", "=", self._name)], limit=1)`

Generates the following query:
  - `SELECT "ir_act_window".id FROM "ir_act_window" LEFT JOIN "ir_translation" AS "ir_act_window__name" ON ("ir_act_window"."id" = "ir_act_window__name"."res_id" AND "ir_act_window__name"."type" = 'model' AND "ir_act_window__name"."name" = 'ir.actions.act_window,name' AND "ir_act_window__name"."lang" = 'en_US' AND "ir_act_window__name"."value" != '') WHERE ("ir_act_window"."res_model" = 'res.config.settings') ORDER BY  COALESCE("ir_act_window__name"."value", "ir_act_window"."name")   LIMIT 1`

Notice the:
 - `ORDER BY  COALESCE("ir_act_window__name"."value", "ir_act_window"."name")`

It means that it will use the first record ordered by translated name of the action

It produces flaky label names in the Settings

You can reproduced it creating a new record similar to:

    <record id="flaky_name" model="ir.actions.act_window">
            <field name="name">Hi</field>
            <field name="type">ir.actions.act_window</field>
            <field name="res_model">res.config.settings</field>
            <field name="view_mode">form</field>
            <field name="target">inline</field>
            <field name="context">{'module' : 'module'}</field>
    </record>

Next time opening any Settings submenu you will see the menu path name as:
 - Hi/Users

Instead of
 - Settings/Users

Ordering by id we can be sure that the same record will be returned each time

No matters if you add a new record with a different name in the future

Using runbot you can reproduce it running the following code in a server action:

```python
env.ref('documents.configuration_action').write({'name': 'Hi!'})
env.cr.commit()

name = 'res.config.settings'
# raise Warning("%s" % env["ir.actions.act_window"].search([("res_model", "=", name)]).mapped('xml_id'))
action_by_name = env["ir.actions.act_window"].search([("res_model", "=", name)], limit=1)
action_by_id = env["ir.actions.act_window"].search([("res_model", "=", name)], limit=1, order='id')

raise Warning("action_by_name %s\naction_by_id %s" % (action_by_name.read(['name']), action_by_id.read(['name'])))
```

The output is:
```txt
action_by_name [{'id': 539, 'name': 'Hi!'}]
action_by_id [{'id': 75, 'name': 'Settings'}]
```

And without this patch it is reproduced:

 - ![hi](https://user-images.githubusercontent.com/6644187/159992894-f4864119-bb81-4cf5-8a94-0680b5b6e61a.gif)

