### PR TITLE
[FIX] web_editor: debug collaboration _resetEditor

### DIFF
--- a/addons/web_editor/static/src/js/wysiwyg/wysiwyg.js
+++ b/addons/web_editor/static/src/js/wysiwyg/wysiwyg.js
@@ -21,6 +21,7 @@ const { PeerToPeer } = require('@web_editor/js/wysiwyg/PeerToPeer');
 const { Mutex } = require('web.concurrency');
 
 var _t = core._t;
+const QWeb = core.qweb;
 
 const OdooEditor = OdooEditorLib.OdooEditor;
 const getDeepRange = OdooEditorLib.getDeepRange;
@@ -517,7 +518,7 @@ const Wysiwyg = Widget.extend({
         }, CHECK_OFFLINE_TIME);
 
         this._peerToPeerLoading = new Promise(async (resolve) => {
-            this._currentRecordWriteDate = this._getRecordWriteDate(await this._getCurrentRecord());
+            this._currentRecord = await this._getCurrentRecord();
             let iceServers = await this._rpc({route: '/web_editor/get_ice_servers'});
             if (!iceServers.length) {
                 iceServers = [
@@ -2015,10 +2016,24 @@ const Wysiwyg = Widget.extend({
             this.preSavePromiseReject = undefined;
         }
         try {
-            const record = await this._getCurrentRecord();
-            const newDate = this._getRecordWriteDate(record);
-            if (newDate !== this._currentRecordWriteDate) {
-                this._resetEditor(record.body);
+            const fieldName = this.options.collaborationChannel.collaborationFieldName;
+            const currentContent = this._currentRecord[fieldName];
+            const currentRecordDate = this._getRecordWriteDate(this._currentRecord);
+            const dbRecord = await this._getCurrentRecord();
+            const dbContent = dbRecord[fieldName];
+            const dbRecordDate = this._getRecordWriteDate(dbRecord);
+
+            if (currentContent !== dbContent && dbRecordDate !== currentRecordDate) {
+                const $dialogContent = $(QWeb.render('web_editor.collaboration-reset-dialog'));
+                $dialogContent.append($(this.odooEditor.editable).clone());
+                const dialog = new Dialog(this, {
+                    title: _t("Content conflict"),
+                    $content: $dialogContent,
+                    size: 'medium',
+                });
+                dialog.open({shouldFocusButtons:true});
+
+                this._resetEditor(dbRecord.body);
             }
             this.preSavePromiseResolve();
             resetPreSavePromise();

--- a/addons/web_editor/static/src/xml/editor.xml
+++ b/addons/web_editor/static/src/xml/editor.xml
@@ -268,6 +268,24 @@
         </we-customizeblock-options>
     </t>
 
+    <!-- Collaboration reset dialog -->
+    <t t-name="web_editor.collaboration-reset-dialog">
+        <div>
+            <div style="color: red;">
+                <p>
+                    There is a conflict between your version and the one in the database.
+                </p>
+                <p>
+                    The version from the database will be used.
+                    If you need to keep your changes, copy the content below and edit the new document.
+                </p>
+                <p style="font-weight: bold;">
+                    Warning: after closing this dialog, the version you were working on will be discarded and will never be available anymore.
+                </p>
+            </div>
+        </div>
+    </t>
+
     <!--=================-->
     <!-- Snippet options -->
     <!--=================-->


### PR DESCRIPTION
There are cases that seems to reset the editor content but shouldn't.
This commit:
- provide a dialog to allow the user to save his content before being
  lost forever
- reset only if the record content has changed

task-2810115





--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
