### PR TITLE
[FIX] stock_account: stock inventory garbage adjustments

### DIFF
--- a/addons/stock_account/models/stock_quant.py
+++ b/addons/stock_account/models/stock_quant.py
@@ -3,6 +3,7 @@
 
 from odoo import api, fields, models
 from odoo.tools.float_utils import float_is_zero
+from odoo.tools.misc import groupby
 
 
 class StockQuant(models.Model):
@@ -62,13 +63,13 @@ class StockQuant(models.Model):
         return res
 
     def _apply_inventory(self):
-        acc_inventories = self.filtered(lambda quant: quant.accounting_date)
-        for inventory in acc_inventories:
-            super(StockQuant, self.with_context(force_period_date=inventory.accounting_date))._apply_inventory()
-            inventory.write({'accounting_date': False})
-        other_inventories = self - acc_inventories
-        if other_inventories:
-            super(StockQuant, other_inventories)._apply_inventory()
+        for accounting_date, inventory_ids in groupby(self, key=lambda q: q.accounting_date):
+            inventories = self.env['stock.quant'].concat(*inventory_ids)
+            if accounting_date:
+                super(StockQuant, inventories.with_context(force_period_date=accounting_date))._apply_inventory()
+                inventories.accounting_date = False
+            else:
+                super(StockQuant, inventories)._apply_inventory()
 
     @api.model
     def _get_inventory_fields_write(self):


### PR DESCRIPTION
**Description of the issue/feature this PR addresses:**
In case you applied inventory in batch the system would create a lot of useless
stock moves and stock move lines.

**Current behavior before PR:**
In batch adjustment applied would create a lot of garbage in the database

**Desired behavior after PR is merged:**
Avoid creating garbage during application of stock adjustment in batch

Info: @wt-io-it



--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
