### PR TITLE
[FIX] Survey: fixes 404 survey management end page + fullscreen

### DIFF
--- a/addons/survey/controllers/survey_session_manage.py
+++ b/addons/survey/controllers/survey_session_manage.py
@@ -53,8 +53,7 @@ class UserInputSession(http.Controller):
 
         survey = self._fetch_from_token(survey_token)
 
-        if not survey or not survey.session_state:
-            # no open session
+        if not survey:
             return NotFound()
 
         if survey.session_state == 'ready':
@@ -66,9 +65,8 @@ class UserInputSession(http.Controller):
             return request.render('survey.user_input_session_open', {
                 'survey': survey
             })
-        else:
-            template_values = self._prepare_manage_session_values(survey)
-            return request.render('survey.user_input_session_manage', template_values)
+        # Note that at this stage survey.session_state can be False meaning that the survey has ended (session closed)
+        return request.render('survey.user_input_session_manage', self._prepare_manage_session_values(survey))
 
     @http.route('/survey/session/next_question/<string:survey_token>', type='json', auth='user', website=True)
     def survey_session_next_question(self, survey_token, go_back=False, **kwargs):
@@ -212,6 +210,7 @@ class UserInputSession(http.Controller):
             'survey': survey,
             'is_last_question': is_last_question,
             'is_first_question': is_first_question,
+            'is_session_closed': not survey.session_state,
         }
 
         values.update(self._prepare_question_results_values(survey, request.env['survey.user_input.line']))

--- a/addons/survey/static/src/js/survey_session_manage.js
+++ b/addons/survey/static/src/js/survey_session_manage.js
@@ -29,6 +29,11 @@ publicWidget.registry.SurveySessionManage = publicWidget.Widget.extend(SurveyPre
         var self = this;
         this.fadeInOutTime = 500;
         return this._super.apply(this, arguments).then(function () {
+            if (self.$el.data('isSessionClosed')) {
+                self._displaySessionClosedPage();
+                self.$el.removeClass('invisible');
+                return;
+            }
             // general survey props
             self.surveyId = self.$el.data('surveyId');
             self.surveyAccessToken = self.$el.data('surveyAccessToken');
@@ -60,6 +65,7 @@ publicWidget.registry.SurveySessionManage = publicWidget.Widget.extend(SurveyPre
             setupPromises.push(self._setupChart());
             setupPromises.push(self._setupLeaderboard());
 
+            self.$el.removeClass('invisible');
             return Promise.all(setupPromises);
         });
     },
@@ -350,6 +356,13 @@ publicWidget.registry.SurveySessionManage = publicWidget.Widget.extend(SurveyPre
         });
     },
 
+    _displaySessionClosedPage:function () {
+        this.$('.o_survey_question_header').addClass('invisible');
+        this.$('.o_survey_session_results, .o_survey_session_navigation_previous, .o_survey_session_navigation_next')
+            .addClass('d-none');
+        this.$('.o_survey_session_description_done').removeClass('d-none');
+    },
+
     /**
      * Refresh the screen with the next question's rendered template.
      *
@@ -389,9 +402,8 @@ publicWidget.registry.SurveySessionManage = publicWidget.Widget.extend(SurveyPre
                 self.leaderBoard.showLeaderboard(false, false);
             });
         } else {
-            self.$('.o_survey_session_close').click();
-            self.$('.o_survey_session_results').addClass('d-none');
-            self.$('.o_survey_session_description_done').prepend($("<h1>").text(_t('Thank you!'))).removeClass('d-none');
+            self.$('.o_survey_session_close').first().click();
+            self._displaySessionClosedPage();
         }
 
         // Background Management

--- a/addons/survey/views/survey_templates_user_input_session.xml
+++ b/addons/survey/views/survey_templates_user_input_session.xml
@@ -64,7 +64,7 @@
         <t t-set="is_scored_question" t-value="any(answer.answer_score for answer in question.suggested_answer_ids)" />
         <t t-set="show_bar_chart" t-value="question.question_type in ['simple_choice', 'multiple_choice']" />
         <t t-set="show_text_answers" t-value="question.question_type in ['char_box', 'date', 'datetime'] and not question.save_as_email and not question.save_as_nickname" />
-        <div class="wrap min-vh-100 align-items-center justify-content-center d-flex flex-column o_survey_session_manage"
+        <div class="wrap min-vh-100 align-items-center justify-content-center d-flex flex-column o_survey_session_manage invisible"
             t-att-style="'display: none;' if is_rpc_call else ''"
             t-att-data-is-rpc-call="is_rpc_call"
             t-att-data-survey-id="survey.id"
@@ -83,8 +83,9 @@
             t-att-data-current-screen="'question' if is_scored_question else 'userInputs'"
             t-att-data-show-bar-chart="show_bar_chart"
             t-att-data-show-text-answers="show_text_answers"
-            t-att-data-refresh-background="any(page.background_image for page in survey.page_ids)">
-            <div class="o_survey_question_header flex-wrap px-3 w-100 d-flex justify-content-between align-items-center position-absolute">
+            t-att-data-refresh-background="any(page.background_image for page in survey.page_ids)"
+            t-att-data-is-session-closed="is_session_closed">
+            <div t-if="not is_session_closed" class="o_survey_question_header flex-wrap px-3 w-100 d-flex justify-content-between align-items-center position-absolute">
                 <h3>
                     <span>Go to <a t-att-href="survey.session_link" t-esc="survey.session_link" target="_blank" /></span>
                     <i class="fa fa-copy font-weight-normal ml-3 mr-1 o_survey_session_copy" />
@@ -105,7 +106,10 @@
                 </div>
             </div>
             <div class="container px-4 pb-3 pt96 d-flex flex-column o_survey_session_manage_container">
-                <div class="o_survey_session_description_done d-none" t-field="survey.description_done" />
+                <div class="o_survey_session_description_done d-none">
+                    <h1>Thank you!</h1>
+                    <div t-field="survey.description_done"/>
+                </div>
                 <a role="button"
                     class="font-weight-bold fa fa-chevron-right o_survey_session_navigation o_survey_session_navigation_next p-3" />
                 <a role="button"


### PR DESCRIPTION
Set the survey in fullscreen (without the ribbon) and fixes the 404 page when
refreshing the survey management end page.

The end page has also been slightly modified by:
- hiding the header because it only contains relevant information when the
survey is running (link to join, number of person having answered the current
question, ...)
- hiding previous arrow which were not working (as the session is closed)
- hiding the next arrow which is not relevant and wasn't working

Task-2791044

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
