### PR TITLE
[FIX] website_sale: correctly translate product variant

### DIFF
--- a/addons/sale/models/sale.py
+++ b/addons/sale/models/sale.py
@@ -1804,6 +1804,7 @@ class SaleOrderLine(models.Model):
             return ""
 
         name = "\n"
+        lang = self.env.context['lang'] if self.env.context.get('from_website', False) else self.order_id.partner_id.lang
 
         custom_ptavs = self.product_custom_attribute_value_ids.custom_product_template_attribute_value_id
         no_variant_ptavs = self.product_no_variant_attribute_value_ids._origin
@@ -1811,12 +1812,12 @@ class SaleOrderLine(models.Model):
         # display the no_variant attributes, except those that are also
         # displayed by a custom (avoid duplicate description)
         for ptav in (no_variant_ptavs - custom_ptavs):
-            name += "\n" + ptav.with_context(lang=self.order_id.partner_id.lang).display_name
+            name += "\n" + ptav.with_context(lang=lang).display_name
 
         # Sort the values according to _order settings, because it doesn't work for virtual records in onchange
         custom_values = sorted(self.product_custom_attribute_value_ids, key=lambda r: (r.custom_product_template_attribute_value_id.id, r.id))
         # display the is_custom values
         for pacv in custom_values:
-            name += "\n" + pacv.with_context(lang=self.order_id.partner_id.lang).display_name
+            name += "\n" + pacv.with_context(lang=lang).display_name
 
         return name

--- a/addons/website_sale/models/sale_order.py
+++ b/addons/website_sale/models/sale_order.py
@@ -391,4 +391,4 @@ class SaleOrderLine(models.Model):
             record.name_short = record.product_id.with_context(display_default_code=False).display_name
 
     def get_description_following_lines(self):
-        return self.name.splitlines()[1:]
+        return self.with_context(from_website=True)._get_sale_order_line_multiline_description_variants().splitlines()[1:]


### PR DESCRIPTION
### Current behavior
Product variant isn't translated on cart summary when language is changed

### Steps
- Install eCommerce
- Enable at least one more language
- Get an attribute with translations done (creation mode : `never`)
- Get a product with this attribute
- Go to the shop and add the product to the cart
- Go to the summary page and change the language
-> Attributes fields aren't translated

OPW-2790240