### PR TITLE
[FIX] fix missing translation terms of action menus

### DIFF
--- a/addons/web/i18n/web.pot
+++ b/addons/web/i18n/web.pot
@@ -408,6 +408,13 @@ msgstr ""
 #. openerp-web
 #: code:addons/web/static/src/legacy/xml/base.xml:0
 #, python-format
+msgid "Action"
+msgstr ""
+
+#. module: web
+#. openerp-web
+#: code:addons/web/static/src/legacy/xml/base.xml:0
+#, python-format
 msgid "Action ID:"
 msgstr ""
 
@@ -549,6 +556,13 @@ msgstr ""
 #: code:addons/web/static/src/legacy/js/fields/basic_fields.js:0
 #, python-format
 msgid "Add to Favorites"
+msgstr ""
+
+#. module: web
+#. openerp-web
+#: code:addons/web/static/src/legacy/xml/base.xml:0
+#, python-format
+msgid "Additional actions"
 msgstr ""
 
 #. module: web
@@ -3358,6 +3372,13 @@ msgstr ""
 #: code:addons/web/static/src/legacy/xml/report.xml:0
 #, python-format
 msgid "Print"
+msgstr ""
+
+#. module: web
+#. openerp-web
+#: code:addons/web/static/src/legacy/xml/report.xml:0
+#, python-format
+msgid "Printing options"
 msgstr ""
 
 #. module: web

--- a/addons/web/static/src/legacy/xml/base.xml
+++ b/addons/web/static/src/legacy/xml/base.xml
@@ -406,7 +406,7 @@
             items="printItems"
             icon="'fa fa-print'"
             hotkey="'shift+u'"
-            hotkeyTitle="'Printing options'"
+            hotkeyTitle="env._t('Printing options')"
         />
         <DropdownMenu t-if="actionItems.length"
             title="env._t('Action')"
@@ -414,7 +414,7 @@
             icon="'fa fa-cog'"
             closeOnSelected="true"
             hotkey="'u'"
-            hotkeyTitle="'Additional actions'"
+            hotkeyTitle="env._t('Additional actions')"
         />
     </div>
 </t>


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
'Action' button of action menu cannot be translated

Desired behavior after PR is merged:
'Action' button of action menu can be translated as others



--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
