### PR TITLE
[FIX] stock: avoid inter-warehouse transfer only if planned

### DIFF
--- a/addons/stock/i18n/stock.pot
+++ b/addons/stock/i18n/stock.pot
@@ -7161,9 +7161,9 @@ msgstr ""
 #: code:addons/stock/models/stock_picking.py:0
 #, python-format
 msgid ""
-"You should not use an internal transfer to move some products between two "
-"warehouses. Instead, use two pickings: a delivery from %s and a receipt to "
-"%s"
+"You should not use a planned internal transfer to move some products between"
+" two warehouses. Instead, use an immediate internal transfer or the resupply"
+" route."
 msgstr ""
 
 #. module: stock

--- a/addons/stock/models/stock_picking.py
+++ b/addons/stock/models/stock_picking.py
@@ -576,11 +576,12 @@ class Picking(models.Model):
     def onchange_locations(self):
         from_wh = self.location_id.get_warehouse()
         to_wh = self.location_dest_id.get_warehouse()
-        if self.picking_type_id.code == 'internal' and from_wh and to_wh and from_wh != to_wh:
+        is_immediate = self.immediate_transfer if self.id else self._context.get('default_immediate_transfer')
+        if self.picking_type_id.code == 'internal' and not is_immediate and from_wh and to_wh and from_wh != to_wh:
             return {'warning': {
                 'title': _("Warning"),
-                'message': _("You should not use an internal transfer to move some products between two warehouses. "
-                             "Instead, use two pickings: a delivery from %s and a receipt to %s") % (from_wh.display_name, to_wh.display_name),
+                'message': _("You should not use a planned internal transfer to move some products between two warehouses. "
+                             "Instead, use an immediate internal transfer or the resupply route.")
             }}
 
     @api.model


### PR DESCRIPTION
Improve 06188f6180136df39d57498272cc4c63a7ae73b1

The user does not have the possibility to create a delivery to the
inter-warehouse transit location (the destination location is
invisible). Same for the receipt.

So, the user should only avoid to transfer some products between two
warehouses if the internal transfer is a planned one.