### PR TITLE
[FIX] website_blog, web_editor: refresh options UI after adding a new tag

### DIFF
--- a/addons/web_editor/static/src/js/editor/snippets.options.js
+++ b/addons/web_editor/static/src/js/editor/snippets.options.js
@@ -2584,18 +2584,6 @@ const Many2oneUserValueWidget = SelectUserValueWidget.extend({
      * @private
      */
     async _search(needle) {
-        this._userValueWidgets = this._userValueWidgets.filter(widget => !widget.isDestroyed());
-        // Remove select options
-        this._userValueWidgets
-            .filter(widget => {
-                return widget instanceof ButtonUserValueWidget &&
-                    widget.el.parentElement.matches('we-selection-items');
-            }).forEach(button => {
-                if (button.isPreviewed()) {
-                    button.notifyValueChange('reset');
-                }
-                button.destroy();
-            });
         const recTuples = await this._rpc({
             model: this.options.model,
             method: 'name_search',
@@ -2611,6 +2599,18 @@ const Many2oneUserValueWidget = SelectUserValueWidget.extend({
             method: 'read',
             args: [recTuples.map(([id, _name]) => id), this.options.fields],
         });
+        // Remove select options.
+        this._userValueWidgets.filter(widget => {
+            return widget instanceof ButtonUserValueWidget &&
+                !widget.isDestroyed() &&
+                widget.el.parentElement.matches('we-selection-items');
+        }).forEach(button => {
+            if (button.isPreviewed()) {
+                button.notifyValueChange('reset');
+            }
+            button.destroy();
+        });
+        this._userValueWidgets = this._userValueWidgets.filter(widget => !widget.isDestroyed());
         records.forEach(record => {
             this.displayNameCache[record.id] = record.display_name;
         });

--- a/addons/web_editor/static/src/js/editor/snippets.options.js
+++ b/addons/web_editor/static/src/js/editor/snippets.options.js
@@ -2747,6 +2747,11 @@ const Many2oneUserValueWidget = SelectUserValueWidget.extend({
             return;
         }
         if (widget && widget === this.createButton) {
+            // When the create button is clicked, make sure the text
+            // value is restored from the actual input element because
+            // it might have been removed when hovering existing tags.
+            // TODO review this, there is probably better to do
+            this.createInput._value = this.createInput.el.querySelector('input').value;
             if (!this.createInput._value) {
                 ev.stopPropagation();
             }

--- a/addons/website_blog/__manifest__.py
+++ b/addons/website_blog/__manifest__.py
@@ -41,6 +41,9 @@
             'website_blog/static/src/js/website_blog.editor.js',
             'website_blog/static/src/js/tours/website_blog.js',
         ],
+        'web.assets_tests': [
+            'website_blog/static/tests/**/*',
+        ],
         'web.assets_frontend': [
             'website_blog/static/src/scss/website_blog.scss',
             'website_blog/static/src/js/contentshare.js',

--- a/addons/website_blog/static/src/js/options.js
+++ b/addons/website_blog/static/src/js/options.js
@@ -111,7 +111,12 @@ options.registry.BlogPostTagSelection = options.Class.extend({
         if (!widgetValue) {
             return;
         }
-        const existing = Object.values(this.allTagsByID).some(tag => tag.name.toLowerCase() === widgetValue.toLowerCase());
+        const existing = Object.values(this.allTagsByID).some(tag => {
+            // A tag is already existing only if it was already defined (i.e.
+            // id is a number) or if it appears in the current list of tags.
+            return tag.name.toLowerCase() === widgetValue.toLowerCase()
+                && (typeof(tag.id) === 'number' || this.tagIDs.includes(tag.id));
+        });
         if (existing) {
             return this.displayNotification({
                 type: 'warning',

--- a/addons/website_blog/static/src/js/options.js
+++ b/addons/website_blog/static/src/js/options.js
@@ -98,6 +98,10 @@ options.registry.BlogPostTagSelection = options.Class.extend({
      * @see this.selectClass for params
      */
     setTags(previewMode, widgetValue, params) {
+        if (this._preventNextSetTagsCall) {
+            this._preventNextSetTagsCall = false;
+            return;
+        }
         this.tagIDs = JSON.parse(widgetValue).map(tag => tag.id);
     },
     /**
@@ -121,6 +125,11 @@ options.registry.BlogPostTagSelection = options.Class.extend({
             'display_name': widgetValue,
         };
         this.tagIDs.push(newTagID);
+        // TODO Find a smarter way to achieve this.
+        // Because of the invocation order of methods, setTags will be called
+        // after createTag. This would reset the tagIds to the value before
+        // adding the newly created tag. It therefore needs to be prevented.
+        this._preventNextSetTagsCall = true;
     },
 
     //--------------------------------------------------------------------------

--- a/addons/website_blog/static/tests/tours/blog_tags_tour.js
+++ b/addons/website_blog/static/tests/tours/blog_tags_tour.js
@@ -1,0 +1,57 @@
+/** @odoo-module **/
+
+import tour from 'web_tour.tour';
+
+/**
+ * Makes sure that blog tags can be created and removed.
+ */
+tour.register('blog_tags', {
+    test: true,
+    url: '/blog',
+}, [{
+        content: "Go to first blog",
+        trigger: "article[name=blog_post] a",
+    }, {
+        content: "Edit blog post",
+        trigger: "a[data-action=edit]",
+        extra_trigger: "section#o_wblog_post_main",
+    }, {
+        content: "Open tag dropdown",
+        trigger: "we-customizeblock-option:contains(Tags) we-toggler",
+    }, {
+        content: "Enter tag name",
+        trigger: "we-customizeblock-option:contains(Tags) we-selection-items .o_we_m2o_create input",
+        run: "text testtag",
+    }, {
+        content: "Click Create",
+        trigger: "we-customizeblock-option:contains(Tags) we-selection-items .o_we_m2o_create we-button",
+    }, {
+        content: "Verify tag appears in options",
+        trigger: "we-customizeblock-option:contains(Tags) we-list input[data-name=testtag]",
+        run: () => {}, // it's a check
+    }, {
+        content: "Click Save",
+        trigger: "button[data-action=save]",
+    }, {
+        content: "Verify tag appears in blog post",
+        trigger: "#o_wblog_post_content .badge:contains(testtag)",
+        run: () => {}, // it's a check
+    }, {
+        content: "Edit blog post",
+        trigger: "a[data-action=edit]",
+    }, {
+        content: "Remove tag",
+        trigger: "we-customizeblock-option:contains(Tags) we-list tr:has(input[data-name=testtag]) we-button.fa-minus",
+    }, {
+        content: "Verify tag does not appear in options anymore",
+        trigger: "we-customizeblock-option:contains(Tags) we-list:not(:has(input[data-name=testtag]))",
+        run: () => {}, // it's a check
+    }, {
+        content: "Click Save",
+        trigger: "button[data-action=save]",
+    }, {
+        content: "Verify tag does not appear in blog post anymore",
+        trigger: "#o_wblog_post_content div:has(.badge):not(:contains(testtag))",
+        run: () => {}, // it's a check
+    }]
+);

--- a/addons/website_blog/tests/test_ui.py
+++ b/addons/website_blog/tests/test_ui.py
@@ -20,3 +20,6 @@ class TestUi(odoo.tests.HttpCase):
         })
 
         self.start_tour("/", 'blog', login='admin')
+
+    def test_blog_post_tags(self):
+        self.start_tour("/blog", 'blog_tags', login='admin')


### PR DESCRIPTION
Since [1] adding a new tag on a blog does not refresh the tag list in
the options tab. That commit sorts the `methodsNames` aplhabetically.
Previously, the unspecified order of the methods just happened to make
the add operation work.

After this commit the tag list is refreshed when a new element is added
to it, in order to not rely on the order of methods anymore.

This PR also fixes three other issues:
- create button now works after hovering suggested tags
- a deleted custom tag can now be re-created
- a race condition during the refreshing of the list of suggested tags

[1]: https://github.com/odoo/odoo/commit/a48a30f954afcb6ff3a59c4f32b05fd0c2cfcd2b

task-2811746
