### PR TITLE
[FIX] web: make Action menu dropdown title translatable

### DIFF
--- a/addons/web/static/src/legacy/js/components/action_menus.js
+++ b/addons/web/static/src/legacy/js/components/action_menus.js
@@ -4,6 +4,7 @@ odoo.define('web.ActionMenus', function (require) {
     const Context = require('web.Context');
     const DropdownMenu = require('web.DropdownMenu');
     const Registry = require('web.Registry');
+    const {_t} = require('web.core');
 
     const { Component } = owl;
 
@@ -26,6 +27,11 @@ odoo.define('web.ActionMenus', function (require) {
         async willStart() {
             this.actionItems = await this._setActionItems(this.props);
             this.printItems = await this._setPrintItems(this.props);
+            // Workaround in legacy code to make dropdown strings translatable
+            this.printTitle = _t('Print');
+            this.printTooltip = _t('Printing options');
+            this.actionTitle = _t('Action');
+            this.actionTooltip = _t('Additional actions');
         }
 
         async willUpdateProps(nextProps) {

--- a/addons/web/static/src/legacy/xml/base.xml
+++ b/addons/web/static/src/legacy/xml/base.xml
@@ -402,19 +402,19 @@
 <t t-name="web.ActionMenus" owl="1">
     <div class="o_cp_action_menus" t-on-item-selected.stop="_onItemSelected">
         <DropdownMenu t-if="printItems.length"
-            title="env._t('Print')"
+            title="printTitle"
             items="printItems"
             icon="'fa fa-print'"
             hotkey="'shift+u'"
-            hotkeyTitle="'Printing options'"
+            hotkeyTitle="printTooltip"
         />
         <DropdownMenu t-if="actionItems.length"
-            title="env._t('Action')"
+            title="actionTitle"
             items="actionItems"
             icon="'fa fa-cog'"
             closeOnSelected="true"
             hotkey="'u'"
-            hotkeyTitle="'Additional actions'"
+            hotkeyTitle="actionTooltip"
         />
     </div>
 </t>


### PR DESCRIPTION
Before this commit there is construction env._t() for Action dropdown title that doesn't include this string in .pot file
This commit contains workaround instead of strong solution because of legacy code

This fixes #88675




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
