### PR TITLE
[FIX] mail: prevents access error when portal users opens a channel link

### DIFF
--- a/addons/mail/__manifest__.py
+++ b/addons/mail/__manifest__.py
@@ -133,6 +133,7 @@
             'mail/static/src/main.js',
         ],
         'mail.assets_discuss_public_test_tours': [
+            'mail/static/tests/tours/discuss_public_tour.js',
             'mail/static/tests/tours/mail_channel_as_guest_tour.js',
         ],
         'web.assets_tests': [

--- a/addons/mail/models/res_users_settings.py
+++ b/addons/mail/models/res_users_settings.py
@@ -24,9 +24,9 @@ class ResUsersSettings(models.Model):
 
     @api.model
     def _find_or_create_for_user(self, user):
-        settings = user.res_users_settings_ids
+        settings = user.sudo().res_users_settings_ids
         if not settings:
-            settings = self.create({'user_id': user.id})
+            settings = self.sudo().create({'user_id': user.id})
         return settings
 
     def _res_users_settings_format(self):

--- a/addons/mail/static/tests/tours/discuss_public_tour.js
+++ b/addons/mail/static/tests/tours/discuss_public_tour.js
@@ -1,0 +1,30 @@
+/** @odoo-module **/
+
+import tour from 'web_tour.tour';
+
+tour.register('mail/static/tests/tours/discuss_public_tour.js', {
+    test: true,
+}, [{
+    trigger: '.o_DiscussPublicView',
+    extraTrigger: '.o_ThreadView',
+}, {
+    content: "Check that we are on channel page",
+    trigger: '.o_ThreadView',
+    run() {
+        if (!window.location.pathname.startsWith('/discuss/channel')) {
+            console.error('Did not automatically redirect to channel page');
+        }
+        // Wait for modules to be loaded or failed for the next step
+        odoo.__DEBUG__.didLogInfo.then(() => {
+            const { missing, failed, unloaded } = odoo.__DEBUG__.jsModules;
+            if ([missing, failed, unloaded].some(arr => arr.length)) {
+                console.error("Couldn't load all JS modules.", JSON.stringify({ missing, failed, unloaded }));
+            }
+            document.body.classList.add('o_mail_channel_public_modules_loaded');
+        });
+    },
+    extraTrigger: '.o_mail_channel_public_modules_loaded',
+}, {
+    content: "Wait for all modules loaded check in previous step",
+    trigger: '.o_mail_channel_public_modules_loaded',
+}]);

--- a/addons/mail/tests/test_mail_channel_as_guest.py
+++ b/addons/mail/tests/test_mail_channel_as_guest.py
@@ -4,13 +4,37 @@
 import odoo
 from odoo.tests import HttpCase
 
+
 @odoo.tests.tagged('-at_install', 'post_install')
-class TestMailGuestPages(HttpCase):
-    def test_mail_channel_as_guest(self):
-        """Checks that the invite page redirects to the channel and that all
-        modules load correctly on the welcome and channel page"""
-        channel = self.env['mail.channel'].create({
+class TestMailPublicPage(HttpCase):
+    """Checks that the invite page redirects to the channel and that all
+    modules load correctly on the welcome and channel page when authenticated as various users"""
+
+    def setUp(self):
+        super().setUp()
+        self.channel = self.env['mail.channel'].create({
             'name': 'Test channel',
             'public': 'public',
         })
-        self.start_tour(f"/chat/{channel.id}/{channel.uuid}", "mail/static/tests/tours/mail_channel_as_guest_tour.js")
+        self.route = f"/chat/{self.channel.id}/{self.channel.uuid}"
+        self.tour = "mail/static/tests/tours/discuss_public_tour.js"
+
+    def _open_channel_page_as_user(self, login):
+        self.start_tour(self.route, self.tour, login=login)
+        # Second run of the tour as the first call has side effects, like creating user settings or adding members to
+        # the channel, so we need to run it again to test different parts of the code.
+        self.start_tour(self.route, self.tour, login=login)
+
+    def test_mail_channel_public_page_as_admin(self):
+        self._open_channel_page_as_user('admin')
+
+    def test_mail_channel_public_page_as_guest(self):
+        self.start_tour(self.route, "mail/static/tests/tours/mail_channel_as_guest_tour.js")
+        guest = self.env['mail.guest'].search([('channel_ids', 'in', self.channel.id)], limit=1, order='id desc')
+        self.start_tour(self.route, self.tour, cookies={guest._cookie_name: f"{guest.id}{guest._cookie_separator}{guest.access_token}"})
+
+    def test_mail_channel_public_page_as_internal(self):
+        self._open_channel_page_as_user('demo')
+
+    def test_mail_channel_public_page_as_portal(self):
+        self._open_channel_page_as_user('portal')

--- a/odoo/tests/common.py
+++ b/odoo/tests/common.py
@@ -1551,7 +1551,7 @@ class HttpCase(TransactionCase):
 
         return session
 
-    def browser_js(self, url_path, code, ready='', login=None, timeout=60, **kw):
+    def browser_js(self, url_path, code, ready='', login=None, timeout=60, cookies=None, **kw):
         """ Test js code running in the browser
         - optionnally log as 'login'
         - load page given by url_path
@@ -1583,6 +1583,9 @@ class HttpCase(TransactionCase):
             if self.browser.screencasts_dir:
                 self._logger.info('Starting screencast')
                 self.browser.start_screencast()
+            if cookies:
+                for name, value in cookies.items():
+                    self.browser.set_cookie(name, value, '/', HOST)
             self.browser.navigate_to(url, wait_stop=not bool(ready))
 
             # Needed because tests like test01.js (qunit tests) are passing a ready


### PR DESCRIPTION
Before this commit, since https://github.com/odoo/odoo/pull/83574,
attempting to join a call through the channel guest page while being
logged as a portal user would give an acess error.

This commit fixes this issue