### PR TITLE
[FIX] project_timesheet_holidays: don't show private task in timeshee…

### DIFF
--- a/addons/project_timesheet_holidays/models/hr_holidays.py
+++ b/addons/project_timesheet_holidays/models/hr_holidays.py
@@ -24,6 +24,7 @@ class HolidaysType(models.Model):
         'project.task', string="Task", compute='_compute_timesheet_task_id',
         store=True, readonly=False, default=_default_task_id,
         domain="[('project_id', '=', timesheet_project_id),"
+                "('project_id', '!=', False),"
                 "('company_id', '=', company_id)]")
 
     @api.depends('timesheet_task_id', 'timesheet_project_id')

--- a/addons/project_timesheet_holidays/views/hr_holidays_views.xml
+++ b/addons/project_timesheet_holidays/views/hr_holidays_views.xml
@@ -10,7 +10,8 @@
                 <group name="timesheet" groups="base.group_no_one" style="width:50%">
                     <h2>Timesheets</h2>
                     <field name="timesheet_project_id" context="{'active_test': False}"/>
-                    <field name="timesheet_task_id" context="{'active_test': False}" attrs="{'required': [('timesheet_project_id', '!=', False)]}"/>
+                    <field name="timesheet_task_id" context="{'active_test': False, 'default_project_id': timesheet_project_id}" attrs="
+                        {'invisible': [('timesheet_project_id', '=', False)], 'required': [('timesheet_project_id', '!=', False)]}"/>
                     <field name="timesheet_generate" invisible="1"/>
                 </group>
 


### PR DESCRIPTION
…t task

before this commit,
In time off form view, task field contains the private task .

so this commit fixes the issue by not displaying the private task
in task field of time off form view

task-2733415