### PR TITLE
[FIX] l10n_de: “Invoice” not translated in template preview

### DIFF
--- a/addons/l10n_de/i18n/l10n_de.pot
+++ b/addons/l10n_de/i18n/l10n_de.pot
@@ -169,6 +169,7 @@ msgstr ""
 
 #. module: l10n_de
 #: code:addons/l10n_de/models/account_move.py:0
+#: code:addons/l10n_de/models/base_document_layout.py:0
 #, python-format
 msgid "Invoice"
 msgstr ""

--- a/addons/l10n_de/models/base_document_layout.py
+++ b/addons/l10n_de/models/base_document_layout.py
@@ -24,4 +24,4 @@ class BaseDocumentLayout(models.TransientModel):
         ]
 
     def _compute_l10n_de_document_title(self):
-        self.l10n_de_document_title = 'Invoice'
+        self.l10n_de_document_title = _('Invoice')


### PR DESCRIPTION
Reproduction:
1. Setting up a database with location in Germany and choose German as
the system language
2. Go to Settings->General Settings->Configure document layout, choose
DIN5008
3. The word “Invoice” is not translated

Fix: translate the title in python file

opw-2795031


--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
