### PR TITLE
[14.0][ADD] account : account_move_line add index

### DIFF
--- a/addons/account/models/account_move.py
+++ b/addons/account/models/account_move.py
@@ -3978,6 +3978,9 @@ class AccountMoveLine(models.Model):
         """
         cr = self._cr
         cr.execute('DROP INDEX IF EXISTS account_move_line_partner_id_index')
+        cr.execute("""CREATE INDEX IF NOT EXISTS account_move_line_date_move_name_id
+            ON account_move_line
+            (date desc, move_name desc, id);""")
         cr.execute('SELECT indexname FROM pg_indexes WHERE indexname = %s', ('account_move_line_partner_id_ref_idx',))
         if not cr.fetchone():
             cr.execute('CREATE INDEX account_move_line_partner_id_ref_idx ON account_move_line (partner_id, ref)')


### PR DESCRIPTION

Description of the issue/feature this PR addresses:

the problem occurs when loading the list view of journal items
the lines are sorted on (_order = 'date desc, move_name desc, id')
but there is no index for that
on my test database : this index divides by 4 the loading time of this view



--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
