### PR TITLE
[FIX] website: routingmap was recomputed too often

### DIFF
--- a/addons/website/models/ir_http.py
+++ b/addons/website/models/ir_http.py
@@ -67,7 +67,8 @@ class Http(models.AbstractModel):
 
     @classmethod
     def clear_caches(cls):
-        super(Http, cls)._clear_routing_map()
+        if any(getattr(cls, '_rewrite_len', {}).values()):
+            super(Http, cls)._clear_routing_map()
         return super(Http, cls).clear_caches()
 
     @classmethod


### PR DESCRIPTION
When one decides to rename /shop to /garden, it is important to redirect
all request made on /shop to /garden. The solution is to modify the
routing-map, the map that binds an URL to a controller endpoint, so that
both /shop and /garden exists. Changing the routing-map should be done
on all workers, the current mechanism is based on
`registry.signal_changes()`, i.e. the mechanism used to signal a cache
invalidation.

The performence problem is that not all cache-invalidation should
trigger a routing-map invalidation. At the time the feature was
implemented there were discussions about using a new signal, similar but
independant of `registry.signal_changes` to solve that matter but the
idea was rejected.

With this changes, when there are no redirection such as /shop->/garden
the database, the routing-map is not recomputed.

Benchmark
---------

Setup: clean database with -i website, --workers=4, --max-cron-threads=0
Case: /web/health * 10 + (signal_changes() + /web/health * 10) * 20
Wall-clock without fix: 4.16ms
Wall-clock with fix: 2.55ms

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
