### PR TITLE
[FIX] google_calendar: get RRULE when recurrence contains more items

### DIFF
--- a/addons/google_calendar/utils/google_event.py
+++ b/addons/google_calendar/utils/google_event.py
@@ -68,8 +68,9 @@ class GoogleEvent(abc.Set):
 
     @property
     def rrule(self):
-        if self.recurrence and 'RRULE:' in self.recurrence[0]:  # LUL TODO what if there are something else in the list?
-            return self.recurrence[0][6:]  # skip "RRULE:" in the rrule string
+        if self.recurrence and any('RRULE' in item for item in self.recurrence):
+            rrule = next(item for item in self.recurrence if 'RRULE' in item)
+            return rrule[6:]  # skip "RRULE:" in the rrule string
 
     def odoo_id(self, env):
         self.odoo_ids(env)  # load ids


### PR DESCRIPTION
Before this commit: we assumed an event's recurrence only contains
RRULE, and we were getting the RRULE from the first element in the
list. But it could have EXRULE, RDATE, and EXDATE, so in this case,
the first element could be other items.
https://developers.google.com/calendar/api/v3/reference/events#:~:text=default%20is%20False.-,recurrence%5B%5D,-list

The solution is to iterate through all items and return the RRULE.

opw-2797968

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
