### PR TITLE
[FIX] mail: message star status badly sync

### DIFF
--- a/addons/mail/models/mail_message.py
+++ b/addons/mail/models/mail_message.py
@@ -679,6 +679,9 @@ class Message(models.Model):
         thread = self.env[self.model].browse(self.res_id)
         thread._check_can_update_message_content(self)
         self.body = body
+        # if the message is starred, unstar it when it is deleted (i.e. when `body` is empty)
+        if not self.body and self.starred:
+            self.toggle_message_starred()
         if not attachment_ids:
             self.attachment_ids._delete_and_notify()
         else:


### PR DESCRIPTION
**Current behavior before PR:**

- When deleting the starred message, the message won't be unstarred.

**Desired behavior after PR is merged:**

-  unstar deleted messages that are starred

**Task**-2679220
