### PR TITLE
[FIX] stock: Wrong next_inventory_date

### DIFF
--- a/addons/stock/models/stock_location.py
+++ b/addons/stock/models/stock_location.py
@@ -133,7 +133,7 @@ class Location(models.Model):
                         if days_until_next_inventory <= 0:
                             location.next_inventory_date = fields.Date.today() + timedelta(days=1)
                         else:
-                            location.next_inventory_date = location.last_inventory_date + timedelta(days=days_until_next_inventory)
+                            location.next_inventory_date = location.last_inventory_date + timedelta(days=location.cyclic_inventory_frequency)
                     else:
                         location.next_inventory_date = fields.Date.today() + timedelta(days=location.cyclic_inventory_frequency)
                 except OverflowError:


### PR DESCRIPTION
Issue:
Imagine today is the April 7th 2022 and we set the inventory frequency to 90 days. If our last inventory date was on January 12th 2022, the next inventory date should be set to April 12th 2022. However, it is being set to January 27th 2022 which is wrong.
The next inventory date should be last inventory date + cyclic inventory frequency.

OPW-2795459

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
