### PR TITLE
Update stock_rule

### DIFF
--- a/addons/mrp_account/models/stock_rule.py
+++ b/addons/mrp_account/models/stock_rule.py
@@ -10,5 +10,5 @@ class StockRule(models.Model):
     def _prepare_mo_vals(self, product_id, product_qty, product_uom, location_id, name, origin, company_id, values, bom):
         res = super()._prepare_mo_vals(product_id, product_qty, product_uom, location_id, name, origin, company_id, values, bom)
         if not bom.analytic_account_id and values.get('analytic_account_id'):
-            res['analytic_account_id'] = values.get('analytic_account_id').id
+            res['analytic_account_id'] = values.get('analytic_account_id')
         return res


### PR DESCRIPTION
values.get('analytic_account_id') is already a integer

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
