### PR TITLE
[FIX] l10n_ch: use consistent name on QR bill when using acc_holder_name on bank account

### DIFF
--- a/addons/l10n_ch/report/swissqr_report.xml
+++ b/addons/l10n_ch/report/swissqr_report.xml
@@ -44,7 +44,7 @@
                             <div class="swissqr_text">
                               <span class="title">Account / Payable to</span><br/>
                               <span class="content" t-field="o.invoice_partner_bank_id.acc_number"/><br/>
-                              <span class="content" t-field="o.company_id.name"/><br/>
+                              <span class="content" t-esc="o.invoice_partner_bank_id.acc_holder_name or o.company_id.name"/><br/>
                               <span class="content" t-field="o.company_id.street"/><br/>
                               <span class="content" t-field="o.company_id.country_id.code"/>
                               <span class="content" t-field="o.company_id.zip"/>
@@ -101,7 +101,7 @@
                             <div class="swissqr_text">
                                 <span class="title">Account / Payable to</span><br/>
                                 <span class="content" t-field="o.invoice_partner_bank_id.acc_number"/><br/>
-                                <span class="content" t-field="o.company_id.name"/><br/>
+                                <span class="content" t-esc="o.invoice_partner_bank_id.acc_holder_name or o.company_id.name"/><br/>
                                 <span class="content" t-field="o.company_id.street"/><br/>
                                 <span class="content" t-field="o.company_id.country_id.code"/>
                                 <span class="content" t-field="o.company_id.zip"/>


### PR DESCRIPTION
When setting acc_holder_name on the bank account receiving the payment of a QR-bill, acc_holder_name was used instead of the company's name inside the QR-code, but not on the summary text displayed next to it. This fix replaces the company name there as well. The behavior is unchanged when acc_holder_name isn't set.
