### PR TITLE
[FIX] core: make "generator didn't yield" in assertRaises easier to debug

### DIFF
--- a/odoo/addons/test_testing_utilities/tests/test_methods.py
+++ b/odoo/addons/test_testing_utilities/tests/test_methods.py
@@ -1,8 +1,18 @@
 # -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
+import itertools
+from unittest import mock, TestCase
 
+import psycopg2
+
+from odoo.exceptions import AccessError
+from odoo.sql_db import BaseCursor
 from odoo.tests import common
+from odoo.tools import mute_logger
 
+
+class CustomError(Exception):
+    ...
 
 class TestBasic(common.TransactionCase):
     def test_assertRecordValues(self):
@@ -28,3 +38,52 @@ class TestBasic(common.TransactionCase):
             self.assertRecordValues(records, [X1, Y3])
         with self.assertRaises(AssertionError):
             self.assertRecordValues(records, [Y3, X1])
+
+    def test_assertRaises_rollbacks(self):
+        """Checks that a "correctly" executing assertRaises (where the expected
+        exception has been raised and caught) will properly rollback.
+        """
+        self.env.cr.execute("SET LOCAL test_testing_utilities.a_flag = ''")
+        with self.assertRaises(CustomError):
+            self.env.cr.execute("SET LOCAL test_testing_utilities.a_flag = 'yes'")
+            raise CustomError
+
+        self.env.cr.execute("SHOW test_testing_utilities.a_flag")
+        self.assertEqual(self.env.cr.fetchone(), ('',))
+
+    def test_assertRaises_error(self):
+        """Checks that an exception raised during the *setup* of assertRaises
+        bubbles up correctly.
+
+        Raises an exception when `savepoint()` calls `flush()` during setup.
+        """
+        # ensure we catch the error with the "base" method to avoid any interference
+        with mock.patch.object(BaseCursor, 'flush', side_effect=CustomError), \
+             TestCase.assertRaises(self, CustomError):
+            with self.assertRaises(CustomError):
+                raise NotImplementedError
+
+    @mute_logger('odoo.sql_db')
+    def test_assertRaises_clear_recovery(self):
+        """Checks that the savepoint is correctly rolled back if an error occurs
+        during the assertRaises setup
+
+        Raises an exception during the first `clear()` calls which immediately
+        follows the initialisation of the savepoint iff we're expecting an
+        AccessError.
+        """
+        # on the first `clear` call, break the current transaction with nonsense
+        # (on further calls do nothing as savepoint() needs to clear() for its
+        # own recovery)
+        def clear(call_count=itertools.count()):
+            if next(call_count) == 0:
+                self.env.cr.execute('select nonsense')
+
+        with mock.patch.object(BaseCursor, 'clear', side_effect=clear),\
+             TestCase.assertRaises(self, psycopg2.Error):
+            with self.assertRaises(AccessError):
+                raise NotImplementedError
+
+        # check that the transaction has been rolled back and we can perform
+        # queries again
+        self.env.cr.execute('select 1')


### PR DESCRIPTION
Because the `savepoint` and `clear` calls were nested inside the `assertRaises` context, if one of them happens to throw *the exception we're looking for* the interpreter will jump back to the `with`, the `assertRaises` will swallow the exception (and count it as a success) and the function will end having not gone through a `yield`.

This is rather frustrating to debug as it's easy to forget that a `with` is a control flow structure, leading to a seemingly impossible error.

I first tried to swap the two, but obviously that's broken as now the exact exception we're waiting for is not protected by the savepoint anymore, which seems undesirable.

Instead, log a clear error message in case of conflict. It does not *fix* the error per-se, but it does make it much easier to diagnose.

I considered raising a different exception, but technically any exception we pick could be the one being awaited, leading it to being suppressed.

An alternative change would be to "weave" the two context managers non-lexically, such that we setup `savepoint()` first, then setup the `assertRaises`, then exit `savepoint()`, and finally exit `assertRaises`. While that seems possible -- especially using [`ExitStack.push`](https://docs.python.org/3/library/contextlib.html#contextlib.ExitStack.push) it felt overly complicated and difficult to follow. Hence I decided to simply go with better reporting of the problematic condition.
