### PR TITLE
[ADD] website_sale_picking : Asking to pay/ship at physical store

### DIFF
--- a/addons/website_sale/controllers/main.py
+++ b/addons/website_sale/controllers/main.py
@@ -1236,6 +1236,13 @@ class WebsiteSale(http.Controller):
 
 class PaymentPortal(payment_portal.PaymentPortal):
 
+    def _validate_transaction_for_order(self, transaction, sale_order_id):
+        """
+        Perform final checks against the transaction & sale_order.
+        Override me to apply payment unrelated checks & processing
+        """
+        return
+
     @http.route(
         '/shop/payment/transaction/<int:order_id>', type='json', auth='public', website=True
     )
@@ -1273,5 +1280,7 @@ class PaymentPortal(payment_portal.PaymentPortal):
         if last_tx:
             PaymentPostProcessing.remove_transactions(last_tx)
         request.session['__website_sale_last_tx_id'] = tx_sudo.id
+
+        self._validate_transaction_for_order(tx_sudo, order_id)
 
         return tx_sudo._get_processing_values()

--- a/addons/website_sale/models/res_config_settings.py
+++ b/addons/website_sale/models/res_config_settings.py
@@ -28,6 +28,7 @@ class ResConfigSettings(models.TransientModel):
     module_website_sale_wishlist = fields.Boolean("Wishlists")
     module_website_sale_comparison = fields.Boolean("Product Comparison Tool")
     module_account = fields.Boolean("Invoicing")
+    module_website_sale_picking = fields.Boolean('On Site Payments & Picking')
 
     cart_recovery_mail_template = fields.Many2one('mail.template', string='Cart Recovery Email', domain="[('model', '=', 'sale.order')]",
                                                   related='website_id.cart_recovery_mail_template_id', readonly=False)

--- a/addons/website_sale/views/res_config_settings_views.xml
+++ b/addons/website_sale/views/res_config_settings_views.xml
@@ -300,6 +300,17 @@
                             </div>
                         </div>
                     </div>
+                    <div class="col-12 col-lg-6 o_setting_box" id="onsite_payment_setting">
+                        <div class="o_setting_left_pane">
+                            <field name="module_website_sale_picking"/>
+                        </div>
+                        <div class="o_setting_right_pane">
+                            <label for="module_website_sale_picking"/>
+                            <div class="text-muted">
+                                Allow customers to pay in person at your stores
+                            </div>
+                        </div>
+                    </div>
                 </div>
 
                 <field name='module_account' invisible="1"/>

--- a/addons/website_sale_picking/__init__.py
+++ b/addons/website_sale_picking/__init__.py
@@ -1,0 +1,5 @@
+# -*- coding: utf-8 -*-
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from . import models
+from . import controllers

--- a/addons/website_sale_picking/__manifest__.py
+++ b/addons/website_sale_picking/__manifest__.py
@@ -1,0 +1,29 @@
+# -*- coding: utf-8 -*-
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+{
+    'name': 'On site Payment & Picking',
+    'version': '1.0',
+    'category': 'Website/Website',
+    'description': """
+Allows customers to pay for their orders at a shop, instead of paying online.
+""",
+    'depends': ['website_sale_delivery', 'payment_transfer'],
+    'data': [
+        'data/website_sale_picking_data.xml',
+        'views/res_config_settings_views.xml',
+        'views/templates.xml',
+        'views/delivery_view.xml'
+    ],
+    'assets': {
+        'web.assets_frontend': [
+            'website_sale_picking/static/src/js/checkout_form.js'
+        ],
+        'web.assets_tests': [
+            'website_sale_picking/static/tests/tours/**/*.js'
+        ]
+    },
+    'application': False,
+    'auto_install': False,
+    'license': 'LGPL-3',
+}

--- a/addons/website_sale_picking/controllers/__init__.py
+++ b/addons/website_sale_picking/controllers/__init__.py
@@ -1,0 +1,4 @@
+# -*- coding: utf-8 -*-
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from . import main

--- a/addons/website_sale_picking/controllers/main.py
+++ b/addons/website_sale_picking/controllers/main.py
@@ -1,0 +1,25 @@
+# -*- coding: utf-8 -*-
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from odoo import _
+from odoo.addons.website_sale.controllers.main import PaymentPortal
+from odoo.exceptions import ValidationError
+from odoo.http import request
+
+
+class PaymentPortalOnsite(PaymentPortal):
+
+    def _validate_transaction_for_order(self, transaction, sale_order_id):
+        """
+        Throws a ValidationError if the user tries to pay on site without also using an onsite delivery carrier
+        Also sets the sale order's warhouse id to the carrier's if it exists
+        """
+        sale_order = request.env['sale.order'].browse(sale_order_id)
+        super()._validate_transaction_for_order(transaction, sale_order)
+
+        # This should never be triggered unless the user intentionally forges a request.
+        if transaction.acquirer_id.is_onsite_acquirer and sale_order.carrier_id.delivery_type != 'onsite':
+            raise ValidationError(_('You cannot pay onsite if the delivery is not onsite'))
+
+        if sale_order.carrier_id.delivery_type == 'onsite' and sale_order.carrier_id.warehouse_id:
+            sale_order.warehouse_id = sale_order.carrier_id.warehouse_id

--- a/addons/website_sale_picking/data/website_sale_picking_data.xml
+++ b/addons/website_sale_picking/data/website_sale_picking_data.xml
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+
+    <record id="payment_acquirer_onsite" model="payment.acquirer">
+        <field name="name">Pay in store when picking the product</field>
+        <field name="description" type="html">
+            <p>
+                Allows your customers to pay in person, at your shops.
+            </p>
+        </field>
+        <field name="provider">transfer</field>
+        <field name="state">enabled</field>
+        <field name="is_onsite_acquirer">true</field>
+        <field name="redirect_form_view_id" ref="payment_transfer.redirect_form"/>
+        <field name="pending_msg" type="xml">
+            <p>
+                <i>Your order has been saved.</i> Please come to the store to pay for your products
+            </p>
+        </field>
+    </record>
+
+    <record id="onsite_delivery_product" model="product.product">
+        <field name="name">On site picking</field>
+        <field name="description">Pay in store when picking the product</field>
+        <field name="type">service</field>
+        <field name="list_price">0</field>
+        <field name="purchase_ok">false</field>
+        <field name="sale_ok">false</field>
+    </record>
+
+    <record model="delivery.carrier" id="website_sale_picking.default_onsite_carrier">
+        <field name="name">[On Site Pick] My Shop 1</field>
+        <field name="delivery_type">onsite</field>
+        <field name="website_published">true</field>
+        <field name="product_id" ref="website_sale_picking.onsite_delivery_product"/>
+        <field name="website_id" ref="website.default_website"/>
+    </record>
+
+</odoo>

--- a/addons/website_sale_picking/models/__init__.py
+++ b/addons/website_sale_picking/models/__init__.py
@@ -1,0 +1,7 @@
+# -*- coding: utf-8 -*-
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from . import website
+from . import res_config_settings
+from . import payment_acquirer
+from . import delivery_carrier

--- a/addons/website_sale_picking/models/delivery_carrier.py
+++ b/addons/website_sale_picking/models/delivery_carrier.py
@@ -1,0 +1,43 @@
+# -*- coding: utf-8 -*-
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from odoo import models, fields, _, api
+from odoo.exceptions import ValidationError
+
+
+class DeliveryCarrier(models.Model):
+    _inherit = 'delivery.carrier'
+
+    # Onsite delivery means the client comes to a physical store to get the products himself.
+    delivery_type = fields.Selection(selection_add=[
+        ('onsite', 'Pickup in store')
+    ], ondelete={'onsite': 'set default'})
+
+    # If set, the sales order shipping address will take this warehouse's address.
+    warehouse_id = fields.Many2one('stock.warehouse', 'Warehouse')
+
+    @api.constrains('warehouse_id', 'company_id')
+    def _check_warehouse_company(self):
+        for carrier in self:
+            if carrier.warehouse_id.company_id and carrier.company_id != carrier.warehouse_id.company_id:
+                raise ValidationError(_("The picking site and warehouse must share the same company"))
+
+    def onsite_rate_shipment(self, order):
+        """
+        Required to show the price on the checkout page for the onsite delivery type
+        """
+        return {
+            'success': True,
+            'price': self.product_id.list_price,
+            'error_message': False,
+            'warning_message': False
+        }
+
+    def onsite_send_shipping(self, pickings):
+        return [{
+            'exact_price': p.carrier_id.fixed_price,
+            'tracking_number': False
+        } for p in pickings]
+
+    def onsite_cancel_shipment(self, pickings):
+        pass  # No need to communicate to an external service, however the method must exist so that cancel_shipment() works.

--- a/addons/website_sale_picking/models/payment_acquirer.py
+++ b/addons/website_sale_picking/models/payment_acquirer.py
@@ -1,0 +1,31 @@
+# -*- coding: utf-8 -*-
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from odoo import fields, models
+
+
+class PaymentAcquirer(models.Model):
+    _inherit = 'payment.acquirer'
+
+    is_onsite_acquirer = fields.Boolean('Is Onsite Acquirer', default=False)
+
+    def _get_compatible_acquirers(self, *args, sale_order_id=None, website_id=None, **kwargs):
+        compatible_acquirers = super()._get_compatible_acquirers(*args, sale_order_id=sale_order_id, website_id=website_id, **kwargs)
+        # Show on site picking only if delivery carriers onsite exists
+        onsite_carriers = self.env['delivery.carrier'].search(
+            ['&',
+                ('website_published', '=', True),
+                ('delivery_type', '=', 'onsite'),
+             '|',
+                ('website_id', '=?', website_id),
+                ('website_id', '=', False)
+             ])
+        if not onsite_carriers:
+            compatible_acquirers -= self.env.ref('website_sale_picking.payment_acquirer_onsite')
+
+        # Show onsite payment only if it is a physical product
+        order = self.env['sale.order'].browse(sale_order_id).exists()
+        if not any(product.type in ['consu', 'product'] for product in order.order_line.product_id):
+            compatible_acquirers -= self.env.ref('website_sale_picking.payment_acquirer_onsite')
+
+        return compatible_acquirers

--- a/addons/website_sale_picking/models/res_config_settings.py
+++ b/addons/website_sale_picking/models/res_config_settings.py
@@ -1,0 +1,14 @@
+# -*- coding: utf-8 -*-
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from odoo import fields, models
+
+
+class ResConfigSettings(models.TransientModel):
+    _inherit = 'res.config.settings'
+
+    picking_site_ids = fields.Many2many(
+        'delivery.carrier',
+        related='website_id.picking_site_ids',
+        readonly=False,
+    )

--- a/addons/website_sale_picking/models/website.py
+++ b/addons/website_sale_picking/models/website.py
@@ -1,0 +1,16 @@
+# -*- coding: utf-8 -*-
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from odoo import fields, models
+
+
+class Website(models.Model):
+    _inherit = 'website'
+
+    picking_site_ids = fields.Many2many('delivery.carrier', string='Picking sites',
+                                        compute='_compute_picking_sites')
+
+    def _compute_picking_sites(self):
+        delivery_carriers = self.env['delivery.carrier'].search([('delivery_type', '=', 'onsite')])
+        for website in self:
+            website.picking_site_ids = delivery_carriers.filtered_domain([('website_id.id', '=', website.id)])

--- a/addons/website_sale_picking/static/src/js/checkout_form.js
+++ b/addons/website_sale_picking/static/src/js/checkout_form.js
@@ -1,0 +1,83 @@
+/** @odoo-module */
+
+import publicWidget from 'web.public.widget';
+import { _t } from 'web.core';
+import 'website_sale_delivery.checkout';
+
+publicWidget.registry.websiteSaleDelivery.include({
+    start: function () {
+        this.onsiteOptions = document.querySelectorAll('.o_payment_option_card input[type=radio][data-is-onsite="1"]');
+        if(this.onsiteOptions.length > 0){ // Falsy evaluation does not work with NodeList
+            this.paymentOptions = document.querySelectorAll('.o_payment_option_card input[type=radio]');
+
+            this.warning = document.createElement('p');
+            const boldMsg = document.createElement('b');
+            boldMsg.innerText = _t('No suitable payment option could be found.');
+            this.warning.innerText = _t('If you believe that it is an error, please contact the website administrator.');
+            boldMsg.classList.add('d-block');
+            this.warning.prepend(boldMsg);
+            this.warning.classList.add('alert-warning', 'p-3', 'm-1', 'd-none');
+
+            this.paymentOptionsContainer = document.querySelector('#payment_method');
+            this.paymentOptionsContainer.querySelector('div.card').prepend(this.warning);
+        }
+        return this._super.apply(this, ...arguments);
+    },
+
+    /**
+     * Hides or shows a payment option card.
+     * @param node the input element of the payment option card
+     * @param enabled whether to show or hide the card
+     * @private
+     */
+    _setEnablePaymentOption(node, enabled) {
+        if (enabled) {
+            node.parentNode.parentNode.classList.remove('d-none');
+        } else {
+            node.parentNode.parentNode.classList.add('d-none');
+            node.checked = false;
+        }
+    },
+
+    /**
+     * Checks all payment options and hides them if it is an onsite payment option and the delivery is not onsite.
+     * @param {Event} ev the triggered document event
+     * @private
+     * @override
+     */
+    _onCarrierClick: function (ev) {
+        this._super(...arguments);
+
+        if(this.onsiteOptions.length === 0){ // Falsy evaluation does not work with NodeList
+            return;
+        }
+
+        this.warning.classList.add('d-none');
+
+        const input = ev.currentTarget.querySelector('input');
+        let atLeastOneOptionAvailable = false;
+        for (let option of this.paymentOptions) {
+            if (option.dataset.isOnsite && input.dataset.deliveryType !== 'onsite') {
+                this._setEnablePaymentOption(option, false);
+            } else{
+                if(option.dataset.isOnsite){
+                    this._setEnablePaymentOption(option, true);
+                }
+                atLeastOneOptionAvailable = true;
+            }
+        }
+
+        // Jquery because the button does not behave nicely with vanilla dataset.
+        let $payButton = $('button[name="o_payment_submit_button"]');
+        let disabledReasons = $payButton.data('disabled_reasons') || {};
+        disabledReasons.noOptionAvailableOnsite = false;
+
+        if (!atLeastOneOptionAvailable) {
+            this.warning.classList.remove('d-none');
+            disabledReasons.noOptionAvailableOnsite = true;
+        } else if (this.paymentOptions.length === 1) {
+            $(this.paymentOptions[0]).click(); // Make sure the option is selected if that's the only one, because the input is hidden in that case.
+        }
+        $payButton.data('disabled_reasons', disabledReasons);
+    }
+});

--- a/addons/website_sale_picking/static/tests/tours/onsite_payment_tour.js
+++ b/addons/website_sale_picking/static/tests/tours/onsite_payment_tour.js
@@ -1,0 +1,97 @@
+/** @odoo-module */
+
+import tour from 'web_tour.tour'
+
+tour.register('onsite_payment_tour', {
+    test: true,
+    url: '/shop'
+}, [ // first test : test whole onsite payment flow with physical products.
+    {
+        content: 'Select the first product',
+        trigger: 'a:contains("Customizable Desk")',
+    }, {
+        content: 'Add the product to the cart',
+        trigger: 'a:contains("ADD TO CART")'
+    }, {
+        content: 'Go to checkout page',
+        trigger: 'button:contains("Proceed to Checkout")'
+    }, {
+        content: 'Go to payment page',
+        trigger: 'a:contains("Process Checkout")'
+    }, {
+        content: 'Click on onsite delivery carrier',
+        trigger: '.o_delivery_carrier_select:contains("On Site")'
+    }, {
+        content: 'Click on on site payment acquirer',
+        trigger: '.o_payment_option_card:contains("Pay in store when picking the product")'
+    }, {
+        content: 'Click the pay button',
+        trigger: 'button[name="o_payment_submit_button"]:visible:not(:disabled)'
+    }, {
+        content: 'Await the confirmation page',
+        trigger: 'td:contains("Pay in store when picking the product")'
+    }, {
+        content: 'Head back to main page',
+        trigger: '.nav-link:contains("Shop")'
+    },
+
+
+    { // Test multi products (Either physical or not)
+        content: 'Select the first product',
+        trigger: 'a:contains("Customizable Desk")',
+    }, {
+        content: 'Add the product to the cart',
+        trigger: 'a:contains("ADD TO CART")'
+    }, {
+        content: 'Validate variant choice',
+        trigger: 'button:contains("Continue Shopping")'
+    }, {
+        content: 'Head back to main page',
+        trigger: '.nav-link:contains("Shop")'
+    }, {
+        content: 'Select the second product (Non physical)',
+        trigger: 'a:contains("Warranty")',
+    }, {
+        content: 'Add the product to the cart',
+        trigger: 'a:contains("ADD TO CART")'
+    }, {
+        content: 'Go to cart',
+        trigger: '.nav-link[href="/shop/cart"]:contains("2")'
+    }, {
+        content: 'Go to payment page',
+        trigger: 'a:contains("Process Checkout")'
+    }, {
+        content: 'Click on onsite delivery carrier',
+        trigger: '.o_delivery_carrier_select:contains("On Site")'
+    }, {
+        content: 'Click on on site payment acquirer',
+        trigger: '.o_payment_option_card:contains("Pay in store when picking the product")'
+    }, {
+        content: 'Click the pay button',
+        trigger: 'button[name="o_payment_submit_button"]:visible:not(:disabled)'
+    }, {
+        content: 'Await the confirmation page',
+        trigger: 'td:contains("Pay in store when picking the product")'
+    }, {
+        content: 'Head back to main page',
+        trigger: '.nav-link:contains("Shop")'
+    },
+    // Test without any physical product (option pay on site should not appear)
+
+    {
+        content: 'Select the (Non physical) product',
+        trigger: 'a:contains("Warranty")',
+    }, {
+        content: 'Add the product to the cart',
+        trigger: 'a:contains("ADD TO CART")'
+    }, {
+        content: 'Go to cart',
+        trigger: '.nav-link[href="/shop/cart"]:contains("1")'
+    }, {
+        content: 'Go to payment page',
+        trigger: 'a:contains("Process Checkout")'
+    }, {
+        content: 'Assert pay on site is NOT an option',
+        trigger: 'body:not(:contains("Pay in store when picking the product"))'
+    }
+]);

--- a/addons/website_sale_picking/tests/__init__.py
+++ b/addons/website_sale_picking/tests/__init__.py
@@ -1,0 +1,4 @@
+# -*- coding: utf-8 -*-
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from . import test_ui

--- a/addons/website_sale_picking/tests/test_ui.py
+++ b/addons/website_sale_picking/tests/test_ui.py
@@ -1,0 +1,17 @@
+# -*- coding: utf-8 -*-
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from odoo.tests import HttpCase, tagged
+
+
+@tagged('-at_install', 'post_install')
+class TestUi(HttpCase):
+    def test_onsite_payment_tour(self):
+        # Make sure at least one onsite payment option exists.
+        self.env['delivery.carrier'].create({
+            'delivery_type': 'onsite',
+            'website_published': True,
+            'name': 'Example shipping On Site',
+            'product_id': self.env.ref('website_sale_picking.onsite_delivery_product').id
+        })
+        self.start_tour('/shop', 'onsite_payment_tour', login='admin')

--- a/addons/website_sale_picking/views/delivery_view.xml
+++ b/addons/website_sale_picking/views/delivery_view.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<odoo>
+     <record id="view_delivery_carrier_form_with_onsite_picking" model="ir.ui.view">
+         <field name="inherit_id" ref="delivery.view_delivery_carrier_form"/>
+         <field name="name">Delivery Carrier with Onsite Picking</field>
+         <field name="model">delivery.carrier</field>
+         <field name="arch" type="xml">
+             <xpath expr="//field[@name='integration_level']" position="before">
+                 <field attrs="{'invisible': [('delivery_type', '!=', 'onsite')]}" name="warehouse_id" options="{'no_quick_create': True}"
+                        domain="[('company_id', '=?', company_id)]"/>
+             </xpath>
+         </field>
+    </record>
+</odoo>

--- a/addons/website_sale_picking/views/res_config_settings_views.xml
+++ b/addons/website_sale_picking/views/res_config_settings_views.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+
+    <record id="res_config_settings_view_form" model="ir.ui.view">
+        <field name="name">res.config.settings.view.form.inherit.website.sale.onsite</field>
+        <field name="model">res.config.settings</field>
+        <field name="inherit_id" ref="website_sale.res_config_settings_view_form" />
+        <field name="arch" type="xml">
+            <xpath expr="//div[@id='onsite_payment_setting']/div[hasclass('o_setting_right_pane')]" position="inside">
+                <div class="content-group">
+                    <label class="col-lg-3" string="Picking sites" for="picking_site_ids"/>
+                    <field name="picking_site_ids" domain="[('delivery_type', '=', 'onsite')]" widget="many2many_tags"
+                           context="{'default_website_id': website_id, 'default_product_id': %(website_sale_picking.onsite_delivery_product)d, 'default_delivery_type': 'onsite', 'default_website_published': True, 'default_company_id': company_id}"/>
+                </div>
+                <div class="mt8">
+                    <button name="%(delivery.action_delivery_carrier_form)d" icon="fa-arrow-right" type="action" string="Customize Pickup Sites" class="btn-link" context="{'search_default_delivery_type': 'onsite'}"/>
+                </div>
+            </xpath>
+        </field>
+    </record>
+
+</odoo>

--- a/addons/website_sale_picking/views/templates.xml
+++ b/addons/website_sale_picking/views/templates.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<odoo>
+    <template id="checkout_delivery" inherit_id="website_sale_delivery.payment_delivery_methods">
+        <xpath expr="//input[@name='delivery_type']" position="attributes">
+            <attribute name="t-att-data-delivery-type">delivery.delivery_type</attribute>
+        </xpath>
+    </template>
+    <template id="checkout_payment" inherit_id="payment.checkout">
+        <xpath expr="//input[@name='o_payment_radio']" position="attributes">
+            <attribute name="t-att-data-is-onsite">1 if acquirer.is_onsite_acquirer else 0</attribute>
+        </xpath>
+    </template>
+
+    <template id="payment_confirmation_status" inherit_id="website_sale.payment_confirmation_status">
+        <xpath expr="(//div[hasclass('card-body')])[1]" position="replace">
+            <t t-if="payment_tx_id.acquirer_id.is_onsite_acquirer">
+                <div class="card-body">
+                    <div class="o_header_carrier_message">
+                        <b t-out="order.carrier_id.name"/><span class="text-muted"> (On site picking)</span>
+                    </div>
+                    <div class="o_body_carrier_message">
+                        <t t-out="order.carrier_id.website_description"/>
+                    </div>
+                </div>
+            </t>
+            <t t-else="">
+                <t>$0</t> <!-- Replace by old content -->
+            </t>
+        </xpath>
+    </template>
+</odoo>


### PR DESCRIPTION
Task-id : 2791237

Allows customers to see a list of delivery carriers as shops in the website page;
A delivery carrier may now be an onsite one, which means the client comes to the corresponding store to pickup the products.

Also adds a payment acquirer based on wire transfer, for paying on site.
The customer can only pay on site if he also comes to pick the product on site

Notes :

- If a warehouse is set on a delivery carrier, the sales order will take it's address.
