### PR TITLE
[IMP] account: improve quicksearch on journal entry/item

### DIFF
--- a/addons/account/views/account_move_views.xml
+++ b/addons/account/views/account_move_views.xml
@@ -337,6 +337,8 @@
                     <field name="name" string="Journal Item" filter_domain="[
                         '|', '|', '|',
                         ('name', 'ilike', self), ('ref', 'ilike', self), ('account_id', 'ilike', self), ('partner_id', 'ilike', self)]"/>
+                    <field name="name"/>
+                    <field name="ref"/>
                     <field name="date"/>
                     <field name="account_id"/>
                     <field name="account_root_id"/>
@@ -1283,6 +1285,8 @@
             <field name="arch" type="xml">
                 <search string="Search Move">
                     <field name="name" string="Journal Entry" filter_domain="['|', '|', ('name', 'ilike', self), ('ref', 'ilike', self), ('partner_id', 'ilike', self)]"/>
+                    <field name="name"/>
+                    <field name="ref"/>
                     <field name="date"/>
                     <field name="partner_id"/>
                     <field name="journal_id"/>


### PR DESCRIPTION
Add quicksearch on 'Number' (name) and 'Reference' (ref) for the journal entries
Add quicksearch on 'Label' (name) and 'Reference' (ref) for the journal items

Even though those fields are already searched on in the 'main' quicksearch
of each view (i.e. 'Journal Entry' and 'Journal Item'), users might look to
specifically search on the label and reference, and get frustrated when they
won't find it in the available quicksearches.

task-2753889