### PR TITLE
[13.0][FIX] fix mrp `compute_quantities_dict`

### DIFF
--- a/addons/mrp/models/product.py
+++ b/addons/mrp/models/product.py
@@ -143,13 +143,17 @@ class ProductProduct(models.Model):
                 if not qty_per_kit:
                     continue
                 rounding = component.uom_id.rounding
-                component_res = res.get(component.id, {
-                    "virtual_available": float_round(component.virtual_available, precision_rounding=rounding),
-                    "qty_available": float_round(component.qty_available, precision_rounding=rounding),
-                    "incoming_qty": float_round(component.incoming_qty, precision_rounding=rounding),
-                    "outgoing_qty": float_round(component.outgoing_qty, precision_rounding=rounding),
-                    "free_qty": float_round(component.free_qty, precision_rounding=rounding),
-                })
+                component_res = (
+                    res.get(component.id)
+                    if component.id in res
+                    else {
+                        "virtual_available": float_round(component.virtual_available, precision_rounding=rounding),
+                        "qty_available": float_round(component.qty_available, precision_rounding=rounding),
+                        "incoming_qty": float_round(component.incoming_qty, precision_rounding=rounding),
+                        "outgoing_qty": float_round(component.outgoing_qty, precision_rounding=rounding),
+                        "free_qty": float_round(component.free_qty, precision_rounding=rounding),
+                    }
+                )
                 ratios_virtual_available.append(component_res["virtual_available"] / qty_per_kit)
                 ratios_qty_available.append(component_res["qty_available"] / qty_per_kit)
                 ratios_incoming_qty.append(component_res["incoming_qty"] / qty_per_kit)


### PR DESCRIPTION
**Description of the issue/feature this PR addresses:**

``get`` default is a dict that gets evaluated to be sent as parameter, causing an unnecessary read on the component's computed fields.

The read should only happen only if we don't have a value in ``qties``.






--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
