### PR TITLE
[IMP] account: change the date for calculating the currency exchange

### DIFF
--- a/addons/account/tests/test_account_move_in_invoice.py
+++ b/addons/account/tests/test_account_move_in_invoice.py
@@ -1048,6 +1048,7 @@ class TestAccountMoveInInvoiceOnchanges(AccountTestInvoicingCommon):
 
         move_form = Form(self.invoice)
         # Change the date to get another rate: 1/3 instead of 1/2.
+        move_form.invoice_date = fields.Date.from_string('2016-01-01')
         move_form.date = fields.Date.from_string('2016-01-01')
         move_form.save()
 
@@ -1081,6 +1082,7 @@ class TestAccountMoveInInvoiceOnchanges(AccountTestInvoicingCommon):
                 'currency_id': self.currency_data['currency'].id,
                 'amount_currency': -1128.0,
                 'credit': 376.0,
+                'date_maturity': fields.Date.from_string('2016-01-01'),
             },
         ], {
             **self.move_vals,
@@ -1136,6 +1138,7 @@ class TestAccountMoveInInvoiceOnchanges(AccountTestInvoicingCommon):
                 'price_total': -208.006,
                 'amount_currency': -208.006,
                 'credit': 69.33,
+                'date_maturity': fields.Date.from_string('2016-01-01'),
             },
         ], {
             **self.move_vals,
@@ -1178,6 +1181,7 @@ class TestAccountMoveInInvoiceOnchanges(AccountTestInvoicingCommon):
                 'price_total': -208.01,
                 'amount_currency': -208.01,
                 'credit': 208.01,
+                'date_maturity': fields.Date.from_string('2016-01-01'),
             },
         ], {
             **self.move_vals,

--- a/addons/account/tests/test_account_move_in_refund.py
+++ b/addons/account/tests/test_account_move_in_refund.py
@@ -732,6 +732,7 @@ class TestAccountMoveInRefundOnchanges(AccountTestInvoicingCommon):
 
         move_form = Form(self.invoice)
         # Change the date to get another rate: 1/3 instead of 1/2.
+        move_form.invoice_date = fields.Date.from_string('2016-01-01')
         move_form.date = fields.Date.from_string('2016-01-01')
         move_form.save()
 
@@ -765,6 +766,7 @@ class TestAccountMoveInRefundOnchanges(AccountTestInvoicingCommon):
                 'currency_id': self.currency_data['currency'].id,
                 'amount_currency': 1128.0,
                 'debit': 376.0,
+                'date_maturity': fields.Date.from_string('2016-01-01'),
             },
         ], {
             **self.move_vals,
@@ -820,6 +822,7 @@ class TestAccountMoveInRefundOnchanges(AccountTestInvoicingCommon):
                 'price_total': -208.006,
                 'amount_currency': 208.006,
                 'debit': 69.33,
+                'date_maturity': fields.Date.from_string('2016-01-01'),
             },
         ], {
             **self.move_vals,
@@ -862,6 +865,7 @@ class TestAccountMoveInRefundOnchanges(AccountTestInvoicingCommon):
                 'price_total': -208.01,
                 'amount_currency': 208.01,
                 'debit': 208.01,
+                'date_maturity': fields.Date.from_string('2016-01-01'),
             },
         ], {
             **self.move_vals,

--- a/addons/account/tests/test_account_move_out_invoice.py
+++ b/addons/account/tests/test_account_move_out_invoice.py
@@ -1652,7 +1652,7 @@ class TestAccountMoveOutInvoiceOnchanges(AccountTestInvoicingCommon):
 
         move_form = Form(self.invoice)
         # Change the date to get another rate: 1/3 instead of 1/2.
-        move_form.date = fields.Date.from_string('2016-01-01')
+        move_form.invoice_date = fields.Date.from_string('2016-01-01')
         move_form.save()
 
         self.assertInvoiceValues(self.invoice, [
@@ -1685,6 +1685,7 @@ class TestAccountMoveOutInvoiceOnchanges(AccountTestInvoicingCommon):
                 'currency_id': self.currency_data['currency'].id,
                 'amount_currency': 1410.0,
                 'debit': 470.0,
+                'date_maturity': fields.Date.from_string('2016-01-01'),
             },
         ], {
             **self.move_vals,
@@ -1740,6 +1741,7 @@ class TestAccountMoveOutInvoiceOnchanges(AccountTestInvoicingCommon):
                 'price_total': -260.006,
                 'amount_currency': 260.006,
                 'debit': 86.67,
+                'date_maturity': fields.Date.from_string('2016-01-01'),
             },
         ], {
             **self.move_vals,
@@ -1782,6 +1784,7 @@ class TestAccountMoveOutInvoiceOnchanges(AccountTestInvoicingCommon):
                 'price_total': -260.01,
                 'amount_currency': 260.01,
                 'debit': 260.01,
+                'date_maturity': fields.Date.from_string('2016-01-01'),
             },
         ], {
             **self.move_vals,
@@ -2405,7 +2408,7 @@ class TestAccountMoveOutInvoiceOnchanges(AccountTestInvoicingCommon):
         move = self.env['account.move'].create({
             'move_type': 'out_invoice',
             'partner_id': self.partner_a.id,
-            'invoice_date': fields.Date.from_string('2016-01-01'),
+            'invoice_date': fields.Date.from_string('2017-01-15'),
             'date': fields.Date.from_string('2015-01-01'),
             'currency_id': self.currency_data['currency'].id,
             'invoice_payment_term_id': self.pay_terms_a.id,
@@ -2492,7 +2495,7 @@ class TestAccountMoveOutInvoiceOnchanges(AccountTestInvoicingCommon):
                 'amount_currency': 1430.0,
                 'debit': 715.0,
                 'credit': 0.0,
-                'date_maturity': fields.Date.from_string('2016-01-01'),
+                'date_maturity': fields.Date.from_string('2017-01-15'),
             },
         ], {
             **self.move_vals,

--- a/addons/account/tests/test_account_move_out_refund.py
+++ b/addons/account/tests/test_account_move_out_refund.py
@@ -731,7 +731,7 @@ class TestAccountMoveOutRefundOnchanges(AccountTestInvoicingCommon):
 
         move_form = Form(self.invoice)
         # Change the date to get another rate: 1/3 instead of 1/2.
-        move_form.date = fields.Date.from_string('2016-01-01')
+        move_form.invoice_date = fields.Date.from_string('2016-01-01')
         move_form.save()
 
         self.assertInvoiceValues(self.invoice, [
@@ -764,6 +764,7 @@ class TestAccountMoveOutRefundOnchanges(AccountTestInvoicingCommon):
                 'currency_id': self.currency_data['currency'].id,
                 'amount_currency': -1410.0,
                 'credit': 470.0,
+                'date_maturity': fields.Date.from_string('2016-01-01'),
             },
         ], {
             **self.move_vals,
@@ -819,6 +820,7 @@ class TestAccountMoveOutRefundOnchanges(AccountTestInvoicingCommon):
                 'price_total': -260.006,
                 'amount_currency': -260.006,
                 'credit': 86.67,
+                'date_maturity': fields.Date.from_string('2016-01-01'),
             },
         ], {
             **self.move_vals,
@@ -861,6 +863,7 @@ class TestAccountMoveOutRefundOnchanges(AccountTestInvoicingCommon):
                 'price_total': -260.01,
                 'amount_currency': -260.01,
                 'credit': 260.01,
+                'date_maturity': fields.Date.from_string('2016-01-01'),
             },
         ], {
             **self.move_vals,


### PR DESCRIPTION
Currently, the currency conversion rate used is based on the accounting date on invoices and bills.
According to partner feedback and the official documentation, we should use the exchange rate on the invoice/bill date.
Moves that are not invoices or bills should still use the accounting date.

Task: 2807136


--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
