### PR TITLE
[FIX] sale_timesheet: fix sale order stat button issue

### DIFF
--- a/addons/sale_project/models/project.py
+++ b/addons/sale_project/models/project.py
@@ -527,11 +527,8 @@ class ProjectTask(models.Model):
     # Actions
     # ---------------------------------------------------
 
-    def _get_action_view_so_ids(self):
-        return self.sale_order_id.ids
-
     def action_view_so(self):
-        so_ids = self._get_action_view_so_ids()
+        so_ids = self.sale_order_id.ids
         action_window = {
             "type": "ir.actions.act_window",
             "res_model": "sale.order",

--- a/addons/sale_timesheet/models/project.py
+++ b/addons/sale_timesheet/models/project.py
@@ -628,9 +628,6 @@ class ProjectTask(models.Model):
         timesheet_ids = super(ProjectTask, self)._get_timesheet()
         return timesheet_ids.filtered(lambda t: t._is_not_billed())
 
-    def _get_action_view_so_ids(self):
-        return list(set((self.sale_order_id + self.timesheet_ids.so_line.order_id).ids))
-
 class ProjectTaskRecurrence(models.Model):
     _inherit = 'project.task.recurrence'
 


### PR DESCRIPTION
Before this commit, sale order stat button shows all 
the SOL which are linked with the SO on timesheet.

After this commit, sale order stat button show only SO.

task-2821947