### PR TITLE
[IMP] point_of_sale: add an option to hide info icon on the product

### DIFF
--- a/addons/point_of_sale/models/pos_config.py
+++ b/addons/point_of_sale/models/pos_config.py
@@ -180,6 +180,8 @@ class PosConfig(models.Model):
                                                    "In the meantime, you can use the 'Load Customers' button to load partners from database.")
     limited_partners_amount = fields.Integer(default=100)
     partner_load_background = fields.Boolean()
+    show_product_info_icon = fields.Boolean('Show Product Info Icon', default=True,
+                                    help="Show an i-icon on the top-left corner of the product.")
 
     @api.depends('payment_method_ids')
     def _compute_cash_control(self):

--- a/addons/point_of_sale/static/src/xml/Screens/ProductScreen/ProductItem.xml
+++ b/addons/point_of_sale/static/src/xml/Screens/ProductScreen/ProductItem.xml
@@ -7,7 +7,7 @@
                  t-att-data-product-id="props.product.id"
                  t-attf-aria-labelledby="article_product_{{props.product.id}}">
             <div class="product-img">
-                <i role="img" aria-label="Info" title="Info" class="product-info-button fa fa-info-circle"
+                <i t-if="env.pos.config.show_product_info_icon" role="img" aria-label="Info" title="Info" class="product-info-button fa fa-info-circle"
                     t-on-click.stop="onProductInfoClick"
                 />
                 <img t-att-src="imageUrl" t-att-alt="props.product.display_name" />

--- a/addons/point_of_sale/views/pos_config_view.xml
+++ b/addons/point_of_sale/views/pos_config_view.xml
@@ -189,6 +189,17 @@
                                 </div>
                             </div>
                         </div>
+                        <div class="col-12 col-lg-6 o_setting_box" id="product_info_icon">
+                            <div class="o_setting_left_pane">
+                                <field name="show_product_info_icon" />
+                            </div>
+                            <div class="o_setting_right_pane">
+                                <label for="show_product_info_icon" />
+                                <div class="text-muted">
+                                    Show info icon on the product
+                                </div>
+                            </div>
+                        </div>
                     </div>
                     <h2>Connected Devices</h2>
                     <div class="row mt16 o_settings_container" id="posbox_reference">


### PR DESCRIPTION
Before this commit,
There is no way to hide the i-icon shown on the product in POS.

After this commit,
Added a new option in the configuration of the POS,
thus a user can uncheck it to hide the i-icon,
which is typically shown in the top-left corner of the Product.