### PR TITLE
[FIX] delivery: remove wrong currency conversion for delivery carrier price

### DIFF
--- a/addons/delivery/models/delivery_carrier.py
+++ b/addons/delivery/models/delivery_carrier.py
@@ -266,9 +266,6 @@ class DeliveryCarrier(models.Model):
                     'error_message': _('Error: this delivery method is not available for this address.'),
                     'warning_message': False}
         price = order.pricelist_id.get_product_price(self.product_id, 1.0, order.partner_id)
-        company = self.company_id or order.company_id or self.env.company
-        if company.currency_id and company.currency_id != order.currency_id:
-            price = company.currency_id._convert(price, order.currency_id, company, fields.Date.today())
         return {'success': True,
                 'price': price,
                 'error_message': False,

--- a/addons/delivery/tests/test_delivery_cost.py
+++ b/addons/delivery/tests/test_delivery_cost.py
@@ -196,3 +196,45 @@ class TestDeliveryCost(common.TransactionCase):
                                           ('product_id', '=', self.normal_delivery.product_id.id)])
         self.assertEqual(len(line), 1, "Delivery cost hasn't been added to SO")
         self.assertEqual(line.price_subtotal, 5.0, "Delivery cost does not correspond to 5.0")
+
+    def test_02_delivery_cost_from_different_currency(self):
+        """ This test aims to validate the use of a pricelist using a different currency to compute the delivery cost in
+            the case the associated product of the shipping method is defined in the pricelist """
+
+        # Create pricelist with a custom price for the standard shipping method
+        my_pricelist = self.env['product.pricelist'].create({
+            'name': 'shipping_cost_change',
+            'item_ids': [(0, 0, {
+                'compute_price': 'fixed',
+                'fixed_price': 5,
+                'applied_on': '0_product_variant',
+                'product_id': self.normal_delivery.product_id.id,
+            })],
+            'currency_id': self.env.ref('base.EUR').id,
+        })
+
+        # Create sales order with Normal Delivery Charges
+        sale_pricelist_based_delivery_charges = self.SaleOrder.create({
+            'partner_id': self.partner_18.id,
+            'pricelist_id': my_pricelist.id,
+            'order_line': [(0, 0, {
+                'name': 'PC Assamble + 2GB RAM',
+                'product_id': self.product_4.id,
+                'product_uom_qty': 1,
+                'product_uom': self.product_uom_unit.id,
+                'price_unit': 750.00,
+            })],
+        })
+
+        # Add of delivery cost in Sales order
+        delivery_wizard = Form(self.env['choose.delivery.carrier'].with_context({
+            'default_order_id': sale_pricelist_based_delivery_charges.id,
+            'default_carrier_id': self.normal_delivery.id
+        }))
+        self.assertEqual(delivery_wizard.delivery_price, 5.0, "Delivery cost does not correspond to 5.0 in wizard")
+        delivery_wizard.save().button_confirm()
+
+        line = self.SaleOrderLine.search([('order_id', '=', sale_pricelist_based_delivery_charges.id),
+                                          ('product_id', '=', self.normal_delivery.product_id.id)])
+        self.assertEqual(len(line), 1, "Delivery cost hasn't been added to SO")
+        self.assertEqual(line.price_subtotal, 5.0, "Delivery cost does not correspond to 5.0")


### PR DESCRIPTION
### Observed Behaviour

When using a pricelist with a fixed price for all products with a different currency than the one of the company, adding shipping cost in a sale order using this pricelist will give a wrong value of the shipping cost

### Expect Behaviour

The computed shipping cost added in the sale order should be the same as the fixed price defined in the pricelist

### Reproducibility

This issue can be reproduced using the following steps :
1. Define a pricelist PL1 with a fixed price for all products and a different currency than the one used in the company (eg fixed price to 15KR)
2. Create a sale order and select PL1 as pricelist
3. Add a product and add a shipping cost

The shipping cost should be the defined fixed price (15KR) but it gives another value, depending of the company currency

### Fix Description

This fix remove a useless currency conversion coming from the fact that since https://github.com/odoo/odoo/pull/86484 we get the delivery price from the SO priceliste (using  pricelist.get_product_price) giving us a price that  is already converted to the correct currency

### Related issue/PR
- opw-2810506

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
