### PR TITLE
[FIX] website_crm_partner_assign: split costly search

### DIFF
--- a/addons/crm/models/res_partner.py
+++ b/addons/crm/models/res_partner.py
@@ -59,7 +59,7 @@ class Partner(models.Model):
         action = self.env['ir.actions.act_window']._for_xml_id('crm.crm_lead_opportunities')
         action['context'] = {'active_test': False}
         if self.is_company:
-            action['domain'] = [('partner_id.commercial_partner_id.id', '=', self.id)]
+            action['domain'] = [('partner_id.commercial_partner_id', '=', self.id)]
         else:
-            action['domain'] = [('partner_id.id', '=', self.id)]
+            action['domain'] = [('partner_id', '=', self.id)]
         return action

--- a/addons/website_crm_partner_assign/models/res_partner.py
+++ b/addons/website_crm_partner_assign/models/res_partner.py
@@ -94,6 +94,18 @@ class ResPartner(models.Model):
             partner.opportunity_count += assign_counts.get(partner.id, 0)
 
     def action_view_opportunity(self):
+        self.ensure_one()  # especially here as we are doing an id, in, IDS domain
         action = super().action_view_opportunity()
-        action['domain'] = expression.OR([action.get('domain', []), [('partner_assigned_id', '=', self.id)]])
+        action_domain_origin = action.get('domain')
+        action_context_origin = action.get('context') or {}
+        action_domain_assign = [('partner_assigned_id', '=', self.id)]
+        if not action_domain_origin:
+            action['domain'] = action_domain_assign
+            return action
+        # perform searches independently as having OR with those leaves seems to
+        # be counter productive
+        Lead = self.env['crm.lead'].with_context(**action_context_origin)
+        ids_origin = Lead.search(action_domain_origin).ids
+        ids_new = Lead.search(action_domain_assign).ids
+        action['domain'] = [('id', 'in', sorted(list(set(ids_origin) | set(ids_new))))]
         return action

--- a/addons/website_crm_partner_assign/tests/test_partner_assign.py
+++ b/addons/website_crm_partner_assign/tests/test_partner_assign.py
@@ -37,6 +37,66 @@ class TestPartnerAssign(TransactionCase):
         patcher.start()
         self.addCleanup(patcher.stop)
 
+    def test_opportunity_count(self):
+        self.customer_uk.write({
+            'is_company': True,
+            'child_ids': [
+                (0, 0, {'name': 'Uk Children 1',
+                       }),
+                (0, 0, {'name': 'Uk Children 2',
+                       }),
+            ],
+        })
+        lead_uk_assigned = self.env['crm.lead'].create({
+            'name': 'Office Design and Architecture',
+            'partner_assigned_id': self.customer_uk.id,
+            'type': 'opportunity',
+        })
+        children_leads = self.env['crm.lead'].create([
+            {'name': 'Children 1 Lead 1',
+             'partner_id': self.customer_uk.child_ids[0].id,
+             'type': 'lead'},
+            {'name': 'Children 1 Lead 2',
+             'partner_id': self.customer_uk.child_ids[0].id,
+             'type': 'lead'},
+            {'name': 'Children 2 Lead 1',
+             'partner_id': self.customer_uk.child_ids[1].id,
+             'type': 'lead'},
+            {'name': 'Children 2 Lead 2',
+             'partner_id': self.customer_uk.child_ids[1].id,
+             'type': 'lead'},
+        ])
+        children_leads_assigned = self.env['crm.lead'].create([
+            {'name': 'Children 1 Lead 1',
+             'partner_assigned_id': self.customer_uk.child_ids[0].id,
+             'type': 'lead'},
+            {'name': 'Children 1 Lead 2',
+             'partner_assigned_id': self.customer_uk.child_ids[0].id,
+             'type': 'lead'},
+            {'name': 'Children 2 Lead 1',
+             'partner_assigned_id': self.customer_uk.child_ids[1].id,
+             'type': 'lead'},
+            {'name': 'Children 2 Lead 2',
+             'partner_assigned_id': self.customer_uk.child_ids[1].id,
+             'type': 'lead'},
+        ])
+
+        self.assertEqual(
+            repr(self.customer_uk.action_view_opportunity()['domain']),
+            repr([('id', 'in', sorted(self.lead_uk.ids + lead_uk_assigned.ids + children_leads.ids))]),
+            'Parent: own + children leads + assigned'
+        )
+        self.assertEqual(
+            repr(self.customer_uk.child_ids[0].action_view_opportunity()['domain']),
+            repr([('id', 'in', sorted(children_leads[0:2].ids + children_leads_assigned[0:2].ids))]),
+            'Children: own leads + assigned'
+        )
+        self.assertEqual(
+            repr(self.customer_uk.child_ids[1].action_view_opportunity()['domain']),
+            repr([('id', 'in', sorted(children_leads[2:].ids + children_leads_assigned[2:].ids))]),
+            'Children: own leads + assigned'
+        )
+
     def test_partner_assign(self):
         """ Test the automatic assignation using geolocalisation """
         partner_be = self.env['res.partner'].create({


### PR DESCRIPTION
On an heavy database searching for company leads or assigned leads can be
costly. Having an OR does not necessarily triggers index usage and query plan
uses an index scan.

It is less costly to do two searches: one for the base domain (based on
commercial entity) and one for the assign domain (based on partner assigned).

Task-2770994
