### PR TITLE
[FIX] point_of_sale,pos_hr: allow all pos users to cash in/out

### DIFF
--- a/addons/point_of_sale/models/pos_session.py
+++ b/addons/point_of_sale/models/pos_session.py
@@ -1537,6 +1537,10 @@ class PosSession(models.Model):
         return True
 
     def try_cash_in_out(self, _type, amount, reason, extras):
+        user_id = self.env.context.get('user_id', False)
+        if user_id:
+            self = self.with_user(self.env['res.users'].browse(user_id))
+
         sign = 1 if _type == 'in' else -1
         self.env['cash.box.out']\
             .with_context({'active_model': 'pos.session', 'active_ids': self.ids})\

--- a/addons/point_of_sale/static/src/js/ChromeWidgets/CashMoveButton.js
+++ b/addons/point_of_sale/static/src/js/ChromeWidgets/CashMoveButton.js
@@ -23,11 +23,13 @@ odoo.define('point_of_sale.CashMoveButton', function (require) {
                     3000
                 );
             }
+            const cashier = this.env.pos.get('cashier');
             const extras = { formattedAmount, translatedType };
             await this.rpc({
                 model: 'pos.session',
                 method: 'try_cash_in_out',
                 args: [[this.env.pos.pos_session.id], type, amount, reason, extras],
+                context: { user_id: cashier.user_id ? cashier.user_id[0] : false },
             });
             if (this.env.pos.proxy.printer) {
                 const renderedReceipt = this.env.qweb.renderToString('point_of_sale.CashMoveReceipt', {

--- a/addons/point_of_sale/static/src/js/models.js
+++ b/addons/point_of_sale/static/src/js/models.js
@@ -393,12 +393,16 @@ exports.PosModel = Backbone.Model.extend({
         loaded: function(self,users){
             users.forEach(function(user) {
                 user.role = 'cashier';
-                user.groups_id.some(function(group_id) {
-                    if (group_id === self.config.group_pos_manager_id[0]) {
-                        user.role = 'manager';
-                        return true;
-                    }
-                });
+
+                const isPosUser = user.groups_id.some(groupId => groupId === self.config.group_pos_user_id[0])
+                const isPosManager = user.groups_id.some(groupId => groupId === self.config.group_pos_manager_id[0])
+
+                if (isPosManager) {
+                    user.role = 'manager';
+                } else if (isPosUser) {
+                    user.role = 'user';
+                }
+
                 if (user.id === self.session.uid) {
                     self.user = user;
                     self.employee.name = user.name;

--- a/addons/pos_hr/static/src/js/Chrome.js
+++ b/addons/pos_hr/static/src/js/Chrome.js
@@ -15,7 +15,7 @@ odoo.define('pos_hr.chrome', function (require) {
                 return !this.env.pos.config.module_pos_hr || this.env.pos.get('cashier').role == 'manager' || this.env.pos.get_cashier().user_id[0] === this.env.pos.user.id;
             }
             showCashMoveButton() {
-                return super.showCashMoveButton() && this.env.pos.get('cashier').role == 'manager';
+                return super.showCashMoveButton() && ['user', 'manager'].includes(this.env.pos.get('cashier').role);
             }
             shouldShowCashControl() {
                 return super.shouldShowCashControl() && this.env.pos.hasLoggedIn;


### PR DESCRIPTION
Before this commit:

1. [OKAY] Use pos without pos_hr -> Any user can cash in/out.
2. [BUG] Use pos with pos_hr -> Only user with manager access can.

After this commit:

We now allow any user (and employee linked to a user) with minimum
pos access to cash in/out. Message is posted accordingly.


--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
