### PR TITLE
[FIX] mrp: produce a tracked and manufactured component

### DIFF
--- a/addons/mrp/models/mrp_production.py
+++ b/addons/mrp/models/mrp_production.py
@@ -1441,8 +1441,8 @@ class MrpProduction(models.Model):
         for order in self:
             finish_moves = order.move_finished_ids.filtered(lambda m: m.product_id == order.product_id and m.state not in ('done', 'cancel'))
             # the finish move can already be completed by the workorder.
-            if not finish_moves.quantity_done:
-                finish_moves.quantity_done = float_round(order.qty_producing - order.qty_produced, precision_rounding=order.product_uom_id.rounding, rounding_method='HALF-UP')
+            if finish_moves and not finish_moves.quantity_done:
+                finish_moves._set_quantity_done(float_round(order.qty_producing - order.qty_produced, precision_rounding=order.product_uom_id.rounding, rounding_method='HALF-UP'))
                 finish_moves.move_line_ids.lot_id = order.lot_producing_id
             order._cal_price(moves_to_do_by_order[order.id])
         moves_to_finish = self.move_finished_ids.filtered(lambda x: x.state not in ('done', 'cancel'))


### PR DESCRIPTION
In some cases, it is not possible to produce a tracked product that has
been used as a component of another product.

To reproduce the issue:
1. Create three products A, B, C:
    - A storable
    - B storable and tracked by lot
    - C consumable
2. Update on-hand qty of B
    - 10 x lot L01
    - 5 x lot L02
3. Create two bills of materials
    - Product: A
        - Components: 1 x B
    - Product: B
        - Components: 1 x C
4. Produce 15 x A (MO01)
    - Note: it should use 10 L01 and 5 L02
5. Produce 15 x B with lot L03 (MO02)

Error: When marking MO02 as done, a user error is displayed: "Cannot set
the done quantity from this stock move, work directly with the move
lines." The user should be able to mark the MO as done.

When confirming MO02, it confirms the associated SMs. Since the
conditions are respected, we then try to assign both consumed and
finished moves. This is the issue, we should not try to assign the
finished move. Indeed, because of this, at some point it leads to
`_update_reserved_quantity`:
https://github.com/odoo/odoo/blob/9e5f76a759640e1072560a60c6e3d608296d7feb/addons/stock/models/stock_move.py#L1355-L1360
We try to reserve some quants in the production location. Thanks to step
4, two quants (L01 and L02) are available. As a result, two SMLs are
created. Lastly, when marking MO02 as done, since the user has not
defined the done quantity on each SML, the error is raised.

We should prevent the finished move to be assigned.

OPW-2752436