### PR TITLE
[IMP] mail: make start method handle hasWebClient parameter properly

### DIFF
--- a/addons/mail/static/tests/helpers/test_utils.js
+++ b/addons/mail/static/tests/helpers/test_utils.js
@@ -805,12 +805,13 @@ async function start(param0 = {}) {
         }),
     }, param0.services);
 
-    if (!param0.data && !param0.serverData) {
+    if (!param0.data && (!param0.serverData || !param0.serverData.models)) {
         pyEnv = pyEnv || await startServer();
         const data = pyEnv.mockServer.data;
         Object.assign(data, TEST_USER_IDS);
         if (hasWebClient) {
-            param0.serverData = { models: data };
+            param0.serverData = param0.serverData || getActionManagerServerData();
+            param0.serverData.models = data;
         } else {
             param0.data = data;
         }


### PR DESCRIPTION
startServer method ease data seeding by providing an environment that
can be used to interact with the underlying mock server. Previously,
it was not possible to call this method twice (eg. once in the beforeEach
and once in the test), the method have been adapted to do so. Moreover,
the createWebClient method was not supported well. Indeed, we could either
pass serverData or not. But we could not pass only the views and take
the data from the startServer method. This has been corrected as well.

task-2792108