### PR TITLE
[FIX] mail: put back removed css rules

### DIFF
--- a/addons/mail/static/src/components/dialog/dialog.xml
+++ b/addons/mail/static/src/components/dialog/dialog.xml
@@ -3,7 +3,7 @@
 
     <t t-name="mail.Dialog" owl="1">
         <t t-if="dialog">
-            <div class="o_Dialog fixed-top bottom-0 d-flex" t-attf-class="{{ className }}" t-att-style="dialog.style" t-ref="root">
+            <div class="o_Dialog fixed-top bottom-0 d-flex justify-content-center align-items-center" t-attf-class="{{ className }}" t-att-style="dialog.style" t-ref="root">
                 <t
                     t-component="constructor.components[dialog.componentName]"
                     t-props="{


### PR DESCRIPTION
Task-2812497 accidentaly removed some CSS rules, causing the dialog not to be centered properly. This commit put the rules back.
