### PR TITLE
[IMP] hr_timesheet: improve generic UX

### DIFF
--- a/addons/hr_timesheet/models/hr_timesheet.py
+++ b/addons/hr_timesheet/models/hr_timesheet.py
@@ -49,6 +49,7 @@ class AccountAnalyticLine(models.Model):
         compute='_compute_project_id', store=True, readonly=False)
     user_id = fields.Many2one(compute='_compute_user_id', store=True, readonly=False)
     employee_id = fields.Many2one('hr.employee', "Employee", domain=_domain_employee_id, context={'active_test': False})
+    job_title = fields.Char(related='employee_id.job_title')
     department_id = fields.Many2one('hr.department', "Department", compute='_compute_department_id', store=True, compute_sudo=True)
     manager_id = fields.Many2one('hr.employee', "Manager", related='employee_id.parent_id', store=True)
     encoding_uom_id = fields.Many2one('uom.uom', compute='_compute_encoding_uom_id')

--- a/addons/hr_timesheet/views/hr_timesheet_views.xml
+++ b/addons/hr_timesheet/views/hr_timesheet_views.xml
@@ -22,14 +22,14 @@
             <field name="name">account.analytic.line.tree.hr_timesheet</field>
             <field name="model">account.analytic.line</field>
             <field name="arch" type="xml">
-                <tree editable="top" string="Timesheet Activities" sample="1">
+                <tree editable="bottom" string="Timesheet Activities" sample="1">
                     <field name="date"/>
                     <field name="employee_id" invisible="1"/>
                     <field name="project_id" required="1" options="{'no_create_edit': True}"/>
-                    <field name="task_id" optional="show" options="{'no_create_edit': True, 'no_open': True}" widget="task_with_hours" context="{'default_project_id': project_id}" domain="[('project_id', '=', project_id)]"/>
+                    <field name="task_id" optional="show" options="{'no_create_edit': True, 'no_open': True}" widget="task_with_hours" context="{'default_project_id': project_id}"/>
                     <field name="name" optional="show" required="0"/>
                     <field name="tag_ids" groups="analytic.group_analytic_tags" widget="many2many_tags" optional="hide"/>
-                    <field name="unit_amount" optional="show" widget="timesheet_uom" sum="Total" decoration-danger="unit_amount &gt; 24"/>
+                    <field name="unit_amount" optional="show" widget="timesheet_uom" sum="Total" decoration-danger="unit_amount &gt; 24 or unit_amount &lt; 0"/>
                     <field name="company_id" invisible="1"/>
                     <field name="user_id" invisible="1"/>
                 </tree>
@@ -138,7 +138,7 @@
                         <group>
                             <group>
                                 <field name="project_id" required="1"/>
-                                <field name="task_id" widget="task_with_hours" context="{'default_project_id': project_id}" domain="[('project_id', '=', project_id)]"/>
+                                <field name="task_id" widget="task_with_hours" context="{'default_project_id': project_id}"/>
                                 <field name="tag_ids" groups="analytic.group_analytic_tags" widget="many2many_tags"/>
                                 <field name="name"/>
                                 <field name="company_id" groups="base.group_multi_company" invisible="1"/>


### PR DESCRIPTION
Purpose of this PR to improve generic UX of timesheet app.

So, in this PR:
- make tree view editable bottom.
- remove extra domain from task_id field in tree view show user
  able to select all non-private tasks.
- add job_title non-store field to add a custom filter on job_title.
- show unit_amount in red in tree view when its value is less
  than 0.

task-2784776