### PR TITLE
[FIX] payment_stripe: turn credentials helper methods into functions

### DIFF
--- a/addons/payment_stripe/controllers/main.py
+++ b/addons/payment_stripe/controllers/main.py
@@ -12,6 +12,9 @@ from odoo.exceptions import ValidationError
 from odoo.http import request
 from odoo.tools import consteq
 
+from odoo.addons.payment_stripe import utils as stripe_utils
+
+
 _logger = logging.getLogger(__name__)
 
 
@@ -90,7 +93,9 @@ class StripeController(http.Controller):
                 tx_sudo = request.env['payment.transaction'].sudo()._get_tx_from_feedback_data(
                     'stripe', data
                 )
-                if self._verify_webhook_signature(tx_sudo.acquirer_id._get_stripe_webhook_secret()):
+                if self._verify_webhook_signature(
+                    stripe_utils.get_webhook_secret(tx_sudo.acquirer_id)
+                ):
                     # Fetch the PaymentIntent, Charge and PaymentMethod objects from Stripe
                     if checkout_session.get('payment_intent'):  # Can be None
                         payment_intent = tx_sudo.acquirer_id._stripe_make_request(

--- a/addons/payment_stripe/models/payment_transaction.py
+++ b/addons/payment_stripe/models/payment_transaction.py
@@ -9,8 +9,10 @@ from odoo import _, api, fields, models
 from odoo.exceptions import UserError, ValidationError
 
 from odoo.addons.payment import utils as payment_utils
+from odoo.addons.payment_stripe import utils as stripe_utils
 from odoo.addons.payment_stripe.const import INTENT_STATUS_MAPPING, PAYMENT_METHOD_TYPES
 from odoo.addons.payment_stripe.controllers.main import StripeController
+
 
 _logger = logging.getLogger(__name__)
 
@@ -35,7 +37,7 @@ class PaymentTransaction(models.Model):
 
         checkout_session = self._stripe_create_checkout_session()
         return {
-            'publishable_key': self.acquirer_id._get_stripe_publishable_key(),
+            'publishable_key': stripe_utils.get_publishable_key(self.acquirer_id),
             'session_id': checkout_session['id'],
         }
 
@@ -144,7 +146,7 @@ class PaymentTransaction(models.Model):
     def _get_common_stripe_session_values(self, pmt_values, customer):
         """ Return the Stripe Session values that are common to redirection and validation.
 
-        Note: This method is overridden by the internal module responsible for Stripe Connect.
+        Note: This method serves as a hook for modules that would fully implement Stripe Connect.
 
         :param dict pmt_values: The payment method types values
         :param dict customer: The Stripe customer to assign to the session
@@ -214,7 +216,7 @@ class PaymentTransaction(models.Model):
     def _stripe_prepare_payment_intent_payload(self):
         """ Prepare the payload for the creation of a payment intent in Stripe format.
 
-        Note: This method is overridden by the internal module responsible for Stripe Connect.
+        Note: This method serves as a hook for modules that would fully implement Stripe Connect.
         Note: self.ensure_one()
 
         :return: The Stripe-formatted payload for the payment intent request

--- a/addons/payment_stripe/utils.py
+++ b/addons/payment_stripe/utils.py
@@ -1,0 +1,39 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+def get_publishable_key(acquirer_sudo):
+    """ Return the publishable key for Stripe.
+
+    Note: This method serves as a hook for modules that would fully implement Stripe Connect.
+
+    :param recordset acquirer_sudo: The acquirer on which the key should be read, as a sudoed
+                                    `payment.acquire` record.
+    :return: The publishable key
+    :rtype: str
+    """
+    return acquirer_sudo.stripe_publishable_key
+
+
+def get_secret_key(acquirer_sudo):
+    """ Return the secret key for Stripe.
+
+    Note: This method serves as a hook for modules that would fully implement Stripe Connect.
+
+    :param recordset acquirer_sudo: The acquirer on which the key should be read, as a sudoed
+                                    `payment.acquire` record.
+    :return: The secret key
+    :rtype: str
+    """
+    return acquirer_sudo.stripe_secret_key
+
+
+def get_webhook_secret(acquirer_sudo):
+    """ Return the webhook secret for Stripe.
+
+    Note: This method serves as a hook for modules that would fully implement Stripe Connect.
+
+    :param recordset acquirer_sudo: The acquirer on which the key should be read, as a sudoed
+                                    `payment.acquire` record.
+    :returns: The webhook secret
+    :rtype: str
+    """
+    return acquirer_sudo.stripe_webhook_secret


### PR DESCRIPTION
This commit removes the access to stripe credentials through model
helper methods.