### PR TITLE
[MERGE][IMP] base,website_profile: improve the rank layout

### DIFF
--- a/addons/website_profile/views/website_profile.xml
+++ b/addons/website_profile/views/website_profile.xml
@@ -339,9 +339,15 @@
                     <span t-else="" t-field="user.rank_id.name"/>
                 </h4>
                 <small>
-                    <span class="font-weight-bold text-primary" t-field="user.karma"/> /
-                    <span t-if="next_rank_id" class="font-weight-bold" t-field="next_rank_id.karma_min"/>
-                    <span t-else="" class="font-weight-bold" t-field="user.rank_id.karma_min"/>
+                    <span class="font-weight-bold text-primary"
+                        t-field="user.karma"
+                        t-options="{'format_decimalized_number': True, 'precision_digits': 2}"/> /
+                    <span t-if="next_rank_id" class="font-weight-bold"
+                        t-field="next_rank_id.karma_min"
+                        t-options="{'format_decimalized_number': True, 'precision_digits': 2}"/>
+                    <span t-else="" class="font-weight-bold"
+                        t-field="user.rank_id.karma_min"
+                        t-options="{'format_decimalized_number': True, 'precision_digits': 2}"/>
                      xp
                 </small>
             </div>

--- a/odoo/addons/base/models/ir_qweb_fields.py
+++ b/odoo/addons/base/models/ir_qweb_fields.py
@@ -142,13 +142,14 @@ class IntegerConverter(models.AbstractModel):
         options = super(IntegerConverter, self).get_available_options()
         options.update(
             format_decimalized_number=dict(type='boolean', string=_('Decimalized number')),
+            precision_digits=dict(type='integer', string=_('Precision Digits')),
         )
         return options
 
     @api.model
     def value_to_html(self, value, options):
         if options.get('format_decimalized_number'):
-            return tools.format_decimalized_number(value)
+            return tools.format_decimalized_number(value, options.get('precision_digits', 1))
         return pycompat.to_text(self.user_lang().format('%d', value, grouping=True).replace(r'-', '-\N{ZERO WIDTH NO-BREAK SPACE}'))
 
 

--- a/odoo/addons/base/tests/test_qweb_field.py
+++ b/odoo/addons/base/tests/test_qweb_field.py
@@ -42,3 +42,17 @@ class TestQwebFieldTime(common.TransactionCase):
         # Only values inferior to 24 can be used
         with self.assertRaises(ValueError):
             self.value_to_html(24)
+
+
+class TestQwebFieldInteger(common.TransactionCase):
+    def value_to_html(self, value, options=None):
+        options = options or {}
+        return self.env['ir.qweb.field.integer'].value_to_html(value, options)
+
+    def test_integer_value_to_html(self):
+        self.assertEqual(self.value_to_html(1000), "1,000")
+        self.assertEqual(self.value_to_html(1000000, {'format_decimalized_number': True}), "1M")
+        self.assertEqual(
+            self.value_to_html(125125, {'format_decimalized_number': True, 'precision_digits': 3}),
+            "125.125k"
+        )


### PR DESCRIPTION
Currently if a user is having huge number of karma/xp (for example
10000), when viewing the website profile, these numbers overlap the
design of a next rank layout card.

This commit formats the karma/xp into decimal number (allowing up
to two decimal points so that the information is meaningful) and
thus reducing the space being occupied by large numbers.

task-2792149