### PR TITLE
[FIX] account_analytic_default: fixing restrictions on analytic tags

### DIFF
--- a/addons/account_analytic_default/i18n/account_analytic_default.pot
+++ b/addons/account_analytic_default/i18n/account_analytic_default.pot
@@ -238,3 +238,9 @@ msgstr ""
 #: model_terms:ir.ui.view,arch_db:account_analytic_default.view_account_analytic_default_kanban
 msgid "to"
 msgstr ""
+
+#. module: account_analytic_default
+#: code:addons/account_analytic_default/models/account_move.py:30
+#, python-format
+msgid "An analytic default requires an analytic account or an analytic tag used for analytic distribution."
+msgstr ""

--- a/addons/account_analytic_default/models/account_analytic_default.py
+++ b/addons/account_analytic_default/models/account_analytic_default.py
@@ -24,8 +24,10 @@ class AccountAnalyticDefault(models.Model):
 
     @api.constrains('analytic_id', 'analytic_tag_ids')
     def _check_account_or_tags(self):
-        if any(not default.analytic_id and not default.analytic_tag_ids for default in self):
-            raise ValidationError(_('An analytic default requires at least an analytic account or an analytic tag.'))
+        if any(not default.analytic_id
+               and not default.analytic_tag_ids
+               or not any(tag.analytic_distribution_ids for tag in default.analytic_tag_ids) for default in self):
+            raise ValidationError(_('An analytic default requires an analytic account or an analytic tag used for analytic distribution.'))
 
     @api.model
     def account_get(self, product_id=None, partner_id=None, account_id=None, user_id=None, date=None, company_id=None):


### PR DESCRIPTION
If applied, this commit will fix the following bug by adding some
restrictions on the creation of analytic default
and the uses of tags in account.move

Steps to reproduce:
1- install account.accountant, account_analytic_default
2- Accounting --> Configuration --> Analytic Tags, analytic accounting
3-  Create an Analytic Tag, with no Analytic Distribution.
4-  Accounting --> Configuration --> Analytic Default Rules.
Create an Analytic Default Rule, using the Analytic Tag above
and select a Partner
5- Create a Vendor Bill on that partner. The Analytic Tag is added to
the invoice, as expected
6- However when selecting Accounting --> Reporting --> Analytic Report,
the report is empty and does not contain the Analytic Tag. Adding the
 Analytic Tag to the filter has no effect.
Bug/Issue:
An analytic tag is meant to be an additional dimension of analysis.
Dimension which is only worth/valid when an analytic account is
specified.

An analytic default rule should never be applied without
- either an analytic account
- or analytic tag used for distribution
Fixes:
1- changing the error condition on creating analytic default
2- changing the error message accordingly to better explain the issue
3- raise an error when the user creates an account.move with analytic
tags without (analytic tags + analytic account) or (analytic tags with
analytic distrubtion)

Please refer to the ticket for the whole discussion on this

OPW-2766749

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
