### PR TITLE
[MERGE][IMP] event_booth[_sale]: improves UX

### DIFF
--- a/addons/event_booth/__manifest__.py
+++ b/addons/event_booth/__manifest__.py
@@ -4,7 +4,7 @@
 {
     'name': "Events Booths",
     'category': 'Marketing/Events',
-    'version': '1.0',
+    'version': '1.1',
     'summary': "Manage event booths",
     'description': """
 Create booths for your favorite event.

--- a/addons/event_booth/views/event_booth_views.xml
+++ b/addons/event_booth/views/event_booth_views.xml
@@ -166,19 +166,41 @@
                 <filter string="Unavailable" name="filter_booth_unavailable"
                     domain="[('state', '=', 'unavailable')]"/>
                 <group expand="0" string="Group By">
-                    <filter string="Booth Type" name="group_by_booth_category_id" context="{'group_by': 'booth_category_id'}"/>
+                    <filter name="group_by_state" context="{'group_by': 'state'}"/>
+                    <filter name="group_by_partner_id" context="{'group_by': 'partner_id'}"/>
+                    <filter name="group_by_booth_category_id" context="{'group_by': 'booth_category_id'}"/>
                     <filter string="Event" name="group_by_event_id" context="{'group_by': 'event_id'}"/>
                 </group>
             </search>
         </field>
     </record>
 
+    <record id="event_booth_view_graph" model="ir.ui.view">
+        <field name="name">event.booth.view.graph</field>
+        <field name="model">event.booth</field>
+        <field name="arch" type="xml">
+            <graph string="Event booth" sample="1" type="pie">
+                <field name="booth_category_id"/>
+            </graph>
+        </field>
+    </record>
+
+    <record id="event_booth_view_pivot" model="ir.ui.view">
+        <field name="name">event.booth.view.pivot</field>
+        <field name="model">event.booth</field>
+        <field name="arch" type="xml">
+            <pivot string="Event booth" sample="1">
+                <field name="booth_category_id" type="row"/>
+            </pivot>
+        </field>
+    </record>
+
     <record id="event_booth_action" model="ir.actions.act_window">
         <field name="name">Booths</field>
         <field name="res_model">event.booth</field>
-        <field name="view_mode">kanban,tree,form</field>
+        <field name="view_mode">kanban,tree,form,graph,pivot</field>
         <field name="domain">[]</field>
-        <field name="context">{}</field>
+        <field name="context">{'search_default_group_by_state': 1}</field>
         <field name="help" type="html">
             <p class="o_view_nocontent_smiling_face">
                 Create a Booth
@@ -191,9 +213,9 @@
     <record id="event_booth_action_from_event" model="ir.actions.act_window">
         <field name="name">Booths</field>
         <field name="res_model">event.booth</field>
-        <field name="view_mode">kanban,tree,form</field>
+        <field name="view_mode">kanban,tree,form,graph,pivot</field>
         <field name="domain">[('event_id', '=', active_id)]</field>
-        <field name="context">{'default_event_id': active_id}</field>
+        <field name="context">{'default_event_id': active_id, 'search_default_group_by_state': 1}</field>
         <field name="help" type="html">
             <p class="o_view_nocontent_smiling_face">
                 Create a Booth

--- a/addons/event_booth/views/event_booth_views.xml
+++ b/addons/event_booth/views/event_booth_views.xml
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <odoo><data>
 
-    <record id="event_booth_view_form_from_event" model="ir.ui.view">
-        <field name="name">event.booth.view.form.from.event</field>
+    <record id="event_booth_view_form" model="ir.ui.view">
+        <field name="name">event.booth.view.form</field>
         <field name="model">event.booth</field>
-        <field name="priority">32</field>
+        <field name="priority">16</field>
         <field name="arch" type="xml">
             <form string="Booths">
                 <header>
@@ -18,6 +18,7 @@
                     </div>
                     <group>
                         <group name="details">
+                            <field name="event_id" invisible="context.get('event_booth_hide_event_field', False)"/>
                             <field name="booth_category_id"/>
                         </group>
                         <group name="renter">
@@ -38,38 +39,14 @@
         </field>
     </record>
 
-    <record id="event_booth_view_form" model="ir.ui.view">
-        <field name="name">event.booth.view.form</field>
+    <record id="event_booth_view_tree" model="ir.ui.view">
+        <field name="name">event.booth.view.tree</field>
         <field name="model">event.booth</field>
-        <field name="inherit_id" ref="event_booth_view_form_from_event"/>
-        <field name="mode">primary</field>
         <field name="priority">16</field>
-        <field name="arch" type="xml">
-            <field name="booth_category_id" position="before">
-                <field name="event_id"/>
-            </field>
-        </field>
-    </record>
-
-    <record id="event_booth_view_form_simple_from_event" model="ir.ui.view">
-        <field name="name">event.booth.view.form.simple.from.event</field>
-        <field name="model">event.booth</field>
-        <field name="inherit_id" ref="event_booth_view_form_from_event"/>
-        <field name="mode">primary</field>
-        <field name="priority">48</field>
-        <field name="arch" type="xml">
-            <xpath expr="//div[@name='button_box']" position="replace"/>
-            <xpath expr="//div[hasclass('oe_chatter')]" position="replace"/>
-        </field>
-    </record>
-
-    <record id="event_booth_view_tree_from_event" model="ir.ui.view">
-        <field name="name">event.booth.view.tree.from.event</field>
-        <field name="model">event.booth</field>
-        <field name="priority">32</field>
         <field name="arch" type="xml">
             <tree string="Booths" sample="1" expand="1">
                 <field name="name" decoration-bf="1"/>
+                <field name="event_id" invisible="context.get('event_booth_hide_event_field', False)"/>
                 <field name="booth_category_id"/>
                 <field name="partner_id"/>
                 <field name="contact_name" optional="hide"/>
@@ -83,23 +60,10 @@
         </field>
     </record>
 
-    <record id="event_booth_view_tree" model="ir.ui.view">
-        <field name="name">event.booth.view.tree</field>
-        <field name="model">event.booth</field>
-        <field name="inherit_id" ref="event_booth_view_tree_from_event"/>
-        <field name="mode">primary</field>
-        <field name="priority">16</field>
-        <field name="arch" type="xml">
-            <field name="name" position="after">
-                <field name="event_id"/>
-            </field>
-        </field>
-    </record>
-
-    <record id="event_booth_view_kanban_from_event" model="ir.ui.view">
+    <record id="event_booth_view_kanban" model="ir.ui.view">
         <field name="name">event.booth.view.kanban</field>
         <field name="model">event.booth</field>
-        <field name="priority">32</field>
+        <field name="priority">16</field>
         <field name="arch" type="xml">
             <kanban default_group_by="state" quick_create_view="event_booth.event_booth_view_form_quick_create" sample="1">
                 <field name="name"/>
@@ -110,6 +74,7 @@
                                 <field name="name"/>
                             </div>
                             <div class="d-flex flex-column">
+                                <field name="event_id" invisible="context.get('event_booth_hide_event_field', False)"/>
                                 <div class="o_kanban_record_bottom">
                                     <div class="oe_kanban_bottom_left">
                                         <field name="booth_category_id"/>
@@ -123,19 +88,6 @@
                     </t>
                 </templates>
             </kanban>
-        </field>
-    </record>
-
-    <record id="event_booth_view_kanban" model="ir.ui.view">
-        <field name="name">event.booth.view.kanban</field>
-        <field name="model">event.booth</field>
-        <field name="inherit_id" ref="event_booth_view_kanban_from_event"/>
-        <field name="mode">primary</field>
-        <field name="priority">16</field>
-        <field name="arch" type="xml">
-            <xpath expr="//div[hasclass('o_kanban_record_bottom')]" position="before">
-                <field name="event_id"/>
-            </xpath>
         </field>
     </record>
 
@@ -215,7 +167,11 @@
         <field name="res_model">event.booth</field>
         <field name="view_mode">kanban,tree,form,graph,pivot</field>
         <field name="domain">[('event_id', '=', active_id)]</field>
-        <field name="context">{'default_event_id': active_id, 'search_default_group_by_state': 1}</field>
+        <field name="context">{
+            'default_event_id': active_id,
+            'search_default_group_by_state': 1,
+            'event_booth_hide_event_field': True
+        }</field>
         <field name="help" type="html">
             <p class="o_view_nocontent_smiling_face">
                 Create a Booth
@@ -227,19 +183,19 @@
     <record id="event_booth_action_from_event_view_kanban" model="ir.actions.act_window.view">
         <field name="sequence">1</field>
         <field name="view_mode">kanban</field>
-        <field name="view_id" ref="event_booth_view_kanban_from_event"/>
+        <field name="view_id" ref="event_booth_view_kanban"/>
         <field name="act_window_id" ref="event_booth_action_from_event"/>
     </record>
     <record id="event_booth_action_from_event_view_tree" model="ir.actions.act_window.view">
         <field name="sequence">2</field>
         <field name="view_mode">tree</field>
-        <field name="view_id" ref="event_booth_view_tree_from_event"/>
+        <field name="view_id" ref="event_booth_view_tree"/>
         <field name="act_window_id" ref="event_booth_action_from_event"/>
     </record>
     <record id="event_booth_action_from_event_view_form" model="ir.actions.act_window.view">
         <field name="sequence">3</field>
         <field name="view_mode">form</field>
-        <field name="view_id" ref="event_booth_view_form_from_event"/>
+        <field name="view_id" ref="event_booth_view_form"/>
         <field name="act_window_id" ref="event_booth_action_from_event"/>
     </record>
 

--- a/addons/event_booth_sale/__manifest__.py
+++ b/addons/event_booth_sale/__manifest__.py
@@ -4,7 +4,7 @@
 {
     'name': "Events Booths Sales",
     'category': 'Marketing/Events',
-    'version': '1.0',
+    'version': '1.1',
     'summary': "Manage event booths sale",
     'description': """
 Sell your event booths and track payments on sale orders.

--- a/addons/event_booth_sale/models/event_type_booth.py
+++ b/addons/event_booth_sale/models/event_type_booth.py
@@ -8,7 +8,7 @@ class EventTypeBooth(models.Model):
     _inherit = 'event.type.booth'
 
     product_id = fields.Many2one(related='booth_category_id.product_id')
-    price = fields.Float(related='booth_category_id.price')
+    price = fields.Float(related='booth_category_id.price', store=True)
     currency_id = fields.Many2one(related='booth_category_id.currency_id')
 
     @api.model

--- a/addons/event_booth_sale/views/event_booth_views.xml
+++ b/addons/event_booth_sale/views/event_booth_views.xml
@@ -40,14 +40,14 @@
         </field>
     </record>
 
-    <record id="event_booth_view_tree" model="ir.ui.view">
-        <field name="name">event.booth.view.tree.inherit.sale</field>
+    <record id="event_booth_view_tree_from_event" model="ir.ui.view">
+        <field name="name">event.booth.view.tree.from.event.inherit.sale</field>
         <field name="model">event.booth</field>
-        <field name="inherit_id" ref="event_booth.event_booth_view_tree"/>
+        <field name="inherit_id" ref="event_booth.event_booth_view_tree_from_event"/>
         <field name="arch" type="xml">
-            <field name="booth_category_id" position="after">
+            <field name="partner_id" position="after">
                 <field name="currency_id" invisible="1"/>
-                <field name="price" widget="monetary" options="{'currency_field': 'currency_id'}"/>
+                <field name="price" widget="monetary" options="{'currency_field': 'currency_id'}" sum="Total"/>
             </field>
         </field>
     </record>
@@ -59,6 +59,31 @@
         <field name="arch" type="xml">
             <xpath expr="//field[@name='name']" position="after">
                 <field name="sale_order_id"/>
+            </xpath>
+            <xpath expr="//search/group/filter[@name='group_by_booth_category_id']" position="after">
+                <filter name="is_paid" context="{'group_by': 'is_paid'}"/>
+            </xpath>
+        </field>
+    </record>
+
+    <record id="event_booth_view_graph" model="ir.ui.view">
+        <field name="name">event.booth.event.booth.view.graph.inherit.sale</field>
+        <field name="model">event.booth</field>
+        <field name="inherit_id" ref="event_booth.event_booth_view_graph"/>
+        <field name="arch" type="xml">
+            <xpath expr="//graph" position="inside">
+                <field name="price" type="measure"/>
+            </xpath>
+        </field>
+    </record>
+
+    <record id="event_booth_view_pivot" model="ir.ui.view">
+        <field name="name">event.booth.event.booth.view.pivot.inherit.sale</field>
+        <field name="model">event.booth</field>
+        <field name="inherit_id" ref="event_booth.event_booth_view_pivot"/>
+        <field name="arch" type="xml">
+            <xpath expr="//pivot" position="inside">
+                <field name="price" type="measure"/>
             </xpath>
         </field>
     </record>

--- a/addons/event_booth_sale/views/event_booth_views.xml
+++ b/addons/event_booth_sale/views/event_booth_views.xml
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <odoo><data>
 
-    <record id="event_booth_view_form_from_event" model="ir.ui.view">
+    <record id="event_booth_view_form" model="ir.ui.view">
         <field name="name">event.booth.view.form.inherit.sale</field>
         <field name="model">event.booth</field>
-        <field name="inherit_id" ref="event_booth.event_booth_view_form_from_event"/>
+        <field name="inherit_id" ref="event_booth.event_booth_view_form"/>
         <field name="priority">10</field>
         <field name="arch" type="xml">
             <div name="button_box" position="inside">
@@ -40,10 +40,10 @@
         </field>
     </record>
 
-    <record id="event_booth_view_tree_from_event" model="ir.ui.view">
-        <field name="name">event.booth.view.tree.from.event.inherit.sale</field>
+    <record id="event_booth_view_tree" model="ir.ui.view">
+        <field name="name">event.booth.view.tree.inherit.sale</field>
         <field name="model">event.booth</field>
-        <field name="inherit_id" ref="event_booth.event_booth_view_tree_from_event"/>
+        <field name="inherit_id" ref="event_booth.event_booth_view_tree"/>
         <field name="arch" type="xml">
             <field name="partner_id" position="after">
                 <field name="currency_id" invisible="1"/>

--- a/addons/test_event_full/tests/test_performance.py
+++ b/addons/test_event_full/tests/test_performance.py
@@ -144,7 +144,7 @@ class TestEventPerformance(EventPerformanceCase):
         has_social = 'social_menu' in self.env['event.event']  # otherwise view may crash in enterprise
 
         # type and website
-        with freeze_time(self.reference_now), self.assertQueryCount(event_user=700):  # tef only: 673 - com runbot: 604 - ent runbot: 700
+        with freeze_time(self.reference_now), self.assertQueryCount(event_user=700):  # tef only: 601 - com runbot: 604 - ent runbot: 700
             self.env.cr._now = self.reference_now  # force create_date to check schedulers
             with Form(self.env['event.event']) as event_form:
                 event_form.name = 'Test Event'

--- a/addons/website_event_booth_exhibitor/__manifest__.py
+++ b/addons/website_event_booth_exhibitor/__manifest__.py
@@ -3,7 +3,7 @@
 {
     'name': 'Booths/Exhibitors Bridge',
     'category': 'Marketing/Events',
-    'version': '1.0',
+    'version': '1.1',
     'summary': 'Event Booths, automatically create a sponsor.',
     'description': """
 Automatically create a sponsor when renting a booth.

--- a/addons/website_event_booth_exhibitor/views/event_booth_views.xml
+++ b/addons/website_event_booth_exhibitor/views/event_booth_views.xml
@@ -16,15 +16,4 @@
         </field>
     </record>
 
-    <record id="event_booth_view_search" model="ir.ui.view">
-        <field name="name">event.booth.view.search.inherit.website.event.booth.exhibitor</field>
-        <field name="model">event.booth</field>
-        <field name="inherit_id" ref="event_booth.event_booth_view_search"/>
-        <field name="arch" type="xml">
-            <xpath expr="//filter[@name='group_by_booth_category_id']" position="after">
-                <filter string="Sponsor" name="group_by_sponsor_id" context="{'group_by': 'sponsor_id'}"/>
-            </xpath>
-        </field>
-    </record>
-
 </data></odoo>

--- a/addons/website_event_booth_exhibitor/views/event_booth_views.xml
+++ b/addons/website_event_booth_exhibitor/views/event_booth_views.xml
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <odoo><data>
 
-    <record id="event_booth_view_form_from_event" model="ir.ui.view">
+    <record id="event_booth_view_form" model="ir.ui.view">
         <field name="name">event.booth.view.form.inherit.website.event.booth.exhibitor</field>
         <field name="model">event.booth</field>
-        <field name="inherit_id" ref="event_booth.event_booth_view_form_from_event"/>
+        <field name="inherit_id" ref="event_booth.event_booth_view_form"/>
         <field name="priority">5</field>
         <field name="arch" type="xml">
             <div name="button_box" position="inside">


### PR DESCRIPTION
1. Improve the filters & actions in booths to ease overview and reporting by:
- adding and renaming some group by filters
- adding a price column in the list view of booth event
- adding a graph and a pivot table view (category/price)

2. Simplify the views definition

event_booth_view_form_from_event, event_booth_view_tree_from_event,
event_booth_view_kanban_from_event have been removed because the only
difference with the main view was that the event was not displayed. Instead, we
use the main view with a context variable "event_booth_hide_event_field" to
hide the event field.

event_booth_view_form_simple_from_event view has been deleted because it is
not used.

Technical note:
As the from_event was previously defined as the main view (top of inheritance),
it was that view that was modified in other module so we have also removed the
"_from_event" in other modules when there was a reference to the removed views.

Task-2808962

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
