### PR TITLE
[13.0][FIX] mrp: use 'qties' context based cache in _compute_quantities_dict

### DIFF
--- a/addons/mrp/models/product.py
+++ b/addons/mrp/models/product.py
@@ -144,8 +144,8 @@ class ProductProduct(models.Model):
                     continue
                 rounding = component.uom_id.rounding
                 component_res = (
-                    res.get(component.id)
-                    if component.id in res
+                    qties.get(component.id)
+                    if component.id in qties
                     else {
                         "virtual_available": float_round(component.virtual_available, precision_rounding=rounding),
                         "qty_available": float_round(component.qty_available, precision_rounding=rounding),


### PR DESCRIPTION
@yelizariev @amoyaux this is what I was talking about here: https://github.com/odoo/odoo/pull/87941#issuecomment-1088768064

It's a regression introduced here: fba9c9f32 that affects performance of nested boms
ping @dwa-odoo 

Before that commit, it was getting the values from `qties`, and after it's getting them directly from `res`.
`qties` has some context based caching mechanism that is just ignored without this fix 

see : https://github.com/odoo/odoo/blob/4d16869e5c0a627dfe32ad1c8f54e83373dc3c8b/addons/mrp/models/product.py#L124-L126

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
