### PR TITLE
[13.0][FIX] sale_product_configurator/website_sale: Don't restrict company on optional/alternative/accessory products

### DIFF
--- a/addons/sale_product_configurator/models/product.py
+++ b/addons/sale_product_configurator/models/product.py
@@ -6,13 +6,12 @@ from odoo import fields, models, api
 
 class ProductTemplate(models.Model):
     _inherit = 'product.template'
-    _check_company_auto = True
 
     optional_product_ids = fields.Many2many(
         'product.template', 'product_optional_rel', 'src_id', 'dest_id',
         string='Optional Products', help="Optional Products are suggested "
         "whenever the customer hits *Add to Cart* (cross-sell strategy, "
-        "e.g. for computers: warranty, software, etc.).", check_company=True)
+        "e.g. for computers: warranty, software, etc.).")
 
     @api.depends('attribute_line_ids.value_ids.is_custom', 'attribute_line_ids.attribute_id.create_variant')
     def _compute_has_configurable_attributes(self):

--- a/addons/website_sale/models/product.py
+++ b/addons/website_sale/models/product.py
@@ -184,15 +184,14 @@ class ProductTemplate(models.Model):
     _inherit = ["product.template", "website.seo.metadata", 'website.published.multi.mixin', 'rating.mixin']
     _name = 'product.template'
     _mail_post_access = 'read'
-    _check_company_auto = True
 
     website_description = fields.Html('Description for the website', sanitize_attributes=False, translate=html_translate)
     alternative_product_ids = fields.Many2many(
-        'product.template', 'product_alternative_rel', 'src_id', 'dest_id', check_company=True,
+        'product.template', 'product_alternative_rel', 'src_id', 'dest_id',
         string='Alternative Products', help='Suggest alternatives to your customer (upsell strategy). '
                                             'Those products show up on the product page.')
     accessory_product_ids = fields.Many2many(
-        'product.product', 'product_accessory_rel', 'src_id', 'dest_id', string='Accessory Products', check_company=True,
+        'product.product', 'product_accessory_rel', 'src_id', 'dest_id', string='Accessory Products',
         help='Accessories show up when the customer reviews the cart before payment (cross-sell strategy).')
     website_size_x = fields.Integer('Size X', default=1)
     website_size_y = fields.Integer('Size Y', default=1)


### PR DESCRIPTION
There can be situations where you have a product that is visible to all the companies, but having alternative, optional or accessory products that are specific to a company.

There's no sense on limiting the possibility of adding these products to the corresponding fields, moreover being many2many fields, where the values will be fetched by ORM according to the allowed companies, so in the context of the e-commerce, restricted to the website company.

@Tecnativa TT35577