### PR TITLE
[FIX] cloc: do not count studio qweb

### DIFF
--- a/addons/base_import_module/tests/test_cloc.py
+++ b/addons/base_import_module/tests/test_cloc.py
@@ -50,6 +50,17 @@ class TestClocFields(test_cloc.TestClocCustomization):
             'state': 'installed',
             'summary': 'Test imported module for cloc',
         })
+        # Studio module does not exist at this stage, so we simulate it
+        # Check for existing module in case the test run on an existing database
+        if not self.env['ir.module.module'].search([('name', '=', 'studio_customization')]):
+            self.env['ir.module.module'].create({
+                'author': 'Odoo',
+                'imported': True,
+                'latest_version': '15.0.1.0.0',
+                'name': 'studio_customization',
+                'state': 'installed',
+                'summary': 'Studio Customization',
+            })
         qweb_view = self.env['ir.ui.view'].create({
             "name": "Qweb Test",
             "type": "qweb",
@@ -78,6 +89,7 @@ class TestClocFields(test_cloc.TestClocCustomization):
         cl = cloc.Cloc()
         cl.count_customization(self.env)
         self.assertEqual(cl.code.get('test_imported_module', 0), 5, "Count only qweb view from imported module")
+        self.assertEqual(cl.code.get('studio_customization', 0), 0, "Do not count from studio_customization module")
 
     def test_count_attachment_imported_module(self):
         manifest_content = json.dumps({

--- a/odoo/tools/cloc.py
+++ b/odoo/tools/cloc.py
@@ -201,13 +201,13 @@ class Cloc(object):
         if not imported_module:
             return
 
-        # Count qweb view only from imported module
+        # Count qweb view only from imported module and not studio
         query = """
             SELECT view.id, data.module
               FROM ir_ui_view view
         INNER JOIN ir_model_data data ON view.id = data.res_id AND data.model = 'ir.ui.view'
         INNER JOIN ir_module_module mod ON mod.name = data.module AND mod.imported = True
-             WHERE view.type = 'qweb'
+             WHERE view.type = 'qweb' AND mod.name != 'studio_customization'
         """
         env.cr.execute(query)
         custom_views = dict(env.cr.fetchall())


### PR DESCRIPTION
Since
https://github.com/odoo/odoo/commit/d2e0b48271dbd8cd7bbdbc5c2c1649c55c51417b,
qweb view from imported module are counted. the issue is that qweb view
created with the wysiwig editor of studio got an external ID from
studio_customization module which is declared as imported

So those views were wrongly counted for the maintenance fee.

Solution
--------
Exclude qweb view from studio_customization module



--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
