### PR TITLE
[FIX] microsoft_calendar: Send html description to outlook

### DIFF
--- a/addons/microsoft_calendar/models/calendar.py
+++ b/addons/microsoft_calendar/models/calendar.py
@@ -7,7 +7,7 @@ from dateutil.relativedelta import relativedelta
 
 from odoo import api, fields, models, _
 from odoo.exceptions import UserError, ValidationError
-from odoo.tools import html2plaintext, is_html_empty, plaintext2html
+from odoo.tools import is_html_empty
 
 ATTENDEE_CONVERTER_O2M = {
     'needsAction': 'notresponded',
@@ -274,8 +274,8 @@ class Meeting(models.Model):
 
         if 'description' in fields_to_sync:
             values['body'] = {
-                'content': html2plaintext(self.description) if not is_html_empty(self.description) else '',
-                'contentType': "text",
+                'content': self.description if not is_html_empty(self.description) else '',
+                'contentType': "html",
             }
 
         if any(x in fields_to_sync for x in ['allday', 'start', 'date_end', 'stop']):

--- a/addons/microsoft_calendar/tests/test_sync_odoo2microsoft.py
+++ b/addons/microsoft_calendar/tests/test_sync_odoo2microsoft.py
@@ -88,7 +88,7 @@ class TestSyncOdoo2Microsoft(TransactionCase):
             'start': {'dateTime': '%s-01-15T08:00:00+00:00' % year, 'timeZone': 'Europe/London'},
             'end': {'dateTime': '%s-01-15T18:00:00+00:00' % year, 'timeZone': 'Europe/London'},
             'subject': 'Event',
-            'body': {'content': '', 'contentType': 'text'},
+            'body': {'content': '', 'contentType': 'html'},
             'attendees': [],
             'isAllDay': False,
             'isOrganizer': True,


### PR DESCRIPTION
Step to reproduce:
- Create an event with a link in the decription
- Edit + Save multiple times

Current behaviour :
- Since c2b545fd8d91b7d24380ada07adee02f24623ecf we fetch the full
description with html tags which are rendered via the
- When we resend this message to outlook, the description
 will be updated via html2plaintext.
 In the case of URL, they will be added as a footnote and thus
 duplicated if the url is it's own name

Behaviour after thr PR:
- We could then also send the description with the html tags to
ensure full compatibility between the description
- Using html2plaintext update the descrtiption to markdown, with some
issues, since html is now supported in the odoo editor, using
html on both end will remove the need to use html2plaintext and
the descriptions changes stemming from it.

opw-2746358

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
