### PR TITLE
[FIX] stock_account: fix consistency error on stock_move return valuation

### DIFF
--- a/addons/stock_account/models/stock_move.py
+++ b/addons/stock_account/models/stock_move.py
@@ -39,9 +39,8 @@ class StockMove(models.Model):
         precision = self.env['decimal.precision'].precision_get('Product Price')
         # If the move is a return, use the original move's price unit.
         if self.origin_returned_move_id and self.origin_returned_move_id.sudo().stock_valuation_layer_ids:
-            layers = self.origin_returned_move_id.sudo().stock_valuation_layer_ids
-            quantity = sum(layers.mapped("quantity"))
-            return layers.currency_id.round(sum(layers.mapped("value")) / quantity) if not float_is_zero(quantity, layers.uom_id.rounding) else 0
+            # Filtered on svl quantity to exclude revaluation layers
+            return self.origin_returned_move_id.sudo().stock_valuation_layer_ids.filtered(lambda s: not float_is_zero(s.quantity, precision_rounding=s.product_id.uom_id.rounding))[-1].unit_cost
         return price_unit if not float_is_zero(price_unit, precision) or self._should_force_price_unit() else self.product_id.standard_price
 
     @api.model

--- a/addons/stock_account/tests/test_stockvaluationlayer.py
+++ b/addons/stock_account/tests/test_stockvaluationlayer.py
@@ -518,10 +518,10 @@ class TestStockValuationAVCO(TestStockValuationCommon):
     def test_return_delivery_2(self):
         self.product1.write({"standard_price": 1})
         move1 = self._make_out_move(self.product1, 10, create_picking=True, force_assign=True)
-        move2 = self._make_in_move(self.product1, 10, unit_cost=2)
-        move3 = self._make_return(move1, 10)
+        self._make_in_move(self.product1, 10, unit_cost=2)
+        self._make_return(move1, 10)
 
-        self.assertEqual(self.product1.value_svl, 20)
+        self.assertEqual(self.product1.value_svl, 10)
         self.assertEqual(self.product1.quantity_svl, 10)
         self.assertEqual(self.product1.standard_price, 2)
 
@@ -698,10 +698,10 @@ class TestStockValuationFIFO(TestStockValuationCommon):
     def test_return_delivery_3(self):
         self.product1.write({"standard_price": 1})
         move1 = self._make_out_move(self.product1, 10, create_picking=True, force_assign=True)
-        move2 = self._make_in_move(self.product1, 10, unit_cost=2)
-        move3 = self._make_return(move1, 10)
+        self._make_in_move(self.product1, 10, unit_cost=2)
+        self._make_return(move1, 10)
 
-        self.assertEqual(self.product1.value_svl, 20)
+        self.assertEqual(self.product1.value_svl, 10)
         self.assertEqual(self.product1.quantity_svl, 10)
 
 


### PR DESCRIPTION
This PR fix a consistency error after this PR was merged: https://github.com/odoo/odoo/pull/85751

If you follow these steps: ('Test Val' in screenshot)
- Create Storable Product "P1", avco or fifo, unit cost to 1 and **on hand quantity 0.**
- Create SO with 10 units of P1.
- Create PO with 10 units of P1 and unit cost of 2.
- Return the delivery order of SO.
==> The return delivery **unit cost is 2**

While if you do: ('Test Val 2' in screenshot)
- Create Storable Product "P2", avco or fifo, unit cost to 1 and **on hand quantity 10.**
- Create SO with 10 units of P2.
- Create PO with 10 units of P2 and unit cost of 2.
- Return the delivery order of SO.
==> The return delivery **unit cost is 1**

![image](https://user-images.githubusercontent.com/29302288/162935174-8f26b2de-d2ad-4490-8e1e-8ddd06bd668e.png)

The unit cost should be the same in both cases.

---

The revaluation layer does not change the original stock move price unit.
And when doing a return, we want to use the original stock move price unit, so we should not take the revaluation layer in consideration.

OPW-2784033

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
