### PR TITLE
[FIX] web: Datepicker uses static date format

### DIFF
--- a/addons/web/static/src/core/datepicker/datepicker.js
+++ b/addons/web/static/src/core/datepicker/datepicker.js
@@ -30,6 +30,18 @@ const luxonFormatToMomentFormat = (format) => {
 };
 
 /**
+ * @param {string} format
+ * @returns {boolean}
+ */
+const isValidStaticFormat = (format) => {
+    try {
+        return /^[\d\s/:-]+$/.test(DateTime.local().toFormat(format));
+    } catch (_err) {
+        return false;
+    }
+};
+
+/**
  * Date picker
  *
  * This component exposes the API of the tempusdominus datepicker library.
@@ -48,33 +60,52 @@ export class DatePicker extends Component {
         this.state = useState({ warning: false });
 
         this.datePickerId = `o_datepicker_${datePickerId++}`;
+        // Manually keep track of the "open" state to write the date in the
+        // static format just before bootstrap parses it.
+        this.datePickerShown = false;
 
         this.initFormat();
         this.setDate(this.props);
+        this.setFormat(this.props);
 
         useAutofocus();
         useExternalListener(window, "scroll", this.onWindowScroll);
     }
 
     mounted() {
-        window.$(this.el).on("show.datetimepicker", () => this.inputRef.el.select());
-        window.$(this.el).on("hide.datetimepicker", () => this.onDateChange());
-        window.$(this.el).on("error.datetimepicker", () => false); // Ignores datepicker errors
-
         this.bootstrapDateTimePicker(this.props);
         this.updateInput();
+
+        window.$(this.el).on("show.datetimepicker", () => {
+            this.datePickerShown = true;
+            this.inputRef.el.select();
+        });
+        window.$(this.el).on("hide.datetimepicker", () => {
+            this.datePickerShown = false;
+            this.onDateChange({ useStatic: true });
+        });
+        window.$(this.el).on("error.datetimepicker", () => false);
     }
 
     willUpdateProps(nextProps) {
         const pickerParams = {};
+        let shouldUpdateInput = false;
         for (const prop in nextProps) {
-            if (this.props[prop] !== nextProps[prop]) {
+            const prev = this.props[prop];
+            const next = nextProps[prop];
+            if ((prev instanceof DateTime && !prev.equals(next)) || prev !== next) {
                 pickerParams[prop] = nextProps[prop];
                 if (prop === "date") {
                     this.setDate(nextProps);
-                    this.updateInput();
+                    shouldUpdateInput = true;
+                } else if (prop === "format") {
+                    this.setFormat(nextProps);
+                    shouldUpdateInput = true;
                 }
             }
+        }
+        if (shouldUpdateInput) {
+            this.updateInput();
         }
         this.bootstrapDateTimePicker(pickerParams);
     }
@@ -86,36 +117,32 @@ export class DatePicker extends Component {
     }
 
     //---------------------------------------------------------------------
-    // Getters
+    // Protected
     //---------------------------------------------------------------------
 
-    get options() {
+    getOptions(useStatic = false) {
         return {
-            // Fallback to default localization format in `core/l10n/dates.js`.
-            format: this.props.format,
-            locale: this.props.locale || this.date.locale,
+            format: !useStatic || isValidStaticFormat(this.format) ? this.format : this.staticFormat,
+            locale: this.date.locale,
             timezone: this.isLocal,
         };
     }
-
-    //---------------------------------------------------------------------
-    // Protected
-    //---------------------------------------------------------------------
 
     /**
      * Initialises formatting and parsing parameters
      */
     initFormat() {
         this.defaultFormat = localization.dateFormat;
-        this.format = formatters.get("date");
-        this.parse = parsers.get("date");
+        this.staticFormat = "yyyy/MM/dd";
+        this.formatValue = formatters.get("date");
+        this.parseValue = parsers.get("date");
         this.isLocal = false;
     }
 
     /**
      * Sets the current date value. If a locale is provided, the given date
      * will first be set in that locale.
-     * @param {object} params
+     * @param {Object} params
      * @param {DateTime} params.date
      * @param {string} [params.locale]
      */
@@ -124,13 +151,25 @@ export class DatePicker extends Component {
     }
 
     /**
-     * Updates the input element with the current formatted date value.
+     * Sets the current format.
+     * @param {Object} params
+     * @param {string} [params.format]
      */
-    updateInput() {
+    setFormat({ format }) {
+        // Fallback to default localization format in `@web/core/l10n/dates.js`.
+        this.format = format || this.defaultFormat;
+    }
+
+    /**
+     * Updates the input element with the current formatted date value.
+     * @param {Object} [params={}]
+     * @param {boolean} [params.useStatic]
+     */
+    updateInput({ useStatic } = {}) {
         try {
-            this.inputRef.el.value = this.format(this.date, this.options);
-        } catch (err) {
-            // Do nothing
+            this.inputRef.el.value = this.formatValue(this.date, this.getOptions(useStatic));
+        } catch (_err) {
+            // Ignore
         }
     }
 
@@ -144,8 +183,8 @@ export class DatePicker extends Component {
      */
     bootstrapDateTimePicker(commandOrParams) {
         if (typeof commandOrParams === "object") {
-            const format = luxonFormatToMomentFormat(this.props.format || this.defaultFormat);
-            const params = { ...commandOrParams, format };
+            const format = isValidStaticFormat(this.format) ? this.format : this.staticFormat;
+            const params = { ...commandOrParams, format: luxonFormatToMomentFormat(format) };
             if (!params.locale && commandOrParams.date) {
                 params.locale = commandOrParams.date.locale;
             }
@@ -158,7 +197,7 @@ export class DatePicker extends Component {
             }
             commandOrParams = params;
         }
-        window.$(this.el).datetimepicker(commandOrParams);
+        return window.$(this.el).datetimepicker(commandOrParams);
     }
 
     //---------------------------------------------------------------------
@@ -166,6 +205,9 @@ export class DatePicker extends Component {
     //---------------------------------------------------------------------
 
     onInputClick() {
+        if (!this.datePickerShown) {
+            this.updateInput({ useStatic: true });
+        }
         this.bootstrapDateTimePicker("toggle");
     }
 
@@ -173,17 +215,21 @@ export class DatePicker extends Component {
      * Called either when the input value has changed or when the boostrap
      * datepicker is closed. The actual "datetime-changed" emitted by the
      * component is only triggered if the date value has changed.
+     * @param {Object} [params={}]
+     * @param {boolean} [params.useStatic]
      */
-    onDateChange() {
+    onDateChange({ useStatic } = {}) {
+        let date;
         try {
-            const date = this.parse(this.inputRef.el.value, this.options);
-            if (!date.equals(this.props.date)) {
-                this.state.warning = date > DateTime.local();
-                this.trigger("datetime-changed", { date });
-            }
-        } catch (err) {
+            date = this.parseValue(this.inputRef.el.value, this.getOptions(useStatic));
+        } catch (_err) {
             // Reset to default (= given) date.
+        }
+        if (!date || date.equals(this.date)) {
             this.updateInput();
+        } else {
+            this.state.warning = date > DateTime.local();
+            this.trigger("datetime-changed", { date });
         }
     }
 
@@ -271,8 +317,9 @@ export class DateTimePicker extends DatePicker {
      */
     initFormat() {
         this.defaultFormat = localization.dateTimeFormat;
-        this.format = formatters.get("datetime");
-        this.parse = parsers.get("datetime");
+        this.staticFormat = "yyyy/MM/dd HH:mm:ss";
+        this.formatValue = formatters.get("datetime");
+        this.parseValue = parsers.get("datetime");
         this.isLocal = true;
     }
 }

--- a/addons/web/static/src/core/datepicker/datepicker.xml
+++ b/addons/web/static/src/core/datepicker/datepicker.xml
@@ -12,7 +12,7 @@
                 t-attf-data-target="#{{ datePickerId }}"
                 t-att-readonly="props.readonly"
                 t-ref="input"
-                t-on-change="onDateChange"
+                t-on-change="() => this.onDateChange()"
                 t-on-click="onInputClick"
             />
             <span t-if="props.warn_future and state.warning" class="fa fa-exclamation-triangle text-danger o_tz_warning o_datepicker_warning">

--- a/addons/web/static/tests/core/datepicker_tests.js
+++ b/addons/web/static/tests/core/datepicker_tests.js
@@ -14,7 +14,7 @@ import { editSelect } from 'web.test_utils_fields';
 import { createComponent } from 'web.test_utils';
 
 const { DateTime } = luxon;
-const { Component, mount, tags } = owl;
+const { Component, mount, tags, useState } = owl;
 const { xml } = tags;
 const serviceRegistry = registry.category("services");
 
@@ -34,14 +34,23 @@ const mountPicker = async (Picker, { props, onDateChange } = {}) => {
         )
         .add("ui", uiService);
 
-    class Parent extends Component {}
+    class Parent extends Component {
+        setup() {
+            this.state = useState(props);
+        }
+
+        onDateChange(ev) {
+            onDateChange(ev);
+            this.state.date = ev.detail.date;
+        }
+    }
     Parent.template = xml/* xml */ `
-        <t t-component="props.Picker" t-props="props.props" t-on-datetime-changed="props.onDateChange" />
+        <t t-component="props.Picker" t-props="state" t-on-datetime-changed="onDateChange" />
     `;
 
     const env = await makeTestEnv();
     const target = getFixture();
-    const parent = await mount(Parent, { env, props: { Picker, props, onDateChange }, target });
+    const parent = await mount(Parent, { env, props: { Picker }, target });
     registerCleanup(() => parent.destroy());
     return parent;
 };
@@ -66,6 +75,27 @@ const useFRLocale = () => {
         registerCleanup(() => window.moment.updateLocale("fr", null));
     }
     return "fr";
+};
+
+const useNOLocale = () => {
+    if (!window.moment.locales().includes("nb")) {
+        const originalLocale = window.moment.locale();
+        window.moment.defineLocale("nb", {
+            months: "januar_februar_mars_april_mai_juni_juli_august_september_oktober_november_desember".split(
+                "_"
+            ),
+            monthsShort: "jan._feb._mars_april_mai_juni_juli_aug._sep._okt._nov._des.".split("_"),
+            monthsParseExact: true,
+            week: {
+                dow: 1, // Monday is the first day of the week.
+                doy: 4, // The week that contains Jan 4th is the first week of the year.
+            },
+        });
+        // Moment automatically assigns newly defined locales.
+        window.moment.locale(originalLocale);
+        registerCleanup(() => window.moment.updateLocale("nb", null));
+    }
+    return "nb";
 };
 
 QUnit.module("Components", () => {
@@ -442,6 +472,41 @@ QUnit.module("Components", () => {
         await click(input);
 
         assert.strictEqual(input.value, "12:30:01 1997/01/09");
+    });
+
+    QUnit.test("Datepicker works with norwegian locale", async (assert) => {
+        assert.expect(6);
+
+        await mountPicker(DatePicker, {
+            props: {
+                date: DateTime.fromFormat("09/04/1997 12:30:01", "dd/MM/yyyy HH:mm:ss"),
+                format: "dd MMM, yyyy",
+                locale: useNOLocale(),
+            },
+            onDateChange: (ev) => {
+                assert.step("datetime-changed");
+                assert.strictEqual(
+                    ev.detail.date.toFormat("dd/MM/yyyy"),
+                    "01/04/1997",
+                    "Event should transmit the correct date"
+                );
+            },
+        });
+
+        const target = getFixture();
+        const input = target.querySelector(".o_datepicker_input");
+
+        assert.strictEqual(input.value, "09 apr., 1997");
+
+        await click(input);
+
+        assert.strictEqual(input.value, "1997/04/09");
+
+        const days = [...document.querySelectorAll(".datepicker .day")];
+        await click(days.find((d) => d.innerText.trim() === "1")); // first day of april
+
+        assert.strictEqual(input.value, "01 apr., 1997");
+        assert.verifySteps(["datetime-changed"]);
     });
 
     QUnit.test('custom filter date', async function (assert) {


### PR DESCRIPTION
The current datepicker implementation uses Luxon to send and receive
dates from the client and Moment to create and communicate with the
bootstrap datepicker.

Before this commit: the current database date/time format was used to
convert dates from one system to the other. However there are
inconsistencies in notation for some formats, for which the conversion
could not be made properly.

Now: a static format is used to translate dates and the actual database
format is applied only after both systems have been notified of a date
change.

Tasks [2794506](https://www.odoo.com/web#id=2794506&cids=1&menu_id=5879&action=3531&model=project.task&view_type=form), [2797949](https://www.odoo.com/web#id=2797949&menu_id=5879&action=3531&model=project.task&view_type=form&cids=1)