### PR TITLE
[FIX] web: action service: concurrency issue on inexistant view

### DIFF
--- a/addons/web/static/src/webclient/actions/action_service.js
+++ b/addons/web/static/src/webclient/actions/action_service.js
@@ -1219,7 +1219,6 @@ function makeActionManager(env) {
      * @returns {Promise<Number>}
      */
     async function switchView(viewType, props = {}) {
-        await keepLast.add(Promise.resolve());
         const controller = controllerStack[controllerStack.length - 1];
         const view = _getView(viewType);
         if (!view) {
@@ -1230,6 +1229,7 @@ function makeActionManager(env) {
                 )
             );
         }
+        await keepLast.add(Promise.resolve());
         const newController = controller.action.controllers[viewType] || {
             jsId: `controller_${++id}`,
             Component: view.isLegacy ? view : View,


### PR DESCRIPTION
Since fb9c8cd6fee476d2506b8c1338bf88c4520ea7b6 if and inexistant
view was called after an existant view, the inexistant view would
be skipped as it wasn't called last.
This fix ensure that the last view exist before skipping the first.

Step to reproduce:
- Go to Lunch
- In kanban view click on an item

Current beahviour:
- No wizard pop-up
- Wizard is skipped because we try to open a form view in `_onOpenWizard`

Behaviour after PR:
- Wizard pop-up

opw-2809120


--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
