### PR TITLE
[IMP] mail: add invitation_url on channel

### DIFF
--- a/addons/mail/models/mail_channel.py
+++ b/addons/mail/models/mail_channel.py
@@ -89,6 +89,7 @@ class Channel(models.Model):
         required=True, default='groups',
         help='This group is visible by non members. Invisible groups can add members through the invite button.')
     group_public_id = fields.Many2one('res.groups', string='Authorized Group', compute='_compute_group_public_id', readonly=False, store=True)
+    invitation_url = fields.Char('Invitation URL', compute='_compute_invitation_url')
 
     _sql_constraints = [
         ('channel_type_not_null', 'CHECK(channel_type IS NOT NULL)', 'The channel type cannot be empty'),
@@ -182,6 +183,11 @@ class Channel(models.Model):
         channels = self.filtered(lambda channel: channel.channel_type == 'channel')
         channels.filtered(lambda channel: not channel.group_public_id).group_public_id = self.env.ref('base.group_user')
         (self - channels).group_public_id = None
+
+    @api.depends('uuid')
+    def _compute_invitation_url(self):
+        for channel in self:
+            channel.invitation_url = f"/chat/{channel.id}/{channel.uuid}"
 
     # ONCHANGE
 

--- a/addons/mail/tests/test_mail_channel_as_guest.py
+++ b/addons/mail/tests/test_mail_channel_as_guest.py
@@ -13,4 +13,4 @@ class TestMailGuestPages(HttpCase):
             'name': 'Test channel',
             'public': 'public',
         })
-        self.start_tour(f"/chat/{channel.id}/{channel.uuid}", "mail/static/tests/tours/mail_channel_as_guest_tour.js")
+        self.start_tour(channel.invitation_url, "mail/static/tests/tours/mail_channel_as_guest_tour.js")


### PR DESCRIPTION
In mail we currently create the invitation URL by concatenating the values when
needed. However this could be improved so that when this url is used in other
places we don't need to create it again. Therefore it makes sense to have a
computed field that does that for us.

task-2685472

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
