### PR TITLE
[FIX] web: navbar: set action id in menu href

### DIFF
--- a/addons/web/static/src/webclient/navbar/navbar.js
+++ b/addons/web/static/src/webclient/navbar/navbar.js
@@ -189,8 +189,8 @@ export class NavBar extends Component {
 
     getMenuItemHref(payload) {
         const parts = [`menu_id=${payload.id}`];
-        if (payload.action) {
-            parts.push(`action=${payload.action.split(",")[1]}`);
+        if (payload.actionID) {
+            parts.push(`action=${payload.actionID}`);
         }
         return "#" + parts.join("&");
     }

--- a/addons/web/static/tests/webclient/navbar_tests.js
+++ b/addons/web/static/tests/webclient/navbar_tests.js
@@ -65,6 +65,22 @@ QUnit.test("dropdown menu can be toggled", async (assert) => {
     navbar.destroy();
 });
 
+QUnit.test("href attribute on apps menu items", async (assert) => {
+    baseConfig.serverData.menus = {
+        root: { id: "root", children: [1], name: "root", appID: "root" },
+        1: { id: 1, children: [2], name: "My app", appID: 1, actionID: 339 },
+    };
+    const env = await makeTestEnv(baseConfig);
+    const target = getFixture();
+    const navbar = await mount(NavBar, { env, target });
+    const appsMenu = navbar.el.querySelector(".o_navbar_apps_menu");
+    await click(appsMenu, "button.dropdown-toggle");
+    const dropdownItem = navbar.el.querySelector(".o_navbar_apps_menu .dropdown-item");
+    assert.strictEqual(dropdownItem.getAttribute("href"), "#menu_id=1&action=339");
+
+    navbar.destroy();
+});
+
 QUnit.test("data-menu-xmlid attribute on AppsMenu items", async (assert) => {
     baseConfig.serverData.menus = {
         root: { id: "root", children: [1, 2], name: "root", appID: "root" },


### PR DESCRIPTION
Before this commit, the href attribute of menu elements didn't
contain the "action=xx" part but only the id of the menu.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
