### PR TITLE
[IMP] mail: move component handlers to models (step 3)

### DIFF
--- a/addons/mail/static/src/components/chat_window/chat_window.js
+++ b/addons/mail/static/src/components/chat_window/chat_window.js
@@ -22,7 +22,6 @@ export class ChatWindow extends Component {
         // the following are passed as props to children
         this._onAutocompleteSelect = this._onAutocompleteSelect.bind(this);
         this._onAutocompleteSource = this._onAutocompleteSource.bind(this);
-        this._onClickedHeader = this._onClickedHeader.bind(this);
         this._onFocusinThread = this._onFocusinThread.bind(this);
     }
 
@@ -109,25 +108,6 @@ export class ChatWindow extends Component {
             keyword: _.escape(req.term),
             limit: 10,
         });
-    }
-
-    /**
-     * Called when clicking on header of chat window. Usually folds the chat
-     * window.
-     *
-     * @private
-     */
-    _onClickedHeader() {
-        if (!this.chatWindow || this.messaging.device.isMobile) {
-            return;
-        }
-        if (this.chatWindow.isFolded) {
-            this.chatWindow.unfold();
-            this.chatWindow.focus();
-        } else {
-            this.chatWindow.saveThreadScrollTop();
-            this.chatWindow.fold();
-        }
     }
 
     /**

--- a/addons/mail/static/src/components/chat_window/chat_window.xml
+++ b/addons/mail/static/src/components/chat_window/chat_window.xml
@@ -17,7 +17,7 @@
                     chatWindowLocalId="chatWindow.localId"
                     hasCloseAsBackButton="props.hasCloseAsBackButton"
                     isExpandable="props.isExpandable"
-                    onClicked="_onClickedHeader"
+                    onClicked="chatWindow.onClickHeader"
                 />
                 <t t-if="chatWindow.thread and chatWindow.thread.hasMemberListFeature and chatWindow.isMemberListOpened">
                     <ChannelMemberList channelLocalId="chatWindow.thread.localId" className="'bg-white'"/>

--- a/addons/mail/static/src/components/composer/composer.js
+++ b/addons/mail/static/src/components/composer/composer.js
@@ -18,8 +18,6 @@ export class Composer extends Component {
         useComponentToModel({ fieldName: 'component', modelName: 'ComposerView' });
         useRefToModel({ fieldName: 'buttonEmojisRef', modelName: 'ComposerView', refName: 'buttonEmojis' });
         this._onDropZoneFilesDropped = this._onDropZoneFilesDropped.bind(this);
-        this._onComposerTextInputSendShortcut = this._onComposerTextInputSendShortcut.bind(this);
-        this._onPasteTextInput = this._onPasteTextInput.bind(this);
     }
 
     //--------------------------------------------------------------------------
@@ -38,33 +36,6 @@ export class Composer extends Component {
     //--------------------------------------------------------------------------
 
     /**
-     * Called when clicking on "discard" button.
-     *
-     * @private
-     * @param {MouseEvent} ev
-     */
-    _onClickDiscard(ev) {
-        this.composerView.discard();
-    }
-
-    /**
-     * Called when clicking on "send" button.
-     *
-     * @private
-     */
-    _onClickSend() {
-        this.composerView.sendMessage();
-        this.composerView.update({ doFocus: true });
-    }
-
-    /**
-     * @private
-     */
-    _onComposerTextInputSendShortcut() {
-        this.composerView.sendMessage();
-    }
-
-    /**
      * Called when some files have been dropped in the dropzone.
      *
      * @private
@@ -74,17 +45,6 @@ export class Composer extends Component {
     async _onDropZoneFilesDropped(detail) {
         await this.composerView.fileUploader.uploadFiles(detail.files);
         this.isDropZoneVisible.value = false;
-    }
-
-    /**
-     * @private
-     * @param {CustomEvent} ev
-     */
-    async _onPasteTextInput(ev) {
-        if (!ev.clipboardData || !ev.clipboardData.files) {
-            return;
-        }
-        await this.composerView.fileUploader.uploadFiles(ev.clipboardData.files);
     }
 
 }

--- a/addons/mail/static/src/components/composer/composer.xml
+++ b/addons/mail/static/src/components/composer/composer.xml
@@ -77,8 +77,6 @@
                         }"
                         localId="composerView.localId"
                         hasMentionSuggestionsBelowPosition="props.hasMentionSuggestionsBelowPosition"
-                        onComposerTextInputSendShortcut="_onComposerTextInputSendShortcut"
-                        onPaste="_onPasteTextInput"
                         t-key="composerView.localId"
                     />
                     <div class="o_Composer_buttons" t-att-class="{ 'o-composer-is-compact': composerView.isCompact, 'o-mobile': messaging.device.isMobile, 'o-messaging-in-editing': composerView and composerView.messageViewInEditing }">
@@ -150,14 +148,14 @@
                     }"
                     t-att-disabled="!composerView.composer.canPostMessage ? 'disabled' : ''"
                     type="button"
-                    t-on-click="_onClickSend"
+                    t-on-click="composerView.onClickSend"
                 >
                     <t t-if="!messaging.device.isMobile"><t t-esc="composerView.sendButtonText"/></t>
                     <t t-else=""><i class="fa fa-paper-plane-o"/></t>
                 </button>
             </t>
             <t t-if="!messaging.device.isMobile and props.hasDiscardButton">
-                <button class="o_Composer_actionButton o-last o_Composer_button o_Composer_buttonDiscard btn btn-secondary" t-att-class="{ 'o-composer-is-compact': composerView.isCompact, 'o-has-current-partner-avatar': props.hasCurrentPartnerAvatar }" type="button" t-on-click="_onClickDiscard">
+                <button class="o_Composer_actionButton o-last o_Composer_button o_Composer_buttonDiscard btn btn-secondary" t-att-class="{ 'o-composer-is-compact': composerView.isCompact, 'o-has-current-partner-avatar': props.hasCurrentPartnerAvatar }" type="button" t-on-click="composerView.onClickDiscard">
                     Discard
                 </button>
             </t>

--- a/addons/mail/static/src/components/composer_suggestion/composer_suggestion.js
+++ b/addons/mail/static/src/components/composer_suggestion/composer_suggestion.js
@@ -48,19 +48,6 @@ export class ComposerSuggestion extends Component {
         }
     }
 
-    //--------------------------------------------------------------------------
-    // Handlers
-    //--------------------------------------------------------------------------
-
-    /**
-     * @private
-     * @param {Event} ev
-     */
-    _onClick(ev) {
-        ev.preventDefault();
-        this.composerSuggestion.composerViewOwner.onClickSuggestion(this.composerSuggestion);
-    }
-
 }
 
 Object.assign(ComposerSuggestion, {

--- a/addons/mail/static/src/components/composer_suggestion/composer_suggestion.xml
+++ b/addons/mail/static/src/components/composer_suggestion/composer_suggestion.xml
@@ -3,7 +3,7 @@
 
     <t t-name="mail.ComposerSuggestion" owl="1">
         <t t-if="composerSuggestion">
-            <a class="o_ComposerSuggestion dropdown-item d-flex w-100 py-2 px-4" t-att-class="{ 'active bg-300': props.isActive }" t-attf-class="{{ className }}" href="#" t-att-title="composerSuggestion.title" role="menuitem" t-on-click="_onClick" t-ref="root">
+            <a class="o_ComposerSuggestion dropdown-item d-flex w-100 py-2 px-4" t-att-class="{ 'active bg-300': props.isActive }" t-attf-class="{{ className }}" href="#" t-att-title="composerSuggestion.title" role="menuitem" t-on-click="composerSuggestion.onClick" t-ref="root">
                 <t t-if="composerSuggestion.cannedResponse">
                     <strong class="o_ComposerSuggestion_part1 flex-shrink-0 mw-100 pr-2 text-truncate"><t t-esc="composerSuggestion.record.source"/></strong>
                     <em class="o_ComposerSuggestion_part2 text-600 text-truncate"><t t-esc="composerSuggestion.record.substitution"/></em>

--- a/addons/mail/static/src/components/composer_text_input/composer_text_input.xml
+++ b/addons/mail/static/src/components/composer_text_input/composer_text_input.xml
@@ -3,14 +3,14 @@
 
     <t t-name="mail.ComposerTextInput" owl="1">
         <t t-if="composerView">
-            <div class="o_ComposerTextInput" t-attf-class="{{ className }}" t-on-paste="props.onPaste" t-ref="root">
+            <div class="o_ComposerTextInput" t-attf-class="{{ className }}" t-on-paste="composerView.onPasteTextInput" t-ref="root">
                 <t t-if="composerView.hasSuggestions">
                     <ComposerSuggestionList
                         composerViewLocalId="composerView.localId"
                         isBelow="props.hasMentionSuggestionsBelowPosition"
                     />
                 </t>
-                <textarea class="o_ComposerTextInput_textarea o_ComposerTextInput_textareaStyle" t-att-class="{ 'o-composer-is-compact': composerView.isCompact }" t-esc="composerView.composer.textInputContent" t-att-placeholder="composerView.composer.placeholder" t-on-click="_onClickTextarea" t-on-focusin="_onFocusinTextarea" t-on-focusout="_onFocusoutTextarea" t-on-keydown="_onKeydownTextarea" t-on-keyup="_onKeyupTextarea" t-on-input="_onInputTextarea" t-ref="textarea"/>
+                <textarea class="o_ComposerTextInput_textarea o_ComposerTextInput_textareaStyle" t-att-class="{ 'o-composer-is-compact': composerView.isCompact }" t-esc="composerView.composer.textInputContent" t-att-placeholder="composerView.composer.placeholder" t-on-click="_onClickTextarea" t-on-focusin="composerView.onFocusinTextarea" t-on-focusout="_onFocusoutTextarea" t-on-keydown="_onKeydownTextarea" t-on-keyup="_onKeyupTextarea" t-on-input="_onInputTextarea" t-ref="textarea"/>
                 <!--
                      This is an invisible textarea used to compute the composer
                      height based on the text content. We need it to downsize

--- a/addons/mail/static/src/models/chat_window.js
+++ b/addons/mail/static/src/models/chat_window.js
@@ -136,6 +136,22 @@ registerModel({
             this.expand();
         },
         /**
+         * Called when clicking on header of chat window. Usually folds the chat
+         * window.
+         */
+        onClickHeader(ev) {
+            if (!this.exists() || this.messaging.device.isMobile) {
+                return;
+            }
+            if (this.isFolded) {
+                this.unfold();
+                this.focus();
+            } else {
+                this.saveThreadScrollTop();
+                this.fold();
+            }
+        },
+        /**
          * Handles click on the "stop adding users" button.
          *
          * @param {MouseEvent} ev

--- a/addons/mail/static/src/models/composer_suggestion.js
+++ b/addons/mail/static/src/models/composer_suggestion.js
@@ -14,6 +14,13 @@ registerModel({
     name: 'ComposerSuggestion',
     identifyingFields: [['composerViewOwnerAsExtraSuggestion', 'composerViewOwnerAsMainSuggestion'], ['cannedResponse', 'channelCommand', 'partner', 'thread']],
     recordMethods: {
+        /**
+         * @param {Event} ev
+         */
+        onClick(ev) {
+            ev.preventDefault();
+            this.composerViewOwner.onClickSuggestion(this);
+        },
          /**
          * @private
          * @returns {FieldCommand}

--- a/addons/mail/static/src/models/composer_view.js
+++ b/addons/mail/static/src/models/composer_view.js
@@ -215,6 +215,14 @@ registerModel({
             this.discard();
         },
         /**
+         * Called when clicking on "discard" button.
+         *
+         * @param {MouseEvent} ev
+         */
+        onClickDiscard(ev) {
+            this.discard();
+        },
+        /**
          * @private
          * @param {MouseEvent} ev
          */
@@ -257,6 +265,13 @@ registerModel({
             this.postMessage();
         },
         /**
+         * Called when clicking on "send" button.
+         */
+        onClickSend() {
+            this.sendMessage();
+            this.update({ doFocus: true });
+        },
+        /**
          * Handles click on the "stop replying" button.
          *
          * @param {MouseEvent} ev
@@ -274,6 +289,12 @@ registerModel({
             this.insertSuggestion();
             this.closeSuggestions();
             this.update({ doFocus: true });
+        },
+        onFocusinTextarea() {
+            if (!this.exists()) {
+                return;
+            }
+            this.update({ isFocused: true });
         },
         /**
          * @param {KeyboardEvent} ev
@@ -302,6 +323,15 @@ registerModel({
                 });
                 markEventHandled(ev, 'Composer.closeEmojisPopover');
             }
+        },
+        /**
+         * @param {ClipboardEvent} ev
+         */
+        async onPasteTextInput(ev) {
+            if (!ev.clipboardData || !ev.clipboardData.files) {
+                return;
+            }
+            await this.fileUploader.uploadFiles(ev.clipboardData.files);
         },
         /**
          * Open the full composer modal.
@@ -1226,6 +1256,12 @@ registerModel({
             readonly: true,
         }),
         /**
+         * This is the invisible textarea used to compute the composer height
+         * based on the text content. We need it to downsize the textarea
+         * properly without flicker.
+         */
+        mirroredTextareaRef: attr(),
+        /**
          * Determines the label on the send button of this composer view.
          */
         sendButtonText: attr({
@@ -1270,6 +1306,10 @@ registerModel({
         suggestionSearchTerm: attr({
             compute: '_computeSuggestionSearchTerm',
         }),
+        /**
+         * Reference of the textarea. Useful to set height, selection and content.
+         */
+        textareaRef: attr(),
         /**
          * States the OWL text input component of this composer view.
          */


### PR DESCRIPTION
This commit moves some handler methods from components to models,
as a step closer to having most of business code in models.

Having business code in models is desirable so that the code is much more maintainable:
easier to change and more robust code.

Task-2579306