### PR TITLE
[FIX] pos_coupon : create rewards per tax with fixed promo

### DIFF
--- a/addons/coupon/views/coupon_program_views.xml
+++ b/addons/coupon/views/coupon_program_views.xml
@@ -41,6 +41,7 @@
                             <label string="Quantity" for="reward_product_quantity" attrs="{'invisible': ['|', ('reward_type', 'in', ('discount', 'free_shipping')), ('reward_product_id', '=',False)]}"/>
                             <div attrs="{'invisible': ['|', ('reward_type', 'in', ('discount', 'free_shipping')),('reward_product_id', '=',False)]}">
                                 <field name="reward_product_quantity" class="oe_inline"/>
+                                &amp;nbsp;
                                 <field name="reward_product_uom_id" class="oe_inline"/>
                             </div>
                             <label string="Apply Discount" for="discount_type" attrs="{'invisible': [('reward_type', 'in', ('product', 'free_shipping'))]}"/>

--- a/addons/pos_coupon/static/src/js/coupon.js
+++ b/addons/pos_coupon/static/src/js/coupon.js
@@ -902,20 +902,11 @@ odoo.define('pos_coupon.pos', function (require) {
          * @returns {[Reward[], string | null]}
          */
         _getFixedDiscount: function (program, coupon_id) {
-            const discountAmount = Math.min(program.discount_fixed_amount, program.discount_max_amount || Infinity);
-            return [
-                [
-                    new Reward({
-                        product: this.pos.db.get_product_by_id(program.discount_line_product_id[0]),
-                        unit_price: -discountAmount,
-                        quantity: 1,
-                        program: program,
-                        tax_ids: [],
-                        coupon_id: coupon_id,
-                    }),
-                ],
-                null,
-            ];
+            const amountsToDiscount = {};
+            for (let line of this._getRegularOrderlines()) {
+                this._updateAmountsToDiscount(amountsToDiscount, line);
+            }
+            return this._createFixedDiscountRewards(program, coupon_id, amountsToDiscount);
         },
         /**
          * This method is called via `collectRewards` inside `_calculateRewards`.
@@ -933,12 +924,7 @@ odoo.define('pos_coupon.pos', function (require) {
             const amountsToDiscount = {};
             for (let line of this._getRegularOrderlines()) {
                 if (program.discount_specific_product_ids.has(line.get_product().id)) {
-                    const key = this._getGroupKey(line);
-                    if (!(key in amountsToDiscount)) {
-                        amountsToDiscount[key] = line.get_quantity() * line.price;
-                    } else {
-                        amountsToDiscount[key] += line.get_quantity() * line.price;
-                    }
+                    this._updateAmountsToDiscount(amountsToDiscount, line);
                     productIdsToAccount.add(line.get_product().id);
                 }
             }
@@ -985,12 +971,7 @@ odoo.define('pos_coupon.pos', function (require) {
             const productIdsToAccount = new Set();
             const amountsToDiscount = {};
             for (let line of this._getRegularOrderlines()) {
-                const key = this._getGroupKey(line);
-                if (!(key in amountsToDiscount)) {
-                    amountsToDiscount[key] = line.get_quantity() * line.price;
-                } else {
-                    amountsToDiscount[key] += line.get_quantity() * line.price;
-                }
+                this._updateAmountsToDiscount(amountsToDiscount, line);
                 productIdsToAccount.add(line.get_product().id);
             }
             this._considerProductRewards(amountsToDiscount, productIdsToAccount, productRewards);
@@ -1031,6 +1012,32 @@ odoo.define('pos_coupon.pos', function (require) {
                 });
             });
             return [discountRewards, discountRewards.length > 0 ? null : 'No items to discount.'];
+        },
+
+        _createFixedDiscountRewards: function (program, coupon_id, amountsToDiscount) {
+            const discountAmount = Math.min(program.discount_fixed_amount, program.discount_max_amount || Infinity);
+            const discountRatio = discountAmount / this.get_total_with_tax();
+            const discountRewards = Object.entries(amountsToDiscount).map(([tax_keys, amount]) => {
+                let discountAmount = amount * discountRatio;
+                return new Reward({
+                    product: this.pos.db.get_product_by_id(program.discount_line_product_id[0]),
+                    unit_price: -discountAmount,
+                    quantity: 1,
+                    program: program,
+                    tax_ids: tax_keys !== '' ? tax_keys.split(',').map((val) => parseInt(val, 10)) : [],
+                    coupon_id: coupon_id,
+                });
+            });
+            return [discountRewards, discountRewards.length > 0 ? null : 'No items to discount.'];
+        },
+
+        _updateAmountsToDiscount: function (amountsToDiscount, line) {
+            const key = this._getGroupKey(line);
+            if (!(key in amountsToDiscount)) {
+                amountsToDiscount[key] = line.get_quantity() * line.price;
+            } else {
+                amountsToDiscount[key] += line.get_quantity() * line.price;
+            }
         },
     });
 
@@ -1073,6 +1080,16 @@ odoo.define('pos_coupon.pos', function (require) {
                 }
             }
             return result;
+        },
+        get_full_product_name: function () {
+            if (this.is_program_reward && this.pos.coupon_programs_by_id[this.program_id].reward_type != "product") {
+                const taxes  = this.get_taxes();
+                const taxInfo = taxes.length
+                              ? taxes.map(tax => tax.name).join(', ')
+                              : "no tax";
+                return `${this.product.display_name} (${taxInfo})`;
+            }
+            return _orderline_super.get_full_product_name.apply(this);
         },
     });
 });


### PR DESCRIPTION
Steps :
Create a promotion with fixed price discount.
Add promotion to POS session.
Sell several products with different taxes (incl and excl).

Issue :
Fixed amount promotion does not take taxes into account.

Fix :
Calculate the discount ratio = promotion/ total taxed.
Just like for percentage discount :
Group by taxes and create a discount line for each group.
Give the live a more explanatory name.

This has been done earlier for sale_coupon :
https://github.com/odoo/odoo/pull/85955

opw-2800670

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
