### PR TITLE
[FIX] website_slides: correctly retrieve xmlid lookup result

### DIFF
--- a/addons/website_slides/models/ir_http.py
+++ b/addons/website_slides/models/ir_http.py
@@ -14,7 +14,7 @@ class Http(models.AbstractModel):
         obj = None
         if xmlid:
             obj = self._xmlid_to_obj(self.env, xmlid)
-            if obj._name != 'slide.slide':
+            if obj and obj._name != 'slide.slide':
                 obj = None
         elif id and model == 'slide.slide':
             obj = self.env[model].browse(int(id))


### PR DESCRIPTION
This commit is to prevent "AttributeError: 'NoneType' object has no
attribute '_name'"
When an xmlid does not exists, the _xmlid_to_obj returns None and the
condition was failing when trying to retrive the model name.

Closes odoo/odoo#88273
