### PR TITLE
[FIX] action in payload is no longer exists

### DIFF
--- a/addons/web/static/src/webclient/navbar/navbar.js
+++ b/addons/web/static/src/webclient/navbar/navbar.js
@@ -189,8 +189,8 @@ export class NavBar extends Component {
 
     getMenuItemHref(payload) {
         const parts = [`menu_id=${payload.id}`];
-        if (payload.action) {
-            parts.push(`action=${payload.action.split(",")[1]}`);
+        if (payload.actionID) {
+            parts.push(`action=${payload.actionID}`);
         }
         return "#" + parts.join("&");
     }


### PR DESCRIPTION
Eeplace action with actionID in getMenuItemHref js method

Description of the issue/feature this PR addresses:
payload.action always show undefined 

Current behavior before PR:
payload.action always show undefined 

Desired behavior after PR is merged:
payload.actionID shows the the action id of the app.



--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
