### PR TITLE
[FIX] product: search shows incorrect result

### DIFF
--- a/addons/product/models/product.py
+++ b/addons/product/models/product.py
@@ -516,7 +516,7 @@ class ProductProduct(models.Model):
             positive_operators = ['=', 'ilike', '=ilike', 'like', '=like']
             product_ids = []
             if operator in positive_operators:
-                product_ids = list(self._search([('default_code', '=', name)] + args, limit=limit, access_rights_uid=name_get_uid))
+                product_ids = list(self._search([('default_code', operator, name)] + args, limit=limit, access_rights_uid=name_get_uid))
                 if not product_ids:
                     product_ids = list(self._search([('barcode', '=', name)] + args, limit=limit, access_rights_uid=name_get_uid))
             if not product_ids and operator not in expression.NEGATIVE_TERM_OPERATORS:


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
The aim of this PR is to fix the issue with the search function for a product, if a product has an internal reference, and there's many product that has almost the same characters in the internal reference ( ex: product one = AXXXX and the second product = AXXXX-A2). in this case, depending if your search is upper or lower case characters your will get different result.

Current behavior before PR:
The search function for a product has an issue with the character case, it shows different result depending if the search is upper or lower case.

Desired behavior after PR is merged:
To show more accurate search result.

opw-2675253