### PR TITLE
[FIX] hr: Fix error when an internal user opens the department's list view

### DIFF
--- a/addons/hr/models/hr_employee.py
+++ b/addons/hr/models/hr_employee.py
@@ -225,6 +225,12 @@ class HrEmployeePrivate(models.Model):
             ids = super(HrEmployeePrivate, self.sudo())._search([('id', 'in', ids)])
         return ids
 
+    @api.model
+    def read_group(self, domain, fields, groupby, offset=0, limit=None, orderby=False, lazy=True):
+        if self.check_access_rights('read', raise_exception=False):
+            return super(HrEmployeePrivate, self).read_group(domain, fields, groupby, offset, limit, orderby, lazy)
+        return self.env['hr.employee.public'].read_group(domain, fields, groupby, offset, limit, orderby, lazy)
+
     def get_formview_id(self, access_uid=None):
         """ Override this method in order to redirect many2one towards the right model depending on access_uid """
         if access_uid:


### PR DESCRIPTION
Description of the issue/feature this PR addresses:

Current behavior before PR:
- When an internal user (without any HR groups) open the departments list view (by clicking 'Search More' on a many2one field, for example), an Access Error appears because of the 'total_employee' field. It is computed by calling 'read_group' on the model 'hr.employee', which normal internal user does not have the right to access on.

Desired behavior after PR is merged:
- This PR solves the issue by overriding the 'read_group' method on 'hr.employee' model.



--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
