### PR TITLE
[FIX] web: get timezone offset from local time


### DIFF
--- a/addons/web/static/src/js/core/session.js
+++ b/addons/web/static/src/js/core/session.js
@@ -326,7 +326,7 @@ var Session = core.Class.extend(mixins.EventDispatcherMixin, {
      * @returns {integer}
      */
     getTZOffset: function (date) {
-        return -new Date(date).getTimezoneOffset();
+        return -new Date(new Date(date).toISOString().replace('Z', '')).getTimezoneOffset();
     },
     //--------------------------------------------------------------------------
     // Public


### PR DESCRIPTION

Currently, the timezone offset is taken from the date with reverse
timezone offset applied.

So if there is a change of timezone offset between the wrong date and
the local date, we apply the wrong timezone.

Example:

- be in "Australia/Sydney" timezone
- select date in datetime field 2021-04-03 16:12:34 (at UTC+11)
- save => time becomes 17:12:34
- change time to 17:12:35 and save => time becomes 18:12:35
- change time to 18:12:36 and save => time becomes 19:12:36
- ...
- this issue is happening until 01:59:59 of the following day

Fix:

When we are selecting "2021-04-03 16:01:23" we will get the timezone
offset from the date "Sun Apr 04 2021 02:01:23 GMT+1000" (at UTC+10)
but the DST change was at "2021-04-04 03:00:00 (UTC+11)" with time
becoming "2021-04-04 02:00:00 (UTC+10)".

With this changeset, we are getting the timezone from the local time,
not from local time with reverse timezone offset applied.

opw-2735369
