### PR TITLE
[FIX] website_blog: remove stars from blog description

### DIFF
--- a/addons/website_blog/models/website_blog.py
+++ b/addons/website_blog/models/website_blog.py
@@ -3,12 +3,13 @@
 
 from datetime import datetime
 import random
+import re
 
 from odoo import api, models, fields, _
 from odoo.addons.http_routing.models.ir_http import slug, unslug
+from odoo.addons.website.tools import text_from_html
 from odoo.tools.json import scriptsafe as json_scriptsafe
 from odoo.tools.translate import html_translate
-from odoo.tools import html2plaintext
 
 
 class Blog(models.Model):
@@ -197,7 +198,8 @@ class BlogPost(models.Model):
             if blog_post.teaser_manual:
                 blog_post.teaser = blog_post.teaser_manual
             else:
-                content = html2plaintext(blog_post.content).replace('\n', ' ')
+                content = text_from_html(blog_post.content)
+                content = re.sub('\\s+', ' ', content).strip()
                 blog_post.teaser = content[:200] + '...'
 
     def _set_teaser(self):

--- a/addons/website_blog/tests/test_website_blog_flow.py
+++ b/addons/website_blog/tests/test_website_blog_flow.py
@@ -108,3 +108,11 @@ class TestWebsiteBlogFlow(TestWebsiteBlogCommon):
 
         self.assertFalse(self.env['mail.message'].sudo().search(
             [('model', '=', 'blog.post'), ('attachment_ids', 'in', second_attachment.ids)]))
+
+    def test_website_blog_teaser_content(self):
+        """ Make sure that the content of the post is correctly rendered in
+            proper plain text. """
+
+        self.test_blog_post.content = "<h2>Test Content</h2>"
+
+        self.assertEqual(self.test_blog_post.teaser, "Test Content...")


### PR DESCRIPTION
Current behavior:
When adding a "Heading" in the first 200 characters of a blog with /Heading,
the short description of the blog preview would have unwanted stars (*) around the heading

Steps to reproduce:
- Create a blog article
- In the first 200 characters of the blog use a heading (e.g. /Heading1)
- Go back to the blog list, the description of the new article contains unwanted stars (*)

opw-2798595
--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
