### PR TITLE
[FIX] website: not split fuzzy matching candidates on hyphen

### DIFF
--- a/addons/website/models/website.py
+++ b/addons/website/models/website.py
@@ -1637,7 +1637,7 @@ class Website(models.Model):
         :param limit: maximum number of records fetched per model to build the word list
         :return: yields words
         """
-        match_pattern = '\\w{%s,}' % min(4, len(search) - 3)
+        match_pattern = r'[\w-]{%s,}' % min(4, len(search) - 3)
         similarity_threshold = 0.3
         for search_detail in search_details:
             model_name, fields = search_detail['model'], search_detail['search_fields']
@@ -1753,7 +1753,7 @@ class Website(models.Model):
         :param limit: maximum number of records fetched per model to build the word list
         :return: yields words
         """
-        match_pattern = '\\w{%s,}' % min(4, len(search) - 3)
+        match_pattern = r'[\w-]{%s,}' % min(4, len(search) - 3)
         first = escape_psql(search[0])
         for search_detail in search_details:
             model_name, fields = search_detail['model'], search_detail['search_fields']

--- a/addons/website/tests/test_fuzzy.py
+++ b/addons/website/tests/test_fuzzy.py
@@ -125,7 +125,7 @@ class TestAutoComplete(TransactionCase):
             "Many results contain this page",
             "How many times does the word many appear",
             "Will there be many results",
-            "Welcome to our many friends",
+            "Welcome to our many friends next week-end",
             "This should only be approximately matched",
         ]
         for text in texts:
@@ -245,3 +245,12 @@ class TestAutoComplete(TransactionCase):
         suggestions = self._autocomplete("iphone7")
         self.assertEqual(1, suggestions['results_count'], "Test data contains one fuzzy match")
         self.assertTrue(suggestions['fuzzy_search'], "Expects an fuzzy match")
+
+    def test_09_hyphen(self):
+        """ Ensures that hyphen is considered part of word """
+        suggestions = self._autocomplete("weekend")
+        self.assertEqual(1, suggestions['results_count'], "Text data contains one page with 'weekend'")
+        self.assertEqual('week-end', suggestions['fuzzy_search'], "Expects a fuzzy match")
+        suggestions = self._autocomplete("week-end")
+        self.assertEqual(1, len(suggestions['results']), "All results must be present")
+        self.assertFalse(suggestions['fuzzy_search'], "Expects an exact match")


### PR DESCRIPTION
Since [1] when the fuzzy search was introduced, the candidate words used
for the fuzzy matching were split on non-'\w' (all non alphanumeric
characters + underscore).

This commit adds '-' (hyphen) to the list of characters that should be
considered part of the same word.

Steps to reproduce:
- Specify a product with name 'micro-vis'
- search for 'micro-vis' or 'microvis'
=> Was not returning any match
=> Now returns fuzzy match even for 'micro-vs'

opw-2801704

[1]: https://github.com/odoo/odoo/commit/c6ba756e4b4704089d02434871788a82d90cb195

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
