### PR TITLE
[FIX] Requests version should support urllib3 version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -38,7 +38,7 @@ pytz==2019.3
 pyusb==1.0.2
 qrcode==6.1
 reportlab==3.5.59 # version < 3.5.54 are not compatible with Pillow 8.1.2 and 3.5.59 is bullseye
-requests==2.22.0
+requests==2.25.0
 vobject==0.9.6.1
 Werkzeug==0.16.1
 xlrd==1.1.0; python_version < '3.8'


### PR DESCRIPTION
This fixes #87444: Unable to build Odee because of incompatibilities in reuirements.txt

Description of the issue/feature this PR addresses:

Building Odoo results in an exception because requirements.txt specifies incompatible libraries:

Current behavior before PR:

ERROR: Cannot install -r requirements.txt (line 1) and urllib3==1.26.5 because these package versions have conflicting dependencies.

The conflict is caused by:
    The user requested urllib3==1.26.5
    requests 2.22.0 depends on urllib3!=1.25.0, !=1.25.1, <1.26 and >=1.21.1

To fix this you could try to:
1. loosen the range of package versions you've specified
2. remove package versions to allow pip attempt to solve the dependency conflict

ERROR: ResolutionImpossible: for help visit https://pip.pypa.io/en/latest/user_guide/#fixing-conflicting-dependencies

Desired behavior after PR is merged:

Succesfull build of Odoo 15.0




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
