### PR TITLE
[FIX] web_tour: display the tour tooltip as expected

### DIFF
--- a/addons/web_tour/i18n/web_tour.pot
+++ b/addons/web_tour/i18n/web_tour.pot
@@ -25,6 +25,13 @@ msgstr ""
 
 #. module: web_tour
 #. openerp-web
+#: code:addons/web_tour/static/src/js/tip.js:0
+#, python-format
+msgid "Click here to go to the next step."
+msgstr ""
+
+#. module: web_tour
+#. openerp-web
 #: code:addons/web_tour/static/src/js/tour_step_utils.js:0
 #, python-format
 msgid "Click on the <i>Home icon</i> to navigate across apps."

--- a/addons/web_tour/static/src/js/tip.js
+++ b/addons/web_tour/static/src/js/tip.js
@@ -43,6 +43,7 @@ var Tip = Widget.extend({
                 x: 50,
                 y: 50,
             },
+            content: _t("Click here to go to the next step."),
             scrollContent: _t("Scroll to reach the next step."),
         });
         this.position = {


### PR DESCRIPTION
Currently, when we do not have tooltip content,
content height is calculated without content,
content is added after the height is calculated,
so tour tooltip don't look as expected.

In this PR, the tour tooltip displays correctly by providing
the default content before calculating its height.

taskID: 2792218