### PR TITLE
[FIX] l10n_it_edi,sdicoop: minimise edi filename duplication

### DIFF
--- a/addons/l10n_it_edi/models/account_edi_format.py
+++ b/addons/l10n_it_edi/models/account_edi_format.py
@@ -30,8 +30,22 @@ class AccountEdiFormat(models.Model):
         '''Returns a name conform to the Fattura pa Specifications:
            See ES documentation 2.2
         '''
-        a = "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ"
-        n = invoice.id
+        a = "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz"
+        # Each company should have its own filename sequence. If it does not exist, create it
+        n = self.env['ir.sequence'].with_company(invoice.company_id).next_by_code('l10n_it_edi.fattura_filename')
+        if not n:
+            # The offset is used to avoid conflicts with existing filenames
+            offset = 62 ** 4
+            sequence = self.env['ir.sequence'].sudo().create({
+                'name': 'FatturaPA Filename Sequence',
+                'code': 'l10n_it_edi.fattura_filename',
+                'company_id': invoice.company_id.id,
+                'number_next': offset,
+            })
+            n = sequence._next()
+        # The n is returned as a string, but we require an int
+        n = int(''.join(filter(lambda c: c.isdecimal(), n)))
+
         progressive_number = ""
         while n:
             (n, m) = divmod(n, len(a))

--- a/addons/l10n_it_edi_sdicoop/i18n_extra/l10n_it_edi_sdicoop.pot
+++ b/addons/l10n_it_edi_sdicoop/i18n_extra/l10n_it_edi_sdicoop.pot
@@ -195,6 +195,14 @@ msgstr ""
 #: code:addons/l10n_it_edi_sdicoop/models/account_edi_format.py:0
 #, python-format
 msgid ""
+"The filename is duplicated. Try again (or adjust the FatturaPA Filename "
+"sequence). Original message from the SDI: %s"
+msgstr ""
+
+#. module: l10n_it_edi_sdicoop
+#: code:addons/l10n_it_edi_sdicoop/models/account_edi_format.py:0
+#, python-format
+msgid ""
 "The invoice has been issued, but the delivery to the Addressee has failed. "
 "You will be required to send a courtesy copy of the invoice to your customer"
 " through another channel, outside of the Exchange System, and promptly "

--- a/addons/l10n_it_edi_sdicoop/models/account_edi_format.py
+++ b/addons/l10n_it_edi_sdicoop/models/account_edi_format.py
@@ -251,6 +251,13 @@ class AccountEdiFormat(models.Model):
                         ' Original message from the SDI: %s', errors[idx]))
                     to_return[invoice] = {'attachment': invoice.l10n_it_edi_attachment_id, 'success': True}
                 else:
+                    # Add helpful text if duplicated filename error
+                    if '00002' in error_codes:
+                        idx = error_codes.index('00002')
+                        errors[idx] = _(
+                            'The filename is duplicated. Try again (or adjust the FatturaPA Filename sequence).'
+                            ' Original message from the SDI: %s', [errors[idx]]
+                        )
                     to_return[invoice] = {'error': self._format_error_message(_('The invoice has been refused by the Exchange System'), errors), 'blocking_level': 'error'}
                     invoice.l10n_it_edi_transaction = False
             elif state == 'notificaMancataConsegna':


### PR DESCRIPTION
The problem is that we have a limited space in the filename for
differentiating one file from the other. Only the five characters at the
end of the filename are used, this looks like:

    <CODICE_FISCALE>_NNNNN.xml (where N is a character a-zA-Z0-9)

(It should be noted that we are not currently using lower case
characters, as doing so will increase the likelyhood of filename
collisions for existing users)

The current version utilises the invoice id to get the unique filename.
This has a couple of problems:
 - Draft invoices still have invoice ids
 - In a multicompany environment, the invoice ids are not unique to the
   company (i.e. another company creating an invoice will increment the
   value of the invoice.id on your company)
These above problems mean that we're not currently utilising the hashing
space available to us by the characters of the filename.

The solution is to utilise an ir.sequence, that is used to determine
each filename. This has the benefit of being editable by the user, so if
they continue to get duplications, they can offset them by adjusting the
value of the sequence's next number.

A more descriptive error message has also been added.

relates to
task-id: 2813957
ticket-id: 2788927