### PR TITLE
[IMP] crm: improve _compute_meeting performance

### DIFF
--- a/addons/crm/models/res_partner.py
+++ b/addons/crm/models/res_partner.py
@@ -62,18 +62,19 @@ class Partner(models.Model):
     def _compute_meeting(self):
         if self.ids:
             all_partners = self.with_context(active_test=False).search([('id', 'child_of', self.ids)])
+
+            event_id = self.env['calendar.event']._search([])  # ir.rules will be applied
+            subquery_string, subquery_params = event_id.select()
+            subquery = self.env.cr.mogrify(subquery_string, subquery_params).decode()
+
             self.env.cr.execute("""
                 SELECT res_partner_id, calendar_event_id, count(1)
                   FROM calendar_event_res_partner_rel
-                 WHERE res_partner_id IN %s
+                 WHERE res_partner_id IN %s AND calendar_event_id IN ({})
               GROUP BY res_partner_id, calendar_event_id
-            """, [tuple(all_partners.ids)])
-            meeting_data = self.env.cr.fetchall()
+            """.format(subquery), [tuple(all_partners.ids)])
 
-            # Keep only valid meeting data based on record rules of events
-            events = [row[1] for row in meeting_data]
-            events = self.env['calendar.event'].search([('id', 'in', events)]).ids
-            meeting_data = [m for m in meeting_data if m[1] in events]
+            meeting_data = self.env.cr.fetchall()
 
             # Create a dict {partner_id: event_ids} and fill with events linked to the partner
             meetings = {p.id: set() for p in all_partners}

--- a/addons/crm/tests/__init__.py
+++ b/addons/crm/tests/__init__.py
@@ -9,3 +9,4 @@ from . import test_crm_lead_merge
 from . import test_crm_activity
 from . import test_crm_ui
 from . import test_crm_pls
+from . import test_res_partner

--- a/addons/crm/tests/test_res_partner.py
+++ b/addons/crm/tests/test_res_partner.py
@@ -1,0 +1,73 @@
+# -*- coding: utf-8 -*-
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from odoo.tests.common import TransactionCase
+from odoo.tests.common import new_test_user
+
+
+class TestResPartner(TransactionCase):
+
+    def test_meeting_count(self):
+        test_user = new_test_user(self.env, login='test_user', groups='sales_team.group_sale_salesman')
+        Partner = self.env['res.partner'].with_user(test_user)
+        Event = self.env['calendar.event'].with_user(test_user)
+
+        # Partner hierarchy
+        #     1       5
+        #    /|
+        #   2 3
+        #     |
+        #     4
+
+        test_partner_1 = Partner.create({'name': 'test_partner_1'})
+        test_partner_2 = Partner.create({'name': 'test_partner_2', 'parent_id': test_partner_1.id})
+        test_partner_3 = Partner.create({'name': 'test_partner_3', 'parent_id': test_partner_1.id})
+        test_partner_4 = Partner.create({'name': 'test_partner_4', 'parent_id': test_partner_3.id})
+        test_partner_5 = Partner.create({'name': 'test_partner_5'})
+
+        Event.create({'name': 'event_1',
+                      'partner_ids': [(6, 0, [test_partner_1.id,
+                                              test_partner_2.id,
+                                              test_partner_3.id,
+                                              test_partner_4.id])]})
+        Event.create({'name': 'event_2',
+                      'partner_ids': [(6, 0, [test_partner_1.id,
+                                              test_partner_3.id])]})
+        Event.create({'name': 'event_2',
+                      'partner_ids': [(6, 0, [test_partner_2.id,
+                                              test_partner_3.id])]})
+        Event.create({'name': 'event_3',
+                      'partner_ids': [(6, 0, [test_partner_3.id,
+                                              test_partner_4.id])]})
+        Event.create({'name': 'event_4',
+                      'partner_ids': [(6, 0, [test_partner_1.id])]})
+        Event.create({'name': 'event_5',
+                      'partner_ids': [(6, 0, [test_partner_3.id])]})
+        Event.create({'name': 'event_6',
+                      'partner_ids': [(6, 0, [test_partner_4.id])]})
+        Event.create({'name': 'event_7',
+                      'partner_ids': [(6, 0, [test_partner_5.id])]})
+        Event.create({'name': 'event_8',
+                      'partner_ids': [(6, 0, [test_partner_5.id])]})
+
+        #Test rule to see if ir.rules are applied
+        calendar_event_model_id = self.env['ir.model']._get('calendar.event').id
+        self.env['ir.rule'].create({'name': 'test_rule',
+                                    'model_id': calendar_event_model_id,
+                                    'domain_force': [('name', 'not in', ['event_9', 'event_10'])],
+                                    'perm_read': True,
+                                    'perm_create': False,
+                                    'perm_write': False})
+
+        Event.create({'name': 'event_9',
+                      'partner_ids': [(6, 0, [test_partner_2.id,
+                                              test_partner_3.id])]})
+
+        Event.create({'name': 'event_10',
+                      'partner_ids': [(6, 0, [test_partner_5.id])]})
+
+        self.assertEqual(test_partner_1.meeting_count, 7)
+        self.assertEqual(test_partner_2.meeting_count, 2)
+        self.assertEqual(test_partner_3.meeting_count, 6)
+        self.assertEqual(test_partner_4.meeting_count, 3)
+        self.assertEqual(test_partner_5.meeting_count, 2)


### PR DESCRIPTION
We can use ._search() to make sure that permissions and ir.rules are applied. By making use of psql subqueries, we remove the need of costly python filtering afterwards, thus increasing performance.

Benchmarks:

Running _compute_meeting on 1k partners in a local database.

| Number of active calendar_event | before PR | after PR |
|---|---|---|
| ~80k active calendar_event | 102.8200888633728 seconds | 0.7052993774414062 seconds |
| ~57k active calendar_event | 83.73815631866455 seconds | 0.5997936725616455 seconds |
| ~20k active calendar_event | 36.86744427680969 seconds | 0.3385133743286133 seconds |
| ~10k active calendar_event | 20.13909530639648 seconds | 0.2384305000305175 seconds |
| ~1k  active calendar_event | 4.009946823120117 seconds | 0.1153726577758789 seconds |


--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
