### PR TITLE
[FIX] (mrp,stock)_account: fix user group check

### DIFF
--- a/addons/mrp_account/views/product_views.xml
+++ b/addons/mrp_account/views/product_views.xml
@@ -5,7 +5,7 @@
             <field name="model">product.template</field>
             <field name="priority">3</field>
             <field name="inherit_id" ref="product.product_template_only_form_view" />
-            <field name="groups_id" eval="[(4, ref('mrp.group_mrp_user'))]"/>
+            <field name="groups_id" eval="[(4, ref('mrp.group_mrp_manager'))]"/>
             <field name="arch" type="xml">
                 <xpath expr="//span[@name='update_cost_price']" position="inside">
                     <button name="button_bom_cost"
@@ -22,7 +22,7 @@
             <field name="model">product.product</field>
             <field name="priority">4</field>
             <field name="inherit_id" ref="product.product_normal_form_view"/>
-            <field name="groups_id" eval="[(4, ref('mrp.group_mrp_user'))]"/>
+            <field name="groups_id" eval="[(4, ref('mrp.group_mrp_manager'))]"/>
             <field name="arch" type="xml">
                 <xpath expr="//span[@name='update_cost_price']" position="inside">
                     <button name="button_bom_cost"
@@ -39,6 +39,7 @@
             <field name="name">product.product.product.view.form.easy.bom.inherit</field>
             <field name="model">product.product</field>
             <field name="inherit_id" ref="product.product_variant_easy_edit_view"/>
+            <field name="groups_id" eval="[(4, ref('mrp.group_mrp_manager'))]"/>
             <field name="arch" type="xml">
                 <data>
                 <xpath expr="//div[@name='update_cost_price']" position="inside">

--- a/addons/stock_account/views/product_views.xml
+++ b/addons/stock_account/views/product_views.xml
@@ -40,6 +40,7 @@
             <field name="name">product.template.stock.property.form.inherit</field>
             <field name="model">product.template</field>
             <field name="inherit_id" ref="product.product_template_form_view"/>
+            <field name="groups_id" eval="[(4, ref('stock.group_stock_manager'))]"/>
             <field name="arch" type="xml">
                 <data>
                     <field name="list_price" position="after">
@@ -68,6 +69,7 @@
             <field name="name">product.product.normal.form.view.inherit</field>
             <field name="model">product.product</field>
             <field name="inherit_id" ref="product.product_normal_form_view"/>
+            <field name="groups_id" eval="[(4, ref('stock.group_stock_manager'))]"/>
             <field name="arch" type="xml">
                 <data>
                     <field name="standard_price" position="replace">
@@ -87,6 +89,7 @@
             <field name="name">product.product.product.view.form.easy.inherit</field>
             <field name="model">product.product</field>
             <field name="inherit_id" ref="product.product_variant_easy_edit_view"/>
+            <field name="groups_id" eval="[(4, ref('stock.group_stock_manager'))]"/>
             <field name="arch" type="xml">
                 <data>
                     <field name="standard_price" position="replace">


### PR DESCRIPTION
Steps to reproduce the bug:
1:/
- Give user access to Marc Demo
- Connect with Marc
- Go to any product
- The "update cost" button is visible

Problem:
Marc can modify the cost, whereas normally only users with manager rights can modify the product

2:/
- remove MRP access to Marc Demo
- connect with Marc
- Go to any product with variant and BOM > variants > then open any variant

Problem:
The user could Compute Price from BoM, while he does not have manager access to MRP

opw-2794179




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
