### PR TITLE
[FIX] website_forum: avoid error when the sort param is encoded

### DIFF
--- a/addons/website_forum/controllers/main.py
+++ b/addons/website_forum/controllers/main.py
@@ -14,6 +14,7 @@ from odoo import http, tools, _
 from odoo.addons.http_routing.models.ir_http import slug
 from odoo.addons.website.models.ir_http import sitemap_qs2dom
 from odoo.addons.website_profile.controllers.main import WebsiteProfile
+from odoo.exceptions import UserError
 from odoo.http import request
 
 _logger = logging.getLogger(__name__)
@@ -110,8 +111,9 @@ class WebsiteForum(WebsiteProfile):
             # check that sorting is valid
             # retro-compatibily for V8 and google links
             try:
+                sorting = werkzeug.urls.url_unquote_plus(sorting)
                 Post._generate_order_by(sorting, None)
-            except ValueError:
+            except (UserError, ValueError):
                 sorting = False
 
         if not sorting:


### PR DESCRIPTION
Description of the issue/feature this PR addresses:

Current behavior before PR:

Currently, when accessing a URL with an invalid sorting value, the system will raise an error with a specific message, which feels unfriendly to the user as well as saves unnecessary logs in the log file. This becomes serious if someone spams with this url

Example:
Valid url: https://www.odoo.com/forum/help-1?sorting=relevancy+desc
Invalid url: https://www.odoo.com/forum/help-1?sorting=relevancy%2Bdesc


Desired behavior after PR is merged:
Do not sort a page if the sorting value is not valid




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
