### PR TITLE
Master timesheet overtime contract damr

### DIFF
--- a/addons/hr/data/hr_demo.xml
+++ b/addons/hr/data/hr_demo.xml
@@ -161,6 +161,7 @@ If you have development competencies, we can propose you specific traineeships</
           <field name='state_id' ref="base.state_us_39"/>
           <field name="phone">+1 555-555-5555</field>
           <field name="email">admin@yourcompany.example.com</field>
+          <field name="create_date">2010-01-01 00:00:00</field>
       </record>
       <record id="res_partner_demo_private_address" model="res.partner">
           <field name="name">Mark Demo</field>
@@ -171,6 +172,7 @@ If you have development competencies, we can propose you specific traineeships</
           <field name="phone">+1 555-555-5757</field>
           <field name="email">demo@yourcompany.example.com</field>
           <field name="type">private</field>
+          <field name="create_date">2010-01-01 00:00:00</field>
       </record>
 
     <!--Employees-->
@@ -183,6 +185,7 @@ If you have development competencies, we can propose you specific traineeships</
           <field name="job_id" ref="hr.job_ceo"/>
           <field name="job_title">Chief Executive Officer</field>
           <field name="department_id" ref="dep_management"/>
+          <field name="create_date">2010-01-01 00:00:00</field>
       </record>
 
       <record id="employee_al" model="hr.employee">
@@ -195,6 +198,7 @@ If you have development competencies, we can propose you specific traineeships</
           <field name="work_phone">(376)-310-7863</field>
           <field name="work_email">ronnie.hart87@example.com</field>
           <field name="image_1920" type="base64" file="hr/static/img/employee_al-image.jpg"/>
+          <field name="create_date">2010-01-01 00:00:00</field>
       </record>
 
       <record id="employee_mit" model="hr.employee">
@@ -209,6 +213,7 @@ If you have development competencies, we can propose you specific traineeships</
           <field name="mobile_phone">(538)-672-3185</field>
           <field name="work_email">anita.oliver32@example.com</field>
           <field name="image_1920" type="base64" file="hr/static/img/employee_mit-image.jpg"/>
+          <field name="create_date">2010-01-01 00:00:00</field>
       </record>
 
       <record id="employee_niv" model="hr.employee">
@@ -222,6 +227,7 @@ If you have development competencies, we can propose you specific traineeships</
           <field name="work_phone">(450)-719-4182</field>
           <field name="work_email">sharlene.rhodes49@example.com</field>
           <field name="image_1920" type="base64" file="hr/static/img/employee_niv-image.jpg"/>
+          <field name="create_date">2010-01-01 00:00:00</field>
       </record>
 
       <record id="employee_stw" model="hr.employee">
@@ -235,6 +241,7 @@ If you have development competencies, we can propose you specific traineeships</
           <field name="work_phone">(332)-775-6660</field>
           <field name="work_email">randall.lewis74@example.com</field>
           <field name="image_1920" type="base64" file="hr/static/img/employee_stw-image.jpg"/>
+          <field name="create_date">2010-01-01 00:00:00</field>
       </record>
 
       <record id="employee_chs" model="hr.employee">
@@ -248,6 +255,7 @@ If you have development competencies, we can propose you specific traineeships</
           <field name="work_phone">(157)-363-8229</field>
           <field name="work_email">jennie.fletcher76@example.com</field>
           <field name="image_1920" type="base64" file="hr/static/img/employee_chs-image.jpg"/>
+          <field name="create_date">2010-01-01 00:00:00</field>
       </record>
 
       <record id="employee_qdp" model="hr.employee">
@@ -263,6 +271,7 @@ If you have development competencies, we can propose you specific traineeships</
           <field name="work_phone">+3281813700</field>
           <field name="work_email">gilles@odoo.com</field>
           <field name="image_1920" type="base64" file="hr/static/img/employee_qdp-image.png"/>
+          <field name="create_date">2010-01-01 00:00:00</field>
       </record>
 
       <record id="employee_fme" model="hr.employee">
@@ -276,6 +285,7 @@ If you have development competencies, we can propose you specific traineeships</
           <field name="work_phone">(449)-505-5146</field>
           <field name="work_email">keith.byrd52@example.com</field>
           <field name="image_1920" type="base64" file="hr/static/img/employee_fme-image.jpg"/>
+          <field name="create_date">2010-01-01 00:00:00</field>
       </record>
 
       <record id="employee_fpi" model="hr.employee">
@@ -289,6 +299,7 @@ If you have development competencies, we can propose you specific traineeships</
           <field name="work_phone">(203)-276-7903</field>
           <field name="work_email">audrey.peterson25@example.com</field>
           <field name="image_1920" type="base64" file="hr/static/img/employee_fpi-image.jpg"/>
+          <field name="create_date">2010-01-01 00:00:00</field>
       </record>
 
       <record id="employee_jth" model="hr.employee">
@@ -302,6 +313,7 @@ If you have development competencies, we can propose you specific traineeships</
           <field name="work_phone">(663)-707-8451</field>
           <field name="work_email">toni.jimenez23@example.com</field>
           <field name="image_1920" type="base64" file="hr/static/img/employee_jth-image.jpg"/>
+          <field name="create_date">2010-01-01 00:00:00</field>
       </record>
 
       <record id="employee_ngh" model="hr.employee">
@@ -315,6 +327,7 @@ If you have development competencies, we can propose you specific traineeships</
           <field name="work_phone">(916)-264-7362</field>
           <field name="work_email">jeffrey.kelly72@example.com</field>
           <field name="image_1920" type="base64" file="hr/static/img/employee_ngh-image.jpg"/>
+          <field name="create_date">2010-01-01 00:00:00</field>
       </record>
 
       <record id="employee_vad" model="hr.employee">
@@ -328,6 +341,7 @@ If you have development competencies, we can propose you specific traineeships</
           <field name="work_phone">(360)-694-7266</field>
           <field name="work_email">tina.williamson98@example.com</field>
           <field name="image_1920" type="base64" file="hr/static/img/employee_vad-image.jpg"/>
+          <field name="create_date">2010-01-01 00:00:00</field>
       </record>
 
       <record id="employee_han" model="hr.employee">
@@ -339,6 +353,7 @@ If you have development competencies, we can propose you specific traineeships</
           <field name="work_phone">(350)-912-1201</field>
           <field name="work_email">walter.horton80@example.com</field>
           <field name="image_1920" type="base64" file="hr/static/img/employee_han-image.jpg"/>
+          <field name="create_date">2010-01-01 00:00:00</field>
       </record>
 
       <record id="employee_jve" model="hr.employee">
@@ -350,6 +365,7 @@ If you have development competencies, we can propose you specific traineeships</
           <field name="work_phone">(114)-262-1607</field>
           <field name="work_email">paul.williams59@example.com</field>
           <field name="image_1920" type="base64" file="hr/static/img/employee_jve-image.jpg"/>
+          <field name="create_date">2010-01-01 00:00:00</field>
       </record>
 
       <record id="employee_jep" model="hr.employee">
@@ -361,6 +377,7 @@ If you have development competencies, we can propose you specific traineeships</
           <field name="work_phone">(883)-331-5378</field>
           <field name="work_email">doris.cole31@example.com</field>
           <field name="image_1920" type="base64" file="hr/static/img/employee_jep-image.jpg"/>
+          <field name="create_date">2010-01-01 00:00:00</field>
       </record>
 
       <record id="employee_jod" model="hr.employee">
@@ -372,6 +389,7 @@ If you have development competencies, we can propose you specific traineeships</
           <field name="work_phone">(206)-267-3735</field>
           <field name="work_email">jod@odoo.com</field>
           <field name="image_1920" type="base64" file="hr/static/img/employee_jod-image.jpg"/>
+          <field name="create_date">2010-01-01 00:00:00</field>
       </record>
 
       <record id="employee_jog" model="hr.employee">
@@ -383,6 +401,7 @@ If you have development competencies, we can propose you specific traineeships</
           <field name="work_phone">(754)-532-3841</field>
           <field name="work_email">beth.evans77@example.com</field>
           <field name="image_1920" type="base64" file="hr/static/img/employee_jog-image.jpg"/>
+          <field name="create_date">2010-01-01 00:00:00</field>
       </record>
 
       <record id="employee_jgo" model="hr.employee">
@@ -394,6 +413,7 @@ If you have development competencies, we can propose you specific traineeships</
           <field name="work_phone">(944)-518-8232</field>
           <field name="work_email">ernest.reed47@example.com</field>
           <field name="image_1920" type="base64" file="hr/static/img/employee_jgo-image.jpg"/>
+          <field name="create_date">2010-01-01 00:00:00</field>
       </record>
 
       <record id="employee_lur" model="hr.employee">
@@ -405,6 +425,7 @@ If you have development competencies, we can propose you specific traineeships</
           <field name="work_phone">(644)-169-1352</field>
           <field name="work_email">eli.lambert22@example.com</field>
           <field name="image_1920" type="base64" file="hr/static/img/employee_lur-image.jpg"/>
+          <field name="create_date">2010-01-01 00:00:00</field>
       </record>
 
       <record id="employee_hne" model="hr.employee">
@@ -416,6 +437,7 @@ If you have development competencies, we can propose you specific traineeships</
           <field name="work_email">abigail.peterson39@example.com</field>
           <field name="work_phone">(482)-233-3393</field>
           <field name="image_1920" type="base64" file="hr/static/img/employee_hne-image.jpg"/>
+          <field name="create_date">2010-01-01 00:00:00</field>
       </record>
     </data>
 </odoo>


### PR DESCRIPTION
Allows the timesheet overtime computation to be based on the contract
the employee had on the day of the timesheet instead of his current
contract. 
The demo data of the hr.employee were updated to have a create_date consistent with the timesheets 

TaskID-2652259




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
