### PR TITLE
[FIX] microsoft_outlook: do not auto install microsoft_outlook

### DIFF
--- a/addons/microsoft_outlook/__manifest__.py
+++ b/addons/microsoft_outlook/__manifest__.py
@@ -14,5 +14,5 @@
         "views/res_config_settings_views.xml",
         "views/templates.xml",
     ],
-    "auto_install": True,
+    "auto_install": False,
 }


### PR DESCRIPTION
Purpose
=======
Do not auto install microsoft_outlook.

fetchmail_outlook is still auto installed because it
depends on microsoft_outlook.

Task-2751996