### PR TITLE
[FIX] account: enable tour for all l10n

### DIFF
--- a/addons/account/tests/test_tour.py
+++ b/addons/account/tests/test_tour.py
@@ -1,6 +1,5 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
-from odoo import Command
 import odoo.tests
 
 
@@ -8,19 +7,6 @@ import odoo.tests
 class TestUi(odoo.tests.HttpCase):
 
     def test_01_account_tour(self):
-        # Reset country and fiscal country, so that fields added by localizations are
-        # hidden and non-required, and don't make the tour crash.
-        # Also remove default taxes from the company and its accounts, to avoid inconsistencies
-        # with empty fiscal country.
-        self.env.company.write({
-            'country_id': None, # Also resets account_fiscal_country_id
-            'account_sale_tax_id': None,
-            'account_purchase_tax_id': None,
-        })
-        account_with_taxes = self.env['account.account'].search([('tax_ids', '!=', False), ('company_id', '=', self.env.company.id)])
-        account_with_taxes.write({
-            'tax_ids': [Command.clear()],
-        })
         # This tour doesn't work with demo data on runbot
         all_moves = self.env['account.move'].search([('move_type', '!=', 'entry')])
         all_moves.button_draft()


### PR DESCRIPTION
Instead of trying to hide the fact that the tour doesn't work for some
countries, fix it for said countries.
* Hiding it doesn't work because some fields can be required depending
  on fields that are not the country_id, for instance journal
  configuration [1]
* This is not a test tour; it is supposed to be followed by real users
  that need help to make their first steps in the software.

[1]: https://runbot.odoo.com/runbot/build/14430992 
[1]: This happens because the journal is configured to require use documents
(`l10n_latam_use_documents=True`) but the fields depending on country
specific fields (`l10n_ar_afip_responsibility_type_id`) are not set
