### PR TITLE
[FIX] web_editor: provide proper support for mixed language directions

### DIFF
--- a/addons/web_editor/static/lib/odoo-editor/src/OdooEditor.js
+++ b/addons/web_editor/static/lib/odoo-editor/src/OdooEditor.js
@@ -207,6 +207,7 @@ export class OdooEditor extends EventTarget {
                 onChange: () => {},
                 isHintBlacklisted: () => false,
                 filterMutationRecords: (records) => records,
+                direction: 'ltr',
                 _t: string => string,
                 allowCommandVideo: true,
             },
@@ -270,6 +271,7 @@ export class OdooEditor extends EventTarget {
         this._idToNodeMap.set(1, editable);
         this.editable = this.options.toSanitize ? sanitize(editable) : editable;
         this.editable.classList.add("odoo-editor-editable");
+        this.editable.setAttribute('dir', this.options.direction);
 
         // Set contenteditable before clone as FF updates the content at this point.
         this._activateContenteditable();
@@ -1838,6 +1840,15 @@ export class OdooEditor extends EventTarget {
                     this.commandbarTablePicker.show();
                 },
             },
+            {
+                groupName: 'Basic blocks',
+                title: this.options._t('Switch direction'),
+                description: this.options._t('Switch the text\'s direction.'),
+                fontawesome: 'fa-exchange',
+                callback: () => {
+                    this.execCommand('switchDirection');
+                },
+            },
         ];
         this.commandBar = new Powerbox({
             editable: this.editable,
@@ -1938,7 +1949,7 @@ export class OdooEditor extends EventTarget {
             const selectionStartStyle = getComputedStyle(closestStartContainer);
 
             // queryCommandState does not take stylesheets into account
-            for (const format of ['bold', 'italic', 'underline', 'strikeThrough']) {
+            for (const format of ['bold', 'italic', 'underline', 'strikeThrough', 'switchDirection']) {
                 const formatButton = this.toolbar.querySelector(`#${format.toLowerCase()}`);
                 if (formatButton) {
                     formatButton.classList.toggle('active', isSelectionFormat(this.editable, format));

--- a/addons/web_editor/static/lib/odoo-editor/src/commands/shiftTab.js
+++ b/addons/web_editor/static/lib/odoo-editor/src/commands/shiftTab.js
@@ -49,6 +49,7 @@ HTMLLIElement.prototype.oShiftTab = function () {
         return li;
     } else {
         const ul = li.parentNode;
+        const dir = ul.getAttribute('dir');
         let p;
         while (li.firstChild) {
             if (isBlock(li.firstChild)) {
@@ -56,6 +57,10 @@ HTMLLIElement.prototype.oShiftTab = function () {
                 ul.after(li.firstChild);
             } else {
                 p = p || document.createElement('P');
+                if (dir) {
+                    p.setAttribute('dir', dir);
+                    p.style.setProperty('text-align', ul.style.getPropertyValue('text-align'));
+                }
                 p.append(li.firstChild);
             }
         }

--- a/addons/web_editor/static/lib/odoo-editor/src/commands/toggleList.js
+++ b/addons/web_editor/static/lib/odoo-editor/src/commands/toggleList.js
@@ -30,6 +30,9 @@ HTMLElement.prototype.oToggleList = function (offset, mode = 'UL') {
         restoreCursor();
     } else {
         const list = insertListAfter(this, mode, [this]);
+        for (const attribute of this.attributes) {
+            list.setAttribute(attribute.name, attribute.value);
+        }
         restoreCursor(new Map([[this, list.firstElementChild]]));
     }
 };
@@ -37,6 +40,9 @@ HTMLElement.prototype.oToggleList = function (offset, mode = 'UL') {
 HTMLParagraphElement.prototype.oToggleList = function (offset, mode = 'UL') {
     const restoreCursor = preserveCursor(this.ownerDocument);
     const list = insertListAfter(this, mode, [[...this.childNodes]]);
+    for (const attribute of this.attributes) {
+        list.setAttribute(attribute.name, attribute.value);
+    }
     this.remove();
 
     restoreCursor(new Map([[this, list.firstChild]]));

--- a/addons/web_editor/static/lib/odoo-editor/src/utils/utils.js
+++ b/addons/web_editor/static/lib/odoo-editor/src/utils/utils.js
@@ -908,11 +908,27 @@ export function isStrikeThrough(node) {
     }
     return false;
 }
+/**
+ * Return true if the given node appears in a different direction than that of
+ * the editable ('ltr' or 'rtl').
+ *
+ * Note: The direction of the editable is set on its "dir" attribute, to the
+ * value of the "direction" option on instantiation of the editor.
+ *
+ * @param {Node} node
+ * @param {Element} editable
+ * @returns {boolean}
+ */
+ export function isDirectionSwitched(node, editable) {
+    const defaultDirection = editable.getAttribute('dir');
+    return getComputedStyle(closestElement(node)).direction !== defaultDirection;
+}
 export const isFormat = {
     bold: isBold,
     italic: isItalic,
     underline: isUnderline,
     strikeThrough: isStrikeThrough,
+    switchDirection: isDirectionSwitched,
 };
 /**
  * Return true if the current selection on the editable appears as the given
@@ -920,16 +936,16 @@ export const isFormat = {
  * node in it appears as that format.
  *
  * @param {Element} editable
- * @param {String} format 'bold'|'italic'|'underline'|'strikeThrought'
+ * @param {String} format 'bold'|'italic'|'underline'|'strikeThrough'|'switchDirection'
  * @returns {boolean}
  */
 export function isSelectionFormat(editable, format) {
     const selectedText = getSelectedNodes(editable)
         .filter(n => n.nodeType === Node.TEXT_NODE && n.nodeValue.trim().length);
     if (selectedText.length) {
-        return selectedText.every(n => isFormat[format](n.parentElement));
+        return selectedText.every(n => isFormat[format](n.parentElement, editable))
     } else {
-        return isFormat[format](closestElement(editable.ownerDocument.getSelection().anchorNode));
+        return isFormat[format](closestElement(editable.ownerDocument.getSelection().anchorNode), editable);
     }
 }
 

--- a/addons/web_editor/static/src/js/wysiwyg/wysiwyg.js
+++ b/addons/web_editor/static/src/js/wysiwyg/wysiwyg.js
@@ -11,6 +11,7 @@ const {ColorpickerWidget} = require('web.Colorpicker');
 const concurrency = require('web.concurrency');
 const { device } = require('web.config');
 const weContext = require('web_editor.context');
+const { localization } = require('@web/core/l10n/localization');
 const OdooEditorLib = require('@web_editor/../lib/odoo-editor/src/OdooEditor');
 const snippetsEditor = require('web_editor.snippet.editor');
 const Toolbar = require('web_editor.toolbar');
@@ -161,6 +162,7 @@ const Wysiwyg = Widget.extend({
             commands: commands,
             onChange: options.onChange,
             plugins: options.editorPlugins,
+            direction: localization.direction || 'ltr',
         }, editorCollaborationOptions));
 
         document.addEventListener("mousemove", this._signalOnline, true);


### PR DESCRIPTION
This introduces a "direction" option on the editor to set the text direction of the editor (passed by Odoo based on the localization), and a Powerbox command to switch said direction on a given block. This allows users to mix several text directions within the same text, eg. when quoting Hebrew in an English text.

task-2814004

--
I confirm I have signed the CLA and read the PR guidelines at [www.odoo.com/submit-pr](http://www.odoo.com/submit-pr)