### PR TITLE
[FIX] website: allow user to access HTML/CSS editor

### DIFF
--- a/addons/website/models/assets.py
+++ b/addons/website/models/assets.py
@@ -46,6 +46,8 @@ class Assets(models.AbstractModel):
         See web_editor.Assets._get_custom_attachment
         Extend to only return the attachments related to the current website.
         """
+        if self.env.user.has_group('website.group_website_designer'):
+            self = self.sudo()
         website = self.env['website'].get_current_website()
         res = super(Assets, self)._get_custom_attachment(custom_url, op=op)
         return res.with_context(website_id=website.id).filtered(lambda x: not x.website_id or x.website_id == website)

--- a/addons/website/static/tests/tours/html_editor.js
+++ b/addons/website/static/tests/tours/html_editor.js
@@ -3,6 +3,9 @@ odoo.define('website.test.html_editor', function (require) {
 
 var tour = require('web_tour.tour');
 
+const adminCssModif = '#wrap {display: none;}';
+const demoCssModif = '// demo_edition';
+
 tour.register('html_editor_multiple_templates', {
     test: true,
     url: '/aboutus',
@@ -108,12 +111,12 @@ tour.register('test_html_editor_scss', {
             content: "add some scss content in the file",
             trigger: 'div.ace_line .ace_comment:contains("footer {")',
             run: function () {
-                ace.edit('ace-view-editor').getSession().insert({row: 2, column: 0}, '#wrap {display: none;}\n');
+                ace.edit('ace-view-editor').getSession().insert({row: 2, column: 0}, `${adminCssModif}\n`);
             },
         },
         {
             content: "save the html editor",
-            extra_trigger: 'div.ace_line:contains("#wrap {display: none;}")',
+            extra_trigger: `div.ace_line:contains("${adminCssModif}")`,
             trigger: ".o_ace_view_editor button[data-action=save]",
         },
          {
@@ -132,6 +135,93 @@ tour.register('test_html_editor_scss', {
         {
             content: "check that the scss file was reset correctly, wrap content should now be visible again",
             trigger: '#wrap:visible',
+            run: function () {}, // it's a check
+        },
+        // 3. Customize again that file (will be used in second part of the test
+        //    to ensure restricted user can still use the HTML Editor)
+        {
+            content: "add some scss content in the file",
+            trigger: 'div.ace_line .ace_comment:contains("footer {")',
+            run: function () {
+                ace.edit('ace-view-editor').getSession().insert({row: 2, column: 0}, `${adminCssModif}\n`);
+            },
+        },
+        {
+            content: "save the html editor",
+            extra_trigger: `div.ace_line:contains("${adminCssModif}")`,
+            trigger: '.o_ace_view_editor button[data-action=save]',
+        },
+        {
+            content: "check that the scss modification got applied",
+            trigger: 'body:has(#wrap:hidden)',
+            run: function () {
+                window.location.href = '/web/session/logout?redirect=/web/login';
+            },
+        },
+
+        // This part of the test ensures that a restricted user can still use
+        // the HTML Editor if someone else made a customization previously.
+
+        {
+            content: "Submit login",
+            trigger: '.oe_login_form',
+            run: function () {
+                $('.oe_login_form input[name="login"]').val("demo");
+                $('.oe_login_form input[name="password"]').val("demo");
+                $('.oe_login_form input[name="redirect"]').val("/");
+                $('.oe_login_form').submit();
+            },
+        },
+        // 4. Open Html Editor and select a scss file
+        {
+            content: "open customize menu",
+            trigger: '#customize-menu > a',
+        },
+        {
+            content: "open html editor",
+            trigger: '#html_editor',
+        },
+        {
+            content: "open type switcher",
+            trigger: '.o_ace_type_switcher button',
+        },
+        {
+            content: "select scss files",
+            trigger: '.o_ace_type_switcher_choice[data-type="scss"]',
+        },
+        {
+            content: "select 'user_custom_rules'",
+            trigger: 'body:has(#ace-scss-list option:contains("user_custom_rules"))',
+            run: function () {
+                var scssId = $('#ace-scss-list option:contains("user_custom_rules")').val();
+                $('#ace-scss-list').val(scssId).trigger('change');
+            },
+        },
+        // 5. Edit that file and ensure it was saved then reset it
+        {
+            content: "add some scss content in the file",
+            trigger: `div.ace_line:contains("${adminCssModif}")`, // ensure the admin modification is here
+            run: function () {
+                ace.edit('ace-view-editor').getSession().insert({row: 2, column: 0}, `${demoCssModif}\n`);
+            },
+        },
+        {
+            content: "save the html editor",
+            extra_trigger: `div.ace_line:contains("${demoCssModif}")`,
+            trigger: ".o_ace_view_editor button[data-action=save]",
+        },
+        {
+            content: "reset view (after reload, html editor should have been reopened where it was)",
+            trigger: '#ace-view-id button[data-action="reset"]',
+        },
+        {
+            content: "confirm reset warning",
+            trigger: '.modal-footer .btn-primary',
+        },
+        {
+            content: "check that the scss file was reset correctly",
+            extra_trigger: `body:not(:has(div.ace_line:contains("${adminCssModif}")))`,
+            trigger: `body:not(:has(div.ace_line:contains("${demoCssModif}")))`,
             run: function () {}, // it's a check
         },
     ]

--- a/addons/website/tests/test_ui.py
+++ b/addons/website/tests/test_ui.py
@@ -81,7 +81,14 @@ class TestUiHtmlEditor(odoo.tests.HttpCase):
         self.assertEqual(len(specific_aboutus.inherit_children_ids.filtered(lambda v: 'oe_structure' in v.name)), 1, "oe_structure view should have been created on the specific tree")
 
     def test_html_editor_scss(self):
+        self.env.ref('base.user_demo').write({
+            'groups_id': [(6, 0, [
+                self.env.ref('base.group_user').id,
+                self.env.ref('website.group_website_designer').id
+            ])]
+        })
         self.start_tour("/", 'test_html_editor_scss', login='admin')
+
 
 @odoo.tests.tagged('-at_install', 'post_install')
 class TestUiTranslate(odoo.tests.HttpCase):


### PR DESCRIPTION
Current behavior:
When an admin user modified a file with the HTML/CSS/JS editor in a
website, users that had "editor and designer" right couldn't access
the HTML/CSS/JS editor anymore.

Steps to reproduce:
- Have user 1 (U1) admin
- Have user 2 (U2) with website access set to "Editor and Designer"
- U1 modify the css user_custom_rules.scss with the HTML/CSS Editor
- U2 can't open the editor of that website because he is not in the
  setting groups or the one that created it

opw-2733109
--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
