### PR TITLE
[FIX] mrp_{subcontracting_}account: read price unit at validation

### DIFF
--- a/addons/mrp_subcontracting_account/models/__init__.py
+++ b/addons/mrp_subcontracting_account/models/__init__.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
+from . import mrp_production
 from . import stock_picking
 from . import stock_move

--- a/addons/mrp_subcontracting_account/models/mrp_production.py
+++ b/addons/mrp_subcontracting_account/models/mrp_production.py
@@ -1,0 +1,15 @@
+# -*- coding: utf-8 -*-
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from odoo import models
+
+
+class MrpProduction(models.Model):
+    _inherit = 'mrp.production'
+
+    def _cal_price(self, consumed_moves):
+        finished_move = self.move_finished_ids.filtered(lambda x: x.product_id == self.product_id and x.state not in ('done', 'cancel') and x.quantity_done > 0)
+        # Take the price unit of the reception move
+        if finished_move.move_dest_ids.is_subcontract:
+            self.extra_cost = finished_move.move_dest_ids._get_price_unit()
+        return super()._cal_price(consumed_moves=consumed_moves)

--- a/addons/mrp_subcontracting_account/models/stock_picking.py
+++ b/addons/mrp_subcontracting_account/models/stock_picking.py
@@ -17,9 +17,3 @@ class StockPicking(models.Model):
         domain_subcontracting = [('id', 'in', (subcontracted_productions.move_raw_ids | subcontracted_productions.move_finished_ids).stock_valuation_layer_ids.ids)]
         domain = OR([domain, domain_subcontracting])
         return dict(action, domain=domain)
-
-    def _prepare_subcontract_mo_vals(self, subcontract_move, bom):
-        vals = super(StockPicking, self)._prepare_subcontract_mo_vals(subcontract_move, bom)
-        if bom.product_tmpl_id.cost_method in ('fifo', 'average'):
-            vals = dict(vals, extra_cost=subcontract_move._get_price_unit())
-        return vals


### PR DESCRIPTION
In a subcontracting flow, the extra_cost on the subcontracted production
is read on the purchase line (via _get_price_unit() ) at the production
creation. In case the price unit on this purchase line change before the
validation, the stock valuation layer linked to the production will not
take this new value into account.

This commit ensures the price unit is the right one at validation

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
