### PR TITLE
[FIX] sale_timesheet: remove the 'grid' in the view mode

### DIFF
--- a/addons/sale_timesheet/views/account_invoice_views.xml
+++ b/addons/sale_timesheet/views/account_invoice_views.xml
@@ -5,7 +5,7 @@
         <field name="name">Timesheets</field>
         <field name="type">ir.actions.act_window</field>
         <field name="res_model">account.analytic.line</field>
-        <field name="view_mode">tree,form,graph,pivot,kanban,grid</field>
+        <field name="view_mode">tree,form,graph,pivot,kanban</field>
         <field name="context">{'create': False, 'edit': False, 'delete': False}</field>
         <field name="domain">[('timesheet_invoice_id', '=', active_id)]</field>
         <field name="help" type="html">


### PR DESCRIPTION
Before this commit, the `grid` is asked in a window action used when
the user clicks on the stat button to see the timesheets related in
account move form view. When the user clicks on that button he has a
traceback because the grid only exists in the enterprise version and not
in community version.

This commit removes the 'grid' in the `view_mode` of that action since
in community version the grid view does not exist.

closes #88274





--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
