### PR TITLE
[FIX] pos_adyen: leaving PaymentScreen while paying/cancelling

### DIFF
--- a/addons/pos_adyen/static/src/js/PaymentScreen.js
+++ b/addons/pos_adyen/static/src/js/PaymentScreen.js
@@ -1,0 +1,36 @@
+odoo.define('pos_adyen.PaymentScreen', function(require) {
+    "use strict";
+
+    const PaymentScreen = require('point_of_sale.PaymentScreen');
+    const Registries = require('point_of_sale.Registries');
+    const { onMounted } = owl.hooks;
+
+    const PosAdyenPaymentScreen = PaymentScreen => class extends PaymentScreen {
+        constructor() {
+            super(...arguments);
+            onMounted(() => {
+                const pendingPaymentLine = this.currentOrder.paymentlines.find(
+                    paymentLine => paymentLine.payment_method.use_payment_terminal === 'adyen' &&
+                        (!paymentLine.is_done() && paymentLine.get_payment_status() !== 'pending')
+                );
+                if (pendingPaymentLine) {
+                    const paymentTerminal = pendingPaymentLine.payment_method.payment_terminal;
+                    paymentTerminal.set_most_recent_service_id(pendingPaymentLine.terminalServiceId);
+                    pendingPaymentLine.set_payment_status('waiting');
+                    paymentTerminal.start_get_status_polling().then(isPaymentSuccessful => {
+                        if (isPaymentSuccessful) {
+                            pendingPaymentLine.set_payment_status('done');
+                            pendingPaymentLine.can_be_reversed = paymentTerminal.supports_reversals;
+                        } else {
+                            pendingPaymentLine.set_payment_status('retry');
+                        }
+                    });
+                }
+            });
+        }
+    };
+
+    Registries.Component.extend(PaymentScreen, PosAdyenPaymentScreen);
+
+    return PaymentScreen;
+});

--- a/addons/pos_adyen/static/src/js/models.js
+++ b/addons/pos_adyen/static/src/js/models.js
@@ -5,4 +5,25 @@ var PaymentAdyen = require('pos_adyen.payment');
 models.register_payment_method('adyen', PaymentAdyen);
 models.register_payment_method('odoo_adyen', PaymentAdyen);
 models.load_fields('pos.payment.method', 'adyen_terminal_identifier');
+
+const superPaymentline = models.Paymentline.prototype;
+models.Paymentline = models.Paymentline.extend({
+    initialize: function(attr, options) {
+        superPaymentline.initialize.call(this,attr,options);
+        this.terminalServiceId = this.terminalServiceId  || null;
+    },
+    export_as_JSON: function(){
+        const json = superPaymentline.export_as_JSON.call(this);
+        json.terminal_service_id = this.terminalServiceId;
+        return json;
+    },
+    init_from_JSON: function(json){
+        superPaymentline.init_from_JSON.apply(this,arguments);
+        this.terminalServiceId = json.terminal_service_id;
+    },
+    setTerminalServiceId: function(id) {
+        this.terminalServiceId = id;
+    }
+});
+
 });

--- a/addons/pos_adyen/views/point_of_sale_assets.xml
+++ b/addons/pos_adyen/views/point_of_sale_assets.xml
@@ -3,6 +3,7 @@
     <template id="assets" inherit_id="point_of_sale.assets">
         <xpath expr="." position="inside">
             <script type="text/javascript" src="/pos_adyen/static/src/js/payment_adyen.js"></script>
+            <script type="text/javascript" src="/pos_adyen/static/src/js/PaymentScreen.js"></script>
             <script type="text/javascript" src="/pos_adyen/static/src/js/models.js"></script>
         </xpath>
     </template>


### PR DESCRIPTION
Before this commit: whenever we left the PaymentScreen when we were paying (either by reloading the page or by backing to the ProductScreen), the real payment status was not properly saved even tho the payment has been paid or cancelled.

With this commit: whenever we go to the PaymentScreen with a pending payment line with Adyen, we fetch the latest status from the back end. This way, the front end will always have the latest status of the payment.

opw-2802676