### PR TITLE
[FIX] sale_project: sales orders link blocked even user has correct s…

### DIFF
--- a/addons/sale_project/models/sale_order.py
+++ b/addons/sale_project/models/sale_order.py
@@ -36,11 +36,8 @@ class SaleOrder(models.Model):
     @api.depends('order_line.product_id', 'order_line.project_id')
     def _compute_project_ids(self):
         for order in self:
-            projects = order.order_line.mapped('product_id.project_id')
-            projects |= order.order_line.mapped('project_id')
-            projects |= order.project_id
-            order.project_ids = projects
-            order.project_count = len(projects)
+            order.project_ids = self.env['project.project'].search(['|', '|', ('sale_order_id', '=', order.id), ('id', 'in', order.order_line.project_id.ids), ('id', 'in', order.order_line.product_id.project_id.ids)])
+            order.project_count = len(order.project_ids)
 
     @api.onchange('project_id')
     def _onchange_project_id(self):


### PR DESCRIPTION
…ales rights

Before this commit, it raises an access rights error when a user clicks on
sales orders in a project, even though the user has the correct rights

With this commit, this issue is fixed by adding a search domain on projects,
so that a project with sales rights will appear on projects

task-2792884

