### PR TITLE
[IMP] website_payment: handle stripe supported countries

### DIFF
--- a/addons/payment_stripe/const.py
+++ b/addons/payment_stripe/const.py
@@ -42,3 +42,53 @@ HANDLED_WEBHOOK_EVENTS = [
     'charge.refunded',  # A refund has been issued.
     'charge.refund.updated',  # The refund status has changed, possibly from succeeded to failed.
 ]
+
+# The countries supported by Stripe. See https://stripe.com/global page.
+SUPPORTED_COUNTRIES = {
+    'AE',
+    'AT',
+    'AU',
+    'BE',
+    'BG',
+    'BR',
+    'CA',
+    'CH',
+    'CY',
+    'CZ',
+    'DE',
+    'DK',
+    'EE',
+    'ES',
+    'FI',
+    'FR',
+    'GB',
+    'GI',  # Beta
+    'GR',
+    'HK',
+    'HR',  # Beta
+    'HU',
+    'ID',  # Beta
+    'IE',
+    'IT',
+    'JP',
+    'LI',  # Beta
+    'LT',
+    'LU',
+    'LV',
+    'MT',
+    'MX',
+    'MY',
+    'NL',
+    'NO',
+    'NZ',
+    'PH',  # Beta
+    'PL',
+    'PT',
+    'RO',
+    'SE',
+    'SG',
+    'SI',
+    'SK',
+    'TH',  # Beta
+    'US',
+}

--- a/addons/website_payment/__manifest__.py
+++ b/addons/website_payment/__manifest__.py
@@ -15,6 +15,7 @@ This is a bridge module that adds multi-website support for payment acquirers.
     ],
     'data': [
         'data/donation_data.xml',
+        'data/ir_action_data.xml',
         'views/payment_acquirer.xml',
         'views/res_config_settings_views.xml',
         'views/donation_templates.xml',

--- a/addons/website_payment/data/ir_action_data.xml
+++ b/addons/website_payment/data/ir_action_data.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<odoo>
+    <record id="action_stripe_connect_account" model="ir.actions.server">
+        <field name="name">Connect to Stripe</field>
+        <field name="model_id" ref="payment.model_payment_acquirer"/>
+        <field name="groups_id" eval="[(4, ref('base.group_system'))]"/>
+        <field name="state">code</field>
+        <field name="code">
+stripe = env.ref('payment.payment_acquirer_stripe')
+menu_id = env.ref('website.menu_website_website_settings').id
+action = stripe.action_stripe_connect_account(menu_id=menu_id)
+        </field>
+    </record>
+</odoo>

--- a/addons/website_payment/models/__init__.py
+++ b/addons/website_payment/models/__init__.py
@@ -5,3 +5,4 @@ from . import account_payment
 from . import payment_acquirer
 from . import payment_transaction
 from . import res_config_settings
+from . import res_country

--- a/addons/website_payment/models/res_country.py
+++ b/addons/website_payment/models/res_country.py
@@ -1,0 +1,15 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from odoo import api, fields, models
+from odoo.addons.payment_stripe.const import SUPPORTED_COUNTRIES as STRIPE_SUPPORTED_COUNTRIES
+
+
+class ResCountry(models.Model):
+    _inherit = 'res.country'
+
+    is_stripe_supported_country = fields.Boolean(compute='_compute_is_stripe_supported_country')
+
+    @api.depends('code')
+    def _compute_is_stripe_supported_country(self):
+        for country in self:
+            country.is_stripe_supported_country = country.code in STRIPE_SUPPORTED_COUNTRIES

--- a/addons/website_payment/views/res_config_settings_views.xml
+++ b/addons/website_payment/views/res_config_settings_views.xml
@@ -18,7 +18,13 @@
                             <div class="content-group">
                                 <div class="row mt8 ml-4" attrs="{'invisible': [('acquirers_state', '=', 'other_than_paypal')]}">
                                     <field name="acquirers_state" invisible="1"/>
-                                    <button name="action_activate_stripe" type="object" string="Activate Stripe" class="btn-primary"/>
+                                    <field name="is_stripe_supported_country" invisible="1"/>
+                                    <button attrs="{'invisible': [('is_stripe_supported_country', '=', False)]}"
+                                            name="action_activate_stripe" type="object" string="Activate Stripe" class="btn-primary"/>
+                                    <div attrs="{'invisible': [('is_stripe_supported_country', '=', True)]}" data-toggle="tooltip" title="Stripe Connect is not available in your country, please use another payment provider.">
+                                        <button string="Activate Stripe" class="btn-primary pe-none" disabled=""
+                                                style="pointer-events: none;"/>
+                                    </div>
                                     <button type="action" name="%(payment.action_payment_acquirer)d" string="View Alternatives" class="btn-link" icon="fa-arrow-right"/>
                                 </div>
                                 <div class="row mt8 ml-4" attrs="{'invisible': [('acquirers_state', '!=', 'other_than_paypal')]}">


### PR DESCRIPTION
This commit warns company from countries not supported by Stripe to
activate Stripe from the settings page.

This commit also enable the Stripe Connect Onboarding from the website
settings page.

task-2789227

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
