### PR TITLE
[FIX] sale_coupon: Apply taxes to fixed_price discount

### DIFF
--- a/addons/sale_coupon/models/sale_order.py
+++ b/addons/sale_coupon/models/sale_order.py
@@ -363,8 +363,11 @@ class SaleOrder(models.Model):
             lines = order.order_line.filtered(lambda line: line.product_id == program.discount_line_product_id)
             if program.reward_type == 'discount' and program.discount_type == 'percentage':
                 lines_to_remove = lines
+                lines_to_add = []
                 # Values is what discount lines should really be, lines is what we got in the SO at the moment
                 # 1. If values & lines match, we should update the line (or delete it if no qty or price?)
+                #    As removing a lines remove all the other lines linked to the same program, we need to save them
+                #    using lines_to_keep
                 # 2. If the value is not in the lines, we should add it
                 # 3. if the lines contains a tax not in value, we should remove it
                 for value in values:
@@ -377,11 +380,13 @@ class SaleOrder(models.Model):
                             lines_to_remove -= line
                             lines_to_remove += update_line(order, line, value)
                             continue
-                    # Case 2.
+                    # Working on Case 2.
                     if not value_found:
-                        order.write({'order_line': [(0, False, value)]})
+                        lines_to_add += [(0, False, value)]
                 # Case 3.
                 lines_to_remove.unlink()
+                # Case 2.
+                order.write({'order_line': lines_to_add})
             else:
                 update_line(order, lines, values[0]).unlink()
 

--- a/addons/sale_coupon/models/sale_order.py
+++ b/addons/sale_coupon/models/sale_order.py
@@ -141,6 +141,10 @@ class SaleOrder(models.Model):
         discount_amount = line.product_uom_qty * line.price_reduce * (program.discount_percentage / 100)
         return discount_amount
 
+    def _get_max_reward_values_per_tax(self, program, taxes):
+        lines = self.order_line.filtered(lambda l: l.tax_id == taxes and l.product_id != program.discount_line_product_id)
+        return sum(lines.mapped(lambda l: l.price_reduce * l.product_uom_qty))
+
     def _get_reward_values_fixed_amount(self, program):
         discount_amount = self._get_reward_values_discount_fixed_amount(program)
 
@@ -421,6 +425,7 @@ class SaleOrder(models.Model):
             if program.reward_type == 'discount':
                 lines_to_remove = lines
                 lines_to_add = []
+                lines_to_keep = []
                 # Values is what discount lines should really be, lines is what we got in the SO at the moment
                 # 1. If values & lines match, we should update the line (or delete it if no qty or price?)
                 #    As removing a lines remove all the other lines linked to the same program, we need to save them
@@ -443,9 +448,12 @@ class SaleOrder(models.Model):
                     if not value_found:
                         lines_to_add += [(0, False, value)]
                 # Case 3.
-                lines_to_remove.unlink()
-                # Case 2.
-                order.write({'order_line': lines_to_add})
+                line_update = []
+                if lines_to_remove:
+                    line_update += [(3, line_id, 0) for line_id in lines_to_remove.ids]
+                    line_update += lines_to_keep
+                line_update += lines_to_add
+                order.write({'order_line': line_update})
             else:
                 update_line(order, lines, values[0]).unlink()
 

--- a/addons/sale_coupon/models/sale_order.py
+++ b/addons/sale_coupon/models/sale_order.py
@@ -141,20 +141,77 @@ class SaleOrder(models.Model):
         discount_amount = line.product_uom_qty * line.price_reduce * (program.discount_percentage / 100)
         return discount_amount
 
-    def _get_reward_values_discount(self, program):
-        if program.discount_type == 'fixed_amount':
-            taxes = program.discount_line_product_id.taxes_id
-            if self.fiscal_position_id:
-                taxes = self.fiscal_position_id.map_tax(taxes)
+    def _get_reward_values_fixed_amount(self, program):
+        discount_amount = self._get_reward_values_discount_fixed_amount(program)
+
+        # In case there is a tax set on the promotion product, we give priority to it.
+        # This allow manual overwrite of taxes for promotion.
+        if program.discount_line_product_id.taxes_id:
+            line_taxes = self.fiscal_position_id.map_tax(program.discount_line_product_id.taxes_id) if self.fiscal_position_id else program.discount_line_product_id.taxes_id
             return [{
                 'name': _("Discount: ") + program.name,
                 'product_id': program.discount_line_product_id.id,
-                'price_unit': - self._get_reward_values_discount_fixed_amount(program),
+                'price_unit': -discount_amount,
                 'product_uom_qty': 1.0,
                 'product_uom': program.discount_line_product_id.uom_id.id,
                 'is_reward_line': True,
-                'tax_id': [(4, tax.id, False) for tax in taxes],
+                'tax_id': [(4, tax.id, False) for tax in line_taxes],
             }]
+
+        lines = self._get_paid_order_lines()
+        # Remove Free Lines
+        lines = lines.filtered('price_reduce')
+        reward_lines = {}
+
+        tax_groups = set([line.tax_id for line in lines])
+        max_discount_per_tax_groups = {tax_ids: self._get_max_reward_values_per_tax(program, tax_ids) for tax_ids in tax_groups}
+
+        for tax_ids in sorted(tax_groups, key=lambda tax_ids: max_discount_per_tax_groups[tax_ids], reverse=True):
+
+            if discount_amount <= 0:
+                return reward_lines.values()
+
+            curr_lines = lines.filtered(lambda l: l.tax_id == tax_ids)
+            lines_price = sum(curr_lines.mapped(lambda l: l.price_reduce * l.product_uom_qty))
+            lines_total = sum(curr_lines.mapped('price_total'))
+
+            discount_line_amount_price = min(max_discount_per_tax_groups[tax_ids], (discount_amount * lines_price / lines_total))
+
+            if not discount_line_amount_price:
+                continue
+
+            discount_amount -= discount_line_amount_price * lines_total / lines_price
+
+            tax_name = ""
+            if len(tax_ids) == 1:
+                tax_name = " - " + _("On product with following tax: ") + ', '.join(tax_ids.mapped('name'))
+            elif len(tax_ids) > 1:
+                tax_name = " - " + _("On product with following taxes: ") + ', '.join(tax_ids.mapped('name'))
+
+            reward_lines[tax_ids] = {
+                'name': _("Discount: ") + program.name + tax_name,
+                'product_id': program.discount_line_product_id.id,
+                'price_unit': -discount_line_amount_price,
+                'product_uom_qty': 1.0,
+                'product_uom': program.discount_line_product_id.uom_id.id,
+                'is_reward_line': True,
+                'tax_id': [(4, tax.id, False) for tax in tax_ids],
+                }
+        return reward_lines.values()
+
+    def _get_reward_values_discount(self, program):
+        if program.discount_type == 'fixed_amount':
+            return self._get_reward_values_fixed_amount(program)
+        else:
+            return self._get_reward_values_percentage_amount(program)
+
+    def _get_reward_values_percentage_amount(self, program):
+        # Invalidate multiline fixed_price discount line as they should apply after % discount
+        fixed_price_products = self._get_applied_programs().filtered(
+            lambda p: p.discount_type == 'fixed_amount'
+        ).mapped('discount_line_product_id')
+        self.order_line.filtered(lambda l: l.product_id in fixed_price_products).write({'price_unit': 0})
+
         reward_dict = {}
         lines = self._get_paid_order_lines()
         amount_total = sum([any(line.tax_id.mapped('price_include')) and line.price_total or line.price_subtotal
@@ -358,10 +415,10 @@ class SaleOrder(models.Model):
         self.ensure_one()
         order = self
         applied_programs = order._get_applied_programs_with_rewards_on_current_order()
-        for program in applied_programs:
+        for program in applied_programs.sorted(lambda ap: (ap.discount_type == 'fixed_amount', ap.discount_apply_on == 'on_order')):
             values = order._get_reward_line_values(program)
             lines = order.order_line.filtered(lambda line: line.product_id == program.discount_line_product_id)
-            if program.reward_type == 'discount' and program.discount_type == 'percentage':
+            if program.reward_type == 'discount':
                 lines_to_remove = lines
                 lines_to_add = []
                 # Values is what discount lines should really be, lines is what we got in the SO at the moment
@@ -377,9 +434,11 @@ class SaleOrder(models.Model):
                         if not len(set(line.tax_id.mapped('id')).symmetric_difference(set([v[1] for v in value['tax_id']]))):
                             value_found = True
                             # Working on Case 3.
-                            lines_to_remove -= line
-                            lines_to_remove += update_line(order, line, value)
-                            continue
+                            # update_line update the line to the correct value and returns them if they should be unlinked
+                            update_to_remove = update_line(order, line, value)
+                            if not update_to_remove:
+                                lines_to_keep += [(0, False, value)]
+                                lines_to_remove -= line
                     # Working on Case 2.
                     if not value_found:
                         lines_to_add += [(0, False, value)]

--- a/addons/sale_coupon/tests/common.py
+++ b/addons/sale_coupon/tests/common.py
@@ -44,6 +44,28 @@ class TestSaleCouponCommon(TestSaleProductAttributeValueSetup):
             'price_include': True,
         })
 
+        self.tax_10pc_base_incl = self.env['account.tax'].create({
+            'name': "10% Tax incl base amount",
+            'amount_type': 'percent',
+            'amount': 10,
+            'price_include': True,
+            'include_base_amount': True,
+        })
+
+        self.tax_10pc_excl = self.env['account.tax'].create({
+            'name': "10% Tax excl",
+            'amount_type': 'percent',
+            'amount': 10,
+            'price_include': False,
+        })
+
+        self.tax_20pc_excl = self.env['account.tax'].create({
+            'name': "20% Tax excl",
+            'amount_type': 'percent',
+            'amount': 20,
+            'price_include': False,
+        })
+
         #products
         self.product_A = self.env['product.product'].create({
             'name': 'Product A',

--- a/addons/sale_coupon/tests/test_program_numbers.py
+++ b/addons/sale_coupon/tests/test_program_numbers.py
@@ -4,6 +4,7 @@
 from odoo.addons.sale_coupon.tests.common import TestSaleCouponCommon
 from odoo.exceptions import UserError
 from odoo.tests import tagged
+from odoo.tools.float_utils import float_compare
 
 
 @tagged('post_install', '-at_install')
@@ -492,6 +493,7 @@ class TestSaleCouponProgramNumbers(TestSaleCouponCommon):
             'name': 'Drawer Black',
             'product_uom_qty': 1.0,
             'order_id': order.id,
+            'tax_id': [(4, self.tax_0pc_excl.id)]
         })
         order.recompute_coupon_lines()
         self.assertEqual(order.amount_total, 0, "Total should be null. The fixed amount discount is higher than the SO total, it should be reduced to the SO total")
@@ -681,15 +683,9 @@ class TestSaleCouponProgramNumbers(TestSaleCouponCommon):
             'coupon_code': coupon.code
         }).process_coupon()
         order.recompute_coupon_lines()
-        #TODO fix numbers
-        # Need an in-depth inspection on the behavior with
-        # - multiple product with different VAT +
-        # - a fixed amount (greater than remaining amount to pay) +
-        # - discount amount
-        # And user should be able to swap the promotion order with a meaningful result.
-        self.assertEqual(order.amount_tax, 13.5)
+        self.assertEqual(order.amount_tax, 0)
         self.assertEqual(order.amount_untaxed, 0.0, "The untaxed amount should not go below 0")
-        self.assertEqual(order.amount_total, 13.5, "The promotion program should not make the order total go below 0")
+        self.assertEqual(order.amount_total, 0, "The promotion program should not make the order total go below 0")
 
         order.order_line[3:].unlink() #remove all coupon
 
@@ -704,10 +700,9 @@ class TestSaleCouponProgramNumbers(TestSaleCouponCommon):
                 'coupon_code': 'test_10pc'
             }).process_coupon()
         order.recompute_coupon_lines()
-        #TODO fix numbers
-        self.assertEqual(order.amount_tax, 13.5)
+        self.assertEqual(order.amount_tax, 0)
         self.assertEqual(order.amount_untaxed, 0.0)
-        self.assertEqual(order.amount_total, 13.5, "The promotion program should not make the order total go below 0be altered after recomputation")
+        self.assertEqual(order.amount_total, 0, "The promotion program should not make the order total go below 0be altered after recomputation")
 
     def test_coupon_and_coupon_discount_fixed_amount_tax_incl(self):
         """ Ensure multiple coupon can cohexists without making
@@ -1229,3 +1224,227 @@ class TestSaleCouponProgramNumbers(TestSaleCouponCommon):
         self.assertEqual(len(order.order_line.ids), 2, "discount should be applied")
         # applying the code again should return that it has been expired.
         self.assertDictEqual(self.env['sale.coupon.apply.code'].sudo().apply_coupon(order, 'promo1'), {'error': 'Promo code promo1 has been expired.'})
+
+    def test_fixed_amount_taxes_attribution(self):
+
+        self.env['sale.coupon.program'].create({
+            'name': '$5 coupon',
+            'program_type': 'promotion_program',
+            'promo_code_usage': 'no_code_needed',
+            'reward_type': 'discount',
+            'discount_type': 'fixed_amount',
+            'discount_fixed_amount': 5,
+            'active': True,
+            'discount_apply_on': 'on_order',
+        })
+
+        order = self.empty_order
+        sol = self.env['sale.order.line'].create({
+            'product_id': self.drawerBlack.id,
+            'price_unit': 10,
+            'product_uom_qty': 1.0,
+            'order_id': order.id,
+        })
+
+        order.recompute_coupon_lines()
+
+        self.assertEqual(order.amount_total, 5, 'Price should be 10$ - 5$(discount) = 5$')
+        self.assertEqual(order.amount_tax, 0, 'No taxes are applied yet')
+
+        sol.tax_id = self.tax_10pc_base_incl
+        order.recompute_coupon_lines()
+
+        self.assertEqual(order.amount_total, 5, 'Price should be 10$ - 5$(discount) = 5$')
+        self.assertEqual(float_compare(order.amount_tax, 5 / 11, precision_rounding=3), 0, '10% Tax included in 5$')
+
+        sol.tax_id = self.tax_10pc_excl
+        order.recompute_coupon_lines()
+
+        # Value is 5.99 instead of 6 because you cannot have 6 with 10% tax excluded and a precision rounding of 2
+        self.assertAlmostEqual(order.amount_total, 6, 1, msg='Price should be 11$ - 5$(discount) = 6$')
+        self.assertEqual(float_compare(order.amount_tax, 6 / 11, precision_rounding=3), 0, '10% Tax included in 6$')
+
+        sol.tax_id = self.tax_20pc_excl
+        order.recompute_coupon_lines()
+
+        self.assertEqual(order.amount_total, 7, 'Price should be 12$ - 5$(discount) = 7$')
+        self.assertEqual(float_compare(order.amount_tax, 7 / 12, precision_rounding=3), 0, '20% Tax included on 7$')
+
+        sol.tax_id = self.tax_10pc_base_incl + self.tax_10pc_excl
+        order.recompute_coupon_lines()
+
+        self.assertAlmostEqual(order.amount_total, 6, 1, msg='Price should be 11$ - 5$(discount) = 6$')
+        self.assertEqual(float_compare(order.amount_tax, 6 / 12, precision_rounding=3), 0, '20% Tax included on 6$')
+
+    def test_fixed_amount_taxes_attribution_multiline(self):
+
+        self.env['sale.coupon.program'].create({
+            'name': '$5 coupon',
+            'program_type': 'promotion_program',
+            'promo_code_usage': 'no_code_needed',
+            'reward_type': 'discount',
+            'discount_type': 'fixed_amount',
+            'discount_fixed_amount': 5,
+            'active': True,
+            'discount_apply_on': 'on_order',
+        })
+
+        order = self.empty_order
+        sol1 = self.env['sale.order.line'].create({
+            'product_id': self.drawerBlack.id,
+            'price_unit': 10,
+            'product_uom_qty': 1.0,
+            'order_id': order.id,
+        })
+        sol2 = self.env['sale.order.line'].create({
+            'product_id': self.drawerBlack.id,
+            'price_unit': 10,
+            'product_uom_qty': 1.0,
+            'order_id': order.id,
+        })
+
+        order.recompute_coupon_lines()
+
+        self.assertAlmostEqual(order.amount_total, 15, 1, msg='Price should be 20$ - 5$(discount) = 15$')
+        self.assertEqual(order.amount_tax, 0, 'No taxes are applied yet')
+
+        sol1.tax_id = self.tax_10pc_base_incl
+        order.recompute_coupon_lines()
+
+        self.assertAlmostEqual(order.amount_total, 15, 1, msg='Price should be 20$ - 5$(discount) = 15$')
+        self.assertEqual(float_compare(order.amount_tax, 5 / 11 + 0, precision_rounding=3), 0,
+                         '10% Tax included in 5$ in sol1 (highest cost) and 0 in sol2')
+
+        sol2.tax_id = self.tax_10pc_excl
+        order.recompute_coupon_lines()
+
+        self.assertAlmostEqual(order.amount_total, 16, 1, msg='Price should be 21$ - 5$(discount) = 16$')
+        # Tax amount = 10% in 10$ + 10% in 11$ - 10% in 5$ (apply on excluded)
+        self.assertEqual(float_compare(order.amount_tax, 5 / 11, precision_rounding=3), 0)
+
+        sol2.tax_id = self.tax_10pc_base_incl + self.tax_10pc_excl
+        order.recompute_coupon_lines()
+
+        self.assertAlmostEqual(order.amount_total, 16, 1, msg='Price should be 21$ - 5$(discount) = 16$')
+        # Promo apply on line 2 (10% inc + 10% exc)
+        # Tax amount = 10% in 10$ + 10% in 10$ + 10% in 11 - 10% in 5$ - 10% in 4.55$ (100/110*5)
+        #            = 10/11 + 10/11 + 11/11 - 5/11 - 4.55/11
+        #            = 21.45/11
+        self.assertEqual(float_compare(order.amount_tax, 21.45 / 11, precision_rounding=3), 0)
+
+        sol3 = self.env['sale.order.line'].create({
+            'product_id': self.drawerBlack.id,
+            'price_unit': 10,
+            'product_uom_qty': 1.0,
+            'order_id': order.id,
+        })
+        sol3.tax_id = self.tax_10pc_excl
+        order.recompute_coupon_lines()
+
+        self.assertAlmostEqual(order.amount_total, 27, 1, msg='Price should be 32$ - 5$(discount) = 27$')
+        # Promo apply on line 2 (10% inc + 10% exc)
+        # Tax amount = 10% in 10$ + 10% in 10$ + 10% in 11$ + 10% in 11$ - 10% in 5$ - 10% in 4.55$ (100/110*5)
+        #            = 10/11 + 10/11 + 11/11 + 11/11 - 5/11 - 4.55/11
+        #            = 32.45/11
+        self.assertEqual(float_compare(order.amount_tax, 32.45 / 11, precision_rounding=3), 0)
+
+    def test_order_promo(self):
+
+        promo_5off = self.env['sale.coupon.program'].create({
+            'name': '$5 coupon',
+            'program_type': 'promotion_program',
+            'promo_code_usage': 'code_needed',
+            'promo_code': '5off',
+            'reward_type': 'discount',
+            'discount_type': 'fixed_amount',
+            'discount_fixed_amount': 5,
+            'discount_apply_on': 'on_order',
+        })
+
+        promo_20pc = self.env['sale.coupon.program'].create({
+            'name': '20% reduction on order',
+            'promo_code_usage': 'no_code_needed',
+            'promo_code': '20pc',
+            'reward_type': 'discount',
+            'program_type': 'promotion_program',
+            'discount_type': 'percentage',
+            'discount_percentage': 20.0,
+            'discount_apply_on': 'on_order',
+        })
+
+        order = self.empty_order
+
+        self.env['sale.order.line'].create({
+            'product_id': self.drawerBlack.id,
+            'price_unit': 10,
+            'product_uom_qty': 1.0,
+            'order_id': order.id,
+        })
+
+        # Test percentage then flat
+        order.recompute_coupon_lines()
+        self.env['sale.coupon.apply.code'].sudo().apply_coupon(order, '5off')
+        order.recompute_coupon_lines()
+
+        self.assertEqual(order.amount_total, 3, 'Price should be 10$ - 2$(20% of 10$) - 5$(flat discount) = 3$')
+        self.assertEqual(len(order.order_line), 3, 'There should be 3 lines')
+
+        order.order_line[1:].unlink()
+
+        # Test flat then percentage
+        promo_20pc.promo_code_usage = 'code_needed'
+        promo_5off.promo_code_usage = 'no_code_needed'
+        order.recompute_coupon_lines()
+        self.env['sale.coupon.apply.code'].sudo().apply_coupon(order, '20pc')
+        order.recompute_coupon_lines()
+
+        self.assertEqual(order.amount_total, 3, 'Price should be 10$ - 2$(20% of 10$) - 5$(flat discount) = 3$')
+        self.assertEqual(len(order.order_line), 3, 'There should be 3 lines')
+
+        # Test reapplying already present promo
+        self.env['sale.coupon.apply.code'].sudo().apply_coupon(order, '20pc')
+        order.recompute_coupon_lines()
+
+        self.assertEqual(order.amount_total, 3, 'Price should be 10$ - 2$(20% of 10$) - 5$(flat discount) = 3$')
+        self.assertEqual(len(order.order_line), 3, 'There should be 3 lines')
+
+    def test_fixed_amount_with_negative_cost(self):
+
+        self.env['sale.coupon.program'].create({
+            'name': '$10 coupon',
+            'program_type': 'promotion_program',
+            'promo_code_usage': 'no_code_needed',
+            'reward_type': 'discount',
+            'discount_type': 'fixed_amount',
+            'discount_fixed_amount': 10,
+            'active': True,
+            'discount_apply_on': 'on_order',
+        })
+
+        order = self.empty_order
+
+        sol1 = self.env['sale.order.line'].create({
+            'product_id': self.drawerBlack.id,
+            'price_unit': 10,
+            'product_uom_qty': 1.0,
+            'order_id': order.id,
+        })
+
+        self.env['sale.order.line'].create({
+            'product_id': self.drawerBlack.id,
+            'name': 'hand discount',
+            'price_unit': -5,
+            'product_uom_qty': 1.0,
+            'order_id': order.id,
+        })
+
+        order.recompute_coupon_lines()
+
+        self.assertEqual(len(order.order_line), 3)
+        self.assertEqual(order.amount_total, 0, '10$ discount should cover the whole price')
+
+        sol1.price_unit = 20
+        order.recompute_coupon_lines()
+
+        self.assertEqual(len(order.order_line), 3)
+        self.assertEqual(order.amount_total, 5, '10$ discount should be applied on top of the 15$ original price')


### PR DESCRIPTION
Step to reproduce:
- Create a promotion with fixed price discount
- Create a SO where the promotion can apply with taxes on the
products
- Trigger the computation of the taxes

Current behaviour:
- No taxes are applied on the fixed price discount

Behaviour after PR:
- Taxes are applied on the fixed price based on their
proportion to the total amount.

opw-2806780


--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
