### PR TITLE
[FIX] hr: use correct name when creating employee from user wizard

### DIFF
--- a/addons/hr/models/res_users.py
+++ b/addons/hr/models/res_users.py
@@ -3,6 +3,7 @@
 
 from odoo import api, models, fields, _, SUPERUSER_ID
 from odoo.exceptions import AccessError
+from odoo.tools.misc import clean_context
 
 
 HR_READABLE_FIELDS = [
@@ -208,7 +209,7 @@ class User(models.Model):
                     **self.env['hr.employee']._sync_user(user)
                 ))
         if employee_create_vals:
-            self.env['hr.employee'].create(employee_create_vals)
+            self.env['hr.employee'].with_context(clean_context(self.env.context)).create(employee_create_vals)
         return res
 
     def write(self, vals):


### PR DESCRIPTION
When creating a user and employee from the wizard, the employee was
taking the default name from the context instead of the one chosen
in the wizard.

TaskID: 2819821

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
