### PR TITLE
[FIX] stock,purchase_stock,mrp: replenishment notification

### DIFF
--- a/addons/mrp/models/stock_orderpoint.py
+++ b/addons/mrp/models/stock_orderpoint.py
@@ -13,10 +13,11 @@ class StockWarehouseOrderpoint(models.Model):
         'mrp.bom', string='Bill of Materials', check_company=True,
         domain="[('type', '=', 'normal'), '&', '|', ('company_id', '=', company_id), ('company_id', '=', False), '|', ('product_id', '=', product_id), '&', ('product_id', '=', False), ('product_tmpl_id', '=', product_tmpl_id)]")
 
-    def _get_replenishment_order_notification(self):
+    def _get_replenishment_order_notification(self, written_after):
         self.ensure_one()
         production = self.env['mrp.production'].search([
-            ('orderpoint_id', 'in', self.ids)
+            ('orderpoint_id', 'in', self.ids),
+            ('write_date', '>', written_after)
         ], order='create_date desc', limit=1)
         if production:
             action = self.env.ref('mrp.action_mrp_production_form')
@@ -33,7 +34,7 @@ class StockWarehouseOrderpoint(models.Model):
                     'sticky': False,
                 }
             }
-        return super()._get_replenishment_order_notification()
+        return super()._get_replenishment_order_notification(written_after)
 
     @api.depends('route_id')
     def _compute_show_bom(self):

--- a/addons/purchase_stock/models/stock.py
+++ b/addons/purchase_stock/models/stock.py
@@ -237,10 +237,11 @@ class Orderpoint(models.Model):
 
         return result
 
-    def _get_replenishment_order_notification(self):
+    def _get_replenishment_order_notification(self, written_after):
         self.ensure_one()
         order = self.env['purchase.order.line'].search([
-            ('orderpoint_id', 'in', self.ids)
+            ('orderpoint_id', 'in', self.ids),
+            ('write_date', '>', written_after)
         ], limit=1).order_id
         if order:
             action = self.env.ref('purchase.action_rfq_form')
@@ -257,7 +258,7 @@ class Orderpoint(models.Model):
                     'sticky': False,
                 }
             }
-        return super()._get_replenishment_order_notification()
+        return super()._get_replenishment_order_notification(written_after)
 
     def _prepare_procurement_values(self, date=False, group=False):
         values = super()._prepare_procurement_values(date=date, group=group)

--- a/addons/stock/models/stock_orderpoint.py
+++ b/addons/stock/models/stock_orderpoint.py
@@ -212,10 +212,11 @@ class StockWarehouseOrderpoint(models.Model):
         return self._get_orderpoint_action()
 
     def action_replenish(self):
+        now = datetime.now()
         self._procure_orderpoint_confirm(company_id=self.env.company)
         notification = False
         if len(self) == 1:
-            notification = self._get_replenishment_order_notification()
+            notification = self._get_replenishment_order_notification(now)
         # Forced to call compute quantity because we don't have a link.
         self._compute_qty()
         self.filtered(lambda o: o.create_uid.id == SUPERUSER_ID and o.qty_to_order <= 0.0 and o.trigger == 'manual').unlink()
@@ -422,7 +423,21 @@ class StockWarehouseOrderpoint(models.Model):
             'trigger': 'manual',
         }
 
-    def _get_replenishment_order_notification(self):
+    def _get_replenishment_order_notification(self, written_after):
+        self.ensure_one()
+        move = self.env['stock.move'].search([
+            ('orderpoint_id', 'in', self.ids),
+            ('write_date', '>', written_after)
+        ], limit=1)
+        if move.picking_id:
+            return {
+                'type': 'ir.actions.client',
+                'tag': 'display_notification',
+                'params': {
+                    'title': _('The inter-warehouse transfers have been generated'),
+                    'sticky': False,
+                }
+            }
         return False
 
     def _quantity_in_progress(self):


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
Problem occurs when clicking order now on a replenishment line (orderpoint) for a manufacture or WH resupply route.

Current behavior before PR:
Notification contents on replenishment action are for a previously created PO from this orderpoint, instead of the currently created MO/inter-warehouse transfer.

Desired behavior after PR is merged:
Notification contents on replenishment action match the created PO/MO/inter-warehouse transfer.


--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
