### PR TITLE
[FIX] mrp: Use the same condition for run_manufacture and run_pull

### DIFF
--- a/addons/mrp/models/stock_rule.py
+++ b/addons/mrp/models/stock_rule.py
@@ -139,7 +139,7 @@ class StockRule(models.Model):
         }
         # Use the procurement group created in _run_pull mrp override
         # Preserve the origin from the original stock move, if available
-        if location_id.warehouse_id.manufacture_steps == 'pbm_sam' and values.get('move_dest_ids') and values.get('group_id') and values['move_dest_ids'][0].origin != values['group_id'].name:
+        if values.get('move_dest_ids') and values.get('group_id') and values['move_dest_ids'].picking_type_id == location_id.warehouse_id.sam_type_id:
             origin = values['move_dest_ids'][0].origin
             mo_values.update({
                 'name': values['group_id'].name,


### PR DESCRIPTION
In store finished product scenario, if the rules has been created
manualy then you could have a different behavior than if it was
selected on the stock.warehouse. It should not because the warehouse is
just a tool to help in the database configuration and the code should
not refer to it

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
