### PR TITLE
[FIX] mrp_subcontracting_account: Account for multiple dest moves

### DIFF
--- a/addons/mrp_subcontracting_account/models/mrp_production.py
+++ b/addons/mrp_subcontracting_account/models/mrp_production.py
@@ -10,6 +10,7 @@ class MrpProduction(models.Model):
     def _cal_price(self, consumed_moves):
         finished_move = self.move_finished_ids.filtered(lambda x: x.product_id == self.product_id and x.state not in ('done', 'cancel') and x.quantity_done > 0)
         # Take the price unit of the reception move
-        if finished_move.move_dest_ids.is_subcontract:
-            self.extra_cost = finished_move.move_dest_ids._get_price_unit()
+        dest_move = finished_move.move_dest_ids.filtered(lambda m: m.state not in ('done', 'cancel'))
+        if dest_move.is_subcontract:
+            self.extra_cost = dest_move._get_price_unit()
         return super()._cal_price(consumed_moves=consumed_moves)


### PR DESCRIPTION
Description of the issue/feature this PR addresses:

- When creating a subcontracted backorder from a Reception picking, it errors with singleton due to having multiple destination moves
- https://github.com/odoo/odoo/issues/87993

Current behavior before PR:

- Unable to close any manufacturing order that is related to multiple pickings with multiple destination moves
- This is a regression due to https://github.com/odoo/odoo/commit/6c086d820b05602c149f4387d3d19c8e4eed0c8c changes

Desired behavior after PR is merged:

- ~~For it to work~~
- Return to being able to have multiple pickings related to a series of backorders

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
