### PR TITLE
[FIX] sale: properly cycle through style

### DIFF
--- a/addons/sale/data/mail_template_data.xml
+++ b/addons/sale/data/mail_template_data.xml
@@ -95,7 +95,7 @@
         <t t-foreach="object.order_line" t-as="line">
             <t t-if="(not hasattr(line, 'is_delivery') or not line.is_delivery) and line.display_type in ['line_section', 'line_note']">
                 <table width="100%" style="color: #454748; font-size: 12px; border-collapse: collapse;">
-                    <t t-set="loop_cycle_number" t-value="0" />
+                    <t t-set="loop_cycle_number" t-value="loop_cycle_number or 0" />
                     <tr t-att-style="'background-color: #f2f2f2' if loop_cycle_number % 2 == 0 else 'background-color: #ffffff'">
                         <t t-set="loop_cycle_number" t-value="loop_cycle_number + 1" />
                         <td colspan="4">
@@ -111,7 +111,7 @@
             </t>
             <t t-elif="(not hasattr(line, 'is_delivery') or not line.is_delivery)">
                 <table width="100%" style="color: #454748; font-size: 12px; border-collapse: collapse;">
-                    <t t-set="loop_cycle_number" t-value="0" />
+                    <t t-set="loop_cycle_number" t-value="loop_cycle_number or 0" />
                     <tr t-att-style="'background-color: #f2f2f2' if loop_cycle_number % 2 == 0 else 'background-color: #ffffff'">
                         <t t-set="loop_cycle_number" t-value="loop_cycle_number + 1" />
                         <td style="width: 150px;">


### PR DESCRIPTION
Before this commit
At each iteration, the `loop_cycle_number` was reset to 0.
This caused the cycle condition to always be the same.

After this commit
The cycle condition will properly make the style cycle.




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
