### PR TITLE
[REF] mail: bring dataChannels model closer to the rtc implementation

### DIFF
--- a/addons/mail/static/src/models/rtc.js
+++ b/addons/mail/static/src/models/rtc.js
@@ -170,7 +170,6 @@ registerModel({
                 rtcSession.update({
                     connectionRecoveryTimeout: clear(),
                     isCurrentUserInitiatorOfConnectionOffer: clear(),
-                    rtcDataChannel: clear(),
                 });
             }
             this.update({
@@ -474,7 +473,7 @@ registerModel({
             rtcSession.update({ rtcPeerConnection: insertAndReplace({ peerConnection }) });
             this.messaging.models['RtcDataChannel'].insert({
                 dataChannel,
-                rtcSession: replace(rtcSession),
+                rtcPeerConnectionAsNotificationDataChannel: replace(rtcSession.rtcPeerConnection),
             });
             return rtcSession;
         },
@@ -644,7 +643,7 @@ registerModel({
                     if (!rtcSession) {
                         continue;
                     }
-                    const rtcDataChannel = rtcSession.rtcDataChannel;
+                    const rtcDataChannel = rtcSession.rtcPeerConnection.notificationDataChannel;
                     if (!rtcDataChannel || rtcDataChannel.dataChannel.readyState !== 'open') {
                         continue;
                     }

--- a/addons/mail/static/src/models/rtc_data_channel.js
+++ b/addons/mail/static/src/models/rtc_data_channel.js
@@ -5,7 +5,7 @@ import { attr, one } from '@mail/model/model_field';
 
 registerModel({
     name: 'RtcDataChannel',
-    identifyingFields: ['rtcSession'],
+    identifyingFields: ['rtcPeerConnectionAsNotificationDataChannel'],
     lifecycleHooks: {
         _willDelete() {
             this.dataChannel.close();
@@ -16,8 +16,8 @@ registerModel({
             required: true,
             readonly: true,
         }),
-        rtcSession: one('RtcSession', {
-            inverse: 'rtcDataChannel',
+        rtcPeerConnectionAsNotificationDataChannel: one('RtcPeerConnection', {
+            inverse: 'notificationDataChannel',
             readonly: true,
             required: true,
         }),

--- a/addons/mail/static/src/models/rtc_peer_connection.js
+++ b/addons/mail/static/src/models/rtc_peer_connection.js
@@ -17,6 +17,13 @@ registerModel({
          * If unset, this RTC Session is not considered as connected
          */
         peerConnection: attr(),
+        /**
+         * The RTCDataChannel used to send notifications to the peer
+         */
+        notificationDataChannel: one('RtcDataChannel', {
+            inverse: 'rtcPeerConnectionAsNotificationDataChannel',
+            isCausal: true,
+        }),
         rtcSession: one('RtcSession', {
             inverse: 'rtcPeerConnection',
             readonly: true,

--- a/addons/mail/static/src/models/rtc_session.js
+++ b/addons/mail/static/src/models/rtc_session.js
@@ -433,13 +433,6 @@ registerModel({
             isCausal: true,
         }),
         /**
-         * Contains the RTCDataChannel of the rtc session.
-         */
-        rtcDataChannel: one('RtcDataChannel', {
-            inverse: 'rtcSession',
-            isCausal: true,
-        }),
-        /**
          * MediaStream of the user's video.
          *
          * Should be divided into userVideoStream and displayStream,


### PR DESCRIPTION
This commit puts the rtcDataChannels field on RtcPeerConnection which
is closer to the webRtc implementation.