### PR TITLE
[FIX]hr_recruiment: fix bug not auto add recruiter when apply job on 3rd

### DIFF
--- a/addons/hr_recruitment/models/hr_recruitment.py
+++ b/addons/hr_recruitment/models/hr_recruitment.py
@@ -421,8 +421,11 @@ class Applicant(models.Model):
         # found.
         self = self.with_context(default_user_id=False)
         stage = False
+        user_id = False
         if custom_values and 'job_id' in custom_values:
-            stage = self.env['hr.job'].browse(custom_values['job_id'])._get_first_stage()
+            hr_job = self.env['hr.job'].browse(custom_values['job_id'])
+            stage = hr_job._get_first_stage()
+            user_id = hr_job.user_id.id
         val = msg.get('from').split('<')[0]
         defaults = {
             'name': msg.get('subject') or _("No Subject"),
@@ -435,6 +438,8 @@ class Applicant(models.Model):
         if stage and stage.id:
             defaults['stage_id'] = stage.id
         if custom_values:
+            if user_id:
+                custom_values.update({'user_id': user_id})
             defaults.update(custom_values)
         return super(Applicant, self).message_new(msg, custom_values=defaults)
 


### PR DESCRIPTION
- **Problems encountered**: Currently, when applying for jobs on a 3rd party software, the software does not automatically add recruiters like in version 13.0.
- **Solving problems**: This PR allows to automatically add recruiters when applying for jobs on 3rd party software




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
