### PR TITLE
[FIX] l10n_ar: Gross Income fields in form view

### DIFF
--- a/addons/l10n_ar/views/res_partner_view.xml
+++ b/addons/l10n_ar/views/res_partner_view.xml
@@ -25,13 +25,11 @@
             </xpath>
 
             <field name="property_account_position_id" position="after">
-                <group name="gross_income">
-                    <label for="l10n_ar_gross_income_number" string="Gross Income"/>
-                    <div>
-                        <field name="l10n_ar_gross_income_type" class="oe_inline"/>
-                        <field name="l10n_ar_gross_income_number" placeholder="Number..." class="oe_inline" attrs="{'invisible': [('l10n_ar_gross_income_type', 'not in', ['multilateral', 'local'])], 'required': [('l10n_ar_gross_income_type', 'in', ['multilateral', 'local'])]}"/>
-                    </div>
-                </group>
+                <label for="l10n_ar_gross_income_number" string="Gross Income"/>
+                <div name="gross_income">
+                    <field name="l10n_ar_gross_income_type" class="oe_inline"/>
+                    <field name="l10n_ar_gross_income_number" placeholder="Number..." class="oe_inline" attrs="{'invisible': [('l10n_ar_gross_income_type', 'not in', ['multilateral', 'local'])], 'required': [('l10n_ar_gross_income_type', 'in', ['multilateral', 'local'])]}"/>
+                </div>
             </field>
 
         </field>


### PR DESCRIPTION

### Description of the issue/feature this PR addresses:

In res.partner the Fiscal Information Tab content was broken than to a bad adding of the  Gross Income fields. This PR solves the problem.

### Current behavior before PR:

![image](https://user-images.githubusercontent.com/7593953/163037774-cefab200-34fd-4a65-8cdd-1b6e603b17be.png)


### Desired behavior after PR is merged:
![after-change](https://user-images.githubusercontent.com/7593953/163037620-11b0f721-96da-415a-8e1c-9ef579f1c939.png)




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
