### PR TITLE
[FIX] point_of_sale: speed-up picking creation at closing

### DIFF
--- a/addons/point_of_sale/models/stock_picking.py
+++ b/addons/point_of_sale/models/stock_picking.py
@@ -6,6 +6,7 @@ from odoo.exceptions import UserError, ValidationError
 from odoo.tools import float_is_zero, float_compare
 
 from itertools import groupby
+from collections import defaultdict
 
 class StockPicking(models.Model):
     _inherit='stock.picking'
@@ -86,13 +87,13 @@ class StockPicking(models.Model):
     def _create_move_from_pos_order_lines(self, lines):
         self.ensure_one()
         lines_by_product = groupby(sorted(lines, key=lambda l: l.product_id.id), key=lambda l: l.product_id.id)
-        for product, lines in lines_by_product:
-            order_lines = self.env['pos.order.line'].concat(*lines)
-            current_move = self.env['stock.move'].create(
-                self._prepare_stock_move_vals(order_lines[0], order_lines)
-            )
-            confirmed_moves = current_move._action_confirm()
-            confirmed_moves._add_mls_related_to_order(order_lines)
+        move_vals = []
+        for dummy, olines in lines_by_product:
+            order_lines = self.env['pos.order.line'].concat(*olines)
+            move_vals.append(self._prepare_stock_move_vals(order_lines[0], order_lines))
+        moves = self.env['stock.move'].create(move_vals)
+        confirmed_moves = moves._action_confirm()
+        confirmed_moves._add_mls_related_to_order(lines, are_qties_done=True)
 
     def _send_confirmation_email(self):
         # Avoid sending Mail/SMS for POS deliveries
@@ -117,72 +118,111 @@ class StockMove(models.Model):
         keys = super(StockMove, self)._key_assign_picking()
         return keys + (self.group_id.pos_order_id,)
 
-    def _complete_done_qties(self):
-        self.ensure_one()
+    @api.model
+    def _prepare_lines_data_dict(self, order_lines):
+        lines_data = defaultdict(dict)
+        for product_id, olines in groupby(sorted(order_lines, key=lambda l: l.product_id.id), key=lambda l: l.product_id.id):
+            lines_data[product_id].update({'order_lines': self.env['pos.order.line'].concat(*olines)})
+        return lines_data
+
+    def _complete_done_qties(self, set_quantity_done_on_move=False):
+        self._action_assign()
         for move_line in self.move_line_ids:
             move_line.qty_done = move_line.product_uom_qty
-        if float_compare(self.product_uom_qty, self.quantity_done, precision_rounding=self.product_uom.rounding) > 0:
-            remaining_qty = self.product_uom_qty - self.quantity_done
-            ml_vals = self._prepare_move_line_vals()
-            ml_vals.update({'qty_done': remaining_qty})
-            self.env['stock.move.line'].create(ml_vals)
+        mls_vals = []
+        moves_to_set = set()
+        for move in self:
+            if float_compare(move.product_uom_qty, move.quantity_done, precision_rounding=move.product_uom.rounding) > 0:
+                remaining_qty = move.product_uom_qty - move.quantity_done
+                mls_vals.append(dict(move._prepare_move_line_vals(), qty_done=remaining_qty))
+                moves_to_set.add(move.id)
+        self.env['stock.move.line'].create(mls_vals)
+        if set_quantity_done_on_move:
+            for move in self.env['stock.move'].browse(moves_to_set):
+                move.quantity_done = move.product_uom_qty
+
+    def _create_production_lots_for_pos_order(self, lines):
+        ''' Search for existing lots and create missing ones.
+
+            :param lines: pos order lines with pack lot ids.
+            :type lines: pos.order.line recordset.
+
+            :return stock.product.lot recordset.
+        '''
+        valid_lots = self.env['stock.production.lot']
+        moves = self.filtered(lambda m: m.picking_type_id.use_existing_lots)
+        # Already called in self._action_confirm() but just to be safe when coming from _launch_stock_rule_from_pos_order_lines.
+        self._check_company()
+        if moves:
+            moves_product_ids = set(moves.mapped('product_id').ids)
+            lots = lines.pack_lot_ids.filtered(lambda l: l.lot_name and l.product_id.id in moves_product_ids)
+            lots_data = set(lots.mapped(lambda l: (l.product_id.id, l.lot_name)))
+            existing_lots = self.env['stock.production.lot'].search([
+                ('company_id', '=', moves[0].picking_type_id.company_id.id),
+                ('product_id', 'in', lines.product_id.ids),
+                ('name', 'in', lots.mapped('lot_name')),
+            ])
+            #The previous search may return (product_id.id, lot_name) combinations that have no matching in lines.pack_lot_ids.
+            for lot in existing_lots:
+                if (lot.product_id.id, lot.name) in lots_data:
+                    valid_lots |= lot
+                    lots_data.remove((lot.product_id.id, lot.name))
+            moves = moves.filtered(lambda m: m.picking_type_id.use_create_lots)
+            if moves:
+                moves_product_ids = set(moves.mapped('product_id').ids)
+                missing_lot_values = []
+                for lot_product_id, lot_name in filter(lambda l: l[0] in moves_product_ids, lots_data):
+                    missing_lot_values.append({'company_id': self.company_id.id, 'product_id': lot_product_id, 'name': lot_name})
+                valid_lots |= self.env['stock.production.lot'].create(missing_lot_values)
+        return valid_lots
 
     def _add_mls_related_to_order(self, related_order_lines, are_qties_done=True):
+        lines_data = self._prepare_lines_data_dict(related_order_lines)
         qty_fname = 'qty_done' if are_qties_done else 'product_uom_qty'
-        for move in self:
-            if related_order_lines[0].product_id == move.product_id and related_order_lines[0].product_id.tracking != 'none':
-                if move.picking_type_id.use_existing_lots or move.picking_type_id.use_create_lots:
-                    for line in related_order_lines:
-                        sum_of_lots = 0
-                        for lot in line.pack_lot_ids.filtered(lambda l: l.lot_name):
-                            if line.product_id.tracking == 'serial':
-                                qty = 1
-                            else:
-                                qty = abs(line.qty)
-                            ml_vals = move._prepare_move_line_vals()
-                            if move.picking_type_id.use_existing_lots:
-                                existing_lot = self.env['stock.production.lot'].search([
-                                    ('company_id', '=', self.company_id.id),
-                                    ('product_id', '=', line.product_id.id),
-                                    ('name', '=', lot.lot_name)
-                                ])
-                                if not existing_lot and move.picking_type_id.use_create_lots:
-                                    existing_lot = self.env['stock.production.lot'].create({
-                                        'company_id': self.company_id.id,
-                                        'product_id': line.product_id.id,
-                                        'name': lot.lot_name,
-                                    })
-                                quant = existing_lot.quant_ids.filtered(
-                                    lambda q: q.quantity > 0.0 and q.location_id.parent_path.startswith(
-                                        move.location_id.parent_path))[-1:]
-                                ml_vals.update({
-                                    'lot_id': existing_lot.id,
-                                    'location_id': quant.location_id.id or move.location_id.id
-                                })
-                            else:
-                                ml_vals.update({
-                                    'lot_name': lot.lot_name,
-                                })
-                            ml = self.env['stock.move.line'].create(ml_vals)
-                            ml.write({qty_fname: qty})
-                            sum_of_lots += qty
-                        if abs(line.qty) != sum_of_lots:
-                            difference_qty = abs(line.qty) - sum_of_lots
-                            ml_vals = self[0]._prepare_move_line_vals()
-                            if line.product_id.tracking == 'serial':
-                                mls = self.env['stock.move.line']
-                                for i in range(int(difference_qty)):
-                                    mls |= self.env['stock.move.line'].create(ml_vals)
-                                mls.write({qty_fname: 1})
-                            else:
-                                ml = self.env['stock.move.line'].create(ml_vals)
-                                ml.write({qty_fname: difference_qty})
-                else:
-                    move._action_assign()
-                    if are_qties_done:
-                        move._complete_done_qties()
-            else:
-                move._action_assign()
-                if are_qties_done:
-                    move._complete_done_qties()
-                    move.quantity_done = move.product_uom_qty
+        # Moves with product_id not in related_order_lines. This can happend e.g. when product_id has a phantom-type bom.
+        moves_to_assign = self.filtered(lambda m: m.product_id.id not in lines_data or m.product_id.tracking == 'none'
+                                                  or (not m.picking_type_id.use_existing_lots and not m.picking_type_id.use_create_lots))
+        moves_to_assign._complete_done_qties(set_quantity_done_on_move=True)
+        moves_remaining = self - moves_to_assign
+        existing_lots = moves_remaining._create_production_lots_for_pos_order(related_order_lines)
+        move_lines_to_create = []
+        mls_qties = []
+        for move in moves_remaining:
+            for line in lines_data[move.product_id.id]['order_lines']:
+                sum_of_lots = 0
+                for lot in line.pack_lot_ids.filtered(lambda l: l.lot_name):
+                    if line.product_id.tracking == 'serial':
+                        qty = 1
+                    else:
+                        qty = abs(line.qty)
+                    ml_vals = dict(move._prepare_move_line_vals())
+                    if existing_lots:
+                        existing_lot = existing_lots.filtered_domain([('product_id', '=', line.product_id.id), ('name', '=', lot.lot_name)])
+                        quant = self.env['stock.quant']
+                        if existing_lot:
+                            quant = self.env['stock.quant'].search(
+                                [('lot_id', '=', existing_lot.id), ('quantity', '>', '0.0'), ('location_id', 'child_of', move.location_id.id)],
+                                order='id desc',
+                                limit=1
+                            )
+                        ml_vals.update({
+                            'lot_id': existing_lot.id,
+                            'location_id': quant.location_id.id or move.location_id.id
+                        })
+                    else:
+                        ml_vals.update({'lot_name': lot.lot_name})
+                    move_lines_to_create.append(ml_vals)
+                    mls_qties.append(qty)
+                    sum_of_lots += qty
+                if abs(line.qty) != sum_of_lots:
+                    difference_qty = abs(line.qty) - sum_of_lots
+                    ml_vals = self[0]._prepare_move_line_vals()
+                    if line.product_id.tracking == 'serial':
+                        move_lines_to_create.extend([ml_vals for i in range(int(difference_qty))])
+                        mls_qties.extend([1]*int(difference_qty))
+                    else:
+                        move_lines_to_create.append(ml_vals)
+                        mls_qties.append(difference_qty)
+        move_lines = self.env['stock.move.line'].create(move_lines_to_create)
+        for move_line, qty in zip(move_lines, mls_qties):
+            move_line.write({qty_fname: qty})


### PR DESCRIPTION
Forward-port of PR odoo/odoo#86643.

Add a unittest for multi_step route on Ship Later warehouse to
ensure that the fix https://github.com/odoo/odoo/commit/5959d77f3448eb4cafabeb744a94b21471353e02 is not unintentionally reverted.


#### speed

As for the v14 PR the speed depends on a number of things. First in a customer DB with no products tracked,
realtime inventory valuation and no Bills of materials. Speedup when closing different sessions:

- 149 orders, 346 lines, 288 products: 410s -> 380s
- 381 orders, 1048 lines, 687 products: 766s -> 301s
- 572 orders, 1395 lines, 830 products: 536s -> 367s

Then, in a testing database with no products tracked, no anglo-saxon accounting, real-time inventory valuation,
phantom boms for each product with 5-30 components:

- 70 orders, 350 lines, 350 products: 32 min -> 13 min.

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
