### PR TITLE
[IMP] website_crm_partner_assign: improve location in google map

### DIFF
--- a/addons/website_google_map/controllers/main.py
+++ b/addons/website_google_map/controllers/main.py
@@ -41,8 +41,8 @@ class GoogleMap(http.Controller):
                 'id': partner.id,
                 'name': partner.name,
                 'address': '\n'.join(partner.name_get()[0][1].split('\n')[1:]),
-                'latitude': str(partner.partner_latitude),
-                'longitude': str(partner.partner_longitude),
+                'latitude': str(partner.partner_latitude) if partner.partner_latitude else False,
+                'longitude': str(partner.partner_longitude) if partner.partner_longitude else False,
             })
         if 'customers' in post.get('partner_url', ''):
             partner_url = '/customers/'


### PR DESCRIPTION
[IMP] website_crm_partner_assign: improve partner location in map 

Right now, when the geolocation coordinates (latitude & longitude) of the
partner are not set, then the location of the partners is shown in the middle of
the sea as the default coordinates are (0.0, 0.0).

After this PR, if the coordinates are not set then it will calculate the
coordinates based on the address of the partner with the help of Google Geocode
API and show the location on the google map.

taskID: 2819772