### PR TITLE
[IMP] web,*: update templates to owl 2

### DIFF
--- a/addons/account/static/src/xml/account_resequence.xml
+++ b/addons/account/static/src/xml/account_resequence.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <templates>
 
-    <div t-name="account.ResequenceRenderer" owl="1" class="d-block">
+    <div t-name="account.ResequenceRenderer" owl="2" class="d-block">
         <table t-if="data.changeLines.length" class="table table-sm">
             <thead><tr>
                 <th>Date</th>
@@ -14,7 +14,7 @@
         </table>
     </div>
 
-    <t t-name="account.ResequenceChangeLine" owl="1">
+    <t t-name="account.ResequenceChangeLine" owl="2">
         <tr>
             <td t-esc="props.changeLine.date"/>
             <td t-esc="props.changeLine.current_name"/>

--- a/addons/account/static/src/xml/grouped_view_widget.xml
+++ b/addons/account/static/src/xml/grouped_view_widget.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <templates>
-    <div t-name="account.GroupedListTemplate" owl="1" class="d-block">
+    <div t-name="account.GroupedListTemplate" owl="2" class="d-block">
         <table t-if="data.groups_vals.length" class="table table-sm o_list_table table table-sm table-hover table-striped o_list_table_grouped">
             <thead><tr>
                 <t t-foreach="data.options.columns" t-as="col" t-key="col_index">
@@ -16,7 +16,7 @@
         </t>
     </div>
 
-    <tbody t-name="account.GroupedItemsTemplate" owl="1">
+    <tbody t-name="account.GroupedItemsTemplate" owl="2">
         <tr style="background-color: #dee2e6;">
             <td t-attf-colspan="{{props.options.columns.length}}">
                 <t t-esc="props.group_vals.group_name"/>
@@ -27,7 +27,7 @@
         </t>
     </tbody>
 
-    <tr t-name="account.GroupedItemTemplate" owl="1">
+    <tr t-name="account.GroupedItemTemplate" owl="2">
         <t t-foreach="props.options.columns" t-as="col" t-key="col_index">
             <td t-esc="props.item_vals[col['field']]" t-attf-class="{{col['class']}}"/>
         </t>

--- a/addons/account/static/src/xml/tax_totals.xml
+++ b/addons/account/static/src/xml/tax_totals.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <templates>
 
-    <t t-name="account.TaxGroupComponent" owl="1">
+    <t t-name="account.TaxGroupComponent" owl="2">
         <tr>
             <td class="o_td_label">
                 <label class="o_form_label o_tax_total_label" t-esc="props.taxGroup.tax_group_name"/>
@@ -38,7 +38,7 @@
         </tr>
     </t>
 
-    <div t-name="account.TaxTotalsField" owl="1">
+    <div t-name="account.TaxTotalsField" owl="2">
         <table t-if="totals.value" class="oe_right">
             <tbody>
                 <t t-foreach="totals.value.subtotals" t-as="subtotal" t-key="subtotal['name']">

--- a/addons/base_automation/static/src/xml/base_automation_error_dialog.xml
+++ b/addons/base_automation/static/src/xml/base_automation_error_dialog.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
 <templates>
-    <t t-name="base_automation.ErrorDialogBody" t-inherit="web.ErrorDialogBody" t-inherit-mode="primary" owl="1">
+    <t t-name="base_automation.ErrorDialogBody" t-inherit="web.ErrorDialogBody" t-inherit-mode="primary" owl="2">
         <xpath expr="//div[@role='alert']" position="inside">
             <p>
                 The error occurred during the execution of the automated action

--- a/addons/base_import/static/src/import_records/import_records.xml
+++ b/addons/base_import/static/src/import_records/import_records.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <templates xml:space="preserve">
 
-    <t t-name="base_import.ImportRecords" owl="1">
+    <t t-name="base_import.ImportRecords" owl="2">
         <DropdownItem class="'o_import_menu'" onSelected.bind="importRecords">
             Import records
         </DropdownItem>

--- a/addons/board/static/src/add_to_board/add_to_board.xml
+++ b/addons/board/static/src/add_to_board/add_to_board.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <templates xml:space="preserve">
 
-    <t t-name="board.AddToBoard" owl="1">
+    <t t-name="board.AddToBoard" owl="2">
         <Dropdown class="'o_add_to_board'">
             <t t-set-slot="toggler">Add to my dashboard</t>
             <div class="px-3 py-2">

--- a/addons/google_drive/static/src/xml/gdrive.xml
+++ b/addons/google_drive/static/src/xml/gdrive.xml
@@ -1,5 +1,5 @@
 <templates>
-    <t t-name="GoogleDriveMenu" owl="1">
+    <t t-name="GoogleDriveMenu" owl="2">
         <li>
             <ul class="o_embed_menu p-0">
                 <li t-foreach="props.items" t-as="gdriveItem" t-key="gdriveItem.id"

--- a/addons/google_spreadsheet/static/src/add_to_google_spreadsheet/add_to_google_spreadsheet.xml
+++ b/addons/google_spreadsheet/static/src/add_to_google_spreadsheet/add_to_google_spreadsheet.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <templates xml:space="preserve">
 
-    <t t-name="google_spreadsheet.AddToGoogleSpreadsheet" owl="1">
+    <t t-name="google_spreadsheet.AddToGoogleSpreadsheet" owl="2">
         <DropdownItem class="'o_add_to_spreadsheet'" onSelected.bind="addToGoogleSpreadsheet">
             Add to Google Spreadsheet
         </DropdownItem>

--- a/addons/hr_holidays/static/src/dashboard/time_off_card.xml
+++ b/addons/hr_holidays/static/src/dashboard/time_off_card.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <templates xml:space="preserve">
-    <div t-name="hr_holidays.TimeOffCard" owl="1" class="o_timeoff_card py-3">
+    <div t-name="hr_holidays.TimeOffCard" owl="2" class="o_timeoff_card py-3">
         <t t-set="data" t-value="props.data"/>
         <t t-set="duration" t-value="props.requires_allocation ? data.virtual_remaining_leaves : data.virtual_leaves_taken"/>
         <t t-set="show_popover" t-value="true"/>
@@ -40,7 +40,7 @@
         </span>
     </div>
 
-    <t t-name="hr_holidays.TimeOffCardMobile" owl="1">
+    <t t-name="hr_holidays.TimeOffCardMobile" owl="2">
         <t t-set="data" t-value="props.data"/>
         <t t-set="duration" t-value="props.requires_allocation ? data.virtual_remaining_leaves : data.virtual_leaves_taken" />
 
@@ -54,7 +54,7 @@
         </span>
     </t>
 
-    <t t-name="hr_holidays.TimeOffCardPopover" owl="1">
+    <t t-name="hr_holidays.TimeOffCardPopover" owl="2">
         <div class="o_timeoff_info">
             <Popover position="'right'" popoverClass="'o_timeoff_popover'">
                 <span class="fa fa-question-circle-o"/>

--- a/addons/hr_holidays/static/src/dashboard/time_off_dashboard.xml
+++ b/addons/hr_holidays/static/src/dashboard/time_off_dashboard.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <templates xml:space="preserve">
-    <div t-name="hr_holidays.TimeOffDashboard" owl="1" class="o_timeoff_dashboard">
+    <div t-name="hr_holidays.TimeOffDashboard" owl="2" class="o_timeoff_dashboard">
         <t t-foreach="props.holidays" t-as="holiday" t-key="holiday[3]">
             <TimeOffCard name="holiday[0]" data="holiday[1]" requires_allocation="holiday[2] == 'yes'" id="holiday[3]"/>
         </t>

--- a/addons/hr_holidays/static/src/leave_stats/leave_stats.xml
+++ b/addons/hr_holidays/static/src/leave_stats/leave_stats.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <templates xml:space="preserve">
-    <div t-name="hr_holidays.LeaveStatsComponent" owl="1" class="o_leave_stats">
+    <div t-name="hr_holidays.LeaveStatsComponent" owl="2" class="o_leave_stats">
         <div t-if="employee" id="o_leave_stats_employee">
             <div class="o_hr_leave_subtitle">
                 <t t-esc="employee.display_name"/> in <t t-esc="thisYear"/>

--- a/addons/hr_holidays_attendance/static/src/xml/time_off_calendar.xml
+++ b/addons/hr_holidays_attendance/static/src/xml/time_off_calendar.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
 <templates id="template" xml:space="preserve">
-    <t t-name="hr_holidays_attendance.TimeOffCard" t-inherit="hr_holidays.TimeOffCard" t-inherit-mode="extension" owl="1">
+    <t t-name="hr_holidays_attendance.TimeOffCard" t-inherit="hr_holidays.TimeOffCard" t-inherit-mode="extension" owl="2">
         <xpath expr="//t[@t-set='duration']" position="replace">
             <t t-set="duration" t-value="props.requires_allocation || props.data['overtime_deductible']?props.data['virtual_remaining_leaves']:props.data['virtual_leaves_taken']" />
         </xpath>
@@ -13,7 +13,7 @@
         </xpath>
     </t>
 
-    <t t-name="hr_holidays_attendance.TimeOffCardMobile" t-inherit="hr_holidays.TimeOffCardMobile" t-inherit-mode="extension" owl="1">
+    <t t-name="hr_holidays_attendance.TimeOffCardMobile" t-inherit="hr_holidays.TimeOffCardMobile" t-inherit-mode="extension" owl="2">
         <xpath expr="//t[@t-set='duration']" position="replace">
             <t t-set="duration" t-value="props.requires_allocation || props.data['overtime_deductible']?props.data['virtual_remaining_leaves']:props.data['virtual_leaves_taken']" />
         </xpath>

--- a/addons/iap/static/src/xml/iap_templates.xml
+++ b/addons/iap/static/src/xml/iap_templates.xml
@@ -2,7 +2,7 @@
 <template id="template" xml:space="preserve">
 
     <!-- LAYOUT TEMPLATES -->
-    <div t-name="iap.redirect_to_odoo_credit" t-att-style="style" owl="1">
+    <div t-name="iap.redirect_to_odoo_credit" t-att-style="style" owl="2">
         <t t-if="props.errorData.body">
             <div t-raw="props.errorData.body"/>
         </t>
@@ -16,7 +16,7 @@
         </t>
     </div>
 
-    <div t-name="iap.InsufficientCreditFooter" owl="1">
+    <div t-name="iap.InsufficientCreditFooter" owl="2">
         <button class="btn btn-primary" t-on-click="buyCredits" t-esc="buttonMessage"/>
         <button class="btn" t-on-click="close">Cancel</button>
     </div>

--- a/addons/l10n_ae_pos/static/src/xml/Screens/ReceiptScreen/OrderReceipt.xml
+++ b/addons/l10n_ae_pos/static/src/xml/Screens/ReceiptScreen/OrderReceipt.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <templates id="template" xml:space="preserve">
-    <t t-name="OrderReceiptVAT" t-inherit="point_of_sale.OrderReceipt" t-inherit-mode="extension" owl="1">
+    <t t-name="OrderReceiptVAT" t-inherit="point_of_sale.OrderReceipt" t-inherit-mode="extension" owl="2">
         <xpath expr="//div[contains(text(), 'Total Taxes')]" position="replace">
             <div>
                 <t t-if="env.pos.company.country.code == 'AE'">VAT</t>

--- a/addons/l10n_co_pos/static/src/xml/pos.xml
+++ b/addons/l10n_co_pos/static/src/xml/pos.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
 <templates id="template" xml:space="preserve">
-    <t t-name="OrderReceipt" t-inherit="point_of_sale.OrderReceipt" t-inherit-mode="extension" owl="1">
+    <t t-name="OrderReceipt" t-inherit="point_of_sale.OrderReceipt" t-inherit-mode="extension" owl="2">
         <xpath expr="//div[hasclass('pos-receipt-order-data')]" position="inside">
             <t t-if="receipt.l10n_co_dian !== false">
                 <div style="word-wrap:break-word;"><t t-esc="receipt.l10n_co_dian"/></div>

--- a/addons/l10n_fr_pos_cert/static/src/xml/OrderReceipt.xml
+++ b/addons/l10n_fr_pos_cert/static/src/xml/OrderReceipt.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <templates id="template" xml:space="preserve">
-    <t t-name="OrderReceipt" t-inherit="point_of_sale.OrderReceipt" t-inherit-mode="extension" owl="1">
+    <t t-name="OrderReceipt" t-inherit="point_of_sale.OrderReceipt" t-inherit-mode="extension" owl="2">
         <xpath expr="//div[hasclass('pos-receipt-order-data')]" position="inside">
             <t t-if="receipt.l10n_fr_hash !== false">
                 <br/>

--- a/addons/l10n_gcc_pos/static/src/xml/OrderReceipt.xml
+++ b/addons/l10n_gcc_pos/static/src/xml/OrderReceipt.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <templates id="template" xml:space="preserve">
-    <t t-inherit="point_of_sale.OrderReceipt" t-inherit-mode="extension" owl="1">
+    <t t-inherit="point_of_sale.OrderReceipt" t-inherit-mode="extension" owl="2">
 
         <xpath expr="//div[hasclass('pos-receipt-contact')]" position="after">
             <t t-if="receipt.is_gcc_country">
@@ -95,7 +95,7 @@
         </xpath>
     </t>
 
-    <t t-inherit="point_of_sale.OrderLinesReceipt" t-inherit-mode="extension" owl="1">
+    <t t-inherit="point_of_sale.OrderLinesReceipt" t-inherit-mode="extension" owl="2">
         <xpath expr="//t[@t-if='isSimple(line)']/div/span[hasclass('price_display')]" position="attributes">
             <attribute name="t-if">!receipt.is_gcc_country</attribute>
         </xpath>

--- a/addons/l10n_in_pos/static/src/xml/pos_receipt.xml
+++ b/addons/l10n_in_pos/static/src/xml/pos_receipt.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <templates id="template" xml:space="preserve">
-    <t t-name="OrderReceipt" t-inherit="point_of_sale.OrderReceipt" t-inherit-mode="extension" owl="1">
+    <t t-name="OrderReceipt" t-inherit="point_of_sale.OrderReceipt" t-inherit-mode="extension" owl="2">
         <xpath expr="//div[hasclass('orderlines')]" position="before">
             <t t-if="receipt.partner and env.pos.company.country and env.pos.company.country.code == 'IN'">
                 <div class="pos-receipt-center-align">
@@ -17,7 +17,7 @@
         </xpath>
     </t>
 
-    <t t-name="OrderLinesReceipt" t-inherit="point_of_sale.OrderLinesReceipt" t-inherit-mode="extension" owl="1">
+    <t t-name="OrderLinesReceipt" t-inherit="point_of_sale.OrderLinesReceipt" t-inherit-mode="extension" owl="2">
         <xpath expr="//t[@t-foreach='receipt.orderlines']" position="inside">
             <t t-if="line.l10n_in_hsn_code and env.pos.company.country and env.pos.company.country.code == 'IN'">
                 <div class="pos-receipt-left-padding">

--- a/addons/l10n_sa_pos/static/src/xml/OrderReceipt.xml
+++ b/addons/l10n_sa_pos/static/src/xml/OrderReceipt.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <templates id="template" xml:space="preserve">
-    <t t-inherit="point_of_sale.OrderReceipt" t-inherit-mode="extension" owl="1">
+    <t t-inherit="point_of_sale.OrderReceipt" t-inherit-mode="extension" owl="2">
         <xpath expr="//img[hasclass('pos-receipt-logo')]" position="after">
             <t if="receipt.is_gcc_country">
                 <img t-if="receipt.qr_code" id="qrcode" t-att-src="receipt.qr_code" class="pos-receipt-logo"/>

--- a/addons/mail/static/src/components/activity/activity.xml
+++ b/addons/mail/static/src/components/activity/activity.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <templates xml:space="preserve">
 
-    <t t-name="mail.Activity" owl="1">
+    <t t-name="mail.Activity" owl="2">
         <t t-if="activityView">
             <div class="o_Activity d-flex p-2" t-attf-class="{{ className }}" t-on-click="activityView.onClickActivity" t-ref="root">
                 <div class="o_Activity_sidebar mr-3">

--- a/addons/mail/static/src/components/activity_box/activity_box.xml
+++ b/addons/mail/static/src/components/activity_box/activity_box.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <templates xml:space="preserve">
 
-    <t t-name="mail.ActivityBox" owl="1">
+    <t t-name="mail.ActivityBox" owl="2">
         <t t-if="activityBoxView">
             <div class="o_ActivityBox" t-attf-class="{{ className }}" t-ref="root">
                 <a role="button" class="o_ActivityBox_title btn d-flex align-items-center mt-4 p-0 w-100 font-weight-bold" t-on-click="activityBoxView.onClickActivityBoxTitle">

--- a/addons/mail/static/src/components/activity_mark_done_popover/activity_mark_done_popover.xml
+++ b/addons/mail/static/src/components/activity_mark_done_popover/activity_mark_done_popover.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <templates xml:space="preserve">
 
-    <t t-name="mail.ActivityMarkDonePopover" owl="1">
+    <t t-name="mail.ActivityMarkDonePopover" owl="2">
         <t t-if="activityMarkDonePopoverView">
             <div class="o_ActivityMarkDonePopover" t-attf-class="{{ className }}" t-on-keydown="activityMarkDonePopoverView.onKeydown" t-ref="root">
                 <textarea class="form-control o_ActivityMarkDonePopover_feedback mb-2" rows="3" placeholder="Write Feedback" t-on-blur="activityMarkDonePopoverView.onBlur" t-ref="feedbackTextarea"/>

--- a/addons/mail/static/src/components/attachment_box/attachment_box.xml
+++ b/addons/mail/static/src/components/attachment_box/attachment_box.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <templates xml:space="preserve">
 
-    <t t-name="mail.AttachmentBox" owl="1">
+    <t t-name="mail.AttachmentBox" owl="2">
         <t t-if="attachmentBoxView">
             <div class="o_AttachmentBox position-relative" t-attf-class="{{ className }}" t-ref="root">
                 <div class="o_AttachmentBox_title d-flex align-items-center">

--- a/addons/mail/static/src/components/attachment_card/attachment_card.xml
+++ b/addons/mail/static/src/components/attachment_card/attachment_card.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <templates xml:space="preserve">
-    <t t-name="mail.AttachmentCard" owl="1">
+    <t t-name="mail.AttachmentCard" owl="2">
         <t t-if="attachmentCard">
             <div t-attf-class="{{ className }}" t-ref="root">
                 <div class="o_AttachmentCard o-has-card-details d-flex rounded bg-300"

--- a/addons/mail/static/src/components/attachment_delete_confirm/attachment_delete_confirm.xml
+++ b/addons/mail/static/src/components/attachment_delete_confirm/attachment_delete_confirm.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <templates xml:space="preserve">
-    <t t-name="mail.AttachmentDeleteConfirm" owl="1">
+    <t t-name="mail.AttachmentDeleteConfirm" owl="2">
         <t t-if="attachmentDeleteConfirmView">
             <div class="o_AttachmentDeleteConfirm card bg-white" t-attf-class="{{ className }}" t-ref="root">
                 <h4 class="m-3">Confirmation</h4>

--- a/addons/mail/static/src/components/attachment_image/attachment_image.xml
+++ b/addons/mail/static/src/components/attachment_image/attachment_image.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <templates xml:space="preserve">
-    <t t-name="mail.AttachmentImage" owl="1">
+    <t t-name="mail.AttachmentImage" owl="2">
         <t t-if="attachmentImage">
             <div t-attf-class="{{ className }}" t-ref="root">
                 <div class="o_AttachmentImage d-flex position-relative m-1 flex-shrink-0"

--- a/addons/mail/static/src/components/attachment_list/attachment_list.xml
+++ b/addons/mail/static/src/components/attachment_list/attachment_list.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <templates xml:space="preserve">
 
-    <t t-name="mail.AttachmentList" owl="1">
+    <t t-name="mail.AttachmentList" owl="2">
         <t t-if="attachmentList">
             <div class="o_AttachmentList d-flex flex-column justify-content-start" t-attf-class="{{ className }}" t-ref="root">
                 <div class="o_AttachmentList_partialList o_AttachmentList_partialListImages d-flex flex-grow-1 flex-wrap">

--- a/addons/mail/static/src/components/attachment_viewer/attachment_viewer.xml
+++ b/addons/mail/static/src/components/attachment_viewer/attachment_viewer.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <templates xml:space="preserve">
 
-    <t t-name="mail.AttachmentViewer" owl="1">
+    <t t-name="mail.AttachmentViewer" owl="2">
         <t t-if="attachmentViewer">
             <div class="o_AttachmentViewer flex-column align-items-center d-flex w-100 h-100" t-attf-class="{{ className }}" t-on-click="_onClick" t-on-keydown="_onKeydown" tabindex="0" t-ref="root">
                 <div class="o_AttachmentViewer_header d-flex w-100 bg-black-75 text-400" t-on-click="_onClickHeader">

--- a/addons/mail/static/src/components/autocomplete_input/autocomplete_input.xml
+++ b/addons/mail/static/src/components/autocomplete_input/autocomplete_input.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <templates xml:space="preserve">
 
-    <t t-name="mail.AutocompleteInput" owl="1">
+    <t t-name="mail.AutocompleteInput" owl="2">
         <input class="o_AutocompleteInput" t-attf-class="{{ className }}" t-on-blur="_onBlur" t-on-focusin="props.onFocusin" t-on-keydown="_onKeydown" t-att-placeholder="props.placeholder" t-ref="root"/>
     </t>
 

--- a/addons/mail/static/src/components/channel_invitation_form/channel_invitation_form.xml
+++ b/addons/mail/static/src/components/channel_invitation_form/channel_invitation_form.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <templates xml:space="preserve">
 
-    <t t-name="mail.ChannelInvitationForm" owl="1">
+    <t t-name="mail.ChannelInvitationForm" owl="2">
         <t t-if="channelInvitationForm">
             <div class="o_ChannelInvitationForm d-flex flex-column" t-attf-class="{{ className }}" t-ref="root">
                 <h3 class="mx-3 mt-3 mb-2">Invite people</h3>

--- a/addons/mail/static/src/components/channel_member_list/channel_member_list.xml
+++ b/addons/mail/static/src/components/channel_member_list/channel_member_list.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <templates xml:space="preserve">
 
-    <t t-name="mail.ChannelMemberList" owl="1">
+    <t t-name="mail.ChannelMemberList" owl="2">
         <t t-if="channel">
             <div class="o_ChannelMemberList d-flex flex-column overflow-auto bg-light" t-attf-class="{{ className }}" t-ref="root">
                 <t t-if="channel.orderedOnlineMembers.length > 0">
@@ -29,7 +29,7 @@
                 </t>
             </div>
         </t>
-    </t>
+    </t>owl="2"
 
     <t t-name="mail.ChannelMemberList_memberList" owl="1">
         <h6 class="m-2"><t t-esc="title"/> - <t t-esc="members.length"/></h6>

--- a/addons/mail/static/src/components/chat_window/chat_window.xml
+++ b/addons/mail/static/src/components/chat_window/chat_window.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <templates xml:space="preserve">
 
-    <t t-name="mail.ChatWindow" owl="1">
+    <t t-name="mail.ChatWindow" owl="2">
         <t t-if="chatWindow">
             <div class="o_ChatWindow bg-white" t-attf-class="{{ className }}" tabindex="0" t-att-data-visible-index="chatWindow.visibleIndex"
                 t-att-class="{

--- a/addons/mail/static/src/components/chat_window_header/chat_window_header.xml
+++ b/addons/mail/static/src/components/chat_window_header/chat_window_header.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <templates xml:space="preserve">
 
-    <t t-name="mail.ChatWindowHeader" owl="1">
+    <t t-name="mail.ChatWindowHeader" owl="2">
         <t t-if="chatWindow">
             <div class="o_ChatWindowHeader" t-att-class="{ 'o-mobile': messaging.device.isMobile }" t-attf-class="{{ className }}" t-on-click="_onClick" t-ref="root">
                 <t t-if="props.hasCloseAsBackButton">

--- a/addons/mail/static/src/components/chat_window_hidden_menu/chat_window_hidden_menu.xml
+++ b/addons/mail/static/src/components/chat_window_hidden_menu/chat_window_hidden_menu.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <templates xml:space="preserve">
 
-    <t t-name="mail.ChatWindowHiddenMenu" owl="1">
+    <t t-name="mail.ChatWindowHiddenMenu" owl="2">
         <div class="o_ChatWindowHiddenMenu dropup position-fixed bottom-0 align-items-stretch d-flex px-2 py-1 rounded-lg-top bg-900 o_cursor_pointer" t-attf-class="{{ className }}" t-ref="root">
             <div class="o_ChatWindowHiddenMenu_dropdownToggle dropdown-toggle justify-content-center align-items-center flex-grow-1 d-flex mw-100" t-att-class="{ 'show opacity-50': messaging.chatWindowManager.isHiddenMenuOpen }" t-on-click="_onClickToggle">
                 <div class="o_ChatWindowHiddenMenu_dropdownToggleIcon o_ChatWindowHiddenMenu_dropdownToggleItem me-1 fa fa-comments-o"/>

--- a/addons/mail/static/src/components/chat_window_manager/chat_window_manager.xml
+++ b/addons/mail/static/src/components/chat_window_manager/chat_window_manager.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <templates xml:space="preserve">
 
-    <t t-name="mail.ChatWindowManager" owl="1">
+    <t t-name="mail.ChatWindowManager" owl="2">
         <div class="o_ChatWindowManager flex-row-reverse d-flex" t-attf-class="{{ className }}" t-ref="root">
             <t t-if="messaging and messaging.chatWindowManager">
                 <!-- Note: DOM elements are ordered from left to right -->

--- a/addons/mail/static/src/components/chatter/chatter.xml
+++ b/addons/mail/static/src/components/chatter/chatter.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <templates xml:space="preserve">
 
-    <t t-name="mail.Chatter" owl="1">
+    <t t-name="mail.Chatter" owl="2">
         <t t-if="chatter">
             <div class="o_Chatter position-relative flex-grow-1 flex-column d-flex w-100 bg-white" t-attf-class="{{ className }}" t-ref="root">
                 <div class="o_Chatter_fixedPanel">

--- a/addons/mail/static/src/components/chatter_container/chatter_container.xml
+++ b/addons/mail/static/src/components/chatter_container/chatter_container.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <templates xml:space="preserve">
 
-    <t t-name="mail.ChatterContainer" owl="1">
+    <t t-name="mail.ChatterContainer" owl="2">
         <div class="o_ChatterContainer flex-grow-1 d-flex w-100" t-attf-class="{{ className }}" data-command-category="mail" t-ref="root">
             <t t-if="chatter">
                 <Chatter localId="chatter.localId"/>

--- a/addons/mail/static/src/components/chatter_topbar/chatter_topbar.xml
+++ b/addons/mail/static/src/components/chatter_topbar/chatter_topbar.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <templates xml:space="preserve">
 
-    <t t-name="mail.ChatterTopbar" owl="1">
+    <t t-name="mail.ChatterTopbar" owl="2">
         <t t-if="chatter">
             <div class="o_ChatterTopbar justify-content-between d-flex" t-attf-class="{{ className }}" t-ref="root">
                 <div class="o_ChatterTopbar_actions flex-wrap-reverse flex-fill d-flex border-bottom" t-attf-class="{{ chatter.composerView ? 'o-has-active-button' : 'border-white' }}">

--- a/addons/mail/static/src/components/composer/composer.xml
+++ b/addons/mail/static/src/components/composer/composer.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <templates xml:space="preserve">
 
-    <t t-name="mail.Composer" owl="1">
+    <t t-name="mail.Composer" owl="2">
         <t t-if="composerView">
             <div class="o_Composer"
                 t-att-class="{
@@ -140,7 +140,7 @@
     </t>
 
     <t t-name="mail.Composer.actionButtons" owl="1">
-        <div class="o_Composer_actionButtons" t-att-class="{ 'o-composer-is-compact': composerView.isCompact }">
+        <div class="o_Composer_actionButtonsowl="2"-class="{ 'o-composer-is-compact': composerView.isCompact }">
             <t t-if="props.hasSendButton">
                 <button class="o_Composer_actionButton o_Composer_button o_Composer_buttonSend btn btn-primary"
                     t-att-class="{

--- a/addons/mail/static/src/components/composer_suggested_recipient/composer_suggested_recipient.xml
+++ b/addons/mail/static/src/components/composer_suggested_recipient/composer_suggested_recipient.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <templates xml:space="preserve">
-    <t t-name="mail.ComposerSuggestedRecipient" owl="1">
+    <t t-name="mail.ComposerSuggestedRecipient" owl="2">
         <t t-if="suggestedRecipientInfo">
             <div class="o_ComposerSuggestedRecipient" t-attf-class="{{ className }}" t-att-data-partner-id="suggestedRecipientInfo.partner and suggestedRecipientInfo.partner.id ? suggestedRecipientInfo.partner.id : false" t-att-title="suggestedRecipientInfo.titleText" t-ref="root">
                 <div class="custom-control custom-checkbox">

--- a/addons/mail/static/src/components/composer_suggested_recipient_list/composer_suggested_recipient_list.xml
+++ b/addons/mail/static/src/components/composer_suggested_recipient_list/composer_suggested_recipient_list.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <templates xml:space="preserve">
-    <t t-name="mail.ComposerSuggestedRecipientList" owl="1">
+    <t t-name="mail.ComposerSuggestedRecipientList" owl="2">
         <t t-if="thread">
             <div class="o_ComposerSuggestedRecipientList mb-2" t-attf-class="{{ className }}" t-ref="root">
                 <t t-foreach="state.hasShowMoreButton ? thread.suggestedRecipientInfoList : thread.suggestedRecipientInfoList.slice(0,3)" t-as="recipientInfo" t-key="recipientInfo.localId">

--- a/addons/mail/static/src/components/composer_suggestion/composer_suggestion.xml
+++ b/addons/mail/static/src/components/composer_suggestion/composer_suggestion.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <templates xml:space="preserve">
 
-    <t t-name="mail.ComposerSuggestion" owl="1">
+    <t t-name="mail.ComposerSuggestion" owl="2">
         <t t-if="composerSuggestion">
             <a class="o_ComposerSuggestion dropdown-item" t-att-class="{ 'active bg-300': props.isActive }" t-attf-class="{{ className }}" href="#" t-att-title="title()" role="menuitem" t-on-click="_onClick" t-ref="root">
                 <t t-if="isCannedResponse">

--- a/addons/mail/static/src/components/composer_suggestion_list/composer_suggestion_list.xml
+++ b/addons/mail/static/src/components/composer_suggestion_list/composer_suggestion_list.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <templates xml:space="preserve">
 
-    <t t-name="mail.ComposerSuggestionList" owl="1">
+    <t t-name="mail.ComposerSuggestionList" owl="2">
         <t t-if="composerView">
             <div class="o_ComposerSuggestionList" t-att-class="{ 'o-lowPosition': props.isBelow }" t-attf-class="{{ className }}" t-ref="root">
                 <div class="o_ComposerSuggestionList_drop" t-att-class="{ 'dropdown': props.isBelow, 'dropup': !props.isBelow }">

--- a/addons/mail/static/src/components/composer_text_input/composer_text_input.xml
+++ b/addons/mail/static/src/components/composer_text_input/composer_text_input.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <templates xml:space="preserve">
 
-    <t t-name="mail.ComposerTextInput" owl="1">
+    <t t-name="mail.ComposerTextInput" owl="2">
         <t t-if="composerView">
             <div class="o_ComposerTextInput" t-attf-class="{{ className }}" t-on-paste="props.onPaste" t-ref="root">
                 <t t-if="composerView.hasSuggestions">

--- a/addons/mail/static/src/components/delete_message_confirm/delete_message_confirm.xml
+++ b/addons/mail/static/src/components/delete_message_confirm/delete_message_confirm.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <templates xml:space="preserve">
-    <t t-name="mail.DeleteMessageConfirm" owl="1">
+    <t t-name="mail.DeleteMessageConfirm" owl="2">
         <t t-if="deleteMessageConfirmView">
             <div class="o_DeleteMessageConfirm card bg-white" t-attf-class="{{ className }}" t-ref="root">
                 <h4 class="m-3">Confirmation</h4>

--- a/addons/mail/static/src/components/dialog/dialog.xml
+++ b/addons/mail/static/src/components/dialog/dialog.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <templates xml:space="preserve">
 
-    <t t-name="mail.Dialog" owl="1">
+    <t t-name="mail.Dialog" owl="2">
         <t t-if="dialog">
             <div class="o_Dialog" t-attf-class="{{ className }}" t-att-style="dialog.style" t-ref="root">
                 <t

--- a/addons/mail/static/src/components/dialog_manager/dialog_manager.xml
+++ b/addons/mail/static/src/components/dialog_manager/dialog_manager.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <templates xml:space="preserve">
 
-    <t t-name="mail.DialogManager" owl="1">
+    <t t-name="mail.DialogManager" owl="2">
         <div class="o_DialogManager" t-attf-class="{{ className }}" t-ref="root">
             <t t-if="messaging and messaging.dialogManager">
                 <t t-foreach="messaging.dialogManager.dialogs" t-as="dialog" t-key="dialog.localId">

--- a/addons/mail/static/src/components/discuss/discuss.xml
+++ b/addons/mail/static/src/components/discuss/discuss.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <templates xml:space="preserve">
 
-    <t t-name="mail.Discuss" owl="1">
+    <t t-name="mail.Discuss" owl="2">
         <t t-if="discussView">
             <div class="o_Discuss" t-attf-class="{{ className }}"
                 t-att-class="{
@@ -23,7 +23,7 @@
         </t>
     </t>
 
-    <t t-name="mail.Discuss.content" owl="1">
+    <t t-name="mail.Discuss.content" owl="2">
         <t t-if="messaging.device.isMobile and discussView.discuss.activeMobileNavbarTabId === 'mailbox'">
             <DiscussMobileMailboxSelection className="'o_Discuss_mobileMailboxSelection border-bottom'"/>
         </t>

--- a/addons/mail/static/src/components/discuss_container/discuss_container.xml
+++ b/addons/mail/static/src/components/discuss_container/discuss_container.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <templates xml:space="preserve">
 
-    <t t-name="mail.DiscussContainer" owl="1">
+    <t t-name="mail.DiscussContainer" owl="2">
         <div class="o_DiscussContainer d-flex flex-grow-1 flex-column">
             <Discuss t-if="messaging and messaging.discuss and messaging.discuss.discussView and messaging.isInitialized" className="'flex-grow-1'" localId="messaging.discuss.discussView.localId"/>
             <div t-else="" class="o_DiscussContainer_spinner d-flex flex-grow-1 align-items-center justify-content-center">

--- a/addons/mail/static/src/components/discuss_mobile_mailbox_selection/discuss_mobile_mailbox_selection.xml
+++ b/addons/mail/static/src/components/discuss_mobile_mailbox_selection/discuss_mobile_mailbox_selection.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <templates xml:space="preserve">
 
-    <t t-name="mail.DiscussMobileMailboxSelection" owl="1">
+    <t t-name="mail.DiscussMobileMailboxSelection" owl="2">
         <div class="o_DiscussMobileMailboxSelection" t-attf-class="{{ className }}" t-ref="root">
             <t t-foreach="discuss.orderedMailboxes" t-as="mailbox" t-key="mailbox.localId">
                 <button class="o_DiscussMobileMailboxSelection_button btn btn-secondary"

--- a/addons/mail/static/src/components/discuss_public_view/discuss_public_view.xml
+++ b/addons/mail/static/src/components/discuss_public_view/discuss_public_view.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <templates xml:space="preserve">
-    <t t-name="mail.DiscussPublicView" owl="1">
+    <t t-name="mail.DiscussPublicView" owl="2">
         <t t-if="discussPublicView">
             <div class="o_DiscussPublicView d-flex flex-column h-100" t-attf-class="{{ className }}" t-ref="root">
                 <ThreadView t-if="discussPublicView.threadView"

--- a/addons/mail/static/src/components/discuss_sidebar/discuss_sidebar.xml
+++ b/addons/mail/static/src/components/discuss_sidebar/discuss_sidebar.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <templates xml:space="preserve">
 
-    <t t-name="mail.DiscussSidebar" owl="1">
+    <t t-name="mail.DiscussSidebar" owl="2">
         <t t-if="discussView">
             <div name="root" class="o_DiscussSidebar" t-attf-class="{{ className }}" t-ref="root">
                 <div class="d-flex justify-content-center">

--- a/addons/mail/static/src/components/discuss_sidebar_category/discuss_sidebar_category.xml
+++ b/addons/mail/static/src/components/discuss_sidebar_category/discuss_sidebar_category.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
 <templates xml:space="preserve">
-    <t t-name="mail.DiscussSidebarCategory" owl="1">
+    <t t-name="mail.DiscussSidebarCategory" owl="2">
         <t t-if="category">
             <div class="o_DiscussSidebarCategory" t-attf-class="{{ className }}" t-att-data-category-local-id="category.localId" t-ref="root">
                 <div class="o_DiscussSidebarCategory_header">

--- a/addons/mail/static/src/components/discuss_sidebar_category_item/discuss_sidebar_category_item.xml
+++ b/addons/mail/static/src/components/discuss_sidebar_category_item/discuss_sidebar_category_item.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <templates xml:space="preserve">
-    <t t-name="mail.DiscussSidebarCategoryItem" owl="1">
+    <t t-name="mail.DiscussSidebarCategoryItem" owl="2">
         <t t-if="categoryItem">
             <div class="o_DiscussSidebarCategoryItem"
                 t-att-class="{

--- a/addons/mail/static/src/components/discuss_sidebar_mailbox/discuss_sidebar_mailbox.xml
+++ b/addons/mail/static/src/components/discuss_sidebar_mailbox/discuss_sidebar_mailbox.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <templates xml:space="preserve">
-    <t t-name="mail.DiscussSidebarMailbox" owl="1">
+    <t t-name="mail.DiscussSidebarMailbox" owl="2">
         <t t-if="mailbox">
             <div class="o_DiscussSidebarMailbox"
                 t-att-class="{

--- a/addons/mail/static/src/components/drop_zone/drop_zone.xml
+++ b/addons/mail/static/src/components/drop_zone/drop_zone.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <templates xml:space="preserve">
 
-    <t t-name="mail.DropZone" owl="1">
+    <t t-name="mail.DropZone" owl="2">
         <div class="o_DropZone" t-att-class="{ 'o-dragging-inside': state.isDraggingInside }" t-attf-class="{{ className }}" t-on-dragenter="_onDragenter" t-on-dragleave="_onDragleave" t-on-dragover="_onDragover" t-on-drop="_onDrop" t-ref="root">
             <h4>
                 Drag Files Here <i class="fa fa-download"/>

--- a/addons/mail/static/src/components/emoji_list/emoji_list.xml
+++ b/addons/mail/static/src/components/emoji_list/emoji_list.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <templates xml:space="preserve">
 
-    <t t-name="mail.EmojiList" owl="1">
+    <t t-name="mail.EmojiList" owl="2">
         <div class="o_EmojiList" t-attf-class="{{ className }}" t-ref="root">
             <t t-if="emojiListView">
                 <t t-foreach="emojis" t-as="emoji" t-key="emoji.unicode">

--- a/addons/mail/static/src/components/follow_button/follow_button.xml
+++ b/addons/mail/static/src/components/follow_button/follow_button.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <templates xml:space="preserve">
 
-    <t t-name="mail.FollowButton" owl="1">
+    <t t-name="mail.FollowButton" owl="2">
         <t t-if="thread">
             <div class="o_FollowButton" t-attf-class="{{ className }}" t-ref="root">
                 <t t-if="thread.isCurrentPartnerFollowing">

--- a/addons/mail/static/src/components/follower/follower.xml
+++ b/addons/mail/static/src/components/follower/follower.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <templates xml:space="preserve">
 
-    <t t-name="mail.Follower" owl="1">
+    <t t-name="mail.Follower" owl="2">
         <t t-if="follower">
             <div class="o_Follower" t-attf-class="{{ className }}" t-on-click="props.onClick" t-ref="root">
                 <a class="o_Follower_details d-flex" t-att-class="{ 'o-inactive': !follower.isActive }" href="#" t-on-click="_onClickDetails">

--- a/addons/mail/static/src/components/follower_list_menu/follower_list_menu.xml
+++ b/addons/mail/static/src/components/follower_list_menu/follower_list_menu.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <templates xml:space="preserve">
 
-    <t t-name="mail.FollowerListMenu" owl="1">
+    <t t-name="mail.FollowerListMenu" owl="2">
         <t t-if="thread">
             <div class="o_FollowerListMenu position-relative d-flex" t-attf-class="{{ className }}" t-on-keydown="_onKeydown" t-ref="root">
                 <div class="o_FollowerListMenu_followers d-flex" t-ref="dropdown">

--- a/addons/mail/static/src/components/follower_subtype/follower_subtype.xml
+++ b/addons/mail/static/src/components/follower_subtype/follower_subtype.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <templates xml:space="preserve">
 
-    <t t-name="mail.FollowerSubtype" owl="1">
+    <t t-name="mail.FollowerSubtype" owl="2">
         <t t-if="followerSubtypeView">
             <div class="o_FollowerSubtype" t-attf-class="{{ className }}" t-att-data-local-id="followerSubtypeView.localId" t-ref="root">
                 <label class="o_FollowerSubtype_label">

--- a/addons/mail/static/src/components/follower_subtype_list/follower_subtype_list.xml
+++ b/addons/mail/static/src/components/follower_subtype_list/follower_subtype_list.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <templates xml:space="preserve">
 
-    <t t-name="mail.FollowerSubtypeList" owl="1">
+    <t t-name="mail.FollowerSubtypeList" owl="2">
         <t t-if="followerSubtypeList">
             <div class="o_FollowerSubtypeList modal-dialog" t-attf-class="{{ className }}" t-ref="root">
                 <div class="modal-content">

--- a/addons/mail/static/src/components/mail_template/mail_template.xml
+++ b/addons/mail/static/src/components/mail_template/mail_template.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <templates xml:space="preserve">
 
-    <t t-name="mail.MailTemplate" owl="1">
+    <t t-name="mail.MailTemplate" owl="2">
         <t t-if="mailTemplateView">
             <div class="o_MailTemplate" t-attf-class="{{ className }}" t-ref="root">
                 <i class="fa fa-envelope-o" title="Mail" role="img"/>

--- a/addons/mail/static/src/components/media_preview/media_preview.xml
+++ b/addons/mail/static/src/components/media_preview/media_preview.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <templates xml:space="preserve">
 
-    <t t-name="mail.MediaPreview" owl="1">
+    <t t-name="mail.MediaPreview" owl="2">
         <t t-if="mediaPreview">
             <div class="o_MediaPreview position-relative d-flex justify-content-center" t-attf-class="{{ className }}" t-ref="root">
                 <video class="o_MediaPreview_videoDisplay shadow rounded bg-dark" height="480" width="640" autoplay="" t-ref="video"/>

--- a/addons/mail/static/src/components/message/message.xml
+++ b/addons/mail/static/src/components/message/message.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <templates xml:space="preserve">
 
-    <t t-name="mail.Message" owl="1">
+    <t t-name="mail.Message" owl="2">
         <t t-if="messageView">
             <div class="o_Message position-relative pt-1"
                 t-att-class="{

--- a/addons/mail/static/src/components/message_action_list/message_action_list.xml
+++ b/addons/mail/static/src/components/message_action_list/message_action_list.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <templates>
-    <t t-name="mail.MessageActionList" owl="1">
+    <t t-name="mail.MessageActionList" owl="2">
         <t t-if="messageActionList">
             <div class="o_MessageActionList d-flex" t-attf-class="{{ className }}" t-on-click="messageActionList.onClick" t-ref="root">
                 <i t-if="messageActionList.message.hasReactionIcon" class="o_MessageActionList_action o_MessageActionList_actionReaction p-2 fa fa-lg fa-smile-o" t-att-title="ADD_A_REACTION" t-on-click="messageActionList.onClickActionReaction" t-ref="actionReaction"/>

--- a/addons/mail/static/src/components/message_author_prefix/message_author_prefix.xml
+++ b/addons/mail/static/src/components/message_author_prefix/message_author_prefix.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <templates xml:space="preserve">
 
-    <t t-name="mail.MessageAuthorPrefix" owl="1">
+    <t t-name="mail.MessageAuthorPrefix" owl="2">
         <t t-if="messageAuthorPrefixView">
             <span class="o_MessageAuthorPrefix" t-attf-class="{{ className }}" t-ref="root">
                 <t t-if="messageAuthorPrefixView.message">

--- a/addons/mail/static/src/components/message_in_reply_to_view/message_in_reply_to_view.xml
+++ b/addons/mail/static/src/components/message_in_reply_to_view/message_in_reply_to_view.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <templates xml:space="preserve">
-    <t t-name="mail.MessageInReplyToView" owl="1">
+    <t t-name="mail.MessageInReplyToView" owl="2">
         <t t-if="messageInReplyToView">
             <small class="o_MessageInReplyToView text-small pt-1 pr-2 position-relative" t-attf-class="{{ className }}" t-ref="root">
                 <t t-if="!messageInReplyToView.messageView.message.parentMessage.isEmpty">

--- a/addons/mail/static/src/components/message_list/message_list.xml
+++ b/addons/mail/static/src/components/message_list/message_list.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <templates xml:space="preserve">
 
-    <t t-name="mail.MessageList" owl="1">
+    <t t-name="mail.MessageList" owl="2">
         <t t-if="messageListView">
             <div class="o_MessageList" t-att-class="{ 'o-empty': messageListView.threadViewOwner.messages.length === 0 }" t-attf-class="{{ className }}" t-on-scroll="onScroll" t-ref="root">
                 <!-- No result messages -->
@@ -72,7 +72,7 @@
         </t>
     </t>
 
-    <t t-name="mail.MessageList.loadMore" owl="1">
+    <t t-name="mail.MessageList.loadMore" owl="2">
         <t t-if="messageListView.threadViewOwner.threadCache.isLoadingMore">
             <div class="o_MessageList_item o_MessageList_isLoadingMore">
                 <i class="o_MessageList_isLoadingMoreIcon fa fa-spin fa-circle-o-notch"/>

--- a/addons/mail/static/src/components/message_reaction_group/message_reaction_group.xml
+++ b/addons/mail/static/src/components/message_reaction_group/message_reaction_group.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <templates xml:space="preserve">
 
-    <t t-name="mail.MessageReactionGroup" owl="1">
+    <t t-name="mail.MessageReactionGroup" owl="2">
         <t t-if="messageReactionGroup">
             <div class="o_MessageReactionGroup d-flex" t-att-class="{'o-hasUserReacted': messageReactionGroup.hasUserReacted}" t-attf-class="{{ className }}" t-att-title="messageReactionGroup.summary" t-on-click="messageReactionGroup.onClick" t-ref="root">
                 <span class="o_MessageReactionGroup_content mx-1">

--- a/addons/mail/static/src/components/message_seen_indicator/message_seen_indicator.xml
+++ b/addons/mail/static/src/components/message_seen_indicator/message_seen_indicator.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <templates xml:space="preserve">
 
-    <t t-name="mail.MessageSeenIndicator" owl="1">
+    <t t-name="mail.MessageSeenIndicator" owl="2">
         <t t-if="messageSeenIndicator">
             <span class="o_MessageSeenIndicator" t-att-class="{ 'o-all-seen': messageSeenIndicator.hasEveryoneSeen }" t-attf-class="{{ className }}" t-att-title="messageSeenIndicator.text" t-ref="root">
                 <t t-if="!messageSeenIndicator.isMessagePreviousToLastCurrentPartnerMessageSeenByEveryone">

--- a/addons/mail/static/src/components/messaging_menu/messaging_menu.xml
+++ b/addons/mail/static/src/components/messaging_menu/messaging_menu.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <templates xml:space="preserve">
 
-    <t t-name="mail.MessagingMenu" owl="1">
+    <t t-name="mail.MessagingMenu" owl="2">
         <t t-if="messagingMenu">
             <div class="o_MessagingMenu dropdown" t-att-class="{ 'show': messagingMenu.isOpen, 'o-mobile': messaging.device.isMobile }" t-attf-class="{{ className }}" t-ref="root">
                 <a class="o_MessagingMenu_toggler dropdown-toggle o-no-caret o-dropdown--narrow" t-att-class="{ 'o-no-notification': !messagingMenu.counter }" href="#" title="Conversations" role="button" t-att-aria-expanded="messagingMenu.isOpen ? 'true' : 'false'" aria-haspopup="true" t-on-click="_onClickToggler">
@@ -64,7 +64,7 @@
                 </t>
             </div>
         </t>
-    </t>
+    </t>owl="2"
 
     <t t-name="mail.MessagingMenu.newMessageButton" owl="1">
         <button class="o_MessagingMenu_newMessageButton btn"

--- a/addons/mail/static/src/components/messaging_menu_container/messaging_menu_container.xml
+++ b/addons/mail/static/src/components/messaging_menu_container/messaging_menu_container.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <templates xml:space="preserve">
 
-    <t t-name="mail.MessagingMenuContainer" owl="1">
+    <t t-name="mail.MessagingMenuContainer" owl="2">
         <div class="MessagingMenuContainer">
             <t t-if="messaging and messaging.messagingMenu">
                 <MessagingMenu localId="messaging.messagingMenu.localId"/>

--- a/addons/mail/static/src/components/mobile_messaging_navbar/mobile_messaging_navbar.xml
+++ b/addons/mail/static/src/components/mobile_messaging_navbar/mobile_messaging_navbar.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <templates xml:space="preserve">
 
-    <t t-name="mail.MobileMessagingNavbar" owl="1">
+    <t t-name="mail.MobileMessagingNavbar" owl="2">
         <t t-if="mobileMessagingNavbarView">
             <div class="o_MobileMessagingNavbar" t-attf-class="{{ className }}" t-ref="root">
                 <t t-foreach="mobileMessagingNavbarView.tabs" t-as="tab" t-key="tab.id">

--- a/addons/mail/static/src/components/notification_alert/notification_alert.xml
+++ b/addons/mail/static/src/components/notification_alert/notification_alert.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <templates xml:space="preserve">
 
-    <t t-name="mail.NotificationAlert" owl="1">
+    <t t-name="mail.NotificationAlert" owl="2">
         <div class="o_NotificationAlert" t-attf-class="{{ className }}" t-ref="root">
             <t t-if="messaging">
                 <center t-if="messaging.isNotificationBlocked" class="o_notification_alert alert alert-primary">

--- a/addons/mail/static/src/components/notification_group/notification_group.xml
+++ b/addons/mail/static/src/components/notification_group/notification_group.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <templates xml:space="preserve">
 
-    <t t-name="mail.NotificationGroup" owl="1">
+    <t t-name="mail.NotificationGroup" owl="2">
         <t t-if="notificationGroupView">
             <div class="o_NotificationGroup" t-attf-class="{{ className }}" t-on-click="_onClick" t-ref="root">
                 <div class="o_NotificationGroup_sidebar">

--- a/addons/mail/static/src/components/notification_list/notification_list.xml
+++ b/addons/mail/static/src/components/notification_list/notification_list.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <templates xml:space="preserve">
 
-    <t t-name="mail.NotificationList" owl="1">
+    <t t-name="mail.NotificationList" owl="2">
         <t t-if="notificationListView">
             <div class="o_NotificationList" t-att-class="{ 'o-empty': notificationListView.notificationViews.length === 0 }" t-attf-class="{{ className }}" t-ref="root">
                 <t t-if="notificationListView.notificationViews.length === 0">

--- a/addons/mail/static/src/components/notification_popover/notification_popover.xml
+++ b/addons/mail/static/src/components/notification_popover/notification_popover.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <templates xml:space="preserve">
 
-    <t t-name="mail.NotificationPopover" owl="1">
+    <t t-name="mail.NotificationPopover" owl="2">
         <t t-if="messageView">
             <div class="o_NotificationPopover" t-attf-class="{{ className }}" t-ref="root">
                 <t t-if="messageView.message">

--- a/addons/mail/static/src/components/notification_request/notification_request.xml
+++ b/addons/mail/static/src/components/notification_request/notification_request.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <templates xml:space="preserve">
 
-    <t t-name="mail.NotificationRequest" owl="1">
+    <t t-name="mail.NotificationRequest" owl="2">
         <t t-if="notificationRequestView">
             <div class="o_NotificationRequest" t-attf-class="{{ className }}" t-on-click="_onClick" t-ref="root">
                 <div class="o_NotificationRequest_sidebar">

--- a/addons/mail/static/src/components/partner_im_status_icon/partner_im_status_icon.xml
+++ b/addons/mail/static/src/components/partner_im_status_icon/partner_im_status_icon.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <templates xml:space="preserve">
 
-    <t t-name="mail.PartnerImStatusIcon" owl="1">
+    <t t-name="mail.PartnerImStatusIcon" owl="2">
         <t t-if="partner">
             <span class="o_PartnerImStatusIcon fa-stack"
                 t-att-class="{

--- a/addons/mail/static/src/components/popover_view/popover_view.xml
+++ b/addons/mail/static/src/components/popover_view/popover_view.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <templates xml:space="preserve">
 
-    <t t-name="mail.PopoverView" owl="1">
+    <t t-name="mail.PopoverView" owl="2">
         <t t-if="popoverView">
             <div class="o_PopoverView" t-attf-class="{{ className }}" t-ref="root">
                 <t

--- a/addons/mail/static/src/components/rtc_activity_notice/rtc_activity_notice.xml
+++ b/addons/mail/static/src/components/rtc_activity_notice/rtc_activity_notice.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <templates xml:space="preserve">
 
-    <t t-name="mail.RtcActivityNotice" owl="1">
+    <t t-name="mail.RtcActivityNotice" owl="2">
         <div class="o_RtcActivityNotice dropdown" t-attf-class="{{ className }}" t-ref="root">
             <t t-if="messaging">
                 <RtcInvitations/>

--- a/addons/mail/static/src/components/rtc_activity_notice_container/rtc_activity_notice_container.xml
+++ b/addons/mail/static/src/components/rtc_activity_notice_container/rtc_activity_notice_container.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <templates xml:space="preserve">
 
-    <t t-name="mail.RtcActivityNoticeContainer" owl="1">
+    <t t-name="mail.RtcActivityNoticeContainer" owl="2">
         <div class="RtcActivityNoticeContainer">
             <t t-if="messaging">
                 <RtcActivityNotice/>

--- a/addons/mail/static/src/components/rtc_call_participant_card/rtc_call_participant_card.xml
+++ b/addons/mail/static/src/components/rtc_call_participant_card/rtc_call_participant_card.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <templates xml:space="preserve">
 
-    <t t-name="mail.RtcCallParticipantCard" owl="1">
+    <t t-name="mail.RtcCallParticipantCard" owl="2">
         <t t-if="callParticipantCard">
             <div class="o_RtcCallParticipantCard"
                 t-att-class="{

--- a/addons/mail/static/src/components/rtc_call_viewer/rtc_call_viewer.xml
+++ b/addons/mail/static/src/components/rtc_call_viewer/rtc_call_viewer.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <templates xml:space="preserve">
 
-<t t-name="mail.RtcCallViewer" owl="1">
+<t t-name="mail.RtcCallViewer" owl="2">
     <t t-if="rtcCallViewer">
         <div class="o_RtcCallViewer" t-att-class="{ 'o-fullScreen': rtcCallViewer.isFullScreen, 'o-isMinimized': rtcCallViewer.isMinimized }" t-attf-class="{{ className }}" t-ref="root">
             <!-- Used to make the component depend on the window size and trigger an update when the window size changes. -->

--- a/addons/mail/static/src/components/rtc_configuration_menu/rtc_configuration_menu.xml
+++ b/addons/mail/static/src/components/rtc_configuration_menu/rtc_configuration_menu.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <templates xml:space="preserve">
 
-    <t t-name="mail.RtcConfigurationMenu" owl="1">
+    <t t-name="mail.RtcConfigurationMenu" owl="2">
         <div class="o_RtcConfigurationMenu" t-attf-class="{{ className }}" t-ref="root">
             <div class="o_RtcConfigurationMenu_option">
                 <label class="o_RtcConfigurationMenu_optionLabel" title="Input device" aria-label="Input device">

--- a/addons/mail/static/src/components/rtc_controller/rtc_controller.xml
+++ b/addons/mail/static/src/components/rtc_controller/rtc_controller.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <templates xml:space="preserve">
 
-    <t t-name="mail.RtcController" owl="1">
+    <t t-name="mail.RtcController" owl="2">
         <t t-if="rtcController">
             <div class="o_RtcController" t-attf-class="{{ className }}" t-ref="root">
                 <div class="o_RtcController_buttons">

--- a/addons/mail/static/src/components/rtc_invitation_card/rtc_invitation_card.xml
+++ b/addons/mail/static/src/components/rtc_invitation_card/rtc_invitation_card.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <templates xml:space="preserve">
 
-    <t t-name="mail.RtcInvitationCard" owl="1">
+    <t t-name="mail.RtcInvitationCard" owl="2">
         <t t-if="thread">
             <div class="o_RtcInvitationCard" t-attf-class="{{ className }}" t-ref="root">
                 <t t-if="thread.rtcInvitingSession">

--- a/addons/mail/static/src/components/rtc_invitations/rtc_invitations.xml
+++ b/addons/mail/static/src/components/rtc_invitations/rtc_invitations.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <templates xml:space="preserve">
 
-    <t t-name="mail.RtcInvitations" owl="1">
+    <t t-name="mail.RtcInvitations" owl="2">
         <div class="o_RtcInvitations" t-attf-class="{{ className }}" t-ref="root">
             <t t-if="messaging.ringingThreads">
                 <t t-foreach="messaging.ringingThreads" t-as="thread" t-key="thread.localId">

--- a/addons/mail/static/src/components/rtc_layout_menu/rtc_layout_menu.xml
+++ b/addons/mail/static/src/components/rtc_layout_menu/rtc_layout_menu.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <templates xml:space="preserve">
 
-    <t t-name="mail.RtcLayoutMenu" owl="1">
+    <t t-name="mail.RtcLayoutMenu" owl="2">
         <t t-if="layoutMenu">
             <div class="o_RtcLayoutMenu" t-attf-class="{{ className }}" t-ref="root">
                 <t t-if="layoutMenu.callViewer.threadView.thread.videoCount > 0">
@@ -52,7 +52,7 @@
 
     <!-- TODO TEMPORARY ICONS -->
 
-    <t t-name="mail.RtcLayoutMenu_gridSvg" owl="1">
+    <t t-name="mail.RtcLayoutMenu_gridSvg" owl="2">
         <svg viewBox="0 0 300 300">
             <g transform="matrix(1.08 0 0 1.29 63.85 96.61)">
                 <rect style="fill: currentColor" x="-37.46" y="-19.415" rx="0" ry="0" width="74.92" height="38.83"/>
@@ -84,7 +84,7 @@
         </svg>
     </t>
 
-    <t t-name="mail.RtcLayoutMenu_spotlightSvg" owl="1">
+    <t t-name="mail.RtcLayoutMenu_spotlightSvg" owl="2">
         <svg viewBox="0 0 300 300">
             <g transform="matrix(3.38 0 0 4.04 150 150)">
                 <rect style="fill: currentColor" x="-38" y="-20" rx="0" ry="0" width="75" height="39"/>
@@ -92,7 +92,7 @@
         </svg>
     </t>
 
-    <t t-name="mail.RtcLayoutMenu_sidebarSvg" owl="1">
+    <t t-name="mail.RtcLayoutMenu_sidebarSvg" owl="2">
         <svg viewBox="0 0 300 300">
             <g transform="matrix(2.66 0 0 4.04 122.89 150.02)">
                 <rect style="fill: currentColor" x="-37.46" y="-19.415" rx="0" ry="0" width="74.92" height="38.83"/>

--- a/addons/mail/static/src/components/rtc_option_list/rtc_option_list.xml
+++ b/addons/mail/static/src/components/rtc_option_list/rtc_option_list.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <templates xml:space="preserve">
 
-    <t t-name="mail.RtcOptionList" owl="1">
+    <t t-name="mail.RtcOptionList" owl="2">
         <t t-if="rtcOptionList">
             <div class="o_RtcOptionList" t-attf-class="{{ className }}" t-ref="root">
                 <button class="o_RtcOptionList_button" t-on-click="rtcOptionList.onClickLayout">

--- a/addons/mail/static/src/components/rtc_video/rtc_video.xml
+++ b/addons/mail/static/src/components/rtc_video/rtc_video.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <templates xml:space="preserve">
 
-    <t t-name="mail.RtcVideo" owl="1">
+    <t t-name="mail.RtcVideo" owl="2">
         <t t-if="rtcSession">
             <video class="o_RtcVideo"
                 t-attf-class="{{ className }}"

--- a/addons/mail/static/src/components/thread_icon/thread_icon.xml
+++ b/addons/mail/static/src/components/thread_icon/thread_icon.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <templates xml:space="preserve">
 
-    <t t-name="mail.ThreadIcon" owl="1">
+    <t t-name="mail.ThreadIcon" owl="2">
         <t t-if="thread">
             <div class="o_ThreadIcon" t-attf-class="{{ className }}" t-ref="root" name="root">
                 <t t-if="thread.channel_type === 'channel'">

--- a/addons/mail/static/src/components/thread_needaction_preview/thread_needaction_preview.xml
+++ b/addons/mail/static/src/components/thread_needaction_preview/thread_needaction_preview.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <templates xml:space="preserve">
 
-    <t t-name="mail.ThreadNeedactionPreview" owl="1">
+    <t t-name="mail.ThreadNeedactionPreview" owl="2">
         <t t-if="threadNeedactionPreviewView">
             <!--
                 The preview template is used by the discuss in mobile, and by the systray

--- a/addons/mail/static/src/components/thread_preview/thread_preview.xml
+++ b/addons/mail/static/src/components/thread_preview/thread_preview.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <templates xml:space="preserve">
 
-    <t t-name="mail.ThreadPreview" owl="1">
+    <t t-name="mail.ThreadPreview" owl="2">
         <t t-if="threadPreviewView">
             <!--
                 The preview template is used by the discuss in mobile, and by the systray

--- a/addons/mail/static/src/components/thread_textual_typing_status/thread_textual_typing_status.xml
+++ b/addons/mail/static/src/components/thread_textual_typing_status/thread_textual_typing_status.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <templates xml:space="preserve">
 
-    <t t-name="mail.ThreadTextualTypingStatus" owl="1">
+    <t t-name="mail.ThreadTextualTypingStatus" owl="2">
         <t t-if="thread">
             <div class="o_ThreadTextualTypingStatus" t-attf-class="{{ className }}" t-ref="root">
                 <t t-if="thread.orderedOtherTypingMembers.length > 0">

--- a/addons/mail/static/src/components/thread_typing_icon/thread_typing_icon.xml
+++ b/addons/mail/static/src/components/thread_typing_icon/thread_typing_icon.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <templates xml:space="preserve">
 
-    <t t-name="mail.ThreadTypingIcon" owl="1">
+    <t t-name="mail.ThreadTypingIcon" owl="2">
         <div class="o_ThreadTypingIcon" t-attf-class="{{ className }}" t-att-title="props.title" t-ref="root">
             <span class="o_ThreadTypingIcon_dot o_ThreadTypingIcon_dot1" t-att-class="{
                 'o-animationBounce': props.animation === 'bounce',

--- a/addons/mail/static/src/components/thread_view/thread_view.xml
+++ b/addons/mail/static/src/components/thread_view/thread_view.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <templates xml:space="preserve">
 
-    <t t-name="mail.ThreadView" owl="1">
+    <t t-name="mail.ThreadView" owl="2">
         <t t-if="threadView">
             <div class="o_ThreadView" t-att-class="threadView.extraClass" t-attf-class="{{ className }}" t-att-data-correspondent-id="threadView.thread and threadView.thread.correspondent and threadView.thread.correspondent.id" t-att-data-thread-local-id="threadView.thread and threadView.thread.localId" t-on-focusin="props.onFocusin" t-ref="root">
                 <t t-if="threadView.topbar">

--- a/addons/mail/static/src/components/thread_view_topbar/thread_view_topbar.xml
+++ b/addons/mail/static/src/components/thread_view_topbar/thread_view_topbar.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <templates xml:space="preserve">
 
-    <t t-name="mail.ThreadViewTopbar" owl="1">
+    <t t-name="mail.ThreadViewTopbar" owl="2">
         <t t-if="threadViewTopbar">
             <div class="o_ThreadViewTopbar d-flex flex-shrink-0 w-100 px-3" t-attf-class="{{ className }}" t-ref="root">
                 <t t-if="threadViewTopbar.thread">

--- a/addons/mail/static/src/components/welcome_view/welcome_view.xml
+++ b/addons/mail/static/src/components/welcome_view/welcome_view.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <templates xml:space="preserve">
 
-    <t t-name="mail.WelcomeView" owl="1">
+    <t t-name="mail.WelcomeView" owl="2">
         <t t-if="welcomeView">
             <div class="o_WelcomeView h-100 d-flex flex-column justify-content-center align-items-center bg-light" t-attf-class="{{ className }}" t-ref="root">
                 <h1 class="font-weight-light">

--- a/addons/mail/static/src/xml/activity_view.xml
+++ b/addons/mail/static/src/xml/activity_view.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <templates xml:space="preserve">
 
-<t t-name="mail.ActivityViewHeader" owl="1">
+<t t-name="mail.ActivityViewHeader" owl="2">
     <thead>
         <tr>
             <th></th>
@@ -35,7 +35,7 @@
     </thead>
 </t>
 
-<t t-name="mail.ActivityViewBody" owl="1">
+<t t-name="mail.ActivityViewBody" owl="2">
     <tbody>
         <t t-foreach="activityResIds" t-as="resId" t-key="resId">
             <t t-call="mail.ActivityViewRow"/>
@@ -43,7 +43,7 @@
     </tbody>
 </t>
 
-<t t-name="mail.ActivityViewRow" owl="1">
+<t t-name="mail.ActivityViewRow" owl="2">
     <tr class="o_data_row" t-att-data-res-id="resId">
         <t t-set="record" t-value="props.data.find(data => data.res_id === resId)"/>
         <td t-attf-class="{{ activeFilter.resIds.includes(resId) ? 'o_activity_filter_' + activeFilter.state.value : '' }}">
@@ -56,7 +56,7 @@
     </tr>
 </t>
 
-<t t-name="mail.ActivityViewCell" owl="1">
+<t t-name="mail.ActivityViewCell" owl="2">
     <t t-set="activityGroup" t-value="props.grouped_activities[resId] and props.grouped_activities[resId][type[0]] or {count: 0, ids: [], state: false}"/>
     <t t-set="isCellHidden" t-value="activeFilter.resIds.length and !activeFilter.resIds.includes(resId) and activeFilter.activityTypeId === type[0]"/>
     <td t-if="activityGroup.state and !isCellHidden" t-att-data-res-id="resId" t-att-data-activity-type-id="type[0]"
@@ -72,7 +72,7 @@
     </td>
 </t>
 
-<t t-name="mail.ActivityViewFooter" owl="1">
+<t t-name="mail.ActivityViewFooter" owl="2">
     <tfoot>
         <tr class="o_data_row">
             <td class="o_record_selector p-3" t-on-click.prevent.stop="() => this.trigger('schedule_activity')">
@@ -82,7 +82,7 @@
     </tfoot>
 </t>
 
-<div t-name="mail.ActivityRenderer" class="o_activity_view" owl="1">
+<div t-name="mail.ActivityRenderer" class="o_activity_view" owl="2">
     <t t-if="!props.activity_types.length" t-call="web.NoContentHelper"/>
     <table t-else="" class="table-bordered mb-5">
         <t t-call="mail.ActivityViewHeader"/>

--- a/addons/point_of_sale/static/src/xml/Chrome.xml
+++ b/addons/point_of_sale/static/src/xml/Chrome.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <templates id="template" xml:space="preserve">
 
-    <t t-name="Chrome" owl="1">
+    <t t-name="Chrome" owl="2">
         <div class="pos" t-att-class="{ 'big-scrollbars': state.hasBigScrollBars }">
             <div class="pos-receipt-print"></div>
             <div class="pos-topheader" t-att-class="{ oe_hidden: state.uiState !== 'READY' }">

--- a/addons/point_of_sale/static/src/xml/ChromeWidgets/CashMoveButton.xml
+++ b/addons/point_of_sale/static/src/xml/ChromeWidgets/CashMoveButton.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <templates id="template" xml:space="preserve">
 
-    <t t-name="point_of_sale.CashMoveButton" owl="1">
+    <t t-name="point_of_sale.CashMoveButton" owl="2">
         <div class="cash-move-button" t-on-click="onClick">
             <i class="fa fa-money" aria-hidden="true"></i>
             <span style="padding-left: 10px;">Cash In/Out</span>

--- a/addons/point_of_sale/static/src/xml/ChromeWidgets/CashierName.xml
+++ b/addons/point_of_sale/static/src/xml/ChromeWidgets/CashierName.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <templates id="template" xml:space="preserve">
 
-    <t t-name="CashierName" owl="1">
+    <t t-name="CashierName" owl="2">
         <div class="oe_status">
             <span><img t-att-src="avatar" t-att-alt="username" class="avatar"/> <span t-if="!env.isMobile" t-esc="username" class="username"/></span>
         </div>

--- a/addons/point_of_sale/static/src/xml/ChromeWidgets/DebugWidget.xml
+++ b/addons/point_of_sale/static/src/xml/ChromeWidgets/DebugWidget.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <templates id="template" xml:space="preserve">
 
-    <t t-name="DebugWidget" owl="1">
+    <t t-name="DebugWidget" owl="2">
         <Draggable limitArea="'.pos'">
             <div class="debug-widget" t-att-class="props.className">
                 <header class="drag-handle">

--- a/addons/point_of_sale/static/src/xml/ChromeWidgets/HeaderButton.xml
+++ b/addons/point_of_sale/static/src/xml/ChromeWidgets/HeaderButton.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <templates id="template" xml:space="preserve">
 
-    <t t-name="HeaderButton" owl="1">
+    <t t-name="HeaderButton" owl="2">
         <div class="header-button" t-on-click="onClick">
             <span><i class="fa fa-sign-out" role="img"/> <t t-if="!env.isMobile">Close</t></span>
         </div>

--- a/addons/point_of_sale/static/src/xml/ChromeWidgets/ProxyStatus.xml
+++ b/addons/point_of_sale/static/src/xml/ChromeWidgets/ProxyStatus.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <templates id="template" xml:space="preserve">
 
-    <t t-name="ProxyStatus" owl="1">
+    <t t-name="ProxyStatus" owl="2">
         <div class="oe_status js_proxy" t-on-click="() => this.trigger('connect-to-proxy')">
             <span t-if="state.msg and !env.isMobile" class="js_msg">
                 <t t-esc="state.msg" />

--- a/addons/point_of_sale/static/src/xml/ChromeWidgets/SaleDetailsButton.xml
+++ b/addons/point_of_sale/static/src/xml/ChromeWidgets/SaleDetailsButton.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <templates id="template" xml:space="preserve">
 
-    <t t-name="SaleDetailsButton" owl="1">
+    <t t-name="SaleDetailsButton" owl="2">
         <div class="oe_status">
             <div class="js_connected oe_icon">
                 <i class="fa fa-fw fa-print" role="img" aria-label="Print" t-on-click="onClick"

--- a/addons/point_of_sale/static/src/xml/ChromeWidgets/SyncNotification.xml
+++ b/addons/point_of_sale/static/src/xml/ChromeWidgets/SyncNotification.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <templates id="template" xml:space="preserve">
 
-    <t t-name="SyncNotification" owl="1">
+    <t t-name="SyncNotification" owl="2">
         <div class="oe_status" t-on-click="onClick">
             <span t-if="env.pos.synch.pending" class="js_msg">
                 <t t-esc="env.pos.synch.pending" />

--- a/addons/point_of_sale/static/src/xml/ChromeWidgets/TicketButton.xml
+++ b/addons/point_of_sale/static/src/xml/ChromeWidgets/TicketButton.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <templates id="template" xml:space="preserve">
 
-    <t t-name="TicketButton" owl="1">
+    <t t-name="TicketButton" owl="2">
         <div class="ticket-button" t-att-class="{ highlight: props.isTicketScreenShown }" t-on-click="onClick">
             <div class="with-badge" t-att-badge="count">
                 <i class="fa fa-ticket" aria-hidden="true"></i>

--- a/addons/point_of_sale/static/src/xml/Misc/CurrencyAmount.xml
+++ b/addons/point_of_sale/static/src/xml/Misc/CurrencyAmount.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <templates id="template" xml:space="preserve">
-    <t t-name="CurrencyAmount" owl="1">
+    <t t-name="CurrencyAmount" owl="2">
         <label t-att-for="props.forTarget" t-att-class="{'oe_link_icon': props.forTarget}">
             <t t-if="props.currency.position === 'before'"><t t-esc="props.currency.symbol"/><![CDATA[ ]]></t>
             <t t-esc="props.amount"/>

--- a/addons/point_of_sale/static/src/xml/Misc/Draggable.xml
+++ b/addons/point_of_sale/static/src/xml/Misc/Draggable.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <templates id="template" xml:space="preserve">
 
-    <t t-name="Draggable" owl="1">
+    <t t-name="Draggable" owl="2">
         <t t-slot="default"></t>
     </t>
 

--- a/addons/point_of_sale/static/src/xml/Misc/MobileOrderWidget.xml
+++ b/addons/point_of_sale/static/src/xml/Misc/MobileOrderWidget.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <templates id="template" xml:space="preserve">
 
-    <t t-name="MobileOrderWidget" owl="1">
+    <t t-name="MobileOrderWidget" owl="2">
         <div class="switchpane">
             <button class="btn-switchpane" t-on-click="() => this.trigger('click-pay')">
                 <h1>Pay</h1>

--- a/addons/point_of_sale/static/src/xml/Misc/NotificationSound.xml
+++ b/addons/point_of_sale/static/src/xml/Misc/NotificationSound.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <templates id="template" xml:space="preserve">
 
-    <t t-name="NotificationSound" owl="1">
+    <t t-name="NotificationSound" owl="2">
         <audio t-att-src="props.sound.src" autoplay="true"></audio>
     </t>
 

--- a/addons/point_of_sale/static/src/xml/Misc/SearchBar.xml
+++ b/addons/point_of_sale/static/src/xml/Misc/SearchBar.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <templates id="template" xml:space="preserve">
 
-    <t t-name="point_of_sale.SearchBar" owl="1">
+    <t t-name="point_of_sale.SearchBar" owl="2">
         <div class="pos-search-bar">
             <div class="search">
                 <span class="search-icon" t-if="!env.isMobile"><i class="fa fa-search"></i></span>

--- a/addons/point_of_sale/static/src/xml/Notification.xml
+++ b/addons/point_of_sale/static/src/xml/Notification.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <templates id="template" xml:space="preserve">
 
-    <t t-name="Notification" owl="1">
+    <t t-name="Notification" owl="2">
         <div class="notification" t-att-class="props.className">
             <span>
                 <t t-esc="props.message" />

--- a/addons/point_of_sale/static/src/xml/Popups/CashMovePopup.xml
+++ b/addons/point_of_sale/static/src/xml/Popups/CashMovePopup.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <templates id="template" xml:space="preserve">
 
-    <t t-name="point_of_sale.CashMovePopup" owl="1">
+    <t t-name="point_of_sale.CashMovePopup" owl="2">
         <div role="dialog" class="modal-dialog">
             <Draggable>
                 <div class="popup drag-handle">

--- a/addons/point_of_sale/static/src/xml/Popups/CashMoveReceipt.xml
+++ b/addons/point_of_sale/static/src/xml/Popups/CashMoveReceipt.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <templates id="template" xml:space="preserve">
 
-    <t t-name="point_of_sale.CashMoveReceipt" owl="1">
+    <t t-name="point_of_sale.CashMoveReceipt" owl="2">
         <div class="pos-receipt">
             <t t-if="_receipt.company.logo">
                 <img class="pos-receipt-logo" t-att-src="_receipt.company.logo" alt="Logo" />

--- a/addons/point_of_sale/static/src/xml/Popups/CashOpeningPopup.xml
+++ b/addons/point_of_sale/static/src/xml/Popups/CashOpeningPopup.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <templates id="template" xml:space="preserve">
-    <t t-name="CashOpeningPopup" owl="1">
+    <t t-name="CashOpeningPopup" owl="2">
         <div role="dialog" class="modal-dialog">
             <div class="popup opening-cash-control">
                 <header class="title drag-handle">

--- a/addons/point_of_sale/static/src/xml/Popups/ClosePosPopup.xml
+++ b/addons/point_of_sale/static/src/xml/Popups/ClosePosPopup.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <templates id="template" xml:space="preserve">
 
-    <t t-name="ClosePosPopup" owl="1">
+    <t t-name="ClosePosPopup" owl="2">
         <div role="dialog" class="modal-dialog">
             <div class="popup close-pos-popup">
                 <header class="title">

--- a/addons/point_of_sale/static/src/xml/Popups/ConfirmPopup.xml
+++ b/addons/point_of_sale/static/src/xml/Popups/ConfirmPopup.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <templates id="template" xml:space="preserve">
 
-    <t t-name="ConfirmPopup" owl="1">
+    <t t-name="ConfirmPopup" owl="2">
         <div role="dialog" class="modal-dialog">
             <Draggable>
                 <div class="popup popup-confirm">

--- a/addons/point_of_sale/static/src/xml/Popups/ControlButtonPopup.xml
+++ b/addons/point_of_sale/static/src/xml/Popups/ControlButtonPopup.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <templates id="template" xml:space="preserve">
 
-    <t t-name="ControlButtonPopup" owl="1">
+    <t t-name="ControlButtonPopup" owl="2">
         <div role="dialog" class="modal-dialog">
             <Draggable>
                 <div class="popup popup-control-buttons">

--- a/addons/point_of_sale/static/src/xml/Popups/EditListInput.xml
+++ b/addons/point_of_sale/static/src/xml/Popups/EditListInput.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <templates id="template" xml:space="preserve">
 
-    <t t-name="EditListInput" owl="1">
+    <t t-name="EditListInput" owl="2">
         <div>
             <input type="text" t-model="props.item.text" class="popup-input list-line-input"
                    placeholder="Serial/Lot Number" t-on-keyup="onKeyup" />

--- a/addons/point_of_sale/static/src/xml/Popups/EditListPopup.xml
+++ b/addons/point_of_sale/static/src/xml/Popups/EditListPopup.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <templates id="template" xml:space="preserve">
 
-    <t t-name="EditListPopup" owl="1">
+    <t t-name="EditListPopup" owl="2">
         <div role="dialog" class="modal-dialog">
             <div class="popup popup-text">
                 <header class="title">

--- a/addons/point_of_sale/static/src/xml/Popups/ErrorBarcodePopup.xml
+++ b/addons/point_of_sale/static/src/xml/Popups/ErrorBarcodePopup.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <templates id="template" xml:space="preserve">
 
-    <t t-name="ErrorBarcodePopup" owl="1">
+    <t t-name="ErrorBarcodePopup" owl="2">
         <div role="dialog" class="modal-dialog">
             <Draggable>
                 <div class="popup popup-barcode">

--- a/addons/point_of_sale/static/src/xml/Popups/ErrorPopup.xml
+++ b/addons/point_of_sale/static/src/xml/Popups/ErrorPopup.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <templates id="template" xml:space="preserve">
 
-    <t t-name="ErrorPopup" owl="1">
+    <t t-name="ErrorPopup" owl="2">
         <div role="dialog" class="modal-dialog">
             <div class="popup popup-error">
                 <p class="title">

--- a/addons/point_of_sale/static/src/xml/Popups/ErrorTracebackPopup.xml
+++ b/addons/point_of_sale/static/src/xml/Popups/ErrorTracebackPopup.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <templates id="template" xml:space="preserve">
 
-    <t t-name="ErrorTracebackPopup" owl="1">
+    <t t-name="ErrorTracebackPopup" owl="2">
         <div role="dialog" class="modal-dialog">
             <div class="popup popup-error">
                 <header class="title">

--- a/addons/point_of_sale/static/src/xml/Popups/MoneyDetailsPopup.xml
+++ b/addons/point_of_sale/static/src/xml/Popups/MoneyDetailsPopup.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <templates id="template" xml:space="preserve">
-    <t t-name="MoneyDetailsPopup" owl="1">
+    <t t-name="MoneyDetailsPopup" owl="2">
         <div class="popup money-details">
             <main class="body">
                 <div class="money-details-title">

--- a/addons/point_of_sale/static/src/xml/Popups/NumberPopup.xml
+++ b/addons/point_of_sale/static/src/xml/Popups/NumberPopup.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <templates id="template" xml:space="preserve">
 
-    <t t-name="NumberPopup" owl="1">
+    <t t-name="NumberPopup" owl="2">
         <div role="dialog" class="modal-dialog">
             <Draggable>
                 <div class="popup popup-number" t-att-class="{ 'popup-password': props.isPassword }">

--- a/addons/point_of_sale/static/src/xml/Popups/OfflineErrorPopup.xml
+++ b/addons/point_of_sale/static/src/xml/Popups/OfflineErrorPopup.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <templates id="template" xml:space="preserve">
 
-    <t t-name="OfflineErrorPopup" owl="1">
+    <t t-name="OfflineErrorPopup" owl="2">
         <div role="dialog" class="modal-dialog">
             <Draggable>
                 <div class="popup popup-error">

--- a/addons/point_of_sale/static/src/xml/Popups/OrderImportPopup.xml
+++ b/addons/point_of_sale/static/src/xml/Popups/OrderImportPopup.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <templates id="template" xml:space="preserve">
 
-    <t t-name="OrderImportPopup" owl="1">
+    <t t-name="OrderImportPopup" owl="2">
         <div role="dialog" class="modal-dialog">
             <Draggable>
                 <div class="popup popup-import">

--- a/addons/point_of_sale/static/src/xml/Popups/ProductConfiguratorPopup.xml
+++ b/addons/point_of_sale/static/src/xml/Popups/ProductConfiguratorPopup.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <templates id="template" xml:space="preserve">
 
-    <t t-name="ProductConfiguratorPopup" owl="1">
+    <t t-name="ProductConfiguratorPopup" owl="2">
         <div role="dialog" class="modal-dialog">
             <div class="popup popup-text popup-med product-configurator-popup">
                 <header class="title">
@@ -29,7 +29,7 @@
         </div>
     </t>
 
-    <t t-name="RadioProductAttribute" owl="1">
+    <t t-name="RadioProductAttribute" owl="2">
         <div class="configurator_radio">
             <div class="table">
                 <t t-foreach="values" t-as="value" t-key="value.id">
@@ -57,7 +57,7 @@
         </div>
     </t>
 
-    <t t-name="SelectProductAttribute" owl="1">
+    <t t-name="SelectProductAttribute" owl="2">
         <div>
             <t t-set="is_custom" t-value="false"/>
 
@@ -75,7 +75,7 @@
         </div>
     </t>
 
-    <t t-name="ColorProductAttribute" owl="1">
+    <t t-name="ColorProductAttribute" owl="2">
         <div>
             <t t-set="is_custom" t-value="false"/>
 

--- a/addons/point_of_sale/static/src/xml/Popups/ProductInfoPopup.xml
+++ b/addons/point_of_sale/static/src/xml/Popups/ProductInfoPopup.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <templates id="template" xml:space="preserve">
-    <t t-name="ProductInfoPopup" owl="1">
+    <t t-name="ProductInfoPopup" owl="2">
         <div role="dialog" class="modal-dialog">
             <div class="popup product-info-popup">
                 <header class="title">

--- a/addons/point_of_sale/static/src/xml/Popups/SelectionPopup.xml
+++ b/addons/point_of_sale/static/src/xml/Popups/SelectionPopup.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <templates id="template" xml:space="preserve">
 
-    <t t-name="SelectionPopup" owl="1">
+    <t t-name="SelectionPopup" owl="2">
         <div role="dialog" class="modal-dialog">
             <Draggable>
                 <div class="popup popup-selection">

--- a/addons/point_of_sale/static/src/xml/Popups/TextAreaPopup.xml
+++ b/addons/point_of_sale/static/src/xml/Popups/TextAreaPopup.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <templates id="template" xml:space="preserve">
 
-    <t t-name="TextAreaPopup" owl="1">
+    <t t-name="TextAreaPopup" owl="2">
         <div role="dialog" class="modal-dialog">
             <Draggable>
                 <div class="popup popup-textarea">

--- a/addons/point_of_sale/static/src/xml/Popups/TextInputPopup.xml
+++ b/addons/point_of_sale/static/src/xml/Popups/TextInputPopup.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <templates id="template" xml:space="preserve">
 
-    <t t-name="TextInputPopup" owl="1">
+    <t t-name="TextInputPopup" owl="2">
         <div role="dialog" class="modal-dialog">
             <div class="popup popup-textinput">
                 <header class="title">

--- a/addons/point_of_sale/static/src/xml/SaleDetailsReport.xml
+++ b/addons/point_of_sale/static/src/xml/SaleDetailsReport.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <templates id="template" xml:space="preserve">
 
-    <t t-name="SaleDetailsReport" owl="1">
+    <t t-name="SaleDetailsReport" owl="2">
         <div class="pos-receipt">
             <t t-if="pos.company_logo_base64">
                 <img class="pos-receipt-logo" t-att-src="pos.company_logo_base64" alt="Logo"/>

--- a/addons/point_of_sale/static/src/xml/Screens/PaymentScreen/PSNumpadInputButton.xml
+++ b/addons/point_of_sale/static/src/xml/Screens/PaymentScreen/PSNumpadInputButton.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <templates id="template" xml:space="preserve">
 
-    <t t-name="PSNumpadInputButton" owl="1">
+    <t t-name="PSNumpadInputButton" owl="2">
         <button t-attf-class="{{ _class }}"
                 t-on-click="() => this.trigger('input-from-numpad', { key: props.value })">
             <t t-slot="default">

--- a/addons/point_of_sale/static/src/xml/Screens/PaymentScreen/PaymentScreen.xml
+++ b/addons/point_of_sale/static/src/xml/Screens/PaymentScreen/PaymentScreen.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <templates id="template" xml:space="preserve">
 
-    <t t-name="PaymentScreen" owl="1">
+    <t t-name="PaymentScreen" owl="2">
         <div class="payment-screen screen" t-att-class="{ oe_hidden: !props.isShown }">
             <div class="screen-content">
                 <t t-if="!env.isMobile">

--- a/addons/point_of_sale/static/src/xml/Screens/PaymentScreen/PaymentScreenNumpad.xml
+++ b/addons/point_of_sale/static/src/xml/Screens/PaymentScreen/PaymentScreenNumpad.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <templates id="template" xml:space="preserve">
 
-    <t t-name="PaymentScreenNumpad" owl="1">
+    <t t-name="PaymentScreenNumpad" owl="2">
         <div class="numpad">
             <PSNumpadInputButton value="'1'" />
             <PSNumpadInputButton value="'2'" />

--- a/addons/point_of_sale/static/src/xml/Screens/PaymentScreen/PaymentScreenPaymentLines.xml
+++ b/addons/point_of_sale/static/src/xml/Screens/PaymentScreen/PaymentScreenPaymentLines.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <templates id="template" xml:space="preserve">
 
-    <t t-name="PaymentScreenPaymentLines" owl="1">
+    <t t-name="PaymentScreenPaymentLines" owl="2">
             <div class="paymentlines">
                 <t t-foreach="props.paymentLines" t-as="line" t-key="line.cid">
                     <t t-if="line.selected">

--- a/addons/point_of_sale/static/src/xml/Screens/PaymentScreen/PaymentScreenStatus.xml
+++ b/addons/point_of_sale/static/src/xml/Screens/PaymentScreen/PaymentScreenStatus.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <templates id="template" xml:space="preserve">
 
-<t t-name="PaymentScreenStatus" owl="1">
+<t t-name="PaymentScreenStatus" owl="2">
     <div t-if="props.order.get_paymentlines().length === 0" class="paymentlines-empty">
         <div class="total">
             <t t-esc="totalDueText" />

--- a/addons/point_of_sale/static/src/xml/Screens/ProductScreen/ActionpadWidget.xml
+++ b/addons/point_of_sale/static/src/xml/Screens/ProductScreen/ActionpadWidget.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <templates id="template" xml:space="preserve">
 
-    <t t-name="ActionpadWidget" owl="1">
+    <t t-name="ActionpadWidget" owl="2">
         <div class="actionpad">
             <button class="button set-partner" t-att-class="{'decentered': isLongName}"
                     t-on-click="() => this.trigger('click-partner')">

--- a/addons/point_of_sale/static/src/xml/Screens/ProductScreen/CategoryButton.xml
+++ b/addons/point_of_sale/static/src/xml/Screens/ProductScreen/CategoryButton.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <templates id="template" xml:space="preserve">
 
-    <t t-name="CategoryButton" owl="1">
+    <t t-name="CategoryButton" owl="2">
         <span class="category-button" t-on-click="() => this.trigger('switch-category', props.category.id)">
             <div class="category-img">
                 <img t-att-src="imageUrl" alt="Category" />

--- a/addons/point_of_sale/static/src/xml/Screens/ProductScreen/ControlButtons/OrderlineCustomerNoteButton.xml
+++ b/addons/point_of_sale/static/src/xml/Screens/ProductScreen/ControlButtons/OrderlineCustomerNoteButton.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <templates id="template" xml:space="preserve">
 
-    <t t-name="OrderlineCustomerNoteButton" owl="1">
+    <t t-name="OrderlineCustomerNoteButton" owl="2">
         <div class="control-button">
             <i class="fa fa-sticky-note" />
             <span> </span>

--- a/addons/point_of_sale/static/src/xml/Screens/ProductScreen/ControlButtons/ProductInfoButton.xml
+++ b/addons/point_of_sale/static/src/xml/Screens/ProductScreen/ControlButtons/ProductInfoButton.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <templates id="template" xml:space="preserve">
 
-    <t t-name="ProductInfoButton" owl="1">
+    <t t-name="ProductInfoButton" owl="2">
         <div class="control-button">
             <i class="fa fa-info-circle" role="img" aria-label="Info" title="Info"/>
             Info

--- a/addons/point_of_sale/static/src/xml/Screens/ProductScreen/ControlButtons/RefundButton.xml
+++ b/addons/point_of_sale/static/src/xml/Screens/ProductScreen/ControlButtons/RefundButton.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <templates id="template" xml:space="preserve">
 
-    <t t-name="point_of_sale.RefundButton" owl="1">
+    <t t-name="point_of_sale.RefundButton" owl="2">
         <div class="control-button">
             <i class="fa fa-undo" role="img" aria-label="Refund" title="Refund" />
             Refund

--- a/addons/point_of_sale/static/src/xml/Screens/ProductScreen/ControlButtons/SetFiscalPositionButton.xml
+++ b/addons/point_of_sale/static/src/xml/Screens/ProductScreen/ControlButtons/SetFiscalPositionButton.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <templates id="template" xml:space="preserve">
 
-    <t t-name="SetFiscalPositionButton" owl="1">
+    <t t-name="SetFiscalPositionButton" owl="2">
         <div class="control-button o_fiscal_position_button">
             <i class="fa fa-book" role="img" aria-label="Set fiscal position"
                title="Set fiscal position" />

--- a/addons/point_of_sale/static/src/xml/Screens/ProductScreen/ControlButtons/SetPricelistButton.xml
+++ b/addons/point_of_sale/static/src/xml/Screens/ProductScreen/ControlButtons/SetPricelistButton.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <templates id="template" xml:space="preserve">
 
-    <t t-name="SetPricelistButton" owl="1">
+    <t t-name="SetPricelistButton" owl="2">
         <div class="control-button o_pricelist_button">
             <i class="fa fa-th-list" role="img" aria-label="Price list" title="Price list" />
             <t t-esc="currentPricelistName" />

--- a/addons/point_of_sale/static/src/xml/Screens/ProductScreen/NumpadWidget.xml
+++ b/addons/point_of_sale/static/src/xml/Screens/ProductScreen/NumpadWidget.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <templates id="template" xml:space="preserve">
 
-    <t t-name="NumpadWidget" owl="1">
+    <t t-name="NumpadWidget" owl="2">
         <div class="numpad">
             <button class="input-button number-char" t-on-click="() => this.sendInput('1')">1</button>
             <button class="input-button number-char" t-on-click="() => this.sendInput('2')">2</button>

--- a/addons/point_of_sale/static/src/xml/Screens/ProductScreen/OrderSummary.xml
+++ b/addons/point_of_sale/static/src/xml/Screens/ProductScreen/OrderSummary.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <templates id="template" xml:space="preserve">
 
-    <t t-name="OrderSummary" owl="1">
+    <t t-name="OrderSummary" owl="2">
         <div class="summary clearfix">
             <t t-set="_total" t-value="getTotal()" />
             <t t-set="_tax" t-value="getTax()" />

--- a/addons/point_of_sale/static/src/xml/Screens/ProductScreen/OrderWidget.xml
+++ b/addons/point_of_sale/static/src/xml/Screens/ProductScreen/OrderWidget.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <templates id="template" xml:space="preserve">
 
-    <t t-name="OrderWidget" owl="1">
+    <t t-name="OrderWidget" owl="2">
         <div class="order-container" t-ref="scrollable">
             <div class="order">
                 <t t-if="orderlinesArray.length === 0" >

--- a/addons/point_of_sale/static/src/xml/Screens/ProductScreen/Orderline.xml
+++ b/addons/point_of_sale/static/src/xml/Screens/ProductScreen/Orderline.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <templates id="template" xml:space="preserve">
 
-    <t t-name="Orderline" owl="1">
+    <t t-name="Orderline" owl="2">
         <li t-on-click="selectLine" class="orderline" t-att-class="addedClasses">
             <span class="product-name">
                 <t t-esc="props.line.get_full_product_name()"/>

--- a/addons/point_of_sale/static/src/xml/Screens/ProductScreen/ProductItem.xml
+++ b/addons/point_of_sale/static/src/xml/Screens/ProductScreen/ProductItem.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <templates id="template" xml:space="preserve">
 
-    <t t-name="ProductItem" owl="1">
+    <t t-name="ProductItem" owl="2">
         <article class="product" tabindex="0" t-on-keypress="spaceClickProduct"
                  t-on-click="() => this.trigger('click-product', props.product)"
                  t-att-data-product-id="props.product.id"

--- a/addons/point_of_sale/static/src/xml/Screens/ProductScreen/ProductScreen.xml
+++ b/addons/point_of_sale/static/src/xml/Screens/ProductScreen/ProductScreen.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <templates id="template" xml:space="preserve">
 
-    <t t-name="ProductScreen" owl="1">
+    <t t-name="ProductScreen" owl="2">
         <div class="product-screen screen" t-att-class="{ oe_hidden: !props.isShown }">
             <div class="screen-full-width">
                 <div class="leftpane pane-border" t-if="!env.isMobile || state.mobile_pane === 'left'">

--- a/addons/point_of_sale/static/src/xml/Screens/ProductScreen/ProductsWidget.xml
+++ b/addons/point_of_sale/static/src/xml/Screens/ProductScreen/ProductsWidget.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <templates id="template" xml:space="preserve">
 
-    <t t-name="ProductsWidget" owl="1">
+    <t t-name="ProductsWidget" owl="2">
       <div class="products-widget">
             <ProductsWidgetControlPanel mobileSearchBarIsShown="props.mobileSearchBarIsShown" breadcrumbs="breadcrumbs" subcategories="subcategories" hasNoCategories="hasNoCategories" />
             <div class="product-list-container">

--- a/addons/point_of_sale/static/src/xml/Screens/ProductScreen/ProductsWidgetControlPanel.xml
+++ b/addons/point_of_sale/static/src/xml/Screens/ProductScreen/ProductsWidgetControlPanel.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <templates id="template" xml:space="preserve">
 
-    <t t-name="ProductsWidgetControlPanel" owl="1">
+    <t t-name="ProductsWidgetControlPanel" owl="2">
         <div class="products-widget-control">
             <t t-if="!props.hasNoCategories">
                 <div class="rightpane-header" t-att-class="{

--- a/addons/point_of_sale/static/src/xml/Screens/ReceiptScreen/OrderReceipt.xml
+++ b/addons/point_of_sale/static/src/xml/Screens/ReceiptScreen/OrderReceipt.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <templates id="template" xml:space="preserve">
 
-    <t t-name="OrderReceipt" owl="1">
+    <t t-name="OrderReceipt" owl="2">
         <div class="pos-receipt">
             <t t-if="receipt.company.logo">
                 <img class="pos-receipt-logo" t-att-src="receipt.company.logo" alt="Logo"/>
@@ -157,7 +157,7 @@
             </div>
         </div>
     </t>
-    <t t-name="OrderLinesReceipt" owl="1">
+    <t t-name="OrderLinesReceipt" owl="2">
         <t t-foreach="receipt.orderlines" t-as="line" t-key="line.id">
             <t t-if="isSimple(line)">
                 <div class="responsive-price">

--- a/addons/point_of_sale/static/src/xml/Screens/ReceiptScreen/ReceiptScreen.xml
+++ b/addons/point_of_sale/static/src/xml/Screens/ReceiptScreen/ReceiptScreen.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <templates id="template" xml:space="preserve">
 
-    <t t-name="ReceiptScreen" owl="1">
+    <t t-name="ReceiptScreen" owl="2">
         <div class="receipt-screen screen">
             <div class="screen-content">
                 <div class="top-content">

--- a/addons/point_of_sale/static/src/xml/Screens/ReceiptScreen/WrappedProductNameLines.xml
+++ b/addons/point_of_sale/static/src/xml/Screens/ReceiptScreen/WrappedProductNameLines.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <templates id="template" xml:space="preserve">
 
-    <t t-name="WrappedProductNameLines" owl="1">
+    <t t-name="WrappedProductNameLines" owl="2">
         <span>
             <t t-foreach="props.line.product_name_wrapped.slice(1)" t-as="wrapped_line" t-key="wrapped_line_index">
                 <t t-esc="wrapped_line"/>

--- a/addons/point_of_sale/static/src/xml/Screens/ScaleScreen/ScaleScreen.xml
+++ b/addons/point_of_sale/static/src/xml/Screens/ScaleScreen/ScaleScreen.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <templates id="template" xml:space="preserve">
 
-    <t t-name="ScaleScreen" owl="1">
+    <t t-name="ScaleScreen" owl="2">
         <div class="scale-screen screen">
             <div class="screen-content">
                 <div class="top-content">

--- a/addons/point_of_sale/static/src/xml/Screens/TicketScreen/ControlButtons/InvoiceButton.xml
+++ b/addons/point_of_sale/static/src/xml/Screens/TicketScreen/ControlButtons/InvoiceButton.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <templates id="template" xml:space="preserve">
 
-    <t t-name="InvoiceButton" owl="1">
+    <t t-name="InvoiceButton" owl="2">
         <div class="control-button">
             <i class="fa fa-file-pdf-o"></i>
             <span> </span>

--- a/addons/point_of_sale/static/src/xml/Screens/TicketScreen/ControlButtons/ReprintReceiptButton.xml
+++ b/addons/point_of_sale/static/src/xml/Screens/TicketScreen/ControlButtons/ReprintReceiptButton.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <templates id="template" xml:space="preserve">
 
-    <t t-name="ReprintReceiptButton" owl="1">
+    <t t-name="ReprintReceiptButton" owl="2">
         <div class="control-button">
             <i class="fa fa-print"></i>
             <span> </span>

--- a/addons/point_of_sale/static/src/xml/Screens/TicketScreen/OrderDetails.xml
+++ b/addons/point_of_sale/static/src/xml/Screens/TicketScreen/OrderDetails.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <templates id="template" xml:space="preserve">
 
-    <t t-name="OrderDetails" owl="1">
+    <t t-name="OrderDetails" owl="2">
         <div class="order-container">
             <div t-ref="scrollable" class="order-scroller touch-scrollable">
                 <div class="order">

--- a/addons/point_of_sale/static/src/xml/Screens/TicketScreen/OrderlineDetails.xml
+++ b/addons/point_of_sale/static/src/xml/Screens/TicketScreen/OrderlineDetails.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <templates id="template" xml:space="preserve">
 
-    <t t-name="OrderlineDetails" owl="1">
+    <t t-name="OrderlineDetails" owl="2">
         <li class="orderline" t-on-click="() => this.trigger('click-order-line', props.line)" t-att-class="{ selected: props.isSelected }">
             <span class="product-name">
                 <t t-esc="productName" />

--- a/addons/point_of_sale/static/src/xml/Screens/TicketScreen/ReprintReceiptScreen.xml
+++ b/addons/point_of_sale/static/src/xml/Screens/TicketScreen/ReprintReceiptScreen.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <templates id="template" xml:space="preserve">
 
-    <t t-name="ReprintReceiptScreen" owl="1">
+    <t t-name="ReprintReceiptScreen" owl="2">
         <div class="receipt-screen screen">
             <div class="screen-content">
                 <div class="top-content">

--- a/addons/point_of_sale/static/src/xml/Screens/TicketScreen/TicketScreen.xml
+++ b/addons/point_of_sale/static/src/xml/Screens/TicketScreen/TicketScreen.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <templates id="template" xml:space="preserve">
 
-    <t t-name="TicketScreen" owl="1">
+    <t t-name="TicketScreen" owl="2">
         <div class="ticket-screen screen" t-att-class="{ oe_hidden: !props.isShown }">
             <div class="screen-full-width">
                 <div class="rightpane pane-border">

--- a/addons/pos_coupon/static/src/xml/ControlButtons/PromoCodeButton.xml
+++ b/addons/pos_coupon/static/src/xml/ControlButtons/PromoCodeButton.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <templates id="template" xml:space="preserve">
 
-    <t t-name="PromoCodeButton" owl="1">
+    <t t-name="PromoCodeButton" owl="2">
         <span class="control-button">
             <i class="fa fa-barcode"></i>
             <span> </span>

--- a/addons/pos_coupon/static/src/xml/ControlButtons/ResetProgramsButton.xml
+++ b/addons/pos_coupon/static/src/xml/ControlButtons/ResetProgramsButton.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <templates id="template" xml:space="preserve">
 
-    <t t-name="ResetProgramsButton" owl="1">
+    <t t-name="ResetProgramsButton" owl="2">
         <span class="control-button">
             <i class="fa fa-star"></i>
             <span> </span>

--- a/addons/pos_coupon/static/src/xml/OrderReceipt.xml
+++ b/addons/pos_coupon/static/src/xml/OrderReceipt.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <templates id="template" xml:space="preserve">
 
-    <t t-name="pos_coupon.OrderReceipt" t-inherit="point_of_sale.OrderReceipt" t-inherit-mode="extension" owl="1">
+    <t t-name="pos_coupon.OrderReceipt" t-inherit="point_of_sale.OrderReceipt" t-inherit-mode="extension" owl="2">
         <xpath expr="//div[hasclass('before-footer')]" position="inside">
             <t t-if="receipt.generated_coupons and receipt.generated_coupons.length !== 0">
                 <div class="pos-coupon-rewards">

--- a/addons/pos_coupon/static/src/xml/OrderWidget.xml
+++ b/addons/pos_coupon/static/src/xml/OrderWidget.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <templates id="template" xml:space="preserve">
 
-    <t t-name="pos_coupon.OrderWidget" t-inherit="point_of_sale.OrderWidget" t-inherit-mode="extension" owl="1">
+    <t t-name="pos_coupon.OrderWidget" t-inherit="point_of_sale.OrderWidget" t-inherit-mode="extension" owl="2">
         <xpath expr="//OrderSummary" position="after">
             <div class="active-programs">
                 <div t-if="show">

--- a/addons/pos_discount/static/src/xml/DiscountButton.xml
+++ b/addons/pos_discount/static/src/xml/DiscountButton.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <templates id="template" xml:space="preserve">
 
-    <t t-name="DiscountButton" owl="1">
+    <t t-name="DiscountButton" owl="2">
         <span class="control-button js_discount">
             <i class="fa fa-tag"></i>
             <span> </span>

--- a/addons/pos_gift_card/static/src/xml/GiftCardButton.xml
+++ b/addons/pos_gift_card/static/src/xml/GiftCardButton.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <templates id="template" xml:space="preserve">
 
-    <t t-name="GiftCardButton" owl="1">
+    <t t-name="GiftCardButton" owl="2">
         <span class="control-button">
             <i class="fa fa-gift"></i>
             <span> </span>

--- a/addons/pos_gift_card/static/src/xml/GiftCardPopup.xml
+++ b/addons/pos_gift_card/static/src/xml/GiftCardPopup.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <templates id="template" xml:space="preserve">
 
-    <t t-name="GiftCardPopup" owl="1">
+    <t t-name="GiftCardPopup" owl="2">
         <div role="dialog" class="modal-dialog">
             <Draggable>
                 <div class="popup popup-textarea">

--- a/addons/pos_hr/static/src/xml/CashierName.xml
+++ b/addons/pos_hr/static/src/xml/CashierName.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <templates id="template" xml:space="preserve">
 
-    <t t-name="CashierName" t-inherit="point_of_sale.CashierName" t-inherit-mode="extension" owl="1">
+    <t t-name="CashierName" t-inherit="point_of_sale.CashierName" t-inherit-mode="extension" owl="2">
         <xpath expr="//div" position="attributes">
             <attribute name="t-on-click">selectCashier</attribute>
         </xpath>

--- a/addons/pos_hr/static/src/xml/Chrome.xml
+++ b/addons/pos_hr/static/src/xml/Chrome.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <templates id="template" xml:space="preserve">
 
-    <t t-name="Chrome" t-inherit="point_of_sale.Chrome" t-inherit-mode="extension" owl="1">
+    <t t-name="Chrome" t-inherit="point_of_sale.Chrome" t-inherit-mode="extension" owl="2">
         <xpath expr="//HeaderButton" position="replace">
             <HeaderLockButton t-if="env.pos.config.module_pos_hr" />
             <HeaderButton t-if="headerButtonIsShown" />

--- a/addons/pos_hr/static/src/xml/HeaderLockButton.xml
+++ b/addons/pos_hr/static/src/xml/HeaderLockButton.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <templates id="template" xml:space="preserve">
 
-    <t t-name="HeaderLockButton" owl="1">
+    <t t-name="HeaderLockButton" owl="2">
         <div class="header-button lock-button" t-on-mouseover="() => this.onMouseOver(true)"
              t-on-click="showLoginScreen" t-on-mouseout="() => this.onMouseOver(false)">
             <span class="lock-button">

--- a/addons/pos_hr/static/src/xml/LoginScreen.xml
+++ b/addons/pos_hr/static/src/xml/LoginScreen.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <templates id="template" xml:space="preserve">
-    <t t-name="LoginScreen" owl="1">
+    <t t-name="LoginScreen" owl="2">
         <div class="login-overlay">
             <div class="screen-login">
                 <div class="login-title"><small>Log in to </small>

--- a/addons/pos_mercury/static/src/xml/OrderReceipt.xml
+++ b/addons/pos_mercury/static/src/xml/OrderReceipt.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <templates id="template" xml:space="preserve">
 
-    <t t-name="pos_mercury.OrderReceipt" t-inherit="point_of_sale.OrderReceipt" t-inherit-mode="extension" owl="1">
+    <t t-name="pos_mercury.OrderReceipt" t-inherit="point_of_sale.OrderReceipt" t-inherit-mode="extension" owl="2">
         <xpath expr="//t[@t-foreach='receipt.paymentlines']" position="inside">
             <t t-if="line.mercury_data">
                 <div class="pos-receipt-left-padding">

--- a/addons/pos_mercury/static/src/xml/PaymentScreenPaymentLines.xml
+++ b/addons/pos_mercury/static/src/xml/PaymentScreenPaymentLines.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <templates id="template" xml:space="preserve">
 
-    <t t-name="pos_mercury.PaymentScreenPaymentLines" t-inherit="point_of_sale.PaymentScreenPaymentLines" t-inherit-mode="extension" owl="1">
+    <t t-name="pos_mercury.PaymentScreenPaymentLines" t-inherit="point_of_sale.PaymentScreenPaymentLines" t-inherit-mode="extension" owl="2">
         <xpath expr="//div[hasclass('paymentline')]//t[@t-esc='line.payment_method.name']" position="replace">
             <t t-if="!line.payment_method.is_cash_count and line.mercury_swipe_pending">
                 <span>WAITING FOR SWIPE</span>

--- a/addons/pos_mercury/static/src/xml/PaymentTransactionPopup.xml
+++ b/addons/pos_mercury/static/src/xml/PaymentTransactionPopup.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <templates id="template" xml:space="preserve">
 
-    <t t-name="PaymentTransactionPopup" owl="1">
+    <t t-name="PaymentTransactionPopup" owl="2">
         <div role="dialog" class="modal-dialog">
             <div class="popup">
                 <p class="title">

--- a/addons/pos_restaurant/static/src/xml/Chrome.xml
+++ b/addons/pos_restaurant/static/src/xml/Chrome.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <templates id="template" xml:space="preserve">
 
-    <t t-name="Chrome" t-inherit="point_of_sale.Chrome" t-inherit-mode="extension" owl="1">
+    <t t-name="Chrome" t-inherit="point_of_sale.Chrome" t-inherit-mode="extension" owl="2">
         <xpath expr="//div[hasclass('search-bar-portal')]" position="before">
             <BackToFloorButton mobileSearchBarIsShown="state.mobileSearchBarIsShown"/>
         </xpath>

--- a/addons/pos_restaurant/static/src/xml/ChromeWidgets/BackToFloorButton.xml
+++ b/addons/pos_restaurant/static/src/xml/ChromeWidgets/BackToFloorButton.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <templates id="template" xml:space="preserve">
 
-    <t t-name="BackToFloorButton" owl="1">
+    <t t-name="BackToFloorButton" owl="2">
         <span
             t-if="hasTable"
             class="order-button floor-button"

--- a/addons/pos_restaurant/static/src/xml/Resizeable.xml
+++ b/addons/pos_restaurant/static/src/xml/Resizeable.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <templates id="template" xml:space="preserve">
 
-    <t t-name="Resizeable" owl="1">
+    <t t-name="Resizeable" owl="2">
         <t t-slot="default"></t>
     </t>
 

--- a/addons/pos_restaurant/static/src/xml/Screens/BillScreen.xml
+++ b/addons/pos_restaurant/static/src/xml/Screens/BillScreen.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <templates id="template" xml:space="preserve">
 
-    <t t-name="BillScreen" owl="1">
+    <t t-name="BillScreen" owl="2">
         <div class="receipt-screen screen">
             <div class="screen-content">
                 <div class="top-content">

--- a/addons/pos_restaurant/static/src/xml/Screens/FloorScreen/EditBar.xml
+++ b/addons/pos_restaurant/static/src/xml/Screens/FloorScreen/EditBar.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <templates id="template" xml:space="preserve">
 
-    <t t-name="EditBar" owl="1">
+    <t t-name="EditBar" owl="2">
         <div class="edit-bar" t-attf-style="top:{{props.floorMapScrollTop}}px;">
             <span class="edit-button" t-on-click.stop="() => this.trigger('create-table')">
                 <i class="fa fa-plus" role="img" aria-label="Add" title="Add"></i>

--- a/addons/pos_restaurant/static/src/xml/Screens/FloorScreen/EditableTable.xml
+++ b/addons/pos_restaurant/static/src/xml/Screens/FloorScreen/EditableTable.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <templates id="template" xml:space="preserve">
 
-    <t t-name="EditableTable" owl="1">
+    <t t-name="EditableTable" owl="2">
         <Draggable limitArea="'.floor-map'">
             <Resizeable limitArea="'.floor-map'">
                 <div class="table selected" t-on-click.stop="">

--- a/addons/pos_restaurant/static/src/xml/Screens/FloorScreen/FloorScreen.xml
+++ b/addons/pos_restaurant/static/src/xml/Screens/FloorScreen/FloorScreen.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <templates id="template" xml:space="preserve">
 
-    <t t-name="FloorScreen" owl="1">
+    <t t-name="FloorScreen" owl="2">
         <div class="floor-screen screen">
             <div class="screen-content-flexbox">
                 <t t-if="env.pos.floors.length > 1">

--- a/addons/pos_restaurant/static/src/xml/Screens/FloorScreen/TableWidget.xml
+++ b/addons/pos_restaurant/static/src/xml/Screens/FloorScreen/TableWidget.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <templates id="template" xml:space="preserve">
 
-    <t t-name="TableWidget" owl="1">
+    <t t-name="TableWidget" owl="2">
         <div t-if="!props.isSelected" class="table" t-on-click.stop="() => this.trigger('select-table', props.table)">
             <span class="table-cover" t-att-class="{ full: fill >= 1 }"></span>
             <span t-att-class="orderCountClass" t-att-hidden="orderCount === 0">

--- a/addons/pos_restaurant/static/src/xml/Screens/PaymentScreen/PaymentScreen.xml
+++ b/addons/pos_restaurant/static/src/xml/Screens/PaymentScreen/PaymentScreen.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <templates id="template" xml:space="preserve">
 
-    <t t-name="PaymentScreen" t-inherit="point_of_sale.PaymentScreen" t-inherit-mode="extension" owl="1">
+    <t t-name="PaymentScreen" t-inherit="point_of_sale.PaymentScreen" t-inherit-mode="extension" owl="2">
         <xpath expr="//div[hasclass('button') and hasclass('next')]" position="attributes">
             <attribute name="t-att-hidden">env.pos.config.set_tip_after_payment and !currentOrder.is_paid()</attribute>
         </xpath>

--- a/addons/pos_restaurant/static/src/xml/Screens/ProductScreen/ControlButtons/OrderlineNoteButton.xml
+++ b/addons/pos_restaurant/static/src/xml/Screens/ProductScreen/ControlButtons/OrderlineNoteButton.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <templates id="template" xml:space="preserve">
 
-    <t t-name="OrderlineNoteButton" owl="1">
+    <t t-name="OrderlineNoteButton" owl="2">
         <div class="control-button">
             <i class="fa fa-tag" />
             <span> </span>

--- a/addons/pos_restaurant/static/src/xml/Screens/ProductScreen/ControlButtons/PrintBillButton.xml
+++ b/addons/pos_restaurant/static/src/xml/Screens/ProductScreen/ControlButtons/PrintBillButton.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <templates id="template" xml:space="preserve">
 
-    <t t-name="PrintBillButton" owl="1">
+    <t t-name="PrintBillButton" owl="2">
         <span class="control-button order-printbill">
             <i class="fa fa-print"></i>
             <span> </span>

--- a/addons/pos_restaurant/static/src/xml/Screens/ProductScreen/ControlButtons/SplitBillButton.xml
+++ b/addons/pos_restaurant/static/src/xml/Screens/ProductScreen/ControlButtons/SplitBillButton.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <templates id="template" xml:space="preserve">
 
-    <t t-name="SplitBillButton" owl="1">
+    <t t-name="SplitBillButton" owl="2">
         <span class="control-button order-split">
             <i class="fa fa-files-o"></i>
             <span> </span>

--- a/addons/pos_restaurant/static/src/xml/Screens/ProductScreen/ControlButtons/SubmitOrderButton.xml
+++ b/addons/pos_restaurant/static/src/xml/Screens/ProductScreen/ControlButtons/SubmitOrderButton.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <templates id="template" xml:space="preserve">
 
-    <t t-name="SubmitOrderButton" owl="1">
+    <t t-name="SubmitOrderButton" owl="2">
         <span class="control-button" t-att-class="addedClasses">
             <i class="fa fa-cutlery"></i>
             <span> </span>

--- a/addons/pos_restaurant/static/src/xml/Screens/ProductScreen/ControlButtons/TableGuestsButton.xml
+++ b/addons/pos_restaurant/static/src/xml/Screens/ProductScreen/ControlButtons/TableGuestsButton.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <templates id="template" xml:space="preserve">
 
-    <t t-name="TableGuestsButton" owl="1">
+    <t t-name="TableGuestsButton" owl="2">
         <div class="control-button">
             <span class="control-button-number">
                 <t t-esc="nGuests" />

--- a/addons/pos_restaurant/static/src/xml/Screens/ProductScreen/ControlButtons/TransferOrderButton.xml
+++ b/addons/pos_restaurant/static/src/xml/Screens/ProductScreen/ControlButtons/TransferOrderButton.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <templates id="template" xml:space="preserve">
 
-    <t t-name="TransferOrderButton" owl="1">
+    <t t-name="TransferOrderButton" owl="2">
         <div class="control-button">
             <i class="fa fa-arrow-right" />
             <span> </span>

--- a/addons/pos_restaurant/static/src/xml/Screens/ProductScreen/Orderline.xml
+++ b/addons/pos_restaurant/static/src/xml/Screens/ProductScreen/Orderline.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <templates id="template" xml:space="preserve">
 
-    <t t-name="Orderline" t-inherit="point_of_sale.Orderline" t-inherit-mode="extension" owl="1">
+    <t t-name="Orderline" t-inherit="point_of_sale.Orderline" t-inherit-mode="extension" owl="2">
         <xpath expr="//ul[hasclass('info-list')]" position="inside">
             <t t-if="props.line.get_note()">
                 <li class="info orderline-note">

--- a/addons/pos_restaurant/static/src/xml/Screens/ReceiptScreen/OrderReceipt.xml
+++ b/addons/pos_restaurant/static/src/xml/Screens/ReceiptScreen/OrderReceipt.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <templates id="template" xml:space="preserve">
 
-    <t t-name="OrderReceipt" t-inherit="point_of_sale.OrderReceipt" t-inherit-mode="extension" owl="1">
+    <t t-name="OrderReceipt" t-inherit="point_of_sale.OrderReceipt" t-inherit-mode="extension" owl="2">
         <xpath expr="//div[hasclass('pos-receipt-order-data')]" position="inside">
             <t t-if="props.isBill">
                 <div>PRO FORMA</div>

--- a/addons/pos_restaurant/static/src/xml/Screens/SplitBillScreen/SplitBillScreen.xml
+++ b/addons/pos_restaurant/static/src/xml/Screens/SplitBillScreen/SplitBillScreen.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <templates id="template" xml:space="preserve">
 
-    <t t-name="SplitBillScreen" owl="1">
+    <t t-name="SplitBillScreen" owl="2">
         <div class="splitbill-screen screen">
             <div class="contents">
                 <div class="top-content">

--- a/addons/pos_restaurant/static/src/xml/Screens/SplitBillScreen/SplitOrderline.xml
+++ b/addons/pos_restaurant/static/src/xml/Screens/SplitBillScreen/SplitOrderline.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <templates id="template" xml:space="preserve">
 
-    <t t-name="SplitOrderline" owl="1">
+    <t t-name="SplitOrderline" owl="2">
         <li class="orderline" t-att-class="{ selected: isSelected, partially: props.split.quantity !== props.line.get_quantity() }">
             <span class="product-name">
                 <t t-esc="props.line.get_product().display_name" />

--- a/addons/pos_restaurant/static/src/xml/Screens/TicketScreen.xml
+++ b/addons/pos_restaurant/static/src/xml/Screens/TicketScreen.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <templates id="template" xml:space="preserve">
 
-    <t t-name="TicketScreen" t-inherit="point_of_sale.TicketScreen" t-inherit-mode="extension" owl="1">
+    <t t-name="TicketScreen" t-inherit="point_of_sale.TicketScreen" t-inherit-mode="extension" owl="2">
         <xpath expr="//div[hasclass('header-row')]//div[@name='delete']" position="before">
             <div t-if="env.pos.config.iface_floorplan" class="col" name="table">Table</div>
             <div t-if="_state.ui.filter == 'TIPPING'" class="col end narrow" name="tip">Tip</div>
@@ -21,7 +21,7 @@
         </xpath>
     </t>
 
-    <t t-name="TipCell" owl="1">
+    <t t-name="TipCell" owl="2">
         <div class="tip-cell" t-on-click.stop="editTip">
             <t t-if="state.isEditing">
                 <input type="text" name="tip-amount" t-ref="autofocus" t-model="orderUiState.inputTipAmount" t-on-blur="onBlur" t-on-keydown="onKeydown" />

--- a/addons/pos_restaurant/static/src/xml/Screens/TipScreen.xml
+++ b/addons/pos_restaurant/static/src/xml/Screens/TipScreen.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <templates id="template" xml:space="preserve">
 
-    <t t-name="pos_restaurant.TipScreen" owl="1">
+    <t t-name="pos_restaurant.TipScreen" owl="2">
         <div class="tip-screen screen">
             <div class="pos-receipt-container"/>
             <div class="screen-content">

--- a/addons/pos_restaurant/static/src/xml/TipReceipt.xml
+++ b/addons/pos_restaurant/static/src/xml/TipReceipt.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <templates id="template" xml:space="preserve">
 
-    <t t-name="TipReceipt" owl="1">
+    <t t-name="TipReceipt" owl="2">
         <div class="pos-receipt">
             <t t-if="receipt.company.logo">
                 <img class="pos-receipt-logo" t-att-src="receipt.company.logo" alt="Logo"/>

--- a/addons/pos_sale/static/src/xml/OrderManagementScreen/MobileSaleOrderManagementScreen.xml
+++ b/addons/pos_sale/static/src/xml/OrderManagementScreen/MobileSaleOrderManagementScreen.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <templates id="template" xml:space="preserve">
 
-    <div t-name="MobileSaleOrderManagementScreen" class="screen-full-width" owl="1">
+    <div t-name="MobileSaleOrderManagementScreen" class="screen-full-width" owl="2">
         <div t-if="mobileState.showDetails" class="leftpane">
             <OrderDetails order="orderManagementContext.selectedOrder" />
             <div class="pads">

--- a/addons/pos_sale/static/src/xml/OrderManagementScreen/SaleOrderList.xml
+++ b/addons/pos_sale/static/src/xml/OrderManagementScreen/SaleOrderList.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <templates id="template" xml:space="preserve">
 
-    <t t-name="SaleOrderList" owl="1">
+    <t t-name="SaleOrderList" owl="2">
         <div class="orders">
             <div class="header-row" t-att-class="{ oe_hidden: env.isMobile }">
                 <div class="col name">Order</div>

--- a/addons/pos_sale/static/src/xml/OrderManagementScreen/SaleOrderManagementControlPanel.xml
+++ b/addons/pos_sale/static/src/xml/OrderManagementScreen/SaleOrderManagementControlPanel.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <templates id="template" xml:space="preserve">
 
-    <t t-name="SaleOrderManagementControlPanel" owl="1">
+    <t t-name="SaleOrderManagementControlPanel" owl="2">
         <div class="control-panel">
             <div class="item button back" t-on-click="() => this.trigger('close-screen')">
                 <i class="fa fa-angle-double-left"></i>

--- a/addons/pos_sale/static/src/xml/OrderManagementScreen/SaleOrderManagementScreen.xml
+++ b/addons/pos_sale/static/src/xml/OrderManagementScreen/SaleOrderManagementScreen.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <templates id="template" xml:space="preserve">
 
-    <t t-name="SaleOrderManagementScreen" owl="1">
+    <t t-name="SaleOrderManagementScreen" owl="2">
         <div class="order-management-screen screen" t-att-class="{ oe_hidden: !props.isShown }">
             <div t-if="!env.isMobile" class="screen-full-width">
                 <div class="rightpane">

--- a/addons/pos_sale/static/src/xml/OrderManagementScreen/SaleOrderRow.xml
+++ b/addons/pos_sale/static/src/xml/OrderManagementScreen/SaleOrderRow.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <templates id="template" xml:space="preserve">
 
-    <t t-name="SaleOrderRow" owl="1">
+    <t t-name="SaleOrderRow" owl="2">
         <div class="order-row"
         t-att-class="{ highlight: highlighted }"
         t-on-click="() => this.trigger('click-sale-order', props.order)">

--- a/addons/pos_sale/static/src/xml/ProductScreen/Orderline.xml
+++ b/addons/pos_sale/static/src/xml/ProductScreen/Orderline.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <templates id="template" xml:space="preserve">
 
-    <t t-name="Orderline" t-inherit="point_of_sale.Orderline" t-inherit-mode="extension" owl="1">
+    <t t-name="Orderline" t-inherit="point_of_sale.Orderline" t-inherit-mode="extension" owl="2">
         <xpath expr="//ul[hasclass('info-list')]" position="inside">
             <t t-if="props.line.get_sale_order()">
                 <li class="info orderline-sale-order">

--- a/addons/pos_sale/static/src/xml/ReceiptScreen/OrderReceipt.xml
+++ b/addons/pos_sale/static/src/xml/ReceiptScreen/OrderReceipt.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <templates id="template" xml:space="preserve">
 
-    <t t-name="OrderReceipt" t-inherit="point_of_sale.OrderLinesReceipt" t-inherit-mode="extension" owl="1">
+    <t t-name="OrderReceipt" t-inherit="point_of_sale.OrderLinesReceipt" t-inherit-mode="extension" owl="2">
         <xpath expr="//t[@t-foreach]" position="inside">
             <div class="pos-receipt-left-padding" t-if="line.so_reference">From <t t-esc="line.so_reference"/></div>
             <div class="pos-receipt-left-padding" t-if="line.down_payment_details">

--- a/addons/pos_sale/static/src/xml/SetSaleOrderButton.xml
+++ b/addons/pos_sale/static/src/xml/SetSaleOrderButton.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <templates id="template" xml:space="preserve">
 
-    <t t-name="SetSaleOrderButton" owl="1">
+    <t t-name="SetSaleOrderButton" owl="2">
         <div class="control-button o_sale_order_button">
             <i class="fa fa-link" role="img" aria-label="Set Sale Order"
                title="Set Sale Order" /> Quotation/Order

--- a/addons/pos_sale_product_configurator/static/src/xml/Popups/ProductInfoPopup.xml
+++ b/addons/pos_sale_product_configurator/static/src/xml/Popups/ProductInfoPopup.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <templates id="template" xml:space="preserve">
-    <t t-name="ProductInfoPopup" t-inherit="point_of_sale.ProductInfoPopup" t-inherit-mode="extension" owl="1">
+    <t t-name="ProductInfoPopup" t-inherit="point_of_sale.ProductInfoPopup" t-inherit-mode="extension" owl="2">
         <xpath expr="//div[hasclass('extra')]" position="inside">
             <div class="section-optional-product" t-if="productInfo.optional_products.length > 0">
                 <div class="section-title">

--- a/addons/pos_six/static/src/xml/BalanceButton.xml
+++ b/addons/pos_six/static/src/xml/BalanceButton.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <templates id="template" xml:space="preserve">
 
-    <t t-name="BalanceButton" owl="1">
+    <t t-name="BalanceButton" owl="2">
         <div class="header-button balance-button" t-on-click="sendBalance">
             <span class="lock-button">
                 Send Balance

--- a/addons/pos_six/static/src/xml/Chrome.xml
+++ b/addons/pos_six/static/src/xml/Chrome.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <templates id="template" xml:space="preserve">
 
-    <t t-name="Chrome" t-inherit="point_of_sale.Chrome" t-inherit-mode="extension" owl="1">
+    <t t-name="Chrome" t-inherit="point_of_sale.Chrome" t-inherit-mode="extension" owl="2">
         <xpath expr="//SyncNotification" position="after">
             <BalanceButton t-if="balanceButtonIsShown" />
         </xpath>

--- a/addons/project/static/src/burndown_chart/burndown_chart_view.xml
+++ b/addons/project/static/src/burndown_chart/burndown_chart_view.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <templates xml:space="preserve">
 
-    <t t-name="project.BurndownChartView.Buttons" t-inherit="web.GraphView.Buttons" t-inherit-mode="primary" owl="1">
+    <t t-name="project.BurndownChartView.Buttons" t-inherit="web.GraphView.Buttons" t-inherit-mode="primary" owl="2">
         <xpath expr="//button[@data-mode='pie']" position="replace">
         </xpath>
         <xpath expr="//div[@role='toolbar'][3]" position="attributes">

--- a/addons/project/static/src/project_control_panel/project_control_panel.xml
+++ b/addons/project/static/src/project_control_panel/project_control_panel.xml
@@ -1,14 +1,14 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <templates xml:space="preserve">
 
-    <t t-name="project.ProjectControlPanelContentBadge" owl="1">
+    <t t-name="project.ProjectControlPanelContentBadge" owl="2">
         <t t-tag="isProjectUser ? 'button' : 'span'" class="badge border d-flex p-2 ml-2 bg-white" data-hotkey="y">
             <span t-attf-class="o_status_bubble o_color_bubble_{{data.color}}"/>
             <span t-att-class="'font-weight-normal ml-1' + (data.color === 0 ? ' text-muted' : '')" t-esc="data.status"/>
         </t>
     </t>
 
-    <t t-name="project.ProjectControlPanelContent" owl="1">
+    <t t-name="project.ProjectControlPanelContent" owl="2">
         <t t-if="showProjectUpdate">
             <li t-if="isProjectUser" class="o_project_updates_breadcrumb pl-3" t-on-click="onStatusClick">
                 <t t-call="project.ProjectControlPanelContentBadge"></t>
@@ -19,13 +19,13 @@
         </t>
     </t>
 
-    <t t-name="project.Breadcrumbs" t-inherit="web.Breadcrumbs" t-inherit-mode="primary" owl="1">
+    <t t-name="project.Breadcrumbs" t-inherit="web.Breadcrumbs" t-inherit-mode="primary" owl="2">
         <xpath expr="//ol" position="inside">
             <t t-call="project.ProjectControlPanelContent"/>
         </xpath>
     </t>
 
-    <t t-name="project.ProjectControlPanel" t-inherit="web.ControlPanel" t-inherit-mode="primary" owl="1">
+    <t t-name="project.ProjectControlPanel" t-inherit="web.ControlPanel" t-inherit-mode="primary" owl="2">
         <xpath expr="//t[@t-call='web.Breadcrumbs']" position="replace">
             <t t-call="project.Breadcrumbs"/>
         </xpath>

--- a/addons/project/static/src/project_sharing/project_sharing.xml
+++ b/addons/project/static/src/project_sharing/project_sharing.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <templates xml:space="preserve">
 
-    <t t-name="project.ProjectSharingWebClient" owl="1">
+    <t t-name="project.ProjectSharingWebClient" owl="2">
         <ActionContainer />
         <MainComponentsContainer/>
     </t>

--- a/addons/project/static/src/xml/project_templates.xml
+++ b/addons/project/static/src/xml/project_templates.xml
@@ -17,7 +17,7 @@
 
     <span t-name="project.statusWithColor" t-att-class="'o_status_bubble mr-2 o_color_bubble_' + color"></span>
 
-    <div t-name="project.ControlPanel" t-inherit="web.Legacy.ControlPanel" t-inherit-mode="extension" owl="1">
+    <div t-name="project.ControlPanel" t-inherit="web.Legacy.ControlPanel" t-inherit-mode="extension" owl="2">
         <xpath expr="//ol[hasclass('breadcrumb')]" position="inside">
             <t t-call="project.ProjectControlPanelContent">
                 <t t-set="showProjectUpdate" t-value="show_project_update"/>
@@ -26,7 +26,7 @@
         </xpath>
     </div>
 
-    <t t-name="project.ProjectRightPanel" owl="1">
+    <t t-name="project.ProjectRightPanel" owl="2">
         <div t-if="project_id" class="o_rightpanel">
             <t t-call="project.StatButtonsSection"/>
             <t t-call="project.MilestoneSection"/>
@@ -35,7 +35,7 @@
         <div t-else=""/>
     </t>
 
-    <t t-name="project.StatButtonsSection" owl="1">
+    <t t-name="project.StatButtonsSection" owl="2">
         <div class="o_rightpanel_section">
             <div class="o_form_view">
                 <div class="oe_button_box o_full">
@@ -61,7 +61,7 @@
         </div>
     </t>
 
-    <t t-name="project.MilestoneSection" owl="1">
+    <t t-name="project.MilestoneSection" owl="2">
         <t t-set="milestones" t-value="state.data.milestones"/>
         <div class="o_rightpanel_section" name="milestone">
             <div class="o_rightpanel_header">
@@ -83,7 +83,7 @@
         </div>
     </t>
 
-    <t t-name="project.AddMilestone" owl="1">
+    <t t-name="project.AddMilestone" owl="2">
         <div class="o_add_milestone">
             <a t-on-click="onAddMilestoneClick">Add Milestone</a>
         </div>
@@ -104,7 +104,7 @@
             </div>
             <span class="o_rightpanel_right_col">
                 <a class="o_delete_icon" t-on-click="onDeleteMilestone" title="Delete Milestone"><i class="fa fa-trash"></i></a>
-            </span>
+            </span>owl="2"
         </div>
     </t>
     <t t-name="project.task.PrivateProjectName">

--- a/addons/sale_timesheet/static/src/xml/sale_project_templates.xml
+++ b/addons/sale_timesheet/static/src/xml/sale_project_templates.xml
@@ -5,7 +5,7 @@
         Create Sales Order
     </button>
 
-    <t t-inherit="project.ProjectRightPanel" t-inherit-mode="extension" owl="1">
+    <t t-inherit="project.ProjectRightPanel" t-inherit-mode="extension" owl="2">
         <xpath expr="//t[@t-call='project.StatButtonsSection']" position="after">
             <t t-call="sale_timesheet.SoldSection"/>
             <t t-call="sale_timesheet.TotalSoldSection"/>
@@ -13,7 +13,7 @@
         </xpath>
     </t>
 
-    <t t-name="sale_timesheet.SoldSection" owl="1">
+    <t t-name="sale_timesheet.SoldSection" owl="2">
         <t t-set="sold_items" t-value="state.data.sold_items"/>
         <t t-if="sold_items.number_sols and sold_items.allow_billable"> 
             <div name="sold" class="o_rightpanel_section">
@@ -33,7 +33,7 @@
         </t>
     </t>
 
-    <t t-name="sale_timesheet.TotalSoldSection" owl="1">
+    <t t-name="sale_timesheet.TotalSoldSection" owl="2">
         <t t-set="sold_items" t-value="state.data.sold_items"/>
         <t t-if="sold_items.allow_billable"> 
             <div name="total_sold" class="o_rightpanel_section">
@@ -61,7 +61,7 @@
         </t>
     </t>
     
-    <t t-name="sale_timesheet.ProfitabilitySection" owl="1">
+    <t t-name="sale_timesheet.ProfitabilitySection" owl="2">
         <t t-if="state.data.user.is_project_user &amp;&amp; state.data.profitability_items.data.length > 0 &amp;&amp; state.data.analytic_account_id">
             <t t-set="profitability_items" t-value="state.data.profitability_items"/>
             <div name="profitability" class="o_rightpanel_section">

--- a/addons/snailmail/static/src/components/snailmail_error/snailmail_error.xml
+++ b/addons/snailmail/static/src/components/snailmail_error/snailmail_error.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <templates xml:space="preserve">
 
-    <t t-name="snailmail.SnailmailError" owl="1">
+    <t t-name="snailmail.SnailmailError" owl="2">
         <t t-if="snailmailErrorView">
             <div class="o_SnailmailError card bg-white" t-attf-class="{{ className }}" t-ref="root">
                 <h4 class="m-3">Failed letter</h4>

--- a/addons/snailmail/static/src/components/snailmail_notification_popover/snailmail_notification_popover.xml
+++ b/addons/snailmail/static/src/components/snailmail_notification_popover/snailmail_notification_popover.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <templates xml:space="preserve">
 
-    <t t-name="snailmail.SnailmailNotificationPopover" owl="1">
+    <t t-name="snailmail.SnailmailNotificationPopover" owl="2">
         <t t-if="message">
             <div class="o_SnailmailNotificationPopover" t-attf-class="{{ className }}" t-ref="root">
                 <t t-if="notification">

--- a/addons/web/static/src/core/checkbox/checkbox.xml
+++ b/addons/web/static/src/core/checkbox/checkbox.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <templates xml:space="preserve">
 
-<t t-name="web.CheckBox" owl="1">
+<t t-name="web.CheckBox" owl="2">
     <div class="custom-control custom-checkbox">
         <input
             t-att-id="props.id or id"

--- a/addons/web/static/src/core/commands/command_items.xml
+++ b/addons/web/static/src/core/commands/command_items.xml
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <templates xml:space="preserve">
 
-  <t t-name="web.DefaultCommandItem" owl="1">
+  <t t-name="web.DefaultCommandItem" owl="2">
     <div class="o_command_default d-flex align-items-center justify-content-between px-4 py-2 o_cursor_pointer">
       <t t-slot="name"/>
     </div>
   </t>
 
-  <t t-name="web.HotkeyCommandItem" owl="1">
+  <t t-name="web.HotkeyCommandItem" owl="2">
     <div class="o_command_hotkey d-flex align-items-center justify-content-between px-4 py-2 o_cursor_pointer">
       <t t-slot="name"/>
       <span>

--- a/addons/web/static/src/core/commands/command_palette.xml
+++ b/addons/web/static/src/core/commands/command_palette.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <templates xml:space="preserve">
 
-  <t t-name="web.CommandPalette" owl="1">
+  <t t-name="web.CommandPalette" owl="2">
     <div>
       <div class="o_command_palette_search input-group mb-2 px-4 py-3 border-bottom">
         <span t-if="state.namespace !== 'default'" class="o_namespace d-flex align-items-center mr-1" t-out="state.namespace"/>

--- a/addons/web/static/src/core/commands/command_palette_dialog.xml
+++ b/addons/web/static/src/core/commands/command_palette_dialog.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <templates xml:space="preserve">
 
-  <t t-name="web.CommandPaletteDialogBody" owl="1">
+  <t t-name="web.CommandPaletteDialogBody" owl="2">
     <CommandPalette t-props="props" closeMe="close"/>
   </t>
 

--- a/addons/web/static/src/core/confirmation_dialog/confirmation_dialog.xml
+++ b/addons/web/static/src/core/confirmation_dialog/confirmation_dialog.xml
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <templates xml:space="preserve">
 
-  <t t-name="web.ConfirmationDialogBody" owl="1">
+  <t t-name="web.ConfirmationDialogBody" owl="2">
     <t t-esc="props.body" />
   </t>
 
-  <t t-name="web.ConfirmationDialogFooter" owl="1">
+  <t t-name="web.ConfirmationDialogFooter" owl="2">
     <button class="btn btn-primary" t-on-click="_confirm">
       Ok
     </button>

--- a/addons/web/static/src/core/datepicker/datepicker.xml
+++ b/addons/web/static/src/core/datepicker/datepicker.xml
@@ -2,7 +2,7 @@
 <templates xml:space="preserve">
 
 
-    <t t-name="web.DatePicker" owl="1">
+    <t t-name="web.DatePicker" owl="2">
         <div class="o_datepicker" aria-atomic="true" t-att-id="datePickerId" data-target-input="nearest" t-ref="root">
             <input type="text"
                 class="o_datepicker_input o_input datetimepicker-input"

--- a/addons/web/static/src/core/debug/debug_menu.xml
+++ b/addons/web/static/src/core/debug/debug_menu.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <templates xml:space="preserve">
 
-    <t t-name="web.DebugMenu" owl="1">
+    <t t-name="web.DebugMenu" owl="2">
         <Dropdown class="'o_debug_manager'"
           beforeOpen="getElements"
           position="'bottom-end'"

--- a/addons/web/static/src/core/debug/debug_menu_items.xml
+++ b/addons/web/static/src/core/debug/debug_menu_items.xml
@@ -1,12 +1,12 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <templates xml:space="preserve">
 
-    <t t-name="web.DebugMenu.SetDefaultFooter" owl="1">
+    <t t-name="web.DebugMenu.SetDefaultFooter" owl="2">
         <button class="btn btn-secondary" t-on-click="() => this.trigger('dialog-closed')">Close</button>
         <button class="btn btn-secondary" t-on-click="saveDefault">Save default</button>
     </t>
 
-    <t t-name="web.DebugMenu.setDefaultBody" owl="1">
+    <t t-name="web.DebugMenu.setDefaultBody" owl="2">
         <table style="width: 100%">
             <tr>
                 <td>
@@ -62,7 +62,7 @@
         </table>
     </t>
 
-    <t t-name="web.DebugMenu.getMetadataBody" owl="1">
+    <t t-name="web.DebugMenu.getMetadataBody" owl="2">
         <table class="table table-sm table-striped">
             <tr>
                 <th>ID:</th>

--- a/addons/web/static/src/core/debug/profiling/profiling_item.xml
+++ b/addons/web/static/src/core/debug/profiling/profiling_item.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <templates xml:space="preserve">
 
-    <t t-name="web.DebugMenu.ProfilingItem" owl="1">
+    <t t-name="web.DebugMenu.ProfilingItem" owl="2">
         <DropdownItem class="o_debug_profiling_item_wrapper">
             <div class="o_debug_profiling_item d-flex justify-content-between">
                 <div class="align-self-center">

--- a/addons/web/static/src/core/dialog/dialog.xml
+++ b/addons/web/static/src/core/dialog/dialog.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <templates xml:space="preserve">
 
-    <t t-name="web.Dialog" owl="1">
+    <t t-name="web.Dialog" owl="2">
         <div class="o_dialog" t-att-class="{ o_inactive_modal: !props.isActive }" t-on-dialog-closed="close">
             <div role="dialog" class="modal d-block"
                 tabindex="-1"
@@ -28,7 +28,7 @@
         </div>
     </t>
 
-    <t t-name="web.DialogFooterDefault" owl="1">
+    <t t-name="web.DialogFooterDefault" owl="2">
         <button class="btn btn-primary" t-on-click="close">
             <t>Ok</t>
         </button>

--- a/addons/web/static/src/core/dropdown/dropdown.xml
+++ b/addons/web/static/src/core/dropdown/dropdown.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <templates xml:space="preserve">
 
-  <t t-name="web.Dropdown" owl="1">
+  <t t-name="web.Dropdown" owl="2">
     <div
       class="o-dropdown dropdown"
       t-att-class="props.class"

--- a/addons/web/static/src/core/dropdown/dropdown_item.xml
+++ b/addons/web/static/src/core/dropdown/dropdown_item.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <templates xml:space="preserve">
 
-  <t t-name="web.DropdownItem" owl="1">
+  <t t-name="web.DropdownItem" owl="2">
     <t
       t-tag="props.href ? 'a' : 'span'"
       t-att-href="props.href"

--- a/addons/web/static/src/core/effects/rainbow_man.xml
+++ b/addons/web/static/src/core/effects/rainbow_man.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <templates xml:space="preserve">
 
-    <t t-name="web.RainbowMan" owl="1">
+    <t t-name="web.RainbowMan" owl="2">
         <div class="o_reward position-absolute top-0 bottom-0 start-0 end-0 w-100 h-100" t-att-class="{ o_reward_fading: state.isFading }" t-on-animationend="onAnimationEnd">
             <svg class="o_reward_rainbow_man position-absolute top-0 bottom-0 start-0 end-0 m-auto overflow-visible" viewBox="0 0 400 400">
                 <defs>
@@ -51,7 +51,7 @@
             </svg>
             <div class="o_reward_rainbow_man o_reward_msg_container position-absolute top-0 bottom-0 start-0 end-0 m-auto">
                 <div class="o_reward_face_group h-100 w-75 mx-auto">
-                    <svg viewBox="0 0 42 60" preserveAspectRatio="xMinYMax meet" width="37" height="65%" class="overflow-visible position-relative ms-5">
+                    <svg viewBox="0 owl="2"" preserveAspectRatio="xMinYMax meet" width="37" height="65%" class="overflow-visible position-relative ms-5">
                         <g class="o_reward_box">
                             <use href="#o_reward_thumb" x="-60%" y="0" transform="rotate(-90) scale(1 -1)" transform-origin="center"/>
                         </g>

--- a/addons/web/static/src/core/errors/error_dialogs.xml
+++ b/addons/web/static/src/core/errors/error_dialogs.xml
@@ -1,24 +1,24 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <templates xml:space="preserve">
 
-    <t t-name="web.WarningDialogBody" owl="1">
+    <t t-name="web.WarningDialogBody" owl="2">
       <div role="alert" class="o_dialog_warning">
         <p t-esc="message" style="white-space: pre-wrap;"/>
       </div>
     </t>
 
-    <t t-name="web.RedirectWarningDialogBody" owl="1">
+    <t t-name="web.RedirectWarningDialogBody" owl="2">
       <div role="alert">
         <p t-esc="message" style="white-space: pre-wrap;"/>
       </div>
     </t>
 
-    <t t-name="web.RedirectWarningDialogFooter" owl="1">
+    <t t-name="web.RedirectWarningDialogFooter" owl="2">
       <button  class="btn btn-primary" t-on-click="onClick"><t t-esc="env._t(buttonText)"/></button>
       <button  class="btn btn-secondary" t-on-click="onCancel">Cancel</button>
     </t>
 
-    <t t-name="web.Error504DialogBody" owl="1">
+    <t t-name="web.Error504DialogBody" owl="2">
         <div role="alert">
             <p style="white-space: pre-wrap;">
             The operation was interrupted. This usually means that the current operation is taking too much time.
@@ -26,7 +26,7 @@
         </div>
     </t>
 
-    <t t-name="web.SessionExpiredDialogBody" owl="1">
+    <t t-name="web.SessionExpiredDialogBody" owl="2">
       <div role="alert">
         <p style="white-space: pre-wrap;">
           Your Odoo session expired. The current page is about to be refreshed.
@@ -34,11 +34,11 @@
       </div>
     </t>
 
-    <t t-name="web.SessionExpiredDialogFooter" owl="1">
+    <t t-name="web.SessionExpiredDialogFooter" owl="2">
         <button class="btn btn-primary" t-on-click="onClick">Ok</button>
     </t>
 
-     <t t-name="web.ErrorDialogBody" owl="1">
+     <t t-name="web.ErrorDialogBody" owl="2">
       <div class="alert alert-warning clearfix" role="alert">
           <div class="float-right ml8 btn-group-vertical">
               <button class="btn btn-primary" t-on-click="onClickClipboard">

--- a/addons/web/static/src/core/file_input/file_input.xml
+++ b/addons/web/static/src/core/file_input/file_input.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <templates xml:space="preserve">
 
-    <t t-name="web.FileInput" owl="1">
+    <t t-name="web.FileInput" owl="2">
         <span class="o_file_input" aria-atomic="true">
             <span class="o_file_input_trigger" t-on-click.prevent="onTriggerClicked">
                 <t t-slot="default">

--- a/addons/web/static/src/core/notifications/notification.xml
+++ b/addons/web/static/src/core/notifications/notification.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <templates xml:space="preserve">
 
-    <t t-name="web.NotificationWowl" owl="1">
+    <t t-name="web.NotificationWowl" owl="2">
         <div t-attf-class="o_notification {{props.className}} border border-{{props.type}} bg-white mb-2 position-relative"
          role="alert" aria-live="assertive" aria-atomic="true">
             <strong t-if="props.title" t-attf-class="o_notification_title d-block text-{{props.type}} py-2 pl-3 pr-5" t-out="props.title"/>

--- a/addons/web/static/src/core/pager/pager.xml
+++ b/addons/web/static/src/core/pager/pager.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <templates xml:space="preserve">
 
-    <t t-name="web.Pager" owl="1">
+    <t t-name="web.Pager" owl="2">
         <nav class="o_pager align-items-center d-flex gap-2" aria-label="Pager">
             <span class="o_pager_counter" t-on-click.stop="">
                 <t t-if="state.isEditing">

--- a/addons/web/static/src/core/popover/popover.xml
+++ b/addons/web/static/src/core/popover/popover.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <templates xml:space="preserve">
 
-    <t t-name="web.PopoverWowl" owl="1">
+    <t t-name="web.PopoverWowl" owl="2">
         <div role="tooltip" class="o_popover popover mw-100 shadow-sm"
             t-att-class="props.popoverClass"
             t-ref="popper"

--- a/addons/web/static/src/core/tooltip/tooltip.xml
+++ b/addons/web/static/src/core/tooltip/tooltip.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <templates xml:space="preserve">
 
-    <t t-name="web.Tooltip" owl="1">
+    <t t-name="web.Tooltip" owl="2">
         <div class="o-tooltip px-2 py-1">
             <t t-if="props.template" t-call="{{props.template}}">
                  <t t-set="info" t-value="props.info"/>

--- a/addons/web/static/src/legacy/xml/base.xml
+++ b/addons/web/static/src/legacy/xml/base.xml
@@ -3,7 +3,7 @@
 
 <!-- Owl Templates -->
 
-<t t-name="web.Legacy.ControlPanel" owl="1">
+<t t-name="web.Legacy.ControlPanel" owl="2">
     <div class="o_control_panel" data-command-category="actions">
         <div class="o_cp_top">
             <div class="o_cp_top_left">
@@ -86,7 +86,7 @@
             <t t-slot="buttons"/>
         </div>
         <div class="o_cp_pager" role="search" t-ref="pager">
-            <Pager t-if="_shouldShowPager()" t-props="props.pager"/>
+            <Pager t-if="_shouldShowPager(owl="2"ops="props.pager"/>
         </div>
     </div>
 </t>
@@ -97,7 +97,7 @@
             t-att-id="props.id or _id"
             type="checkbox"
             class="custom-control-input"
-            t-att-disabled="props.disabled"
+            t-att-disabled="proowl="2"bled"
             t-att-checked="props.value"
             t-on-change="(ev) => props.onChange(ev.target.checked)"
             />
@@ -112,7 +112,7 @@
         <span class="o_file_input_trigger" t-on-click.prevent="() => this._onTriggerClicked()">
             <t t-slot="default">
                 <button class="btn btn-primary">Choose File</button>
-            </t>
+            </t>owl="2"
         </span>
         <input type="file" name="ufile" class="o_input_file d-none"
             t-att="{multiple: props.multi_upload, accept: props.accepted_file_extensions}"
@@ -127,7 +127,7 @@
         <input type="text" class="o_datepicker_input o_input datetimepicker-input"
             t-att-name="props.name"
             t-att-placeholder="props.placeholder"
-            t-attf-data-target="#{{ datePickerId }}"
+            t-attf-data-target="#{owl="2"ickerId }}"
             t-att-readonly="props.readonly"
             t-ref="autofocus"
             t-on-change="_onInputChange"
@@ -145,7 +145,7 @@
         <div class="tooltip-inner">
             <t>Hit ENTER to <t t-esc="title"/></t>
         </div>
-    </div>
+    </div>owl="2"
 </t>
 
 <t t-name="web.DropdownMenu" owl="1">
@@ -153,7 +153,7 @@
         <button type="button"
             class="dropdown-toggle btn btn-secondary o-no-caret"
             t-attf-class="{{ icon || displayCaret || displayChevron ? 'd-flex align-items-center ' : ''}} {{ displayCaret || displayChevron ? 'pr-1 ' : ''}}"
-            t-att-aria-expanded="state.open ? 'true' : 'false'"
+            t-att-aria-expandowl="2"te.open ? 'true' : 'false'"
             tabindex="-1"
             t-on-click="() => { state.open = !state.open }"
             t-on-keydown="_onButtonKeydown"
@@ -184,7 +184,7 @@
         <t t-if="canBeOpened">
             <a class="o_menu_item_parent dropdown-item d-flex align-items-center justify-content-between"
                 t-att-class="{ selected: props.isActive }"
-                t-att-aria-checked="props.isActive ? 'true' : 'false'"
+                t-att-aria-checkeowl="2"s.isActive ? 'true' : 'false'"
                 role="menuitemcheckbox"
                 href="#"
                 t-ref="fallback-focus"
@@ -242,7 +242,7 @@
         <div class="o_dialog" t-on-focus="_onFocus" t-on-click="_onClick" t-on-dialog-closed="_onDialogClosed" t-ref="dialog">
             <div role="dialog" class="modal"
                 tabindex="-1"
-                t-att-class="{ o_technical_modal: props.technical, o_modal_full: props.fullscreen }"
+                t-att-clasowl="2"technical_modal: props.technical, o_modal_full: props.fullscreen }"
                 t-att-data-backdrop="'' + props.backdrop"
                 t-ref="modal"
                 t-on-close_dialog.stop="_close"
@@ -279,7 +279,7 @@
         <t t-slot="default"/>
         <t t-portal="'body'" t-if="state.displayed">
             <div role="tooltip" class="o_popover" t-att-class="props.popoverClass" t-ref="popover">
-                <div class="arrow"/>
+                <divowl="2""arrow"/>
                 <h3 t-if="props.title" class="o_popover_header"><t t-esc="props.title"/></h3>
                 <div class="popover-body" t-on-o-popover-close="_onPopoverClose">
                     <t t-slot="opened"/>
@@ -294,7 +294,7 @@
         <span class="o_pager_counter" t-on-click.stop="">
             <input t-if="state.editing" type="text"
                 class="o_pager_value o_input d-inline-block w-auto text-right"
-                size="7"
+                size="7"owl="2"
                 t-ref="autofocus"
                 t-att-value="value"
                 t-on-blur="() => { this.state.editing = false }"
@@ -337,7 +337,7 @@
     <div class="o_searchview_input_container">
         <div t-foreach="model.get('facets')" t-as="facet" t-key="facet_index"
             tabindex="0"
-            class="o_searchview_facet"
+            class="o_searchview_fowl="2"
             role="img"
             aria-label="search"
             t-on-keydown="(ev) => this._onFacetKeydown(facet, facet_index, ev)">
@@ -401,7 +401,7 @@
         <DropdownMenu t-if="printItems.length"
             title="env._t('Print')"
             items="printItems"
-            icon="'fa fa-print'"
+            icon="'fa fa-priowl="2"
             hotkey="'shift+u'"
             hotkeyTitle="'Printing options'"
         />
@@ -421,7 +421,7 @@
     <button type="button"
         t-att-accesskey="view.accessKey"
         t-attf-class="btn btn-light o_switch_view o_{{ view.type }} {{ view.icon }}"
-        t-att-class="{ active: env.view.type === view.type }"
+        t-att-class="{ active: env.owl="2"pe === view.type }"
         t-att-aria-label="sprintf(buttonLabel.toString(), view.type)"
         t-att-data-tooltip="view.name"
         tabindex="-1"

--- a/addons/web/static/src/legacy/xml/control_panel.xml
+++ b/addons/web/static/src/legacy/xml/control_panel.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <templates id="template" xml:space="preserve">
 
-<t t-name="web.Legacy.FavoriteMenu" t-inherit="web.FavoriteMenu" t-inherit-mode="primary" owl="1">
+<t t-name="web.Legacy.FavoriteMenu" t-inherit="web.FavoriteMenu" t-inherit-mode="primary" owl="2">
     <xpath expr="//t[@t-set-slot='toggler']" position="inside">
         <Dialog t-if="state.deletedFavorite"
             title="'Warning'"
@@ -22,7 +22,7 @@
     </xpath>
 </t>
 
-<t t-name="web.legacy.FilterMenu" t-inherit="web.FilterMenu" t-inherit-mode="primary" owl="1">
+<t t-name="web.legacy.FilterMenu" t-inherit="web.FilterMenu" t-inherit-mode="primary" owl="2">
     <xpath expr="//CustomFilterItem" position="attributes">
         <attribute name="fields">props.fields</attribute>
     </xpath>

--- a/addons/web/static/src/legacy/xml/fields.xml
+++ b/addons/web/static/src/legacy/xml/fields.xml
@@ -1,12 +1,12 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <templates id="template" xml:space="preserve">
 
-    <t t-name="web.FieldBoolean" owl="1">
+    <t t-name="web.FieldBoolean" owl="2">
         <CustomCheckbox disabled="hasReadonlyModifier"
             value="value" class="'o_field_boolean'" onChange.bind="_onChange"/>
     </t>
 
-    <t t-name="web.FieldBadge" owl="1">
+    <t t-name="web.FieldBadge" owl="2">
         <span class="badge badge-pill o_field_badge" t-esc="_formatValue(value)"/>
     </t>
 

--- a/addons/web/static/src/legacy/xml/graph.xml
+++ b/addons/web/static/src/legacy/xml/graph.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <templates>
 
-    <t t-name="web.Legacy.GraphRenderer" owl="1">
+    <t t-name="web.Legacy.GraphRenderer" owl="2">
         <div class="o_legacy_graph_renderer">
             <label t-if="props.title" t-esc="props.title"/>
             <t t-if="noContentHelperData" t-call="web.NoContentHelper">

--- a/addons/web/static/src/legacy/xml/pivot.xml
+++ b/addons/web/static/src/legacy/xml/pivot.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <templates>
 
-    <div t-name="web.legacy.PivotRenderer" class="o_legacy_pivot" owl="1">
+    <div t-name="web.legacy.PivotRenderer" class="o_legacy_pivot" owl="2">
         <t t-if="!(props.hasData and props.measures.length) or (props.isSample and !props.isEmbedded)">
             <t t-if="props.noContentHelp" t-call="web.ActionHelper" >
                 <t t-set="noContentHelp" t-value="props.noContentHelp"/>
@@ -54,7 +54,7 @@
         </table>
     </div>
 
-    <t t-name="web.legacy.PivotHeader" owl="1">
+    <t t-name="web.legacy.PivotHeader" owl="2">
         <th t-att-colspan="isXAxis ? cell.width : undefined" t-att-rowspan="isXAxis ? cell.height : undefined" t-att-class="{
                 o_pivot_header_cell_closed: cell.isLeaf,
                 o_pivot_header_cell_opened: !cell.isLeaf,
@@ -64,7 +64,7 @@
         </th>
     </t>
 
-    <t t-name="web.legacy.PivotMeasure" owl="1">
+    <t t-name="web.legacy.PivotMeasure" owl="2">
         <th class="text-muted" t-att-colspan="cell.width" t-att-rowspan="cell.height" t-att-class="{
                 o_pivot_origin_row: cell.originIndexes,
                 o_pivot_measure_row: !cell.originIndexes,
@@ -75,7 +75,7 @@
         </th>
     </t>
 
-    <t t-name="web.legacy.PivotGroupBySelection" owl="1">
+    <t t-name="web.legacy.PivotGroupBySelection" owl="2">
         <PivotGroupByMenu
             customGroupBys="customGroupBys"
             fields="props.groupableFields"
@@ -85,7 +85,7 @@
         />
     </t>
 
-    <t t-name="web.legacy.PivotGroupByMenu" owl="1">
+    <t t-name="web.legacy.PivotGroupByMenu" owl="2">
         <Dropdown class="'o_pivot_field_menu'" toggler="'parent'">
             <t t-set="currentGroup" t-value="null"/>
             <t t-foreach="items" t-as="item" t-key="item.id">

--- a/addons/web/static/src/legacy/xml/search_panel.xml
+++ b/addons/web/static/src/legacy/xml/search_panel.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <templates id="template" xml:space="preserve">
 
-<t t-name="web.Legacy.SearchPanel" owl="1">
+<t t-name="web.Legacy.SearchPanel" owl="2">
     <div class="o_search_panel" t-att-class="props.className" t-ref="legacySearchPanel">
         <section t-foreach="model.get('sections', s => !s.empty)" t-as="section" t-key="section.id"
             t-attf-class="o_search_panel_section o_search_panel_{{ section.type }}"
@@ -73,7 +73,7 @@
     </div>
 </t>
 
-<t t-name="web.Legacy.SearchPanel.Category" owl="1">
+<t t-name="web.Legacy.SearchPanel.Category" owl="2">
     <t t-foreach="values" t-as="valueId" t-key="valueId">
         <t t-set="value" t-value="section.values.get(valueId)"/>
         <li class="o_search_panel_category_value list-group-item border-0">
@@ -104,7 +104,7 @@
     </t>
 </t>
 
-<t t-name="web.Legacy.SearchPanel.FiltersGroup" owl="1">
+<t t-name="web.Legacy.SearchPanel.FiltersGroup" owl="2">
     <li t-foreach="[...values.keys()]" t-as="valueId" t-key="valueId"
         class="o_search_panel_filter_value list-group-item border-0"
         >

--- a/addons/web/static/src/legacy/xml/week_days.xml
+++ b/addons/web/static/src/legacy/xml/week_days.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <template>
-    <t t-name="web.RecurrentTask" owl="1">
+    <t t-name="web.RecurrentTask" owl="2">
         <div class="o_recurrent_weekdays border mt-2 mb-2">
             <table class="table table-responsive mb-0">
                 <tr>

--- a/addons/web/static/src/search/comparison_menu/comparison_menu.xml
+++ b/addons/web/static/src/search/comparison_menu/comparison_menu.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <templates xml:space="preserve">
 
-    <t t-name="web.ComparisonMenu" owl="1">
+    <t t-name="web.ComparisonMenu" owl="2">
         <Dropdown class="'o_comparison_menu btn-group'" togglerClass="'btn btn-light'">
             <t t-set-slot="toggler">
                 <i class="mr-1" t-att-class="icon"/>

--- a/addons/web/static/src/search/control_panel/control_panel.xml
+++ b/addons/web/static/src/search/control_panel/control_panel.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <templates xml:space="preserve">
 
-    <t t-name="web.ControlPanel" owl="1">
+    <t t-name="web.ControlPanel" owl="2">
         <div class="o_control_panel">
             <div t-if="display['top']" class="o_cp_top">
                 <div t-if="display['top-left']" class="o_cp_top_left">
@@ -51,7 +51,7 @@
     <t t-name="web.Breadcrumbs" owl="1">
         <ol class="breadcrumb">
             <t t-foreach="env.config.breadcrumbs" t-as="breadcrumb" t-key="breadcrumb.jsId">
-                <t t-set="isPenultimate" t-value="breadcrumb_index === env.config.breadcrumbs.length - 2"/>
+                <t t-set="isPenuowl="2"" t-value="breadcrumb_index === env.config.breadcrumbs.length - 2"/>
                 <li t-if="!breadcrumb_last"
                     class="breadcrumb-item"
                     t-att-class="{ o_back_button: isPenultimate}"

--- a/addons/web/static/src/search/favorite_menu/custom_favorite_item.xml
+++ b/addons/web/static/src/search/favorite_menu/custom_favorite_item.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <templates xml:space="preserve">
 
-    <t t-name="web.CustomFavoriteItem" owl="1" >
+    <t t-name="web.CustomFavoriteItem" owl="2" >
         <Dropdown class="'o_add_favorite'">
             <t t-set-slot="toggler">
                 Save current search

--- a/addons/web/static/src/search/favorite_menu/favorite_menu.xml
+++ b/addons/web/static/src/search/favorite_menu/favorite_menu.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <templates xml:space="preserve">
 
-    <t t-name="web.FavoriteMenu" owl="1">
+    <t t-name="web.FavoriteMenu" owl="2">
         <Dropdown class="'o_favorite_menu btn-group'" togglerClass="'btn btn-light'">
             <t t-set-slot="toggler">
                 <i class="mr-1" t-att-class="icon"/>

--- a/addons/web/static/src/search/filter_menu/custom_filter_item.xml
+++ b/addons/web/static/src/search/filter_menu/custom_filter_item.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <templates xml:space="preserve">
 
-    <t t-name="web.CustomFilterItem" owl="1">
+    <t t-name="web.CustomFilterItem" owl="2">
         <Dropdown class="'o_add_custom_filter_menu'">
             <t t-set-slot="toggler">
                 Add Custom Filter

--- a/addons/web/static/src/search/filter_menu/filter_menu.xml
+++ b/addons/web/static/src/search/filter_menu/filter_menu.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <templates xml:space="preserve">
 
-    <t t-name="web.FilterMenu" owl="1">
+    <t t-name="web.FilterMenu" owl="2">
         <Dropdown class="'o_filter_menu btn-group ' + props.class" togglerClass="'btn btn-light'">
             <t t-set-slot="toggler">
                 <i class="mr-1" t-att-class="icon"/>

--- a/addons/web/static/src/search/group_by_menu/custom_group_by_item.xml
+++ b/addons/web/static/src/search/group_by_menu/custom_group_by_item.xml
@@ -1,6 +1,6 @@
 <templates xml:space="preserve">
 
-    <t t-name="web.CustomGroupByItem" owl="1">
+    <t t-name="web.CustomGroupByItem" owl="2">
         <Dropdown class="'o_add_custom_group_menu'">
             <t t-set-slot="toggler">
                 Add Custom Group

--- a/addons/web/static/src/search/group_by_menu/group_by_menu.xml
+++ b/addons/web/static/src/search/group_by_menu/group_by_menu.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <templates xml:space="preserve">
 
-    <t t-name="web.GroupByMenu" owl="1">
+    <t t-name="web.GroupByMenu" owl="2">
         <Dropdown class="'o_group_by_menu btn-group'"
             togglerClass="'btn btn-light'"
             t-props="dropdownProps"

--- a/addons/web/static/src/search/search_bar/search_bar.xml
+++ b/addons/web/static/src/search/search_bar/search_bar.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <templates xml:space="preserve">
 
-    <t t-name="web.SearchBar.Facets" owl="1">
+    <t t-name="web.SearchBar.Facets" owl="2">
         <t t-foreach="env.searchModel.facets" t-as="facet" t-key="facet_index">
             <div class="o_searchview_facet"
                 role="img"
@@ -33,7 +33,7 @@
         </t>
     </t>
 
-    <t t-name="web.SearchBar.Input" owl="1">
+    <t t-name="web.SearchBar.Input" owl="2">
         <input type="text"
             class="o_searchview_input"
             accesskey="Q"
@@ -46,7 +46,7 @@
     </t>
 
     <t t-name="web.SearchBar.Items" owl="1">
-        <ul class="dropdown-menu o_searchview_autocomplete dropdown-menu show" role="menu">
+        <ul class="dropdown-menu o_sowl="2"ew_autocomplete dropdown-menu show" role="menu">
             <t t-foreach="items" t-as="item" t-key="item.id">
                 <li class="o_menu_item"
                     t-att-class="{ o_indent: item.isChild, o_selection_focus: item_index === state.focusedIndex}"
@@ -76,7 +76,7 @@
     </t>
 
     <t t-name="web.SearchBar" owl="1">
-        <div class="o_cp_searchview" role="search" t-ref="root">
+        <div class="o_cp_searcowl="2"role="search" t-ref="root">
             <div class="o_searchview" role="search" aria-autocomplete="list">
                 <i class="o_searchview_icon oi oi-search"
                     role="img"

--- a/addons/web/static/src/search/search_panel/search_panel.xml
+++ b/addons/web/static/src/search/search_panel/search_panel.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <templates id="template" xml:space="preserve">
 
-<t t-name="web.SearchPanel" owl="1">
+<t t-name="web.SearchPanel" owl="2">
     <div class="o_search_panel" t-att-class="env.searchModel.searchPanelInfo.className" t-ref="root">
         <section t-foreach="sections" t-as="section" t-key="section.id"
             t-attf-class="o_search_panel_section o_search_panel_{{ section.type }}"
@@ -73,7 +73,7 @@
     </div>
 </t>
 
-<t t-name="web.SearchPanel.Category" owl="1">
+<t t-name="web.SearchPanel.Category" owl="2">
     <t t-foreach="values" t-as="valueId" t-key="valueId">
         <t t-set="value" t-value="section.values.get(valueId)"/>
         <li class="o_search_panel_category_value list-group-item border-0">
@@ -104,7 +104,7 @@
     </t>
 </t>
 
-<t t-name="web.SearchPanel.FiltersGroup" owl="1">
+<t t-name="web.SearchPanel.FiltersGroup" owl="2">
     <li t-foreach="[...values.keys()]" t-as="valueId" t-key="valueId"
         class="o_search_panel_filter_value list-group-item border-0"
         >

--- a/addons/web/static/src/search/with_search/with_search.xml
+++ b/addons/web/static/src/search/with_search/with_search.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <templates xml:space="preserve">
 
-  <t t-name="web.WithSearch" owl="1">
+  <t t-name="web.WithSearch" owl="2">
     <t t-component="Component" t-props="componentProps" />
   </t>
 

--- a/addons/web/static/src/views/graph/graph_renderer.xml
+++ b/addons/web/static/src/views/graph/graph_renderer.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <templates xml:space="preserve">
 
-    <t t-name="web.GraphRenderer.CustomTooltip" owl="1">
+    <t t-name="web.GraphRenderer.CustomTooltip" owl="2">
         <div class="o_graph_custom_tooltip popover show p-2 o_debounce_disabled mw-100">
             <table class="table table-sm overflow-hidden m-0">
                 <thead>
@@ -27,7 +27,7 @@
         </div>
     </t>
 
-    <t t-name="web.GraphRenderer" owl="1">
+    <t t-name="web.GraphRenderer" owl="2">
         <div t-att-class="'o_graph_renderer o_renderer h-100 ' + props.class" t-ref="root">
             <div class="o_graph_canvas_container h-100 position-relative" t-ref="container">
                 <canvas t-ref="canvas" />

--- a/addons/web/static/src/views/graph/graph_view.xml
+++ b/addons/web/static/src/views/graph/graph_view.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <templates xml:space="preserve">
 
-    <t t-name="web.GraphView.Buttons" owl="1">
+    <t t-name="web.GraphView.Buttons" owl="2">
         <div class="btn-group" role="toolbar" aria-label="Main actions">
             <t t-call="web.ReportViewMeasures">
                 <t t-set="measures" t-value="model.metaData.measures"/>
@@ -45,7 +45,7 @@
         </div>
     </t>
 
-    <t t-name="web.GraphView" owl="1">
+    <t t-name="web.GraphView" owl="2">
         <div t-att-class="props.className">
             <Layout className="model.useSampleModel ? 'o_view_sample_data' : ''">
                 <t t-set-slot="control-panel-bottom-left">

--- a/addons/web/static/src/views/helpers/no_content_helpers.xml
+++ b/addons/web/static/src/views/helpers/no_content_helpers.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <templates xml:space="preserve">
 
-    <t t-name="web.ActionHelper" owl="1">
+    <t t-name="web.ActionHelper" owl="2">
         <div class="o_view_nocontent">
             <div class="o_nocontent_help">
                 <t t-out="noContentHelp"/>
@@ -9,7 +9,7 @@
         </div>
     </t>
 
-    <t t-name="web.NoContentHelper" owl="1">
+    <t t-name="web.NoContentHelper" owl="2">
         <div class="o_view_nocontent" role="alert">
             <div class="o_nocontent_help">
                 <p class="o_view_nocontent_empty_folder">

--- a/addons/web/static/src/views/pivot/pivot_renderer.xml
+++ b/addons/web/static/src/views/pivot/pivot_renderer.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <templates xml:space="preserve">
 
-    <t t-name="web.PivotRenderer" owl="1">
+    <t t-name="web.PivotRenderer" owl="2">
         <div class="o_pivot table-responsive">
 
             <table
@@ -46,7 +46,7 @@
                                         <CheckBox disabled="true" value="cell.value" />
                                     </div>
                                     <div t-else="1" class="o_value" t-esc="getFormattedValue(cell)"/>
-                                </t>
+                                owl="2"
                             </td>
                         </t>
                     </tr>
@@ -81,7 +81,7 @@
                     position="isXAxis ? 'bottom-start' : 'bottom-end'"
                     cell="cell"
                     customGroupBys="model.metaData.customGroupBys"
-                    showActiveItems="false"
+                    showActiveIteowl="2"se"
                     onItemSelected="(payload) => this.onGroupBySelected(isXAxis ? 'col' : 'row', payload)"
                     onAddCustomGroupBy="fieldName => this.onAddCustomGroupBy(isXAxis ? 'col' : 'row', cell.groupId, fieldName)"
                 />

--- a/addons/web/static/src/views/pivot/pivot_view.xml
+++ b/addons/web/static/src/views/pivot/pivot_view.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <templates xml:space="preserve">
 
-    <t t-name="web.PivotView.Buttons" owl="1">
+    <t t-name="web.PivotView.Buttons" owl="2">
         <div class="btn-group" role="toolbar" aria-label="Main actions">
             <t t-call="web.ReportViewMeasures">
                 <t t-set="measures" t-value="model.metaData.measures"/>
@@ -16,7 +16,7 @@
         </div>
     </t>
 
-    <t t-name="web.PivotView" owl="1">
+    <t t-name="web.PivotView" owl="2">
         <div t-att-class="props.className">
             <Layout className="model.useSampleModel ? 'o_view_sample_data' : ''">
                 <t t-set-slot="control-panel-bottom-left">

--- a/addons/web/static/src/views/view.xml
+++ b/addons/web/static/src/views/view.xml
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <templates xml:space="preserve">
 
-  <t t-name="web.View" owl="1">
+  <t t-name="web.View" owl="2">
       <WithSearch t-props="withSearchProps" t-on-click="handleActionLinks"/>
   </t>
 
-  <t t-name="web.ReportViewMeasures" owl="1">
+  <t t-name="web.ReportViewMeasures" owl="2">
     <Dropdown togglerClass="'btn btn-primary'">
             <t t-set-slot="toggler">
                 Measures <i class="fa fa-caret-down ml-1"/>

--- a/addons/web/static/src/webclient/actions/action_dialog.xml
+++ b/addons/web/static/src/webclient/actions/action_dialog.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <templates xml:space="preserve">
 
-  <t t-name="web.ActionDialog" t-inherit="web.Dialog" t-inherit-mode="primary" owl="1">
+  <t t-name="web.ActionDialog" t-inherit="web.Dialog" t-inherit-mode="primary" owl="2">
     <xpath expr="//header/h4[contains(concat(' ',normalize-space(@class),' '),' modal-title ')]" position="before">
       <DebugMenu t-if="env.debug" />
     </xpath>
@@ -12,11 +12,11 @@
     </xpath>
   </t>
 
-  <t t-name="web.ActionDialogBody" owl="1">
+  <t t-name="web.ActionDialogBody" owl="2">
     <t t-if="props.ActionComponent" t-component="props.ActionComponent" t-props="props.actionProps"/>
   </t>
 
-  <t t-name="web.LegacyAdaptedActionDialogFooter" owl="1">
+  <t t-name="web.LegacyAdaptedActionDialogFooter" owl="2">
     <t t-if="!isLegacy">
       <t t-slot="buttons">
         <button class="btn btn-primary" t-on-click="_close">

--- a/addons/web/static/src/webclient/loading_indicator/loading_indicator.xml
+++ b/addons/web/static/src/webclient/loading_indicator/loading_indicator.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <templates xml:space="preserve">
 
-    <t t-name="web.LoadingIndicator" owl="1">
+    <t t-name="web.LoadingIndicator" owl="2">
         <Transition visible="state.show" name="'o-fade'" t-slot-scope="transition" leaveDuration="400">
             <span class="o_loading_indicator" t-att-class="transition.className">Loading<t t-if="env.debug" t-esc="' (' + state.count + ')'" /></span>
         </Transition>

--- a/addons/web/static/src/webclient/menus/menu_command_item.xml
+++ b/addons/web/static/src/webclient/menus/menu_command_item.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <templates xml:space="preserve">
 
-  <t t-name="web.AppIconCommand" owl="1">
+  <t t-name="web.AppIconCommand" owl="2">
     <div class="o_command_default position-relative d-flex align-items-center justify-content-between px-4 py-2 o_cursor_pointer">
       <t t-slot="name"/>
       <img t-if="props.webIconData" class="o_app_icon position-relative rounded-sm" t-attf-src="{{props.webIconData}}"/>

--- a/addons/web/static/src/webclient/navbar/navbar.xml
+++ b/addons/web/static/src/webclient/navbar/navbar.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <templates xml:space="preserve">
 
-  <t t-name="web.NavBar" owl="1">
+  <t t-name="web.NavBar" owl="2">
     <header class="o_navbar" t-ref="root">
       <nav
         class="o_main_navbar"
@@ -41,7 +41,7 @@
 
   <t t-name="web.NavBar.AppsMenu" owl="1">
     <Dropdown hotkey="'h'" title="'Home Menu'" class="'o_navbar_apps_menu'">
-      <t t-set-slot="toggler">
+      <t t-set-slot="toggler">owl="2"
         <i class="oi oi-apps" />
       </t>
       <DropdownItem
@@ -60,7 +60,7 @@
   <t t-name="web.NavBar.SectionsMenu" owl="1">
     <div class="o_menu_sections d-none d-md-flex flex-grow-1 flex-shrink-1" t-ref="appSubMenus" role="menu">
 
-      <t t-foreach="sections" t-as="section" t-key="section.id">
+      <t t-foreach="sections" t-as="seowl="2"t-key="section.id">
         <t
           t-set="sectionsVisibleCount"
           t-value="(sections.length - currentAppSectionsExtra.length)"
@@ -113,7 +113,7 @@
   <t t-name="web.NavBar.SectionsMenu.Dropdown.MenuSlot" owl="1">
     <t t-foreach="items" t-as="item" t-key="item.id">
       <DropdownItem
-        t-if="!item.childrenTree.length"
+        t-if="!item.childrenTree.length"owl="2"
         href="getMenuItemHref(item)"
         class="'dropdown-item'"
         t-esc="item.name"
@@ -140,7 +140,7 @@
   <t t-name="web.NavBar.SectionsMenu.MoreDropdown" owl="1">
     <Dropdown class="'o_menu_sections_more'" title="'More Menu'" hotkey="hotkey">
       <t t-set-slot="toggler">
-        <i class="fa fa-plus"/>
+        <i class="fa fa-plus"/>owl="2"
       </t>
       <t t-foreach="sections" t-as="section" t-key="section.id">
 

--- a/addons/web/static/src/webclient/switch_company_menu/switch_company_menu.xml
+++ b/addons/web/static/src/webclient/switch_company_menu/switch_company_menu.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <templates xml:space="preserve">
 
-<t t-name="web.SwitchCompanyMenu" owl="1">
+<t t-name="web.SwitchCompanyMenu" owl="2">
     <Dropdown class="'o_switch_company_menu d-none d-md-block'" position="'bottom-end'">
         <t t-set-slot="toggler">
             <i class="fa fa-building d-lg-none"/>
@@ -17,7 +17,7 @@
 
 
 <t t-name="web.SwitchCompanyItem" owl="1">
-    <DropdownItem class="'p-0 bg-white'">
+    <DropdownItem class="'p-0 bg-wowl="2"
         <t t-set="isCompanySelected" t-value="selectedCompanies.includes(company.id)"/>
         <t t-set="isCurrent" t-value="company.id === companyService.currentCompany.id"/>
         <div class="d-flex" data-menu="company" t-att-data-company-id="company.id">

--- a/addons/web/static/src/webclient/user_menu/user_menu.xml
+++ b/addons/web/static/src/webclient/user_menu/user_menu.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <templates xml:space="preserve">
 
-    <t t-name="web.UserMenu" owl="1">
+    <t t-name="web.UserMenu" owl="2">
         <Dropdown class="'o_user_menu d-none d-md-block pr-0'" togglerClass="'py-1 py-lg-0'">
             <t t-set-slot="toggler">
                 <img class="rounded-circle o_user_avatar h-75 py-1" t-att-src="source" alt="User"/>

--- a/addons/web/static/src/webclient/user_menu/user_menu_items.xml
+++ b/addons/web/static/src/webclient/user_menu/user_menu_items.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <templates xml:space="preserve">
 
-    <t t-name="web.UserMenu.shortcutsTable" owl="1">
+    <t t-name="web.UserMenu.shortcutsTable" owl="2">
         <div>
             <div class="container-fluid">
                 <div class="row">

--- a/addons/web/static/src/webclient/webclient.xml
+++ b/addons/web/static/src/webclient/webclient.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <templates xml:space="preserve">
 
-    <t t-name="web.WebClient" owl="1">
+    <t t-name="web.WebClient" owl="2">
         <t t-if="!state.fullscreen">
             <NavBar/>
         </t>

--- a/addons/web_tour/static/src/debug/tour_dialog_component.xml
+++ b/addons/web_tour/static/src/debug/tour_dialog_component.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <templates id="template" xml:space="preserve">
 
-<t t-name="web_tour.ToursDialog" owl="1">
+<t t-name="web_tour.ToursDialog" owl="2">
     <div>
         <t t-call="web_tour.ToursDialog.Table">
             <t t-set="caption">Onboarding tours</t>
@@ -14,7 +14,7 @@
     </div>
 </t>
 
-<t t-name="web_tour.ToursDialog.Table" owl="1">
+<t t-name="web_tour.ToursDialog.Table" owl="2">
     <div class="table-responsive">
         <table class="table table-sm table-striped">
             <caption style="caption-side: top; font-size: 14px">

--- a/addons/website/static/src/components/configurator/configurator.xml
+++ b/addons/website/static/src/components/configurator/configurator.xml
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <templates id="template" xml:space="preserve">
 
-    <t t-name="website.Configurator.SkipButton" owl="1">
+    <t t-name="website.Configurator.SkipButton" owl="2">
         <div class="container-fluid py-2 pb-md-3 text-right pr-lg-5">
             <button class="btn btn-link" t-on-click="skip">Skip and start from scratch</button>
         </div>
     </t>
 
-    <t t-name="website.Configurator.WelcomeScreen" owl="1">
+    <t t-name="website.Configurator.WelcomeScreen" owl="2">
         <div class="o_configurator_screen h-100 d-flex flex-column o_welcome_screen">
             <div class="container-fluid pt-3 pb-2">
                 <img class="ml-lg-5" style="height: 31px; width: 99px;" src="/website/static/src/img/odoo_logo.svg" title="Odoo Logo"/>
@@ -26,7 +26,7 @@
     </div>
 </t>
 
-<t t-name="website.Configurator.DescriptionScreen" owl="1">
+<t t-name="website.Configurator.DescriptionScreen" owl="2">
     <div class="o_configurator_screen h-100 d-flex flex-column o_description_screen">
         <div class="container-fluid pt-3 pb-2">
             <img class="ml-lg-5" style="height: 31px; width: 99px;" src="/website/static/src/img/odoo_logo.svg" title="Odoo Logo"/>
@@ -87,7 +87,7 @@
     </div>
 </t>
 
-<t t-name="website.Configurator.PaletteSelectionScreen" owl="1">
+<t t-name="website.Configurator.PaletteSelectionScreen" owl="2">
     <div class="o_configurator_screen h-100 d-flex flex-column o_palette_selection_screen">
         <div class="container-fluid pt-3 pb-2">
             <img class="ml-lg-5" style="height: 31px; width: 99px;" src="/website/static/src/img/odoo_logo.svg" title="Odoo Logo"/>
@@ -149,7 +149,7 @@
     </div>
 </t>
 
-<t t-name="website.Configurator.FeatureSelection" owl="1">
+<t t-name="website.Configurator.FeatureSelection" owl="2">
     <div class="o_configurator_screen h-100 d-flex flex-column o_feature_selection_screen">
         <div class="container-fluid pt-3 pb-2">
             <img class="ml-lg-5" style="height: 31px; width: 99px;" src="/website/static/src/img/odoo_logo.svg" title="Odoo Logo"/>
@@ -191,7 +191,7 @@
     </div>
 </t>
 
-<t t-name="website.Configurator.ThemeSelectionScreen" owl="1">
+<t t-name="website.Configurator.ThemeSelectionScreen" owl="2">
     <div class="o_configurator_screen h-100 d-flex flex-column o_theme_selection_screen">
         <div class="container-fluid pt-3 pb-2">
             <img class="ml-lg-5" style="height: 31px; width: 99px;" src="/website/static/src/img/odoo_logo.svg" title="Odoo Logo"/>

--- a/addons/website_livechat/static/src/components/visitor_banner/visitor_banner.xml
+++ b/addons/website_livechat/static/src/components/visitor_banner/visitor_banner.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <templates xml:space="preserve">
 
-    <t t-name="website_livechat.VisitorBanner" owl="1">
+    <t t-name="website_livechat.VisitorBanner" owl="2">
         <t t-if="visitor">
             <div class="o_VisitorBanner" t-attf-class="{{ className }}" t-ref="root">
                 <div class="o_VisitorBanner_sidebar">


### PR DESCRIPTION
From now on, Owl will only accept owl 2 templates. Old templates
will be considered old, and should be retired from active service.

Note that this commit uses the simple "2" value, but you can use a more
interesting expression. For example, owl="1+1"

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
