### PR TITLE
[FIX] website_blog: remove negative word spacing in blog snippet

### DIFF
--- a/addons/website_blog/static/src/scss/website_blog.scss
+++ b/addons/website_blog/static/src/scss/website_blog.scss
@@ -438,7 +438,6 @@ $o-wblog-title-sizes-variants: (
         .s_latest_posts_post_title  {
             @include font-size($h3-font-size);
             margin-bottom: 0.5em;
-            word-spacing: -0.15em;
         }
 
         @include s-latest-posts-figure-hook;


### PR DESCRIPTION
Since [1] when the blog layout was refactored between 12.0 and 13.0, a
negative word spacing was introduced in the blog post snippet with the
big pictures layout.

This commit removes this negative word spacing.

Before:
![image](https://user-images.githubusercontent.com/71644421/162988327-0333bc2c-ad1c-45b1-b478-88461d06ec3c.png)

After:
![image](https://user-images.githubusercontent.com/71644421/162988196-ddb90c6a-2e4b-4d6e-87b8-a175c7c06692.png)

[1]: https://github.com/odoo/odoo/commit/bb0cdec4594fab8c22265ed8af0c2d431a263b72

task-2822436

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
