### PR TITLE
[FIX] l10n_it_edi, l10n_it_edi_sdicoop: Translations and better filter names

### DIFF
--- a/addons/l10n_it_edi/i18n/it.po
+++ b/addons/l10n_it_edi/i18n/it.po
@@ -1,0 +1,1151 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+# 	* l10n_it_edi
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 14.0+e\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2022-03-29 14:31+0000\n"
+"PO-Revision-Date: 2022-03-29 14:31+0000\n"
+"Last-Translator: \n"
+"Language-Team: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: \n"
+
+#. module: l10n_it_edi
+#: code:addons/l10n_it_edi/models/account_edi_format.py:0
+#, python-format
+msgid "%s has an amount of 0.0, you must indicate the kind of exoneration."
+msgstr "%s ha valore di 0.0, devi indicare il tipo di esenzione."
+
+#. module: l10n_it_edi
+#: code:addons/l10n_it_edi/models/account_invoice.py:0
+#, python-format
+msgid ""
+"%s isn't in a right state. It must be in a 'Not yet send' or 'Invalid' "
+"state."
+msgstr "%s non è uno stato corretto. Lo stato dev'essere 'Non ancora inviato' o 'Errato'."
+
+#. module: l10n_it_edi
+#: code:addons/l10n_it_edi/models/account_edi_format.py:0
+#, python-format
+msgid "%s must have a VAT number"
+msgstr "%s deve avere una Partita IVA"
+
+#. module: l10n_it_edi
+#: code:addons/l10n_it_edi/models/account_edi_format.py:0
+#: code:addons/l10n_it_edi/models/account_edi_format.py:0
+#, python-format
+msgid "%s must have a city."
+msgstr "%s deve avere una Cittá."
+
+#. module: l10n_it_edi
+#: code:addons/l10n_it_edi/models/account_edi_format.py:0
+#, python-format
+msgid "%s must have a codice fiscale number"
+msgstr "%s deve avere un Codice Fiscale"
+
+#. module: l10n_it_edi
+#: code:addons/l10n_it_edi/models/account_edi_format.py:0
+#, python-format
+msgid "%s must have a country"
+msgstr "%s deve avere una Nazione"
+
+#. module: l10n_it_edi
+#: code:addons/l10n_it_edi/models/account_edi_format.py:0
+#: code:addons/l10n_it_edi/models/account_edi_format.py:0
+#, python-format
+msgid "%s must have a country."
+msgstr "%s deve avere una Nazione."
+
+#. module: l10n_it_edi
+#: code:addons/l10n_it_edi/models/account_edi_format.py:0
+#: code:addons/l10n_it_edi/models/account_edi_format.py:0
+#, python-format
+msgid "%s must have a post code of length 5."
+msgstr "%s deve avere un CAP di lunghezza 5."
+
+#. module: l10n_it_edi
+#: code:addons/l10n_it_edi/models/account_edi_format.py:0
+#: code:addons/l10n_it_edi/models/account_edi_format.py:0
+#, python-format
+msgid "%s must have a post code."
+msgstr "%s deve avere un CAP."
+
+#. module: l10n_it_edi
+#: code:addons/l10n_it_edi/models/account_edi_format.py:0
+#: code:addons/l10n_it_edi/models/account_edi_format.py:0
+#, python-format
+msgid "%s must have a street."
+msgstr "%s deve avere un Indirizzo."
+
+#. module: l10n_it_edi
+#: code:addons/l10n_it_edi/models/account_invoice.py:0
+#, python-format
+msgid ""
+"'Scissione dei pagamenti' is not compatible with exoneration of kind 'N6'"
+msgstr "'Scissione dei pagamenti' non è compatibile con l'esenzione di tipo 'N6'"
+
+#. module: l10n_it_edi
+#: code:addons/l10n_it_edi/models/res_company.py:0
+#, python-format
+msgid ""
+"All fields about the Economic and Administrative Index must be completed."
+msgstr "Tutti i campi che riguardano l'Indice Economico e Amministrativo devono essere completati."
+
+#. module: l10n_it_edi
+#: code:addons/l10n_it_edi/models/account_edi_format.py:0
+#, python-format
+msgid "Attachment from XML"
+msgstr "Allegato dall'XML"
+
+#. module: l10n_it_edi
+#: code:addons/l10n_it_edi/models/account_edi_format.py:0
+#: code:addons/l10n_it_edi/models/account_edi_format.py:0
+#, python-format
+msgid "Bank account not found, useful informations from XML file:"
+msgstr "Conto bancario non trovato, informazioni utili dal file XML:"
+
+#. module: l10n_it_edi
+#: model:ir.model.fields,field_description:l10n_it_edi.field_res_company__l10n_it_codice_fiscale
+#: model:ir.model.fields,field_description:l10n_it_edi.field_res_partner__l10n_it_codice_fiscale
+#: model:ir.model.fields,field_description:l10n_it_edi.field_res_users__l10n_it_codice_fiscale
+msgid "Codice Fiscale"
+msgstr "Codice Fiscale"
+
+#. module: l10n_it_edi
+#: model:ir.model.constraint,message:l10n_it_edi.constraint_res_partner_l10n_it_codice_fiscale
+msgid "Codice fiscale must have between 11 and 16 characters."
+msgstr "Il Codice Fiscale deve avere fra 11 e 16 caratteri."
+
+#. module: l10n_it_edi
+#: model:ir.model,name:l10n_it_edi.model_res_company
+msgid "Companies"
+msgstr "Aziende"
+
+#. module: l10n_it_edi
+#: model:ir.model.fields,field_description:l10n_it_edi.field_res_company__l10n_it_address_send_fatturapa
+msgid "Company PEC-mail"
+msgstr "Indirizzo PEC aziendale"
+
+#. module: l10n_it_edi
+#: model_terms:ir.ui.view,arch_db:l10n_it_edi.res_company_form_l10n_it
+msgid "Company have a tax representative"
+msgstr "L'azienda ha un rappresentante fiscale"
+
+#. module: l10n_it_edi
+#: model_terms:ir.ui.view,arch_db:l10n_it_edi.res_company_form_l10n_it
+msgid "Company listed on the register of companies"
+msgstr "L'azienda compare nel Registro delle Imprese"
+
+#. module: l10n_it_edi
+#: model:ir.model.fields,help:l10n_it_edi.field_res_company__l10n_it_mail_pec_server_id
+msgid "Configure your PEC-mail server to send electronic invoices."
+msgstr "Configura il server mail PEC per inviare le Fatture Elettroniche."
+
+#. module: l10n_it_edi
+#: model:ir.model,name:l10n_it_edi.model_res_partner
+msgid "Contact"
+msgstr "Contatto"
+
+#. module: l10n_it_edi
+#: model:ir.model.fields,field_description:l10n_it_edi.field_l10n_it_ddt__create_uid
+msgid "Created by"
+msgstr "Creato da"
+
+#. module: l10n_it_edi
+#: model:ir.model.fields,field_description:l10n_it_edi.field_l10n_it_ddt__create_date
+msgid "Created on"
+msgstr "Creato il"
+
+#. module: l10n_it_edi
+#: model:ir.model.fields,field_description:l10n_it_edi.field_account_bank_statement_line__l10n_it_ddt_id
+#: model:ir.model.fields,field_description:l10n_it_edi.field_account_move__l10n_it_ddt_id
+#: model:ir.model.fields,field_description:l10n_it_edi.field_account_payment__l10n_it_ddt_id
+#: model:ir.ui.menu,name:l10n_it_edi.menu_action_ddt_account
+msgid "DDT"
+msgstr "DDT"
+
+#. module: l10n_it_edi
+#: model:ir.model.fields,field_description:l10n_it_edi.field_l10n_it_ddt__date
+msgid "Data DDT"
+msgstr "Data DDT"
+
+#. module: l10n_it_edi
+#: model:ir.model.fields,field_description:l10n_it_edi.field_account_bank_statement_line__l10n_it_stamp_duty
+#: model:ir.model.fields,field_description:l10n_it_edi.field_account_move__l10n_it_stamp_duty
+#: model:ir.model.fields,field_description:l10n_it_edi.field_account_payment__l10n_it_stamp_duty
+msgid "Dati Bollo"
+msgstr "Dati Bollo"
+
+#. module: l10n_it_edi
+#: model:ir.model.fields.selection,name:l10n_it_edi.selection__account_move__l10n_it_send_state__failed_delivery
+msgid ""
+"Delivery impossible, ES certify that it has received the invoice and that "
+"the file                         could not be delivered to the addressee"
+msgstr "Consegna non riuscita, il SdI certifica che ha ricevuto la fattura "
+"e che non è stato possibile consegnare il file al destinatario"
+
+#. module: l10n_it_edi
+#: model:ir.model.fields,field_description:l10n_it_edi.field_account_edi_format__display_name
+#: model:ir.model.fields,field_description:l10n_it_edi.field_account_move__display_name
+#: model:ir.model.fields,field_description:l10n_it_edi.field_account_tax__display_name
+#: model:ir.model.fields,field_description:l10n_it_edi.field_fetchmail_server__display_name
+#: model:ir.model.fields,field_description:l10n_it_edi.field_ir_mail_server__display_name
+#: model:ir.model.fields,field_description:l10n_it_edi.field_l10n_it_ddt__display_name
+#: model:ir.model.fields,field_description:l10n_it_edi.field_res_company__display_name
+#: model:ir.model.fields,field_description:l10n_it_edi.field_res_partner__display_name
+msgid "Display Name"
+msgstr "Nome visualizzato"
+
+#. module: l10n_it_edi
+#: code:addons/l10n_it_edi/models/ir_mail_server.py:0
+#, python-format
+msgid "E-Invoice is delivery to the destinatory:<br/>%s"
+msgstr "La Fattura Elettronica è stata consegnata al destinatario:<br/>%s"
+
+#. module: l10n_it_edi
+#: code:addons/l10n_it_edi/models/account_invoice.py:0
+#, python-format
+msgid "E-Invoice is generated on %s by %s"
+msgstr "La Fattura Elettronica è stata generata il %s da %s"
+
+#. module: l10n_it_edi
+#: model_terms:ir.ui.view,arch_db:l10n_it_edi.account_invoice_line_it_FatturaPA
+msgid "EAN"
+msgstr "EAN"
+
+#. module: l10n_it_edi
+#: model:ir.model,name:l10n_it_edi.model_account_edi_format
+msgid "EDI format"
+msgstr "Formato EDI"
+
+#. module: l10n_it_edi
+#: code:addons/l10n_it_edi/models/ir_mail_server.py:0
+#, python-format
+msgid ""
+"ES certify that it has received the invoice and that the file"
+"                         could not be delivered to the addressee. <br/>%s"
+msgstr "Il SdI certifica che ha ricevuto la Fattura e che non è stato possibile "
+"consegnare il file al destinatario. <br/>%s"
+
+#. module: l10n_it_edi
+#: model_terms:ir.ui.view,arch_db:l10n_it_edi.res_company_form_l10n_it
+msgid "Economic and Administrative Index"
+msgstr "Indice Economico e Amministrativo"
+
+#. module: l10n_it_edi
+#: model_terms:ir.ui.view,arch_db:l10n_it_edi.account_invoice_form_l10n_it
+#: model_terms:ir.ui.view,arch_db:l10n_it_edi.res_company_form_l10n_it
+msgid "Electronic Invoicing"
+msgstr "Fatturazione Elettronica"
+
+#. module: l10n_it_edi
+#: model:ir.model.fields,field_description:l10n_it_edi.field_account_bank_statement_line__l10n_it_einvoice_id
+#: model:ir.model.fields,field_description:l10n_it_edi.field_account_move__l10n_it_einvoice_id
+#: model:ir.model.fields,field_description:l10n_it_edi.field_account_payment__l10n_it_einvoice_id
+msgid "Electronic invoice"
+msgstr "Fattura Elettronica"
+
+#. module: l10n_it_edi
+#: model:ir.model.fields,help:l10n_it_edi.field_res_company__l10n_it_address_recipient_fatturapa
+msgid "Enter Government PEC-mail address. Ex: sdi01@pec.fatturapa.it"
+msgstr "Inserire l'indirizzo PEC statale, Es: sdi01@pec.fatturapa.it"
+
+#. module: l10n_it_edi
+#: model:ir.model.fields,help:l10n_it_edi.field_res_company__l10n_it_address_send_fatturapa
+msgid "Enter your company PEC-mail address. Ex: yourcompany@pec.mail.it"
+msgstr "Inserire il proprio indirizzo PEC. Es: miaazienda@pec.mail.it"
+
+#. module: l10n_it_edi
+#: code:addons/l10n_it_edi/models/account_invoice.py:0
+#, python-format
+msgid "Error when sending mail with E-Invoice: %s"
+msgstr "Errore nell'invio della mail con la Fattura Elettronica: %s"
+
+#. module: l10n_it_edi
+#: code:addons/l10n_it_edi/models/account_invoice.py:0
+#, python-format
+msgid ""
+"Error when sending mail with E-Invoice: Your company must have a mail PEC "
+"server and must indicate the mail PEC that will send electronic invoice."
+msgstr "Errore nell'invio della mail con la Fattura Elettronica: la tua "
+"azienda deve avere un server email PEC e deve indicare l'indirizzo da "
+"cui spedire"
+
+#. module: l10n_it_edi
+#: code:addons/l10n_it_edi/models/ir_mail_server.py:0
+#, python-format
+msgid "Errors in the E-Invoice :<br/>%s"
+msgstr "Errori nella Fattura Elettronica: <br/>%s"
+
+#. module: l10n_it_edi
+#: model:ir.model.fields,field_description:l10n_it_edi.field_account_tax__l10n_it_kind_exoneration
+msgid "Exoneration"
+msgstr "Esenzione"
+
+#. module: l10n_it_edi
+#: model:ir.model.fields,help:l10n_it_edi.field_account_tax__l10n_it_kind_exoneration
+msgid "Exoneration type"
+msgstr "Tipo esenzione"
+
+#. module: l10n_it_edi
+#: code:addons/l10n_it_edi/models/ir_mail_server.py:0
+#, python-format
+msgid ""
+"Expiration of the maximum term for communication of acceptance/refusal:"
+"                 %s<br/>%s"
+msgstr "Termine massimo di decorrenza per l'accettazione o il rifiuto della comunicazione:"
+"                 %s<br/>%s"
+
+#. module: l10n_it_edi
+#: model:ir.model.fields,field_description:l10n_it_edi.field_account_bank_statement_line__l10n_it_send_state
+#: model:ir.model.fields,field_description:l10n_it_edi.field_account_move__l10n_it_send_state
+#: model:ir.model.fields,field_description:l10n_it_edi.field_account_payment__l10n_it_send_state
+msgid "FatturaPA Send State"
+msgstr "Stato di invio della FatturaPA"
+
+#. module: l10n_it_edi
+#: model:ir.model.fields,help:l10n_it_edi.field_res_company__l10n_it_codice_fiscale
+msgid "Fiscal code of your company"
+msgstr "Codice Fiscale dell'azienda"
+
+#. module: l10n_it_edi
+#: model:ir.model.fields,field_description:l10n_it_edi.field_res_company__l10n_it_address_recipient_fatturapa
+msgid "Government PEC-mail"
+msgstr "Indirizzo PEC statale"
+
+#. module: l10n_it_edi
+#: model:ir.model.fields,field_description:l10n_it_edi.field_account_tax__l10n_it_has_exoneration
+msgid "Has exoneration of tax (Italy)"
+msgstr "Esente dalle tasse (Italia)"
+
+#. module: l10n_it_edi
+#: model:ir.model.fields,field_description:l10n_it_edi.field_account_edi_format__id
+#: model:ir.model.fields,field_description:l10n_it_edi.field_account_move__id
+#: model:ir.model.fields,field_description:l10n_it_edi.field_account_tax__id
+#: model:ir.model.fields,field_description:l10n_it_edi.field_fetchmail_server__id
+#: model:ir.model.fields,field_description:l10n_it_edi.field_ir_mail_server__id
+#: model:ir.model.fields,field_description:l10n_it_edi.field_l10n_it_ddt__id
+#: model:ir.model.fields,field_description:l10n_it_edi.field_res_company__id
+#: model:ir.model.fields,field_description:l10n_it_edi.field_res_partner__id
+msgid "ID"
+msgstr "ID"
+
+#. module: l10n_it_edi
+#: model_terms:ir.ui.view,arch_db:l10n_it_edi.account_invoice_line_it_FatturaPA
+msgid "INTERNAL"
+msgstr "INTERNO"
+
+#. module: l10n_it_edi
+#: model:ir.model.fields,help:l10n_it_edi.field_fetchmail_server__l10n_it_is_pec
+msgid ""
+"If PEC Server, only mail from '...@pec.fatturapa.it' will be processed."
+msgstr "Se è un server PEC, solo le email da '...@pec.fatturapa.it' verranno prese in carico."
+
+#. module: l10n_it_edi
+#: code:addons/l10n_it_edi/models/account_invoice.py:0
+#, python-format
+msgid ""
+"If the tax has exoneration, you must enter a kind of exoneration, a law "
+"reference and the amount of the tax must be 0.0."
+msgstr "Se l'Imposta risulta essere un'Esenzione, bisogna compilare il Tipo "
+"di Esenzione e il suo valore dev'essere 0.0."
+
+#. module: l10n_it_edi
+#: model:ir.model,name:l10n_it_edi.model_fetchmail_server
+msgid "Incoming Mail Server"
+msgstr "Server Email in ingresso"
+
+#. module: l10n_it_edi
+#: code:addons/l10n_it_edi/models/res_partner.py:0
+#, python-format
+msgid ""
+"Invalid Codice Fiscale '%s': should be like 'MRTMTT91D08F205J' for physical "
+"person and '12345678901' or 'IT12345678901' for businesses."
+msgstr "Codice Fiscale non valido '%s': dev'essere come 'MRTMTT91D08F205J' per "
+"persone fisiche e '12345678901' o 'IT12345678901' per le aziende"
+
+#. module: l10n_it_edi
+#: code:addons/l10n_it_edi/models/account_invoice.py:0
+#, python-format
+msgid "Invalid configuration:"
+msgstr "Configurazione non valida:"
+
+#. module: l10n_it_edi
+#: model:ir.model.fields,field_description:l10n_it_edi.field_l10n_it_ddt__invoice_id
+msgid "Invoice Reference"
+msgstr "Riferimento Fattura"
+
+#. module: l10n_it_edi
+#: code:addons/l10n_it_edi/models/account_edi_format.py:0
+#, python-format
+msgid ""
+"Invoices for PA are not managed by Odoo, you can download the document and "
+"send it on your own."
+msgstr "Le Fatture verso la PA non sono gestite da Odoo, puoi scaricare il "
+"documento ed inviarlo manualmente."
+
+#. module: l10n_it_edi
+#: code:addons/l10n_it_edi/models/account_invoice.py:0
+#, python-format
+msgid "Italian invoice: %s"
+msgstr "Fattura italiana: %s"
+
+#. module: l10n_it_edi
+#: model:ir.model,name:l10n_it_edi.model_account_move
+msgid "Journal Entry"
+msgstr "Movimento Contabile"
+
+#. module: l10n_it_edi
+#: model:ir.model.fields,field_description:l10n_it_edi.field_account_bank_statement_line__l10n_it_einvoice_name
+#: model:ir.model.fields,field_description:l10n_it_edi.field_account_move__l10n_it_einvoice_name
+#: model:ir.model.fields,field_description:l10n_it_edi.field_account_payment__l10n_it_einvoice_name
+msgid "L10N It Einvoice Name"
+msgstr "Nome Fattura Elettronica"
+
+#. module: l10n_it_edi
+#: model:ir.model.fields,field_description:l10n_it_edi.field_res_company__l10n_it_has_eco_index
+msgid "L10N It Has Eco Index"
+msgstr "Ha indice Eco"
+
+#. module: l10n_it_edi
+#: model:ir.model.fields,field_description:l10n_it_edi.field_res_company__l10n_it_has_tax_representative
+msgid "L10N It Has Tax Representative"
+msgstr "Ha rappresentante fiscale"
+
+#. module: l10n_it_edi
+#: model:ir.model.fields,field_description:l10n_it_edi.field_account_edi_format____last_update
+#: model:ir.model.fields,field_description:l10n_it_edi.field_account_move____last_update
+#: model:ir.model.fields,field_description:l10n_it_edi.field_account_tax____last_update
+#: model:ir.model.fields,field_description:l10n_it_edi.field_fetchmail_server____last_update
+#: model:ir.model.fields,field_description:l10n_it_edi.field_ir_mail_server____last_update
+#: model:ir.model.fields,field_description:l10n_it_edi.field_l10n_it_ddt____last_update
+#: model:ir.model.fields,field_description:l10n_it_edi.field_res_company____last_update
+#: model:ir.model.fields,field_description:l10n_it_edi.field_res_partner____last_update
+msgid "Last Modified on"
+msgstr "Ultima modifica il"
+
+#. module: l10n_it_edi
+#: model:ir.model.fields,field_description:l10n_it_edi.field_l10n_it_ddt__write_uid
+msgid "Last Updated by"
+msgstr "Ultimo aggiornamento di"
+
+#. module: l10n_it_edi
+#: model:ir.model.fields,field_description:l10n_it_edi.field_l10n_it_ddt__write_date
+msgid "Last Updated on"
+msgstr "Ultimo aggiornamento il"
+
+#. module: l10n_it_edi
+#: model:ir.model.fields,field_description:l10n_it_edi.field_fetchmail_server__l10n_it_last_uid
+msgid "Last message UID"
+msgstr "UID ultimo messaggio"
+
+#. module: l10n_it_edi
+#: model:ir.model.fields,field_description:l10n_it_edi.field_account_tax__l10n_it_law_reference
+msgid "Law Reference"
+msgstr "Riferimento alla Legge"
+
+#. module: l10n_it_edi
+#: model:ir.model.fields,field_description:l10n_it_edi.field_res_company__l10n_it_eco_index_liquidation_state
+msgid "Liquidation state"
+msgstr "Stato Liquidazione"
+
+#. module: l10n_it_edi
+#: model_terms:ir.ui.view,arch_db:l10n_it_edi.account_invoice_it_FatturaPA_export
+msgid "MP05"
+msgstr ""
+
+#. module: l10n_it_edi
+#: model:ir.model,name:l10n_it_edi.model_ir_mail_server
+msgid "Mail Server"
+msgstr "Server Email"
+
+#. module: l10n_it_edi
+#: code:addons/l10n_it_edi/models/account_invoice.py:0
+#, python-format
+msgid "Mail sent on %s by %s"
+msgstr "Email inviata a %s da %s"
+
+#. module: l10n_it_edi
+#: model:ir.model.fields,help:l10n_it_edi.field_res_company__l10n_it_eco_index_share_capital
+msgid ""
+"Mandatory if the seller/provider is a company with share        capital "
+"(SpA, SApA, Srl), this field must contain the amount        of share capital"
+" actually paid up as resulting from the last        financial statement"
+msgstr "Obbligatorio se il venditore/fornitore è una azienda con capitale "
+"sociale (SpA, SApA, Srl), rappresenta l'ammontare del capitale sociale "
+"attuale come risulta dall'ultimo rendiconto finanziario."
+
+#. module: l10n_it_edi
+#: model:ir.model.fields,help:l10n_it_edi.field_res_partner__l10n_it_pa_index
+#: model:ir.model.fields,help:l10n_it_edi.field_res_users__l10n_it_pa_index
+msgid ""
+"Must contain the 6-character (or 7) code, present in the PA              "
+"Index in the information relative to the electronic invoicing service,"
+"              associated with the office which, within the addressee "
+"administration, deals              with receiving (and processing) the "
+"invoice."
+msgstr "Deve contenere il codice da 6-7 caratteri presente nell'indice della PA "
+"nelle informazioni relative al servizio di Fatturazione Elettronica, "
+"associato all'ufficio dell'amministrazione che riceverá (ed elaborerá) la Fattura."
+
+#. module: l10n_it_edi
+#: model:ir.model.fields.selection,name:l10n_it_edi.selection__account_move__l10n_it_send_state__new
+msgid "New"
+msgstr "Nuova"
+
+#. module: l10n_it_edi
+#: model:ir.model.fields.selection,name:l10n_it_edi.selection__res_company__l10n_it_eco_index_sole_shareholder__no
+msgid "Not a limited liability company"
+msgstr "Non è una Societá a Responsabilitá Limitata"
+
+#. module: l10n_it_edi
+#: model:ir.model.fields.selection,name:l10n_it_edi.selection__account_move__l10n_it_send_state__to_send
+msgid "Not yet send"
+msgstr "Non ancora inviata"
+
+#. module: l10n_it_edi
+#: model:ir.model.fields,field_description:l10n_it_edi.field_res_company__l10n_it_eco_index_number
+msgid "Number in register of companies"
+msgstr "Numero nel Registro delle Imprese"
+
+#. module: l10n_it_edi
+#: model:ir.model.fields,field_description:l10n_it_edi.field_l10n_it_ddt__name
+msgid "Numero DDT"
+msgstr "Numero DDT"
+
+#. module: l10n_it_edi
+#: code:addons/l10n_it_edi/models/ir_mail_server.py:0
+#, python-format
+msgid "Original E-invoice XML file"
+msgstr "File XML Fattura Elettronica originale"
+
+#. module: l10n_it_edi
+#: model:ir.model.fields.selection,name:l10n_it_edi.selection__account_move__l10n_it_send_state__other
+msgid "Other"
+msgstr "Altro"
+
+#. module: l10n_it_edi
+#: code:addons/l10n_it_edi/models/ir_mail_server.py:0
+#, python-format
+msgid "Outcome notice: %s<br/>%s"
+msgstr "Notifica esito: %s<br/>%s"
+
+#. module: l10n_it_edi
+#: model:ir.model.fields,field_description:l10n_it_edi.field_res_partner__l10n_it_pa_index
+#: model:ir.model.fields,field_description:l10n_it_edi.field_res_users__l10n_it_pa_index
+msgid "PA index"
+msgstr "Indice PA"
+
+#. module: l10n_it_edi
+#: model:ir.model.constraint,message:l10n_it_edi.constraint_res_partner_l10n_it_pa_index
+msgid "PA index must have between 6 and 7 characters."
+msgstr "L'Indice PA deve avere 6-7 caratteri"
+
+#. module: l10n_it_edi
+#: model_terms:ir.ui.view,arch_db:l10n_it_edi.account_invoice_it_FatturaPA_export
+msgid "PDF"
+msgstr "PDF"
+
+#. module: l10n_it_edi
+#: model:ir.model.fields,field_description:l10n_it_edi.field_res_partner__l10n_it_pec_email
+#: model:ir.model.fields,field_description:l10n_it_edi.field_res_users__l10n_it_pec_email
+msgid "PEC e-mail"
+msgstr "Email PEC"
+
+#. module: l10n_it_edi
+#: code:addons/l10n_it_edi/models/ir_mail_server.py:0
+#, python-format
+msgid "PEC mail server must be of type IMAP."
+msgstr "Il server email PEC deve essere di tipo IMAP."
+
+#. module: l10n_it_edi
+#: model:ir.model.fields,field_description:l10n_it_edi.field_fetchmail_server__l10n_it_is_pec
+msgid "PEC server"
+msgstr "Server PEC"
+
+#. module: l10n_it_edi
+#: model:ir.model.fields.selection,name:l10n_it_edi.selection__res_company__l10n_it_eco_index_sole_shareholder__sm
+msgid "Più soci"
+msgstr ""
+
+#. module: l10n_it_edi
+#: code:addons/l10n_it_edi/models/ir_mail_server.py:0
+#, python-format
+msgid "Please configure Government PEC-mail\tin company settings"
+msgstr "Per favore, configurare l'email PEC statale \n"
+"nelle impostazioni della Societá"
+
+#. module: l10n_it_edi
+#: code:addons/l10n_it_edi/models/ir_mail_server.py:0
+#, python-format
+msgid "Please configure Username for this Server PEC"
+msgstr "Per favore, configurare il Nome Utente per questo server email PEC"
+
+#. module: l10n_it_edi
+#: model:ir.model.fields,help:l10n_it_edi.field_res_company__l10n_it_tax_system
+msgid "Please select the Tax system to which you are subjected."
+msgstr "Per favore, selezionare il Sistema Fiscale a cui si è soggetti."
+
+#. module: l10n_it_edi
+#: model:ir.model.fields,field_description:l10n_it_edi.field_res_company__l10n_it_eco_index_office
+msgid "Province of the register-of-companies office"
+msgstr "Provincia dell'ufficio del Registro delle Imprese"
+
+#. module: l10n_it_edi
+#: model_terms:ir.ui.view,arch_db:l10n_it_edi.account_invoice_it_FatturaPA_export
+msgid "SI"
+msgstr "SI"
+
+#. module: l10n_it_edi
+#: code:addons/l10n_it_edi/models/account_invoice.py:0
+#, python-format
+msgid "Sending file: %s"
+msgstr "Invio file: %s"
+
+#. module: l10n_it_edi
+#: code:addons/l10n_it_edi/models/account_invoice.py:0
+#, python-format
+msgid "Sending file: %s to ES: %s"
+msgstr "Invio file in corso: %s all'SdI: %s"
+
+#. module: l10n_it_edi
+#: model:ir.model.fields.selection,name:l10n_it_edi.selection__account_move__l10n_it_send_state__invalid
+msgid "Sent, but invalid"
+msgstr "Inviata, ma non corretta"
+
+#. module: l10n_it_edi
+#: model:ir.model.fields.selection,name:l10n_it_edi.selection__account_move__l10n_it_send_state__sent
+msgid "Sent, waiting for response"
+msgstr "Inviata, in attesa di risposta"
+
+#. module: l10n_it_edi
+#: model:ir.model.fields,field_description:l10n_it_edi.field_res_company__l10n_it_mail_pec_server_id
+msgid "Server PEC"
+msgstr "Server PEC"
+
+#. module: l10n_it_edi
+#: model:ir.model.fields,field_description:l10n_it_edi.field_res_company__l10n_it_eco_index_share_capital
+msgid "Share capital actually paid up"
+msgstr "Capitale sociale investito"
+
+#. module: l10n_it_edi
+#: model:ir.model.fields,field_description:l10n_it_edi.field_res_company__l10n_it_eco_index_sole_shareholder
+msgid "Shareholder"
+msgstr "Socio"
+
+#. module: l10n_it_edi
+#: model:ir.model.fields.selection,name:l10n_it_edi.selection__res_company__l10n_it_eco_index_sole_shareholder__su
+msgid "Socio unico"
+msgstr ""
+
+#. module: l10n_it_edi
+#: model_terms:ir.ui.view,arch_db:l10n_it_edi.account_invoice_it_FatturaPA_export
+msgid "TP01"
+msgstr ""
+
+#. module: l10n_it_edi
+#: model_terms:ir.ui.view,arch_db:l10n_it_edi.account_invoice_it_FatturaPA_export
+msgid "TP02"
+msgstr ""
+
+#. module: l10n_it_edi
+#: model:ir.model,name:l10n_it_edi.model_account_tax
+msgid "Tax"
+msgstr "Imposta"
+
+#. module: l10n_it_edi
+#: model:ir.model.fields,field_description:l10n_it_edi.field_res_company__l10n_it_tax_system
+msgid "Tax System"
+msgstr "Sistema Fiscale"
+
+#. module: l10n_it_edi
+#: model:ir.model.fields,help:l10n_it_edi.field_account_tax__l10n_it_has_exoneration
+msgid "Tax has a tax exoneration."
+msgstr "La tassa ha un'Esenzione."
+
+#. module: l10n_it_edi
+#: code:addons/l10n_it_edi/models/account_edi_format.py:0
+#, python-format
+msgid ""
+"Tax not found with percentage: %s and exoneration %s for the article: %s"
+msgstr "L'imposta con percentuale: %s e Esenzione %s per il prodotto: %s non è stata trovata."
+
+#. module: l10n_it_edi
+#: code:addons/l10n_it_edi/models/account_edi_format.py:0
+#, python-format
+msgid "Tax not found with percentage: %s for the article: %s"
+msgstr "L'imposta con percentuale: %s per il prodotto: %s non è stata trovata"
+
+#. module: l10n_it_edi
+#: model_terms:ir.ui.view,arch_db:l10n_it_edi.res_company_form_l10n_it
+msgid "Tax representative"
+msgstr "Rappresentante fiscale"
+
+#. module: l10n_it_edi
+#: model:ir.model.fields,field_description:l10n_it_edi.field_res_company__l10n_it_tax_representative_partner_id
+msgid "Tax representative partner"
+msgstr "Rappresentante fiscale del partner"
+
+#. module: l10n_it_edi
+#: code:addons/l10n_it_edi/models/account_edi_format.py:0
+#, python-format
+msgid "Tax representative partner %s of %s must have a tax number."
+msgstr "Il rappresentante fiscale del partner %s di %s deve avere un codice fiscale."
+
+#. module: l10n_it_edi
+#: code:addons/l10n_it_edi/models/ir_mail_server.py:0
+#, python-format
+msgid ""
+"The E-invoice is not delivered to the addressee. The Exchange System is"
+"                unable to deliver the file to the Public Administration. The"
+" Exchange System will                contact the PA to report the problem "
+"and request that they provide a solution.                 During the "
+"following 15 days, the Exchange System will try to forward the FatturaPA"
+"                file to the Administration in question again. More "
+"information:<br/>%s"
+msgstr "La Fattura Elettronica non è stata consegnata al destinatario. "
+"Il Sistema d'Interscambio non ha potuto consegnare il file alla Pubblica "
+"Amministrazione. Il Sistema di Interscambio contatterá la PA per far presente "
+"il problema e richiedere una soluzione. Durante i successivi 15 giorni, il "
+"Sistema di Interscambio proverá a re-inoltrare la Fattura all'Amministrazione "
+"in questione:<br/>%s"
+
+#. module: l10n_it_edi
+#: code:addons/l10n_it_edi/models/account_edi_format.py:0
+#, python-format
+msgid ""
+"The buyer, %s, or his company must have either a VAT number either a tax "
+"code (Codice Fiscale)."
+msgstr "L'acquirente, %s, o la sua azienda devono avere la Partita IVA "
+"o il Codice Fiscale compilato."
+
+#. module: l10n_it_edi
+#: model:ir.model.fields.selection,name:l10n_it_edi.selection__res_company__l10n_it_eco_index_liquidation_state__ls
+msgid "The company is in a state of liquidation"
+msgstr "La compagnia è in stato di liquidazione"
+
+#. module: l10n_it_edi
+#: model:ir.model.fields.selection,name:l10n_it_edi.selection__res_company__l10n_it_eco_index_liquidation_state__ln
+msgid "The company is not in a state of liquidation"
+msgstr "La compagnia non è in stato di liquidazione"
+
+#. module: l10n_it_edi
+#: code:addons/l10n_it_edi/models/account_edi_format.py:0
+#, python-format 
+msgid ""
+"The maximum length for VAT number is 30. %s have a VAT number too long: %s."
+msgstr "La lunghezza minima per la Partita IVA è 30. %s ha una Partita IVA troppo lunga: %s."
+
+#. module: l10n_it_edi
+#: code:addons/l10n_it_edi/models/account_edi_format.py:0
+#, python-format
+msgid "The seller must have a bank account."
+msgstr "Il venditore deve avere un conto bancario."
+
+#. module: l10n_it_edi
+#: code:addons/l10n_it_edi/models/account_edi_format.py:0
+#, python-format
+msgid "The seller's company must have a tax system."
+msgstr "L'azienda del venditore deve avere specificato un Sistema Fiscale."
+
+#. module: l10n_it_edi
+#: model_terms:ir.ui.view,arch_db:l10n_it_edi.res_company_form_l10n_it
+msgid ""
+"The seller/provider is a company listed on the register of companies and as\n"
+"                            such must also indicate the registration data on all documents (art. 2250, Italian\n"
+"                            Civil Code)"
+msgstr "Il venditore/fornitore è un'azienda presente nel Registro delle Imprese\n"
+"e come tale deve indicare i dati di registrazione su tutti i documenti\n"
+"(art. 2250 del Codice Civile)"
+
+#. module: l10n_it_edi
+#: model:ir.model.fields,help:l10n_it_edi.field_res_company__l10n_it_has_eco_index
+msgid ""
+"The seller/provider is a company listed on the register of companies and as"
+"        such must also indicate the registration data on all documents (art."
+" 2250, Italian        Civil Code)"
+msgstr "Il venditore/fornitore è un'azienda presente nel Registro delle Imprese"
+"e come tale deve indicare i dati di registrazione su tutti i documenti\n"
+"(art. 2250 del Codice Civile)"
+
+#. module: l10n_it_edi
+#: model:ir.model.fields,help:l10n_it_edi.field_res_company__l10n_it_has_tax_representative
+msgid ""
+"The seller/provider is a non-resident subject which        carries out "
+"transactions in Italy with relevance for VAT        purposes and which takes"
+" avail of a tax representative in        Italy"
+msgstr "Il venditore/fornitore è un soggetto non-residente che svolge "
+"le sue transazioni in Italia con rilevanza fiscale e che fa riferimento "
+" a un rappresentante fiscale in Italia."
+
+#. module: l10n_it_edi
+#: model_terms:ir.ui.view,arch_db:l10n_it_edi.res_company_form_l10n_it
+msgid ""
+"The seller/provider is a non-resident subject which carries out transactions in Italy\n"
+"                            with relevance for VAT purposes and which takes avail of a tax representative in Italy"
+msgstr "Il venditore/fornitore è un soggetto non-residente che svolge "
+"le sue transazioni in Italia con rilevanza fiscale e che fa riferimento "
+" a un rappresentante fiscale in Italia."
+
+#. module: l10n_it_edi
+#: model:ir.model.fields,help:l10n_it_edi.field_res_company__l10n_it_eco_index_number
+msgid ""
+"This field must contain the number under which the        seller/provider is"
+" listed on the register of companies."
+msgstr "Questo campo deve contenere il numero sotto il quale è presente "
+"nel Registro delle Imprese"
+
+#. module: l10n_it_edi
+#: model:ir.model.fields.selection,name:l10n_it_edi.selection__account_move__l10n_it_send_state__delivered
+msgid "This invoice is delivered"
+msgstr "Questa Fattura è consegnata"
+
+#. module: l10n_it_edi
+#: model:ir.model.fields.selection,name:l10n_it_edi.selection__account_move__l10n_it_send_state__delivered_accepted
+msgid "This invoice is delivered and accepted by destinatory"
+msgstr "Questa fattura è consegnata e accettata dal destinatario"
+
+#. module: l10n_it_edi
+#: model:ir.model.fields.selection,name:l10n_it_edi.selection__account_move__l10n_it_send_state__delivered_expired
+msgid ""
+"This invoice is delivered and expired (expiry of the maximum term for "
+"communication of acceptance/refusal)"
+msgstr "Questa fattura è consegnata e scaduta (è passato il termine "
+"massimo per la comunicazione dell'accettazione/rifiuto)"
+
+#. module: l10n_it_edi
+#: model:ir.model.fields.selection,name:l10n_it_edi.selection__account_move__l10n_it_send_state__delivered_refused
+msgid "This invoice is delivered and refused by destinatory"
+msgstr "Questa fattura è consegnata e rifiutata dal destinatario"
+
+#. module: l10n_it_edi
+#: code:addons/l10n_it_edi/models/account_edi_format.py:0
+#, python-format
+msgid "Total amount from the XML File: %s"
+msgstr "Valore totale del file XML: %s"
+
+#. module: l10n_it_edi
+#: model:ir.actions.act_window,name:l10n_it_edi.action_ddt_account
+#: model:ir.model,name:l10n_it_edi.model_l10n_it_ddt
+msgid "Transport Document"
+msgstr "Documento Di Trasporto"
+
+#. module: l10n_it_edi
+#: model:ir.model.fields,help:l10n_it_edi.field_l10n_it_ddt__date
+msgid "Transport document date"
+msgstr "Data Documento Di Trasporto"
+
+#. module: l10n_it_edi
+#: model:ir.model.fields,help:l10n_it_edi.field_l10n_it_ddt__name
+msgid "Transport document number"
+msgstr "Numero Documento Di Trasporto"
+
+#. module: l10n_it_edi
+#: code:addons/l10n_it_edi/models/account_edi_format.py:0
+#, python-format
+msgid "Transport informations from XML file:"
+msgstr "Informazioni di Trasporto dal file XML:"
+
+#. module: l10n_it_edi
+#: model:ir.model.fields,field_description:l10n_it_edi.field_account_tax__l10n_it_vat_due_date
+msgid "VAT due date"
+msgstr "Data scadenza IVA"
+
+#. module: l10n_it_edi
+#: code:addons/l10n_it_edi/models/account_edi_format.py:0
+#, python-format
+msgid "Vendor not found, useful informations from XML file:"
+msgstr "Fornitore non trovato, informazioni dal file XML:"
+
+#. module: l10n_it_edi
+#: code:addons/l10n_it_edi/models/account_edi_format.py:0
+#, python-format
+msgid ""
+"You can't regenerate an E-Invoice when the first one is sent and there are "
+"no errors"
+msgstr "Non puoi rigenerare una Fattura Elettronica se è giá stata inviata senza errori."
+
+#. module: l10n_it_edi
+#: code:addons/l10n_it_edi/models/res_company.py:0
+#, python-format
+msgid "You must select a tax representative."
+msgstr "Devi selezionare un rappresentante fiscale"
+
+#. module: l10n_it_edi
+#: code:addons/l10n_it_edi/models/account_edi_format.py:0
+#, python-format
+msgid "You must select one and only one tax by line."
+msgstr "Devi selezionare una e solo una imposta per linea."
+
+#. module: l10n_it_edi
+#: code:addons/l10n_it_edi/models/res_company.py:0
+#, python-format
+msgid "Your tax representative partner must have a country."
+msgstr "Il tuo rappresentante fiscale deve avere una Nazione."
+
+#. module: l10n_it_edi
+#: code:addons/l10n_it_edi/models/res_company.py:0
+#, python-format
+msgid "Your tax representative partner must have a tax number."
+msgstr "Il tuo rappresentante fiscale deve avere un Codice Fiscale."
+
+#. module: l10n_it_edi
+#: model:ir.model.fields.selection,name:l10n_it_edi.selection__account_tax__l10n_it_vat_due_date__d
+msgid "[D] IVA ad esigibilità differita"
+msgstr ""
+
+#. module: l10n_it_edi
+#: model:ir.model.fields.selection,name:l10n_it_edi.selection__account_tax__l10n_it_vat_due_date__i
+msgid "[I] IVA ad esigibilità immediata"
+msgstr ""
+
+#. module: l10n_it_edi
+#: model:ir.model.fields.selection,name:l10n_it_edi.selection__account_tax__l10n_it_kind_exoneration__n1
+msgid "[N1] Escluse ex art. 15"
+msgstr ""
+
+#. module: l10n_it_edi
+#: model:ir.model.fields.selection,name:l10n_it_edi.selection__account_tax__l10n_it_kind_exoneration__n2_1
+msgid ""
+"[N2.1] Non soggette ad IVA ai sensi degli artt. Da 7 a 7-septies del DPR "
+"633/72"
+msgstr ""
+
+#. module: l10n_it_edi
+#: model:ir.model.fields.selection,name:l10n_it_edi.selection__account_tax__l10n_it_kind_exoneration__n2_2
+msgid "[N2.2] Non soggette – altri casi"
+msgstr ""
+
+#. module: l10n_it_edi
+#: model:ir.model.fields.selection,name:l10n_it_edi.selection__account_tax__l10n_it_kind_exoneration__n2
+msgid "[N2] Non soggette"
+msgstr ""
+
+#. module: l10n_it_edi
+#: model:ir.model.fields.selection,name:l10n_it_edi.selection__account_tax__l10n_it_kind_exoneration__n3_1
+msgid "[N3.1] Non imponibili – esportazioni"
+msgstr ""
+
+#. module: l10n_it_edi
+#: model:ir.model.fields.selection,name:l10n_it_edi.selection__account_tax__l10n_it_kind_exoneration__n3_2
+msgid "[N3.2] Non imponibili – cessioni intracomunitarie"
+msgstr ""
+
+#. module: l10n_it_edi
+#: model:ir.model.fields.selection,name:l10n_it_edi.selection__account_tax__l10n_it_kind_exoneration__n3_3
+msgid "[N3.3] Non imponibili – cessioni verso San Marino"
+msgstr ""
+
+#. module: l10n_it_edi
+#: model:ir.model.fields.selection,name:l10n_it_edi.selection__account_tax__l10n_it_kind_exoneration__n3_4
+msgid ""
+"[N3.4] Non imponibili – operazioni assimilate alle cessioni all’esportazione"
+msgstr ""
+
+#. module: l10n_it_edi
+#: model:ir.model.fields.selection,name:l10n_it_edi.selection__account_tax__l10n_it_kind_exoneration__n3_5
+msgid "[N3.5] Non imponibili – a seguito di dichiarazioni d’intento"
+msgstr ""
+
+#. module: l10n_it_edi
+#: model:ir.model.fields.selection,name:l10n_it_edi.selection__account_tax__l10n_it_kind_exoneration__n3_6
+msgid ""
+"[N3.6] Non imponibili – altre operazioni che non concorrono alla formazione "
+"del plafond"
+msgstr ""
+
+#. module: l10n_it_edi
+#: model:ir.model.fields.selection,name:l10n_it_edi.selection__account_tax__l10n_it_kind_exoneration__n3
+msgid "[N3] Non imponibili"
+msgstr ""
+
+#. module: l10n_it_edi
+#: model:ir.model.fields.selection,name:l10n_it_edi.selection__account_tax__l10n_it_kind_exoneration__n4
+msgid "[N4] Esenti"
+msgstr ""
+
+#. module: l10n_it_edi
+#: model:ir.model.fields.selection,name:l10n_it_edi.selection__account_tax__l10n_it_kind_exoneration__n5
+msgid "[N5] Regime del margine / IVA non esposta in fattura"
+msgstr ""
+
+#. module: l10n_it_edi
+#: model:ir.model.fields.selection,name:l10n_it_edi.selection__account_tax__l10n_it_kind_exoneration__n6_1
+msgid ""
+"[N6.1] Inversione contabile – cessione di rottami e altri materiali di "
+"recupero"
+msgstr ""
+
+#. module: l10n_it_edi
+#: model:ir.model.fields.selection,name:l10n_it_edi.selection__account_tax__l10n_it_kind_exoneration__n6_2
+msgid "[N6.2] Inversione contabile – cessione di oro e argento puro"
+msgstr ""
+
+#. module: l10n_it_edi
+#: model:ir.model.fields.selection,name:l10n_it_edi.selection__account_tax__l10n_it_kind_exoneration__n6_3
+msgid "[N6.3] Inversione contabile – subappalto nel settore edile"
+msgstr ""
+
+#. module: l10n_it_edi
+#: model:ir.model.fields.selection,name:l10n_it_edi.selection__account_tax__l10n_it_kind_exoneration__n6_4
+msgid "[N6.4] Inversione contabile – cessione di fabbricati"
+msgstr ""
+
+#. module: l10n_it_edi
+#: model:ir.model.fields.selection,name:l10n_it_edi.selection__account_tax__l10n_it_kind_exoneration__n6_5
+msgid "[N6.5] Inversione contabile – cessione di telefoni cellulari"
+msgstr ""
+
+#. module: l10n_it_edi
+#: model:ir.model.fields.selection,name:l10n_it_edi.selection__account_tax__l10n_it_kind_exoneration__n6_6
+msgid "[N6.6] Inversione contabile – cessione di prodotti elettronici"
+msgstr ""
+
+#. module: l10n_it_edi
+#: model:ir.model.fields.selection,name:l10n_it_edi.selection__account_tax__l10n_it_kind_exoneration__n6_7
+msgid ""
+"[N6.7] Inversione contabile – prestazioni comparto edile esettori connessi"
+msgstr ""
+
+#. module: l10n_it_edi
+#: model:ir.model.fields.selection,name:l10n_it_edi.selection__account_tax__l10n_it_kind_exoneration__n6_8
+msgid "[N6.8] Inversione contabile – operazioni settore energetico"
+msgstr ""
+
+#. module: l10n_it_edi
+#: model:ir.model.fields.selection,name:l10n_it_edi.selection__account_tax__l10n_it_kind_exoneration__n6_9
+msgid "[N6.9] Inversione contabile – altri casi"
+msgstr ""
+
+#. module: l10n_it_edi
+#: model:ir.model.fields.selection,name:l10n_it_edi.selection__account_tax__l10n_it_kind_exoneration__n6
+msgid ""
+"[N6] Inversione contabile (per le operazioni in reverse charge ovvero nei "
+"casi di autofatturazione per acquisti extra UE di servizi ovvero per "
+"importazioni di beni nei soli casi previsti)"
+msgstr ""
+
+#. module: l10n_it_edi
+#: model:ir.model.fields.selection,name:l10n_it_edi.selection__account_tax__l10n_it_kind_exoneration__n7
+msgid ""
+"[N7] IVA assolta in altro stato UE (vendite a distanza ex art. 40 c. 3 e 4 e"
+" art. 41 c. 1 lett. b,  DL 331/93; prestazione di servizi di "
+"telecomunicazioni, tele-radiodiffusione ed elettronici ex art. 7-sexies "
+"lett. f, g, art. 74-sexies DPR 633/72)"
+msgstr ""
+
+#. module: l10n_it_edi
+#: model:ir.model.fields.selection,name:l10n_it_edi.selection__res_company__l10n_it_tax_system__rf01
+msgid "[RF01] Ordinario"
+msgstr ""
+
+#. module: l10n_it_edi
+#: model:ir.model.fields.selection,name:l10n_it_edi.selection__res_company__l10n_it_tax_system__rf02
+msgid "[RF02] Contribuenti minimi (art.1, c.96-117, L. 244/07)"
+msgstr ""
+
+#. module: l10n_it_edi
+#: model:ir.model.fields.selection,name:l10n_it_edi.selection__res_company__l10n_it_tax_system__rf04
+msgid ""
+"[RF04] Agricoltura e attività connesse e pesca (artt.34 e 34-bis, DPR "
+"633/72)"
+msgstr ""
+
+#. module: l10n_it_edi
+#: model:ir.model.fields.selection,name:l10n_it_edi.selection__res_company__l10n_it_tax_system__rf05
+msgid "[RF05] Vendita sali e tabacchi (art.74, c.1, DPR. 633/72)"
+msgstr ""
+
+#. module: l10n_it_edi
+#: model:ir.model.fields.selection,name:l10n_it_edi.selection__res_company__l10n_it_tax_system__rf06
+msgid "[RF06] Commercio fiammiferi (art.74, c.1, DPR  633/72)"
+msgstr ""
+
+#. module: l10n_it_edi
+#: model:ir.model.fields.selection,name:l10n_it_edi.selection__res_company__l10n_it_tax_system__rf07
+msgid "[RF07] Editoria (art.74, c.1, DPR  633/72)"
+msgstr ""
+
+#. module: l10n_it_edi
+#: model:ir.model.fields.selection,name:l10n_it_edi.selection__res_company__l10n_it_tax_system__rf08
+msgid "[RF08] Gestione servizi telefonia pubblica (art.74, c.1, DPR 633/72)"
+msgstr ""
+
+#. module: l10n_it_edi
+#: model:ir.model.fields.selection,name:l10n_it_edi.selection__res_company__l10n_it_tax_system__rf09
+msgid ""
+"[RF09] Rivendita documenti di trasporto pubblico e di sosta (art.74, c.1, "
+"DPR  633/72)"
+msgstr ""
+
+#. module: l10n_it_edi
+#: model:ir.model.fields.selection,name:l10n_it_edi.selection__res_company__l10n_it_tax_system__rf10
+msgid ""
+"[RF10] Intrattenimenti, giochi e altre attività di cui alla tariffa allegata"
+" al DPR 640/72 (art.74, c.6, DPR 633/72)"
+msgstr ""
+
+#. module: l10n_it_edi
+#: model:ir.model.fields.selection,name:l10n_it_edi.selection__res_company__l10n_it_tax_system__rf11
+msgid "[RF11] Agenzie viaggi e turismo (art.74-ter, DPR 633/72)"
+msgstr ""
+
+#. module: l10n_it_edi
+#: model:ir.model.fields.selection,name:l10n_it_edi.selection__res_company__l10n_it_tax_system__rf12
+msgid "[RF12] Agriturismo (art.5, c.2, L. 413/91)"
+msgstr ""
+
+#. module: l10n_it_edi
+#: model:ir.model.fields.selection,name:l10n_it_edi.selection__res_company__l10n_it_tax_system__rf13
+msgid "[RF13] Vendite a domicilio (art.25-bis, c.6, DPR  600/73)"
+msgstr ""
+
+#. module: l10n_it_edi
+#: model:ir.model.fields.selection,name:l10n_it_edi.selection__res_company__l10n_it_tax_system__rf14
+msgid ""
+"[RF14] Rivendita beni usati, oggetti d’arte, d’antiquariato o da collezione "
+"(art.36, DL 41/95)"
+msgstr ""
+
+#. module: l10n_it_edi
+#: model:ir.model.fields.selection,name:l10n_it_edi.selection__res_company__l10n_it_tax_system__rf15
+msgid ""
+"[RF15] Agenzie di vendite all’asta di oggetti d’arte, antiquariato o da "
+"collezione (art.40-bis, DL 41/95)"
+msgstr ""
+
+#. module: l10n_it_edi
+#: model:ir.model.fields.selection,name:l10n_it_edi.selection__res_company__l10n_it_tax_system__rf16
+msgid "[RF16] IVA per cassa P.A. (art.6, c.5, DPR 633/72)"
+msgstr ""
+
+#. module: l10n_it_edi
+#: model:ir.model.fields.selection,name:l10n_it_edi.selection__res_company__l10n_it_tax_system__rf17
+msgid "[RF17] IVA per cassa (art. 32-bis, DL 83/2012)"
+msgstr ""
+
+#. module: l10n_it_edi
+#: model:ir.model.fields.selection,name:l10n_it_edi.selection__res_company__l10n_it_tax_system__rf18
+msgid "[RF18] Altro"
+msgstr ""
+
+#. module: l10n_it_edi
+#: model:ir.model.fields.selection,name:l10n_it_edi.selection__res_company__l10n_it_tax_system__rf19
+msgid "[RF19] Regime forfettario (art.1, c.54-89, L. 190/2014)"
+msgstr ""
+
+#. module: l10n_it_edi
+#: model:ir.model.fields.selection,name:l10n_it_edi.selection__account_tax__l10n_it_vat_due_date__s
+msgid "[S] Scissione dei pagamenti"
+msgstr ""
+
+#. module: l10n_it_edi
+#: code:addons/l10n_it_edi/models/account_edi_format.py:0
+#, python-format
+msgid "from XML file:"
+msgstr "dal file XML:"

--- a/addons/l10n_it_edi/i18n/l10n_it_edi.pot
+++ b/addons/l10n_it_edi/i18n/l10n_it_edi.pot
@@ -1,0 +1,1122 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+# 	* l10n_it_edi
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 14.0+e\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2022-03-29 14:31+0000\n"
+"PO-Revision-Date: 2022-03-29 14:31+0000\n"
+"Last-Translator: \n"
+"Language-Team: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: \n"
+
+#. module: l10n_it_edi
+#: code:addons/l10n_it_edi/models/account_edi_format.py:0
+#, python-format
+msgid "%s has an amount of 0.0, you must indicate the kind of exoneration."
+msgstr ""
+
+#. module: l10n_it_edi
+#: code:addons/l10n_it_edi/models/account_invoice.py:0
+#, python-format
+msgid ""
+"%s isn't in a right state. It must be in a 'Not yet send' or 'Invalid' "
+"state."
+msgstr ""
+
+#. module: l10n_it_edi
+#: code:addons/l10n_it_edi/models/account_edi_format.py:0
+#, python-format
+msgid "%s must have a VAT number"
+msgstr ""
+
+#. module: l10n_it_edi
+#: code:addons/l10n_it_edi/models/account_edi_format.py:0
+#: code:addons/l10n_it_edi/models/account_edi_format.py:0
+#, python-format
+msgid "%s must have a city."
+msgstr ""
+
+#. module: l10n_it_edi
+#: code:addons/l10n_it_edi/models/account_edi_format.py:0
+#, python-format
+msgid "%s must have a codice fiscale number"
+msgstr ""
+
+#. module: l10n_it_edi
+#: code:addons/l10n_it_edi/models/account_edi_format.py:0
+#, python-format
+msgid "%s must have a country"
+msgstr ""
+
+#. module: l10n_it_edi
+#: code:addons/l10n_it_edi/models/account_edi_format.py:0
+#: code:addons/l10n_it_edi/models/account_edi_format.py:0
+#, python-format
+msgid "%s must have a country."
+msgstr ""
+
+#. module: l10n_it_edi
+#: code:addons/l10n_it_edi/models/account_edi_format.py:0
+#: code:addons/l10n_it_edi/models/account_edi_format.py:0
+#, python-format
+msgid "%s must have a post code of length 5."
+msgstr ""
+
+#. module: l10n_it_edi
+#: code:addons/l10n_it_edi/models/account_edi_format.py:0
+#: code:addons/l10n_it_edi/models/account_edi_format.py:0
+#, python-format
+msgid "%s must have a post code."
+msgstr ""
+
+#. module: l10n_it_edi
+#: code:addons/l10n_it_edi/models/account_edi_format.py:0
+#: code:addons/l10n_it_edi/models/account_edi_format.py:0
+#, python-format
+msgid "%s must have a street."
+msgstr ""
+
+#. module: l10n_it_edi
+#: code:addons/l10n_it_edi/models/account_invoice.py:0
+#, python-format
+msgid ""
+"'Scissione dei pagamenti' is not compatible with exoneration of kind 'N6'"
+msgstr ""
+
+#. module: l10n_it_edi
+#: code:addons/l10n_it_edi/models/res_company.py:0
+#, python-format
+msgid ""
+"All fields about the Economic and Administrative Index must be completed."
+msgstr ""
+
+#. module: l10n_it_edi
+#: code:addons/l10n_it_edi/models/account_edi_format.py:0
+#, python-format
+msgid "Attachment from XML"
+msgstr ""
+
+#. module: l10n_it_edi
+#: code:addons/l10n_it_edi/models/account_edi_format.py:0
+#: code:addons/l10n_it_edi/models/account_edi_format.py:0
+#, python-format
+msgid "Bank account not found, useful informations from XML file:"
+msgstr ""
+
+#. module: l10n_it_edi
+#: model:ir.model.fields,field_description:l10n_it_edi.field_res_company__l10n_it_codice_fiscale
+#: model:ir.model.fields,field_description:l10n_it_edi.field_res_partner__l10n_it_codice_fiscale
+#: model:ir.model.fields,field_description:l10n_it_edi.field_res_users__l10n_it_codice_fiscale
+msgid "Codice Fiscale"
+msgstr ""
+
+#. module: l10n_it_edi
+#: model:ir.model.constraint,message:l10n_it_edi.constraint_res_partner_l10n_it_codice_fiscale
+msgid "Codice fiscale must have between 11 and 16 characters."
+msgstr ""
+
+#. module: l10n_it_edi
+#: model:ir.model,name:l10n_it_edi.model_res_company
+msgid "Companies"
+msgstr ""
+
+#. module: l10n_it_edi
+#: model:ir.model.fields,field_description:l10n_it_edi.field_res_company__l10n_it_address_send_fatturapa
+msgid "Company PEC-mail"
+msgstr ""
+
+#. module: l10n_it_edi
+#: model_terms:ir.ui.view,arch_db:l10n_it_edi.res_company_form_l10n_it
+msgid "Company have a tax representative"
+msgstr ""
+
+#. module: l10n_it_edi
+#: model_terms:ir.ui.view,arch_db:l10n_it_edi.res_company_form_l10n_it
+msgid "Company listed on the register of companies"
+msgstr ""
+
+#. module: l10n_it_edi
+#: model:ir.model.fields,help:l10n_it_edi.field_res_company__l10n_it_mail_pec_server_id
+msgid "Configure your PEC-mail server to send electronic invoices."
+msgstr ""
+
+#. module: l10n_it_edi
+#: model:ir.model,name:l10n_it_edi.model_res_partner
+msgid "Contact"
+msgstr ""
+
+#. module: l10n_it_edi
+#: model:ir.model.fields,field_description:l10n_it_edi.field_l10n_it_ddt__create_uid
+msgid "Created by"
+msgstr ""
+
+#. module: l10n_it_edi
+#: model:ir.model.fields,field_description:l10n_it_edi.field_l10n_it_ddt__create_date
+msgid "Created on"
+msgstr ""
+
+#. module: l10n_it_edi
+#: model:ir.model.fields,field_description:l10n_it_edi.field_account_bank_statement_line__l10n_it_ddt_id
+#: model:ir.model.fields,field_description:l10n_it_edi.field_account_move__l10n_it_ddt_id
+#: model:ir.model.fields,field_description:l10n_it_edi.field_account_payment__l10n_it_ddt_id
+#: model:ir.ui.menu,name:l10n_it_edi.menu_action_ddt_account
+msgid "DDT"
+msgstr ""
+
+#. module: l10n_it_edi
+#: model:ir.model.fields,field_description:l10n_it_edi.field_l10n_it_ddt__date
+msgid "Data DDT"
+msgstr ""
+
+#. module: l10n_it_edi
+#: model:ir.model.fields,field_description:l10n_it_edi.field_account_bank_statement_line__l10n_it_stamp_duty
+#: model:ir.model.fields,field_description:l10n_it_edi.field_account_move__l10n_it_stamp_duty
+#: model:ir.model.fields,field_description:l10n_it_edi.field_account_payment__l10n_it_stamp_duty
+msgid "Dati Bollo"
+msgstr ""
+
+#. module: l10n_it_edi
+#: model:ir.model.fields.selection,name:l10n_it_edi.selection__account_move__l10n_it_send_state__failed_delivery
+msgid ""
+"Delivery impossible, ES certify that it has received the invoice and that "
+"the file                         could not be delivered to the addressee"
+msgstr ""
+
+#. module: l10n_it_edi
+#: model:ir.model.fields,field_description:l10n_it_edi.field_account_edi_format__display_name
+#: model:ir.model.fields,field_description:l10n_it_edi.field_account_move__display_name
+#: model:ir.model.fields,field_description:l10n_it_edi.field_account_tax__display_name
+#: model:ir.model.fields,field_description:l10n_it_edi.field_fetchmail_server__display_name
+#: model:ir.model.fields,field_description:l10n_it_edi.field_ir_mail_server__display_name
+#: model:ir.model.fields,field_description:l10n_it_edi.field_l10n_it_ddt__display_name
+#: model:ir.model.fields,field_description:l10n_it_edi.field_res_company__display_name
+#: model:ir.model.fields,field_description:l10n_it_edi.field_res_partner__display_name
+msgid "Display Name"
+msgstr ""
+
+#. module: l10n_it_edi
+#: code:addons/l10n_it_edi/models/ir_mail_server.py:0
+#, python-format
+msgid "E-Invoice is delivery to the destinatory:<br/>%s"
+msgstr ""
+
+#. module: l10n_it_edi
+#: code:addons/l10n_it_edi/models/account_invoice.py:0
+#, python-format
+msgid "E-Invoice is generated on %s by %s"
+msgstr ""
+
+#. module: l10n_it_edi
+#: model_terms:ir.ui.view,arch_db:l10n_it_edi.account_invoice_line_it_FatturaPA
+msgid "EAN"
+msgstr ""
+
+#. module: l10n_it_edi
+#: model:ir.model,name:l10n_it_edi.model_account_edi_format
+msgid "EDI format"
+msgstr ""
+
+#. module: l10n_it_edi
+#: code:addons/l10n_it_edi/models/ir_mail_server.py:0
+#, python-format
+msgid ""
+"ES certify that it has received the invoice and that the file"
+"                         could not be delivered to the addressee. <br/>%s"
+msgstr ""
+
+#. module: l10n_it_edi
+#: model_terms:ir.ui.view,arch_db:l10n_it_edi.res_company_form_l10n_it
+msgid "Economic and Administrative Index"
+msgstr ""
+
+#. module: l10n_it_edi
+#: model_terms:ir.ui.view,arch_db:l10n_it_edi.account_invoice_form_l10n_it
+#: model_terms:ir.ui.view,arch_db:l10n_it_edi.res_company_form_l10n_it
+msgid "Electronic Invoicing"
+msgstr ""
+
+#. module: l10n_it_edi
+#: model:ir.model.fields,field_description:l10n_it_edi.field_account_bank_statement_line__l10n_it_einvoice_id
+#: model:ir.model.fields,field_description:l10n_it_edi.field_account_move__l10n_it_einvoice_id
+#: model:ir.model.fields,field_description:l10n_it_edi.field_account_payment__l10n_it_einvoice_id
+msgid "Electronic invoice"
+msgstr ""
+
+#. module: l10n_it_edi
+#: model:ir.model.fields,help:l10n_it_edi.field_res_company__l10n_it_address_recipient_fatturapa
+msgid "Enter Government PEC-mail address. Ex: sdi01@pec.fatturapa.it"
+msgstr ""
+
+#. module: l10n_it_edi
+#: model:ir.model.fields,help:l10n_it_edi.field_res_company__l10n_it_address_send_fatturapa
+msgid "Enter your company PEC-mail address. Ex: yourcompany@pec.mail.it"
+msgstr ""
+
+#. module: l10n_it_edi
+#: code:addons/l10n_it_edi/models/account_invoice.py:0
+#, python-format
+msgid "Error when sending mail with E-Invoice: %s"
+msgstr ""
+
+#. module: l10n_it_edi
+#: code:addons/l10n_it_edi/models/account_invoice.py:0
+#, python-format
+msgid ""
+"Error when sending mail with E-Invoice: Your company must have a mail PEC "
+"server and must indicate the mail PEC that will send electronic invoice."
+msgstr ""
+
+#. module: l10n_it_edi
+#: code:addons/l10n_it_edi/models/ir_mail_server.py:0
+#, python-format
+msgid "Errors in the E-Invoice :<br/>%s"
+msgstr ""
+
+#. module: l10n_it_edi
+#: model:ir.model.fields,field_description:l10n_it_edi.field_account_tax__l10n_it_kind_exoneration
+msgid "Exoneration"
+msgstr ""
+
+#. module: l10n_it_edi
+#: model:ir.model.fields,help:l10n_it_edi.field_account_tax__l10n_it_kind_exoneration
+msgid "Exoneration type"
+msgstr ""
+
+#. module: l10n_it_edi
+#: code:addons/l10n_it_edi/models/ir_mail_server.py:0
+#, python-format
+msgid ""
+"Expiration of the maximum term for communication of acceptance/refusal:"
+"                 %s<br/>%s"
+msgstr ""
+
+#. module: l10n_it_edi
+#: model:ir.model.fields,field_description:l10n_it_edi.field_account_bank_statement_line__l10n_it_send_state
+#: model:ir.model.fields,field_description:l10n_it_edi.field_account_move__l10n_it_send_state
+#: model:ir.model.fields,field_description:l10n_it_edi.field_account_payment__l10n_it_send_state
+msgid "FatturaPA Send State"
+msgstr ""
+
+#. module: l10n_it_edi
+#: model:ir.model.fields,help:l10n_it_edi.field_res_company__l10n_it_codice_fiscale
+msgid "Fiscal code of your company"
+msgstr ""
+
+#. module: l10n_it_edi
+#: model:ir.model.fields,field_description:l10n_it_edi.field_res_company__l10n_it_address_recipient_fatturapa
+msgid "Government PEC-mail"
+msgstr ""
+
+#. module: l10n_it_edi
+#: model:ir.model.fields,field_description:l10n_it_edi.field_account_tax__l10n_it_has_exoneration
+msgid "Has exoneration of tax (Italy)"
+msgstr ""
+
+#. module: l10n_it_edi
+#: model:ir.model.fields,field_description:l10n_it_edi.field_account_edi_format__id
+#: model:ir.model.fields,field_description:l10n_it_edi.field_account_move__id
+#: model:ir.model.fields,field_description:l10n_it_edi.field_account_tax__id
+#: model:ir.model.fields,field_description:l10n_it_edi.field_fetchmail_server__id
+#: model:ir.model.fields,field_description:l10n_it_edi.field_ir_mail_server__id
+#: model:ir.model.fields,field_description:l10n_it_edi.field_l10n_it_ddt__id
+#: model:ir.model.fields,field_description:l10n_it_edi.field_res_company__id
+#: model:ir.model.fields,field_description:l10n_it_edi.field_res_partner__id
+msgid "ID"
+msgstr ""
+
+#. module: l10n_it_edi
+#: model_terms:ir.ui.view,arch_db:l10n_it_edi.account_invoice_line_it_FatturaPA
+msgid "INTERNAL"
+msgstr ""
+
+#. module: l10n_it_edi
+#: model:ir.model.fields,help:l10n_it_edi.field_fetchmail_server__l10n_it_is_pec
+msgid ""
+"If PEC Server, only mail from '...@pec.fatturapa.it' will be processed."
+msgstr ""
+
+#. module: l10n_it_edi
+#: code:addons/l10n_it_edi/models/account_invoice.py:0
+#, python-format
+msgid ""
+"If the tax has exoneration, you must enter a kind of exoneration, a law "
+"reference and the amount of the tax must be 0.0."
+msgstr ""
+
+#. module: l10n_it_edi
+#: model:ir.model,name:l10n_it_edi.model_fetchmail_server
+msgid "Incoming Mail Server"
+msgstr ""
+
+#. module: l10n_it_edi
+#: code:addons/l10n_it_edi/models/res_partner.py:0
+#, python-format
+msgid ""
+"Invalid Codice Fiscale '%s': should be like 'MRTMTT91D08F205J' for physical "
+"person and '12345678901' or 'IT12345678901' for businesses."
+msgstr ""
+
+#. module: l10n_it_edi
+#: code:addons/l10n_it_edi/models/account_invoice.py:0
+#, python-format
+msgid "Invalid configuration:"
+msgstr ""
+
+#. module: l10n_it_edi
+#: model:ir.model.fields,field_description:l10n_it_edi.field_l10n_it_ddt__invoice_id
+msgid "Invoice Reference"
+msgstr ""
+
+#. module: l10n_it_edi
+#: code:addons/l10n_it_edi/models/account_edi_format.py:0
+#, python-format
+msgid ""
+"Invoices for PA are not managed by Odoo, you can download the document and "
+"send it on your own."
+msgstr ""
+
+#. module: l10n_it_edi
+#: code:addons/l10n_it_edi/models/account_invoice.py:0
+#, python-format
+msgid "Italian invoice: %s"
+msgstr ""
+
+#. module: l10n_it_edi
+#: model:ir.model,name:l10n_it_edi.model_account_move
+msgid "Journal Entry"
+msgstr ""
+
+#. module: l10n_it_edi
+#: model:ir.model.fields,field_description:l10n_it_edi.field_account_bank_statement_line__l10n_it_einvoice_name
+#: model:ir.model.fields,field_description:l10n_it_edi.field_account_move__l10n_it_einvoice_name
+#: model:ir.model.fields,field_description:l10n_it_edi.field_account_payment__l10n_it_einvoice_name
+msgid "L10N It Einvoice Name"
+msgstr ""
+
+#. module: l10n_it_edi
+#: model:ir.model.fields,field_description:l10n_it_edi.field_res_company__l10n_it_has_eco_index
+msgid "L10N It Has Eco Index"
+msgstr ""
+
+#. module: l10n_it_edi
+#: model:ir.model.fields,field_description:l10n_it_edi.field_res_company__l10n_it_has_tax_representative
+msgid "L10N It Has Tax Representative"
+msgstr ""
+
+#. module: l10n_it_edi
+#: model:ir.model.fields,field_description:l10n_it_edi.field_account_edi_format____last_update
+#: model:ir.model.fields,field_description:l10n_it_edi.field_account_move____last_update
+#: model:ir.model.fields,field_description:l10n_it_edi.field_account_tax____last_update
+#: model:ir.model.fields,field_description:l10n_it_edi.field_fetchmail_server____last_update
+#: model:ir.model.fields,field_description:l10n_it_edi.field_ir_mail_server____last_update
+#: model:ir.model.fields,field_description:l10n_it_edi.field_l10n_it_ddt____last_update
+#: model:ir.model.fields,field_description:l10n_it_edi.field_res_company____last_update
+#: model:ir.model.fields,field_description:l10n_it_edi.field_res_partner____last_update
+msgid "Last Modified on"
+msgstr ""
+
+#. module: l10n_it_edi
+#: model:ir.model.fields,field_description:l10n_it_edi.field_l10n_it_ddt__write_uid
+msgid "Last Updated by"
+msgstr ""
+
+#. module: l10n_it_edi
+#: model:ir.model.fields,field_description:l10n_it_edi.field_l10n_it_ddt__write_date
+msgid "Last Updated on"
+msgstr ""
+
+#. module: l10n_it_edi
+#: model:ir.model.fields,field_description:l10n_it_edi.field_fetchmail_server__l10n_it_last_uid
+msgid "Last message UID"
+msgstr ""
+
+#. module: l10n_it_edi
+#: model:ir.model.fields,field_description:l10n_it_edi.field_account_tax__l10n_it_law_reference
+msgid "Law Reference"
+msgstr ""
+
+#. module: l10n_it_edi
+#: model:ir.model.fields,field_description:l10n_it_edi.field_res_company__l10n_it_eco_index_liquidation_state
+msgid "Liquidation state"
+msgstr ""
+
+#. module: l10n_it_edi
+#: model_terms:ir.ui.view,arch_db:l10n_it_edi.account_invoice_it_FatturaPA_export
+msgid "MP05"
+msgstr ""
+
+#. module: l10n_it_edi
+#: model:ir.model,name:l10n_it_edi.model_ir_mail_server
+msgid "Mail Server"
+msgstr ""
+
+#. module: l10n_it_edi
+#: code:addons/l10n_it_edi/models/account_invoice.py:0
+#, python-format
+msgid "Mail sent on %s by %s"
+msgstr ""
+
+#. module: l10n_it_edi
+#: model:ir.model.fields,help:l10n_it_edi.field_res_company__l10n_it_eco_index_share_capital
+msgid ""
+"Mandatory if the seller/provider is a company with share        capital "
+"(SpA, SApA, Srl), this field must contain the amount        of share capital"
+" actually paid up as resulting from the last        financial statement"
+msgstr ""
+
+#. module: l10n_it_edi
+#: model:ir.model.fields,help:l10n_it_edi.field_res_partner__l10n_it_pa_index
+#: model:ir.model.fields,help:l10n_it_edi.field_res_users__l10n_it_pa_index
+msgid ""
+"Must contain the 6-character (or 7) code, present in the PA              "
+"Index in the information relative to the electronic invoicing service,"
+"              associated with the office which, within the addressee "
+"administration, deals              with receiving (and processing) the "
+"invoice."
+msgstr ""
+
+#. module: l10n_it_edi
+#: model:ir.model.fields.selection,name:l10n_it_edi.selection__account_move__l10n_it_send_state__new
+msgid "New"
+msgstr ""
+
+#. module: l10n_it_edi
+#: model:ir.model.fields.selection,name:l10n_it_edi.selection__res_company__l10n_it_eco_index_sole_shareholder__no
+msgid "Not a limited liability company"
+msgstr ""
+
+#. module: l10n_it_edi
+#: model:ir.model.fields.selection,name:l10n_it_edi.selection__account_move__l10n_it_send_state__to_send
+msgid "Not yet send"
+msgstr ""
+
+#. module: l10n_it_edi
+#: model:ir.model.fields,field_description:l10n_it_edi.field_res_company__l10n_it_eco_index_number
+msgid "Number in register of companies"
+msgstr ""
+
+#. module: l10n_it_edi
+#: model:ir.model.fields,field_description:l10n_it_edi.field_l10n_it_ddt__name
+msgid "Numero DDT"
+msgstr ""
+
+#. module: l10n_it_edi
+#: code:addons/l10n_it_edi/models/ir_mail_server.py:0
+#, python-format
+msgid "Original E-invoice XML file"
+msgstr ""
+
+#. module: l10n_it_edi
+#: model:ir.model.fields.selection,name:l10n_it_edi.selection__account_move__l10n_it_send_state__other
+msgid "Other"
+msgstr ""
+
+#. module: l10n_it_edi
+#: code:addons/l10n_it_edi/models/ir_mail_server.py:0
+#, python-format
+msgid "Outcome notice: %s<br/>%s"
+msgstr ""
+
+#. module: l10n_it_edi
+#: model:ir.model.fields,field_description:l10n_it_edi.field_res_partner__l10n_it_pa_index
+#: model:ir.model.fields,field_description:l10n_it_edi.field_res_users__l10n_it_pa_index
+msgid "PA index"
+msgstr ""
+
+#. module: l10n_it_edi
+#: model:ir.model.constraint,message:l10n_it_edi.constraint_res_partner_l10n_it_pa_index
+msgid "PA index must have between 6 and 7 characters."
+msgstr ""
+
+#. module: l10n_it_edi
+#: model_terms:ir.ui.view,arch_db:l10n_it_edi.account_invoice_it_FatturaPA_export
+msgid "PDF"
+msgstr ""
+
+#. module: l10n_it_edi
+#: model:ir.model.fields,field_description:l10n_it_edi.field_res_partner__l10n_it_pec_email
+#: model:ir.model.fields,field_description:l10n_it_edi.field_res_users__l10n_it_pec_email
+msgid "PEC e-mail"
+msgstr ""
+
+#. module: l10n_it_edi
+#: code:addons/l10n_it_edi/models/ir_mail_server.py:0
+#, python-format
+msgid "PEC mail server must be of type IMAP."
+msgstr ""
+
+#. module: l10n_it_edi
+#: model:ir.model.fields,field_description:l10n_it_edi.field_fetchmail_server__l10n_it_is_pec
+msgid "PEC server"
+msgstr ""
+
+#. module: l10n_it_edi
+#: model:ir.model.fields.selection,name:l10n_it_edi.selection__res_company__l10n_it_eco_index_sole_shareholder__sm
+msgid "Più soci"
+msgstr ""
+
+#. module: l10n_it_edi
+#: code:addons/l10n_it_edi/models/ir_mail_server.py:0
+#, python-format
+msgid "Please configure Government PEC-mail\tin company settings"
+msgstr ""
+
+#. module: l10n_it_edi
+#: code:addons/l10n_it_edi/models/ir_mail_server.py:0
+#, python-format
+msgid "Please configure Username for this Server PEC"
+msgstr ""
+
+#. module: l10n_it_edi
+#: model:ir.model.fields,help:l10n_it_edi.field_res_company__l10n_it_tax_system
+msgid "Please select the Tax system to which you are subjected."
+msgstr ""
+
+#. module: l10n_it_edi
+#: model:ir.model.fields,field_description:l10n_it_edi.field_res_company__l10n_it_eco_index_office
+msgid "Province of the register-of-companies office"
+msgstr ""
+
+#. module: l10n_it_edi
+#: model_terms:ir.ui.view,arch_db:l10n_it_edi.account_invoice_it_FatturaPA_export
+msgid "SI"
+msgstr ""
+
+#. module: l10n_it_edi
+#: code:addons/l10n_it_edi/models/account_invoice.py:0
+#, python-format
+msgid "Sending file: %s"
+msgstr ""
+
+#. module: l10n_it_edi
+#: code:addons/l10n_it_edi/models/account_invoice.py:0
+#, python-format
+msgid "Sending file: %s to ES: %s"
+msgstr ""
+
+#. module: l10n_it_edi
+#: model:ir.model.fields.selection,name:l10n_it_edi.selection__account_move__l10n_it_send_state__invalid
+msgid "Sent, but invalid"
+msgstr ""
+
+#. module: l10n_it_edi
+#: model:ir.model.fields.selection,name:l10n_it_edi.selection__account_move__l10n_it_send_state__sent
+msgid "Sent, waiting for response"
+msgstr ""
+
+#. module: l10n_it_edi
+#: model:ir.model.fields,field_description:l10n_it_edi.field_res_company__l10n_it_mail_pec_server_id
+msgid "Server PEC"
+msgstr ""
+
+#. module: l10n_it_edi
+#: model:ir.model.fields,field_description:l10n_it_edi.field_res_company__l10n_it_eco_index_share_capital
+msgid "Share capital actually paid up"
+msgstr ""
+
+#. module: l10n_it_edi
+#: model:ir.model.fields,field_description:l10n_it_edi.field_res_company__l10n_it_eco_index_sole_shareholder
+msgid "Shareholder"
+msgstr ""
+
+#. module: l10n_it_edi
+#: model:ir.model.fields.selection,name:l10n_it_edi.selection__res_company__l10n_it_eco_index_sole_shareholder__su
+msgid "Socio unico"
+msgstr ""
+
+#. module: l10n_it_edi
+#: model_terms:ir.ui.view,arch_db:l10n_it_edi.account_invoice_it_FatturaPA_export
+msgid "TP01"
+msgstr ""
+
+#. module: l10n_it_edi
+#: model_terms:ir.ui.view,arch_db:l10n_it_edi.account_invoice_it_FatturaPA_export
+msgid "TP02"
+msgstr ""
+
+#. module: l10n_it_edi
+#: model:ir.model,name:l10n_it_edi.model_account_tax
+msgid "Tax"
+msgstr ""
+
+#. module: l10n_it_edi
+#: model:ir.model.fields,field_description:l10n_it_edi.field_res_company__l10n_it_tax_system
+msgid "Tax System"
+msgstr ""
+
+#. module: l10n_it_edi
+#: model:ir.model.fields,help:l10n_it_edi.field_account_tax__l10n_it_has_exoneration
+msgid "Tax has a tax exoneration."
+msgstr ""
+
+#. module: l10n_it_edi
+#: code:addons/l10n_it_edi/models/account_edi_format.py:0
+#, python-format
+msgid ""
+"Tax not found with percentage: %s and exoneration %s for the article: %s"
+msgstr ""
+
+#. module: l10n_it_edi
+#: code:addons/l10n_it_edi/models/account_edi_format.py:0
+#, python-format
+msgid "Tax not found with percentage: %s for the article: %s"
+msgstr ""
+
+#. module: l10n_it_edi
+#: model_terms:ir.ui.view,arch_db:l10n_it_edi.res_company_form_l10n_it
+msgid "Tax representative"
+msgstr ""
+
+#. module: l10n_it_edi
+#: model:ir.model.fields,field_description:l10n_it_edi.field_res_company__l10n_it_tax_representative_partner_id
+msgid "Tax representative partner"
+msgstr ""
+
+#. module: l10n_it_edi
+#: code:addons/l10n_it_edi/models/account_edi_format.py:0
+#, python-format
+msgid "Tax representative partner %s of %s must have a tax number."
+msgstr ""
+
+#. module: l10n_it_edi
+#: code:addons/l10n_it_edi/models/ir_mail_server.py:0
+#, python-format
+msgid ""
+"The E-invoice is not delivered to the addressee. The Exchange System is"
+"                unable to deliver the file to the Public Administration. The"
+" Exchange System will                contact the PA to report the problem "
+"and request that they provide a solution.                 During the "
+"following 15 days, the Exchange System will try to forward the FatturaPA"
+"                file to the Administration in question again. More "
+"information:<br/>%s"
+msgstr ""
+
+#. module: l10n_it_edi
+#: code:addons/l10n_it_edi/models/account_edi_format.py:0
+#, python-format
+msgid ""
+"The buyer, %s, or his company must have either a VAT number either a tax "
+"code (Codice Fiscale)."
+msgstr ""
+
+#. module: l10n_it_edi
+#: model:ir.model.fields.selection,name:l10n_it_edi.selection__res_company__l10n_it_eco_index_liquidation_state__ls
+msgid "The company is in a state of liquidation"
+msgstr ""
+
+#. module: l10n_it_edi
+#: model:ir.model.fields.selection,name:l10n_it_edi.selection__res_company__l10n_it_eco_index_liquidation_state__ln
+msgid "The company is not in a state of liquidation"
+msgstr ""
+
+#. module: l10n_it_edi
+#: code:addons/l10n_it_edi/models/account_edi_format.py:0
+#, python-format
+msgid ""
+"The maximum length for VAT number is 30. %s have a VAT number too long: %s."
+msgstr ""
+
+#. module: l10n_it_edi
+#: code:addons/l10n_it_edi/models/account_edi_format.py:0
+#, python-format
+msgid "The seller must have a bank account."
+msgstr ""
+
+#. module: l10n_it_edi
+#: code:addons/l10n_it_edi/models/account_edi_format.py:0
+#, python-format
+msgid "The seller's company must have a tax system."
+msgstr ""
+
+#. module: l10n_it_edi
+#: model_terms:ir.ui.view,arch_db:l10n_it_edi.res_company_form_l10n_it
+msgid ""
+"The seller/provider is a company listed on the register of companies and as\n"
+"                            such must also indicate the registration data on all documents (art. 2250, Italian\n"
+"                            Civil Code)"
+msgstr ""
+
+#. module: l10n_it_edi
+#: model:ir.model.fields,help:l10n_it_edi.field_res_company__l10n_it_has_eco_index
+msgid ""
+"The seller/provider is a company listed on the register of companies and as"
+"        such must also indicate the registration data on all documents (art."
+" 2250, Italian        Civil Code)"
+msgstr ""
+
+#. module: l10n_it_edi
+#: model:ir.model.fields,help:l10n_it_edi.field_res_company__l10n_it_has_tax_representative
+msgid ""
+"The seller/provider is a non-resident subject which        carries out "
+"transactions in Italy with relevance for VAT        purposes and which takes"
+" avail of a tax representative in        Italy"
+msgstr ""
+
+#. module: l10n_it_edi
+#: model_terms:ir.ui.view,arch_db:l10n_it_edi.res_company_form_l10n_it
+msgid ""
+"The seller/provider is a non-resident subject which carries out transactions in Italy\n"
+"                            with relevance for VAT purposes and which takes avail of a tax representative in Italy"
+msgstr ""
+
+#. module: l10n_it_edi
+#: model:ir.model.fields,help:l10n_it_edi.field_res_company__l10n_it_eco_index_number
+msgid ""
+"This field must contain the number under which the        seller/provider is"
+" listed on the register of companies."
+msgstr ""
+
+#. module: l10n_it_edi
+#: model:ir.model.fields.selection,name:l10n_it_edi.selection__account_move__l10n_it_send_state__delivered
+msgid "This invoice is delivered"
+msgstr ""
+
+#. module: l10n_it_edi
+#: model:ir.model.fields.selection,name:l10n_it_edi.selection__account_move__l10n_it_send_state__delivered_accepted
+msgid "This invoice is delivered and accepted by destinatory"
+msgstr ""
+
+#. module: l10n_it_edi
+#: model:ir.model.fields.selection,name:l10n_it_edi.selection__account_move__l10n_it_send_state__delivered_expired
+msgid ""
+"This invoice is delivered and expired (expiry of the maximum term for "
+"communication of acceptance/refusal)"
+msgstr ""
+
+#. module: l10n_it_edi
+#: model:ir.model.fields.selection,name:l10n_it_edi.selection__account_move__l10n_it_send_state__delivered_refused
+msgid "This invoice is delivered and refused by destinatory"
+msgstr ""
+
+#. module: l10n_it_edi
+#: code:addons/l10n_it_edi/models/account_edi_format.py:0
+#, python-format
+msgid "Total amount from the XML File: %s"
+msgstr ""
+
+#. module: l10n_it_edi
+#: model:ir.actions.act_window,name:l10n_it_edi.action_ddt_account
+#: model:ir.model,name:l10n_it_edi.model_l10n_it_ddt
+msgid "Transport Document"
+msgstr ""
+
+#. module: l10n_it_edi
+#: model:ir.model.fields,help:l10n_it_edi.field_l10n_it_ddt__date
+msgid "Transport document date"
+msgstr ""
+
+#. module: l10n_it_edi
+#: model:ir.model.fields,help:l10n_it_edi.field_l10n_it_ddt__name
+msgid "Transport document number"
+msgstr ""
+
+#. module: l10n_it_edi
+#: code:addons/l10n_it_edi/models/account_edi_format.py:0
+#, python-format
+msgid "Transport informations from XML file:"
+msgstr ""
+
+#. module: l10n_it_edi
+#: model:ir.model.fields,field_description:l10n_it_edi.field_account_tax__l10n_it_vat_due_date
+msgid "VAT due date"
+msgstr ""
+
+#. module: l10n_it_edi
+#: code:addons/l10n_it_edi/models/account_edi_format.py:0
+#, python-format
+msgid "Vendor not found, useful informations from XML file:"
+msgstr ""
+
+#. module: l10n_it_edi
+#: code:addons/l10n_it_edi/models/account_edi_format.py:0
+#, python-format
+msgid ""
+"You can't regenerate an E-Invoice when the first one is sent and there are "
+"no errors"
+msgstr ""
+
+#. module: l10n_it_edi
+#: code:addons/l10n_it_edi/models/res_company.py:0
+#, python-format
+msgid "You must select a tax representative."
+msgstr ""
+
+#. module: l10n_it_edi
+#: code:addons/l10n_it_edi/models/account_edi_format.py:0
+#, python-format
+msgid "You must select one and only one tax by line."
+msgstr ""
+
+#. module: l10n_it_edi
+#: code:addons/l10n_it_edi/models/res_company.py:0
+#, python-format
+msgid "Your tax representative partner must have a country."
+msgstr ""
+
+#. module: l10n_it_edi
+#: code:addons/l10n_it_edi/models/res_company.py:0
+#, python-format
+msgid "Your tax representative partner must have a tax number."
+msgstr ""
+
+#. module: l10n_it_edi
+#: model:ir.model.fields.selection,name:l10n_it_edi.selection__account_tax__l10n_it_vat_due_date__d
+msgid "[D] IVA ad esigibilità differita"
+msgstr ""
+
+#. module: l10n_it_edi
+#: model:ir.model.fields.selection,name:l10n_it_edi.selection__account_tax__l10n_it_vat_due_date__i
+msgid "[I] IVA ad esigibilità immediata"
+msgstr ""
+
+#. module: l10n_it_edi
+#: model:ir.model.fields.selection,name:l10n_it_edi.selection__account_tax__l10n_it_kind_exoneration__n1
+msgid "[N1] Escluse ex art. 15"
+msgstr ""
+
+#. module: l10n_it_edi
+#: model:ir.model.fields.selection,name:l10n_it_edi.selection__account_tax__l10n_it_kind_exoneration__n2_1
+msgid ""
+"[N2.1] Non soggette ad IVA ai sensi degli artt. Da 7 a 7-septies del DPR "
+"633/72"
+msgstr ""
+
+#. module: l10n_it_edi
+#: model:ir.model.fields.selection,name:l10n_it_edi.selection__account_tax__l10n_it_kind_exoneration__n2_2
+msgid "[N2.2] Non soggette – altri casi"
+msgstr ""
+
+#. module: l10n_it_edi
+#: model:ir.model.fields.selection,name:l10n_it_edi.selection__account_tax__l10n_it_kind_exoneration__n2
+msgid "[N2] Non soggette"
+msgstr ""
+
+#. module: l10n_it_edi
+#: model:ir.model.fields.selection,name:l10n_it_edi.selection__account_tax__l10n_it_kind_exoneration__n3_1
+msgid "[N3.1] Non imponibili – esportazioni"
+msgstr ""
+
+#. module: l10n_it_edi
+#: model:ir.model.fields.selection,name:l10n_it_edi.selection__account_tax__l10n_it_kind_exoneration__n3_2
+msgid "[N3.2] Non imponibili – cessioni intracomunitarie"
+msgstr ""
+
+#. module: l10n_it_edi
+#: model:ir.model.fields.selection,name:l10n_it_edi.selection__account_tax__l10n_it_kind_exoneration__n3_3
+msgid "[N3.3] Non imponibili – cessioni verso San Marino"
+msgstr ""
+
+#. module: l10n_it_edi
+#: model:ir.model.fields.selection,name:l10n_it_edi.selection__account_tax__l10n_it_kind_exoneration__n3_4
+msgid ""
+"[N3.4] Non imponibili – operazioni assimilate alle cessioni all’esportazione"
+msgstr ""
+
+#. module: l10n_it_edi
+#: model:ir.model.fields.selection,name:l10n_it_edi.selection__account_tax__l10n_it_kind_exoneration__n3_5
+msgid "[N3.5] Non imponibili – a seguito di dichiarazioni d’intento"
+msgstr ""
+
+#. module: l10n_it_edi
+#: model:ir.model.fields.selection,name:l10n_it_edi.selection__account_tax__l10n_it_kind_exoneration__n3_6
+msgid ""
+"[N3.6] Non imponibili – altre operazioni che non concorrono alla formazione "
+"del plafond"
+msgstr ""
+
+#. module: l10n_it_edi
+#: model:ir.model.fields.selection,name:l10n_it_edi.selection__account_tax__l10n_it_kind_exoneration__n3
+msgid "[N3] Non imponibili"
+msgstr ""
+
+#. module: l10n_it_edi
+#: model:ir.model.fields.selection,name:l10n_it_edi.selection__account_tax__l10n_it_kind_exoneration__n4
+msgid "[N4] Esenti"
+msgstr ""
+
+#. module: l10n_it_edi
+#: model:ir.model.fields.selection,name:l10n_it_edi.selection__account_tax__l10n_it_kind_exoneration__n5
+msgid "[N5] Regime del margine / IVA non esposta in fattura"
+msgstr ""
+
+#. module: l10n_it_edi
+#: model:ir.model.fields.selection,name:l10n_it_edi.selection__account_tax__l10n_it_kind_exoneration__n6_1
+msgid ""
+"[N6.1] Inversione contabile – cessione di rottami e altri materiali di "
+"recupero"
+msgstr ""
+
+#. module: l10n_it_edi
+#: model:ir.model.fields.selection,name:l10n_it_edi.selection__account_tax__l10n_it_kind_exoneration__n6_2
+msgid "[N6.2] Inversione contabile – cessione di oro e argento puro"
+msgstr ""
+
+#. module: l10n_it_edi
+#: model:ir.model.fields.selection,name:l10n_it_edi.selection__account_tax__l10n_it_kind_exoneration__n6_3
+msgid "[N6.3] Inversione contabile – subappalto nel settore edile"
+msgstr ""
+
+#. module: l10n_it_edi
+#: model:ir.model.fields.selection,name:l10n_it_edi.selection__account_tax__l10n_it_kind_exoneration__n6_4
+msgid "[N6.4] Inversione contabile – cessione di fabbricati"
+msgstr ""
+
+#. module: l10n_it_edi
+#: model:ir.model.fields.selection,name:l10n_it_edi.selection__account_tax__l10n_it_kind_exoneration__n6_5
+msgid "[N6.5] Inversione contabile – cessione di telefoni cellulari"
+msgstr ""
+
+#. module: l10n_it_edi
+#: model:ir.model.fields.selection,name:l10n_it_edi.selection__account_tax__l10n_it_kind_exoneration__n6_6
+msgid "[N6.6] Inversione contabile – cessione di prodotti elettronici"
+msgstr ""
+
+#. module: l10n_it_edi
+#: model:ir.model.fields.selection,name:l10n_it_edi.selection__account_tax__l10n_it_kind_exoneration__n6_7
+msgid ""
+"[N6.7] Inversione contabile – prestazioni comparto edile esettori connessi"
+msgstr ""
+
+#. module: l10n_it_edi
+#: model:ir.model.fields.selection,name:l10n_it_edi.selection__account_tax__l10n_it_kind_exoneration__n6_8
+msgid "[N6.8] Inversione contabile – operazioni settore energetico"
+msgstr ""
+
+#. module: l10n_it_edi
+#: model:ir.model.fields.selection,name:l10n_it_edi.selection__account_tax__l10n_it_kind_exoneration__n6_9
+msgid "[N6.9] Inversione contabile – altri casi"
+msgstr ""
+
+#. module: l10n_it_edi
+#: model:ir.model.fields.selection,name:l10n_it_edi.selection__account_tax__l10n_it_kind_exoneration__n6
+msgid ""
+"[N6] Inversione contabile (per le operazioni in reverse charge ovvero nei "
+"casi di autofatturazione per acquisti extra UE di servizi ovvero per "
+"importazioni di beni nei soli casi previsti)"
+msgstr ""
+
+#. module: l10n_it_edi
+#: model:ir.model.fields.selection,name:l10n_it_edi.selection__account_tax__l10n_it_kind_exoneration__n7
+msgid ""
+"[N7] IVA assolta in altro stato UE (vendite a distanza ex art. 40 c. 3 e 4 e"
+" art. 41 c. 1 lett. b,  DL 331/93; prestazione di servizi di "
+"telecomunicazioni, tele-radiodiffusione ed elettronici ex art. 7-sexies "
+"lett. f, g, art. 74-sexies DPR 633/72)"
+msgstr ""
+
+#. module: l10n_it_edi
+#: model:ir.model.fields.selection,name:l10n_it_edi.selection__res_company__l10n_it_tax_system__rf01
+msgid "[RF01] Ordinario"
+msgstr ""
+
+#. module: l10n_it_edi
+#: model:ir.model.fields.selection,name:l10n_it_edi.selection__res_company__l10n_it_tax_system__rf02
+msgid "[RF02] Contribuenti minimi (art.1, c.96-117, L. 244/07)"
+msgstr ""
+
+#. module: l10n_it_edi
+#: model:ir.model.fields.selection,name:l10n_it_edi.selection__res_company__l10n_it_tax_system__rf04
+msgid ""
+"[RF04] Agricoltura e attività connesse e pesca (artt.34 e 34-bis, DPR "
+"633/72)"
+msgstr ""
+
+#. module: l10n_it_edi
+#: model:ir.model.fields.selection,name:l10n_it_edi.selection__res_company__l10n_it_tax_system__rf05
+msgid "[RF05] Vendita sali e tabacchi (art.74, c.1, DPR. 633/72)"
+msgstr ""
+
+#. module: l10n_it_edi
+#: model:ir.model.fields.selection,name:l10n_it_edi.selection__res_company__l10n_it_tax_system__rf06
+msgid "[RF06] Commercio fiammiferi (art.74, c.1, DPR  633/72)"
+msgstr ""
+
+#. module: l10n_it_edi
+#: model:ir.model.fields.selection,name:l10n_it_edi.selection__res_company__l10n_it_tax_system__rf07
+msgid "[RF07] Editoria (art.74, c.1, DPR  633/72)"
+msgstr ""
+
+#. module: l10n_it_edi
+#: model:ir.model.fields.selection,name:l10n_it_edi.selection__res_company__l10n_it_tax_system__rf08
+msgid "[RF08] Gestione servizi telefonia pubblica (art.74, c.1, DPR 633/72)"
+msgstr ""
+
+#. module: l10n_it_edi
+#: model:ir.model.fields.selection,name:l10n_it_edi.selection__res_company__l10n_it_tax_system__rf09
+msgid ""
+"[RF09] Rivendita documenti di trasporto pubblico e di sosta (art.74, c.1, "
+"DPR  633/72)"
+msgstr ""
+
+#. module: l10n_it_edi
+#: model:ir.model.fields.selection,name:l10n_it_edi.selection__res_company__l10n_it_tax_system__rf10
+msgid ""
+"[RF10] Intrattenimenti, giochi e altre attività di cui alla tariffa allegata"
+" al DPR 640/72 (art.74, c.6, DPR 633/72)"
+msgstr ""
+
+#. module: l10n_it_edi
+#: model:ir.model.fields.selection,name:l10n_it_edi.selection__res_company__l10n_it_tax_system__rf11
+msgid "[RF11] Agenzie viaggi e turismo (art.74-ter, DPR 633/72)"
+msgstr ""
+
+#. module: l10n_it_edi
+#: model:ir.model.fields.selection,name:l10n_it_edi.selection__res_company__l10n_it_tax_system__rf12
+msgid "[RF12] Agriturismo (art.5, c.2, L. 413/91)"
+msgstr ""
+
+#. module: l10n_it_edi
+#: model:ir.model.fields.selection,name:l10n_it_edi.selection__res_company__l10n_it_tax_system__rf13
+msgid "[RF13] Vendite a domicilio (art.25-bis, c.6, DPR  600/73)"
+msgstr ""
+
+#. module: l10n_it_edi
+#: model:ir.model.fields.selection,name:l10n_it_edi.selection__res_company__l10n_it_tax_system__rf14
+msgid ""
+"[RF14] Rivendita beni usati, oggetti d’arte, d’antiquariato o da collezione "
+"(art.36, DL 41/95)"
+msgstr ""
+
+#. module: l10n_it_edi
+#: model:ir.model.fields.selection,name:l10n_it_edi.selection__res_company__l10n_it_tax_system__rf15
+msgid ""
+"[RF15] Agenzie di vendite all’asta di oggetti d’arte, antiquariato o da "
+"collezione (art.40-bis, DL 41/95)"
+msgstr ""
+
+#. module: l10n_it_edi
+#: model:ir.model.fields.selection,name:l10n_it_edi.selection__res_company__l10n_it_tax_system__rf16
+msgid "[RF16] IVA per cassa P.A. (art.6, c.5, DPR 633/72)"
+msgstr ""
+
+#. module: l10n_it_edi
+#: model:ir.model.fields.selection,name:l10n_it_edi.selection__res_company__l10n_it_tax_system__rf17
+msgid "[RF17] IVA per cassa (art. 32-bis, DL 83/2012)"
+msgstr ""
+
+#. module: l10n_it_edi
+#: model:ir.model.fields.selection,name:l10n_it_edi.selection__res_company__l10n_it_tax_system__rf18
+msgid "[RF18] Altro"
+msgstr ""
+
+#. module: l10n_it_edi
+#: model:ir.model.fields.selection,name:l10n_it_edi.selection__res_company__l10n_it_tax_system__rf19
+msgid "[RF19] Regime forfettario (art.1, c.54-89, L. 190/2014)"
+msgstr ""
+
+#. module: l10n_it_edi
+#: model:ir.model.fields.selection,name:l10n_it_edi.selection__account_tax__l10n_it_vat_due_date__s
+msgid "[S] Scissione dei pagamenti"
+msgstr ""
+
+#. module: l10n_it_edi
+#: code:addons/l10n_it_edi/models/account_edi_format.py:0
+#, python-format
+msgid "from XML file:"
+msgstr ""

--- a/addons/l10n_it_edi/models/account_invoice.py
+++ b/addons/l10n_it_edi/models/account_invoice.py
@@ -37,7 +37,7 @@ class AccountMove(models.Model):
         ('delivered_expired', 'This invoice is delivered and expired (expiry of the maximum term for communication of acceptance/refusal)'),
         ('failed_delivery', 'Delivery impossible, ES certify that it has received the invoice and that the file \
                         could not be delivered to the addressee') # ok we must do nothing
-    ], default='to_send', copy=False)
+    ], default='to_send', copy=False, string="FatturaPA Send State")
 
     l10n_it_stamp_duty = fields.Float(default=0, string="Dati Bollo", readonly=True, states={'draft': [('readonly', False)]})
 

--- a/addons/l10n_it_edi_sdicoop/i18n_extra/it.po
+++ b/addons/l10n_it_edi_sdicoop/i18n_extra/it.po
@@ -10,6 +10,7 @@ msgstr ""
 "PO-Revision-Date: 2022-03-30 10:14+0000\n"
 "Last-Translator: \n"
 "Language-Team: \n"
+"Language: it\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: \n"
@@ -21,81 +22,81 @@ msgid ""
 "<span class=\"o_form_label\">\n"
 "                                        Fattura Elettronica mode\n"
 "                                    </span>"
-msgstr ""
+msgstr "<span class=\"o_form_label\">Modalitá Fattura Elettronica</span>"
 
 #. module: l10n_it_edi_sdicoop
 #: model_terms:ir.ui.view,arch_db:l10n_it_edi_sdicoop.res_config_settings_view_form
 msgid "<span class=\"o_form_label\">Allow Odoo to process invoices</span>"
-msgstr ""
+msgstr "<span class=\"o_form_label\">Permetti ad Odoo di inviare le fatture</span>"
 
 #. module: l10n_it_edi_sdicoop
 #: model_terms:ir.ui.view,arch_db:l10n_it_edi_sdicoop.res_config_settings_view_form
 msgid "A Demo service is in use."
-msgstr ""
+msgstr "Un servizio Demo è in uso"
 
 #. module: l10n_it_edi_sdicoop
 #: model_terms:ir.ui.view,arch_db:l10n_it_edi_sdicoop.res_config_settings_view_form
 msgid "An Official or Test service has been registered."
-msgstr ""
+msgstr "É giá stato registrato un servizio Ufficiale o di Test."
 
 #. module: l10n_it_edi_sdicoop
 #: code:addons/l10n_it_edi_sdicoop/models/account_edi_format.py:0
 #, python-format
 msgid "Attached file is empty"
-msgstr ""
+msgstr "Il file allegato è vuoto"
 
 #. module: l10n_it_edi_sdicoop
 #: model_terms:ir.ui.view,arch_db:l10n_it_edi_sdicoop.res_config_settings_view_form
 msgid "By checking this box, I accept that Odoo may process my invoices."
-msgstr ""
+msgstr "Selezionando questa casella, accetto che Odoo invii le mie fatture."
 
 #. module: l10n_it_edi_sdicoop
 #: model:ir.model,name:l10n_it_edi_sdicoop.model_res_config_settings
 msgid "Config Settings"
-msgstr ""
+msgstr "Impostazione configurazioni"
 
 #. module: l10n_it_edi_sdicoop
 #: model:ir.model.fields.selection,name:l10n_it_edi_sdicoop.selection__res_config_settings__l10n_it_edi_sdicoop_demo_mode__demo
 msgid "Demo"
-msgstr ""
+msgstr "Demo"
 
 #. module: l10n_it_edi_sdicoop
 #: model:ir.model.fields,field_description:l10n_it_edi_sdicoop.field_account_edi_format__display_name
 #: model:ir.model.fields,field_description:l10n_it_edi_sdicoop.field_account_move__display_name
 #: model:ir.model.fields,field_description:l10n_it_edi_sdicoop.field_res_config_settings__display_name
 msgid "Display Name"
-msgstr ""
+msgstr "Nome visualizzato"
 
 #. module: l10n_it_edi_sdicoop
 #: model:ir.model,name:l10n_it_edi_sdicoop.model_account_edi_format
 msgid "EDI format"
-msgstr ""
+msgstr "Formato EDI"
 
 #. module: l10n_it_edi_sdicoop
 #: model_terms:ir.ui.view,arch_db:l10n_it_edi_sdicoop.res_config_settings_view_form
 msgid "Electronic Document Invoicing"
-msgstr ""
+msgstr "Interscambio di dati in formato elettronico"
 
 #. module: l10n_it_edi_sdicoop
 #: model:ir.model.fields,field_description:l10n_it_edi_sdicoop.field_account_bank_statement_line__l10n_it_edi_attachment_id
 #: model:ir.model.fields,field_description:l10n_it_edi_sdicoop.field_account_move__l10n_it_edi_attachment_id
 #: model:ir.model.fields,field_description:l10n_it_edi_sdicoop.field_account_payment__l10n_it_edi_attachment_id
 msgid "FatturaPA Attachment"
-msgstr ""
+msgstr "Allegato FatturaPA"
 
 #. module: l10n_it_edi_sdicoop
 #: model:ir.model.fields,field_description:l10n_it_edi_sdicoop.field_account_bank_statement_line__l10n_it_edi_transaction
 #: model:ir.model.fields,field_description:l10n_it_edi_sdicoop.field_account_move__l10n_it_edi_transaction
 #: model:ir.model.fields,field_description:l10n_it_edi_sdicoop.field_account_payment__l10n_it_edi_transaction
 msgid "FatturaPA Transaction"
-msgstr ""
+msgstr "Transazione FatturaPA"
 
 #. module: l10n_it_edi_sdicoop
 #: model:ir.actions.server,name:l10n_it_edi_sdicoop.ir_cron_receive_fattura_pa_invoice_ir_actions_server
 #: model:ir.cron,cron_name:l10n_it_edi_sdicoop.ir_cron_receive_fattura_pa_invoice
 #: model:ir.cron,name:l10n_it_edi_sdicoop.ir_cron_receive_fattura_pa_invoice
 msgid "FatturaPA: Receive invoices from the exchange system"
-msgstr ""
+msgstr "FatturaPA: Ricezione fatture dal Sistema d'Interscambio"
 
 #. module: l10n_it_edi_sdicoop
 #: model:ir.model.fields,field_description:l10n_it_edi_sdicoop.field_account_edi_format__id
@@ -111,7 +112,12 @@ msgid ""
 "                                        In test mode (experimental) Odoo will send the invoices to a non-production service.\n"
 "                                        Saving this change will direct all companies on this database to this use this configuration.\n"
 "                                        Once registered for testing or official, the mode cannot be changed."
-msgstr ""
+msgstr "Nella modalitá Demo, Odoo simulerá l'invio delle fatture "
+"all'Agenzia.<br/> Nella modalitá di Test (sperimentale) Odoo manderá le fatture "
+"a un servizio non di produzione. Salvando quest'impostazione fará sì che "
+"tutte le Aziende di questo Database usino questa configurazione. "
+"Una volta registrato per la modalitá Test o Ufficiale, la modalitá non può "
+"più essere cambiata."
 
 #. module: l10n_it_edi_sdicoop
 #: code:addons/l10n_it_edi_sdicoop/models/account_edi_format.py:0
@@ -119,18 +125,19 @@ msgstr ""
 msgid ""
 "Invoices for PA are not managed by Odoo, you can download the document and "
 "send it on your own."
-msgstr ""
+msgstr "Le Fatture per la Pubblica Amministrazione non sono gestite da Odoo. "
+"É possibile scaricare il documento e inviarlo tramite il sito dell'Agenzia delle Entrate."
 
 #. module: l10n_it_edi_sdicoop
 #: model:ir.model.fields,field_description:l10n_it_edi_sdicoop.field_res_config_settings__is_edi_proxy_active
 msgid "Is Edi Proxy Active"
-msgstr ""
+msgstr "É attivo il Proxy EDI"
 
 #. module: l10n_it_edi_sdicoop
 #: code:addons/l10n_it_edi_sdicoop/models/account_edi_format.py:0
 #, python-format
 msgid "Italian invoice: %s"
-msgstr ""
+msgstr "Fattura italiana: %s"
 
 #. module: l10n_it_edi_sdicoop
 #: model:ir.model,name:l10n_it_edi_sdicoop.model_account_move
@@ -140,29 +147,29 @@ msgstr ""
 #. module: l10n_it_edi_sdicoop
 #: model:ir.model.fields,field_description:l10n_it_edi_sdicoop.field_res_config_settings__l10n_it_edi_proxy_current_state
 msgid "L10N It Edi Proxy Current State"
-msgstr ""
+msgstr "Stato corrente del Proxy L10n It EDI"
 
 #. module: l10n_it_edi_sdicoop
 #: model:ir.model.fields,field_description:l10n_it_edi_sdicoop.field_res_config_settings__l10n_it_edi_sdicoop_demo_mode
 msgid "L10N It Edi Sdicoop Demo Mode"
-msgstr ""
+msgstr "Modalitá demo L10n It EDI Sdicoop"
 
 #. module: l10n_it_edi_sdicoop
 #: model:ir.model.fields,field_description:l10n_it_edi_sdicoop.field_res_config_settings__l10n_it_edi_sdicoop_register
 msgid "L10N It Edi Sdicoop Register"
-msgstr ""
+msgstr "Registra L10n It EDI Sdicoop"
 
 #. module: l10n_it_edi_sdicoop
 #: model:ir.model.fields,field_description:l10n_it_edi_sdicoop.field_account_edi_format____last_update
 #: model:ir.model.fields,field_description:l10n_it_edi_sdicoop.field_account_move____last_update
 #: model:ir.model.fields,field_description:l10n_it_edi_sdicoop.field_res_config_settings____last_update
 msgid "Last Modified on"
-msgstr ""
+msgstr "Data Modifica"
 
 #. module: l10n_it_edi_sdicoop
 #: model:ir.model.fields.selection,name:l10n_it_edi_sdicoop.selection__res_config_settings__l10n_it_edi_sdicoop_demo_mode__prod
 msgid "Official"
-msgstr ""
+msgstr "Ufficiale"
 
 #. module: l10n_it_edi_sdicoop
 #: code:addons/l10n_it_edi_sdicoop/models/account_edi_format.py:0
@@ -170,18 +177,18 @@ msgstr ""
 msgid ""
 "Please fill your codice fiscale to be able to receive invoices from "
 "FatturaPA"
-msgstr ""
+msgstr "Per favore, inserire il Codice Fiscale per poter ricevere le fatture da FatturaPA"
 
 #. module: l10n_it_edi_sdicoop
 #: code:addons/l10n_it_edi_sdicoop/models/account_edi_format.py:0
 #, python-format
 msgid "Service momentarily unavailable"
-msgstr ""
+msgstr "Servizio momentaneamente non disponibile"
 
 #. module: l10n_it_edi_sdicoop
 #: model:ir.model.fields.selection,name:l10n_it_edi_sdicoop.selection__res_config_settings__l10n_it_edi_sdicoop_demo_mode__test
 msgid "Test (experimental)"
-msgstr ""
+msgstr "Test (sperimentale)"
 
 #. module: l10n_it_edi_sdicoop
 #: code:addons/l10n_it_edi_sdicoop/models/res_config_settings.py:0
@@ -189,7 +196,7 @@ msgstr ""
 msgid ""
 "The company has already registered with the service as 'Test' or 'Official',"
 " it cannot change."
-msgstr ""
+msgstr "L'Azienda è giá registrata al servizio con la modalitá Test o Officiale, non può essere cambiata."
 
 #. module: l10n_it_edi_sdicoop
 #: code:addons/l10n_it_edi_sdicoop/models/account_edi_format.py:0
@@ -200,7 +207,11 @@ msgid ""
 " through another channel, outside of the Exchange System, and promptly "
 "notify him that the original is deposited in his personal area on the portal"
 " \"Invoices and Fees\" of the Revenue Agency."
-msgstr ""
+msgstr "La fattura è stata inviata, ma la consegna al Destinatario è fallita. "
+"É necessario mandare una copia di cortesia della fattura al cliente "
+"tramite un altro canale al di fuori dell'SdI, e notificarlo che l'originale "
+"è depositato nella sua Area Personale all' interno del portale 'Fatture e Corrispettivi' "
+"sul sito dell'Agenzia delle Entrate"
 
 #. module: l10n_it_edi_sdicoop
 #: code:addons/l10n_it_edi_sdicoop/models/account_edi_format.py:0
@@ -214,13 +225,19 @@ msgid ""
 "notify Odoo of the failed delivery, and you will be required to send the "
 "invoice to the Administration through another channel, outside of the "
 "Exchange System."
-msgstr ""
+msgstr "La fattura è stata inviata, ma la consegna alla Pubblica Amministrazione "
+"è fallita. Il Sistema d'Interscambio contatterá il Destinatario per far rapporto "
+"sul problema, e richiederá che venga approntata una soluzione. Durante i "
+"10 giorni successivi, il Sistema d'Interscambio proverá a inoltrare il file "
+"FatturaPA in questione ancora. Dovesse fallire anche questo tentativo, il "
+"sistema notificherá Odoo della mancata consegna, e sará necessario inviare "
+"la fattura tramite un altro canale, al di fuori dell'SdI"
 
 #. module: l10n_it_edi_sdicoop
 #: code:addons/l10n_it_edi_sdicoop/models/account_edi_format.py:0
 #, python-format
 msgid "The invoice has been refused by the Exchange System"
-msgstr ""
+msgstr "La fattura è stata rifiutata dal Sistema d'Interscambio"
 
 #. module: l10n_it_edi_sdicoop
 #: code:addons/l10n_it_edi_sdicoop/models/account_edi_format.py:0
@@ -228,13 +245,13 @@ msgstr ""
 msgid ""
 "The invoice has been succesfully transmitted. The addressee has 15 days to "
 "accept or reject it."
-msgstr ""
+msgstr "La fattura è stata trasmessa con successo. Il Destinatario ha 15 giorni per accettarla o rifiutarla."
 
 #. module: l10n_it_edi_sdicoop
 #: code:addons/l10n_it_edi_sdicoop/models/account_edi_format.py:0
 #, python-format
 msgid "The invoice was refused by the addressee."
-msgstr ""
+msgstr "La fattura è stata rifiutata dal Destinatario."
 
 #. module: l10n_it_edi_sdicoop
 #: code:addons/l10n_it_edi_sdicoop/models/account_edi_format.py:0
@@ -242,7 +259,8 @@ msgstr ""
 msgid ""
 "The invoice was successfully transmitted to the Public Administration and we"
 " are waiting for confirmation"
-msgstr ""
+msgstr "La fattura è stata trasmessa con successo alla Pubblica Amministrazione "
+"e siamo in attesa di conferma."
 
 #. module: l10n_it_edi_sdicoop
 #: code:addons/l10n_it_edi_sdicoop/models/account_edi_format.py:0
@@ -250,7 +268,8 @@ msgstr ""
 msgid ""
 "The invoice was successfully transmitted to the Public Administration and we"
 " are waiting for confirmation."
-msgstr ""
+msgstr "La fattura è stata inviata con successo alla Pubblica Amministrazione "
+"e siamo in attesa di conferma."
 
 #. module: l10n_it_edi_sdicoop
 #: code:addons/l10n_it_edi_sdicoop/models/account_edi_format.py:0
@@ -258,19 +277,22 @@ msgstr ""
 msgid ""
 "This invoice number had already been submitted to the SdI, so it is set as Sent. Please verify that the system is correctly configured, because the correct flow does not need to send the same invoice twice for any reason.\n"
 " Original message from the SDI: %s"
-msgstr ""
+msgstr "Una fattura con questo numero è giá stata inviata all'SdI, quindi viene impostata come inviata. "
+"Per favore, verificare che il sistema sia configurato correttamente, perchè in nessun caso il sistema "
+"ha motivo di inviare la stessa fattura più volte.\n"
+"Messaggio originale dall'SdI: %s"
 
 #. module: l10n_it_edi_sdicoop
 #: code:addons/l10n_it_edi_sdicoop/models/account_edi_format.py:0
 #, python-format
 msgid "Unauthorized user"
-msgstr ""
+msgstr "Utente non autorizzato"
 
 #. module: l10n_it_edi_sdicoop
 #: code:addons/l10n_it_edi_sdicoop/models/account_edi_format.py:0
 #, python-format
 msgid "You are not allowed to check the status of this invoice."
-msgstr ""
+msgstr "Non sei autorizzato a controllare lo stato di questa fattura."
 
 #. module: l10n_it_edi_sdicoop
 #: code:addons/l10n_it_edi_sdicoop/models/account_edi_format.py:0
@@ -279,4 +301,5 @@ msgstr ""
 #, python-format
 msgid ""
 "You must accept the terms and conditions in the settings to use FatturaPA."
-msgstr ""
+msgstr "Devi accettare i Termini e le Condizioni d'uso nelle impostazioni "
+"per poter utilizzare FatturaPA."

--- a/addons/l10n_it_edi_sdicoop/models/account_invoice.py
+++ b/addons/l10n_it_edi_sdicoop/models/account_invoice.py
@@ -13,8 +13,8 @@ DEFAULT_FACTUR_ITALIAN_DATE_FORMAT = '%Y-%m-%d'
 class AccountMove(models.Model):
     _inherit = 'account.move'
 
-    l10n_it_edi_transaction = fields.Char(copy=False)
-    l10n_it_edi_attachment_id = fields.Many2one('ir.attachment', copy=False)
+    l10n_it_edi_transaction = fields.Char(copy=False, string="FatturaPA Transaction")
+    l10n_it_edi_attachment_id = fields.Many2one('ir.attachment', copy=False, string="FatturaPA Attachment")
 
     def send_pec_mail(self):
         self.ensure_one()


### PR DESCRIPTION
Italian translation added.

Add string parameter to the fields so that the filter names are more
usable. Since the filter names are taken automatically from the field
names, the string paramter allows us to change the filter names:
L10N It Edi Transaction -> FatturaPA Transaction
L10N It Edi Attachment  -> FatturaPA Attachment
L10N It Send State      -> FatturaPA Send State

task-id: 2795241