### PR TITLE
[FIX] mail: tests: properly call _mockWrite in mock server

### DIFF
--- a/addons/mail/static/tests/helpers/mock_server.js
+++ b/addons/mail/static/tests/helpers/mock_server.js
@@ -1838,10 +1838,10 @@ MockServer.include({
 
             // notify update of last_interest_dt
             const now = datetime_to_str(new Date());
-            this._mockWrite('mail.channel',
+            this._mockWrite('mail.channel', [
                 [channel.id],
                 { last_interest_dt: now },
-            );
+            ]);
             notifications.push({
                 type: 'mail.channel/last_interest_dt_changed',
                 payload: {


### PR DESCRIPTION
2nd parameter of `_mockWrite` must necessarily be an array.
