### PR TITLE
[IMP] base: allow company selection while creating a user 

### DIFF
--- a/addons/crm/models/crm_stage.py
+++ b/addons/crm/models/crm_stage.py
@@ -45,5 +45,6 @@ class Stage(models.Model):
     # This field for interface only
     team_count = fields.Integer('team_count', compute='_compute_team_count')
 
+    @api.depends('team_id')
     def _compute_team_count(self):
         self.team_count = self.env['crm.team'].search_count([])

--- a/odoo/addons/base/models/res_users.py
+++ b/odoo/addons/base/models/res_users.py
@@ -415,6 +415,7 @@ class Users(models.Model):
         internal_users.share = False
         (self - internal_users).share = True
 
+    @api.depends('company_id')
     def _compute_companies_count(self):
         self.companies_count = self.env['res.company'].sudo().search_count([])
 


### PR DESCRIPTION
This PR having two tasks
1) Currently, when creating a new user, even if there are multi-companies available to select, the `companies_count` 
   always displays zero, because it is a computed field but is not dependent on any other field.

   The behaviour improved by small hack, which makes the compute method dependent on `company_id` field so that it 
   can be triggered while creating a record.

2) Similarly, when creating a new stage, even if there are sales team(s) available, the `team_count` always displays 
   zero, because it is a computed field but is not dependent on any other field.

   we have made the compute method dependent on `team_id` field so that it can be triggered while creating a record.

taskID-2819559