### PR TITLE
[FIX] core: field display_name should be "" instead of False

### DIFF
--- a/odoo/addons/test_new_api/tests/test_onchange.py
+++ b/odoo/addons/test_new_api/tests/test_onchange.py
@@ -599,10 +599,11 @@ class TestOnChange(SavepointCaseWithUserDemo):
 
         form = common.Form(self.env['test_new_api.multi.tag'])
         self.assertEqual(form.name, False)
-        self.assertEqual(form.display_name, False)
+        self.assertEqual(form.display_name, "")
 
         record = form.save()
-        self.assertEqual(record.display_name, False)
+        self.assertEqual(record.name, False)
+        self.assertEqual(record.display_name, "")
         self.assertEqual(record.name_get(), [(record.id, "")])
 
 

--- a/odoo/models.py
+++ b/odoo/models.py
@@ -1831,7 +1831,7 @@ class BaseModel(metaclass=MetaModel):
         """
         names = dict(self.name_get())
         for record in self:
-            record.display_name = names.get(record.id) or False
+            record.display_name = names.get(record.id)
 
     def name_get(self):
         """Returns a textual representation for the records in ``self``, with


### PR DESCRIPTION
This is a followup of #86567, where we change the computation of `display_name` to match the values of `name_get()`.  Forcing its value to `False` instead of the empty string causes many regressions in frontend applications like `website_blog`.