### PR TITLE
[IMP] core: warn when bad fields detected during setup

### DIFF
--- a/odoo/models.py
+++ b/odoo/models.py
@@ -2747,13 +2747,14 @@ class BaseModel(MetaModel('DummyModel', (object,), {'_register': False})):
         for name, field in cls._fields.items():
             try:
                 field.setup_full(self)
-            except Exception:
+            except Exception as e:
                 if field.base_field.manual:
                     # Something goes wrong when setup a manual field.
                     # This can happen with related fields using another manual many2one field
                     # that hasn't been loaded because the comodel does not exist yet.
                     # This can also be a manual function field depending on not loaded fields yet.
                     bad_fields.append(name)
+                    _logger.warning(e)
                     continue
                 raise
 


### PR DESCRIPTION
During fields setup, in case there is an Exception and the field is a
manual one, it gets silently deleted out of the fields registry.
Instead, there should be a warning logged to inform the user about the
problem.

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
