### PR TITLE
[FIX] account_payment: hide payment methods

### DIFF
--- a/addons/account/models/account_payment.py
+++ b/addons/account/models/account_payment.py
@@ -402,13 +402,13 @@ class AccountPayment(models.Model):
                                            and payment.partner_id == payment.journal_id.company_id.partner_id \
                                            and payment.destination_journal_id
 
-    @api.depends('payment_type', 'journal_id')
+    @api.depends('available_payment_method_line_ids')
     def _compute_payment_method_line_id(self):
         ''' Compute the 'payment_method_line_id' field.
-        This field is not computed in '_compute_payment_method_fields' because it's a stored editable one.
+        This field is not computed in '_compute_payment_method_line_fields' because it's a stored editable one.
         '''
         for pay in self:
-            available_payment_method_lines = pay.journal_id._get_available_payment_method_lines(pay.payment_type)
+            available_payment_method_lines = pay.available_payment_method_line_ids
 
             # Select the first available one by default.
             if pay.payment_method_line_id in available_payment_method_lines:
@@ -422,7 +422,7 @@ class AccountPayment(models.Model):
     def _compute_payment_method_line_fields(self):
         for pay in self:
             pay.available_payment_method_line_ids = pay.journal_id._get_available_payment_method_lines(pay.payment_type)
-            to_exclude = self._get_payment_method_codes_to_exclude()
+            to_exclude = pay._get_payment_method_codes_to_exclude()
             if to_exclude:
                 pay.available_payment_method_line_ids = pay.available_payment_method_line_ids.filtered(lambda x: x.code not in to_exclude)
             if pay.payment_method_line_id.id not in pay.available_payment_method_line_ids.ids:


### PR DESCRIPTION
[VIDEO](https://drive.google.com/file/d/1Y2NxmGZvVJ_s7MBNGIbkSNk5B4qbbGEH/view)

## Description of the issue/feature this PR addresses:
_get_payment_method_codes_to_exclude is not being used on _compute_payment_method_line_id

## Current behavior before PR:
1. Create a bank journal with only with incoming payment method "SEPA Direct Debit"
2. Create a customer payment: choose journal = the new bank
3. Set "internal transfer = True"
4. change payment_type to "send" and then to "receive" (to force _compute_payment_method_line_fields recomputation)
5. "SEPA Direct Debit" is selected on "Payment Method" but it's not a selectable value (try to choose again manually)

## Desired behavior after PR is merged:
* Payment Method should be empty

## Changes on this PR

1. _get_payment_method_codes_to_exclude was not considered on _compute_payment_method_line_id
2. to avoid duplicating code on _compute_payment_method_line_id we can directly call available_payment_method_line_ids
3. to avoid re-defining dependencies (and make inheritance easier) we can use 'available_payment_method_line_ids' on _compute_payment_method_line_id
4. fix docstring, _compute_payment_method_fields does not exists anymore, it's called _compute_payment_method_line_fields
5. fix using "self" instead of pay when calling _get_payment_method_codes_to_exclude


## FIX on enterprise
Another fix proposed on enterprise: https://github.com/odoo/enterprise/pull/26127





--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
