### PR TITLE
[IMP] website_livechat: adapt chatbot delay while testing to speedup …

### DIFF
--- a/addons/website_livechat/static/tests/tours/website_livechat_chatbot_flow.js
+++ b/addons/website_livechat/static/tests/tours/website_livechat_chatbot_flow.js
@@ -6,14 +6,14 @@ import LivechatButton from "im_livechat.legacy.im_livechat.im_livechat";
 LivechatButton.LivechatButton.include({
     /**
      * Let us make it a bit faster than the default delay (3500ms).
-     * Let us also debounce waiting for more user inputs for only 1000ms.
+     * Let us also debounce waiting for more user inputs for only 500ms.
      */
     start: function () {
-        this._chatbotMessageDelay = 1000;
+        this._chatbotMessageDelay = 100;
 
         this._debouncedChatbotAwaitUserInput = _.debounce(
             this._chatbotAwaitUserInput.bind(this),
-            1000);
+            500);
 
         return this._super(...arguments);
     },


### PR DESCRIPTION
…tours

This commit simply lowers the delay between receiving an answer and reacting to
it within a chatbot.script.

The previous delay of one whole second would slow down the testing phase and
could even break builds as the tour would not detect the messages fast enough
if under heavy load (such as during multi-builds).

This comes from the fact that adding and displaying a message within the chat
window actually re-renders the whole thread (see '_renderMessages').

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
