### PR TITLE
[FIX] hr: disable create_employee from employee form view

### DIFF
--- a/addons/hr/views/hr_employee_views.xml
+++ b/addons/hr/views/hr_employee_views.xml
@@ -195,7 +195,7 @@
                                 <group>
                                     <group string='Status' name="active_group">
                                         <field name="employee_type"/>
-                                        <field name="user_id" string="Related User" domain="[('share', '=', False)]"/>
+                                        <field name="user_id" string="Related User" domain="[('share', '=', False)]" context="{'allow_create_employee': False, 'default_create_employee': False}"/>
                                     </group>
                                     <group string="Attendance/Point of Sale" name="identification_group">
                                         <field name="pin" string="PIN Code"/>

--- a/addons/hr/views/res_users.xml
+++ b/addons/hr/views/res_users.xml
@@ -205,7 +205,7 @@
             <field name="inherit_id" ref="base.view_users_simple_form"/>
             <field name="arch" type="xml">
                 <xpath expr="//field[@name='mobile']" position="after">
-                    <field name="create_employee" force_save="1" string="Create Employee" attrs="{'invisible': [('id', '>', 0)]}"/>
+                    <field name="create_employee" force_save="1" string="Create Employee" invisible="not context.get('allow_create_employee', True)" attrs="{'invisible': [('id', '>', 0)]}"/>
                     <field name="create_employee_id" force_save="1" invisible="1"/>
                 </xpath>
             </field>


### PR DESCRIPTION
Prior to this commit the create_employee option was enabled by default
even from the employee's form view which would lead to a loop.