### PR TITLE
[FIX] google_calendar: accept events that start and end dates are equal

### DIFF
--- a/addons/google_calendar/models/calendar.py
+++ b/addons/google_calendar/models/calendar.py
@@ -87,6 +87,7 @@ class Meeting(models.Model):
         else:
             start = parse(google_event.start.get('date'))
             stop = parse(google_event.end.get('date')) - relativedelta(days=1)
+            stop = max(start, stop)  # For the cases that start date and end date were the same
             values['allday'] = True
         values['start'] = start
         values['stop'] = stop


### PR DESCRIPTION
What is the problem?
We assumed that an all-day event's end date is exclusive which means
that, for example, for a single all-day event on the 2022-03-20,
we have:
start = {'date': '2022-03-20'}
end = {'date': '2022-03-21'}

But it's acceptable for Google to have an all-day event where the start
and end dates are the same:
start = {'date': '2022-03-20'}
end = {'date': '2022-03-20'}

For checking the acceptability of this format, you can test it:
https://developers.google.com/calendar/api/v3/reference/events/insert

It caused an issue because we decreased one day from the end date to
convert it to the odoo values, so the stop became smaller than
the start:
start = '2022-03-20 00:00:00'
stop = '2022-03-19 00:00:00'

It's not possible to reproduce the issue by the Google calendar UI.
However, you can insert an event with this format by using the APIs
and get that event to reproduce the problem.

The solution is to use start if the stop becomes smaller than it.

opw-2753872

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
