### PR TITLE
[FIX] survey: Fix cropped out timer on mobile devices.

### DIFF
--- a/addons/survey/views/survey_templates.xml
+++ b/addons/survey/views/survey_templates.xml
@@ -65,11 +65,11 @@
         <div class="o_survey_nav pt16 mb-2">
             <div class="container m-0 p-0">
                 <div class="row">
-                    <div  class="col-10">
+                    <div  class="col-lg-10">
                         <h1 t-if="answer.state == 'new' or survey.questions_layout != 'page_per_question'"
                             t-esc="survey.title" class="o_survey_main_title pt-4"></h1>
                     </div>
-                    <div class="o_survey_timer col-2 pt-4">
+                    <div class="o_survey_timer col-lg-2 pt-4">
                         <h1 class="o_survey_timer_container timer text-right">
                         </h1>
                     </div>


### PR DESCRIPTION
This commit fixes the timer that was cropped out when taking a
survey having a time limit on mobile devices.

Task-2810299