### PR TITLE
[FIX] sale_project: fix the SO access error even user has correct so rights

### DIFF
--- a/addons/sale_project/models/sale_order.py
+++ b/addons/sale_project/models/sale_order.py
@@ -17,8 +17,8 @@ class SaleOrder(models.Model):
     project_id = fields.Many2one(
         'project.project', 'Project', readonly=True, states={'draft': [('readonly', False)], 'sent': [('readonly', False)]},
         help='Select a non billable project on which tasks can be created.')
-    project_ids = fields.Many2many('project.project', compute="_compute_project_ids", string='Projects', copy=False, groups="project.group_project_user", help="Projects used in this sales order.")
-    project_count = fields.Integer(string='Number of Projects', compute='_compute_project_ids', groups='project.group_project_user')
+    project_ids = fields.Many2many('project.project', compute="_compute_project_ids", string='Projects', copy=False, groups="project.group_project_manager", help="Projects used in this sales order.")
+    project_count = fields.Integer(string='Number of Projects', compute='_compute_project_ids', groups='project.group_project_manager')
 
     @api.depends('order_line.product_id.project_id')
     def _compute_tasks_ids(self):


### PR DESCRIPTION
Before this commit, When a user has a sale order all document right, project the user right, and try to open a sale order linked with a private project then it raises an access rights error when a user clicks on sales orders in a project, even though the user has the correct rights due to invalid access on the project_ids field.

so in this commit, fixes the issue by changing the group on those fields as those fields are only used in the stat button and it will be only visible to the project manager.

task-2792884