### PR TITLE
[FIX] l10n_it_edi: DatiPagamento non-mandatory

### DIFF
--- a/addons/l10n_it_edi/data/invoice_it_template.xml
+++ b/addons/l10n_it_edi/data/invoice_it_template.xml
@@ -176,19 +176,21 @@
                             </DatiRiepilogo>
                         </t>
                     </DatiBeniServizi>
-                    <DatiPagamento>
+                    <t t-set="company_bank_account" t-value="record.partner_bank_id"/>
+                    <DatiPagamento t-if="company_bank_account and record.move_type != 'out_refund'">
                         <t t-set="payments" t-value="record.line_ids.filtered(lambda line: line.account_id.user_type_id.type in ('receivable', 'payable'))"/>
                         <CondizioniPagamento><t t-if="len(payments) == 1">TP02</t><t t-else="">TP01</t></CondizioniPagamento>
-                        <DettaglioPagamento>
-                            <t t-set="company_bank_account" t-value="record.partner_bank_id"/>
-                            <ModalitaPagamento t-if="company_bank_account">MP05</ModalitaPagamento>
-                            <DataScadenzaPagamento t-esc="format_date(record.invoice_date_due)"/>
-                            <ImportoPagamento t-esc="format_numbers_two(record.amount_total)"/>
-                            <IstitutoFinanziario t-if="company_bank_account.bank_id" t-esc="company_bank_account.bank_id.name[:80]"/>
-                            <IBAN t-if="company_bank_account.acc_type == 'iban'" t-esc="company_bank_account.sanitized_acc_number"/>
-                            <BIC t-if="company_bank_account.acc_type == 'bank' and company_bank_account.bank_id.bic" t-esc="company_bank_account.bank_id.bic"/>
-                            <CodicePagamento t-esc="record.payment_reference[:60]"/>
-                        </DettaglioPagamento>
+                        <t t-foreach="payments" t-as="payment">
+                            <DettaglioPagamento>
+                                <ModalitaPagamento>MP05</ModalitaPagamento>
+                                <DataScadenzaPagamento t-esc="format_date(payment.date_maturity)"/>
+                                <ImportoPagamento t-esc="format_monetary(abs(payment.price_total), currency)"/>
+                                <IstitutoFinanziario t-if="company_bank_account.bank_id" t-esc="company_bank_account.bank_id.name[:80]"/>
+                                <IBAN t-if="company_bank_account.acc_type == 'iban'" t-esc="company_bank_account.sanitized_acc_number"/>
+                                <BIC t-if="company_bank_account.acc_type == 'bank' and company_bank_account.bank_id.bic" t-esc="company_bank_account.bank_id.bic"/>
+                                <CodicePagamento t-esc="record.payment_reference[:60]"/>
+                            </DettaglioPagamento>
+                        </t>
                     </DatiPagamento>
                     <Allegati t-if="pdf">
                         <NomeAttachment t-esc="pdf_name"/>

--- a/addons/l10n_it_edi/models/account_edi_format.py
+++ b/addons/l10n_it_edi/models/account_edi_format.py
@@ -120,9 +120,6 @@ class AccountEdiFormat(models.Model):
             if not tax_line.tax_line_id.l10n_it_kind_exoneration and tax_line.tax_line_id.amount == 0:
                 errors.append(_("%s has an amount of 0.0, you must indicate the kind of exoneration.", tax_line.name))
 
-        if not invoice.partner_bank_id:
-            errors.append(_("The seller must have a bank account."))
-
         return errors
 
     # -------------------------------------------------------------------------


### PR DESCRIPTION
DatiPagamento is non mandatory, and it's contents 'DettaglioPagamento'
can be multiple (e.g. when there are payment terms, and amounts are
receivable upon different days). This commit adapts the DatiPagmento
section of the invoice template to not occur when the invoice is a
credit note (there is no sense in providing payment info for a credit
note) and creates a number of payment lines if there are multiple payments.
