### PR TITLE
[FIX] website_sale: edit a product template's price from quotation

### DIFF
--- a/addons/website_sale/models/product_template.py
+++ b/addons/website_sale/models/product_template.py
@@ -74,7 +74,8 @@ class ProductTemplate(models.Model):
     @api.depends('price', 'list_price', 'base_unit_count')
     def _compute_base_unit_price(self):
         for template in self:
-            template.base_unit_price = template.base_unit_count and (template.price or template.list_price) / template.base_unit_count
+            template_price = (template.price or template.list_price) if template.id else template.list_price
+            template.base_unit_price = template.base_unit_count and template_price / template.base_unit_count
 
     @api.depends('uom_name', 'base_unit_id.name')
     def _compute_base_unit_name(self):


### PR DESCRIPTION
An error is thrown when editing a product template's price from the
quick edit of a quotation

Steps to reproduce:
1. Install Sales and eCommerce app
2. Go to Settings > Sales > Product Catalog and enable Product
Configurator
3. Open Sales and create a quotation
4. Add a customer and a product to the quotation
5. Open the product template's form using the edit button
6. Change the product's sales price and save
7. An error is thrown

Solution:
Check if the template has a real id and don't use `template.price` if it
doesn't

Problem:
Accessing the field `template.price` throws an error because the
template doesn't have an id (something like `NewId_23`) which cannot be
used in the SQL query of `_compute_price_rule_get_items`

opw-2810719