### PR TITLE
[FIX] web_editor: prevent powerbox step from staying in history

### DIFF
--- a/addons/web_editor/static/lib/odoo-editor/src/OdooEditor.js
+++ b/addons/web_editor/static/lib/odoo-editor/src/OdooEditor.js
@@ -1818,6 +1818,7 @@ export class OdooEditor extends EventTarget {
             preValidate: () => {
                 this._historyRevertUntil(this._beforeCommandbarStepIndex);
                 this.historyStep(true);
+                this._historyStepsStates.set(peek(this._historySteps).id, 'consumed');
                 setTimeout(() => {
                     this.editable.focus();
                     getDeepRange(this.editable, { select: true });


### PR DESCRIPTION
Before this commit
Calling a command of the powerbox created a step that delete the input
content of the powerbox. That input content came back upon undo.

After this commit
The input content that select a command from the powerbox should
never come back upon undo.

task-2806849





--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
