### PR TITLE
[FIX] mrp: always confirm empty production

### DIFF
--- a/addons/mrp/models/stock_rule.py
+++ b/addons/mrp/models/stock_rule.py
@@ -58,7 +58,7 @@ class StockRule(models.Model):
             self.env['stock.move'].sudo().create(productions._get_moves_raw_values())
             self.env['stock.move'].sudo().create(productions._get_moves_finished_values())
             productions._create_workorder()
-            productions.filtered(lambda p: not p.orderpoint_id).action_confirm()
+            productions.filtered(lambda p: not p.orderpoint_id or not p.move_raw_ids).action_confirm()
 
             for production in productions:
                 origin_production = production.move_dest_ids and production.move_dest_ids[0].raw_material_production_id or False


### PR DESCRIPTION
Before this commit, production created via `_run_manufacture()` without
bom or with a bom without component, will not be confirmed because of b4fd050e20c1

Task: 2802652

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
