### PR TITLE
[FIX] sale_management: automatically set/update uom if needed

### DIFF
--- a/addons/sale_management/models/sale_order.py
+++ b/addons/sale_management/models/sale_order.py
@@ -250,6 +250,8 @@ class SaleOrderOption(models.Model):
             lang=self.order_id.partner_id.lang,
         )
         self.name = product.get_product_multiline_description_sale()
+        if not self.uom_id or self.uom_id.category_id.id != product.uom_id.category_id.id:
+            self.uom_id = product.uom_id
         self._update_price_and_discount()
 
     def button_add_to_order(self):


### PR DESCRIPTION
**Description of the issue/feature this PR addresses:**
Especially in case you are not using the unit of measurement for an instance you will be trapped
and it is not possible to save an added optional product in the backend.

**Current behavior before PR:**
It is impossible without seeing the UoM (in case it is not activated) to save an added optional product

**Desired behavior after PR is merged:**
Automatically set the UoM of the product

Info: @wt-io-it



--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
