### PR TITLE
[FIX] purchase: fix inherit order of portal and mail thread

### DIFF
--- a/addons/purchase/models/purchase.py
+++ b/addons/purchase/models/purchase.py
@@ -20,7 +20,7 @@ from odoo.tools.misc import formatLang, get_lang, format_amount
 
 class PurchaseOrder(models.Model):
     _name = "purchase.order"
-    _inherit = ['mail.thread', 'mail.activity.mixin', 'portal.mixin']
+    _inherit = ['portal.mixin', 'mail.thread', 'mail.activity.mixin']
     _description = "Purchase Order"
     _order = 'priority desc, id desc'
 


### PR DESCRIPTION
### Expected Behaviour
When sending an RFQ/PO link by email, the associated client should receive a mail with token access in the link so that he can access the documents without to need to create an odoo account

### Obeserved Behaviour
When sending this kind of link, the client comes to a login page which then redirect him (in case of correct login) to the RFQ/PO model view in DB instead of the associated portal page

### Fix Description
We changed to order of the inherited models so that the method `_notify_get_groups` from `portal_mixin` is used instead of the one from `mail_thread`, according to https://github.com/odoo/odoo/commit/139e90027686b0471c3f2c9efa46d531c3abef5a

### Related issues/PR
 - opw-2765294
 - Backport of https://github.com/odoo/odoo/commit/139e90027686b0471c3f2c9efa46d531c3abef5a

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
