### PR TITLE
[FIX] point_of_sale: access error when limited partners

### DIFF
--- a/addons/point_of_sale/models/pos_config.py
+++ b/addons/point_of_sale/models/pos_config.py
@@ -729,8 +729,11 @@ class PosConfig(models.Model):
             LEFT JOIN pm
             ON        (
                                 partner.id = pm.partner_id)
+            WHERE (
+                partner.company_id=%s OR partner.company_id IS NULL
+            )
             ORDER BY  COALESCE(pm.order_count, 0) DESC,
                       NAME limit %s;
-        """, [str(self.limited_partners_amount)])
+        """, [self.company_id.id, str(self.limited_partners_amount)])
         result = self.env.cr.fetchall()
         return result

--- a/addons/point_of_sale/tests/test_pos_basic_config.py
+++ b/addons/point_of_sale/tests/test_pos_basic_config.py
@@ -807,3 +807,25 @@ class TestPoSBasicConfig(TestPoSCommon):
 
         open_and_check(pos01_data)
         open_and_check(pos02_data)
+
+    def test_load_pos_data_should_not_fail(self):
+        """load_pos_data shouldn't fail
+
+        (Include test conditions here if possible)
+
+        - When there are partners that belong to different company
+        """
+
+        # create a partner that belongs to different company
+        company2 = self.company_data_2['company']
+        self.env['res.partner'].create({
+            'name': 'Test',
+            'company_id': company2.id,
+        })
+
+        # activate limited partners loading
+        self.config.limited_partners_loading = True
+        self.open_new_session()
+
+        # calling load_pos_data should not raise an error
+        self.pos_session.load_pos_data()


### PR DESCRIPTION
Steps to reproduce:
1. pos.config is in company1
2. create a partner with company = company2
3. change pos.config to limited partners loading
4. open the pos ui (to call load_pos_data)

old behavior: access error
now: method is called without error

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
