### PR TITLE
[FIX] account: No CABA Bases when Anglosaxon Reconciled

### DIFF
--- a/addons/account/models/account_move.py
+++ b/addons/account/models/account_move.py
@@ -2429,7 +2429,7 @@ class AccountMove(models.Model):
                 values['to_process_lines'].append(('tax', line))
                 currencies.add(line.currency_id)
 
-            elif 'on_payment' in line.tax_ids.mapped('tax_exigibility') and not line.reconciled:
+            elif 'on_payment' in line.tax_ids.mapped('tax_exigibility'):
                 values['to_process_lines'].append(('base', line))
                 currencies.add(line.currency_id)
 


### PR DESCRIPTION
Was Closed with
-

https://github.com/odoo/odoo/pull/88321

Main
-
No CABA bases are generated when AngloSaxon Lines are Reconciled.

Important Notice:
-
**If not CABA Bases are created DIOT Report in Mexican Localization will be wrong.**

Explain
=

- Set Automated Inventory.
- Use Stockable products.

Create a purchase order at Date 23th February.
-

- Set currency USD.
- 25 units @ 3.72 + 16% Taxes (CABA TAX)
- Subtotal = USD 93.00
- Receipt merchandise at Date 25th February

 - Rate: 28th FEB : 20.28250 MXN/USD

 - Posted Entry

|account|debit|credit|amount_currency|
|-|-:|-:|-:|
|Inventory|1882.62||USD 93.OO|
|Stock-In||1882.62|USD -93.OO|

Receipt Vendor Bill at Account Date 28th February
-

- Rate: 28th FEB : 20.6525 MXN/USD

- Posted Entry

|account|debit|credit|amount_currency|
|-|-:|-:|-:|
|Stock-In|1920.68||USD 93.OO|
|Interin Tax|307.31||USD 14.88|
|Payable||1882.62|USD -107.88|

- FX Due to AngloSaxon Entries

|account|debit|credit|amount_currency|
|-|-:|-:|-:|
|FX Loss|38.03||USD 0.OO|
|Stock-In||38.03|USD 0.00|

Pay the Vendor Bill at Date 28th March
-

This payment is made with a surplus amount to be used in another Vendor Bill. (A Real Case Scenerario is being depicted).

- Rate: 28th MAR : 20.1313 MXN/USD

|account|debit|credit|amount_currency|
|-|-:|-:|-:|
|Payable|10,535.31||USD 523.33|
|Out. Payment||10,535.31|USD -523.33|

At this point as no full-reconcilation has been achieved then there is no FX Entry for this reconciliation.

But there is CABA Journal Entry Created.

Current Situation
-

|account|debit|credit|amount_currency|
|-|-:|-:|-:|
|Awarded Tax|299.55||USD 14.88|
|Interin Tax||299.55|USD -14.88|

There are no CABA Base Lines generated. Which causes issues to properly report the taxes to the Estatury Entity. That is, a wrong DIOT report is created.

Expected Situation
-

|account|debit|credit|amount_currency|
|-|-:|-:|-:|
|Awarded Tax|299.55||USD 14.88|
|Interin Tax||299.55|USD -14.88|
|CABA Base|1872.21||USD 93.00|
|CABA Base||1872.21|USD -93.00|

- FX Entry for Taxes.

Exchange Rate difference is OK.

|account|debit|credit|amount_currency|
|-|-:|-:|-:|
|FX Loss|7.76||USD 0.OO|
|Interin Tax||7.76|USD 0.00|


OPW Tickets
-
 
- 2818397
- 2818456

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
