### PR TITLE
[FIX] mrp_subcontracting: landed cost

### DIFF
--- a/addons/mrp_subcontracting/views/mrp_production_views.xml
+++ b/addons/mrp_subcontracting/views/mrp_production_views.xml
@@ -54,5 +54,27 @@
             </xpath>
         </field>
     </record>
+
+    <record id="mrp_production_subcontracting_tree_view" model="ir.ui.view">
+        <field name="name">mrp.production.subcontracting.tree</field>
+        <field name="model">mrp.production</field>
+        <field name="inherit_id" ref="mrp.mrp_production_tree_view" />
+        <field name="arch" type="xml">
+            <xpath expr="//field[@name='name']" position="after">
+                <field name="incoming_picking"/>
+            </xpath>
+        </field>
+    </record>
+
+    <record id="mrp_production_subcontracting_filter" model="ir.ui.view">
+        <field name="name">mrp.production.subcontracting.select</field>
+        <field name="model">mrp.production</field>
+        <field name="inherit_id" ref="mrp.view_mrp_production_filter" />
+        <field name="arch" type="xml">
+            <xpath expr="//field[@name='name']" position="after">
+                <field name="name" string="Incoming transfer" filter_domain="[('incoming_picking.name', 'ilike', self)]"/>
+            </xpath>
+        </field>
+    </record>
 </odoo>
 


### PR DESCRIPTION
When adding a landed cost and selecting Manufacturing Order, the name of the receipt of the subcontracted products is now shown as well as the MO name for subcontracting orders.

Task: 2667152

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
