### PR TITLE
[FIX] website: allow theme customizations by multiple users

### DIFF
--- a/addons/website/models/assets.py
+++ b/addons/website/models/assets.py
@@ -47,7 +47,8 @@ class Assets(models.AbstractModel):
         Extend to only return the attachments related to the current website.
         """
         website = self.env['website'].get_current_website()
-        res = super(Assets, self)._get_custom_attachment(custom_url, op=op)
+        is_designer = self.env.user.has_group('website.group_website_designer')
+        res = super(Assets, self.sudo(is_designer))._get_custom_attachment(custom_url, op=op)
         return res.with_context(website_id=website.id).filtered(lambda x: not x.website_id or x.website_id == website)
 
     def _get_custom_view(self, custom_url, op='='):


### PR DESCRIPTION
When customizing the theme, a customized scss containing the customized variables file is saved as an attachment. This poses a problem when a second user tries to modify the same asset file, having neither read or write access to the attachment. The problem is resolved by allowing superuser access to the attachment for all users having website designer rights.

opw-2722459