### PR TITLE
Render `product.product` record id instead of `lunch.product.report` id

### DIFF
--- a/addons/lunch/static/src/js/lunch_list_renderer.js
+++ b/addons/lunch/static/src/js/lunch_list_renderer.js
@@ -27,7 +27,7 @@ var LunchListRenderer = ListRenderer.extend({
      */
     _renderRow: function (record) {
         var tr = this._super.apply(this, arguments);
-        tr.attr('data-product-id', record.data.id);
+        tr.attr('data-product-id', record.data.product_id.data.id);
         return tr;
     },
 


### PR DESCRIPTION
Description of the issue/feature this PR addresses:

Seems like Odoo renders wrong value on `My Lunch` menu when trying to add product to cart from list view with non admin user. Odoo renders incorrect `productId` where it takes `lunch.product.report` id instead of `product_id` from `lunch.product.report`.

Current behavior before PR:

Missing error when trying to select product from My Lunch menu on list view with non admin user.

```
Missing Error
Record does not exist or has been deleted.
(Record: lunch.product(33,), User: 6)
```

Desired behavior after PR is merged:

No error, [productId](https://github.com/odoo/odoo/blob/14.0/addons/lunch/static/src/js/lunch_list_renderer.js#L46) is gotten correctly.

Solves [#86372](https://github.com/odoo/odoo/issues/86372) issue.


--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
