### PR TITLE
[FIX] purchase: dashboard should respect user language

### DIFF
--- a/addons/purchase/i18n/purchase.pot
+++ b/addons/purchase/i18n/purchase.pot
@@ -2045,7 +2045,9 @@ msgid "Quantity:"
 msgstr ""
 
 #. module: purchase
+#: code:addons/purchase/models/purchase.py:0
 #: model:ir.model.fields.selection,name:purchase.selection__purchase_order__state__draft
+#, python-format
 msgid "RFQ"
 msgstr ""
 
@@ -2065,8 +2067,10 @@ msgid "RFQ Done"
 msgstr ""
 
 #. module: purchase
+#: code:addons/purchase/models/purchase.py:0
 #: model:ir.model.fields.selection,name:purchase.selection__purchase_order__state__sent
 #: model:ir.model.fields.selection,name:purchase.selection__purchase_report__state__sent
+#, python-format
 msgid "RFQ Sent"
 msgstr ""
 

--- a/addons/purchase/models/purchase.py
+++ b/addons/purchase/models/purchase.py
@@ -625,12 +625,12 @@ class PurchaseOrder(models.Model):
                    WHERE m.create_date >= %s
                      AND m.model = 'purchase.order'
                      AND m.message_type = 'notification'
-                     AND v.old_value_char = 'RFQ'
-                     AND v.new_value_char = 'RFQ Sent'
+                     AND v.old_value_char = %s
+                     AND v.new_value_char = %s
                      AND po.company_id = %s;
                 """
 
-        self.env.cr.execute(query, (one_week_ago, self.env.company.id))
+        self.env.cr.execute(query, (one_week_ago, _('RFQ'), _('RFQ Sent'), self.env.company.id))
         res = self.env.cr.fetchone()
         result['all_sent_rfqs'] = res[0] or 0
 


### PR DESCRIPTION
# Issues
Purchase Dashboard gives wong value for PO in `RFQ` and `RFQ sent` when user's language is not English

# Current behavior before PR:
1. Create some RFQ and RFQ Sent to see its statistic in dashboard
2. Swith user language to another one that is other than English
3. Statistic in the dashboard is wrong now

# Solution
Passing translated `RFQ` and `RFQ Sent` into the dashboard query in stead of passing pure text without translation.

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
