### PR TITLE
[FIX] crm: Lead 2 opportunities error when no salespersons

### DIFF
--- a/addons/crm/tests/common.py
+++ b/addons/crm/tests/common.py
@@ -281,6 +281,13 @@ class TestCrmCommon(TestSalesCommon, MailCase):
             'user_id': cls.user_sales_manager.id,
         })
 
+        cls.partner_c2 = cls.env['res.partner'].create({
+            'company_id': cls.company_2.id,
+            'email': '"Partner C2" <partner_c2@multicompany.example.com>',
+            'name': 'Customer for C2',
+            'phone': '+32455001122',
+        })
+
     def _create_leads_batch(self, lead_type='lead', count=10, email_dup_count=0,
                             partner_count=0, partner_ids=None, user_ids=None,
                             country_ids=None, probabilities=None, suffix=''):

--- a/addons/crm/tests/test_crm_lead_multicompany.py
+++ b/addons/crm/tests/test_crm_lead_multicompany.py
@@ -2,8 +2,7 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 from odoo.addons.crm.tests.common import TestCrmCommon
-from odoo.addons.mail.tests.common import mail_new_test_user
-from odoo.exceptions import AccessError
+from odoo.exceptions import AccessError, UserError
 from odoo.tests import Form, tagged
 from odoo.tests.common import users
 
@@ -117,6 +116,38 @@ class TestCRMLeadMultiCompany(TestCrmCommon):
         self.assertEqual(lead.team_id, self.sales_team_1)
         self.assertEqual(lead.user_id, self.user_sales_manager_mc)
 
+
+    @users('user_sales_manager_mc')
+    def test_lead_mc_company_computation_partner_restrict(self):
+        """ Check company on partner limits the company on lead. As contacts may
+        be separated by company, lead with a partner should be limited to that
+        company. """
+        partner_c2 = self.partner_c2.with_env(self.env)
+        self.assertEqual(partner_c2.company_id, self.company_2)
+        lead = self.env['crm.lead'].create({
+            'partner_id': partner_c2.id,
+            'name': 'MC Partner, no company lead',
+            'user_id': False,
+            'team_id': False,
+        })
+        self.assertEqual(lead.company_id, self.company_2)
+
+        partner_main = self.env['res.partner'].create({
+            'company_id': self.company_main.id,
+            'email': 'partner_main@multicompany.example.com',
+            'name': 'Customer for Main',
+        })
+        lead.write({'partner_id': partner_main})
+        self.assertEqual(lead.company_id, self.company_main)
+
+        # writing current user on lead would imply putting its team and team's company
+        # on lead (aka self.company_2), and this clashes with company restriction on
+        # customer
+        with self.assertRaises(UserError):
+            lead.write({
+                'user_id': self.env.user,
+            })
+
     @users('user_sales_manager_mc')
     def test_lead_mc_company_form(self):
         """ Test lead company computation using form view """
@@ -188,3 +219,21 @@ class TestCRMLeadMultiCompany(TestCrmCommon):
         crm_lead_form.user_id = self.env.user
         # self.assertEqual(crm_lead_form.company_id, self.env['res.company'])  # FIXME
         self.assertEqual(crm_lead_form.company_id, self.company_2)
+
+    @users('user_sales_manager_mc')
+    def test_lead_mc_company_form_w_partner_id(self):
+        """ Test lead company computation with partner having a company. """
+        partner_c2 = self.partner_c2.with_env(self.env)
+        crm_lead_form = Form(self.env['crm.lead'])
+        crm_lead_form.name = "Test Lead"
+
+        crm_lead_form.user_id = self.user_sales_manager_mc
+        crm_lead_form.partner_id = partner_c2
+        self.assertEqual(crm_lead_form.company_id, self.company_2, 'Crm: company comes from sales')
+        self.assertEqual(crm_lead_form.team_id, self.team_company2, 'Crm: team comes from sales')
+
+        # reset sales: should not reset company, as partner constrains it
+        crm_lead_form.team_id = self.env['crm.team']
+        crm_lead_form.user_id = self.env['res.users']
+        # ensuring that company_id is not overwritten when the salesperson becomes empty (w\o any team_id)
+        self.assertEqual(crm_lead_form.company_id, self.company_2, 'Crm: company comes from partner')


### PR DESCRIPTION
In a multi-company environment, when we transform a lead (which has
no salesperson) into an opportunity, we get an error.

To reproduce the issue:
1) Create a new company
2) Create a Lead for a customer with the Company set
3) Remove the Sales Team
4) Set the company on the Lead
5) Convert to an opportunity and you will see an error showing up

Solution:
A previous commit (1fad826743de9c8f916ef083e8de453212df6959) adapted the `_compute_company_id`
computation in which a case was forgotten (the case described here-above). The fix was to force
the `company_id` to the one of the `partner_id` if it has one.

opw-2805181