### PR TITLE
[FIX] website: hide logo height scrolled option if no logo

### DIFF
--- a/addons/website/static/src/js/editor/snippets.options.js
+++ b/addons/website/static/src/js/editor/snippets.options.js
@@ -1800,7 +1800,7 @@ options.registry.HeaderNavbar = options.Class.extend({
      */
     async _computeWidgetVisibility(widgetName, params) {
         if (widgetName === 'option_logo_height_scrolled') {
-            return !this.$('.navbar-brand').hasClass('d-none');
+            return !!this.$('.navbar-brand').length;
         }
         return this._super(...arguments);
     },


### PR DESCRIPTION
Before this commit, the logo height scrolled option was displayed even
if there was no logo.

It was because the condition to display or not this option (in the
"_computeWidgetVisibility") had not been updated correctly when the DOM
of the navbar was refactored.

task-2800680

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
