### PR TITLE
[FIX] mrp_subcontracting: properly import template helpers

### DIFF
--- a/addons/mrp_subcontracting/controllers/portal.py
+++ b/addons/mrp_subcontracting/controllers/portal.py
@@ -9,7 +9,7 @@ from odoo.http import request
 from odoo.exceptions import AccessError, MissingError
 from odoo.addons.portal.controllers import portal
 from odoo.addons.portal.controllers.portal import pager as portal_pager
-from odoo.addons.web.controllers.main import HomeStaticTemplateHelpers
+from odoo.addons.web.controllers.utils import HomeStaticTemplateHelpers
 
 
 class CustomerPortal(portal.CustomerPortal):


### PR DESCRIPTION
Since bcf665a291b, this helper has moved.

