### PR TITLE
[FIX] website: fix logo type selector not displayed if logo type is text

### DIFF
--- a/addons/website/views/snippets/snippets.xml
+++ b/addons/website/views/snippets/snippets.xml
@@ -326,14 +326,6 @@
         data-allow-delete="true" data-fakem2m="true"/>
 </template>
 
-<template id="snippet_options_header_brand">
-    <we-select t-att-string="label" data-reload="/" t-att-data-dependencies="dependencies">
-        <we-button data-customize-website-views="" data-name="option_header_brand_none">None</we-button>
-        <we-button data-customize-website-views="website.option_header_brand_name">Text</we-button>
-        <we-button data-customize-website-views="website.option_header_brand_logo">Image</we-button>
-    </we-select>
-</template>
-
 <template id="snippet_options">
     <t t-call="web_editor.snippet_options"/>
 
@@ -857,23 +849,18 @@
             <we-button data-customize-website-views="website.header_language_selector_flag, website.header_language_selector_no_text">Flag</we-button>
             <we-button data-customize-website-views="website.header_language_selector_flag">Flag and Text</we-button>
         </we-select>
-        <t t-call="website.snippet_options_header_brand">
-            <t t-set="label">Logo Type</t>
-            <t t-set="dependencies" t-valuef="option_header_brand_none"/>
-        </t>
-    </div>
-    <div data-selector="#wrapwrap > header nav.navbar .navbar-brand img" data-no-check="true">
-        <t t-call="website.snippet_options_header_brand">
-            <t t-set="label">Type</t>
-        </t>
-
-        <we-input string="Height"
+        <we-select string="Logo" data-reload="/">
+            <we-button data-customize-website-views="" data-name="option_header_brand_none">None</we-button>
+            <we-button data-customize-website-views="website.option_header_brand_name">Text</we-button>
+            <we-button data-customize-website-views="website.option_header_brand_logo">Image</we-button>
+        </we-select>
+        <we-input string="⌙ Height"
                   data-dependencies="!option_header_brand_none"
                   data-customize-website-variable="null"
                   data-variable="logo-height"
                   data-unit="px"
                   data-save-unit="rem"/>
-        <we-input string="Height (Scrolled)"
+        <we-input string="⌙ Height (Scrolled)"
                   data-name="option_logo_height_scrolled"
                   data-customize-website-variable="null"
                   data-variable="fixed-logo-height"


### PR DESCRIPTION
Before this commit, the logo type selector was not displayed in the
navbar options when the logo type was "Text".

After this commit, the logo type selector is moved in the navbar options
to be always displayed in any case. We also moved the height and height
scrolled logo options in the navbar options because otherwise those
options are not displayed if the logo type is "text".

task-2800680

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
