### PR TITLE
[FIX] mrp_subcontracting_account: validate a picking

### DIFF
--- a/addons/mrp_subcontracting_account/models/mrp_production.py
+++ b/addons/mrp_subcontracting_account/models/mrp_production.py
@@ -10,6 +10,7 @@ class MrpProduction(models.Model):
     def _cal_price(self, consumed_moves):
         finished_move = self.move_finished_ids.filtered(lambda x: x.product_id == self.product_id and x.state not in ('done', 'cancel') and x.quantity_done > 0)
         # Take the price unit of the reception move
-        if finished_move.move_dest_ids.is_subcontract:
-            self.extra_cost = finished_move.move_dest_ids._get_price_unit()
+        last_done_receipt = finished_move.move_dest_ids.filtered(lambda m: m.state == 'done')[-1:]
+        if last_done_receipt.is_subcontract:
+            self.extra_cost = last_done_receipt._get_price_unit()
         return super()._cal_price(consumed_moves=consumed_moves)

--- a/addons/mrp_subcontracting_account/tests/test_subcontracting_account.py
+++ b/addons/mrp_subcontracting_account/tests/test_subcontracting_account.py
@@ -47,9 +47,11 @@ class TestAccountSubcontractingFlows(TestMrpSubcontractingCommon):
             move.product_id = self.finished
             move.product_uom_qty = 1
         picking_receipt = picking_form.save()
-        picking_receipt.move_lines.price_unit = 30.0
+        picking_receipt.move_lines.price_unit = 15.0
 
         picking_receipt.action_confirm()
+        # Suppose the additional cost changes:
+        picking_receipt.move_lines.price_unit = 30.0
         picking_receipt.move_lines.quantity_done = 1.0
         picking_receipt._action_done()
 
@@ -150,3 +152,55 @@ class TestAccountSubcontractingFlows(TestMrpSubcontractingCommon):
         self.assertEqual(len(f_layers), 4)
         for layer in f_layers:
             self.assertEqual(layer.value, 100 + 50)
+
+    def test_tracked_compo_and_backorder(self):
+        """
+        Suppose a subcontracted product P with two tracked components, P is FIFO
+        Create a receipt for 10 x P, receive 5, then 3 and then 2
+        """
+        self.env.ref('product.product_category_all').property_cost_method = 'fifo'
+        self.comp1.tracking = 'lot'
+        self.comp1.standard_price = 10
+        self.comp2.tracking = 'lot'
+        self.comp2.standard_price = 20
+
+        lot01, lot02 = self.env['stock.production.lot'].create([{
+            'name': "Lot of %s" % product.name,
+            'product_id': product.id,
+            'company_id': self.env.company.id,
+        } for product in (self.comp1, self.comp2)])
+
+        receipt_form = Form(self.env['stock.picking'])
+        receipt_form.picking_type_id = self.env.ref('stock.picking_type_in')
+        receipt_form.partner_id = self.subcontractor_partner1
+        with receipt_form.move_ids_without_package.new() as move:
+            move.product_id = self.finished
+            move.product_uom_qty = 10
+        receipt = receipt_form.save()
+        # add an extra cost
+        receipt.move_lines.price_unit = 50
+        receipt.action_confirm()
+
+        for qty_producing in (5, 3, 2):
+            action = receipt.action_record_components()
+            mo = self.env['mrp.production'].browse(action['res_id'])
+            mo_form = Form(mo.with_context(**action['context']), view=action['view_id'])
+            mo_form.qty_producing = qty_producing
+            with mo_form.move_line_raw_ids.edit(0) as ml:
+                ml.lot_id = lot01
+            with mo_form.move_line_raw_ids.edit(1) as ml:
+                ml.lot_id = lot02
+            mo = mo_form.save()
+            mo.subcontracting_record_component()
+
+            action = receipt.button_validate()
+            if isinstance(action, dict):
+                wizard = Form(self.env[action['res_model']].with_context(action['context'])).save()
+                wizard.process()
+                receipt = receipt.backorder_ids
+
+        self.assertRecordValues(self.finished.stock_valuation_layer_ids, [
+            {'quantity': 5, 'value': 5 * (10 + 20 + 50)},
+            {'quantity': 3, 'value': 3 * (10 + 20 + 50)},
+            {'quantity': 2, 'value': 2 * (10 + 20 + 50)},
+        ])


### PR DESCRIPTION
When validating a picking that comes from a subcontractor, if there is a
backorder, it will lead to an odoo error

To reproduce the issue:
(Need purchase)
1. Create a product category PC:
    - Costing Method: FIFO
2. Create two products P_compo, P_finished
    - Both storable
    - P_compo:
        - Tracked by lot
    - P_finished:
        - With a vendor V
3. Create a BoM:
    - Product: P_finished
    - Type: Subcontracting
    - Subcontractors: V
    - Components:
        - 1 x P_compo
4. Create and confirm a PO:
    - Vendor: V
    - Products:
        - 10 x P_finished
5. On the receipt, record the production of 7 x P_finished
6. Validate the receipt (with backorder)

Error: An Odoo Error is displayed "ValueError: Expected singleton"

When recording the production, because the producing quantity is not the
expected one, a second manufacturing order MO02 is created. Therefore,
the stock move SM01 that brings the P_finished in the stock has now two
origin moves: the finished moves of MO01 and MO02.

Then, when validating the picking, SM01 is split into two SM:
https://github.com/odoo/odoo/blob/30cc4b5050f538ac4b9152dd78686682d42e7036/addons/stock/models/stock_move.py#L1542-L1547
And this new stock move SM02 has the same origin moves (i.e., the
finished moves of MO01 and MO02). Later on, still while validating the
receipt, it leads to:
https://github.com/odoo/odoo/blob/6c086d820b05602c149f4387d3d19c8e4eed0c8c/addons/mrp_subcontracting_account/models/mrp_production.py#L10-L14
where `self` is MO01. So, here is the issue: as explained above, the
finished moves of M01 contains two moves: SM01 and SM02. Therefore,
reading `is_subcontract` on the recordset or calling `_get_price_unit`
(which is an `ensure_one` method) on this recordset will raise the
error.

OPW-2814448
OPW-2817512