### PR TITLE
[FIX] hr_recruitment: fix perf of new_application_count

### DIFF
--- a/addons/hr_recruitment/models/hr_job.py
+++ b/addons/hr_recruitment/models/hr_job.py
@@ -87,10 +87,35 @@ class Job(models.Model):
             ('job_ids', '=', self.id)], order='sequence asc', limit=1)
 
     def _compute_new_application_count(self):
+        self.env.cr.execute(
+            """
+                WITH job_stage AS (
+                    SELECT DISTINCT ON (j.id) j.id AS job_id, s.id AS stage_id, s.sequence AS sequence
+                      FROM hr_job j
+                 LEFT JOIN hr_job_hr_recruitment_stage_rel rel
+                        ON rel.hr_job_id = j.id
+                      JOIN hr_recruitment_stage s
+                        ON s.id = rel.hr_recruitment_stage_id
+                        OR s.id NOT IN (
+                                        SELECT "hr_recruitment_stage_id"
+                                          FROM "hr_job_hr_recruitment_stage_rel"
+                                         WHERE "hr_recruitment_stage_id" IS NOT NULL
+                                        )
+                     WHERE j.id in %s
+                  ORDER BY 1, 3 asc
+                )
+                SELECT s.job_id, COUNT(a.id) AS new_applicant
+                  FROM hr_applicant a
+                  JOIN job_stage s
+                    ON s.job_id = a.job_id
+                   AND a.stage_id = s.stage_id
+              GROUP BY s.job_id
+            """, [tuple(self.ids), ]
+        )
+
+        new_applicant_count = dict(self.env.cr.fetchall())
         for job in self:
-            job.new_application_count = self.env["hr.applicant"].search_count(
-                [("job_id", "=", job.id), ("stage_id", "=", job._get_first_stage().id)]
-            )
+            job.new_application_count = new_applicant_count.get(job.id, 0)
 
     def get_alias_model_name(self, vals):
         return 'hr.applicant'

--- a/addons/hr_recruitment/models/hr_recruitment.py
+++ b/addons/hr_recruitment/models/hr_recruitment.py
@@ -135,7 +135,7 @@ class Applicant(models.Model):
     date_open = fields.Datetime("Assigned", readonly=True, index=True)
     date_last_stage_update = fields.Datetime("Last Stage Update", index=True, default=fields.Datetime.now)
     priority = fields.Selection(AVAILABLE_PRIORITIES, "Appreciation", default='0')
-    job_id = fields.Many2one('hr.job', "Applied Job", domain="['|', ('company_id', '=', False), ('company_id', '=', company_id)]")
+    job_id = fields.Many2one('hr.job', "Applied Job", domain="['|', ('company_id', '=', False), ('company_id', '=', company_id)]", index=True)
     salary_proposed_extra = fields.Char("Proposed Salary Extra", help="Salary Proposed by the Organisation, extra advantages")
     salary_expected_extra = fields.Char("Expected Salary Extra", help="Salary Expected by Applicant, extra advantages")
     salary_proposed = fields.Float("Proposed Salary", group_operator="avg", help="Salary Proposed by the Organisation")


### PR DESCRIPTION
On large databases, the method `_compute_new_application_count` could
take up to 80% of the total loading time of the Job positions as each
job was generating 2 queries.

TaskID: 2812400

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
