### PR TITLE
[FIX] web_editor: make o_not_editable contenteditable=false

### DIFF
--- a/addons/web_editor/static/src/js/wysiwyg/wysiwyg.js
+++ b/addons/web_editor/static/src/js/wysiwyg/wysiwyg.js
@@ -90,6 +90,7 @@ const Wysiwyg = Widget.extend({
         this._isOnline = true;
         this._signalOnline = this._signalOnline.bind(this);
         Wysiwyg.activeWysiwygs.add(this);
+        this._oNotEditableObservers = new Map();
     },
     /**
      *
@@ -137,6 +138,7 @@ const Wysiwyg = Widget.extend({
             document: this.options.document,
             autohideToolbar: !!this.options.autohideToolbar,
             isRootEditable: this.options.isRootEditable,
+            onPostSanitize: this._setONotEditable.bind(this),
             placeholder: this.options.placeholder,
             showEmptyElementHint: this.options.showEmptyElementHint,
             controlHistoryFromDocument: this.options.controlHistoryFromDocument,
@@ -335,6 +337,15 @@ const Wysiwyg = Widget.extend({
 
         this._onSelectionChange = this._onSelectionChange.bind(this);
         this.odooEditor.document.addEventListener('selectionchange', this._onSelectionChange);
+
+        this.odooEditor.addEventListener('preObserverActive', () => {
+            // The setONotEditable will be called right after the
+            // editor sanitization (to be right before the historyStep).
+            // If any `.o_not_editable` is created while the observer is
+            // unactive, now is the time to call `setONotEditable` before the
+            // editor could register a mutation.
+            this._setONotEditable(this.odooEditor.editable);
+        });
 
         return _super.apply(this, arguments).then(() => {
             if (this.options.autohideToolbar) {
@@ -645,6 +656,9 @@ const Wysiwyg = Widget.extend({
             this.odooEditor.document.removeEventListener("keydown", this._signalOnline, true);
             this.odooEditor.document.removeEventListener("keyup", this._signalOnline, true);
             this.odooEditor.document.removeEventListener('selectionchange', this._onSelectionChange);
+            for (const observer of this._oNotEditableObservers.values()) {
+                observer.disconnect();
+            }
             this.odooEditor.destroy();
         }
         // If peer to peer is initializing, wait for properly closing it.
@@ -2138,7 +2152,46 @@ const Wysiwyg = Widget.extend({
         this.setValue(value);
         this.odooEditor.historyReset();
         this.ptp.notifyAllClients('ptp_join');
+    },
+    /**
+     * Set contenteditable=false for all `.o_not_editable` found within node if
+     * node is an element.
+     *
+     * For all `.o_not_editable` element found, the attribute contenteditable
+     * will be removed if the class is removed.
+     *
+     * @param {Node} node
+     */
+    _setONotEditable: function (node) {
+        const nodes = (node && node.querySelectorAll && node.querySelectorAll('.o_not_editable:not([contenteditable=false])')) || [];
+        for (const node of nodes) {
+            node.setAttribute('contenteditable', false);
+            let observer = this._oNotEditableObservers.get(node);
+            if (!observer) {
+                observer = new MutationObserver((records) => {
+                    for (const record of records) {
+                        if (record.type === 'attributes' && record.attributeName === 'class') {
+                            // Remove contenteditable=false on nodes that were
+                            // previsouly o_not_editable but are no longer
+                            // o_not_editable.
+                            if (!node.classList.contains('o_not_editable')) {
+                                this.odooEditor.observerUnactive('_setONotEditable');
+                                node.removeAttribute('contenteditable');
+                                this.odooEditor.observerActive('_setONotEditable');
+                                observer.disconnect();
+                                this._oNotEditableObservers.delete(node);
+                            }
+                        }
+                    }
+                });
+                this._oNotEditableObservers.set(node, observer);
+                observer.observe(node, {
+                    attributes: true,
+                });
+            }
+        }
     }
+
 });
 Wysiwyg.activeCollaborationChannelNames = new Set();
 Wysiwyg.activeWysiwygs = new Set();


### PR DESCRIPTION
The fix 1b80fe9 removed the behavior that made `.o_not_editable`
`contenteditable=false`. Without this behavior, other issues could
arises.





--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
