### PR TITLE
[IMP] crm: detect leads based on similar phone/mobile number

### DIFF
--- a/addons/iap/tools/iap_tools.py
+++ b/addons/iap/tools/iap_tools.py
@@ -10,7 +10,7 @@ from unittest.mock import patch
 
 from odoo import exceptions, _
 from odoo.tests.common import BaseCase
-from odoo.tools import pycompat
+from odoo.tools import email_normalize, pycompat
 
 _logger = logging.getLogger(__name__)
 
@@ -72,6 +72,39 @@ _MAIL_DOMAIN_BLACKLIST = set([
 _STATES_FILTER_COUNTRIES_WHITELIST = set([
     'AR', 'AU', 'BR', 'CA', 'IN', 'MY', 'MX', 'NZ', 'AE', 'US'
 ])
+
+
+#----------------------------------------------------------
+# Tools
+#----------------------------------------------------------
+
+def mail_prepare_for_domain_search(email, min_email_length=0):
+    """ Return an email address to use for a domain-based search. For generic
+    email providers like gmail (see ``_MAIL_DOMAIN_BLACKLIST``) we consider
+    each email as being independant (and return the whole email). Otherwise
+    we return only the right-part of the email (aka "mydomain.com" if email is
+    "Raoul Lachignole" <raoul@mydomain.com>).
+
+    :param integer min_email_length: skip if email has not the sufficient minimal
+      length, indicating a probably fake / wrong value (skip if 0);
+    """
+    if not email:
+        return False
+    email_tocheck = email_normalize(email, strict=False)
+    if not email_tocheck:
+        email_tocheck = email.casefold()
+
+    if email_tocheck and min_email_length and len(email_tocheck) < min_email_length:
+        return False
+
+    parts = email_tocheck.rsplit('@', maxsplit=1)
+    if len(parts) == 1:
+        return email_tocheck
+    email_domain = parts[1]
+    if email_domain not in _MAIL_DOMAIN_BLACKLIST:
+        return '@' + email_domain
+    return email_tocheck
+
 
 #----------------------------------------------------------
 # Helpers for both clients and proxy

--- a/addons/test_crm_full/tests/test_performance.py
+++ b/addons/test_crm_full/tests/test_performance.py
@@ -70,7 +70,7 @@ class TestCrmPerformance(CrmPerformanceCase):
         country_be = self.env.ref('base.be')
         lang_be = self.env['res.lang']._lang_get('fr_BE')
 
-        with freeze_time(self.reference_now), self.assertQueryCount(user_sales_leads=178):  # tcf 164 / com 166
+        with freeze_time(self.reference_now), self.assertQueryCount(user_sales_leads=186):  # tcf 174 / com 175
             self.env.cr._now = self.reference_now  # force create_date to check schedulers
             with Form(self.env['crm.lead']) as lead_form:
                 lead_form.country_id = country_be
@@ -89,7 +89,7 @@ class TestCrmPerformance(CrmPerformanceCase):
     @warmup
     def test_lead_create_form_partner(self):
         """ Test a single lead creation using Form with a partner """
-        with freeze_time(self.reference_now), self.assertQueryCount(user_sales_leads=186):  # tcf 173 / com 175
+        with freeze_time(self.reference_now), self.assertQueryCount(user_sales_leads=199):  # tcf 186 / com 188
             self.env.cr._now = self.reference_now  # force create_date to check schedulers
             with self.debug_mode():
                 # {'invisible': ['|', ('type', '=', 'opportunity'), ('is_partner_visible', '=', False)]}

--- a/odoo/tools/mail.py
+++ b/odoo/tools/mail.py
@@ -519,7 +519,7 @@ def email_split_and_format(text):
         return []
     return [formataddr((name, email)) for (name, email) in email_split_tuples(text)]
 
-def email_normalize(text):
+def email_normalize(text, strict=True):
     """ Sanitize and standardize email address entries.
         A normalized email is considered as :
         - having a left part + @ + a right part (the domain can be without '.something')
@@ -528,12 +528,17 @@ def email_normalize(text):
         Ex:
         - Possible Input Email : 'Name <NaMe@DoMaIn.CoM>'
         - Normalized Output Email : 'name@domain.com'
+
+    :param bool strict: text should contain exactly one email (default behavior
+      and unique behavior before Odoo16);
+
+    :return: False if no email found (or if more than 1 email found when being
+      in strict mode); normalized email otherwise;
     """
     emails = email_split(text)
-    if not emails or len(emails) != 1:
+    if not emails or (strict and len(emails) != 1):
         return False
     return emails[0].lower()
-
 
 def email_domain_extract(email):
     """ Extract the company domain to be used by IAP services notably. Domain


### PR DESCRIPTION
Right now, the 'similar lead detection' mechanism only considers email,
contact name, and partner name while finding duplicate leads in CRM.

After this PR, it will also consider the mobile/phone number for
the same. Note that the mobile numbers and phone numbers both will be
matched with each other while finding duplicate leads.

taskID-2817884