### PR TITLE
[FIX] sale: Force Description field visible in SO

### DIFF
--- a/addons/sale/views/sale_views.xml
+++ b/addons/sale/views/sale_views.xml
@@ -476,7 +476,7 @@
                                       }"
                                       domain="[('sale_ok', '=', True), '|', ('company_id', '=', False), ('company_id', '=', parent.company_id)]"
                                       widget="product_configurator"/>
-                                    <field name="name" widget="section_and_note_text" optional="show"/>
+                                    <field name="name" widget="section_and_note_text"/>
                                     <field
                                         name="analytic_tag_ids"
                                         optional="hide"


### PR DESCRIPTION
When creating an SO, we have the capability to create a Section/Note.
When we filter the Description field, we can no longer view the Sections/Notes content.
Furthermore, when filtering the Description field, we can no longer create a Section/Note.

To reproduce the issue:
1. Create a new SO with one item (for simplicity)
2. Create a note/section
3. Filter out the Description field
We can no longer see the content of the note/section newly created.

Solution: The bug is raised because a Note/Section is basically an `order_line` which its content is stored
in the Description (`name`) field of an `order_line`. A javascript trick is done in the UI to properly display
the Section/Note. However, when we filter the Description field, we obviously also hide the content of the notes/sections. The solution here was to add another trick in javascript by extending some existing classes. The idea is to,
instead of removing the Description columns from the HTML entirely (as it is done when we filter in a normal way).
We simply hides the Description column (using display:none CSS style) expect for the Notes/Sections rows.

opw-2819904