### PR TITLE
[FIX] web_editor: remove anchor option on navbar logo

### DIFF
--- a/addons/web_editor/static/src/js/editor/snippets.options.js
+++ b/addons/web_editor/static/src/js/editor/snippets.options.js
@@ -4716,7 +4716,27 @@ registry.SnippetMove = SnippetOptionWidget.extend({
 /**
  * Allows for media to be replaced.
  */
-registry.ReplaceMedia = SnippetOptionWidget.extend({
+registry.ReplaceMediaField = SnippetOptionWidget.extend({
+    //--------------------------------------------------------------------------
+    // Options
+    //--------------------------------------------------------------------------
+
+    /**
+     * Replaces the media.
+     *
+     * @see this.selectClass for parameters
+     */
+    async replaceMedia() {
+        // TODO for now, this simulates a double click on the media,
+        // to be refactored when the new editor is merged
+        this.$target.dblclick();
+    },
+});
+
+/**
+ * Allows for media to be replaced and a link to be added.
+ */
+ registry.ReplaceMedia = registry.ReplaceMediaField.extend({
     xmlDependencies: ['/web_editor/static/src/xml/image_link_tools.xml'],
 
     /**
@@ -4739,16 +4759,6 @@ registry.ReplaceMedia = SnippetOptionWidget.extend({
     // Options
     //--------------------------------------------------------------------------
 
-    /**
-     * Replaces the media.
-     *
-     * @see this.selectClass for parameters
-     */
-    async replaceMedia() {
-        // TODO for now, this simulates a double click on the media,
-        // to be refactored when the new editor is merged
-        this.$target.dblclick();
-    },
     /**
      * Makes the image a clickable link by wrapping it in an <a>.
      * This function is also called for the opposite operation.

--- a/addons/web_editor/views/snippets.xml
+++ b/addons/web_editor/views/snippets.xml
@@ -378,7 +378,13 @@
 
     <!-- Replace a media -->
     <!-- TODO probably review this system once the new editor is merged to not duplicate the selector, etc -->
-    <div data-js="ReplaceMedia" data-selector="img, .media_iframe_video, span.fa, i.fa">
+    <div data-js="ReplaceMediaField" data-selector="[data-oe-type='image'] > img">
+        <we-row string="Media">
+            <we-button class="o_we_bg_brand_primary" data-replace-media="true" data-no-preview="true">Replace</we-button>
+        </we-row>
+    </div>
+    <div data-js="ReplaceMedia" data-selector="img, .media_iframe_video, span.fa, i.fa"
+        data-exclude="[data-oe-type='image'] > img">
         <we-row string="Media">
             <we-button class="o_we_bg_brand_primary" data-replace-media="true" data-no-preview="true">Replace</we-button>
         </we-row>


### PR DESCRIPTION
Since [commit 1] it is (once again) possible to add links on images. The functionality was added to the `ReplaceMedia` options widget. Before [commit 1] this options widget was only responsible for opening the `MediaDialog`.

The ReplaceMedia widget applies both to images in an editable DOM and database fields rendered using `data-oe-type` set to image type. In the second case, this poses a problem, since the database field only stores the `src` attribute of the image, unable to save any other DOM changes.

This happens, for example, when trying to add a link on the logo image in the navbar. An a tag is added around the image tag, resulting in the image being removed when saved.

The functionality added in [commit 1] should only apply to the first case, and not to images corresponding to database fields. This is achieved by restoring the old options widget (as `ReplaceMediaField`) and keep the anchor options in a separate widget (`ReplaceMedia`) extending `ReplaceMediaField`.

[commit 1]: https://github.com/odoo/odoo/commit/bfcd25c5d66765b7436114dba3316ac7331a4d97

opw-2751711