### PR TITLE
[FIX] Shadowed attachment filename

### DIFF
--- a/addons/web/tests/test_image.py
+++ b/addons/web/tests/test_image.py
@@ -6,6 +6,7 @@ import base64
 
 from PIL import Image
 
+from odoo.http import content_disposition
 from odoo.tests.common import HttpCase
 
 
@@ -57,3 +58,25 @@ class TestImage(HttpCase):
         response2 = self.url_open('/web/image/%s' % attachment.id, headers={"If-None-Match": etag})
         self.assertEqual(response2.status_code, 304)
         self.assertEqual(len(response2.content), 0)
+
+    def test_03_web_content_filename(self):
+        """This test makes sure the Content-Disposition header matches the given filename"""
+
+        att = self.env['ir.attachment'].create({
+            'datas': b'R0lGODdhAQABAIAAAP///////ywAAAAAAQABAAACAkQBADs=',
+            'name': 'testFilename.gif',
+            'public': True,
+            'mimetype': 'image/gif'
+        })
+
+        # CASE: no filename given
+        res = self.url_open('/web/image/%s/0x0/?download=true' % att.id)
+        self.assertEqual(res.headers['Content-Disposition'], content_disposition('testFilename.gif'))
+
+        # CASE: given filename without extension
+        res = self.url_open('/web/image/%s/0x0/custom?download=true' % att.id)
+        self.assertEqual(res.headers['Content-Disposition'], content_disposition('custom.gif'))
+
+        # CASE: given filename and extention
+        res = self.url_open('/web/image/%s/0x0/custom.png?download=true' % att.id)
+        self.assertEqual(res.headers['Content-Disposition'], content_disposition('custom.png'))

--- a/odoo/addons/base/models/ir_http.py
+++ b/odoo/addons/base/models/ir_http.py
@@ -455,7 +455,8 @@ class IrHttp(models.AbstractModel):
         content, headers, status = None, [], None
 
         if record._name == 'ir.attachment':
-            status, content, filename, mimetype, filehash = self._binary_ir_attachment_redirect_content(record, default_mimetype=default_mimetype)
+            status, content, default_filename, mimetype, filehash = self._binary_ir_attachment_redirect_content(record, default_mimetype=default_mimetype)
+            filename = filename or default_filename
         if not content:
             status, content, filename, mimetype, filehash = self._binary_record_content(
                 record, field=field, filename=filename, filename_field=filename_field,


### PR DESCRIPTION
When a filename is given to the function binary_content it was shadowed
by _binary_ir_attachment_redirect_content if it is an ir.attachment.

To reproduce:
  1. Start a brand-new database in V14, install any app on which you can add an attachment (like Project or CRM)
  2. Add a file as an attachment
  3. Try to call the route `"/web/content/<string:model>/<int:id>/<string:field>/<string:filename>"`

Solution: Use another variable to store the return value of _binary_ir_attachment_redirect_content and use it if the filename is not provided.

@lse-odoo 