### PR TITLE
[FIX] _vendor: fix compatibility with werkzeug 2.0+

### DIFF
--- a/odoo/tools/_vendor/sessions.py
+++ b/odoo/tools/_vendor/sessions.py
@@ -19,14 +19,13 @@ import os
 import re
 import tempfile
 from hashlib import sha1
-from os import path
+from os import path, replace as rename
 from pickle import dump
 from pickle import HIGHEST_PROTOCOL
 from pickle import load
 from time import time
 
 from werkzeug.datastructures import CallbackDict
-from werkzeug.posixemulation import rename
 
 _sha1_re = re.compile(r"^[a-f0-9]{40}$")
 


### PR DESCRIPTION
As of werkzeug 2.0, the `posixemulation` compatibility layer for atomic rename operations is abandoned[1]. In the mean time an atomic, cross-platform file renaming function was introduced in the stdlib, as of Python 3.3: `os.replace()`.

By using `os.replace()` instead of `posixemulation.rename()`, we can ensure compatibility with versions 0.x, 1.x and 2.x of werkzeug.

We've always required Python 3.5+ since the P3 support, so `os.replace()` is always available.

This is a follow-up of the work for supporting werkzeug 1.x [2]

References:
[1] https://github.com/pallets/werkzeug/pull/1790
[2] vendoring of werkzeug.sessions: odoo/odoo#45931
