### PR TITLE
[IMP] base: make `model` field optional when inheriting views

### DIFF
--- a/odoo/addons/base/models/ir_ui_view.py
+++ b/odoo/addons/base/models/ir_ui_view.py
@@ -522,7 +522,8 @@ actual arch.
             if 'arch_db' in values and not values['arch_db']:
                 # delete empty arch_db to avoid triggering _check_xml before _inverse_arch_base is called
                 del values['arch_db']
-
+            if 'model' not in values and values.get('inherit_id'):
+                values['model'] = self.browse(values['inherit_id']).model
             if not values.get('type'):
                 if values.get('inherit_id'):
                     values['type'] = self.browse(values['inherit_id']).type

--- a/odoo/addons/base/tests/test_views.py
+++ b/odoo/addons/base/tests/test_views.py
@@ -1639,7 +1639,6 @@ class TestViews(ViewCase):
         })
         view3 = self.View.create({
             'name': 'jake',
-            'model': 'ir.ui.view',
             'inherit_id': view1.id,
             'priority': 17,
             'arch': """
@@ -1651,6 +1650,8 @@ class TestViews(ViewCase):
                 </footer>
             """
         })
+
+        self.assertEqual(view3.model, 'ir.ui.view', 'Model is copied from parent when not specified')
 
         view = self.View.with_context(check_view_ids=[view2.id, view3.id]).get_view(view2.id, 'form')
         self.assertEqual(


### PR DESCRIPTION
It slightly decreases the amount of needed boilerplate code when creating inheriting views, by simply assuming the model is the same as the inherited one.

For example,

```xml
    <!-- The commented line is no longer required -->
    <record id="view_partner_form" model="ir.ui.view">
        <!-- <field name="model">res.partner</field> -->
        <field name="inherit_id" ref="base.view_partner_form" />
        <field name="arch" type="xml">
            <field name="name" position="after">
                <field name="id" />
            </field>
        </field>
    </record>
```

NOTE: A similar technique is already used to guess the view type. In the same spirit, it's extended to also guess the model.



--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
