### PR TITLE
[FIX] microsoft_calendar: cancelled event without Odoo organizer

### DIFF
--- a/addons/microsoft_calendar/models/calendar.py
+++ b/addons/microsoft_calendar/models/calendar.py
@@ -430,9 +430,14 @@ class Meeting(models.Model):
         return values
 
     def _cancel_microsoft(self):
-        # only owner can delete => others refuse the event
+        """
+        Cancel an Microsoft event.
+        There are 2 cases:
+          1) the organizer is an Odoo user: he's the only one able to delete the Odoo event. Attendees can just decline.
+          2) the organizer is NOT an Odoo user: any attendee should remove the Odoo event.
+        """
         user = self.env.user
-        my_cancelled_records = self.filtered(lambda e: e.user_id == user)
-        super(Meeting, my_cancelled_records)._cancel_microsoft()
-        attendees = (self - my_cancelled_records).attendee_ids.filtered(lambda a: a.partner_id == user.partner_id)
+        records = self.filtered(lambda e: not e.user_id or e.user_id == user)
+        super(Meeting, records)._cancel_microsoft()
+        attendees = (self - records).attendee_ids.filtered(lambda a: a.partner_id == user.partner_id)
         attendees.do_decline()

--- a/addons/microsoft_calendar/tests/test_sync_microsoft2odoo.py
+++ b/addons/microsoft_calendar/tests/test_sync_microsoft2odoo.py
@@ -271,7 +271,9 @@ class TestSyncMicrosoft2Odoo(TransactionCase):
 
         self.env['calendar.event']._sync_microsoft2odoo(MicrosoftEvent(second_sync_values))
         self.assertEqual(len(recurrent_event.calendar_event_ids), 2)
-        self.assertEqual(recurrent_event.calendar_event_ids[0].start, datetime(2021, 7, 15, 15, 00))
-        self.assertEqual(recurrent_event.calendar_event_ids[0].stop, datetime(2021, 7, 15, 15, 30))
-        self.assertEqual(recurrent_event.calendar_event_ids[1].start, datetime(2021, 7, 17, 15, 00))
-        self.assertEqual(recurrent_event.calendar_event_ids[1].stop, datetime(2021, 7, 17, 15, 30))
+
+        events = recurrent_event.calendar_event_ids.sorted(key=lambda e: e.start)
+        self.assertEqual(events[0].start, datetime(2021, 7, 15, 15, 00))
+        self.assertEqual(events[0].stop, datetime(2021, 7, 15, 15, 30))
+        self.assertEqual(events[1].start, datetime(2021, 7, 17, 15, 00))
+        self.assertEqual(events[1].stop, datetime(2021, 7, 17, 15, 30))


### PR DESCRIPTION
When an event is created in Outlook by an Outlook user (user A) who does not exist in Odoo but who invites an Odoo user (user B) who syncs his calendar with his Outlook calendar, the event will appear in the user B Odoo calendar.

If user A cancels this event in Outlook, then when user B syncs his Odoo calendar, the event must be removed.

task-id: 2746046

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
