### PR TITLE
[FIX] sale: rouding issue at creation

### DIFF
--- a/addons/sale/models/sale_order_line.py
+++ b/addons/sale/models/sale_order_line.py
@@ -156,6 +156,19 @@ class SaleOrderLine(models.Model):
             # If company_id is set, always filter taxes by the company
             line.tax_id = line.order_id.fiscal_position_id.map_tax(taxes)
 
+    def _add_precomputed_values(self, vals_list):
+        """ In the specific case where the discount is provided in the create values
+        without being rounded, we have to 'manually' round it otherwise it won't be,
+        because editable precomputed field values are kept 'as is'.
+
+        This is a temporary fix until the problem is fixed in the ORM.
+        """
+        precision = self.env['decimal.precision'].precision_get('Discount')
+        for vals in vals_list:
+            if vals.get('discount'):
+                vals['discount'] = float_round(vals['discount'], precision_digits=precision)
+        return super()._add_precomputed_values(vals_list)
+
     @api.model_create_multi
     def create(self, vals_list):
         for vals in vals_list:

--- a/addons/sale/tests/test_sale_order.py
+++ b/addons/sale/tests/test_sale_order.py
@@ -820,6 +820,23 @@ class TestSaleOrder(TestSaleCommon):
         self.assertEqual(sale_order.amount_undiscounted, 272.72)
         self.assertEqual(line.price_subtotal, 136.36)
 
+    def test_discount_rounding(self):
+        """
+            Check the discount is properly rounded and the price subtotal
+            computed with this rounded discount
+        """
+        sale_order = self.env['sale.order'].create({
+            'partner_id': self.partner_a.id,
+            'order_line': [(0, 0, {
+                'product_id': self.product_a.id,
+                'product_uom_qty': 1,
+                'price_unit': 192,
+                'discount': 74.246,
+            })]
+        })
+        self.assertEqual(sale_order.order_line.price_subtotal, 49.44, "Subtotal should be equal to 192 * (1 - 0.7425)")
+        self.assertEqual(sale_order.order_line.discount, 74.25)
+
     def test_free_product_and_price_include_fixed_tax(self):
         """ Check that fixed tax include are correctly computed while the price_unit is 0
         """


### PR DESCRIPTION
Use case
--------

Field computed with precompute=True at creation get the value
of the float without beeing rounded this can lead to rounding
issue where the value computed at creation is different from
the value computed later.

This can lead to the following issue
A so line is create with a unit price of 192 and a discount of
74.246 the price subtotal it thus 49.45

Later a invoice is created based on the same unit price and a discount
rounded at 74.25 and thus a subtotal 49.44



Solution
--------
Since the issue is not fixed (yet) in the orm, we should remove the
precompute on the problematic field since precompute is not mandatory
for non required computed stored field





--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
