### PR TITLE
[13.0][FIX] account_check_printing: Duplicate journal generate duplicate check sequence

### DIFF
--- a/addons/account_check_printing/models/account_journal.py
+++ b/addons/account_check_printing/models/account_journal.py
@@ -47,12 +47,6 @@ class AccountJournal(models.Model):
             rec._create_check_sequence()
         return rec
 
-    @api.returns('self', lambda value: value.id)
-    def copy(self, default=None):
-        rec = super(AccountJournal, self).copy(default)
-        rec._create_check_sequence()
-        return rec
-
     def _create_check_sequence(self):
         """ Create a check sequence for the journal """
         for journal in self:


### PR DESCRIPTION
Unnecessary call to _create_check_sequence because is called in create method and create is called in super().copy()

TT35608

Description of the issue/feature this PR addresses:
If you duplicate a journal two check sequence are created.

Current behavior before PR:
If you duplicate a journal two check sequence are created.

Desired behavior after PR is merged:
If you duplicate a journal one check sequence is created.



--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
