### PR TITLE
[FIX] stock: display the date in the breadcrumb

### DIFF
--- a/addons/stock/wizard/stock_quantity_history.py
+++ b/addons/stock/wizard/stock_quantity_history.py
@@ -3,6 +3,7 @@
 
 from odoo import _, fields, models
 from odoo.osv import expression
+from odoo.tools.misc import format_datetime
 
 
 class StockQuantityHistory(models.TransientModel):
@@ -33,5 +34,6 @@ class StockQuantityHistory(models.TransientModel):
             'res_model': 'product.product',
             'domain': domain,
             'context': dict(self.env.context, to_date=self.inventory_datetime),
+            'display_name': format_datetime(self.env, self.inventory_datetime)
         }
         return action


### PR DESCRIPTION
Steps to reproduce the bug:
- Go to inventory > Reporting > Inventory report
- Click on “Inventory At Date” > Select a date > Confirm

Problem:
The date is not displayed in the breadcrumb, like in inventory valuation

Before the fix:
![2022-04-04_15-04](https://user-images.githubusercontent.com/78867936/161553864-529db284-a838-4f57-8f45-3ee4e4d1d58a.png)

After:
![P1](https://user-images.githubusercontent.com/78867936/161553785-fb11f6d1-18e2-4107-b035-e7f09d646bfd.png)




opw-2791566




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
