### PR TITLE
[FIX] web: missing translation terms from Action Menu

### DIFF
--- a/addons/web/i18n/web.pot
+++ b/addons/web/i18n/web.pot
@@ -408,6 +408,13 @@ msgstr ""
 #. openerp-web
 #: code:addons/web/static/src/legacy/xml/base.xml:0
 #, python-format
+msgid "Action"
+msgstr ""
+
+#. module: web
+#. openerp-web
+#: code:addons/web/static/src/legacy/xml/base.xml:0
+#, python-format
 msgid "Action ID:"
 msgstr ""
 
@@ -549,6 +556,13 @@ msgstr ""
 #: code:addons/web/static/src/legacy/js/fields/basic_fields.js:0
 #, python-format
 msgid "Add to Favorites"
+msgstr ""
+
+#. module: web
+#. openerp-web
+#: code:addons/web/static/src/legacy/xml/base.xml:0
+#, python-format
+msgid "Additional actions"
 msgstr ""
 
 #. module: web
@@ -3358,6 +3372,13 @@ msgstr ""
 #: code:addons/web/static/src/legacy/xml/report.xml:0
 #, python-format
 msgid "Print"
+msgstr ""
+
+#. module: web
+#. openerp-web
+#: code:addons/web/static/src/legacy/xml/report.xml:0
+#, python-format
+msgid "Printing options"
 msgstr ""
 
 #. module: web

--- a/addons/web/static/src/legacy/js/components/action_menus.js
+++ b/addons/web/static/src/legacy/js/components/action_menus.js
@@ -22,6 +22,16 @@ odoo.define('web.ActionMenus', function (require) {
      * @extends Component
      */
     class ActionMenus extends Component {
+        setup() {
+            this.actionButtonStrings = {
+                title: this.env._t("Action"),
+                hotkey: this.env._t("Additionnal actions"),
+            };
+            this.printButtonStrings = {
+                title: this.env._t("Print"),
+                hotkey: this.env._t("Printing options"),
+            };
+        }
 
         async willStart() {
             this.actionItems = await this._setActionItems(this.props);

--- a/addons/web/static/src/legacy/xml/base.xml
+++ b/addons/web/static/src/legacy/xml/base.xml
@@ -402,19 +402,19 @@
 <t t-name="web.ActionMenus" owl="1">
     <div class="o_cp_action_menus" t-on-item-selected.stop="_onItemSelected">
         <DropdownMenu t-if="printItems.length"
-            title="env._t('Print')"
+            title="printButtonStrings.title"
             items="printItems"
             icon="'fa fa-print'"
             hotkey="'shift+u'"
-            hotkeyTitle="'Printing options'"
+            hotkeyTitle="printButtonStrings.hotkey"
         />
         <DropdownMenu t-if="actionItems.length"
-            title="env._t('Action')"
+            title="actionButtonStrings.title"
             items="actionItems"
             icon="'fa fa-cog'"
             closeOnSelected="true"
             hotkey="'u'"
-            hotkeyTitle="'Additional actions'"
+            hotkeyTitle="actionButtonStrings.hotkey"
         />
     </div>
 </t>


### PR DESCRIPTION
This commit adds missing translations in the 'Print' and
'Action' items of the action menu. It also fixes the
current translation (env._t must not be used in the
template directly).

Co-authored-by: SplashS <sergey@shebanin.ru>

Original PRs: #88596, #88735
