### PR TITLE
[FIX] account,sale: fix tax excl -> tax incl price include

### DIFF
--- a/addons/account/models/product.py
+++ b/addons/account/models/product.py
@@ -96,20 +96,20 @@ class ProductProduct(models.Model):
         # Apply fiscal position.
         if product_taxes and fiscal_position:
             product_taxes_after_fp = fiscal_position.map_tax(product_taxes)
+            flattened_taxes_after_fp = product_taxes_after_fp._origin.flatten_taxes_hierarchy()
+            flattened_taxes_before_fp = product_taxes._origin.flatten_taxes_hierarchy()
+            taxes_before_included = any(tax.price_include for tax in flattened_taxes_before_fp)
 
-            if set(product_taxes.ids) != set(product_taxes_after_fp.ids):
-                flattened_taxes_before_fp = product_taxes._origin.flatten_taxes_hierarchy()
-                if any(tax.price_include for tax in flattened_taxes_before_fp):
-                    taxes_res = flattened_taxes_before_fp.compute_all(
-                        product_price_unit,
-                        quantity=1.0,
-                        currency=currency,
-                        product=product,
-                        is_refund=is_refund_document,
-                    )
-                    product_price_unit = taxes_res['total_excluded']
+            if set(product_taxes.ids) != set(product_taxes_after_fp.ids) and taxes_before_included:
+                taxes_res = flattened_taxes_before_fp.compute_all(
+                    product_price_unit,
+                    quantity=1.0,
+                    currency=currency,
+                    product=product,
+                    is_refund=is_refund_document,
+                )
+                product_price_unit = taxes_res['total_excluded']
 
-                flattened_taxes_after_fp = product_taxes_after_fp._origin.flatten_taxes_hierarchy()
                 if any(tax.price_include for tax in flattened_taxes_after_fp):
                     taxes_res = flattened_taxes_after_fp.compute_all(
                         product_price_unit,


### PR DESCRIPTION
Create a 15% tax [TaxA] *not* included in price
Create a 15% tax [TaxB] included in price
Create a fiscal position mapping TaxA to TaxB
Create a customer and assign this fiscal position
Create a product :
Price = 100€
Tax = TaxA
Create a SO with this customer and this product

We have this situation

| Price Unit | Tax | Subtotal |
|------------|-----|----------|
|     115    | TaxB|   100    |

While it should be

| Price Unit | Tax | Subtotal |
|------------|-----|----------|
|     100    | TaxB| 86.96    |

after tax mapping, as it was before
https://github.com/odoo/odoo/commit/625486a8382fde9033b73e2a4b4e7713cf4131c1

opw-2811596

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
