### PR TITLE
[FIX] website_slides: fix sign in from quiz for non-members

### DIFF
--- a/addons/website_slides/static/src/js/slides_course_quiz.js
+++ b/addons/website_slides/static/src/js/slides_course_quiz.js
@@ -470,20 +470,14 @@
          * @private
          */
         _saveQuizAnswersToSession: function () {
-            var quizAnswers = this._getQuizAnswers();
-            if (quizAnswers.length === this.quiz.questions.length) {
-                this._hideErrorMessage();
+            this._hideErrorMessage();
 
-                return this._rpc({
-                    route: '/slides/slide/quiz/save_to_session',
-                    params: {
-                        'quiz_answers': {'slide_id': this.slide.id, 'slide_answers': quizAnswers},
-                    }
-                });
-            } else {
-                this._showErrorMessage('slide_quiz_incomplete');
-                return Promise.reject('The quiz is incomplete');
-            }
+            return this._rpc({
+                route: '/slides/slide/quiz/save_to_session',
+                params: {
+                    'quiz_answers': {'slide_id': this.slide.id, 'slide_answers': this._getQuizAnswers()},
+                }
+            });
         },
         /**
         * After joining the course, we immediately submit the quiz and get the correction.

--- a/addons/website_slides/static/src/xml/slide_course_join.xml
+++ b/addons/website_slides/static/src/xml/slide_course_join.xml
@@ -6,12 +6,7 @@
                 class="btn btn-primary o_wslides_js_course_join_link text-uppercase font-weight-bold"
                 title="Join the Course" aria-label="Join the Course"
                 href="#">
-                <t t-if="widget.channel.channelEnroll == 'public'">
-                    <t t-if="widget.publicUser">
-                        Sign in
-                    </t>
-                    <t t-else="" t-esc="widget.joinMessage" />
-                </t>
+                <t t-if="widget.channel.channelEnroll == 'public'" t-esc="widget.joinMessage"/>
             </a>
         </div>
     </t>


### PR DESCRIPTION
When a non-member of a course tried to sign in from a quiz page,
the button seemed unresponsive. In fact, the element to show the error
message was not there to show that the answers to all questions had to be
provided to move forward. Likely introduced by 4a329da6.

However, the desired behavior is to not prevent a visitor from joining or
buying the course immediately when they didn't answer all questions.

It was also necessary to show clearly that clicking on the quiz validation
button would lead to validating the answers after logging in via this button.

Task-2821644
Part of Task-2663320
