### PR TITLE
[FIX] hr_timesheet: Adapt graph view to dashboard

### DIFF
--- a/addons/hr_timesheet/__manifest__.py
+++ b/addons/hr_timesheet/__manifest__.py
@@ -58,6 +58,9 @@ up a management by affair.
             'hr_timesheet/static/src/js/timesheet_graph_view.js',
             'hr_timesheet/static/src/js/timesheet_graph_model.js',
         ],
+        "web.assets_backend_legacy_lazy": [
+            'hr_timesheet/static/src/js/*_legacy.js',
+        ],
         'web.qunit_suite_tests': [
             'hr_timesheet/static/tests/**/*',
         ],

--- a/addons/hr_timesheet/static/src/js/timesheet_graph_legacy.js
+++ b/addons/hr_timesheet/static/src/js/timesheet_graph_legacy.js
@@ -1,0 +1,39 @@
+odoo.define('hr_timesheet.GraphView', function (require) {
+    "use strict";
+
+    const viewRegistry = require('web.view_registry');
+    const GraphView = require('web.GraphView');
+    const GraphModel = require('web.GraphModel');
+
+    const hrTimesheetGraphModel = GraphModel.extend({
+        /*
+         * Override the _processData to take into account the analytic line uom.
+         */
+        _processData: function (originIndex, rawData) {
+            this._super.apply(this, arguments);
+            const session = this.getSession();
+            const currentCompanyId = session.user_context.allowed_company_ids[0];
+            const currentCompany = session.user_companies.allowed_companies[currentCompanyId];
+            const currentCompanyTimesheetUOMFactor = currentCompany.timesheet_uom_factor || 1;
+            const fields = ['unit_amount', 'effective_hours', 'planned_hours', 'remaining_hours', 'total_hours_spent', 'subtask_effective_hours',
+            'overtime', 'number_hours', 'difference', 'hours_effective', 'hours_planned', 'timesheet_unit_amount'];
+
+            if (fields.includes(this.chart.measure) && currentCompanyTimesheetUOMFactor !== 1) {
+                // recalculate the Duration values according to the timesheet_uom_factor
+                this.chart.dataPoints.forEach(function (dataPt) {
+                    dataPt.value *= currentCompanyTimesheetUOMFactor;
+                });
+            }
+        },
+    });
+
+
+    const hrTimesheetGraphView = GraphView.extend({
+        config: Object.assign({}, GraphView.prototype.config, {
+            Model: hrTimesheetGraphModel,
+        }),
+    });
+
+    viewRegistry.add('hr_timesheet_graphview', hrTimesheetGraphView);
+    return hrTimesheetGraphView;
+});


### PR DESCRIPTION
For now `hr_timesheet_graphview` doesn't work with dashboard because
`board` is still in legacy and `hr_timesheet_graphview` in owl.

So we have to create a legacy version of it to adapt it to dashboard.

Similar fix: https://github.com/odoo/odoo/pull/86571/files

opw-2793729