### PR TITLE
[IMP] project: improve generic ux of project

### DIFF
--- a/addons/project/static/src/js/project_task_kanban_examples.js
+++ b/addons/project/static/src/js/project_task_kanban_examples.js
@@ -67,12 +67,6 @@ kanbanExamplesRegistry.add('project', {
             'feedback is accepted %s and which feedback is moved to the %s column. %s'), greenBullet, _lt('"Refused"'), descriptionActivities),
         bullets: [greenBullet, redBullet],
     }, {
-        name: _lt('Getting Things Done (GTD)'),
-        columns: [_lt('Inbox'), _lt('Today'), _lt('This Week'), _lt('This Month'), _lt('Long Term')],
-        description: escFormat(_lt('Fill your Inbox easily with the email gateway. Periodically review your ' +
-            'Inbox and schedule tasks by moving them to other columns. Every day, you review the ' +
-            '%s column to move important tasks %s. Every Monday, you review the %s column. %s'), _lt('"This Week"'), _lt('"Today"'), _lt('"This Month"'), descriptionActivities),
-    }, {
         name: _lt('Consulting'),
         columns: [_lt('New Projects'), _lt('Resources Allocation'), _lt('In Progress'), _lt('Done')],
         description: escFormat(_lt('Manage the lifecycle of your project using the kanban view. Add newly acquired projects, assign them and use the %s and %s to define if the project is ready for the next step. %s'), greenBullet, redBullet, descriptionActivities),

--- a/addons/project/static/src/scss/project_rightpanel.scss
+++ b/addons/project/static/src/scss/project_rightpanel.scss
@@ -186,7 +186,7 @@ html .o_web_client > .o_action_manager > .o_action > .o_content > .o_controller_
                     margin-left: -1px;
                     height: 57.5px;
 
-                    &:nth-child(3n){
+                    &:nth-child(3n):not(:last-child){
                         border-right-width: 0px;
                     }
 

--- a/addons/project/views/project_update_views.xml
+++ b/addons/project/views/project_update_views.xml
@@ -19,7 +19,7 @@
                 <sheet>
                     <div class="oe_title">
                         <h1>
-                            <field name="name" class="o_text_overflow" placeholder="Title of the Update"/>
+                            <field name="name" class="o_text_overflow" placeholder="e.g. Monthly review"/>
                         </h1>
                     </div>
                     <group>
@@ -128,7 +128,7 @@
                     <group>
                         <group name="main_details">
                             <field name="project_id" invisible="1"/>
-                            <field name="name" placeholder="E.g: Product Launch"/>
+                            <field name="name" placeholder="e.g. Product Launch"/>
                             <field name="deadline"/>
                             <field name="is_reached"/>
                         </group>

--- a/addons/project/views/project_views.xml
+++ b/addons/project/views/project_views.xml
@@ -34,6 +34,7 @@
                     <filter string="Open" name="open_tasks" domain="[('is_closed', '=', False)]"/>
                     <filter string="Closed" name="closed_tasks" domain="[('is_closed', '!=', False)]"/>
                     <separator/>
+                    <filter string="Tasks Due Today" name="tasks_due_today" domain="[('date_deadline', '=', context_today().strftime('%Y-%m-%d'))]"/>
                     <filter string="Late Tasks" name="late" domain="[('date_deadline', '&lt;', context_today().strftime('%Y-%m-%d'))]"/>
                     <separator/>
                     <filter name="rating_satisfied" string="Satisfied" domain="[('rating_avg', '&gt;=', 3.66)]" groups="project.group_project_rating"/>
@@ -1002,7 +1003,7 @@
                             <i class="fa fa-fw o_button_icon fa-frown-o text-danger" attrs="{'invisible': [('rating_avg', '&gt;=', 2.33)]}" title="Dissatisfied"/>
                             <div class="o_field_widget o_stat_info">
                                 <span class="o_stat_value"><field name="rating_avg_text" nolabel="1"/></span>
-                                <span class="o_stat_text">Rating</span>
+                                <span class="o_stat_text">Last Rating</span>
                             </div>
                         </button>
                         <!-- Dummy tag used to organize buttons -->
@@ -1159,6 +1160,7 @@
                         <page name="extra_info" string="Extra Info" groups="base.group_no_one">
                             <group>
                                 <group>
+                                    <field name="is_analytic_account_id_changed" invisible="1"/>
                                     <field name="analytic_account_id" groups="analytic.group_analytic_accounting" context="{'default_partner_id': partner_id}"/>
                                     <field name="analytic_tag_ids" groups="analytic.group_analytic_tags" widget="many2many_tags"/>
                                     <field name="parent_id" attrs="{'invisible': [('allow_subtasks', '=', False)]}" groups="base.group_no_one"/>

--- a/addons/sale_timesheet/data/sale_service_demo.xml
+++ b/addons/sale_timesheet/data/sale_service_demo.xml
@@ -262,7 +262,7 @@
             <field name="name">Cabinets</field>
             <field name="project_id" search="[('sale_line_id', '=', ref('sale_line_13'))]"/>
             <field name="is_reached">True</field>
-            <field name="sale_line_id" ref="sale_line_18"/>
+            <field name="sale_line_id" ref="sale_line_12"/>
             <field name="quantity_percentage">0.25</field>
         </record>
 
@@ -433,7 +433,7 @@
             <value model="project.project" search="[('sale_line_id', '=', ref('sale_line_13'))]"/>
             <value eval="{'sale_line_employee_ids': [
                 Command.create({
-                    'employee_id': ref('hr.employee_admin'),
+                    'employee_id': ref('hr.employee_mit'),
                     'sale_line_id': ref('sale_line_11'),
                     'cost': 220,
                 }),


### PR DESCRIPTION
Purpose of this commit to improve generic usage of project
app.

So, in this commit done following changes:
-change the placeholder of the name to 'e.g. Monthly review' in
project_update_view_form
-set the 'analytic account' of the project on the tasks by default
-change the placeholder to 'e.g. Product Launch' in project_milestone_view_form
-the 'cabinets' milestone should be linked to a milestone service,
not a manual one so change data to milestone in demo data
-rename the 'rating' stat button into 'last rating' in view_task_form2
-set another employee than Mitchell for the 'customer care (prepaid hours)'
SOL field in sale_service_demo_data
-display a separator on the right of the stat button so remove unwanted
properties in project_rightpanel.scss
-add the 'name' field to the 'fields to export' when 'i want to update data'
is set to true
-remove the 'Getting Things Done (GTD)' example from kanban examples wizard
-add a 'tasks due today' filter that should return tasks whose deadline falls on
 today's date in view_task_search_form

task-2809188

