### PR TITLE
[FIX] web: prevent error when home action is set but not existing

### DIFF
--- a/addons/web/models/ir_http.py
+++ b/addons/web/models/ir_http.py
@@ -56,7 +56,7 @@ class Http(models.AbstractModel):
             'profile_collectors': request.session.profile_collectors,
             'profile_params': request.session.profile_params,
             "max_file_upload_size": max_file_upload_size,
-            "home_action_id": user.action_id.id,
+            "home_action_id": user.action_id.exists().id,
             "cache_hashes": {
                 "translations": translation_hash,
             },


### PR DESCRIPTION
Steps to reproduce:
- Set a Home Action for a User
- Delete action

Issue:
Whenever we refresh the following message appears "action id # not found".

Cause:
The ondelete doesn't work on `fields.Many2one('ir.actions.actions')` since we don't put foreign keys on ir_actions
https://github.com/odoo/odoo/blob/c52f8ea061f99e48df87ad608e9f878158bd184f/odoo/fields.py#L2746-L2748
because foreign keys only target one table and not the table's inherited children,
so it wouldn't find anything in ir_actions table (ir.actions.actions) that is inherited by other tables ( ir.actions.act_window, ir.actions.act_url,...)

Solution:
Check if action exists, if not set home action to False

opw-2728824
related pr: https://github.com/odoo/odoo/pull/85039