### PR TITLE
[FIX] l10n_it_edi: demo data bank and partner

### DIFF
--- a/addons/l10n_it_edi/data/account_invoice_demo.xml
+++ b/addons/l10n_it_edi/data/account_invoice_demo.xml
@@ -3,7 +3,11 @@
     <data noupdate="1">
         <!-- add VAT, codice fiscal and tax system for main company -->
         <record id="l10n_it.demo_company_it" model="res.company">
-            <field name="l10n_it_codice_fiscale">09814700101</field>
+            <field name="vat">IT01654010345</field>
+            <field name="street">Test Street</field>
+            <field name="city">Prova</field>
+            <field name="zip">12345</field>
+            <field name="l10n_it_codice_fiscale">01654010345</field>
             <field name="l10n_it_tax_system">RF01</field>
             <field name="zip">12345</field>
         </record>
@@ -29,5 +33,23 @@
             <field name="l10n_it_pa_index">XS00001</field>
         </record>
 
+    <record id="demo_l10n_it_edi_bank" model="res.partner.bank">
+        <field name="acc_type">iban</field>
+        <field name="acc_number">BE71096123456769</field>
+        <field name="bank_id" ref="base.bank_bnp"/>
+        <field name="partner_id" ref="l10n_it.partner_demo_company_it"/>
+        <field name="company_id" ref="l10n_it.demo_company_it"/>
+    </record>
+
+    <record id="demo_l10n_it_edi_partner_a" model="res.partner">
+      <field name="name">Vendhoreconi</field>
+      <field name="company_type">company</field>
+      <field name="country_id" ref="base.it"/>
+      <field name="street">1234 Strada del Caffè</field>
+      <field name="city">Test Milano</field>
+      <field name="zip">12345</field>
+      <field name="vat">IT04353580402</field>
+      <field name="l10n_it_codice_fiscale">04353580402</field>
+    </record>
     </data>
 </odoo>


### PR DESCRIPTION
Demo data to improve the flow of testing the edi. A bank account and a
partner with a street/city/zipcode/codice fiscale are required for the
edi, so having these as demo data is useful.
The demo company vat code and codice fiscale are also changed to those
of a valid company, so that they will be accepted by the sdi testing
environment. The address of the demo company is updated so that, if by
accident, an invoice is sent using the demo company, through the
official channel, the address will make it an obvious test.

task-id: 2809328