### PR TITLE
[FIX] point_of_sale: make background product loading silent

### DIFF
--- a/addons/point_of_sale/static/src/js/models.js
+++ b/addons/point_of_sale/static/src/js/models.js
@@ -957,7 +957,7 @@ exports.PosModel = Backbone.Model.extend({
                     'limit': this.env.pos.config.limited_products_amount
                 },
                 context: { ...this.session.user_context, ...product_model.context() },
-            });
+            }, { shadow: true });
             product_model.loaded(this, products);
             page += 1;
         } while(products.length == this.config.limited_products_amount);
@@ -976,7 +976,7 @@ exports.PosModel = Backbone.Model.extend({
                     offset: this.env.pos.config.limited_partners_amount * i
                 },
                 context: this.env.session.user_context,
-            });
+            }, { shadow: true });
             this.env.pos.db.add_partners(PartnerIds);
             i += 1;
         } while(PartnerIds.length);


### PR DESCRIPTION
Loading in background is supposed be background and not block UI after 3 sec of
loading.

STEPS:
* In `pos.config` set `[x] Limited Products Loading`, and `[x] ​Load all
remaining products in the background`
* add enough products to POS, e.g. 40 000
* Open pos

BEFORE: background loading triggers UI Blocking if it takes more than 3 seconds
AFTER:  products are loaded in background without interrupting UI

---

opw-2817770

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
