### PR TITLE
Expecting an ID in write

### DIFF
--- a/addons/sale_project/models/sale_order.py
+++ b/addons/sale_project/models/sale_order.py
@@ -219,7 +219,7 @@ class SaleOrderLine(models.Model):
             # duplicating a project doesn't set the SO on sub-tasks
             project.tasks.filtered(lambda task: task.parent_id != False).write({
                 'sale_line_id': self.id,
-                'sale_order_id': self.order_id,
+                'sale_order_id': self.order_id.id,
             })
         else:
             project = self.env['project.project'].create(values)


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
When overwriting `def write`, the values for many2one fields are the ids (int).

Current behavior before PR:
In _timesheet_create_project, an object is passed.

Desired behavior after PR is merged:
Pass the int.

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
