### PR TITLE
[FIX] sale,l10n_de_sale: Add the proforma in the title for din5008 sale report

### DIFF
--- a/addons/l10n_de_sale/i18n/l10n_de_sale.pot
+++ b/addons/l10n_de_sale/i18n/l10n_de_sale.pot
@@ -90,6 +90,12 @@ msgstr ""
 #. module: l10n_de_sale
 #: code:addons/l10n_de_sale/models/sale.py:0
 #, python-format
+msgid "Pro Forma Invoice"
+msgstr ""
+
+#. module: l10n_de_sale
+#: code:addons/l10n_de_sale/models/sale.py:0
+#, python-format
 msgid "Quotation"
 msgstr ""
 

--- a/addons/l10n_de_sale/models/sale.py
+++ b/addons/l10n_de_sale/models/sale.py
@@ -33,7 +33,9 @@ class SaleOrder(models.Model):
 
     def _compute_l10n_de_document_title(self):
         for record in self:
-            if record.state in ('draft', 'sent'):
+            if self._context.get('proforma'):
+                record.l10n_de_document_title = _('Pro Forma Invoice')
+            elif record.state in ('draft', 'sent'):
                 record.l10n_de_document_title = _('Quotation')
             else:
                 record.l10n_de_document_title = _('Sales Order')

--- a/addons/sale/report/sale_report_templates.xml
+++ b/addons/sale/report/sale_report_templates.xml
@@ -190,6 +190,7 @@
 <template id="report_saleorder_pro_forma">
     <t t-call="web.html_container">
         <t t-set="is_pro_forma" t-value="True"/>
+        <t t-set="docs" t-value="docs.with_context(proforma=True)"/>
         <t t-foreach="docs" t-as="doc">
             <t t-call="sale.report_saleorder_document" t-lang="doc.partner_id.lang"/>
         </t>


### PR DESCRIPTION
Step to reproduce:
	- install sale, accounting and l10n_de
	- activate proforma in sale settings
	- set the template to external_layout_din5008 in the settings (use developer mod)
	- create sales order or quotation
	- print it as a proforma

Current behavior:
	- the proforma is missing from the title in the document

Behaviour after PR:
	- the proforma is in the document title

The l10n_de_sale module was missing the case scenario of a proforma sales report and the sale module only
gives the information of a proforma report in the xml context. The title is set here in the document 
https://github.com/odoo/odoo/blob/15.0/addons/l10n_de/report/din5008_report.xml#L102-L109

and proforma info could only be accessed using is_pro_forma: 
https://github.com/odoo/odoo/blob/15.0/addons/sale/report/sale_report_templates.xml#L192
https://github.com/odoo/odoo/blob/15.0/addons/sale/report/sale_report_templates.xml#L30-L39

Then we add the case scenario and propagate the proforma info from the sale module also in the python context using the proforma variable.

opw-2796603