### PR TITLE
[FIX] web: allow hotkeys for editable elements

### DIFF
--- a/addons/web/static/src/core/commands/command_palette.xml
+++ b/addons/web/static/src/core/commands/command_palette.xml
@@ -4,7 +4,7 @@
   <t t-name="web.CommandPalette" owl="1">
     <div>
       <div class="o_command_palette_search">
-        <input type="text" t-model="state.searchValue" t-on-input="onDebouncedSearchInput" autofocus="" t-att-placeholder="state.placeholder"/>
+        <input type="text" data-allow-hotkeys="true" t-model="state.searchValue" t-on-input="onDebouncedSearchInput" autofocus="" t-att-placeholder="state.placeholder"/>
         <i  t-att-title="state.placeholder" role="img"  t-att-aria-label="state.placeholder" class="fa fa-search"></i>
       </div>
 

--- a/addons/web/static/src/core/hotkeys/hotkey_service.js
+++ b/addons/web/static/src/core/hotkeys/hotkey_service.js
@@ -96,11 +96,13 @@ export const hotkeyService = {
                 return;
             }
 
+            // Protect any editable target that does not explicitly accept hotkeys
+            // NB: except for ESC, which is always allowed as hotkey in editables.
             const targetIsEditable =
-                (event.target instanceof Element && /input|textarea/i.test(event.target.tagName)) ||
-                (event.target instanceof HTMLElement && event.target.isContentEditable);
+                event.target instanceof HTMLElement &&
+                (/input|textarea/i.test(event.target.tagName) || event.target.isContentEditable);
             const shouldProtectEditable =
-                targetIsEditable && [...ALPHANUM_KEYS, ...NAV_KEYS].includes(singleKey);
+                targetIsEditable && !event.target.dataset.allowHotkeys && singleKey !== "escape";
 
             // Finally, prepare and dispatch.
             const infos = {

--- a/addons/web/static/tests/core/hotkeys/hotkey_service_tests.js
+++ b/addons/web/static/tests/core/hotkeys/hotkey_service_tests.js
@@ -679,6 +679,37 @@ QUnit.test("protects editable elements: can bypassEditableProtection", async (as
     );
 });
 
+QUnit.test("protects editable elements: an editable can allow hotkeys", async (assert) => {
+    class Comp extends Component {
+        setup() {
+            useHotkey("arrowleft", () => assert.step("called"));
+        }
+    }
+    Comp.template = xml`<div><input class="foo" data-allow-hotkeys="true"/><input class="bar"/></div>`;
+    await mount(Comp, { env, target });
+    const fooInput = target.querySelector(".foo");
+    const barInput = target.querySelector(".bar");
+
+    assert.verifySteps([]);
+    document.dispatchEvent(new KeyboardEvent("keydown", { key: "ArrowLeft", bubbles: true }));
+    await nextTick();
+    assert.verifySteps(["called"]);
+
+    fooInput.dispatchEvent(new KeyboardEvent("keydown", { key: "ArrowLeft", bubbles: true }));
+    await nextTick();
+    assert.verifySteps(
+        ["called"],
+        "the callback gets called as the foo editable allows it"
+    );
+
+    barInput.dispatchEvent(new KeyboardEvent("keydown", { key: "ArrowLeft", bubbles: true }));
+    await nextTick();
+    assert.verifySteps(
+        [],
+        "the callback does not get called as the bar editable does not explicitly allow hotkeys"
+    );
+});
+
 QUnit.test("ignore numpad keys", async (assert) => {
     assert.expect(3);
 

--- a/addons/web/static/tests/helpers/utils.js
+++ b/addons/web/static/tests/helpers/utils.js
@@ -313,8 +313,12 @@ export function triggerHotkey(hotkey, addOverlayModParts = false, eventAttrs = {
         }
     }
 
-    window.dispatchEvent(new KeyboardEvent("keydown", eventAttrs));
-    window.dispatchEvent(new KeyboardEvent("keyup", eventAttrs));
+    if (!("bubbles" in eventAttrs)) {
+        eventAttrs.bubbles = true;
+    }
+
+    document.activeElement.dispatchEvent(new KeyboardEvent("keydown", eventAttrs));
+    document.activeElement.dispatchEvent(new KeyboardEvent("keyup", eventAttrs));
 }
 
 export async function legacyExtraNextTick() {


### PR DESCRIPTION
Since 43463a1 it was not possible anymore to trigger hotkeys
from an editable element excepted through
the hotkey option "bypassEditableProtection".
But there are cases where the editable element may want to always
allow any hotkey: e.g. the command palette search input.

Before This Commit
Impossible to trigger hotkeys from the command palette.

After This Commit
The command palette search input now allows any hotkeys.

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
