### PR TITLE
[FIX] POS: search from database doens't rewrite available_in_pos

### DIFF
--- a/addons/point_of_sale/static/src/js/Screens/ProductScreen/ProductsWidgetControlPanel.js
+++ b/addons/point_of_sale/static/src/js/Screens/ProductScreen/ProductsWidgetControlPanel.js
@@ -53,7 +53,7 @@ odoo.define('point_of_sale.ProductsWidgetControlPanel', function(require) {
                 let ProductIds = await this.rpc({
                     model: 'product.product',
                     method: 'search',
-                    args: [[['name', 'ilike', this.searchWordInput.el.value + "%"]]],
+                    args: [['&', ['name', 'ilike', this.searchWordInput.el.value + "%"], ['available_in_pos', '=', true]]],
                     context: this.env.session.user_context,
                 });
                 if(!ProductIds.length) {
@@ -62,7 +62,7 @@ odoo.define('point_of_sale.ProductsWidgetControlPanel', function(require) {
                         body: this.env._t("No product found"),
                     });
                 } else {
-                    await this.env.pos._addProducts(ProductIds);
+                    await this.env.pos._addProducts(ProductIds, false);
                 }
                 this.trigger('update-product-list');
             } catch (error) {

--- a/addons/point_of_sale/static/src/js/models.js
+++ b/addons/point_of_sale/static/src/js/models.js
@@ -1561,13 +1561,15 @@ exports.PosModel = Backbone.Model.extend({
      * Make the products corresponding to the given ids to be available_in_pos and
      * fetch them to be added on the loaded products.
      */
-    async _addProducts(ids){
-        await this.rpc({
-            model: 'product.product',
-            method: 'write',
-            args: [ids, {'available_in_pos': true}],
-            context: this.session.user_context,
-        });
+    async _addProducts(ids, setAvailable=true){
+        if(setAvailable){
+            await this.rpc({
+                model: 'product.product',
+                method: 'write',
+                args: [ids, {'available_in_pos': true}],
+                context: this.session.user_context,
+            });
+        }
         let product_model = _.find(this.models, (model) => model.model === 'product.product');
         let product = await this.rpc({
             model: 'product.product',


### PR DESCRIPTION
### Observed Behaviour
When loading limited number of products in POS, we have the "database search" functionality allowing use to search in non-loaded product. Anyway, using this method will make all products found in the search available in POS, despite having set it to "False" on the product page.

### Desired Behaviour
This search method should only search on the already checked "available in POS" products and shouldn't in any case write in the models.

### Fix Description
A filter on "available_in_pos" property has been added to the search, and, because we now only search on already availaible products, rewriting on this fields isn't necessary, which has allowed us to remove the write operation.

### Related Issues/PR
- opw-2766095

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
