### PR TITLE
[FIX][I18n][14.0] web: Fix calendar translation error

### DIFF
--- a/addons/web/static/src/js/views/calendar/calendar_renderer.js
+++ b/addons/web/static/src/js/views/calendar/calendar_renderer.js
@@ -578,7 +578,7 @@ return AbstractRenderer.extend({
                 });
             },
             'showOtherMonths': true,
-            'dayNamesMin': this.state.fc_options.dayNamesMin.map(x => x[0]),
+            'dayNamesMin': this.state.fc_options.dayNamesMin.map(x => x.substring(0,2)),
             'monthNames': this.state.fc_options.monthNamesShort,
             'firstDay': this.state.fc_options.firstDay,
         });


### PR DESCRIPTION
Description of the issue/feature this PR addresses: Fix Vietnamese translate error

Current behavior before PR:
- User Vietnamese
- On calendar mini show all day of week: "T", "T", "T", "T", "T", "T", "C"

Desired behavior after PR is merged:
- Show day of week: "T2", "T3", "T4", "T5", "T6", "T7", "CN", 

With Chinese, the days in dayNamesMin only have 1 character so x.substring(0,2) only returns 1 character as expected.
Other languages will return the same 2 characters as before


--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
