### PR TITLE
[FIX] lunch: properly open lunch products

### DIFF
--- a/addons/lunch/static/src/js/lunch_kanban_record.js
+++ b/addons/lunch/static/src/js/lunch_kanban_record.js
@@ -29,6 +29,8 @@ odoo.define('lunch.LunchKanbanRecord', function (require) {
                 this.trigger_up('open_wizard', {productId: this.recordData.product_id ? this.recordData.product_id.res_id: this.recordData.id});
             }
         },
+
+        _openRecord() {},
     });
 
     return LunchKanbanRecord;


### PR DESCRIPTION
Since `fb9c8cd6fee4` it was no longer possible to open the lunch product
in the kanban view as both _openRecord() (from base class) and
_onSelectRecord() were triggering events.

TaskID: 2810219

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
