### PR TITLE
[FIX] multiwebsite published link redirect

### DIFF
--- a/addons/website/models/mixins.py
+++ b/addons/website/models/mixins.py
@@ -285,7 +285,7 @@ class WebsitePublishedMultiMixin(WebsitePublishedMixin):
     def open_website_url(self):
         return {
             'type': 'ir.actions.act_url',
-            'url': url_join(self.website_id.domain, self.website_url) if self.website_id else self.website_url,
+            'url': url_join(self.website_id.domain, self.website_url) if self.website_id.domain else self.website_url,
             'target': 'self',
         }
 


### PR DESCRIPTION
Since commit [1], we should use domain instead of _get_http_domain().
However, _get_http_domain() checks if the domain exists which is not the
case in commit [2]. It only impacts databases having multiple websites.

[1]: https://github.com/odoo/odoo/commit/7d8a8ddea0b363732f2177ad589a3e0e10e2fb6c
[2]: https://github.com/odoo/odoo/commit/ee71cdff0786d5c41fbcc50894cd06811d3d8d5b

Steps to reproduce:
  1. Install the eCommerce app
  2. Keep the domain field of the website empty
  3. Set the website field of a product to a website.
  4. Click 'Go to Website'

Current behavior before PR:
  - RPC_ERROR: Odoo Server Error

Desired behavior after PR is merged:
  - Redirected to the product's page
