### PR TITLE
[FIX] website_slides: remove "List" placeholder in edit mode

### DIFF
--- a/addons/website_slides/views/website_slides_templates_lesson.xml
+++ b/addons/website_slides/views/website_slides_templates_lesson.xml
@@ -186,12 +186,12 @@
                                 <t t-call="website_slides.join_course_link"/>
                             </li>
                         </div>
-                        <li class="pl-4">
-                            <a t-if="can_access and aside_slide.question_ids and aside_slide.slide_type != 'quiz'" t-att-href="'/slides/slide/%s#lessonQuiz' % (slug(aside_slide))" class="o_wslides_lesson_aside_list_link text-decoration-none small text-600">
+                        <li t-if="aside_slide.question_ids and aside_slide.slide_type != 'quiz'" class="pl-4">
+                            <a t-if="can_access" t-att-href="'/slides/slide/%s#lessonQuiz' % (slug(aside_slide))"
+                                class="o_wslides_lesson_aside_list_link text-decoration-none small text-600">
                                 <i class="fa fa-flag text-warning"/> Quiz
                             </a>
-                            <span t-elif="not can_access and aside_slide.question_ids and aside_slide.slide_type != 'quiz'"
-                                class="o_wslides_lesson_aside_list_link text-decoration-none small text-600 text-muted">
+                            <span t-else="" class="o_wslides_lesson_aside_list_link text-decoration-none small text-600 text-muted">
                                 <i class="fa fa-flag text-warning"/> Quiz
                             </span>
                         </li>


### PR DESCRIPTION
# Purpose
Remove the placeholder "List" when we are in the website editor

# Specifications

Ensure that we don't have void "<li>" which create a placeholder
in edit mode that we don't want to display.
Indeed, the web_editor add a placeholder and the class "oe-hint" when
the content of particular blocks are void (li, h1, h2, ...)

See the OdooEditor.js file and the _handleCommandHint() and _makeHint()
function for more info.

# Links
task-2813583
