### PR TITLE
[FIX] mail: enforce scroll position when shifting chat windows

### DIFF
--- a/addons/mail/static/src/components/chat_window_manager/chat_window_manager_tests.js
+++ b/addons/mail/static/src/components/chat_window_manager/chat_window_manager_tests.js
@@ -2416,6 +2416,122 @@ QUnit.test('chat window should remain folded when new message is received', asyn
     );
 });
 
+QUnit.test('chat window scroll position should remain the same after switching left', async function (assert) {
+    assert.expect(2);
+
+    this.data['mail.channel'].records.push({
+        id: 20,
+        is_minimized: true,
+        state: 'open',
+    });
+    this.data['mail.channel'].records.push({
+        id: 21,
+        is_minimized: true,
+        state: 'open',
+    });
+    for (let i = 0; i < 10; i++) {
+        this.data['mail.message'].records.push({
+            body: "not empty",
+            channel_ids: [20],
+        });
+    }
+    for (let i = 0; i < 10; i++) {
+        this.data['mail.message'].records.push({
+            body: "not empty",
+            channel_ids: [21],
+        });
+    }
+    await this.start();
+
+    const thread1LocalId = this.env.models['mail.thread'].findFromIdentifyingData({
+        id: 20,
+        model: 'mail.channel',
+    }).localId;
+    const thread2LocalId = this.env.models['mail.thread'].findFromIdentifyingData({
+        id: 21,
+        model: 'mail.channel',
+    }).localId;
+    document.querySelector(`.o_ChatWindow[data-thread-local-id="${thread1LocalId}"] .o_ThreadView_messageList`).scrollTop = 100;
+    document.querySelector(`.o_ChatWindow[data-thread-local-id="${thread2LocalId}"] .o_ThreadView_messageList`).scrollTop = 110;
+
+    await this.afterEvent({
+        eventName: 'o-thread-view-hint-processed',
+        func: () => document.querySelector('.o_ChatWindowHeader_commandShiftLeft').click(),
+        message: "Should wait until the scroll is adjusted after a command shift.",
+        predicate: ({ hint }) => {
+            return hint.type === 'adjust-scroll';
+        },
+    });
+    assert.strictEqual(
+        document.querySelector(`.o_ChatWindow[data-thread-local-id="${thread2LocalId}"] .o_ThreadView_messageList`).scrollTop,
+        110,
+        "Scroll position should remain the same after a chat window shift"
+    );
+    assert.strictEqual(
+        document.querySelector(`.o_ChatWindow[data-thread-local-id="${thread1LocalId}"] .o_ThreadView_messageList`).scrollTop,
+        100,
+        "Scroll position should remain the same after a chat window shift"
+    );
+});
+
+QUnit.test('chat window scroll position should remain the same after switching right', async function (assert) {
+    assert.expect(2);
+
+    this.data['mail.channel'].records.push({
+        id: 20,
+        is_minimized: true,
+        state: 'open',
+    });
+    this.data['mail.channel'].records.push({
+        id: 21,
+        is_minimized: true,
+        state: 'open',
+    });
+    for (let i = 0; i < 10; i++) {
+        this.data['mail.message'].records.push({
+            body: "not empty",
+            channel_ids: [20],
+        });
+    }
+    for (let i = 0; i < 10; i++) {
+        this.data['mail.message'].records.push({
+            body: "not empty",
+            channel_ids: [21],
+        });
+    }
+    await this.start();
+    const thread1LocalId = this.env.models['mail.thread'].findFromIdentifyingData({
+        id: 20,
+        model: 'mail.channel',
+    }).localId;
+    const thread2LocalId = this.env.models['mail.thread'].findFromIdentifyingData({
+        id: 21,
+        model: 'mail.channel',
+    }).localId;
+    document.querySelector(`.o_ChatWindow[data-thread-local-id="${thread1LocalId}"] .o_ThreadView_messageList`).scrollTop = 100;
+    document.querySelector(`.o_ChatWindow[data-thread-local-id="${thread2LocalId}"] .o_ThreadView_messageList`).scrollTop = 110;
+
+    await this.afterEvent({
+        eventName: 'o-thread-view-hint-processed',
+        func: () => document.querySelector('.o_ChatWindowHeader_commandShiftRight').click(),
+        message: "Should wait until the scroll is adjusted after a command shift.",
+        predicate: ({ hint }) => {
+            return hint.type === 'adjust-scroll';
+        },
+    });
+    assert.strictEqual(
+        document.querySelector(`.o_ChatWindow[data-thread-local-id="${thread2LocalId}"] .o_ThreadView_messageList`).scrollTop,
+        110,
+        "Scroll position should remain the same after a chat window shift"
+    );
+    assert.strictEqual(
+        document.querySelector(`.o_ChatWindow[data-thread-local-id="${thread1LocalId}"] .o_ThreadView_messageList`).scrollTop,
+        100,
+        "Scroll position should remain the same after a chat window shift"
+    );
+});
+
+
 });
 });
 });

--- a/addons/mail/static/src/components/message_list/message_list.js
+++ b/addons/mail/static/src/components/message_list/message_list.js
@@ -143,6 +143,7 @@ class MessageList extends Component {
                 case 'change-of-thread-cache':
                 case 'home-menu-hidden':
                 case 'home-menu-shown':
+                case 'adjust-scroll':
                     // thread just became visible, the goal is to restore its
                     // saved position if it exists or scroll to the end
                     this._adjustScrollFromModel();

--- a/addons/mail/static/src/models/chat_window_manager/chat_window_manager.js
+++ b/addons/mail/static/src/models/chat_window_manager/chat_window_manager.js
@@ -161,6 +161,11 @@ function factory(dependencies) {
             _newOrdered[index + 1] = chatWindow.localId;
             this.update({ _ordered: _newOrdered });
             chatWindow.focus();
+            for (const loopedChatWindow of [chatWindow, otherChatWindow]) {
+                if (loopedChatWindow.threadView) {
+                    loopedChatWindow.threadView.addComponentHint('adjust-scroll');
+                }
+            }
         }
 
         /**
@@ -181,6 +186,11 @@ function factory(dependencies) {
             _newOrdered[index - 1] = chatWindow.localId;
             this.update({ _ordered: _newOrdered });
             chatWindow.focus();
+            for (const loopedChatWindow of [chatWindow, otherChatWindow]) {
+                if (loopedChatWindow.threadView) {
+                    loopedChatWindow.threadView.addComponentHint('adjust-scroll');
+                }
+            }
         }
 
         /**
@@ -198,6 +208,11 @@ function factory(dependencies) {
             _newOrdered[index1] = chatWindow2.localId;
             _newOrdered[index2] = chatWindow1.localId;
             this.update({ _ordered: _newOrdered });
+            for (const chatWindow of [chatWindow1, chatWindow2]) {
+                if (chatWindow.threadView) {
+                    chatWindow.threadView.addComponentHint('adjust-scroll');
+                }
+            }
         }
 
         //----------------------------------------------------------------------


### PR DESCRIPTION
Before this PR, chat window scroll position was reset to top when it was
switched to the left.
This PR introduce a component hit that restore the position saved inside the
models when a chatwindow is switched.

task-2746500

