### PR TITLE
[IMP] hr_holidays: align legend labels in calendar view

### DIFF
--- a/addons/hr_holidays/static/src/xml/time_off_calendar.xml
+++ b/addons/hr_holidays/static/src/xml/time_off_calendar.xml
@@ -62,9 +62,9 @@
         <t t-jquery='.o_calendar_sidebar_container' t-operation="append">
             <div class="o_timeoff_legend">
                 <h5>Legend</h5>
-                <img src="/hr/static/src/img/icons/plain.svg" width="30px"/><span>Validated</span><br/>
-                <img src="/hr/static/src/img/icons/hatched.svg" width="30px"/><span>To Approve</span><br/>
-                <img src="/hr/static/src/img/icons/line.svg" width="30px"/><span>Refused</span><br/>
+                <img src="/hr/static/src/img/icons/plain.svg" width="30px" class="mb-1"/><span>Validated</span><br/>
+                <img src="/hr/static/src/img/icons/hatched.svg" width="30px" class="mb-1"/><span>To Approve</span><br/>
+                <img src="/hr/static/src/img/icons/line.svg" width="30px" class="mb-1"/><span>Refused</span><br/>
             </div>
         </t>
     </t>


### PR DESCRIPTION
In this PR we aligned legend labels to the corresponding icon.

task-2784839

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
