### PR TITLE
[FIX] account_edi: make tests run

### DIFF
--- a/addons/account/tests/common.py
+++ b/addons/account/tests/common.py
@@ -24,6 +24,8 @@ class AccountTestInvoicingCommon(SavepointCase):
     def setUpClass(cls, chart_template_ref=None):
         super(AccountTestInvoicingCommon, cls).setUpClass()
 
+        assert 'post_install' in cls.test_tags, 'This test requires a CoA to be installed, it should be tagged "post_install"'
+
         if chart_template_ref:
             chart_template = cls.env.ref(chart_template_ref)
         else:

--- a/addons/account_edi/tests/test_edi.py
+++ b/addons/account_edi/tests/test_edi.py
@@ -3,8 +3,10 @@
 
 from odoo.addons.account_edi.tests.common import AccountEdiTestCommon
 from unittest.mock import patch
+from odoo.tests import tagged
 
 
+@tagged('post_install', '-at_install')
 class TestAccountEdi(AccountEdiTestCommon):
 
     def test_export_edi(self):

--- a/addons/account_edi_extended/tests/test_edi.py
+++ b/addons/account_edi_extended/tests/test_edi.py
@@ -3,8 +3,10 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 from odoo.addons.account_edi_extended.tests.common import AccountEdiExtendedTestCommon, _mocked_post, _mocked_post_two_steps, _generate_mocked_needs_web_services, _mocked_cancel_failed, _generate_mocked_support_batching
+from odoo.tests import tagged
 
 
+@tagged('post_install', '-at_install')
 class TestAccountEdi(AccountEdiExtendedTestCommon):
 
     @classmethod

--- a/addons/account_qr_code_sepa/tests/test_sepa_qr.py
+++ b/addons/account_qr_code_sepa/tests/test_sepa_qr.py
@@ -2,8 +2,10 @@
 
 from odoo.exceptions import UserError
 from odoo.addons.account.tests.common import AccountTestInvoicingCommon
+from odoo.tests import tagged
 
 
+@tagged('post_install', '-at_install')
 class TestSEPAQRCode(AccountTestInvoicingCommon):
     """ Tests the generation of Swiss QR-codes on invoices
     """
@@ -60,4 +62,3 @@ class TestSEPAQRCode(AccountTestInvoicingCommon):
         """
         self.sepa_qr_invoice.generate_qr_code()
         self.assertEqual(self.sepa_qr_invoice.qr_code_method, 'sct_qr', "SEPA QR-code generator should have been chosen for this invoice.")
-

--- a/addons/l10n_be_edi/tests/test_ubl.py
+++ b/addons/l10n_be_edi/tests/test_ubl.py
@@ -1,7 +1,9 @@
 # -*- coding: utf-8 -*-
 from odoo.addons.account_edi.tests.common import AccountEdiTestCommon
+from odoo.tests.common import tagged
 
 
+@tagged('post_install', '-at_install')
 class TestUBL(AccountEdiTestCommon):
     @classmethod
     def setUpClass(cls, chart_template_ref='l10n_be.l10nbe_chart_template', edi_format_ref='l10n_be_edi.edi_efff_1'):

--- a/addons/procurement_jit/tests/test_sale_stock.py
+++ b/addons/procurement_jit/tests/test_sale_stock.py
@@ -1,15 +1,13 @@
 # -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
-from odoo.addons.sale.tests.common import TestSaleCommon
+from odoo.tests.common import SavepointCase
 from odoo.tests import Form
+from odoo.tests import tagged
 
 
-class TestSaleStockOnly(TestSaleCommon):
-
-    @classmethod
-    def setUpClass(cls, chart_template_ref=None):
-        super().setUpClass(chart_template_ref=chart_template_ref)
+@tagged('post_install', '-at_install')
+class TestSaleStockOnly(SavepointCase):
 
     def test_automatic_assign(self):
         """
@@ -22,7 +20,7 @@ class TestSaleStockOnly(TestSaleCommon):
         self.env['stock.quant']._update_available_quantity(product, warehouse.lot_stock_id, 3)
 
         so_form = Form(self.env['sale.order'])
-        so_form.partner_id = self.partner_a
+        so_form.partner_id = self.env['res.partner'].create({'name': 'Res Partner Test'})
         with so_form.order_line.new() as line:
             line.product_id = product
             line.product_uom_qty = 3

--- a/addons/sale_stock/tests/test_sale_stock.py
+++ b/addons/sale_stock/tests/test_sale_stock.py
@@ -6,6 +6,7 @@ from odoo.addons.stock_account.tests.test_anglo_saxon_valuation_reconciliation_c
 from odoo.addons.sale.tests.common import TestSaleCommon
 from odoo.exceptions import UserError
 from odoo.tests import Form, tagged
+from odoo.tests.common import SavepointCase
 
 
 @tagged('post_install', '-at_install')
@@ -1082,11 +1083,7 @@ class TestSaleStock(TestSaleCommon, ValuationReconciliationTestCommon):
         self.assertEqual(so.order_line[1].product_uom.id, uom_km_id)
 
 
-class TestSaleStockOnly(TestSaleCommon):
-
-    @classmethod
-    def setUpClass(cls, chart_template_ref=None):
-        super().setUpClass(chart_template_ref=chart_template_ref)
+class TestSaleStockOnly(SavepointCase):
 
     def test_no_automatic_assign(self):
         """
@@ -1099,7 +1096,7 @@ class TestSaleStockOnly(TestSaleCommon):
         self.env['stock.quant']._update_available_quantity(product, warehouse.lot_stock_id, 3)
 
         so_form = Form(self.env['sale.order'])
-        so_form.partner_id = self.partner_a
+        so_form.partner_id = self.env['res.partner'].create({'name': 'Res Partner Test'})
         with so_form.order_line.new() as line:
             line.product_id = product
             line.product_uom_qty = 3


### PR DESCRIPTION
The tags are missing from account_edi tests, making it so that they
don't run.
Fix this, and fix a test during the forward port.

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
