### PR TITLE
[FIX] hr: Use reason_code on departure.reason

### DIFF
--- a/addons/hr/models/hr_departure_reason.py
+++ b/addons/hr/models/hr_departure_reason.py
@@ -15,13 +15,11 @@ class DepartureReason(models.Model):
 
     def _get_default_departure_reasons(self):
         return {
-            'fired': self.env.ref('hr.departure_fired', False),
-            'resigned': self.env.ref('hr.departure_resigned', False),
-            'retired': self.env.ref('hr.departure_retired', False),
+            'fired': 342,
+            'resigned': 343,
+            'retired': 340,
         }
 
     @api.ondelete(at_uninstall=False)
     def _unlink_except_default_departure_reasons(self):
-        ids = set(map(lambda a: a.id, self._get_default_departure_reasons().values()))
-        if set(self.ids) & ids:
-            raise UserError(_('Default departure reasons cannot be deleted.'))
+        raise UserError(_('Default departure reasons cannot be deleted.'))


### PR DESCRIPTION
Purpose
=======

Departure reasons could be used on business code (eg: payroll).

Currently the mapping is made based on the xmlid, but it could
happen for some customers to create several departure reasons
of the same kind. (ex: "Resigned - Salary" or even
"Resigned - Personal Reasons").

This commit uses the departure reason on _get_default_departure_reasons
to allow considering them together.

TaskID: 2811192
