### PR TITLE
[FIX] mrp: procure_method lost on mrp backorders

### DIFF
--- a/addons/mrp/models/stock_move.py
+++ b/addons/mrp/models/stock_move.py
@@ -420,7 +420,8 @@ class StockMove(models.Model):
             'reservation_date': self.reservation_date,
             'manual_consumption': self.bom_line_id.manual_consumption or self.product_id.tracking != 'none',
             'move_orig_ids': [Command.link(m.id) for m in self.mapped('move_orig_ids')],
-            'move_dest_ids': [Command.link(m.id) for m in self.mapped('move_dest_ids')]
+            'move_dest_ids': [Command.link(m.id) for m in self.mapped('move_dest_ids')],
+            'procure_method': self.procure_method,
         }
 
     def _get_source_document(self):


### PR DESCRIPTION
When creating a backorder for a manufacturing order, procure method for
its moves are lost in the process, as the the field is set to copy
False. But the split of a manufacturing order is not a usual copy case.

In this specific case, we need to keep the procure_method of the copied
moves, as it keeps the two/three-steps working for the splitted
manufacturing order.

Task-2797359

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
