### PR TITLE
[FIX] reqs: bump deps for deployments without security backports

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-Babel==2.6.0
+Babel==2.9.1  # min version = 2.6.0 (Focal with security backports)
 chardet==3.0.4
 decorator==4.4.2
 docutils==0.16
@@ -10,20 +10,16 @@ gevent==20.9.0 ; python_version >= '3.8'
 greenlet==0.4.15 ; python_version == '3.7'
 greenlet==0.4.17 ; python_version > '3.7'
 idna==2.8
-Jinja2==2.10.1; python_version < '3.8'
-# bullseye version, focal patched 2.10
-Jinja2==2.11.2; python_version >= '3.8'
+Jinja2==2.11.3 # min version = 2.10.1 (Focal - with security backports)
 libsass==0.18.0
-lxml==4.3.2 ; sys_platform != 'win32' and python_version == '3.7'
-lxml==4.6.1 ; sys_platform != 'win32' and python_version > '3.7'
-lxml ; sys_platform == 'win32'
+lxml==4.6.5 # min version = 4.5.0 (Focal - with security backports)
 MarkupSafe==1.1.0
 num2words==0.5.6
 ofxparse==0.19
-passlib==1.7.2
-Pillow==8.1.2  # could be 7.0.0 (Focal) when backported security patches are present
+passlib==1.7.3 # min version = 1.7.2 (Focal with security backports)
+Pillow==9.0.1  # min version = 7.0.0 (Focal with security backports)
 polib==1.1.0
-psutil==5.6.6
+psutil==5.6.7 # min version = 5.5.1 (Focal with security backports)
 psycopg2==2.7.7; sys_platform != 'win32' and python_version < '3.8'
 psycopg2==2.8.6; sys_platform == 'win32' or python_version >= '3.8'
 pydot==1.4.1
@@ -32,13 +28,14 @@ PyPDF2==1.26.0
 pypiwin32 ; sys_platform == 'win32'
 pyserial==3.4
 python-dateutil==2.7.3
-python-ldap==3.2.0; sys_platform != 'win32'
+python-ldap==3.4.0 ; sys_platform != 'win32'  # min version = 3.2.0 (Focal with security backports)
 python-stdnum==1.13
 pytz==2019.3
 pyusb==1.0.2
 qrcode==6.1
 reportlab==3.5.59 # version < 3.5.54 are not compatible with Pillow 8.1.2 and 3.5.59 is bullseye
 requests==2.22.0
+urllib3==1.26.5 # indirect / min version = 1.25.8 (Focal with security backports)
 vobject==0.9.6.1
 Werkzeug==0.16.1
 xlrd==1.1.0; python_version < '3.8'


### PR DESCRIPTION
Update the default requirements according to latest security risks in
relevant dependencies. The baseline required version is kept in
comments, and it perfectly safe to use when security backports are
present. In other words, using the official Debian/Ubuntu packages
on a supported LTS version of these operating systems, with
unattended upgrades turned on, is a simpler safe option.
