### PR TITLE
[FIX] account: method was wrongly called on self

### DIFF
--- a/addons/account/models/account_payment.py
+++ b/addons/account/models/account_payment.py
@@ -422,7 +422,7 @@ class AccountPayment(models.Model):
     def _compute_payment_method_line_fields(self):
         for pay in self:
             pay.available_payment_method_line_ids = pay.journal_id._get_available_payment_method_lines(pay.payment_type)
-            to_exclude = self._get_payment_method_codes_to_exclude()
+            to_exclude = pay._get_payment_method_codes_to_exclude()
             if to_exclude:
                 pay.available_payment_method_line_ids = pay.available_payment_method_line_ids.filtered(lambda x: x.code not in to_exclude)
             if pay.payment_method_line_id.id not in pay.available_payment_method_line_ids.ids:


### PR DESCRIPTION
When computing _compute_payment_method_line_fields,
_get_payment_method_codes_to_exclude would be called on self in the loop
instead of being called on the payment.
This is wrong, even more since there is an ensure_one in the method.

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
