### PR TITLE
[FIX] base,http_routing: move keep_query method

### DIFF
--- a/addons/http_routing/models/ir_qweb.py
+++ b/addons/http_routing/models/ir_qweb.py
@@ -1,35 +1,9 @@
 # -*- coding: ascii -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
-import fnmatch
-import werkzeug
-
 from odoo import models
 from odoo.http import request
 from odoo.addons.http_routing.models.ir_http import slug, unslug_url, url_for
-
-
-def keep_query(*keep_params, **additional_params):
-    """
-    Generate a query string keeping the current request querystring's parameters specified
-    in ``keep_params`` and also adds the parameters specified in ``additional_params``.
-
-    Multiple values query string params will be merged into a single one with comma seperated
-    values.
-
-    The ``keep_params`` arguments can use wildcards too, eg:
-
-        keep_query('search', 'shop_*', page=4)
-    """
-    if not keep_params and not additional_params:
-        keep_params = ('*',)
-    params = additional_params.copy()
-    qs_keys = list(request.httprequest.args) if request else []
-    for keep_param in keep_params:
-        for param in fnmatch.filter(qs_keys, keep_param):
-            if param not in additional_params and param in qs_keys:
-                params[param] = request.httprequest.args.getlist(param)
-    return werkzeug.urls.url_encode(params)
 
 
 class IrQweb(models.AbstractModel):
@@ -39,7 +13,6 @@ class IrQweb(models.AbstractModel):
         irQweb = super()._prepare_environment(values)
         values['slug'] = slug
         values['unslug_url'] = unslug_url
-        values['keep_query'] = keep_query
 
         if (not irQweb.env.context.get('minimal_qcontext') and
                 request and request.is_frontend):

--- a/addons/survey/controllers/main.py
+++ b/addons/survey/controllers/main.py
@@ -9,7 +9,7 @@ from datetime import datetime, timedelta
 from dateutil.relativedelta import relativedelta
 
 from odoo import fields, http, SUPERUSER_ID, _
-from odoo.addons.http_routing.models.ir_qweb import keep_query
+from odoo.addons.base.models.ir_qweb import keep_query
 from odoo.exceptions import UserError
 from odoo.http import request, content_disposition
 from odoo.osv import expression

--- a/odoo/addons/base/models/ir_qweb.py
+++ b/odoo/addons/base/models/ir_qweb.py
@@ -367,6 +367,7 @@ structure.
 
 """
 
+import fnmatch
 import logging
 import re
 import traceback
@@ -442,6 +443,26 @@ SPECIAL_DIRECTIVES = {'t-translation', 't-ignore', 't-title'}
 # Name of the variable to insert the content in t-call in the template.
 # The slot will be replaced by the `t-call` tag content of the caller.
 T_CALL_SLOT = '0'
+
+
+def keep_query(*keep_params, **additional_params):
+    """
+    Generate a query string keeping the current request querystring's parameters specified
+    in ``keep_params`` and also adds the parameters specified in ``additional_params``.
+    Multiple values query string params will be merged into a single one with comma seperated
+    values.
+    The ``keep_params`` arguments can use wildcards too, eg:
+        keep_query('search', 'shop_*', page=4)
+    """
+    if not keep_params and not additional_params:
+        keep_params = ('*',)
+    params = additional_params.copy()
+    qs_keys = list(request.httprequest.args) if request else []
+    for keep_param in keep_params:
+        for param in fnmatch.filter(qs_keys, keep_param):
+            if param not in additional_params and param in qs_keys:
+                params[param] = request.httprequest.args.getlist(param)
+    return werkzeug.urls.url_encode(params)
 
 
 def indent_code(code, level):
@@ -793,6 +814,7 @@ class IrQWeb(models.AbstractModel):
             values.setdefault('res_company', self.env.company.sudo())
 
             values.update(
+                keep_query=keep_query,
                 request=request,  # might be unbound if we're not in an httprequest context
                 test_mode_enabled=bool(config['test_enable'] or config['test_file']),
                 json=scriptsafe,


### PR DESCRIPTION
It is used by some modules like auth_signup that do not depend of
http_routing
It was moved from base to http_routing at 880954ebfc110 but it should
have stayed in base

Before this commit it was not possible to access the /web/login page
when only the auth_signup module is installed.
