### PR TITLE
[FIX] sale_management: Allow user to add section note to quotation template

### DIFF
--- a/addons/sale_management/models/sale_order_template.py
+++ b/addons/sale_management/models/sale_order_template.py
@@ -156,7 +156,7 @@ class SaleOrderTemplateLine(models.Model):
 
     product_id = fields.Many2one(
         comodel_name='product.product',
-        required=True, check_company=True,
+        required=False, check_company=True,
         domain="[('sale_ok', '=', True), ('company_id', 'in', [company_id, False])]")
 
     name = fields.Text(


### PR DESCRIPTION
For now we can't save a quotation template record if there is a section
note.
Normally (before saas15-2) when we click outside the section input

opw-2805034