### PR TITLE
[FIX] account: trigger show_credit_limit on partner creation

### DIFF
--- a/addons/account/models/partner.py
+++ b/addons/account/models/partner.py
@@ -452,6 +452,7 @@ class ResPartner(models.Model):
         string='Partner Limit', groups='account.group_account_invoice,account.group_account_readonly',
         compute='_compute_use_partner_credit_limit', inverse='_inverse_use_partner_credit_limit')
     show_credit_limit = fields.Boolean(
+        default=lambda self: self.env.company.account_use_credit_limit,
         compute='_compute_show_credit_limit', groups='account.group_account_invoice,account.group_account_readonly')
     debit = fields.Monetary(
         compute='_credit_debit_get', search=_debit_search, string='Total Payable',


### PR DESCRIPTION
The Credit Limit group on the res.partner record
doesn't appear until you save the record.

This means you have to perform extra clicks
if you want to edit this value.

The goal is to show the `credit` field on the accounting tab
on creation if `res.partner` is a company and
Credit Limit setting is activated.

task-2817650

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
