### PR TITLE
[IMP] account,mail : Use job queue to send by mail invoices

### DIFF
--- a/addons/account/wizard/account_invoice_send.py
+++ b/addons/account/wizard/account_invoice_send.py
@@ -90,7 +90,7 @@ class AccountInvoiceSend(models.TransientModel):
                 })
             else:
                 self.composer_id.composition_mode = 'comment' if len(res_ids) == 1 else 'mass_mail'
-                self.composer_id.res_id = self.invoice_ids.ids[0]
+                self.composer_id.res_id = self.res_id
                 self.composer_id.template_id = self.template_id.id
                 self._compute_composition_mode()
             self.composer_id._onchange_template_id_wrapper()

--- a/addons/account_edi/__init__.py
+++ b/addons/account_edi/__init__.py
@@ -1,3 +1,4 @@
 # -*- encoding: utf-8 -*-
 
 from . import models
+from . import wizard

--- a/addons/account_edi/__manifest__.py
+++ b/addons/account_edi/__manifest__.py
@@ -19,6 +19,7 @@ governements, etc.)
         'views/account_move_views.xml',
         'views/account_payment_views.xml',
         'views/account_journal_views.xml',
+        'views/mass_mail_confirm_views.xml',
         'data/cron.xml'
     ],
     'installable': True,

--- a/addons/account_edi/__manifest__.py
+++ b/addons/account_edi/__manifest__.py
@@ -20,6 +20,7 @@ governements, etc.)
         'views/account_payment_views.xml',
         'views/account_journal_views.xml',
         'views/mass_mail_confirm_views.xml',
+        'views/account_invoice_send_views.xml',
         'data/cron.xml'
     ],
     'installable': True,

--- a/addons/account_edi/models/account_move.py
+++ b/addons/account_edi/models/account_move.py
@@ -450,6 +450,12 @@ class AccountMove(models.Model):
                 move_result.setdefault('attachments', []).extend(edi_attachments.get('attachments', []))
         return result
 
+    def action_invoice_sent(self):
+        res = super(AccountMove, self).action_invoice_sent()
+        compose_form = self.env.ref('account_edi.account_edi_account_invoice_send_form', raise_if_not_found=False)
+        res['view_id'] = compose_form.id
+        res['views'] = [(compose_form.id, 'form')]
+        return res
 
 class AccountMoveLine(models.Model):
     _inherit = 'account.move.line'

--- a/addons/account_edi/security/ir.model.access.csv
+++ b/addons/account_edi/security/ir.model.access.csv
@@ -3,3 +3,4 @@ access_account_edi_format_readonly,account.edi.format,model_account_edi_format,,
 access_account_edi_format_group_invoice,account.edi.format,model_account_edi_format,account.group_account_invoice,1,1,1,1
 access_account_edi_document_readonly,account.edi.document,model_account_edi_document,,1,0,0,0
 access_account_edi_document_group_invoice,account.edi.document,model_account_edi_document,account.group_account_invoice,1,1,1,1
+account_edi.access_mass_mail_confirm,access_mass_mail_confirm,account_edi.model_mass_mail_confirm,base.group_user,1,1,1,0

--- a/addons/account_edi/views/account_invoice_send_views.xml
+++ b/addons/account_edi/views/account_invoice_send_views.xml
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <data>
+        <record id="account_edi_account_invoice_send_form" model="ir.ui.view">
+            <field name="name">account.edi.account.invoice.send.inherit</field>
+            <field name="model">account.invoice.send</field>
+            <field name="inherit_id" ref="account.account_invoice_send_wizard_form"/>
+            <field name="arch" type="xml">
+                <xpath expr="//field[@name='composition_mode']" position="before">
+                    <field name="all_valid" invisible="1" readonly="1"/>
+                    <div class="alert alert-warning text-center mb-0 no_print" attrs="{'invisible': [('all_valid', '=', True)]}">
+                        <span>
+                            Some mail can't be sent (<a type="object" name="action_invalid_edi_moves">Invoices</a>).
+                        </span>
+                    </div>
+                </xpath>
+            </field>
+        </record>
+
+        <record id="account_move_tree_view_edi_state" model="ir.ui.view">
+            <field name="name">account.move.tree.edi.state</field>
+            <field name="model">account.move</field>
+            <field name="mode">primary</field>
+            <field eval="7" name="priority"/>
+            <field name="arch" type="xml">
+                <tree js_class="account_tree" string="Account move" create="false" delete="false" expand="true" multi_edit="0" duplicate="false" editable="bottom">
+                    <field name="date" readonly="1"/>
+                    <field name="name" readonly="1"/>
+                    <field name="partner_id" readonly="1"/>
+                    <field name="amount_total" readonly="1"/>
+                    <field name="edi_state" readonly="1"/>
+                </tree>
+            </field>
+        </record>
+    </data>
+</odoo>

--- a/addons/account_edi/views/account_invoice_send_views.xml
+++ b/addons/account_edi/views/account_invoice_send_views.xml
@@ -8,7 +8,7 @@
             <field name="arch" type="xml">
                 <xpath expr="//field[@name='composition_mode']" position="before">
                     <field name="all_valid" invisible="1" readonly="1"/>
-                    <div class="alert alert-warning text-center mb-0 no_print" attrs="{'invisible': [('all_valid', '=', True)]}">
+                    <div class="alert alert-warning text-center mb-0 no_print" role="alert" attrs="{'invisible': [('all_valid', '=', True)]}">
                         <span>
                             Some mail can't be sent (<a type="object" name="action_invalid_edi_moves">Invoices</a>).
                         </span>

--- a/addons/account_edi/views/account_move_views.xml
+++ b/addons/account_edi/views/account_move_views.xml
@@ -69,13 +69,13 @@
                          <div>The invoice will be processed asynchronously by the following E-invoicing service :
                             <field name="edi_web_services_to_process" class="oe_inline"/>
                          </div>
-                         <button name="button_process_edi_web_services" type="object" class="oe_link" string="Process now" /> 
+                         <button name="button_process_edi_web_services" type="object" class="oe_link" string="Process now" />
                     </div>
                     <div class="alert alert-danger" role="alert" style="margin-bottom:0px;"
                         attrs="{'invisible': ['|', ('edi_error_count', '=', 0), ('edi_blocking_level', '!=', 'error')]}">
                         <div class="o_row">
                             <field name="edi_error_message" />
-                            <button name="%(account_edi.action_open_edi_documents)d" string="⇒ See errors" type="action" class="oe_link" attrs="{'invisible': [('edi_error_count', '=', 1)]}" /> 
+                            <button name="%(account_edi.action_open_edi_documents)d" string="⇒ See errors" type="action" class="oe_link" attrs="{'invisible': [('edi_error_count', '=', 1)]}" />
                             <button name="action_retry_edi_documents_error" type="object" class="oe_link oe_inline" string="Retry" />
                         </div>
                     </div>
@@ -83,14 +83,14 @@
                         attrs="{'invisible': ['|', ('edi_error_count', '=', 0), ('edi_blocking_level', '!=', 'warning')]}">
                         <div class="o_row">
                             <field name="edi_error_message" />
-                            <button name="%(account_edi.action_open_edi_documents)d" string="⇒ See errors" type="action" class="oe_link" attrs="{'invisible': [('edi_error_count', '=', 1)]}" /> 
+                            <button name="%(account_edi.action_open_edi_documents)d" string="⇒ See errors" type="action" class="oe_link" attrs="{'invisible': [('edi_error_count', '=', 1)]}" />
                         </div>
                     </div>
                     <div class="alert alert-info" role="alert" style="margin-bottom:0px;"
                         attrs="{'invisible': ['|', ('edi_error_count', '=', 0), ('edi_blocking_level', '!=', 'info')]}">
                         <div class="o_row">
                             <field name="edi_error_message" />
-                            <button name="%(account_edi.action_open_edi_documents)d" string="⇒ See errors" type="action" class="oe_link" attrs="{'invisible': [('edi_error_count', '=', 1)]}" /> 
+                            <button name="%(account_edi.action_open_edi_documents)d" string="⇒ See errors" type="action" class="oe_link" attrs="{'invisible': [('edi_error_count', '=', 1)]}" />
                         </div>
                     </div>
                 </xpath>

--- a/addons/account_edi/views/account_move_views.xml
+++ b/addons/account_edi/views/account_move_views.xml
@@ -15,7 +15,7 @@
             <field name="inherit_id" ref="account.view_out_invoice_tree" />
             <field name="arch" type="xml">
                 <field name="state" position="before">
-                    <field name="edi_state" optional="hide"/>
+                    <field name="edi_state" optional="context.get('edi_state', 'hide')"/>
                 </field>
             </field>
         </record>

--- a/addons/account_edi/views/mass_mail_confirm_views.xml
+++ b/addons/account_edi/views/mass_mail_confirm_views.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <record id="view_mass_mail_confirm" model="ir.ui.view">
+        <field name="name">Confirm Mass Mail</field>
+        <field name="model">mass.mail.confirm</field>
+        <field name="arch" type="xml">
+            <form string="Confirm Sending of Mass Mail">
+                <group>
+                    <div>
+                        Some selected invoice cannot be send and/or print because their EDI is not ready. Confirm sending of those who are available ?
+                    </div>
+                    <field name='test_fields'/>
+                </group>
+                <footer>
+                    <button name="action_confirm_sending" string="Yes" type="object" class="oe_highlight" />
+                    or
+                    <button string="Cancel" class="oe_link" special="cancel" />
+                </footer>
+            </form>
+        </field>
+    </record>
+</odoo>

--- a/addons/account_edi/wizard/__init__.py
+++ b/addons/account_edi/wizard/__init__.py
@@ -1,0 +1,5 @@
+# -*- coding: utf-8 -*-
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from . import account_invoice_send
+from . import mass_mail_confirm

--- a/addons/account_edi/wizard/account_invoice_send.py
+++ b/addons/account_edi/wizard/account_invoice_send.py
@@ -16,9 +16,11 @@ class AccountInvoiceSend(models.TransientModel):
         res = super(AccountInvoiceSend, self).default_get(fields)
         invoice_ids = self.env['account.move'].browse(res['invoice_ids'])
         invoice_edi_not_valid = invoice_ids.filtered(lambda i: i.edi_state in ('to_send', 'to_cancel'))
+        invoice_edi_valid = invoice_ids - invoice_edi_not_valid
         if len(invoice_edi_not_valid) > 0:
             res['all_valid'] = False
             res['invalid_invoices_ids'] = invoice_edi_not_valid.ids
+            res['invoice_ids'] = invoice_edi_valid.ids
         return res
 
     def action_invalid_edi_moves(self):
@@ -35,5 +37,6 @@ class AccountInvoiceSend(models.TransientModel):
                 'create': False,
                 'delete': False,
                 'expand': True,
-            }
+                'edi_state': 'show',
+            },
         }

--- a/addons/account_edi/wizard/account_invoice_send.py
+++ b/addons/account_edi/wizard/account_invoice_send.py
@@ -1,41 +1,41 @@
 # -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
+from re import A
 from odoo import api, fields, models, _
-from odoo.exceptions import UserError
+from odoo.exceptions import RedirectWarning, UserError
 
 
 class AccountInvoiceSend(models.TransientModel):
     _inherit = 'account.invoice.send'
 
+    # not_validated_account_move_id = fields.Many2one('account_move', "Account move not validated by an edi")
+    all_valid = fields.Boolean("All mail have valide edi", default=True)
+    invalid_invoices_ids = fields.Many2many('account.move', 'account_move_edi_account_invoice_send_rel', string='Invalid Invoices')
+
     @api.model
     def default_get(self, fields):
         res = super(AccountInvoiceSend, self).default_get(fields)
-        edi_state = self.env['account.move'].browse(res['invoice_ids']).mapped('edi_state')
-        if any(state in edi_state for state in ['to_send', 'to_cancel']):
-            if len(res['invoice_ids']) == 1:
-                raise UserError("You can send and/or print an invoice which hasn't be validate by the EDI")
-            ids_to_remove = self.env['account.move'].search([('id', 'in', res['invoice_ids']), '|', ('edi_state', '=', 'to_send'), ('edi_state', '=', 'to_cancel')]).mapped('id')
-            res['invoice_ids'] = list(set(res['invoice_ids']) - set(ids_to_remove))
-
-            # return {
-            #     'warning':
-            #         {'title': 'Warning',
-            #         'message': ("Some invoices couldn't be send due to their EDI status"),
-            #         }
-            #     }
+        invoice_ids = self.env['account.move'].browse(res['invoice_ids'])
+        invoice_edi_not_valid = invoice_ids.filtered(lambda i: i.edi_state in ('to_send', 'to_cancel'))
+        if len(invoice_edi_not_valid) > 0:
+            res['all_valid'] = False
+            res['invalid_invoices_ids'] = invoice_edi_not_valid.ids
         return res
 
-    def _return_confirmation_popup(self):
-        view_id = self.env.ref('account_edi.view_mass_mail_confirm').id
-        new_wizard = self.env['mass.mail.confirm'].create({})
+    def action_invalid_edi_moves(self):
         return {
-                'type': 'ir.actions.act_window',
-                'name': _('Confirm'),
-                'view_mode': 'form',
-                'view_type' : 'form',
-                'view_id' : self.env.ref('account_edi.view_mass_mail_confirm'),
-                'res_model': 'mass.mail.confirm',
-                'res_id' : new_wizard.id,
-                'target': 'current',
+            'type': 'ir.actions.act_window',
+            'name': _('Unprocess invoice by edi service.'),
+            'res_model': 'account.move',
+            'views': [(
+                self.env.ref('account_edi.view_out_invoice_tree_inherit').id,
+                'list',
+            ), (False, 'form')],
+            'domain': [('id', 'in', self.invalid_invoices_ids.ids)],
+            'context': {
+                'create': False,
+                'delete': False,
+                'expand': True,
             }
+        }

--- a/addons/account_edi/wizard/account_invoice_send.py
+++ b/addons/account_edi/wizard/account_invoice_send.py
@@ -1,9 +1,7 @@
 # -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
-from re import A
 from odoo import api, fields, models, _
-from odoo.exceptions import RedirectWarning, UserError
 
 
 class AccountInvoiceSend(models.TransientModel):

--- a/addons/account_edi/wizard/account_invoice_send.py
+++ b/addons/account_edi/wizard/account_invoice_send.py
@@ -1,0 +1,41 @@
+# -*- coding: utf-8 -*-
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from odoo import api, fields, models, _
+from odoo.exceptions import UserError
+
+
+class AccountInvoiceSend(models.TransientModel):
+    _inherit = 'account.invoice.send'
+
+    @api.model
+    def default_get(self, fields):
+        res = super(AccountInvoiceSend, self).default_get(fields)
+        edi_state = self.env['account.move'].browse(res['invoice_ids']).mapped('edi_state')
+        if any(state in edi_state for state in ['to_send', 'to_cancel']):
+            if len(res['invoice_ids']) == 1:
+                raise UserError("You can send and/or print an invoice which hasn't be validate by the EDI")
+            ids_to_remove = self.env['account.move'].search([('id', 'in', res['invoice_ids']), '|', ('edi_state', '=', 'to_send'), ('edi_state', '=', 'to_cancel')]).mapped('id')
+            res['invoice_ids'] = list(set(res['invoice_ids']) - set(ids_to_remove))
+
+            # return {
+            #     'warning':
+            #         {'title': 'Warning',
+            #         'message': ("Some invoices couldn't be send due to their EDI status"),
+            #         }
+            #     }
+        return res
+
+    def _return_confirmation_popup(self):
+        view_id = self.env.ref('account_edi.view_mass_mail_confirm').id
+        new_wizard = self.env['mass.mail.confirm'].create({})
+        return {
+                'type': 'ir.actions.act_window',
+                'name': _('Confirm'),
+                'view_mode': 'form',
+                'view_type' : 'form',
+                'view_id' : self.env.ref('account_edi.view_mass_mail_confirm'),
+                'res_model': 'mass.mail.confirm',
+                'res_id' : new_wizard.id,
+                'target': 'current',
+            }

--- a/addons/account_edi/wizard/mass_mail_confirm.py
+++ b/addons/account_edi/wizard/mass_mail_confirm.py
@@ -1,0 +1,13 @@
+# -*- coding: utf-8 -*-
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from odoo import models, fields
+
+class MassMailConfirm(models.TransientModel):
+    _name = "mass.mail.confirm"
+    _description = "Confirm the sending of invoice woth edi in mass mail"
+
+    test_fields = fields.Text('Hello', readonly=True)
+
+    def action_confirm_sending(self):
+        pass


### PR DESCRIPTION
This commit uses the mail queue when the user uses the "Send & Print"
functionality. The behavior before this commit is a synchronous send,
meaning that the app wait for EDI validation before sending the mail and
closing the wizard.

It creates a new model, mail_message_pending, that
represents a mail_message that is yet to be send and store all values
that will be used to send it.

We have used this approach because we wanted to put the message in the
chatter at the right time, i.e. when the mail is send (and not when the
message is created). Since the order of messages in the chatter is
linked to id (in js) it is the easiest way of doing it.

task-2764998