### PR TITLE
[FIX] product: search on template's default code

### DIFF
--- a/addons/product/tests/test_name.py
+++ b/addons/product/tests/test_name.py
@@ -22,3 +22,8 @@ class TestName(TransactionCase):
         display_name = self.product.with_context(display_default_code=False).display_name
         self.assertEqual(display_name, self.product_name,
                          "Code should not be preprended to the name as context should prevent it.")
+
+    def test_default_code_and_negative_operator(self):
+        res = self.env['product.template'].name_search(name='PTN', operator='not ilike')
+        res_ids = [r[0] for r in res]
+        self.assertNotIn(self.product.id, res_ids)

--- a/addons/stock/tests/test_product.py
+++ b/addons/stock/tests/test_product.py
@@ -81,3 +81,63 @@ class TestVirtualAvailable(TestStockCommon):
         self.picking_out_2.do_unreserve()
         # 8 units are available again
         self.assertAlmostEqual(40.0, self.product_3.free_qty)
+
+    def test_search_product_template(self):
+        """
+        Suppose a variant V01 that can not be deleted because it is used by a
+        lot [1]. Then, the variant's template T is changed: we add a dynamic
+        attribute. Because of [1], V01 is archived. This test ensures that
+        `name_search` still finds T.
+        Then, we create a new variant V02 of T. This test also ensures that
+        calling `name_search` with a negative operator will exclude T from the
+        result.
+        """
+        template = self.env['product.template'].create({
+            'name': 'Super Product',
+        })
+        product01 = template.product_variant_id
+
+        self.env['stock.production.lot'].create({
+            'name': 'lot1',
+            'product_id': product01.id,
+            'company_id': self.env.company.id,
+        })
+
+        product_attribute = self.env['product.attribute'].create({
+            'name': 'PA',
+            'create_variant': 'dynamic'
+        })
+
+        self.env['product.attribute.value'].create([{
+            'name': 'PAV' + str(i),
+            'attribute_id': product_attribute.id
+        } for i in range(2)])
+
+        tmpl_attr_lines = self.env['product.template.attribute.line'].create({
+            'attribute_id': product_attribute.id,
+            'product_tmpl_id': product01.product_tmpl_id.id,
+            'value_ids': [(6, 0, product_attribute.value_ids.ids)],
+        })
+
+        self.assertFalse(product01.active)
+        self.assertTrue(template.active)
+        self.assertFalse(template.product_variant_ids)
+
+        res = self.env['product.template'].name_search(name='super', operator='ilike')
+        res_ids = [r[0] for r in res]
+        self.assertIn(template.id, res_ids)
+
+        product02 = self.env['product.product'].create({
+            'default_code': '123',
+            'product_tmpl_id': template.id,
+            'product_template_attribute_value_ids': [(6, 0, tmpl_attr_lines.product_template_value_ids[0].ids)]
+        })
+
+        self.assertFalse(product01.active)
+        self.assertTrue(product02.active)
+        self.assertTrue(template)
+        self.assertEqual(template.product_variant_ids, product02)
+
+        res = self.env['product.template'].name_search(name='123', operator='not ilike')
+        res_ids = [r[0] for r in res]
+        self.assertNotIn(template.id, res_ids)


### PR DESCRIPTION
When filtering on product templates with a negative operator, the result
is incorrect

To reproduce the issue:
(Need mrp)
1. Create two products P_compo, P_finished:
    - Internal Reference:
        - P_compo: 123
        - P_finished: 456
2. Create a BoM:
    - Product: P_finished
    - Components:
        - 1 x P_compo
3. Manufacturing > Master Data > Bills Of Materials
4. Remove search filters and apply this custom one:
    - "Product doesn't contain 456"

Error: P_finished's BoM is still in the list, but '456' is the internal
reference of P_finished, so this BoM should not be displayed

The filter is applied on the field `product_tmpl_id` of the BoM, which
leads to the override of `_name_search` in `product.template`. In this
method, a call to the `_name_search` of `product.product` is executed:
https://github.com/odoo/odoo/blob/5ff4eb022757d7a522ccb975f8eb64053ef9780b/addons/product/models/product_template.py#L456
which is a good thing because the version of `product.product` handles
the case of the Internal Reference (`default_code`)
https://github.com/odoo/odoo/blob/1e8982e4cf6b604e4da2773f10bdf6cf94c7e683/addons/product/models/product.py#L532-L538
So, the call to this `_name_search` will not return P_finished. However,
later on in the `_name_search` of `product.template`, we call the
`_name_search` of `super` with the same domain (i.e., 'not 456 in name')
https://github.com/odoo/odoo/blob/5ff4eb022757d7a522ccb975f8eb64053ef9780b/addons/product/models/product_template.py#L474-L485
This is the issue: it leads to the `_name_search` of `BaseModel`, which
is the classic version: it does only consider the record's name. So,
this call will return P_finished.

In the `_name_search` of `product.template`, there are actually two
calls to `super`. Considering the commits [1] and [2], it seems that the
goal is the same in both cases: find the `product.template` that do have
any variant yet. However, in the first commit, the domain given to
`super` excludes the templates that have at least one variant, which is
not the case with the second commit (the problematic one).

Since both codes have the same goal, we should merge them by keeping the
best idea of each one. From [1], we keep the idea of restricting the
domain: we only look for templates that do not have any variant.
However, this domain needs to be improved: we need to include the
templates whose all variants are archived. From [2], we keep the idea of
looking for the templates outside the `while True` loop. This allows us
to do the search only if required.

[1] 21ae503cf401afe4dddae6225fd346f89a210aeb
[2] 99bae2cdb794051a931fac0b0ac53f2915fd3032

OPW-2791255