### PR TITLE
[FIX] l10n_mx: correct repartition for credit notes account

### DIFF
--- a/addons/l10n_mx/data/account_tax_data.xml
+++ b/addons/l10n_mx/data/account_tax_data.xml
@@ -266,7 +266,7 @@
             (0,0, {
                 'factor_percent': 100,
                 'repartition_type': 'tax',
-                'account_id': ref('cuenta216_10'),
+                'account_id': ref('cuenta216_10_20'),
             }),
         ]"/>
     </record>
@@ -306,7 +306,7 @@
             (0,0, {
                 'factor_percent': 100,
                 'repartition_type': 'tax',
-                'account_id': ref('cuenta216_10'),
+                'account_id': ref('cuenta216_10_20'),
             }),
         ]"/>
     </record>
@@ -333,6 +333,7 @@
             (0,0, {
                 'factor_percent': 100,
                 'repartition_type': 'tax',
+                'account_id': ref('cuenta118_01'),
             }),
         ]"/>
         <field name="refund_repartition_line_ids" eval="[(5, 0, 0),
@@ -345,6 +346,7 @@
             (0,0, {
                 'factor_percent': 100,
                 'repartition_type': 'tax',
+                'account_id': ref('cuenta118_01'),
             }),
         ]"/>
     </record>
@@ -384,7 +386,7 @@
             (0,0, {
                 'factor_percent': 100,
                 'repartition_type': 'tax',
-                'account_id': ref('cuenta119_01'),
+                'account_id': ref('cuenta118_01'),
             }),
         ]"/>
     </record>
@@ -423,7 +425,7 @@
             (0,0, {
                 'factor_percent': 100,
                 'repartition_type': 'tax',
-                'account_id': ref('cuenta119_01'),
+                'account_id': ref('cuenta118_01'),
             }),
         ]"/>
     </record>
@@ -463,7 +465,7 @@
                 'factor_percent': 100,
                 'repartition_type': 'tax',
                 'tag_ids': [ref('l10n_mx.tag_iva')],
-                'account_id': ref('cuenta209_01'),
+                'account_id': ref('cuenta208_01'),
                 'tag_ids': [ref('tag_iva')],
             }),
         ]"/>


### PR DESCRIPTION
The account used in the Repartition for Credit Notes is wrong for taxes
`IVA(8%) COMPRAS`, `IVA(16%) COMPRAS`, `IVA(8%) VENTAS`, `RETENCION IVA
ARRENDAMIENTO 10.67%`, `RETENCION IVA HONORARIOS 10.67%` and `IVA(0%)
COMPRAS`

Steps to reproduce:
1. Install Accounting app and l10n_mx module
2. Go to Accounting > Configuration > Invoicing > Taxes
3. Open any one of the taxes mentioned above
4. The account in Repartition for Invoices should be the same as the
account in Repartition for Credit Notes

Solution:
Change the default account used in Repartion for Credit Notes

opw-2806228