### PR TITLE
[FIX] point_of_sale: unescape nbsp characters in reports

### DIFF
--- a/addons/web/static/lib/owl/owl.js
+++ b/addons/web/static/lib/owl/owl.js
@@ -1379,7 +1379,7 @@
         }
         const p = document.createElement("p");
         p.textContent = str;
-        return p.innerHTML;
+        return p.innerHTML.replace(/&nbsp;/g, String.fromCharCode(160));
     }
     /**
      * Returns a function, that, as long as it continues to be invoked, will not


### PR DESCRIPTION
Non breakable spaces (aka NBSP) characters are rendered into &nbsp;
instead of the correct character in the reports.

Steps to reproduces:
 1. Install the PoS app
 2. Go to the PoS app and open a shop's settings
 3. Set either the IoT box printer or the Direct devices ip
 4. Go to your language settings and change the thousands separator
    to the NBSP character
 5. Go back to the PoS app and open a session
 6. Sell for more than 3 digits worth
 7. Print the receipt using the Printer button in the top-right

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
