### PR TITLE
[REV][FIX] web: radio widget ignores required attribute

### DIFF
--- a/addons/web/static/src/js/fields/relational_fields.js
+++ b/addons/web/static/src/js/fields/relational_fields.js
@@ -2886,6 +2886,14 @@ var FieldRadio = FieldSelection.extend({
     //--------------------------------------------------------------------------
 
     /**
+     * @override
+     * @returns {boolean} always true
+     */
+    isSet: function () {
+        return true;
+    },
+
+    /**
      * Returns the currently-checked radio button, or the first one if no radio
      * button is checked.
      *

--- a/addons/web/static/tests/fields/relational_fields_tests.js
+++ b/addons/web/static/tests/fields/relational_fields_tests.js
@@ -1970,34 +1970,6 @@ QUnit.module('relational_fields', {
         form.destroy();
     });
 
-    QUnit.test('required fieldradio widget on a many2one', async function (assert) {
-        assert.expect(6);
-
-        const form = await createView({
-            View: FormView,
-            model: 'partner',
-            data: this.data,
-            arch: '<form>' +
-                '<field name="product_id" widget="radio" required="1"/>' +
-                '</form>',
-        });
-
-        testUtils.mock.intercept(form, 'call_service', function (event) {
-            if (event.data.service === 'notification' && event.data.method === 'notify') {
-                assert.step('danger');
-                assert.equal(event.data.args[0].type, 'danger');
-                assert.equal(event.data.args[0].title, 'The following fields are invalid:');
-                assert.equal(event.data.args[0].message, '<ul><li>Product</li></ul>');
-            }
-        });
-
-        assert.containsNone(form, 'input:checked', "none of the input should be checked");
-
-        await testUtils.form.clickSave(form);
-        assert.verifySteps(['danger']);
-        form.destroy();
-    });
-
     QUnit.test('fieldradio change value by onchange', async function (assert) {
         assert.expect(4);
 


### PR DESCRIPTION
This reverts https://github.com/odoo/odoo/pull/87375

`auth_signup_uninvited` is be set as required in the
settings view but a value is missing in the case where the current
company has no website.
This then prevents the settings from being saved.
This could also be an issue with other settings in custom code.
We should revert this fix in stable.

opw-2819061