### PR TITLE
[IMP] website, *: use upsert to improve visitor perf

### DIFF
--- a/addons/test_event_full/tests/test_performance.py
+++ b/addons/test_event_full/tests/test_performance.py
@@ -452,7 +452,7 @@ class TestOnlineEventPerformance(EventPerformanceCase, UtilPerf):
         # website customer data
         with freeze_time(self.reference_now):
             self.authenticate(None, None)
-            with self.assertQueryCount(default=39):  # com runbot: 39 - ent runbot: 39
+            with self.assertQueryCount(default=34):  # com runbot: 34 - ent runbot: 34
                 self._test_url_open('/event')
 
     # @warmup

--- a/addons/test_event_full/tests/test_wevent_register.py
+++ b/addons/test_event_full/tests/test_wevent_register.py
@@ -37,10 +37,8 @@ class TestWEventRegister(TestWEventCommon):
         )
 
         # check visitor stored information
-        self.assertEqual(visitor.name, "Raoulette Poiluchette")
+        self.assertEqual(visitor.display_name, "Raoulette Poiluchette")
         self.assertEqual(visitor.event_registration_ids, new_registrations)
         self.assertEqual(visitor.partner_id, self.env['res.partner'])
         self.assertEqual(visitor.mobile, "0456112233")
         self.assertEqual(visitor.email, "raoulette@example.com")
-        self.assertFalse(visitor.parent_id)
-        self.assertTrue(visitor.active)

--- a/addons/website/data/website_visitor_demo.xml
+++ b/addons/website/data/website_visitor_demo.xml
@@ -2,34 +2,22 @@
 <odoo>
 
     <record id="website_visitor_0" model="website.visitor">
-        <field name="name">Edwin Hansen</field>
-        <field name="partner_id" ref="base.res_partner_address_5"/>
         <field name="country_id" ref="base.nl"/>
         <field name="page_ids" eval="[(4, ref('website.homepage_page'))]"/>
         <field name="website_track_ids" eval="[(0, 0, {'page_id': ref('website.homepage_page'), 'url': '/'})]"/>
+        <field name="access_token" ref="base.res_partner_address_5"/>
     </record>
     <record id="website_visitor_1" model="website.visitor">
-        <field name="name">Soham Palmer</field>
-        <field name="partner_id" ref="base.res_partner_address_11"/>
         <field name="country_id" ref="base.us"/>
         <field name="page_ids" eval="[(4, ref('website.contactus_page'))]"/>
         <field name="website_track_ids" eval="[(0, 0, {'page_id': ref('website.contactus_page'), 'url': '/contactus'})]"/>
+        <field name="access_token" ref="base.res_partner_address_11"/>
     </record>
     <record id="website_visitor_2" model="website.visitor">
-        <field name="name">Philipe J. Fry</field>
-        <field name="partner_id" eval="False"/>
         <field name="country_id" ref="base.be"/>
         <field name="page_ids" eval="[(4, ref('website.homepage_page'))]"/>
         <field name="website_track_ids" eval="[(0, 0, {'page_id': ref('website.homepage_page'), 'url': '/'})]"/>
-    </record>
-    <record id="website_visitor_2_1" model="website.visitor">
-        <field name="name">Philipe J. Fry (old)</field>
-        <field name="active" eval="False"></field>
-        <field name="parent_id" ref="website.website_visitor_2"/>
-        <field name="partner_id" eval="False"/>
-        <field name="country_id" ref="base.be"/>
-        <field name="page_ids" eval="[(4, ref('website.contactus_page'))]"/>
-        <field name="website_track_ids" eval="[(0, 0, {'page_id': ref('website.contactus_page'), 'url': '/contactus'})]"/>
+        <field name="access_token">f9d24e459528093a790f38e5cc989a8d</field>
     </record>
 
 </odoo>

--- a/addons/website/models/ir_http.py
+++ b/addons/website/models/ir_http.py
@@ -148,7 +148,7 @@ class Http(models.AbstractModel):
 
         view = template and request.env['website'].get_template(template)
         if view and view.track:
-            request.env['website.visitor']._handle_webpage_dispatch(response, website_page)
+            request.env['website.visitor']._handle_webpage_dispatch(website_page)
 
         return False
 

--- a/addons/website/models/ir_http.py
+++ b/addons/website/models/ir_http.py
@@ -133,6 +133,8 @@ class Http(models.AbstractModel):
 
     @classmethod
     def _register_website_track(cls, response):
+        if request.env['ir.http'].is_a_bot():
+            return False
         if getattr(response, 'status_code', 0) != 200 or request.httprequest.headers.get('X-Disable-Tracking') == '1':
             return False
 

--- a/addons/website/models/website_visitor.py
+++ b/addons/website/models/website_visitor.py
@@ -2,7 +2,9 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 from datetime import datetime, timedelta
-import uuid
+from psycopg2 import sql
+
+import hashlib
 import pytz
 
 from odoo import fields, models, api, _
@@ -28,14 +30,29 @@ class WebsiteTrack(models.Model):
 class WebsiteVisitor(models.Model):
     _name = 'website.visitor'
     _description = 'Website Visitor'
-    _order = 'last_connection_datetime DESC'
+    _order = 'id DESC'
 
-    name = fields.Char('Name')
-    access_token = fields.Char(required=True, default=lambda x: uuid.uuid4().hex, copy=False, groups='website.group_website_publisher')
-    active = fields.Boolean('Active', default=True)
+    def _get_access_token(self):
+        """ Either the user's partner.id or a hash. """
+        if not request:
+            raise ValueError("Visitors can only be created through the frontend.")
+
+        if not self.env.user._is_public():
+            return self.env.user.partner_id.id
+
+        msg = repr((
+            request.httprequest.remote_addr,
+            request.httprequest.environ.get('HTTP_USER_AGENT'),
+            request.session.sid,
+        )).encode('utf-8')
+        # Keep same length (32) as before, it will ease the migration without
+        # any real downside
+        return hashlib.sha1(msg).hexdigest()[:32]
+
+    name = fields.Char('Name', related='partner_id.name')
+    access_token = fields.Char(required=True, default=_get_access_token, copy=False)
     website_id = fields.Many2one('website', "Website", readonly=True)
-    partner_id = fields.Many2one('res.partner', string="Contact", help="Partner of the last logged in user.", index='btree_not_null')
-    parent_id = fields.Many2one('website.visitor', string="Parent", ondelete='set null', index='btree_not_null', help="Main identity")
+    partner_id = fields.Many2one('res.partner', string="Contact", help="Partner of the last logged in user.", compute='_compute_partner_id', store=True, index='btree_not_null')
     partner_image = fields.Binary(related='partner_id.image_1920')
 
     # localisation and info
@@ -62,18 +79,26 @@ class WebsiteVisitor(models.Model):
 
     _sql_constraints = [
         ('access_token_unique', 'unique(access_token)', 'Access token should be unique.'),
-        ('partner_uniq', 'unique(partner_id)', 'A partner is linked to only one visitor.'),
     ]
 
-    @api.depends('name')
+    @api.depends('partner_id')
     def name_get(self):
         res = []
         for record in self:
             res.append((
                 record.id,
-                record.name or _('Website Visitor #%s', record.id)
+                record.partner_id.name or _('Website Visitor #%s', record.id)
             ))
         return res
+
+    @api.depends('access_token')
+    def _compute_partner_id(self):
+        # The browse in the loop is fine, there is no SQL Query on partner here
+        for visitor in self:
+            # If the access_token is not a 32 length hexa string, it means that
+            # the visitor is linked to a logged in user, in which case its
+            # partner_id is used instead as the token.
+            visitor.partner_id = len(visitor.access_token) != 32 and self.env['res.partner'].browse([visitor.access_token])
 
     @api.depends('partner_id.email_normalized', 'partner_id.mobile', 'partner_id.phone')
     def _compute_email_phone(self):
@@ -118,9 +143,10 @@ class WebsiteVisitor(models.Model):
 
     @api.depends('website_track_ids.page_id')
     def _compute_last_visited_page_id(self):
-        results = self.env['website.track']._read_group([('visitor_id', 'in', self.ids)],
-                                                       ['visitor_id', 'page_id', 'visit_datetime:max'],
-                                                       ['visitor_id', 'page_id'], lazy=False)
+        results = self.env['website.track']._read_group(
+            [('visitor_id', 'in', self.ids)],
+            ['visitor_id', 'page_id', 'visit_datetime:max'],
+            ['visitor_id', 'page_id'], lazy=False)
         mapped_data = {result['visitor_id'][0]: result['page_id'][0] for result in results if result['page_id']}
         for visitor in self:
             visitor.last_visited_page_id = mapped_data.get(visitor.id, False)
@@ -166,88 +192,115 @@ class WebsiteVisitor(models.Model):
             'context': compose_ctx,
         }
 
-    def _get_visitor_from_request(self, force_create=False):
-        """ Return the visitor as sudo from the request if there is a
-        visitor_uuid cookie.
+    def _upsert_visitor(self, access_token, force_track_values=None):
+        """ Based on the given `access_token`, either create or return the
+        related visitor if exists, through a single raw SQL UPSERT Query.
 
-        When fetching visitor, now that duplicates are linked to a main visitor
-        instead of unlinked, you may have more collisions issues with cookie
-        being set (after a de-connection for example).
+        It will also create a tracking record if requested, in the same query.
 
-        The visitor associated to a partner in case of public user is not taken
-        into account, it is considered as desynchronized cookie.
-        In addition, we also discard if the visitor has a main visitor whose
-        partner is set (aka wrong after logout partner). """
+        :param access_token: token to be used to upsert the visitor
+        :param force_track_values: an optional dict to create a track at the
+            same time.
+        :return: a tuple containing the visitor id and the upsert result (either
+            `inserted` or `updated).
+        """
+        country_code = request.geoip.get('country_code')
+        country_id = request.env['res.country'].sudo().search([
+            ('code', '=', country_code)
+        ], limit=1).id if country_code else None
+        create_values = {
+            'access_token': access_token,
+            'lang_id': request.lang.id,
+            'country_id': country_id,
+            'website_id': request.website.id,
+            'timezone': self._get_visitor_timezone() or None,
+            'write_uid': self.env.uid,
+            'create_uid': self.env.uid,
+            # If the access_token is not a 32 length hexa string, it means that the
+            # visitor is linked to a logged in user, in which case its partner_id is
+            # used instead as the token.
+            'partner_id': None if len(str(access_token)) == 32 else access_token,
+        }
+
+        query = """
+            INSERT INTO website_visitor (
+                partner_id, access_token, last_connection_datetime, visit_count, lang_id,
+                country_id, website_id, timezone, write_uid, create_uid, write_date, create_date)
+            VALUES (
+                %(partner_id)s, %(access_token)s, now() at time zone 'UTC', 1, %(lang_id)s,
+                %(country_id)s, %(website_id)s, %(timezone)s, %(create_uid)s, %(write_uid)s,
+                now() at time zone 'UTC', now() at time zone 'UTC')
+            ON CONFLICT (access_token)
+            DO UPDATE SET
+                last_connection_datetime=excluded.last_connection_datetime,
+                visit_count = CASE WHEN website_visitor.last_connection_datetime < NOW() AT TIME ZONE 'UTC' - INTERVAL '8 hours'
+                                    THEN website_visitor.visit_count + 1
+                                    ELSE website_visitor.visit_count
+                                END
+            RETURNING id, CASE WHEN create_date = now() at time zone 'UTC' THEN 'inserted' ELSE 'updated' END AS upsert
+        """
+
+        if force_track_values:
+            create_values['url'] = force_track_values['url']
+            create_values['page_id'] = force_track_values.get('page_id')
+            query = sql.SQL("""
+                WITH visitor AS (
+                    {query}, %(url)s AS url, %(page_id)s AS page_id
+                ), track AS (
+                    INSERT INTO website_track (visitor_id, url, page_id, visit_datetime)
+                    SELECT id, url, page_id::integer, now() at time zone 'UTC' FROM visitor
+                )
+                SELECT id, upsert from visitor;
+            """).format(query=sql.SQL(query))
+
+        self.env.cr.execute(query, create_values)
+        return self.env.cr.fetchone()
+
+    def _get_visitor_from_request(self, force_create=False, force_track_values=None):
+        """ Return the visitor as sudo from the request.
+
+        :param bool force_create: force a visitor creation if no visitor exists
+        :param force_track_values: an optional dict to create a track at the
+            same time.
+        :return: the website visitor if exists or forced, empty recordset
+                 otherwise.
+        """
 
         # This function can be called in json with mobile app.
         # In case of mobile app, no uid is set on the jsonRequest env.
         # In case of multi db, _env is None on request, and request.env unbound.
         if not (request and request.env and request.env.uid):
             return None
+
         Visitor = self.env['website.visitor'].sudo()
         visitor = Visitor
-        access_token = request.httprequest.cookies.get('visitor_uuid')
-        if access_token:
-            visitor = Visitor.with_context(active_test=False).search([('access_token', '=', access_token)])
-            # Prefetch access_token and other fields. Since access_token has a restricted group and we access
-            # a non restricted field (partner_id) first it is not fetched and will require an additional query to be retrieved.
-            visitor.access_token
+        access_token = self._get_access_token()
 
-        if not self.env.user._is_public():
-            partner_id = self.env.user.partner_id
-            if not visitor or visitor.partner_id and visitor.partner_id != partner_id:
-                # Partner and no cookie or wrong cookie
-                visitor = Visitor.with_context(active_test=False).search([('partner_id', '=', partner_id.id)])
-        elif visitor and visitor.partner_id:
-            # Cookie associated to a Partner
-            visitor = Visitor
+        if force_create:
+            visitor_id, _ = self._upsert_visitor(access_token, force_track_values)
+            visitor = Visitor.browse(visitor_id)
+        else:
+            visitor = Visitor.search([('access_token', '=', access_token)])
 
-        # also check that visitor parent partner is not different from user's one
-        # (indicates duplicate due to invalid or wrong cookie)
-        if visitor and visitor.parent_id.partner_id:
-            if self.env.user._is_public():
-                visitor = self.env['website.visitor'].sudo()
-            elif not visitor.partner_id:
-                visitor = self.env['website.visitor'].sudo().with_context(active_test=False).search(
-                    [('partner_id', '=', self.env.user.partner_id.id)]
-                )
-
-        if visitor and not visitor.timezone:
+        if not force_create and visitor and not visitor.timezone:
             tz = self._get_visitor_timezone()
             if tz:
                 visitor._update_visitor_timezone(tz)
 
-        if not visitor and force_create:
-            visitor = self._create_visitor()
-
         return visitor
 
-    def _handle_webpage_dispatch(self, response, website_page):
-        # get visitor. Done here to avoid having to do it multiple times in case of override.
-        visitor_sudo = self._get_visitor_from_request(force_create=True)
-        if request.httprequest.cookies.get('visitor_uuid', '') != visitor_sudo.access_token:
-            expiration_date = datetime.now() + timedelta(days=365)
-            response.set_cookie('visitor_uuid', visitor_sudo.access_token, expires=expiration_date)
-        self._handle_website_page_visit(website_page, visitor_sudo)
+    def _handle_webpage_dispatch(self, website_page):
+        """ Create a website.visitor if the http request object is a tracked
+        website.page or a tracked ir.ui.view.
+        Since this method is only called on tracked elements, the
+        last_connection_datetime might not be accurate as the visitor could have
+        been visiting only untracked page during his last visit."""
 
-    def _handle_website_page_visit(self, website_page, visitor_sudo):
-        """ Called on dispatch. This will create a website.visitor if the http request object
-        is a tracked website page or a tracked view. Only on tracked elements to avoid having
-        too much operations done on every page or other http requests.
-        Note: The side effect is that the last_connection_datetime is updated ONLY on tracked elements."""
         url = request.httprequest.url
-        website_track_values = {
-            'url': url,
-            'visit_datetime': datetime.now(),
-        }
+        website_track_values = {'url': url}
         if website_page:
             website_track_values['page_id'] = website_page.id
-            domain = [('page_id', '=', website_page.id)]
-        else:
-            domain = [('url', '=', url)]
-        visitor_sudo._add_tracking(domain, website_track_values)
-        if visitor_sudo.lang_id.id != request.lang.id:
-            visitor_sudo.write({'lang_id': request.lang.id})
+        self._get_visitor_from_request(force_create=True, force_track_values=website_track_values)
 
     def _add_tracking(self, domain, website_track_values):
         """ Add the track and update the visitor"""
@@ -258,76 +311,44 @@ class WebsiteVisitor(models.Model):
             self.env['website.track'].create(website_track_values)
         self._update_visitor_last_visit()
 
-    def _create_visitor(self):
-        """ Create a visitor. Tracking is added after the visitor has been created."""
-        country_code = request.geoip.get('country_code')
-        country_id = request.env['res.country'].sudo().search([('code', '=', country_code)], limit=1).id if country_code else False
-        vals = {
-            'lang_id': request.lang.id,
-            'country_id': country_id,
-            'website_id': request.website.id,
-        }
+    def _merge_visitor(self, target):
+        """ Merge an anonymous visitor data to a partner visitor then unlink
+        that anonymous visitor.
+        Purpose is to try to aggregate as much sub-records (tracked pages,
+        leads, ...) as possible.
+        It is especially useful to aggregate data from the same user on
+        different devices.
 
-        tz = self._get_visitor_timezone()
-        if tz:
-            vals['timezone'] = tz
+        This method is meant to be overridden for other modules to merge their
+        own anonymous visitor data to the partner visitor before unlink.
 
-        if not self.env.user._is_public():
-            vals['partner_id'] = self.env.user.partner_id.id
-            vals['name'] = self.env.user.partner_id.name
-        return self.sudo().create(vals)
-
-    def _link_to_partner(self, partner, update_values=None):
-        """ Link visitors to a partner. This method is meant to be overridden in
-        order to propagate, if necessary, partner information to sub records.
-
-        :param partner: partner used to link sub records;
-        :param update_values: optional values to update visitors to link;
-        """
-        vals = {'name': partner.name}
-        if update_values:
-            vals.update(update_values)
-        self.write(vals)
-
-    def _link_to_visitor(self, target):
-        """ Link visitors to target visitors, because they are linked to the
-        same identity. Purpose is mainly to propagate partner identity to sub
-        records to ease database update and decide what to do with "duplicated".
-        This method is meant to be overridden in order to implement some specific
-        behavior linked to sub records of duplicate management.
+        This method is only called after the user logs in.
 
         :param target: main visitor, target of link process;
         """
-        # Link sub records of self to target partner
-        if target.partner_id:
-            self._link_to_partner(target.partner_id)
-        # Link sub records of self to target visitor
-        self.website_track_ids.write({'visitor_id': target.id})
-
-        # Archive current record and set its parent visitor
-        self.partner_id = False
-        self.parent_id = target.id
-        self.active = False
-
-        return target
+        if not target.partner_id:
+            raise ValueError("The `target` visitor should be linked to a partner.")
+        self.website_track_ids.visitor_id = target.id
+        self.unlink()
 
     def _cron_unlink_old_visitors(self):
-        """ Unlink inactive visitors (see '_inactive_visitors_domain' for details).
+        """ Unlink inactive visitors (see '_inactive_visitors_domain' for
+        details).
 
-        Visitors were previously archived but we came to the conclusion that archived visitors
-        have very little value and bloat the database for no reason. """
+        Visitors were previously archived but we came to the conclusion that
+        archived visitors have very little value and bloat the database for no
+        reason. """
 
-        inactive_visitors = self.env['website.visitor'].sudo() \
-            .with_context(active_test=False) \
-            .search(self._inactive_visitors_domain())
-        inactive_visitors.unlink()
+        self.env['website.visitor'].sudo().search(self._inactive_visitors_domain()).unlink()
 
     def _inactive_visitors_domain(self):
-        """ This method defines the domain of visitors that can be cleaned. By default visitors
-        not linked to any partner and not active for 'website.visitor.live.days' days (default being 60)
-        are considered as inactive.
+        """ This method defines the domain of visitors that can be cleaned. By
+        default visitors not linked to any partner and not active for
+        'website.visitor.live.days' days (default being 60) are considered as
+        inactive.
 
-        This method is meant to be overridden by sub-modules to further refine inactivity conditions. """
+        This method is meant to be overridden by sub-modules to further refine
+        inactivity conditions. """
 
         delay_days = int(self.env['ir.config_parameter'].sudo().get_param('website.visitor.live.days', 60))
         deadline = datetime.now() - timedelta(days=delay_days)
@@ -346,24 +367,18 @@ class WebsiteVisitor(models.Model):
         self.env.cr.execute(query, (timezone, self.id))
 
     def _update_visitor_last_visit(self):
-        """ We need to do this part here to avoid concurrent updates error. """
-        try:
-            with self.env.cr.savepoint():
-                query_lock = "SELECT * FROM website_visitor where id = %s FOR NO KEY UPDATE NOWAIT"
-                self.env.cr.execute(query_lock, (self.id,), log_exceptions=False)
-
-                date_now = datetime.now()
-                query = "UPDATE website_visitor SET "
-                if self.last_connection_datetime < (date_now - timedelta(hours=8)):
-                    query += "visit_count = visit_count + 1,"
-                query += """
-                    active = True,
-                    last_connection_datetime = %s
-                    WHERE id = %s
-                """
-                self.env.cr.execute(query, (date_now, self.id), log_exceptions=False)
-        except Exception:
-            pass
+        date_now = datetime.now()
+        query = "UPDATE website_visitor SET "
+        if self.last_connection_datetime < (date_now - timedelta(hours=8)):
+            query += "visit_count = visit_count + 1,"
+        query += """
+            last_connection_datetime = %s
+            WHERE id IN (
+                SELECT id FROM website_visitor WHERE id = %s
+                FOR NO KEY UPDATE SKIP LOCKED
+            )
+        """
+        self.env.cr.execute(query, (date_now, self.id), log_exceptions=False)
 
     def _get_visitor_timezone(self):
         tz = request.httprequest.cookies.get('tz') if request else None

--- a/addons/website/models/website_visitor.py
+++ b/addons/website/models/website_visitor.py
@@ -182,7 +182,7 @@ class WebsiteVisitor(models.Model):
         # This function can be called in json with mobile app.
         # In case of mobile app, no uid is set on the jsonRequest env.
         # In case of multi db, _env is None on request, and request.env unbound.
-        if not request:
+        if not (request and request.env and request.env.uid):
             return None
         Visitor = self.env['website.visitor'].sudo()
         visitor = Visitor

--- a/addons/website/tests/test_performance.py
+++ b/addons/website/tests/test_performance.py
@@ -104,16 +104,16 @@ class TestWebsitePerformance(UtilPerf):
     def test_15_perf_sql_queries_page(self):
         # standard tracked website.page
         self.page.track = True
-        self.assertEqual(self._get_url_hot_query(self.page.url), 14)
-        self.assertEqual(self._get_url_hot_query(self.page.url, cache=False), 18)
+        self.assertEqual(self._get_url_hot_query(self.page.url), 7)
+        self.assertEqual(self._get_url_hot_query(self.page.url, cache=False), 11)
         self.menu.unlink()
-        self.assertEqual(self._get_url_hot_query(self.page.url), 14)
-        self.assertEqual(self._get_url_hot_query(self.page.url, cache=False), 18)
+        self.assertEqual(self._get_url_hot_query(self.page.url), 7)
+        self.assertEqual(self._get_url_hot_query(self.page.url, cache=False), 11)
 
     def test_20_perf_sql_queries_homepage(self):
         # homepage "/" has its own controller
-        self.assertEqual(self._get_url_hot_query('/'), 14)
-        self.assertEqual(self._get_url_hot_query('/', cache=False), 16)
+        self.assertEqual(self._get_url_hot_query('/'), 7)
+        self.assertEqual(self._get_url_hot_query('/', cache=False), 9)
 
     def test_30_perf_sql_queries_page_no_layout(self):
         # website.page with no call to layout templates

--- a/addons/website/tests/test_website_visitor.py
+++ b/addons/website/tests/test_website_visitor.py
@@ -1,12 +1,13 @@
 # coding: utf-8
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
+import random
+
 from contextlib import contextmanager
 from datetime import datetime, timedelta
 from unittest.mock import patch
 
 from odoo.addons.base.tests.common import HttpCaseWithUserDemo
-from odoo.addons.website.tools import MockRequest
 from odoo.addons.website.models.website_visitor import WebsiteVisitor
 from odoo.tests import common, tagged
 
@@ -34,7 +35,6 @@ class WebsiteVisitorTests(MockVisitor, HttpCaseWithUserDemo):
         self.website = self.env['website'].search([
             ('company_id', '=', self.env.user.company_id.id)
         ], limit=1)
-        self.cookies = {}
 
         untracked_view = self.env['ir.ui.view'].create({
             'name': 'UntackedView',
@@ -122,17 +122,28 @@ class WebsiteVisitorTests(MockVisitor, HttpCaseWithUserDemo):
     def assertVisitorDeactivated(self, visitor, main_visitor):
         """ Method that checks that a visitor has been de-activated / merged
         with other visitor, notably in case of login (see User.authenticate() as
-        well as Visitor._link_to_visitor() ). """
-        self.assertTrue(bool(visitor))
-        self.assertFalse(visitor.active)
-        self.assertTrue(main_visitor.active)
-        self.assertEqual(visitor.parent_id, main_visitor)
-
-        # tracks are linked
+        well as Visitor._merge_visitor() ). """
+        self.assertFalse(visitor.exists(), "The anonymous visitor should be deleted")
         self.assertTrue(visitor.website_track_ids < main_visitor.website_track_ids)
 
     def test_visitor_creation_on_tracked_page(self):
         """ Test various flows involving visitor creation and update. """
+
+        def authenticate(login, pwd):
+            # We can't call `self.authenticate` because that tour util is
+            # regenerating a new session.id before calling the real
+            # `authenticate` method.
+            # But we need the session id in the `authenticate` method because
+            # we need to retrieve the visitor before the authentication, which
+            # require the session id.
+            res = self.url_open('/web/login')
+            csrf_anchor = '<input type="hidden" name="csrf_token" value="'
+            self.url_open('/web/login', timeout=200, data={
+                'login': login,
+                'password': pwd,
+                'csrf_token': res.text.partition(csrf_anchor)[2].partition('"')[0],
+            })
+
         existing_visitors = self.env['website.visitor'].search([])
         existing_tracks = self.env['website.track'].search([])
         self.url_open(self.untracked_page.url)
@@ -142,25 +153,25 @@ class WebsiteVisitorTests(MockVisitor, HttpCaseWithUserDemo):
         new_visitor = self.env['website.visitor'].search([('id', 'not in', existing_visitors.ids)])
         new_track = self.env['website.track'].search([('id', 'not in', existing_tracks.ids)])
         self.assertEqual(len(new_visitor), 1, "1 visitor should be created")
-        self.assertEqual(len(new_track), 1, "There should be 1 tracked page")
+        self.assertEqual(len(new_track), 2, "There should be 2 tracked page")
         self.assertEqual(new_visitor.visit_count, 1)
         self.assertEqual(new_visitor.website_track_ids, new_track)
-        self.assertVisitorTracking(new_visitor, self.tracked_page)
+        self.assertVisitorTracking(new_visitor, self.tracked_page + self.tracked_page)
 
         # ------------------------------------------------------------
         # Admin connects
         # ------------------------------------------------------------
 
-        self.cookies = {'visitor_uuid': new_visitor.access_token}
-        with MockRequest(self.env, website=self.website, cookies=self.cookies):
-            self.authenticate(self.user_admin.login, 'admin')
+        authenticate(self.user_admin.login, 'admin')
 
         visitor_admin = new_visitor
         # visit a page
         self.url_open(self.tracked_page_2.url)
 
         # check tracking and visitor / user sync
-        self.assertVisitorTracking(visitor_admin, self.tracked_page | self.tracked_page_2)
+        new_visitors = self.env['website.visitor'].search([('id', 'not in', existing_visitors.ids)])
+        self.assertEqual(len(new_visitors), 1, "There should still be only one visitor.")
+        self.assertVisitorTracking(visitor_admin, self.tracked_page + self.tracked_page + self.tracked_page_2)
         self.assertEqual(visitor_admin.partner_id, self.partner_admin)
         self.assertEqual(visitor_admin.name, self.partner_admin.name)
 
@@ -168,8 +179,8 @@ class WebsiteVisitorTests(MockVisitor, HttpCaseWithUserDemo):
         # Portal connects
         # ------------------------------------------------------------
 
-        with MockRequest(self.env, website=self.website, cookies=self.cookies):
-            self.authenticate(self.user_portal.login, 'portal')
+        self.url_open('/web/session/logout')
+        authenticate(self.user_portal.login, 'portal')
 
         self.assertFalse(
             self.env['website.visitor'].search([('id', 'not in', (existing_visitors | visitor_admin).ids)]),
@@ -179,7 +190,6 @@ class WebsiteVisitorTests(MockVisitor, HttpCaseWithUserDemo):
         self.url_open(self.tracked_page.url)
         self.url_open(self.untracked_page.url)
         self.url_open(self.tracked_page_2.url)
-        self.url_open(self.tracked_page_2.url)  # 2 time to be sure it does not record twice
 
         # new visitor is created
         new_visitors = self.env['website.visitor'].search([('id', 'not in', existing_visitors.ids)])
@@ -194,19 +204,17 @@ class WebsiteVisitorTests(MockVisitor, HttpCaseWithUserDemo):
         # ------------------------------------------------------------
 
         # portal user disconnects
-        self.logout()
+        self.url_open('/web/session/logout')
 
         # visit some pages
         self.url_open(self.tracked_page.url)
         self.url_open(self.untracked_page.url)
         self.url_open(self.tracked_page_2.url)
-        self.url_open(self.tracked_page_2.url)  # 2 time to be sure it does not record twice
 
         # new visitor is created
         new_visitors = self.env['website.visitor'].search([('id', 'not in', existing_visitors.ids)])
         self.assertEqual(len(new_visitors), 3, "One extra visitor should be created")
         visitor_anonymous = new_visitors[0]
-        self.cookies['visitor_uuid'] = visitor_anonymous.access_token
         self.assertFalse(visitor_anonymous.name)
         self.assertFalse(visitor_anonymous.partner_id)
         self.assertVisitorTracking(visitor_anonymous, self.tracked_page | self.tracked_page_2)
@@ -216,37 +224,31 @@ class WebsiteVisitorTests(MockVisitor, HttpCaseWithUserDemo):
         # Admin connects again
         # ------------------------------------------------------------
 
-        with MockRequest(self.env, website=self.website, cookies=self.cookies):
-            self.authenticate(self.user_admin.login, 'admin')
+        authenticate(self.user_admin.login, 'admin')
 
-        # one visitor is deleted
-        visitor_anonymous = self.env['website.visitor'].with_context(active_test=False).search([('id', '=', visitor_anonymous.id)])
-        self.assertVisitorDeactivated(visitor_anonymous, visitor_admin)
         new_visitors = self.env['website.visitor'].search([('id', 'not in', existing_visitors.ids)])
         self.assertEqual(new_visitors, visitor_admin | visitor_portal)
         visitor_admin = self.env['website.visitor'].search([('partner_id', '=', self.partner_admin.id)])
         # tracks are linked
         self.assertTrue(visitor_anonymous_tracks < visitor_admin.website_track_ids)
-        self.assertEqual(len(visitor_admin.website_track_ids), 4, "There should be 4 tracked page for the admin")
+        self.assertEqual(len(visitor_admin.website_track_ids), 5, "There should be 5 tracked page for the admin")
 
         # ------------------------------------------------------------
         # Back to anonymous
         # ------------------------------------------------------------
 
         # admin disconnects
-        self.logout()
+        self.url_open('/web/session/logout')
 
         # visit some pages
         self.url_open(self.tracked_page.url)
         self.url_open(self.untracked_page.url)
         self.url_open(self.tracked_page_2.url)
-        self.url_open(self.tracked_page_2.url)  # 2 time to be sure it does not record twice
 
         # new visitor created
         new_visitors = self.env['website.visitor'].search([('id', 'not in', existing_visitors.ids)])
         self.assertEqual(len(new_visitors), 3, "One extra visitor should be created")
         visitor_anonymous_2 = new_visitors[0]
-        self.cookies['visitor_uuid'] = visitor_anonymous_2.access_token
         self.assertFalse(visitor_anonymous_2.name)
         self.assertFalse(visitor_anonymous_2.partner_id)
         self.assertVisitorTracking(visitor_anonymous_2, self.tracked_page | self.tracked_page_2)
@@ -255,8 +257,7 @@ class WebsiteVisitorTests(MockVisitor, HttpCaseWithUserDemo):
         # ------------------------------------------------------------
         # Portal connects again
         # ------------------------------------------------------------
-        with MockRequest(self.env, website=self.website, cookies=self.cookies):
-            self.authenticate(self.user_portal.login, 'portal')
+        authenticate(self.user_portal.login, 'portal')
 
         # one visitor is deleted
         new_visitors = self.env['website.visitor'].search([('id', 'not in', existing_visitors.ids)])
@@ -276,7 +277,7 @@ class WebsiteVisitorTests(MockVisitor, HttpCaseWithUserDemo):
         self.assertEqual(len(visitor_portal.website_track_ids), 5, "There should be 5 tracked page for the portal user")
 
         # simulate the portal user comes back 8hours later
-        visitor_portal.write({'last_connection_datetime': visitor_portal.last_connection_datetime - timedelta(hours=8)})
+        visitor_portal.write({'last_connection_datetime': visitor_portal.last_connection_datetime - timedelta(hours=9)})
         self.url_open(self.tracked_page.url)
         visitor_portal.invalidate_model(['visit_count'])
         # check number of visits
@@ -284,32 +285,32 @@ class WebsiteVisitorTests(MockVisitor, HttpCaseWithUserDemo):
 
     def test_clean_inactive_visitors(self):
         inactive_visitors = self.env['website.visitor'].create([{
-            'name': 'Crazy Lazy Bernie',
             'lang_id': self.env.ref('base.lang_en').id,
             'country_id': self.env.ref('base.be').id,
             'website_id': 1,
-            'last_connection_datetime': datetime.now() - timedelta(days=8)
+            'last_connection_datetime': datetime.now() - timedelta(days=8),
+            'access_token': 'f9d2b14b21be669518b14a9590cb62ed',
         }, {
-            'name': 'Sleeping Joe',
             'lang_id': self.env.ref('base.lang_en').id,
             'country_id': self.env.ref('base.be').id,
             'website_id': 1,
-            'last_connection_datetime': datetime.now() - timedelta(days=15)
+            'last_connection_datetime': datetime.now() - timedelta(days=15),
+            'access_token': 'f9d2d261a725da7f596574ca84e52f47',
         }])
 
         active_visitors = self.env['website.visitor'].create([{
-            'name': 'Active Donald',
             'lang_id': self.env.ref('base.lang_en').id,
             'country_id': self.env.ref('base.be').id,
             'website_id': 1,
-            'last_connection_datetime': datetime.now() - timedelta(days=1)
+            'last_connection_datetime': datetime.now() - timedelta(days=1),
+            'access_token': 'f9d2526d9c15658bdc91d2119e54b554',
         }, {
-            'name': 'Vladimir Customer',
             'lang_id': self.env.ref('base.lang_en').id,
             'country_id': self.env.ref('base.be').id,
             'website_id': 1,
             'partner_id': self.partner_demo.id,
-            'last_connection_datetime': datetime.now() - timedelta(days=15)
+            'last_connection_datetime': datetime.now() - timedelta(days=15),
+            'access_token': self.partner_demo.id,
         }])
 
         self._test_unlink_old_visitors(inactive_visitors, active_visitors)
@@ -325,7 +326,7 @@ class WebsiteVisitorTests(MockVisitor, HttpCaseWithUserDemo):
         We use this method as a private tool so that sub-module can also test the cleaning of visitors
         based on their own sets of conditions. """
 
-        WebsiteVisitor = self.env['website.visitor'].with_context(active_test=False)
+        WebsiteVisitor = self.env['website.visitor']
 
         self.env['ir.config_parameter'].sudo().set_param('website.visitor.live.days', 7)
 
@@ -351,7 +352,7 @@ class WebsiteVisitorTests(MockVisitor, HttpCaseWithUserDemo):
         This can happen quite often if the user switches browsers / hardwares.
 
         When 'linking' visitors together, the new visitor is archived and all its relevant data is
-        merged within the main visitor. See 'website.visitor#_link_to_visitor' for more details.
+        merged within the main visitor. See 'website.visitor#_merge_visitor' for more details.
 
         This test ensures that all the relevant data are properly merged.
 
@@ -362,16 +363,16 @@ class WebsiteVisitorTests(MockVisitor, HttpCaseWithUserDemo):
             self._prepare_main_visitor_data(),
             self._prepare_linked_visitor_data()
         ])
-        linked_visitor._link_to_visitor(main_visitor)
+        linked_visitor._merge_visitor(main_visitor)
 
         self.assertVisitorDeactivated(linked_visitor, main_visitor)
 
     def _prepare_main_visitor_data(self):
         return {
-            'name': "Mitchell Main",
             'lang_id': self.env.ref('base.lang_en').id,
             'country_id': self.env.ref('base.be').id,
             'website_id': 1,
+            'access_token': self.partner_admin.id,
             'website_track_ids': [(0, 0, {
                 'page_id': self.tracked_page.id,
                 'url': self.tracked_page.url
@@ -380,10 +381,10 @@ class WebsiteVisitorTests(MockVisitor, HttpCaseWithUserDemo):
 
     def _prepare_linked_visitor_data(self):
         return {
-            'name': "Mitchell Main's Phone",
             'lang_id': self.env.ref('base.lang_en').id,
             'country_id': self.env.ref('base.be').id,
             'website_id': 1,
+            'access_token': '%032x' % random.randrange(16**32),
             'website_track_ids': [(0, 0, {
                 'page_id': self.tracked_page_2.id,
                 'url': self.tracked_page_2.url

--- a/addons/website/tools.py
+++ b/addons/website/tools.py
@@ -16,12 +16,13 @@ from odoo.tools.misc import DotDict, frozendict
 def MockRequest(
         env, *, path='/mockrequest/', routing=True, multilang=True,
         context=frozendict(), cookies=frozendict(), country_code=None,
-        website=None, sale_order_id=None, website_sale_current_pl=None,
+        website=None, remote_addr=HOST, environ_base=None,
+        # website_sale
+        sale_order_id=None, website_sale_current_pl=None,
 ):
 
     lang_code = context.get('lang', env.context.get('lang', 'en_US'))
     env = env(context=dict(context, lang=lang_code))
-
     request = Mock(
         # request
         httprequest=Mock(
@@ -31,12 +32,14 @@ def MockRequest(
             environ=dict(
                 EnvironBuilder(
                     path=path,
-                    base_url=HttpCase.base_url()
+                    base_url=HttpCase.base_url(),
+                    environ_base=environ_base,
                 ).get_environ(),
-                REMOTE_ADDR=HOST,
+                REMOTE_ADDR=remote_addr,
             ),
             cookies=cookies,
             referrer='',
+            remote_addr=remote_addr,
         ),
         type='http',
         future_response=odoo.http.FutureResponse(),

--- a/addons/website/views/website_visitor_views.xml
+++ b/addons/website/views/website_visitor_views.xml
@@ -212,7 +212,6 @@
                     </div>
                     <group id="general_info">
                         <group string="Details">
-                            <field name="active" invisible="1"/>
                             <field name="is_connected" invisible="1"/>
                             <field name="partner_id"/>
                             <field name="email"/>
@@ -270,8 +269,6 @@
                 <filter string="Contacts" name="filter_type_customer" domain="[('partner_id', '!=', False)]"/>
                 <separator/>
                 <filter string="Connected" name="filter_is_connected" domain="[('last_connection_datetime', '&gt;', datetime.datetime.now() - datetime.timedelta(minutes=5))]"/>
-                <separator/>
-                <filter string="Archived" name="filter_is_archived" domain="[('active', '=', False)]"/>
                 <separator/>
                 <group string="Group By">
                     <filter string="Country" name="group_by_country" context="{'group_by': 'country_id'}"/>

--- a/addons/website_blog/tests/test_performance.py
+++ b/addons/website_blog/tests/test_performance.py
@@ -28,8 +28,8 @@ class TestBlogPerformance(UtilPerf):
             blog_tags = blog_tags[:-1]
         self.assertEqual(self._get_url_hot_query('/blog'), 11)
         self.assertEqual(self._get_url_hot_query('/blog', cache=False), 34)
-        self.assertEqual(self._get_url_hot_query(blog_post[0].website_url), 26)
-        self.assertEqual(self._get_url_hot_query(blog_post[0].website_url, cache=False), 29)
+        self.assertEqual(self._get_url_hot_query(blog_post[0].website_url), 19)
+        self.assertEqual(self._get_url_hot_query(blog_post[0].website_url, cache=False), 22)
 
     def test_30_perf_sql_blog_bigger_data_scaling(self):
         BlogPost = self.env['blog.post']

--- a/addons/website_crm/models/crm_lead.py
+++ b/addons/website_crm/models/crm_lead.py
@@ -21,7 +21,7 @@ class Lead(models.Model):
                         JOIN crm_lead_website_visitor_rel lv ON l.id = lv.crm_lead_id
                         JOIN website_visitor v ON v.id = lv.website_visitor_id
                         JOIN website_track p ON p.visitor_id = v.id
-                        WHERE l.id in %s AND v.active = TRUE
+                        WHERE l.id in %s
                         GROUP BY l.id"""
             self.env.cr.execute(sql, (tuple(self.ids),))
             page_data = self.env.cr.dictfetchall()

--- a/addons/website_crm/models/website_visitor.py
+++ b/addons/website_crm/models/website_visitor.py
@@ -48,14 +48,14 @@ class WebsiteVisitor(models.Model):
         domain = super()._inactive_visitors_domain()
         return expression.AND([domain, [('lead_ids', '=', False)]])
 
-    def _link_to_visitor(self, target):
+    def _merge_visitor(self, target):
         """ Link the leads to the main visitor to avoid them being lost. """
         if self.lead_ids:
             target.write({
                 'lead_ids': [(4, lead.id) for lead in self.lead_ids]
             })
 
-        return super(WebsiteVisitor, self)._link_to_visitor(target)
+        return super()._merge_visitor(target)
 
     def _prepare_message_composer_context(self):
         if not self.partner_id and self.lead_ids:

--- a/addons/website_crm/tests/test_crm_lead_merge.py
+++ b/addons/website_crm/tests/test_crm_lead_merge.py
@@ -22,11 +22,13 @@ class TestLeadVisitorMerge(TestLeadMergeCommon):
         TestLeadMergeCommon.merge_fields.append('visitor_ids')
 
         visitors = self.env['website.visitor'].sudo().create([
-            {'name': 'Visitor 1',
-             'lead_ids': [(4, self.lead_w_partner_company.id)],
+            {
+                'access_token': 'f9d2ffa0427d4e4b1d740cf5eb3cdc20',
+                'lead_ids': [(4, self.lead_w_partner_company.id)],
             },
-            {'name': 'Visitor 2',
-             'lead_ids': [(4, self.lead_w_partner.id)],
+            {
+                'access_token': 'f9d2c3f741a79200487728eac989e678',
+                'lead_ids': [(4, self.lead_w_partner.id)],
             }
         ])
         self.assertEqual(self.lead_w_partner_company.visitor_ids, visitors[0])

--- a/addons/website_crm/tests/test_website_visitor.py
+++ b/addons/website_crm/tests/test_website_visitor.py
@@ -24,7 +24,7 @@ class TestWebsiteVisitor(TestCrmCommon, WebsiteVisitorTests):
     @users('user_sales_manager')
     def test_compute_email_phone(self):
         visitor_sudo = self.env['website.visitor'].sudo().create({
-            'name': 'Mega Visitor',
+            'access_token': 'f9d2c6f3b024320ac31248595ac7fcb6',
         })
         visitor = visitor_sudo.with_user(self.env.user)  # as of 13.0 salesmen cannot create visitors, only read them
         customer = self.test_partner.with_user(self.env.user)
@@ -75,11 +75,11 @@ class TestWebsiteVisitor(TestCrmCommon, WebsiteVisitorTests):
     def test_clean_inactive_visitors_crm(self):
         """ Visitors attached to leads should not be deleted even if not connected recently. """
         active_visitors = self.env['website.visitor'].create([{
-            'name': 'Lead Carl',
             'lang_id': self.env.ref('base.lang_en').id,
             'country_id': self.env.ref('base.be').id,
             'website_id': 1,
             'last_connection_datetime': datetime.now() - timedelta(days=8),
+            'access_token': 'f9d28aad05ebee0bca215837b129aa00',
             'lead_ids': [(0, 0, {
                 'name': 'Lead Carl'
             })]
@@ -96,7 +96,7 @@ class TestWebsiteVisitor(TestCrmCommon, WebsiteVisitorTests):
             self._prepare_linked_visitor_data()
         ])
         all_leads = (main_visitor + linked_visitor).lead_ids
-        linked_visitor._link_to_visitor(main_visitor)
+        linked_visitor._merge_visitor(main_visitor)
 
         self.assertVisitorDeactivated(linked_visitor, main_visitor)
 

--- a/addons/website_event/controllers/main.py
+++ b/addons/website_event/controllers/main.py
@@ -287,8 +287,6 @@ class WebsiteEventController(http.Controller):
         as much informations as possible, notably to ease future communications.
         Also try to update visitor informations based on registration info. """
         visitor_sudo = request.env['website.visitor']._get_visitor_from_request(force_create=True)
-        visitor_sudo._update_visitor_last_visit()
-        visitor_values = {}
 
         registrations_to_create = []
         for registration_values in registration_data:
@@ -298,17 +296,10 @@ class WebsiteEventController(http.Controller):
             elif not registration_values.get('partner_id'):
                 registration_values['partner_id'] = False if request.env.user._is_public() else request.env.user.partner_id.id
 
-            if visitor_sudo:
-                # registration may give a name to the visitor, yay
-                if registration_values.get('name') and not visitor_sudo.name and not visitor_values.get('name'):
-                    visitor_values['name'] = registration_values['name']
-                # update registration based on visitor
-                registration_values['visitor_id'] = visitor_sudo.id
+            # update registration based on visitor
+            registration_values['visitor_id'] = visitor_sudo.id
 
             registrations_to_create.append(registration_values)
-
-        if visitor_values:
-            visitor_sudo.write(visitor_values)
 
         return request.env['event.registration'].sudo().create(registrations_to_create)
 

--- a/addons/website_event/tests/test_event_visitor.py
+++ b/addons/website_event/tests/test_event_visitor.py
@@ -15,11 +15,11 @@ class TestEventVisitor(TestEventOnlineCommon, WebsiteVisitorTests):
     def test_clean_inactive_visitors_event(self):
         """ Visitors registered to events should not be deleted even if not connected recently. """
         active_visitors = self.env['website.visitor'].create([{
-            'name': 'Lead Douglas',
             'lang_id': self.env.ref('base.lang_en').id,
             'country_id': self.env.ref('base.be').id,
             'website_id': 1,
             'last_connection_datetime': datetime.now() - timedelta(days=8),
+            'access_token': 'f9d2af99f543874642f89bd334fa4a49',
             'event_registration_ids': [(0, 0, {
                 'event_id': self.event_0.id
             })]
@@ -50,7 +50,7 @@ class TestEventVisitor(TestEventOnlineCommon, WebsiteVisitorTests):
         self.assertEqual(self.event_0, main_visitor.event_registered_ids)
         self.assertEqual(event_1, linked_visitor.event_registered_ids)
 
-        linked_visitor._link_to_visitor(main_visitor)
+        linked_visitor._merge_visitor(main_visitor)
         self.assertVisitorDeactivated(linked_visitor, main_visitor)
 
         # main_visitor is now attending both events

--- a/addons/website_event/views/website_visitor_views.xml
+++ b/addons/website_event/views/website_visitor_views.xml
@@ -1,17 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <odoo><data>
 
-   <record id="website_visitor_view_search" model="ir.ui.view">
-        <field name="name">website.visitor.view.search.inherit.event</field>
-        <field name="model">website.visitor</field>
-        <field name="inherit_id" ref="website.website_visitor_view_search"/>
-        <field name="arch" type="xml">
-            <xpath expr="//filter[@name='group_by_lang']" position="after">
-                <filter string="Main Contact" name="group_by_parent_id" groups="base.group_no_one" context="{'group_by': 'parent_id'}"/>
-            </xpath>
-        </field>
-    </record>
-
     <record id="website_visitor_view_tree" model="ir.ui.view">
         <field name="name">website.visitor.view.tree.inherit.event</field>
         <field name="model">website.visitor</field>
@@ -35,9 +24,6 @@
                     attrs="{'invisible': [('event_registration_count', '=', 0)]}">
                     <field name="event_registration_count" widget="statinfo" string="Registrations"/>
                 </button>
-            </xpath>
-            <xpath expr="//field[@name='page_ids']" position="after">
-                <field name="parent_id" groups="base.group_no_one"/>
             </xpath>
         </field>
     </record>

--- a/addons/website_event_meet_quiz/views/event_meet_templates.xml
+++ b/addons/website_event_meet_quiz/views/event_meet_templates.xml
@@ -25,7 +25,7 @@
                     t-att-src="image_data_uri(visitor['visitor'].partner_image) if visitor['visitor'].partner_image else '/web/static/img/user_placeholder.jpg'"
                     t-att-alt="visitor['visitor'].display_name"/>
                 <div class="o_we_leaderboard_name">
-                    <span t-if="visitor['visitor'] == current_visitor and not visitor['visitor'].name" class="font-weight-bold">You</span>
+                    <span t-if="visitor['visitor'] == current_visitor and not visitor['visitor'].partner_id" class="font-weight-bold">You</span>
                     <span t-else="" class="font-weight-bold" t-out="visitor['visitor'].display_name"/>
                 </div>
             </div></td>

--- a/addons/website_event_track/controllers/event_track.py
+++ b/addons/website_event_track/controllers/event_track.py
@@ -384,7 +384,6 @@ class EventTrackController(http.Controller):
         track = self._fetch_track(track_id, allow_sudo=True)
         force_create = set_reminder_on or track.wishlisted_by_default
         event_track_partner = track._get_event_track_visitors(force_create=force_create)
-        visitor_sudo = event_track_partner.visitor_id
 
         if not track.wishlisted_by_default:
             if not event_track_partner or event_track_partner.is_wishlisted == set_reminder_on:  # ignore if new state = old state
@@ -396,8 +395,6 @@ class EventTrackController(http.Controller):
             event_track_partner.is_blacklisted = not set_reminder_on
 
         result = {'reminderOn': set_reminder_on}
-        if request.httprequest.cookies.get('visitor_uuid', '') != visitor_sudo.access_token:
-            result['visitor_uuid'] = visitor_sudo.access_token
 
         return result
 

--- a/addons/website_event_track/models/website_visitor.py
+++ b/addons/website_event_track/models/website_visitor.py
@@ -53,15 +53,10 @@ class WebsiteVisitor(models.Model):
         domain = super()._inactive_visitors_domain()
         return expression.AND([domain, [('event_track_visitor_ids', '=', False)]])
 
-    def _link_to_partner(self, partner, update_values=None):
-        """ Propagate partner update to track_visitor records """
-        if partner:
-            track_visitor_wo_partner = self.event_track_visitor_ids.filtered(lambda track_visitor: not track_visitor.partner_id)
-            if track_visitor_wo_partner:
-                track_visitor_wo_partner.partner_id = partner
-        super(WebsiteVisitor, self)._link_to_partner(partner, update_values=update_values)
-
-    def _link_to_visitor(self, target):
+    def _merge_visitor(self, target):
         """ Override linking process to link wishlist to the final visitor. """
         self.event_track_visitor_ids.visitor_id = target.id
-        return super(WebsiteVisitor, self)._link_to_visitor(target)
+        track_visitor_wo_partner = self.event_track_visitor_ids.filtered(lambda track_visitor: not track_visitor.partner_id)
+        if track_visitor_wo_partner:
+            track_visitor_wo_partner.partner_id = target.partner_id
+        return super()._merge_visitor(target)

--- a/addons/website_event_track/static/src/js/event_track_reminder.js
+++ b/addons/website_event_track/static/src/js/event_track_reminder.js
@@ -3,7 +3,6 @@ odoo.define('website_event_track.website_event_track_reminder', function (requir
 
 var core = require('web.core');
 var _t = core._t;
-var utils = require('web.utils');
 var publicWidget = require('web.public.widget');
 
 publicWidget.registry.websiteEventTrackReminder = publicWidget.Widget.extend({
@@ -70,9 +69,6 @@ publicWidget.registry.websiteEventTrackReminder = publicWidget.Widget.extend({
                         delay: 0
                     });
                 }
-            }
-            if (result.visitor_uuid) {
-                utils.set_cookie('visitor_uuid', result.visitor_uuid);
             }
         });
     },

--- a/addons/website_event_track/tests/test_track_internals.py
+++ b/addons/website_event_track/tests/test_track_internals.py
@@ -145,8 +145,8 @@ class TestTrackSuggestions(TestEventOnlineCommon):
         }])
 
         emp_visitor = self.env['website.visitor'].create({
-            'name': 'Visitor',
-            'partner_id': self.user_employee.partner_id.id
+            'partner_id': self.user_employee.partner_id.id,
+            'access_token': self.user_employee.partner_id.id,
         })
         visitor_track = self.env['event.track.visitor'].create({
             'visitor_id': emp_visitor.id,

--- a/addons/website_event_track/tests/test_website_visitor.py
+++ b/addons/website_event_track/tests/test_website_visitor.py
@@ -25,6 +25,7 @@ class WebsiteVisitorTestsEventTrack(TestEventOnlineCommon, WebsiteVisitorTests):
             'country_id': self.env.ref('base.be').id,
             'website_id': 1,
             'last_connection_datetime': datetime.now() - timedelta(days=8),
+            'access_token': 'f9d2b93591d6f602e5e8afa238e35a6c',
             'event_track_visitor_ids': [(0, 0, {
                 'track_id': track_1.id,
                 'is_wishlisted': True
@@ -60,7 +61,7 @@ class WebsiteVisitorTestsEventTrack(TestEventOnlineCommon, WebsiteVisitorTests):
             'is_wishlisted': True,
         }])
 
-        linked_visitor._link_to_visitor(main_visitor)
+        linked_visitor._merge_visitor(main_visitor)
 
         self.assertVisitorDeactivated(linked_visitor, main_visitor)
 

--- a/addons/website_event_track_quiz/controllers/event_track_quiz.py
+++ b/addons/website_event_track_quiz/controllers/event_track_quiz.py
@@ -19,7 +19,6 @@ class WebsiteEventTrackQuiz(EventTrackController):
         track_sudo = track.sudo()
 
         event_track_visitor = track._get_event_track_visitors(force_create=True)
-        visitor_sudo = event_track_visitor.visitor_id
         if event_track_visitor.quiz_completed:
             return {'error': 'track_quiz_done'}
 
@@ -45,8 +44,6 @@ class WebsiteEventTrackQuiz(EventTrackController):
             'quiz_completed': event_track_visitor.quiz_completed,
             'quiz_points': answers_details['points']
         }
-        if visitor_sudo and request.httprequest.cookies.get('visitor_uuid', '') != visitor_sudo.access_token:
-            result['visitor_uuid'] = visitor_sudo.access_token
         return result
 
     @http.route('/event_track/quiz/reset', type="json", auth="public", website=True)

--- a/addons/website_event_track_quiz/static/src/js/event_quiz.js
+++ b/addons/website_event_track_quiz/static/src/js/event_quiz.js
@@ -5,7 +5,6 @@ odoo.define('website_event_track_quiz.event.quiz', function (require) {
 var publicWidget = require('web.public.widget');
 var core = require('web.core');
 var session = require('web.session');
-var utils = require('web.utils');
 
 var QWeb = core.qweb;
 var _t = core._t;
@@ -235,9 +234,6 @@ var Quiz = publicWidget.Widget.extend({
                 }
                 self._renderAnswersHighlightingAndComments();
                 self._renderValidationInfo();
-                if (data.visitor_uuid) {
-                    utils.set_cookie('visitor_uuid', data.visitor_uuid);
-                }
             }
 
             return Promise.resolve(data);

--- a/addons/website_event_track_quiz/views/event_leaderboard_templates.xml
+++ b/addons/website_event_track_quiz/views/event_leaderboard_templates.xml
@@ -61,7 +61,7 @@
                     t-att-src="image_data_uri(visitor['visitor'].partner_image) if visitor['visitor'].partner_image else '/web/static/img/user_placeholder.jpg'"/>
                 <img class="position-absolute" t-attf-src="/website_profile/static/src/img/rank_#{visitor['position']}.svg" alt="User rank" style="bottom: 0; right: -10px"/>
             </div>
-            <h3 t-if="visitor['visitor'] == current_visitor and not visitor['visitor'].name" class="mt-2 mb-0">You</h3>
+            <h3 t-if="visitor['visitor'] == current_visitor and not visitor['visitor'].partner_id" class="mt-2 mb-0">You</h3>
             <h3 t-else="" class="mt-2 mb-0" t-out="visitor['visitor'].display_name"/>
         </div>
         <div class="row mx-0 o_wprofile_top3_card_footer text-nowrap">
@@ -81,7 +81,7 @@
         t-att-src="image_data_uri(visitor['visitor'].partner_image) if visitor['visitor'].partner_image else '/web/static/img/user_placeholder.jpg'"/>
     </td>
     <td class="align-middle w-md-75">
-        <span t-if="visitor['visitor'] == current_visitor and not visitor['visitor'].name" class="font-weight-bold">You</span>
+        <span t-if="visitor['visitor'] == current_visitor and not visitor['visitor'].partner_id" class="font-weight-bold">You</span>
         <span t-else="" class="font-weight-bold" t-out="visitor['visitor'].display_name"/><br/>
     </td>
     <td class="align-middle font-weight-bold text-right text-nowrap">

--- a/addons/website_livechat/models/website_visitor.py
+++ b/addons/website_livechat/models/website_visitor.py
@@ -92,28 +92,24 @@ class WebsiteVisitor(models.Model):
                 notifications.append([operator.partner_id, 'website_livechat.send_chat_request', mail_channel_info])
             self.env['bus.bus']._sendmany(notifications)
 
-    def _link_to_visitor(self, target):
+    def _merge_visitor(self, target):
         """ Copy sessions of the secondary visitors to the main partner visitor. """
-        if target.partner_id:
-            target.mail_channel_ids |= self.mail_channel_ids
-        super(WebsiteVisitor, self)._link_to_visitor(target)
+        target.mail_channel_ids |= self.mail_channel_ids
+        self.mail_channel_ids.channel_partner_ids = [
+            (3, self.env.ref('base.public_partner').id),
+            (4, target.partner_id.id),
+        ]
+        return super()._merge_visitor(target)
 
-    def _link_to_partner(self, partner, update_values=None):
-        """ Adapt partner in members of related livechats """
-        if partner:
-            self.mail_channel_ids.channel_partner_ids = [
-                (3, self.env.ref('base.public_partner').id),
-                (4, partner.id),
-            ]
-        super(WebsiteVisitor, self)._link_to_partner(partner, update_values=update_values)
-
-    def _create_visitor(self):
-        visitor = super(WebsiteVisitor, self)._create_visitor()
-        mail_channel_uuid = json.loads(request.httprequest.cookies.get('im_livechat_session', '{}')).get('uuid')
-        if mail_channel_uuid:
-            mail_channel = request.env["mail.channel"].sudo().search([("uuid", "=", mail_channel_uuid)])
-            mail_channel.write({
-                'livechat_visitor_id': visitor.id,
-                'anonymous_name': visitor.display_name
-            })
-        return visitor
+    def _upsert_visitor(self, access_token, force_track_values=None):
+        visitor_id, upsert = super()._upsert_visitor(access_token, force_track_values=force_track_values)
+        if upsert == 'inserted':
+            visitor_sudo = self.sudo().browse(visitor_id)
+            mail_channel_uuid = json.loads(request.httprequest.cookies.get('im_livechat_session', '{}')).get('uuid')
+            if mail_channel_uuid:
+                mail_channel = request.env["mail.channel"].sudo().search([("uuid", "=", mail_channel_uuid)])
+                mail_channel.write({
+                    'livechat_visitor_id': visitor_sudo.id,
+                    'anonymous_name': visitor_sudo.display_name
+                })
+        return visitor_id, upsert

--- a/addons/website_livechat/tests/common.py
+++ b/addons/website_livechat/tests/common.py
@@ -1,6 +1,8 @@
 # -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
+import random
+
 from odoo import fields, tests
 
 
@@ -39,7 +41,11 @@ class TestLivechatCommon(tests.TransactionCase):
             'country_id': self.env.ref('base.de').id,
             'website_id': self.env.ref('website.default_website').id,
             'partner_id': self.env.ref('base.user_demo').partner_id.id,
-        }] + [visitor_vals]*self.max_sessions_per_operator)
+            'access_token': self.env.ref('base.user_demo').partner_id.id,
+        }] + [
+            dict(visitor_vals, access_token='%032x' % random.randrange(16**32))
+            for _ in range(self.max_sessions_per_operator)
+        ])
         self.visitor_demo, self.visitor = self.visitors[0], self.visitors[1]
 
         base_url = self.livechat_channel.get_base_url()

--- a/addons/website_livechat/tests/test_ui.py
+++ b/addons/website_livechat/tests/test_ui.py
@@ -10,7 +10,7 @@ class TestLivechatUI(tests.HttpCase, TestLivechatCommon):
     def setUp(self):
         super(TestLivechatUI, self).setUp()
         self.visitor_tour = self.env['website.visitor'].create({
-            'name': 'Visitor Tour',
+            'access_token': 'f9d2e784d3d96a904fca2f5e2a559a19',
             'website_id': self.env.ref('website.default_website').id,
         })
         self.target_visitor = self.visitor_tour

--- a/addons/website_livechat/tests/test_website_visitor.py
+++ b/addons/website_livechat/tests/test_website_visitor.py
@@ -16,7 +16,7 @@ class WebsiteVisitorTestsLivechat(WebsiteVisitorTests):
             self._prepare_linked_visitor_data()
         ])
         all_mail_channels = (main_visitor + linked_visitor).mail_channel_ids
-        linked_visitor._link_to_visitor(main_visitor)
+        linked_visitor._merge_visitor(main_visitor)
 
         self.assertVisitorDeactivated(linked_visitor, main_visitor)
 

--- a/addons/website_sale/controllers/main.py
+++ b/addons/website_sale/controllers/main.py
@@ -1241,10 +1241,7 @@ class WebsiteSale(http.Controller):
     def products_recently_viewed_update(self, product_id, **kwargs):
         res = {}
         visitor_sudo = request.env['website.visitor']._get_visitor_from_request(force_create=True)
-        if visitor_sudo:
-            if request.httprequest.cookies.get('visitor_uuid', '') != visitor_sudo.access_token:
-                res['visitor_uuid'] = visitor_sudo.access_token
-            visitor_sudo._add_viewed_product(product_id)
+        visitor_sudo._add_viewed_product(product_id)
         return res
 
     @http.route('/shop/products/recently_viewed_delete', type='json', auth='public', website=True)

--- a/addons/website_sale/models/website_visitor.py
+++ b/addons/website_sale/models/website_visitor.py
@@ -44,5 +44,5 @@ class WebsiteVisitor(models.Model):
         self.ensure_one()
         if product_id and self.env['product.product'].browse(product_id)._is_variant_possible():
             domain = [('product_id', '=', product_id)]
-            website_track_values = {'product_id': product_id, 'visit_datetime': datetime.now()}
+            website_track_values = {'product_id': product_id}
             self._add_tracking(domain, website_track_values)

--- a/addons/website_sale/static/src/js/website_sale_recently_viewed.js
+++ b/addons/website_sale/static/src/js/website_sale_recently_viewed.js
@@ -45,9 +45,6 @@ publicWidget.registry.productsRecentlyViewedUpdate = publicWidget.Widget.extend(
                 product_id: productId,
             }
         }).then(function (res) {
-            if (res && res.visitor_uuid) {
-                utils.set_cookie('visitor_uuid', res.visitor_uuid);
-            }
             utils.set_cookie(cookieName, productId, 30 * 60);
         });
     },


### PR DESCRIPTION
The easiest way to review this PR is to read it commit by commit.

- `[IMP] website: stop creating visitors and tracks for bots/crawlers`
Small fix to prevent bots to be tracked

- `[FIX] website: ensure request.env and env.uid are set`
Small fix to restore another fix lost in yet another fix. The follow commit is highlighting that issue and that missing fix.

- `[IMP] website, *: use upsert to improve visitor perf`
**This is the main change(s) of this PR, encapsulating 95% of the diff.** Full details inside that commit message.

- `[IMP] website: avoid SQL NOW() query to get create_date`
Small change on previous commit, encapsulated here (just for the review?) as it makes the code a bit uglier and won't be needed once commit on `now()` from PR-85078 is merged (if it happens).

Later commits are small one-liner that can be ignored for now (details either to be reverted later or to be done after current PR approach is validated).

Finally, note that a later pass will be done to adapt docstrings here and there.

**Benchmark**
Tracked Homepage, using `ab`, 10.000 loop.

| Tracked Homepage | Query |   Time |
| --------------------- | ----- | ------ |
| Before                |    13 | 19.705ms |
| Now                   |    6 | 14.678ms |
