### PR TITLE
[REF] mass_mailing, web_editor: don't redefine target in generic methods

### DIFF
--- a/addons/mass_mailing/static/src/js/mass_mailing_snippets.js
+++ b/addons/mass_mailing/static/src/js/mass_mailing_snippets.js
@@ -277,6 +277,14 @@ options.registry.DesignTab = options.Class.extend({
     /**
      * @override
      */
+    init() {
+        this._super(...arguments);
+        // Set the target on the whole editable so apply-to looks within it.
+        this.setTarget(this.options.wysiwyg.getEditable());
+    },
+    /**
+     * @override
+     */
     async start() {
         const res = await this._super(...arguments);
         const $editable = this.options.wysiwyg.getEditable();

--- a/addons/mass_mailing/views/snippets_themes.xml
+++ b/addons/mass_mailing/views/snippets_themes.xml
@@ -523,26 +523,23 @@
     <!-- DESIGN OPTIONS -->
     <div data-js="DesignTab" data-selector="design-options" data-no-check="true">
         <!-- BODY WIDTH -->
-        <we-row string="Body Width">
-            <we-button-group data-target=".o_mail_wrapper" data-no-preview="true">
-                <we-button data-select-class="o_mail_small"
-                            data-img="/mass_mailing/static/src/img/snippets_options/content_width_small.svg"
-                            title="Small"/>
-                <we-button data-select-class="o_mail_regular"
-                            data-img="/mass_mailing/static/src/img/snippets_options/content_width_normal.svg"
-                            title="Regular"/>
-                <we-button data-select-class=""
-                            data-img="/mass_mailing/static/src/img/snippets_options/content_width_full.svg"
-                            title="Full"/>
-            </we-button-group>
-        </we-row>
-        <we-row string="Background Color">
-            <we-colorpicker data-target=".o_layout, .note-editable > div:not(.o_layout)"
-                            data-select-style="true"
-                            data-no-transparency="true"
-                            data-css-property="background-color"
-                            data-color-prefix="bg-"/>
-        </we-row>
+        <we-button-group string="Body Width" data-apply-to=".o_mail_wrapper" data-no-preview="true">
+            <we-button data-select-class="o_mail_small"
+                        data-img="/mass_mailing/static/src/img/snippets_options/content_width_small.svg"
+                        title="Small"/>
+            <we-button data-select-class="o_mail_regular"
+                        data-img="/mass_mailing/static/src/img/snippets_options/content_width_normal.svg"
+                        title="Regular"/>
+            <we-button data-select-class=""
+                        data-img="/mass_mailing/static/src/img/snippets_options/content_width_full.svg"
+                        title="Full"/>
+        </we-button-group>
+        <we-colorpicker string="Background Color"
+                        data-apply-to=".o_layout, > div:not(.o_layout)"
+                        data-select-style="true"
+                        data-no-transparency="true"
+                        data-css-property="background-color"
+                        data-color-prefix="bg-"/>
         <!-- HEADING 1 -->
         <we-row string="Heading 1" class="o_design_tab_title">
             <we-input data-customize-css-property=""

--- a/addons/web_editor/static/src/js/editor/snippets.options.js
+++ b/addons/web_editor/static/src/js/editor/snippets.options.js
@@ -3087,17 +3087,13 @@ const SnippetOptionWidget = Widget.extend({
      * @returns {Promise|undefined}
      */
     selectClass: function (previewMode, widgetValue, params) {
-        const $target = params.target ? this.options.wysiwyg.getEditable().find(params.target) : this.$target;
-        if (!$target[0]) {
-            return;
-        }
         for (const classNames of params.possibleValues) {
             if (classNames) {
-                $target[0].classList.remove(...classNames.trim().split(/\s+/g));
+                this.$target[0].classList.remove(...classNames.trim().split(/\s+/g));
             }
         }
         if (widgetValue) {
-            $target[0].classList.add(...widgetValue.trim().split(/\s+/g));
+            this.$target[0].classList.add(...widgetValue.trim().split(/\s+/g));
         }
     },
     /**
@@ -3159,30 +3155,26 @@ const SnippetOptionWidget = Widget.extend({
      * @returns {Promise|undefined}
      */
     selectStyle: async function (previewMode, widgetValue, params) {
-        const $target = params.target ? this.options.wysiwyg.getEditable().find(params.target) : this.$target;
-        if (!$target[0]) {
-            return;
-        }
         // Disable all transitions for the duration of the method as many
         // comparisons will be done on the element to know if applying a
         // property has an effect or not. Also, changing a css property via the
         // editor should not show any transition as previews would not be done
         // immediately, which is not good for the user experience.
-        $target[0].classList.add('o_we_force_no_transition');
-        const _restoreTransitions = () => $target[0].classList.remove('o_we_force_no_transition');
+        this.$target[0].classList.add('o_we_force_no_transition');
+        const _restoreTransitions = () => this.$target[0].classList.remove('o_we_force_no_transition');
 
         if (params.cssProperty === 'background-color') {
-            $target.trigger('background-color-event', previewMode);
+            this.$target.trigger('background-color-event', previewMode);
         }
 
         // Always reset the inline style first to not put inline style on an
         // element which already have this style through css stylesheets.
         let cssProps = weUtils.CSS_SHORTHANDS[params.cssProperty] || [params.cssProperty];
         for (const cssProp of cssProps) {
-            $target[0].style.setProperty(cssProp, '');
+            this.$target[0].style.setProperty(cssProp, '');
         }
         if (params.extraClass) {
-            $target.removeClass(params.extraClass);
+            this.$target.removeClass(params.extraClass);
         }
         // Plain color and gradient are mutually exclusive as background so in
         // case we edit a background-color we also have to reset the gradient
@@ -3192,11 +3184,11 @@ const SnippetOptionWidget = Widget.extend({
         // reset anyway).
         let bgImageParts = undefined;
         if (params.withGradients && params.cssProperty === 'background-color') {
-            const styles = getComputedStyle($target[0]);
+            const styles = getComputedStyle(this.$target[0]);
             bgImageParts = backgroundImageCssToParts(styles['background-image']);
             delete bgImageParts.gradient;
             const combined = backgroundImagePartsToCss(bgImageParts);
-            $target[0].style.setProperty('background-image', '');
+            this.$target[0].style.setProperty('background-image', '');
             applyCSS.call(this, 'background-image', combined, styles);
         }
 
@@ -3208,28 +3200,28 @@ const SnippetOptionWidget = Widget.extend({
         if (params.colorNames && params.colorPrefix) {
             const colorNames = params.colorNames.filter(name => !weUtils.isColorCombinationName(name));
             const classes = weUtils.computeColorClasses(colorNames, params.colorPrefix);
-            $target[0].classList.remove(...classes);
+            this.$target[0].classList.remove(...classes);
 
             if (colorNames.includes(widgetValue)) {
-                const originalCSSValue = window.getComputedStyle($target[0])[cssProps[0]];
+                const originalCSSValue = window.getComputedStyle(this.$target[0])[cssProps[0]];
                 const className = params.colorPrefix + widgetValue;
-                $target[0].classList.add(className);
-                if (originalCSSValue !== window.getComputedStyle($target[0])[cssProps[0]]) {
+                this.$target[0].classList.add(className);
+                if (originalCSSValue !== window.getComputedStyle(this.$target[0])[cssProps[0]]) {
                     // If applying the class did indeed changed the css
                     // property we are editing, nothing more has to be done.
                     // (except adding the extra class)
-                    $target.addClass(params.extraClass);
+                    this.$target.addClass(params.extraClass);
                     _restoreTransitions();
                     return;
                 }
                 // Otherwise, it means that class probably does not exist,
                 // we remove it and continue. Especially useful for some
                 // prefixes which only work with some color names but not all.
-                $target[0].classList.remove(className);
+                this.$target[0].classList.remove(className);
             }
         }
 
-        const styles = window.getComputedStyle($target[0]);
+        const styles = window.getComputedStyle(this.$target[0]);
 
         // At this point, the widget value is either a property/color name or
         // an actual css property value. If it is a property/color name, we will
@@ -3281,15 +3273,15 @@ const SnippetOptionWidget = Widget.extend({
         hasUserValue = applyCSS.call(this, cssProps[0], values.join(' '), styles) || hasUserValue;
 
         function applyCSS(cssProp, cssValue, styles) {
-            if (!weUtils.areCssValuesEqual(styles[cssProp], cssValue, cssProp, $target[0])) {
-                $target[0].style.setProperty(cssProp, cssValue, 'important');
+            if (!weUtils.areCssValuesEqual(styles[cssProp], cssValue, cssProp, this.$target[0])) {
+                this.$target[0].style.setProperty(cssProp, cssValue, 'important');
                 return true;
             }
             return false;
         }
 
         if (params.extraClass) {
-            $target.toggleClass(params.extraClass, hasUserValue);
+            this.$target.toggleClass(params.extraClass, hasUserValue);
         }
 
         _restoreTransitions();
@@ -3545,10 +3537,6 @@ const SnippetOptionWidget = Widget.extend({
      * @returns {Promise<string|undefined>|string|undefined}
      */
     _computeWidgetState: async function (methodName, params) {
-        const $target = params.target ? this.options.wysiwyg.getEditable().find(params.target) : this.$target;
-        if (!$target[0]) {
-            return;
-        }
         switch (methodName) {
             case 'selectClass': {
                 let maxNbClasses = 0;
@@ -3559,7 +3547,7 @@ const SnippetOptionWidget = Widget.extend({
                     }
                     const classes = classNames.split(/\s+/g);
                     if (params.stateToFirstClass) {
-                        if ($target[0].classList.contains(classes[0])) {
+                        if (this.$target[0].classList.contains(classes[0])) {
                             return classNames;
                         } else {
                             continue;
@@ -3567,7 +3555,7 @@ const SnippetOptionWidget = Widget.extend({
                     }
 
                     if (classes.length >= maxNbClasses
-                            && classes.every(className => $target[0].classList.contains(className))) {
+                            && classes.every(className => this.$target[0].classList.contains(className))) {
                         maxNbClasses = classes.length;
                         activeClassNames = classNames;
                     }
@@ -3579,9 +3567,9 @@ const SnippetOptionWidget = Widget.extend({
                 const attrName = params.attributeName;
                 let attrValue;
                 if (methodName === 'selectAttribute') {
-                    attrValue = $target[0].getAttribute(attrName);
+                    attrValue = this.$target[0].getAttribute(attrName);
                 } else if (methodName === 'selectDataAttribute') {
-                    attrValue = $target[0].dataset[attrName];
+                    attrValue = this.$target[0].dataset[attrName];
                 }
                 attrValue = (attrValue || '').trim();
                 if (params.saveUnit && !params.withUnit) {
@@ -3594,7 +3582,7 @@ const SnippetOptionWidget = Widget.extend({
                 if (params.colorPrefix && params.colorNames) {
                     for (const c of params.colorNames) {
                         const className = weUtils.computeColorClasses([c], params.colorPrefix)[0];
-                        if ($target[0].classList.contains(className)) {
+                        if (this.$target[0].classList.contains(className)) {
                             if (weUtils.isColorCombinationName(c)) {
                                 usedCC = c;
                                 continue;
@@ -3607,10 +3595,10 @@ const SnippetOptionWidget = Widget.extend({
                 // Disable all transitions for the duration of the style check
                 // as we want to know the final value of a property to properly
                 // update the UI.
-                $target[0].classList.add('o_we_force_no_transition');
-                const _restoreTransitions = () => $target[0].classList.remove('o_we_force_no_transition');
+                this.$target[0].classList.add('o_we_force_no_transition');
+                const _restoreTransitions = () => this.$target[0].classList.remove('o_we_force_no_transition');
 
-                const styles = window.getComputedStyle($target[0]);
+                const styles = window.getComputedStyle(this.$target[0]);
 
                 if (params.withGradients && params.cssProperty === 'background-color') {
                     // Check if there is a gradient, in that case this is the
@@ -3636,13 +3624,13 @@ const SnippetOptionWidget = Widget.extend({
                     }
                     return value;
                 });
-                if (cssValues.length === 4 && weUtils.areCssValuesEqual(cssValues[3], cssValues[1], params.cssProperty, $target)) {
+                if (cssValues.length === 4 && weUtils.areCssValuesEqual(cssValues[3], cssValues[1], params.cssProperty, this.$target)) {
                     cssValues.pop();
                 }
-                if (cssValues.length === 3 && weUtils.areCssValuesEqual(cssValues[2], cssValues[0], params.cssProperty, $target)) {
+                if (cssValues.length === 3 && weUtils.areCssValuesEqual(cssValues[2], cssValues[0], params.cssProperty, this.$target)) {
                     cssValues.pop();
                 }
-                if (cssValues.length === 2 && weUtils.areCssValuesEqual(cssValues[1], cssValues[0], params.cssProperty, $target)) {
+                if (cssValues.length === 2 && weUtils.areCssValuesEqual(cssValues[1], cssValues[0], params.cssProperty, this.$target)) {
                     cssValues.pop();
                 }
 
@@ -3680,7 +3668,7 @@ const SnippetOptionWidget = Widget.extend({
                             continue;
                         }
                         const className = weUtils.computeColorClasses([c])[0];
-                        if ($target[0].classList.contains(className)) {
+                        if (this.$target[0].classList.contains(className)) {
                             return c;
                         }
                     }


### PR DESCRIPTION
Commit [1] redefined the target in generic methods of snippet options so that some buttons of the Design Tab snippet option could target a different node than their parent option. This reverts that in favor of the more generic `apply-to` data attribute.

[1]: https://github.com/odoo-dev/odoo/commit/c4bfedc37b730c8ca304c41125461e01f2911881

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
