### PR TITLE
[IMP] project: adjust portal visibility followers behavior

### DIFF
--- a/addons/project/tests/test_project_sharing.py
+++ b/addons/project/tests/test_project_sharing.py
@@ -39,6 +39,7 @@ class TestProjectSharingCommon(TestProjectCommon):
             'partner_id': cls.user_portal.partner_id.id,
             'type_ids': project_sharing_stages_vals_list,
         })
+        cls.project_portal.message_subscribe(partner_ids=[cls.partner_portal.id])
 
         cls.task_cow = cls.env['project.task'].with_context({'mail_create_nolog': True}).create({
             'name': 'Cow UserTask',

--- a/addons/project/views/project_views.xml
+++ b/addons/project/views/project_views.xml
@@ -544,6 +544,10 @@
                                     <field name="analytic_account_id" domain="['|', ('company_id', '=', company_id), ('company_id', '=', False)]" context="{'default_partner_id': partner_id}" groups="analytic.group_analytic_accounting"/>
                                     <field name="analytic_tag_ids" groups="analytic.group_analytic_tags" widget="many2many_tags"/>
                                     <field name="privacy_visibility" widget="radio"/>
+                                    <span colspan="2" class="text-muted" attrs="{'invisible':[('privacy_visibility_warning', '=', '')]}">
+                                        <i class="fa fa-warning">&amp;nbsp;</i>
+                                        <field name="privacy_visibility_warning" nolabel="1"/>  
+                                    </span>
                                 </group>
                                 <group>
                                     <div name="alias_def" colspan="2" class="pb-2" attrs="{'invisible': [('alias_domain', '=', False)]}">


### PR DESCRIPTION
Currently, portal followers of a project and its tasks are removed when the project visibility is changed to something else than portal.
=> We want to keep the behavior, but only when changing the visibility from portal to something else.

When the project visibility is changed to portal, we currently add its customer to its followers.
=> In that case, we also want to add the customer of the tasks to the followers of the corresponding task.

When the customer of a project in portal visibility is changed, the new customer is added to the followers of the project.
=> We want to remove this behavior.

When a project is created with a customer and the portal visibility, the customer is added to the followers of the project.
=> We want to remove this behavior to avoid mistakenly showing a project that is not ready yet to the customer.

This commit implements those changes, and also adds a warning when changing the visibility of the project if that change will automatically add/remove followers to the project and its tasks.

Related: https://github.com/odoo/enterprise/pull/25800

Task-2812551