### PR TITLE
[FIX] reqs: bump requests to match urllib3 requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -34,7 +34,7 @@ pytz==2019.3
 pyusb==1.0.2
 qrcode==6.1
 reportlab==3.5.59 # version < 3.5.54 are not compatible with Pillow 8.1.2 and 3.5.59 is bullseye
-requests==2.22.0
+requests==2.25.1 # versions < 2.25 aren't compatible w/ urllib3 1.26. Bullseye = 2.25.1. min version = 2.22.0 (Focal)
 urllib3==1.26.5 # indirect / min version = 1.25.8 (Focal with security backports)
 vobject==0.9.6.1
 Werkzeug==0.16.1


### PR DESCRIPTION
The urrilb3 version was bumped to 1.26.5 in a87af91211bb but it appears
that requests 2.22.0 needs an urllib version < 1.26 [0].

With this commit, the requests version is bumped to 2.25.1 which needs urllib3 < 1.27 [1].

Debian Bullseye also provides requests 2.25.1 [2] while Ubuntu Focal
provides 2.22.0 [3].

[0] https://github.com/psf/requests/blob/aeda65bbe57ac5edbcc2d80db85d010befb7d419/setup.py#L47
[1] https://github.com/psf/requests/blob/c2b307dbefe21177af03f9feb37181a89a799fcc/setup.py#L47
[2] https://packages.debian.org/bullseye/python3-requests
[3] https://packages.ubuntu.com/focal/python3-requests
