### PR TITLE
[14.0][FIX] membership cancel must be superseeded by membership stop date

### DIFF
--- a/addons/membership/models/partner.py
+++ b/addons/membership/models/partner.py
@@ -60,8 +60,9 @@ class Partner(models.Model):
             ], limit=1, order='date_cancel').date_cancel
 
             if partner.membership_cancel and today > partner.membership_cancel:
-                partner.membership_state = 'free' if partner.free_member else 'canceled'
-                continue
+                if not partner.membership_stop or partner.membership_stop and partner.membership_stop < partner.membership_cancel:
+                    partner.membership_state = 'free' if partner.free_member else 'canceled'
+                    continue
             if partner.membership_stop and today > partner.membership_stop:
                 if partner.free_member:
                     partner.membership_state = 'free'


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
A partner who has a membership cancelled date must not have the cancelled state if he has a valid membership (membership stop date > today)

Current behavior before PR:
The membership state is cancelled

Desired behavior after PR is merged:
The membership state is ok




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
