### PR TITLE
[IMP] mass_mailing: improvement of favorite filter layout

### DIFF
--- a/addons/mass_mailing/static/src/xml/mailing_filter_widget.xml
+++ b/addons/mass_mailing/static/src/xml/mailing_filter_widget.xml
@@ -5,7 +5,10 @@
         <t t-jquery="div.o_field_many2one_selection" t-operation="append">
             <div class="o_mass_mailing_filter_container">
                 <div class="o_mass_mailing_save_filter_container pt-1">
-                    <i class="o_mass_mailing_add_filter fa fa-floppy-o px-3 py-1" data-toggle="dropdown" title="Add to favorite filters"/>
+                    <span class="o_mass_mailing_add_filter" data-toggle="dropdown" title="Add to favorite filters">
+                        <span class="o_mass_mailing_no_filter">Save as Favorite Filter</span>
+                        <i class="fa fa-floppy-o px-3 py-1"/>
+                    </span>
                     <div class="dropdown-menu dropdown-menu-right">
                         <span class="ml-2 text-muted">Create Favorite Filter</span><br/>
                         <div class="d-inline-flex">

--- a/addons/mass_mailing/static/tests/mass_mailing_favourite_filter_tests.js
+++ b/addons/mass_mailing/static/tests/mass_mailing_favourite_filter_tests.js
@@ -40,6 +40,10 @@ QUnit.module('favorite filter widget', {
                         type: 'char',
                         related: 'mailing_filter_id.mailing_domain',
                     },
+                    mailing_filter_count: {
+                        string: 'filter Count',
+                        type: 'integer',
+                    },
                 },
                 records: [{
                     id: 1,
@@ -49,12 +53,14 @@ QUnit.module('favorite filter widget', {
                     mailing_model_name: 'event',
                     mailing_domain: '[["country","=","be"]]',
                     mailing_filter_id: 1,
+                    mailing_filter_count: 1,
                     mailing_filter_domain: '[["country","=","be"]]',
                 }, {
                     id: 2,
                     display_name: 'New Users Promotion',
                     subject: 'Early bird discount for new users! Register Now!',
                     mailing_model_id: 1,
+                    mailing_filter_count: 1,
                     mailing_model_name: 'event',
                     mailing_domain: '[["new_user","=",True]]',
                     mailing_filter_domain: '[["new_user","=",True]]',
@@ -111,6 +117,7 @@ QUnit.module('favorite filter widget', {
                     <field name="mailing_domain"/>
                     <field name="mailing_model_name" invisible="1"/>
                     <field name="mailing_model_id"/>
+                    <field name="mailing_filter_count"/>
                     <field name="mailing_filter_domain" invisible="1"/>
                     <field name="mailing_filter_id"
                         widget="mailing_filter"
@@ -174,6 +181,7 @@ QUnit.module('favorite filter widget', {
                     <field name="mailing_domain"/>
                     <field name="mailing_model_id"/>
                     <field name="mailing_filter_domain" invisible="1"/>
+                    <field name="mailing_filter_count"/>
                     <field name="mailing_filter_id"
                         widget="mailing_filter"
                         options="{'no_create': '1', 'no_open': '1', 'domain_field': 'mailing_domain', 'model': 'mailing_model_id'}"/>
@@ -246,6 +254,7 @@ QUnit.module('favorite filter widget', {
             subject: 'Early bird discount for Partners!',
             mailing_model_id: 2,
             mailing_model_name: 'partner',
+            mailing_filter_count: 1,
             mailing_domain: "[['name','!=', 'Azure Interior']]",
         });
 
@@ -264,6 +273,7 @@ QUnit.module('favorite filter widget', {
                     <field name="subject"/>
                     <field name="mailing_model_name" invisible="1"/>
                     <field name="mailing_model_id"/>
+                    <field name="mailing_filter_count" />
                     <field name="mailing_filter_id" widget="mailing_filter" options="{'no_create': '1', 'no_open': '1', 'domain_field': 'mailing_domain', 'model': 'mailing_model_id'}"/>
                     <group>
                         <field name="mailing_domain"
@@ -284,6 +294,122 @@ QUnit.module('favorite filter widget', {
         assert.equal(form.$('.o_domain_show_selection_button').text().trim(), '1 record(s)',
             "applied filter should only display single record (only Azure)");
         await testUtils.form.clickSave(form);
+
+        form.destroy();
+    });
+
+    QUnit.test('filter drop-down and filter icons visibility toggles properly based on filters available', async function (assert) {
+        assert.expect(11);
+
+        this.data.partner = {
+            fields: {
+                name: {string: 'Name', type: 'char', searchable: true},
+            },
+            records: [
+                {id: 1, name: 'Azure Interior'},
+            ]
+        };
+        this.data.event = {
+            fields: {
+                name: {string: 'Name', type: 'char', searchable: true},
+                country: {string: 'Country', type: 'char', searchable: true},
+            },
+            records: [
+                {id: 1, name: 'BE Event', country: 'be'},
+            ]
+        };
+
+        this.data['mailing.filter'].records = [{
+            id: 2,
+            name: 'Azure partner',
+            mailing_domain: '[["name","=","Azure Interior"]]',
+            mailing_model_id: 2,
+        }, {
+            id: 3,
+            name: 'Ready Mat partner',
+            mailing_domain: '[["name","=","Ready Mat"]]',
+            mailing_model_id: 2,
+        }];
+
+        this.data['mailing.mailing'].records = [{
+            id: 1,
+            display_name: 'Belgian Event promotion',
+            subject: 'Early bird discount for Belgian Events! Register Now!',
+            mailing_model_id: 1,
+            mailing_model_name: 'event',
+            mailing_domain: '[["country","=","be"]]',
+            mailing_filter_id: false,
+            mailing_filter_count: 0,
+        }];
+
+        this.data['mailing.mailing'].onchanges = {
+            mailing_model_id: obj => {
+                obj.mailing_filter_count = this.data['mailing.filter'].records.filter(r => r.mailing_model_id === obj.mailing_model_id).length;
+            },
+            mailing_filter_id: obj => {
+                const filterDomain = this.data['mailing.filter'].records.filter(r => r.id === obj.mailing_filter_id)[0].mailing_domain;
+                obj.mailing_domain = filterDomain, obj.mailing_filter_domain = filterDomain;
+            },
+        };
+
+        const form = await testUtils.createView({
+            View: FormView,
+            model: 'mailing.mailing',
+            data: this.data,
+            arch: `<form>
+                    <field name="display_name"/>
+                    <field name="subject"/>
+                    <field name="mailing_model_name" invisible="1"/>
+                    <field name="mailing_model_id"/>
+                    <field name="mailing_filter_count" />
+                    <field name="mailing_filter_id" widget="mailing_filter"
+                        options="{'no_create': '1', 'no_open': '1', 'domain_field': 'mailing_domain', 'model': 'mailing_model_id'}"/>
+                    <field name="mailing_filter_domain" invisible="1"/>
+                    <group>
+                        <field name="mailing_domain"
+                            widget="domain"
+                            options="{'model': 'mailing_model_name'}"/>
+                    </group>
+                </form>`,
+            res_id: 1,
+        });
+
+        await testUtils.form.clickEdit(form);
+        assert.isNotVisible(form.$('.o_field_many2one[name="mailing_filter_id"] .o_input_dropdown'),
+            "should hide the drop-down to select a filter because there is no filter available for 'Event'");
+        assert.isVisible(form.$('.o_mass_mailing_no_filter'),
+            "should show custom message because there is no filter available for 'Event'");
+        assert.isVisible(form.$('.o_mass_mailing_save_filter_container'),
+            "should show icon to save the filter because domain is set in the mailing");
+
+        // If domain is not set on mailing and no filter available, both drop-down and icon container are hidden
+        await testUtils.dom.click(form.$('.o_domain_delete_node_button'));
+        assert.isNotVisible(form.$('.o_field_many2one[name="mailing_filter_id"] .o_input_dropdown'),
+            "should not display drop-down because there is still no filter available to select from");
+        assert.isNotVisible(form.$('.o_mass_mailing_filter_container'),
+            "should not show filter container because there is no filter available and no domain set in mailing");
+
+        // If domain is not set on mailing but filters available, display drop-down but hide the icon container
+        await testUtils.fields.many2one.clickOpenDropdown('mailing_model_id');
+        await testUtils.fields.many2one.clickItem('mailing_model_id', 'Partner');
+        assert.isVisible(form.$('.o_field_many2one[name="mailing_filter_id"] .o_input_dropdown'),
+            "should show the drop-down to select a filter because there are filters available for 'Partner'");
+        assert.isNotVisible(form.$('.o_mass_mailing_filter_container'),
+            "should not show filter container because there is no filter selected and no domain set in mailing");
+
+        // Save / Remove icons visibility
+        await testUtils.dom.click('.o_field_many2one[name="mailing_filter_id"] input');
+        await testUtils.fields.many2one.clickItem('mailing_filter_id', 'Azure partner');
+        assert.isVisible(form.$('.o_mass_mailing_remove_filter'),
+            "should have option to remove filter if filter is selected");
+        assert.isNotVisible(form.$('.o_mass_mailing_save_filter_container'),
+            "should not have option to save filter if filter is selected");
+
+        await testUtils.dom.click(form.$('.o_domain_add_node_button').first());
+        assert.isVisible(form.$('.o_mass_mailing_save_filter_container'),
+            "should have option to save filter because mailing domain is changed");
+        assert.isNotVisible(form.$('.o_mass_mailing_remove_filter'),
+            "should not have option to remove filter because mailing domain is changed");
 
         form.destroy();
     });

--- a/addons/mass_mailing/views/mailing_mailing_views.xml
+++ b/addons/mass_mailing/views/mailing_mailing_views.xml
@@ -219,6 +219,7 @@
                                                options="{'no_create': 1, 'no_open': 1, 'domain_field': 'mailing_domain', 'model_field': 'mailing_model_id'}"
                                                attrs="{'readonly': [('state', 'in', ('sending', 'done'))]}"/>
                                     </div>
+                                    <field name="mailing_filter_count" invisible="1"/>
                                     <field name="mailing_filter_domain" invisible="1"/>
                                 </div>
 


### PR DESCRIPTION
If you do not have favorite filters in the mass mailing UI, they will show an
empty drop down. It generates confusion when we don't have any filters yet,
so why the meaning of the empty drop down?

This commit can solve the above problem and also make some improvements
to the  following changes in UX related to favorite filter:
1. If we do not have any filters related to the current mailing model, it shows
   a custom message instead of an empty drop down.
2. Once saved, the favorite filter, then drop down menu is visible.

In this commit we can use a new variable `mailing_filter_count`,
whose value changes the behavior of the layout.

task-2711258

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
