### PR TITLE
[FIX] [14.0] hr_expense: Cannot access expenses

### DIFF
--- a/addons/hr_expense/models/hr_expense.py
+++ b/addons/hr_expense/models/hr_expense.py
@@ -74,7 +74,7 @@ class HrExpense(models.Model):
         domain="[('company_id', '=', company_id), ('type_tax_use', '=', 'purchase')]", string='Taxes')
     untaxed_amount = fields.Float("Subtotal", store=True, compute='_compute_amount', digits='Account')
     total_amount = fields.Monetary("Total", compute='_compute_amount', store=True, currency_field='currency_id', tracking=True)
-    amount_residual = fields.Monetary(string='Amount Due', compute='_compute_amount_residual')
+    amount_residual = fields.Monetary(string='Amount Due', compute='_compute_amount_residual', compute_sudo=True)
     company_currency_id = fields.Many2one('res.currency', string="Report Company Currency", related='sheet_id.currency_id', store=True, readonly=False)
     total_amount_company = fields.Monetary("Total (Company Currency)", compute='_compute_total_amount_company', store=True, currency_field='company_currency_id')
     company_id = fields.Many2one('res.company', string='Company', required=True, readonly=True, states={'draft': [('readonly', False)], 'refused': [('readonly', False)]}, default=lambda self: self.env.company)


### PR DESCRIPTION
In case the user is not in the accounting group, they won't be able to see the expenses they generate if the expense has account entry.

Steps:
1. The user is not in the accounting group, create expense 1
2. manager approve and post expense sheet
3. The user can't access the expense 1


Solution: use `compute_sudo=True`

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
