### PR TITLE
[FIX] web: multi edit in custom groupby list view

### DIFF
--- a/addons/web/static/src/js/views/basic/basic_model.js
+++ b/addons/web/static/src/js/views/basic/basic_model.js
@@ -4868,8 +4868,16 @@ var BasicModel = AbstractModel.extend({
         var fieldNames = list.getFieldNames();
         var prom;
         if (list.__data) {
-            // the data have already been fetched (alonside the groups by the
+            // the data have already been fetched (alongside the groups by the
             // call to 'web_read_group'), so we can bypass the search_read
+            // But the web_read_group returns the rawGroupBy field's value, which may not be present
+            // in the view. So we filter it out.
+            const fieldNameSet = new Set(fieldNames);
+            fieldNameSet.add("id"); // don't filter out the id
+            list.__data.records.forEach(record =>
+                Object.keys(record)
+                    .filter(fieldName => !fieldNameSet.has(fieldName))
+                    .forEach(fieldName => delete record[fieldName]));
             prom = Promise.resolve(list.__data);
         } else {
             prom = this._rpc({

--- a/addons/web/static/tests/views/list_tests.js
+++ b/addons/web/static/tests/views/list_tests.js
@@ -5907,6 +5907,54 @@ QUnit.module('Views', {
         list.destroy();
     });
 
+    QUnit.test('multi edit in view grouped by field not in view', async function (assert) {
+        assert.expect(3);
+
+        this.data.foo.records = [
+            // group 1
+            {id: 1, foo: '1', m2o: 1},
+            {id: 3, foo: '2', m2o: 1},
+            //group 2
+            {id: 2, foo: '1', m2o: 2},
+            {id: 4, foo: '2', m2o: 2},
+            // group 3
+            {id: 5, foo: '2', m2o: 3},
+        ];
+
+        const list = await createView({
+            View: ListView,
+            model: 'foo',
+            data: this.data,
+            arch: `<tree expand="1" multi_edit="1">
+                   <field name="foo"/>
+               </tree>`,
+            groupBy: ['m2o'],
+        });
+
+        // Select items from the first group
+        await testUtils.dom.click(list.$('.o_data_row .o_list_record_selector input:eq(0)'));
+        await testUtils.dom.click(list.$('.o_data_row .o_list_record_selector input:eq(1)'));
+
+        await testUtils.dom.click(list.$('.o_list_char:eq(0)'));
+
+        await testUtils.fields.editInput(list.$('.o_field_widget[name=foo]'), 'test');
+
+        assert.containsOnce(document.body, '.modal');
+        await testUtils.dom.click($('.modal .modal-footer .btn-primary'));
+        assert.containsNone(document.body, '.modal');
+
+        const allNames = [...document.querySelectorAll('.o_data_cell')].map(n => n.textContent);
+        assert.deepEqual(allNames, [
+            'test',
+            'test',
+            '1',
+            '2',
+            '2',
+        ]);
+
+        list.destroy();
+    });
+
     QUnit.test('multi edit reference field batched in grouped list', async function (assert) {
         assert.expect(18);
 


### PR DESCRIPTION
**Steps to follow**

  - Go to Accounting > Accounting > Sales (account.move.line model)
  - Remove any existing group by
  - Group by Products
  - Select multiples lines of the same product
  - Try to modify the account of the select line
  -> `this.localData[value] is undefined

**Cause of the issue**

  When grouping by a field not in the view, `list.__data` contains the
  groupedBy field value because we fetched the group through a web_read_group

**Solution**

  Filter out absent fields before creating the group datapoint

opw-2784995