### PR TITLE
[FIX] hr_expense: set copy to true to untaxed_amount

### DIFF
--- a/addons/hr_expense/models/hr_expense.py
+++ b/addons/hr_expense/models/hr_expense.py
@@ -75,7 +75,7 @@ class HrExpense(models.Model):
         domain="[('company_id', '=', company_id), ('type_tax_use', '=', 'purchase'), ('price_include', '=', True)]", string='Taxes',
         help="The taxes should be \"Included In Price\"")
     # TODO SGV can be removed
-    untaxed_amount = fields.Float("Subtotal", store=True, compute='_compute_amount', digits='Account')
+    untaxed_amount = fields.Float("Subtotal", store=True, compute='_compute_amount', digits='Account', copy=True)
     amount_residual = fields.Monetary(string='Amount Due', compute='_compute_amount_residual')
     total_amount = fields.Monetary("Total In Currency", compute='_compute_amount', store=True, currency_field='currency_id', tracking=True, readonly=False)
     company_currency_id = fields.Many2one('res.currency', string="Report Company Currency", related='company_id.currency_id', readonly=True)


### PR DESCRIPTION
Reproduction:

1. Duplicate an expense and save it
2. The subtotal field is not copied to the new expense

Reason: the field untaxed_amount is a compute field which is not copied
by default

Fix: set the copy to True for this field. It’s a patch for fix:
45fcd62205aeb73937cc6def35939e63eee01400

opw-2725901
