### PR TITLE
[FIX] google_calendar: add Meeting URL and show_as on sync

### DIFF
--- a/addons/google_calendar/models/calendar.py
+++ b/addons/google_calendar/models/calendar.py
@@ -95,7 +95,8 @@ class Meeting(models.Model):
             'attendee_ids': attendee_commands,
             'alarm_ids': alarm_commands,
             'recurrency': google_event.is_recurrent(),
-            'videocall_location': google_event.get_meeting_url()
+            'videocall_location': google_event.get_meeting_url(),
+            'show_as': 'free' if google_event.is_available() else 'busy'
         }
         if partner_commands:
             # Add partner_commands only if set from Google. The write method on calendar_events will

--- a/addons/google_calendar/models/calendar.py
+++ b/addons/google_calendar/models/calendar.py
@@ -94,7 +94,8 @@ class Meeting(models.Model):
             'privacy': google_event.visibility or self.default_get(['privacy'])['privacy'],
             'attendee_ids': attendee_commands,
             'alarm_ids': alarm_commands,
-            'recurrency': google_event.is_recurrent()
+            'recurrency': google_event.is_recurrent(),
+            'videocall_location': google_event.get_meeting_url()
         }
         if partner_commands:
             # Add partner_commands only if set from Google. The write method on calendar_events will

--- a/addons/google_calendar/tests/test_sync_google2odoo.py
+++ b/addons/google_calendar/tests/test_sync_google2odoo.py
@@ -1087,3 +1087,33 @@ class TestSyncGoogle2Odoo(TestSyncGoogle):
         self.assertTrue(event, "It should have created an event")
         self.assertEqual(event.videocall_location, 'https://meet.google.com/odoo-random-test')
         self.assertGoogleAPINotCalled()
+
+    @patch_api
+    def test_event_with_availability(self):
+        values = {
+            'id': 'oj44nep1ldf8a3ll02uip0c9aa',
+            'description': 'Small mini desc',
+            'organizer': {'email': 'odoocalendarref@gmail.com', 'self': True},
+            'summary': 'Pricing new update',
+            'visibility': 'public',
+            'attendees': [{
+                'displayName': 'Mitchell Admin',
+                'email': 'admin@yourcompany.example.com',
+                'responseStatus': 'needsAction'
+            },],
+            'reminders': {'useDefault': True},
+            'start': {
+                'dateTime': '2020-01-13T16:55:00+01:00',
+                'timeZone': 'Europe/Brussels'
+            },
+            'end': {
+                'dateTime': '2020-01-13T19:55:00+01:00',
+                'timeZone': 'Europe/Brussels'
+            },
+            'transparency': 'transparent'
+        }
+        self.env['calendar.event']._sync_google2odoo(GoogleEvent([values]))
+        event = self.env['calendar.event'].search([('google_id', '=', values.get('id'))])
+        self.assertTrue(event, "It should have created an event")
+        self.assertEqual(event.show_as, 'free')
+        self.assertGoogleAPINotCalled

--- a/addons/google_calendar/tests/test_sync_google2odoo.py
+++ b/addons/google_calendar/tests/test_sync_google2odoo.py
@@ -1047,3 +1047,43 @@ class TestSyncGoogle2Odoo(TestSyncGoogle):
         self.assertEqual(mails, ['odoobot@example.com'])
 
         self.assertGoogleAPINotCalled()
+
+    @patch_api
+    def test_event_with_meeting_url(self):
+        values = {
+            'id': 'oj44nep1ldf8a3ll02uip0c9aa',
+            'description': 'Small mini desc',
+            'organizer': {'email': 'odoocalendarref@gmail.com', 'self': True},
+            'summary': 'Pricing new update',
+            'visibility': 'public',
+            'attendees': [{
+                'displayName': 'Mitchell Admin',
+                'email': 'admin@yourcompany.example.com',
+                'responseStatus': 'needsAction'
+            },],
+            'reminders': {'useDefault': True},
+            'start': {
+                'dateTime': '2020-01-13T16:55:00+01:00',
+                'timeZone': 'Europe/Brussels'
+            },
+            'end': {
+                'dateTime': '2020-01-13T19:55:00+01:00',
+                'timeZone': 'Europe/Brussels'
+            },
+            'conferenceData': {
+                'entryPoints': [{
+                    'entryPointType': 'video',
+                    'uri': 'https://meet.google.com/odoo-random-test',
+                    'label': 'meet.google.com/odoo-random-test'
+                }, {
+                    'entryPointType': 'more',
+                    'uri':'https://tel.meet/odoo-random-test?pin=42424242424242',
+                    'pin':'42424242424242'
+                }]
+            }
+        }
+        self.env['calendar.event']._sync_google2odoo(GoogleEvent([values]))
+        event = self.env['calendar.event'].search([('google_id', '=', values.get('id'))])
+        self.assertTrue(event, "It should have created an event")
+        self.assertEqual(event.videocall_location, 'https://meet.google.com/odoo-random-test')
+        self.assertGoogleAPINotCalled()

--- a/addons/google_calendar/utils/google_event.py
+++ b/addons/google_calendar/utils/google_event.py
@@ -193,3 +193,9 @@ class GoogleEvent(abc.Set):
         if all(not e.is_recurrence() for e in self):
             return env['calendar.event']
         raise TypeError("Mixing Google events and Google recurrences")
+
+    def get_meeting_url(self):
+        if not self.conferenceData:
+            return False
+        video_meeting = list(filter(lambda entryPoints: entryPoints['entryPointType'] == 'video', self.conferenceData['entryPoints']))
+        return video_meeting[0]['uri'] if video_meeting else False

--- a/addons/google_calendar/utils/google_event.py
+++ b/addons/google_calendar/utils/google_event.py
@@ -199,3 +199,6 @@ class GoogleEvent(abc.Set):
             return False
         video_meeting = list(filter(lambda entryPoints: entryPoints['entryPointType'] == 'video', self.conferenceData['entryPoints']))
         return video_meeting[0]['uri'] if video_meeting else False
+
+    def is_available(self):
+        return self.transparency == 'transparent'


### PR DESCRIPTION
### Current behavior
When a Google Agenda event is created with a meeting, the Meeting URL (`videocall_location`) isn't set at creation.
When a Google Agenda event is created with "Show as" set to Available, Show as (`show_as`) isn't set accordingly

### Steps
- Install Calendar
- setup and activate Google Calendar sync
- Create an event with a meeting via Google Calendar and set "Show as" on Available
- Refresh Odoo calendar to sync it
-> Created event doesn't contains a Meeting URL and "Show as" is set to Busy

OPW-2805096