### PR TITLE
Fix calculations on New Zealand GST Report

### DIFF
--- a/addons/l10n_nz/data/account_tax_report_data.xml
+++ b/addons/l10n_nz/data/account_tax_report_data.xml
@@ -98,14 +98,14 @@
         <field name="name">[BOX 14] Total GST credit for purchases and expenses</field>
         <field name="parent_id" ref="tax_report_purchases_and_expenses"/>
         <field name="sequence" eval="4"/>
-        <field name="formula">((NZBOX11 * 3)/23)</field>
+        <field name="formula">((NZBOX11 * 3)/23) + NZBOX13</field>
         <field name="report_id" ref="tax_report"/>
     </record>
 
     <record id="tax_report_box15" model="account.tax.report.line">
         <field name="name">[BOX 15]  Difference between BOX10 and BOX14</field>
         <field name="sequence" eval="3"/>
-        <field name="formula">((((NZBOX5 - NZBOX6) * 3)/23) + NZBOX9) - ((NZBOX11 * 3)/23)</field>
+        <field name="formula">((((NZBOX5 - NZBOX6) * 3)/23) + NZBOX9) - (((NZBOX11 * 3)/23) + NZBOX13)</field>
         <field name="report_id" ref="tax_report"/>
     </record>
 

--- a/doc/cla/corporate/smithfieldroadsoftwareltd.md
+++ b/doc/cla/corporate/smithfieldroadsoftwareltd.md
@@ -1,0 +1,14 @@
+New Zealand, 30-Mar-2022
+Smithfield Road Software Ltf agrees to the terms of the Odoo Corporate Contributor License
+Agreement v1.0.
+
+I declare that I am authorized and able to make this agreement and sign this
+declaration.
+
+Signed,
+
+Richard Collins richardc@richardc.net https://github.com/richardcrichardc
+
+List of contributors:
+
+Richard Collins richardc@richardc.net https://github.com/richardcrichardc


### PR DESCRIPTION
Description of the issue/feature this PR addresses:

This pull request fixes the Box14 and Box15 calculations in the New Zealand GST Tax Report.

Current behavior before PR:

Box14 and Box15 do not include the value from Box13.  

Desired behavior after PR is merged:

Box14 and Box15 do include the value from Box13.  

The Tax report for New Zealand clearly is based on the GST101a form published by the New Zealand Inland Revenue Department (https://www.ird.govt.nz/-/media/project/ir/home/documents/forms-and-guides/gst100---gst199/gst101a/gst101a-2017.pdf?modified=20201127025858&modified=20201127025858). Box14 and Box15 calculations have not been correctly transcribed from the form. Box 14 should "Add Box12 and Box13", instead it had been implemented as just copying the value from Box12. This error has been made in the Box15 formula as well.

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr

Confirmed