### PR TITLE
[FIX] website: use correct endpoint in get_canonical_url

### DIFF
--- a/addons/website/models/website.py
+++ b/addons/website/models/website.py
@@ -872,13 +872,14 @@ class Website(models.Model):
         """
         self.ensure_one()
         if request.endpoint:
-            router = http.root.get_db_router(request.db).bind('')
+            router = http.root.get_db_router(request.db).bind_to_environ(request.httprequest.environ)
             arguments = dict(request.endpoint_arguments)
             for key, val in list(arguments.items()):
                 if isinstance(val, models.BaseModel):
                     if val.env.context.get('lang') != lang.code:
                         arguments[key] = val.with_context(lang=lang.code)
-            path = router.build(request.endpoint, arguments)
+            endpoint = router.match(path_info=request.httprequest.path, return_rule=True)[0].endpoint
+            path = router.build(endpoint, arguments)
         else:
             # The build method returns a quoted URL so convert in this case for consistency.
             path = urls.url_quote_plus(request.httprequest.path, safe='/')

--- a/addons/website/views/website_templates.xml
+++ b/addons/website/views/website_templates.xml
@@ -243,13 +243,13 @@
             </t>
         </t>
 
-        <t t-if="request and request.is_frontend_multilang and website">
+        <t t-if="request and request.is_frontend_multilang and website and website.is_public_user()">
             <t t-set="alternate_languages" t-value="website._get_alternate_languages(canonical_params=canonical_params)"/>
             <t t-foreach="alternate_languages" t-as="lg">
                 <link rel="alternate" t-att-hreflang="lg['hreflang']" t-att-href="lg['href']"/>
             </t>
         </t>
-        <link t-if="request and website" rel="canonical" t-att-href="website._get_canonical_url(canonical_params=canonical_params)"/>
+        <link t-if="request and website and website.is_public_user()" rel="canonical" t-att-href="website._get_canonical_url(canonical_params=canonical_params)"/>
 
         <link rel="preconnect" href="https://fonts.gstatic.com/" crossorigin=""/>
     </xpath>


### PR DESCRIPTION
`router` is a routing map which might be different than the request's. In this case, `request.endpoint` won't be found as a key of this routing map, and it will lead to a werkzeug.routing.Builderror.

By re-matching the current path on this specific router, we make sure that the endpoint will be found in this routing map.