### PR TITLE
[FIX] sale: sale report properly populate with group by

### DIFF
--- a/addons/sale/report/sale_report_views.xml
+++ b/addons/sale/report/sale_report_views.xml
@@ -91,4 +91,14 @@
         <field name="context">{'search_default_Sales':1, 'group_by_no_leaf':1,'group_by':[]}</field>
         <field name="help">This report performs analysis on your quotations and sales orders. Analysis check your sales revenues and sort it by different group criteria (salesman, partner, product, etc.) Use this report to perform analysis on sales not having invoiced yet. If you want to analyse your turnover, you should use the Invoice Analysis report in the Accounting application.</field>
     </record>
+
+    <record id="action_order_report_all" model="ir.actions.act_window">
+        <field name="name">Sales Analysis</field>
+        <field name="res_model">sale.report</field>
+        <field name="view_mode">list</field>
+        <field name="view_id"></field>  <!-- force empty -->
+        <field name="search_view_id" ref="view_order_product_search"/>
+        <field name="context">{'search_default_Sales':1,'group_by':[]}</field>
+        <field name="help">This report performs analysis on your quotations and sales orders. Analysis check your sales revenues and sort it by different group criteria (salesman, partner, product, etc.) Use this report to perform analysis on sales not having invoiced yet. If you want to analyse your turnover, you should use the Invoice Analysis report in the Accounting application.</field>
+    </record>
 </odoo>


### PR DESCRIPTION
Step to reproduce:
- Go to Sale reporting pivot view
- Click on a number -> lead to sale.report list view
- Group by any category

Current behaviour:
- Leaf are not properly populated
- The context key 'group_by_no_leaf' is set and prevent correct
 population

Behaviour after PR:
- Leaf are correctly populated

opw-2793097


--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
