### PR TITLE
[FIX] hr_holidays: Explicitly set permit on rule

### DIFF
--- a/addons/hr_holidays/security/hr_holidays_security.xml
+++ b/addons/hr_holidays/security/hr_holidays_security.xml
@@ -65,6 +65,7 @@
         <field name="perm_read" eval="False"/>
         <field name="perm_write" eval="False"/>
         <field name="perm_create" eval="False"/>
+        <field name="perm_unlink" eval="True"/>
         <field name="groups" eval="[(4, ref('base.group_user'))]"/>
     </record>
 


### PR DESCRIPTION
In v15, the rule `hr_leave_rule_employee_unlink` has been modified.
Because of that, during an upgrade to v15, the rule is reloaded from the
security xml.

If the rule had been edited and `perm_unlink` was set to False, since its
value is not explicitly stated in the xml, the upgrade will fail by
violating the constraint `ir_rule_no_access_rights`.

Related:
https://github.com/odoo/upgrade/pull/2127
https://github.com/odoo/odoo/pull/65361

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
