### PR TITLE
[FIX] l10n_es_edi: no commits in tests

### DIFF
--- a/addons/account_edi/models/account_move.py
+++ b/addons/account_edi/models/account_move.py
@@ -616,9 +616,9 @@ class AccountMove(models.Model):
     # Business operations
     ####################################################
 
-    def action_process_edi_web_services(self):
+    def action_process_edi_web_services(self, with_commit=True):
         docs = self.edi_document_ids.filtered(lambda d: d.state in ('to_send', 'to_cancel') and d.blocking_level != 'error')
-        docs._process_documents_web_services()
+        docs._process_documents_web_services(with_commit=with_commit)
 
     def _retry_edi_documents_error_hook(self):
         ''' Hook called when edi_documents are retried. For example, when it's needed to clean a field.

--- a/addons/l10n_es_edi_sii/tests/test_edi_web_services.py
+++ b/addons/l10n_es_edi_sii/tests/test_edi_web_services.py
@@ -53,7 +53,7 @@ class TestEdiWebServices(TestEsEdiCommon):
     def test_edi_aeat(self):
         self.env.company.l10n_es_edi_tax_agency = 'aeat'
 
-        self.moves.action_process_edi_web_services()
+        self.moves.action_process_edi_web_services(with_commit=False)
         generated_files = self._process_documents_web_services(self.moves, {'es_sii'})
         self.assertTrue(generated_files)
         self.assertRecordValues(self.out_invoice, [{'edi_state': 'sent'}])
@@ -62,7 +62,7 @@ class TestEdiWebServices(TestEsEdiCommon):
     def test_edi_gipuzkoa(self):
         self.env.company.l10n_es_edi_tax_agency = 'gipuzkoa'
 
-        self.moves.action_process_edi_web_services()
+        self.moves.action_process_edi_web_services(with_commit=False)
         generated_files = self._process_documents_web_services(self.moves, {'es_sii'})
         self.assertTrue(generated_files)
         self.assertRecordValues(self.out_invoice, [{'edi_state': 'sent'}])
@@ -71,7 +71,7 @@ class TestEdiWebServices(TestEsEdiCommon):
     def test_edi_bizkaia(self):
         self.env.company.l10n_es_edi_tax_agency = 'bizkaia'
 
-        self.moves.action_process_edi_web_services()
+        self.moves.action_process_edi_web_services(with_commit=False)
         generated_files = self._process_documents_web_services(self.moves, {'es_sii'})
         self.assertTrue(generated_files)
         self.assertRecordValues(self.out_invoice, [{'edi_state': 'sent'}])


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
Behavior of account_move.action_process_edi_web_services() is fixed to have the same behavior as in [v14](https://github.com/odoo/odoo/blob/7c2d68b466e13a25a6dd7091383b1f9810f1a630/addons/account_edi/models/account_move.py#L409).

Current behavior before PR:
SII's external tests fail for one of the following reasons
- `psycopg2.errors.InvalidSavepointSpecification: savepoint "test_xx" does not exist`
- `psycopg2.errors.InFailedSqlTransaction: current transaction is aborted, commands ignored until end of transaction block`
- `psycopg2.errors.UniqueViolation: duplicate key value violates unique constraint "res_users_login_key" DETAIL:  Key (login)=(accountman) already exists.`

Desired behavior after PR is merged:
Those tests no longer fail (at least for those reasons)



--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
