### PR TITLE
[FIX] project: random cache flushing issue in test_task_portal_no_read

### DIFF
--- a/addons/project/tests/test_access_rights.py
+++ b/addons/project/tests/test_access_rights.py
@@ -116,6 +116,7 @@ class TestCRUDVisibilityPortal(TestAccessRights):
     def setUp(self):
         super().setUp()
         self.project_pigs.privacy_visibility = 'portal'
+        self.env['base'].flush()
 
     @users('Portal user')
     def test_task_portal_no_read(self):


### PR DESCRIPTION
`test_task_postal_no_read` calls `assertEqual`, which internally creates a savepoint which flushes pending computations.

This is done by flushing the transaction (through the cursor), which in turn goes and flushes the models.

The environment being used to flush the models is arbitrary, picked from the set of all living environments associated with the transaction favoring those with a user set. This means the environment used to perform the pending computation can be a lot more restrictive than the operation used to initiate said computation, which may lead to the computation being flushed not being *possible to perform*.

The issue here is that the test specifically involves a restricted user ("Portal user", created for the occasion). Logging the set, at the start of the test function there are 11 active environments associated with the superuser and one (1) environment associated with that user, let's call it 19 (because that's the uid it gets when running only that job).

On the runbot the envset seems to shuffle really well and about 2/10 of the runs will have the env(uid=19) in leading position[^0], thus try to flush the *creation of the task* with the portal user, which specifically does not have access to tasks.

This works around the issue by flushing the task creation in the `setUp`, however the underlying issues remain.

[^0]: This also seems to require some load on the runbots, if the runbots are pretty much unloaded (no pending builds) reproduction is never achieved. It is not clear why load would matter.

      Local reproduction was not successful, even using a dump from the runbot and inducing artificial load (via stress-ng).
