### PR TITLE
[IMP] payment(_adyen): allow partial capture

### DIFF
--- a/addons/account_payment/models/account_move.py
+++ b/addons/account_payment/models/account_move.py
@@ -60,14 +60,17 @@ class AccountMove(models.Model):
 
     def payment_action_capture(self):
         """ Capture all transactions linked to this invoice. """
+        self.ensure_one()
         payment_utils.check_rights_on_recordset(self)
-        # In sudo mode because we need to be able to read on provider fields.
-        self.authorized_transaction_ids.sudo().action_capture()
+
+        # In sudo mode to bypass the checks on the rights on the transactions.
+        return self.transaction_ids.sudo().action_capture()
 
     def payment_action_void(self):
         """ Void all transactions linked to this invoice. """
         payment_utils.check_rights_on_recordset(self)
-        # In sudo mode because we need to be able to read on provider fields.
+
+        # In sudo mode to bypass the checks on the rights on the transactions.
         self.authorized_transaction_ids.sudo().action_void()
 
     def action_view_payment_transactions(self):

--- a/addons/payment/__manifest__.py
+++ b/addons/payment/__manifest__.py
@@ -23,6 +23,7 @@
         'security/ir.model.access.csv',
         'security/payment_security.xml',
 
+        'wizards/payment_capture_wizard_views.xml',
         'wizards/payment_link_wizard_views.xml',
         'wizards/payment_onboarding_views.xml',
     ],

--- a/addons/payment/models/payment_provider.py
+++ b/addons/payment/models/payment_provider.py
@@ -163,8 +163,10 @@ class PaymentProvider(models.Model):
     support_tokenization = fields.Boolean(
         string="Tokenization Supported", compute='_compute_feature_support_fields'
     )
-    support_manual_capture = fields.Boolean(
-        string="Manual Capture Supported", compute='_compute_feature_support_fields'
+    support_manual_capture = fields.Selection(
+        string="Manual Capture Supported",
+        selection=[('full_only', "Full Only"), ('partial', "Partial")],
+        compute='_compute_feature_support_fields',
     )
     support_express_checkout = fields.Boolean(
         string="Express Checkout Supported", compute='_compute_feature_support_fields'

--- a/addons/payment/models/payment_transaction.py
+++ b/addons/payment/models/payment_transaction.py
@@ -70,7 +70,7 @@ class PaymentTransaction(models.Model):
             ('online_token', "Online payment by token"),
             ('validation', "Validation of the payment method"),
             ('offline', "Offline payment by token"),
-            ('refund', "Refund")
+            ('refund', "Refund"),
         ],
         readonly=True,
         index=True,
@@ -78,12 +78,12 @@ class PaymentTransaction(models.Model):
     source_transaction_id = fields.Many2one(
         string="Source Transaction",
         comodel_name='payment.transaction',
-        help="The source transaction of related refund transactions",
+        help="The source transaction of the related child transactions",
         readonly=True,
     )
     child_transaction_ids = fields.One2many(
         string="Child Transactions",
-        help="The child transactions of the source transaction.",
+        help="The child transactions of the transaction.",
         comodel_name='payment.transaction',
         inverse_name='source_transaction_id',
         readonly=True,
@@ -262,24 +262,46 @@ class PaymentTransaction(models.Model):
         return action
 
     def action_capture(self):
-        """ Check the state of the transactions and request their capture. """
-        if any(tx.state != 'authorized' for tx in self):
-            raise ValidationError(_("Only authorized transactions can be captured."))
+        """ Open the partial capture wizard if it is supported by the related providers, otherwise
+        capture the transactions immediately.
 
+        :return: The action to open the partial capture wizard, if supported.
+        :rtype: action.act_window|None
+        """
         payment_utils.check_rights_on_recordset(self)
-        for tx in self:
-            # In sudo mode because we need to be able to read on provider fields.
-            tx.sudo()._send_capture_request()
+
+        if any(tx.provider_id.sudo().support_manual_capture == 'partial' for tx in self):
+            return {
+                'name': _("Capture"),
+                'type': 'ir.actions.act_window',
+                'view_mode': 'form',
+                'res_model': 'payment.capture.wizard',
+                'target': 'new',
+                'context': {
+                    'active_model': 'payment.transaction',
+                    # Consider also confirmed transactions to calculate the total authorized amount.
+                    'active_ids': self.filtered(lambda tx: tx.state in ['authorized', 'done']).ids,
+                },
+            }
+        else:
+            for tx in self.filtered(lambda tx: tx.state == 'authorized'):
+                # In sudo mode because we need to be able to read on provider fields.
+                tx.sudo()._send_capture_request()
 
     def action_void(self):
         """ Check the state of the transaction and request to have them voided. """
+        payment_utils.check_rights_on_recordset(self)
+
         if any(tx.state != 'authorized' for tx in self):
             raise ValidationError(_("Only authorized transactions can be voided."))
 
-        payment_utils.check_rights_on_recordset(self)
         for tx in self:
+            # Consider all the confirmed partial capture (same operation as parent) child txs.
+            captured_amount = sum(child_tx.amount for child_tx in tx.child_transaction_ids.filtered(
+                lambda t: t.state == 'done' and t.operation == tx.operation
+            ))
             # In sudo mode because we need to be able to read on provider fields.
-            tx.sudo()._send_void_request()
+            tx.sudo()._send_void_request(amount_to_void=tx.amount - captured_amount)
 
     def action_refund(self, amount_to_refund=None):
         """ Check the state of the transactions and request their refund.
@@ -524,58 +546,52 @@ class PaymentTransaction(models.Model):
         self.ensure_one()
         self._ensure_provider_is_not_disabled()
 
-        refund_tx = self._create_refund_transaction(amount_to_refund=amount_to_refund)
+        refund_tx = self._create_child_transaction(amount_to_refund or self.amount, is_refund=True)
         refund_tx._log_sent_message()
         return refund_tx
 
-    def _create_refund_transaction(self, amount_to_refund=None, **custom_create_values):
-        """ Create a new transaction with the operation `refund` and the current transaction as
-        source transaction.
-
-        :param float amount_to_refund: The strictly positive amount to refund, in the same currency
-                                       as the source transaction.
-        :return: The refund transaction.
-        :rtype: recordset of `payment.transaction`
-        """
-        self.ensure_one()
-
-        return self.create({
-            'provider_id': self.provider_id.id,
-            'reference': self._compute_reference(self.provider_code, prefix=f'R-{self.reference}'),
-            'amount': -(amount_to_refund or self.amount),
-            'currency_id': self.currency_id.id,
-            'token_id': self.token_id.id,
-            'operation': 'refund',
-            'source_transaction_id': self.id,
-            'partner_id': self.partner_id.id,
-            **custom_create_values,
-        })
-
-    def _send_capture_request(self):
+    def _send_capture_request(self, amount_to_capture=None):
         """ Request the provider handling the transaction to capture the payment.
+
+        For partial captures, create a child transaction linked to the source transaction.
 
         For a provider to support authorization, it must override this method and make an API
         request to capture the payment.
 
         Note: `self.ensure_one()`
 
-        :return: None
+        :param float amount_to_capture: The amount to capture.
+        :return: The created capture child transaction, if any.
+        :rtype: `payment.transaction`
         """
         self.ensure_one()
         self._ensure_provider_is_not_disabled()
 
-    def _send_void_request(self):
+        if amount_to_capture and amount_to_capture != self.amount:
+            return self._create_child_transaction(amount_to_capture)
+        return self.env['payment.transaction']
+
+    def _send_void_request(self, amount_to_void=None):
         """ Request the provider handling the transaction to void the payment.
+
+        For partial voids, create a child transaction linked to the source transaction.
 
         For a provider to support authorization, it must override this method and make an API
         request to void the payment.
 
         Note: `self.ensure_one()`
 
-        :return: None
+        :param float amount_to_void: The amount to be voided.
+        :return: The created void child transaction, if any.
+        :rtype: payment.transaction
         """
         self.ensure_one()
         self._ensure_provider_is_not_disabled()
+
+        if amount_to_void and amount_to_void != self.amount:
+            return self._create_child_transaction(amount_to_void)
+
+        return self.env['payment.transaction']
 
     def _ensure_provider_is_not_disabled(self):
         """ Ensure that the provider's state is not `disabled` before sending a request to its
@@ -588,6 +604,42 @@ class PaymentTransaction(models.Model):
             raise UserError(_(
                 "Making a request to the provider is not possible because the provider is disabled."
             ))
+
+    def _create_child_transaction(self, amount, is_refund=False, **custom_create_values):
+        """ Create a new transaction with the current transaction as its parent transaction.
+
+        This happens only in case of a refund or a partial capture (where the initial transaction is
+        split between smaller transactions, either captured or voided).
+
+        Note: self.ensure_one()
+
+        :param float amount: The strictly positive amount of the child transaction, in the same
+                             currency as the source transaction.
+        :param bool is_refund: Whether the child transaction is a refund.
+        :return: The created child transaction.
+        :rtype: payment.transaction
+        """
+        self.ensure_one()
+
+        if is_refund:
+            reference_prefix = f'R-{self.reference}'
+            amount = -amount
+            operation = 'refund'
+        else:  # Partial capture or void.
+            reference_prefix = f'P-{self.reference}'
+            operation = self.operation
+
+        return self.create({
+            'provider_id': self.provider_id.id,
+            'reference': self._compute_reference(self.provider_code, prefix=reference_prefix),
+            'amount': amount,
+            'currency_id': self.currency_id.id,
+            'token_id': self.token_id.id,
+            'operation': operation,
+            'source_transaction_id': self.id,
+            'partner_id': self.partner_id.id,
+            **custom_create_values,
+        })
 
     def _handle_notification_data(self, provider_code, notification_data):
         """ Match the transaction with the notification data, update its state and return it.
@@ -679,6 +731,7 @@ class PaymentTransaction(models.Model):
         txs_to_process = self._update_state(
             allowed_states + extra_allowed_states, target_state, state_message
         )
+        txs_to_process._update_source_transaction_state()
         txs_to_process._log_received_message()
         return txs_to_process
 
@@ -696,7 +749,7 @@ class PaymentTransaction(models.Model):
         txs_to_process = self._update_state(
             allowed_states + extra_allowed_states, target_state, state_message
         )
-        # Cancel the existing payments.
+        txs_to_process._update_source_transaction_state()
         txs_to_process._log_received_message()
         return txs_to_process
 
@@ -775,6 +828,28 @@ class PaymentTransaction(models.Model):
             'last_state_change': fields.Datetime.now(),
         })
         return txs_to_process
+
+    def _update_source_transaction_state(self):
+        """ Update the state of the source transactions for which all child transactions have
+        reached a final state.
+
+        :return: None
+        """
+        for child_tx in self.filtered('source_transaction_id'):
+            sibling_txs = child_tx.source_transaction_id.child_transaction_ids.filtered(
+                lambda tx: tx.state in ['done', 'cancel'] and tx.operation == child_tx.operation
+            )
+            processed_amount = round(
+                sum(tx.amount for tx in sibling_txs), child_tx.currency_id.decimal_places
+            )
+            if child_tx.source_transaction_id.amount == processed_amount:
+                state_message = _(
+                    "This transaction has been confirmed following the processing of its partial "
+                    "capture and partial void transactions (%(provider)s).",
+                    provider=child_tx.provider_id.name,
+                )
+                # Call `_update_state` directly instead of `_set_authorized` to avoid looping.
+                child_tx.source_transaction_id._update_state(('authorized',), 'done', state_message)
 
     def _execute_callback(self):
         """ Execute the callbacks defined on the transactions.
@@ -884,7 +959,7 @@ class PaymentTransaction(models.Model):
                 ('state', '=', 'done'),
                 ('is_post_processed', '=', False),
                 '|', ('last_state_change', '<=', client_handling_limit_date),
-                     ('operation', '=', 'refund'),
+                     ('source_transaction_id', '!=', False),
                 ('last_state_change', '>=', retry_limit_date),
             ])
         for tx in txs_to_post_process:

--- a/addons/payment/security/ir.model.access.csv
+++ b/addons/payment/security/ir.model.access.csv
@@ -1,5 +1,6 @@
 id,name,model_id:id,group_id:id,perm_read,perm_write,perm_create,perm_unlink
 access_payment_link_wizard,access_payment_link_wizard,payment.model_payment_link_wizard,base.group_user,0,0,0,0
+payment_capture_wizard_user,payment.capture.wizard,model_payment_capture_wizard,base.group_user,1,1,1,0
 payment_provider_onboarding_wizard,payment.provider.onboarding.wizard,model_payment_provider_onboarding_wizard,base.group_system,1,1,1,0
 payment_provider_system,payment.provider.system,model_payment_provider,base.group_system,1,1,1,1
 payment_method_all,payment.method.all,model_payment_method,,1,0,0,0

--- a/addons/payment/security/payment_security.xml
+++ b/addons/payment/security/payment_security.xml
@@ -41,4 +41,12 @@
         <field name="domain_force">[('company_id', 'in', company_ids)]</field>
     </record>
 
+    <!-- Wizards -->
+
+    <record id="payment_capture_wizard_rule" model="ir.rule">
+        <field name="name">Payment Capture Wizard</field>
+        <field name="model_id" ref="model_payment_capture_wizard"/>
+        <field name="domain_force">[('create_uid', '=', user.id)]</field>
+     </record>
+
 </odoo>

--- a/addons/payment/views/payment_transaction_views.xml
+++ b/addons/payment/views/payment_transaction_views.xml
@@ -54,6 +54,8 @@
                             <field name="partner_lang"/>
                         </group>
                     </group>
+                    <separator string="Child transactions" attrs="{'invisible': [('child_transaction_ids', '=', [])]}"/>
+                    <field name="child_transaction_ids" attrs="{'invisible': [('child_transaction_ids', '=', [])]}"/>
                     <group string="Message" attrs="{'invisible': [('state_message', '=', False)]}">
                         <field name="state_message" colspan="2" nolabel="1"/>
                     </group>

--- a/addons/payment/wizards/__init__.py
+++ b/addons/payment/wizards/__init__.py
@@ -1,4 +1,5 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
+from . import payment_capture_wizard
 from . import payment_link_wizard
 from . import payment_onboarding_wizard

--- a/addons/payment/wizards/payment_capture_wizard.py
+++ b/addons/payment/wizards/payment_capture_wizard.py
@@ -1,0 +1,152 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from odoo import _, api, fields, models
+from odoo.exceptions import ValidationError
+from odoo.tools import format_amount
+
+
+class PaymentCaptureWizard(models.TransientModel):
+    _name = 'payment.capture.wizard'
+    _description = "Payment Capture Wizard"
+
+    transaction_ids = fields.Many2many(  # All the source txs related to the capture request
+        comodel_name='payment.transaction',
+        default=lambda self: self.env.context.get('active_ids'),
+        readonly=True,
+    )
+    authorized_amount = fields.Monetary(
+        string="Authorized Amount", compute='_compute_authorized_amount'
+    )
+    captured_amount = fields.Monetary(string="Already Captured", compute='_compute_captured_amount')
+    voided_amount = fields.Monetary(string="Already Voided", compute='_compute_voided_amount')
+    available_amount = fields.Monetary(
+        string="Maximum Capture Allowed", compute='_compute_available_amount'
+    )
+    amount_to_capture = fields.Monetary(
+        compute='_compute_amount_to_capture', store=True, readonly=False
+    )
+    is_amount_to_capture_valid = fields.Boolean(compute='_compute_is_amount_to_capture_valid')
+    void_remaining_amount = fields.Boolean()
+    currency_id = fields.Many2one(related='transaction_ids.currency_id')
+    support_partial_capture = fields.Boolean(
+        help="Whether each of the transactions' provider supports the partial capture.",
+        compute='_compute_support_partial_capture',
+        compute_sudo=True,
+    )
+    has_draft_children = fields.Boolean(compute='_compute_has_draft_children')
+    has_remaining_amount = fields.Boolean(compute='_compute_has_remaining_amount')
+
+    #=== COMPUTE METHODS ===#
+
+    @api.depends('transaction_ids')
+    def _compute_authorized_amount(self):
+        for wizard in self:
+            wizard.authorized_amount = sum(wizard.transaction_ids.mapped('amount'))
+
+    @api.depends('transaction_ids')
+    def _compute_captured_amount(self):
+        for wizard in self:
+            full_capture_txs = wizard.transaction_ids.filtered(
+                lambda tx: tx.state == 'done' and not tx.child_transaction_ids
+            )  # Transactions that have been fully captured in a single capture operation.
+            partial_capture_child_txs = wizard.transaction_ids.child_transaction_ids.filtered(
+                lambda tx: tx.state == 'done'
+            )  # Transactions that represent a partial capture of their source transaction.
+            wizard.captured_amount = sum(
+                (full_capture_txs | partial_capture_child_txs).mapped('amount')
+            )
+
+    @api.depends('transaction_ids')
+    def _compute_voided_amount(self):
+        for wizard in self:
+            void_child_txs = wizard.transaction_ids.child_transaction_ids.filtered(
+                lambda tx: tx.state == 'cancel'
+            )
+            wizard.voided_amount = sum(void_child_txs.mapped('amount'))
+
+    @api.depends('authorized_amount', 'captured_amount', 'voided_amount')
+    def _compute_available_amount(self):
+        for wizard in self:
+            wizard.available_amount = wizard.authorized_amount \
+                                      - wizard.captured_amount \
+                                      - wizard.voided_amount
+
+    @api.depends('available_amount')
+    def _compute_amount_to_capture(self):
+        """ Set the default amount to capture to the amount available for capture. """
+        for wizard in self:
+            wizard.amount_to_capture = wizard.available_amount
+
+    @api.depends('amount_to_capture', 'available_amount')
+    def _compute_is_amount_to_capture_valid(self):
+        for wizard in self:
+            is_valid = 0 < wizard.amount_to_capture <= wizard.available_amount
+            wizard.is_amount_to_capture_valid = is_valid
+
+    @api.depends('transaction_ids')
+    def _compute_support_partial_capture(self):
+        for wizard in self:
+            wizard.support_partial_capture = all(
+                tx.provider_id.support_manual_capture == 'partial' for tx in wizard.transaction_ids
+            )
+
+    @api.depends('transaction_ids')
+    def _compute_has_draft_children(self):
+        for wizard in self:
+            wizard.has_draft_children = bool(wizard.transaction_ids.child_transaction_ids.filtered(
+                lambda tx: tx.state == 'draft'
+            ))
+
+    @api.depends('available_amount', 'amount_to_capture')
+    def _compute_has_remaining_amount(self):
+        for wizard in self:
+            wizard.has_remaining_amount = wizard.amount_to_capture < wizard.available_amount
+            if not wizard.has_remaining_amount:
+                wizard.void_remaining_amount = False
+
+    #=== CONSTRAINT METHODS ===#
+
+    @api.constrains('amount_to_capture')
+    def _check_amount_to_capture_within_boundaries(self):
+        for wizard in self:
+            if not wizard.is_amount_to_capture_valid:
+                formatted_amount = format_amount(
+                    self.env, wizard.available_amount, wizard.currency_id
+                )
+                raise ValidationError(_(
+                    "The amount to capture must be positive and cannot be superior to %s.",
+                    formatted_amount
+                ))
+            if not wizard.support_partial_capture \
+               and wizard.amount_to_capture != wizard.available_amount:
+                raise ValidationError(_(
+                    "Some of the transactions you intend to capture can only be captured in full. "
+                    "Handle the transactions individually to capture a partial amount."
+                ))
+
+    #=== ACTION METHODS ===#
+
+    def action_capture(self):
+        for wizard in self:
+            remaining_amount_to_capture = wizard.amount_to_capture
+            for source_tx in wizard.transaction_ids.filtered(lambda tx: tx.state == 'authorized'):
+                partial_capture_child_txs = wizard.transaction_ids.child_transaction_ids.filtered(
+                    lambda tx: tx.source_transaction_id == source_tx and tx.state == 'done'
+                )  # We can void all the remaining amount only at once => don't check cancel state.
+                source_tx_remaining_amount = source_tx.currency_id.round(
+                    source_tx.amount - sum(partial_capture_child_txs.mapped('amount'))
+                )
+                if remaining_amount_to_capture:
+                    amount_to_capture = min(source_tx_remaining_amount, remaining_amount_to_capture)
+                    # In sudo mode because we need to be able to read on provider fields.
+                    source_tx.sudo()._send_capture_request(amount_to_capture=amount_to_capture)
+                    remaining_amount_to_capture -= amount_to_capture
+                    source_tx_remaining_amount -= amount_to_capture
+
+                if source_tx_remaining_amount and wizard.void_remaining_amount:
+                    # The source tx isn't fully captured and the user wants to void the remaining.
+                    # In sudo mode because we need to be able to read on provider fields.
+                    source_tx.sudo()._send_void_request(amount_to_void=source_tx_remaining_amount)
+                elif not remaining_amount_to_capture and not wizard.void_remaining_amount:
+                    # The amount to capture has been completely captured.
+                    break  # Skip the remaining transactions.

--- a/addons/payment/wizards/payment_capture_wizard_views.xml
+++ b/addons/payment/wizards/payment_capture_wizard_views.xml
@@ -1,0 +1,58 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+
+    <record id="payment_capture_wizard_view_form" model="ir.ui.view">
+        <field name="name">payment.capture.wizard.form</field>
+        <field name="model">payment.capture.wizard</field>
+        <field name="arch" type="xml">
+            <form string="Capture">
+                <field name="transaction_ids" invisible="1"/>
+                <field name="is_amount_to_capture_valid" invisible="1"/>
+                <field name="currency_id" invisible="1"/>
+                <field name="support_partial_capture" invisible="1"/>
+                <field name="has_draft_children" invisible="1"/>
+                <field name="has_remaining_amount" invisible="1"/>
+                <div id="alert_draft_capture_tx"
+                     role="alert"
+                     class="alert alert-warning"
+                     attrs="{'invisible': [('has_draft_children', '=', False)]}">
+                    <strong>Warning!</strong> There is a partial capture pending. Please wait a
+                    moment for it to be processed. Check your payment provider configuration if
+                    the capture is still pending after a few minutes.
+                </div>
+                <group name="readonly_fields">
+                    <field name="authorized_amount"/>
+                    <field name="captured_amount"
+                           attrs="{'invisible': [('captured_amount', '&lt;=', 0)]}"/>
+                    <field name="voided_amount"
+                           attrs="{'invisible': [('voided_amount', '&lt;=', 0)]}"/>
+                </group>
+                <hr/>
+                <group name="input_fields">
+                    <label for="amount_to_capture" class="oe_inline"/>
+                    <div class="o_row">
+                        <field name="amount_to_capture"
+                               class="oe_inline"
+                               attrs="{'readonly': [('support_partial_capture', '=', 'full_only')]}"/>
+                        <i class="fa fa-info-circle oe_inline"
+                           attrs="{'invisible': [('support_partial_capture', '!=', 'full_only')]}"
+                           title="Some of the transactions you intend to capture can only be captured in full. Handle the transactions individually to capture a partial amount."/>
+                    </div>
+                    <field name="void_remaining_amount" attrs="{'readonly': [('has_remaining_amount', '=', False)]}"/>
+                </group>
+                <div id="alert_amount_to_capture_above_authorized_amount"
+                     role="alert"
+                     class="alert alert-warning mb-2"
+                     attrs="{'invisible': [('is_amount_to_capture_valid', '=', True)]}">
+                    <strong>Warning!</strong> You can not capture a negative amount nor more
+                    than <field name='available_amount' class='oe_inline' widget='monetary'/>.
+                </div>
+                <footer>
+                    <button string="Capture" type="object" name="action_capture" class="btn-primary"/>
+                    <button string="Close" special="cancel" class="btn-secondary"/>
+                </footer>
+            </form>
+        </field>
+    </record>
+
+</odoo>

--- a/addons/payment_adyen/__init__.py
+++ b/addons/payment_adyen/__init__.py
@@ -2,6 +2,7 @@
 
 from . import controllers
 from . import models
+from . import wizards
 
 from odoo.addons.payment import setup_provider, reset_payment_provider
 

--- a/addons/payment_adyen/__manifest__.py
+++ b/addons/payment_adyen/__manifest__.py
@@ -13,6 +13,8 @@
         'views/payment_templates.xml',  # Only load the SDK on pages with a payment form.
 
         'data/payment_provider_data.xml',  # Depends on views/payment_adyen_templates.xml
+
+        'wizards/payment_capture_wizard_views.xml',
     ],
     'post_init_hook': 'post_init_hook',
     'uninstall_hook': 'uninstall_hook',

--- a/addons/payment_adyen/controllers/main.py
+++ b/addons/payment_adyen/controllers/main.py
@@ -280,6 +280,9 @@ class AdyenController(http.Controller):
                     notification_data['resultCode'] = 'Cancelled' if success else 'Error'
                 elif event_code in ['REFUND', 'CAPTURE']:
                     notification_data['resultCode'] = 'Authorised' if success else 'Error'
+                elif event_code == 'CAPTURE_FAILED' and success:
+                    # The capture failed after a capture notification with success = True was sent
+                    notification_data['resultCode'] = 'Error'
                 else:
                     continue  # Don't handle unsupported event codes and failed events
 

--- a/addons/payment_adyen/models/payment_provider.py
+++ b/addons/payment_adyen/models/payment_provider.py
@@ -67,7 +67,7 @@ class PaymentProvider(models.Model):
         """ Override of `payment` to enable additional features. """
         super()._compute_feature_support_fields()
         self.filtered(lambda p: p.code == 'adyen').update({
-            'support_manual_capture': True,
+            'support_manual_capture': 'partial',
             'support_refund': 'partial',
             'support_tokenization': True,
         })

--- a/addons/payment_adyen/models/payment_transaction.py
+++ b/addons/payment_adyen/models/payment_transaction.py
@@ -3,8 +3,9 @@
 import logging
 import pprint
 
-from odoo import _, api, fields, models
+from odoo import _, models
 from odoo.exceptions import UserError, ValidationError
+from odoo.tools import format_amount
 
 from odoo.addons.payment import utils as payment_utils
 from odoo.addons.payment_adyen import utils as adyen_utils
@@ -156,19 +157,15 @@ class PaymentTransaction(models.Model):
 
         return refund_tx
 
-    def _send_capture_request(self):
-        """ Override of payment to send a capture request to Adyen.
-
-        Note: self.ensure_one()
-
-        :return: None
-        """
-        super()._send_capture_request()
+    def _send_capture_request(self, amount_to_capture=None):
+        """ Override of `payment` to send a capture request to Adyen. """
+        capture_child_tx = super()._send_capture_request(amount_to_capture=amount_to_capture)
         if self.provider_code != 'adyen':
-            return
+            return capture_child_tx
 
+        amount_to_capture = amount_to_capture or self.amount
         converted_amount = payment_utils.to_minor_currency_units(
-            self.amount, self.currency_id, CURRENCY_DECIMALS.get(self.currency_id.name)
+            amount_to_capture, self.currency_id, CURRENCY_DECIMALS.get(self.currency_id.name)
         )
         data = {
             'merchantAccount': self.provider_id.adyen_merchant_account,
@@ -189,22 +186,26 @@ class PaymentTransaction(models.Model):
 
         # Handle the capture request response
         status = response_content.get('status')
+        formatted_amount = format_amount(self.env, amount_to_capture, self.currency_id)
         if status == 'received':
             self._log_message_on_linked_documents(_(
-                "The capture of the transaction with reference %s has been requested (%s).",
-                self.reference, self.provider_id.name
+                "The capture request of %(amount)s for the transaction with reference %(ref)s has "
+                "been requested (%(provider_name)s).",
+                amount=formatted_amount, ref=self.reference, provider_name=self.provider_id.name
             ))
 
-    def _send_void_request(self):
-        """ Override of payment to send a void request to Adyen.
+        if capture_child_tx:
+            # The PSP reference associated with this capture request is different from the PSP
+            # reference associated with the original payment request.
+            capture_child_tx.provider_reference = response_content.get('pspReference')
 
-        Note: self.ensure_one()
+        return capture_child_tx
 
-        :return: None
-        """
-        super()._send_void_request()
+    def _send_void_request(self, amount_to_void=None):
+        """ Override of `payment` to send a void request to Adyen. """
+        child_void_tx = super()._send_void_request(amount_to_void=amount_to_void)
         if self.provider_code != 'adyen':
-            return
+            return child_void_tx
 
         data = {
             'merchantAccount': self.provider_id.adyen_merchant_account,
@@ -226,6 +227,13 @@ class PaymentTransaction(models.Model):
                 "A request was sent to void the transaction with reference %s (%s).",
                 self.reference, self.provider_id.name
             ))
+
+        if child_void_tx:
+            # The PSP reference associated with this void request is different from the PSP
+            # reference associated with the original payment request.
+            child_void_tx.provider_reference = response_content.get('pspReference')
+
+        return child_void_tx
 
     def _get_tx_from_notification_data(self, provider_code, notification_data):
         """ Override of payment to find the transaction based on Adyen data.
@@ -250,13 +258,47 @@ class PaymentTransaction(models.Model):
         source_reference = notification_data.get('originalReference')
         if event_code == 'AUTHORISATION':
             tx = self.search([('reference', '=', reference), ('provider_code', '=', 'adyen')])
-        elif event_code in ['CAPTURE', 'CANCELLATION']:
+        elif event_code in ['CANCELLATION', 'CAPTURE', 'CAPTURE_FAILED']:
             # The capture/void may be initiated from Adyen, so we can't trust the reference.
             # We find the transaction based on the original provider reference since Adyen will have
-            # two different references: one for the original transaction and one for the capture.
-            tx = self.search(
+            # two different references: one for the original transaction and one for the capture or
+            # void. We keep the second one only for child transactions. For full capture/void, no
+            # child transaction are created. Thus, we first look for the source transaction before
+            # checking if we need to find/create a child transaction.
+            source_tx = self.search(
                 [('provider_reference', '=', source_reference), ('provider_code', '=', 'adyen')]
             )
+            if source_tx:
+                notification_data_amount = notification_data.get('amount', {}).get('value')
+                converted_notification_amount = payment_utils.to_major_currency_units(
+                    notification_data_amount, source_tx.currency_id
+                )
+                if source_tx.amount == converted_notification_amount:  # Full capture/void.
+                    tx = source_tx
+                else:  # Partial capture/void; we search for the child transaction instead.
+                    tx = self.search([
+                        ('provider_reference', '=', provider_reference),
+                        ('provider_code', '=', 'adyen'),
+                    ])
+                    if tx and tx.amount != converted_notification_amount:
+                        # If the void was requested expecting a certain amount but, in the meantime,
+                        # others captures that Odoo was unaware of were done, the amount voided will
+                        # be different from the amount of the existing transaction.
+                        tx._set_error(_(
+                            "The amount processed by Adyen for the transaction %s is different than"
+                            " the one requested. Another transaction is created with the correct"
+                            " amount.", tx.reference
+                        ))
+                        tx = self.env['payment.transaction']
+                    if not tx:  # Partial capture/void initiated from Adyen or with a wrong amount.
+                        # Manually create a child transaction with a new reference. The reference of
+                        # the child transaction was personalized from Adyen and could be identical
+                        # to that of an existing transaction.
+                        tx = self._adyen_create_child_tx_from_notification_data(
+                            source_tx, notification_data
+                        )
+            else:  # The capture/void was initiated for an unknown source transaction
+                pass  # Don't do anything with the capture/void notification
         else:  # 'REFUND'
             # The refund may be initiated from Adyen, so we can't trust the reference, which could
             # be identical to another existing transaction. We find the transaction based on the
@@ -273,8 +315,8 @@ class PaymentTransaction(models.Model):
                     # Manually create a refund transaction with a new reference. The reference of
                     # the refund transaction was personalized from Adyen and could be identical to
                     # that of an existing transaction.
-                    tx = self._adyen_create_refund_tx_from_notification_data(
-                        source_tx, notification_data
+                    tx = self._adyen_create_child_tx_from_notification_data(
+                        source_tx, notification_data, is_refund=True
                     )
                 else:  # The refund was initiated for an unknown source transaction
                     pass  # Don't do anything with the refund notification
@@ -285,28 +327,30 @@ class PaymentTransaction(models.Model):
             )
         return tx
 
-    def _adyen_create_refund_tx_from_notification_data(self, source_tx, notification_data):
-        """ Create a refund transaction based on Adyen data.
+    def _adyen_create_child_tx_from_notification_data(
+        self, source_tx, notification_data, is_refund=False
+    ):
+        """ Create a child transaction based on Adyen data.
 
-        :param recordset source_tx: The source transaction for which a refund is initiated, as a
-                                    `payment.transaction` recordset
+        :param payment.transaction source_tx: The source transaction for which a new operation is
+                                              initiated.
         :param dict notification_data: The notification data sent by the provider
-        :return: The newly created refund transaction
-        :rtype: recordset of `payment.transaction`
-        :raise: ValidationError if inconsistent data were received
+        :param string operation: The operation of the child transaction, e.g. 'refund'. Defaults to
+                                 `self.operation`.
+        :return: The newly created child transaction.
+        :rtype: payment.transaction
+        :raise ValidationError: If inconsistent data were received.
         """
-        refund_provider_reference = notification_data.get('pspReference')
-        amount_to_refund = notification_data.get('amount', {}).get('value')
-        if not refund_provider_reference or not amount_to_refund:
+        provider_reference = notification_data.get('pspReference')
+        amount = notification_data.get('amount', {}).get('value')
+        if not provider_reference or amount is None:  # amount == 0 if success == False
             raise ValidationError(
-                "Adyen: " + _("Received refund data with missing transaction values")
+                "Adyen: " + _("Received data for child transaction with missing transaction values")
             )
 
-        converted_amount = payment_utils.to_major_currency_units(
-            amount_to_refund, source_tx.currency_id
-        )
-        return source_tx._create_refund_transaction(
-            amount_to_refund=converted_amount, provider_reference=refund_provider_reference
+        converted_amount = payment_utils.to_major_currency_units(amount, source_tx.currency_id)
+        return source_tx._create_child_transaction(
+            converted_amount, is_refund=is_refund, provider_reference=provider_reference
         )
 
     def _process_notification_data(self, notification_data):
@@ -371,21 +415,21 @@ class PaymentTransaction(models.Model):
                     _("An error occurred during the processing of your payment. Please try again.")
                 )
             elif event_code == 'CANCELLATION':
-                _logger.warning(
-                    "the void of the transaction with reference %s failed. reason: %s",
-                    self.reference, refusal_reason
-                )
-                self._log_message_on_linked_documents(
-                    _("The void of the transaction with reference %s failed.", self.reference)
-                )
-            else:  # 'CAPTURE'
-                _logger.warning(
-                    "the capture of the transaction with reference %s failed. reason: %s",
-                    self.reference, refusal_reason
-                )
-                self._log_message_on_linked_documents(
-                    _("The capture of the transaction with reference %s failed.", self.reference)
-                )
+                failed_void_msg = "The void of the transaction with reference %s failed."
+                logger_msg = failed_void_msg + " reason: %s"
+                _logger.warning(logger_msg, self.reference, refusal_reason)
+                if self.source_transaction_id:  # child tx => The event can't be retried.
+                    self._set_error(_(failed_void_msg, self.reference))
+                else:  # source tx with failed void stays in its state, could be voided again
+                    self._log_message_on_linked_documents(_(failed_void_msg, self.reference))
+            else:  # 'CAPTURE', 'CAPTURE_FAILED'
+                failed_capture_msg = "The capture of the transaction with reference %s failed."
+                logger_msg = failed_capture_msg + " reason: %s"
+                _logger.warning(logger_msg, self.reference, refusal_reason)
+                if self.source_transaction_id:  # child_tx => The event can't be retried.
+                    self._set_error(_(failed_capture_msg, self.reference))
+                else:  # source tx with failed capture stays in its state, could be captured again
+                    self._log_message_on_linked_documents(_(failed_capture_msg, self.reference))
         elif payment_state in RESULT_CODES_MAPPING['refused']:
             _logger.warning(
                 "the transaction with reference %s was refused. reason: %s",

--- a/addons/payment_adyen/wizards/__init__.py
+++ b/addons/payment_adyen/wizards/__init__.py
@@ -1,0 +1,2 @@
+
+from . import payment_capture_wizard

--- a/addons/payment_adyen/wizards/payment_capture_wizard.py
+++ b/addons/payment_adyen/wizards/payment_capture_wizard.py
@@ -1,0 +1,14 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from odoo import api, fields, models
+
+
+class PaymentCaptureWizard(models.TransientModel):
+    _inherit = 'payment.capture.wizard'
+
+    has_adyen_tx = fields.Boolean(compute='_compute_has_adyen_tx')
+
+    @api.depends('transaction_ids')
+    def _compute_has_adyen_tx(self):
+        for wizard in self:
+            wizard.has_adyen_tx = any(tx.provider_code == 'adyen' for tx in wizard.transaction_ids)

--- a/addons/payment_adyen/wizards/payment_capture_wizard_views.xml
+++ b/addons/payment_adyen/wizards/payment_capture_wizard_views.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+
+    <record id="payment_capture_wizard_view_form" model="ir.ui.view">
+        <field name="name">payment.adyen.capture.wizard.form</field>
+        <field name="model">payment.capture.wizard</field>
+        <field name="inherit_id" ref="payment.payment_capture_wizard_view_form"/>
+        <field name="arch" type="xml">
+            <footer position="before">
+                <field name="has_adyen_tx" invisible="1"/>
+                <div id="alert_delayed_capture_tx"
+                     role="alert"
+                     class="alert alert-info mb-2"
+                     attrs="{'invisible': [('has_adyen_tx', '=', False)]}">
+                    The capture or void of the transaction might take a few minutes to be
+                    processed by Adyen and reflected in Odoo.
+                </div>
+            </footer>
+        </field>
+    </record>
+
+</odoo>

--- a/addons/payment_authorize/models/payment_provider.py
+++ b/addons/payment_authorize/models/payment_provider.py
@@ -63,7 +63,7 @@ class PaymentProvider(models.Model):
         """ Override of `payment` to enable additional features. """
         super()._compute_feature_support_fields()
         self.filtered(lambda p: p.code == 'authorize').update({
-            'support_manual_capture': True,
+            'support_manual_capture': 'full_only',
             'support_refund': 'full_only',
             'support_tokenization': True,
         })

--- a/addons/payment_authorize/models/payment_transaction.py
+++ b/addons/payment_authorize/models/payment_transaction.py
@@ -144,16 +144,11 @@ class PaymentTransaction(models.Model):
             ))
         return refund_tx
 
-    def _send_capture_request(self):
-        """ Override of payment to send a capture request to Authorize.
-
-        Note: self.ensure_one()
-
-        :return: None
-        """
-        super()._send_capture_request()
+    def _send_capture_request(self, amount_to_capture=None):
+        """ Override of `payment` to send a capture request to Authorize. """
+        child_capture_tx = super()._send_capture_request(amount_to_capture=amount_to_capture)
         if self.provider_code != 'authorize':
-            return
+            return child_capture_tx
 
         authorize_API = AuthorizeAPI(self.provider_id)
         rounded_amount = round(self.amount, self.currency_id.decimal_places)
@@ -164,16 +159,13 @@ class PaymentTransaction(models.Model):
         )
         self._handle_notification_data('authorize', {'response': res_content})
 
-    def _send_void_request(self):
-        """ Override of payment to send a void request to Authorize.
+        return child_capture_tx
 
-        Note: self.ensure_one()
-
-        :return: None
-        """
-        super()._send_void_request()
+    def _send_void_request(self, amount_to_void=None):
+        """ Override of payment to send a void request to Authorize. """
+        child_void_tx = super()._send_void_request(amount_to_void=amount_to_void)
         if self.provider_code != 'authorize':
-            return
+            return child_void_tx
 
         authorize_API = AuthorizeAPI(self.provider_id)
         res_content = authorize_API.void(self.provider_reference)
@@ -182,6 +174,8 @@ class PaymentTransaction(models.Model):
             self.reference, pprint.pformat(res_content)
         )
         self._handle_notification_data('authorize', {'response': res_content})
+
+        return child_void_tx
 
     def _get_tx_from_notification_data(self, provider_code, notification_data):
         """ Find the transaction based on Authorize.net data.

--- a/addons/payment_demo/models/payment_provider.py
+++ b/addons/payment_demo/models/payment_provider.py
@@ -25,7 +25,7 @@ class PaymentProvider(models.Model):
         super()._compute_feature_support_fields()
         self.filtered(lambda p: p.code == 'demo').update({
             'support_fees': True,
-            'support_manual_capture': True,
+            'support_manual_capture': 'full_only',
             'support_refund': 'partial',
             'support_tokenization': True,
         })

--- a/addons/payment_demo/models/payment_transaction.py
+++ b/addons/payment_demo/models/payment_transaction.py
@@ -97,16 +97,11 @@ class PaymentTransaction(models.Model):
 
         return refund_tx
 
-    def _send_capture_request(self):
-        """ Override of payment to simulate a capture request.
-
-        Note: self.ensure_one()
-
-        :return: None
-        """
-        super()._send_capture_request()
+    def _send_capture_request(self, amount_to_capture=None):
+        """ Override of `payment` to simulate a capture request. """
+        child_capture_tx = super()._send_capture_request(amount_to_capture=amount_to_capture)
         if self.provider_code != 'demo':
-            return
+            return child_capture_tx
 
         notification_data = {
             'reference': self.reference,
@@ -115,19 +110,18 @@ class PaymentTransaction(models.Model):
         }
         self._handle_notification_data('demo', notification_data)
 
-    def _send_void_request(self):
-        """ Override of payment to simulate a void request.
+        return child_capture_tx
 
-        Note: self.ensure_one()
-
-        :return: None
-        """
-        super()._send_void_request()
+    def _send_void_request(self, amount_to_void=None):
+        """ Override of `payment` to simulate a void request. """
+        child_void_tx = super()._send_void_request(amount_to_void=amount_to_void)
         if self.provider_code != 'demo':
-            return
+            return child_void_tx
 
         notification_data = {'reference': self.reference, 'simulated_state': 'cancel'}
         self._handle_notification_data('demo', notification_data)
+
+        return child_void_tx
 
     def _get_tx_from_notification_data(self, provider_code, notification_data):
         """ Override of payment to find the transaction based on dummy data.

--- a/addons/payment_razorpay/models/payment_provider.py
+++ b/addons/payment_razorpay/models/payment_provider.py
@@ -45,7 +45,7 @@ class PaymentProvider(models.Model):
         """ Override of `payment` to enable additional features. """
         super()._compute_feature_support_fields()
         self.filtered(lambda p: p.code == 'razorpay').update({
-            'support_manual_capture': True,
+            'support_manual_capture': 'full_only',
             'support_refund': 'partial',
         })
 

--- a/addons/payment_stripe/controllers/main.py
+++ b/addons/payment_stripe/controllers/main.py
@@ -192,7 +192,7 @@ class StripeController(http.Controller):
         converted_amount = payment_utils.to_major_currency_units(
             amount_to_refund, source_tx_sudo.currency_id
         )
-        return source_tx_sudo._create_refund_transaction(amount_to_refund=converted_amount)
+        return source_tx_sudo._create_child_transaction(converted_amount, is_refund=True)
 
     def _verify_notification_signature(self, tx_sudo):
         """ Check that the received signature matches the expected one.

--- a/addons/payment_stripe/models/payment_provider.py
+++ b/addons/payment_stripe/models/payment_provider.py
@@ -41,7 +41,7 @@ class PaymentProvider(models.Model):
         super()._compute_feature_support_fields()
         self.filtered(lambda p: p.code == 'stripe').update({
             'support_express_checkout': True,
-            'support_manual_capture': True,
+            'support_manual_capture': 'full_only',
             'support_refund': 'partial',
             'support_tokenization': True,
         })

--- a/addons/payment_stripe/models/payment_transaction.py
+++ b/addons/payment_stripe/models/payment_transaction.py
@@ -300,16 +300,11 @@ class PaymentTransaction(models.Model):
 
         return refund_tx
 
-    def _send_capture_request(self):
-        """ Override of payment to send a capture request to Stripe.
-
-        Note: self.ensure_one()
-
-        :return: None
-        """
-        super()._send_capture_request()
+    def _send_capture_request(self, amount_to_capture=None):
+        """ Override of `payment` to send a capture request to Stripe. """
+        child_capture_tx = super()._send_capture_request(amount_to_capture=amount_to_capture)
         if self.provider_code != 'stripe':
-            return
+            return child_capture_tx
 
         # Make the capture request to Stripe
         payment_intent = self.provider_id._stripe_make_request(
@@ -327,16 +322,13 @@ class PaymentTransaction(models.Model):
         )
         self._handle_notification_data('stripe', notification_data)
 
-    def _send_void_request(self):
-        """ Override of payment to send a void request to Stripe.
+        return child_capture_tx
 
-        Note: self.ensure_one()
-
-        :return: None
-        """
-        super()._send_void_request()
+    def _send_void_request(self, amount_to_void=None):
+        """ Override of `payment` to send a void request to Stripe. """
+        child_void_tx = super()._send_void_request(amount_to_void=amount_to_void)
         if self.provider_code != 'stripe':
-            return
+            return child_void_tx
 
         # Make the void request to Stripe
         payment_intent = self.provider_id._stripe_make_request(
@@ -353,6 +345,8 @@ class PaymentTransaction(models.Model):
             payment_intent, notification_data
         )
         self._handle_notification_data('stripe', notification_data)
+
+        return child_void_tx
 
     def _get_tx_from_notification_data(self, provider_code, notification_data):
         """ Override of payment to find the transaction based on Stripe data.

--- a/addons/payment_stripe/tests/test_refund_flows.py
+++ b/addons/payment_stripe/tests/test_refund_flows.py
@@ -36,8 +36,8 @@ class TestRefundFlows(StripeCommon, PaymentHttpCommon):
         """ Test that receiving a webhook notification for a refund cancellation
         (`charge.refund.updated` event) triggers the processing of the notification data. """
         source_tx = self._create_transaction('redirect', state='done')
-        source_tx._create_refund_transaction(
-            amount_to_refund=source_tx.amount, provider_reference=self.refund_object['id']
+        source_tx._create_child_transaction(
+            source_tx.amount, is_refund=True, provider_reference=self.refund_object['id']
         )
         url = self._build_url(StripeController._webhook_url)
         with patch(

--- a/addons/sale/models/payment_transaction.py
+++ b/addons/sale/models/payment_transaction.py
@@ -108,7 +108,7 @@ class PaymentTransaction(models.Model):
         """
         super()._log_message_on_linked_documents(message)
         self = self.with_user(SUPERUSER_ID)  # Log messages as 'OdooBot'
-        for order in self.sale_order_ids:
+        for order in self.sale_order_ids or self.source_transaction_id.sale_order_ids:
             order.message_post(body=message)
 
     def _reconcile_after_done(self):

--- a/addons/sale/models/sale_order.py
+++ b/addons/sale/models/sale_order.py
@@ -1337,14 +1337,17 @@ class SaleOrder(models.Model):
 
     def payment_action_capture(self):
         """ Capture all transactions linked to this sale order. """
+        self.ensure_one()
         payment_utils.check_rights_on_recordset(self)
-        # In sudo mode because we need to be able to read on provider fields.
-        self.authorized_transaction_ids.sudo().action_capture()
+
+        # In sudo mode to bypass the checks on the rights on the transactions.
+        return self.transaction_ids.sudo().action_capture()
 
     def payment_action_void(self):
         """ Void all transactions linked to this sale order. """
         payment_utils.check_rights_on_recordset(self)
-        # In sudo mode because we need to be able to read on provider fields.
+
+        # In sudo mode to bypass the checks on the rights on the transactions.
         self.authorized_transaction_ids.sudo().action_void()
 
     def get_portal_last_transaction(self):

--- a/addons/website_sale/tests/test_website_sale_cart_payment.py
+++ b/addons/website_sale/tests/test_website_sale_cart_payment.py
@@ -43,7 +43,7 @@ class WebsiteSaleCartPayment(PaymentCommon):
     def test_paid_orders_cannot_be_retrieved(self):
         """ Test that fetching sales orders linked to a payment transaction in the states 'pending',
         'authorized', or 'done' returns an empty recordset to prevent updating the paid orders. """
-        self.tx.provider_id.support_manual_capture = True
+        self.tx.provider_id.support_manual_capture = 'full_only'
         for paid_order_tx_state in ('pending', 'authorized', 'done'):
             self.tx.state = paid_order_tx_state
             with MockRequest(self.env, website=self.website, sale_order_id=self.order.id):


### PR DESCRIPTION
Before this commit, it was not possible to partially capture a
transaction from Odoo, and doing so in the provider backend would often
result in a full capture in Odoo when capture was supported.

With this commit, partial captures are made available in Odoo directly
from the sales order or invoice, for providers that support them.
Acquirer can either only support full capture or also support partial
ones. It also optionally managed the automatic void of the remaining
amount at the user request when multiple captures are supported by the
provider.

As of now, the only provider allowing partial capture is Adyen.

task-2728768

See also:
- https://github.com/odoo/enterprise/pull/35205
- https://github.com/odoo/documentation/pull/2063