### PR TITLE
[FIX] stock_account: compute new price with correct rounding

### DIFF
--- a/addons/stock_account/models/product.py
+++ b/addons/stock_account/models/product.py
@@ -223,7 +223,8 @@ class ProductProduct(models.Model):
             quantity_svl = product.sudo().quantity_svl
             if float_compare(quantity_svl, 0.0, precision_rounding=product.uom_id.rounding) <= 0:
                 continue
-            diff = new_price - product.standard_price
+            rounded_new_price = company_id.currency_id.round(new_price)
+            diff = rounded_new_price - product.standard_price
             value = company_id.currency_id.round(quantity_svl * diff)
             if company_id.currency_id.is_zero(value):
                 continue
@@ -231,7 +232,7 @@ class ProductProduct(models.Model):
             svl_vals = {
                 'company_id': company_id.id,
                 'product_id': product.id,
-                'description': _('Product value manually modified (from %s to %s)') % (product.standard_price, new_price),
+                'description': _('Product value manually modified (from %s to %s)') % (product.standard_price, rounded_new_price),
                 'value': value,
                 'quantity': 0,
             }


### PR DESCRIPTION
# Steps to reproduce:

Decimal Accuracy - Product Price = 2
- create a product `alc 50%` with BOM (10 unites = 1 unit Water [cost=0.14]; 1 unit Alc [cost=0.08])
- Set `quantity on hands` = 10,000
- Trigger `Compute Price from BoM`

-> In Reporting > Inventory Valuation; click on the layer; in Other Info: You will see "Product value manually modified (from 0.0 to 0.022000000000000002)"
=> It can cause computing mistakes as we changed the costs

# Cause:

The value is calculated as the difference between the New Price (cost) and and the current Product Standard Price (cost).
But, on one hand the Product Standard Price is rounded to the number of digits defined in the Decimal Accuracy for the Product Price.
On the other hand, the New Price is used as is with no rounding.

If we add an extra step and modify the cost of the Water to 0.45 and trigger again the `Compute Price from BoM` we will have:
"Product value manually modified (from 0.02 to 0.053000000000000005)"

# Solution:

Use for the New Price the same rounding precision as we use for the Standard Price.

# Example (based on the test):
## Set up

#### BoM: Alc. 50%
```
Product 	quantity_needed
Water 		0.1
Alc. 100% 	0.1
```
## Stage1: Init

#### Products
```
Product 	price_unit
Water 		0.14
Alc. 100% 	0.08
```
___
#### Stock Valuation
```
Cost/unit of Alc. 50%: 0.022 => 0.02 (standard_price is rounded)
Set Quantity on Hand: 10,000
```
```
Layer 		Computation 			Total
#1 		0.02 * 10,000 			200
Total		200 				200
```
=> The standard_price is rounded to the second digit when intialized

## Stage 2: Increase price of water

#### Products
```
Product 	price_unit
Water 		0.45
Alc. 100% 	0.08
```
____
#### Stock Valuation
```
Cost/unit of Alc. 50%: 0.053
Quantity on Hand: 10,000
```
```
Without Fix
Layer		Computation 			Total
#1 		0.02 * 10,000 			200
#2 		(0.053-0.02) * 10,000 		330
Total 		200 + 330 			530
____
With Fix
Layer		Computation 			Total
#1 		0.02 * 10,000 			200
#2		(0.05-0.02) * 10, 000 		300
Total 		200 + 300 			500
```
=> Without fix, the value is computed with the rounded standard_price and the not rounded new_price.
=> With fix, the new_price is rounded the same way as the standard_price

opw-2724975