### PR TITLE
[FIX] web_editor: fix destroy editors in modal

### DIFF
--- a/addons/web_editor/static/src/js/editor/snippets.editor.js
+++ b/addons/web_editor/static/src/js/editor/snippets.editor.js
@@ -1650,10 +1650,13 @@ var SnippetsMenu = Widget.extend({
                 return;
             }
             await snippetEditor.cleanForSave();
+
+            // No need to clean the `this.snippetEditors` array as each
+            // individual destroy notifies this class instance to remove the
+            // element from the array.
             snippetEditor.destroy();
         });
         await Promise.all(proms);
-        this.snippetEditors.splice(0);
     },
     /**
      * Calls a given callback 'on' the given snippet and all its child ones if


### PR DESCRIPTION
After the following steps, snippets overlays are not properly removed
from the DOM:

- In edit mode, drop 2-3 snippets in the page.
- Click on these snippets to activate their overlays.
- Drag and drop a popup in the page.
- Drag and drop a snippet in the popup.
- Move this snippet inside the popup thanks to the move handle button.
- Click on the "eye" button to hide the popup.
- Click on snippets of the page, the overlays are no longer removed when
they should.

It was because since this commit [1], it is allowed to define an element
in which `_destroyEditors` destroys the editors but we forgot not to
completely empty the array that contains them.

But anyway, the editors list doesn't need to be updated in
`_destroyEditors` (since this commit [2]) as it's already done in the
`destroy` method of `SnippetEditor`.

[1]: https://github.com/odoo/odoo/commit/b7d522e9e7e31ac6bf926aae65e58d9f6cfa8903
[2]: https://github.com/odoo/odoo/commit/2a19a83762c1bc74dd7336378d254ab6da8e3a22

task-2799602

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
