### PR TITLE
[FIX] web_editor: improve mailing conversion for client compatibility

### DIFF
--- a/addons/mass_mailing/views/assets.xml
+++ b/addons/mass_mailing/views/assets.xml
@@ -67,6 +67,9 @@
                 td > img:only-child {
                     min-width: 100% !important;
                 }
+                .o_desktop_h100 {
+                    height: unset !important;
+                }
             }
         </style>
     </template>

--- a/addons/mass_mailing/views/assets.xml
+++ b/addons/mass_mailing/views/assets.xml
@@ -60,6 +60,14 @@
                     width: 100% !important;
                 }
             }
+            @media screen and (max-width: 1135px) {
+                td {
+                    max-width: inherit !important;
+                }
+                td > img:only-child {
+                    min-width: 100% !important;
+                }
+            }
         </style>
     </template>
 

--- a/addons/mass_mailing/views/assets.xml
+++ b/addons/mass_mailing/views/assets.xml
@@ -59,6 +59,13 @@
                 .o_mail_table_styles {
                     width: 100% !important;
                 }
+                .s_header_social table td, .s_header_text_social table td, .s_header_logo table td,
+                .o_mail_block_footer_social td,
+                .s_showcase td,
+                .s_mail_product_list td,
+                .s_references td {
+                	text-align: center !important;
+                }
             }
             @media screen and (max-width: 1135px) {
                 td {

--- a/addons/web_editor/static/lib/odoo-editor/src/utils/utils.js
+++ b/addons/web_editor/static/lib/odoo-editor/src/utils/utils.js
@@ -2067,15 +2067,19 @@ export function enforceWhitespace(el, offset, direction, rule) {
 }
 
 export function rgbToHex(rgb = '') {
-    return (
-        '#' +
-        (rgb.match(/\d{1,3}/g) || [])
-            .map(x => {
-                x = parseInt(x).toString(16);
-                return x.length === 1 ? '0' + x : x;
-            })
-            .join('')
-    );
+    if (rgb.startsWith('#')) {
+        return rgb;
+    } else {
+        return (
+            '#' +
+            (rgb.match(/\d{1,3}/g) || [])
+                .map(x => {
+                    x = parseInt(x).toString(16);
+                    return x.length === 1 ? '0' + x : x;
+                })
+                .join('')
+        );
+    }
 }
 
 export function getRangePosition(el, document, options = {}) {

--- a/addons/web_editor/static/src/js/backend/convert_inline.js
+++ b/addons/web_editor/static/src/js/backend/convert_inline.js
@@ -429,9 +429,26 @@ function enforceTablesResponsivity(editable) {
         tr.style.setProperty('width', '100%');
     }
     for (const td of editable.querySelectorAll('td[colspan]')) {
-        td.setAttribute('width', '100%');
-        td.style.setProperty('width', '100%');
-        td.style.setProperty('display', 'inline-block'); // Allow cells to wrap.
+        const colspan = +td.getAttribute('colspan');
+        const tdSiblings = [...td.parentElement.children].filter(child => child.nodeName === 'TD');
+        if ( // Don't allow little duos of columns to wrap (eg., col-2 col-10).
+            colspan > 2 && colspan < 10 || tdSiblings.length > 2
+            || tdSiblings.some(td => [...td.children].some(child => child.style.width === '100%')) // Unless they have a full width child.
+           ) {
+            td.setAttribute('width', '100%');
+            td.style.setProperty('width', '100%');
+            td.style.setProperty('display', 'inline-block'); // Allow cells to wrap.
+        } else if (td.getAttribute('width') === '100%') {
+            if (td.children.length === 1 && td.firstElementChild.nodeName === 'IMG') {
+                const width = td.firstElementChild.getAttribute('width');
+                td.setAttribute('width', width);
+                td.style.removeProperty('width');
+                td.style.setProperty('min-width', width + 'px');
+            } else {
+                td.removeAttribute('width');
+                td.style.removeProperty('width');
+            }
+        }
     }
     // Masonry has crazy nested tables that require some extra treatment.
     for (const td of editable.querySelectorAll('.s_masonry_block td')) {

--- a/addons/web_editor/static/src/js/backend/convert_inline.js
+++ b/addons/web_editor/static/src/js/backend/convert_inline.js
@@ -91,8 +91,8 @@ function attachmentThumbnailToLinkImg($editable) {
         const image = document.createElement('img');
         image.setAttribute('src', _getStylePropertyValue(link, 'background-image').replace(/(^url\(['"])|(['"]\)$)/g, ''));
         // Note: will trigger layout thrashing.
-        image.setAttribute('height', Math.max(1, _getHeight(link)) + 'px');
-        image.setAttribute('width', Math.max(1, _getWidth(link)) + 'px');
+        image.setAttribute('height', Math.max(1, _getHeight(link)));
+        image.setAttribute('width', Math.max(1, _getWidth(link)));
         link.prepend(image);
     };
 }
@@ -372,14 +372,22 @@ function classToStyle($editable, cssRules) {
             writes.push(() => {
                 node.setAttribute('style', style);
                 if (node.style.width) {
-                    node.setAttribute('width', node.style.width);
+                    node.setAttribute('width', node.style.width.replace('px', '').trim());
                 }
             });
         }
 
-        // Media list images should not have an inline height
-        if (node.nodeName === 'IMG' && node.classList.contains('s_media_list_img')) {
-            writes.push(() => { node.style.removeProperty('height'); });
+        if (node.nodeName === 'IMG') {
+            writes.push(() => {
+                // Media list images should not have an inline height
+                if (node.classList.contains('s_media_list_img')) {
+                    node.style.removeProperty('height');
+                }
+                // Protect aspect ratio when resizing in mobile.
+                if (node.style.getPropertyValue('width') === '100%' && node.style.getPropertyValue('object-fit') === '') {
+                    node.style.setProperty('object-fit', 'cover');
+                }
+            });
         }
         // Apple Mail
         if (node.nodeName === 'TD' && !node.childNodes.length) {
@@ -429,7 +437,8 @@ function enforceTablesResponsivity(editable) {
     for (const td of editable.querySelectorAll('.s_masonry_block td')) {
         td.classList.toggle('o_desktop_h100', true);
         td.style.setProperty('height', '100%');
-        if ([...td.children].map(child => child.nodeName.toLowerCase()).includes('table')) {
+        const childrenNames = [...td.children].map(child => child.nodeName);
+        if (childrenNames.includes('TABLE')) {
             td.style.setProperty('height', _getHeight(td.parentElement) + 'px');
         } else {
             // Hack that makes vertical-align possible within an inline-block.
@@ -445,6 +454,31 @@ function enforceTablesResponsivity(editable) {
             centeringSpan.style.setProperty('vertical-align', 'middle');
             td.prepend(centeringSpan);
         }
+    }
+}
+/**
+ * Modify the styles of images so they are responsive.
+ *
+ * @param {Element} editable
+ */
+function enforceImagesResponsivity(editable) {
+    // Images with 100% height in cells should preserve that height and the
+    // height of the row should be applied to the cell.
+    for (const image of editable.querySelectorAll('td > img')) {
+        const td = image.parentElement;
+        if (td.childElementCount === 1 && (image.classList.contains('h-100') || _getStylePropertyValue(image, 'height') === '100%')) {
+            td.style.setProperty('height', _getHeight(td.parentElement) + 'px');
+            image.style.setProperty('height', '100%');
+        }
+    }
+    // Remove the height attribute in card images so they can resize
+    // responsively, but leave it for Outlook.
+    for (const image of editable.querySelectorAll('img[width="100%"][height]')) {
+        image.before(document.createComment(`[if mso]>${image.outerHTML}<![endif]`))
+        image.classList.toggle('mso-hide', true);
+        image.before(document.createComment('[if !mso]><!'));
+        image.after(document.createComment('<![endif]'));
+        image.removeAttribute('height');
     }
 }
 /**
@@ -519,7 +553,14 @@ async function toInline($editable, cssRules, $iframe) {
     responsiveToStaticForOutlook(editable);
     enforceTablesResponsivity(editable);
     formatTables($editable);
+    enforceImagesResponsivity(editable);
     await flattenBackgroundImages(editable);
+
+    // Hide replaced cells on Outlook
+    for (const toHide of editable.querySelectorAll('.mso-hide')) {
+        const style = toHide.getAttribute('style') || '';
+        toHide.setAttribute('style', `${style} mso-hide: all;`.trim());
+    }
 
     // Styles were applied inline, we don't need a style element anymore.
     $editable.find('style').remove();
@@ -610,8 +651,8 @@ function fontToImg($editable) {
                 padding += hPadding ? hPadding + 'px' : '0';
             }
             const image = document.createElement('img');
-            image.setAttribute('width', width);
-            image.setAttribute('height', height);
+            image.setAttribute('width', intrinsicWidth);
+            image.setAttribute('height', intrinsicHeight);
             image.setAttribute('src', `/web_editor/font_to_img/${content.charCodeAt(0)}/${window.encodeURI(color)}/${window.encodeURI(bg)}/${Math.max(1, Math.round(intrinsicWidth))}x${Math.max(1, Math.round(intrinsicHeight))}`);
             image.setAttribute('data-class', font.getAttribute('class'));
             image.setAttribute('data-style', style);
@@ -747,11 +788,6 @@ function formatTables($editable) {
                 table.style.setProperty('text-align', ancestor.style.textAlign);
             }
         }
-    }
-    // Hide replaced cells on Outlook
-    for (const toHide of editable.querySelectorAll('.mso-hide')) {
-        const style = toHide.getAttribute('style') || '';
-        toHide.setAttribute('style', `${style} mso-hide: all;`.trim());
     }
 }
 /**

--- a/addons/web_editor/static/src/js/backend/convert_inline.js
+++ b/addons/web_editor/static/src/js/backend/convert_inline.js
@@ -663,6 +663,18 @@ function formatTables($editable) {
             cell.style.verticalAlign = 'bottom';
         }
     }
+    // Tables don't properly inherit alignments from their ancestors in Outlook.
+    for (const table of editable.querySelectorAll('table')) {
+        if (table.style.textAlign === 'inherit') {
+            let ancestor = table;
+            while (ancestor && (!ancestor.style.textAlign || ancestor.style.textAlign === 'inherit')) {
+                ancestor = ancestor.parentElement;
+            }
+            if (ancestor) {
+                table.style.setProperty('text-align', ancestor.style.textAlign);
+            }
+        }
+    }
 }
 /**
  * Parse through the given document's stylesheets, preprocess(*) them and return

--- a/addons/web_editor/static/tests/convert_inline_tests.js
+++ b/addons/web_editor/static/tests/convert_inline_tests.js
@@ -1,6 +1,6 @@
 /** @odoo-module **/
 import convertInline from '@web_editor/js/backend/convert_inline';
-import {getGridHtml, getTableHtml, getRegularGridHtml, getRegularTableHtml} from 'web_editor.test_utils';
+import {getGridHtml, getTableHtml, getRegularGridHtml, getRegularTableHtml, removeComments} from 'web_editor.test_utils';
 
 QUnit.module('web_editor', {}, function () {
 QUnit.module('convert_inline', {}, function () {
@@ -13,25 +13,25 @@ QUnit.module('convert_inline', {}, function () {
         // 1x1
         let $editable = $(`<div>${getRegularGridHtml(1, 1)}</div>`);
         convertInline.bootstrapToTable($editable);
-        assert.strictEqual($editable.html(), getRegularTableHtml(1, 1, 12, 100),
+        assert.strictEqual(removeComments($editable.html()), getRegularTableHtml(1, 1, 12, 100),
             "should have converted a 1x1 grid to an equivalent table");
 
         // 1x2
         $editable = $(`<div>${getRegularGridHtml(1, 2)}</div>`);
         convertInline.bootstrapToTable($editable);
-        assert.strictEqual($editable.html(), getRegularTableHtml(1, 2, 6, 50),
+        assert.strictEqual(removeComments($editable.html()), getRegularTableHtml(1, 2, 6, 50),
             "should have converted a 1x2 grid to an equivalent table");
 
         // 1x3
         $editable = $(`<div>${getRegularGridHtml(1, 3)}</div>`);
         convertInline.bootstrapToTable($editable);
-        assert.strictEqual($editable.html(), getRegularTableHtml(1, 3, 4, 33.33),
+        assert.strictEqual(removeComments($editable.html()), getRegularTableHtml(1, 3, 4, 33.33),
             "should have converted a 1x3 grid to an equivalent table");
 
         // 1x12
         $editable = $(`<div>${getRegularGridHtml(1, 12)}</div>`);
         convertInline.bootstrapToTable($editable);
-        assert.strictEqual($editable.html(), getRegularTableHtml(1, 12, 1, 8.33),
+        assert.strictEqual(removeComments($editable.html()), getRegularTableHtml(1, 12, 1, 8.33),
             "should have converted a 1x12 grid to an equivalent table");
     });
     QUnit.test('convert a single-row regular overflowing grid', async function (assert) {
@@ -40,39 +40,39 @@ QUnit.module('convert_inline', {}, function () {
         // 1x13
         let $editable = $(`<div>${getRegularGridHtml(1, 13)}</div>`);
         convertInline.bootstrapToTable($editable);
-        assert.strictEqual($editable.html(),
+        assert.strictEqual(removeComments($editable.html()),
             getRegularTableHtml(1, 12, 1, 8.33).slice(0, -8) +
-                `<tr><td colspan="12" width="100%" style="width: 100%;">(0, 12)</td></tr></table>`,
+                `<tr><td colspan="12">(0, 12)</td></tr></table>`,
             "should have converted a 1x13 grid to an equivalent table (overflowing)");
 
         // 1x14
         $editable = $(`<div>${getRegularGridHtml(1, 14)}</div>`);
         convertInline.bootstrapToTable($editable);
-        assert.strictEqual($editable.html(),
+        assert.strictEqual(removeComments($editable.html()),
             getRegularTableHtml(1, 12, 1, 8.33).slice(0, -8) +
-                `<tr><td colspan="1" width="8.33%" style="width: 8.33%;">(0, 12)</td>` +
-                `<td colspan="11" width="91.67%" style="width: 91.67%;">(0, 13)</td></tr></table>`,
+                `<tr><td colspan="1">(0, 12)</td>` +
+                `<td colspan="11">(0, 13)</td></tr></table>`,
             "should have converted a 1x14 grid to an equivalent table (overflowing)");
 
         // 1x25
         $editable = $(`<div>${getRegularGridHtml(1, 25)}</div>`);
         convertInline.bootstrapToTable($editable);
-        assert.strictEqual($editable.html(),
+        assert.strictEqual(removeComments($editable.html()),
             getRegularTableHtml(1, 12, 1, 8.33).slice(0, -8) +
             getRegularTableHtml(1, 12, 1, 8.33).replace(/\(0, (\d+)\)/g, (s, c) => `(0, ${+c + 12})`)
                 .replace(/^<table[^<]*>/, '').slice(0, -8) +
-                `<tr><td colspan="12" width="100%" style="width: 100%;">(0, 24)</td></tr></table>`,
+                `<tr><td colspan="12">(0, 24)</td></tr></table>`,
             "should have converted a 1x25 grid to an equivalent table (overflowing)");
 
         // 1x26
         $editable = $(`<div>${getRegularGridHtml(1, 26)}</div>`);
         convertInline.bootstrapToTable($editable);
-        assert.strictEqual($editable.html(),
+        assert.strictEqual(removeComments($editable.html()),
             getRegularTableHtml(1, 12, 1, 8.33).slice(0, -8) +
             getRegularTableHtml(1, 12, 1, 8.33).replace(/\(0, (\d+)\)/g, (s, c) => `(0, ${+c + 12})`)
                 .replace(/^<table[^<]*>/, '').slice(0, -8) +
-                `<tr><td colspan="1" width="8.33%" style="width: 8.33%;">(0, 24)</td>` +
-                `<td colspan="11" width="91.67%" style="width: 91.67%;">(0, 25)</td></tr></table>`,
+                `<tr><td colspan="1">(0, 24)</td>` +
+                `<td colspan="11">(0, 25)</td></tr></table>`,
             "should have converted a 1x26 grid to an equivalent table (overflowing)");
     });
     QUnit.test('convert a multi-row regular grid', async function (assert) {
@@ -81,25 +81,25 @@ QUnit.module('convert_inline', {}, function () {
         // 2x1
         let $editable = $(`<div>${getRegularGridHtml(2, 1)}</div>`);
         convertInline.bootstrapToTable($editable);
-        assert.strictEqual($editable.html(), getRegularTableHtml(2, 1, 12, 100),
+        assert.strictEqual(removeComments($editable.html()), getRegularTableHtml(2, 1, 12, 100),
             "should have converted a 2x1 grid to an equivalent table");
 
         // 2x[1,2]
         $editable = $(`<div>${getRegularGridHtml(2, [1, 2])}</div>`);
         convertInline.bootstrapToTable($editable);
-        assert.strictEqual($editable.html(), getRegularTableHtml(2, [1, 2], [12, 6], [100, 50]),
+        assert.strictEqual(removeComments($editable.html()), getRegularTableHtml(2, [1, 2], [12, 6], [100, 50], true),
             "should have converted a 2x[1,2] grid to an equivalent table");
 
         // 3x3
         $editable = $(`<div>${getRegularGridHtml(3, 3)}</div>`);
         convertInline.bootstrapToTable($editable);
-        assert.strictEqual($editable.html(), getRegularTableHtml(3, 3, 4, 33.33),
+        assert.strictEqual(removeComments($editable.html()), getRegularTableHtml(3, 3, 4, 33.33),
             "should have converted a 3x3 grid to an equivalent table");
 
         // 3x[3,2,1]
         $editable = $(`<div>${getRegularGridHtml(3, [3,2,1])}</div>`);
         convertInline.bootstrapToTable($editable);
-        assert.strictEqual($editable.html(), getRegularTableHtml(3, [3, 2, 1], [4, 6, 12], [33.33, 50, 100]),
+        assert.strictEqual(removeComments($editable.html()), getRegularTableHtml(3, [3, 2, 1], [4, 6, 12], [33.33, 50, 100], true),
             "should have converted a 3x[3,2,1] grid to an equivalent table");
     });
     QUnit.test('convert a multi-row regular overflowing grid', async function (assert) {
@@ -108,35 +108,35 @@ QUnit.module('convert_inline', {}, function () {
         // 2x[13,1]
         let $editable = $(`<div>${getRegularGridHtml(2, [13, 1])}</div>`);
         convertInline.bootstrapToTable($editable);
-        assert.strictEqual($editable.html(),
+        assert.strictEqual(removeComments($editable.html()),
             getRegularTableHtml(1, 12, 1, 8.33).slice(0, -8) +
-                `<tr><td colspan="12" width="100%" style="width: 100%;">(0, 12)</td></tr>` +
-                `<tr><td colspan="12" width="100%" style="width: 100%;">(1, 0)</td></tr></table>`,
+                `<tr><td colspan="12">(0, 12)</td></tr>` +
+                `<tr><td colspan="12">(1, 0)</td></tr></table>`,
             "should have converted a 2x[13,1] grid to an equivalent table (overflowing)");
 
         // 2x[1,13]
         $editable = $(`<div>${getRegularGridHtml(2, [1, 13])}</div>`);
         convertInline.bootstrapToTable($editable);
-        assert.strictEqual($editable.html(),
-            getRegularTableHtml(2, [1, 12], [12, 1], [100, 8.33]).slice(0, -8) +
-                `<tr><td colspan="12" width="100%" style="width: 100%;">(1, 12)</td></tr></table>`,
+        assert.strictEqual(removeComments($editable.html()),
+            getRegularTableHtml(2, [1, 12], [12, 1], [100, 8.33], true).slice(0, -8) +
+                `<tr><td colspan="12">(1, 12)</td></tr></table>`,
             "should have converted a 2x[1,13] grid to an equivalent table (overflowing)");
 
         // 3x[1,13,6]
         $editable = $(`<div>${getRegularGridHtml(3, [1, 13, 6])}</div>`);
         convertInline.bootstrapToTable($editable);
-        assert.strictEqual($editable.html(),
-            getRegularTableHtml(2, [1, 12], [12, 1], [100, 8.33]).slice(0, -8) +
-                `<tr><td colspan="12" width="100%" style="width: 100%;">(1, 12)</td></tr>` +
+        assert.strictEqual(removeComments($editable.html()),
+            getRegularTableHtml(2, [1, 12], [12, 1], [100, 8.33], true).slice(0, -8) +
+                `<tr><td colspan="12">(1, 12)</td></tr>` +
                 getRegularTableHtml(1, 6, 2, 16.67).replace(/\(0,/g, `(2,`).replace(/^<table[^<]*>/, ''),
             "should have converted a 3x[1,13,6] grid to an equivalent table (overflowing)");
 
         // 3x[1,6,13]
         $editable = $(`<div>${getRegularGridHtml(3, [1, 6, 13])}</div>`);
         convertInline.bootstrapToTable($editable);
-        assert.strictEqual($editable.html(),
-            getRegularTableHtml(3, [1, 6, 12], [12, 2, 1], [100, 16.67, 8.33]).slice(0, -8) +
-                `<tr><td colspan="12" width="100%" style="width: 100%;">(2, 12)</td></tr></table>`,
+        assert.strictEqual(removeComments($editable.html()),
+            getRegularTableHtml(3, [1, 6, 12], [12, 2, 1], [100, 16.67, 8.33], true).slice(0, -8) +
+                `<tr><td colspan="12">(2, 12)</td></tr></table>`,
             "should have converted a 3x[1,6,13] grid to an equivalent table (overflowing)");
     });
     QUnit.test('convert a single-row irregular grid', async function (assert) {assert.expect(4);
@@ -145,13 +145,13 @@ QUnit.module('convert_inline', {}, function () {
         // 1x2
         let $editable = $(`<div>${getGridHtml([[8, 4]])}</div>`);
         convertInline.bootstrapToTable($editable);
-        assert.strictEqual($editable.html(), getTableHtml([[[8, 66.67], [4, 33.33]]]),
+        assert.strictEqual(removeComments($editable.html()), getTableHtml([[[8, 66.67], [4, 33.33]]], true),
             "should have converted a 1x2 irregular grid to an equivalent table");
 
         // 1x3
         $editable = $(`<div>${getGridHtml([[2, 3, 7]])}</div>`);
         convertInline.bootstrapToTable($editable);
-        assert.strictEqual($editable.html(), getTableHtml([[[2, 16.67], [3, 25], [7, 58.33]]]),
+        assert.strictEqual(removeComments($editable.html()), getTableHtml([[[2, 16.67], [3, 25], [7, 58.33]]], true),
             "should have converted a 1x3 grid to an equivalent table");
     });
     QUnit.test('convert a single-row irregular overflowing grid', async function (assert) {assert.expect(4);
@@ -160,20 +160,20 @@ QUnit.module('convert_inline', {}, function () {
         // 1x2
         let $editable = $(`<div>${getGridHtml([[8, 5]])}</div>`);
         convertInline.bootstrapToTable($editable);
-        assert.strictEqual($editable.html(), getTableHtml([
+        assert.strictEqual(removeComments($editable.html()), getTableHtml([
                 [[8, 66.67], [4, 33.33, '']],
                 [[5, 41.67, '(0, 1)'], [7, 58.33, '']],
-            ]),
+            ], true),
             "should have converted a 1x2 irregular overflowing grid to an equivalent table");
 
         // 1x3
         $editable = $(`<div>${getGridHtml([[7, 6, 9]])}</div>`);
         convertInline.bootstrapToTable($editable);
-        assert.strictEqual($editable.html(), getTableHtml([
+        assert.strictEqual(removeComments($editable.html()), getTableHtml([
                 [[7, 58.33], [5, 41.67, '']],
                 [[6, 50, '(0, 1)'], [6, 50, '']],
                 [[9, 75, '(0, 2)'], [3, 25, '']],
-            ]),
+            ], true),
             "should have converted a 1x3 irregular overflowing grid to an equivalent table");
     });
     QUnit.test('convert a multi-row irregular grid', async function (assert) {
@@ -182,13 +182,13 @@ QUnit.module('convert_inline', {}, function () {
         // 2x2
         let $editable = $(`<div>${getGridHtml([[1, 11], [2, 10]])}</div>`);
         convertInline.bootstrapToTable($editable);
-        assert.strictEqual($editable.html(), getTableHtml([[[1, 8.33], [11, 91.67]], [[2, 16.67], [10, 83.33]]]),
+        assert.strictEqual(removeComments($editable.html()), getTableHtml([[[1, 8.33], [11, 91.67]], [[2, 16.67], [10, 83.33]]], true),
             "should have converted a 2x2 irregular grid to an equivalent table");
 
         // 2x[2,3]
         $editable = $(`<div>${getGridHtml([[3, 9], [4, 6, 2]])}</div>`);
         convertInline.bootstrapToTable($editable);
-        assert.strictEqual($editable.html(), getTableHtml([[[3, 25], [9, 75]], [[4, 33.33], [6, 50], [2, 16.67]]]),
+        assert.strictEqual(removeComments($editable.html()), getTableHtml([[[3, 25], [9, 75]], [[4, 33.33], [6, 50], [2, 16.67]]], true),
             "should have converted a 2x[2,3] irregular grid to an equivalent table");
     });
     QUnit.test('convert a multi-row irregular overflowing grid', async function (assert) {
@@ -197,35 +197,35 @@ QUnit.module('convert_inline', {}, function () {
         // 2x2 (both rows overflow)
         let $editable = $(`<div>${getGridHtml([[6, 8], [7, 9]])}</div>`);
         convertInline.bootstrapToTable($editable);
-        assert.strictEqual($editable.html(),
+        assert.strictEqual(removeComments($editable.html()),
             getTableHtml([
                 [[6, 50], [6, 50, '']],
                 [[8, 66.67, '(0, 1)'], [4, 33.33, '']],
                 [[7, 58.33, '(1, 0)'], [5, 41.67, '']],
                 [[9, 75, '(1, 1)'], [3, 25, '']],
-            ]),
+            ], true),
             "should have converted a 2x[1,13] irregular grid to an equivalent table (both rows overflowing)");
 
         // 2x[2,3] (first row overflows)
         $editable = $(`<div>${getGridHtml([[5, 8], [4, 2, 6]])}</div>`);
         convertInline.bootstrapToTable($editable);
-        assert.strictEqual($editable.html(),
+        assert.strictEqual(removeComments($editable.html()),
             getTableHtml([
                 [[5, 41.67], [7, 58.33, '']],
                 [[8, 66.67, '(0, 1)'], [4, 33.33, '']],
                 [[4, 33.33, '(1, 0)'], [2, 16.67, '(1, 1)'], [6, 50, '(1, 2)']],
-            ]),
+            ], true),
             "should have converted a 2x[2,3] irregular grid to an equivalent table (first row overflowing)");
 
         // 2x[3,2] (second row overflows)
         $editable = $(`<div>${getGridHtml([[4, 2, 6], [5, 8]])}</div>`);
         convertInline.bootstrapToTable($editable);
-        assert.strictEqual($editable.html(),
+        assert.strictEqual(removeComments($editable.html()),
             getTableHtml([
                 [[4, 33.33], [2, 16.67], [6, 50]],
                 [[5, 41.67], [7, 58.33, '']],
                 [[8, 66.67, '(1, 1)'], [4, 33.33, '']],
-            ]),
+            ], true),
             "should have converted a 2x[3,2] irregular grid to an equivalent table (second row overflowing)");
     });
     QUnit.test('convert a card to a table', async function (assert) {
@@ -247,7 +247,7 @@ QUnit.module('convert_inline', {}, function () {
         convertInline.cardToTable($editable);
         assert.strictEqual($editable.html(),
             getRegularTableHtml(3, 1, 12, 100)
-                .split('style="').join('class="card" style="')
+                .replace('role=\"presentation\"', 'role=\"presentation\" class=\"card\"')
                 .replace(/<td[^>]*>\(0, 0\)<\/td>/,
                     `<td>` +
                         `<table cellspacing=\"0\" cellpadding=\"0\" border=\"0\" width=\"100%\" align=\"center\" ` +

--- a/addons/web_editor/static/tests/test_utils.js
+++ b/addons/web_editor/static/tests/test_utils.js
@@ -801,7 +801,7 @@ function getTableHtml(matrix) {
         matrix.map((row, iRow) => (
             `<tr>` +
             row.map((col, iCol) => (
-                `<td colspan="${col[0]}" width="${col[1]}%" style="width: ${col[1]}%;">` +
+                `<td colspan="${col[0]}">` +
                 (col.length === 3 ? col[2] : `(${iRow}, ${iCol})`) +
                 `</td>`
             )).join('') +
@@ -852,6 +852,23 @@ function getRegularTableHtml(nRows, nCols, colspan, width) {
     );
     return getTableHtml(matrix);
 }
+/**
+ * Take an HTML string and returns that string stripped from any HTML comments.
+ * By default, also removes the mso-hide class which is only there for outlook
+ * to hide elements when we use mso conditional comments.
+ *
+ * @param {string} html
+ * @param {boolean} [removeMsoHide=true]
+ * @returns {string}
+ */
+function removeComments(html, removeMsoHide=true) {
+    const cleanHtml = html.replace(/<!--(.*?)-->/g, '');
+    if (removeMsoHide) {
+        return cleanHtml.replaceAll(' class="mso-hide"', '').replace(/\s*mso-hide/g, '').replace(/mso-hide\s*/g, '');
+    } else {
+        return cleanHtml;
+    }
+}
 
 return {
     wysiwygData: wysiwygData,
@@ -865,6 +882,7 @@ return {
     getTableHtml: getTableHtml,
     getRegularGridHtml: getRegularGridHtml,
     getRegularTableHtml: getRegularTableHtml,
+    removeComments: removeComments,
 };
 
 


### PR DESCRIPTION
The main improvement here is a new support for responsive columns. In order for it not to break Outlook rendering, we hide the responsive columns in Outlook in favor of non-responsive columns (in mso conditionals). This means a lot of the html is written twice, in different ways. The mail is therefore heavier, which is sadly the price of having a proper rendering cross-clients.

This also fixes the rendering of buttons in Outlook, and text alignment.

task-2761098

--
I confirm I have signed the CLA and read the PR guidelines at [www.odoo.com/submit-pr](http://www.odoo.com/submit-pr)