### PR TITLE
[FIX] sale_project: fix access rights error while creating sale order

### DIFF
--- a/addons/sale_project/models/sale_order.py
+++ b/addons/sale_project/models/sale_order.py
@@ -17,7 +17,7 @@ class SaleOrder(models.Model):
     project_id = fields.Many2one(
         'project.project', 'Project', readonly=True, states={'draft': [('readonly', False)], 'sent': [('readonly', False)]},
         help='Select a non billable project on which tasks can be created.')
-    project_ids = fields.Many2many('project.project', compute="_compute_project_ids", string='Projects', copy=False, groups="project.group_project_user", help="Projects used in this sales order.")
+    project_ids = fields.Many2many('project.project', compute="_compute_project_ids", string='Projects', copy=False, groups="project.group_project_manager", help="Projects used in this sales order.")
 
     @api.depends('order_line.product_id.project_id')
     def _compute_tasks_ids(self):


### PR DESCRIPTION
before this commit, current user didn't have access to sale service product
which is creating a task.
after this commit, it should be possible for current user to sell service of
sale order.

Task-2818646

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
