### PR TITLE
[FIX] https://github.com/odoo/odoo/issues/85643

### DIFF
--- a/addons/web/controllers/main.py
+++ b/addons/web/controllers/main.py
@@ -1479,6 +1479,9 @@ class Binary(http.Controller):
         '/web/partner_image/<int:rec_id>/<string:field>',
         '/web/partner_image/<int:rec_id>/<string:field>/<string:model>/'], type='http', auth="public")
     def content_image_partner(self, rec_id, field='image_128', model='res.partner', **kwargs):
+        # read access for public user
+        if not request.uid:
+            request.uid = odoo.SUPERUSER_ID
         # other kwargs are ignored on purpose
         return self._content_image(id=rec_id, model='res.partner', field=field,
             placeholder='user_placeholder.jpg')


### PR DESCRIPTION
https://github.com/odoo/odoo/issues/85643
This can also be solved by delete the rule for public user in the line
https://github.com/odoo/odoo/blob/14.0/odoo/addons/base/security/base_security.xml#L26

And in general, it's very strange to assign a public user to the res.partner model for a parent campaign. After all, by default, public user should not have any campaigns because there is no access.
But in the end, I think the solution through python is safer and solves the issue, which is also observed on odoo apps when you chat you don't see a photo of a technical specialist in the presence of this placeholder, which is not very nice.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
