### PR TITLE
[IMP] web: bs5 utility-class, add font-style

### DIFF
--- a/addons/web/static/src/libs/bs5_utility_classes.scss
+++ b/addons/web/static/src/libs/bs5_utility_classes.scss
@@ -84,3 +84,12 @@ $position-properties: (
 .overflow-visible {
   overflow: visible !important;
 }
+
+// == Font Style
+//------------------------------------------------------------------------------
+// "Bootstrap v5 ready" utility-class to handle font-style.
+// These class definition can be safely removed after migrating to BTS v5.
+
+.fst-normal {
+  font-style: normal !important;
+}


### PR DESCRIPTION
Define "Bootstrap v5 ready" utility-class to handle font-style.
This class definition can be safely removed after migrating to v5.

This class is needed for https://github.com/odoo/odoo/pull/87639

task-2811202

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
