### PR TITLE
[FIX] hr_holidays : set allocation with enough days left

### DIFF
--- a/addons/hr_holidays/models/hr_leave_allocation.py
+++ b/addons/hr_holidays/models/hr_leave_allocation.py
@@ -135,6 +135,7 @@ class HolidaysAllocation(models.Model):
     accrual_plan_id = fields.Many2one('hr.leave.accrual.plan', compute="_compute_from_holiday_status_id", store=True, readonly=False, domain="['|', ('time_off_type_id', '=', False), ('time_off_type_id', '=', holiday_status_id)]", tracking=True)
     max_leaves = fields.Float(compute='_compute_leaves')
     leaves_taken = fields.Float(compute='_compute_leaves')
+    leaves_left = fields.Float(compute='_compute_leaves')
     taken_leave_ids = fields.One2many('hr.leave', 'holiday_allocation_id', domain="[('state', 'in', ['confirm', 'validate1', 'validate'])]")
 
     _sql_constraints = [
@@ -199,6 +200,8 @@ class HolidaysAllocation(models.Model):
             allocation.leaves_taken = sum(taken_leave.number_of_hours_display if taken_leave.leave_type_request_unit == 'hour' else taken_leave.number_of_days\
                 for taken_leave in allocation.taken_leave_ids\
                 if taken_leave.state == 'validate')
+            allocation.leaves_left = allocation.max_leaves - sum(taken_leave.number_of_hours_display if taken_leave.leave_type_request_unit == 'hour' else taken_leave.number_of_days\
+                for taken_leave in allocation.taken_leave_ids)
 
     @api.depends('number_of_days')
     def _compute_number_of_days_display(self):


### PR DESCRIPTION
Steps :
Create a Time Off Type T.
Create 2 Allocations :
	> Type : T
	> Start date : monday D
	> End date : /
	> Number of days : resp 4 and 1
	> Employee : Admin
Create 2 Time Off Requests :
	> Type : T
	> Dates : resp monday D to thursday and friday to friday.
Validate both.

Issue :
Allocation's days taken are resp 5.0/4.0 and 0.0/1.0.

Cause :
We set allocation to leave before validating.
To do so, we take the alloc with max allocated days.

Fix :
Take the alloc with max days left = allocated - taken.
Recompute the allocation before validating,
to check that enough days are left.

opw-2812534

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
