### PR TITLE
[FIX] product: use auto_join for partner link in supplier_info

### DIFF
--- a/addons/product/models/product.py
+++ b/addons/product/models/product.py
@@ -732,6 +732,7 @@ class SupplierInfo(models.Model):
     name = fields.Many2one(
         'res.partner', 'Vendor',
         ondelete='cascade', required=True,
+        auto_join=True,
         help="Vendor of this product", check_company=True)
     product_name = fields.Char(
         'Vendor Product Name',


### PR DESCRIPTION
`_prepare_sellers` method uses domain
`self.env['product.supplierinfo'].search([('name.active', '=', True)] ... ])`

Without `auto_join`, ORM first loads ids for active partners and then uses those
ids to select `product.supplierinfo`. It works too slow when there are 1M
records in `res.partner`.

---

opw-2740114

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
