### PR TITLE
[REV] (mrp,stock)_account: revert commit `4289887`

### DIFF
--- a/addons/mrp_account/views/product_views.xml
+++ b/addons/mrp_account/views/product_views.xml
@@ -5,7 +5,6 @@
             <field name="model">product.template</field>
             <field name="priority">3</field>
             <field name="inherit_id" ref="product.product_template_only_form_view" />
-            <field name="groups_id" eval="[(4, ref('mrp.group_mrp_manager'))]"/>
             <field name="arch" type="xml">
                 <xpath expr="//span[@name='update_cost_price']" position="inside">
                     <button name="button_bom_cost"
@@ -22,7 +21,6 @@
             <field name="model">product.product</field>
             <field name="priority">4</field>
             <field name="inherit_id" ref="product.product_normal_form_view"/>
-            <field name="groups_id" eval="[(4, ref('mrp.group_mrp_manager'))]"/>
             <field name="arch" type="xml">
                 <xpath expr="//span[@name='update_cost_price']" position="inside">
                     <button name="button_bom_cost"
@@ -39,7 +37,6 @@
             <field name="name">product.product.product.view.form.easy.bom.inherit</field>
             <field name="model">product.product</field>
             <field name="inherit_id" ref="product.product_variant_easy_edit_view"/>
-            <field name="groups_id" eval="[(4, ref('mrp.group_mrp_manager'))]"/>
             <field name="arch" type="xml">
                 <data>
                 <xpath expr="//div[@name='update_cost_price']" position="inside">

--- a/addons/stock_account/views/product_views.xml
+++ b/addons/stock_account/views/product_views.xml
@@ -40,7 +40,6 @@
             <field name="name">product.template.stock.property.form.inherit</field>
             <field name="model">product.template</field>
             <field name="inherit_id" ref="product.product_template_form_view"/>
-            <field name="groups_id" eval="[(4, ref('stock.group_stock_manager'))]"/>
             <field name="arch" type="xml">
                 <data>
                     <field name="list_price" position="after">
@@ -69,7 +68,6 @@
             <field name="name">product.product.normal.form.view.inherit</field>
             <field name="model">product.product</field>
             <field name="inherit_id" ref="product.product_normal_form_view"/>
-            <field name="groups_id" eval="[(4, ref('stock.group_stock_manager'))]"/>
             <field name="arch" type="xml">
                 <data>
                     <field name="standard_price" position="replace">
@@ -89,7 +87,6 @@
             <field name="name">product.product.product.view.form.easy.inherit</field>
             <field name="model">product.product</field>
             <field name="inherit_id" ref="product.product_variant_easy_edit_view"/>
-            <field name="groups_id" eval="[(4, ref('stock.group_stock_manager'))]"/>
             <field name="arch" type="xml">
                 <data>
                     <field name="standard_price" position="replace">


### PR DESCRIPTION
Commit that introduced the bug: https://github.com/odoo/odoo/commit/4289887496a155bc863f1e26bbec5c2cbb8c451c

Steps to reproduce the bug:
- Install mrp_account and stock_account
- Create a new user with:
    - mrp_manager and stock_user access right
- Go to inventory > products

Problem:
Traceback is triggered when trying to get the product view.
It's not a good idea to limit the `update_cost_price` button to only stock_manager users. Because we use this button in other views of MRP.

It's better to revert the commit in V13 to avoid other BUGs in a stable version




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
