### PR TITLE
[FIX] sale_timesheet : display uom and plan hours correctly

### DIFF
--- a/addons/sale_timesheet/models/project.py
+++ b/addons/sale_timesheet/models/project.py
@@ -310,6 +310,10 @@ class Project(models.Model):
         return self.env['sale.order.line'].search([('order_id', 'in', sale_orders.ids), ('is_service', '=', True), ('is_downpayment', '=', False)], order='id asc')
 
     def _get_sold_items(self):
+        timesheet_encode_uom = self.env.company.timesheet_encode_uom_id
+        product_uom_unit = self.env.ref('uom.product_uom_unit')
+        product_uom_hour = self.env.ref('uom.product_uom_hour')
+
         sols = self._get_sale_order_lines()
         number_sale_orders = len(sols.order_id)
         sold_items = {
@@ -318,21 +322,28 @@ class Project(models.Model):
             'number_sols': len(sols),
             'total_sold': 0,
             'effective_sold': 0,
-            'company_unit_name': self.env.company.timesheet_encode_uom_id.name
+            'company_unit_name': timesheet_encode_uom.name
         }
-        product_uom_unit = self.env.ref('uom.product_uom_unit')
+
         for sol in sols:
             name = [x[1] for x in sol.name_get()] if number_sale_orders > 1 else sol.name
-            qty_delivered = sol.product_uom._compute_quantity(sol.qty_delivered, self.env.company.timesheet_encode_uom_id, raise_if_failure=False)
-            product_uom_qty = sol.product_uom._compute_quantity(sol.product_uom_qty, self.env.company.timesheet_encode_uom_id, raise_if_failure=False)
+
+            product_uom_convert = sol.product_uom
+            if product_uom_convert == product_uom_unit:
+                product_uom_convert = product_uom_hour
+            qty_delivered = product_uom_convert._compute_quantity(sol.qty_delivered, timesheet_encode_uom, raise_if_failure=False)
+            product_uom_qty = product_uom_convert._compute_quantity(sol.product_uom_qty, timesheet_encode_uom, raise_if_failure=False)
+            if product_uom_convert.category_id == timesheet_encode_uom.category_id:
+                product_uom_convert = timesheet_encode_uom
+
             if qty_delivered > 0 or product_uom_qty > 0:
                 sold_items['data'].append({
                     'name': name,
-                    'value': '%s / %s %s' % (formatLang(self.env, qty_delivered, 1), formatLang(self.env, product_uom_qty, 1), sol.product_uom.name if sol.product_uom == product_uom_unit else self.env.company.timesheet_encode_uom_id.name),
+                    'value': '%s / %s %s' % (formatLang(self.env, qty_delivered, 1), formatLang(self.env, product_uom_qty, 1), product_uom_convert.name),
                     'color': 'red' if qty_delivered > product_uom_qty else 'black'
                 })
                 #We only want to consider hours and days for this calculation, and eventually units if the service policy is not based on milestones
-                if sol.product_uom.category_id == self.env.company.timesheet_encode_uom_id.category_id or (sol.product_uom == product_uom_unit and sol.product_id.service_policy != 'delivered_manual'):
+                if sol.product_uom.category_id == timesheet_encode_uom.category_id or (sol.product_uom == product_uom_unit and sol.product_id.service_policy != 'delivered_manual'):
                     sold_items['total_sold'] += product_uom_qty
                     sold_items['effective_sold'] += qty_delivered
         remaining = sold_items['total_sold'] - sold_items['effective_sold']

--- a/addons/sale_timesheet/models/sale_order.py
+++ b/addons/sale_timesheet/models/sale_order.py
@@ -231,10 +231,15 @@ class SaleOrderLine(models.Model):
 
     def _convert_qty_company_hours(self, dest_company):
         company_time_uom_id = dest_company.project_time_mode_id
-        if self.product_uom.id != company_time_uom_id.id and self.product_uom.category_id.id == company_time_uom_id.category_id.id:
-            planned_hours = self.product_uom._compute_quantity(self.product_uom_qty, company_time_uom_id)
-        else:
-            planned_hours = self.product_uom_qty
+        planned_hours = 0.0
+        product_uom = self.product_uom
+        if product_uom == self.env.ref('uom.product_uom_unit'):
+            product_uom = self.env.ref('uom.product_uom_hour')
+        if product_uom.category_id == company_time_uom_id.category_id:
+            if product_uom != company_time_uom_id:
+                planned_hours = product_uom._compute_quantity(self.product_uom_qty, company_time_uom_id)
+            else:
+                planned_hours = self.product_uom_qty
         return planned_hours
 
     def _timesheet_create_project(self):

--- a/addons/sale_timesheet/tests/test_sale_service.py
+++ b/addons/sale_timesheet/tests/test_sale_service.py
@@ -656,3 +656,70 @@ class TestSaleService(TestCommonSaleTimesheet):
         })
         self.assertEqual(timesheet.so_line, prepaid_service_sol, "The SOL should be the same than one containing the prepaid service product.")
         self.assertEqual(prepaid_service_sol.remaining_hours, 2, "The remaining hours should not change.")
+
+    def test_several_uom_sol_to_planned_hours(self):
+        planned_hours_for_uom = {
+            'day': 8.0,
+            'hour': 1.0,
+            'unit': 1.0,
+            'gram': 0.0,
+        }
+
+        Product = self.env['product.product']
+        product_vals = {
+            'type': 'service',
+            'service_type': 'timesheet',
+            'project_id': self.project_global.id,
+            'service_tracking': 'task_global_project',
+        }
+
+        SaleOrderLine = self.env['sale.order.line']
+        sol_vals = {
+            'product_uom_qty': 1,
+            'price_unit': 100,
+            'order_id': self.sale_order.id,
+        }
+
+        self.project_global.task_ids = False
+        for uom_name in planned_hours_for_uom:
+            uom_id = self.env.ref('uom.product_uom_%s' % uom_name)
+
+            product_vals.update({
+                'name': uom_name,
+                'uom_id': uom_id.id,
+                'uom_po_id': uom_id.id,
+            })
+            product = Product.create(product_vals)
+
+            sol_vals.update({
+                'name': uom_name,
+                'product_id': product.id,
+                'product_uom': uom_id.id,
+            })
+            SaleOrderLine.create(sol_vals)
+
+        self.sale_order.action_confirm()
+
+        tasks = self.project_global.task_ids
+        for task in tasks:
+            self.assertEqual(task.planned_hours, planned_hours_for_uom[task.sale_line_id.name])
+
+        project_updates_data = self.project_global._get_sold_items()['data']
+        for datum in project_updates_data:
+            # A datum looks like this: {'name': 'day', 'value': '0.0 / 8.0 Hours',...}
+            uom_in = datum['name']
+
+            # So the value looks like this: '0.0 / 8.0 Hours'
+            # We extract the ordered quantity (second number in the string) and the displayed unit of measure
+            values = datum['value'][6:].split(' ')
+            qty = float(values[0])
+            uom_out = values[1]
+
+            # All uom but grams should have been converted to company's project time unit
+            company_time_uom = self.env.company.project_time_mode_id
+            if uom_in == 'gram':
+                self.assertEqual(qty, 1.0)
+                self.assertEqual(uom_out, self.env.ref('uom.product_uom_gram').display_name)
+            else:
+                self.assertEqual(qty, planned_hours_for_uom[uom_in])
+                self.assertEqual(uom_out, company_time_uom.display_name)


### PR DESCRIPTION
- Steps :
Create 4 Services :
	> Product Type : Service
	> Create on Order : Project & Task
	> Unit of Measure -respectively- :
		>> Hours (H),
		>> Days  (D),
		>> Units (U),
		>> g     (Other).
Create a SO with the for of them (1 uom_qty for each) and confirm.

- Expected :
For both the 'Planned Hours' on the Tasks
and the section 'Sold' of the Project Updates,
the conversion to time should be processed as follows :
H     : qty =     uom_qty [Hours]
D     : qty = uom_qty * 8 [Hours]
U     : qty =     uom_qty [Hours]
Other : qty =           0 [Hours] or uom_qty [uom]

- Issues :
The Task linked to SOL (Other) has 1 Planned Hour i/o 0.
In Project Updates, uom (U) is Units i/o Hours
and uom (Other) is Hours i/o g.

- Fix :
This fix corrects everything as expected.

opw-2784992

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
