### PR TITLE
[FIX] l10n_cl: fix invoice totals

### DIFF
--- a/addons/l10n_cl/views/report_invoice.xml
+++ b/addons/l10n_cl/views/report_invoice.xml
@@ -104,7 +104,7 @@
                 <br/>
                 <strong>Address:</strong>
                 <span t-field="o.partner_id"
-                      t-options="{'widget': 'contact', 'fields': ['address'], 'no_marker': true, 'no_tag_br': True}"/>
+                      t-options="{'widget': 'contact', 'fields': ['address'], 'no_marker': True}"/>
 
                 <strong>Payment Terms:</strong>
                 <span t-esc="o.invoice_payment_term_id.name or ''"/>


### PR DESCRIPTION
Task: 2817024

1. l10n_cl uses ```_prepare_tax_lines_data_for_totals_from_invoice()``` and ```_get_tax_totals()``` to prepare invoice totals for exporting invoices in pdf.
After the recent changes, these methods no longer exist, and invoice totals should be calculated in a different way.
2. Contact widget should not have ```'no_tag_br': True``` anymore to show the address properly.



--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
