### PR TITLE
[FIX] mrp_landed_costs: validate a landed cost without the need for MRP access

### DIFF
--- a/addons/mrp_landed_costs/models/stock_landed_cost.py
+++ b/addons/mrp_landed_costs/models/stock_landed_cost.py
@@ -12,9 +12,9 @@ class StockLandedCost(models.Model):
     ], ondelete={'manufacturing': 'set default'})
     mrp_production_ids = fields.Many2many(
         'mrp.production', string='Manufacturing order',
-        copy=False, states={'done': [('readonly', True)]}, groups='mrp.group_mrp_user')
+        copy=False, states={'done': [('readonly', True)]}, groups='stock.group_stock_manager')
     allowed_mrp_production_ids = fields.Many2many(
-        'mrp.production', compute='_compute_allowed_mrp_production_ids', groups='mrp.group_mrp_user')
+        'mrp.production', compute='_compute_allowed_mrp_production_ids', groups='stock.group_stock_manager')
 
     @api.depends('company_id')
     def _compute_allowed_mrp_production_ids(self):

--- a/addons/mrp_landed_costs/tests/test_stock_landed_costs_mrp.py
+++ b/addons/mrp_landed_costs/tests/test_stock_landed_costs_mrp.py
@@ -139,3 +139,43 @@ class TestStockLandedCostsMrp(ValuationReconciliationTestCommon):
         self.assertEqual(len(landed_cost.stock_valuation_layer_ids), 1)
         self.assertEqual(landed_cost.stock_valuation_layer_ids.product_id, self.product_refrigerator)
         self.assertEqual(landed_cost.stock_valuation_layer_ids.value, 5.0)
+
+    def test_landed_cost_on_mrp_02(self):
+        """
+            Test that a user who has manager access to stock can create and validate a landed cost linked
+            to a Manufacturing order without the need for MRP access
+        """
+        # Create a user with only manager access to stock
+        stock_manager = self.env['res.users'].with_context({'no_reset_password': True}).create({
+            'name': "Stock Manager",
+            'login': "test",
+            'email': "test@test.com",
+            'groups_id': [(6, 0, [self.env.ref('stock.group_stock_manager').id])]
+        })
+        # Make some stock and reserve
+        self.env['stock.quant']._update_available_quantity(self.product_component1, self.warehouse_1.lot_stock_id, 10)
+        self.env['stock.quant']._update_available_quantity(self.product_component2, self.warehouse_1.lot_stock_id, 10)
+
+        # Create and confirm a MO with a user who has access to MRP
+        man_order_form = Form(self.env['mrp.production'].with_user(self.allow_user))
+        man_order_form.product_id = self.product_refrigerator
+        man_order_form.bom_id = self.bom_refri
+        man_order_form.product_qty = 1.0
+        man_order = man_order_form.save()
+        man_order.action_confirm()
+        # produce product
+        man_order_form.qty_producing = 1
+        man_order_form.save()
+        man_order.button_mark_done()
+
+        # Create the landed cost with the stock_manager user
+        landed_cost = Form(self.env['stock.landed.cost'].with_user(stock_manager)).save()
+        landed_cost.target_model = 'manufacturing'
+
+        # Check that the MO can be selected by the stock_manger user
+        self.assertTrue(man_order.id in landed_cost.allowed_mrp_production_ids.ids)
+        landed_cost.mrp_production_ids = [(6, 0, [man_order.id])]
+
+        # Check that he can validate the landed cost without an access error
+        landed_cost.with_user(stock_manager).button_validate()
+        self.assertEqual(landed_cost.state, 'done')

--- a/addons/mrp_landed_costs/views/stock_landed_cost_views.xml
+++ b/addons/mrp_landed_costs/views/stock_landed_cost_views.xml
@@ -7,7 +7,7 @@
         <field name="arch" type="xml">
             <field name="target_model" position="attributes">
                 <attribute name="invisible">0</attribute>
-                <attribute name="groups">mrp.group_mrp_user</attribute>
+                <attribute name="groups">stock.group_stock_manager</attribute>
             </field>
             <field name="picking_ids" position="after">
                 <field name="allowed_mrp_production_ids" invisible="1"/>


### PR DESCRIPTION
Steps to reproduce the bug:
- Install mrp_landed_costs
- Connect as Admin
- Remove MRP access to Admin and Give him Stock manager access
- Go to inventory settings > Enable “Landed costs”
- Go to inventory > operation > Select any landed cost
- Try to validate

Problem:
An access error is triggered because we check if there are finished moves in the associated pickings and manufacturing orders
before validating the landed cost, but in the "_get_targeted_move_ids" function we access the "mrp_production_ids" field, which is reserved for mrp users.

Solution:
Creating and validating a landed cost is a feature for stock manager users.
We can therefore have users who do not need access to MRP, but who need to  validate and submit landed costs.
So we can give access to all of them even if they are not MRP users.

opw-2800367




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
