### PR TITLE
[FIX] tools: prevent errors when exporting Vendor Bills

### DIFF
--- a/odoo/tools/pdf.py
+++ b/odoo/tools/pdf.py
@@ -95,7 +95,6 @@ def add_banner(pdf_stream, text=None, logo=False, thickness=2 * cm):
     """
 
     old_pdf = PdfFileReader(pdf_stream, strict=False, overwriteWarnings=False)
-    old_pdf.getNumPages()
     packet = io.BytesIO()
     can = canvas.Canvas(packet)
     odoo_logo = Image.open(file_open('base/static/img/main_partner-image.png', mode='rb'))
@@ -134,6 +133,9 @@ def add_banner(pdf_stream, text=None, logo=False, thickness=2 * cm):
     new_pdf = PdfFileWriter()
     for p in range(old_pdf.getNumPages()):
         new_page = old_pdf.getPage(p)
+        # Remove annotations (if any), to prevent errors in PyPDF2
+        if '/Annots' in new_page:
+            del new_page['/Annots']
         new_page.mergePage(watermark_pdf.getPage(p))
         new_pdf.addPage(new_page)
 


### PR DESCRIPTION
This fix prevents the `/Annot` key from a PDF PageObject
to cause errors during its handling by PyPDF2.

Feature introduced here : https://github.com/odoo/odoo/commit/f0ea39791c70cc63fe39665514e5344a56ed5b71

opw-2811793

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
