### PR TITLE
[FIX] crm: team_count

### DIFF
--- a/addons/crm/models/crm_stage.py
+++ b/addons/crm/models/crm_stage.py
@@ -32,6 +32,10 @@ class Stage(models.Model):
             ctx.pop('default_team_id')
         return super(Stage, self.with_context(ctx)).default_get(fields)
 
+    @api.model
+    def _get_team_count(self):
+        return self.env['crm.team'].search_count([])
+
     name = fields.Char('Stage Name', required=True, translate=True)
     sequence = fields.Integer('Sequence', default=1, help="Used to order stages. Lower is better.")
     is_won = fields.Boolean('Is Won Stage?')
@@ -42,8 +46,11 @@ class Stage(models.Model):
         help='This stage is folded in the kanban view when there are no records in that stage to display.')
 
     # This field for interface only
-    team_count = fields.Integer('team_count', compute='_compute_team_count')
+    team_count = fields.Integer(
+        'team_count',
+        compute='_compute_team_count',
+        default=_get_team_count,
+    )
 
     def _compute_team_count(self):
-        for stage in self:
-            stage.team_count = self.env['crm.team'].search_count([])
+        self.update({'team_count': self._get_team_count()})


### PR DESCRIPTION
When stage is being created, `team_count` was not computed, because it
has not dependencies. To workaround it, default must be used to force
set value, when stage form is opened for new record.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Team count is not computed before user is created

Desired behavior after PR is merged:

Team count is computed before user is created

P.S. same problem occurs for 14.0 and 15.0

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
