### PR TITLE
[FIX] #88367 Wrong Validation Error message on HR Expense

### DIFF
--- a/addons/hr_expense/models/hr_expense.py
+++ b/addons/hr_expense/models/hr_expense.py
@@ -957,7 +957,7 @@ class HrExpenseSheet(models.Model):
         for sheet in self:
             employee_ids = sheet.expense_line_ids.mapped('employee_id')
             if len(employee_ids) > 1 or (len(employee_ids) == 1 and employee_ids != sheet.employee_id):
-                raise ValidationError(_('You cannot add expenses of another employee.'))
+                raise ValidationError(_('Employee field on the report must have the same employee selected as on the expense lines.'))
 
     @api.constrains('expense_line_ids', 'company_id')
     def _check_expense_lines_company(self):

--- a/doc/cla/individual/alyssalroach.md
+++ b/doc/cla/individual/alyssalroach.md
@@ -1,0 +1,11 @@
+United States of America, 2022-04-11
+
+I hereby agree to the terms of the Odoo Individual Contributor License
+Agreement v1.0.
+
+I declare that I am authorized and able to make this agreement and sign this
+declaration.
+
+Signed,
+
+Alyssa Roach alyroach@umich.edu https://github.com/alyssalroach


### PR DESCRIPTION
Description of the issue/feature this PR addresses: #88367 Wrong Validation Error message on HR Expense

Steps to reproduce:
1. Open expenses,
2. Create expense for employee A,
3. Click on "Create report",
4. In field "Employee" choose employee B,
5. Click save,

Current behavior before PR:
User gets error "You cannot add expenses of another employee."

Desired behavior after PR is merged:
User should get this error: "Employee field on the report must have the same employee selected as on the expense lines."

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
