### PR TITLE
[FIX] website: prevent inconsistent state of the navbar publish toggle

### DIFF
--- a/addons/website/static/src/js/content/website_root.js
+++ b/addons/website/static/src/js/content/website_root.js
@@ -157,7 +157,7 @@ var WebsiteRoot = publicRootData.PublicRoot.extend({
             },
         })
         .then(function (result) {
-            $data.toggleClass("css_unpublished css_published");
+            $data.toggleClass("css_published", result).toggleClass("css_unpublished", !result);
             $data.find('input').prop("checked", result);
             $data.parents("[data-publish]").attr("data-publish", +result ? 'on' : 'off');
         });

--- a/addons/website/views/website_navbar_templates.xml
+++ b/addons/website/views/website_navbar_templates.xml
@@ -52,7 +52,7 @@
                 <ul class="o_menu_systray d-none d-md-block" groups="website.group_website_publisher">
                     <li t-if="'website_published' in main_object.fields_get() and ('can_publish' not in main_object.fields_get() or main_object.can_publish)" t-attf-class="js_publish_management #{main_object.website_published and 'css_published' or 'css_unpublished'}" t-att-data-id="main_object.id" t-att-data-object="main_object._name" t-att-data-controller="publish_controller">
                         <label class="o_switch o_switch_danger js_publish_btn" for="id">
-                            <input type="checkbox" t-att-checked="main_object.website_published" id="id"/>
+                            <input type="checkbox" disabled="disabled" t-att-checked="main_object.website_published" id="id"/>
                             <span/>
                             <span class="css_publish">Unpublished</span>
                             <span class="css_unpublish">Published</span>


### PR DESCRIPTION
Currently, if a page is loading and someone quickly clicks exactly on
the on the input checkbox within publish management button of website
navbar, the checkbox (input) is toggled but the string does not change.
This happens because the checkbox is toggled before the click event on
`js_publish_btn` is bound. Ideally, the checkbox should be toggled only
based on the state of the object (whenever it's changed after a
successful RPC call) so that the information we see is correct.

This commit fixes the issue by disabling the input checkbox so that
it is toggled only after the state is changed by RPC call and not
when user simply clicks on the input.

task-2819345
--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
