### PR TITLE
[IMP] mass_mailing:  enhance the behavior of the template preview

### DIFF
--- a/addons/mass_mailing/static/src/js/mass_mailing_widget.js
+++ b/addons/mass_mailing/static/src/js/mass_mailing_widget.js
@@ -467,6 +467,12 @@ var MassMailingFieldHtml = FieldHtml.extend({
             $dropdown.find('.dropdown-item:eq(' + themesParams.indexOf(selectedTheme) + ')').addClass('selected');
         });
 
+        // Prevent expansion of drop-down while clicking on empty area during theme selection
+        $dropdown.on("click", ".dropdown-menu", function (ev) {
+            ev.preventDefault();
+            ev.stopPropagation();
+        });
+
         /**
          * If the user opens the theme selection screen, indicates which one is active and
          * saves the information...

--- a/addons/mass_mailing/static/src/scss/mass_mailing.ui.scss
+++ b/addons/mass_mailing/static/src/scss/mass_mailing.ui.scss
@@ -77,6 +77,10 @@
                 }
             }
 
+            &:focus {
+                background-color: $o-we-sidebar-bg;
+            }
+
             &.selected .o_thumb {
                 border: 2px solid $o-brand-odoo;
                 background-color: $o-we-sidebar-bg;


### PR DESCRIPTION
This PR contains two tasks,
1) If user clicks the mass mailing template (theme) and holds the click while moving the mouse
    (as if performing drag and drop), a weird white highlight appears on the preview of the template.

     We have fixed the behaviour by setting appropriate background color instead of the default one 
     of drop-down item, when the template is focused.

2) When clicking on the empty area during theme selection, the snippet menu is visible on the top because the drop- 
    down is expanded which should only happen clicking on the '[data-toggle="dropdown"]' button for the css and 
    transformation etc to be applied correctly.

    This PR solves the problem by preventing click event and it's propagation on the whole drop-down, and instead it 
    lets the clicks being handled only where needed.

taskID: 2812312
