### PR TITLE
[IMP] base: update industry list

### DIFF
--- a/odoo/addons/base/data/res_partner_data.xml
+++ b/odoo/addons/base/data/res_partner_data.xml
@@ -56,107 +56,107 @@
 
         <record id="res_partner_industry_A" model="res.partner.industry">
             <field name="name">Agriculture</field>
-            <field name="full_name">A AGRICULTURE, FORESTRY AND FISHING</field>
+            <field name="full_name">A - AGRICULTURE, FORESTRY AND FISHING</field>
         </record>
 
         <record id="res_partner_industry_B" model="res.partner.industry">
             <field name="name">Mining</field>
-            <field name="full_name">B MINING AND QUARRYING</field>
+            <field name="full_name">B - MINING AND QUARRYING</field>
         </record>
 
         <record id="res_partner_industry_C" model="res.partner.industry">
             <field name="name">Manufacturing</field>
-            <field name="full_name">C MANUFACTURING</field>
+            <field name="full_name">C - MANUFACTURING</field>
         </record>
 
         <record id="res_partner_industry_D" model="res.partner.industry">
             <field name="name">Energy supply</field>
-            <field name="full_name">D ELECTRICITY,GAS,STEAM AND AIR CONDITIONING SUPPLY</field>
+            <field name="full_name">D - ELECTRICITY, GAS, STEAM AND AIR CONDITIONING SUPPLY</field>
         </record>
 
         <record id="res_partner_industry_E" model="res.partner.industry">
             <field name="name">Water supply</field>
-            <field name="full_name">E WATER SUPPLY;SEWERAGE,WASTE MANAGEMENT AND REMEDIATION ACTIVITIES</field>
+            <field name="full_name">E - WATER SUPPLY; SEWERAGE, WASTE MANAGEMENT AND REMEDIATION ACTIVITIES</field>
         </record>
 
         <record id="res_partner_industry_F" model="res.partner.industry">
             <field name="name">Construction</field>
-            <field name="full_name">F CONSTRUCTION</field>
+            <field name="full_name">F - CONSTRUCTION</field>
         </record>
 
         <record id="res_partner_industry_G" model="res.partner.industry">
             <field name="name">Wholesale/Retail</field>
-            <field name="full_name">G WHOLESALE AND RETAIL TRADE;REPAIR OF MOTOR VEHICLES AND MOTORCYCLES</field>
+            <field name="full_name">G - WHOLESALE AND RETAIL TRADE; REPAIR OF MOTOR VEHICLES AND MOTORCYCLES</field>
         </record>
 
         <record id="res_partner_industry_H" model="res.partner.industry">
-            <field name="name">Transportation</field>
-            <field name="full_name">H TRANSPORTATION AND STORAGE</field>
+            <field name="name">Transportation/Logistics</field>
+            <field name="full_name">H - TRANSPORTATION AND STORAGE</field>
         </record>
 
         <record id="res_partner_industry_I" model="res.partner.industry">
-            <field name="name">Food</field>
-            <field name="full_name">I ACCOMMODATION AND FOOD SERVICE ACTIVITIES</field>
+            <field name="name">Food/Hospitality</field>
+            <field name="full_name">I - ACCOMMODATION AND FOOD SERVICE ACTIVITIES</field>
         </record>
 
         <record id="res_partner_industry_J" model="res.partner.industry">
             <field name="name">IT/Communication</field>
-            <field name="full_name">J INFORMATION AND COMMUNICATION</field>
+            <field name="full_name">J - INFORMATION AND COMMUNICATION</field>
         </record>
 
         <record id="res_partner_industry_K" model="res.partner.industry">
             <field name="name">Finance/Insurance</field>
-            <field name="full_name">K FINANCIAL AND INSURANCE ACTIVITIES</field>
+            <field name="full_name">K - FINANCIAL AND INSURANCE ACTIVITIES</field>
         </record>
 
         <record id="res_partner_industry_L" model="res.partner.industry">
             <field name="name">Real Estate</field>
-            <field name="full_name">L REAL ESTATE ACTIVITIES</field>
+            <field name="full_name">L - REAL ESTATE ACTIVITIES</field>
         </record>
 
         <record id="res_partner_industry_M" model="res.partner.industry">
             <field name="name">Scientific</field>
-            <field name="full_name">M PROFESSIONAL, SCIENTIFIC AND TECHNICAL ACTIVITIES</field>
+            <field name="full_name">M - PROFESSIONAL, SCIENTIFIC AND TECHNICAL ACTIVITIES</field>
         </record>
 
         <record id="res_partner_industry_N" model="res.partner.industry">
-            <field name="name">Administrative</field>
-            <field name="full_name">N ADMINISTRATIVE AND SUPPORT SERVICE ACTIVITIES</field>
+            <field name="name">Administrative/Utilities</field>
+            <field name="full_name">N - ADMINISTRATIVE AND SUPPORT SERVICE ACTIVITIES</field>
         </record>
 
         <record id="res_partner_industry_O" model="res.partner.industry">
             <field name="name">Public Administration</field>
-            <field name="full_name">O PUBLIC ADMINISTRATION AND DEFENCE;COMPULSORY SOCIAL SECURITY</field>
+            <field name="full_name">O - PUBLIC ADMINISTRATION AND DEFENCE; COMPULSORY SOCIAL SECURITY</field>
         </record>
 
         <record id="res_partner_industry_P" model="res.partner.industry">
             <field name="name">Education</field>
-            <field name="full_name">P EDUCATION</field>
+            <field name="full_name">P - EDUCATION</field>
         </record>
 
         <record id="res_partner_industry_Q" model="res.partner.industry">
             <field name="name">Health/Social</field>
-            <field name="full_name">Q HUMAN HEALTH AND SOCIAL WORK ACTIVITIES</field>
+            <field name="full_name">Q - HUMAN HEALTH AND SOCIAL WORK ACTIVITIES</field>
         </record>
 
         <record id="res_partner_industry_R" model="res.partner.industry">
             <field name="name">Entertainment</field>
-            <field name="full_name">R ARTS, ENTERTAINMENT AND RECREATION</field>
+            <field name="full_name">R - ARTS, ENTERTAINMENT AND RECREATION</field>
         </record>
 
         <record id="res_partner_industry_S" model="res.partner.industry">
             <field name="name">Other Services</field>
-            <field name="full_name">S OTHER SERVICE ACTIVITIES</field>
+            <field name="full_name">S - OTHER SERVICE ACTIVITIES</field>
         </record>
 
         <record id="res_partner_industry_T" model="res.partner.industry">
             <field name="name">Households</field>
-            <field name="full_name">T ACTIVITIES OF HOUSEHOLDS AS EMPLOYERS;UNDIFFERENTIATED GOODS- AND SERVICES-PRODUCING ACTIVITIES OF HOUSEHOLDS FOR OWN USE</field>
+            <field name="full_name">T - ACTIVITIES OF HOUSEHOLDS AS EMPLOYERS; UNDIFFERENTIATED GOODS- AND SERVICES-PRODUCING ACTIVITIES OF HOUSEHOLDS FOR OWN USE</field>
         </record>
 
         <record id="res_partner_industry_U" model="res.partner.industry">
             <field name="name">Extraterritorial</field>
-            <field name="full_name">U ACTIVITIES OF EXTRA TERRITORIAL ORGANISATIONS AND BODIES</field>
+            <field name="full_name">U - ACTIVITIES OF EXTRATERRITORIAL ORGANISATIONS AND BODIES</field>
         </record>
 
     </data>


### PR DESCRIPTION
In the current version, some industries are named things like `Administrative`,
`Food`, and `Transportation`, and do not have the proper space and dash after
the first alphabet in full name.

This commit renames the above industries to `Administrative/Utilities`,
`Food/Hospitality`, and `Transportation/Logistic` respectively, and also adds
 space after comma and semicolon according to `NACE` rules, and also adds a dash
 after the first alphabet in the full name.

task-2674365

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
