### PR TITLE
[FIX] l10n_it_edi : fix _l10n_it_onchange_vat

### DIFF
--- a/addons/l10n_it_edi/models/res_partner.py
+++ b/addons/l10n_it_edi/models/res_partner.py
@@ -36,10 +36,12 @@ class ResPartner(models.Model):
             return codice[2:13]
         return codice
 
-    @api.onchange('vat')
+    @api.onchange('vat', 'country_id')
     def _l10n_it_onchange_vat(self):
-        if not self.l10n_it_codice_fiscale:
+        if not self.l10n_it_codice_fiscale and (self.country_id.code == "IT" or (self.vat and self.vat.startswith("IT"))):
             self.l10n_it_codice_fiscale = self._l10n_it_normalize_codice_fiscale(self.vat)
+        elif self.country_id.code not in [False, "IT"]:
+            self.l10n_it_codice_fiscale = ""
 
     @api.constrains('l10n_it_codice_fiscale')
     def validate_codice_fiscale(self):


### PR DESCRIPTION
To reproduce
============

- Create one french company and one italian company with their respective localization packages.
- Go to the French company and create a contact, first set the country and then the VAT.
An error message will appear referring to Codice Fiscale but this information is not relevant on the French Company.

Purpose
=======

The VAT field has an onchange trigger `_l10n_it_onchange_vat`  to set `l10n_it_codice_fiscale` value.
on `_l10n_it_onchange_vat` there is no verification if the VAT number is Italian, so we try to get
a Codice Fiscale from it, which leads to error if the VAT number is not Italian.

Specification
=============

To solve the issue we added a verification on the VAT number to make sure that it is an Italian one before
trying to get Codice Fiscale from it.

opw-2777519