### PR TITLE
[FIX] account_payment : limit token acquirers to invoice's partner

### DIFF
--- a/addons/payment/i18n/payment.pot
+++ b/addons/payment/i18n/payment.pot
@@ -940,12 +940,6 @@ msgid "Invalid token found! Token acquirer %s != %s"
 msgstr ""
 
 #. module: payment
-#: code:addons/payment/models/account_invoice.py:0
-#, python-format
-msgid "Invalid token found! Token partner %s != %s"
-msgstr ""
-
-#. module: payment
 #: model_terms:ir.ui.view,arch_db:payment.transaction_form
 msgid "Invoice(s)"
 msgstr ""
@@ -1732,6 +1726,14 @@ msgstr ""
 #: code:addons/payment/models/payment_acquirer.py:0
 #, python-format
 msgid "The transaction %s with %s for %s is pending."
+msgstr ""
+
+#. module: payment
+#: code:addons/payment/models/account_invoice.py:0
+#, python-format
+msgid ""
+"The transaction was aborted because you are not the customer of this "
+"invoice. Log in as %s to be able to use this payment method."
 msgstr ""
 
 #. module: payment

--- a/addons/payment/models/account_invoice.py
+++ b/addons/payment/models/account_invoice.py
@@ -56,8 +56,10 @@ class AccountMove(models.Model):
                 acquirer = payment_token.acquirer_id
 
             if payment_token and payment_token.partner_id != partner:
-                raise ValidationError(_('Invalid token found!'))
-
+                raise ValidationError(_(
+                    'The transaction was aborted because you are not the customer of this invoice. '
+                    'Log in as %s to be able to use this payment method.'
+                ) % partner.name)
         # Check an acquirer is there.
         if not acquirer_id and not acquirer:
             raise ValidationError(_('A payment acquirer is required to create a transaction.'))


### PR DESCRIPTION
Steps:
Log in with admin.
Configure Stripe for direct payment (from Odoo).
Create an invoice for portal.
Click on Preview, then Pay Now.
Select Stripe, enter your credentials and pay.

Issue:
Error message: Invalid token found!

Cause:
Paying this way creates a token for admin.
Yet, later, we check that invoice's partner = token's.
Accessing token-implemented acquirers should not be allowed
when the current user's partner is not the invoice's customer.

Fix:
Remove those acquirers and display a warning :
If current user wants to access them, he should log in
as the invoice's customer.

opw-2730967

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
