### PR TITLE
[FIX] website: fix css of publication toggler in mobile

### DIFF
--- a/addons/website/static/src/scss/website.navbar.mobile.scss
+++ b/addons/website/static/src/scss/website.navbar.mobile.scss
@@ -37,7 +37,7 @@
         .o_mobile_menu_toggle,
         .dropdown-toggle,
         .dropdown-item,
-        .o_menu_sections > .css_published {
+        .o_menu_sections > .js_publish_management {
             height: $o-navbar-height;
             @include o-hover-text-color(rgba($-color, .9), $-color);
         }
@@ -112,4 +112,8 @@
             padding: 10px;
         }
     }
+}
+
+.o_menu_sections > .js_publish_management {
+    @extend %-main-navbar-entry-spacing;
 }


### PR DESCRIPTION
Before this commit, the publication toggler in mobile
(`.css_unpublished`) was not styled correctly and the whole button was
not aligned with the menu.

After this commit, the correct style and alignment are applied.

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
