### PR TITLE
[FIX] hr_expense: Expense unit price is readonly if it has a cost

### DIFF
--- a/addons/hr_expense/views/hr_expense_views.xml
+++ b/addons/hr_expense/views/hr_expense_views.xml
@@ -143,7 +143,7 @@
                             <field name="company_currency_id" invisible="1"/>
                             <field name="sheet_is_editable" invisible="1"/>
                             <field name="product_id" required="1" attrs="{'readonly': [('sheet_is_editable', '=', False)]}" context="{'default_can_be_expensed': 1, 'tree_view_ref': 'hr_expense.product_product_expense_tree_view', 'form_view_ref': 'hr_expense.product_product_expense_form_view'}"/>
-                            <field name="unit_amount" required="1" widget="monetary" options="{'currency_field': 'currency_id', 'field_digits': True}" attrs="{'invisible': [('product_has_cost', '=', False)], 'readonly': [('sheet_is_editable', '=', False)]}"/>
+                            <field name="unit_amount" required="1" force_save="1" widget="monetary" options="{'currency_field': 'currency_id', 'field_digits': True}" attrs="{'invisible': [('product_has_cost', '=', False)], 'readonly': ['|', ('sheet_is_editable', '=', False), ('product_has_cost', '=', True)]}"/>
                             <field name="untaxed_amount" invisible="1" force_save="1"/>
                             <field name="product_uom_category_id" invisible="1"/>
                             <label for="quantity" attrs="{'invisible': [('product_has_cost', '=', False)]}"/>


### PR DESCRIPTION
Step to reproduce:
- Create an expense for an expense product which has a cost

Current behaviour:
- Expense's unit price is modifiable which shouldn't be
 the case according to the help message of hr.expense.unit_amount

Behaviour after PR:
- Expense unit price is only modifiable is there is no unit_amount
(unit_amount = 0)

opw-2781040


--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
