### PR TITLE
[FIX] point_of_sale: pricelist date_{start,end} are in utc

### DIFF
--- a/addons/point_of_sale/static/src/js/models.js
+++ b/addons/point_of_sale/static/src/js/models.js
@@ -1579,8 +1579,8 @@ exports.Product = Backbone.Model.extend({
             return (! item.product_tmpl_id || item.product_tmpl_id[0] === self.product_tmpl_id) &&
                    (! item.product_id || item.product_id[0] === self.id) &&
                    (! item.categ_id || _.contains(category_ids, item.categ_id[0])) &&
-                   (! item.date_start || moment(item.date_start).isSameOrBefore(date)) &&
-                   (! item.date_end || moment(item.date_end).isSameOrAfter(date));
+                   (! item.date_start || moment.utc(item.date_start).isSameOrBefore(date)) &&
+                   (! item.date_end || moment.utc(item.date_end).isSameOrAfter(date));
         });
 
         var price = self.lst_price;


### PR DESCRIPTION
**Steps to follow**

  - Use a browser timezone of GMT +2
  - Create a pricelist ending in an hour with a matching product
  - Add the pricelist to advanced pricelists in the POS settings
  - Open a POS session
  - Add the aforementioned product
  - Apply the pricelist
  -> The custom price is not applied

**Cause of the issue**

  `date_start` and `date_end` are stored in utc
  They are then off by the amount of the offset in the browser timezone

opw-2794490