### PR TITLE
[FIX] microsoft_calendar: sync events without body property

### DIFF
--- a/addons/microsoft_calendar/models/calendar.py
+++ b/addons/microsoft_calendar/models/calendar.py
@@ -100,7 +100,7 @@ class Meeting(models.Model):
         values = {
             **default_values,
             'name': microsoft_event.subject or _("(No title)"),
-            'description': microsoft_event.body['content'],
+            'description': microsoft_event.body and microsoft_event.body['content'],
             'location': microsoft_event.location and microsoft_event.location.get('displayName') or False,
             'user_id': microsoft_event.owner(self.env).id,
             'privacy': sensitivity_o2m.get(microsoft_event.sensitivity, self.default_get(['privacy'])['privacy']),


### PR DESCRIPTION
Before this commit: if a Microsoft event didn't have body property,
it couldn't get synced with Odoo and raised an error.

The solution is first to check if it contains the body and then gets
its content value.

opw-2765443

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
