### PR TITLE
FIX: BUG#88086 :Time Off Calendar (hr.leave.report.calendar) gives er…

### DIFF
--- a/addons/hr_holidays/report/hr_leave_report_calendar.py
+++ b/addons/hr_holidays/report/hr_leave_report_calendar.py
@@ -16,7 +16,6 @@ class LeaveReportCalendar(models.Model):
     start_datetime = fields.Datetime(string='From', readonly=True)
     stop_datetime = fields.Datetime(string='To', readonly=True)
     tz = fields.Selection(_tz_get, string="Timezone", readonly=True)
-    duration = fields.Float(string='Duration', readonly=True)
     employee_id = fields.Many2one('hr.employee', readonly=True)
     department_id = fields.Many2one('hr.department', readonly=True)
     job_id = fields.Many2one('hr.job', readonly=True)


### PR DESCRIPTION
Time Off Calendar (hr.leave.report.calendar) gives error on read method for Duration field 

Description of the issue/feature this PR addresses: #88086 https://github.com/odoo/odoo/issues/88086

Current behavior before PR: Traceback on read

Desired behavior after PR is merged: no errro




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
