### PR TITLE
[FIX] website_event_sale: use event_ticket_id to get event ticket

### DIFF
--- a/addons/website_event_sale/models/sale_order.py
+++ b/addons/website_event_sale/models/sale_order.py
@@ -2,6 +2,7 @@
 
 from odoo import api, models, _
 from odoo.exceptions import UserError
+from odoo.osv import expression
 
 
 class SaleOrder(models.Model):
@@ -71,8 +72,10 @@ class SaleOrder(models.Model):
             if ticket.id:
                 self = self.with_context(event_ticket_id=ticket.id, fixed_price=1)
         else:
-            line = None
-            ticket = self.env['event.event.ticket'].search([('product_id', '=', product_id)], limit=1)
+            ticket_domain = [('product_id', '=', product_id)]
+            if self.env.context.get("event_ticket_id"):
+                ticket_domain = expression.AND([ticket_domain, [('id', '=', self.env.context['event_ticket_id'])]])
+            ticket = self.env['event.event.ticket'].search(ticket_domain, limit=1)
             old_qty = 0
         new_qty = set_qty if set_qty else (add_qty or 0 + old_qty)
 


### PR DESCRIPTION
### Expected Behaviour
When buying multiple tickets for an event on the website, we should have the correct number of tickets in our cart

### Observed Behaviour
When buying multiple tickets from an event B where the associated product has already been associated to another event A , the maximum number of tickets from the event A is used instead of the correct one (from B), leading the client not to be able to buy as much ticket as he want in case the limit of A is lower than the limit of B.

### Reproducibility
This issue can be reproduced using the following steps :
1. Create an event A with a maximum number of 1 tickets and a product P
2. Buy and confirm 1 ticket
3. Copy the event A to an event B
4. Set the maximum number of tickets to 3 (keeping product P)
5. Go to the website page of event B and try to buy 3 tickets
6. On the checkout page you should have only 1 ticket for event B

### Fix Description
The issue was coming from the fact we use the associated product to get the event's ticket ID in the `_cart_update` method, here: https://github.com/odoo/odoo/blob/e36dbb8317ec6588641766a7d654fcaa9fd33c10/addons/website_event_sale/models/sale_order.py#L75
This fix proposes to use the `event_ticket_id` value, already set in the sale_order context, to find the correct ticket.

### Related Issue(s)/PR
- opw-2761303

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
