### PR TITLE
[FIX] mass_mailing: disallow to create/delete record

### DIFF
--- a/addons/mass_mailing/report/mailing_trace_report_views.xml
+++ b/addons/mass_mailing/report/mailing_trace_report_views.xml
@@ -4,7 +4,7 @@
             <field name="name">mailing.trace.report.view.tree</field>
             <field name="model">mailing.trace.report</field>
             <field name="arch" type="xml">
-                <tree string="Mass Mailing Statistics" sample="1">
+                <tree string="Mass Mailing Statistics" sample="1" create="false" delete="false">
                     <field name="name"/>
                     <field name="campaign" groups="mass_mailing.group_mass_mailing_campaign"/>
                     <field name="mailing_type" invisible="1"/>


### PR DESCRIPTION
Create/Delete action should not be displayed as it is not intended
to create records from this view.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
