### PR TITLE
[IMP] point_of_sale: show invoice origin on pos close error

### DIFF
--- a/addons/point_of_sale/models/pos_session.py
+++ b/addons/point_of_sale/models/pos_session.py
@@ -195,7 +195,7 @@ class PosSession(models.Model):
         if unposted_invoices:
             raise UserError(_('You cannot close the POS when invoices are not posted.\n'
                               'Invoices: %s') % str.join('\n',
-                                                         ['%s - %s' % (invoice.name, invoice.state) for invoice in
+                                                         ['%s - %s - %s' % (invoice.display_name, invoice.invoice_origin, invoice.state) for invoice in
                                                           unposted_invoices]))
 
     @api.model


### PR DESCRIPTION
Description of the issue/feature this PR addresses:

More precise reporting of the concerned invoices when the session cannot be close because of a draft invoice.

Current behavior before PR:

The invoice being draft, it does not have a name (number) chosen. So in the error message, the invoice shown is ` / - draft`. Which is not helpful at all.

Desired behavior after PR is merged:

The error reports the display name of the invoice, which shows the `id` and also the invoice origin which should show the order name.
It is therefore easier to find and fix the invoice.

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
