### PR TITLE
[FIX] sale: prevent display sale_warn when "no message"

### DIFF
--- a/addons/sale/views/res_partner_views.xml
+++ b/addons/sale/views/res_partner_views.xml
@@ -51,7 +51,7 @@
                         <separator string="Warning on the Sales Order" colspan="4" />
                             <field name="sale_warn" nolabel="1" />
                             <field name="sale_warn_msg" colspan="3" nolabel="1"
-                                    attrs="{'required':[('sale_warn', '!=', False), ('sale_warn','!=','no-message')],'readonly':[('sale_warn','=','no-message')]}"/>
+                                    attrs="{'required':[('sale_warn', '!=', False), ('sale_warn','!=','no-message')], 'invisible':[('sale_warn','in',(False,'no-message'))]}"/>
                     </group>
                 </page>
             </field>


### PR DESCRIPTION
Steps to reproduce:
- Sales > Config/Settings > Enable 'Sale Warnings' + Save >
- Go to Orders/Customers > Select any + Edit > Go to 'Internal Notes' tab > For the Sales warning
- Select Warning (or Blocking message) and set any message + Save
- Hit Edit again, switch to 'No Message'

Issue:
You will see the message is still displayed.

Solution:
Change the domain

opw-2819279