### PR TITLE
[FIX] web: basic_model: applyOnChange with 2 consecutive one2many

### DIFF
--- a/addons/web/static/src/js/views/basic/basic_model.js
+++ b/addons/web/static/src/js/views/basic/basic_model.js
@@ -1870,7 +1870,7 @@ var BasicModel = AbstractModel.extend({
                         });
                     }
                 });
-                var def = self._readUngroupedList(list).then(function () {
+                var def = self._readUngroupedList(list).then(function (list) {
                     var x2ManysDef = self._fetchX2ManysBatched(list);
                     var referencesDef = self._fetchReferencesBatched(list);
                     return Promise.all([x2ManysDef, referencesDef]);

--- a/addons/web/static/tests/fields/relational_fields_tests.js
+++ b/addons/web/static/tests/fields/relational_fields_tests.js
@@ -3702,6 +3702,56 @@ QUnit.module('relational_fields', {
 
         form.destroy();
     });
+    QUnit.test('Check onchange with two consecutive many2one', async function (assert) {
+        assert.expect(2);
+        this.data.product.fields.product_partner_ids = { string: "User", type: 'one2many', relation: 'partner' };
+        this.data.product.records[0].product_partner_ids = [1];
+        this.data.product.records[1].product_partner_ids = [2];
+        this.data.turtle.fields.product_ids = { string: "Product", type: "one2many", relation: 'product' };
+        this.data.turtle.fields.user_ids = { string: "Product", type: "one2many", relation: 'user' };
+        this.data.turtle.onchanges = {
+            turtle_trululu: function (record) {
+                record.product_ids = [37];
+                record.user_ids = [17, 19];
+            },
+        };
+        var form = await createView({
+            View: FormView,
+            model: 'turtle',
+            data: this.data,
+            arch: 
+                '<form string="Turtles">' +
+                    '<field string="Product" name="turtle_trululu"/>' +
+                    '<field readonly="1" string="Related field" name="product_ids">' +
+                        '<tree>' +
+                            '<field widget="many2many_tags" name="product_partner_ids"/>' +
+                        '</tree>' +
+                    '</field>' +
+                    '<field readonly="1" string="Second related field" name="user_ids">' +
+                        '<tree>' +
+                            '<field widget="many2many_tags" name="partner_ids"/>' +
+                        '</tree>' +
+                    '</field>' +
+                '</form>',
+            res_id: 1,
+        });
+
+        await testUtils.form.clickEdit(form);
+        await testUtils.fields.many2one.clickOpenDropdown("turtle_trululu");
+        await testUtils.fields.many2one.searchAndClickItem('turtle_trululu', {search: 'first record'});
+
+        const getElementTextContent = name => [...document.querySelectorAll(`.o_field_many2manytags[name="${name}"] .badge.o_tag_color_0 > span`)]
+            .map(x=>x.textContent);
+        assert.deepEqual(
+            getElementTextContent('product_partner_ids'),
+            ['first record'],
+            "should have the correct value in the many2many tag widget");
+        assert.deepEqual(
+            getElementTextContent('partner_ids'),
+            ['first record', 'second record'],
+            "should have the correct values in the many2many tag widget");
+        form.destroy();
+    });
 });
 });
 });


### PR DESCRIPTION
In the "then" of readUngroupedList, list may have changed.
This fix may work as long as readUngroupedList is guaranteed to return the
right datapoint list.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
