### PR TITLE
[FIX] hr_timesheet: properly display recorded hour in button

### DIFF
--- a/addons/hr_timesheet/views/project_views.xml
+++ b/addons/hr_timesheet/views/project_views.xml
@@ -41,7 +41,7 @@
                         <div class="o_field_widget o_stat_info">
                             <div class="oe_inline">
                                 <span class="o_stat_value mr-1">
-                                    <field name="total_timesheet_time" widget="statinfo" nolabel="1"/>
+                                    <field name="total_timesheet_time" widget="timesheet_uom" nolabel="1"/>
                                 </span>
                                 <span class="o_stat_value">
                                     <field name="timesheet_encode_uom_id" class="o_stat_text" options="{'no_open' : True}"/>


### PR DESCRIPTION
before this commit, the recorded hours are not correctly
computed on the project.project form view

so this commit fixes the issue by correctly computing recorded hours
so that the project.project form view contains the correct recorded hour

task-2788878