### PR TITLE
[FIX] AttributeError: 'NoneType' object has no attribute '_name'

### DIFF
--- a/addons/website_slides/models/ir_http.py
+++ b/addons/website_slides/models/ir_http.py
@@ -14,7 +14,7 @@ class Http(models.AbstractModel):
         obj = None
         if xmlid:
             obj = self._xmlid_to_obj(self.env, xmlid)
-            if obj._name != 'slide.slide':
+            if obj and obj._name != 'slide.slide':
                 obj = None
         elif id and model == 'slide.slide':
             obj = self.env[model].browse(int(id))


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
Solves AttributeError: 'NoneType' object has no attribute '_name' when we access obj._name 

Current behavior before PR:
Raises AttributeError if the object is none.

Desired behavior after PR is merged:
It will check for the obj availability before accessing _name attribute from it.


--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
