### PR TITLE
[IMP] account,mail: remove select * in exist subselect

### DIFF
--- a/addons/account/models/account_account.py
+++ b/addons/account/models/account_account.py
@@ -294,7 +294,7 @@ class AccountAccount(models.Model):
             value = not value
         self._cr.execute("""
             SELECT id FROM account_account account
-            WHERE EXISTS (SELECT * FROM account_move_line aml WHERE aml.account_id = account.id LIMIT 1)
+            WHERE EXISTS (SELECT 1 FROM account_move_line aml WHERE aml.account_id = account.id LIMIT 1)
         """)
         return [('id', 'in' if value else 'not in', [r[0] for r in self._cr.fetchall()])]
 

--- a/addons/im_livechat/models/mail_channel.py
+++ b/addons/im_livechat/models/mail_channel.py
@@ -118,7 +118,7 @@ class MailChannel(models.Model):
             SELECT id as id
             FROM mail_channel C
             WHERE NOT EXISTS (
-                SELECT *
+                SELECT 1
                 FROM mail_message M
                 WHERE M.res_id = C.id AND m.model = 'mail.channel'
             ) AND C.channel_type = 'livechat' AND livechat_channel_id IS NOT NULL AND

--- a/addons/mail/models/mail_channel.py
+++ b/addons/mail/models/mail_channel.py
@@ -886,7 +886,7 @@ class Channel(models.Model):
                 AND P.partner_id IN %s
                 AND C.channel_type LIKE 'chat'
                 AND NOT EXISTS (
-                    SELECT *
+                    SELECT 1
                     FROM mail_channel_partner P2
                     WHERE P2.channel_id = C.id
                         AND P2.partner_id NOT IN %s


### PR DESCRIPTION
no need to select * in a query that looks like
select ...
from A
where exists(select * from B where ...)

we can instead use
select ...
from A
where exists(select 1 from B where ...)






--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
