### PR TITLE
[FIX] l10n_it_edi: use the invoicing address elements for the address…

### DIFF
--- a/addons/l10n_it_edi/data/invoice_it_template.xml
+++ b/addons/l10n_it_edi/data/invoice_it_template.xml
@@ -128,7 +128,7 @@
                             </Anagrafica>
                         </DatiAnagrafici>
                         <t t-call="l10n_it_edi.account_invoice_it_FatturaPA_sede">
-                            <t t-set="partner" t-value="record.commercial_partner_id"/>
+                            <t t-set="partner" t-value="record.partner_id"/>
                         </t>
                     </CessionarioCommittente>
                 </FatturaElettronicaHeader>


### PR DESCRIPTION
… instead of its parent

We use commercial_partner_id everywhere in the XML, because it is
possible that someone forgets to set the codice fiscale on the contact.
(it does not copy it to the child contacts)

However it is possible that the address is different and that we
want to send it to a child address on purpose instead of the
partner commercial_partner_id.  (the codice fiscale would be
the same as the parent anyways)

So, only for the address of the customer in the XML, we use
the one from the invoicing address itself and not its commercial_partner_id

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
