### PR TITLE
[FIX] mrp: Preserve component registration steps on backorder creation

### DIFF
--- a/addons/mrp/models/mrp_production.py
+++ b/addons/mrp/models/mrp_production.py
@@ -1600,7 +1600,7 @@ class MrpProduction(models.Model):
                     state='confirmed'
                 ))
 
-        backorders = self.env['mrp.production'].create(backorder_vals_list)
+        backorders = self.env['mrp.production'].with_context(skip_confirm=True).create(backorder_vals_list)
 
         index = 0
         production_to_backorders = {}

--- a/addons/mrp/models/mrp_workorder.py
+++ b/addons/mrp/models/mrp_workorder.py
@@ -436,6 +436,8 @@ class MrpWorkorder(models.Model):
         # Auto-confirm manually added workorders.
         # We need to go through `_action_confirm` for all workorders of the current productions to
         # make sure the links between them are correct.
+        if self.env.context.get('skip_confirm'):
+            return res
         to_confirm = res.filtered(lambda wo: wo.production_id.state in ("confirmed", "progress", "to_close"))
         to_confirm = to_confirm.production_id.workorder_ids
         to_confirm._action_confirm()


### PR DESCRIPTION
Impacted versions:
 - 15.0

Steps to reproduce (starting from ENTERPRISE 15.2):
- enable Work Orders
- create new BoM for a new product
- add 1 operation w/ 1 step (e.g. Instructions)
- add 1 component to BoM with operation_id (Consumed in Operation) = the operation
- Create and confirm a MO with new BoM + 2 Quantity to Produce
- Produce 1 product via the tablet view flow (i.e. complete instruction step + Validate 1 component in "Register Consumed Materials" step + Mark As Done)

Current behaviour:
Backorder is correctly created, but its workorder is missing the "Register Consumed Materials" step

Expected behaviour:
Step is correctly created

Note: same issue occurs with Byproducts having a operation_id (i.e. "Produced in Operation")

Issue is due to when `_split_productions()` first creates the backorders, they are created without `move_raw_ids` and `move_finished_ids` (see: `_get_backorder_mo_vals()`). When the backorders are created, they auto-create and auto-confirm their workorders. Since a quality point (e.g. operation step) exists for the workorder, the initial `_action_confirm` will `_create_checks()` for the quality point, but the "Register Consumed Materials" steps are created by the `operation_id` values in the `move_raw_ids` and `move_finished_ids` which haven't been set yet. This makes it so when the second `_action_confirm()` is called on the workorders (i.e. after their moves have been set) at the end of `_split_productions()`, the `_create_checks()` will be skipped because it assumes all the quality points have been created since one already exists.

Task: 2800975
Enterprise PR: https://github.com/odoo/enterprise/pull/26437
--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
