### PR TITLE
[FIX] l10n_ch : fix body style in swissqr_report

### DIFF
--- a/addons/l10n_ch/report/swissqr_report.xml
+++ b/addons/l10n_ch/report/swissqr_report.xml
@@ -22,8 +22,8 @@
         <template id="l10n_ch_swissqr_template">
             <t t-set="o" t-value="o.with_context(lang=lang)"/>
             <t t-call="web.external_layout">
-                <!-- add class to body tag -->
-                <script>document.body.className += " l10n_ch_qr";</script>
+                <!-- TODO master: remove this -->
+                <script t-if="0">document.body.className += " l10n_ch_qr";</script>
                 <!-- add default margin for header (matching A4 European margin) -->
                 <t t-set="report_header_style">padding-top:6.2mm; padding-left:8.2mm; padding-right:8.2mm;</t>
 
@@ -160,5 +160,10 @@
                 </t>
             </t>
         </template>
+        <template id="minimal_layout_with_report_attribute" inherit_id="web.minimal_layout">
+            <body position="attributes">
+                <attribute name="t-att-data-report-id">report_xml_id</attribute>
+            </body>
+        </template> 
     </data>
 </odoo>

--- a/addons/l10n_ch/static/src/scss/report_swissqr.scss
+++ b/addons/l10n_ch/static/src/scss/report_swissqr.scss
@@ -1,4 +1,4 @@
-body.l10n_ch_qr {
+body.l10n_ch_qr, body[data-oe-report="l10n_ch.l10n_ch_qr_report"] {
     padding: 0;
 
     /* Disable custom bakground */

--- a/addons/web/views/report_templates.xml
+++ b/addons/web/views/report_templates.xml
@@ -117,7 +117,7 @@
                     </script>
                 </t>
             </head>
-            <body class="container" t-att-onload="subst_needed and 'subst()'">
+            <body class="container" t-att-data-report-id="report_xml_id" t-att-onload="subst_needed and 'subst()'">
                 <t t-raw="body"/>
             </body>
         </html>

--- a/odoo/addons/base/models/ir_actions_report.py
+++ b/odoo/addons/base/models/ir_actions_report.py
@@ -371,7 +371,7 @@ class IrActionsReport(models.Model):
             # set context language to body language
             if node.get('data-oe-lang'):
                 layout_with_lang = layout_with_lang.with_context(lang=node.get('data-oe-lang'))
-            body = layout_with_lang.render(dict(subst=False, body=lxml.html.tostring(node), base_url=base_url))
+            body = layout_with_lang.render(dict(subst=False, body=lxml.html.tostring(node), base_url=base_url, report_xml_id=self.xml_id))
             bodies.append(body)
             if node.get('data-oe-model') == self.model:
                 res_ids.append(int(node.get('data-oe-id', 0)))


### PR DESCRIPTION
To reproduce
============

- Create a company with a complete Swiss address (street, city, zip and country).
- Install the l10n_ch modules and install the Swiss plan comptable in the Settings of the Accounting app.
- Go to Accounting > Configuration > Settings > Activate the "QR codes" > Save
- Go to Accounting > Configuration > Journals > Choose the journal for the invoices > In "Advanced settings" verify that the communication type is "Based on invoice" and the communication standard is "Switzerland"
- Go to Accounting > Configuration > Journals > Select your bank journal(s) > Verify that you have set up your bank account number and the name of the bank
- Go to the Contact app > Configuration > Bank Accounts > Choose the one you use for the QR-bills > Edit > In "ISR Client Identification Number" refer a client number and make sure account type is 'IBAN' > Save.
- Verify that you have a complete address on the contact form of the customer (street, city, zip and country).
- create multiple invoices for this client
- try to print QR-bill for these invoices at once -> and assert error is raised

Purpose
=======

the `assert len(outlines_pages) == len(res_ids)` fails because the generated pdf
contains only a single invoice.

this issue is caused by the line `<script>document.body.className += " l10n_ch_qr";</script>` in `swissqr_report.xml`,
when `wkhtmltopdf` generates the pdf from html, it doesn't wait for all javascript to finish before rendering the page,
which lead to not execute the script `<script>document.body.className += " l10n_ch_qr";</script>` for some pages then the final pdf
is missing some pages.

Specification
=============

To solve the issue we removed the javascript block `<script>document.body.className += " l10n_ch_qr";</script>` from the template
and move it to python, by setting the body style when generating the html.

opw-2772396