### PR TITLE
[FIX] l10n_cl: unable to issue credit note (vendor bill)

### DIFF
--- a/addons/l10n_cl/models/account_move.py
+++ b/addons/l10n_cl/models/account_move.py
@@ -29,9 +29,14 @@ class AccountMove(models.Model):
             if self.company_id.partner_id.l10n_cl_sii_taxpayer_type == '1':
                 domain += [('code', '!=', '71')]  # Companies with VAT Affected doesn't have "Boleta de honorarios Electrónica"
             return domain
+        if self.move_type == 'in_refund':
+            internal_types_domain = ('internal_type', '=', 'credit_note')
+        else:
+            internal_types_domain = ('internal_type', 'in', ['invoice', 'debit_note', 'credit_note', 'invoice_in'])
         domain = [
             ('country_id.code', '=', 'CL'),
-            ('internal_type', 'in', ['invoice', 'debit_note', 'credit_note', 'invoice_in'])]
+            internal_types_domain,
+        ]
         if self.partner_id.l10n_cl_sii_taxpayer_type == '1' and self.partner_id_vat != '60805000-0':
             domain += [('code', 'not in', ['39', '70', '71', '914', '911'])]
         elif self.partner_id.l10n_cl_sii_taxpayer_type == '1' and self.partner_id_vat == '60805000-0':


### PR DESCRIPTION
Have a CL company setup
Issue a vendor bill
Then generate the credit note via 'Add Credit Note' wizard
Add a reason and confirm
Error will raise “You can not use a invoice document type with a refund
invoice”

As
https://github.com/odoo/odoo/commit/c9ff9d28ab75c02093ca54d9fbd1d2e203c5ee2e
for the invoice case
we need to add specific logic to handle credit notes in l10n_cl

opw-2801576

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
