### PR TITLE
[FIX] core, base: set res_id when adding attachment to m2m

### DIFF
--- a/addons/test_mail/tests/test_performance.py
+++ b/addons/test_mail/tests/test_performance.py
@@ -755,7 +755,7 @@ class TestMailPerformancePost(BaseMailPerformance):
         ]
         self.attachements = self.env['ir.attachment'].with_user(self.env.user).create(self.vals)
         attachement_ids = self.attachements.ids
-        with self.assertQueryCount(emp=103):  # runbot 103 // test_mail only: 92
+        with self.assertQueryCount(emp=104):  # runbot 104 // test_mail only: 93
             self.cr.sql_log = self.warm and self.cr.sql_log_count
             record.with_context({}).message_post(
                 body='<p>Test body <img src="cid:cid1"> <img src="cid:cid2"></p>',


### PR DESCRIPTION
Issue missed in the fixes to attachment ACLs: linking multiple attachments to a single record is done via an m2m, there are two issues there:

- when performing such linkage programmatically, forgetting to explicitly update the res_model/res_id of an attachment being set or moved (between records) could leave it in an incorrect state
- while the `many2many_binary` widget properly passes the record's id when adding an attachment to an *existing* record, it completely fails to predict and set the id of a record being created, thus leaving attachments added while creating the record in an oddball state

This fixes both issues by adding a special case to the write process of `fields.Many2many`: iff the comodel is ir.attachment, set the current record's id on the attachments being added to it.

However there is still the issue of existing attachments in oddball states, that is what the update in `ir_attachment` tries to fix: it hooks in at the end of registry initialisation and looks for attachments linked to through an m2m which have the wrong model/id. This is added because currently such database can severely hamper users (cf ticket)

This seems to not be overly expensive: on a database with 680000 messages, and nearly 100000 mis-configured attachments linked to messages, the initial update takes 6s:

    mail.message 95967 5.90

afterwards, the initialisation cost is not free but it drops drastically:

    mail.message 24 0.16

Do note one minor issue here: situations where an m2m is actually used in an m2m configuration (rather than the more common situation where the m2m is really used as an o2m, each attachment being linked
to a single "owning" record). In that case I guess the attachment gets "bounced" between records and has to be updated on every initialisation, but this seems relatively benign.

https://github.com/odoo/odoo/commit/5e81850ea6#r64852486

OPW-2794177
