### PR TITLE
[FIX] account: display correct price_unit with 100% taxes

### DIFF
--- a/addons/account/models/account_move.py
+++ b/addons/account/models/account_move.py
@@ -3644,8 +3644,9 @@ class AccountMoveLine(models.Model):
                 'discount': 0.0,
                 'price_unit': amount_currency / (quantity or 1.0),
             }
-        elif not discount_factor:
-            # balance of line is 0, but discount  == 100% so we display the normal unit_price
+        elif not discount_factor or not amount_currency:
+            # balance of line is 0, but discount == 100% or taxes (price included) == 100%,
+            # so we display the normal unit_price
             vals = {}
         else:
             # balance is 0, so unit price is 0 as well


### PR DESCRIPTION
Currently, when modifying an invoice line and setting taxes
(price included) for 100%, the price_unit field will
be displayed as 0.

This is incorrect and is being fixed here.

opw-2793284

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
