### PR TITLE
[IMP] crm_iap_lead: handle server error messages

### DIFF
--- a/addons/crm_iap_mine/models/crm_iap_lead_mining_request.py
+++ b/addons/crm_iap_mine/models/crm_iap_lead_mining_request.py
@@ -253,8 +253,11 @@ class CRMLeadMiningRequest(models.Model):
             raise UserError(_("Your request could not be executed: %s", e))
 
     def _iap_contact_mining(self, params, timeout=300):
-        endpoint = self.env['ir.config_parameter'].sudo().get_param('reveal.endpoint', DEFAULT_ENDPOINT) + '/iap/clearbit/1/lead_mining_request'
-        return iap_tools.iap_jsonrpc(endpoint, params=params, timeout=timeout)
+        endpoint = self.env['ir.config_parameter'].sudo().get_param('reveal.endpoint', DEFAULT_ENDPOINT) + '/iap/clearbit/2/lead_mining_request'
+        response = iap_tools.iap_jsonrpc(endpoint, params=params, timeout=timeout)
+        if response.get('error') == 'insufficient_credit':
+            raise iap_tools.InsufficientCreditError()
+        return response
 
     def _create_leads_from_response(self, result):
         """ This method will get the response from the service and create the leads accordingly """


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
Support version 2 of the IAP-API ('/iap/clearbit/2/lead_mining_request') which does not raise InsufficientCreditError anymore.

Current behavior before PR:
If the account has not enough credits, the IAP server raises InsufficientCreditError.

Desired behavior after PR is merged:
If the account has not enough credits, the IAP server returns a dictionary containing the key-value-pair ('error' -> 'insufficient_credit').



--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
