### PR TITLE
[FIX] mail: ensure that voice threshold is updated across tabs

### DIFF
--- a/addons/mail/static/src/models/user_setting/user_setting.js
+++ b/addons/mail/static/src/models/user_setting/user_setting.js
@@ -17,6 +17,8 @@ function factory(dependencies) {
             const res = super._created(...arguments);
             this._timeoutIds = {};
             this._loadLocalSettings();
+            this._onStorage = this._onStorage.bind(this);
+            browser.addEventListener('storage', this._onStorage);
             return res;
         }
 
@@ -24,6 +26,7 @@ function factory(dependencies) {
          * @override
          */
         _willDelete() {
+            browser.removeEventListener('storage', this._onStorage);
             for (const timeoutId of Object.values(this._timeoutIds)) {
                 browser.clearTimeout(timeoutId);
             }
@@ -254,6 +257,17 @@ function factory(dependencies) {
                     { shadow: true },
                 ));
             }, 2000, 'globalSettings');
+        }
+
+        /**
+         * @private
+         * @param {Event} ev
+         */
+        async _onStorage(ev) {
+            if (ev.key === 'mail_user_setting_voice_threshold') {
+                this.update({ voiceActivationThreshold: ev.newValue });
+                await this.messaging.rtc.updateVoiceActivation();
+            }
         }
 
     }


### PR DESCRIPTION
Before this commit, updating the voice activation threshold in one tab
would not affect the other tabs as the localStorage was only read when
discuss was initialized.

This commit fixes this issue.

task-2679234
