### PR TITLE
[FIX] mass_mailing: handle comma-separated template styles 

### DIFF
--- a/addons/mass_mailing/static/src/js/mass_mailing_snippets.js
+++ b/addons/mass_mailing/static/src/js/mass_mailing_snippets.js
@@ -40,8 +40,8 @@ const DEFAULT_CSS_OBJECT = {
         color: '#212529',
         'font-family': 'Arial,Helvetica Neue,Helvetica,sans-serif',
     },
-    'p, p *, li, li *': {
-        'font-size': '14x',
+    'p, p > *, li, li > *': {
+        'font-size': '14px',
         color: '#212529',
         'font-family': 'Arial,Helvetica Neue,Helvetica,sans-serif',
     },

--- a/addons/mass_mailing/views/snippets_themes.xml
+++ b/addons/mass_mailing/views/snippets_themes.xml
@@ -629,28 +629,28 @@
         <we-row string="Text" class="o_design_tab_title">
             <we-input data-customize-css-property=""
                         data-css-property="font-size"
-                        data-selector-text="p, p *, li, li *"
+                        data-selector-text="p, p > *, li, li > *"
                         data-unit="px"/>
             <we-colorpicker data-customize-css-property=""
                             data-css-property="color"
-                            data-selector-text="p, p *, li, li *"
+                            data-selector-text="p, p > *, li, li > *"
                             data-no-transparency="true"
                             data-color-prefix="text-"/>
         </we-row>
         <we-row string="⌙ " class="o_short_title">
-            <we-fontfamilypicker data-selector-text="p, p *, li, li *"/>
+            <we-fontfamilypicker data-selector-text="p, p > *, li, li > *"/>
             <span>​</span> <!-- Separate the select from the buttons (styling) -->
             <we-button title="Bold" class="fa fa-fw fa-bold" data-no-preview="true" data-toggle="true"
                         data-customize-css-property="bolder"
-                        data-selector-text="p, p *, li, li *"
+                        data-selector-text="p, p > *, li, li > *"
                         data-css-property="font-weight"/>
             <we-button title="Italic" class="fa fa-fw fa-italic" data-no-preview="true" data-toggle="true"
                         data-customize-css-property="italic"
-                        data-selector-text="p, p *, li, li *"
+                        data-selector-text="p, p > *, li, li > *"
                         data-css-property="font-style"/>
             <we-button title="Underline" class="fa fa-fw fa-underline" data-no-preview="true" data-toggle="true"
                         data-customize-css-property="underline"
-                        data-selector-text="p, p *, li, li *"
+                        data-selector-text="p, p > *, li, li > *"
                         data-css-property="text-decoration-line"/>
         </we-row>
         <!-- LINKS -->

--- a/addons/mass_mailing/views/snippets_themes.xml
+++ b/addons/mass_mailing/views/snippets_themes.xml
@@ -669,20 +669,20 @@
         <we-row string="Primary Buttons" class="o_design_tab_title">
             <we-input data-customize-css-property=""
                         data-css-property="font-size"
-                        data-selector-text="a[href].btn-primary, a[href].btn-outline-primary, a[href].btn-fill-primary"
+                        data-selector-text="a.btn-primary, a.btn-outline-primary, a.btn-fill-primary"
                         data-unit="px"/>
             <we-colorpicker data-customize-css-property=""
                             data-css-property="color"
-                            data-selector-text="a[href].btn-primary, a[href].btn-outline-primary, a[href].btn-fill-primary"
+                            data-selector-text="a.btn-primary, a.btn-outline-primary, a.btn-fill-primary"
                             data-no-transparency="true"
                             data-color-prefix="text-"/>
             <we-colorpicker data-customize-css-property=""
                             data-css-property="background-color"
-                            data-selector-text="a[href].btn-primary, a[href].btn-outline-primary, a[href].btn-fill-primary"
+                            data-selector-text="a.btn-primary, a.btn-outline-primary, a.btn-fill-primary"
                             data-no-transparency="true"
                             data-color-prefix="bg-"/>
         </we-row>
-        <we-select string="⌙ Size" data-selector-text="a[href].btn-primary, a[href].btn-outline-primary, a[href].btn-fill-primary">
+        <we-select string="⌙ Size" data-selector-text="a.btn-primary, a.btn-outline-primary, a.btn-fill-primary">
             <we-button data-apply-button-size="btn-sm">Small</we-button>
             <we-button data-apply-button-size="btn-md">Medium</we-button>
             <we-button data-apply-button-size="btn-lg">Large</we-button>
@@ -690,9 +690,9 @@
         <we-row string="⌙ Border">
             <we-input data-customize-css-property=""
                         data-css-property="border-width"
-                        data-selector-text="a[href].btn-primary, a[href].btn-outline-primary, a[href].btn-fill-primary"
+                        data-selector-text="a.btn-primary, a.btn-outline-primary, a.btn-fill-primary"
                         data-unit="px"/>
-            <we-select data-selector-text="a[href].btn-primary, a[href].btn-outline-primary, a[href].btn-fill-primary" data-css-property="border-style">
+            <we-select data-selector-text="a.btn-primary, a.btn-outline-primary, a.btn-fill-primary" data-css-property="border-style">
                 <we-button title="Solid" data-customize-css-property="solid">
                     <div class="o_we_fake_img_item o_we_border_preview" style="border-style: solid;"/>
                 </we-button>
@@ -708,7 +708,7 @@
             </we-select>
             <we-colorpicker data-customize-css-property=""
                             data-css-property="border-color"
-                            data-selector-text="a[href].btn-primary, a[href].btn-outline-primary, a[href].btn-fill-primary"
+                            data-selector-text="a.btn-primary, a.btn-outline-primary, a.btn-fill-primary"
                             data-no-transparency="true"
                             data-color-prefix="border-"/>
         </we-row>
@@ -716,20 +716,20 @@
         <we-row string="Secondary Buttons" class="o_design_tab_title">
             <we-input data-customize-css-property=""
                         data-css-property="font-size"
-                        data-selector-text="a[href].btn-secondary, a[href].btn-outline-secondary, a[href].btn-fill-secondary"
+                        data-selector-text="a.btn-secondary, a.btn-outline-secondary, a.btn-fill-secondary"
                         data-unit="px"/>
             <we-colorpicker data-customize-css-property=""
                             data-css-property="color"
-                            data-selector-text="a[href].btn-secondary, a[href].btn-outline-secondary, a[href].btn-fill-secondary"
+                            data-selector-text="a.btn-secondary, a.btn-outline-secondary, a.btn-fill-secondary"
                             data-no-transparency="true"
                             data-color-prefix="text-"/>
             <we-colorpicker data-customize-css-property=""
                             data-css-property="background-color"
-                            data-selector-text="a[href].btn-secondary, a[href].btn-outline-secondary, a[href].btn-fill-secondary"
+                            data-selector-text="a.btn-secondary, a.btn-outline-secondary, a.btn-fill-secondary"
                             data-no-transparency="true"
                             data-color-prefix="bg-"/>
         </we-row>
-        <we-select string="⌙ Size" data-selector-text="a[href].btn-secondary, a[href].btn-outline-secondary, a[href].btn-fill-secondary">
+        <we-select string="⌙ Size" data-selector-text="a.btn-secondary, a.btn-outline-secondary, a.btn-fill-secondary">
             <we-button data-apply-button-size="btn-sm">Small</we-button>
             <we-button data-apply-button-size="btn-md">Medium</we-button>
             <we-button data-apply-button-size="btn-lg">Large</we-button>
@@ -737,9 +737,9 @@
         <we-row string="⌙ Border">
             <we-input data-customize-css-property=""
                         data-css-property="border-width"
-                        data-selector-text="a[href].btn-secondary, a[href].btn-outline-secondary, a[href].btn-fill-secondary"
+                        data-selector-text="a.btn-secondary, a.btn-outline-secondary, a.btn-fill-secondary"
                         data-unit="px"/>
-            <we-select data-selector-text="a[href].btn-secondary, a[href].btn-outline-secondary, a[href].btn-fill-secondary" data-css-property="border-style">
+            <we-select data-selector-text="a.btn-secondary, a.btn-outline-secondary, a.btn-fill-secondary" data-css-property="border-style">
                 <we-button title="Solid" data-customize-css-property="solid">
                     <div class="o_we_fake_img_item o_we_border_preview" style="border-style: solid;"/>
                 </we-button>
@@ -755,7 +755,7 @@
             </we-select>
             <we-colorpicker data-customize-css-property=""
                             data-css-property="border-color"
-                            data-selector-text="a[href].btn-secondary, a[href].btn-outline-secondary, a[href].btn-fill-secondary"
+                            data-selector-text="a.btn-secondary, a.btn-outline-secondary, a.btn-fill-secondary"
                             data-no-transparency="true"
                             data-color-prefix="border-"/>
         </we-row>


### PR DESCRIPTION
To give a custom style to a template, we need to add a style element at its top, with the id "design-element", and apply to it the supported styles. These supported styles and their selectors can be seen in the `DEFAULT_CSS_OBJECT` constant in `mass_mailing_snippets.js`. However, comma-separated selectors were not supported, meaning styles could only be incomplete.

Inline styles applied by the editor should always have priority over the general stylesheet. This failed in the case of nested styles (a <font> with a color within a <span> with a font size for instance).

task-2816655

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
