### PR TITLE
[FIX] mass_mailing: prevent use of unsupported image transform option

### DIFF
--- a/addons/mass_mailing/static/src/js/mass_mailing_snippets.js
+++ b/addons/mass_mailing/static/src/js/mass_mailing_snippets.js
@@ -95,6 +95,26 @@ options.registry.BackgroundImage = options.registry.BackgroundImage.extend({
     }
 });
 
+options.registry.ImageTools.include({
+
+    //--------------------------------------------------------------------------
+    // Public
+    //--------------------------------------------------------------------------
+
+    /**
+     * @override
+     */
+    async updateUIVisibility() {
+        await this._super(...arguments);
+
+        // Transform is _very_ badly supported in mail clients. Hide the option.
+        const transformEl = this.el.querySelector('[data-transform="true"]');
+        if (transformEl) {
+            transformEl.classList.toggle('d-none', true);
+        }
+    },
+});
+
 options.registry.ImageOptimize.include({
 
     //--------------------------------------------------------------------------


### PR DESCRIPTION
- The image transform option uses the `transform` CSS property, which is very poorly supported in email clients. This hides that option so as to avoid bad surprises.
- Images with an aspect ratio of 299×524 that aren't linked to anything are treated as downloadable attachments by GMail and get a little "download" icon. This tends to ruin carefully crafted mailing designs so this ensures all images are actually linked to something (at the very least, to `#`) so the icon doesn't appear.

task-2802705

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
