### PR TITLE
[FIX] 15.0-Customer display not updated when quantity of product is changed

### DIFF
--- a/addons/point_of_sale/static/src/js/Screens/ProductScreen/ProductScreen.js
+++ b/addons/point_of_sale/static/src/js/Screens/ProductScreen/ProductScreen.js
@@ -179,15 +179,18 @@ odoo.define('point_of_sale.ProductScreen', function(require) {
                 }
                 const parsedInput = event.detail.buffer && parse.float(event.detail.buffer) || 0;
                 if(lastId != selectedLine.cid)
-                    this._showDecreaseQuantityPopup();
+                    await this._showDecreaseQuantityPopup();
                 else if(currentQuantity < parsedInput)
                     this._setValue(event.detail.buffer);
                 else if(parsedInput < currentQuantity)
-                    this._showDecreaseQuantityPopup();
+                    await this._showDecreaseQuantityPopup();
             } else {
                 let { buffer } = event.detail;
                 let val = buffer === null ? 'remove' : buffer;
                 this._setValue(val);
+            }
+            if (this.env.pos.config.iface_customer_facing_display) {
+                this.env.pos.send_current_order_to_customer_facing_display();
             }
         }
         async _newOrderlineSelected() {
@@ -205,9 +208,6 @@ odoo.define('point_of_sale.ProductScreen', function(require) {
                     var selected_orderline = this.currentOrder.get_selected_orderline();
                     selected_orderline.price_manually_set = true;
                     selected_orderline.set_unit_price(val);
-                }
-                if (this.env.pos.config.iface_customer_facing_display) {
-                    this.env.pos.send_current_order_to_customer_facing_display();
                 }
             }
         }


### PR DESCRIPTION
[FIX] point_of_sale: update screen at every orderline update

In version 15 when product is added or deleted, it is shown accordingly in customer display.
However, when product quantity is changed through popup, Customer Display does not update until another product
is added to order. One way to reproduce issue is to have french localization while using PoS. Since french
anti-fraud module does not let user to simply delete the added product, instead it will show popup to alter
the quantity of the product. Once user changes product quantity and closes the popup, they'll notice that
customer display will not be updated.

With this fix, customer display will update every time orderline is updated.

fixes OPW-2734487






--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
