### PR TITLE
[FIX] stock: Add strong linking on moves in Forecasted Report

### DIFF
--- a/addons/stock/report/report_stock_forecasted.py
+++ b/addons/stock/report/report_stock_forecasted.py
@@ -144,7 +144,7 @@ class ReplenishmentReport(models.AbstractModel):
             for index, in_ in enumerate(ins):
                 if float_is_zero(in_['qty'], precision_rounding=out.product_id.uom_id.rounding):
                     continue
-                if only_matching_move_dest and in_['move_dests'] and out.id not in in_['move_dests']:
+                if only_matching_move_dest and out.id not in in_['move_dests']:
                     continue
                 taken_from_in = min(demand, in_['qty'])
                 demand -= taken_from_in


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
---
Why do we need to check `in_['move_dests']`? Because it doesn't work correctly. For example, we have table where MO1 is related with MO1.1 and MO2 with MO2.1 (they have related moves by origins and dests):
| Replenishment | Quantity | Used By |
|------------------------------------------|
|   MO1.1          |   4         |  MO1     |
|   MO2.1          |   4         |  MO2     |

Let's cancel MO1

Current behavior before PR:
---
Then forecasted report will be like this:
| Replenishment | Quantity | Used By |
|------------------------------------------|
|   MO1.1          |   4         |  MO2     |
|   MO2.1          |   4         |  -           |

Desired behavior after PR is merged:
---
But I think it should be:
| Replenishment | Quantity | Used By |
|------------------------------------------|
|   MO2.1          |   4         |  MO2     |
|   MO1.1          |   4         |  -           |

I suggest to remove checking `in_['move_dests']` so linking between moves should be saved




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
