### PR TITLE
[FIX] web: fix x2m dialog not opening

### DIFF
--- a/addons/web/static/src/legacy/js/views/basic/basic_renderer.js
+++ b/addons/web/static/src/legacy/js/views/basic/basic_renderer.js
@@ -42,6 +42,7 @@ var BasicRenderer = AbstractRenderer.extend(WidgetAdapterMixin, {
         // This attribute lets us know if there is a handle widget on a field,
         // and on which field it is set.
         this.handleField = null;
+        this.viewEditable = params.viewEditable;
     },
     /**
      * @override
@@ -736,7 +737,7 @@ var BasicRenderer = AbstractRenderer.extend(WidgetAdapterMixin, {
             // Distinct readonly from renderer and readonly from modifier,
             // renderer can be readonly while modifier not.
             // This is needed as modifiers are set after first render
-            hasReadonlyModifier: modifiers.readonly,
+            hasReadonlyModifier: modifiers.readonly || this.viewEditable === false,
             mode: modifiers.readonly ? 'readonly' : mode,
             viewType: this.viewType,
         };

--- a/addons/web/static/src/legacy/js/views/basic/basic_view.js
+++ b/addons/web/static/src/legacy/js/views/basic/basic_view.js
@@ -46,6 +46,7 @@ var BasicView = AbstractView.extend({
         this.fieldsInfo[this.viewType] = this.fieldsView.fieldsInfo[this.viewType];
 
         this.rendererParams.viewType = this.viewType;
+        this.rendererParams.viewEditable = this.controllerParams.activeActions.edit;
 
         this.controllerParams.confirmOnDelete = true;
         this.controllerParams.archiveEnabled = 'active' in this.fields || 'x_active' in this.fields;

--- a/addons/web/static/tests/legacy/views/form_tests.js
+++ b/addons/web/static/tests/legacy/views/form_tests.js
@@ -10926,6 +10926,44 @@ QUnit.module('Views', {
         form.destroy();
     });
 
+    QUnit.test('Quick Edition: Readonly one2many list (non editable form)', async function (assert) {
+        assert.expect(7);
+
+        this.data.partner.records[0].p.push(2);
+
+        const form = await createView({
+            View: FormView,
+            model: 'partner',
+            data: this.data,
+            arch: `
+                <form edit="0">
+                    <field name="p">
+                        <tree>
+                            <field name="foo"/>
+                        </tree>
+                        <form>
+                            <field name="foo"/>
+                        </form>
+                    </field>
+                </form>`,
+            res_id: 1,
+        });
+
+        assert.containsOnce(form, '.o_form_view.o_form_readonly');
+        assert.containsNone(document.body, '.modal');
+
+        assert.containsNone(form, '.o_field_x2many_list_row_add a', 'no add button should be displayed');
+        assert.containsNone(form, '.o_list_record_remove', 'no remove button should be displayed');
+
+        await testUtils.dom.click(form.$('.o_field_cell:first'));
+
+        assert.containsOnce(form, '.o_form_view.o_form_readonly', 'should not switch into edit mode');
+        assert.containsOnce(document.body, '.modal');
+        assert.containsOnce(document.body, '.modal span.o_field_widget[name="foo"]');
+
+        form.destroy();
+    });
+
     QUnit.test('Quick Edition: Editable one2many list (click cell: editable)', async function (assert) {
         assert.expect(3);
 


### PR DESCRIPTION
Before this commit, clicking on a x2m field when form view is not
editable (edit=0) did not open the dialog to show the related record.

After this commit, the dialog opens when clicking in a x2m field
of a non editable form view.