### PR TITLE
[FIX] hr_holidays: fix holiday with multiple employees

### DIFF
--- a/addons/hr_holidays/models/hr_leave.py
+++ b/addons/hr_holidays/models/hr_leave.py
@@ -294,7 +294,7 @@ class HolidaysRequest(models.Model):
     @api.constrains('holiday_status_id', 'number_of_days')
     def _check_allocation_duration(self):
         for holiday in self:
-            if holiday.holiday_status_id.requires_allocation == 'yes' and holiday.number_of_days > holiday.holiday_allocation_id.number_of_days:
+            if holiday.holiday_status_id.requires_allocation == 'yes' and holiday.holiday_allocation_id and holiday.number_of_days > holiday.holiday_allocation_id.number_of_days:
                 raise ValidationError(_("You have several allocations for those type and period.\nPlease split your request to fit in their number of days."))
 
     @api.depends_context('uid')


### PR DESCRIPTION
https://github.com/odoo/odoo/pull/86101 introduced a check of the number of days
of the allocation when a time off is taken.

The _compute_from_holiday_status_id method search for allocations based on employee_id.
If a holiday has multiple employees, no allocation will be found and the validation error
message asking to split the request to fit in their number of days will appear

task-2812415

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
