### PR TITLE
[FIX] sale_stock: display only outgoing transfers to portal users

### DIFF
--- a/addons/sale_stock/views/sale_stock_portal_template.xml
+++ b/addons/sale_stock/views/sale_stock_portal_template.xml
@@ -14,7 +14,7 @@
                     <strong>Delivery Orders</strong>
                 </div>
                 <div>
-                    <t t-foreach="sale_order.picking_ids.filtered(lambda picking: picking.picking_type_id.code != 'internal')" t-as="i">
+                    <t t-foreach="sale_order.picking_ids.filtered(lambda picking: picking.picking_type_id.code == 'outgoing')" t-as="i">
                         <t t-set="delivery_report_url" t-value="'/my/picking/pdf/%s?%s' % (i.id, keep_query())"/>
                         <div class="d-flex flex-wrap align-items-center justify-content-between o_sale_stock_picking">
                             <div>


### PR DESCRIPTION
Steps to reproduce the bug:
- Create a storable product with routes: MTO + Buy
- Create a Portal user “pu1”
- Create a SO > select the “pu1” as customer
- Validate and confirm the created PO
- Connect as “pu1”:
    - Go to the sales order view:

Problem:
The client can see outgoing and receipt(PO picking) transfers, this is a problem because then the customer can see information from the vendor

Solution:
A portal user should only see outgoing type transfers in the sale order view

opw-2816719




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
