### PR TITLE
[IMP] odoo: use search in x2many convert to record

### DIFF
--- a/odoo/fields.py
+++ b/odoo/fields.py
@@ -2832,7 +2832,7 @@ class _RelationalMulti(_Relational):
             'active' in corecords
             and self.context.get('active_test', record.env.context.get('active_test', True))
         ):
-            corecords = corecords.filtered('active').with_prefetch(prefetch_ids)
+            corecords = corecords.search([("id", "in", corecords._ids), ("active", "=", True)])
         return corecords
 
     def convert_to_read(self, value, record, use_name_get=True):


### PR DESCRIPTION
**Description of the issue/feature this PR addresses:**

I have a case in which I have added a many2many relation between partners and product variants. Each partner is related to a set of products (in the use case the size is ~70000 products for a partner). Then I am using this relation to check whether a product can be used in a sales order line based on the partner of the sales order.

When the code accesses the many2many relation, I can see that internally Odoo is executing the 'convert_to_record' method for x2many relations. This method is taking ~6 seconds to execute due to the filtered that is perform to get the active records of the relation (https://github.com/odoo/odoo/blob/c14b1364cc114613278f9d078eeccb2739d25cfd/odoo/fields.py#L2835).

With the change that I am proposing, which I am not 100% sure it is the best one, the method executes in ~110ms.

It is not the first time that I have noticed the bad performance of the filtered method over large recordsets, so I would really like to know if my approach is fine or if it could be fixed in some other way :)

**Current behavior before PR:**

Currently, in x2many fields, the convert to record is performing a
filtered operation to get the active corecords.

When the number of corecords is quite significant, the filtered
operation performance is heavily affected.

**Desired behavior after PR is merged:**

By dropping the use of the filtered the performance is boosted significantly.



--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
