### PR TITLE
[FIX] crm: fix user-defined values in lead2opp wizard

### DIFF
--- a/addons/crm/wizard/crm_lead_to_opportunity.py
+++ b/addons/crm/wizard/crm_lead_to_opportunity.py
@@ -40,7 +40,7 @@ class Lead2OpportunityPartner(models.TransientModel):
                 result['user_id'] = lead.user_id.id
             if lead.team_id:
                 result['team_id'] = lead.team_id.id
-            if not partner_id and not lead.contact_name:
+            if not partner_id and not lead.contact_name and not result.get('action'):
                 result['action'] = 'nothing'
         return result
 


### PR DESCRIPTION
STEPS:
* create user-defined value for field `action` with a value other than `nothing`
* create a lead with empty values for fields **Partner** and **Contact Name**

BEFORE: `action` value is `nothing`
AFTER:  `action` value is equal to user defined one

opw-2809507

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
