### PR TITLE
[REF] models: Refactor `load_views` to send only once the fields

### DIFF
--- a/addons/board/controllers/main.py
+++ b/addons/board/controllers/main.py
@@ -16,10 +16,9 @@ class Board(Controller):
         if action and action['res_model'] == 'board.board' and action['views'][0][1] == 'form' and action_id:
             # Maybe should check the content instead of model board.board ?
             view_id = action['views'][0][0]
-            board = request.env['board.board'].fields_view_get(view_id, 'form')
-            if board and 'arch' in board:
-                xml = ElementTree.fromstring(board['arch'])
-                column = xml.find('./board/column')
+            board_arch, _view = request.env['board.board']._get_view(view_id, 'form')
+            if board_arch:
+                column = board_arch.find('./board/column')
                 if column is not None:
                     new_action = ElementTree.Element('action', {
                         'name': str(action_id),
@@ -29,7 +28,7 @@ class Board(Controller):
                         'domain': str(domain)
                     })
                     column.insert(0, new_action)
-                    arch = ElementTree.tostring(xml, encoding='unicode')
+                    arch = ElementTree.tostring(board_arch, encoding='unicode')
                     request.env['ir.ui.view.custom'].create({
                         'user_id': request.session.uid,
                         'ref_id': view_id,

--- a/addons/board/models/board.py
+++ b/addons/board/models/board.py
@@ -20,13 +20,13 @@ class Board(models.AbstractModel):
         return self
 
     @api.model
-    def fields_view_get(self, view_id=None, view_type='form', toolbar=False, submenu=False):
+    def get_view(self, view_id=None, view_type='form', **options):
         """
         Overrides orm field_view_get.
         @return: Dictionary of Fields, arch and toolbar.
         """
 
-        res = super(Board, self).fields_view_get(view_id=view_id, view_type=view_type, toolbar=toolbar, submenu=submenu)
+        res = super().get_view(view_id, view_type, **options)
 
         custom_view = self.env['ir.ui.view.custom'].search([('user_id', '=', self.env.uid), ('ref_id', '=', view_id)], limit=1)
         if custom_view:

--- a/addons/board/static/tests/dashboard_tests.js
+++ b/addons/board/static/tests/dashboard_tests.js
@@ -365,7 +365,7 @@ odoo.define("board.dashboard_tests", function (require) {
                         ],
                     });
                 }
-                if (args.method === "load_views") {
+                if (args.method === "get_views") {
                     assert.deepEqual(
                         args.kwargs.context,
                         { a: 1, b: 2 },
@@ -656,8 +656,8 @@ odoo.define("board.dashboard_tests", function (require) {
                 "</board>" +
                 "</form>",
             intercepts: {
-                load_views: function () {
-                    throw new Error("load_views should not be called");
+                get_views: function () {
+                    throw new Error("get_views should not be called");
                 },
             },
             mockRPC: function (route) {
@@ -1048,7 +1048,7 @@ odoo.define("board.dashboard_tests", function (require) {
                 "</board>" +
                 "</form>",
             mockRPC: function (route, args) {
-                if (args.method === "load_views") {
+                if (args.method === "get_views") {
                     assert.deepEqual(
                         pyUtils.eval("context", args.kwargs.context),
                         { lang: "fr_FR" },

--- a/addons/crm/models/crm_lead.py
+++ b/addons/crm/models/crm_lead.py
@@ -862,16 +862,16 @@ class Lead(models.Model):
         return super(Lead, self.with_context(context)).copy(default=default)
 
     @api.model
-    def _fields_view_get(self, view_id=None, view_type='form', toolbar=False, submenu=False):
+    def _get_view(self, view_id=None, view_type='form', **options):
         if self._context.get('opportunity_id'):
             opportunity = self.browse(self._context['opportunity_id'])
             action = opportunity.get_formview_action()
             if action.get('views') and any(view_id for view_id in action['views'] if view_id[1] == view_type):
                 view_id = next(view_id[0] for view_id in action['views'] if view_id[1] == view_type)
-        res = super(Lead, self)._fields_view_get(view_id=view_id, view_type=view_type, toolbar=toolbar, submenu=submenu)
+        arch, view = super()._get_view(view_id, view_type, **options)
         if view_type == 'form':
-            res['arch'] = self._fields_view_get_address(res['arch'])
-        return res
+            arch = self._view_get_address(arch)
+        return arch, view
 
     @api.model
     def _read_group_stage_ids(self, stages, domain, order):

--- a/addons/google_spreadsheet/models/google_drive.py
+++ b/addons/google_spreadsheet/models/google_drive.py
@@ -26,8 +26,8 @@ class GoogleDrive(models.Model):
     def write_config_formula(self, attachment_id, spreadsheet_key, model, domain, groupbys, view_id):
         access_token = self.get_access_token(scope='https://www.googleapis.com/auth/spreadsheets')
 
-        fields = self.env[model].fields_view_get(view_id=view_id, view_type='tree')
-        doc = etree.XML(fields.get('arch'))
+        arch, _view = self.env[model]._get_view(view_id, 'tree')
+        doc = arch
         display_fields = []
         for node in doc.xpath("//field"):
             if node.get('modifiers'):

--- a/addons/hr/models/hr_employee.py
+++ b/addons/hr/models/hr_employee.py
@@ -217,10 +217,10 @@ class HrEmployeePrivate(models.Model):
         return self.env['hr.employee.public'].browse(self.ids).read(fields, load=load)
 
     @api.model
-    def load_views(self, views, options=None):
+    def get_view(self, view_id=None, view_type='form', **options):
         if self.check_access_rights('read', raise_exception=False):
-            return super(HrEmployeePrivate, self).load_views(views, options=options)
-        return self.env['hr.employee.public'].load_views(views, options=options)
+            return super().get_view(view_id, view_type, **options)
+        return self.env['hr.employee.public'].get_view(view_id, view_type, **options)
 
     @api.model
     def _search(self, args, offset=0, limit=None, order=None, count=False, access_rights_uid=None):

--- a/addons/hr/models/res_users.py
+++ b/addons/hr/models/res_users.py
@@ -169,7 +169,7 @@ class User(models.Model):
         return super().SELF_WRITEABLE_FIELDS + HR_WRITABLE_FIELDS
 
     @api.model
-    def fields_view_get(self, view_id=None, view_type='form', toolbar=False, submenu=False):
+    def get_view(self, view_id=None, view_type='form', **options):
         # When the front-end loads the views it gets the list of available fields
         # for the user (according to its access rights). Later, when the front-end wants to
         # populate the view with data, it only asks to read those available fields.
@@ -182,11 +182,11 @@ class User(models.Model):
         original_user = self.env.user
         if profile_view and view_id == profile_view.id:
             self = self.with_user(SUPERUSER_ID)
-        result = super(User, self).fields_view_get(view_id=view_id, view_type=view_type, toolbar=toolbar, submenu=submenu)
+        result = super(User, self).get_view(view_id, view_type, **options)
         # Due to using the SUPERUSER the result will contain action that the user may not have access too
         # here we filter out actions that requires special implicit rights to avoid having unusable actions
         # in the dropdown menu.
-        if toolbar and self.env.user != original_user:
+        if options.get('toolbar') and self.env.user != original_user:
             self = self.with_user(original_user.id)
             if not self.user_has_groups("base.group_erp_manager"):
                 change_password_action = self.env.ref("base.change_password_wizard_action")

--- a/addons/hr/tests/test_self_user_access.py
+++ b/addons/hr/tests/test_self_user_access.py
@@ -3,6 +3,7 @@
 
 from collections import OrderedDict
 from itertools import chain
+from lxml import etree
 
 from odoo.addons.hr.tests.common import TestHrCommon
 from odoo.tests import new_test_user, tagged, Form
@@ -20,8 +21,8 @@ class TestSelfAccessProfile(TestHrCommon):
             'user_id': james.id,
         })
         view = self.env.ref('hr.res_users_view_form_profile')
-        view_infos = james.fields_view_get(view_id=view.id)
-        fields = view_infos['fields'].keys()
+        view_infos = james.get_view(view.id)
+        fields = [el.get('name') for el in etree.fromstring(view_infos['arch']).xpath('//field[not(ancestor::field)]')]
         james.read(fields)
 
     def test_readonly_fields(self):
@@ -35,12 +36,12 @@ class TestSelfAccessProfile(TestHrCommon):
         })
 
         view = self.env.ref('hr.res_users_view_form_profile')
-        view_infos = james.fields_view_get(view_id=view.id)
-
+        fields = james._fields
+        view_infos = james.get_view(view.id)
         employee_related_fields = {
-            field_name
-            for field_name, field_attrs in view_infos['fields'].items()
-            if field_attrs.get('related', (None,))[0] == 'employee_id'
+            el.get('name')
+            for el in etree.fromstring(view_infos['arch']).xpath('//field[not(ancestor::field)]')
+            if fields[el.get('name')].related and fields[el.get('name')].related.split('.')[0] == 'employee_id'
         }
 
         form = Form(james, view=view)
@@ -65,16 +66,16 @@ class TestSelfAccessProfile(TestHrCommon):
             all_groups |= self.env.ref(xml_id.strip())
         user_all_groups = new_test_user(self.env, groups='base.group_user', login='hel', name='God')
         user_all_groups.write({'groups_id': [(4, group.id, False) for group in all_groups]})
-        view_infos = self.env['res.users'].with_user(user_all_groups).fields_view_get(view_id=view.id)
-        full_fields = view_infos['fields']
+        view_infos = self.env['res.users'].with_user(user_all_groups).get_view(view.id)
+        full_fields = [el.get('name') for el in etree.fromstring(view_infos['arch']).xpath('//field[not(ancestor::field)]')]
 
         # Now check the view for a simple user
         user = new_test_user(self.env, login='gro', name='Grouillot')
-        view_infos = self.env['res.users'].with_user(user).fields_view_get(view_id=view.id)
-        fields = view_infos['fields']
+        view_infos = self.env['res.users'].with_user(user).get_view(view.id)
+        fields = [el.get('name') for el in etree.fromstring(view_infos['arch']).xpath('//field[not(ancestor::field)]')]
 
         # Compare both
-        self.assertEqual(full_fields.keys(), fields.keys(), "View fields should not depend on user's groups")
+        self.assertEqual(full_fields, fields, "View fields should not depend on user's groups")
 
     def test_access_my_profile_toolbar(self):
         """ A simple user shouldn't have the possibilities to see the 'Change Password' action"""
@@ -85,7 +86,7 @@ class TestSelfAccessProfile(TestHrCommon):
             'user_id': james.id,
         })
         view = self.env.ref('hr.res_users_view_form_profile')
-        available_actions = james.fields_view_get(view_id=view.id, toolbar=True)['toolbar']['action']
+        available_actions = james.get_view(view.id, toolbar=True)['toolbar']['action']
         change_password_action = self.env.ref("base.change_password_wizard_action")
 
         self.assertFalse(any(x['id'] == change_password_action.id for x in available_actions))
@@ -98,7 +99,7 @@ class TestSelfAccessProfile(TestHrCommon):
             'user_id': john.id,
         })
         view = self.env.ref('hr.res_users_view_form_profile')
-        available_actions = john.fields_view_get(view_id=view.id, toolbar=True)['toolbar']['action']
+        available_actions = john.get_view(view.id, toolbar=True)['toolbar']['action']
         self.assertTrue(any(x['id'] == change_password_action.id for x in available_actions))
 
 

--- a/addons/hr_recruitment/models/hr_recruitment.py
+++ b/addons/hr_recruitment/models/hr_recruitment.py
@@ -52,14 +52,12 @@ class RecruitmentSource(models.Model):
             source.alias_id = self.env['mail.alias'].create(vals)
 
     @api.model
-    def fields_view_get(self, view_id=None, view_type='form', toolbar=False, submenu=False):
-        res = super().fields_view_get(view_id, view_type, toolbar, submenu)
+    def _get_view(self, view_id=None, view_type='form', **options):
+        arch, view = super()._get_view(view_id, view_type, **options)
         if view_type == 'tree' and not bool(self.env["ir.config_parameter"].sudo().get_param("mail.catchall.domain")):
-            arch = etree.fromstring(res['arch'])
             email = arch.xpath("//field[@name='email']")[0]
             email.getparent().remove(email)
-            res['arch'] = etree.tostring(arch, encoding='unicode')
-        return res
+        return arch, view
 
 class RecruitmentStage(models.Model):
     _name = "hr.recruitment.stage"
@@ -437,10 +435,10 @@ class Applicant(models.Model):
         return nocontent_body % nocontent_values
 
     @api.model
-    def fields_view_get(self, view_id=None, view_type='form', toolbar=False, submenu=False):
+    def get_view(self, view_id=None, view_type='form', **options):
         if view_type == 'form' and self.user_has_groups('hr_recruitment.group_hr_recruitment_interviewer'):
             view_id = self.env.ref('hr_recruitment.hr_applicant_view_form_interviewer').id
-        return super().fields_view_get(view_id, view_type, toolbar, submenu)
+        return super().get_view(view_id, view_type, **options)
 
     def _notify_compute_recipients(self, message, msg_vals):
         """

--- a/addons/hr_timesheet/models/hr_timesheet.py
+++ b/addons/hr_timesheet/models/hr_timesheet.py
@@ -157,26 +157,26 @@ class AccountAnalyticLine(models.Model):
         return result
 
     @api.model
-    def fields_view_get(self, view_id=None, view_type='form', toolbar=False, submenu=False):
+    def _get_view(self, view_id=None, view_type='form', **options):
         """ Set the correct label for `unit_amount`, depending on company UoM """
-        result = super(AccountAnalyticLine, self).fields_view_get(view_id=view_id, view_type=view_type, toolbar=toolbar, submenu=submenu)
-        result['arch'] = self._apply_timesheet_label(result['arch'], view_type=view_type)
-        return result
+        arch, view = super()._get_view(view_id, view_type, **options)
+        arch = self._apply_timesheet_label(arch, view_type=view_type)
+        return arch, view
 
     @api.model
-    def _apply_timesheet_label(self, view_arch, view_type='form'):
-        doc = etree.XML(view_arch)
+    def _apply_timesheet_label(self, view_node, view_type='form'):
+        doc = view_node
         encoding_uom = self.env.company.timesheet_encode_uom_id
         # Here, we select only the unit_amount field having no string set to give priority to
         # custom inheretied view stored in database. Even if normally, no xpath can be done on
         # 'string' attribute.
         for node in doc.xpath("//field[@name='unit_amount'][@widget='timesheet_uom'][not(@string)]"):
             node.set('string', _('%s Spent') % (re.sub(r'[\(\)]', '', encoding_uom.name or '')))
-        return etree.tostring(doc, encoding='unicode')
+        return doc
 
     @api.model
-    def _apply_time_label(self, view_arch, related_model):
-        doc = etree.XML(view_arch)
+    def _apply_time_label(self, view_node, related_model):
+        doc = view_node
         Model = self.env[related_model]
         # Just fetch the name of the uom in `timesheet_encode_uom_id` of the current company
         encoding_uom_name = self.env.company.timesheet_encode_uom_id.with_context(prefetch_fields=False).sudo().name
@@ -184,7 +184,7 @@ class AccountAnalyticLine(models.Model):
             name_with_uom = re.sub(_('Hours') + "|Hours", encoding_uom_name or '', Model._fields[node.get('name')]._description_string(self.env), flags=re.IGNORECASE)
             node.set('string', name_with_uom)
 
-        return etree.tostring(doc, encoding='unicode')
+        return doc
 
     def _timesheet_get_portal_domain(self):
         if self.env.user.has_group('hr_timesheet.group_hr_timesheet_user'):

--- a/addons/hr_timesheet/models/project.py
+++ b/addons/hr_timesheet/models/project.py
@@ -81,11 +81,11 @@ class Project(models.Model):
         return [('id', operator_new, (query, ()))]
 
     @api.model
-    def _fields_view_get(self, view_id=None, view_type='form', toolbar=False, submenu=False):
-        result = super()._fields_view_get(view_id=view_id, view_type=view_type, toolbar=toolbar, submenu=submenu)
+    def _get_view(self, view_id=None, view_type='form', **options):
+        arch, view = super()._get_view(view_id, view_type, **options)
         if view_type in ['tree', 'form'] and self.env.company.timesheet_encode_uom_id == self.env.ref('uom.product_uom_day'):
-            result['arch'] = self.env['account.analytic.line']._apply_time_label(result['arch'], related_model=self._name)
-        return result
+            arch = self.env['account.analytic.line']._apply_time_label(arch, related_model=self._name)
+        return arch, view
 
     @api.depends('allow_timesheets', 'timesheet_ids')
     def _compute_remaining_hours(self):
@@ -368,16 +368,16 @@ class Task(models.Model):
         return super().name_get()
 
     @api.model
-    def _fields_view_get(self, view_id=None, view_type='form', toolbar=False, submenu=False):
+    def _get_view(self, view_id=None, view_type='form', **options):
         """ Set the correct label for `unit_amount`, depending on company UoM """
-        result = super(Task, self)._fields_view_get(view_id=view_id, view_type=view_type, toolbar=toolbar, submenu=submenu)
+        arch, view = super()._get_view(view_id, view_type, **options)
         # Use of sudo as the portal user doesn't have access to uom
-        result['arch'] = self.env['account.analytic.line'].sudo()._apply_timesheet_label(result['arch'])
+        arch = self.env['account.analytic.line'].sudo()._apply_timesheet_label(arch)
 
         if view_type in ['tree', 'pivot', 'graph'] and self.env.company.timesheet_encode_uom_id == self.env.ref('uom.product_uom_day'):
-            result['arch'] = self.env['account.analytic.line']._apply_time_label(result['arch'], related_model=self._name)
+            arch = self.env['account.analytic.line']._apply_time_label(arch, related_model=self._name)
 
-        return result
+        return arch, view
 
     @api.ondelete(at_uninstall=False)
     def _unlink_except_contains_entries(self):

--- a/addons/hr_timesheet/report/project_report.py
+++ b/addons/hr_timesheet/report/project_report.py
@@ -33,8 +33,8 @@ class ReportProjectTaskUser(models.Model):
         return super(ReportProjectTaskUser, self)._group_by() + group_by_append
 
     @api.model
-    def _fields_view_get(self, view_id=None, view_type='form', toolbar=False, submenu=False):
-        result = super(ReportProjectTaskUser, self)._fields_view_get(view_id=view_id, view_type=view_type, toolbar=toolbar, submenu=submenu)
+    def _get_view(self, view_id=None, view_type='form', **options):
+        arch, view = super()._get_view(view_id, view_type, **options)
         if view_type in ['pivot', 'graph'] and self.env.company.timesheet_encode_uom_id == self.env.ref('uom.product_uom_day'):
-            result['arch'] = self.env['account.analytic.line']._apply_time_label(result['arch'], related_model=self._name)
-        return result
+            arch = self.env['account.analytic.line']._apply_time_label(arch, related_model=self._name)
+        return arch, view

--- a/addons/mail/__manifest__.py
+++ b/addons/mail/__manifest__.py
@@ -99,6 +99,7 @@
             'web/static/src/legacy/js/services/data_manager.js',
             'web/static/src/legacy/js/services/session.js',
             'web/static/src/legacy/js/widgets/date_picker.js',
+            'web/static/src/legacy/legacy_load_views.js',
             'web/static/src/legacy/legacy_promise_error_handler.js',
             'web/static/src/legacy/legacy_rpc_error_handler.js',
             'web/static/src/legacy/utils.js',

--- a/addons/mail/models/ir_ui_view.py
+++ b/addons/mail/models/ir_ui_view.py
@@ -6,3 +6,10 @@ class View(models.Model):
     _inherit = 'ir.ui.view'
 
     type = fields.Selection(selection_add=[('activity', 'Activity')])
+
+    def _postprocess_tag_field(self, node, name_manager, node_info):
+        if node.xpath("ancestor::div[hasclass('oe_chatter')]"):
+            # Pass the postprocessing of the mail thread fields
+            # The web client makes it completely custom, and this is therefore pointless.
+            return
+        return super()._postprocess_tag_field(node, name_manager, node_info)

--- a/addons/membership/models/product.py
+++ b/addons/membership/models/product.py
@@ -18,10 +18,10 @@ class Product(models.Model):
     ]
 
     @api.model
-    def fields_view_get(self, view_id=None, view_type='form', toolbar=False, submenu=False):
+    def get_view(self, view_id=None, view_type='form', **options):
         if self._context.get('product') == 'membership_product':
             if view_type == 'form':
                 view_id = self.env.ref('membership.membership_products_form').id
             else:
                 view_id = self.env.ref('membership.membership_products_tree').id
-        return super(Product, self).fields_view_get(view_id=view_id, view_type=view_type, toolbar=toolbar, submenu=submenu)
+        return super().get_view(view_id, view_type, **options)

--- a/addons/project/tests/test_project_sharing_portal_access.py
+++ b/addons/project/tests/test_project_sharing_portal_access.py
@@ -2,6 +2,7 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 from collections import OrderedDict
+from lxml import etree
 from odoo import Command
 from odoo.exceptions import AccessError
 from odoo.tests import tagged
@@ -49,10 +50,11 @@ class TestProjectSharingPortalAccess(TestProjectSharingCommon):
 
     def test_readonly_fields(self):
         """ The fields are not writeable should not be editable by the portal user. """
-        view_infos = self.task_portal.fields_view_get(view_id=self.env.ref(self.project_sharing_form_view_xml_id).id)
+        view_infos = self.task_portal.get_view(self.env.ref(self.project_sharing_form_view_xml_id).id)
+        fields = [el.get('name') for el in etree.fromstring(view_infos['arch']).xpath('//field[not(ancestor::field)]')]
         project_task_fields = {
             field_name
-            for field_name, field_attrs in view_infos['fields'].items()
+            for field_name in fields
             if field_name not in self.write_protected_fields_task
         }
         with self.get_project_sharing_form_view(self.task_portal, self.user_portal) as form:

--- a/addons/stock/models/product.py
+++ b/addons/stock/models/product.py
@@ -428,35 +428,33 @@ class Product(models.Model):
         return res
 
     @api.model
-    def fields_view_get(self, view_id=None, view_type='form', toolbar=False, submenu=False):
-        res = super(Product, self).fields_view_get(view_id=view_id, view_type=view_type, toolbar=toolbar, submenu=submenu)
+    def fields_get(self, allfields=None, attributes=None):
+        res = super().fields_get(allfields, attributes)
         if self._context.get('location') and isinstance(self._context['location'], int):
             location = self.env['stock.location'].browse(self._context['location'])
-            fields = res.get('fields')
-            if fields:
-                if location.usage == 'supplier':
-                    if fields.get('virtual_available'):
-                        res['fields']['virtual_available']['string'] = _('Future Receipts')
-                    if fields.get('qty_available'):
-                        res['fields']['qty_available']['string'] = _('Received Qty')
-                elif location.usage == 'internal':
-                    if fields.get('virtual_available'):
-                        res['fields']['virtual_available']['string'] = _('Forecasted Quantity')
-                elif location.usage == 'customer':
-                    if fields.get('virtual_available'):
-                        res['fields']['virtual_available']['string'] = _('Future Deliveries')
-                    if fields.get('qty_available'):
-                        res['fields']['qty_available']['string'] = _('Delivered Qty')
-                elif location.usage == 'inventory':
-                    if fields.get('virtual_available'):
-                        res['fields']['virtual_available']['string'] = _('Future P&L')
-                    if fields.get('qty_available'):
-                        res['fields']['qty_available']['string'] = _('P&L Qty')
-                elif location.usage == 'production':
-                    if fields.get('virtual_available'):
-                        res['fields']['virtual_available']['string'] = _('Future Productions')
-                    if fields.get('qty_available'):
-                        res['fields']['qty_available']['string'] = _('Produced Qty')
+            if location.usage == 'supplier':
+                if res.get('virtual_available'):
+                    res['virtual_available']['string'] = _('Future Receipts')
+                if res.get('qty_available'):
+                    res['qty_available']['string'] = _('Received Qty')
+            elif location.usage == 'internal':
+                if res.get('virtual_available'):
+                    res['virtual_available']['string'] = _('Forecasted Quantity')
+            elif location.usage == 'customer':
+                if res.get('virtual_available'):
+                    res['virtual_available']['string'] = _('Future Deliveries')
+                if res.get('qty_available'):
+                    res['qty_available']['string'] = _('Delivered Qty')
+            elif location.usage == 'inventory':
+                if res.get('virtual_available'):
+                    res['virtual_available']['string'] = _('Future P&L')
+                if res.get('qty_available'):
+                    res['qty_available']['string'] = _('P&L Qty')
+            elif location.usage == 'production':
+                if res.get('virtual_available'):
+                    res['virtual_available']['string'] = _('Future Productions')
+                if res.get('qty_available'):
+                    res['qty_available']['string'] = _('Produced Qty')
         return res
 
     def action_view_orderpoints(self):

--- a/addons/test_mail/static/tests/activity_tests.js
+++ b/addons/test_mail/static/tests/activity_tests.js
@@ -562,7 +562,7 @@ QUnit.test("Schedule activity dialog uses the same search view as activity view"
     });
 
     function mockRPC(route, args) {
-        if (args.method === "load_views") {
+        if (args.method === "get_views") {
             assert.step(JSON.stringify(args.kwargs.views));
         }
     }

--- a/addons/web/__manifest__.py
+++ b/addons/web/__manifest__.py
@@ -145,6 +145,7 @@ This module provides the core of the Odoo Web Client.
             'web/static/src/legacy/legacy_service_provider.js',
             'web/static/src/legacy/legacy_client_actions.js',
             'web/static/src/legacy/legacy_dialog.js',
+            'web/static/src/legacy/legacy_load_views.js',
             'web/static/src/legacy/legacy_views.js',
             'web/static/src/legacy/legacy_promise_error_handler.js',
             'web/static/src/legacy/legacy_rpc_error_handler.js',

--- a/addons/web/models/models.py
+++ b/addons/web/models/models.py
@@ -237,15 +237,15 @@ class Base(models.AbstractModel):
             })
 
     @api.model
-    def fields_view_get(self, view_id=None, view_type='form', toolbar=False, submenu=False):
-        r = super().fields_view_get(view_id, view_type, toolbar, submenu)
+    def _get_view(self, view_id=None, view_type='form', **options):
+        arch, view = super()._get_view(view_id, view_type, **options)
         # avoid leaking the raw (un-rendered) template, also avoids bloating
         # the response payload for no reason. Only send the root node,
         # to send attributes such as `js_class`.
-        if r['type'] == 'qweb':
-            root = etree.fromstring(r['arch'])
-            r['arch'] = etree.tostring(etree.Element('qweb', root.attrib))
-        return r
+        if view_type == 'qweb':
+            root = arch
+            arch = etree.Element('qweb', root.attrib)
+        return arch, view
 
     @api.model
     def _search_panel_field_image(self, field_name, **kwargs):

--- a/addons/web/static/src/core/py_js/py_builtin.js
+++ b/addons/web/static/src/core/py_js/py_builtin.js
@@ -58,4 +58,7 @@ export const BUILTINS = {
     },
 
     relativedelta: PyRelativeDelta,
+
+    true: true,
+    false: false,
 };

--- a/addons/web/static/src/core/utils/arrays.js
+++ b/addons/web/static/src/core/utils/arrays.js
@@ -53,6 +53,17 @@ function _getExtractorFrom(criterion) {
 }
 
 /**
+ * Returns the array of elements contained in both arrays.
+ *
+ * @param {any[]} array1
+ * @param {any[]} array2
+ * @returns {any[]}
+ */
+export function intersection(array1, array2) {
+    return array1.filter((v) => array2.includes(v));
+}
+
+/**
  * Returns an object holding different groups defined by a given criterion
  * or a default one. Each group is a subset of the original given list.
  * The given criterion can either be:

--- a/addons/web/static/src/legacy/js/services/data_manager.js
+++ b/addons/web/static/src/legacy/js/services/data_manager.js
@@ -89,6 +89,9 @@ return core.Class.extend({
         if (shouldLoadViews) {
             // Views info should be loaded
             options.load_filters = shouldLoadFilters;
+            if (config.device.isMobile) {
+                options.mobile = config.device.isMobile;
+            }
             this._cache.views[viewsKey] = rpc.query({
                 args: [],
                 kwargs: { context, options, views: views_descr },

--- a/addons/web/static/src/legacy/js/services/data_manager.js
+++ b/addons/web/static/src/legacy/js/services/data_manager.js
@@ -5,7 +5,7 @@ var config = require('web.config');
 var core = require('web.core');
 var rpc = require('web.rpc');
 var session = require('web.session');
-var utils = require('web.utils');
+const { generateLegacyLoadViewsResult } = require("@web/legacy/legacy_load_views");
 
 return core.Class.extend({
     init: function () {
@@ -96,11 +96,13 @@ return core.Class.extend({
                 args: [],
                 kwargs: { context, options, views: views_descr },
                 model,
-                method: 'load_views',
+                method: 'get_views',
             }).then(result => {
+                const { models, views } = result;
+                result = generateLegacyLoadViewsResult(model, views, models);
                 // Freeze the fields dict as it will be shared between views and
                 // no one should edit it
-                utils.deepFreeze(result.fields);
+                // utils.deepFreeze(result.fields); // OWL issue regarding proxies and frozen objects https://github.com/odoo/owl/issues/1158
                 for (const [ /* viewId */ , viewType] of views_descr) {
                     const fvg = result.fields_views[viewType];
                     fvg.viewFields = fvg.fields;

--- a/addons/web/static/src/legacy/legacy_load_views.js
+++ b/addons/web/static/src/legacy/legacy_load_views.js
@@ -1,0 +1,116 @@
+/** @odoo-module **/
+
+const xmlSerializer = new XMLSerializer();
+const domParser = new DOMParser();
+
+function traverse(tree, f) {
+    if (f(tree)) {
+        _.each(tree.children, function (c) {
+            traverse(c, f);
+        });
+    }
+}
+
+/**
+ * Given the result of a get_views, produces the equivalent of what was previously
+ * returned, such that legacy views continue working as before without any adaptations.
+ *
+ * @param {string} resModel
+ * @param {Object} views "views" key of the result of a get_views
+ * @param {Object} models maps of model name -> fields_get
+ * @returns {Object} similar to what was previously returned by load_views
+ */
+export function generateLegacyLoadViewsResult(resModel, views, models) {
+    const legacyFieldViews = {
+        fields: models[resModel],
+        fields_views: {},
+    };
+    if (views.search && views.search.filters) {
+        legacyFieldViews.filters = views.search.filters;
+    }
+    for (const viewType in views) {
+        const { arch, toolbar, id } = views[viewType];
+        const { arch: processedArch, viewFields } = processArch(arch, viewType, resModel, models);
+        legacyFieldViews.fields_views[viewType] = {
+            arch: processedArch,
+            fields: viewFields,
+            model: resModel,
+            toolbar,
+            view_id: id,
+        };
+    }
+    return legacyFieldViews;
+}
+
+/**
+ * Given an arch with inline x2many subviews, generates the object of fields
+ * appearing in the arch, with a "views" key that contains the descriptions of
+ * their subviews (whose archs are removed from the main arch).
+ *
+ * @param {string} arch
+ * @param {string} viewType
+ * @param {string} resModel
+ * @param {Object} models
+ * @returns {Object} the processed arch and the (view) fields description
+ */
+export function processArch(arch, viewType, resModel, models) {
+    const viewFields = {};
+    const archDoc = domParser.parseFromString(arch, "text/xml").documentElement;
+    traverse(archDoc, function (node) {
+        if (node.nodeType === 3) {
+            return false;
+        }
+        if (node.tagName === "field") {
+            const fieldName = node.getAttribute("name");
+            viewFields[fieldName] = viewFields[fieldName] || {
+                ...models[resModel][fieldName],
+                views: {},
+            };
+            // extract subviews
+            // note: this should only be done for form views, because x2many subviews doesn't make
+            // any sense in any other view type, but sometimes in the codebase, people inline
+            // subviews in list views (e.g. sale.order.form.inherit.sale.product.configurator) so
+            // we remove them from the main arch anyway, to mock the previous behavior
+            if (viewType === "form" || viewType === "list") {
+                const coModel = models[resModel][fieldName].relation;
+                const views = {};
+                for (const childNode of [...node.children]) {
+                    const viewType = childNode.tagName === "tree" ? "list" : childNode.tagName;
+                    const { arch: subViewArch, viewFields: subViewFields } = processArch(
+                        xmlSerializer.serializeToString(childNode),
+                        viewType,
+                        coModel,
+                        models
+                    );
+                    views[viewType] = { arch: subViewArch, fields: subViewFields };
+                    node.removeChild(childNode);
+                }
+                viewFields[fieldName].views = views;
+            }
+            return false;
+        }
+        // list: extract groupby informations
+        if (viewType === "list" && node.tagName === "groupby" && node !== archDoc) {
+            const fieldName = node.getAttribute("name");
+            const coModel = models[resModel][fieldName].relation;
+            const { arch: subViewArch, viewFields: subViewFields } = processArch(
+                xmlSerializer.serializeToString(node),
+                "groupby",
+                coModel,
+                models
+            );
+            const groupbyView = { arch: subViewArch, fields: subViewFields };
+            viewFields[fieldName] = viewFields[fieldName] || {
+                ...models[resModel][fieldName],
+                views: {},
+            };
+            viewFields[fieldName].views.groupby = groupbyView;
+            for (const child of [...node.children]) {
+                node.removeChild(child);
+            }
+            return false;
+        }
+        return true;
+    });
+    return { arch: xmlSerializer.serializeToString(archDoc), viewFields };
+}

--- a/addons/web/static/src/legacy/legacy_views.js
+++ b/addons/web/static/src/legacy/legacy_views.js
@@ -116,6 +116,7 @@ function registerView(name, LegacyView) {
             this.viewInfo = Object.assign({}, fieldsInfo, {
                 fields: result.fields,
                 viewFields: fieldsInfo.fields,
+                type: this.props.type,
             });
             let controlPanelFieldsView;
             if (result.fields_views.search) {

--- a/addons/web/static/src/search/search_arch_parser.js
+++ b/addons/web/static/src/search/search_arch_parser.js
@@ -36,10 +36,10 @@ function reduceType(type) {
 }
 
 export class SearchArchParser extends XMLParser {
-    constructor(searchViewDescription, searchDefaults = {}, searchPanelDefaults = {}) {
+    constructor(searchViewDescription, fields, searchDefaults = {}, searchPanelDefaults = {}) {
         super();
 
-        const { fields, irFilters, arch } = searchViewDescription;
+        const { irFilters, arch } = searchViewDescription;
 
         this.fields = fields || {};
         this.irFilters = irFilters || [];

--- a/addons/web/static/src/views/view.js
+++ b/addons/web/static/src/views/view.js
@@ -199,32 +199,31 @@ export class View extends Component {
         if (loadView || loadSearchView) {
             // view description (or search view description if required) is incomplete
             // a loadViews is done to complete the missing information
-            const viewDescriptions = await this.viewService.loadViews(
+            const result = await this.viewService.loadViews(
                 { context, resModel, views },
                 { actionId: this.env.config.actionId, loadActionMenus, loadIrFilters }
             );
             // Note: if this.props.views is different from views, the cached descriptions
             // will certainly not be reused! (but for the standard flow this will work as
             // before)
-            viewDescription = viewDescriptions[type];
-            view[0] = viewDescription.viewId;
-            searchViewDescription = viewDescriptions.search;
+            viewDescription = result.views[type];
+            searchViewDescription = result.views.search;
             if (loadSearchView) {
-                searchViewId = searchViewId || searchViewDescription.viewId;
+                searchViewId = searchViewId || searchViewDescription.id;
                 if (!searchViewArch) {
                     searchViewArch = searchViewDescription.arch;
-                    searchViewFields = searchViewDescription.fields;
+                    searchViewFields = result.fields;
                 }
                 if (!irFilters) {
                     irFilters = searchViewDescription.irFilters;
                 }
             }
             this.env.config.views = views;
+            fields = fields || result.fields;
         }
 
         if (!arch) {
             arch = viewDescription.arch;
-            fields = viewDescription.fields;
         }
         if (!actionMenus) {
             actionMenus = viewDescription.actionMenus;
@@ -244,7 +243,7 @@ export class View extends Component {
         }
 
         Object.assign(this.env.config, {
-            viewId: viewDescription.viewId,
+            viewId: viewDescription.id,
             viewType: type,
             viewSubType: subType,
             bannerRoute,

--- a/addons/web/static/src/views/view_service.js
+++ b/addons/web/static/src/views/view_service.js
@@ -1,6 +1,7 @@
 /** @odoo-module **/
 
 import { registry } from "@web/core/registry";
+import { device } from 'web.config';
 
 /**
  * @typedef {Object} IrFilter
@@ -65,14 +66,18 @@ export const viewService = {
         async function loadViews(params, options) {
             const key = JSON.stringify([params.resModel, params.views, params.context, options]);
             if (!cache[key]) {
+                var load_views_options = {
+                    action_id: options.actionId || false,
+                    load_filters: options.loadIrFilters || false,
+                    toolbar: options.loadActionMenus || false,
+                }
+                if (device.isMobile){
+                    load_views_options.mobile = device.isMobile;
+                }
                 cache[key] = orm
                     .call(params.resModel, "load_views", [], {
                         views: params.views,
-                        options: {
-                            action_id: options.actionId || false,
-                            load_filters: options.loadIrFilters || false,
-                            toolbar: options.loadActionMenus || false,
-                        },
+                        options: load_views_options,
                         context: params.context,
                     })
                     .then((result) => {

--- a/addons/web/static/tests/core/py_js/py_interpreter_tests.js
+++ b/addons/web/static/tests/core/py_js/py_interpreter_tests.js
@@ -145,6 +145,11 @@ QUnit.module("py", {}, () => {
             }
         );
 
+        QUnit.test("true and false available in context", (assert) => {
+            assert.strictEqual(evaluateExpr("true"), true);
+            assert.strictEqual(evaluateExpr("false"), false);
+        });
+
         QUnit.test("throw error if name is not defined", (assert) => {
             assert.throws(() => evaluateExpr("a"));
         });

--- a/addons/web/static/tests/core/utils/arrays_tests.js
+++ b/addons/web/static/tests/core/utils/arrays_tests.js
@@ -1,6 +1,6 @@
 /** @odoo-module **/
 
-import { cartesian, groupBy, sortBy, unique } from "@web/core/utils/arrays";
+import { cartesian, groupBy, intersection, sortBy, unique } from "@web/core/utils/arrays";
 
 QUnit.module("utils", () => {
     QUnit.module("Arrays");
@@ -151,6 +151,14 @@ QUnit.module("utils", () => {
             { x: "b" },
             { x: "a" },
         ]);
+    });
+
+    QUnit.test("intersection of arrays", function (assert) {
+        assert.deepEqual(intersection([], [1, 2]), []);
+        assert.deepEqual(intersection([1, 2], []), []);
+        assert.deepEqual(intersection([1], [2]), []);
+        assert.deepEqual(intersection([1, 2], [2, 3]), [2]);
+        assert.deepEqual(intersection([1, 2, 3], [1, 2, 3]), [1, 2, 3]);
     });
 
     QUnit.test("cartesian product of zero arrays", function (assert) {

--- a/addons/web/static/tests/helpers/mock_server.js
+++ b/addons/web/static/tests/helpers/mock_server.js
@@ -3,6 +3,8 @@
 import { browser } from "@web/core/browser/browser";
 import { Domain } from "@web/core/domain";
 import { evaluateExpr } from "@web/core/py_js/py";
+import { deepCopy } from "@web/core/utils/objects";
+import { intersection } from "@web/core/utils/arrays";
 import { registry } from "@web/core/registry";
 import { makeFakeRPCService, makeMockFetch } from "./mock_services";
 import { patchWithCleanup } from "./utils";
@@ -10,6 +12,9 @@ import { parseDateTime } from "@web/core/l10n/dates";
 
 const { DateTime } = luxon;
 const serviceRegistry = registry.category("services");
+
+const domParser = new DOMParser();
+const xmlSerializer = new XMLSerializer();
 
 // -----------------------------------------------------------------------------
 // Utils
@@ -19,197 +24,6 @@ function traverseElementTree(tree, cb) {
     if (cb(tree)) {
         Array.from(tree.children).forEach((c) => traverseElementTree(c, cb));
     }
-}
-
-export function _fieldsViewGet(params) {
-    let processedNodes = params.processedNodes || [];
-    const { arch, context, fields, modelName } = params;
-    function isNodeProcessed(node) {
-        return processedNodes.findIndex((n) => n.isSameNode(node)) > -1;
-    }
-    const modifiersNames = ["invisible", "readonly", "required"];
-    const onchanges = params.models[modelName].onchanges || {};
-    const fieldNodes = {};
-    const groupbyNodes = {};
-    let doc;
-    if (typeof arch === "string") {
-        const domParser = new DOMParser();
-        doc = domParser.parseFromString(arch, "text/xml").documentElement;
-    } else {
-        doc = arch;
-    }
-    const inTreeView = doc.tagName === "tree";
-    // mock _postprocess_access_rights
-    const isBaseModel = !context.base_model_name || modelName === context.base_model_name;
-    const views = ["kanban", "tree", "form", "gantt", "activity"];
-    if (isBaseModel && views.indexOf(doc.tagName) !== -1) {
-        for (const action of ["create", "delete", "edit", "write"]) {
-            if (!doc.getAttribute(action) && action in context && !context[action]) {
-                doc.setAttribute(action, "false");
-            }
-        }
-    }
-
-    traverseElementTree(doc, (node) => {
-        if (node.nodeType === Node.TEXT_NODE) {
-            return false;
-        }
-        const modifiers = {};
-        const isField = node.tagName === "field";
-        const isGroupby = node.tagName === "groupby";
-        if (isField) {
-            const fieldName = node.getAttribute("name");
-            fieldNodes[fieldName] = node;
-            // 'transfer_field_to_modifiers' simulation
-            const field = fields[fieldName];
-            if (!field) {
-                throw new Error("Field " + fieldName + " does not exist");
-            }
-            const defaultValues = {};
-            const stateExceptions = {}; // what is this ?
-            modifiersNames.forEach((attr) => {
-                stateExceptions[attr] = [];
-                defaultValues[attr] = !!field[attr];
-            });
-            // LPE: what is this ?
-            /*                _.each(field.states || {}, function (modifs, state) {
-                        _.each(modifs, function (modif) {
-                            if (defaultValues[modif[0]] !== modif[1]) {
-                                stateExceptions[modif[0]].append(state);
-                            }
-                        });
-                    });*/
-            Object.entries(defaultValues).forEach(([attr, defaultValue]) => {
-                if (stateExceptions[attr].length) {
-                    modifiers[attr] = [
-                        ["state", defaultValue ? "not in" : "in", stateExceptions[attr]],
-                    ];
-                } else {
-                    modifiers[attr] = defaultValue;
-                }
-            });
-        } else if (isGroupby && !isNodeProcessed(node)) {
-            const groupbyName = node.getAttribute("name");
-            fieldNodes[groupbyName] = node;
-            groupbyNodes[groupbyName] = node;
-        }
-        // 'transfer_node_to_modifiers' simulation
-        let attrs = node.getAttribute("attrs");
-        if (attrs) {
-            attrs = evaluateExpr(attrs);
-            Object.assign(modifiers, attrs);
-        }
-        const states = node.getAttribute("states");
-        if (states) {
-            if (!modifiers.invisible) {
-                modifiers.invisible = [];
-            }
-            modifiers.invisible.push(["state", "not in", states.split(",")]);
-        }
-        const inListHeader = inTreeView && node.closest("header");
-        modifiersNames.forEach((attr) => {
-            const mod = node.getAttribute(attr);
-            if (mod) {
-                // TODO
-                // const pyevalContext = window.py.dict.fromJSON(context || {});
-                // var v = pyUtils.py_eval(mod, {context: pyevalContext}) ? true : false;
-                console.info(
-                    "MockServer: naive parse of modifier value in",
-                    QUnit.config.current.testName
-                );
-                const v = JSON.parse(mod);
-                if (inTreeView && !inListHeader && attr === "invisible") {
-                    modifiers.column_invisible = v;
-                } else if (v || !(attr in modifiers) || !Array.isArray(modifiers[attr])) {
-                    modifiers[attr] = v;
-                }
-            }
-        });
-        modifiersNames.forEach((attr) => {
-            if (
-                attr in modifiers &&
-                (!!modifiers[attr] === false ||
-                    (Array.isArray(modifiers[attr]) && !modifiers[attr].length))
-            ) {
-                delete modifiers[attr];
-            }
-        });
-        if (Object.keys(modifiers).length) {
-            node.setAttribute("modifiers", JSON.stringify(modifiers));
-        }
-        if (isGroupby && !isNodeProcessed(node)) {
-            return false;
-        }
-        return !isField;
-    });
-    let relModel, relFields;
-    Object.entries(fieldNodes).forEach(([name, node]) => {
-        const field = fields[name];
-        if (field.type === "many2one" || field.type === "many2many") {
-            const canCreate = node.getAttribute("can_create");
-            node.setAttribute("can_create", canCreate || "true");
-            const canWrite = node.getAttribute("can_write");
-            node.setAttribute("can_write", canWrite || "true");
-        }
-        if (field.type === "one2many" || field.type === "many2many") {
-            field.views = {};
-            Array.from(node.children).forEach((children) => {
-                if (children.tagName) {
-                    // skip text nodes
-                    relModel = field.relation;
-                    relFields = Object.assign({}, params.models[relModel].fields);
-                    field.views[children.tagName] = _fieldsViewGet({
-                        models: params.models,
-                        arch: children,
-                        modelName: relModel,
-                        fields: relFields,
-                        context: Object.assign({}, context, { base_model_name: modelName }),
-                        processedNodes,
-                    });
-                }
-            });
-        }
-        // add onchanges
-        if (name in onchanges) {
-            node.setAttribute("on_change", "1");
-        }
-    });
-    Object.entries(groupbyNodes).forEach(([name, node]) => {
-        const field = fields[name];
-        if (field.type !== "many2one") {
-            throw new Error("groupby can only target many2one");
-        }
-        field.views = {};
-        relModel = field.relation;
-        relFields = Object.assign({}, params.models[relModel].fields);
-        processedNodes.push(node);
-        // postprocess simulation
-        field.views.groupby = _fieldsViewGet({
-            models: params.models,
-            arch: node,
-            modelName: relModel,
-            fields: relFields,
-            context,
-            processedNodes,
-        });
-        while (node.firstChild) {
-            node.removeChild(node.firstChild);
-        }
-    });
-    const xmlSerializer = new XMLSerializer();
-    const processedArch = xmlSerializer.serializeToString(doc);
-    const fieldsInView = {};
-    Object.entries(fields).forEach(([fname, field]) => {
-        if (fname in fieldNodes) {
-            fieldsInView[fname] = field;
-        }
-    });
-    return {
-        arch: processedArch,
-        fields: fieldsInView,
-        model: modelName,
-        type: doc.tagName === "tree" ? "list" : doc.tagName,
-    };
 }
 
 // -----------------------------------------------------------------------------
@@ -298,7 +112,7 @@ export class MockServer {
         // def.abort = abort;
     }
 
-    fieldsViewGet(modelName, args, kwargs) {
+    getView(modelName, args, kwargs) {
         if (!(modelName in this.models)) {
             throw new Error(`Model ${modelName} was not defined in mock server data`);
         }
@@ -331,7 +145,7 @@ export class MockServer {
             fields[fieldName].name = fieldName;
         }
         // var viewOptions = params.viewOptions || {};
-        const fvg = _fieldsViewGet({
+        const view = this._getView({
             arch,
             modelName,
             fields,
@@ -339,13 +153,231 @@ export class MockServer {
             models: this.models,
         });
         if (kwargs.options.toolbar) {
-            fvg.toolbar = this.models[modelName].toolbar || {};
+            view.toolbar = this.models[modelName].toolbar || {};
         }
         if (viewId !== undefined) {
-            fvg.view_id = viewId;
-            fvg.name = key;
+            view.id = viewId;
         }
-        return fvg;
+        return view;
+    }
+
+    _getView(params) {
+        let processedNodes = params.processedNodes || [];
+        const { arch, context, modelName } = params;
+        const level = params.level || 0;
+        const fields = deepCopy(params.fields);
+        function isNodeProcessed(node) {
+            return processedNodes.findIndex((n) => n.isSameNode(node)) > -1;
+        }
+        const modifiersNames = ["invisible", "readonly", "required"];
+        const onchanges = params.models[modelName].onchanges || {};
+        const fieldNodes = {};
+        const groupbyNodes = {};
+        const relatedModels = new Set([modelName]);
+        let doc;
+        if (typeof arch === "string") {
+            doc = domParser.parseFromString(arch, "text/xml").documentElement;
+        } else {
+            doc = arch;
+        }
+        const inTreeView = doc.tagName === "tree";
+        const inFormView = doc.tagName === "form";
+        // mock _postprocess_access_rights
+        const isBaseModel = !context.base_model_name || modelName === context.base_model_name;
+        const views = ["kanban", "tree", "form", "gantt", "activity"];
+        if (isBaseModel && views.indexOf(doc.tagName) !== -1) {
+            for (const action of ["create", "delete", "edit", "write"]) {
+                if (!doc.getAttribute(action) && action in context && !context[action]) {
+                    doc.setAttribute(action, "false");
+                }
+            }
+        }
+
+        traverseElementTree(doc, (node) => {
+            if (node.nodeType === Node.TEXT_NODE) {
+                return false;
+            }
+            const modifiers = {};
+            const isField = node.tagName === "field";
+            const isGroupby = node.tagName === "groupby";
+            if (isField) {
+                const fieldName = node.getAttribute("name");
+                fieldNodes[fieldName] = node;
+                // 'transfer_field_to_modifiers' simulation
+                const field = fields[fieldName];
+                if (!field) {
+                    throw new Error("Field " + fieldName + " does not exist");
+                }
+                const defaultValues = {};
+                const stateExceptions = {}; // what is this ?
+                modifiersNames.forEach((attr) => {
+                    stateExceptions[attr] = [];
+                    defaultValues[attr] = !!field[attr];
+                });
+                // LPE: what is this ?
+                /*                _.each(field.states || {}, function (modifs, state) {
+                            _.each(modifs, function (modif) {
+                                if (defaultValues[modif[0]] !== modif[1]) {
+                                    stateExceptions[modif[0]].append(state);
+                                }
+                            });
+                        });*/
+                Object.entries(defaultValues).forEach(([attr, defaultValue]) => {
+                    if (stateExceptions[attr].length) {
+                        modifiers[attr] = [
+                            ["state", defaultValue ? "not in" : "in", stateExceptions[attr]],
+                        ];
+                    } else {
+                        modifiers[attr] = defaultValue;
+                    }
+                });
+            } else if (isGroupby && !isNodeProcessed(node)) {
+                const groupbyName = node.getAttribute("name");
+                fieldNodes[groupbyName] = node;
+                groupbyNodes[groupbyName] = node;
+            }
+            // 'transfer_node_to_modifiers' simulation
+            let attrs = node.getAttribute("attrs");
+            if (attrs) {
+                attrs = evaluateExpr(attrs);
+                Object.assign(modifiers, attrs);
+            }
+            const states = node.getAttribute("states");
+            if (states) {
+                if (!modifiers.invisible) {
+                    modifiers.invisible = [];
+                }
+                modifiers.invisible.push(["state", "not in", states.split(",")]);
+            }
+            const inListHeader = inTreeView && node.closest("header");
+            modifiersNames.forEach((attr) => {
+                const mod = node.getAttribute(attr);
+                if (mod) {
+                    const v = evaluateExpr(mod, { context }) ? true : false;
+                    if (inTreeView && !inListHeader && attr === "invisible") {
+                        modifiers.column_invisible = v;
+                    } else if (v || !(attr in modifiers) || !Array.isArray(modifiers[attr])) {
+                        modifiers[attr] = v;
+                    }
+                }
+            });
+            modifiersNames.forEach((attr) => {
+                if (
+                    attr in modifiers &&
+                    (!!modifiers[attr] === false ||
+                        (Array.isArray(modifiers[attr]) && !modifiers[attr].length))
+                ) {
+                    delete modifiers[attr];
+                }
+            });
+            if (Object.keys(modifiers).length) {
+                node.setAttribute("modifiers", JSON.stringify(modifiers));
+            }
+            if (isGroupby && !isNodeProcessed(node)) {
+                return false;
+            }
+            return !isField;
+        });
+        let relModel, relFields;
+        Object.entries(fieldNodes).forEach(([name, node]) => {
+            const field = fields[name];
+            if (field.type === "many2one" || field.type === "many2many") {
+                const canCreate = node.getAttribute("can_create");
+                node.setAttribute("can_create", canCreate || "true");
+                const canWrite = node.getAttribute("can_write");
+                node.setAttribute("can_write", canWrite || "true");
+            }
+            if (field.type === "one2many" || field.type === "many2many") {
+                relModel = field.relation;
+                relatedModels.add(relModel);
+                // inline subviews: in forms if field is visible and has no widget (1st level only)
+                if (
+                    inFormView &&
+                    level === 0 &&
+                    !node.getAttribute("widget") &&
+                    !node.getAttribute("invisible")
+                ) {
+                    const inlineViewTypes = Array.from(node.children).map((c) => c.tagName);
+                    const missingViewtypes = inlineViewTypes.includes("form") ? [] : ["form"];
+                    const mode = node.getAttribute("mode") || "kanban,tree";
+                    if (!intersection(inlineViewTypes, mode.split(",")).length) {
+                        // TODO: use a kanban view by default in mobile
+                        missingViewtypes.push((node.getAttribute("mode") || "list").split(",")[0]);
+                    }
+                    for (let type of missingViewtypes) {
+                        type = type === "tree" ? "list" : type;
+                        let key = `${field.relation},false,${type}`;
+                        if (!this.archs[key]) {
+                            const regexp = new RegExp(`${field.relation},[a-z._0-9]+,${type}`);
+                            key = Object.keys(this.archs).find((k) => regexp.test(k));
+                        }
+                        // in a lot of tests, we don't need the form view, so it doesn't even exist
+                        const arch = this.archs[key] || (type === "form" ? "<form/>" : null);
+                        if (!arch) {
+                            throw new Error(`Can't find ${type} view to inline`);
+                        }
+                        node.appendChild(
+                            domParser.parseFromString(arch, "text/xml").documentElement
+                        );
+                    }
+                }
+                Array.from(node.children).forEach((childNode) => {
+                    if (childNode.tagName) {
+                        relFields = Object.assign({}, params.models[relModel].fields);
+                        // this is hackhish, but _getView modifies the subview document in place,
+                        // especially to generate the "modifiers" attribute
+                        const { models } = this._getView({
+                            models: params.models,
+                            arch: childNode,
+                            modelName: relModel,
+                            fields: relFields,
+                            context,
+                            processedNodes,
+                            level: level + 1,
+                        });
+                        [...models].forEach((modelName) => relatedModels.add(modelName));
+                    }
+                });
+            }
+            // add onchanges
+            if (name in onchanges) {
+                node.setAttribute("on_change", "1");
+            }
+        });
+        Object.entries(groupbyNodes).forEach(([name, node]) => {
+            const field = fields[name];
+            if (field.type !== "many2one") {
+                throw new Error("groupby can only target many2one");
+            }
+            field.views = {};
+            relModel = field.relation;
+            relatedModels.add(relModel);
+            relFields = Object.assign({}, params.models[relModel].fields);
+            processedNodes.push(node);
+            // postprocess simulation
+            const { models } = this._getView({
+                models: params.models,
+                arch: node,
+                modelName: relModel,
+                fields: relFields,
+                context,
+                processedNodes,
+            });
+            [...models].forEach((modelName) => relatedModels.add(modelName));
+        });
+        const processedArch = xmlSerializer.serializeToString(doc);
+        const fieldsInView = {};
+        Object.entries(fields).forEach(([fname, field]) => {
+            if (fname in fieldNodes) {
+                fieldsInView[fname] = field;
+            }
+        });
+        return {
+            arch: processedArch,
+            model: modelName,
+            type: doc.tagName === "tree" ? "list" : doc.tagName,
+            models: relatedModels,
+        };
     }
 
     /**
@@ -419,8 +451,8 @@ export class MockServer {
                 return this.mockCreate(args.model, args.args[0]);
             case "fields_get":
                 return this.mockFieldsGet(args.model);
-            case "load_views":
-                return this.mockLoadViews(args.model, args.kwargs);
+            case "get_views":
+                return this.mockGetViews(args.model, args.kwargs);
             case "name_create":
                 return this.mockNameCreate(args.model, args.args[0]);
             case "name_get":
@@ -536,19 +568,20 @@ export class MockServer {
         return menus;
     }
 
-    mockLoadViews(modelName, kwargs) {
-        const fieldsViews = {};
+    mockGetViews(modelName, kwargs) {
+        const views = {};
+        const models = {};
+        models[modelName] = this.mockFieldsGet(modelName);
         kwargs.views.forEach(([viewId, viewType]) => {
-            fieldsViews[viewType] = this.fieldsViewGet(modelName, [viewId, viewType], kwargs);
+            views[viewType] = this.getView(modelName, [viewId, viewType], kwargs);
+            if (kwargs.options.load_filters && viewType === "search") {
+                views[viewType].filters = this.models[modelName].filters || [];
+            }
+            for (const modelName of views[viewType].models) {
+                models[modelName] = models[modelName] || this.mockFieldsGet(modelName);
+            }
         });
-        const result = {
-            fields: this.mockFieldsGet(modelName),
-            fields_views: fieldsViews,
-        };
-        if (kwargs.options.load_filters) {
-            result.filters = this.models[modelName].filters || [];
-        }
-        return result;
+        return { models, views };
     }
 
     /**

--- a/addons/web/static/tests/legacy/fields/relational_fields/field_many2many_tests.js
+++ b/addons/web/static/tests/legacy/fields/relational_fields/field_many2many_tests.js
@@ -446,7 +446,7 @@ QUnit.module('fields', {}, function () {
                 },
                 res_id: 1,
                 mockRPC: function (route, args) {
-                    if (args.method !== 'load_views') {
+                    if (args.method !== 'get_views') {
                         assert.step(_.last(route.split('/')));
                     }
                     if (args.method === 'write' && args.model === 'partner') {
@@ -550,7 +550,7 @@ QUnit.module('fields', {}, function () {
                     'partner_type,false,search': '<search><field name="display_name"/></search>',
                 },
                 mockRPC: function (route, args) {
-                    if (args.method !== 'load_views') {
+                    if (args.method !== 'get_views') {
                         assert.step(_.last(route.split('/')));
                     }
                     if (args.method === 'write') {
@@ -1139,7 +1139,7 @@ QUnit.module('fields', {}, function () {
                         '</search>',
                 },
                 mockRPC: function (route, args) {
-                    if (args.method !== 'load_views') {
+                    if (args.method !== 'get_views') {
                         assert.step(_.last(route.split('/')) + ' on ' + args.model);
                     }
                     if (args.model === 'turtle') {
@@ -1264,7 +1264,7 @@ QUnit.module('fields', {}, function () {
             assert.verifySteps([
                 'read', // read initial record (on partner)
                 'read', // read many2many turtles
-                'load_views', // load arch of turtles form view
+                'get_views', // load arch of turtles form view
                 'read', // read missing field when opening record in modal form view
                 'write', // when saving the modal
                 'onchange', // onchange should be triggered on partner

--- a/addons/web/static/tests/legacy/fields/relational_fields/field_many2one_tests.js
+++ b/addons/web/static/tests/legacy/fields/relational_fields/field_many2one_tests.js
@@ -629,7 +629,7 @@ QUnit.module('fields', {}, function () {
 
             // save the modal and make sure an onchange is triggered
             await testUtils.dom.click($('.modal .modal-footer .btn-primary').first());
-            assert.verifySteps(['read', 'get_formview_id', 'load_views', 'read', 'write', 'read', 'onchange']);
+            assert.verifySteps(['read', 'get_formview_id', 'get_views', 'read', 'write', 'read', 'onchange']);
 
             // save the main record, and check that no extra rpcs are done (record
             // is not dirty, only a related record was modified)
@@ -3117,7 +3117,7 @@ QUnit.module('fields', {}, function () {
             assert.verifySteps([
                 'onchange',
                 'name_search', // to display results in the dropdown
-                'load_views', // list view in dialog
+                'get_views', // list view in dialog
                 '/web/dataset/search_read', // to display results in the dialog
             ]);
 
@@ -3173,7 +3173,7 @@ QUnit.module('fields', {}, function () {
                 'name_search', // empty search, triggered when the user clicks in the input
                 'name_search', // to display results in the dropdown
                 'name_search', // to get preselected ids matching the search
-                'load_views', // list view in dialog
+                'get_views', // list view in dialog
                 '/web/dataset/search_read', // to display results in the dialog
                 '/web/dataset/search_read', // after removal of dynamic filter
             ]);
@@ -3339,7 +3339,7 @@ QUnit.module('fields', {}, function () {
             assert.verifySteps([
                 'onchange',
                 'name_search', // to display results in the dropdown
-                'load_views', // list view in dialog
+                'get_views', // list view in dialog
                 '/web/dataset/search_read', // to display results in the dialog
                 '/web/dataset/resequence', // resequencing lines
                 'read',

--- a/addons/web/static/tests/legacy/fields/relational_fields/field_one2many_tests.js
+++ b/addons/web/static/tests/legacy/fields/relational_fields/field_one2many_tests.js
@@ -6233,7 +6233,7 @@ QUnit.module('fields', {}, function () {
             await testUtils.owlCompatibilityExtraNextTick();
             assert.strictEqual(form.$('.o_field_widget[name="int_field"]').val(), "0",
                 "int_field should still be 0 (no onchange should have been done yet)");
-            assert.verifySteps(['load_views', 'read', 'onchange']);
+            assert.verifySteps(['get_views', 'read', 'onchange']);
 
             // fill turtle_foo field
             await testUtils.fields.editInput(form.$('.o_field_widget[name="turtle_foo"]'), "some text");
@@ -7964,7 +7964,7 @@ QUnit.module('fields', {}, function () {
             // swap 2 lines in the one2many
             await testUtils.dom.dragAndDrop(form.$('.ui-sortable-handle:eq(1)'), form.$('tbody tr').first(),
                 { position: 'top' });
-            assert.verifySteps(['load_views', 'read', 'read', 'onchange', 'onchange']);
+            assert.verifySteps(['get_views', 'read', 'read', 'onchange', 'onchange']);
             form.destroy();
         });
 
@@ -8004,7 +8004,7 @@ QUnit.module('fields', {}, function () {
                 "should have triggered the onchange");
 
             assert.verifySteps([
-                'load_views', // load sub list
+                'get_views', // load sub list
                 'onchange', // main record
                 'onchange', // sub record
                 'onchange', // edition of display_name of sub record

--- a/addons/web/static/tests/legacy/helpers/test_utils.js
+++ b/addons/web/static/tests/legacy/helpers/test_utils.js
@@ -141,7 +141,7 @@ odoo.define('web.test_utils', async function (require) {
             patch: testUtilsMock.patch,
             patchDate: testUtilsMock.patchDate,
             unpatch: testUtilsMock.unpatch,
-            fieldsViewGet: testUtilsMock.fieldsViewGet,
+            getView: testUtilsMock.getView,
             patchSetTimeout: testUtilsMock.patchSetTimeout,
         },
         controlPanel: {
@@ -269,7 +269,7 @@ odoo.define('web.test_utils', async function (require) {
         // backward-compatibility
         addMockEnvironment: deprecated(testUtilsMock.addMockEnvironment, 'mock'),
         dragAndDrop: deprecated(testUtilsDom.dragAndDrop, 'dom'),
-        fieldsViewGet: deprecated(testUtilsMock.fieldsViewGet, 'mock'),
+        getView: deprecated(testUtilsMock.getView, 'mock'),
         intercept: deprecated(testUtilsMock.intercept, 'mock'),
         openDatepicker: deprecated(testUtilsDom.openDatepicker, 'dom'),
         patch: deprecated(testUtilsMock.patch, 'mock'),

--- a/addons/web/static/tests/legacy/helpers/test_utils_create.js
+++ b/addons/web/static/tests/legacy/helpers/test_utils_create.js
@@ -142,13 +142,13 @@ odoo.define('web.test_utils_create', function (require) {
                 new Widget(),
                 serverParams,
             );
-            const { arch, fields } = testUtilsMock.fieldsViewGet(mockServer, {
+            const { arch } = testUtilsMock.getView(mockServer, {
                 arch: globalConfig.arch,
                 fields: globalConfig.fields,
                 model,
                 viewOptions: { context: globalConfig.context },
             });
-            Object.assign(globalConfig, { arch, fields });
+            Object.assign(globalConfig, { arch });
         }
 
         globalConfig.env = env;
@@ -283,7 +283,7 @@ odoo.define('web.test_utils_create', function (require) {
 
         // add mock environment: mock server, session, fieldviewget, ...
         const mockServer = await testUtilsMock.addMockEnvironment(widget, params);
-        const viewInfo = testUtilsMock.fieldsViewGet(mockServer, params);
+        const viewInfo = testUtilsMock.getView(mockServer, params);
 
         params.server = mockServer;
 
@@ -297,7 +297,7 @@ odoo.define('web.test_utils_create', function (require) {
         };
         const viewOptions = Object.assign({
             action: Object.assign(defaultAction, params.action),
-            view: viewInfo,
+            view: { ...viewInfo, fields: mockServer.fieldsGet(params.model) },
             modelName: modelName,
             ids: 'res_id' in params ? [params.res_id] : undefined,
             currentId: 'res_id' in params ? params.res_id : undefined,
@@ -323,7 +323,7 @@ odoo.define('web.test_utils_create', function (require) {
             // TODO: probably needs to create an helper just for that
             view = new params.View({ viewInfo, modelName });
         } else {
-            viewOptions.controlPanelFieldsView = Object.assign(testUtilsMock.fieldsViewGet(mockServer, {
+            viewOptions.controlPanelFieldsView = Object.assign(testUtilsMock.getView(mockServer, {
                 arch: params.archs && params.archs[params.model + ',false,search'] || '<search/>',
                 fields: viewInfo.fields,
                 model: params.model,

--- a/addons/web/static/tests/legacy/views/basic_model_tests.js
+++ b/addons/web/static/tests/legacy/views/basic_model_tests.js
@@ -154,7 +154,7 @@ odoo.define('web.basic_model_tests', function (require) {
             });
 
             assert.verifySteps([
-                'load_views',
+                'get_views',
                 'onchange',
             ]);
             assert.containsOnce(form, '.o_field_x2many_list', 'should have rendered a x2many list');

--- a/addons/web/static/tests/legacy/views/calendar_tests.js
+++ b/addons/web/static/tests/legacy/views/calendar_tests.js
@@ -3295,7 +3295,7 @@ QUnit.module('Views', {
                 initialDate: initialDate,
             },
             mockRPC: function (route, args) {
-                if (args.method === "load_views") {
+                if (args.method === "get_views") {
                     assert.strictEqual(args.kwargs.views[0][0], 1,
                         "should load view with id 1");
                 }

--- a/addons/web/static/tests/legacy/views/form_tests.js
+++ b/addons/web/static/tests/legacy/views/form_tests.js
@@ -521,10 +521,14 @@ QUnit.module('Views', {
         serverData.models.product.records = [{id: 1, name: 'Tromblon', partner_type_ids: [12,14]}];
         serverData.models.partner.records[0].product_id = 1;
 
+        // This is an old test, written before "get_views" (formerly "load_views") automatically
+        // inlines x2many subviews. As the purpose of this test is to assert that the js fetches
+        // the correct sub view when it is not inline (which can still happen in nested form views),
+        // we bypass the inline mecanism of "get_views" by setting widget="one2many" on the field.
         serverData.views = {
             'product,false,form': '<form>'+
                                         '<field name="name"/>'+
-                                        '<field name="partner_type_ids" context="{\'tree_view_ref\': \'some_other_tree_view\'}"/>' +
+                                        '<field name="partner_type_ids" widget="one2many" context="{\'tree_view_ref\': \'some_other_tree_view\'}"/>' +
                                     '</form>',
 
             'partner_type,false,list': '<tree>'+
@@ -539,7 +543,7 @@ QUnit.module('Views', {
         };
 
         const mockRPC = (route, args) => {
-            if (args.method === 'load_views') {
+            if (args.method === 'get_views') {
                 var context = args.kwargs.context;
                 if (args.model === 'product') {
                     assert.strictEqual(context.tree_view_ref, 'some_tree_view',
@@ -6192,7 +6196,7 @@ QUnit.module('Views', {
             "the row should contains the 2 fields defined in the form view");
         assert.strictEqual($(modal_row).text(), "gold2",
             "the value of the fields should be fetched and displayed");
-        assert.verifySteps(['read', 'read', 'load_views', 'read', 'read'],
+        assert.verifySteps(['read', 'read', 'get_views', 'read', 'read'],
             "there should be 4 read rpcs");
         form.destroy();
     });
@@ -8222,10 +8226,10 @@ QUnit.module('Views', {
         assert.verifySteps([
             "read", // main record
             "get_formview_id", // id of first form view opened in a dialog
-            "load_views", // arch of first form view opened in a dialog
+            "get_views", // arch of first form view opened in a dialog
             "read", // first dialog
             "get_formview_id", // id of second form view opened in a dialog
-            "load_views", // arch of second form view opened in a dialog
+            "get_views", // arch of second form view opened in a dialog
             "read", // second dialog
             "write", // save second dialog
             "read", // reload first dialog
@@ -8799,7 +8803,7 @@ QUnit.module('Views', {
             }
         });
 
-        assert.verifySteps(['partner_type:load_views', 'partner:read', 'partner_type:read']);
+        assert.verifySteps(['partner_type:get_views', 'partner:read', 'partner_type:read']);
 
         form.destroy();
     });

--- a/addons/web/static/tests/legacy/views/kanban_tests.js
+++ b/addons/web/static/tests/legacy/views/kanban_tests.js
@@ -745,11 +745,11 @@ QUnit.module('Views', {
             'web_read_group', // initial read_group
             '/web/dataset/search_read', // initial search_read (first column)
             '/web/dataset/search_read', // initial search_read (second column)
-            'load_views', // form view in quick create
+            'get_views', // form view in quick create
             'onchange', // quick create
             'create', // should perform a create to create the record
             'read', // read the created record
-            'load_views', // form view in quick create (is actually in cache)
+            'get_views', // form view in quick create (is actually in cache)
             'onchange', // reopen the quick create automatically
         ]);
 
@@ -870,11 +870,11 @@ QUnit.module('Views', {
             'web_read_group', // initial read_group
             '/web/dataset/search_read', // initial search_read (first column)
             '/web/dataset/search_read', // initial search_read (second column)
-            'load_views', // form view in quick create
+            'get_views', // form view in quick create
             'onchange', // quick create
             'create', // should perform a create to create the record
             'read', // read the created record
-            'load_views', // form view in quick create (is actually in cache)
+            'get_views', // form view in quick create (is actually in cache)
             'onchange', // reopen the quick create automatically
         ]);
 
@@ -934,7 +934,7 @@ QUnit.module('Views', {
             'web_read_group', // initial read_group
             '/web/dataset/search_read', // initial search_read (first column)
             '/web/dataset/search_read', // initial search_read (second column)
-            'load_views', // form view in quick create
+            'get_views', // form view in quick create
             'onchange', // quick create
             'onchange', // onchange due to 'foo' field change
         ]);
@@ -2600,7 +2600,7 @@ QUnit.module('Views', {
             groupBy: ['product_id'],
             async mockRPC(route, args) {
                 const result = this._super(...arguments);
-                if (args.method === 'load_views') {
+                if (args.method === 'get_views') {
                     await def;
                 }
                 return result;

--- a/addons/web/static/tests/search/search_panel_tests.js
+++ b/addons/web/static/tests/search/search_panel_tests.js
@@ -1060,7 +1060,7 @@ QUnit.module("Search", (hooks) => {
         promise.resolve();
         await compPromise;
 
-        assert.verifySteps(["load_views", "search_panel_select_range"]);
+        assert.verifySteps(["get_views", "search_panel_select_range"]);
 
         // Case 2: search domain changed so we wait for the search panel once again
         promise = makeDeferred();
@@ -1123,7 +1123,7 @@ QUnit.module("Search", (hooks) => {
         await compPromise;
 
         assert.verifySteps([
-            "load_views",
+            "get_views",
             "search_panel_select_range",
             "search_panel_select_multi_range",
         ]);
@@ -1160,7 +1160,7 @@ QUnit.module("Search", (hooks) => {
         await compPromise;
 
         assert.verifySteps([
-            "load_views",
+            "get_views",
             "search_panel_select_range",
             "search_panel_select_multi_range",
         ]);

--- a/addons/web/static/tests/search/with_search_tests.js
+++ b/addons/web/static/tests/search/with_search_tests.js
@@ -137,8 +137,8 @@ QUnit.module("Search", (hooks) => {
         await makeWithSearch({
             serverData,
             mockRPC: function (_, args) {
-                if (args.method === "load_views") {
-                    throw new Error("No load_views should be done");
+                if (args.method === "get_views") {
+                    throw new Error("No get_views should be done");
                 }
             },
             resModel: "animal",
@@ -159,7 +159,7 @@ QUnit.module("Search", (hooks) => {
             await makeWithSearch({
                 serverData,
                 mockRPC: function (_, args) {
-                    if (args.method === "load_views") {
+                    if (args.method === "get_views") {
                         assert.deepEqual(args.kwargs, {
                             context: {
                                 lang: "en",
@@ -193,8 +193,8 @@ QUnit.module("Search", (hooks) => {
             await makeWithSearch({
                 serverData,
                 mockRPC: function (_, args) {
-                    if (args.method === "load_views") {
-                        throw new Error("No load_views should be done");
+                    if (args.method === "get_views") {
+                        throw new Error("No get_views should be done");
                     }
                 },
                 resModel: "animal",
@@ -218,7 +218,7 @@ QUnit.module("Search", (hooks) => {
             await makeWithSearch({
                 serverData,
                 mockRPC: function (_, args) {
-                    if (args.method === "load_views") {
+                    if (args.method === "get_views") {
                         assert.deepEqual(args.kwargs.options, {
                             action_id: false,
                             load_filters: true,
@@ -253,7 +253,7 @@ QUnit.module("Search", (hooks) => {
             await makeWithSearch({
                 serverData,
                 mockRPC: function (_, args) {
-                    if (args.method === "load_views") {
+                    if (args.method === "get_views") {
                         assert.deepEqual(args.kwargs.views, [[1, "search"]]);
                     }
                 },

--- a/addons/web/static/tests/views/helpers.js
+++ b/addons/web/static/tests/views/helpers.js
@@ -3,7 +3,7 @@
 import { makeTestEnv } from "@web/../tests/helpers/mock_env";
 import { getFixture, mount } from "@web/../tests/helpers/utils";
 import { getDefaultConfig, View } from "@web/views/view";
-import { _fieldsViewGet } from "../helpers/mock_server";
+import { _getView } from "../helpers/mock_server";
 import { addLegacyMockEnvironment } from "../webclient/helpers";
 
 /**
@@ -46,15 +46,14 @@ export const makeView = async (params) => {
                 props.fields[fieldName].name = fieldName;
             }
         }
-        const fvg = _fieldsViewGet({
+        const view = _getView({
             arch: props.arch,
             modelName: props.resModel,
             fields: props.fields,
             context: props.context || {},
             models: serverData.models,
         });
-        props.arch = fvg.arch;
-        props.fields = Object.assign({}, props.fields, fvg.fields);
+        props.arch = view.arch;
         props.searchViewArch = props.searchViewArch || "<search/>";
         props.searchViewFields = props.searchViewFields || Object.assign({}, props.fields);
     }

--- a/addons/web/static/tests/views/pivot_view_tests.js
+++ b/addons/web/static/tests/views/pivot_view_tests.js
@@ -4780,7 +4780,7 @@ QUnit.module("Views", (hooks) => {
         assert.containsOnce(target, ".o_pivot_view");
         assert.strictEqual(getCurrentValues(target), ["4", "2", "2"].join(","));
 
-        assert.verifySteps(["/web/webclient/load_menus", "load_views", "read_group", "read_group"]);
+        assert.verifySteps(["/web/webclient/load_menus", "get_views", "read_group", "read_group"]);
 
         // switch to list view
         await click(target.querySelector(".o_control_panel .o_switch_view.o_list"));

--- a/addons/web/static/tests/views/view_service_tests.js
+++ b/addons/web/static/tests/views/view_service_tests.js
@@ -20,16 +20,29 @@ QUnit.module("View service", (hooks) => {
             },
         };
 
+        const fakeUiService = {
+            start(env) {
+                Object.defineProperty(env, "isSmall", {
+                    get() {
+                        return false;
+                    },
+                });
+            },
+        };
         serverData = { models, views };
-        registry.category("services").add("views", viewService).add("orm", ormService);
+        registry
+            .category("services")
+            .add("views", viewService)
+            .add("orm", ormService)
+            .add("ui", fakeUiService);
     });
 
     QUnit.test("stores calls in cache in success", async (assert) => {
         assert.expect(2);
 
         const mockRPC = (route, args) => {
-            if (route.includes("load_views")) {
-                assert.step("load_views");
+            if (route.includes("get_views")) {
+                assert.step("get_views");
             }
         };
 
@@ -51,15 +64,15 @@ QUnit.module("View service", (hooks) => {
             {}
         );
 
-        assert.verifySteps(["load_views"]);
+        assert.verifySteps(["get_views"]);
     });
 
     QUnit.test("stores calls in cache when failed", async (assert) => {
         assert.expect(5);
 
         const mockRPC = (route, args) => {
-            if (route.includes("load_views")) {
-                assert.step("load_views");
+            if (route.includes("get_views")) {
+                assert.step("get_views");
                 return Promise.reject("my little error");
             }
         };
@@ -91,6 +104,6 @@ QUnit.module("View service", (hooks) => {
             assert.strictEqual(error, "my little error");
         }
 
-        assert.verifySteps(["load_views", "load_views"]);
+        assert.verifySteps(["get_views", "get_views"]);
     });
 });

--- a/addons/web/static/tests/views/view_tests.js
+++ b/addons/web/static/tests/views/view_tests.js
@@ -110,7 +110,7 @@ QUnit.module("Views", (hooks) => {
     QUnit.module("View component");
 
     ////////////////////////////////////////////////////////////////////////////
-    // load_views
+    // get_views
     ////////////////////////////////////////////////////////////////////////////
 
     QUnit.test("simple rendering", async function (assert) {
@@ -132,7 +132,7 @@ QUnit.module("Views", (hooks) => {
             serverData,
             mockRPC: (_, args) => {
                 assert.strictEqual(args.model, "animal");
-                assert.strictEqual(args.method, "load_views");
+                assert.strictEqual(args.method, "get_views");
                 assert.deepEqual(args.kwargs.views, [[false, "toy"]]);
                 assert.deepEqual(args.kwargs.options, {
                     action_id: false,

--- a/addons/web/static/tests/views/view_tests.js
+++ b/addons/web/static/tests/views/view_tests.js
@@ -10,13 +10,12 @@ import {
     patchWithCleanup,
 } from "@web/../tests/helpers/utils";
 import { setupControlPanelServiceRegistry } from "@web/../tests/search/helpers";
-import { makeView } from "@web/../tests/views/helpers";
 import { registry } from "@web/core/registry";
 import { OnboardingBanner } from "@web/views/onboarding_banner";
 import { View } from "@web/views/view";
 import { actionService } from "@web/webclient/actions/action_service";
 
-const { Component, useState, xml } = owl;
+const { Component, onWillStart, onWillUpdateProps, useState, xml } = owl;
 
 const serviceRegistry = registry.category("services");
 const viewRegistry = registry.category("views");
@@ -128,21 +127,22 @@ QUnit.module("Views", (hooks) => {
             },
         });
 
-        await makeView({
-            serverData,
-            mockRPC: (_, args) => {
-                assert.strictEqual(args.model, "animal");
-                assert.strictEqual(args.method, "get_views");
-                assert.deepEqual(args.kwargs.views, [[false, "toy"]]);
-                assert.deepEqual(args.kwargs.options, {
-                    action_id: false,
-                    load_filters: false,
-                    toolbar: false,
-                });
-            },
+        const mockRPC = (_, args) => {
+            assert.strictEqual(args.model, "animal");
+            assert.strictEqual(args.method, "get_views");
+            assert.deepEqual(args.kwargs.views, [[false, "toy"]]);
+            assert.deepEqual(args.kwargs.options, {
+                action_id: false,
+                load_filters: false,
+                toolbar: false,
+            });
+        };
+        const env = await makeTestEnv({ serverData, mockRPC });
+        const props = {
             resModel: "animal",
             type: "toy",
-        });
+        };
+        await mount(View, target, { env, props });
         assert.containsOnce(target, ".o_toy_view.o_view_controller");
         assert.strictEqual(
             target.querySelector(".o_toy_view.toy").innerHTML,
@@ -165,20 +165,21 @@ QUnit.module("Views", (hooks) => {
             },
         });
 
-        await makeView({
-            serverData,
-            mockRPC: (_, args) => {
-                assert.deepEqual(args.kwargs.views, [[1, "toy"]]);
-                assert.deepEqual(args.kwargs.options, {
-                    action_id: false,
-                    load_filters: false,
-                    toolbar: false,
-                });
-            },
+        const mockRPC = (_, args) => {
+            assert.deepEqual(args.kwargs.views, [[1, "toy"]]);
+            assert.deepEqual(args.kwargs.options, {
+                action_id: false,
+                load_filters: false,
+                toolbar: false,
+            });
+        };
+        const env = await makeTestEnv({ serverData, mockRPC });
+        const props = {
             resModel: "animal",
             type: "toy",
             viewId: 1,
-        });
+        };
+        await mount(View, target, { env, props });
         assert.containsOnce(target, ".o_toy_view");
         assert.strictEqual(
             target.querySelector(".o_toy_view.toy").innerHTML,
@@ -201,23 +202,23 @@ QUnit.module("Views", (hooks) => {
             },
         });
 
-        await makeView({
-            serverData,
-            mockRPC: (_, args) => {
-                console.log(_);
-                assert.deepEqual(args.kwargs.views, [[1, "toy"]]);
-                assert.deepEqual(args.kwargs.options, {
-                    action_id: false,
-                    load_filters: false,
-                    toolbar: false,
-                });
-            },
+        const mockRPC = (_, args) => {
+            assert.deepEqual(args.kwargs.views, [[1, "toy"]]);
+            assert.deepEqual(args.kwargs.options, {
+                action_id: false,
+                load_filters: false,
+                toolbar: false,
+            });
+        };
+        const config = {
+            views: [[1, "toy"]],
+        };
+        const env = await makeTestEnv({ serverData, mockRPC, config });
+        const props = {
             resModel: "animal",
             type: "toy",
-            config: {
-                views: [[1, "toy"]],
-            },
-        });
+        };
+        await mount(View, target, { env, props });
         assert.containsOnce(target, ".o_toy_view");
         assert.strictEqual(
             target.querySelector(".o_toy_view.toy").innerHTML,
@@ -242,25 +243,26 @@ QUnit.module("Views", (hooks) => {
                 },
             });
 
-            await makeView({
-                serverData,
-                mockRPC: (_, args) => {
-                    assert.deepEqual(args.kwargs.views, [
-                        [false, "other"],
-                        [false, "toy"],
-                    ]);
-                    assert.deepEqual(args.kwargs.options, {
-                        action_id: false,
-                        load_filters: false,
-                        toolbar: false,
-                    });
-                },
+            const mockRPC = (_, args) => {
+                assert.deepEqual(args.kwargs.views, [
+                    [false, "other"],
+                    [false, "toy"],
+                ]);
+                assert.deepEqual(args.kwargs.options, {
+                    action_id: false,
+                    load_filters: false,
+                    toolbar: false,
+                });
+            };
+            const config = {
+                views: [[false, "other"]],
+            };
+            const env = await makeTestEnv({ serverData, mockRPC, config });
+            const props = {
                 resModel: "animal",
                 type: "toy",
-                config: {
-                    views: [[false, "other"]],
-                },
-            });
+            };
+            await mount(View, target, { env, props });
             assert.containsOnce(target, ".o_toy_view");
             assert.strictEqual(
                 target.querySelector(".o_toy_view.toy").innerHTML,
@@ -284,29 +286,30 @@ QUnit.module("Views", (hooks) => {
             },
         });
 
-        await makeView({
-            serverData,
-            mockRPC: (_, args) => {
-                assert.deepEqual(args.kwargs.views, [
-                    [1, "toy"],
-                    [false, "other"],
-                ]);
-                assert.deepEqual(args.kwargs.options, {
-                    action_id: false,
-                    load_filters: false,
-                    toolbar: false,
-                });
-            },
+        const mockRPC = (_, args) => {
+            assert.deepEqual(args.kwargs.views, [
+                [1, "toy"],
+                [false, "other"],
+            ]);
+            assert.deepEqual(args.kwargs.options, {
+                action_id: false,
+                load_filters: false,
+                toolbar: false,
+            });
+        };
+        const config = {
+            views: [
+                [3, "toy"],
+                [false, "other"],
+            ],
+        };
+        const env = await makeTestEnv({ serverData, mockRPC, config });
+        const props = {
             resModel: "animal",
             type: "toy",
             viewId: 1,
-            config: {
-                views: [
-                    [3, "toy"],
-                    [false, "other"],
-                ],
-            },
-        });
+        };
+        await mount(View, target, { env, props });
         assert.containsOnce(target, ".o_toy_view");
         assert.strictEqual(
             target.querySelector(".o_toy_view.toy").innerHTML,
@@ -329,16 +332,17 @@ QUnit.module("Views", (hooks) => {
             },
         });
 
-        await makeView({
-            serverData,
-            mockRPC: () => {
-                throw new Error("no RPC expected");
-            },
+        const mockRPC = () => {
+            throw new Error("no RPC expected");
+        };
+        const env = await makeTestEnv({ serverData, mockRPC });
+        const props = {
             resModel: "animal",
             type: "toy",
             arch: `<toy>Specific arch content</toy>`,
             fields: {},
-        });
+        };
+        await mount(View, target, { env, props });
         assert.containsOnce(target, ".o_toy_view");
         assert.strictEqual(
             target.querySelector(".o_toy_view.toy").innerHTML,
@@ -361,21 +365,22 @@ QUnit.module("Views", (hooks) => {
             },
         });
 
-        await makeView({
-            serverData,
-            mockRPC: (_, args) => {
-                // the rpc is done for fields
-                assert.deepEqual(args.kwargs.views, [[false, "toy"]]);
-                assert.deepEqual(args.kwargs.options, {
-                    action_id: false,
-                    load_filters: false,
-                    toolbar: true,
-                });
-            },
+        const mockRPC = (_, args) => {
+            // the rpc is done for fields
+            assert.deepEqual(args.kwargs.views, [[false, "toy"]]);
+            assert.deepEqual(args.kwargs.options, {
+                action_id: false,
+                load_filters: false,
+                toolbar: true,
+            });
+        };
+        const env = await makeTestEnv({ serverData, mockRPC });
+        const props = {
             resModel: "animal",
             type: "toy",
             loadActionMenus: true,
-        });
+        };
+        await mount(View, target, { env, props });
         assert.containsOnce(target, ".o_toy_view");
         assert.strictEqual(
             target.querySelector(".o_toy_view.toy").innerHTML,
@@ -400,23 +405,24 @@ QUnit.module("Views", (hooks) => {
                 },
             });
 
-            await makeView({
-                serverData,
-                mockRPC: (_, args) => {
-                    // the rpc is done for fields
-                    assert.deepEqual(args.kwargs.views, [[false, "toy"]]);
-                    assert.deepEqual(args.kwargs.options, {
-                        action_id: false,
-                        load_filters: false,
-                        toolbar: true,
-                    });
-                },
+            const mockRPC = (_, args) => {
+                // the rpc is done for fields
+                assert.deepEqual(args.kwargs.views, [[false, "toy"]]);
+                assert.deepEqual(args.kwargs.options, {
+                    action_id: false,
+                    load_filters: false,
+                    toolbar: true,
+                });
+            };
+            const env = await makeTestEnv({ serverData, mockRPC });
+            const props = {
                 resModel: "animal",
                 type: "toy",
                 arch: `<toy>Specific arch content</toy>`,
                 fields: {},
                 loadActionMenus: true,
-            });
+            };
+            await mount(View, target, { env, props });
             assert.containsOnce(target, ".o_toy_view");
             assert.strictEqual(
                 target.querySelector(".o_toy_view.toy").innerHTML,
@@ -442,11 +448,11 @@ QUnit.module("Views", (hooks) => {
                 },
             });
 
-            await makeView({
-                serverData,
-                mockRPC: () => {
-                    throw new Error("no RPC expected");
-                },
+            const mockRPC = () => {
+                throw new Error("no RPC expected");
+            };
+            const env = await makeTestEnv({ serverData, mockRPC });
+            const props = {
                 resModel: "animal",
                 type: "toy",
                 arch: `<toy>Specific arch content</toy>`,
@@ -455,7 +461,8 @@ QUnit.module("Views", (hooks) => {
                     /** ... */
                 },
                 loadActionMenus: true,
-            });
+            };
+            await mount(View, target, { env, props });
             assert.containsOnce(target, ".o_toy_view");
             assert.strictEqual(
                 target.querySelector(".o_toy_view.toy").innerHTML,
@@ -484,24 +491,25 @@ QUnit.module("Views", (hooks) => {
             },
         });
 
-        await makeView({
-            serverData,
-            mockRPC: (_, args) => {
-                // the rpc is done for fields
-                assert.deepEqual(args.kwargs.views, [
-                    [false, "toy"],
-                    [false, "search"],
-                ]);
-                assert.deepEqual(args.kwargs.options, {
-                    action_id: false,
-                    load_filters: false,
-                    toolbar: false,
-                });
-            },
+        const mockRPC = (_, args) => {
+            // the rpc is done for fields
+            assert.deepEqual(args.kwargs.views, [
+                [false, "toy"],
+                [false, "search"],
+            ]);
+            assert.deepEqual(args.kwargs.options, {
+                action_id: false,
+                load_filters: false,
+                toolbar: false,
+            });
+        };
+        const env = await makeTestEnv({ serverData, mockRPC });
+        const props = {
             resModel: "animal",
             type: "toy",
             searchViewId: false,
-        });
+        };
+        await mount(View, target, { env, props });
         assert.containsOnce(target, ".o_toy_view");
         assert.strictEqual(
             target.querySelector(".o_toy_view").innerText,
@@ -531,11 +539,11 @@ QUnit.module("Views", (hooks) => {
                 },
             });
 
-            await makeView({
-                serverData,
-                mockRPC: () => {
-                    throw new Error("no RPC expected");
-                },
+            const mockRPC = () => {
+                throw new Error("no RPC expected");
+            };
+            const env = await makeTestEnv({ serverData, mockRPC });
+            const props = {
                 resModel: "animal",
                 type: "toy",
                 arch: `<toy>Specific arch content</toy>`,
@@ -543,7 +551,8 @@ QUnit.module("Views", (hooks) => {
                 searchViewId: false,
                 searchViewArch: `<search/>`,
                 searchViewFields: {},
-            });
+            };
+            await mount(View, target, { env, props });
             assert.containsOnce(target, ".o_toy_view");
             assert.strictEqual(
                 target.querySelector(".o_toy_view").innerText,
@@ -574,18 +583,19 @@ QUnit.module("Views", (hooks) => {
                 },
             });
 
-            await makeView({
-                serverData,
-                mockRPC: () => {
-                    throw new Error("no RPC expected");
-                },
+            const mockRPC = () => {
+                throw new Error("no RPC expected");
+            };
+            const env = await makeTestEnv({ serverData, mockRPC });
+            const props = {
                 resModel: "animal",
                 type: "toy",
                 arch: `<toy>Specific arch content</toy>`,
                 fields: {},
                 searchViewArch: `<search/>`,
                 searchViewFields: {},
-            });
+            };
+            await mount(View, target, { env, props });
             assert.containsOnce(target, ".o_toy_view");
             assert.strictEqual(
                 target.querySelector(".o_toy_view").innerText,
@@ -616,20 +626,20 @@ QUnit.module("Views", (hooks) => {
                 },
             });
 
-            await makeView({
-                serverData,
-                mockRPC: (_, args) => {
-                    // the rpc is done for fields
-                    assert.deepEqual(args.kwargs.views, [
-                        [false, "toy"],
-                        [false, "search"],
-                    ]);
-                    assert.deepEqual(args.kwargs.options, {
-                        action_id: false,
-                        load_filters: true,
-                        toolbar: false,
-                    });
-                },
+            const mockRPC = (_, args) => {
+                // the rpc is done for fields
+                assert.deepEqual(args.kwargs.views, [
+                    [false, "toy"],
+                    [false, "search"],
+                ]);
+                assert.deepEqual(args.kwargs.options, {
+                    action_id: false,
+                    load_filters: true,
+                    toolbar: false,
+                });
+            };
+            const env = await makeTestEnv({ serverData, mockRPC });
+            const props = {
                 resModel: "animal",
                 type: "toy",
                 arch: `<toy>Specific arch content</toy>`,
@@ -638,7 +648,8 @@ QUnit.module("Views", (hooks) => {
                 searchViewArch: `<search/>`,
                 searchViewFields: {},
                 loadIrFilters: true,
-            });
+            };
+            await mount(View, target, { env, props });
             assert.containsOnce(target, ".o_toy_view");
             assert.strictEqual(
                 target.querySelector(".o_toy_view").innerText,
@@ -680,11 +691,11 @@ QUnit.module("Views", (hooks) => {
                 },
             });
 
-            await makeView({
-                serverData,
-                mockRPC: () => {
-                    throw new Error("no RPC expected");
-                },
+            const mockRPC = () => {
+                throw new Error("no RPC expected");
+            };
+            const env = await makeTestEnv({ serverData, mockRPC });
+            const props = {
                 resModel: "animal",
                 type: "toy",
                 arch: `<toy>Specific arch content</toy>`,
@@ -693,7 +704,8 @@ QUnit.module("Views", (hooks) => {
                 searchViewFields: {},
                 loadIrFilters: true,
                 irFilters,
-            });
+            };
+            await mount(View, target, { env, props });
             assert.containsOnce(target, ".o_toy_view");
             assert.strictEqual(
                 target.querySelector(".o_toy_view").innerText,
@@ -741,16 +753,15 @@ QUnit.module("Views", (hooks) => {
                 };
             }
         };
-
-        await makeView({
-            serverData,
-            mockRPC,
+        const config = {
+            views: [[1, "toy"]],
+        };
+        const env = await makeTestEnv({ serverData, mockRPC, config });
+        const props = {
             resModel: "animal",
             type: "toy",
-            config: {
-                views: [[1, "toy"]],
-            },
-        });
+        };
+        await mount(View, target, { env, props });
 
         assert.containsOnce(target, "a");
         await click(target.querySelector("a"));
@@ -788,14 +799,15 @@ QUnit.module("Views", (hooks) => {
                 <a type="action" name="myLittleAction" data-context="{ &quot;somekey&quot;: &quot;somevalue&quot; }"/>
             </toy>`;
 
-        await makeView({
-            serverData,
+        const config = {
+            views: [[1, "toy"]],
+        };
+        const env = await makeTestEnv({ serverData, config });
+        const props = {
             resModel: "animal",
             type: "toy",
-            config: {
-                views: [[1, "toy"]],
-            },
-        });
+        };
+        await mount(View, target, { env, props });
 
         assert.containsOnce(target, "a");
         await click(target.querySelector("a"));
@@ -840,14 +852,15 @@ QUnit.module("Views", (hooks) => {
                 <a type="action" title="myTitle" data-model="animal" data-resId="66" data-views="[[55, 'toy']]" data-domain="[['field', '=', 'val']]" data-context="{ &quot;somekey&quot;: &quot;somevalue&quot; }"/>
             </toy>`;
 
-        await makeView({
-            serverData,
+        const config = {
+            views: [[1, "toy"]],
+        };
+        const env = await makeTestEnv({ serverData, config });
+        const props = {
             resModel: "animal",
             type: "toy",
-            config: {
-                views: [[1, "toy"]],
-            },
-        });
+        };
+        await mount(View, target, { env, props });
 
         assert.containsOnce(target, "a");
         await click(target.querySelector("a"));
@@ -866,16 +879,15 @@ QUnit.module("Views", (hooks) => {
                 return { html: `<div class="setmybodyfree">myBanner</div>` };
             }
         };
-
-        await makeView({
-            serverData,
-            mockRPC,
+        const config = {
+            views: [[1, "toy"]],
+        };
+        const env = await makeTestEnv({ serverData, mockRPC, config });
+        const props = {
             resModel: "animal",
             type: "toy",
-            config: {
-                views: [[1, "toy"]],
-            },
-        });
+        };
+        await mount(View, target, { env, props });
 
         assert.verifySteps(["/mybody/isacage"]);
         assert.containsOnce(target, ".setmybodyfree");
@@ -929,15 +941,15 @@ QUnit.module("Views", (hooks) => {
 
         patchWithCleanup(document, { createElement });
 
-        await makeView({
-            serverData,
-            mockRPC,
+        const config = {
+            views: [[1, "toy"]],
+        };
+        const env = await makeTestEnv({ serverData, mockRPC, config });
+        const props = {
             resModel: "animal",
             type: "toy",
-            config: {
-                views: [[1, "toy"]],
-            },
-        });
+        };
+        await mount(View, target, { env, props });
 
         assert.verifySteps(["/mybody/isacage", "js loaded", "css loaded"]);
         assert.containsOnce(target, ".setmybodyfree");
@@ -946,7 +958,6 @@ QUnit.module("Views", (hooks) => {
     });
 
     QUnit.test("banner can re-render with new HTML", async (assert) => {
-        assert.expect(10);
         assert.expect(8);
 
         serviceRegistry.add("action", actionService, { force: true });
@@ -975,16 +986,15 @@ QUnit.module("Views", (hooks) => {
                 };
             }
         };
-
-        await makeView({
-            serverData,
-            mockRPC,
+        const config = {
+            views: [[1, "toy"]],
+        };
+        const env = await makeTestEnv({ serverData, mockRPC, config });
+        const props = {
             resModel: "animal",
             type: "toy",
-            config: {
-                views: [[1, "toy"]],
-            },
-        });
+        };
+        await mount(View, target, { env, props });
 
         assert.verifySteps(["/mybody/isacage"]);
         assert.containsOnce(target, ".banner1");
@@ -1007,22 +1017,31 @@ QUnit.module("Views", (hooks) => {
                 myBanner
             </div>`;
 
+        let toy;
+        const ToyView = viewRegistry.get("toy");
+        class ToyViewExtended extends ToyView {
+            setup() {
+                super.setup();
+                toy = this;
+            }
+        }
+        viewRegistry.add("toy", ToyViewExtended, { force: true });
+
         const mockRPC = (route) => {
             if (route === "/mybody/isacage") {
                 assert.step(route);
                 return { html: bannerArch };
             }
         };
-
-        const toy = await makeView({
-            serverData,
-            mockRPC,
+        const config = {
+            views: [[1, "toy"]],
+        };
+        const env = await makeTestEnv({ serverData, mockRPC, config });
+        const props = {
             resModel: "animal",
             type: "toy",
-            config: {
-                views: [[1, "toy"]],
-            },
-        });
+        };
+        await mount(View, target, { env, props });
 
         assert.verifySteps(["/mybody/isacage"]);
         assert.containsOnce(target, ".setmybodyfree");
@@ -1081,16 +1100,15 @@ QUnit.module("Views", (hooks) => {
                 };
             }
         };
-
-        await makeView({
-            mockRPC,
-            serverData,
+        const config = {
+            views: [[1, "toy"]],
+        };
+        const env = await makeTestEnv({ serverData, mockRPC, config });
+        const props = {
             resModel: "animal",
             type: "toy",
-            config: {
-                views: [[1, "toy"]],
-            },
-        });
+        };
+        await mount(View, target, { env, props });
 
         await click(target.querySelector("a[data-method='setTheControl']"));
         click(target.querySelector("a[data-method='heartOfTheSun']"));
@@ -1147,16 +1165,15 @@ QUnit.module("Views", (hooks) => {
                 return true;
             }
         };
-
-        await makeView({
-            serverData,
-            mockRPC,
+        const config = {
+            views: [[1, "toy"]],
+        };
+        const env = await makeTestEnv({ serverData, mockRPC, config });
+        const props = {
             resModel: "animal",
             type: "toy",
-            config: {
-                views: [[1, "toy"]],
-            },
-        });
+        };
+        await mount(View, target, { env, props });
 
         const prom = new Promise((resolve) => {
             const complete = (ev) => {
@@ -1191,19 +1208,20 @@ QUnit.module("Views", (hooks) => {
 
     QUnit.test("rendering with given jsClass", async function (assert) {
         assert.expect(4);
-        await makeView({
-            serverData,
-            mockRPC: (_, args) => {
-                assert.deepEqual(args.kwargs.views, [[false, "toy"]]);
-                assert.deepEqual(args.kwargs.options, {
-                    action_id: false,
-                    load_filters: false,
-                    toolbar: false,
-                });
-            },
+        const mockRPC = (_, args) => {
+            assert.deepEqual(args.kwargs.views, [[false, "toy"]]);
+            assert.deepEqual(args.kwargs.options, {
+                action_id: false,
+                load_filters: false,
+                toolbar: false,
+            });
+        };
+        const env = await makeTestEnv({ serverData, mockRPC });
+        const props = {
             resModel: "animal",
             type: "toy_imp",
-        });
+        };
+        await mount(View, target, { env, props });
         assert.containsOnce(target, ".o_toy_view.toy_imp");
         assert.strictEqual(
             target.querySelector(".o_toy_view.toy_imp").innerText,
@@ -1213,20 +1231,21 @@ QUnit.module("Views", (hooks) => {
 
     QUnit.test("rendering with loaded arch attribute 'js_class'", async function (assert) {
         assert.expect(4);
-        await makeView({
-            serverData,
-            mockRPC: (_, args) => {
-                assert.deepEqual(args.kwargs.views, [[2, "toy"]]);
-                assert.deepEqual(args.kwargs.options, {
-                    action_id: false,
-                    load_filters: false,
-                    toolbar: false,
-                });
-            },
+        const mockRPC = (_, args) => {
+            assert.deepEqual(args.kwargs.views, [[2, "toy"]]);
+            assert.deepEqual(args.kwargs.options, {
+                action_id: false,
+                load_filters: false,
+                toolbar: false,
+            });
+        };
+        const env = await makeTestEnv({ serverData, mockRPC });
+        const props = {
             resModel: "animal",
             type: "toy",
             viewId: 2,
-        });
+        };
+        await mount(View, target, { env, props });
         assert.containsOnce(target, ".o_toy_view.toy_imp");
         assert.strictEqual(
             target.querySelector(".o_toy_view.toy_imp").innerText,
@@ -1235,17 +1254,17 @@ QUnit.module("Views", (hooks) => {
     });
 
     QUnit.test("rendering with given arch attribute 'js_class'", async function (assert) {
-        assert.expect(2);
-        await makeView({
-            serverData,
-            mockRPC: () => {
-                throw new Error("no RPC expected");
-            },
+        const mockRPC = () => {
+            throw new Error("no RPC expected");
+        };
+        const env = await makeTestEnv({ serverData, mockRPC });
+        const props = {
             resModel: "animal",
             type: "toy",
             arch: `<toy js_class="toy_imp">Specific arch content for specific class</toy>`,
             fields: {},
-        });
+        };
+        await mount(View, target, { env, props });
         assert.containsOnce(target, ".o_toy_view.toy_imp");
         assert.strictEqual(
             target.querySelector(".o_toy_view.toy_imp").innerText,
@@ -1263,20 +1282,21 @@ QUnit.module("Views", (hooks) => {
             ToyView2.type = "toy";
             viewRegistry.add("toy_2", ToyView2);
 
-            await makeView({
-                serverData,
-                mockRPC: (_, args) => {
-                    assert.deepEqual(args.kwargs.views, [[2, "toy"]]);
-                    assert.deepEqual(args.kwargs.options, {
-                        action_id: false,
-                        load_filters: false,
-                        toolbar: false,
-                    });
-                },
+            const mockRPC = (_, args) => {
+                assert.deepEqual(args.kwargs.views, [[2, "toy"]]);
+                assert.deepEqual(args.kwargs.options, {
+                    action_id: false,
+                    load_filters: false,
+                    toolbar: false,
+                });
+            };
+            const env = await makeTestEnv({ serverData, mockRPC });
+            const props = {
                 resModel: "animal",
                 type: "toy_2",
                 viewId: 2,
-            });
+            };
+            await mount(View, target, { env, props });
             assert.containsOnce(target, ".o_toy_view.toy_imp", "jsClass from arch prefered");
         }
     );
@@ -1284,23 +1304,22 @@ QUnit.module("Views", (hooks) => {
     QUnit.test(
         "rendering with given arch attribute 'js_class' and given jsClass",
         async function (assert) {
-            assert.expect(1);
-
             class ToyView2 extends Component {}
             ToyView2.template = xml`<div class="o_toy_view_2"/>`;
             ToyView2.type = "toy";
             viewRegistry.add("toy_2", ToyView2);
 
-            await makeView({
-                serverData,
-                mockRPC: () => {
-                    throw new Error("no RPC expected");
-                },
+            const mockRPC = () => {
+                throw new Error("no RPC expected");
+            };
+            const env = await makeTestEnv({ serverData, mockRPC });
+            const props = {
                 resModel: "animal",
                 type: "toy_2",
                 arch: `<toy js_class="toy_imp"/>`,
                 fields: {},
-            });
+            };
+            await mount(View, target, { env, props });
             assert.containsOnce(target, ".o_toy_view.toy_imp", "jsClass from arch prefered");
         }
     );
@@ -1310,9 +1329,10 @@ QUnit.module("Views", (hooks) => {
     ////////////////////////////////////////////////////////////////////////////
 
     QUnit.test("'resModel' must be passed as prop", async function (assert) {
-        assert.expect(2);
+        const env = await makeTestEnv({ serverData });
+        const props = {};
         try {
-            await makeView({ serverData });
+            await mount(View, target, { env, props });
         } catch (error) {
             assert.step(error.message);
         }
@@ -1320,9 +1340,10 @@ QUnit.module("Views", (hooks) => {
     });
 
     QUnit.test("'type' must be passed as prop", async function (assert) {
-        assert.expect(2);
+        const env = await makeTestEnv({ serverData });
+        const props = { resModel: "animal" };
         try {
-            await makeView({ serverData, resModel: "animal" });
+            await mount(View, target, { env, props });
         } catch (error) {
             assert.step(error.message);
         }
@@ -1330,9 +1351,7 @@ QUnit.module("Views", (hooks) => {
     });
 
     QUnit.test("'arch' cannot be passed as prop alone", async function (assert) {
-        assert.expect(2);
         const env = await makeTestEnv({ serverData });
-        const target = getFixture();
         const props = { resModel: "animal", type: "toy", arch: "<toy/>" };
         try {
             await mount(View, target, { env, props });
@@ -1343,9 +1362,10 @@ QUnit.module("Views", (hooks) => {
     });
 
     QUnit.test("'fields' cannot be passed as prop alone", async function (assert) {
-        assert.expect(2);
+        const env = await makeTestEnv({ serverData });
+        const props = { resModel: "animal", type: "toy", fields: {} };
         try {
-            await makeView({ serverData, resModel: "animal", type: "toy", fields: {} });
+            await mount(View, target, { env, props });
         } catch (error) {
             assert.step(error.message);
         }
@@ -1353,14 +1373,10 @@ QUnit.module("Views", (hooks) => {
     });
 
     QUnit.test("'searchViewArch' cannot be passed as prop alone", async function (assert) {
-        assert.expect(2);
+        const env = await makeTestEnv({ serverData });
+        const props = { resModel: "animal", type: "toy", searchViewArch: "<toy/>" };
         try {
-            await makeView({
-                serverData,
-                resModel: "animal",
-                type: "toy",
-                searchViewArch: "<toy/>",
-            });
+            await mount(View, target, { env, props });
         } catch (error) {
             assert.step(error.message);
         }
@@ -1370,9 +1386,10 @@ QUnit.module("Views", (hooks) => {
     });
 
     QUnit.test("'searchViewFields' cannot be passed as prop alone", async function (assert) {
-        assert.expect(2);
+        const env = await makeTestEnv({ serverData });
+        const props = { resModel: "animal", type: "toy", searchViewFields: {} };
         try {
-            await makeView({ serverData, resModel: "animal", type: "toy", searchViewFields: {} });
+            await mount(View, target, { env, props });
         } catch (error) {
             assert.step(error.message);
         }
@@ -1409,15 +1426,16 @@ QUnit.module("Views", (hooks) => {
 
             viewRegistry.add("toy", ToyView, { force: true });
 
-            await makeView({
-                serverData,
+            const env = await makeTestEnv({ serverData });
+            const props = {
                 resModel: "animal",
                 type: "toy",
                 domain: [[0, "=", 1]],
                 groupBy: ["birthday"],
                 context: { key: "val" },
                 orderBy: ["bar"],
-            });
+            };
+            await mount(View, target, { env, props });
         }
     );
 
@@ -1433,12 +1451,13 @@ QUnit.module("Views", (hooks) => {
         ToyView.type = "toy";
         viewRegistry.add("toy", ToyView, { force: true });
 
-        await makeView({
-            serverData,
+        const env = await makeTestEnv({ serverData });
+        const props = {
             resModel: "animal",
             type: "toy",
             noContentHelp: "<div>Help</div>",
-        });
+        };
+        await mount(View, target, { env, props });
     });
 
     QUnit.test("useSampleModel false by default", async function (assert) {
@@ -1453,7 +1472,9 @@ QUnit.module("Views", (hooks) => {
         ToyView.type = "toy";
         viewRegistry.add("toy", ToyView, { force: true });
 
-        await makeView({ serverData, resModel: "animal", type: "toy" });
+        const env = await makeTestEnv({ serverData });
+        const props = { resModel: "animal", type: "toy" };
+        await mount(View, target, { env, props });
     });
 
     QUnit.test("sample='1' on arch", async function (assert) {
@@ -1468,13 +1489,14 @@ QUnit.module("Views", (hooks) => {
         ToyView.type = "toy";
         viewRegistry.add("toy", ToyView, { force: true });
 
-        await makeView({
-            serverData,
+        const env = await makeTestEnv({ serverData });
+        const props = {
             resModel: "animal",
             type: "toy",
             arch: `<toy sample="1"/>`,
             fields: {},
-        });
+        };
+        await mount(View, target, { env, props });
     });
 
     QUnit.test("sample='0' on arch and useSampleModel=true", async function (assert) {
@@ -1489,14 +1511,15 @@ QUnit.module("Views", (hooks) => {
         ToyView.type = "toy";
         viewRegistry.add("toy", ToyView, { force: true });
 
-        await makeView({
-            serverData,
+        const env = await makeTestEnv({ serverData });
+        const props = {
             resModel: "animal",
             type: "toy",
             useSampleModel: true,
             arch: `<toy sample="0"/>`,
             fields: {},
-        });
+        };
+        await mount(View, target, { env, props });
     });
 
     QUnit.test("sample='1' on arch and useSampleModel=false", async function (assert) {
@@ -1511,14 +1534,15 @@ QUnit.module("Views", (hooks) => {
         ToyView.type = "toy";
         viewRegistry.add("toy", ToyView, { force: true });
 
-        await makeView({
-            serverData,
+        const env = await makeTestEnv({ serverData });
+        const props = {
             resModel: "animal",
             type: "toy",
             useSampleModel: false,
             arch: `<toy sample="1"/>`,
             fields: {},
-        });
+        };
+        await mount(View, target, { env, props });
     });
 
     QUnit.test("useSampleModel=true", async function (assert) {
@@ -1533,7 +1557,9 @@ QUnit.module("Views", (hooks) => {
         ToyView.type = "toy";
         viewRegistry.add("toy", ToyView, { force: true });
 
-        await makeView({ serverData, resModel: "animal", type: "toy", useSampleModel: true });
+        const env = await makeTestEnv({ serverData });
+        const props = { resModel: "animal", type: "toy", useSampleModel: true };
+        await mount(View, target, { env, props });
     });
 
     QUnit.test("rendering with given prop", async function (assert) {
@@ -1548,12 +1574,9 @@ QUnit.module("Views", (hooks) => {
         ToyView.type = "toy";
         viewRegistry.add("toy", ToyView, { force: true });
 
-        await makeView({
-            serverData,
-            resModel: "animal",
-            type: "toy",
-            specificProp: "specificProp",
-        });
+        const env = await makeTestEnv({ serverData });
+        const props = { resModel: "animal", type: "toy", specificProp: "specificProp" };
+        await mount(View, target, { env, props });
     });
 
     QUnit.test(
@@ -1578,8 +1601,8 @@ QUnit.module("Views", (hooks) => {
             ToyView.type = "toy";
             viewRegistry.add("toy", ToyView, { force: true });
 
-            await makeView({
-                serverData,
+            const env = await makeTestEnv({ serverData });
+            const props = {
                 type: "toy",
                 resModel: "animal",
                 searchViewId: 1,
@@ -1587,7 +1610,8 @@ QUnit.module("Views", (hooks) => {
                 groupBy: ["birthday"],
                 context: { search_default_filter: 1, search_default_group_by: 1 },
                 orderBy: ["bar"],
-            });
+            };
+            await mount(View, target, { env, props });
         }
     );
 
@@ -1600,10 +1624,10 @@ QUnit.module("Views", (hooks) => {
 
         class ToyView extends Component {
             setup() {
-                owl.onWillStart(() => {
+                onWillStart(() => {
                     assert.deepEqual(this.props.domain, [["type", "=", "carnivorous"]]);
                 });
-                owl.onWillUpdateProps((nextProps) => {
+                onWillUpdateProps((nextProps) => {
                     assert.deepEqual(nextProps.domain, [["type", "=", "herbivorous"]]);
                 });
             }
@@ -1626,7 +1650,6 @@ QUnit.module("Views", (hooks) => {
         Parent.template = xml`<View t-props="state"/>`;
         Parent.components = { View };
 
-        const target = getFixture();
         const parent = await mount(Parent, target, { env });
 
         parent.state.domain = [["type", "=", "herbivorous"]];

--- a/addons/web/static/tests/webclient/actions/concurrency_tests.js
+++ b/addons/web/static/tests/webclient/actions/concurrency_tests.js
@@ -49,7 +49,7 @@ QUnit.module("ActionManager", (hooks) => {
             "/web/webclient/load_menus",
             "/web/action/load",
             "/web/action/load",
-            "/web/dataset/call_kw/pony/load_views",
+            "/web/dataset/call_kw/pony/get_views",
             "/web/dataset/search_read",
         ]);
     });
@@ -80,7 +80,7 @@ QUnit.module("ActionManager", (hooks) => {
         assert.verifySteps([
             "/web/webclient/load_menus",
             "/web/action/load",
-            "/web/dataset/call_kw/partner/load_views",
+            "/web/dataset/call_kw/partner/get_views",
             "/web/dataset/search_read",
             "/web/dataset/search_read",
             "/web/dataset/search_read",
@@ -187,11 +187,11 @@ QUnit.module("ActionManager", (hooks) => {
             assert.verifySteps([
                 "/web/webclient/load_menus",
                 "/web/action/load",
-                "load_views",
+                "get_views",
                 "read",
                 "/web/dataset/search_read",
                 "/web/action/load",
-                "load_views",
+                "get_views",
                 "/web/dataset/search_read",
             ]);
             // unblock the switch to Kanban in action 4
@@ -238,12 +238,12 @@ QUnit.module("ActionManager", (hooks) => {
         assert.verifySteps([
             "/web/webclient/load_menus",
             "/web/action/load",
-            "load_views",
+            "get_views",
             "/web/dataset/search_read",
             "read",
             "object",
             "/web/action/load",
-            "load_views",
+            "get_views",
             "/web/dataset/search_read",
         ]);
         // unblock the call_button request
@@ -302,11 +302,11 @@ QUnit.module("ActionManager", (hooks) => {
             assert.verifySteps([
                 "/web/webclient/load_menus",
                 "/web/action/load",
-                "load_views",
+                "get_views",
                 "/web/dataset/search_read",
                 "read",
                 "/web/action/load",
-                "load_views",
+                "get_views",
                 "/web/dataset/search_read",
             ]);
             // unblock the switch to the form view in action 3
@@ -332,12 +332,12 @@ QUnit.module("ActionManager", (hooks) => {
         const def = testUtils.makeTestPromise();
         const mockRPC = async function (route, args) {
             assert.step((args && args.method) || route);
-            if (args && args.method === "load_views") {
+            if (args && args.method === "get_views") {
                 await def;
             }
         };
         const webClient = await createWebClient({ serverData, mockRPC });
-        // execute a first action (its 'load_views' RPC is blocked)
+        // execute a first action (its 'get_views' RPC is blocked)
         doAction(webClient, 3);
         await testUtils.nextTick();
         await legacyExtraNextTick();
@@ -358,9 +358,9 @@ QUnit.module("ActionManager", (hooks) => {
         assert.verifySteps([
             "/web/webclient/load_menus",
             "/web/action/load",
-            "load_views",
+            "get_views",
             "/web/action/load",
-            "load_views",
+            "get_views",
             "/web/dataset/search_read",
         ]);
     });
@@ -395,10 +395,10 @@ QUnit.module("ActionManager", (hooks) => {
         assert.verifySteps([
             "/web/webclient/load_menus",
             "/web/action/load",
-            "load_views",
+            "get_views",
             "/web/dataset/search_read",
             "/web/action/load",
-            "load_views",
+            "get_views",
             "/web/dataset/search_read",
         ]);
     });
@@ -499,7 +499,7 @@ QUnit.module("ActionManager", (hooks) => {
         assert.verifySteps([
             "/web/webclient/load_menus",
             "/web/action/load",
-            "load_views",
+            "get_views",
             "/web/dataset/search_read",
             "read",
             "/web/action/load",
@@ -537,19 +537,19 @@ QUnit.module("ActionManager", (hooks) => {
         assert.verifySteps([
             "/web/webclient/load_menus",
             "/web/action/load",
-            "load_views",
+            "get_views",
             "/web/dataset/search_read",
             "/web/action/load",
             "/web/dataset/search_read",
         ]);
     });
 
-    QUnit.test("switching when doing an action -- load_views slow", async function (assert) {
+    QUnit.test("switching when doing an action -- get_views slow", async function (assert) {
         assert.expect(13);
         let def;
         const mockRPC = async (route, args) => {
             assert.step((args && args.method) || route);
-            if (args && args.method === "load_views") {
+            if (args && args.method === "get_views") {
                 return Promise.resolve(def);
             }
         };
@@ -574,10 +574,10 @@ QUnit.module("ActionManager", (hooks) => {
         assert.verifySteps([
             "/web/webclient/load_menus",
             "/web/action/load",
-            "load_views",
+            "get_views",
             "/web/dataset/search_read",
             "/web/action/load",
-            "load_views",
+            "get_views",
             "/web/dataset/search_read",
         ]);
     });
@@ -611,10 +611,10 @@ QUnit.module("ActionManager", (hooks) => {
         assert.verifySteps([
             "/web/webclient/load_menus",
             "/web/action/load",
-            "load_views",
+            "get_views",
             "/web/dataset/search_read",
             "/web/action/load",
-            "load_views",
+            "get_views",
             "/web/dataset/search_read",
             "/web/dataset/search_read",
         ]);

--- a/addons/web/static/tests/webclient/actions/load_state_tests.js
+++ b/addons/web/static/tests/webclient/actions/load_state_tests.js
@@ -216,7 +216,7 @@ QUnit.module("ActionManager", (hooks) => {
         assert.verifySteps([
             "/web/webclient/load_menus",
             "/web/action/load",
-            "load_views",
+            "get_views",
             "/web/dataset/search_read",
         ]);
     });
@@ -239,7 +239,7 @@ QUnit.module("ActionManager", (hooks) => {
             "Second record",
             "should have opened the second record"
         );
-        assert.verifySteps(["/web/webclient/load_menus", "load_views", "read"]);
+        assert.verifySteps(["/web/webclient/load_menus", "get_views", "read"]);
     });
 
     QUnit.test("properly load records with existing first APP", async function (assert) {
@@ -266,7 +266,7 @@ QUnit.module("ActionManager", (hooks) => {
             "should have opened the second record"
         );
         assert.containsNone(target, ".o_menu_brand");
-        assert.verifySteps(["/web/webclient/load_menus", "load_views", "read"]);
+        assert.verifySteps(["/web/webclient/load_menus", "get_views", "read"]);
     });
 
     QUnit.test("properly load default record", async function (assert) {
@@ -287,7 +287,7 @@ QUnit.module("ActionManager", (hooks) => {
         assert.verifySteps([
             "/web/webclient/load_menus",
             "/web/action/load",
-            "load_views",
+            "get_views",
             "onchange",
         ]);
     });
@@ -309,7 +309,7 @@ QUnit.module("ActionManager", (hooks) => {
         assert.verifySteps([
             "/web/webclient/load_menus",
             "/web/action/load",
-            "load_views",
+            "get_views",
             "/web/dataset/search_read",
         ]);
     });
@@ -345,7 +345,7 @@ QUnit.module("ActionManager", (hooks) => {
             assert.verifySteps([
                 "/web/webclient/load_menus",
                 "/web/action/load",
-                "load_views",
+                "get_views",
                 "read",
                 "/web/dataset/search_read",
             ]);
@@ -458,12 +458,12 @@ QUnit.module("ActionManager", (hooks) => {
             "should have opened the requested record"
         );
         // verify steps to ensure that the whole action hasn't been re-executed
-        // (if it would have been, /web/action/load and load_views would appear
+        // (if it would have been, /web/action/load and get_views would appear
         // several times)
         assert.verifySteps([
             "/web/webclient/load_menus",
             "/web/action/load",
-            "load_views",
+            "get_views",
             "/web/dataset/search_read",
             "/web/dataset/search_read",
             "read",
@@ -507,12 +507,12 @@ QUnit.module("ActionManager", (hooks) => {
             "should have switched to the requested record"
         );
         // verify steps to ensure that the whole action hasn't been re-executed
-        // (if it would have been, /web/action/load and load_views would appear
+        // (if it would have been, /web/action/load and get_views would appear
         // twice)
         assert.verifySteps([
             "/web/webclient/load_menus",
             "/web/action/load",
-            "load_views",
+            "get_views",
             "/web/dataset/search_read",
             "read",
             "read",
@@ -717,7 +717,7 @@ QUnit.module("ActionManager", (hooks) => {
         assert.verifySteps([
             "/web/webclient/load_menus",
             "/web/action/load",
-            "load_views",
+            "get_views",
             "/web/dataset/search_read",
             "setItem session current_action",
             "getItem session current_action",
@@ -749,7 +749,7 @@ QUnit.module("ActionManager", (hooks) => {
         assert.verifySteps([
             "/web/webclient/load_menus",
             "/web/action/load",
-            "/web/dataset/call_kw/partner/load_views",
+            "/web/dataset/call_kw/partner/get_views",
             "/web/dataset/search_read",
         ]);
     });
@@ -799,7 +799,7 @@ QUnit.module("ActionManager", (hooks) => {
         assert.verifySteps([
             "/web/webclient/load_menus",
             "/web/action/load",
-            "/web/dataset/call_kw/partner/load_views",
+            "/web/dataset/call_kw/partner/get_views",
             "/web/dataset/search_read",
         ]);
     });
@@ -830,7 +830,7 @@ QUnit.module("ActionManager", (hooks) => {
         assert.verifySteps([
             "/web/webclient/load_menus",
             "/web/action/load",
-            "/web/dataset/call_kw/partner/load_views",
+            "/web/dataset/call_kw/partner/get_views",
             "/web/dataset/call_kw/partner/read",
         ]);
         await loadState(webClient, {

--- a/addons/web/static/tests/webclient/actions/misc_tests.js
+++ b/addons/web/static/tests/webclient/actions/misc_tests.js
@@ -311,7 +311,7 @@ QUnit.module("ActionManager", (hooks) => {
                 },
             });
             const mockRPC = async function (route, args) {
-                if (args && args.method === "load_views") {
+                if (args && args.method === "get_views") {
                     await Promise.resolve(def);
                 }
             };
@@ -319,7 +319,7 @@ QUnit.module("ActionManager", (hooks) => {
             // execute action 4 to know the number of widgets it instantiates
             await doAction(webClient, 4);
             const n = delta;
-            // execute a first action (its 'load_views' RPC is blocked)
+            // execute a first action (its 'get_views' RPC is blocked)
             def = testUtils.makeTestPromise();
             doAction(webClient, 3, { clearBreadcrumbs: true });
             await testUtils.nextTick();

--- a/addons/web/static/tests/webclient/actions/server_action_tests.js
+++ b/addons/web/static/tests/webclient/actions/server_action_tests.js
@@ -32,7 +32,7 @@ QUnit.module("ActionManager", (hooks) => {
             "/web/action/load",
             "/web/action/run",
             "/web/action/load",
-            "load_views",
+            "get_views",
             "/web/dataset/search_read",
         ]);
     });
@@ -62,7 +62,7 @@ QUnit.module("ActionManager", (hooks) => {
         assert.verifySteps([
             "/web/webclient/load_menus",
             "/web/action/load",
-            "load_views",
+            "get_views",
             "onchange",
             "/web/action/load",
             "/web/action/run",

--- a/addons/web/static/tests/webclient/actions/target_tests.js
+++ b/addons/web/static/tests/webclient/actions/target_tests.js
@@ -56,7 +56,7 @@ QUnit.module("ActionManager", (hooks) => {
         assert.verifySteps([
             "/web/webclient/load_menus",
             "/web/action/load",
-            "load_views",
+            "get_views",
             "onchange",
         ]);
     });
@@ -153,7 +153,7 @@ QUnit.module("ActionManager", (hooks) => {
         await doAction(webClient, 4);
         assert.verifySteps([
             "/web/action/load",
-            "/web/dataset/call_kw/partner/load_views",
+            "/web/dataset/call_kw/partner/get_views",
             "/web/dataset/call_kw/partner/onchange",
         ]);
         await testUtils.dom.click(`button[name="5"]`);
@@ -161,7 +161,7 @@ QUnit.module("ActionManager", (hooks) => {
             "/web/dataset/call_kw/partner/create",
             "/web/dataset/call_kw/partner/read",
             "/web/action/load",
-            "/web/dataset/call_kw/partner/load_views",
+            "/web/dataset/call_kw/partner/get_views",
             "/web/dataset/call_kw/partner/onchange",
         ]);
         await legacyExtraNextTick();
@@ -471,7 +471,7 @@ QUnit.module("ActionManager", (hooks) => {
             assert.verifySteps([
                 "/web/webclient/load_menus",
                 "/web/action/load",
-                "load_views",
+                "get_views",
                 "read",
             ]);
         }

--- a/addons/web/static/tests/webclient/actions/window_action_tests.js
+++ b/addons/web/static/tests/webclient/actions/window_action_tests.js
@@ -55,7 +55,7 @@ QUnit.module("ActionManager", (hooks) => {
         assert.verifySteps([
             "/web/webclient/load_menus",
             "/web/action/load",
-            "load_views",
+            "get_views",
             "/web/dataset/search_read",
         ]);
     });
@@ -66,7 +66,7 @@ QUnit.module("ActionManager", (hooks) => {
             print: [{ name: "Print that record" }],
         };
         const mockRPC = async (route, args) => {
-            if (args && args.method === "load_views") {
+            if (args && args.method === "get_views") {
                 assert.strictEqual(
                     args.kwargs.options.toolbar,
                     true,
@@ -122,7 +122,7 @@ QUnit.module("ActionManager", (hooks) => {
         assert.verifySteps([
             "/web/webclient/load_menus",
             "/web/action/load",
-            "load_views",
+            "get_views",
             "/web/dataset/search_read",
             "/web/dataset/search_read",
             "/web/dataset/search_read",
@@ -176,7 +176,7 @@ QUnit.module("ActionManager", (hooks) => {
         assert.verifySteps([
             "/web/webclient/load_menus",
             "/web/action/load",
-            "load_views",
+            "get_views",
             "web_read_group",
             "/web/dataset/search_read",
             "/web/dataset/search_read",
@@ -679,7 +679,7 @@ QUnit.module("ActionManager", (hooks) => {
         assert.verifySteps([
             "/web/webclient/load_menus",
             "/web/action/load",
-            "load_views",
+            "get_views",
             "/web/dataset/search_read",
             "onchange",
             "/web/dataset/search_read",
@@ -737,7 +737,7 @@ QUnit.module("ActionManager", (hooks) => {
         assert.verifySteps([
             "/web/webclient/load_menus",
             "/web/action/load",
-            "load_views",
+            "get_views",
             "/web/dataset/search_read",
             "read",
             "object",
@@ -884,11 +884,11 @@ QUnit.module("ActionManager", (hooks) => {
         assert.verifySteps([
             "/web/webclient/load_menus",
             "/web/action/load",
-            "load_views",
+            "get_views",
             "/web/dataset/search_read",
             "read",
             "/web/action/load",
-            "load_views",
+            "get_views",
             "/web/dataset/search_read",
         ]);
     });
@@ -935,10 +935,10 @@ QUnit.module("ActionManager", (hooks) => {
         assert.verifySteps([
             "/web/webclient/load_menus",
             "/web/action/load",
-            "/web/dataset/call_kw/partner/load_views",
+            "/web/dataset/call_kw/partner/get_views",
             "/web/dataset/call_kw/partner/read",
             "/web/action/load",
-            "/web/dataset/call_kw/partner/load_views",
+            "/web/dataset/call_kw/partner/get_views",
             "/web/dataset/search_read",
         ]);
     });
@@ -1050,7 +1050,7 @@ QUnit.module("ActionManager", (hooks) => {
         assert.verifySteps([
             "/web/webclient/load_menus",
             "/web/action/load",
-            "load_views",
+            "get_views",
             "/web/dataset/search_read",
             "read",
             "/web/dataset/search_read",
@@ -1191,7 +1191,7 @@ QUnit.module("ActionManager", (hooks) => {
         assert.verifySteps([
             "/web/webclient/load_menus",
             "/web/action/load",
-            "/web/dataset/call_kw/partner/load_views",
+            "/web/dataset/call_kw/partner/get_views",
             "/web/dataset/search_read",
             "/web/dataset/call_kw/partner/read",
             "/web/dataset/call_kw/partner/get_formview_id",
@@ -1416,7 +1416,7 @@ QUnit.module("ActionManager", (hooks) => {
         assert.verifySteps([
             "/web/webclient/load_menus",
             "/web/action/load",
-            "load_views",
+            "get_views",
             "/web/dataset/search_read",
         ]);
     });
@@ -1449,7 +1449,7 @@ QUnit.module("ActionManager", (hooks) => {
         assert.verifySteps([
             "/web/webclient/load_menus",
             "/web/action/load",
-            "load_views",
+            "get_views",
             "onchange",
         ]);
     });
@@ -1702,12 +1702,12 @@ QUnit.module("ActionManager", (hooks) => {
         assert.verifySteps([
             "/web/webclient/load_menus",
             "/web/action/load",
-            "load_views",
+            "get_views",
             "/web/dataset/search_read",
             "onchange",
             "get_formview_action",
             "create", // FIXME: to check with mcm
-            "load_views",
+            "get_views",
             "read",
             "read",
         ]);
@@ -1722,7 +1722,7 @@ QUnit.module("ActionManager", (hooks) => {
             print: [],
         };
         const mockRPC = async (route, args) => {
-            if (args && args.method === "load_views" && args.model === "partner") {
+            if (args && args.method === "get_views" && args.model === "partner") {
                 assert.strictEqual(
                     args.kwargs.options.toolbar,
                     true,
@@ -1992,7 +1992,7 @@ QUnit.module("ActionManager", (hooks) => {
             assert.verifySteps([
                 "/web/webclient/load_menus",
                 "/web/action/load",
-                "/web/dataset/call_kw/partner/load_views",
+                "/web/dataset/call_kw/partner/get_views",
                 "/web/dataset/call_kw/partner/read",
             ]);
             assert.containsN(target, ".o_form_buttons_view button:not([disabled])", 2);
@@ -2365,7 +2365,7 @@ QUnit.module("ActionManager", (hooks) => {
         );
     });
 
-    QUnit.test("action and load_views rpcs are cached", async function (assert) {
+    QUnit.test("action and get_views rpcs are cached", async function (assert) {
         const mockRPC = async (route, args) => {
             assert.step(args.method || route);
         };
@@ -2374,7 +2374,7 @@ QUnit.module("ActionManager", (hooks) => {
 
         await doAction(webClient, 1);
         assert.containsOnce(target, ".o_kanban_view");
-        assert.verifySteps(["/web/action/load", "load_views", "/web/dataset/search_read"]);
+        assert.verifySteps(["/web/action/load", "get_views", "/web/dataset/search_read"]);
 
         await doAction(webClient, 1);
         assert.containsOnce(target, ".o_kanban_view");

--- a/addons/web/static/tests/webclient/helpers.js
+++ b/addons/web/static/tests/webclient/helpers.js
@@ -12,6 +12,7 @@ import {
     makeLegacySessionService,
 } from "@web/legacy/utils";
 import { makeLegacyActionManagerService } from "@web/legacy/backend_utils";
+import { generateLegacyLoadViewsResult } from "@web/legacy/legacy_load_views";
 import { viewService } from "@web/views/view_service";
 import { actionService } from "@web/webclient/actions/action_service";
 import { effectService } from "@web/core/effects/effect_service";
@@ -118,16 +119,18 @@ export function addLegacyMockEnvironment(env, legacyParams = {}) {
                 });
             },
             load_views: async (params, options) => {
-                const result = await env.services.rpc(`/web/dataset/call_kw/${params.model}`, {
+                let result = await env.services.rpc(`/web/dataset/call_kw/${params.model}`, {
                     args: [],
                     kwargs: {
                         context: params.context,
                         options: options,
                         views: params.views_descr,
                     },
-                    method: "load_views",
+                    method: "get_views",
                     model: params.model,
                 });
+                const { models, views: _views } = result;
+                result = generateLegacyLoadViewsResult(params.model, _views, models);
                 const views = result.fields_views;
                 for (const [, viewType] of params.views_descr) {
                     const fvg = views[viewType];

--- a/addons/web_editor/models/ir_qweb_fields.py
+++ b/addons/web_editor/models/ir_qweb_fields.py
@@ -76,7 +76,7 @@ class IrQWeb(models.AbstractModel):
         key = el.attrib.pop('t-snippet')
         el.set('t-call', key)
         el.set('t-options', f"{{'snippet-key': {key!r}}}")
-        view = self.env['ir.ui.view']._get_view(key).sudo()
+        view = self.env['ir.ui.view']._get(key).sudo()
         name = view.name
         thumbnail = el.attrib.pop('t-thumbnail', "oe-thumbnail")
         div = '<div name="%s" data-oe-type="snippet" data-oe-thumbnail="%s" data-oe-snippet-id="%s" data-oe-keywords="%s">' % (

--- a/addons/website/models/ir_ui_view.py
+++ b/addons/website/models/ir_ui_view.py
@@ -409,7 +409,7 @@ class View(models.Model):
 
     def _render_template(self, template, values=None):
         """ Render the template. If website is enabled on request, then extend rendering context with website values. """
-        view = self._get_view(template).sudo()
+        view = self._get(template).sudo()
         view._handle_visibility(do_raise=True)
         if values is None:
             values = {}

--- a/addons/website/models/website.py
+++ b/addons/website/models/website.py
@@ -1090,7 +1090,7 @@ class Website(models.Model):
     def get_template(self, template):
         if isinstance(template, str) and '.' not in template:
             template = 'website.%s' % template
-        view = self.env['ir.ui.view']._get_view(template).sudo()
+        view = self.env['ir.ui.view']._get(template).sudo()
         if not view:
             raise NotFound
         return view

--- a/odoo/addons/base/models/ir_actions.py
+++ b/odoo/addons/base/models/ir_actions.py
@@ -218,7 +218,7 @@ class IrActionsActWindow(models.Model):
     @api.depends('res_model', 'search_view_id')
     def _compute_search_view(self):
         for act in self:
-            fvg = self.env[act.res_model].fields_view_get(act.search_view_id.id, 'search')
+            fvg = self.env[act.res_model].get_view(act.search_view_id.id, 'search')
             act.search_view = str(fvg)
 
     name = fields.Char(string='Action Name', translate=True)

--- a/odoo/addons/base/models/ir_module.py
+++ b/odoo/addons/base/models/ir_module.py
@@ -157,8 +157,8 @@ class Module(models.Model):
     _order = 'application desc,sequence,name'
 
     @api.model
-    def fields_view_get(self, view_id=None, view_type='form', toolbar=False, submenu=False):
-        res = super(Module, self).fields_view_get(view_id, view_type, toolbar=toolbar, submenu=False)
+    def get_view(self, view_id=None, view_type='form', **options):
+        res = super().get_view(view_id, view_type, **options)
         if view_type == 'form' and res.get('toolbar',False):
             install_id = self.env.ref('base.action_server_module_immediate_install').id
             action = [rec for rec in res['toolbar']['action'] if rec.get('id', False) != install_id]

--- a/odoo/addons/base/models/ir_qweb.py
+++ b/odoo/addons/base/models/ir_qweb.py
@@ -772,7 +772,7 @@ class IrQWeb(models.AbstractModel):
         :rtype: Tuple[Union[etree, str], Optional[str, int]]
         """
         IrUIView = self.env['ir.ui.view'].sudo()
-        view = IrUIView._get_view(ref)
+        view = IrUIView._get(ref)
         template = IrUIView._read_template(view.id)
         etree_view = etree.fromstring(template)
 

--- a/odoo/addons/base/models/res_config.py
+++ b/odoo/addons/base/models/res_config.py
@@ -384,29 +384,22 @@ class ResConfigSettings(models.TransientModel, ResConfigModuleInstallationMixin)
         raise UserError(_("Cannot duplicate configuration!"))
 
     @api.model
-    def fields_view_get(self, view_id=None, view_type='form',
-                        toolbar=False, submenu=False):
-        ret_val = super(ResConfigSettings, self).fields_view_get(
-            view_id=view_id, view_type=view_type,
-            toolbar=toolbar, submenu=submenu)
+    def _get_view(self, view_id=None, view_type='form', **options):
+        arch, view = super()._get_view(view_id, view_type, **options)
 
         can_install_modules = self.env['ir.module.module'].check_access_rights(
                                     'write', raise_exception=False)
 
-        doc = etree.XML(ret_val['arch'])
-
-        for field in ret_val['fields']:
-            if not field.startswith("module_"):
+        for node in arch.xpath("//field[@name]"):
+            if not node.get('name').startswith("module_"):
                 continue
-            for node in doc.xpath("//field[@name='%s']" % field):
-                if not can_install_modules:
-                    node.set("readonly", "1")
-                    modifiers = json.loads(node.get("modifiers"))
-                    modifiers['readonly'] = True
-                    node.set("modifiers", json.dumps(modifiers))
+            if not can_install_modules:
+                node.set("readonly", "1")
+                modifiers = json.loads(node.get("modifiers"))
+                modifiers['readonly'] = True
+                node.set("modifiers", json.dumps(modifiers))
 
-        ret_val['arch'] = etree.tostring(doc, encoding='unicode')
-        return ret_val
+        return arch, view
 
     def onchange_module(self, field_value, module_name):
         module_sudo = self.env['ir.module.module']._get(module_name[7:])

--- a/odoo/addons/base/models/res_currency.py
+++ b/odoo/addons/base/models/res_currency.py
@@ -285,18 +285,16 @@ class Currency(models.Model):
         """
 
     @api.model
-    def _fields_view_get(self, view_id=None, view_type='form', toolbar=False, submenu=False):
-        result = super(Currency, self)._fields_view_get(view_id=view_id, view_type=view_type, toolbar=toolbar, submenu=submenu)
+    def _get_view(self, view_id=None, view_type='form', **options):
+        arch, view = super()._get_view(view_id, view_type, **options)
         if view_type in ('tree', 'form'):
             currency_name = (self.env['res.company'].browse(self._context.get('company_id')) or self.env.company).currency_id.name
-            doc = etree.XML(result['arch'])
             for field in [['company_rate', _('Unit per %s', currency_name)],
                           ['inverse_company_rate', _('%s per Unit', currency_name)]]:
-                node = doc.xpath("//tree//field[@name='%s']" % field[0])
+                node = arch.xpath("//tree//field[@name='%s']" % field[0])
                 if node:
                     node[0].set('string', field[1])
-            result['arch'] = etree.tostring(doc, encoding='unicode')
-        return result
+        return arch, view
 
 
 class CurrencyRate(models.Model):
@@ -417,18 +415,16 @@ class CurrencyRate(models.Model):
         return super()._name_search(parse_date(self.env, name), args, operator, limit, name_get_uid)
 
     @api.model
-    def _fields_view_get(self, view_id=None, view_type='form', toolbar=False, submenu=False):
-        result = super(CurrencyRate, self)._fields_view_get(view_id=view_id, view_type=view_type, toolbar=toolbar, submenu=submenu)
+    def _get_view(self, view_id=None, view_type='form', **options):
+        arch, view = super()._get_view(view_id, view_type, **options)
         if view_type in ('tree'):
             names = {
                 'company_currency_name': (self.env['res.company'].browse(self._context.get('company_id')) or self.env.company).currency_id.name,
                 'rate_currency_name': self.env['res.currency'].browse(self._context.get('active_id')).name or 'Unit',
             }
-            doc = etree.XML(result['arch'])
             for field in [['company_rate', _('%(rate_currency_name)s per %(company_currency_name)s', **names)],
                           ['inverse_company_rate', _('%(company_currency_name)s per %(rate_currency_name)s', **names)]]:
-                node = doc.xpath("//tree//field[@name='%s']" % field[0])
+                node = arch.xpath("//tree//field[@name='%s']" % field[0])
                 if node:
                     node[0].set('string', field[1])
-            result['arch'] = etree.tostring(doc, encoding='unicode')
-        return result
+        return arch, view

--- a/odoo/addons/base/models/res_partner.py
+++ b/odoo/addons/base/models/res_partner.py
@@ -44,26 +44,22 @@ class FormatAddressMixin(models.AbstractModel):
     _name = "format.address.mixin"
     _description = 'Address Format'
 
-    def _fields_view_get_address(self, arch):
+    def _view_get_address(self, arch):
         # consider the country of the user, not the country of the partner we want to display
         address_view_id = self.env.company.country_id.address_view_id.sudo()
         if address_view_id and not self._context.get('no_address_format') and (not address_view_id.model or address_view_id.model == self._name):
             #render the partner address accordingly to address_view_id
-            doc = etree.fromstring(arch)
-            for address_node in doc.xpath("//div[hasclass('o_address_format')]"):
+            for address_node in arch.xpath("//div[hasclass('o_address_format')]"):
                 Partner = self.env['res.partner'].with_context(no_address_format=True)
-                sub_view = Partner.fields_view_get(
-                    view_id=address_view_id.id, view_type='form', toolbar=False, submenu=False)
-                sub_view_node = etree.fromstring(sub_view['arch'])
+                sub_arch, _sub_view = Partner._get_view(address_view_id.id, 'form')
                 #if the model is different than res.partner, there are chances that the view won't work
                 #(e.g fields not present on the model). In that case we just return arch
                 if self._name != 'res.partner':
                     try:
-                        self.env['ir.ui.view'].postprocess_and_fields(sub_view_node, model=self._name)
+                        self.env['ir.ui.view'].postprocess_and_fields(sub_arch, model=self._name)
                     except ValueError:
                         return arch
-                address_node.getparent().replace(address_node, sub_view_node)
-            arch = etree.tostring(doc, encoding='unicode')
+                address_node.getparent().replace(address_node, sub_arch)
         return arch
 
 class PartnerCategory(models.Model):
@@ -345,13 +341,13 @@ class Partner(models.Model):
             partner.commercial_company_name = p.is_company and p.name or partner.company_name
 
     @api.model
-    def _fields_view_get(self, view_id=None, view_type='form', toolbar=False, submenu=False):
+    def _get_view(self, view_id=None, view_type='form', **options):
         if (not view_id) and (view_type == 'form') and self._context.get('force_email'):
             view_id = self.env.ref('base.view_partner_simple_form').id
-        res = super(Partner, self)._fields_view_get(view_id=view_id, view_type=view_type, toolbar=toolbar, submenu=submenu)
+        arch, view = super()._get_view(view_id, view_type, **options)
         if view_type == 'form':
-            res['arch'] = self._fields_view_get_address(res['arch'])
-        return res
+            arch = self._view_get_address(arch)
+        return arch, view
 
     @api.constrains('parent_id')
     def _check_parent_id(self):

--- a/odoo/addons/base/static/tests/base_settings_tests.js
+++ b/odoo/addons/base/static/tests/base_settings_tests.js
@@ -206,11 +206,11 @@ QUnit.module('base_settings_tests', {
             await legacyExtraNextTick();
             assert.hasClass($(target).find(".o_form_view"), "o_form_editable");
             assert.verifySteps([
-                "load_views", // initial setting action
+                "get_views", // initial setting action
                 "onchange", // this is a setting view => create new record
                 "create", // when we click on action button => save
                 "read", // with save, we have a reload... (not necessary actually)
-                "load_views", // for other action in breadcrumb,
+                "get_views", // for other action in breadcrumb,
                 // with a searchread (not shown here since it is a route)
                 "onchange", // when we come back, we want to restart from scratch
             ]);

--- a/odoo/addons/base/tests/test_acl.py
+++ b/odoo/addons/base/tests/test_acl.py
@@ -48,7 +48,7 @@ class TestACL(TransactionCaseWithUserDemo):
 
         # Verify the test environment first
         original_fields = currency.fields_get([])
-        form_view = currency.fields_view_get(False, 'form')
+        form_view = currency.get_view(False, 'form')
         view_arch = etree.fromstring(form_view.get('arch'))
         has_group_system = self.user_demo.has_group(GROUP_SYSTEM)
         self.assertFalse(has_group_system, "`demo` user should not belong to the restricted group before the test")
@@ -62,7 +62,7 @@ class TestACL(TransactionCaseWithUserDemo):
         self._set_field_groups(currency, 'decimal_places', GROUP_SYSTEM)
 
         fields = currency.fields_get([])
-        form_view = currency.fields_view_get(False, 'form')
+        form_view = currency.get_view(False, 'form')
         view_arch = etree.fromstring(form_view.get('arch'))
         self.assertNotIn('decimal_places', fields, "'decimal_places' field should be gone")
         self.assertEqual(view_arch.xpath("//field[@name='decimal_places']"), [],
@@ -74,7 +74,7 @@ class TestACL(TransactionCaseWithUserDemo):
         self.erp_system_group.users += self.user_demo
         has_group_system = self.user_demo.has_group(GROUP_SYSTEM)
         fields = currency.fields_get([])
-        form_view = currency.fields_view_get(False, 'form')
+        form_view = currency.get_view(False, 'form')
         view_arch = etree.fromstring(form_view.get('arch'))
         self.assertTrue(has_group_system, "`demo` user should now belong to the restricted group")
         self.assertIn('decimal_places', fields, "'decimal_places' field must be properly visible again")
@@ -130,7 +130,7 @@ class TestACL(TransactionCaseWithUserDemo):
         """ Test form view Create, Edit, Delete button visibility based on access right of model"""
         methods = ['create', 'edit', 'delete']
         company = self.env['res.company'].with_user(self.user_demo)
-        company_view = company.fields_view_get(False, 'form')
+        company_view = company.get_view(False, 'form')
         view_arch = etree.fromstring(company_view['arch'])
         for method in methods:
             self.assertEqual(view_arch.get(method), 'false')
@@ -140,7 +140,7 @@ class TestACL(TransactionCaseWithUserDemo):
         self.erp_system_group.users += self.user_demo
         methods = ['create', 'edit', 'delete']
         company = self.env['res.company'].with_user(self.user_demo)
-        company_view = company.fields_view_get(False, 'form')
+        company_view = company.get_view(False, 'form')
         view_arch = etree.fromstring(company_view['arch'])
         for method in methods:
             self.assertIsNone(view_arch.get(method))
@@ -149,7 +149,7 @@ class TestACL(TransactionCaseWithUserDemo):
         """ Test many2one field Create and Edit option visibility based on access rights of relation field""" 
         methods = ['create', 'write']
         company = self.env['res.company'].with_user(self.user_demo)
-        company_view = company.fields_view_get(False, 'form')
+        company_view = company.get_view(False, 'form')
         view_arch = etree.fromstring(company_view['arch'])
         field_node = view_arch.xpath("//field[@name='currency_id']")
         self.assertTrue(len(field_node), "currency_id field should be in company from view")
@@ -161,7 +161,7 @@ class TestACL(TransactionCaseWithUserDemo):
         self.erp_system_group.users += self.user_demo
         methods = ['create', 'write']
         company = self.env['res.company'].with_user(self.user_demo)
-        company_view = company.fields_view_get(False, 'form')
+        company_view = company.get_view(False, 'form')
         view_arch = etree.fromstring(company_view['arch'])
         field_node = view_arch.xpath("//field[@name='currency_id']")
         self.assertTrue(len(field_node), "currency_id field should be in company from view")

--- a/odoo/addons/base/tests/test_translate.py
+++ b/odoo/addons/base/tests/test_translate.py
@@ -638,8 +638,8 @@ class TestTranslationWrite(TransactionCase):
         self.assertEqual(fg['state']['selection'],
                          [('manual', 'Custo'), ('base', 'Pas touche!')])
 
-    def test_fields_view_get(self):
-        """ Test translations of field descriptions in fields_view_get(). """
+    def test_load_views(self):
+        """ Test translations of field descriptions in get_view(). """
         self.env['res.lang']._activate_lang('fr_FR')
 
         # add translation for the string of field ir.model.name
@@ -659,9 +659,9 @@ class TestTranslationWrite(TransactionCase):
         info = model.fields_get(['name'])
         self.assertEqual(info['name']['string'], LABEL)
 
-        # check that fields_view_get() also returns the expected label
-        info = model.fields_view_get()['fields']
-        self.assertEqual(info['name']['string'], LABEL)
+        # check that get_views() also returns the expected label
+        info = model.get_views([(False, 'form')])
+        self.assertEqual(info['models'][model._name]['name']['string'], LABEL)
 
 
 class TestXMLTranslation(TransactionCase):

--- a/odoo/addons/base/tests/test_views.py
+++ b/odoo/addons/base/tests/test_views.py
@@ -1256,9 +1256,7 @@ class TestViews(ViewCase):
             """
         })
 
-        view = self.View.with_context(check_view_ids=[view2.id, view3.id]) \
-                        .fields_view_get(view2.id, view_type='form')
-        self.assertEqual(view['type'], 'form')
+        view = self.View.with_context(check_view_ids=[view2.id, view3.id]).get_view(view2.id, 'form')
         self.assertEqual(
             etree.fromstring(
                 view['arch'],
@@ -1285,8 +1283,7 @@ class TestViews(ViewCase):
             'inherit_id': view1.id,
             'arch': '<div position="inside">a<p/>b<p/>c</div>',
         })
-        view = self.View.with_context(check_view_ids=view2.ids).fields_view_get(view1.id)
-        self.assertEqual(view['type'], 'form')
+        view = self.View.with_context(check_view_ids=view2.ids).get_view(view1.id)
         self.assertEqual(
             view['arch'],
             '<form string="F">(<div>a<p/>b<p/>c</div>)</form>',
@@ -1305,8 +1302,7 @@ class TestViews(ViewCase):
             'inherit_id': view1.id,
             'arch': '<div position="after">a<p/>b<p/>c</div>',
         })
-        view = self.View.with_context(check_view_ids=view2.ids).fields_view_get(view1.id)
-        self.assertEqual(view['type'], 'form')
+        view = self.View.with_context(check_view_ids=view2.ids).get_view(view1.id)
         self.assertEqual(
             view['arch'],
             '<form string="F">(<div/>a<p/>b<p/>c)</form>',
@@ -1325,8 +1321,7 @@ class TestViews(ViewCase):
             'inherit_id': view1.id,
             'arch': '<div position="before">a<p/>b<p/>c</div>',
         })
-        view = self.View.with_context(check_view_ids=view2.ids).fields_view_get(view1.id)
-        self.assertEqual(view['type'], 'form')
+        view = self.View.with_context(check_view_ids=view2.ids).get_view(view1.id)
         self.assertEqual(
             view['arch'],
             '<form string="F">(a<p/>b<p/>c<div/>)</form>',
@@ -1379,8 +1374,7 @@ class TestViews(ViewCase):
         })
 
         view = self.View.with_context(check_view_ids=[view2.id, view3.id]) \
-                        .fields_view_get(view2.id, view_type='form')
-        self.assertEqual(view['type'], 'form')
+                        .get_view(view2.id, view_type='form')
         self.assertEqual(
             etree.fromstring(
                 view['arch'],
@@ -2330,13 +2324,13 @@ class TestViews(ViewCase):
         })
 
         # default view, no address_view defined
-        arch = self.env['res.partner'].fields_view_get(view_id=partner_view.id)['arch']
+        arch = self.env['res.partner'].get_view(partner_view.id)['arch']
         self.assertIn('"street"', arch)
         self.assertNotIn('"parent_name"', arch)
 
         # custom view, address_view defined
         self.env.company.country_id.address_view_id = address_view
-        arch = self.env['res.partner'].fields_view_get(view_id=partner_view.id)['arch']
+        arch = self.env['res.partner'].get_view(partner_view.id)['arch']
         self.assertNotIn('"street"', arch)
         self.assertIn('"parent_name"', arch)
         # weird result: <form> inside a <form>
@@ -3110,12 +3104,12 @@ class TestAccessRights(common.TransactionCase):
         with self.assertRaises(AccessError):
             self.env['ir.ui.view'].search([("model", '=', "res.partner"), ('type', '=', 'form')])
 
-        # but can call fields_view_get
-        self.env['res.partner'].fields_view_get(view_type='form')
+        # but can call view_get
+        self.env['res.partner'].get_view(view_type='form')
 
         # unless he does not have access to the model
         with self.assertRaises(AccessError):
-            self.env['ir.ui.view'].fields_view_get(view_type='form')
+            self.env['ir.ui.view'].get_view(view_type='form')
 
 @common.tagged('post_install', '-at_install', '-standard', 'migration')
 class TestAllViews(common.TransactionCase):
@@ -3142,7 +3136,7 @@ class TestRenderAllViews(common.TransactionCase):
                     for _ in range(5):
                         model.invalidate_cache()
                         before = time.perf_counter()
-                        model.fields_view_get()
+                        model.get_view()
                         times.append(time.perf_counter() - before)
                     count += 1
                     elapsed += min(times)

--- a/odoo/addons/base/wizard/base_module_upgrade.py
+++ b/odoo/addons/base/wizard/base_module_upgrade.py
@@ -23,8 +23,8 @@ class BaseModuleUpgrade(models.TransientModel):
     module_info = fields.Text('Apps to Update', readonly=True, default=_default_module_info)
 
     @api.model
-    def fields_view_get(self, view_id=None, view_type='form', toolbar=False, submenu=False):
-        res = super(BaseModuleUpgrade, self).fields_view_get(view_id, view_type, toolbar=toolbar,submenu=False)
+    def get_view(self, view_id=None, view_type='form', **options):
+        res = super().get_view(view_id, view_type, **options)
         if view_type != 'form':
             return res
 

--- a/odoo/addons/test_action_bindings/tests/test_bindings.py
+++ b/odoo/addons/test_action_bindings/tests/test_bindings.py
@@ -53,19 +53,19 @@ class TestBindingViewFilters(common.TransactionCase):
     def test_act_window(self):
         A = self.env['tab.a']
 
-        form_act = A.fields_view_get(toolbar=True)['toolbar']['action']
+        form_act = A.get_view(toolbar=True)['toolbar']['action']
         self.assertEqual(
             [a['name'] for a in form_act],
             ['Action 1', 'Action 2', 'Action 3'],
             "forms should have all actions")
 
-        list_act = A.fields_view_get(view_type='tree', toolbar=True)['toolbar']['action']
+        list_act = A.get_view(view_type='tree', toolbar=True)['toolbar']['action']
         self.assertEqual(
             [a['name'] for a in list_act],
             ['Action 1', 'Action 3'],
             "lists should not have the form-only action")
 
-        kanban_act = A.fields_view_get(view_type='kanban', toolbar=True)['toolbar']['action']
+        kanban_act = A.get_view(view_type='kanban', toolbar=True)['toolbar']['action']
         self.assertEqual(
             [a['name'] for a in kanban_act],
             ['Action 1'],
@@ -74,19 +74,19 @@ class TestBindingViewFilters(common.TransactionCase):
     def test_act_record(self):
         B = self.env['tab.b']
 
-        form_act = B.fields_view_get(toolbar=True)['toolbar']['action']
+        form_act = B.get_view(toolbar=True)['toolbar']['action']
         self.assertEqual(
             [a['name'] for a in form_act],
             ['Record 1', 'Record 2', 'Record 3'],
             "forms should have all actions")
 
-        list_act = B.fields_view_get(view_type='tree', toolbar=True)['toolbar']['action']
+        list_act = B.get_view(view_type='tree', toolbar=True)['toolbar']['action']
         self.assertEqual(
             [a['name'] for a in list_act],
             ['Record 1', 'Record 3'],
             "lists should not have the form-only action")
 
-        kanban_act = B.fields_view_get(view_type='kanban', toolbar=True)['toolbar']['action']
+        kanban_act = B.get_view(view_type='kanban', toolbar=True)['toolbar']['action']
         self.assertEqual(
             [a['name'] for a in kanban_act],
             ['Record 1'],

--- a/odoo/addons/test_new_api/tests/test_onchange.py
+++ b/odoo/addons/test_new_api/tests/test_onchange.py
@@ -424,9 +424,7 @@ class TestOnChange(SavepointCaseWithUserDemo):
 
         # mimic UI behaviour, so we get subfields
         # (we need at least subfield: 'important_emails.important')
-        view_info = self.Discussion.fields_view_get(
-            view_id=self.env.ref('test_new_api.discussion_form').id,
-            view_type='form')
+        view_info = self.Discussion.get_view(self.env.ref('test_new_api.discussion_form').id, 'form')
         field_onchange = self.Discussion._onchange_spec(view_info=view_info)
         self.assertEqual(field_onchange.get('messages'), '1')
 

--- a/odoo/addons/test_new_api/views/test_new_api_views.xml
+++ b/odoo/addons/test_new_api/views/test_new_api_views.xml
@@ -93,7 +93,7 @@
                                 </field>
                             </page>
                             <page string="Participants">
-                                <field name="participants">
+                                <field name="participants" widget="many2many">
                                     <tree string="Participants">
                                         <field name="display_name"/>
                                     </tree>

--- a/odoo/tests/common.py
+++ b/odoo/tests/common.py
@@ -1766,24 +1766,7 @@ def can_import(module):
     else:
         return True
 
-# TODO: sub-views (o2m, m2m) -> sub-form?
-# TODO: domains
-ref_re = re.compile(r"""
-# first match 'form_view_ref' key, backrefs are used to handle single or
-# double quoting of the value
-(['"])(?P<view_type>\w+_view_ref)\1
-# colon separator (with optional spaces around)
-\s*:\s*
-# open quote for value
-(['"])
-(?P<view_id>
-    # we'll just match stuff which is normally part of an xid:
-    # word and "." characters
-    [.\w]+
-)
-# close with same quote as opening
-\3
-""", re.VERBOSE)
+
 class Form(object):
     """ Server-side form view implementation (partial)
 
@@ -1871,8 +1854,9 @@ class Form(object):
             view_id = env.ref(view).id
         else:
             view_id = view or False
-        fvg = recordp.fields_view_get(view_id, 'form')
+        fvg = recordp.get_view(view_id, 'form')
         fvg['tree'] = etree.fromstring(fvg['arch'])
+        fvg['fields'] = self._get_view_fields(fvg['tree'], recordp)
 
         object.__setattr__(self, '_view', fvg)
 
@@ -1891,37 +1875,40 @@ class Form(object):
         else:
             self._init_from_defaults(self._model)
 
+    def _get_view_fields(self, node, model):
+        level = node.xpath('count(ancestor::field)')
+        fnames = set(el.get('name') for el in node.xpath('.//field[count(ancestor::field) = %s]' % level))
+        fields = {fname: info for fname, info in model.fields_get().items() if fname in fnames}
+        return fields
+
     def _o2m_set_edition_view(self, descr, node, level):
         default_view = next(
             (m for m in node.get('mode', 'tree').split(',') if m != 'form'),
             'tree'
         )
-        refs = {
-            m.group('view_type'): m.group('view_id')
-            for m in ref_re.finditer(node.get('context', ''))
-        }
+        refs = self._env['ir.ui.view']._get_view_refs(node)
         # always fetch for simplicity, ensure we always have a tree and
         # a form view
         submodel = self._env[descr['relation']]
-        views = submodel.with_context(**refs) \
-            .load_views([(False, 'tree'), (False, 'form')])['fields_views']
-        # embedded views should take the priority on externals
-        views.update(descr['views'])
-        # re-set all resolved views on the descriptor
-        descr['views'] = views
+        views = {view.tag: view for view in node.xpath('./*[descendant::field]')}
+        for view_type in ['tree', 'form']:
+            # embedded views should take the priority on externals
+            if view_type not in views:
+                sub_fvg = submodel.with_context(**refs).get_view(view_type=view_type)
+                sub_node = etree.fromstring(sub_fvg['arch'])
+                views[view_type] = sub_node
+                node.append(sub_node)
         # if the default view is a kanban or a non-editable list, the
         # "edition controller" is the form view
-        edition = views['form']
-        edition['tree'] = etree.fromstring(edition['arch'])
-        if default_view == 'tree':
-            subarch = etree.fromstring(views['tree']['arch'])
-            if subarch.get('editable'):
-                edition = views['tree']
-                edition['tree'] = subarch
+        edition_view = 'tree' if default_view == 'tree' and views['tree'].get('editable') else 'form'
+        edition = {
+            'fields': self._get_view_fields(views[edition_view], submodel),
+            'tree': views[edition_view],
+        }
 
         # don't recursively process o2ms in o2ms
         self._process_fvg(submodel, edition, level=level-1)
-        descr['views']['edition'] = edition
+        descr['edition_view'] = edition
 
     def __str__(self):
         return "<%s %s(%s)>" % (
@@ -1931,8 +1918,7 @@ class Form(object):
         )
 
     def _process_fvg(self, model, fvg, level=2):
-        """ Post-processes to augment the fields_view_get with:
-
+        """ Post-processes to augment the view_get with:
         * an id field (may not be present if not in the view but needed)
         * pre-processed modifiers (map of modifier name to json-loaded domain)
         * pre-processed onchanges list
@@ -1942,7 +1928,7 @@ class Form(object):
         modifiers = fvg['modifiers'] = {'id': {'required': False, 'readonly': True}}
         contexts = fvg['contexts'] = {}
         order = fvg['fields_ordered'] = []
-        for f in fvg['tree'].xpath('//field[not(ancestor::field)]'):
+        for f in fvg['tree'].xpath('.//field[count(ancestor::field) = %s]' % fvg['tree'].xpath('count(ancestor::field)')):
             fname = f.get('name')
             order.append(fname)
 
@@ -1962,7 +1948,7 @@ class Form(object):
             if level and descr['type'] == 'one2many':
                 self._o2m_set_edition_view(descr, f, level)
 
-        fvg['onchange'] = model._onchange_spec(fvg)
+        fvg['onchange'] = model._onchange_spec({'arch': etree.tostring(fvg['tree'])})
 
     def _init_from_defaults(self, model):
         vals = self._values
@@ -2207,7 +2193,7 @@ class Form(object):
                     continue
 
             if descr['type'] == 'one2many':
-                subview = descr['views']['edition']
+                subview = descr['edition_view']
                 fields_ = subview['fields']
                 oldvals = v
                 v = []
@@ -2293,7 +2279,7 @@ class Form(object):
         values = {}
         for k, v in record.items():
             if fields[k]['type'] == 'one2many':
-                subfields = fields[k]['views']['edition']['fields']
+                subfields = fields[k]['edition_view']['fields']
                 it = values[k] = []
                 for (c, rid, vs) in v:
                     if c == 1 and isinstance(vs, UpdateDict):
@@ -2317,7 +2303,7 @@ class Form(object):
             return value[0]
         elif descr['type'] == 'one2many':
             # ignore o2ms nested in o2ms
-            if not descr['views']:
+            if not descr['edition_view']:
                 return []
 
             if current is None:
@@ -2326,7 +2312,7 @@ class Form(object):
             c = {t[1] for t in current if t[0] in (1, 2)}
             current_values = {c[1]: c[2] for c in current if c[0] == 1}
             # which view should this be???
-            subfields = descr['views']['edition']['fields']
+            subfields = descr['edition_view']['fields']
             # TODO: simplistic, unlikely to work if e.g. there's a 5 inbetween other commands
             for command in value:
                 if command[0] == 0:
@@ -2402,7 +2388,7 @@ class O2MForm(Form):
         object.__setattr__(self, '_model', m)
 
         # copy so we don't risk breaking it too much (?)
-        fvg = dict(proxy._descr['views']['edition'])
+        fvg = dict(proxy._descr['edition_view'])
         object.__setattr__(self, '_view', fvg)
         self._process_fvg(m, fvg)
 
@@ -2503,7 +2489,7 @@ class O2MProxy(X2MProxy):
         # reify records to a list so they can be manipulated easily?
         self._records = []
         model = self._model
-        fields = self._descr['views']['edition']['fields']
+        fields = self._descr['edition_view']['fields']
         for (command, rid, values) in self._parent._values[self._field]:
             if command == 0:
                 self._records.append(values)

--- a/odoo/tools/test_reports.py
+++ b/odoo/tools/test_reports.py
@@ -10,6 +10,7 @@
 import logging
 import os
 import tempfile
+from lxml import etree
 from subprocess import Popen, PIPE
 
 from .. import api
@@ -170,21 +171,24 @@ def try_report_action(cr, uid, action_id, active_model=None, active_ids=None,
             log_test("will emulate a %s view: %s#%s",
                         view_type, datas['res_model'], view_id or '?')
 
-            view_res = env[datas['res_model']].fields_view_get(view_id, view_type=view_type)
+            model = env[datas['res_model']]
+            view_res = model.get_view(view_id, view_type)
             assert view_res and view_res.get('arch'), "Did not return any arch for the view"
             view_data = {}
-            if view_res.get('fields'):
-                view_data = env[datas['res_model']].default_get(list(view_res['fields']))
+            arch = etree.fromstring(view_res['arch'])
+            fields = [el.get('name') for el in arch.xpath('//field[not(ancestor::field)]')]
+            if fields:
+                view_data = model.default_get(fields)
             if datas.get('form'):
                 view_data.update(datas.get('form'))
             if wiz_data:
                 view_data.update(wiz_data)
             _logger.debug("View data is: %r", view_data)
 
-            for fk, field in view_res.get('fields',{}).items():
+            for fk in fields:
                 # Default fields returns list of int, while at create()
                 # we need to send a [(6,0,[int,..])]
-                if field['type'] in ('one2many', 'many2many') \
+                if model._fields[fk].type in ('one2many', 'many2many') \
                         and view_data.get(fk, False) \
                         and isinstance(view_data[fk], list) \
                         and not isinstance(view_data[fk][0], tuple) :


### PR DESCRIPTION
# Main quest

Refactor the `load_views` API so it no longer sends multiple times the same
fields description.

e.g.
When `load_views` is called to get the kanban, tree and form views,
the list of fields of the model was sent 4 times:
- Once for each view, with only the fields used in the view,
  in `['fields_views']['kanban']['fields']` for instance
- Once globally, with all the fields of the model, in `['fields']`

The goal of this revision is to change that so it sends the list of all fields
only once.

In addition, if a view contains x2many fields,
the fields description of the comodel is also sent.
It was sent in the `views` key of the view fields dict.
e.g.
When calling `load_views` of `res.partner` to get the kanban,
tree and form views,
the `res.partner` fields description was actually sent 6 times:
- Once for each view
- Once globally
- Once for each view of the many2many field `child_ids` of the form view, in 
  - `['fields_views']['form']['fields']['child_ids']['views']['kanban']['fields']`
  - `['fields_views']['form']['fields']['child_ids']['views']['form']['fields']`

The change suggested in this revision is to:
- Remove the fields description for each view in `['fields_views']`.
  As it no longer contains the fields,
  the key becomes `['views']` instead of `['fields_views']`.
- Replace the dict key `['fields']` by `['models']`,
  which is a dict with as key the model name and as values
  the model fields description. It contains the fields description
  for all models implied in the view:
  the model of the main view and the model of all one2many and many2many fields.

With this change, the fields description will only be sent once by model
implied in the view.

In addition, the web client was getting the information about the fields
sometimes in the global fields description list (e.g. `['fields']`),
sometimes in the fields description list of the view type
(e.g. `['fields_views']['form']['fields']`),
making it a pain to try to make changes / performance gain
in these field description dictionaries, because you never knew in which dict
the web client was getting its info.
Now, as there is only one place to get the fields description from,
it's clearer and cleaner.

# Secondary quests

- one2many and many2many fields views are passed directly in the main view
  architecture rather than being put in the `views` key
  of the field description.
  This is actually easier to treat by the web client,
  and this will allow in a future work to cache an entire view in one block
  of text rather than having to combine multiple cached blocks of text
  to return one view.
- one2many and many2many fields which do not have directly embedded views
  have their views directly injected in the architecture,
  so the web client doesn't have to do RPC calls to `load_views`
  for each one2many and many2many fields not having embedded views.
  For instance, this allow to reduce the number of RPC calls to `load_views`
  from 8 to 1 when loading the form of `product.product`.
  Currently, this behavior is limited to 1 level deep but we consider making it
  go all the way down in future works. We did not do it for the moment because
  in certain cases it rises the processing time and the size (bytes) too much.
  e.g. the sale.order view can be 5 levels deep,
  meaning you can reach 4 dialogs on top the main view.
  ```
  sale.order form > order_line > sale.order.line form > invoice_lines > 
  account.move.line form > asset_ids > account.asset form >
  depreciation_move_ids > account.move form.
  ```
  This will also benefit in future works to cache an entire view in one block
  of text rather to having to combine multiple cached block of text
  to get one view.
- `fields_view_get` becomes `get_view`.
  As it no longer returns the fields description,
  keeping the `fields` in the name `fields_view_get` no longer makes sense.
  Hence removing `fields` from the method name, it becomes `view_get`.
  As it gets renamed anyway, we take the opportunity to rename it `get_view`,
  which is more in line with the general getter/setter guidelines
  in the model object world.
- `_fields_view_get` becomes `_get_view`. For the same reasons than above.
- `load_views` becomes `get_views`.
  This is not mandatory, there is no technical reason to rename `load_views` as
  it practically sends the same info as before,
  the view architectures and their fields description. Just in another way.
  We just take the opportunity of this pull request to suggest a cleaner API:
  `_get_view`, `get_view` and `get_views`.
- Arguments `toolbar=False, submenu=False` fo the methods
  `_fields_view_get` and `fields_view_get` are converted to a kwargs `**options`
  in `_get_view` and `get_view`.
  The rationale is that submenu was already no longer used (deprecated)
  and the mobile options is introduced.
  The mobile options is necessary to tell the server to send the mobile views
  for x2many fields (kanban instead of tree).
  Instead of adding a new argument each time we add a new option to
  `fields_view_get`, it seems wiser to have a kwargs `**options` to avoid
  to re-write all overrides each time a new option is introduced.
- `_fields_view_get` returned a dict containing the arch in text and some of the
  view information. Now, `get_view` returns a tuple with the view architecture
  as an `etree` node, and the view as a browse record. The rationale is that all
  overrides of `_fields_view_get` were about modifying the arch only
  (e.g. changing the address format/re-organizing the address related field
  nodes of the partner according to the company country).
  To do so, all these overrides were doing `etree.fromstring` to parse the arch
  which was sent in text to convert it to an `etree`,
  then operations were done on the `etree`,
  and then `etree.tostring` was called to convert back the arch to string.
  With this change of signature to send the arch as an `etree`,
  all these back and forth `etree.fromstring` -> `etree.tostring` are avoided,
  allowing some performance gain and less code in the end.
- A cleanup of the keys returned in the dict of `fields_view_get`
  has been performed in `get_view`:
  - `fields` is removed, as explained above,
  - `view_id` is renamed `id`,
  - `name` is removed, it was unused by the web client,
  - `type` is removed, it was unused by the web client,
  - `field_parent` is removed, it was unused by the web client,
  - `base_model` is removed, it was unused by the web client.
- `filters` is moved from the global dict returned by `load_views`
  (now `get_views`) to the dict returned by `fields_view_get` (now `get_view`)
  as it applies only to the `search` view type.
- Retro-compatible methods for the 3 methods
  `fields_view_get`, `_fields_view_get` and `load_views` are provided,
  with deprecation warnings in them.

# Future quests

- The web client could cache the model fields description
  (as it already caches the views),
  so it doesn't need to fetch them again if it asks for another view of a model
  for which he already has the fields description.
  If we do so, `get_views` could return only the list of models used by
  the views, without the fields description as of now,
  and the web client would then call `fields_get` independently only for
  the models for which it doesn't have yet the fields description.
  This would avoid the server to return the fields description
  and to call `fields_get`, which is costly, for each `get_views`,
  therefore gaining performances.
- Inject the views of the one2many and many2many fields all the way down,
  unlimited depth level, as explained above.
- Cache with `ormcache` the architecture of back-end views.
  This is already done for qweb views, it's not done for back-end views.
  Therefore the postprocessing of the views is performed for each `get_views`,
  which is costly, while the view architecture doesn't change for users
  belonging to the same groups, according to the groups implied by the view.

### Credits
This pull request is co-authored by
Aaron Bohy (aab) for the web client part and
Denis Ledoux (dle) for the server part.
