### PR TITLE
[FIX] sale_management: product should not be required on template lines

### DIFF
--- a/addons/sale_management/models/sale_order_template.py
+++ b/addons/sale_management/models/sale_order_template.py
@@ -156,7 +156,7 @@ class SaleOrderTemplateLine(models.Model):
 
     product_id = fields.Many2one(
         comodel_name='product.product',
-        required=True, check_company=True,
+        check_company=True,
         domain="[('sale_ok', '=', True), ('company_id', 'in', [company_id, False])]")
 
     name = fields.Text(


### PR DESCRIPTION
Because some lines can be sections/notes without a product, and the product
presence when needed is already verified by the sql constraints.

Fixes the mistake from #81818 specifying the field as required when it shouldn't be.


--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
