### PR TITLE
[FIX] payment: default payment acquirer's account type

### DIFF
--- a/addons/payment/models/payment_acquirer.py
+++ b/addons/payment/models/payment_acquirer.py
@@ -256,6 +256,11 @@ class PaymentAcquirer(models.Model):
         '''
         self.ensure_one()
         account_vals = self.company_id.chart_template_id._prepare_transfer_account_for_direct_creation(self.name, self.company_id)
+        liquidity_type = self.env.ref('account.data_account_type_liquidity', raise_if_not_found=False)
+        account_vals.update({
+            'user_type_id': liquidity_type and liquidity_type.id or False,
+            'reconcile': False,
+        })
         account = self.env['account.account'].create(account_vals)
         inbound_payment_method_ids = []
         if self.token_implemented and self.payment_flow == 's2s':


### PR DESCRIPTION
The default account for a payment acquirer is 'Current Assets' and it
should not allow reconciliation

Steps to reproduce:
1. Install Accounting
2. Go to Accounting > Configuration > Payments > Payment Acquirers
3. Install the Stripe payment acquirer
4. Go to Accounting > Configuration > Invoicing > Journals
5. Open the Stripe journal
6. Go to the 'Journal Entries' tab
7. Open the default debit account
8. The account type is 'Current Assets' and reconciliation is allowed
and it should be of type 'Bank and Cash' without reconciliation

Solution:
Change the type of account for payment acquirers to 'Bank and Cash' and
put reconcile to false

opw-2788898