### PR TITLE
[FIX] l10n_it_edi: backport template fixes

### DIFF
--- a/addons/l10n_it_edi/data/invoice_it_template.xml
+++ b/addons/l10n_it_edi/data/invoice_it_template.xml
@@ -19,8 +19,8 @@
                     <t t-if="not line.name" t-esc="'NO NAME'"/>
                 </Descrizione>
                 <Quantita t-esc="format_numbers(line.quantity)"/>
-                <UnitaMisura t-if="line.product_uom_id.category_id.measure_type != 'unit'" t-esc="line.product_uom_id.name"/>
-                <PrezzoUnitario t-esc="format_monetary(taxes['total_excluded'], currency)"/>
+                <UnitaMisura t-if="line.product_uom_id.category_id != env.ref('uom.product_uom_categ_unit')" t-esc="line.product_uom_id.name"/>
+                <PrezzoUnitario t-esc="'%.06f' % (line.price_subtotal / (( 1 - (line.discount or 0.0) / 100.0) * line.quantity) if line.discount != 100.0 else line.price_unit)"/>
                 <ScontoMaggiorazione t-if="line.discount != 0">
                     <!-- [2.2.1.10] -->
                     <Tipo t-esc="discount_type(line.discount)"/>
@@ -52,7 +52,7 @@
                     <DatiTrasmissione>
                         <IdTrasmittente>
                             <IdPaese t-esc="get_vat_country(record.company_id.vat)"/>
-                            <IdCodice t-esc="record.company_id.l10n_it_codice_fiscale"/>
+                            <IdCodice t-esc="record.company_id.l10n_it_codice_fiscale or get_vat_number(record.company_id.vat)"/>
                         </IdTrasmittente>
                         <ProgressivoInvio t-esc="record.name.replace('/','')[-10:]"/>
                         <FormatoTrasmissione t-esc="formato_trasmissione"/>
@@ -116,6 +116,7 @@
                                 <IdCodice t-esc="'OO99999999999'"/>
                             </IdFiscaleIVA>
                             <IdFiscaleIVA t-if="not record.commercial_partner_id.vat and record.commercial_partner_id.country_id.code != 'IT'">
+                                <IdPaese t-esc="record.commercial_partner_id.country_id.code"/>
                                 <IdCodice t-esc="'0000000'"/>
                             </IdFiscaleIVA>
                             <CodiceFiscale t-if="not record.commercial_partner_id.vat" t-esc="record.commercial_partner_id.l10n_it_codice_fiscale"/>
@@ -146,7 +147,7 @@
                             </DatiBollo>
                         </DatiGeneraliDocumento>
                         <DatiOrdineAcquisto t-if="record.ref">
-                            <IdDocumento t-esc="record.ref" />
+                            <IdDocumento t-esc="record.ref[:20]" />
                         </DatiOrdineAcquisto>
                         <DatiDDT t-if="record.l10n_it_ddt_id">
                             <!--2.1.8-->


### PR DESCRIPTION
Backport some changes made to the Italian edi template from v14 onwards. This is relevant since the FatturaPA system has a strict specification for the xml content of the file (regardless of the method of submission).

These changes are:

- line 22: 52ed0be
Change the condition for showing the unit of measurement from a string comparision to a comparison of uom_category objects.

- line 23: 23e8414
Fix the way unit price is calculated when the line is discounted

- line 55: e961ff2
Fix the way that codice fiscale is retrieved for companies where the codice fiscale is undefined but the vat code is defined

- line 119: 3e4361f
Add a country code field so that for foreign invoices, without VAT, we still provide the country code

- line 150: 2c76293c
Limit the length of the invoice reference in the IdDocument field to 20 characters (the length limit in the FatturaPA specs), so that it doesn't get rejected

notably EXCLUDED from this backport is the fix:
exlcuded: 7290467
The fix for price included taxes resulting in xml that fails the edi
constraints relies on code not yet present in v13. (such as the function account_move._prepare_edi_tax_details)