### PR TITLE
[IMP] sale_project: improve domain on a sale_line_id filed in task

### DIFF
--- a/addons/sale_project/models/project.py
+++ b/addons/sale_project/models/project.py
@@ -470,7 +470,7 @@ class ProjectTask(models.Model):
         'sale.order.line', 'Sales Order Item',
         copy=False, tracking=True, index='btree_not_null', recursive=True,
         compute='_compute_sale_line', store=True, readonly=False,
-        domain="[('company_id', '=', company_id), ('is_service', '=', True), ('order_partner_id', '=?', partner_id), ('is_expense', '=', False), ('state', 'in', ['sale', 'done'])]",
+        domain="[('company_id', '=', company_id), ('is_service', '=', True),  '|', ('order_partner_id', '=?', partner_id), ('order_id.partner_shipping_id', '=?', partner_id), ('is_expense', '=', False), ('state', 'in', ['sale', 'done'])]",
         help="Sales Order Item to which the time spent on this task will be added, in order to be invoiced to your customer.")
     project_sale_order_id = fields.Many2one('sale.order', string="Project's sale order", related='project_id.sale_order_id')
     task_to_invoice = fields.Boolean("To invoice", compute='_compute_task_to_invoice', search='_search_task_to_invoice', groups='sales_team.group_sale_salesman_all_leads')


### PR DESCRIPTION
create an SO with product Field Service and Delivery Address different that the Customer.

The sales order item in the task can not be recovered if deleted from the field once
(that is because is linked to the Delivery Address and not to the Customer).

Steps to reproduce the bug:
Delivery Address group enable

Create Sale Order
- Customer :- Customer A
- Delivery Address:- Customer B
Confirm SO
Open the linked task and check the SOL
Technical-
Redefined the sale_line_id field to industry_fsm_sale module and update the domain

Issue is arrived in this commit-65e7eef

task-2794072
