### PR TITLE
[FIX] core: computed stored many2many field not computed at install

### DIFF
--- a/odoo/fields.py
+++ b/odoo/fields.py
@@ -3495,6 +3495,8 @@ class Many2many(_RelationalMulti):
             """.format(rel=self.relation, id1=self.column1, id2=self.column2)
             cr.execute(query, ['RELATION BETWEEN %s AND %s' % (model._table, comodel._table)])
             _schema.debug("Create table %r: m2m relation between %r and %r", self.relation, model._table, comodel._table)
+            model.pool.post_init(self.update_db_foreign_keys, model)
+            return True
 
         model.pool.post_init(self.update_db_foreign_keys, model)
 


### PR DESCRIPTION
Description of the issue/feature this PR addresses:

Current behavior before PR:
- When adding a new Many2many field to an installed module, and that field
is both computed and stored, after upgrading the module, a new relation
table will be created but there will be no data in it, because the
recomputation is not triggered.

Desired behavior after PR is merged:
- Trigger the recomputation for the new compute and stored Many2many field.

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
