### PR TITLE
[IMP] account,stock_account: improve display of invoices/bills in list view

### DIFF
--- a/addons/account/views/account_move_views.xml
+++ b/addons/account/views/account_move_views.xml
@@ -401,7 +401,9 @@
             <field name="arch" type="xml">
                 <tree string="Invoices"
                       js_class="account_tree"
-                      sample="1">
+                      sample="1"
+                      decoration-info="state == 'draft'"
+                      decoration-muted="state == 'cancel'">
                     <header>
                         <button name="action_register_payment" type="object" string="Register Payment"
                             groups="account.group_account_user"


### PR DESCRIPTION
Two problems seem to have emerged in the list view of invoices and vendor bills since 12.0 (account):
~~Amount Due is not 0 for draft and canceled entries. It should be 0 since they haven't been posted yet.~~ (can't do that in stable - will be done in master)
Canceled and draft entries are the same color as posted entries. They should be in a different color (grey/blue) in order to be distinguished from other invoices.

~~A few tests have to be adapted to reflect this change in spec (stock_account).~~

task id=2801521

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
