### PR TITLE
[FIX] hr: prevents server error on a summary view

### DIFF
--- a/addons/hr/models/hr_employee.py
+++ b/addons/hr/models/hr_employee.py
@@ -147,9 +147,8 @@ class HrEmployeePrivate(models.Model):
 
     @api.model
     def load_views(self, views, options=None):
-        if self.check_access_rights('read', raise_exception=False):
-            return super(HrEmployeePrivate, self).load_views(views, options=options)
-        return self.env['hr.employee.public'].load_views(views, options=options)
+        self.check_access_rights('read')
+        return super(HrEmployeePrivate, self).load_views(views, options=options)
 
     @api.model
     def _search(self, args, offset=0, limit=None, order=None, count=False, access_rights_uid=None):


### PR DESCRIPTION
### Current behavior
In some case, an server error is triggered when a user click on Employees' Summary button in the notification tray.

### Steps
- Install Employees
- Create an onboarding plan for an employee
- Remove Employees' access rights for current user
- In notification box, click on Employees' summary icon
-> Server error is raised

OPW-2765032