### PR TITLE
[FIX][14.0]website_slides: fix internal user can review multi times

### DIFF
--- a/addons/website_slides/controllers/mail.py
+++ b/addons/website_slides/controllers/mail.py
@@ -49,7 +49,6 @@ class SlidesPortalChatter(PortalChatter):
         domain = [
             ('model', '=', res_model),
             ('res_id', '=', res_id),
-            ('is_internal', '=', False),
             ('author_id', '=', request.env.user.partner_id.id),
             ('message_type', '=', 'comment'),
             ('id', '=', message_id)

--- a/addons/website_slides/controllers/main.py
+++ b/addons/website_slides/controllers/main.py
@@ -489,7 +489,6 @@ class WebsiteSlides(WebsiteProfile):
                 ('res_id', '=', channel.id),
                 ('author_id', '=', request.env.user.partner_id.id),
                 ('message_type', '=', 'comment'),
-                ('is_internal', '=', False)
             ], order='write_date DESC', limit=1)
             if last_message:
                 last_message_values = last_message.read(['body', 'rating_value', 'attachment_ids'])[0]


### PR DESCRIPTION
On course, when users change status of their review to 'Employees Only', they can add a review multi times. 

Video:

https://user-images.githubusercontent.com/66937593/160749729-642d1051-1878-41a7-a7bd-057ccd6b415b.mp4





--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
