### PR TITLE
[FIX] stock: aggregate qty in Inventory Report

### DIFF
--- a/addons/stock/models/stock_quant.py
+++ b/addons/stock/models/stock_quant.py
@@ -223,12 +223,16 @@ class StockQuant(models.Model):
                 fields.append('quantity')
             if 'reserved_quantity' not in fields:
                 fields.append('reserved_quantity')
+        if 'inventory_quantity_auto_apply' in fields and 'quantity' not in fields:
+            fields.append('quantity')
         result = super(StockQuant, self).read_group(domain, fields, groupby, offset=offset, limit=limit, orderby=orderby, lazy=lazy)
         for group in result:
             if self.env.context.get('inventory_report_mode'):
                 group['inventory_quantity'] = False
             if 'available_quantity' in fields:
                 group['available_quantity'] = group['quantity'] - group['reserved_quantity']
+            if 'inventory_quantity_auto_apply' in fields:
+                group['inventory_quantity_auto_apply'] = group['quantity']
         return result
 
     def write(self, vals):


### PR DESCRIPTION
Going to Inventory > Reporting > Inventory Report, the on-hand
quantities are not added up.

The corresponding field (`inventory_quantity_auto_apply`) is not stored,
so the condition to aggregate the values is not respected:
https://github.com/odoo/odoo/blob/e9c83f6623f74970e7d0c29427a09dd26ded039a/odoo/models.py#L2525-L2527

Considering how the field is computed,
https://github.com/odoo/odoo/blob/91f3005477b92d763e6c35f41804b1ab7c9eb639/addons/stock/models/stock_quant.py#L145-L148
we can use `quantity` to have its aggregated value

OPW-2803350