### PR TITLE
[FIX] web_editor, mass_mailing: provide proper support for (mixed) language directions

### DIFF
--- a/addons/mass_mailing/static/src/js/mass_mailing_widget.js
+++ b/addons/mass_mailing/static/src/js/mass_mailing_widget.js
@@ -5,6 +5,7 @@ var config = require('web.config');
 var core = require('web.core');
 var FieldHtml = require('web_editor.field.html');
 var fieldRegistry = require('web.field_registry');
+const { localization } = require('@web/core/l10n/localization');
 var convertInline = require('web_editor.convertInline');
 
 var _t = core._t;
@@ -274,6 +275,7 @@ var MassMailingFieldHtml = FieldHtml.extend({
         var $newLayout = $('<div/>', {
             class: 'o_layout oe_unremovable oe_unmovable bg-200 ' + themeParams.className,
             'data-name': 'Mailing',
+            dir: localization.direction,
         }).append($new_wrapper);
 
         const $contents = themeParams.template;

--- a/addons/web_editor/static/lib/odoo-editor/demo/index.html
+++ b/addons/web_editor/static/lib/odoo-editor/demo/index.html
@@ -295,6 +295,10 @@
                 </div>
             </div>
 
+            <div class="button-group">
+                <div id="switchdirection" data-call="switchDirection" title="Switch direction for this block" class="btn">↹</div>
+            </div>
+
             <div class="button-group dropdown">
                 <button type="button" class="btn btn-secondary btn-sm dropdown-toggle"
                     data-toggle="dropdown" title="" tabindex="-1"

--- a/addons/web_editor/static/lib/odoo-editor/src/OdooEditor.js
+++ b/addons/web_editor/static/lib/odoo-editor/src/OdooEditor.js
@@ -196,6 +196,7 @@ export class OdooEditor extends EventTarget {
                 },
                 isHintBlacklisted: () => false,
                 filterMutationRecords: (records) => records,
+                direction: 'ltr',
                 _t: string => string,
             },
             options,
@@ -258,6 +259,7 @@ export class OdooEditor extends EventTarget {
         this._idToNodeMap.set(1, editable);
         this.editable = this.options.toSanitize ? sanitize(editable) : editable;
         this.editable.classList.add("odoo-editor-editable");
+        this.editable.setAttribute('dir', this.options.direction);
 
         // Set contenteditable before clone as FF updates the content at this point.
         this._activateContenteditable();
@@ -1923,7 +1925,7 @@ export class OdooEditor extends EventTarget {
             const selectionStartStyle = getComputedStyle(closestStartContainer);
 
             // queryCommandState does not take stylesheets into account
-            for (const format of ['bold', 'italic', 'underline', 'strikeThrough']) {
+            for (const format of ['bold', 'italic', 'underline', 'strikeThrough', 'switchDirection']) {
                 const formatButton = this.toolbar.querySelector(`#${format.toLowerCase()}`);
                 if (formatButton) {
                     formatButton.classList.toggle('active', isSelectionFormat(this.editable, format));

--- a/addons/web_editor/static/lib/odoo-editor/src/commands/commands.js
+++ b/addons/web_editor/static/lib/odoo-editor/src/commands/commands.js
@@ -319,7 +319,10 @@ const styles = {
         is: editable => isSelectionFormat(editable, 'strikeThrough'),
         name: 'textDecorationLine',
         value: 'line-through',
-    }
+    },
+    switchDirection: {
+        is: editable => isSelectionFormat(editable, 'switchDirection'),
+    },
 }
 export function toggleFormat(editor, format) {
     const selection = editor.document.getSelection();
@@ -370,6 +373,15 @@ export function toggleFormat(editor, format) {
             setSelection(zws, 1);
         } else {
             setSelection(anchorNode, anchorOffset, focusNode, focusOffset);
+        }
+    } else if (format === 'switchDirection') {
+        const defaultDirection = editor.options.direction;
+        for (const block of new Set(selectedTextNodes.map(textNode => closestBlock(textNode)))) {
+            if (isAlreadyFormatted) {
+                block.removeAttribute('dir');
+            } else {
+                block.setAttribute('dir', defaultDirection === 'ltr' ? 'rtl' : 'ltr');
+            }
         }
     } else {
         applyInlineStyle(editor, el => {
@@ -494,6 +506,7 @@ export const editorCommands = {
     italic: editor => toggleFormat(editor, 'italic'),
     underline: editor => toggleFormat(editor, 'underline'),
     strikeThrough: editor => toggleFormat(editor, 'strikeThrough'),
+    switchDirection: editor => toggleFormat(editor, 'switchDirection'),
     removeFormat: editor => {
         editor.document.execCommand('removeFormat');
         for (const node of getTraversedNodes(editor.editable)) {

--- a/addons/web_editor/static/lib/odoo-editor/src/style.css
+++ b/addons/web_editor/static/lib/odoo-editor/src/style.css
@@ -180,6 +180,9 @@
 .oe-toolbar #style .dropdown-menu {
     text-align: left;
 }
+.oe-toolbar #switchdirection {
+    font-size: large;
+}
 @media only screen and (max-width: 767px) {
     .oe-toolbar {
         position: relative;

--- a/addons/web_editor/static/lib/odoo-editor/src/utils/utils.js
+++ b/addons/web_editor/static/lib/odoo-editor/src/utils/utils.js
@@ -908,11 +908,27 @@ export function isStrikeThrough(node) {
     }
     return false;
 }
+/**
+ * Return true if the given node appears in a different direction than that of
+ * the editable ('ltr' or 'rtl').
+ *
+ * Note: The direction of the editable is set on its "dir" attribute, to the
+ * value of the "direction" option on instantiation of the editor.
+ *
+ * @param {Node} node
+ * @param {Element} editable
+ * @returns {boolean}
+ */
+export function isDirectionSwitched(node, editable) {
+    const defaultDirection = editable.getAttribute('dir');
+    return getComputedStyle(closestElement(node)).direction !== defaultDirection;
+}
 export const isFormat = {
     bold: isBold,
     italic: isItalic,
     underline: isUnderline,
     strikeThrough: isStrikeThrough,
+    switchDirection: isDirectionSwitched,
 };
 /**
  * Return true if the current selection on the editable appears as the given
@@ -920,16 +936,16 @@ export const isFormat = {
  * node in it appears as that format.
  *
  * @param {Element} editable
- * @param {String} format 'bold'|'italic'|'underline'|'strikeThrought'
+ * @param {String} format 'bold'|'italic'|'underline'|'strikeThrough'|'switchDirection'
  * @returns {boolean}
  */
 export function isSelectionFormat(editable, format) {
     const selectedText = getSelectedNodes(editable)
         .filter(n => n.nodeType === Node.TEXT_NODE && n.nodeValue.trim().length);
     if (selectedText.length) {
-        return selectedText.every(n => isFormat[format](n.parentElement));
+        return selectedText.every(n => isFormat[format](n.parentElement, editable));
     } else {
-        return isFormat[format](closestElement(editable.ownerDocument.getSelection().anchorNode));
+        return isFormat[format](closestElement(editable.ownerDocument.getSelection().anchorNode), editable);
     }
 }
 

--- a/addons/web_editor/static/src/js/backend/convert_inline.js
+++ b/addons/web_editor/static/src/js/backend/convert_inline.js
@@ -340,6 +340,10 @@ function classToStyle($editable, cssRules) {
         if ('font-family' in css) {
             delete css['font-family'];
         }
+        // The "dir" attribute always has priority over the direction property.
+        if ('direction' in css && node.getAttribute('dir')) {
+            delete css['direction'];
+        }
 
         // Do not apply css that would override inline styles (which are prioritary).
         let style = node.getAttribute('style') || '';
@@ -431,6 +435,13 @@ function toInline($editable, cssRules, $iframe) {
             image.style.setProperty(attributeName, image.getAttribute(attributeName));
         };
     };
+
+    // Ensure the mailing has the direction of the editable (this change will be
+    // kept in both fields).
+    const oLayout = editable.querySelector('.o_layout');
+    if (oLayout) {
+        oLayout.setAttribute('dir', editable.getAttribute('dir'));
+    }
 
     attachmentThumbnailToLinkImg($editable);
     fontToImg($editable);
@@ -858,11 +869,12 @@ function _createTable(attributes = []) {
         }
     }
     if (table.classList.contains('o_layout')) {
-        // The top mailing element inherits the body's font size and line-height
-        // and should keep them.
+        // The top mailing element inherits the body's font size, line-height
+        // and text-align and should keep them.
         const layoutStyles = {...TABLE_STYLES};
         delete layoutStyles['font-size'];
         delete layoutStyles['line-height'];
+        delete layoutStyles['text-align'];
         Object.entries(layoutStyles).forEach(([att, value]) => table.style[att] = value)
     } else {
         for (const styleName in TABLE_STYLES) {

--- a/addons/web_editor/static/src/js/backend/field_html.js
+++ b/addons/web_editor/static/src/js/backend/field_html.js
@@ -5,6 +5,7 @@ var ajax = require('web.ajax');
 var basic_fields = require('web.basic_fields');
 var core = require('web.core');
 var wysiwygLoader = require('web_editor.loader');
+const { localization } = require('@web/core/l10n/localization');
 var field_registry = require('web.field_registry');
 const {QWebPlugin} = require('@web_editor/js/backend/QWebPlugin');
 // must wait for web/ to add the default html widget, otherwise it would override the web_editor one
@@ -358,7 +359,7 @@ var FieldHtml = basic_fields.DebouncedField.extend(TranslatableFieldMixin, {
                                     return '<style type="text/css">' + cssContent + '</style>';
                                 }).join('\n') + '\n' +
                             '</head>\n' +
-                            '<body class="o_in_iframe o_readonly" style="overflow: hidden;">\n' +
+                            `<body class="o_in_iframe o_readonly" style="overflow: hidden;" dir="${localization.direction}">\n` +
                                 '<div id="iframe_target">' + value + '</div>\n' +
                                 '<script type="text/javascript">' +
                                     'if (window.top.' + self._onUpdateIframeId + ') {' +
@@ -386,6 +387,7 @@ var FieldHtml = basic_fields.DebouncedField.extend(TranslatableFieldMixin, {
             });
         } else {
             this.$content = $('<div class="o_readonly"/>').html(value);
+            this.$content.attr('dir', localization.direction);
             this.$content.appendTo(this.$el);
             this._qwebPlugin = new QWebPlugin();
             this._qwebPlugin.sanitizeElement(this.$content[0]);

--- a/addons/web_editor/static/src/js/wysiwyg/wysiwyg.js
+++ b/addons/web_editor/static/src/js/wysiwyg/wysiwyg.js
@@ -11,6 +11,7 @@ const {ColorpickerWidget} = require('web.Colorpicker');
 const concurrency = require('web.concurrency');
 const { device } = require('web.config');
 const weContext = require('web_editor.context');
+const { localization } = require('@web/core/l10n/localization');
 const OdooEditorLib = require('@web_editor/../lib/odoo-editor/src/OdooEditor');
 const snippetsEditor = require('web_editor.snippet.editor');
 const Toolbar = require('web_editor.toolbar');
@@ -157,6 +158,7 @@ const Wysiwyg = Widget.extend({
             },
             commands: commands,
             plugins: options.editorPlugins,
+            direction: localization.direction || 'ltr',
         }, editorCollaborationOptions));
 
         document.addEventListener("mousemove", this._signalOnline, true);
@@ -1206,7 +1208,7 @@ const Wysiwyg = Widget.extend({
             }
         };
         if (!this.options.snippets) {
-            $toolbar.find('#justify, #table, #media-insert').remove();
+            $toolbar.find('#table, #media-insert').remove();
         }
         $toolbar.find('#create-link, #media-insert, #media-replace, #media-description').click(openTools);
         $toolbar.find('#image-shape div, #fa-spin').click(e => {

--- a/addons/web_editor/static/src/scss/wysiwyg.scss
+++ b/addons/web_editor/static/src/scss/wysiwyg.scss
@@ -341,6 +341,14 @@ $o-we-toolbar-color-clickable-active: $o-we-bg-darkest;
         }
     }
 
+    #switchdirection {
+        font-size: large;
+    }
+
+    #justify .fa {
+        transform: none;
+    }
+
     #colorInputButtonGroup {
         label:last-of-type .btn {
             margin: 0 1px 0 -1px;

--- a/addons/web_editor/static/src/scss/wysiwyg_snippets.scss
+++ b/addons/web_editor/static/src/scss/wysiwyg_snippets.scss
@@ -664,6 +664,9 @@ body.editor_enable.editor_has_snippets {
                         }
                     }
                 }
+                #switchdirection {
+                    font-size: large;
+                }
             }
 
             .dropdown-menu.colorpicker-menu {

--- a/addons/web_editor/static/src/xml/editor.xml
+++ b/addons/web_editor/static/src/xml/editor.xml
@@ -99,21 +99,25 @@
                 </ul>
             </div>
 
-            <div id="justify" class="btn-group dropdown">
-                <button type="button" class="btn dropdown-toggle"
-                    data-toggle="dropdown" title="Text align" tabindex="-1"
-                    data-original-title="Paragraph" aria-expanded="false">
-                    <i id="paragraphDropdownButton" class="fa fa-align-left fa-fw"></i>
-                </button>
-                <div class="dropdown-menu">
-                    <div class="btn-group">
-                        <div class="btn" id="justifyLeft" data-call='justifyLeft'><i class="fa fa-align-left fa-fw"></i></div>
-                        <div class="btn" id="justifyCenter" data-call='justifyCenter'><i class="fa fa-align-center fa-fw"></i></div>
-                        <div class="btn" id="justifyRight" data-call='justifyRight'><i class="fa fa-align-right fa-fw"></i></div>
-                        <div class="btn" id="justifyFull" data-call='justifyFull'><i class="fa fa-align-justify fa-fw"></i></div>
+            <div id="justify" class="btn-group">
+                <div class="btn-group dropdown">
+                    <button type="button" class="btn dropdown-toggle"
+                        data-toggle="dropdown" title="Text align" tabindex="-1"
+                        data-original-title="Paragraph" aria-expanded="false">
+                        <i id="paragraphDropdownButton" class="fa fa-align-left fa-fw"></i>
+                    </button>
+                    <div class="dropdown-menu">
+                        <div class="btn-group">
+                            <div class="btn" id="justifyLeft" data-call='justifyLeft'><i class="fa fa-align-left fa-fw"></i></div>
+                            <div class="btn" id="justifyCenter" data-call='justifyCenter'><i class="fa fa-align-center fa-fw"></i></div>
+                            <div class="btn" id="justifyRight" data-call='justifyRight'><i class="fa fa-align-right fa-fw"></i></div>
+                            <div class="btn" id="justifyFull" data-call='justifyFull'><i class="fa fa-align-justify fa-fw"></i></div>
+                        </div>
                     </div>
                 </div>
+                <div id="switchdirection" data-call="switchDirection" title="Switch direction for this block" class="btn">↹</div>
             </div>
+
 
             <div id="list" class="btn-group">
                 <div id="unordered" data-call="toggleList" data-arg1="UL" title="Toggle unordered list" class="oe-toggle-unordered fa fa-list-ul fa-fw btn"></div>


### PR DESCRIPTION
This introduces a "direction" option on the editor to set the text direction of the editor (passed by Odoo based on the localization), and a button to switch said direction on a given block. This allows users to mix several text directions within the same text, eg when quoting Hebrew in an English text.
The button was added in the same group as the alignment dropdown, which was at the same time restored in the floating toolbar.

The "dir" attribute should apply to a whole editable so when displaying its contents in readonly or in an email, we need to make sure that attribute is there on the whole contents as well.

Note: All of Odoo is always in LTR so it still displays in ltr in the chatter and probably a number of other places. This is out of scope for this PR but should be handled at the core in a separate PR.

task-2814004

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
