### PR TITLE
[FIX] account: make currency required

### DIFF
--- a/addons/account/wizard/account_payment_register_views.xml
+++ b/addons/account/wizard/account_payment_register_views.xml
@@ -46,6 +46,7 @@
                                  attrs="{'invisible': ['|', ('can_edit_wizard', '=', False), '&amp;', ('can_group_payments', '=', True), ('group_payment', '=', False)]}">
                                 <field name="amount"/>
                                 <field name="currency_id"
+                                       required="1"
                                        options="{'no_create': True, 'no_open': True}"
                                        groups="base.group_multi_currency"/>
                             </div>


### PR DESCRIPTION
Field `currency_id` is required to create payment vals at https://github.com/sswapnesh/odoo/blob/c9f08119a506dbb4c86092408cf17905ea62ab5a/addons/account/wizard/account_payment_register.py#L511.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
