### PR TITLE
[FIX] mass_mailing: display sent div when needed

### DIFF
--- a/addons/mass_mailing/views/mailing_mailing_views.xml
+++ b/addons/mass_mailing/views/mailing_mailing_views.xml
@@ -92,7 +92,7 @@
                                 </strong>
                             </button>
                         </div>
-                        <div class="o_mails_sent" attrs="{'invisible': ['&amp;', ('sent', '=', 0), ('state', 'in', ('draft', 'test', 'in_queue'))]}">
+                        <div class="o_mails_sent" attrs="{'invisible': ['|', ('state', '!=', 'done'), ('sent', '=', 0)]}">
                             <button class="btn-link py-0"
                                     name="action_view_traces_sent"
                                     type="object">


### PR DESCRIPTION
div for sent SMS should be only displayed if we have 
sent SMS count and state is `Done`

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
