### PR TITLE
[FIX] web: closing legacy action Dialog

### DIFF
--- a/addons/web/static/src/webclient/actions/action_dialog.xml
+++ b/addons/web/static/src/webclient/actions/action_dialog.xml
@@ -19,7 +19,7 @@
   <t t-name="web.LegacyAdaptedActionDialogFooter" owl="1">
     <t t-if="!isLegacy">
       <t t-slot="buttons">
-        <button class="btn btn-primary" t-on-click="_close">
+        <button class="btn btn-primary" t-on-click="close">
           <t>Ok</t>
         </button>
       </t>

--- a/addons/web/static/tests/webclient/actions/client_action_tests.js
+++ b/addons/web/static/tests/webclient/actions/client_action_tests.js
@@ -6,7 +6,7 @@ import core from "web.core";
 import AbstractAction from "web.AbstractAction";
 import testUtils from "web.test_utils";
 import { registerCleanup } from "../../helpers/cleanup";
-import { click, legacyExtraNextTick, patchWithCleanup } from "../../helpers/utils";
+import { click, legacyExtraNextTick, nextTick, patchWithCleanup } from "../../helpers/utils";
 import { createWebClient, doAction, getActionManagerServerData } from "./../helpers";
 
 const { Component, tags } = owl;
@@ -32,6 +32,22 @@ QUnit.module("ActionManager", (hooks) => {
         });
         assert.containsOnce(webClient, ".modal .test_client_action");
         assert.strictEqual(webClient.el.querySelector(".modal-title").textContent, "Dialog Test");
+    });
+
+    QUnit.test("can display client actions in Dialog and close the dialog", async function (assert) {
+        assert.expect(3);
+        const webClient = await createWebClient({ serverData });
+        await doAction(webClient, {
+            name: "Dialog Test",
+            target: "new",
+            tag: "__test__client__action__",
+            type: "ir.actions.client",
+        });
+        assert.containsOnce(webClient, ".modal .test_client_action");
+        assert.strictEqual(webClient.el.querySelector(".modal-title").textContent, "Dialog Test");
+        webClient.el.querySelector('.modal footer .btn.btn-primary').click()
+        await nextTick();
+        assert.containsNone(webClient, ".modal .test_client_action");
     });
 
     QUnit.test("can display client actions as main, then in Dialog", async function (assert) {


### PR DESCRIPTION
Before this commit, when closing a legacy action Dialog an error was raised.
