### PR TITLE
[FIX] website: navigate backwards in configurator

### DIFF
--- a/addons/website/static/src/components/configurator/configurator.js
+++ b/addons/website/static/src/components/configurator/configurator.js
@@ -438,6 +438,13 @@ Object.assign(Configurator, {
 class Router {
     constructor() {
         this.location = window.location.pathname;
+        // Using the back button must update the router state.
+        const reactiveRouter = reactive(this);
+        const backListener = () => {
+            reactiveRouter.location = window.location.pathname;
+        };
+        window.addEventListener("popstate", backListener);
+        return reactiveRouter;
     }
 
     navigate(id) {
@@ -730,7 +737,7 @@ async function makeEnvironment() {
     updateStorage(state);
     const env = {
         state,
-        router: reactive(new Router()),
+        router: new Router(),
         services: Component.env.services,
     };
     await session.is_bound;

--- a/addons/website/static/tests/tours/configurator_translation.js
+++ b/addons/website/static/tests/tours/configurator_translation.js
@@ -12,6 +12,17 @@ tour.register('configurator_translation', {
         content: "click next",
         trigger: 'button.o_configurator_show',
     },
+    // Make sure "Back" works
+    {
+        content: "use browser's Back",
+        trigger: 'a.o_change_website_type',
+        run: () => {
+            window.history.back();
+        },
+    }, {
+        content: "return to description screen",
+        trigger: 'button.o_configurator_show',
+    },
     // Description screen
     {
         content: "select a website type",


### PR DESCRIPTION
Since [1] the back button did not navigate within the steps of the
website configurator anymore.

After this commit the window location change that happens within the
browser is copied back into the router state - thus causing a redraw of
the correct configurator step.

Steps to reproduce:
- Create a new website
- Go to second step
- Press browser's Back button
=> Did not navigate to previous configurator step.

[1]: https://github.com/odoo/odoo/commit/56cc3dfab156f21c7ef97b3c407f1480b094fe93

task-2789075

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
