### PR TITLE
[FIX] event(_sale) : auto confirm after payment

### DIFF
--- a/addons/event/models/event_event.py
+++ b/addons/event/models/event_event.py
@@ -573,3 +573,9 @@ class EventEvent(models.Model):
         ])
         if ended_events:
             ended_events.action_set_done()
+
+    def _check_auto_confirmation(self):
+        for event in self:
+            if not event.auto_confirm or (not event.seats_available and event.seats_limited):
+                return False
+        return True

--- a/addons/event/models/event_registration.py
+++ b/addons/event/models/event_registration.py
@@ -186,10 +186,7 @@ class EventRegistration(models.Model):
         return ret_list
 
     def _check_auto_confirmation(self):
-        if any(not registration.event_id.auto_confirm or
-               (not registration.event_id.seats_available and registration.event_id.seats_limited) for registration in self):
-            return False
-        return True
+        return self.event_id._check_auto_confirmation()
 
     # ------------------------------------------------------------
     # ACTIONS / BUSINESS

--- a/addons/event_sale/models/event_registration.py
+++ b/addons/event_sale/models/event_registration.py
@@ -131,3 +131,7 @@ class EventRegistration(models.Model):
             'has_to_pay': not self.is_paid,
         })
         return res
+
+    def _check_auto_confirmation(self):
+        return super()._check_auto_confirmation() and\
+             (not self.sale_order_id or all(so.state != 'draft' for so in self.sale_order_id))

--- a/addons/event_sale/models/sale_order.py
+++ b/addons/event_sale/models/sale_order.py
@@ -22,7 +22,8 @@ class SaleOrder(models.Model):
         res = super(SaleOrder, self).action_confirm()
         for so in self:
             # confirm registration if it was free (otherwise it will be confirmed once invoice fully paid)
-            so.order_line._update_registrations(confirm=so.amount_total == 0, cancel_to_draft=False)
+            auto_confirm = so.order_line.event_id._check_auto_confirmation()
+            so.order_line._update_registrations(confirm=so.amount_total == 0 or auto_confirm, cancel_to_draft=False)
             if any(line.event_id for line in so.order_line):
                 return self.env['ir.actions.act_window'] \
                     .with_context(default_sale_order_id=so.id) \

--- a/addons/event_sale/tests/test_event_sale.py
+++ b/addons/event_sale/tests/test_event_sale.py
@@ -280,3 +280,12 @@ class TestEventSale(TestEventSaleCommon):
         self.assertEqual(event.seats_expected, 1)
         self.sale_order.action_cancel()
         self.assertEqual(event.seats_expected, 0)
+
+    @users('user_salesman')
+    def test_auto_confirm(self):
+        """ This test ensures that auto_confirmation happens only after so confirmation (payment) """
+        self.register_person.action_make_registration()
+        registration = self.register_person.event_registration_ids.event_id.registration_ids
+        self.assertEqual(registration.state, 'draft', "Registration should be in 'draft' state")
+        registration.sale_order_id.sudo().action_confirm()
+        self.assertEqual(registration.state, 'open', "Registration should be in 'open' state")


### PR DESCRIPTION
Steps :
Install Events and enable Online Ticketing.
Configure Stripes.
Go to Website > Select any Event E.
Select a paying ticket > Register and Continue.
Stop the registration there.
Go in Back-end > Events > Event E > Attendees > yours.

Issue :
It is confirmed.

Cause :
The 'Attendee' is creates before checkout process
and the auto-confirmation happens upon Attendee creation.

Fix :
Make it happen upon Sale Order confirmation.

opw-2759803

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
