### PR TITLE
[FIX] account_edi: Display edi cron nextcall, fix confusing banners

### DIFF
--- a/addons/account_edi/models/account_move.py
+++ b/addons/account_edi/models/account_move.py
@@ -2,6 +2,7 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 from odoo import api, fields, models, _
 from odoo.exceptions import UserError
+from odoo.tools import DEFAULT_SERVER_DATETIME_FORMAT, DEFAULT_SERVER_TIME_FORMAT
 
 
 class AccountMove(models.Model):
@@ -26,7 +27,11 @@ class AccountMove(models.Model):
         compute='_compute_edi_error_message')
     # Technical field to display the documents that will be processed by the CRON
     edi_web_services_to_process = fields.Text(
-        compute='_compute_edi_web_services_to_process')
+        compute='_compute_edi_web_services_to_process',
+        help="Technical field to display the documents that will be processed by the CRON")
+    edi_cron_schedule = fields.Char(
+        compute='_compute_edi_cron_schedule',
+        help="Field to display the next scheduled activation of the 'EDI : Perform web services operations' scheduled action")
     edi_show_cancel_button = fields.Boolean(
         compute='_compute_edi_show_cancel_button')
     edi_show_abandon_cancel_button = fields.Boolean(
@@ -86,7 +91,16 @@ class AccountMove(models.Model):
             format_web_services = to_process.edi_format_id.filtered(lambda f: f._needs_web_services())
             move.edi_web_services_to_process = ', '.join(f.name for f in format_web_services)
 
-    @api.depends('edi_document_ids.state')
+    @api.depends('state', 'edi_document_ids.state')
+    def _compute_edi_cron_schedule(self):
+        cron = self.sudo().env.ref('account_edi.ir_cron_edi_network', raise_if_not_found=False)
+        if not cron or cron.active is False:
+            schedule = _("never (no active cron)")
+        elif cron.nextcall:
+            schedule = cron.nextcall.time().strftime(DEFAULT_SERVER_TIME_FORMAT) if cron.nextcall.date() == fields.datetime.today().date() else cron.nextcall.strftime(DEFAULT_SERVER_DATETIME_FORMAT)
+        for move in self:
+            move.edi_cron_schedule = False or schedule
+
     def _compute_show_reset_to_draft_button(self):
         # OVERRIDE
         super()._compute_show_reset_to_draft_button()

--- a/addons/account_edi/views/account_move_views.xml
+++ b/addons/account_edi/views/account_move_views.xml
@@ -64,12 +64,16 @@
                 <xpath expr="//header" position="after">
                     <field name="edi_blocking_level" invisible="1" />
                     <field name="edi_error_count" invisible="1" />
-                    <div class="alert alert-info" role="alert" style="margin-bottom:0px;"
-                        attrs="{'invisible': ['|', ('edi_web_services_to_process', 'in', ['', False]), ('state', '=', 'draft')]}">
-                         <div>The invoice will be processed asynchronously by the following E-invoicing service :
-                            <field name="edi_web_services_to_process" class="oe_inline"/>
-                         </div>
-                         <button name="button_process_edi_web_services" type="object" class="oe_link" string="Process now" /> 
+                    <div class="alert alert-info" role="alert" style="margin-bottom:0px;" attrs="{'invisible': ['|', ('edi_web_services_to_process', 'in', ['', False]), ('state', '=', 'draft')]}">
+                        <div>
+                            <div>
+                                The invoice will be sent to / updated from the following E-invoicing service: <field name="edi_web_services_to_process" class="oe_inline"/>.
+                            </div>
+                            <div>
+                                Scheduled for: <field name="edi_cron_schedule" class="oe_inline"/>.
+                            </div>
+                        </div>
+                        <button name="button_process_edi_web_services" type="object" class="oe_link" string="Send / Update" />
                     </div>
                     <div class="alert alert-danger" role="alert" style="margin-bottom:0px;"
                         attrs="{'invisible': ['|', ('edi_error_count', '=', 0), ('edi_blocking_level', '!=', 'error')]}">

--- a/addons/l10n_it_edi/models/account_edi_format.py
+++ b/addons/l10n_it_edi/models/account_edi_format.py
@@ -900,7 +900,7 @@ class AccountEdiFormat(models.Model):
             if 'id_transaction' in response:
                 invoice.l10n_it_edi_transaction = response['id_transaction']
                 to_return[invoice].update({
-                    'error': _('The invoice was sent to FatturaPA, but we are still awaiting a response. Click the link above to check for an update.'),
+                    'error': _('The invoice was successfully transmitted to the Public Administration and is awaiting confirmation.'),
                     'blocking_level': 'info',
                 })
         return to_return
@@ -937,7 +937,7 @@ class AccountEdiFormat(models.Model):
             state = response['state']
             if state == 'awaiting_outcome':
                 to_return[invoice] = {
-                    'error': _('The invoice was sent to FatturaPA, but we are still awaiting a response. Click the link above to check for an update.'),
+                    'error': _('The invoice was successfully transmitted to the Public Administration and is awaiting confirmation.'),
                     'blocking_level': 'info',
                 }
                 continue


### PR DESCRIPTION
When posting an invoice with edi documents, a banner will appear
informing the user that the invoice will be sent asynchronously, however
the user has no idea when this will occur (unless they know to look at
the correct scheduled action in developer mode). This commit adds a
computed text field to the account_move that is displayed to the user to
inform them of the time of the next cron call (or if it never happens,
it informs the user that the cron will not execute).

the computed field :edi_network_cron_schedule
This provides the string for the time of the cron's next call