### PR TITLE
[FIX] crm: set the date_closed field when a lead is set to lost

### DIFF
--- a/addons/crm/models/crm_lead.py
+++ b/addons/crm/models/crm_lead.py
@@ -589,7 +589,7 @@ class Lead(models.Model):
         # stage change with new stage: update probability and date_closed
         if vals.get('probability', 0) >= 100 or not vals.get('active', True):
             vals['date_closed'] = fields.Datetime.now()
-        elif 'probability' in vals:
+        elif tools.float_compare(vals.get('probability', 0), 0, precision_digits=2) > 0:
             vals['date_closed'] = False
 
         if any(field in ['active', 'stage_id'] for field in vals):

--- a/addons/crm/tests/test_crm_lead.py
+++ b/addons/crm/tests/test_crm_lead.py
@@ -1,6 +1,9 @@
 # -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
+from datetime import datetime
+from freezegun import freeze_time
+
 from odoo.addons.crm.models.crm_lead import PARTNER_FIELDS_TO_SYNC, PARTNER_ADDRESS_FIELDS_TO_SYNC
 from odoo.addons.crm.tests.common import TestCrmCommon, INCOMING_EMAIL
 from odoo.addons.phone_validation.tools.phone_validation import phone_format
@@ -369,6 +372,14 @@ class TestCRMLead(TestCrmCommon):
         lead.action_set_won()
         self.assertEqual(lead.probability, 100.0)
         self.assertEqual(lead.stage_id, self.stage_gen_won)  # generic won stage has lower sequence than team won stage
+
+    @users('user_sales_leads')
+    @freeze_time("2012-01-14")
+    def test_crm_lead_lost_date_closed(self):
+        self.assertFalse(self.lead_1.date_closed, "Initially, closed date is not set")
+        # Mark the lead as lost
+        self.lead_1.action_set_lost()
+        self.assertEqual(self.lead_1.date_closed, datetime.now(), "Closed date is updated after marking lead as lost")
 
     @users('user_sales_leads')
     def test_crm_lead_update_contact(self):


### PR DESCRIPTION
Steps to reproduce:
- Install the CRM module
- Set a lead to lost
- check the date_closed field

Current behavior:
The date_closed is unset

Expected behavior:
The date_closed has a time and date close to now

Explanation:
This is due to the fact that the action_set_lost calls the write function  multiple times, on the first time (via Model.toggle_active) the function set active to False and date_closed to now. On the second time (via Lead.toggle_active), 
https://github.com/odoo/odoo/blob/a6e45c53642003243e8a0f498e69ffddcac6e086/addons/crm/models/crm_lead.py#L892
it sets the probability to 0 but in the write function the logic says that if a probability is set then date_closed should be set to false reverting what was done in the first call of write().
https://github.com/odoo/odoo/blob/a6e45c53642003243e8a0f498e69ffddcac6e086/addons/crm/models/crm_lead.py#L681-L682

To fix the issue we cherry-pick the solution that was made for 15.0 at https://github.com/odoo/odoo/commit/3b9db86b76a838c0ae6cc9d517d7a29bff2c0544

opw-2756449
