### PR TITLE
[FIX] product_expiry: propagate lot's expiration date

### DIFF
--- a/addons/product_expiry/models/stock_move_line.py
+++ b/addons/product_expiry/models/stock_move_line.py
@@ -14,10 +14,12 @@ class StockMoveLine(models.Model):
         help='This is the date on which the goods with this Serial Number may'
         ' become dangerous and must not be consumed.')
 
-    @api.depends('product_id', 'picking_type_use_create_lots')
+    @api.depends('product_id', 'picking_type_use_create_lots', 'lot_id.expiration_date')
     def _compute_expiration_date(self):
         for move_line in self:
-            if move_line.picking_type_use_create_lots:
+            if not move_line.expiration_date and move_line.lot_id.expiration_date:
+                move_line.expiration_date = move_line.lot_id.expiration_date
+            elif move_line.picking_type_use_create_lots:
                 if move_line.product_id.use_expiration_date:
                     if not move_line.expiration_date:
                         move_line.expiration_date = fields.Datetime.today() + datetime.timedelta(days=move_line.product_id.expiration_time)

--- a/addons/product_expiry/tests/test_stock_production_lot.py
+++ b/addons/product_expiry/tests/test_stock_production_lot.py
@@ -499,3 +499,29 @@ class TestStockProductionLot(TestStockCommon):
         new_date = datetime.today() + timedelta(days=15)
         quant.with_user(self.demo_user).with_context(inventory_mode=True).write({'removal_date': new_date})
         self.assertEqual(quant.removal_date, new_date)
+
+    def test_apply_lot_date_on_sml(self):
+        """
+        When assigning a lot to a SML, if the lot has an expiration date,
+        the latter should be applied on the SML
+        """
+        exp_date = fields.Datetime.today() + relativedelta(days=15)
+
+        lot = self.env['stock.production.lot'].create({
+            'name': 'Lot 1',
+            'product_id': self.apple_product.id,
+            'expiration_date': fields.Datetime.to_string(exp_date),
+            'company_id': self.env.company.id,
+        })
+
+        sml = self.env['stock.move.line'].create({
+            'location_id': self.supplier_location,
+            'location_dest_id': self.stock_location,
+            'product_id': self.apple_product.id,
+            'qty_done': 3,
+            'product_uom_id': self.apple_product.uom_id.id,
+            'lot_id': lot.id,
+            'company_id': self.env.company.id,
+        })
+
+        self.assertEqual(sml.expiration_date, exp_date)


### PR DESCRIPTION
On a receipt, when defining the expiration date of a lot, the SML keeps
\<today\> as expiration date

To reproduce the issue:
1. Edit the operation type "Receipts":
    - Show Detailed Operations: True
    - Use Existing Lots/Serial Numbers: True
2. Create a product P:
    - Type: Storable
    - Tracking: By Lots
    - Expiration Date: Enabled
3. Create a planned receipt R with 1 x P
4. Mark R as Todo
5. Add a detailed operations:
    - 1 x P with new lot L
6. Edit the lot:
    - Expiration Date: <today + 7days>

Error: When saving the picking (with the lot updated), the expiration
date is incorrect (set to \<today\>).

OPW-2785256