### PR TITLE
[FIX] website_sale_comparison: Product comparison with base unit price error

### DIFF
--- a/addons/website_sale_comparison/views/website_sale_comparison_template.xml
+++ b/addons/website_sale_comparison/views/website_sale_comparison_template.xml
@@ -130,7 +130,7 @@
                                                 <del t-attf-class="text-danger mr8 {{'' if combination_info['has_discounted_price'] else 'd-none'}}" style="white-space: nowrap;" t-esc="combination_info['list_price']" t-options="{'widget': 'monetary', 'display_currency': website.currency_id}" />
                                                 <span t-esc="combination_info['price']" t-options="{'widget': 'monetary', 'display_currency': website.currency_id}"></span>
                                                 <small class="d-block text-muted" groups="website_sale.group_show_uom_price" t-if="product.base_unit_price">
-                                                    <t t-call='website_sale.base_unit_price'><t t-set='product' t-value='line.product_id' /></t>
+                                                    <t t-call='website_sale.base_unit_price'/>
                                                 </small>
                                             </span>
 


### PR DESCRIPTION
When you compare two products on the ecommerce with the Base Unit Price enabled,
an error occurs.

To reproduce the issue:
1. Install the eCommerce app.
2. Go to the settings of eCommerce and activate the options "Base Unit Price" and "Product Comparison Tool".
3. On the website, go to the shop, and compare two products.

Solution: The XML was passing an invalid argument (unset variable) to the 't-call'.
The argument was in fact unecessary as the argument is already defined in the 't-foreach'.

opw-2802682