### PR TITLE
[FIX] sale_purchase: validate service to purchase

### DIFF
--- a/addons/sale_purchase/i18n/sale_purchase.pot
+++ b/addons/sale_purchase/i18n/sale_purchase.pot
@@ -34,6 +34,14 @@ msgid "<span class=\"o_stat_text\">Sale</span>"
 msgstr ""
 
 #. module: sale_purchase
+#: code:addons/sale_purchase/models/product_template.py:0
+#, python-format
+msgid ""
+"Error with %s: Please define the vendor from whom you would like to purchase"
+" the service automatically."
+msgstr ""
+
+#. module: sale_purchase
 #: model_terms:ir.ui.view,arch_db:sale_purchase.exception_sale_on_purchase_cancellation
 msgid "Exception(s) occurred on the purchase order(s):"
 msgstr ""

--- a/addons/sale_purchase/models/product_template.py
+++ b/addons/sale_purchase/models/product_template.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
-from odoo import api, fields, models
+from odoo import api, fields, models, _
 from odoo.exceptions import ValidationError
 
 
@@ -16,8 +16,9 @@ class ProductTemplate(models.Model):
 
     @api.constrains('service_to_purchase', 'seller_ids')
     def validate_service_to_purchase(self):
-        if self.service_to_purchase and not self.seller_ids:
-            raise ValidationError("Please define the vendor from whom you would like to purchase this service automatically.")
+        for template in self:
+            if template.service_to_purchase and not template.seller_ids:
+                raise ValidationError(_("Error with %s: Please define the vendor from whom you would like to purchase the service automatically.") % template.display_name)
 
     @api.onchange('type')
     def _onchange_type(self):

--- a/addons/sale_purchase/tests/test_sale_purchase.py
+++ b/addons/sale_purchase/tests/test_sale_purchase.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
-from odoo.exceptions import UserError, AccessError
+from odoo.exceptions import UserError, ValidationError
 from odoo.tests import tagged
 from odoo.addons.sale_purchase.tests.common import TestCommonSalePurchaseNoChart
 
@@ -273,3 +273,19 @@ class TestSalePurchase(TestCommonSalePurchaseNoChart):
 
         po = self.env['purchase.order'].search([('partner_id', '=', self.partner_vendor_service.id)], order='id desc', limit=1)
         self.assertEqual(po.order_line.name, "[C01] Name01")
+
+    def test_service_to_purchase_constraint(self):
+        vals_list = [{
+            'name': 'SuperProduct 01',
+            'type': 'service',
+        }, {
+            'name': 'SuperProduct 02',
+            'type': 'service',
+            'service_to_purchase': True,
+        }]
+        with self.assertRaises(ValidationError):
+            self.env['product.product'].create(vals_list)
+
+        # Should not raise anything:
+        vals_list[1]['seller_ids'] = [(0, 0, {'partner_id': self.partner_a.id})]
+        self.env['product.product'].create(vals_list)


### PR DESCRIPTION
To reproduce the issue: create several products at once (`vals_list`)

Error: it will lead to a `ValueError` ("Expected Singleton")

Python constraints are called on recordset. Therefore, in
`validate_service_to_purchase`, reading `service_to_purchase` on `self` is
incorrect.