### PR TITLE
[FIX] mrp: select BoM based on rule

### DIFF
--- a/addons/mrp/models/stock_rule.py
+++ b/addons/mrp/models/stock_rule.py
@@ -35,7 +35,7 @@ class StockRule(models.Model):
     def _run_manufacture(self, procurements):
         productions_values_by_company = defaultdict(list)
         for procurement, rule in procurements:
-            bom = self._get_matching_bom(procurement.product_id, procurement.company_id, procurement.values)
+            bom = rule._get_matching_bom(procurement.product_id, procurement.company_id, procurement.values)
             if not bom:
                 msg = _('There is no Bill of Material of type manufacture or kit found for the product %s. Please define a Bill of Material for this product.') % (procurement.product_id.display_name,)
                 raise UserError(msg)

--- a/addons/mrp/tests/test_procurement.py
+++ b/addons/mrp/tests/test_procurement.py
@@ -308,3 +308,78 @@ class TestProcurement(TestMrpCommon):
         self.assertEqual(mo.state, 'cancel', 'Manufacturing order should be cancelled.')
         self.assertEqual(mo.move_finished_ids[0].state, 'cancel', 'Finished move should be cancelled if mo is cancelled.')
         self.assertEqual(mo.move_dest_ids[0].state, 'waiting', 'Destination move should not be cancelled if prapogation cancel is False on manufacturing rule.')
+
+    def test_several_boms_same_finished_product(self):
+        """
+        Suppose a product with two BoMs, each one based on a different operation type
+        This test ensures that, when running the scheduler, the generated MOs are based
+        on the correct BoMs
+        """
+        warehouse = self.env.ref('stock.warehouse0')
+
+        stock_location01 = warehouse.lot_stock_id
+        stock_location02 = stock_location01.copy()
+
+        manu_operation01 = warehouse.manu_type_id
+        manu_operation02 = manu_operation01.copy()
+        with Form(manu_operation02) as form:
+            form.name = 'Manufacturing 02'
+            form.sequence_code = 'MO2'
+            form.default_location_dest_id = stock_location02
+
+        manu_rule01 = warehouse.manufacture_pull_id
+        manu_route = manu_rule01.route_id
+        manu_rule02 = manu_rule01.copy()
+        with Form(manu_rule02) as form:
+            form.picking_type_id = manu_operation02
+        manu_route.rule_ids = [(6, 0, (manu_rule01 + manu_rule02).ids)]
+
+        compo01, compo02, finished = self.env['product.product'].create([{
+            'name': 'compo 01',
+            'type': 'consu',
+        }, {
+            'name': 'compo 02',
+            'type': 'consu',
+        }, {
+            'name': 'finished',
+            'type': 'product',
+            'route_ids': [(6, 0, manu_route.ids)],
+        }])
+
+        bom01_form = Form(self.env['mrp.bom'])
+        bom01_form.product_tmpl_id = finished.product_tmpl_id
+        bom01_form.code = '01'
+        bom01_form.picking_type_id = manu_operation01
+        with bom01_form.bom_line_ids.new() as line:
+            line.product_id = compo01
+        bom01 = bom01_form.save()
+
+        bom02_form = Form(self.env['mrp.bom'])
+        bom02_form.product_tmpl_id = finished.product_tmpl_id
+        bom02_form.code = '02'
+        bom02_form.picking_type_id = manu_operation02
+        with bom02_form.bom_line_ids.new() as line:
+            line.product_id = compo02
+        bom02 = bom02_form.save()
+
+        self.env['stock.warehouse.orderpoint'].create([{
+            'warehouse_id': warehouse.id,
+            'location_id': stock_location01.id,
+            'product_id': finished.id,
+            'product_min_qty': 1,
+            'product_max_qty': 1,
+        }, {
+            'warehouse_id': warehouse.id,
+            'location_id': stock_location02.id,
+            'product_id': finished.id,
+            'product_min_qty': 2,
+            'product_max_qty': 2,
+        }])
+
+        self.env['procurement.group'].run_scheduler()
+
+        mos = self.env['mrp.production'].search([('product_id', '=', finished.id)], order='origin')
+        self.assertRecordValues(mos, [
+            {'product_qty': 1, 'bom_id': bom01.id, 'picking_type_id': manu_operation01.id, 'location_dest_id': stock_location01.id},
+            {'product_qty': 2, 'bom_id': bom02.id, 'picking_type_id': manu_operation02.id, 'location_dest_id': stock_location02.id},
+        ])


### PR DESCRIPTION
When running the scheduler, if a product has several BoMs, the module
may select an incorrect one.

To reproduce the issue:
1. In Settings, enable:
    - Storage Locations
    - Multi-Step Routes
2. Let L01 be WH/Stock. Create a new location L02:
    - Parent: WH
    - Type: Internal
3. Let OP01 be the operation type 'Manufacturing'. Create a similar
operation type OP02:
    - Default Destination Location: L02
4. Let R01 be the rule Manufacture. Create a similar rule R02:
    - Operation Type: OP02
5. Create three products C01, C02, P:
    - C01, C02: consumable
    - P: storable + route Manufacture
6. Add two reordering rules for P:
    - Min 1 x P at L01
    - Min 2 x P at L02
7. Create two bills of materials
    - Product: P
        - Components: 1 x C01
        - Reference: 01
        - Operation: OP01
    - Product: P
        - Components: 1 x C02
        - Reference: 02
        - Operation: OP02
8. Run the scheduler and open the generated MOs

Error: Both MO use the same BOM

Backport of d43e9cb9ad8d1c0c020209de0e8f6ffdcbc960a1

OPW-2734208