### PR TITLE
[FIX] tests: x2m modifiers not working in subviews in Form tests

### DIFF
--- a/odoo/tests/common.py
+++ b/odoo/tests/common.py
@@ -1708,8 +1708,11 @@ class Form(object):
             return O2MProxy(self, field)
         return v
 
-    def _get_modifier(self, field, modifier, default=False, modmap=None, vals=None):
-        d = (modmap or self._view['modifiers'])[field].get(modifier, default)
+    def _get_modifier(self, field, modifier, *, default=False, view=None, modmap=None, vals=None):
+        if view is None:
+            view = self._view
+
+        d = (modmap or view['modifiers'])[field].get(modifier, default)
         if isinstance(d, bool):
             return d
 
@@ -1750,7 +1753,7 @@ class Form(object):
                     # we're looking up the "current view" so bits might be
                     # missing when processing o2ms in the parent (see
                     # values_to_save:1450 or so)
-                    f_ = self._view['fields'].get(f, {'type': None})
+                    f_ = view['fields'].get(f, {'type': None})
                     if f_['type'] == 'many2many':
                         # field value should be [(6, _, ids)], we want just the ids
                         field_val = field_val[0][2] if field_val else []
@@ -1887,7 +1890,7 @@ class Form(object):
         for f in fields:
             get_modifier = functools.partial(
                 self._get_modifier,
-                f, modmap=view['modifiers'],
+                f, view=view,
                 vals=modifiers_values or record_values
             )
             descr = fields[f]
@@ -2116,11 +2119,11 @@ class O2MForm(Form):
             if hasattr(vals, '_changed'):
                 self._changed.update(vals._changed)
 
-    def _get_modifier(self, field, modifier, default=False, modmap=None, vals=None):
+    def _get_modifier(self, field, modifier, *, default=False, view=None, modmap=None, vals=None):
         if vals is None:
             vals = {**self._values, '•parent•': self._proxy._parent._values}
 
-        return super()._get_modifier(field, modifier, default=default, modmap=modmap, vals=vals)
+        return super()._get_modifier(field, modifier, default=default, view=view, modmap=modmap, vals=vals)
 
     def _onchange_values(self):
         values = super(O2MForm, self)._onchange_values()


### PR DESCRIPTION
In the tests.Form class, in case of embedded views the values of m2m fields in the modifiers of the sub-view evaluated as [(6, _, [ids])] instead of a simple list, this is a hack-ish fix the better fix as recommended in previous commits in this file is to redesign the model and keep x2m fields as simple lists instead.

Description of the issue/feature this PR addresses:
Consider this view:
```xml
<form string="The Parent">
    <field name="line_ids>
        <field name="cond_ids" />
        <field name="foo" attrs="{'required': [('cond_ids', '=', [])]}"
    </field>
 </form>
```
Adding a record with empty cond_ids and empty foo is possible in the browser, but doing it with odoo.tests.Form raises foo is a required field ('required': [('cond_ids', '=', [])])"

Desired behavior after PR is merged:
`tests.Form` works the same as the JS form view


relates to master PR: #85709 

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
