### PR TITLE
[FIX] website_slides: stop tour by getting failed randomly

### DIFF
--- a/addons/website_slides/static/tests/tours/slide_course_publisher_standard.js
+++ b/addons/website_slides/static/tests/tours/slide_course_publisher_standard.js
@@ -45,6 +45,7 @@ tour.register('course_publisher_standard', {
     trigger: 'div[id="edit-page-menu"] a',
 }, {
     content: 'eLearning: double click image to edit it',
+    extra_trigger: 'body.editor_enable',
     trigger: 'img.o_wslides_course_pict',
     run: 'dblclick',
 }, {


### PR DESCRIPTION
Right now, in some cases, the test tour {course_publisher_standard}
fails randomly, because during the step of image changing, the double
click event on the photo happens before the edit mode is fully enabled,
which results in the tour failing randomly.

After this PR, tour will work properly because we have added extra_trigger,
which will cause the tour to move to the next step once edit mode is enabled.

taskID: 2786661