### PR TITLE
[FIX] auth_totp: don't redirect to url prefixed with lang

### DIFF
--- a/addons/auth_totp/controllers/home.py
+++ b/addons/auth_totp/controllers/home.py
@@ -15,7 +15,7 @@ class Home(odoo.addons.web.controllers.main.Home):
     @http.route(
         '/web/login/totp',
         type='http', auth='public', methods=['GET', 'POST'], sitemap=False,
-        website=True, # website breaks the login layout...
+        website=True, multilang=False # website breaks the login layout...
     )
     def web_totp(self, redirect=None, **kwargs):
         if request.session.uid:


### PR DESCRIPTION
This commit removes the multilang feature on the /web/login/totp controller,
it doesn't really add value since it triggers a redirect and that the page is
all the same translated.

It is a good practice by default for SEO, but in this case it brings
some bug with the IOS apps that doesn't follow the redirect, while we don't
need to optimize this page for Search Engine.

The bug into the IOS apps, create a loop when we request the totp screen.
    Device request /web/login/totp
    Server ask a redirect to /fr_FR/web/login/totp
    Device redirect to /web/login/totp
    Server ask a redirect to /fr_FR/web/login/totp
    ...

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
