### PR TITLE
[FIX] mail: fix "you are not allowed to delete 'Listeners of a Channe…

### DIFF
--- a/addons/mail/models/mail_channel.py
+++ b/addons/mail/models/mail_channel.py
@@ -145,7 +145,7 @@ class Channel(models.Model):
         if new_members:
             self.env['mail.channel.partner'].create(new_members)
         if outdated:
-            outdated.unlink()
+            outdated.sudo().unlink()
 
     def _search_channel_partner_ids(self, operator, operand):
         return [(


### PR DESCRIPTION
…l' (mail.channel.partner) records" issue:

To reproduce:
1. Start a meeting in Discuss or start a group conversation of V15, then try to leave this channel by clicking channel's x button in the page's left side `DIRECT MESSAGES` list.
2. After clicking `Leave` button in Confirmation dialog you will get Access Error prompt: Due to security restrictions, you are not allowed to delete 'Listeners of a Channel' (mail.channel.partner) records.

Cause and Solution: the computed field value:
Since in the middle of process, outdated.channel_id.channel_partner_ids doesn't contain current env.user, to bypass access rule restriction we need to use sudo().unlink()

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
