### PR TITLE
[FIX] refresh the value of `outdated`.channel_id.channel_partner_ids …

### DIFF
--- a/addons/mail/models/mail_channel.py
+++ b/addons/mail/models/mail_channel.py
@@ -145,6 +145,7 @@ class Channel(models.Model):
         if new_members:
             self.env['mail.channel.partner'].create(new_members)
         if outdated:
+            outdated.refresh()
             outdated.unlink()
 
     def _search_channel_partner_ids(self, operator, operand):

--- a/addons/mail/models/mail_channel.py
+++ b/addons/mail/models/mail_channel.py
@@ -145,7 +145,7 @@ class Channel(models.Model):
         if new_members:
             self.env['mail.channel.partner'].create(new_members)
         if outdated:
-            outdated.refresh()
+            outdated.invalidate_cache()
             outdated.unlink()
 
     def _search_channel_partner_ids(self, operator, operand):


### PR DESCRIPTION
…to fix access rule issue:

To reproduce:
  1. Start a meeting in Discuss of V15, then just disconnect it by clicking red hangup button, try to leave this channel by clicking channel's  x button in the page's left side `DIRECT MESSAGES` list.
  2. After clicking `Leave` button in Confirmation dialog you will get Access Error prompt: Due to security restrictions, you are not allowed to delete 'Listeners of a Channel' (mail.channel.partner) records.

Cause and Solution: the computed field value: outdated.channel_id.channel_partner_ids doesn't contain its current env.user until explicit refresh.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
