### PR TITLE
[FIX] mail: prevent incorrect loading of settings from the localstorage

### DIFF
--- a/addons/mail/static/src/models/user_setting/user_setting.js
+++ b/addons/mail/static/src/models/user_setting/user_setting.js
@@ -230,13 +230,10 @@ function factory(dependencies) {
             const audioInputDeviceId = this.env.services.local_storage.getItem(
                 "mail_user_setting_audio_input_device_id"
             );
-            const voiceActivationThreshold = parseFloat(voiceActivationThresholdString);
-            if (voiceActivationThreshold > 0) {
-                this.update({
-                    voiceActivationThreshold,
-                    audioInputDeviceId,
-                });
-            }
+            this.update({
+                voiceActivationThreshold: voiceActivationThresholdString ? parseFloat(voiceActivationThresholdString) : undefined,
+                audioInputDeviceId: audioInputDeviceId || undefined,
+            });
         }
 
         /**


### PR DESCRIPTION
Before this commit, the settings recovered from the localStorage were
incorrectly loaded to the model fields.

This commit fixes this issue.

taskId-2823292