### PR TITLE
[FIX] web: basic_model: multi edit in grouped list on absent groubed …

### DIFF
--- a/addons/web/static/src/js/views/basic/basic_model.js
+++ b/addons/web/static/src/js/views/basic/basic_model.js
@@ -4870,6 +4870,15 @@ var BasicModel = AbstractModel.extend({
         if (list.__data) {
             // the data have already been fetched (alonside the groups by the
             // call to 'web_read_group'), so we can bypass the search_read
+            // But the web_read_group returns the rawGroupBy field's value, which may not be present
+            // in the view. So we filter it out.
+            list.__data.records.forEach((rec) => {
+                Object.keys(rec).forEach(fName => {
+                    if (!fieldNames.includes(fName) && fName !== "id") {
+                        delete rec[fName];
+                    }
+                });
+            });
             prom = Promise.resolve(list.__data);
         } else {
             prom = this._rpc({


### PR DESCRIPTION
…by field

When group by a field that is not in the view, list.__data contains the groupedBy field's value
because we fetched the group through a web_read_group (commit: ca19b17fd3e09d2f4e53208542f4356d3a6ee25a)

We filter out those absent field from the web_read_group's output before creating the
datapoint of the group

The multi edit works.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
