### PR TITLE
[IMP] account: improve display of invoices/bills in list view

### DIFF
--- a/addons/account/models/account_move.py
+++ b/addons/account/models/account_move.py
@@ -1139,7 +1139,7 @@ class AccountMove(models.Model):
                         total_tax_currency += line.amount_currency
                         total += line.balance
                         total_currency += line.amount_currency
-                    elif line.account_id.user_type_id.type in ('receivable', 'payable'):
+                    elif line.account_id.user_type_id.type in ('receivable', 'payable') and move.state not in ('draft', 'cancel'):
                         # Residual amount.
                         total_residual += line.amount_residual
                         total_residual_currency += line.amount_residual_currency

--- a/addons/account/tests/test_account_invoice_report.py
+++ b/addons/account/tests/test_account_invoice_report.py
@@ -1,10 +1,7 @@
 # -*- coding: utf-8 -*-
 from odoo.addons.account.tests.account_test_savepoint import AccountTestInvoicingCommon
-from odoo.tests.common import Form
 from odoo.tests import tagged
 from odoo import fields
-
-from unittest.mock import patch
 
 
 @tagged('post_install', '-at_install')
@@ -113,11 +110,11 @@ class TestAccountInvoiceReport(AccountTestInvoicingCommon):
     def test_invoice_report_multiple_types(self):
         self.assertInvoiceReportValues([
             # amount_total  price_average   price_subtotal  residual    quantity
-            [2000,          2000,           2000,           2000,       1],
-            [1000,          1000,           1000,           1000,       1],
-            [750,           250,            750,            750,        3],
-            [6,             6,              6,              6,          1],
-            [-20,           -20,            -20,            -20,        -1],
-            [-20,           -20,            -20,            -20,        -1],
-            [-600,          -600,           -600,           -600,       -1],
+            [2000, 2000, 2000, 0, 1],
+            [1000, 1000, 1000, 0, 1],
+            [750, 250, 750, 0, 3],
+            [6, 6, 6, 0, 1],
+            [-20, -20, -20, 0, -1],
+            [-20, -20, -20, 0, -1],
+            [-600, -600, -600, 0, -1],
         ])


### PR DESCRIPTION
The Amount Due on invoice and vendor bills list view is not 0 for draft and canceled entries. It should be 0 since they haven't been posted yet, like it was for 12.0.

Some tests have to be adapted to reflect the change in spec.

task id=2801521

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
