### PR TITLE
[FIX] point_of_sale: display items in PoS with ru language

### DIFF
--- a/addons/point_of_sale/i18n/ru.po
+++ b/addons/point_of_sale/i18n/ru.po
@@ -3292,7 +3292,7 @@ msgstr "Не найдено товара"
 #: code:addons/point_of_sale/static/src/xml/Screens/ProductScreen/ProductList.xml:0
 #, python-format
 msgid "No results found for \""
-msgstr "Нет результатов для `"
+msgstr "Нет результатов для \""
 
 #. module: point_of_sale
 #: code:addons/point_of_sale/wizard/pos_open_statement.py:0


### PR DESCRIPTION
Current behavior:
When using russian language no products would appear in the PoS

Steps to reproduce:
- Install PoS and inventory
- Add russian language
- Switch user language to russian
- Launch PoS session
- There are no products showing

The problem was the " ` " that was causing an error in owl.

opw-2818132
--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
