### PR TITLE
[FIX] website: routingmap was recomputed too often

### DIFF
--- a/addons/website/models/ir_http.py
+++ b/addons/website/models/ir_http.py
@@ -67,7 +67,9 @@ class Http(models.AbstractModel):
 
     @classmethod
     def clear_caches(cls):
-        super(Http, cls)._clear_routing_map()
+        domain = [('redirect_type', 'in', ('308', '404'))]
+        if request.env['website.rewrite'].sudo().search(domain, limit=1):
+            super(Http, cls)._clear_routing_map()
         return super(Http, cls).clear_caches()
 
     @classmethod


### PR DESCRIPTION
When one decides to rename /shop to /garden, it is important to redirect
all request made on /shop to /garden. The solution is to modify the
routing-map, the map that binds an URL to a controller endpoint, so that
both /shop and /garden exists. Changing the routing-map should be done
on all workers, the current mechanism is based on
`registry.signal_changes()`, i.e. the mechanism used to signal a cache
invalidation.

The performence problem is that not all cache-invalidation should
trigger a routing-map invalidation. At the time the feature was
implemented there were discussions about using a new signal, similar but
independant of `registry.signal_changes` to solve that matter but the
idea was rejected.

With this changes, when there are redirection such as /shop->/garden in
the database, the routing-map is not recomputed.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
