### PR TITLE
[IMP] mail: remove default values from test model definitions

### DIFF
--- a/addons/im_livechat/static/tests/helpers/model_definitions_setup.js
+++ b/addons/im_livechat/static/tests/helpers/model_definitions_setup.js
@@ -1,5 +1,8 @@
 /** @odoo-module **/
 
-import { addModelNamesToFetch } from '@mail/../tests/helpers/model_definitions_helpers';
+import { addModelNamesToFetch, insertModelFields } from '@mail/../tests/helpers/model_definitions_helpers';
 
 addModelNamesToFetch(['im_livechat.channel']);
+insertModelFields('res.users.settings', {
+    is_discuss_sidebar_category_livechat_open: { default: true },
+});

--- a/addons/mail/models/ir_model.py
+++ b/addons/mail/models/ir_model.py
@@ -113,18 +113,10 @@ class IrModel(models.Model):
                 ).items()
                 if not field_data.get('relation') or field_data['relation'] in model_names_to_fetch
             }
-            # exclude date/datetime and binary default values: dates will always be wrong since they are dynamic
-            # and binary values are not needed for now
-            default_values_by_fname = model.default_get([
-                fname for fname, field_data in fields_data_by_fname.items()
-                if field_data['type'] not in ['binary', 'date', 'datetime']
-            ])
             tracked_field_names = model._track_get_fields() if 'mail.thread' in model._inherit else []
             for fname, field_data in fields_data_by_fname.items():
                 if fname in tracked_field_names:
                     field_data['tracking'] = True
-                if fname in default_values_by_fname:
-                    field_data['default'] = default_values_by_fname[fname]
                 if fname in model._fields:
                     inverse_fields = [
                         field for field in model.pool.field_inverses[model._fields[fname]]

--- a/addons/mail/static/tests/helpers/model_definitions_setup.js
+++ b/addons/mail/static/tests/helpers/model_definitions_setup.js
@@ -44,6 +44,7 @@ insertModelFields('mail.channel', {
         },
     },
     avatarCacheKey: { string: "Avatar Cache Key", type: "datetime" },
+    channel_type: { default: 'channel' },
     custom_channel_name: { string: "Custom channel name", type: 'char' },
     fetched_message_id: { relation: 'mail.message', string: "Last Fetched", type: 'many2one' },
     group_based_subscription: { string: "Group based subscription", type: "boolean" },
@@ -64,6 +65,7 @@ insertModelFields('mail.channel', {
     uuid: { default: () => _.uniqueId('mail.channel_uuid-') },
 });
 insertModelFields('mail.message', {
+    author_id: { default: TEST_USER_IDS.currentPartnerId },
     history_partner_ids: { relation: 'res.partner', string: "Partners with History", type: 'many2many' },
     is_discussion: { string: 'Discussion', type: 'boolean' },
     is_note: { string: "Discussion", type: 'boolean' },
@@ -81,6 +83,10 @@ insertModelFields('mail.tracking.value', {
 });
 insertModelFields('res.partner', {
     description: { string: 'description', type: 'text' },
+});
+insertModelFields('res.users.settings', {
+    is_discuss_sidebar_category_channel_open: { default: true },
+    is_discuss_sidebar_category_chat_open: { default: true },
 });
 
 //--------------------------------------------------------------------------

--- a/addons/mail/static/tests/helpers/test_utils.js
+++ b/addons/mail/static/tests/helpers/test_utils.js
@@ -231,6 +231,9 @@ async function getModelDefinitions() {
                     ? () => moment.utc().format('YYYY-MM-DD')
                     : () => moment.utc().format("YYYY-MM-DD HH:mm:ss");
                 field.default = defaultFieldValue;
+            } else if (fname === 'active' && !('default' in field)) {
+                // records are active by default.
+                field.default = true;
             }
         }
     }


### PR DESCRIPTION
The get_model_definitions method returns default values for each field. Those default
values are wrong most of the time (dynamic values, reference to non created records on
the client side, ...).

task-2792108
