### PR TITLE
[FIX] core: improve column ordering

### DIFF
--- a/odoo/tools/sql.py
+++ b/odoo/tools/sql.py
@@ -51,15 +51,18 @@ def table_kind(cr, tablename):
     cr.execute(query, (tablename,))
     return cr.fetchone()[0] if cr.rowcount else None
 
-# prescribed column order by type size: 4 bytes, 1 byte, 8 bytes, variable size
-# (values have been chosen to minimize padding in rows; unknown column types
-# are considered variable size and put last)
-SQL_ORDER_BY_TYPE = defaultdict(lambda: 6, {
-    'int4': 1,        # 4 bytes
-    'date': 2,        # 4 bytes
-    'bool': 3,        # 1 byte
-    'float8': 4,      # 8 bytes
-    'timestamp': 5,   # 8 bytes
+# prescribed column order by type: columns aligned on 4 bytes, columns aligned
+# on 1 byte, columns aligned on 8 bytes(values have been chosen to minimize
+# padding in rows; unknown column types are put last)
+SQL_ORDER_BY_TYPE = defaultdict(lambda: 9, {
+    'int4': 1,          # 4 bytes aligned on 4 bytes
+    'varchar': 2,       # variable aligned on 4 bytes
+    'date': 3,          # 4 bytes aligned on 4 bytes
+    'text': 4,          # variable aligned on 4 bytes
+    'numeric': 5,       # variable aligned on 4 bytes
+    'bool': 6,          # 1 byte aligned on 1 byte
+    'timestamp': 7,     # 8 bytes aligned on 8 bytes
+    'float8': 8,        # 8 bytes aligned on 8 bytes
 })
 
 def create_model_table(cr, tablename, comment=None, columns=()):


### PR DESCRIPTION
This follows up https://github.com/odoo/odoo/pull/87896.

Change the heuristics for ordering columns, as padding is not determined by column size, but by column alignment inside a row.  Because in Odoo a row always starts with a column of size 4, the following columns should be the ones aligned on 4 bytes, then the ones aligned on 1 byte, then the ones aligned on 8 bytes.

The analysis in the commit message was not correct, as it did not take into account the fact that rows themselves are aligned on 8 bytes.  So we have: before each row used 40 bytes (+24b header)
```
       attname   |  typname  | typlen
    -------------+-----------+--------
     id          | int4      |      4
     create_uid  | int4      |      4
     create_date | timestamp |      8
     write_uid   | int4      |      4    -> 4 bytes padding
     write_date  | timestamp |      8
     active      | bool      |      1    -> 7 bytes padding
```
After each row uses 32 bytes (8 bytes saved per row):
```
       attname   |  typname  | typlen
    -------------+-----------+--------
     id          | int4      |      4
     create_uid  | int4      |      4
     write_uid   | int4      |      4
     active      | bool      |      1    -> 3 bytes padding
     create_date | timestamp |      8
     write_date  | timestamp |      8
```
Of course, when more columns are present, the space savings depend on
the alignment of the other columns.