### PR TITLE
[FIX] mail: prevents traceback when ending a videoCall

### DIFF
--- a/addons/mail/static/src/components/rtc_video/rtc_video.js
+++ b/addons/mail/static/src/components/rtc_video/rtc_video.js
@@ -44,7 +44,7 @@ export class RtcVideo extends Component {
      *
      */
     _loadVideo() {
-        if (!this.root) {
+        if (!this.root.el) {
             return;
         }
         if (!this.rtcSession || !this.rtcSession.videoStream) {


### PR DESCRIPTION
Before this commit, there could be a traceback when `_loadVideo()` was
called when the `root.el` of the video component was not set when
closing a videoCall.

This commit fixes this issue.

