### PR TITLE
[IMP] mrp_subcontracting: allow multiple locations

### DIFF
--- a/addons/mrp_subcontracting/__init__.py
+++ b/addons/mrp_subcontracting/__init__.py
@@ -13,6 +13,10 @@ def uninstall_hook(cr, registry):
     warehouses = env["stock.warehouse"].search([])
     subcontracting_routes = warehouses.mapped("subcontracting_route_id")
     warehouses.write({"subcontracting_route_id": False})
+    companies = env["res.company"].search([])
+    subcontracting_locations = companies.mapped("subcontracting_location_id")
+    subcontracting_locations.active = False
+    companies.write({"subcontracting_location_id": False})
     operations_type_to_remove = (warehouses.subcontracting_resupply_type_id | warehouses.subcontracting_type_id)
     operations_type_to_remove.active = False
     # Fail unlink means that the route is used somewhere (e.g. route_id on stock.rule). In this case

--- a/addons/mrp_subcontracting/__manifest__.py
+++ b/addons/mrp_subcontracting/__manifest__.py
@@ -23,6 +23,7 @@
         'views/mrp_production_views.xml',
         'views/subcontracting_portal_views.xml',
         'views/subcontracting_portal_templates.xml',
+        'views/stock_location_views.xml',
         'wizard/stock_picking_return_views.xml',
         'report/mrp_report_bom_structure.xml',
     ],

--- a/addons/mrp_subcontracting/models/res_company.py
+++ b/addons/mrp_subcontracting/models/res_company.py
@@ -27,6 +27,7 @@ class ResCompany(models.Model):
                 'usage': 'internal',
                 'location_id': parent_location.id,
                 'company_id': company.id,
+                'is_subcontracting_location': True,
             })
             self.env['ir.property']._set_default(
                 "property_stock_subcontractor",

--- a/addons/mrp_subcontracting/models/res_partner.py
+++ b/addons/mrp_subcontracting/models/res_partner.py
@@ -9,6 +9,7 @@ class ResPartner(models.Model):
 
     property_stock_subcontractor = fields.Many2one(
         'stock.location', string="Subcontractor Location", company_dependent=True,
+        domain="[('is_subcontracting_location', '=', True)]",
         help="The stock location used as source and destination when sending\
         goods to this contact during a subcontracting process.")
     is_subcontractor = fields.Boolean(

--- a/addons/mrp_subcontracting/models/stock_location.py
+++ b/addons/mrp_subcontracting/models/stock_location.py
@@ -1,11 +1,47 @@
 # -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
-from odoo import models
+from odoo import api, fields, models, _
+from odoo.exceptions import ValidationError
 
 
 class StockLocation(models.Model):
     _inherit = 'stock.location'
+
+    is_subcontracting_location = fields.Boolean(
+        "Is a Subcontracting Location?",
+        help="Check this box to create a new dedicated subcontracting location for this company. Note that standard subcontracting routes will be adapted so as to take these into account automatically."
+    )
+
+    @api.constrains('is_subcontracting_location', 'usage', 'location_id')
+    def _check_subcontracting_location(self):
+        for location in self:
+            if location == location.company_id.subcontracting_location_id:
+                raise ValidationError(_("You cannot alter the company's subcontracting location"))
+            if location.is_subcontracting_location and (location.usage != 'internal' or location.warehouse_id):
+                raise ValidationError(_("In order to manage stock accurately, subcontracting locations must be type Internal, linked to the appropriate company and not specific to a warehouse."))
+
+    @api.constrains('is_subcontracting_location')
+    def _check_is_subcontracting_location(self):
+        for location in self:
+            if not location.is_subcontracting_location and self.env['res.partner'].search([('property_stock_subcontractor', '=', location.id)]):
+                raise ValidationError(_("You cannot change the subcontracting location as it is still linked to a subcontractor partner"))
+
+    @api.model_create_multi
+    def create(self, vals_list):
+        res = super().create(vals_list)
+        new_subcontracting_locations = res.filtered(lambda l: l.is_subcontracting_location)
+        new_subcontracting_locations._activate_subcontracting_location_rules()
+        return res
+
+    def write(self, values):
+        res = super().write(values)
+        if 'is_subcontracting_location' in values:
+            if values['is_subcontracting_location']:
+                self._activate_subcontracting_location_rules()
+            else:
+                self._archive_subcontracting_location_rules()
+        return res
 
     def _check_access_putaway(self):
         """ Use sudo mode for subcontractor """
@@ -13,3 +49,59 @@ class StockLocation(models.Model):
             return self.sudo()
         else:
             return super()._check_access_putaway()
+
+    def _activate_subcontracting_location_rules(self):
+        """ Create or unarchive rules for the 'custom' subcontracting location(s).
+        The subcontracting location defined on the company is considered as the 'reference' one.
+        All rules defined on this 'reference' location will be replicated on 'custom' subcontracting locations.
+        """
+        locations_per_company = {}
+        for location in self:
+            if location.is_subcontracting_location and location != location.company_id.subcontracting_location_id:
+                locations_per_company.setdefault(location.company_id, []).extend(location)
+        new_rules_vals = []
+        rules_to_unarchive = self.env['stock.rule']
+        for company, locations in locations_per_company.items():
+            reference_location_id = company.subcontracting_location_id
+            if reference_location_id:
+                reference_rules_from = self.env['stock.rule'].search([('location_src_id', '=', reference_location_id.id)])
+                reference_rules_to = self.env['stock.rule'].search([('location_dest_id', '=', reference_location_id.id)])
+                for location in locations:
+                    existing_rules = {
+                        (rule.route_id, rule.picking_type_id, rule.action, rule.location_src_id): rule
+                        for rule in self.env['stock.rule'].with_context(active_test=False).search([('location_src_id', '=', location.id)])
+                    }
+                    for rule in reference_rules_from:
+                        if (rule.route_id, rule.picking_type_id, rule.action, location) not in existing_rules:
+                            new_rules_vals.append(rule.copy_data({
+                                'location_src_id': location.id,
+                                'name': rule.name.replace(reference_location_id.name, location.name)
+                            })[0])
+                        else:
+                            existing_rule = existing_rules[(rule.route_id, rule.picking_type_id, rule.action, location)]
+                            if not existing_rule.active:
+                                rules_to_unarchive += existing_rule
+                    existing_rules = {
+                        (rule.route_id, rule.picking_type_id, rule.action, rule.location_dest_id): rule
+                        for rule in self.env['stock.rule'].with_context(active_test=False).search([('location_dest_id', '=', location.id)])
+                    }
+                    for rule in reference_rules_to:
+                        if (rule.route_id, rule.picking_type_id, rule.action, location) not in existing_rules:
+                            new_rules_vals.append(rule.copy_data({
+                                'location_dest_id': location.id,
+                                'name': rule.name.replace(reference_location_id.name, location.name)
+                            })[0])
+                        else:
+                            existing_rule = existing_rules[(rule.route_id, rule.picking_type_id, rule.action, location)]
+                            if not existing_rule.active:
+                                rules_to_unarchive += existing_rule
+        self.env['stock.rule'].create(new_rules_vals)
+        rules_to_unarchive.action_unarchive()
+
+    def _archive_subcontracting_location_rules(self):
+        """ Archive subcontracting rules for locations that are no longer 'custom' subcontracting locations."""
+        reference_location_ids = self.company_id.subcontracting_location_id
+        reference_rules = self.env['stock.rule'].search(['|', ('location_src_id', 'in', reference_location_ids.ids), ('location_dest_id', 'in', reference_location_ids.ids)])
+        reference_routes = reference_rules.route_id
+        rules_to_archive = self.env['stock.rule'].search(['&', ('route_id', 'in', reference_routes.ids), '|', ('location_src_id', 'in', self.ids), ('location_dest_id', 'in', self.ids)])
+        rules_to_archive.action_archive()

--- a/addons/mrp_subcontracting/models/stock_move_line.py
+++ b/addons/mrp_subcontracting/models/stock_move_line.py
@@ -12,7 +12,7 @@ class StockMoveLine(models.Model):
     def _onchange_serial_number(self):
         current_location_id = self.location_id
         res = super()._onchange_serial_number()
-        if res and not self.lot_name and self.company_id.subcontracting_location_id == current_location_id:
+        if res and not self.lot_name and current_location_id.is_subcontracting_location:
             # we want to avoid auto-updating source location in this case + change the warning message
             self.location_id = current_location_id
             res['warning']['message'] = res['warning']['message'].split("\n\n", 1)[0] + "\n\n" + \

--- a/addons/mrp_subcontracting/models/stock_quant.py
+++ b/addons/mrp_subcontracting/models/stock_quant.py
@@ -14,7 +14,7 @@ class StockQuant(models.Model):
         if operator not in ['=', '!='] or not isinstance(value, bool):
             raise UserError(_('Operation not supported'))
 
-        subcontract_locations = self.env['res.company'].search([]).subcontracting_location_id
+        subcontract_locations = self.env['stock.location'].search([('is_subcontracting_location', '=', 'True')])
 
         quant_ids = self.env['stock.quant'].search([
             ('location_id', 'in', subcontract_locations.ids),

--- a/addons/mrp_subcontracting/views/res_partner_views.xml
+++ b/addons/mrp_subcontracting/views/res_partner_views.xml
@@ -6,7 +6,7 @@
         <field name="inherit_id" ref="stock.view_partner_stock_form"/>
         <field name="arch" type="xml">
             <xpath expr="//field[@name='property_stock_supplier']" position="after">
-                <field name="property_stock_subcontractor"/>
+                <field name="property_stock_subcontractor" context="{'default_is_subcontracting_location': True}"/>
                 <separator/>
             </xpath>
         </field>

--- a/addons/mrp_subcontracting/views/stock_location_views.xml
+++ b/addons/mrp_subcontracting/views/stock_location_views.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <record id="view_location_form" model="ir.ui.view">
+        <field name="name">stock.location.form</field>
+        <field name="model">stock.location</field>
+        <field name="inherit_id" ref="stock.view_location_form"/>
+        <field name="arch" type="xml">
+            <xpath expr="//field[@name='return_location']" position='after'>
+                <field name="is_subcontracting_location" attrs="{'invisible': [('usage', '!=', 'internal')]}" readonly="context.get('default_is_subcontracting_location', False)"/>
+            </xpath>
+        </field>
+    </record>
+</odoo>

--- a/addons/mrp_subcontracting_dropshipping/models/stock_rule.py
+++ b/addons/mrp_subcontracting_dropshipping/models/stock_rule.py
@@ -8,6 +8,6 @@ class StockRule(models.Model):
     _inherit = 'stock.rule'
 
     def _prepare_purchase_order(self, company_id, origins, values):
-        if 'partner_id' not in values[0] and company_id.subcontracting_location_id.parent_path in self.location_dest_id.parent_path:
+        if 'partner_id' not in values[0] and self.location_dest_id.is_subcontracting_location:
             values[0]['partner_id'] = values[0]['group_id'].partner_id.id
         return super()._prepare_purchase_order(company_id, origins, values)

--- a/addons/mrp_subcontracting_dropshipping/tests/test_purchase_subcontracting.py
+++ b/addons/mrp_subcontracting_dropshipping/tests/test_purchase_subcontracting.py
@@ -147,11 +147,10 @@ class TestSubcontractingDropshippingFlows(TestMrpSubcontractingCommon):
         sub_location = self.env['stock.location'].create({
             'name': 'Super Location',
             'location_id': subcontract_location.id,
+            'is_subcontracting_location': True,
         })
 
         dropship_subcontractor_route = self.env['stock.route'].search([('name', '=', 'Dropship Subcontractor on Order')])
-        dropship_subcontractor_route.rule_ids.filtered(lambda rule: rule.location_dest_id == subcontract_location).copy(default={'location_dest_id': sub_location.id})
-        dropship_subcontractor_route.rule_ids.filtered(lambda rule: rule.location_src_id == subcontract_location).copy(default={'location_src_id': sub_location.id})
 
         subcontractor, vendor = self.env['res.partner'].create([
             {'name': 'SuperSubcontractor', 'property_stock_subcontractor': sub_location.id},


### PR DESCRIPTION
Ease subcontractor stock tracking by using dedicated locations.
Simply declare location as a subcontracting one (rules are
automatically adapted) and set it on vendor.

task: 2720393

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
