### PR TITLE
[IMP] [im|website]_livechat: make operators avatars publicly available

### DIFF
--- a/addons/im_livechat/models/chatbot_script.py
+++ b/addons/im_livechat/models/chatbot_script.py
@@ -90,10 +90,11 @@ class ChatbotScript(models.Model):
 
     @api.model_create_multi
     def create(self, vals_list):
-        operator_partners_values = [self._prepare_operator_partner_values(
-            vals['title'],
-            vals.get('image_1920', False),
-        ) for vals in vals_list if 'operator_partner_id' not in vals and 'title' in vals]
+        operator_partners_values = [{
+            'name': vals['title'],
+            'image_1920': vals.get('image_1920', False),
+            'active': False,
+        } for vals in vals_list if 'operator_partner_id' not in vals and 'title' in vals]
 
         operator_partners = self.env['res.partner'].create(operator_partners_values)
 
@@ -169,13 +170,6 @@ class ChatbotScript(models.Model):
 
         return posted_messages
 
-    def _prepare_operator_partner_values(self, name, image):
-        return {
-            'name': name,
-            'image_1920': image,
-            'active': False,
-        }
-
     def action_view_livechat_channels(self):
         self.ensure_one()
         action = self.env['ir.actions.act_window']._for_xml_id('im_livechat.im_livechat_channel_action')
@@ -190,15 +184,10 @@ class ChatbotScript(models.Model):
         """ Small utility method that formats the script into a dict usable by the frontend code. """
         self.ensure_one()
 
-        chatbot_avatar_url = '/mail/static/src/img/smiley/avatar.jpg'
-        if bool(self.image_128):
-            chatbot_avatar_url = f'/web/image/chatbot.script/{self.id}/image_128'
-
         return {
             'chatbot_script_id': self.id,
             'chatbot_name': self.title,
             'chatbot_operator_partner_id': self.operator_partner_id.id,
-            'chatbot_avatar_url': chatbot_avatar_url,
             'chatbot_welcome_steps': [
                 step._format_for_frontend()
                 for step in self._get_welcome_steps()

--- a/addons/im_livechat/static/src/legacy/models/website_livechat_message.js
+++ b/addons/im_livechat/static/src/legacy/models/website_livechat_message.js
@@ -39,7 +39,7 @@ var WebsiteLivechatMessage = AbstractMessage.extend({
     getAvatarSource: function () {
         var source = this._serverURL;
         if (this.hasAuthor()) {
-            source += '/web/image/res.partner/' + this.getAuthorID() + '/avatar_128';
+            source += `/im_livechat/operator/${this.getAuthorID()}/avatar`;
         } else {
             source += '/mail/static/src/img/smiley/avatar.jpg';
         }

--- a/addons/im_livechat/static/src/legacy/public_livechat_chatbot.js
+++ b/addons/im_livechat/static/src/legacy/public_livechat_chatbot.js
@@ -410,7 +410,7 @@ const QWeb = core.qweb;
         this.isTypingTimeout = setTimeout(() => {
             this._chatWindow.$('.o_mail_thread_content').append(
                 $(QWeb.render('im_livechat.legacy.chatbot.is_typing_message', {
-                    'chatbotImageSrc': this._chatbot.chatbot_avatar_url,
+                    'chatbotImageSrc': `/im_livechat/operator/${this._livechat.getOperatorPID()[0]}/avatar`,
                     'chatbotName': this._chatbot.chatbot_name,
                     'isWelcomeMessage': isWelcomeMessage,
                 }))

--- a/addons/im_livechat/static/src/legacy/website_livechat_message_chatbot.js
+++ b/addons/im_livechat/static/src/legacy/website_livechat_message_chatbot.js
@@ -20,7 +20,6 @@ WebsiteLivechatMessage.include({
         this._super(...arguments);
 
         if (parent._isChatbot) {
-            this._chatbotAvatarUrl = parent._chatbot.chatbot_avatar_url;
             this._chatbotId = parent._chatbot.chatbot_script_id;
             this._chatbotName = parent._chatbot.chatbot_name;
             this._chatbotOperatorPartnerId = parent._chatbot.chatbot_operator_partner_id;
@@ -34,17 +33,6 @@ WebsiteLivechatMessage.include({
     //--------------------------------------------------------------------------
     // Public
     //--------------------------------------------------------------------------
-
-    /**
-     * Small override to return a placeholder in case there is no image configured on the chatbot.
-     */
-    getAvatarSource: function () {
-        if (this._chatbotAvatarUrl && this.getAuthorID() === this._chatbotOperatorPartnerId) {
-            return this._chatbotAvatarUrl;
-        } else {
-            return this._super(...arguments);
-        }
-    },
 
     /**
      * Get chat bot script step ID

--- a/addons/website_livechat/__init__.py
+++ b/addons/website_livechat/__init__.py
@@ -1,15 +1,3 @@
 # -*- coding: utf-8 -*-
 from . import controllers
 from . import models
-
-from odoo import api, SUPERUSER_ID
-
-
-def _post_init_website_livechat(cr, registry):
-    """ Chatbot operator partners must be 'website_published' to ensure
-    their avatar is visible for end users. """
-
-    env = api.Environment(cr, SUPERUSER_ID, {})
-    env['chatbot.script'].search([]).operator_partner_id.write({
-        'is_published': True
-    })

--- a/addons/website_livechat/__manifest__.py
+++ b/addons/website_livechat/__manifest__.py
@@ -11,7 +11,6 @@ Allow website visitors to chat with the collaborators. This module also brings a
     'installable': True,
     'application': False,
     'auto_install': True,
-    'post_init_hook': '_post_init_website_livechat',
     'data': [
         'views/website_livechat.xml',
         'views/res_config_settings_views.xml',

--- a/addons/website_livechat/models/chatbot_script.py
+++ b/addons/website_livechat/models/chatbot_script.py
@@ -14,8 +14,3 @@ class ChatbotScript(models.Model):
             'url': '/chatbot/%s/test' % self.id,
             'target': 'self',
         }
-
-    def _prepare_operator_partner_values(self, name, image):
-        res = super()._prepare_operator_partner_values(name, image)
-        res['is_published'] = True
-        return res


### PR DESCRIPTION
This commit improves the livechat to always allow website visitors to be able
to see the operator avatar, regardless of ACLs.

Indeed, we currently depend on ACLs and when website is installed, the
visibility of the operator avatar depends on his website_published status.
Which does not make much sense as it requires extra configuration to make it
work.

Instead, we now consider that all livechat operators and all chatbot operators
have their avatar publicly available, using a custom livechat route.

Task-2813529
