### PR TITLE
[FIX] base_import_module: fix theme import

### DIFF
--- a/addons/base_import_module/models/ir_module.py
+++ b/addons/base_import_module/models/ir_module.py
@@ -140,8 +140,7 @@ class IrModule(models.Model):
                     for mod_name in dirs:
                         path = opj(module_dir, mod_name)
                         terp = load_information_from_description_file(mod_name, mod_path=path)
-                        if mod_name not in known_mods_names:
-                            dependencies_by_module[mod_name] = terp['depends']
+                        dependencies_by_module[mod_name] = terp['depends']
                     # Sort the modules so that if module A depends on module B,
                     # B is installed before A.
                     sorted_modules = topological_sort(dependencies_by_module)

--- a/addons/website_theme_install/models/ir_module_module.py
+++ b/addons/website_theme_install/models/ir_module_module.py
@@ -360,10 +360,14 @@ class IrModuleModule(models.Model):
 
         # load the theme and his ancestors (in case the theme has been imported)
         for mod in self._theme_get_stream_themes():
+            print("Loading theme %s" % mod.name)
+            print("For website %s" % website.id)
             mod._theme_load(website)
 
         # this will install 'self' if it is not installed yet
-        self._theme_upgrade_upstream()
+        if self.imported != True:
+            print("upgrade upstream theme", self.imported)
+            self._theme_upgrade_upstream()
 
         return website.button_go_website()
 

--- a/addons/website_theme_install/models/ir_module_module.py
+++ b/addons/website_theme_install/models/ir_module_module.py
@@ -358,6 +358,10 @@ class IrModuleModule(models.Model):
         # website.theme_id must be set before upgrade/install to trigger the load in ``write``
         website.theme_id = self
 
+        # load the theme and his ancestors (in case the theme has been imported)
+        for mod in self._theme_get_stream_themes():
+            mod._theme_load(website)
+
         # this will install 'self' if it is not installed yet
         self._theme_upgrade_upstream()
 


### PR DESCRIPTION
This PR allows users to import theme ZIP files via the base_import_module. This allows to import a theme even without having
access to the addon folder (typically on the SAAS).

**task-2807244**
--

I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
