### PR TITLE
[FIX] sale: Cutoff fields in SO reports for RTL languages

### DIFF
--- a/addons/sale/static/src/scss/sale_report.scss
+++ b/addons/sale/static/src/scss/sale_report.scss
@@ -1,3 +1,9 @@
 .sale_tbody .o_line_note {
     word-break: break-word;
 }
+
+/*rtl:raw:
+.offset-1 {
+    margin-left: 0% !important;
+}
+*/

--- a/addons/web/__manifest__.py
+++ b/addons/web/__manifest__.py
@@ -282,7 +282,7 @@ This module provides the core of the Odoo Web Client.
             'web/static/src/legacy/js/report/report.js',
         ],
         'web.report_assets_pdf': [
-            'web/static/src/css/reset.min.css',
+            'web/static/src/legacy/js/report/reset.min.css',
         ],
 
         # ---------------------------------------------------------------------


### PR DESCRIPTION
The address in a SO report with RTL languages are cutoff, they
overflow the layout of the PDF which makes the address unreadable.

To reproduce the issue:
1. On runbot v15 > make a SO with the recipient in Arabic/Persian/Hebrew language (any language that is RTL)
2. Specify a different delivery/invoicing address than the recipient
3. Print the PDF
Result: Part of the delivery address is cut off

Solution: As for now, two CSS stylesheets are used in the HTML before transforming it to a PDF: *bootstrap.css* & *web.report_assets_common.min.css* (where the latter is mapped in RTL style with RTLCSS). Note that the *web.report_assets_common.min.css* import in itself the bootstrap style BEFORE the RTL mapping. Thus, they both define the `offset-1` class which is used by our problematic component in the HTML/PDF (a `margin-left` for the *bootstrap.css* and a `margin-right` for the *web.report_assets_common.min.css*). Consequently, these 2 margins makes the bootstrap `row` overflow. There are two different margin because the `margin-left` from *bootstrap.css* was translated into `margin-right` in the other CSS when doing the RTL mapping. A quick fix would be to override this undesired `margin-left` and make it null into the sale_report specific CSS style. While it would work, it does not resolve the underlying issue. In normal circumstances, the *bootstrap.css* should not be used into the report. It is in fact included because there is an error into the manifest of the web module (see permalink here-under). The issue comes from a file that was deleted during the migration to the OWL framework which makes its reference pointless now (see commit 29731b4).

https://github.com/odoo/odoo/blob/95bcc8472c3f3ddc8a4c7c1ab4a97ddbd471dba0/odoo/addons/base/models/assetsbundle.py#L166

opw-2767445