### PR TITLE
[IMP] mail: remove ComposerSuggestionComponent getters

### DIFF
--- a/addons/mail/static/src/components/composer_suggestion/composer_suggestion.js
+++ b/addons/mail/static/src/components/composer_suggestion/composer_suggestion.js
@@ -26,42 +26,6 @@ export class ComposerSuggestion extends Component {
         return this.messaging && this.messaging.models['ComposerSuggestion'].get(this.props.localId);
     }
 
-    /**
-     * @returns {ComposerView}
-     */
-    get composerView() {
-        return this.messaging && this.messaging.models['ComposerView'].get(this.props.composerViewLocalId);
-    }
-
-    get record() {
-        return this.messaging && this.messaging.models[this.props.modelName].get(this.props.recordLocalId);
-    }
-
-    /**
-     * Returns a descriptive title for this suggestion. Useful to be able to
-     * read both parts when they are overflowing the UI.
-     *
-     * @returns {string}
-     */
-    title() {
-        if (this.composerSuggestion.cannedResponse) {
-            return _.str.sprintf("%s: %s", this.record.source, this.record.substitution);
-        }
-        if (this.composerSuggestion.thread) {
-            return this.record.name;
-        }
-        if (this.composerSuggestion.channelCommand) {
-            return _.str.sprintf("%s: %s", this.record.name, this.record.help);
-        }
-        if (this.composerSuggestion.partner) {
-            if (this.record.email) {
-                return _.str.sprintf("%s (%s)", this.record.nameOrDisplayName, this.record.email);
-            }
-            return this.record.nameOrDisplayName;
-        }
-        return "";
-    }
-
     //--------------------------------------------------------------------------
     // Private
     //--------------------------------------------------------------------------
@@ -72,14 +36,15 @@ export class ComposerSuggestion extends Component {
     _update() {
         if (
             this.root.el &&
-            this.composerView &&
-            this.composerView.hasToScrollToActiveSuggestion &&
+            this.composerSuggestion &&
+            this.composerSuggestion.composerViewOwner &&
+            this.composerSuggestion.composerViewOwner.hasToScrollToActiveSuggestion &&
             this.props.isActive
         ) {
             this.root.el.scrollIntoView({
                 block: 'center',
             });
-            this.composerView.update({ hasToScrollToActiveSuggestion: false });
+            this.composerSuggestion.composerViewOwner.update({ hasToScrollToActiveSuggestion: false });
         }
     }
 
@@ -93,7 +58,7 @@ export class ComposerSuggestion extends Component {
      */
     _onClick(ev) {
         ev.preventDefault();
-        this.composerView.onClickSuggestion(this.composerSuggestion);
+        this.composerSuggestion.composerViewOwner.onClickSuggestion(this.composerSuggestion);
     }
 
 }
@@ -103,11 +68,8 @@ Object.assign(ComposerSuggestion, {
         isActive: false,
     },
     props: {
-        composerViewLocalId: String,
         isActive: { type: Boolean, optional: true },
         localId: String,
-        modelName: String,
-        recordLocalId: String,
     },
     template: 'mail.ComposerSuggestion',
 });

--- a/addons/mail/static/src/components/composer_suggestion/composer_suggestion.xml
+++ b/addons/mail/static/src/components/composer_suggestion/composer_suggestion.xml
@@ -3,27 +3,27 @@
 
     <t t-name="mail.ComposerSuggestion" owl="1">
         <t t-if="composerSuggestion">
-            <a class="o_ComposerSuggestion dropdown-item d-flex w-100 py-2 px-4" t-att-class="{ 'active bg-300': props.isActive }" t-attf-class="{{ className }}" href="#" t-att-title="title()" role="menuitem" t-on-click="_onClick" t-ref="root">
+            <a class="o_ComposerSuggestion dropdown-item d-flex w-100 py-2 px-4" t-att-class="{ 'active bg-300': props.isActive }" t-attf-class="{{ className }}" href="#" t-att-title="composerSuggestion.title" role="menuitem" t-on-click="_onClick" t-ref="root">
                 <t t-if="composerSuggestion.cannedResponse">
-                    <strong class="o_ComposerSuggestion_part1 flex-shrink-0 mw-100 pr-2 text-truncate"><t t-esc="record.source"/></strong>
-                    <em class="o_ComposerSuggestion_part2 text-600 text-truncate"><t t-esc="record.substitution"/></em>
+                    <strong class="o_ComposerSuggestion_part1 flex-shrink-0 mw-100 pr-2 text-truncate"><t t-esc="composerSuggestion.record.source"/></strong>
+                    <em class="o_ComposerSuggestion_part2 text-600 text-truncate"><t t-esc="composerSuggestion.record.substitution"/></em>
                 </t>
                 <t t-if="composerSuggestion.thread">
-                    <strong class="o_ComposerSuggestion_part1 flex-shrink-0 mw-100 pr-2 text-truncate"><t t-esc="record.name"/></strong>
+                    <strong class="o_ComposerSuggestion_part1 flex-shrink-0 mw-100 pr-2 text-truncate"><t t-esc="composerSuggestion.record.name"/></strong>
                 </t>
                 <t t-if="composerSuggestion.channelCommand">
-                    <strong class="o_ComposerSuggestion_part1 flex-shrink-0 mw-100 pr-2 text-truncate"><t t-esc="record.name"/></strong>
-                    <em class="o_ComposerSuggestion_part2 text-600 text-truncate"><t t-esc="record.help"/></em>
+                    <strong class="o_ComposerSuggestion_part1 flex-shrink-0 mw-100 pr-2 text-truncate"><t t-esc="composerSuggestion.record.name"/></strong>
+                    <em class="o_ComposerSuggestion_part2 text-600 text-truncate"><t t-esc="composerSuggestion.record.help"/></em>
                 </t>
                 <t t-if="composerSuggestion.partner">
                     <PartnerImStatusIcon
                         className="'o_ComposerSuggestion_partnerImStatusIcon flex-shrink-0 mr-1'"
                         hasBackground="false"
-                        partnerLocalId="record.localId"
+                        partnerLocalId="composerSuggestion.record.localId"
                     />
-                    <strong class="o_ComposerSuggestion_part1 flex-shrink-0 mw-100 pr-2 text-truncate"><t t-esc="record.nameOrDisplayName"/></strong>
-                    <t t-if="record.email">
-                        <em class="o_ComposerSuggestion_part2 text-600 text-truncate">(<t t-esc="record.email"/>)</em>
+                    <strong class="o_ComposerSuggestion_part1 flex-shrink-0 mw-100 pr-2 text-truncate"><t t-esc="composerSuggestion.record.nameOrDisplayName"/></strong>
+                    <t t-if="composerSuggestion.record.email">
+                        <em class="o_ComposerSuggestion_part2 text-600 text-truncate">(<t t-esc="composerSuggestion.record.email"/>)</em>
                     </t>
                 </t>
             </a>

--- a/addons/mail/static/src/components/composer_suggestion_list/composer_suggestion_list.xml
+++ b/addons/mail/static/src/components/composer_suggestion_list/composer_suggestion_list.xml
@@ -8,11 +8,8 @@
                     <div class="o_ComposerSuggestionList_list dropdown-menu show w-100 overflow-auto">
                         <t t-foreach="composerView.mainSuggestions" t-as="suggestion" t-key="suggestion.localId">
                             <ComposerSuggestion
-                                composerViewLocalId="composerView.localId"
                                 isActive="suggestion === composerView.activeSuggestion"
                                 localId="suggestion.localId"
-                                modelName="composerView.suggestionModelName"
-                                recordLocalId="suggestion.record.localId"
                             />
                         </t>
                         <t t-if="composerView.mainSuggestions.length > 0 and composerView.extraSuggestions.length > 0">
@@ -20,11 +17,8 @@
                         </t>
                         <t t-foreach="composerView.extraSuggestions" t-as="suggestion" t-key="suggestion.localId">
                             <ComposerSuggestion
-                                composerViewLocalId="composerView.localId"
                                 isActive="suggestion === composerView.activeSuggestion"
                                 localId="suggestion.localId"
-                                modelName="composerView.suggestionModelName"
-                                recordLocalId="suggestion.record.localId"
                             />
                         </t>
                     </div>

--- a/addons/mail/static/src/models/composer_suggestion.js
+++ b/addons/mail/static/src/models/composer_suggestion.js
@@ -14,6 +14,19 @@ registerModel({
     name: 'ComposerSuggestion',
     identifyingFields: [['composerViewOwnerAsExtraSuggestion', 'composerViewOwnerAsMainSuggestion'], ['cannedResponse', 'channelCommand', 'partner', 'thread']],
     recordMethods: {
+         /**
+         * @private
+         * @returns {FieldCommand}
+         */
+        _computeComposerViewOwner() {
+            if (this.composerViewOwnerAsExtraSuggestion) {
+                return replace(this.composerViewOwnerAsExtraSuggestion);
+            }
+            if (this.composerViewOwnerAsMainSuggestion) {
+                return replace(this.composerViewOwnerAsMainSuggestion);
+            }
+            return clear();
+        },
         /**
          * @private
          * @returns {string}
@@ -51,6 +64,28 @@ registerModel({
             }
             return clear();
         },
+        /**
+         * @private
+         * @returns {string|FieldCommand}
+         */
+        _computeTitle() {
+            if (this.cannedResponse) {
+                return _.str.sprintf("%s: %s", this.record.source, this.record.substitution);
+            }
+            if (this.thread) {
+                return this.record.name;
+            }
+            if (this.channelCommand) {
+                return _.str.sprintf("%s: %s", this.record.name, this.record.help);
+            }
+            if (this.partner) {
+                if (this.record.email) {
+                    return _.str.sprintf("%s (%s)", this.record.nameOrDisplayName, this.record.email);
+                }
+                return this.record.nameOrDisplayName;
+            }
+            return clear();
+        },
     },
     fields: {
         cannedResponse: one('CannedResponse', {
@@ -58,6 +93,9 @@ registerModel({
         }),
         channelCommand: one('ChannelCommand', {
             readonly: true,
+        }),
+        composerViewOwner: one('ComposerView', {
+            compute: '_computeComposerViewOwner',
         }),
         composerViewOwnerAsExtraSuggestion: one('ComposerView', {
             inverse: 'extraSuggestions',
@@ -81,6 +119,14 @@ registerModel({
         }),
         thread: one('Thread', {
             readonly: true,
+        }),
+        /**
+         * Descriptive title for this suggestion. Useful to be able to
+         * read both parts when they are overflowing the UI.
+         */
+        title: attr({
+            compute: '_computeTitle',
+            default: "",
         }),
     },
 });


### PR DESCRIPTION
This commit replaces getters in `ComposerSuggestion` component to fields in
model `ComposerSuggestion`.

Getters in component are a problem for many reasons, notably that business
code is in component and not in modelling. Code that are not in modelling are
hacky, hard to maintain, and very prone to bug. That's why it's important to
move most code in components to models.

Task-2793280