### PR TITLE
[FIX] web: fetch right company_id

### DIFF
--- a/addons/web/controllers/main.py
+++ b/addons/web/controllers/main.py
@@ -1532,7 +1532,9 @@ class Binary(http.Controller):
                 filename = unicodedata.normalize('NFD', ufile.filename)
 
             try:
-                attachment = Model.create({
+                cids = request.httprequest.cookies.get('cids', str(request.env.user.company_id.id))
+                allowed_company_ids = [int(cid) for cid in cids.split(',')]
+                attachment = Model.with_context(allowed_company_ids=allowed_company_ids).create({
                     'name': filename,
                     'datas': base64.encodebytes(ufile.read()),
                     'res_model': model,


### PR DESCRIPTION
Steps to reproduce:
- Have two companies set up
- In settings, check for company 2 the Files Centralization
- For a Product, upload a document

Issue:
The document will not appear in Documents.
It will only appear if the option is checked for company 1

Cause:
The company_id is not fetched correctly throughout the process.
There is a similar solution for the specific `documents` upload route:
https://github.com/odoo/enterprise/blob/13.0/documents/controllers/main.py#L147-L149

Solution:
Get the id directly from the cookies

opw-2774365