### PR TITLE
[FIX] stock_account: round SVL's value of incoming move

### DIFF
--- a/addons/stock_account/models/product.py
+++ b/addons/stock_account/models/product.py
@@ -132,9 +132,11 @@ class ProductProduct(models.Model):
         :rtype: dict
         """
         self.ensure_one()
+        company_id = self.env.context.get('force_company', self.env.company.id)
+        company = self.env['res.company'].browse(company_id)
         vals = {
             'product_id': self.id,
-            'value': unit_cost * quantity,
+            'value': company.currency_id.round(unit_cost * quantity),
             'unit_cost': unit_cost,
             'quantity': quantity,
         }
@@ -151,11 +153,14 @@ class ProductProduct(models.Model):
         :rtype: dict
         """
         self.ensure_one()
+        company_id = self.env.context.get('force_company', self.env.company.id)
+        company = self.env['res.company'].browse(company_id)
+        currency = company.currency_id
         # Quantity is negative for out valuation layers.
         quantity = -1 * quantity
         vals = {
             'product_id' : self.id,
-            'value': quantity * self.standard_price,
+            'value': currency.round(quantity * self.standard_price),
             'unit_cost': self.standard_price,
             'quantity': quantity,
         }
@@ -164,7 +169,6 @@ class ProductProduct(models.Model):
             vals['remaining_qty'] = fifo_vals.get('remaining_qty')
             # In case of AVCO, fix rounding issue of standard price when needed.
             if self.cost_method == 'average':
-                currency = self.env.company.currency_id
                 rounding_error = currency.round(self.standard_price * self.quantity_svl - self.value_svl)
                 if rounding_error:
                     # If it is bigger than the (smallest number of the currency * quantity) / 2,

--- a/addons/stock_account/tests/test_stockvaluationlayer.py
+++ b/addons/stock_account/tests/test_stockvaluationlayer.py
@@ -299,6 +299,15 @@ class TestStockValuationStandard(TestStockValuationCommon):
         self.assertTrue(product2.stock_valuation_layer_ids)
         self.assertFalse(product1.stock_valuation_layer_ids)
 
+    def test_currency_precision_and_standard_svl_value(self):
+        self.env.company.currency_id.rounding = 1
+        self.product1.standard_price = 3
+
+        self._make_in_move(self.product1, 0.5)
+        self._make_out_move(self.product1, 0.5)
+
+        self.assertEqual(self.product1.value_svl, 0.0)
+
 
 class TestStockValuationAVCO(TestStockValuationCommon):
     def setUp(self):
@@ -703,6 +712,14 @@ class TestStockValuationFIFO(TestStockValuationCommon):
 
         self.assertEqual(self.product1.value_svl, 20)
         self.assertEqual(self.product1.quantity_svl, 10)
+
+    def test_currency_precision_and_fifo_svl_value(self):
+        self.env.company.currency_id.rounding = 1.0
+
+        self._make_in_move(self.product1, 0.5, unit_cost=3)
+        self._make_out_move(self.product1, 0.5)
+
+        self.assertEqual(self.product1.value_svl, 0.0)
 
 
 class TestStockValuationChangeCostMethod(TestStockValuationCommon):


### PR DESCRIPTION
The SVL of in/out moves may be different because of rounding

To reproduce the issue:
(Need purchase,sale_management,stock)
1. In Settings, enable "Multi-Currencies"
2. Edit the USD currency:
    - Rounding factor: 1.0
3. Create a product category PC:
    - Costing Method: FIFO
4. Create a product P:
    - Type: Storable
    - Category: PC
5. Create a purchase order PO with one line:
    - Product: P
    - Quantity: 0.5
    - Unit Price: 3.0
6. Confirm the PO and receive P
7. Create a sale order SO with 0.5 x P
8. Confirm the SO and deliver P
9. Inventory > Reporting > Inventory Valuation

Error: The quantity of P is zero but its total value is 0.50$

When receiving P, a SVL is created but does not round the value. So, we
have 0.5 x P in stock with a value equal to $1.50
Then, when deliver the product, the FIFO process is executed and create
a second SVL. However, this time the value is rounded:
https://github.com/odoo/odoo/blob/2e4fdcb84ba6375bb51fe71355168cebe2d922a0/addons/stock_account/models/product.py#L290
Therefore, the SVL of the out move has a value equal to $2. This
explains why, when checking the inventory valuation, the value is $-0.50

OPW-2724864