### PR TITLE
[FIX] sale_timesheet: make order_id on analytic line readonly

### DIFF
--- a/addons/sale_timesheet/models/account.py
+++ b/addons/sale_timesheet/models/account.py
@@ -27,7 +27,7 @@ class AccountAnalyticLine(models.Model):
     timesheet_invoice_id = fields.Many2one('account.move', string="Invoice", readonly=True, copy=False, help="Invoice created from the timesheet")
     so_line = fields.Many2one(compute="_compute_so_line", store=True, readonly=False, domain="[('is_service', '=', True), ('is_expense', '=', False), ('state', 'in', ['sale', 'done']), ('order_partner_id', 'child_of', commercial_partner_id)]")
     # we needed to store it only in order to be able to groupby in the portal
-    order_id = fields.Many2one(related='so_line.order_id', store=True, readonly=False)
+    order_id = fields.Many2one(related='so_line.order_id', store=True, readonly=True)
     is_so_line_edited = fields.Boolean("Is Sales Order Item Manually Edited")
 
     @api.depends('project_id.commercial_partner_id', 'task_id.commercial_partner_id')


### PR DESCRIPTION
A field order_id has been introduce on account.analytic.line
in https://github.com/odoo/odoo/commit/dc9ef81ab21cbbf232eca1771ab94dd5a54e9345
to allow to group by order

This field was introduce as related readonly=False.
It has the side effect of modifying the order_id on the sale.order.line
each time a timesheet is created and thus trigger computed field that
are based on that field.

Since the field is only declared for a group by it's pointless to
make it modifiable, it will save a lot a useless computation and avoid
some issue with computed field wrongly triggered




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
