### PR TITLE
[FIX] survey: stats for matrix question is not computed correctly

### DIFF
--- a/addons/survey/views/survey_templates_statistics.xml
+++ b/addons/survey/views/survey_templates_statistics.xml
@@ -365,7 +365,7 @@
                                 <span t-esc="choice_data['row'].value"></span>
                             </td>
                             <td class="survey_answer" t-foreach="choice_data['columns']" t-as="column_data">
-                                <span t-esc="round(column_data['count'] * 100.0/ (len(question_data['answer_line_done_ids']) or 1), 2)"></span> %
+                                <span t-esc="round(column_data['count'] * 100.0/ (len(question_data['answer_input_done_ids']) or 1), 2)"></span> %
                                 <span class="badge badge-primary" t-esc="column_data['count']"></span>
                                 <i class="fa fa-filter text-primary survey_filter"
                                     t-att-data-question_id="question.id"


### PR DESCRIPTION
Reproduction:
1. Install Survey, create a survey with one matrix type question (3 rows
and 3 options for example)
2. Click share, copy the survey link in an incognito tab, and finish it
twice
3. Go to the backend, click “See results”, click “Data” tab
4. The ratio is calculated based on the total number of received options
(#options * #answers)

Reason: the ratio for matrix questions should be computed row by row.
This behavior was correct in V13, but lost in V14 after model rewriting

Fix: Use the number of answers to compute the ratio instead of the
number of options made

opw-2809433


--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
