### PR TITLE
[FIX] web: action service: handle target "main"

### DIFF
--- a/addons/web/static/src/webclient/actions/action_service.js
+++ b/addons/web/static/src/webclient/actions/action_service.js
@@ -23,7 +23,7 @@ const viewRegistry = registry.category("views");
 
 /** @typedef {number|false} ActionId */
 /** @typedef {Object} ActionDescription */
-/** @typedef {"current" | "fullscreen" | "new" | "self" | "inline"} ActionMode */
+/** @typedef {"current" | "fullscreen" | "new" | "main" | "self" | "inline"} ActionMode */
 /** @typedef {string} ActionTag */
 /** @typedef {string} ActionXMLId */
 /** @typedef {Object} Context */
@@ -1103,6 +1103,7 @@ function makeActionManager(env) {
         const actionProm = _loadAction(actionRequest, options.additionalContext);
         let action = await keepLast.add(actionProm);
         action = _preprocessAction(action, options.additionalContext);
+        options.clearBreadcrumbs = action.target === "main" || options.clearBreadcrumbs;
         switch (action.type) {
             case "ir.actions.act_url":
                 return _executeActURLAction(action, options);

--- a/addons/web/static/tests/webclient/actions/target_tests.js
+++ b/addons/web/static/tests/webclient/actions/target_tests.js
@@ -407,6 +407,7 @@ QUnit.module("ActionManager", (hooks) => {
     });
 
     QUnit.module('Actions in target="inline"');
+
     QUnit.test(
         'form views for actions in target="inline" open in edit mode',
         async function (assert) {
@@ -448,6 +449,7 @@ QUnit.module("ActionManager", (hooks) => {
     });
 
     QUnit.module('Actions in target="fullscreen"');
+
     QUnit.test(
         'correctly execute act_window actions in target="fullscreen"',
         async function (assert) {
@@ -529,4 +531,110 @@ QUnit.module("ActionManager", (hooks) => {
             assert.strictEqual($(webClient.el).find("nav .o_menu_brand").text(), "MAIN APP");
         }
     );
+
+    QUnit.module('Actions in target="main"');
+
+    QUnit.test('can execute act_window actions in target="main"', async function (assert) {
+        const webClient = await createWebClient({ serverData });
+        await doAction(webClient, 1);
+
+        assert.containsOnce(webClient, ".o_kanban_view");
+        assert.containsOnce(webClient, ".breadcrumb-item");
+        assert.strictEqual(
+            webClient.el.querySelector(".o_control_panel .breadcrumb").textContent,
+            "Partners Action 1"
+        );
+
+        await doAction(webClient, {
+            name: "Another Partner Action",
+            res_model: "partner",
+            type: "ir.actions.act_window",
+            views: [[false, "list"]],
+            target: "main",
+        });
+
+        assert.containsOnce(webClient, ".o_list_view");
+        assert.containsOnce(webClient, ".breadcrumb-item");
+        assert.strictEqual(
+            webClient.el.querySelector(".o_control_panel .breadcrumb").textContent,
+            "Another Partner Action"
+        );
+    });
+
+    QUnit.test('can switch view in an action in target="main"', async function (assert) {
+        const webClient = await createWebClient({ serverData });
+        await doAction(webClient, {
+            name: "Partner Action",
+            res_model: "partner",
+            type: "ir.actions.act_window",
+            views: [
+                [false, "list"],
+                [false, "form"],
+            ],
+            target: "main",
+        });
+
+        assert.containsOnce(webClient, ".o_list_view");
+        assert.containsOnce(webClient, ".breadcrumb-item");
+        assert.strictEqual(
+            webClient.el.querySelector(".o_control_panel .breadcrumb").textContent,
+            "Partner Action"
+        );
+
+        // open first record
+        await click(webClient.el.querySelector(".o_data_row .o_data_cell"));
+        await legacyExtraNextTick();
+
+        assert.containsOnce(webClient, ".o_form_view");
+        assert.containsN(webClient, ".breadcrumb-item", 2);
+        assert.strictEqual(
+            webClient.el.querySelector(".o_control_panel .breadcrumb").textContent,
+            "Partner ActionFirst record"
+        );
+    });
+
+    QUnit.test('can restore an action in target="main"', async function (assert) {
+        const webClient = await createWebClient({ serverData });
+        await doAction(webClient, {
+            name: "Partner Action",
+            res_model: "partner",
+            type: "ir.actions.act_window",
+            views: [
+                [false, "list"],
+                [false, "form"],
+            ],
+            target: "main",
+        });
+
+        assert.containsOnce(webClient, ".o_list_view");
+        assert.containsOnce(webClient, ".breadcrumb-item");
+        assert.strictEqual(
+            webClient.el.querySelector(".o_control_panel .breadcrumb").textContent,
+            "Partner Action"
+        );
+
+        // open first record
+        await click(webClient.el.querySelector(".o_data_row .o_data_cell"));
+        await legacyExtraNextTick();
+        assert.containsOnce(webClient, ".o_form_view");
+        assert.containsN(webClient, ".breadcrumb-item", 2);
+        assert.strictEqual(
+            webClient.el.querySelector(".o_control_panel .breadcrumb").textContent,
+            "Partner ActionFirst record"
+        );
+
+        await doAction(webClient, 1);
+        assert.containsOnce(webClient, ".o_kanban_view");
+        assert.containsN(webClient, ".breadcrumb-item", 3);
+
+        // go back to form view
+        await click(webClient.el.querySelectorAll(".breadcrumb-item")[1]);
+        await legacyExtraNextTick();
+        assert.containsOnce(webClient, ".o_form_view");
+        assert.containsN(webClient, ".breadcrumb-item", 2);
+        assert.strictEqual(
+            webClient.el.querySelector(".o_control_panel .breadcrumb").textContent,
+            "Partner ActionFirst record"
+        );
+    });
 });


### PR DESCRIPTION
The target "main" feature has been lost during the conversion of
the ActionManager into the action service. An action with target
"main" should always clear the breadcrumbs. This commit
re-introduces the feature.

Fixes #83865

Co-authored-by: "Aaron Bohy <aab@odoo.com>"

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
