### PR TITLE
[FIX] web_editor: fix animations on transformed images

### DIFF
--- a/addons/web_editor/static/src/js/editor/snippets.options.js
+++ b/addons/web_editor/static/src/js/editor/snippets.options.js
@@ -5255,11 +5255,17 @@ registry.ImageTools = ImageHandlerOption.extend({
         this.trigger_up('disable_loading_effect');
 
         const document = this.$target[0].ownerDocument;
+        const playState = this.$target[0].style.animationPlayState;
+        const transition = this.$target[0].style.transition;
         this.$target.transfo({document});
         const mousedown = mousedownEvent => {
             if (!$(mousedownEvent.target).closest('.transfo-container').length) {
                 this.$target.transfo('destroy');
                 $(document).off('mousedown', mousedown);
+                // Restore animation css properties potentially affected by the
+                // jQuery transfo plugin.
+                this.$target[0].style.animationPlayState = playState;
+                this.$target[0].style.transition = transition;
             }
         };
         $(document).on('mousedown', mousedown);

--- a/addons/web_editor/views/snippets.xml
+++ b/addons/web_editor/views/snippets.xml
@@ -522,6 +522,7 @@
             <we-button class="ml-0 border-left-0" data-reset-crop="" data-no-preview="true" title="Reset crop">
                 Reset
             </we-button>
+            <!-- TODO adapt in master, this is patched in JS to simulate a data-dependencies -->
             <we-button class="fa fa-fw fa-object-ungroup" data-transform="true" data-no-preview="true" title="Transform the picture"/>
             <we-button class="ml-0 border-left-0" data-reset-transform="" data-no-preview="true" title="Reset transformation">
                 Reset

--- a/addons/website/static/src/js/editor/snippets.options.js
+++ b/addons/website/static/src/js/editor/snippets.options.js
@@ -3058,6 +3058,20 @@ options.registry.ConditionalVisibility = options.Class.extend({
     },
 });
 
+options.registry.ImageTools.include({
+    /**
+     * @override
+     */
+    async _computeWidgetVisibility(widgetName, params) {
+        const result = await this._super(...arguments);
+        if ('transform' in params.optionsPossibleValues) {
+            // TODO adapt in master, use a data-dependencies
+            return result && !this.$target.hasClass('o_animate');
+        }
+        return result;
+    },
+});
+
 options.registry.WebsiteAnimate = options.Class.extend({
     /**
      * @override
@@ -3140,6 +3154,12 @@ options.registry.WebsiteAnimate = options.Class.extend({
         }
         if (widgetName === 'animation_launch_opt') {
             return !this.$target[0].closest('.dropdown');
+        }
+        if (params.isAnimationTypeSelection) {
+            // TODO adapt in master, use a data-dependencies related to the
+            // transform option
+            const transform = this.$target[0].style.transform;
+            return !transform || transform === 'none';
         }
         return this._super(...arguments);
     },

--- a/addons/website/views/snippets/snippets.xml
+++ b/addons/website/views/snippets/snippets.xml
@@ -1219,6 +1219,7 @@
     <div data-js="WebsiteAnimate"
          data-selector=".o_animable, section .row > div, img, .fa, .btn, .o_animated_text"
          data-exclude=".o_not-animable, .s_col_no_resize.row > div, .s_col_no_resize">
+        <!-- TODO adapt in master, this is patched in JS to simulate a data-dependencies -->
         <we-select string="Animate" data-is-animation-type-selection="true">
             <we-button data-select-class="" data-name="no_animation_opt">No Animation</we-button>
             <we-divider/>


### PR DESCRIPTION
Setting transformations on images is handled by the jQuery transfo plugin. This plugin, however, also manipulates animation related css (notably `animation-play-state` and `transition`) properties allowing the plugin to work on animated images.

After closing the transformation tools these properties stay in the DOM, preventing the animation options to work properly. Animations are not played when previewing or selecting a choice from the dropdown list. Instead they remain stuck in their initial keyframe.

To avoid complications from the interaction between both options, this commit hides either option when the other is activated. Additionally, css properties added by the transform option are cleaned, avoiding potential interactions after the transform option is reset again.

opw-2765529