### PR TITLE
[FIX] web_editor: Background color popup too big in some languages

### DIFF
--- a/addons/web_editor/static/src/scss/wysiwyg.scss
+++ b/addons/web_editor/static/src/scss/wysiwyg.scss
@@ -78,6 +78,7 @@ $o-we-toolbar-color-clickable-active: $o-we-bg-darkest;
 
     .o_we_colorpicker_switch_pane_btn {
         flex: 0 0 auto;
+        width: 60px;
     }
 
     .o_colorpicker_reset {


### PR DESCRIPTION
Current behavior:
Background colorpicker in website editor was too big in some languages because of words being too long.
Some part of the pop where not accessible because of that.

Steps to reproduce:
- Change language to German
- Select text, and click on background color in Inline Text section
- Left part of the popup is too big and is hidden.

opw-2786778
--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
