### PR TITLE
[FIX] website_event_exhibitor: correctly apply event sponsors ordering

### DIFF
--- a/addons/website_event_exhibitor/controllers/exhibitor.py
+++ b/addons/website_event_exhibitor/controllers/exhibitor.py
@@ -2,6 +2,7 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 from ast import literal_eval
+from collections import OrderedDict
 from random import randint, sample
 from werkzeug.exceptions import NotFound, Forbidden
 
@@ -72,12 +73,14 @@ class ExhibitorController(WebsiteEventController):
 
         # fetch data to display; use sudo to allow reading partner info, be sure domain is correct
         event = event.with_context(tz=event.date_tz or 'UTC')
-        sponsors = request.env['event.sponsor'].sudo().search(search_domain)
+        sponsors = request.env['event.sponsor'].sudo().search(
+            search_domain
+        ).sorted(lambda sponsor: (sponsor.sponsor_type_id.sequence, sponsor.sequence))
         sponsors_all = request.env['event.sponsor'].sudo().search(search_domain_base)
         sponsor_types = sponsors_all.mapped('sponsor_type_id')
         sponsor_countries = sponsors_all.mapped('partner_id.country_id').sorted('name')
         # organize sponsors into categories to help display
-        sponsor_categories_dict = dict()
+        sponsor_categories_dict = OrderedDict()
         sponsor_categories = []
         is_event_user = request.env.user.has_group('event.group_event_registration_desk')
         for sponsor in sponsors:

--- a/addons/website_event_exhibitor/views/event_templates_sponsor.xml
+++ b/addons/website_event_exhibitor/views/event_templates_sponsor.xml
@@ -5,7 +5,10 @@
     <xpath expr="//div[@id='wrap']" position="inside">
         <div class="container mt32 mb16 d-none d-md-block d-print-none" t-if="event.sponsor_ids">
             <div t-attf-class="d-flex flex-wrap mb-5 #{'' if (len(event.sponsor_ids) > 10) else 'justify-content-md-center'}">
-                <t t-foreach="event.sponsor_ids.sorted(lambda sponsor: not sponsor.website_published)" t-as="sponsor">
+                <t t-foreach="event.sponsor_ids.sorted(
+                        lambda sponsor: (not sponsor.website_published, sponsor.sponsor_type_id.sequence, sponsor.sequence)
+                    )"
+                    t-as="sponsor">
                     <t t-set="popover_content">
                         <div t-field="sponsor.name" class="h5"/>
                         <div t-if="sponsor.url" class="d-flex align-items-baseline">


### PR DESCRIPTION
Currently, the event sponsor ordering on the website is non-deterministic as it
uses a non-ordered dictionary to accumulate items, which then dictates the
order of display.

We fix that issue by using a OrderedDict that will correctly retain the order.

In addition, we force the sorting of sponsors based on their
event.sponsor.type's sequence first and then based on their own sequence.

The '_order' of event.sponsor is currently 'sequence, sponsor_type_id' which
seems wrong but has to stay that way in order to avoid backend issues.
Indeed, the backend and the "handle widget" do not have the capability to sort
on multiple levels as we would need here (sponsor type sequence, then sponsor
sequence).

To completely fix this issue, we would need to:
- Store the sponsor.type's sequence field on the sponsor (related stored)
- Modify the _order to be sponsor_type_sequence, sequence
- Only allow people to sort event.sponsors within a single category at a time

Those changes would not be doable on a stable branch, hence why we use a local
sorting when displaying sponsors on the website.

Task-2818538

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
