### PR TITLE
[FIX] mrp_workorder: consistent returned view on finish

### DIFF
--- a/addons/mrp/views/mrp_production_views.xml
+++ b/addons/mrp/views/mrp_production_views.xml
@@ -284,7 +284,7 @@
                             </field>
                         </page>
                         <page string="Work Orders" name="operations" groups="mrp.group_mrp_routings">
-                            <field name="workorder_ids" attrs="{'readonly': [('state', 'in', ['cancel', 'done'])]}" context="{'tree_view_ref': 'mrp.mrp_production_workorder_tree_editable_view', 'default_product_uom_id': product_uom_id, 'default_consumption': consumption, 'default_company_id': company_id}"/>
+                            <field name="workorder_ids" attrs="{'readonly': [('state', 'in', ['cancel', 'done'])]}" context="{'tree_view_ref': 'mrp.mrp_production_workorder_tree_editable_view', 'default_product_uom_id': product_uom_id, 'default_consumption': consumption, 'default_company_id': company_id, 'from_manufacturing_order': True}"/>
                         </page>
                         <page string="By-Products" name="finished_products" groups="mrp.group_mrp_byproducts">
                             <field name="move_byproduct_ids" context="{'default_date': date_planned_finished, 'default_date_deadline': date_deadline, 'default_location_id': production_location_id, 'default_location_dest_id': location_src_id, 'default_state': 'draft', 'default_production_id': id, 'default_picking_type_id': picking_type_id, 'default_company_id': company_id}" attrs="{'readonly': ['|', ('state', '=', 'cancel'), '&amp;', ('state', '=', 'done'), ('is_locked', '=', True)]}" options="{'delete': [('state', '=', 'draft')]}">


### PR DESCRIPTION
### Current behavior
When a workorder is marked as done, the returned view is inconsistent between the "control panel" and work orders' list view.
- "Control panel"  : we correctly land back to workorders from this workcenter
- List : we land back to an empty list view

### Steps
- Install Manufacturing
- Get or create a manufactured product
- For this product, plan some orders in a work center
*Control Panel view*
- Proccess to a workorder and mark it as done
-> Correctly redirected to a kanban view with remaining workorder linked to
this work center
*List view*
- Proccess to a workorder and mark it as done
-> Redirected to an empty list view


Linked enterprise PR : https://github.com/odoo/enterprise/pull/26226

OPW-2767737
