### PR TITLE
14.0 fix l10n_nz tax report

### DIFF
--- a/addons/l10n_nz/data/account_tax_report_data.xml
+++ b/addons/l10n_nz/data/account_tax_report_data.xml
@@ -34,6 +34,7 @@
         <field name="name">[BOX 7] The amount in Box 6 is subracted from Box 5</field>
         <field name="parent_id" ref="tax_report_sale_and_income"/>
         <field name="sequence" eval="3"/>
+        <field name="code">NZBOX7</field>
         <field name="formula">NZBOX5 - NZBOX6</field>
         <field name="report_id" ref="tax_report"/>
     </record>
@@ -42,7 +43,8 @@
         <field name="name">[BOX 8] Multiply the amount in Box 7 by 3 and then divide by 23</field>
         <field name="parent_id" ref="tax_report_sale_and_income"/>
         <field name="sequence" eval="4"/>
-        <field name="formula">((NZBOX5 - NZBOX6) * 3)/23</field>
+        <field name="code">NZBOX8</field>
+        <field name="formula">(NZBOX7 * 3)/23</field>
         <field name="report_id" ref="tax_report"/>
     </record>
 
@@ -60,7 +62,8 @@
         <field name="name">[BOX 10] Total GST collected on sales and income</field>
         <field name="parent_id" ref="tax_report_sale_and_income"/>
         <field name="sequence" eval="6"/>
-        <field name="formula">(((NZBOX5 - NZBOX6) * 3)/23) + NZBOX9</field>
+        <field name="code">NZBOX10</field>
+        <field name="formula">NZBOX8 + NZBOX9</field>
         <field name="report_id" ref="tax_report"/>
     </record>
 
@@ -83,6 +86,7 @@
         <field name="name">[BOX 12] Multiply BOX11 by 3 and then divide by 23</field>
         <field name="parent_id" ref="tax_report_purchases_and_expenses"/>
         <field name="sequence" eval="2"/>
+        <field name="code">NZBOX12</field>
         <field name="formula">(NZBOX11 * 3)/23</field>
         <field name="report_id" ref="tax_report"/>
     </record>
@@ -91,6 +95,7 @@
         <field name="name">[BOX 13] Credit adjustments from your calculation sheet</field>
         <field name="parent_id" ref="tax_report_purchases_and_expenses"/>
         <field name="sequence" eval="3"/>
+        <field name="code">NZBOX13</field>
         <field name="report_id" ref="tax_report"/>
     </record>
 
@@ -98,14 +103,15 @@
         <field name="name">[BOX 14] Total GST credit for purchases and expenses</field>
         <field name="parent_id" ref="tax_report_purchases_and_expenses"/>
         <field name="sequence" eval="4"/>
-        <field name="formula">((NZBOX11 * 3)/23)</field>
+        <field name="code">NZBOX14</field>
+        <field name="formula">NZBOX12 + NZBOX13</field>
         <field name="report_id" ref="tax_report"/>
     </record>
 
     <record id="tax_report_box15" model="account.tax.report.line">
         <field name="name">[BOX 15]  Difference between BOX10 and BOX14</field>
         <field name="sequence" eval="3"/>
-        <field name="formula">((((NZBOX5 - NZBOX6) * 3)/23) + NZBOX9) - ((NZBOX11 * 3)/23)</field>
+        <field name="formula">NZBOX10 - NZBOX14</field>
         <field name="report_id" ref="tax_report"/>
     </record>
 


### PR DESCRIPTION
Description of the issue/feature this PR addresses:

This pull request fixes the Box14 and Box15 calculations in the New Zealand GST Tax Report.

Current behavior before PR:

Box14 and Box15 do not include the value from Box13.

Desired behavior after PR is merged:

Box14 and Box15 do include the value from Box13.

The Tax report for New Zealand clearly is based on the GST101a form published by the New Zealand Inland Revenue Department (https://www.ird.govt.nz/-/media/project/ir/home/documents/forms-and-guides/gst100---gst199/gst101a/gst101a-2017.pdf?modified=20201127025858&modified=20201127025858). Box14 and Box15 calculations have not been correctly transcribed from the form. Box 14 should "Add Box12 and Box13", instead it had been implemented as just copying the value from Box12. This error has been made in the Box15 formula as well.

Also uses recursive formula declaration for a cleaner declartion.

closes: #87513
task: [2819502](https://www.odoo.com/web#id=2819502&cids=1&model=project.task&view_type=form)

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
