### PR TITLE
[FIX] website_crm: stat button on crm.lead form view still shows page views count of archived visitor records

### DIFF
--- a/addons/website_crm/models/crm_lead.py
+++ b/addons/website_crm/models/crm_lead.py
@@ -20,7 +20,7 @@ class Lead(models.Model):
                         JOIN crm_lead_website_visitor_rel lv ON l.id = lv.crm_lead_id
                         JOIN website_visitor v ON v.id = lv.website_visitor_id
                         JOIN website_track p ON p.visitor_id = v.id
-                        WHERE l.id in %s
+                        WHERE l.id in %s AND v.active = TRUE
                         GROUP BY l.id"""
             self.env.cr.execute(sql, (tuple(self.ids),))
             page_data = self.env.cr.dictfetchall()


### PR DESCRIPTION
Description of the issue/feature this PR addresses:

**Current behavior before PR:**
Stat button on crm.lead form view still shows page views count of archived visitor records.
In my example, clicking on it will show an empty list. Steps to reproduce:

https://user-images.githubusercontent.com/66666640/160570340-dc9712ee-ac56-4af8-b34d-3ef00bf05ea5.mp4


**Desired behavior after PR is merged:**

Only count page views of active visitors




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
