### PR TITLE
[FIX] hr_recruitment: Improve extended_interviewer_ids computation

### DIFF
--- a/addons/hr_recruitment/models/hr_job.py
+++ b/addons/hr_recruitment/models/hr_job.py
@@ -2,7 +2,8 @@
 
 import ast
 
-from odoo import api, fields, models, _
+from collections import defaultdict
+from odoo import api, fields, models, SUPERUSER_ID, _
 
 
 class Job(models.Model):
@@ -49,8 +50,16 @@ class Job(models.Model):
 
     @api.depends('application_ids.interviewer_id')
     def _compute_extended_interviewer_ids(self):
+        # Use SUPERUSER_ID as the search_read is protected in hr_referral
+        results_raw = self.env['hr.applicant'].with_user(SUPERUSER_ID).search_read([
+            ('job_id', 'in', self.ids),
+            ('interviewer_id', '!=', False)
+        ], ['interviewer_id', 'job_id'])
+        interviewers_by_job = defaultdict(set)
+        for result_raw in results_raw:
+            interviewers_by_job[result_raw['job_id'][0]].add(result_raw['interviewer_id'][0])
         for job in self:
-            job.extended_interviewer_ids = job.application_ids.interviewer_id
+            job.extended_interviewer_ids = [(6, 0, list(interviewers_by_job[job.id]))]
 
     def _compute_is_favorite(self):
         for job in self:

--- a/addons/hr_recruitment/models/hr_recruitment.py
+++ b/addons/hr_recruitment/models/hr_recruitment.py
@@ -177,7 +177,9 @@ class Applicant(models.Model):
     campaign_id = fields.Many2one(ondelete='set null')
     medium_id = fields.Many2one(ondelete='set null')
     source_id = fields.Many2one(ondelete='set null')
-    interviewer_id = fields.Many2one('res.users', string='Interviewer', domain="[('share', '=', False), ('company_ids', 'in', company_id)]")
+    interviewer_id = fields.Many2one(
+        'res.users', string='Interviewer', index=True,
+        domain="[('share', '=', False), ('company_ids', 'in', company_id)]")
 
     @api.depends('date_open', 'date_closed')
     def _compute_day(self):


### PR DESCRIPTION
From 450 to 1.5 ms

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
