### PR TITLE
[FIX] account: remove nested html p tag in p tag for invoicing report

### DIFF
--- a/addons/account/views/report_invoice.xml
+++ b/addons/account/views/report_invoice.xml
@@ -167,15 +167,15 @@
                     <p t-if="o.move_type in ('out_invoice', 'in_refund') and o.payment_reference" name="payment_communication">
                         Please use the following communication for your payment : <b><span t-field="o.payment_reference"/></b>
                     </p>
-                    <p t-if="o.invoice_payment_term_id" name="payment_term">
+                    <div t-if="o.invoice_payment_term_id" name="payment_term">
                         <span t-field="o.invoice_payment_term_id.note"/>
-                    </p>
+                    </div>
                     <div t-if="not is_html_empty(o.narration)" name="comment">
                         <span t-field="o.narration"/>
                     </div>
-                    <p t-if="not is_html_empty(o.fiscal_position_id.note)" name="note">
+                    <div t-if="not is_html_empty(o.fiscal_position_id.note)" name="note">
                         <span t-field="o.fiscal_position_id.note"/>
-                    </p>
+                    </div>
                     <p t-if="o.invoice_incoterm_id" name="incoterm">
                         <strong>Incoterm: </strong><span t-field="o.invoice_incoterm_id.code"/> - <span t-field="o.invoice_incoterm_id.name"/>
                     </p>

--- a/addons/l10n_ae/views/report_invoice_templates.xml
+++ b/addons/l10n_ae/views/report_invoice_templates.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <odoo>
     <template id="report_invoice_document" inherit_id="account.report_invoice_document">
-        <xpath expr="//p[@name='payment_term']" position="after">
+        <xpath expr="//div[@name='payment_term']" position="after">
             <p t-if="o.company_id.country_id.code == 'AE' and o.partner_id.country_id.code != 'AE' and o.env.ref('l10n_ae.gcc_countries_group') in o.partner_id.country_id.country_group_ids">
                 Supply between <b>United Arab Emirates</b> and
                 <b>

--- a/addons/l10n_cl/views/report_invoice.xml
+++ b/addons/l10n_cl/views/report_invoice.xml
@@ -173,7 +173,7 @@
         <xpath expr="//th[@name='th_taxes']" position="replace"/>
         <xpath expr="//span[@id='line_tax_ids']/.." position="replace"/>
 
-        <p name="payment_term" position="replace"/>
+        <div name="payment_term" position="replace"/>
         <xpath expr="//span[@t-field='o.payment_reference']/../.." position="replace"/>
 
         <!-- replace information section and usage chilean style -->


### PR DESCRIPTION
Step to reproduce:
-check the html code of an invoice preview with a payment term or a fiscal position note

Current behavior:
The invoice payment term of the report is a p tag with another p tag inside like:

```
<p name="payment_term">
	<span>
		<p> This is a payment term note</p>
	</span>
</p>
```
but because nested p tags are not supported in html the result in the browser is something like:

```
<p name="payment_term">
        <span></span>
</p>
<p> This is a payment term note</p>
<p></p>
```
Similar behavior can be observe for the fiscal position note.

Expected behavior:
The code should respect html format rules and not have nested p tags.
https://www.w3.org/TR/html401/struct/text.html#h-9.3.1

Solution: We replace the parent p tags by div tags

opw-2804933