### PR TITLE
[FIX] purchase_stock: use a valid route as default buy route

### DIFF
--- a/addons/purchase_stock/models/product.py
+++ b/addons/purchase_stock/models/product.py
@@ -11,7 +11,8 @@ class ProductTemplate(models.Model):
 
     @api.model
     def _get_buy_route(self):
-        buy_route = self.env.ref('purchase_stock.route_warehouse0_buy', raise_if_not_found=False)
+        buy_route_id = self.env.ref('purchase_stock.route_warehouse0_buy', raise_if_not_found=False).id
+        buy_route = self.env['stock.location.route'].search([('id', '=', buy_route_id)])
         if buy_route:
             return buy_route.ids
         return []


### PR DESCRIPTION
In a multi-company environment, creating a product template will always
try to assign it's route to `route_warehouse0_buy` but this throws an
error if the current company is not the one of the route

Steps to reproduce:
1. Install Inventory and Purchase
2. Go to Settings > Inventory > Warehouse and enable Multi-Step Routes
3. Open Inventory and go to Configuration > Warehouse Management >
Routes
4. Open the 'Buy' route, assign it to one of the company for example 'My
Company (San Fransisco)' and save
5. Go to Products and select an other company for example 'My Company
(Chicago)'
6. Click on `CREATE`
7. An error is thrown, preventing the user from creating new products

Problem:
Function `_get_buy_route` always fetched the same route but this route's
company might have been changed so an error is thrown when trying to
access it from the other company

Solution:
Check if we have access to `route_warehouse0_buy` before using it.

opw-2805154