### PR TITLE
[FIX] base: set default `ir.actions.act_window.view` sequence to 0

### DIFF
--- a/odoo/addons/base/models/ir_actions.py
+++ b/odoo/addons/base/models/ir_actions.py
@@ -313,7 +313,7 @@ class IrActionsActWindowView(models.Model):
     _rec_name = 'view_id'
     _order = 'sequence,id'
 
-    sequence = fields.Integer()
+    sequence = fields.Integer(default=0)
     view_id = fields.Many2one('ir.ui.view', string='View')
     view_mode = fields.Selection(VIEW_TYPES, string='View Type', required=True)
     act_window_id = fields.Many2one('ir.actions.act_window', string='Action', ondelete='cascade')


### PR DESCRIPTION
Otherwise, records created with a `data.xml` and with a null sequence value are at a lower order than records with sequence=0
This is an issue particularly because the odoo UI framework hide the null value and displays a zero.

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
