### PR TITLE
[FIX] http_routing,website: missing request attribute during install

### DIFF
--- a/addons/http_routing/__init__.py
+++ b/addons/http_routing/__init__.py
@@ -1,5 +1,12 @@
-# -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 from . import controllers
 from . import models
+
+from odoo.http import request
+
+
+def _post_init_hook(cr, registry):
+    if request:
+        request.is_frontend = False
+        request.is_frontend_multilang = False

--- a/addons/http_routing/__manifest__.py
+++ b/addons/http_routing/__manifest__.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 {
@@ -14,6 +13,7 @@ base modules simple.
         'views/http_routing_template.xml',
         'views/res_lang_views.xml',
     ],
+    'post_init_hook': '_post_init_hook',
     'depends': ['web'],
     'license': 'LGPL-3',
 }

--- a/addons/website/__init__.py
+++ b/addons/website/__init__.py
@@ -1,4 +1,3 @@
-# -*- encoding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 from . import controllers
@@ -7,6 +6,7 @@ from . import wizard
 
 import odoo
 from odoo import api, SUPERUSER_ID
+from odoo.http import request
 from functools import partial
 
 
@@ -34,3 +34,7 @@ def uninstall_hook(cr, registry):
 def post_init_hook(cr, registry):
     env = api.Environment(cr, SUPERUSER_ID, {})
     env['ir.module.module'].update_theme_images()
+
+    if request:
+        env = env(context=request.default_context())
+        request.website_routing = env['website'].get_current_website().id

--- a/odoo/http.py
+++ b/odoo/http.py
@@ -1067,6 +1067,9 @@ class Request:
         hm_expected = hmac.new(secret.encode('ascii'), msg, hashlib.sha1).hexdigest()
         return consteq(hm, hm_expected)
 
+    def default_context(self):
+        return dict(DEFAULT_SESSION['context'], lang=self.default_lang())
+
     def default_lang(self):
         """Returns default user language according to request specification
 


### PR DESCRIPTION
Steps to reproduce:

1) start from a clean database (http_routing should not be installed).
2) go to the app menu and install project (don't install via `-i`!!).
3) traceback: `request` has not attribute `is_frontend` while rendering
   a template.

The `is_frontend` attribute on request is set by the http_routing
module. At the moment the "install now" button is clicked, http_routing
was not installed so the `is_frontend` attribute was not set.

FF to the end of the installation: the registry is reloaded to include
the modules that have been installed, http_routing among them.

We are in a tricky situation: (1) there is a request, (2) http_routing
is installed and (3) the `is_frontend` attribute is missing from the
request.

This situation is illegal, when http_routing is installed, the
`is_frontend` attribut should always be set. In this work we reset the
missing attributes using sensitive default values via post-init hooks.