### PR TITLE
[FIX] base: fix template user action

### DIFF
--- a/odoo/addons/base/models/res_config.py
+++ b/odoo/addons/base/models/res_config.py
@@ -788,7 +788,7 @@ class ResConfigSettings(models.TransientModel, ResConfigModuleInstallationMixin)
     def action_open_template_user(self):
         action = self.env["ir.actions.actions"]._for_xml_id("base.action_res_users")
         template_user_id = literal_eval(self.env['ir.config_parameter'].sudo().get_param('base.template_portal_user_id', 'False'))
-        template_user = self.browse(template_user_id)
+        template_user = self.env['res.users'].browse(template_user_id)
         if not template_user.exists():
             raise ValueError(_('Invalid template user. It seems it has been deleted.'))
         action['res_id'] = template_user_id


### PR DESCRIPTION
A record wasn't found because it wasn't searched on the right model, which
prevented default access to portal users and prevented some configuration.

Likely introduced by 73483c8e

Task-2762102