### PR TITLE
[IMP] crm_iap_lead_enrich: handle server error messages

### DIFF
--- a/addons/crm_iap_lead_enrich/models/iap_enrich_api.py
+++ b/addons/crm_iap_lead_enrich/models/iap_enrich_api.py
@@ -35,4 +35,7 @@ class IapEnrichAPI(models.AbstractModel):
         params = {
             'domains': lead_emails,
         }
-        return self._contact_iap('/iap/clearbit/1/lead_enrichment_email', params=params)
+        response = self._contact_iap('/iap/clearbit/2/lead_enrichment_email', params=params)
+        if response.get('error') == 'insufficient_credit':
+            raise iap.InsufficientCreditError()
+        return response

--- a/addons/crm_iap_lead_enrich/tests/common.py
+++ b/addons/crm_iap_lead_enrich/tests/common.py
@@ -32,7 +32,7 @@ class MockIAPEnrich(common.BaseCase):
             if default_data:
                 sim_result.update(default_data)
             # mock single sms sending
-            if local_endpoint == '/iap/clearbit/1/lead_enrichment_email':
+            if local_endpoint == '/iap/clearbit/2/lead_enrichment_email':
                 result = {}
                 for lead_id, email in params['domains'].items():
                     if sim_error and sim_error == 'credit':


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
Support version 2 of the IAP-API ('/iap/clearbit/2/lead_enrichment_email') which does not raise InsufficientCreditError anymore.

Current behavior before PR:
If the account has not enough credits, the IAP server raises InsufficientCreditError.

Desired behavior after PR is merged:
If the account has not enough credits, the IAP server returns a dictionary containing the key-value-pair ('error' -> 'insufficient_credit').


--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
