### PR TITLE
[FIX] website, web_editor: fix logo selector not displayed if text logo

### DIFF
--- a/addons/web_editor/static/src/js/editor/snippets.editor.js
+++ b/addons/web_editor/static/src/js/editor/snippets.editor.js
@@ -2173,6 +2173,22 @@ var SnippetsMenu = Widget.extend({
         var $html = $(html);
         var $scroll = $html.siblings('#o_scroll');
 
+        // TODO remove me in master: this is a hack that moves the logo options
+        // (type, height, height scrolled) into the navbar section. Before that
+        // these options were not displayed if the logo type was "text".
+        const $logoTypeSelector = $html.find('[data-js="HeaderNavbar"] [data-name="option_header_brand_none"]').parent();
+        if ($logoTypeSelector.length) {
+            $logoTypeSelector[0].dataset.dependencies = "";
+
+            const $logoHeightOptions = $html.find('[data-customize-website-variable][data-variable="logo-height"], [data-customize-website-variable][data-variable="fixed-logo-height"]');
+            $logoHeightOptions.closest('[data-selector]')
+                .find('[data-name="option_header_brand_none"]').parent().remove();
+            for (const el of $logoHeightOptions) {
+                el.setAttribute('string', '⌙ ' + el.getAttribute('string'));
+            }
+            $logoHeightOptions.insertAfter($logoTypeSelector);
+        }
+
         this.templateOptions = [];
         var selectors = [];
         var $styles = $html.find('[data-selector]');

--- a/addons/website/views/snippets/snippets.xml
+++ b/addons/website/views/snippets/snippets.xml
@@ -834,6 +834,8 @@
             <t t-set="dependencies" t-valuef="option_header_brand_none"/>
         </t>
     </div>
+    <!-- TODO adapt in master, the logo image options related to type and -->
+    <!-- height are moved back in the navbar section in JS -->
     <div data-selector="#wrapwrap > header nav.navbar .navbar-brand img" data-no-check="true">
         <t t-call="website.snippet_options_header_brand">
             <t t-set="label">Type</t>


### PR DESCRIPTION
Before this commit, the logo type selector was not displayed in navbar
options when the logo type was "Text".

This commit fix it only in js because we are on a stable version, an
other commit will fix it in the snippets options XML in master.

task-2800680

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
