### PR TITLE
[IMP] account: display company's total amount in payments when grouping

### DIFF
--- a/addons/account/models/account_payment.py
+++ b/addons/account/models/account_payment.py
@@ -155,7 +155,7 @@ class AccountPayment(models.Model):
         currency_field='currency_id', compute='_compute_amount_signed', tracking=True,
         help='Negative value of amount field if payment_type is outbound')
     amount_company_currency_signed = fields.Monetary(
-        currency_field='company_currency_id', compute='_compute_amount_company_currency_signed')
+        currency_field='company_currency_id', compute='_compute_amount_company_currency_signed', store=True)
 
     _sql_constraints = [
         (


### PR DESCRIPTION
When looking at the list of the payments and grouping by company, the total amount per company is no longer displayed since v15.

This is due to the fact that the new variable used to represent this data was no longer stored.

By storing this data, we can regain this ability.

task-2801688

Upgrade PR : https://github.com/odoo/upgrade/pull/3401
