### PR TITLE
[FIX] account: invalidate moves cache after lines invalidation

### DIFF
--- a/addons/account/models/account_move.py
+++ b/addons/account/models/account_move.py
@@ -3729,6 +3729,17 @@ class AccountMoveLine(models.Model):
             result.append((line.id, name))
         return result
 
+    @api.model
+    def invalidate_cache(self, fnames=None, ids=None):
+        # Invalidate cache of related moves
+        if fnames is None or 'move_id' in fnames:
+            field = self._fields['move_id']
+            lines = self.env.cache.get_records(self, field) if ids is None else self.browse(ids)
+            move_ids = {id_ for id_ in self.env.cache.get_values(lines, field) if id_}
+            if move_ids:
+                self.env['account.move'].invalidate_cache(ids=move_ids)
+        return super().invalidate_cache(fnames=fnames, ids=ids)
+
     # -------------------------------------------------------------------------
     # RECONCILIATION
     # -------------------------------------------------------------------------

--- a/addons/account/tests/test_account_move_entry.py
+++ b/addons/account/tests/test_account_move_entry.py
@@ -641,3 +641,18 @@ class TestAccountMove(AccountTestInvoicingCommon):
                 'credit': value['debit'],
             })
         self.assertRecordValues(reversed_caba_move.line_ids, expected_values)
+
+    def _get_cache_count(self, model_name='account.move', field_name='name'):
+        model = self.env[model_name]
+        field = model._fields[field_name]
+        return len(self.env.cache.get_records(model, field))
+
+    def test_cache_invalidation(self):
+        self.env['account.move'].invalidate_cache()
+        lines = self.test_move.line_ids
+        # prefetch
+        lines.mapped('move_id.name')
+        # check account.move cache
+        self.assertEqual(self._get_cache_count(), 1)
+        self.env['account.move.line'].invalidate_cache(ids=lines.ids)
+        self.assertEqual(self._get_cache_count(), 0)


### PR DESCRIPTION
This patch solves memory problem on exporting `account.move.line` records:
while export method invalidate cache for `account.move.line`, it keeps cache for
`account.move`, which may lead to memory error.

opw-2764457
