### PR TITLE
[FIX] l10n_fr_fec: use invoice/bill date when generating FEC

### DIFF
--- a/addons/l10n_fr_fec/wizard/account_fr_fec.py
+++ b/addons/l10n_fr_fec/wizard/account_fr_fec.py
@@ -315,7 +315,7 @@ class AccountFrFec(models.TransientModel):
             ELSE REGEXP_REPLACE(replace(am.ref, '|', '/'), '[\\t\\r\\n]', ' ', 'g')
             END
             AS PieceRef,
-            TO_CHAR(am.date, 'YYYYMMDD') AS PieceDate,
+            TO_CHAR(COALESCE(am.invoice_date, am.date), 'YYYYMMDD') AS PieceDate,
             CASE WHEN aml.name IS NULL OR aml.name = '' THEN '/'
                 WHEN aml.name SIMILAR TO '[\\t|\\s|\\n]*' THEN '/'
                 ELSE REGEXP_REPLACE(replace(aml.name, '|', '/'), '[\\t\\n\\r]', ' ', 'g') END AS EcritureLib,


### PR DESCRIPTION
Install FR accounting and have a FR company setup with VAT
Create a bill with bill date different from accounting date
Export FEC under Accounting>Reporting>FEC

For the created bill the accounting date will be used, while it should
be taken first the bill date

opw-2680288

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
