### PR TITLE
[FIX] account: Fix division by zero on register payment wizard

### DIFF
--- a/addons/account/wizard/account_payment_register.py
+++ b/addons/account/wizard/account_payment_register.py
@@ -564,7 +564,10 @@ class AccountPaymentRegister(models.TransientModel):
                 if payment.currency_id != lines.currency_id:
                     liquidity_lines, counterpart_lines, writeoff_lines = payment._seek_for_lines()
                     source_balance = abs(sum(lines.mapped('amount_residual')))
-                    payment_rate = liquidity_lines[0].amount_currency / liquidity_lines[0].balance
+                    if liquidity_lines[0].balance:
+                        payment_rate = liquidity_lines[0].amount_currency / liquidity_lines[0].balance
+                    else:
+                        payment_rate = 0.0
                     source_balance_converted = abs(source_balance) * payment_rate
 
                     # Translate the balance into the payment currency is order to be able to compare them.

--- a/addons/account/wizard/account_payment_register.py
+++ b/addons/account/wizard/account_payment_register.py
@@ -589,10 +589,11 @@ class AccountPaymentRegister(models.TransientModel):
                     debit_lines = (liquidity_lines + counterpart_lines).filtered('debit')
                     credit_lines = (liquidity_lines + counterpart_lines).filtered('credit')
 
-                    payment.move_id.write({'line_ids': [
-                        (1, debit_lines[0].id, {'debit': debit_lines[0].debit + delta_balance}),
-                        (1, credit_lines[0].id, {'credit': credit_lines[0].credit + delta_balance}),
-                    ]})
+                    if debit_lines and credit_lines:
+                        payment.move_id.write({'line_ids': [
+                            (1, debit_lines[0].id, {'debit': debit_lines[0].debit + delta_balance}),
+                            (1, credit_lines[0].id, {'credit': credit_lines[0].credit + delta_balance}),
+                        ]})
         return payments
 
     def _post_payments(self, to_process, edit_mode=False):


### PR DESCRIPTION
[FIX] account: Fix division by zero on register payment wizard
- Create an invoice having a foreign currency
- Register a payment of 0.0 using a different currency with a write-off of any account
=> traceback

[FIX] account: Fix traceack when registering a 0 amount payment
=> Create an invoice in foreign currency
=> Register a payment of 0 using the currency of the company and select "Keep open"
A traceback is raised

task: 2809565

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
