### PR TITLE
Update Oauth2 Verification Request to use Authorization Headers instead of GET Parameters.

### DIFF
--- a/addons/auth_oauth/models/auth_oauth.py
+++ b/addons/auth_oauth/models/auth_oauth.py
@@ -13,9 +13,9 @@ class AuthOAuthProvider(models.Model):
 
     name = fields.Char(string='Provider name', required=True)  # Name of the OAuth2 entity, Google, etc
     client_id = fields.Char(string='Client ID')  # Our identifier
-    auth_endpoint = fields.Char(string='Authentication URL', required=True)  # OAuth provider URL to authenticate users
+    auth_endpoint = fields.Char(string='Authentication URL', required=True, help='OAuth2 Authentication Endpoint. Must support implicit login flow and token requests.')  # OAuth provider URL to authenticate users
     scope = fields.Char()  # OAUth user data desired to access
-    validation_endpoint = fields.Char(string='Validation URL', required=True)  # OAuth provider URL to validate tokens
+    validation_endpoint = fields.Char(string='Validation URL', required=True, help='User Information URL to validate token. Should have a user_id or id parameter mapped to the preferred_username attribute.')  # OAuth provider URL to validate tokens
     data_endpoint = fields.Char(string='Data URL')
     enabled = fields.Boolean(string='Allowed')
     css_class = fields.Char(string='CSS class', default='fa fa-fw fa-sign-in text-primary')

--- a/addons/auth_oauth/models/res_users.py
+++ b/addons/auth_oauth/models/res_users.py
@@ -25,7 +25,7 @@ class ResUsers(models.Model):
 
     @api.model
     def _auth_oauth_rpc(self, endpoint, access_token):
-        return requests.get(endpoint, params={'access_token': access_token}).json()
+        return requests.get(endpoint, headers={'Authorization': 'Bearer ' + access_token}).json()
 
     @api.model
     def _auth_oauth_validate(self, provider, access_token):

--- a/doc/cla/individual/resba.md
+++ b/doc/cla/individual/resba.md
@@ -8,4 +8,4 @@ declaration.
 
 Signed,
 
-Matthew Sowden matt@sowden.me https://github.com/resba
+Matthew Sowden matt@sowden.me 549624+resba@users.noreply.github.com https://github.com/resba

--- a/doc/cla/individual/resba.md
+++ b/doc/cla/individual/resba.md
@@ -1,0 +1,11 @@
+United States, 4/12/2022
+
+I hereby agree to the terms of the Odoo Individual Contributor License
+Agreement v1.0.
+
+I declare that I am authorized and able to make this agreement and sign this
+declaration.
+
+Signed,
+
+Matthew Sowden matt@sowden.me https://github.com/resba


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
This PR addresses a bug in the core Auth_Oauth module which may have been from a legacy implementation of the Oauth standard.

Current behavior before PR:
Requests to the verification URL use a GET parameter to fetch user info, which results in a failure for most current OAuth2 Providers.

Desired behavior after PR is merged:
Requests to the verification URL should now use a Bearer Authorization header to access user info.


--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
