### PR TITLE
[IMP] mail: cleanup iseditable in attachments

### DIFF
--- a/addons/mail/static/src/components/attachment_card/attachment_card.xml
+++ b/addons/mail/static/src/components/attachment_card/attachment_card.xml
@@ -28,34 +28,32 @@
                         </t>
                     </div>
                     <!-- Attachment aside -->
-                    <t t-if="(!attachmentCard.attachmentList.composerViewOwner or attachmentCard.attachment.isEditable)">
-                        <div class="o_AttachmentCard_aside position-relative rounded-right overflow-hidden" t-att-class="{ 'o-has-multiple-action d-flex flex-column': !attachmentCard.attachmentList.composerViewOwner and attachmentCard.attachment.isEditable }">
-                            <!-- Uploading icon -->
-                            <t t-if="attachmentCard.attachment.isUploading and attachmentCard.attachmentList.composerViewOwner">
-                                <div class="o_AttachmentCard_asideItem o_AttachmentCard_asideItemUploading d-flex justify-content-center align-items-center w-100 h-100" title="Uploading">
-                                    <i class="fa fa-spin fa-spinner"/>
-                                </div>
-                            </t>
-                            <!-- Uploaded icon -->
-                            <t t-if="!attachmentCard.attachment.isUploading and attachmentCard.attachmentList.composerViewOwner">
-                                <div class="o_AttachmentCard_asideItem o_AttachmentCard_asideItemUploaded d-flex justify-content-center align-items-center w-100 h-100 text-primary" title="Uploaded">
-                                    <i class="fa fa-check"/>
-                                </div>
-                            </t>
-                            <!-- Remove button -->
-                            <t t-if="attachmentCard.attachment.isEditable">
-                                <button class="o_AttachmentCard_asideItem o_AttachmentCard_asideItemUnlink btn top-0 justify-content-center align-items-center d-flex w-100 h-100 rounded-0" t-attf-class="{{ attachmentCard.attachmentList.composerViewOwner ? 'o-pretty position-absolute btn-primary' : 'bg-300' }}" t-on-click="attachmentCard.onClickUnlink" title="Remove">
-                                    <i class="fa fa-trash"/>
-                                </button>
-                            </t>
-                            <!-- Download button -->
-                            <t t-if="!attachmentCard.attachmentList.composerViewOwner and !attachmentCard.attachment.isUploading">
-                                <button class="o_AttachmentCard_asideItem o_AttachmentCard_asideItemDownload btn d-flex justify-content-center align-items-center w-100 h-100 rounded-0 bg-300" t-on-click="attachmentCard.attachment.onClickDownload" title="Download">
-                                    <i class="fa fa-download"/>
-                                </button>
-                            </t>
-                        </div>
-                    </t>
+                    <div class="o_AttachmentCard_aside position-relative rounded-right overflow-hidden" t-att-class="{ 'o-has-multiple-action d-flex flex-column': !attachmentCard.attachmentList.composerViewOwner and attachmentCard.attachment.isDeletable }">
+                        <!-- Uploading icon -->
+                        <t t-if="attachmentCard.attachment.isUploading and attachmentCard.attachmentList.composerViewOwner">
+                            <div class="o_AttachmentCard_asideItem o_AttachmentCard_asideItemUploading d-flex justify-content-center align-items-center w-100 h-100" title="Uploading">
+                                <i class="fa fa-spin fa-spinner"/>
+                            </div>
+                        </t>
+                        <!-- Uploaded icon -->
+                        <t t-if="!attachmentCard.attachment.isUploading and attachmentCard.attachmentList.composerViewOwner">
+                            <div class="o_AttachmentCard_asideItem o_AttachmentCard_asideItemUploaded d-flex justify-content-center align-items-center w-100 h-100 text-primary" title="Uploaded">
+                                <i class="fa fa-check"/>
+                            </div>
+                        </t>
+                        <!-- Remove button -->
+                        <t t-if="attachmentCard.attachment.isDeletable">
+                            <button class="o_AttachmentCard_asideItem o_AttachmentCard_asideItemUnlink btn top-0 justify-content-center align-items-center d-flex w-100 h-100 rounded-0" t-attf-class="{{ attachmentCard.attachmentList.composerViewOwner ? 'o-pretty position-absolute btn-primary' : 'bg-300' }}" t-on-click="attachmentCard.onClickUnlink" title="Remove">
+                                <i class="fa fa-trash"/>
+                            </button>
+                        </t>
+                        <!-- Download button -->
+                        <t t-if="!attachmentCard.attachmentList.composerViewOwner and !attachmentCard.attachment.isUploading">
+                            <button class="o_AttachmentCard_asideItem o_AttachmentCard_asideItemDownload btn d-flex justify-content-center align-items-center w-100 h-100 rounded-0 bg-300" t-on-click="attachmentCard.attachment.onClickDownload" title="Download">
+                                <i class="fa fa-download"/>
+                            </button>
+                        </t>
+                    </div>
                 </div>
             </div>
         </t>

--- a/addons/mail/static/src/components/attachment_image/attachment_image.xml
+++ b/addons/mail/static/src/components/attachment_image/attachment_image.xml
@@ -20,7 +20,7 @@
                             <i class="fa fa-spin fa-spinner"/>
                         </div>
                     </t>
-                    <t t-if="attachmentImage.attachment.isEditable">
+                    <t t-if="attachmentImage.attachment.isDeletable">
                         <div class="o_AttachmentImage_imageOverlay position-absolute top-0 bottom-0 start-0 end-0 text-right p-2 text-white opacity-0 opacity-100-hover">
                             <div class="o_AttachmentImage_action o_AttachmentImage_actionUnlink btn btn-sm btn-dark rounded opacity-75 opacity-100-hover"
                                 t-att-class="{'o-pretty': attachmentImage.attachmentList.composerViewOwner}" t-on-click="attachmentImage.onClickUnlink" title="Remove"

--- a/addons/mail/static/src/models/attachment.js
+++ b/addons/mail/static/src/models/attachment.js
@@ -163,9 +163,9 @@ registerModel({
          * @private
          * @returns {boolean}
          */
-        _computeIsEditable() {
+        _computeIsDeletable() {
             if (!this.messaging) {
-                return;
+                return false;
             }
 
             if (this.messages.length && this.originThread && this.originThread.model === 'mail.channel') {
@@ -316,10 +316,10 @@ registerModel({
             required: true,
         }),
         /**
-         * States whether this attachment is editable.
+         * States whether this attachment is deletable.
          */
-        isEditable: attr({
-            compute: '_computeIsEditable',
+        isDeletable: attr({
+            compute: '_computeIsDeletable',
         }),
         /**
          * States id the attachment is an image.


### PR DESCRIPTION
**Current behavior before PR:**

- isEditable field doesn't makes sense as attachments can't be Edited
- There is a Dead code in attachment_card component

**Desired behavior after PR is merged:**

- refactored isEditable to isDeletable
- removed the Dead code

Task-2782079


--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
