### PR TITLE
[FIX] web_editor: improve mailing conversion for client compatibility

### DIFF
--- a/addons/mass_mailing/views/assets.xml
+++ b/addons/mass_mailing/views/assets.xml
@@ -60,14 +60,6 @@
                     width: 100% !important;
                 }
             }
-            @media screen and (max-width: 1135px) {
-                td {
-                    max-width: inherit !important;
-                }
-                td > img:only-child {
-                    min-width: 100% !important;
-                }
-            }
         </style>
     </template>
 

--- a/addons/mass_mailing/views/assets.xml
+++ b/addons/mass_mailing/views/assets.xml
@@ -60,6 +60,14 @@
                     width: 100% !important;
                 }
             }
+            @media screen and (max-width: 1135px) {
+                td {
+                    max-width: inherit !important;
+                }
+                td > img:only-child {
+                    min-width: 100% !important;
+                }
+            }
         </style>
     </template>
 

--- a/addons/web_editor/static/src/js/backend/convert_inline.js
+++ b/addons/web_editor/static/src/js/backend/convert_inline.js
@@ -629,6 +629,18 @@ function formatTables($editable) {
             cell.style.verticalAlign = 'bottom';
         }
     }
+    // Tables don't properly inherit alignments from their ancestors in Outlook.
+    for (const table of editable.querySelectorAll('table')) {
+        if (table.style.textAlign === 'inherit') {
+            let ancestor = table;
+            while (ancestor && (!ancestor.style.textAlign || ancestor.style.textAlign === 'inherit')) {
+                ancestor = ancestor.parentElement;
+            }
+            if (ancestor) {
+                table.style.setProperty('text-align', ancestor.style.textAlign);
+            }
+        }
+    }
 }
 /**
  * Parse through the given document's stylesheets, preprocess(*) them and return

--- a/addons/web_editor/static/src/js/backend/convert_inline.js
+++ b/addons/web_editor/static/src/js/backend/convert_inline.js
@@ -472,6 +472,22 @@ function toInline($editable, cssRules, $iframe) {
         };
     };
 
+    // Todo: remove in master
+    const oLayout = editable.querySelector('.o_layout');
+    if (oLayout) {
+        const style = document.createElement('style');
+        style.textContent = `
+            @media screen and (max-width: 1135px) {
+                td {
+                    max-width: inherit !important;
+                }
+                td > img:only-child {
+                    min-width: 100% !important;
+                }
+            }
+        `;
+        editable.prepend(style);
+    }
     attachmentThumbnailToLinkImg($editable);
     fontToImg($editable);
     classToStyle($editable, cssRules);

--- a/addons/web_editor/static/src/js/backend/convert_inline.js
+++ b/addons/web_editor/static/src/js/backend/convert_inline.js
@@ -346,24 +346,16 @@ function classToStyle($editable, cssRules) {
             delete css['font-family'];
         }
 
-        const stylesObject = {};
+        // Do not apply css that would override inline styles (which are prioritary).
+        let style = node.getAttribute('style') || '';
+        // Outlook doesn't support inline !important
+        style = style.replace(/!important/g,'');
         for (const [key, value] of Object.entries(css)) {
-            stylesObject[key] = value;
-        }
-        // Inline styles override more general css.
-        for (const key of node.style) {
-            stylesObject[key] = node.style[key];
-        }
-        // Media list images should not have an inline height.
-        if (node.nodeName === 'IMG' && node.classList.contains('s_media_list_img')) {
-            delete stylesObject['height'];
-        }
-        // Protect aspect ratio when resizing in mobile.
-        if (node.nodeName === 'IMG' && stylesObject['width'] === '100%' && !('object-fit' in stylesObject)) {
-            stylesObject['object-fit'] = 'cover';
-        }
-        const style = [...Object.keys(stylesObject)].map(key => `${key}:${stylesObject[key]};`).join('');
-        if (!style.trim()) {
+            if (!(new RegExp(`(^|;)\\s*${key}`).test(style))) {
+                style = `${key}:${value};${style}`;
+            }
+        };
+        if (_.isEmpty(style)) {
             writes.push(() => { node.removeAttribute('style'); });
         } else {
             writes.push(() => {
@@ -374,6 +366,18 @@ function classToStyle($editable, cssRules) {
             });
         }
 
+        if (node.nodeName === 'IMG') {
+            writes.push(() => {
+                // Media list images should not have an inline height
+                if (node.classList.contains('s_media_list_img')) {
+                    node.style.removeProperty('height');
+                }
+                // Protect aspect ratio when resizing in mobile.
+                if (node.style.getPropertyValue('width') === '100%' && node.style.getPropertyValue('object-fit' === '')) {
+                    node.style.setProperty('object-fit', 'cover');
+                }
+            });
+        }
         // Apple Mail
         if (node.nodeName === 'TD' && !node.childNodes.length) {
             writes.push(() => { node.appendChild(document.createTextNode('&nbsp;')); });

--- a/addons/web_editor/static/src/js/backend/convert_inline.js
+++ b/addons/web_editor/static/src/js/backend/convert_inline.js
@@ -11,6 +11,7 @@ import { isBlock, rgbToHex } from '../../../lib/odoo-editor/src/utils/utils';
 const RE_COL_MATCH = /(^| )col(-[\w\d]+)*( |$)/;
 const RE_COMMAS_OUTSIDE_PARENTHESES = /,(?![^(]*?\))/g;
 const RE_OFFSET_MATCH = /(^| )offset(-[\w\d]+)*( |$)/;
+const RE_PADDING_MATCH = /[ ]*padding[^;]*;/g;
 const RE_PADDING = /([\d.]+)/;
 const RE_WHITESPACE = /[\s\u200b]*/;
 const SELECTORS_IGNORE = /(^\*$|:hover|:before|:after|:active|:link|::|'|\([^(),]+[,(])/;
@@ -371,8 +372,22 @@ function classToStyle($editable, cssRules) {
         }
         // Outlook
         if (node.nodeName === 'A' && node.classList.contains('btn') && !node.classList.contains('btn-link') && !node.children.length) {
-            writes.push(() => { node.prepend(document.createComment('[if mso]><i style="letter-spacing: 25px; mso-font-width: -100%; mso-text-raise: 30pt;">&nbsp;</i><![endif]')); });
-            writes.push(() => { node.append(document.createComment('[if mso]><i style="letter-spacing: 25px; mso-font-width: -100%;">&nbsp;</i><![endif]')); });
+            writes.push(() => {
+                node.before(document.createComment(`[if mso]>
+                    <table align="center" role="presentation" border="0" cellpadding="0" cellspacing="0" style="border-radius: 6px; border-collapse: separate !important;">
+                        <tbody>
+                            <tr>
+                                <td style="${node.style.cssText.replace(RE_PADDING_MATCH, '')}" ${
+                                    node.parentElement.style.textAlign === 'center' ? 'align="center" ' : ''
+                                }bgcolor="${node.style.backgroundColor}">
+                <![endif]`));
+                node.after(document.createComment(`[if mso]>
+                                </td>
+                            </tr>
+                        </tbody>
+                    </table>
+                <![endif]`));
+            });
         } else if (node.nodeName === 'IMG' && node.classList.contains('mx-auto') && node.classList.contains('d-block')) {
             writes.push(() => { _wrap(node, 'p', 'o_outlook_hack', 'text-align:center;margin:0'); });
         }

--- a/addons/web_editor/static/tests/convert_inline_tests.js
+++ b/addons/web_editor/static/tests/convert_inline_tests.js
@@ -1,6 +1,6 @@
 /** @odoo-module **/
 import convertInline from '@web_editor/js/backend/convert_inline';
-import {getGridHtml, getTableHtml, getRegularGridHtml, getRegularTableHtml} from 'web_editor.test_utils';
+import {getGridHtml, getTableHtml, getRegularGridHtml, getRegularTableHtml, removeComments} from 'web_editor.test_utils';
 
 QUnit.module('web_editor', {}, function () {
 QUnit.module('convert_inline', {}, function () {
@@ -13,25 +13,25 @@ QUnit.module('convert_inline', {}, function () {
         // 1x1
         let $editable = $(`<div>${getRegularGridHtml(1, 1)}</div>`);
         convertInline.bootstrapToTable($editable);
-        assert.strictEqual($editable.html(), getRegularTableHtml(1, 1, 12, 100),
+        assert.strictEqual(removeComments($editable.html()), getRegularTableHtml(1, 1, 12, 100),
             "should have converted a 1x1 grid to an equivalent table");
 
         // 1x2
         $editable = $(`<div>${getRegularGridHtml(1, 2)}</div>`);
         convertInline.bootstrapToTable($editable);
-        assert.strictEqual($editable.html(), getRegularTableHtml(1, 2, 6, 50),
+        assert.strictEqual(removeComments($editable.html()), getRegularTableHtml(1, 2, 6, 50),
             "should have converted a 1x2 grid to an equivalent table");
 
         // 1x3
         $editable = $(`<div>${getRegularGridHtml(1, 3)}</div>`);
         convertInline.bootstrapToTable($editable);
-        assert.strictEqual($editable.html(), getRegularTableHtml(1, 3, 4, 33.33),
+        assert.strictEqual(removeComments($editable.html()), getRegularTableHtml(1, 3, 4, 33.33),
             "should have converted a 1x3 grid to an equivalent table");
 
         // 1x12
         $editable = $(`<div>${getRegularGridHtml(1, 12)}</div>`);
         convertInline.bootstrapToTable($editable);
-        assert.strictEqual($editable.html(), getRegularTableHtml(1, 12, 1, 8.33),
+        assert.strictEqual(removeComments($editable.html()), getRegularTableHtml(1, 12, 1, 8.33),
             "should have converted a 1x12 grid to an equivalent table");
     });
     QUnit.test('convert a single-row regular overflowing grid', async function (assert) {
@@ -40,39 +40,39 @@ QUnit.module('convert_inline', {}, function () {
         // 1x13
         let $editable = $(`<div>${getRegularGridHtml(1, 13)}</div>`);
         convertInline.bootstrapToTable($editable);
-        assert.strictEqual($editable.html(),
+        assert.strictEqual(removeComments($editable.html()),
             getRegularTableHtml(1, 12, 1, 8.33).slice(0, -8) +
-                `<tr><td colspan="12" width="100%" style="width: 100%;">(0, 12)</td></tr></table>`,
+                `<tr><td colspan="12">(0, 12)</td></tr></table>`,
             "should have converted a 1x13 grid to an equivalent table (overflowing)");
 
         // 1x14
         $editable = $(`<div>${getRegularGridHtml(1, 14)}</div>`);
         convertInline.bootstrapToTable($editable);
-        assert.strictEqual($editable.html(),
+        assert.strictEqual(removeComments($editable.html()),
             getRegularTableHtml(1, 12, 1, 8.33).slice(0, -8) +
-                `<tr><td colspan="1" width="8.33%" style="width: 8.33%;">(0, 12)</td>` +
-                `<td colspan="11" width="91.67%" style="width: 91.67%;">(0, 13)</td></tr></table>`,
+                `<tr><td colspan="1">(0, 12)</td>` +
+                `<td colspan="11">(0, 13)</td></tr></table>`,
             "should have converted a 1x14 grid to an equivalent table (overflowing)");
 
         // 1x25
         $editable = $(`<div>${getRegularGridHtml(1, 25)}</div>`);
         convertInline.bootstrapToTable($editable);
-        assert.strictEqual($editable.html(),
+        assert.strictEqual(removeComments($editable.html()),
             getRegularTableHtml(1, 12, 1, 8.33).slice(0, -8) +
             getRegularTableHtml(1, 12, 1, 8.33).replace(/\(0, (\d+)\)/g, (s, c) => `(0, ${+c + 12})`)
                 .replace(/^<table[^<]*>/, '').slice(0, -8) +
-                `<tr><td colspan="12" width="100%" style="width: 100%;">(0, 24)</td></tr></table>`,
+                `<tr><td colspan="12">(0, 24)</td></tr></table>`,
             "should have converted a 1x25 grid to an equivalent table (overflowing)");
 
         // 1x26
         $editable = $(`<div>${getRegularGridHtml(1, 26)}</div>`);
         convertInline.bootstrapToTable($editable);
-        assert.strictEqual($editable.html(),
+        assert.strictEqual(removeComments($editable.html()),
             getRegularTableHtml(1, 12, 1, 8.33).slice(0, -8) +
             getRegularTableHtml(1, 12, 1, 8.33).replace(/\(0, (\d+)\)/g, (s, c) => `(0, ${+c + 12})`)
                 .replace(/^<table[^<]*>/, '').slice(0, -8) +
-                `<tr><td colspan="1" width="8.33%" style="width: 8.33%;">(0, 24)</td>` +
-                `<td colspan="11" width="91.67%" style="width: 91.67%;">(0, 25)</td></tr></table>`,
+                `<tr><td colspan="1">(0, 24)</td>` +
+                `<td colspan="11">(0, 25)</td></tr></table>`,
             "should have converted a 1x26 grid to an equivalent table (overflowing)");
     });
     QUnit.test('convert a multi-row regular grid', async function (assert) {
@@ -81,25 +81,25 @@ QUnit.module('convert_inline', {}, function () {
         // 2x1
         let $editable = $(`<div>${getRegularGridHtml(2, 1)}</div>`);
         convertInline.bootstrapToTable($editable);
-        assert.strictEqual($editable.html(), getRegularTableHtml(2, 1, 12, 100),
+        assert.strictEqual(removeComments($editable.html()), getRegularTableHtml(2, 1, 12, 100),
             "should have converted a 2x1 grid to an equivalent table");
 
         // 2x[1,2]
         $editable = $(`<div>${getRegularGridHtml(2, [1, 2])}</div>`);
         convertInline.bootstrapToTable($editable);
-        assert.strictEqual($editable.html(), getRegularTableHtml(2, [1, 2], [12, 6], [100, 50]),
+        assert.strictEqual(removeComments($editable.html()), getRegularTableHtml(2, [1, 2], [12, 6], [100, 50], true),
             "should have converted a 2x[1,2] grid to an equivalent table");
 
         // 3x3
         $editable = $(`<div>${getRegularGridHtml(3, 3)}</div>`);
         convertInline.bootstrapToTable($editable);
-        assert.strictEqual($editable.html(), getRegularTableHtml(3, 3, 4, 33.33),
+        assert.strictEqual(removeComments($editable.html()), getRegularTableHtml(3, 3, 4, 33.33),
             "should have converted a 3x3 grid to an equivalent table");
 
         // 3x[3,2,1]
         $editable = $(`<div>${getRegularGridHtml(3, [3,2,1])}</div>`);
         convertInline.bootstrapToTable($editable);
-        assert.strictEqual($editable.html(), getRegularTableHtml(3, [3, 2, 1], [4, 6, 12], [33.33, 50, 100]),
+        assert.strictEqual(removeComments($editable.html()), getRegularTableHtml(3, [3, 2, 1], [4, 6, 12], [33.33, 50, 100], true),
             "should have converted a 3x[3,2,1] grid to an equivalent table");
     });
     QUnit.test('convert a multi-row regular overflowing grid', async function (assert) {
@@ -108,35 +108,35 @@ QUnit.module('convert_inline', {}, function () {
         // 2x[13,1]
         let $editable = $(`<div>${getRegularGridHtml(2, [13, 1])}</div>`);
         convertInline.bootstrapToTable($editable);
-        assert.strictEqual($editable.html(),
+        assert.strictEqual(removeComments($editable.html()),
             getRegularTableHtml(1, 12, 1, 8.33).slice(0, -8) +
-                `<tr><td colspan="12" width="100%" style="width: 100%;">(0, 12)</td></tr>` +
-                `<tr><td colspan="12" width="100%" style="width: 100%;">(1, 0)</td></tr></table>`,
+                `<tr><td colspan="12">(0, 12)</td></tr>` +
+                `<tr><td colspan="12">(1, 0)</td></tr></table>`,
             "should have converted a 2x[13,1] grid to an equivalent table (overflowing)");
 
         // 2x[1,13]
         $editable = $(`<div>${getRegularGridHtml(2, [1, 13])}</div>`);
         convertInline.bootstrapToTable($editable);
-        assert.strictEqual($editable.html(),
-            getRegularTableHtml(2, [1, 12], [12, 1], [100, 8.33]).slice(0, -8) +
-                `<tr><td colspan="12" width="100%" style="width: 100%;">(1, 12)</td></tr></table>`,
+        assert.strictEqual(removeComments($editable.html()),
+            getRegularTableHtml(2, [1, 12], [12, 1], [100, 8.33], true).slice(0, -8) +
+                `<tr><td colspan="12">(1, 12)</td></tr></table>`,
             "should have converted a 2x[1,13] grid to an equivalent table (overflowing)");
 
         // 3x[1,13,6]
         $editable = $(`<div>${getRegularGridHtml(3, [1, 13, 6])}</div>`);
         convertInline.bootstrapToTable($editable);
-        assert.strictEqual($editable.html(),
-            getRegularTableHtml(2, [1, 12], [12, 1], [100, 8.33]).slice(0, -8) +
-                `<tr><td colspan="12" width="100%" style="width: 100%;">(1, 12)</td></tr>` +
+        assert.strictEqual(removeComments($editable.html()),
+            getRegularTableHtml(2, [1, 12], [12, 1], [100, 8.33], true).slice(0, -8) +
+                `<tr><td colspan="12">(1, 12)</td></tr>` +
                 getRegularTableHtml(1, 6, 2, 16.67).replace(/\(0,/g, `(2,`).replace(/^<table[^<]*>/, ''),
             "should have converted a 3x[1,13,6] grid to an equivalent table (overflowing)");
 
         // 3x[1,6,13]
         $editable = $(`<div>${getRegularGridHtml(3, [1, 6, 13])}</div>`);
         convertInline.bootstrapToTable($editable);
-        assert.strictEqual($editable.html(),
-            getRegularTableHtml(3, [1, 6, 12], [12, 2, 1], [100, 16.67, 8.33]).slice(0, -8) +
-                `<tr><td colspan="12" width="100%" style="width: 100%;">(2, 12)</td></tr></table>`,
+        assert.strictEqual(removeComments($editable.html()),
+            getRegularTableHtml(3, [1, 6, 12], [12, 2, 1], [100, 16.67, 8.33], true).slice(0, -8) +
+                `<tr><td colspan="12">(2, 12)</td></tr></table>`,
             "should have converted a 3x[1,6,13] grid to an equivalent table (overflowing)");
     });
     QUnit.test('convert a single-row irregular grid', async function (assert) {assert.expect(4);
@@ -145,13 +145,13 @@ QUnit.module('convert_inline', {}, function () {
         // 1x2
         let $editable = $(`<div>${getGridHtml([[8, 4]])}</div>`);
         convertInline.bootstrapToTable($editable);
-        assert.strictEqual($editable.html(), getTableHtml([[[8, 66.67], [4, 33.33]]]),
+        assert.strictEqual(removeComments($editable.html()), getTableHtml([[[8, 66.67], [4, 33.33]]], true),
             "should have converted a 1x2 irregular grid to an equivalent table");
 
         // 1x3
         $editable = $(`<div>${getGridHtml([[2, 3, 7]])}</div>`);
         convertInline.bootstrapToTable($editable);
-        assert.strictEqual($editable.html(), getTableHtml([[[2, 16.67], [3, 25], [7, 58.33]]]),
+        assert.strictEqual(removeComments($editable.html()), getTableHtml([[[2, 16.67], [3, 25], [7, 58.33]]], true),
             "should have converted a 1x3 grid to an equivalent table");
     });
     QUnit.test('convert a single-row irregular overflowing grid', async function (assert) {assert.expect(4);
@@ -160,20 +160,20 @@ QUnit.module('convert_inline', {}, function () {
         // 1x2
         let $editable = $(`<div>${getGridHtml([[8, 5]])}</div>`);
         convertInline.bootstrapToTable($editable);
-        assert.strictEqual($editable.html(), getTableHtml([
+        assert.strictEqual(removeComments($editable.html()), getTableHtml([
                 [[8, 66.67], [4, 33.33, '']],
                 [[5, 41.67, '(0, 1)'], [7, 58.33, '']],
-            ]),
+            ], true),
             "should have converted a 1x2 irregular overflowing grid to an equivalent table");
 
         // 1x3
         $editable = $(`<div>${getGridHtml([[7, 6, 9]])}</div>`);
         convertInline.bootstrapToTable($editable);
-        assert.strictEqual($editable.html(), getTableHtml([
+        assert.strictEqual(removeComments($editable.html()), getTableHtml([
                 [[7, 58.33], [5, 41.67, '']],
                 [[6, 50, '(0, 1)'], [6, 50, '']],
                 [[9, 75, '(0, 2)'], [3, 25, '']],
-            ]),
+            ], true),
             "should have converted a 1x3 irregular overflowing grid to an equivalent table");
     });
     QUnit.test('convert a multi-row irregular grid', async function (assert) {
@@ -182,13 +182,13 @@ QUnit.module('convert_inline', {}, function () {
         // 2x2
         let $editable = $(`<div>${getGridHtml([[1, 11], [2, 10]])}</div>`);
         convertInline.bootstrapToTable($editable);
-        assert.strictEqual($editable.html(), getTableHtml([[[1, 8.33], [11, 91.67]], [[2, 16.67], [10, 83.33]]]),
+        assert.strictEqual(removeComments($editable.html()), getTableHtml([[[1, 8.33], [11, 91.67]], [[2, 16.67], [10, 83.33]]], true),
             "should have converted a 2x2 irregular grid to an equivalent table");
 
         // 2x[2,3]
         $editable = $(`<div>${getGridHtml([[3, 9], [4, 6, 2]])}</div>`);
         convertInline.bootstrapToTable($editable);
-        assert.strictEqual($editable.html(), getTableHtml([[[3, 25], [9, 75]], [[4, 33.33], [6, 50], [2, 16.67]]]),
+        assert.strictEqual(removeComments($editable.html()), getTableHtml([[[3, 25], [9, 75]], [[4, 33.33], [6, 50], [2, 16.67]]], true),
             "should have converted a 2x[2,3] irregular grid to an equivalent table");
     });
     QUnit.test('convert a multi-row irregular overflowing grid', async function (assert) {
@@ -197,35 +197,35 @@ QUnit.module('convert_inline', {}, function () {
         // 2x2 (both rows overflow)
         let $editable = $(`<div>${getGridHtml([[6, 8], [7, 9]])}</div>`);
         convertInline.bootstrapToTable($editable);
-        assert.strictEqual($editable.html(),
+        assert.strictEqual(removeComments($editable.html()),
             getTableHtml([
                 [[6, 50], [6, 50, '']],
                 [[8, 66.67, '(0, 1)'], [4, 33.33, '']],
                 [[7, 58.33, '(1, 0)'], [5, 41.67, '']],
                 [[9, 75, '(1, 1)'], [3, 25, '']],
-            ]),
+            ], true),
             "should have converted a 2x[1,13] irregular grid to an equivalent table (both rows overflowing)");
 
         // 2x[2,3] (first row overflows)
         $editable = $(`<div>${getGridHtml([[5, 8], [4, 2, 6]])}</div>`);
         convertInline.bootstrapToTable($editable);
-        assert.strictEqual($editable.html(),
+        assert.strictEqual(removeComments($editable.html()),
             getTableHtml([
                 [[5, 41.67], [7, 58.33, '']],
                 [[8, 66.67, '(0, 1)'], [4, 33.33, '']],
                 [[4, 33.33, '(1, 0)'], [2, 16.67, '(1, 1)'], [6, 50, '(1, 2)']],
-            ]),
+            ], true),
             "should have converted a 2x[2,3] irregular grid to an equivalent table (first row overflowing)");
 
         // 2x[3,2] (second row overflows)
         $editable = $(`<div>${getGridHtml([[4, 2, 6], [5, 8]])}</div>`);
         convertInline.bootstrapToTable($editable);
-        assert.strictEqual($editable.html(),
+        assert.strictEqual(removeComments($editable.html()),
             getTableHtml([
                 [[4, 33.33], [2, 16.67], [6, 50]],
                 [[5, 41.67], [7, 58.33, '']],
                 [[8, 66.67, '(1, 1)'], [4, 33.33, '']],
-            ]),
+            ], true),
             "should have converted a 2x[3,2] irregular grid to an equivalent table (second row overflowing)");
     });
     QUnit.test('convert a card to a table', async function (assert) {
@@ -247,7 +247,7 @@ QUnit.module('convert_inline', {}, function () {
         convertInline.cardToTable($editable);
         assert.strictEqual($editable.html(),
             getRegularTableHtml(3, 1, 12, 100)
-                .split('style="').join('class="card" style="')
+                .replace('role=\"presentation\"', 'role=\"presentation\" class=\"card\"')
                 .replace(/<td[^>]*>\(0, 0\)<\/td>/,
                     `<td>` +
                         `<table cellspacing=\"0\" cellpadding=\"0\" border=\"0\" width=\"100%\" align=\"center\" ` +

--- a/addons/web_editor/static/tests/test_utils.js
+++ b/addons/web_editor/static/tests/test_utils.js
@@ -793,6 +793,7 @@ function getGridHtml(matrix) {
  * ]                            // </table>
  *
  * @param {Array<Array<Array<[Number, Number, string?]>>>} matrix
+ * @param {boolean} [responsive=false]
  * @returns {string}
  */
 function getTableHtml(matrix) {
@@ -801,7 +802,7 @@ function getTableHtml(matrix) {
         matrix.map((row, iRow) => (
             `<tr>` +
             row.map((col, iCol) => (
-                `<td colspan="${col[0]}" width="${col[1]}%" style="width: ${col[1]}%;">` +
+                `<td colspan="${col[0]}">` +
                 (col.length === 3 ? col[2] : `(${iRow}, ${iCol})`) +
                 `</td>`
             )).join('') +
@@ -841,16 +842,34 @@ function getRegularGridHtml(nRows, nCols) {
  * @param {Number|Number[]} nCols
  * @param {Number|Number[]} colspan
  * @param {Number|Number[]} width
+ * @param {boolean} [responsive=false]
  * @returns {string}
  */
-function getRegularTableHtml(nRows, nCols, colspan, width) {
+function getRegularTableHtml(nRows, nCols, colspan, width, responsive=false) {
     const matrix = new Array(nRows).fill().map((_, iRow) => (
         new Array(Array.isArray(nCols) ? nCols[iRow] : nCols).fill().map(() => ([
             Array.isArray(colspan) ? colspan[iRow] : colspan,
             Array.isArray(width) ? width[iRow] : width,
         ])))
     );
-    return getTableHtml(matrix);
+    return getTableHtml(matrix, responsive);
+}
+/**
+ * Take an HTML string and returns that string stripped from any HTML comments.
+ * By default, also removes the mso-hide class which is only there for outlook
+ * to hide elements when we use mso conditional comments.
+ *
+ * @param {string} html
+ * @param {boolean} [removeMsoHide=true]
+ * @returns {string}
+ */
+function removeComments(html, removeMsoHide=true) {
+    const cleanHtml = html.replace(/<!--(.*?)-->/g, '');
+    if (removeMsoHide) {
+        return cleanHtml.replaceAll(' class="mso-hide"', '').replace(/\s*mso-hide/g, '').replace(/mso-hide\s*/g, '');
+    } else {
+        return cleanHtml;
+    }
 }
 
 return {
@@ -865,6 +884,7 @@ return {
     getTableHtml: getTableHtml,
     getRegularGridHtml: getRegularGridHtml,
     getRegularTableHtml: getRegularTableHtml,
+    removeComments: removeComments,
 };
 
 


### PR DESCRIPTION
The main improvement here is a new support for responsive columns. In order for it not to break Outlook rendering, we hide the responsive columns in Outlook in favor of non-responsive columns (in mso conditionals). This means a lot of the html is written twice, in different ways. The mail is therefore heavier, which is sadly the price of having a proper rendering cross-clients.

This also fixes the rendering of buttons in Outlook, and text alignment.

task-2761098

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
