### PR TITLE
[FIX] auth_signup: impossible to login

### DIFF
--- a/addons/auth_signup/tests/__init__.py
+++ b/addons/auth_signup/tests/__init__.py
@@ -1,0 +1,1 @@
+from . import test_login

--- a/addons/auth_signup/tests/test_login.py
+++ b/addons/auth_signup/tests/test_login.py
@@ -1,0 +1,2 @@
+# rerun TestWebLogin tests with auth_signup installed
+from odoo.addons.web.tests.test_login import TestWebLogin  # pylint: disable=W0611

--- a/addons/http_routing/models/ir_qweb.py
+++ b/addons/http_routing/models/ir_qweb.py
@@ -1,35 +1,8 @@
-# -*- coding: ascii -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
-
-import fnmatch
-import werkzeug
 
 from odoo import models
 from odoo.http import request
 from odoo.addons.http_routing.models.ir_http import slug, unslug_url, url_for
-
-
-def keep_query(*keep_params, **additional_params):
-    """
-    Generate a query string keeping the current request querystring's parameters specified
-    in ``keep_params`` and also adds the parameters specified in ``additional_params``.
-
-    Multiple values query string params will be merged into a single one with comma seperated
-    values.
-
-    The ``keep_params`` arguments can use wildcards too, eg:
-
-        keep_query('search', 'shop_*', page=4)
-    """
-    if not keep_params and not additional_params:
-        keep_params = ('*',)
-    params = additional_params.copy()
-    qs_keys = list(request.httprequest.args) if request else []
-    for keep_param in keep_params:
-        for param in fnmatch.filter(qs_keys, keep_param):
-            if param not in additional_params and param in qs_keys:
-                params[param] = request.httprequest.args.getlist(param)
-    return werkzeug.urls.url_encode(params)
 
 
 class IrQweb(models.AbstractModel):
@@ -39,7 +12,6 @@ class IrQweb(models.AbstractModel):
         irQweb = super()._prepare_environment(values)
         values['slug'] = slug
         values['unslug_url'] = unslug_url
-        values['keep_query'] = keep_query
 
         if (not irQweb.env.context.get('minimal_qcontext') and
                 request and request.is_frontend):

--- a/addons/survey/controllers/main.py
+++ b/addons/survey/controllers/main.py
@@ -9,11 +9,11 @@ from datetime import datetime, timedelta
 from dateutil.relativedelta import relativedelta
 
 from odoo import fields, http, SUPERUSER_ID, _
-from odoo.addons.http_routing.models.ir_qweb import keep_query
 from odoo.exceptions import UserError
 from odoo.http import request, content_disposition
 from odoo.osv import expression
 from odoo.tools import format_datetime, format_date, is_html_empty
+from odoo.addons.base.models.ir_qweb import keep_query
 
 _logger = logging.getLogger(__name__)
 

--- a/addons/web/tests/__init__.py
+++ b/addons/web/tests/__init__.py
@@ -13,3 +13,4 @@ from . import test_profiler
 from . import test_session_info
 from . import test_read_progress_bar
 from . import test_assets
+from . import test_login

--- a/addons/web/tests/test_login.py
+++ b/addons/web/tests/test_login.py
@@ -1,0 +1,28 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from odoo.tests.common import HttpCase, new_test_user
+
+class TestWebLogin(HttpCase):
+    def test_web_login(self):
+        new_test_user(self.env, 'jackoneill', context={'lang': 'en_US'})
+
+        # get login form
+        res_get = self.url_open('/web/login')
+        res_get.raise_for_status()
+        csrf_anchor = '<input type="hidden" name="csrf_token" value="'
+        csrf_token = res_get.text.partition(csrf_anchor)[2].partition('"')[0]
+
+        # login
+        res_post = self.url_open('/web/login', data={
+            'login': 'jackoneill',
+            'password': 'jackoneill',
+            'csrf_token': csrf_token,
+        })
+        res_post.raise_for_status()
+
+        # ensure we are logged-in
+        self.url_open(
+            '/web/session/check',
+            headers={'Content-Type': 'application/json'},
+            data='{}'
+        ).raise_for_status()

--- a/odoo/addons/base/models/ir_ui_view.py
+++ b/odoo/addons/base/models/ir_ui_view.py
@@ -1,10 +1,8 @@
-# -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 import ast
 import collections
 import datetime
-import fnmatch
 import inspect
 import json
 import logging
@@ -19,13 +17,14 @@ from lxml import etree
 from lxml.etree import LxmlError
 from lxml.builder import E
 
+import odoo
 from odoo import api, fields, models, tools, _
 from odoo.exceptions import ValidationError, AccessError
 from odoo.http import request
 from odoo.modules.module import get_resource_from_path, get_resource_path
 from odoo.tools import config, ConstantMapping, get_diff, pycompat, apply_inheritance_specs, locate_node
 from odoo.tools.convert import _fix_multiple_roots
-from odoo.tools import safe_eval, lazy_property, frozendict
+from odoo.tools import safe_eval, lazy, lazy_property, frozendict
 from odoo.tools.view_validation import valid_view, get_variable_names, get_domain_identifiers, get_dict_asts
 from odoo.tools.translate import xml_translate, TRANSLATED_ATTRS
 from odoo.models import check_method_name
@@ -115,6 +114,13 @@ def transfer_modifiers_to_node(modifiers, node):
     if modifiers:
         simplify_modifiers(modifiers)
         node.set('modifiers', json.dumps(modifiers))
+
+
+@lazy
+def keep_query():
+    mod = odoo.addons.base.models.ir_qweb
+    warnings.warn(f"keep_query has been moved to {mod}", DeprecationWarning)
+    return mod.keep_query
 
 
 class ViewCustom(models.Model):


### PR DESCRIPTION
Install auth_signup, go to /web/login, 500 Internal Server Error.

auth_signup extends the /web/login template and in this extension calls
`keep_query()` which has been wrongly moved from base to http_routing in
commit 880954ebfc1. Here, we restored `keep_query()` were it was.