### PR TITLE
[FIX] l10n_id_efaktur: round amounts

### DIFF
--- a/addons/l10n_id_efaktur/models/account_move.py
+++ b/addons/l10n_id_efaktur/models/account_move.py
@@ -181,8 +181,8 @@ class AccountMove(models.Model):
 
             lines = move.line_ids.filtered(lambda x: x.product_id.id == int(dp_product_id) and x.price_unit < 0 and not x.display_type)
             eTax['FG_UANG_MUKA'] = 0
-            eTax['UANG_MUKA_DPP'] = int(abs(sum(lines.mapped('price_subtotal'))))
-            eTax['UANG_MUKA_PPN'] = int(abs(sum(lines.mapped(lambda l: l.price_total - l.price_subtotal))))
+            eTax['UANG_MUKA_DPP'] = int(abs(sum(lines.mapped(lambda l: round(l.price_subtotal, 0)))))
+            eTax['UANG_MUKA_PPN'] = int(abs(sum(lines.mapped(lambda l: round(l.price_total - l.price_subtotal, 0)))))
 
             company_npwp = company_id.partner_id.vat or '000000000000000'
 
@@ -215,10 +215,10 @@ class AccountMove(models.Model):
                 line_dict = {
                     'KODE_OBJEK': line.product_id.default_code or '',
                     'NAMA': line.product_id.name or '',
-                    'HARGA_SATUAN': int(invoice_line_unit_price),
+                    'HARGA_SATUAN': int(round(invoice_line_unit_price, 0)),
                     'JUMLAH_BARANG': line.quantity,
-                    'HARGA_TOTAL': int(invoice_line_total_price),
-                    'DPP': int(line.price_subtotal),
+                    'HARGA_TOTAL': int(round(invoice_line_total_price, 0)),
+                    'DPP': int(round(line.price_subtotal, 0)),
                     'product_id': line.product_id.id,
                 }
 
@@ -227,16 +227,16 @@ class AccountMove(models.Model):
                         free_tax_line += (line.price_subtotal * (tax.amount / 100.0)) * -1.0
 
                     line_dict.update({
-                        'DISKON': int(invoice_line_total_price - line.price_subtotal),
-                        'PPN': int(free_tax_line),
+                        'DISKON': int(round(invoice_line_total_price - line.price_subtotal, 0)),
+                        'PPN': int(round(free_tax_line, 0)),
                     })
                     free.append(line_dict)
                 elif line.price_subtotal != 0.0:
                     invoice_line_discount_m2m = invoice_line_total_price - line.price_subtotal
 
                     line_dict.update({
-                        'DISKON': int(invoice_line_discount_m2m),
-                        'PPN': int(tax_line),
+                        'DISKON': int(round(invoice_line_discount_m2m, 0)),
+                        'PPN': int(round(tax_line, 0)),
                     })
                     sales.append(line_dict)
 
@@ -259,7 +259,7 @@ class AccountMove(models.Model):
                             if tax.amount > 0:
                                 tax_line += sale['DPP'] * (tax.amount / 100.0)
 
-                        sale['PPN'] = int(tax_line)
+                        sale['PPN'] = int(round(tax_line, 0))
 
                         free.remove(f)
 


### PR DESCRIPTION
The e-faktur contains amounts that are not well rounded

Steps to reproduce:
1. Install Accounting app and l10n_id_efaktur module
2. Switch to ID Company
3. Open Accounting
4. Go to Customers > e-Faktur
5. Create a new range (at least one number available)
6. Create a new Customer Invoice for a customer in Indonesia with ID PKP
enabled, specify a 'Kode Transaksi' and add a product with a price of
147.5 and a tax of 10%
7. Download the e-faktur
8. The amounts on the product line are not rounded but truncated

Solution:
Round the amounts that are translated to int

[opw-2793009](https://www.odoo.com/web#id=2793009&model=project.task&view_type=form)