### PR TITLE
[IMP] allow script and iframe tags in all embed code snippets

### DIFF
--- a/addons/sale_quotation_builder/models/sale_order.py
+++ b/addons/sale_quotation_builder/models/sale_order.py
@@ -8,7 +8,7 @@ from odoo.tools.translate import html_translate
 class SaleOrder(models.Model):
     _inherit = 'sale.order'
 
-    website_description = fields.Html('Website Description', sanitize_attributes=False, translate=html_translate, sanitize_form=False)
+    website_description = fields.Html('Website Description', translate=html_translate, sanitize_attributes=False, sanitize_tags=False, sanitize_form=False)
 
     @api.onchange('partner_id')
     def onchange_update_description_lang(self):
@@ -40,7 +40,7 @@ class SaleOrder(models.Model):
 class SaleOrderLine(models.Model):
     _inherit = "sale.order.line"
 
-    website_description = fields.Html('Website Description', sanitize=False, translate=html_translate, sanitize_form=False)
+    website_description = fields.Html('Website Description', translate=html_translate, sanitize_attributes=False, sanitize_tags=False, sanitize_form=False)
 
     @api.model
     def create(self, values):
@@ -62,7 +62,7 @@ class SaleOrderLine(models.Model):
 class SaleOrderOption(models.Model):
     _inherit = "sale.order.option"
 
-    website_description = fields.Html('Website Description', sanitize_attributes=False, translate=html_translate)
+    website_description = fields.Html('Website Description', translate=html_translate, sanitize_attributes=False, sanitize_tags=False)
 
     @api.onchange('product_id', 'uom_id')
     def _onchange_product_id(self):

--- a/addons/sale_quotation_builder/models/sale_order_template.py
+++ b/addons/sale_quotation_builder/models/sale_order_template.py
@@ -8,7 +8,7 @@ from odoo.tools.translate import html_translate
 class SaleOrderTemplate(models.Model):
     _inherit = "sale.order.template"
 
-    website_description = fields.Html('Website Description', translate=html_translate, sanitize_attributes=False, sanitize_form=False)
+    website_description = fields.Html('Website Description', translate=html_translate, sanitize_attributes=False, sanitize_tags=False, sanitize_form=False)
 
     def open_template(self):
         self.ensure_one()

--- a/addons/website_event_exhibitor/models/event_sponsor.py
+++ b/addons/website_event_exhibitor/models/event_sponsor.py
@@ -42,7 +42,7 @@ class Sponsor(models.Model):
         string="Sponsor Type", default="sponsor")
     website_description = fields.Html(
         'Description', compute='_compute_website_description',
-        sanitize_attributes=False, sanitize_form=True, translate=html_translate,
+        sanitize_attributes=False, sanitize_tags=False, sanitize_form=True, translate=html_translate,
         readonly=False, store=True)
     # contact information
     partner_id = fields.Many2one('res.partner', 'Partner', required=True, auto_join=True)

--- a/addons/website_hr_recruitment/models/hr_recruitment.py
+++ b/addons/website_hr_recruitment/models/hr_recruitment.py
@@ -54,7 +54,7 @@ class Job(models.Model):
         return (default_description._render() if default_description else "")
 
     website_published = fields.Boolean(help='Set if the application is published on the website of the company.')
-    website_description = fields.Html('Website description', translate=html_translate, sanitize_attributes=False, default=_get_default_website_description, prefetch=False, sanitize_form=False)
+    website_description = fields.Html('Website description', translate=html_translate, sanitize_attributes=False, sanitize_tags=False, sanitize_form=False, default=_get_default_website_description, prefetch=False)
 
     def _compute_website_url(self):
         super(Job, self)._compute_website_url()

--- a/addons/website_livechat/models/im_livechat.py
+++ b/addons/website_livechat/models/im_livechat.py
@@ -16,4 +16,4 @@ class ImLivechatChannel(models.Model):
         for channel in self:
             channel.website_url = "/livechat/channel/%s" % (slug(channel),)
 
-    website_description = fields.Html("Website description", default=False, help="Description of the channel displayed on the website page", sanitize_attributes=False, translate=html_translate, sanitize_form=False)
+    website_description = fields.Html("Website description", default=False, help="Description of the channel displayed on the website page", translate=html_translate, sanitize_attributes=False, sanitize_tags=False, sanitize_form=False)

--- a/addons/website_sale/models/product_misc.py
+++ b/addons/website_sale/models/product_misc.py
@@ -161,7 +161,7 @@ class ProductPublicCategory(models.Model):
     child_id = fields.One2many('product.public.category', 'parent_id', string='Children Categories')
     parents_and_self = fields.Many2many('product.public.category', compute='_compute_parents_and_self')
     sequence = fields.Integer(help="Gives the sequence order when displaying a list of product categories.", index=True, default=_default_sequence)
-    website_description = fields.Html('Category Description', sanitize_attributes=False, translate=html_translate, sanitize_form=False)
+    website_description = fields.Html('Category Description', translate=html_translate, sanitize_attributes=False, sanitize_tags=False, sanitize_form=False)
     product_tmpl_ids = fields.Many2many('product.template', relation='product_public_category_product_template_rel')
 
     @api.constrains('parent_id')

--- a/addons/website_sale/models/product_template.py
+++ b/addons/website_sale/models/product_template.py
@@ -19,7 +19,7 @@ class ProductTemplate(models.Model):
     _mail_post_access = 'read'
     _check_company_auto = True
 
-    website_description = fields.Html('Description for the website', sanitize_attributes=False, translate=html_translate, sanitize_form=False)
+    website_description = fields.Html('Description for the website', translate=html_translate, sanitize_attributes=False, sanitize_tags=False, sanitize_form=False)
     alternative_product_ids = fields.Many2many(
         'product.template', 'product_alternative_rel', 'src_id', 'dest_id', check_company=True,
         string='Alternative Products', help='Suggest alternatives to your customer (upsell strategy). '

--- a/odoo/tools/mail.py
+++ b/odoo/tools/mail.py
@@ -208,6 +208,11 @@ def html_sanitize(src, silent=True, sanitize_tags=True, sanitize_attributes=Fals
             })
         else:
             kwargs['remove_tags'] = tags_to_kill + tags_to_remove
+    else:
+        kwargs.update({
+            'embedded': False,
+            'scripts': False,
+        })
 
     if sanitize_attributes and etree.LXML_VERSION >= (3, 1, 0):  # lxml < 3.1.0 does not allow to specify safe_attrs. We keep all attributes in order to keep "style"
         if strip_classes:


### PR DESCRIPTION
HTML that is saved in html fields is treated differently than html saved in a customized view. When saving a html field, the code is sanitized, resulting in the removal of certain tags, attributes and styles depending on the options.

To allow adding `iframe` and `script` tags in the embed code snippet, the `embedded` and `scripts` options should be disabled in the `lxml.html.clean.Cleaner` instance. Disabling them whenever `sanitize_tags` is disabled, allows these tags to be allowed through the html field options.

opw-2811850