### PR TITLE
[IMP] project(_sms),hr_timesheet: generic improvements for project

### DIFF
--- a/addons/hr_timesheet/views/project_views.xml
+++ b/addons/hr_timesheet/views/project_views.xml
@@ -374,7 +374,7 @@
             <field name="inherit_id" ref="project.view_project_project_filter"/>
             <field name="arch" type="xml">
                 <filter name="followed_by_me" position='before'>
-                    <filter string="My Team's Projects" name="my_team_projects"  domain="[('user_id.employee_parent_id.user_id', '=', uid)]"/>
+                    <filter string="My Team" name="my_team_projects"  domain="[('user_id.employee_parent_id.user_id', '=', uid)]"/>
                     <filter string="My Department" name="my_department" domain="[('user_id.employee_id.member_of_department', '=', True)]"/>
                 </filter>
                 <filter name="late_milestones" position="before">

--- a/addons/project/data/mail_template_demo.xml
+++ b/addons/project/data/mail_template_demo.xml
@@ -15,7 +15,7 @@
         <t t-out="user.signature or ''">--<br/>Mitchell Admin</t>
     </t>
 </div>
-<br/><span style="margin: 0px 0px 0px 0px; font-size: 12px; opacity: 0.5; color: #454748;">You are receiving this email because your project has been moved to the stage <b t-out="object.stage_id.name or ''">Done</b></span>
+<br/><span style="margin: 0px 0px 0px 0px; font-size: 12px; opacity: 0.5; color: #454748;" groups="project.group_project_stages">You are receiving this email because your project has been moved to the stage <b t-out="object.stage_id.name or ''">Done</b></span>
             </field>
             <field name="lang">{{ object.partner_id.lang }}</field>
             <field name="auto_delete" eval="True"/>

--- a/addons/project/models/project.py
+++ b/addons/project/models/project.py
@@ -186,12 +186,6 @@ class Project(models.Model):
     _rating_satisfaction_days = 30  # takes 30 days by default
     _check_company_auto = True
 
-    def _default_rating_status(self):
-        return self.env['ir.config_parameter'].sudo().get_param('project.rating_status') or 'stage'
-
-    def _default_rating_status_period(self):
-        return self.env['ir.config_parameter'].sudo().get_param('project.rating_status_period') or 'monthly'
-
     def _compute_attached_docs_count(self):
         self.env.cr.execute(
             """
@@ -339,7 +333,7 @@ class Project(models.Model):
     rating_status = fields.Selection(
         [('stage', 'Rating when changing stage'),
          ('periodic', 'Periodic rating')
-        ], 'Customer Ratings Status', default=_default_rating_status, required=True,
+        ], 'Customer Ratings Status', default="stage", required=True,
         help="How to get customer feedback?\n"
              "- Rating when changing stage: an email will be sent when a task is pulled to another stage.\n"
              "- Periodic rating: an email will be sent periodically.\n\n"
@@ -350,7 +344,7 @@ class Project(models.Model):
         ('bimonthly', 'Twice a Month'),
         ('monthly', 'Once a Month'),
         ('quarterly', 'Quarterly'),
-        ('yearly', 'Yearly')], 'Rating Frequency', required=True, default=_default_rating_status_period)
+        ('yearly', 'Yearly')], 'Rating Frequency', required=True, default='monthly')
 
     # Not `required` since this is an option to enable in project settings.
     stage_id = fields.Many2one('project.project.stage', string='Stage', ondelete='restrict', groups="project.group_project_stages",

--- a/addons/project/models/res_config_settings.py
+++ b/addons/project/models/res_config_settings.py
@@ -15,18 +15,6 @@ class ResConfigSettings(models.TransientModel):
     group_project_recurring_tasks = fields.Boolean("Recurring Tasks", implied_group="project.group_project_recurring_tasks")
     group_project_task_dependencies = fields.Boolean("Task Dependencies", implied_group="project.group_project_task_dependencies")
     group_project_milestone = fields.Boolean('Milestones', implied_group='project.group_project_milestone', group='base.group_portal,base.group_user')
-    rating_status = fields.Selection(
-        [('stage', 'Rating when changing stage'),
-         ('periodic', 'Periodic rating')
-        ], 'Customer Ratings Status', default="stage", required=True, config_parameter='project.rating_status')
-    rating_status_period = fields.Selection([
-        ('daily', 'Daily'),
-        ('weekly', 'Weekly'),
-        ('bimonthly', 'Twice a Month'),
-        ('monthly', 'Once a Month'),
-        ('quarterly', 'Quarterly'),
-        ('yearly', 'Yearly')], 'Rating Frequency', required=True, default='monthly', config_parameter='project.rating_status_period')
-
 
     @api.model
     def _get_basic_project_domain(self):

--- a/addons/project/views/project_views.xml
+++ b/addons/project/views/project_views.xml
@@ -392,6 +392,32 @@
             </field>
         </record>
 
+        <record id="action_send_mail_project_task" model="ir.actions.act_window">
+            <field name="name">Send Email</field>
+            <field name="res_model">mail.compose.message</field>
+            <field name="view_mode">form</field>
+            <field name="target">new</field>
+            <field name="context" eval="{
+                'default_composition_mode': 'mass_mail',
+                'default_use_template': False,
+            }"/>
+            <field name="binding_model_id" ref="project.model_project_task"/>
+            <field name="binding_view_types">list</field>
+        </record>
+
+        <record id="action_send_mail_project_project" model="ir.actions.act_window">
+            <field name="name">Send Email</field>
+            <field name="res_model">mail.compose.message</field>
+            <field name="view_mode">form</field>
+            <field name="target">new</field>
+            <field name="context" eval="{
+                'default_composition_mode': 'mass_mail',
+                'default_use_template': False,
+            }"/>
+            <field name="binding_model_id" ref="project.model_project_project"/>
+            <field name="binding_view_types">list</field>
+        </record>
+
         <record id="unlink_task_type_action" model="ir.actions.server">
             <field name="name">Delete</field>
             <field name="model_id" ref="project.model_project_task_type"/>
@@ -1265,13 +1291,13 @@
                             <group>
                                 <group>
                                     <field name="is_analytic_account_id_changed" invisible="1"/>
+                                    <field name="parent_id" attrs="{'invisible': [('allow_subtasks', '=', False)]}" groups="base.group_no_one"/>
                                     <field name="analytic_account_id" groups="analytic.group_analytic_accounting" context="{'default_partner_id': partner_id}"/>
                                     <field name="analytic_tag_ids" groups="analytic.group_analytic_tags" widget="many2many_tags"/>
-                                    <field name="parent_id" attrs="{'invisible': [('allow_subtasks', '=', False)]}" groups="base.group_no_one"/>
+                                    <field name="company_id" groups="base.group_multi_company" options="{'no_create': True}"/>
                                     <field name="sequence" groups="base.group_no_one"/>
                                     <field name="email_from" invisible="1"/>
                                     <field name="email_cc" groups="base.group_no_one"/>
-                                    <field name="company_id" groups="base.group_multi_company" options="{'no_create': True}"/>
                                     <field name="displayed_image_id" groups="base.group_no_one" options="{'no_create': True}"/>
                                 </group>
                                 <group>

--- a/addons/project/views/rating_views.xml
+++ b/addons/project/views/rating_views.xml
@@ -116,6 +116,9 @@
                 <field name="parent_res_name" position="move"/>
                 <field name="res_name" position="move"/>
             </xpath>
+            <xpath expr="//field[@name='rated_partner_id']" position="attributes">
+                <attribute name="string">Assigned to</attribute>
+            </xpath>
             <xpath expr="//field[@name='parent_res_name']" position="attributes">
                 <attribute name="string">Project</attribute>
             </xpath>
@@ -131,7 +134,9 @@
             <xpath expr="//filter[@name='resource']" position="attributes">
                 <attribute name="string">Task</attribute>
             </xpath>
-            <xpath expr="//filter[@name='responsible']" position="replace"></xpath>
+            <xpath expr="//filter[@name='responsible']" position="attributes">
+                <attribute name="string">Assigned to</attribute>
+            </xpath>
             <xpath expr="//filter[@name='filter_create_date']" position="replace">
                 <filter name="filter_write_date" string="Submitted On" date="write_date"/>
             </xpath>

--- a/addons/project/views/res_config_settings_views.xml
+++ b/addons/project/views/res_config_settings_views.xml
@@ -73,17 +73,6 @@
                         </div>
                         <h2>Time Management</h2>
                         <div class="row mt16 o_settings_container" name="project_time">
-                            <div class="col-12 col-lg-6 o_setting_box" name="project_time_management">
-                                <div class="o_setting_left_pane">
-                                    <field name="module_project_forecast" widget="upgrade_boolean"/>
-                                </div>
-                                <div class="o_setting_right_pane">
-                                    <label for="module_project_forecast"/>
-                                    <div class="text-muted" name="project_forecast_msg">
-                                        Plan resource allocation across projects and tasks, and estimate deadlines more accurately
-                                    </div>
-                                </div>
-                            </div>
                             <div class="col-12 col-lg-6 o_setting_box" id="log_time_tasks_setting">
                                 <div class="o_setting_left_pane">
                                     <field name="module_hr_timesheet"/>
@@ -92,6 +81,17 @@
                                     <label for="module_hr_timesheet"/>
                                     <div class="text-muted">
                                         Track time spent on projects and tasks
+                                    </div>
+                                </div>
+                            </div>
+                            <div class="col-12 col-lg-6 o_setting_box" name="project_time_management">
+                                <div class="o_setting_left_pane">
+                                    <field name="module_project_forecast" widget="upgrade_boolean"/>
+                                </div>
+                                <div class="o_setting_right_pane">
+                                    <label for="module_project_forecast"/>
+                                    <div class="text-muted" name="project_forecast_msg">
+                                        Plan resource allocation across projects and tasks, and estimate deadlines more accurately
                                     </div>
                                 </div>
                             </div>
@@ -120,11 +120,6 @@
                                     </div>
                                     <div class="content-group" attrs="{'invisible': [('group_project_rating', '=', False)]}">
                                         <div class="mt16">
-                                            <field name="rating_status" widget="radio" />
-                                            <div attrs="{'required': [('rating_status', '=', 'periodic')], 'invisible': [('rating_status', '!=', 'periodic')]}">
-                                                <label for="rating_status_period"/>
-                                                <field name="rating_status_period"/>
-                                            </div>
                                             <div class="content-group">
                                                 <div class="mt8">
                                                     <button name="%(project.open_task_type_form_domain)d" context="{'project_id':id}" icon="fa-arrow-right" type="action" string="Set a Rating Email Template on Stages" class="btn-link"/>

--- a/addons/project_sms/__manifest__.py
+++ b/addons/project_sms/__manifest__.py
@@ -11,6 +11,7 @@
     'data': [
         'views/project_stage_views.xml',
         'views/project_task_type_views.xml',
+        'views/project_views.xml',
         'security/ir.model.access.csv',
         'security/project_sms_security.xml',
     ],

--- a/addons/project_sms/views/project_views.xml
+++ b/addons/project_sms/views/project_views.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <record id="project_task_act_window_sms_composer" model="ir.actions.act_window">
+        <field name="name">Send SMS Text Message</field>
+        <field name="res_model">sms.composer</field>
+        <field name="view_mode">form</field>
+        <field name="target">new</field>
+        <field name="context">{
+            'default_composition_mode': 'mass',
+            'default_mass_keep_log': True,
+            'default_res_ids': active_ids,
+        }</field>
+        <field name="binding_model_id" ref="model_project_task"/>
+        <field name="binding_view_types">list</field>
+    </record>
+
+    <record id="project_project_act_window_sms_composer" model="ir.actions.act_window">
+        <field name="name">Send SMS Text Message</field>
+        <field name="res_model">sms.composer</field>
+        <field name="view_mode">form</field>
+        <field name="target">new</field>
+        <field name="context">{
+            'default_composition_mode': 'mass',
+            'default_mass_keep_log': True,
+            'default_res_ids': active_ids,
+        }</field>
+        <field name="binding_model_id" ref="model_project_project"/>
+        <field name="binding_view_types">list</field>
+    </record>
+</odoo>


### PR DESCRIPTION
Purpose of this PR to improve generic usage of project
app.

So, in this PR done following changes:
- added group by assigned to under reporting -> customer ratings
- In quick search, changed "rated rated" operator to "assigned to" under
project.project search view
- removed rating_status field from project > configuration > settings > customer
ratings
- switched the 'timesheets' and 'planning' features from place from
project > configuration > settings
- In project.task  extra info notebook:
   - Added the 'parent task' field above the 'analytic account' field
   - Added the 'company' field above the 'sequence' field
- changed toast notification in project.task gantt view
- added send mail and sms action in project.project and project.task
list and form view

task-2806292

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
