### PR TITLE
[IMP] mail: fix performance of channel access rule

### DIFF
--- a/addons/im_livechat/tests/test_get_mail_channel.py
+++ b/addons/im_livechat/tests/test_get_mail_channel.py
@@ -129,10 +129,10 @@ class TestGetMailChannel(TransactionCase):
             'email': 'michel@example.com',
             'livechat_username': 'Michel at your service',
         })
-        channel_info = self.livechat_channel.with_user(public_user)._open_livechat_mail_channel(anonymous_name='whatever')
+        channel_info = self.livechat_channel.with_user(public_user).sudo()._open_livechat_mail_channel(anonymous_name='whatever')
         channel = self.env['mail.channel'].browse(channel_info['id'])
         channel.with_user(operator).message_post(body='Hello', message_type='comment', subtype_xmlid='mail.mt_comment')
-        message_formats = channel.with_user(public_user)._channel_fetch_message()
+        message_formats = channel.with_user(public_user).sudo()._channel_fetch_message()
         self.assertEqual(len(message_formats), 1)
         self.assertEqual(message_formats[0]['author_id'][0], operator.partner_id.id)
         self.assertEqual(message_formats[0]['author_id'][1], operator.livechat_username)

--- a/addons/mail/models/mail_guest.py
+++ b/addons/mail/models/mail_guest.py
@@ -29,6 +29,13 @@ class MailGuest(models.Model):
     timezone = fields.Selection(string="Timezone", selection=_tz_get)
     channel_ids = fields.Many2many(string="Channels", comodel_name='mail.channel', relation='mail_channel_partner', column1='guest_id', column2='channel_id', copy=False)
 
+    def _get_guest_from_context(self):
+        """Returns the current guest record from the context, if applicable."""
+        guest = self.env.context.get('guest')
+        if isinstance(guest, self.pool['mail.guest']):
+            return guest
+        return self.env['mail.guest']
+
     def _get_guest_from_request(self, request):
         parts = request.httprequest.cookies.get(self._cookie_name, '').split(self._cookie_separator)
         if len(parts) != 2:

--- a/addons/mail/security/mail_security.xml
+++ b/addons/mail/security/mail_security.xml
@@ -8,7 +8,7 @@
             <field name="groups" eval="[Command.link(ref('base.group_user')), Command.link(ref('base.group_portal')), Command.link(ref('base.group_public'))]"/>
             <field name="domain_force">['|', '|',
 ('public', '=', 'public'),
-'&amp;', ('public', '=', 'private'), ('channel_partner_ids', 'in', [user.partner_id.id]),
+'&amp;', ('public', '=', 'private'), ('is_member', '=', True),
 '&amp;', ('public', '=', 'groups'), ('group_public_id', 'in', [g.id for g in user.groups_id])]</field>
             <field name="perm_create" eval="False"/>
         </record>
@@ -19,7 +19,7 @@
             <field name="groups" eval="[(4, ref('base.group_user')), (4, ref('base.group_portal'))]"/>
             <field name="domain_force">['|', '|',
 ('channel_id.public', '=', 'public'),
-'&amp;', ('channel_id.public', '=', 'private'), ('channel_id.channel_partner_ids', 'in', [user.partner_id.id]),
+'&amp;', ('channel_id.public', '=', 'private'), ('channel_id.is_member', '=', True),
 '&amp;', ('channel_id.public', '=', 'groups'), ('channel_id.group_public_id', 'in', [g.id for g in user.groups_id])]</field>
             <field name="perm_read" eval="False"/>
             <field name="perm_write" eval="True"/>

--- a/addons/mail/tests/test_mail_channel.py
+++ b/addons/mail/tests/test_mail_channel.py
@@ -43,7 +43,7 @@ class TestChannelAccessRights(MailCommon):
             'public': 'private'})
 
     @mute_logger('odoo.addons.base.models.ir_rule', 'odoo.addons.base.models.ir_model', 'odoo.models')
-    @users('user_public')
+    @users('user_portal')
     def test_access_public(self):
         # Read public group -> ok
         self.env['mail.channel'].browse(self.group_public.id).read()
@@ -56,7 +56,7 @@ class TestChannelAccessRights(MailCommon):
             self.env['mail.channel'].browse(self.group_private.id).read()
 
         # Read a private group when being a member: ok
-        self.group_private.write({'channel_partner_ids': [(4, self.user_public.partner_id.id)]})
+        self.group_private.write({'channel_partner_ids': [(4, self.user_portal.partner_id.id)]})
         self.env['mail.channel'].browse(self.group_private.id).read()
 
         # Create group: ko, no access rights


### PR DESCRIPTION
Current access rule requires fetching all members of each channel, which does not scale.

Use is_member field instead, and make sure itself does not fetch all members.

task-2818759

upgrade: https://github.com/odoo/upgrade/pull/3422