### PR TITLE
[FIX] website_blog, web_editor: show blog tag option

### DIFF
--- a/addons/web_editor/static/src/js/editor/snippets.editor.js
+++ b/addons/web_editor/static/src/js/editor/snippets.editor.js
@@ -2194,6 +2194,7 @@ var SnippetsMenu = Widget.extend({
     _computeSnippetTemplates: function (html) {
         var self = this;
         var $html = $(html);
+        this._patchForComputeSnippetTemplates($html);
         var $scroll = $html.siblings('#o_scroll');
 
         // TODO remove me in master: this is a hack that moves the logo options
@@ -2393,6 +2394,15 @@ var SnippetsMenu = Widget.extend({
         this.trigger_up('snippets_loaded', self.$el);
         $(this.el.ownerDocument.body).addClass('editor_has_snippets');
     },
+    /**
+     * Eases patching the XML definition for snippets and options in stable
+     * versions. Note: in the future, we will probably move to other ways to
+     * define snippets and options.
+     *
+     * @private
+     * @param {jQuery}
+     */
+    _patchForComputeSnippetTemplates($html) {},
     /**
      * Creates a snippet editor to associated to the given snippet. If the given
      * snippet already has a linked snippet editor, the function only returns

--- a/addons/website_blog/__manifest__.py
+++ b/addons/website_blog/__manifest__.py
@@ -36,6 +36,7 @@
             'website_blog/static/src/js/options.js',
             'website_blog/static/src/js/wysiwyg.js',
             'website_blog/static/src/snippets/s_blog_posts/options.js',
+            'website_blog/static/src/js/snippets.editor.js',
         ],
         'website.assets_editor': [
             'website_blog/static/src/js/website_blog.editor.js',

--- a/addons/website_blog/static/src/js/snippets.editor.js
+++ b/addons/website_blog/static/src/js/snippets.editor.js
@@ -1,0 +1,22 @@
+/** @odoo-module **/
+
+import snippetEditor from 'web_editor.snippet.editor';
+
+snippetEditor.SnippetsMenu.include({
+
+    //--------------------------------------------------------------------------
+    // Private
+    //--------------------------------------------------------------------------
+
+    /**
+     * @override
+     */
+    _patchForComputeSnippetTemplates: function ($html) {
+        this._super(...arguments);
+        // TODO: adapt in master - add missing "data-no-check" on blog tag option.
+        const blogPostTagOptionEl = $html.find('[data-js="BlogPostTagSelection"]')[0];
+        if (blogPostTagOptionEl) {
+            blogPostTagOptionEl.dataset.noCheck = true;
+        }
+    },
+});


### PR DESCRIPTION
Since [1] the blog tag option was not shown in the website editor
option's panel anymore. Because the tag is not in an editable element
and the `data-no-check` was not specified.

After this commit the blog tag option is restored.
This PR also aligns the m2m fields label to the top.

[1]: https://github.com/odoo/odoo/commit/86e3bb5e24c2d125ec4ec84ac788601c63182d0f

task-2811746
