### PR TITLE
[FIX] purchase_stock: price diff on vendor bill

### DIFF
--- a/addons/purchase_stock/tests/test_stockvaluation.py
+++ b/addons/purchase_stock/tests/test_stockvaluation.py
@@ -1326,3 +1326,28 @@ class TestStockValuationWithCOA(AccountTestInvoicingCommon):
         self.assertEqual(len(input_aml), 2, "Only two lines should have been generated in stock input account: one when receiving the product, one when making the invoice.")
         self.assertAlmostEqual(sum(input_aml.mapped('debit')), 90, "Total debit value on stock input account should be equal to the original PO price of the product.")
         self.assertAlmostEqual(sum(input_aml.mapped('credit')), 90, "Total credit value on stock input account should be equal to the original PO price of the product.")
+
+    def test_anglosaxon_valuation_price_unit_diff_avco(self):
+        """
+        Inv: price unit: 100
+        """
+        self.env.company.anglo_saxon_accounting = True
+        self.product1.categ_id.property_cost_method = 'average'
+        self.product1.categ_id.property_valuation = 'real_time'
+        self.product1.categ_id.property_account_creditor_price_difference_categ = self.price_diff_account
+        self.product1.standard_price = 1.01
+
+        invoice = self.env['account.move'].create({
+            'move_type': 'in_invoice',
+            'invoice_date': '2022-03-31',
+            'partner_id': self.partner_id.id,
+            'invoice_line_ids': [
+                (0, 0, {'product_id': self.product1.id, 'quantity': 10.50, 'price_unit': 1.01, 'tax_ids': self.tax_purchase_a.ids})
+            ]
+        })
+
+        invoice.action_post()
+
+        # Check if something was posted in the price difference account
+        price_diff_aml = invoice.line_ids.filtered(lambda l: l.account_id == self.price_diff_account)
+        self.assertEqual(len(price_diff_aml), 0, "No line should have been generated in the price difference account.")


### PR DESCRIPTION
Steps to reproduce:

• Create Record: Product Category
- Costing Method: Average
- Inventory Valuation: Automated
- Specify a price difference account (may create new account).
- Ensure Stock Interim (Received) account is reconcilable.

• Create Record: Product
- Product Type: Storable
- Cost Price: 1.01
- Product Category: New Product Category

• Create bill with this product, for a quantity of 10.5

-> The is price difference of 0.1

Issue commes from this commit 286ea6b681e9ba77357f91b546052449f6342f20
which doesn't round if there is a discount.

With this commit we isolate the latter case in order to keep the
price unit rounded if there is no discount.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
