### PR TITLE
[IMP] sale_{mrp,purchase}: Add notifcation in SO if MTO MO/PO qty is decreased

### DIFF
--- a/addons/mrp/wizard/change_production_qty.py
+++ b/addons/mrp/wizard/change_production_qty.py
@@ -72,17 +72,7 @@ class ChangeProductionQty(models.TransientModel):
 
             factor = (new_production_qty - qty_produced) / (old_production_qty - qty_produced)
             update_info = production._update_raw_moves(factor)
-            documents = {}
-            for move, old_qty, new_qty in update_info:
-                iterate_key = production._get_document_iterate_key(move)
-                if iterate_key:
-                    document = self.env['stock.picking']._log_activity_get_documents({move: (new_qty, old_qty)}, iterate_key, 'UP')
-                    for key, value in document.items():
-                        if documents.get(key):
-                            documents[key] += [value]
-                        else:
-                            documents[key] = [value]
-            production._log_manufacture_exception(documents)
+
             self._update_finished_moves(production, new_production_qty - qty_produced, old_production_qty - qty_produced)
             production.write({'product_qty': new_production_qty})
 

--- a/addons/sale_mrp/__manifest__.py
+++ b/addons/sale_mrp/__manifest__.py
@@ -18,7 +18,8 @@ from sales order. It adds sales name and sales Reference on production order.
         'security/ir.model.access.csv',
         'views/mrp_production_views.xml',
         'views/sale_order_views.xml',
-        'views/sale_portal_templates.xml'
+        'views/sale_portal_templates.xml',
+        'data/mail_templates.xml',
     ],
     'installable': True,
     'auto_install': True,

--- a/addons/sale_mrp/data/mail_templates.xml
+++ b/addons/sale_mrp/data/mail_templates.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <template id="exception_sale_on_manufacture_quantity_decreased" name="Message: Alert on sale orders when manufactured quantity decreased on Manufacturing Orders">
+        <div class="alert alert-warning" role="alert">
+            <p>
+                Exception(s) occured on the manufacturing order(s):
+                <t t-foreach="manufacturing_orders" t-as="manufacturing_order">
+                    <a href="#" data-oe-model="mrp.production" t-att-data-oe-id="manufacturing_order.id"><t t-esc="manufacturing_order.name"/></a>.
+                </t>
+                Manual actions may be needed.
+            </p>
+            <div class="mt16">
+                <p>Exception(s):</p>
+                <ul t-foreach="manufacturing_orders" t-as="manufacturing_order">
+                    <li>
+                        <t t-set="unit" t-value="manufacturing_order.product_uom_id.name"/>
+                        <a href="#" data-oe-model="mrp.production" t-att-data-oe-id="manufacturing_order.id"><t t-esc="manufacturing_order.name"/></a>:
+                        <t t-esc="new_quantity"/> <t t-esc="unit"/> of <t t-esc="manufacturing_order.product_id.name"/> to manufacture instead of <t t-esc="manufacturing_order.product_qty"/> <t t-esc="unit"/>.
+                    </li>
+                </ul>
+            </div>
+        </div>
+    </template>
+</odoo>

--- a/addons/sale_mrp/models/__init__.py
+++ b/addons/sale_mrp/models/__init__.py
@@ -6,3 +6,4 @@ from . import mrp_production
 from . import sale_order
 from . import sale_order_line
 from . import stock_move
+from . import stock_picking

--- a/addons/sale_mrp/models/mrp_production.py
+++ b/addons/sale_mrp/models/mrp_production.py
@@ -1,8 +1,10 @@
 # -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
-from odoo import api, fields, models, _
-
+from odoo import api, fields, models, SUPERUSER_ID, _
+from odoo.tools.float_utils import float_compare
+from collections import defaultdict
+from datetime import date
 
 class MrpProduction(models.Model):
     _inherit = 'mrp.production'
@@ -16,6 +18,40 @@ class MrpProduction(models.Model):
     def _compute_sale_order_count(self):
         for production in self:
             production.sale_order_count = len(production.procurement_group_id.mrp_production_ids.move_dest_ids.group_id.sale_id)
+
+    def write(self, vals):
+        if not vals.get('product_qty'):
+            return super().write(vals)
+
+        sales_to_nofify = defaultdict(lambda: self.env['mrp.production'])
+        for manufacturing_order in self:
+            # Compute total quantity to sell for this product in related SO
+            related_so = manufacturing_order.procurement_group_id.mrp_production_ids.move_dest_ids.group_id.sale_id
+            if not related_so:
+                continue
+            total_qty_sold = sum(related_so.order_line.filtered(lambda ol: ol.product_id.id == manufacturing_order.product_id.id).mapped('product_uom_qty'))
+            # Compute total quantity to produce for this product in MO related to those SO
+            all_related_mo = related_so.procurement_group_id.stock_move_ids.created_production_id.procurement_group_id.mrp_production_ids
+            total_qty_produced = sum(all_related_mo.filtered(lambda mo: mo.product_id.id == manufacturing_order.product_id.id and mo.id != manufacturing_order.id).mapped('product_uom_qty'))
+            total_qty_produced += vals.get('product_qty')
+            if float_compare(total_qty_sold, total_qty_produced, precision_rounding=manufacturing_order.product_uom_id.rounding) > 0:
+                for sale_order in related_so:
+                    sales_to_nofify[sale_order] |= manufacturing_order
+
+        for sale_order, manufacturing_orders in sales_to_nofify.items():
+            render_context = {
+                'manufacturing_orders': manufacturing_orders,
+                'new_quantity': vals.get('product_qty')
+            }
+            sale_order._activity_schedule_with_view(
+                'mail.mail_activity_data_warning',
+                date.today(),
+                user_id=sale_order.user_id.id or SUPERUSER_ID,
+                views_or_xmlid='sale_mrp.exception_sale_on_manufacture_quantity_decreased',
+                render_context=render_context
+            )
+
+        return super().write(vals)
 
     def action_view_sale_orders(self):
         self.ensure_one()

--- a/addons/sale_mrp/models/stock_picking.py
+++ b/addons/sale_mrp/models/stock_picking.py
@@ -1,0 +1,21 @@
+# -*- coding: utf-8 -*-
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from odoo import models
+
+
+class StockPicking(models.Model):
+    _inherit = 'stock.picking'
+
+    def _log_activity_get_documents(self, orig_obj_changes, stream_field, stream, groupby_method=False):
+        documents = super()._log_activity_get_documents(orig_obj_changes, stream_field, stream, groupby_method)
+
+        # Filter out documents directly related to a SO.
+        if stream == 'DOWN' and stream_field == 'move_dest_ids':
+            filtered_docs = {}
+            for (parent, responsible), rcontext in documents.items():
+                # Parent can something else than stock_picking. Have to check that sale_id actually exists on that recordset
+                if 'sale_id' not in parent._fields or not parent.sale_id:
+                    filtered_docs[(parent, responsible)] = rcontext
+            documents = filtered_docs
+        return documents

--- a/addons/sale_purchase/data/mail_data.xml
+++ b/addons/sale_purchase/data/mail_data.xml
@@ -25,6 +25,28 @@
     </div>
 </template>
 
+<template id="exception_sale_on_purchase_quantity_decreased" name="Message: Alert on sale orders when ordered quantity decreased on Purchase Orders">
+    <div class="alert alert-warning" role="alert">
+        <p>
+            Exception(s) occured on the purchase order(s):
+            <t t-foreach="purchase_orders" t-as="purchase_order">
+                <a href="#" data-oe-model="purchase.order" t-att-data-oe-id="purchase_order.id"><t t-esc="purchase_order.name"/></a>.
+            </t>
+            Manual actions may be needed.
+        </p>
+        <div class="mt16">
+            <p>Exception(s):</p>
+            <ul t-foreach="purchase_lines" t-as="purchase_line">
+                <li>
+                    <t t-set="unit" t-value="purchase_line.product_uom.name"/>
+                    <a href="#" data-oe-model="purchase.order" t-att-data-oe-id="purchase_line.order_id.id"><t t-esc="purchase_line.order_id.name"/></a>:
+                    <t t-esc="new_quantity"/> <t t-esc="unit"/> of <t t-esc="purchase_line.product_id.name"/> ordered instead of <t t-esc="purchase_line.product_qty"/> <t t-esc="unit"/>.
+                </li>
+            </ul>
+        </div>
+    </div>
+</template>
+
 <template id="exception_purchase_on_sale_cancellation" name="Message: Alert on purchase orders when sales orders are cancelled">
     <div>
         <p>

--- a/addons/sale_purchase/models/purchase_order.py
+++ b/addons/sale_purchase/models/purchase_order.py
@@ -1,8 +1,9 @@
 # -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
-from odoo import api, fields, models, _
-
+from odoo import api, fields, models, SUPERUSER_ID, _
+from odoo.tools.float_utils import float_compare
+from collections import defaultdict
 
 class PurchaseOrder(models.Model):
     _inherit = "purchase.order"
@@ -43,7 +44,7 @@ class PurchaseOrder(models.Model):
         return result
 
     def _get_sale_orders(self):
-        return self.order_line.sale_order_id
+        return self.order_line._get_sale_orders()
 
     def _activity_cancel_on_sale(self):
         """ If some PO are cancelled, we need to put an activity on their origin SO (only the open ones). Since a PO can have
@@ -72,3 +73,41 @@ class PurchaseOrderLine(models.Model):
 
     sale_order_id = fields.Many2one(related='sale_line_id.order_id', string="Sale Order", store=True, readonly=True)
     sale_line_id = fields.Many2one('sale.order.line', string="Origin Sale Item", index='btree_not_null', copy=False)
+
+    def _get_sale_orders(self):
+        return self.sale_order_id
+
+    def write(self, vals):
+        if not vals.get('product_qty'):
+            return super().write(vals)
+
+        sales_to_nofify = defaultdict(lambda: self.env['purchase.order.line'])
+        for purchase_line in self:
+            # Compute total quantity to sell for this product in related SO
+            related_so = purchase_line._get_sale_orders()
+            if not related_so:
+                continue
+            total_qty_sold = sum(related_so.order_line.filtered(lambda ol: ol.product_id.id == purchase_line.product_id.id).mapped('product_uom_qty'))
+            # Compute total quantity to order for this product in PO related to those SO
+            all_related_po = related_so._get_purchase_orders()
+            total_qty_purchased = sum(all_related_po.order_line.filtered(lambda ol: ol.product_id.id == purchase_line.product_id.id and ol.id != purchase_line.id).mapped('product_uom_qty'))
+            total_qty_purchased += vals.get('product_qty')
+            # Notify only Sale Orders if total quantity to order is now under total quantity asked in the relared Sale Orders.
+            if float_compare(total_qty_sold, total_qty_purchased, precision_rounding=purchase_line.product_uom.rounding) > 0:
+                for sale_order in related_so:
+                    sales_to_nofify[sale_order] |= purchase_line
+
+        for sale_order, purchase_lines in sales_to_nofify.items():
+            render_context = {
+                'purchase_lines': purchase_lines,
+                'purchase_orders': purchase_lines.mapped('order_id'),
+                'new_quantity': vals.get('product_qty')
+            }
+            sale_order._activity_schedule_with_view(
+                'mail.mail_activity_data_warning',
+                user_id=sale_order.user_id.id or SUPERUSER_ID,
+                views_or_xmlid='sale_purchase.exception_sale_on_purchase_quantity_decreased',
+                render_context=render_context
+            )
+
+        return super().write(vals)

--- a/addons/sale_purchase_stock/models/purchase_order.py
+++ b/addons/sale_purchase_stock/models/purchase_order.py
@@ -11,5 +11,8 @@ class PurchaseOrder(models.Model):
     def _compute_sale_order_count(self):
         super(PurchaseOrder, self)._compute_sale_order_count()
 
+class PurchaseOrderLine(models.Model):
+    _inherit = 'purchase.order.line'
+
     def _get_sale_orders(self):
-        return super(PurchaseOrder, self)._get_sale_orders() | self.order_line.move_dest_ids.group_id.sale_id | self.order_line.move_ids.move_dest_ids.group_id.sale_id
+        return super()._get_sale_orders() | self.move_dest_ids.group_id.sale_id | self.move_ids.move_dest_ids.group_id.sale_id

--- a/addons/stock/models/stock_move.py
+++ b/addons/stock/models/stock_move.py
@@ -1578,8 +1578,9 @@ class StockMove(models.Model):
             siblings_states = (move.move_dest_ids.mapped('move_orig_ids') - move).mapped('state')
             if move.propagate_cancel:
                 # only cancel the next move if all my siblings are also cancelled
-                if all(state == 'cancel' for state in siblings_states):
-                    move.move_dest_ids.filtered(lambda m: m.state != 'done')._action_cancel()
+                # if all(state == 'cancel' for state in siblings_states):
+                #     move.move_dest_ids.filtered(lambda m: m.state != 'done')._action_cancel()
+                pass
             else:
                 if all(state in ('done', 'cancel') for state in siblings_states):
                     move.move_dest_ids.write({'procure_method': 'make_to_stock'})


### PR DESCRIPTION
Related to https://github.com/odoo/odoo/pull/78079

Alters notifications made in MTO Sale Orders, following modifications made in linked PR.

- Add warning in chatter of sale order if related MTO purchase order's quantity is decreased below total required quantity
- Add warning in chatter of sale order if related MTO manufacturing order's quantity is decreased below total required quantity

Part of Task-2659807

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
