### PR TITLE
[FIX] account: Invoice address beside Shipping address

### DIFF
--- a/addons/account/views/report_invoice.xml
+++ b/addons/account/views/report_invoice.xml
@@ -13,9 +13,8 @@
                         </div>
                     </t>
                 </t>
-                <div t-field="o.partner_id" t-options='{"widget": "contact", "fields": ["address", "name"], "no_marker": True}' groups="account.group_delivery_invoice_address"/>
                 <t t-set="address">
-                    <address t-field="o.partner_id" t-options='{"widget": "contact", "fields": ["address", "name"], "no_marker": True}' groups="!account.group_delivery_invoice_address"/>
+                    <address t-field="o.partner_id" t-options='{"widget": "contact", "fields": ["address", "name"], "no_marker": True}'/>
                     <div t-if="o.partner_id.vat" class="mt16">
                         <t t-if="o.company_id.account_fiscal_country_id.vat_label" t-esc="o.company_id.account_fiscal_country_id.vat_label" id="inv_tax_id_label"/>
                         <t t-else="">Tax ID</t>: <span t-field="o.partner_id.vat"/></div>


### PR DESCRIPTION
When creating a Bill with a `partner_id` different from the
`partner_shipping_id`, the Shipping Address is not beside the Invoice Address

To reproduce the issue:
1. Activate the 'Customer Addresses' option into the Accounting app
2. Create a new invoice with a 'Delivery Address' different from the 'Customer'
3. 'Confirm' then 'Send & Print' the invoice and visualize the PDF
We see the Delivery Address above the Invoice Address while they should be side to side.

Solution: An invalid line was added into the XML of the invoice report (commit 3732aea4b884eb3fadec344c877ebc5763bdbb40). The unecessary line just needed to be removed as it was taking the place (in the HTML) of the correct address (an empty div of 6 column in bootstrap - half of the page).

opw-2817586
