### PR TITLE
[FIX] l10n_ar: Delete “Unified Book” option on sale journals

### DIFF
--- a/addons/l10n_ar/i18n/es.po
+++ b/addons/l10n_ar/i18n/es.po
@@ -1237,12 +1237,6 @@ msgid "Type of gross income: exempt, local, multilateral"
 msgstr "Tipo de ingreso bruto: exento, local, multilateral"
 
 #. module: l10n_ar
-#: model:ir.model.fields,field_description:l10n_ar.field_account_bank_statement_import_journal_creation__l10n_ar_share_sequences
-#: model:ir.model.fields,field_description:l10n_ar.field_account_journal__l10n_ar_share_sequences
-msgid "Unified Book"
-msgstr "Libro Unificado"
-
-#. module: l10n_ar
 #: model:product.product,uom_name:l10n_ar.product_product_arancel
 #: model:product.product,uom_name:l10n_ar.product_product_cero
 #: model:product.product,uom_name:l10n_ar.product_product_exento
@@ -1277,12 +1271,6 @@ msgstr "Conceptos No gravados"
 #: model:l10n_latam.identification.type,name:l10n_ar.it_UpApP
 msgid "UpApP"
 msgstr ""
-
-#. module: l10n_ar
-#: model:ir.model.fields,help:l10n_ar.field_account_bank_statement_import_journal_creation__l10n_ar_share_sequences
-#: model:ir.model.fields,help:l10n_ar.field_account_journal__l10n_ar_share_sequences
-msgid "Use same sequence for documents with the same letter"
-msgstr "Usar la misma secuencia para documentos con misma letra"
 
 #. module: l10n_ar
 #: model:ir.model.fields,field_description:l10n_ar.field_res_partner__l10n_ar_vat

--- a/addons/l10n_ar/i18n/l10n_ar.pot
+++ b/addons/l10n_ar/i18n/l10n_ar.pot
@@ -1185,12 +1185,6 @@ msgid "Type of gross income: exempt, local, multilateral"
 msgstr ""
 
 #. module: l10n_ar
-#: model:ir.model.fields,field_description:l10n_ar.field_account_bank_statement_import_journal_creation__l10n_ar_share_sequences
-#: model:ir.model.fields,field_description:l10n_ar.field_account_journal__l10n_ar_share_sequences
-msgid "Unified Book"
-msgstr ""
-
-#. module: l10n_ar
 #: model:product.product,uom_name:l10n_ar.product_product_arancel
 #: model:product.product,uom_name:l10n_ar.product_product_cero
 #: model:product.product,uom_name:l10n_ar.product_product_exento
@@ -1224,12 +1218,6 @@ msgstr ""
 #. module: l10n_ar
 #: model:l10n_latam.identification.type,name:l10n_ar.it_UpApP
 msgid "UpApP"
-msgstr ""
-
-#. module: l10n_ar
-#: model:ir.model.fields,help:l10n_ar.field_account_bank_statement_import_journal_creation__l10n_ar_share_sequences
-#: model:ir.model.fields,help:l10n_ar.field_account_journal__l10n_ar_share_sequences
-msgid "Use same sequence for documents with the same letter"
 msgstr ""
 
 #. module: l10n_ar

--- a/addons/l10n_ar/models/account_chart_template.py
+++ b/addons/l10n_ar/models/account_chart_template.py
@@ -28,7 +28,6 @@ class AccountChartTemplate(models.Model):
                         "l10n_ar_afip_pos_number": 1,
                         "l10n_ar_afip_pos_partner_id": company.partner_id.id,
                         "l10n_ar_afip_pos_system": 'II_IM',
-                        "l10n_ar_share_sequences": True,
                         "refund_sequence": False
                     })
         return res

--- a/addons/l10n_ar/models/account_journal.py
+++ b/addons/l10n_ar/models/account_journal.py
@@ -17,8 +17,6 @@ class AccountJournal(models.Model):
         'res.partner', 'AFIP POS Address', help='This is the address used for invoice reports of this POS',
         domain="['|', ('id', '=', company_partner), '&', ('id', 'child_of', company_partner), ('type', '!=', 'contact')]"
     )
-    l10n_ar_share_sequences = fields.Boolean(
-        'Unified Book', help='Use same sequence for documents with the same letter')
 
     def _get_l10n_ar_afip_pos_types_selection(self):
         """ Return the list of values of the selection field. """
@@ -100,8 +98,7 @@ class AccountJournal(models.Model):
         elif self.l10n_ar_afip_pos_system in ['FEERCEL', 'FEEWS', 'FEERCELP']:
             return expo_codes
 
-    @api.constrains('type', 'l10n_ar_afip_pos_system', 'l10n_ar_afip_pos_number', 'l10n_ar_share_sequences',
-                    'l10n_latam_use_documents')
+    @api.constrains('type', 'l10n_ar_afip_pos_system', 'l10n_ar_afip_pos_number', 'l10n_latam_use_documents')
     def _check_afip_configurations(self):
         """ Do not let the user update the journal if it already contains confirmed invoices """
         journals = self.filtered(lambda x: x.company_id.account_fiscal_country_id.code == "AR" and x.type in ['sale', 'purchase'])
@@ -122,11 +119,6 @@ class AccountJournal(models.Model):
 
         if to_review.filtered(lambda x: x.l10n_ar_afip_pos_number > 99999):
             raise ValidationError(_('Please define a valid AFIP POS number (5 digits max)'))
-
-    @api.onchange('l10n_ar_afip_pos_system')
-    def _onchange_l10n_ar_afip_pos_system(self):
-        """ On 'Pre-printed Invoice' the usual is to share sequences. On other types, do not share """
-        self.l10n_ar_share_sequences = bool(self.l10n_ar_afip_pos_system == 'II_IM')
 
     @api.onchange('l10n_ar_afip_pos_number', 'type')
     def _onchange_set_short_name(self):

--- a/addons/l10n_ar/models/account_move.py
+++ b/addons/l10n_ar/models/account_move.py
@@ -240,24 +240,12 @@ class AccountMove(models.Model):
                 return self._get_formatted_sequence()
         return super()._get_starting_sequence()
 
-    def _get_last_sequence(self, relaxed=False, with_prefix=None):
-        """ If use share sequences we need to recompute the sequence to add the proper document code prefix """
-        res = super()._get_last_sequence(relaxed=relaxed, with_prefix=with_prefix)
-        if res and self.journal_id.l10n_ar_share_sequences and self.l10n_latam_document_type_id.doc_code_prefix not in res:
-            res = self._get_formatted_sequence(number=self._l10n_ar_get_document_number_parts(
-                res.split()[-1], self.l10n_latam_document_type_id.code)['invoice_number'])
-        return res
 
     def _get_last_sequence_domain(self, relaxed=False):
         where_string, param = super(AccountMove, self)._get_last_sequence_domain(relaxed)
         if self.company_id.account_fiscal_country_id.code == "AR" and self.l10n_latam_use_documents:
-            if not self.journal_id.l10n_ar_share_sequences:
-                where_string += " AND l10n_latam_document_type_id = %(l10n_latam_document_type_id)s"
-                param['l10n_latam_document_type_id'] = self.l10n_latam_document_type_id.id or 0
-            elif self.journal_id.l10n_ar_share_sequences:
-                where_string += " AND l10n_latam_document_type_id in %(l10n_latam_document_type_ids)s"
-                param['l10n_latam_document_type_ids'] = tuple(self.l10n_latam_document_type_id.search(
-                    [('l10n_ar_letter', '=', self.l10n_latam_document_type_id.l10n_ar_letter)]).ids)
+            where_string += " AND l10n_latam_document_type_id = %(l10n_latam_document_type_id)s"
+            param['l10n_latam_document_type_id'] = self.l10n_latam_document_type_id.id or 0
         return where_string, param
 
     def _l10n_ar_get_amounts(self, company_currency=False):

--- a/addons/l10n_ar/views/account_journal_view.xml
+++ b/addons/l10n_ar/views/account_journal_view.xml
@@ -11,7 +11,6 @@
                 <field name="l10n_ar_afip_pos_system" attrs="{'invisible':['|', '|', ('country_code', '!=', 'AR'), ('l10n_latam_use_documents', '=', False), ('type', '!=', 'sale')], 'required':[('country_code', '=', 'AR'), ('l10n_latam_use_documents', '=', True), ('type', '=', 'sale')]}"/>
                 <field name="l10n_ar_afip_pos_number" attrs="{'invisible':['|', '|', ('country_code', '!=', 'AR'), ('l10n_latam_use_documents', '=', False), ('type', '!=', 'sale')], 'required':[('country_code', '=', 'AR'), ('l10n_latam_use_documents', '=', True), ('type', '=', 'sale')]}"/>
                 <field name="l10n_ar_afip_pos_partner_id" attrs="{'invisible':['|', '|', ('country_code', '!=', 'AR'), ('l10n_latam_use_documents', '=', False), ('type', '!=', 'sale')], 'required':[('country_code', '=', 'AR'), ('l10n_latam_use_documents', '=', True), ('type', '=', 'sale')]}"/>
-                <field name="l10n_ar_share_sequences" attrs="{'invisible':[('l10n_ar_afip_pos_system', '!=', 'II_IM')]}"/>
             </field>
         </field>
     </record>


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
Before this change, we bringed to the user the posibility to select the option “Unified Book” (boolean) on journals with type “Sales” and Pre-printed Invoice “AFIP POS System”. This allowed all documents with the same letter document to use the same sequence, and it does not matter if they are invoices, credit notes or debit notes for example.
Now that functionality is deleted and all documents will have their own sequence regardless of the letter document of each receipt.

Current behavior before PR:
![image](https://user-images.githubusercontent.com/89547436/162454485-6e6d639e-f933-472b-a26b-8afcbde1b07d.png)

Documents used on journals with “Unified Book” option selected have the same sequence when they have the same letter document.

Desired behavior after PR is merged:
![image](https://user-images.githubusercontent.com/89547436/162455110-e0dc5714-881d-448e-ada0-c781e6de2661.png)

There is no more “Unified Book” option on jornals and all documents will have their own sequence regardless of the letter document of each one.



--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
