### PR TITLE
[FIX] pos_sale: inconsistent behavior Sales vs. PoS

### DIFF
--- a/addons/pos_sale/static/src/js/OrderManagementScreen/SaleOrderManagementScreen.js
+++ b/addons/pos_sale/static/src/js/OrderManagementScreen/SaleOrderManagementScreen.js
@@ -201,21 +201,23 @@ odoo.define('pos_sale.SaleOrderManagementScreen', function (require) {
                             'total': lines[i].price_total,
                         };
                     }
+                    let down_payment_product = this.env.pos.db.get_product_by_id(this.env.pos.config.down_payment_product_id[0])
+                    let down_payment_tax = this.env.pos.taxes_by_id[down_payment_product.taxes_id]
+                    let down_payment = down_payment_tax.price_include ? sale_order.amount_total : sale_order.amount_untaxed;
 
-                    let down_payment = sale_order.amount_total;
                     const { confirmed, payload } = await this.showPopup('NumberPopup', {
                         title: sprintf(this.env._t("Percentage of %s"), this.env.pos.format_currency(sale_order.amount_total)),
                         startingValue: 0,
                     });
                     if (confirmed){
-                        down_payment = sale_order.amount_total * parse.float(payload) / 100;
+                        down_payment = down_payment * parse.float(payload) / 100;
                     }
 
 
                     let new_line = new models.Orderline({}, {
                         pos: this.env.pos,
                         order: this.env.pos.get_order(),
-                        product: this.env.pos.db.get_product_by_id(this.env.pos.config.down_payment_product_id[0]),
+                        product: down_payment_product,
                         price: down_payment,
                         price_manually_set: true,
                         sale_order_origin_id: clickedOrder,


### PR DESCRIPTION
If applied, this commit will fix the following bug by making the
behavior of applying a down payment similar to doing it in sales app

Steps to reproduce:

1- install sales, POS
2- set customer tax t on down payment product and use the product in
POS and sales
3- Create a product p with tax t
4- add p to a new sales order so
from sales:
5-apply a down payment of a percentage per (let's say 100% for clarity)
6- the down payment is calculated correctly and the total amount to
be paid is per * (p.untaxed_price + t * p.untaxed_price)

now from POS:
5- choose SO from the list
6- apply down payment of percentage per
7- the down payment is calcualted incorrectly. the SO is double taxed.
now the amound due is
(per * (p.untaxed_price + t * p.untaxed_price)) * (1 + pos_default_tax)

Bug:

when applying a down payment the full amount is treated as the untaxed
amound and then later the POS tax is added on it.

Fix:

using the untaxed total and also using the down payment product tax
similar to what happens in sales since the 2 flows can be mixed

OPW-2790821

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
