### PR TITLE
[IMP] hr_contract: properly define first_contract_date

### DIFF
--- a/addons/hr_contract/models/hr_employee_public.py
+++ b/addons/hr_contract/models/hr_employee_public.py
@@ -7,4 +7,4 @@ from odoo import fields, models
 class HrEmployeePublic(models.Model):
     _inherit = "hr.employee.public"
 
-    first_contract_date = fields.Date(related='employee_id.first_contract_date', groups="base.group_user")
+    first_contract_date = fields.Date(readonly=True, groups="base.group_user")


### PR DESCRIPTION
Removing the `related` makes it properly defined on the SQL view and
allows the field to be searched.

TaskID: 2781421

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
