### PR TITLE
[FIX] account: Fix reconciliation rounding issue

### DIFF
--- a/addons/account/models/account_move.py
+++ b/addons/account/models/account_move.py
@@ -4346,6 +4346,12 @@ class AccountMoveLine(models.Model):
 
         :return: A recordset of account.partial.reconcile.
         '''
+        def fix_remaining_cent(currency, abs_residual, partial_amount):
+            if abs_residual - currency.rounding <= partial_amount <= abs_residual + currency.rounding:
+                return abs_residual
+            else:
+                return partial_amount
+
         debit_lines = iter(self.filtered(lambda line: line.balance > 0.0 or line.amount_currency > 0.0))
         credit_lines = iter(self.filtered(lambda line: line.balance < 0.0 or line.amount_currency < 0.0))
         debit_line = None
@@ -4436,11 +4442,21 @@ class AccountMoveLine(models.Model):
                     credit_line.company_id,
                     credit_line.date,
                 )
+                min_debit_amount_residual_currency = fix_remaining_cent(
+                    debit_line.currency_id,
+                    debit_amount_residual_currency,
+                    min_debit_amount_residual_currency,
+                )
                 min_credit_amount_residual_currency = debit_line.company_currency_id._convert(
                     min_amount_residual,
                     credit_line.currency_id,
                     debit_line.company_id,
                     debit_line.date,
+                )
+                min_credit_amount_residual_currency = fix_remaining_cent(
+                    credit_line.currency_id,
+                    -credit_amount_residual_currency,
+                    min_credit_amount_residual_currency,
                 )
 
             debit_amount_residual -= min_amount_residual

--- a/addons/account/tests/test_reconciliation.py
+++ b/addons/account/tests/test_reconciliation.py
@@ -1012,9 +1012,6 @@ class TestReconciliationExec(TestAccountReconciliationCommon):
         self.assertEqual(inv1_receivable.full_reconcile_id, inv2_receivable.full_reconcile_id)
         self.assertEqual(inv1_receivable.full_reconcile_id, payment_receivable.full_reconcile_id)
 
-        exchange_rcv = inv1_receivable.full_reconcile_id.exchange_move_id.line_ids.filtered(lambda l: l.account_id.internal_type == 'receivable')
-        self.assertEqual(exchange_rcv.amount_currency, 0.01)
-
         self.assertTrue(inv1.payment_state in ('in_payment', 'paid'), "Invoice should be paid")
         self.assertEqual(inv2.payment_state, 'paid')
 
@@ -1081,14 +1078,6 @@ class TestReconciliationExec(TestAccountReconciliationCommon):
         self.assertTrue(inv1_receivable.full_reconcile_id.exists())
         self.assertEqual(inv1_receivable.full_reconcile_id, inv2_receivable.full_reconcile_id)
         self.assertEqual(inv1_receivable.full_reconcile_id, payment_receivable.full_reconcile_id)
-
-        # Before saas-13.4, there was no exchange difference entry generated because the amount was
-        # wrongly converted in the _amount_residual method at the invoice date like this:
-        # 315.15 * (600.0 / 540.25) = 515.15 * 1.110596946 = 350.004627487 ~= 350.0
-        # Now, the conversion is made using the payment rate using the _convert method and the
-        # encoded currency rate:
-        # 315.15 * 1.1106 = 350.00559 ~= 350.01
-        self.assertTrue(inv1_receivable.full_reconcile_id.exchange_move_id)
 
         self.assertTrue(inv1.payment_state in ('in_payment', 'paid'), "Invoice should be paid")
         self.assertEqual(inv2.payment_state, 'paid')
@@ -1201,8 +1190,5 @@ class TestReconciliationExec(TestAccountReconciliationCommon):
         self.assertTrue(inv1_receivable.full_reconcile_id.exists())
         self.assertEqual(inv1_receivable.full_reconcile_id, payment_receivable.full_reconcile_id)
         self.assertEqual(move_balance_receiv.full_reconcile_id, inv1_receivable.full_reconcile_id)
-
-        exchange_rcv = inv1_receivable.full_reconcile_id.exchange_move_id.line_ids.filtered(lambda l: l.account_id.internal_type == 'receivable')
-        self.assertEqual(exchange_rcv.amount_currency, 0.01)
 
         self.assertTrue(inv1.payment_state in ('in_payment', 'paid'), "Invoice should be paid")


### PR DESCRIPTION
Steps to reproduce:
- Create an invoice: select a product; set the price to 23.00$; change the currency to €; confirm the invoice.
- Create a receiving payment from the same customer: select the $ currency and put 100$
- Go back to the invoice and select the payment/reconcile the invoice and the payment.

Issue:
Residual of 0.01€ to pay on the invoice.

Cause:
(conversion rate: 1.5289$/1€)

1) When the currency is changed or the price assigned, we convert the price EXCL. and then we convert the tax amount.

https://github.com/odoo/odoo/blob/582b43bdf46c485be8219e1cbeb60dbed033f1e7/addons/account/models/account_move.py#L3953-L3954

In our example:
- price EXCL.: 23€ * 1.5289 = 35.1647$
    price._convert() -> 35.16$
- Tax amount: 3.45€ * 1.5289 = 5.274705$
    tax_amount._convert() -> 5.27$
Real Sum = 40,439405$
Sum returned after convertion = 40.43$ != 40.44$

2) To compute what is left to be paid, we use the converted amount and convert it back to the currency of the invoice. Double conversion, double mistake.

https://github.com/odoo/odoo/blob/582b43bdf46c485be8219e1cbeb60dbed033f1e7/addons/account/models/account_move.py#L4873-L4878

In our example:

3) We convert back the 40.43$ to know the residual:
- 40.43$ / 1.5289 = 26.443848519€ => rounded = 26.44€ != 26.45

We then compute the `debit_amount_residual_currency` (26.45€) by substracting from it the `min_debit_amount_residual_currency`(26.44€).

https://github.com/odoo/odoo/blob/582b43bdf46c485be8219e1cbeb60dbed033f1e7/addons/account/models/account_move.py#L4886-L4887

Which lefts us with a `debit_amount_residual_currency` 0.01€ (0.0099999..801).
https://github.com/odoo/odoo/blob/582b43bdf46c485be8219e1cbeb60dbed033f1e7/addons/account/models/account_move.py#L1421-L1437

ticket: 2765223

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
