### PR TITLE
[IMP] portal: add informative button to internal notes on portal chatter

### DIFF
--- a/addons/portal/i18n/portal.pot
+++ b/addons/portal/i18n/portal.pot
@@ -477,6 +477,20 @@ msgid "In Portal"
 msgstr ""
 
 #. module: portal
+#. openerp-web
+#: code:addons/portal/static/src/xml/portal_chatter.xml:0
+#, python-format
+msgid "Internal Note"
+msgstr ""
+
+#. module: portal
+#. openerp-web
+#: code:addons/portal/static/src/xml/portal_chatter.xml:0
+#, python-format
+msgid "Internal notes are only displayed to internal users."
+msgstr ""
+
+#. module: portal
 #: code:addons/portal/controllers/portal.py:0
 #, python-format
 msgid "Invalid Email! Please enter a valid email address."

--- a/addons/portal/models/mail_message.py
+++ b/addons/portal/models/mail_message.py
@@ -16,8 +16,10 @@ class MailMessage(models.Model):
 
     def _portal_message_format(self, fields_list):
         vals_list = self._message_format(fields_list)
+        message_subtype_note_id = self.env['ir.model.data'].xmlid_to_res_id('mail.mt_note')
         IrAttachmentSudo = self.env['ir.attachment'].sudo()
         for vals in vals_list:
+            vals['is_message_subtype_note'] = message_subtype_note_id and vals.get('subtype_id', [False])[0] == message_subtype_note_id
             for attachment in vals.get('attachment_ids', []):
                 if not attachment.get('access_token'):
                     attachment['access_token'] = IrAttachmentSudo.browse(attachment['id']).generate_access_token()[0]

--- a/addons/portal/static/src/xml/portal_chatter.xml
+++ b/addons/portal/static/src/xml/portal_chatter.xml
@@ -114,7 +114,10 @@
 
     <!-- Chatter: internal toggle widget -->
     <t t-name="portal.chatter_internal_toggle">
-        <div t-attf-class="float-right o_portal_chatter_js_is_internal #{message.is_internal and 'o_portal_message_internal_on' or 'o_portal_message_internal_off'}"
+        <div t-if="message.is_message_subtype_note" class="float-right">
+            <button class="btn btn-secondary" title="Internal notes are only displayed to internal users." disabled="true">Internal Note</button>
+        </div>
+        <div t-else="" t-attf-class="float-right o_portal_chatter_js_is_internal #{message.is_internal and 'o_portal_message_internal_on' or 'o_portal_message_internal_off'}"
                 t-att-data-message-id="message.id"
                 t-att-data-is-internal="message.is_internal">
             <button class="btn btn-danger"


### PR DESCRIPTION
PURPOSE

Before this commit, when the chatter was displayed on a portal
page one could see the internal notes with a button for toggling
his visibility... which was ineffective because a portal user
could never see internal notes and on the opposite internal users
could always see them.
This commit adds another informative (disabled) button for internal
notes.

SPECIFICATION

Adds a 'is_note' param on the message in the _portal_message_format
method.

LINKS

Task-2817892



--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
