### PR TITLE
[FIX] mail: no RecordDeletedError raised with `@`-mentions in discuss

### DIFF
--- a/addons/mail/static/src/components/composer_suggestion/composer_suggestion.js
+++ b/addons/mail/static/src/components/composer_suggestion/composer_suggestion.js
@@ -72,6 +72,7 @@ export class ComposerSuggestion extends Component {
      */
     _update() {
         if (
+            this.root.el &&
             this.composerView &&
             this.composerView.hasToScrollToActiveSuggestion &&
             this.props.isActive


### PR DESCRIPTION
Before this commit, there was a `RecordDeletedError` raised when
mentioning partners in the discuss app.

Steps to reproduce:
- Connect as Mitchell Admin
- Go to Discuss > #General
- In the composer, type (without quotes), character by character:
    1. "@"
    2. "d"
    3. "e"
    4. "m"
    5. "o"

There should be a traceback about `RecordDeletedError` raised.
Actually this error is a consequence of a prior error that is raised:
`root.el` is used without being guarded in an `useUpdate`.
`root.el` should always be guarded.
