### PR TITLE
[FIX] pos_gift_card: add autofocus to the pos giftcard barcode input

### DIFF
--- a/addons/pos_gift_card/static/src/js/GiftCardPopup.js
+++ b/addons/pos_gift_card/static/src/js/GiftCardPopup.js
@@ -1,7 +1,7 @@
 odoo.define("pos_gift_card.GiftCardPopup", function (require) {
   "use strict";
 
-  const { useState, useRef } = owl.hooks;
+  const { useState, useRef, onPatched, useComponent} = owl.hooks;
   const AbstractAwaitablePopup = require("point_of_sale.AbstractAwaitablePopup");
   const Registries = require("point_of_sale.Registries");
 
@@ -17,6 +17,19 @@ odoo.define("pos_gift_card.GiftCardPopup", function (require) {
         amountToSet: 0,
         giftCardBarcode: "",
       });
+      this.useAutoFocus(this.state);
+    }
+
+    useAutoFocus(state) {
+      const component = useComponent();
+      function autofocus() {
+        if (state.showBarcodeGeneration) {
+            const elem = component.el.querySelector(`.giftCardPopupInput`);
+            if (elem)
+                elem.focus();
+        }
+      }
+      onPatched(autofocus);
     }
 
     switchBarcodeView() {


### PR DESCRIPTION
Steps to reproduce:
	-install pos
	-activate giftcard on the configuration and the shop configuration
	-start a session, click on gift card and then on use a gift card

Current behavior:
	-There is no autofocus on the barcode input and the user has to click on the input window before scanning

Expected behavior:
	-The input is already selected and the user just has to scan the barcode

opw-2790665
