### PR TITLE
[FIX] point_of_sale: ui stuck when product has grouped tax

### DIFF
--- a/addons/point_of_sale/static/src/js/models.js
+++ b/addons/point_of_sale/static/src/js/models.js
@@ -1725,7 +1725,7 @@ class Orderline extends PosModel {
         // 1) Flatten the taxes.
 
         var _collect_taxes = function(taxes, all_taxes){
-            taxes.sort(function (tax1, tax2) {
+            taxes = [...taxes].sort(function (tax1, tax2) {
                 return tax1.sequence - tax2.sequence;
             });
             _(taxes).each(function(tax){


### PR DESCRIPTION
To reproduce:

1. Create a grouped tax with multiple taxes. Reorder the tax
   items. (Important step.)
2. Assign tax to the product.
3. Open pos loading the product.
4a. [BUG] If pos config is tax-included -> non-responsive ui.
4b. [BUG] If pos config is tax-excluded:
          Add the product. -> non-responsive ui.

Fix:

With the new reactivity in owl, mutating reactive objects will
trigger rerender. However, computing tax amount of orderline
or product with grouped taxes result to mutation of a reactive
object, triggering an infinite render (render -> compute with
mutation -> will trigger another render -> ...).

The call to sort is mutating the reactive array referred by
`children_tax_ids`. To prevent this infinite render, the solution
is to use a copy of the array when sorting the taxes.

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
