### PR TITLE
[FIX] product: variant sale price is wrong

### DIFF
--- a/addons/product/views/product_views.xml
+++ b/addons/product/views/product_views.xml
@@ -365,9 +365,10 @@
                 </xpath>
                 <field name="list_price" position="attributes">
                    <attribute name="attrs">{'readonly': [('product_variant_count', '&gt;', 1)]}</attribute>
+                   <attribute name="invisible">1</attribute>
                 </field>
                 <field name="list_price" position="after">
-                   <field name="lst_price" invisible="1"/>
+                   <field name="lst_price" class="oe_inline" widget='monetary' options="{'currency_field': 'currency_id', 'field_digits': True}"/>
                 </field>
                 <group name="packaging" position="attributes">
                     <attribute name="attrs">{'invisible': 0}</attribute>


### PR DESCRIPTION
If applied, this commit will fix the following bug by using the price
with the additional cost added instead of only the price

Steps to reproduce:

1- install sales
2- create a product p with variant pv
3- set an extra value for pv
4- go to Products>Product Variants
5- open the pv in form view
6- the Sales Price is the price of p not pv
(which should be p + extra value)
7- also the tax string is calculated on p not pv

Bug:

```list_price``` is being used

Fix:

replace ```list_price``` with  ```lst_price```

OPW-2774199