### PR TITLE
[FIX] project: Copy task dependency on project copy

### DIFF
--- a/addons/project/models/project.py
+++ b/addons/project/models/project.py
@@ -445,7 +445,8 @@ class Project(models.Model):
         # We want to copy archived task, but do not propagate an active_test context key
         task_ids = self.env['project.task'].with_context(active_test=False).search([('project_id', '=', self.id)], order='parent_id').ids
         old_to_new_tasks = {}
-        for task in self.env['project.task'].browse(task_ids):
+        all_tasks = self.env['project.task'].browse(task_ids)
+        for task in all_tasks:
             # preserve task name and stage, normally altered during copy
             defaults = self._map_tasks_default_valeus(task, project)
             if task.parent_id:
@@ -456,6 +457,13 @@ class Project(models.Model):
             new_child_ids = [old_to_new_tasks[child.id] for child in task.child_ids if child.id in old_to_new_tasks]
             tasks.browse(new_child_ids).write({'parent_id': new_task.id})
             old_to_new_tasks[task.id] = new_task.id
+            if task.allow_task_dependencies:
+                depend_on_ids = [t.id if t not in all_tasks else old_to_new_tasks.get(t.id, None) for t in
+                                 task.depend_on_ids]
+                new_task.write({'depend_on_ids': [Command.link(tid) for tid in depend_on_ids if tid]})
+                dependent_ids = [t.id if t not in all_tasks else old_to_new_tasks.get(t.id, None) for t in
+                                 task.dependent_ids]
+                new_task.write({'dependent_ids': [Command.link(tid) for tid in dependent_ids if tid]})
             tasks += new_task
 
         return project.write({'tasks': [(6, 0, tasks.ids)]})
@@ -1003,10 +1011,10 @@ class Task(models.Model):
     allow_task_dependencies = fields.Boolean(related='project_id.allow_task_dependencies')
     # Tracking of this field is done in the write function
     depend_on_ids = fields.Many2many('project.task', relation="task_dependencies_rel", column1="task_id",
-                                     column2="depends_on_id", string="Blocked By", tracking=True,
+                                     column2="depends_on_id", string="Blocked By", tracking=True, copy=False,
                                      domain="[('allow_task_dependencies', '=', True), ('id', '!=', id)]")
     dependent_ids = fields.Many2many('project.task', relation="task_dependencies_rel", column1="depends_on_id",
-                                     column2="task_id", string="Block",
+                                     column2="task_id", string="Block", copy=False,
                                      domain="[('allow_task_dependencies', '=', True), ('id', '!=', id)]")
     dependent_tasks_count = fields.Integer(string="Dependent Tasks", compute='_compute_dependent_tasks_count')
 

--- a/addons/project/tests/test_task_dependencies.py
+++ b/addons/project/tests/test_task_dependencies.py
@@ -159,3 +159,26 @@ class TestTaskDependencies(TestProjectCommon):
             'name': 'My Ducks Project'
         })
         self.assertFalse(self.project_ducks.allow_task_dependencies, "New Projects allow_task_dependencies should default to group_project_task_dependencies")
+
+    def test_duplicate_project_with_task_dependencies(self):
+
+        self.project_pigs.allow_task_dependencies = True
+        self.task_1.depend_on_ids = self.task_2
+        pigs_copy = self.project_pigs.copy()
+
+        task1_copy = pigs_copy.task_ids.filtered(lambda t: t.name == 'Pigs UserTask')
+        task2_copy = pigs_copy.task_ids.filtered(lambda t: t.name == 'Pigs ManagerTask')
+
+        self.assertEqual(len(task1_copy), 1, "Should only contain 1 copy of UserTask")
+        self.assertEqual(len(task2_copy), 1, "Should only contain 1 copy of ManagerTask")
+
+        self.assertEqual(task1_copy.depend_on_ids.ids, [task2_copy.id],
+                         "Copy should only create a relation between both copy if they are both part of the project")
+
+        task1_copy.depend_on_ids = self.task_1
+
+        pigs_copy_copy = pigs_copy.copy()
+        task1_copy_copy = pigs_copy_copy.task_ids.filtered(lambda t: t.name == 'Pigs UserTask')
+
+        self.assertEqual(task1_copy_copy.depend_on_ids.ids, [self.task_1.id],
+                         "Copy should not alter the relation if the other task is in a different project")


### PR DESCRIPTION
Step to reproduce:
- Create a project with 2 task A and B
- Set task A blocked by task B
- Duplicate Project

Current behaviour:
- Duplicate project is also blocked by original project's task
- Original project's tasks are blocked by new duplicate project's
 task

Behaviour after PR:
- Original project's tasks are not changed
- Duplicate project's tasks are blocked by duplicate project's task
 if they were blocked by the original project.
- Tasks are still blocked by tasks not linked to the original
 project

opw-2818476

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
