### PR TITLE
[FIX] sale_management: correctly autocomplete uom on option lines

### DIFF
--- a/addons/sale_management/models/sale_order.py
+++ b/addons/sale_management/models/sale_order.py
@@ -249,6 +249,7 @@ class SaleOrderOption(models.Model):
         product = self.product_id.with_context(
             lang=self.order_id.partner_id.lang,
         )
+        self.uom_id = self.uom_id or product.uom_id
         self.name = product.get_product_multiline_description_sale()
         self._update_price_and_discount()
 

--- a/addons/sale_management/tests/test_sale_order.py
+++ b/addons/sale_management/tests/test_sale_order.py
@@ -2,7 +2,7 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 from odoo.addons.sale.tests.common import TestSaleCommon
-from odoo.tests import tagged
+from odoo.tests import Form, tagged
 
 
 @tagged('-at_install', 'post_install')
@@ -341,3 +341,10 @@ class TestSaleOrder(TestSaleCommon):
             self.pl_option_discount,
             "If a pricelist is set without discount included,"
             " the discount should be correctly computed.")
+
+    def test_option_creation(self):
+        """Make sure the product uom is automatically added to the option when the product is specified"""
+        order_form = Form(self.sale_order)
+        with order_form.sale_order_option_ids.new() as option:
+            option.product_id = self.product_1
+            self.assertTrue(bool(option.uom_id))


### PR DESCRIPTION
Fixes a mistake from 0c468f6c2f160dec672bd25c673401b154b2709b where the uom
autocompletion was lost and adds a test to make sure it won't happen again.



--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
