### PR TITLE
[FIX] add missing help content translation for stock.quant view

### DIFF
--- a/addons/stock/i18n/stock.pot
+++ b/addons/stock/i18n/stock.pot
@@ -3123,6 +3123,12 @@ msgid "Immediate transfer?"
 msgstr ""
 
 #. module: stock
+#: code:addons/stock/models/stock_quant.py:0
+#, python-format
+msgid "Import"
+msgstr ""
+
+#. module: stock
 #: model:ir.model.fields,field_description:stock.field_stock_warehouse__in_type_id
 msgid "In Type"
 msgstr ""
@@ -4422,6 +4428,12 @@ msgid "No stock move found"
 msgstr ""
 
 #. module: stock
+#: code:addons/stock/models/stock_quant.py:0
+#, python-format
+msgid "No Stock On Hand"
+msgstr ""
+
+#. module: stock
 #: model_terms:ir.actions.act_window,help:stock.action_picking_form
 #: model_terms:ir.actions.act_window,help:stock.action_picking_tree_all
 #: model_terms:ir.actions.act_window,help:stock.action_picking_tree_backorder
@@ -5143,6 +5155,12 @@ msgstr ""
 #. module: stock
 #: model:ir.model.fields,help:stock.field_stock_move__route_ids
 msgid "Preferred route"
+msgstr ""
+
+#. module: stock
+#: code:addons/stock/models/stock_quant.py:0
+#, python-format
+msgid "Press the CREATE button to define quantity for each product in your stock or import them from a spreadsheet throughout Favorites"
 msgstr ""
 
 #. module: stock
@@ -7453,6 +7471,12 @@ msgid "There's no product move yet"
 msgstr ""
 
 #. module: stock
+#: code:addons/stock/models/stock_quant.py:0
+#, python-format
+msgid "This analysis gives you an overview of the current stock level of your products."
+msgstr ""
+
+#. module: stock
 #: model:ir.model.fields,help:stock.field_stock_rule__name
 msgid "This field will fill the packing origin and the name of its moves"
 msgstr ""
@@ -8807,6 +8831,12 @@ msgid ""
 "You'll find here smart replenishment propositions based on inventory forecasts.\n"
 "            Choose the quantity to buy or manufacture and launch orders in a click.\n"
 "            To save time in the future, set the rules as \"automated\"."
+msgstr ""
+
+#. module: stock
+#: code:addons/stock/models/stock_quant.py:0
+#, python-format
+msgid "Your stock is currently empty"
 msgstr ""
 
 #. module: stock

--- a/addons/stock/models/stock_quant.py
+++ b/addons/stock/models/stock_quant.py
@@ -284,10 +284,12 @@ class StockQuant(models.Model):
             'domain': [('location_id.usage', 'in', ['internal', 'transit'])],
             'help': """
                 <p class="o_view_nocontent_smiling_face">
-                    Your stock is currently empty
+                    {}
                 </p><p>
-                    Press the CREATE button to define quantity for each product in your stock or import them from a spreadsheet throughout Favorites <span class="fa fa-long-arrow-right"/> Import</p>
-                """
+                    {} <span class="fa fa-long-arrow-right"/> {}</p>
+                """.format(_('Your stock is currently empty'),
+                           _('Press the CREATE button to define quantity for each product in your stock or import them from a spreadsheet throughout Favorites'),
+                           _('Import')),
         }
         return action
 
@@ -854,10 +856,10 @@ class StockQuant(models.Model):
             'context': ctx,
             'domain': domain or [],
             'help': """
-                <p class="o_view_nocontent_empty_folder">No Stock On Hand</p>
-                <p>This analysis gives you an overview of the current stock
-                level of your products.</p>
-                """
+                <p class="o_view_nocontent_empty_folder">{}</p>
+                <p>{}</p>
+                """.format(_('No Stock On Hand'),
+                           _('This analysis gives you an overview of the current stock level of your products.')),
         }
 
         target_action = self.env.ref('stock.dashboard_open_quants', False)


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
Translation missing in help message of stock Inventory Adjustment form while no any record.

Current behavior before PR:
No translation just English message displayed.

Desired behavior after PR is merged:
English prompt message can be translated.



--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
