### PR TITLE
[FIX] l10n_pl: fix tax report Poland

### DIFF
--- a/addons/l10n_pl/data/account_tax_report_data.xml
+++ b/addons/l10n_pl/data/account_tax_report_data.xml
@@ -172,14 +172,14 @@
         <field name="name">Podatek - Do przeniesienia</field>
         <field name="report_id" ref="tax_report"/>
         <field name="sequence" eval="3"/>
-        <field name="formula">PLTAXC_04_16 + PLTAXC_05_18 + PLTAXC_06_20 + PLTAXC_09_24 + PLTAXC_10_26 + PLTAXC_11_28 + PLTAXC_12_32 + PLTAXD_02_42</field>
+        <field name="formula">PLTAXC_04_16 + PLTAXC_05_18 + PLTAXC_06_20 + PLTAXC_09_24 + PLTAXC_10_26 + PLTAXC_11_28 + PLTAXC_12_32 - PLTAXD_02_42</field>
     </record>
 
     <record id="account_tax_report_line_nad_naleznym" model="account.tax.report.line">
         <field name="name">Podatek - Nadwyżka naliczonego nad należnym</field>
         <field name="report_id" ref="tax_report"/>
         <field name="sequence" eval="1"/>
-        <field name="formula">PLTAXC_04_16 + PLTAXC_05_18 + PLTAXC_06_20 + PLTAXC_09_24 + PLTAXC_10_26 + PLTAXC_11_28 + PLTAXC_12_32 + PLTAXD_02_42</field>
+        <field name="formula">PLTAXC_04_16 + PLTAXC_05_18 + PLTAXC_06_20 + PLTAXC_09_24 + PLTAXC_10_26 + PLTAXC_11_28 + PLTAXC_12_32 - PLTAXD_02_42</field>
         <field name="parent_id" ref="account_tax_report_line_do_przeniesienia"/>
     </record>
 
@@ -187,7 +187,7 @@
         <field name="name">Podatek - Do wpłaty do US</field>
         <field name="report_id" ref="tax_report"/>
         <field name="sequence" eval="1"/>
-        <field name="formula">PLTAXC_04_16 + PLTAXC_05_18 + PLTAXC_06_20 + PLTAXC_09_24 + PLTAXC_10_26 + PLTAXC_11_28 + PLTAXC_12_32 + PLTAXD_02_42</field>
+        <field name="formula">PLTAXC_04_16 + PLTAXC_05_18 + PLTAXC_06_20 + PLTAXC_09_24 + PLTAXC_10_26 + PLTAXC_11_28 + PLTAXC_12_32 - PLTAXD_02_42</field>
         <field name="parent_id" ref="account_tax_report_line_nad_naleznym"/>
     </record>
 


### PR DESCRIPTION


Description of the issue/feature this PR addresses:
Fix computation of the tax report in Poland

Current behavior before PR:
Instead of doing the difference between output tax and input tax, the tax report was doing the sum.

Desired behavior after PR is merged:
This commit fixes this computation without revamping the rest of the report



--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
