### PR TITLE
[FIX] rating: missing message_id when related to a message_post

### DIFF
--- a/addons/rating/models/rating_mixin.py
+++ b/addons/rating/models/rating_mixin.py
@@ -196,12 +196,13 @@ class RatingMixin(models.AbstractModel):
             rating.write({'rating': rate, 'feedback': feedback, 'consumed': True})
             if hasattr(self, 'message_post'):
                 feedback = tools.plaintext2html(feedback or '')
-                self.message_post(
+                message = self.message_post(
                     body="<img src='/rating/static/src/img/rating_%s.png' alt=':%s/5' style='width:18px;height:18px;float:left;margin-right: 5px;'/>%s"
                     % (rate, rate, feedback),
                     subtype_xmlid=subtype_xmlid or "mail.mt_comment",
                     author_id=rating.partner_id and rating.partner_id.id or None  # None will set the default author in mail_thread.py
                 )
+                rating.message_id = message.id
             if hasattr(self, 'stage_id') and self.stage_id and hasattr(self.stage_id, 'auto_validation_kanban_state') and self.stage_id.auto_validation_kanban_state:
                 if rating.rating > 2:
                     self.write({'kanban_state': 'done'})

--- a/addons/test_mail_full/tests/test_rating.py
+++ b/addons/test_mail_full/tests/test_rating.py
@@ -63,12 +63,12 @@ class TestRatingFlow(TestMailFullCommon, TestMailFullRecipients):
         self.assertIn('Top Feedback', message.body)
         self.assertIn('rating/static/src/img/rating_5.png', message.body)
         self.assertEqual(message.author_id, self.partner_1)
-        self.assertFalse(message.rating_ids)
+        self.assertEqual(message.rating_ids, rating)
         self.assertEqual(message.notified_partner_ids, self.partner_admin)
         self.assertEqual(message.subtype_id, self.env.ref('mail.mt_comment'))
 
         # check rating update
         self.assertTrue(rating.consumed)
         self.assertEqual(rating.feedback, 'Top Feedback')
-        self.assertFalse(rating.message_id)
+        self.assertEqual(rating.message_id, message)
         self.assertEqual(rating.rating, 5)


### PR DESCRIPTION
Rating records are missing the message_id after the message_post.


--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
