### PR TITLE
15.0 fix sale order to invoice missing field

### DIFF
--- a/addons/sale/models/sale_order.py
+++ b/addons/sale/models/sale_order.py
@@ -631,6 +631,7 @@ class SaleOrder(models.Model):
             'transaction_ids': [(6, 0, self.transaction_ids.ids)],
             'invoice_line_ids': [],
             'company_id': self.company_id.id,
+            'posted_before': False
         }
         return invoice_vals
 

--- a/doc/cla/corporate/strongblue.md
+++ b/doc/cla/corporate/strongblue.md
@@ -1,0 +1,16 @@
+Strasbourg, France, 25/11/2021
+
+Strong Blue Conseil & Télécom SASU agrees to the terms of the Odoo Corporate Contributor License
+Agreement v1.0.
+
+I declare that I am authorized and able to make this agreement and sign this
+declaration.
+
+Signed,
+
+Arnaud Willem arnaud@strong.blue https://github.com/a-willem
+
+List of contributors:
+
+Arnaud Willem arnaud@strong.blue https://github.com/a-willem
+


### PR DESCRIPTION
Description of the issue/feature this PR addresses:

When creating an invoice from an SO, the posted_before boolean was unset, thus breaking sequence number correction in the `account.move.form` view in account, whose filter is : 

attrs="{'invisible':[('name', '=', '/'), ('posted_before', '=', False)]}"


Current behavior before PR:

Users cannot edit a sequence number when an invoice has been created from an SO.

Desired behavior after PR is merged:

User may correct the sequence no when an invoice is imported this way.


--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
