### PR TITLE
[FIX] point_of_sale: offsetParent is null when el is oe_hidden

### DIFF
--- a/addons/point_of_sale/static/src/js/Misc/Draggable.js
+++ b/addons/point_of_sale/static/src/js/Misc/Draggable.js
@@ -49,6 +49,7 @@ odoo.define('point_of_sale.Draggable', function(require) {
                 this.limitArea = this.props.limitArea
                     ? document.querySelector(this.props.limitArea)
                     : this.el.offsetParent;
+                if (!this.limitArea) return;
                 this.limitAreaBoundingRect = this.limitArea.getBoundingClientRect();
                 if (this.limitArea === this.el.offsetParent) {
                     this.limitLeft = 0;


### PR DESCRIPTION
It is now possible to render multiple popups and most of them
are draggable. However, when the popup is hidden, the Draggable
component fails at onMounted because the limitArea (derived from
the offsetParent) is null. To fix, we first check the limitArea
before proceeding to the rest of onMounted procedure.

This fixes the issue when the pos ui is suddenly disconnected
from the server, and the OfflineErrorPopup blocks the ui and
the user can't get rid of it.

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
