### PR TITLE
[FIX] google_calendar: prevent re-syncing of synced recurrence events

### DIFF
--- a/addons/google_calendar/models/res_users.py
+++ b/addons/google_calendar/models/res_users.py
@@ -100,6 +100,7 @@ class User(models.Model):
         recurrences -= synced_recurrences
         recurrences._sync_odoo2google(calendar_service)
         synced_events |= recurrences.calendar_event_ids - recurrences._get_outliers()
+        synced_events |= synced_recurrences.calendar_event_ids - synced_recurrences._get_outliers()
         events = self.env['calendar.event']._get_records_to_sync(full_sync=full_sync)
         (events - synced_events)._sync_odoo2google(calendar_service)
 


### PR DESCRIPTION
Before this commit: When you sync the Odoo calendar with Google for the
first time, it will resync all of the created recurrence events with
Google after fetching all of the Google events. The problem is that it
chooses the 'accepted' state by default for the current user's state.
If you were invited to events and you hadn't accepted that, it would
update your status and send an email per event for all attendees.

Steps to reproduce the issue:
1. Create two new google accounts ( you'll bombard with emails)
2. Create a recurrent event without ending with the first account and
choose the second account as a guest.(don't accept)
3. Sync second account with Odoo
=> It'll send about 700 emails

The solution is to prevent synced recurrence events from syncing and
also set "needsAction" as the state for the created events for the
recurrence events.

opw-2691146

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
