### PR TITLE
[FIX] im_livechat: avoid using bootstrap for chatbot blocks

### DIFF
--- a/addons/im_livechat/static/src/legacy/public_livechat_chatbot.js
+++ b/addons/im_livechat/static/src/legacy/public_livechat_chatbot.js
@@ -242,7 +242,7 @@ const QWeb = core.qweb;
      */
     _chatbotEndScript: function () {
         this._chatWindow.$('.o_composer_text_field').addClass('d-none');
-        this._chatWindow.$('.o_livechat_chatbot_end').removeClass('d-none');
+        this._chatWindow.$('.o_livechat_chatbot_end').show();
         this._chatWindow.$('.o_livechat_chatbot_restart').one('click',
             this._onChatbotRestartScript.bind(this));
 
@@ -565,7 +565,7 @@ const QWeb = core.qweb;
         this._super(...arguments);
 
         this._chatWindow.$('.o_livechat_chatbot_main_restart').addClass('d-none');
-        this._chatWindow.$('.o_livechat_chatbot_end').addClass('d-none');
+        this._chatWindow.$('.o_livechat_chatbot_end').hide();
         this._chatWindow.$('.o_composer_text_field')
             .removeClass('d-none')
             .val('');
@@ -770,7 +770,7 @@ const QWeb = core.qweb;
      */
     _onChatbotRestartScript: async function (ev) {
         this._chatWindow.$('.o_composer_text_field').removeClass('d-none');
-        this._chatWindow.$('.o_livechat_chatbot_end').addClass('d-none');
+        this._chatWindow.$('.o_livechat_chatbot_end').hide();
 
         if (this.nextStepTimeout) {
             clearTimeout(this.nextStepTimeout);

--- a/addons/im_livechat/static/src/legacy/public_livechat_chatbot.xml
+++ b/addons/im_livechat/static/src/legacy/public_livechat_chatbot.xml
@@ -10,7 +10,7 @@
     <!-- Extend the base livechat window to include a div allowing to restart the script at the end -->
     <t t-extend="im_livechat.legacy.mail.AbstractThreadWindow">
         <t t-jquery='div.o_chat_mini_composer' t-operation="after">
-            <div class="d-none o_livechat_chatbot_end bg-200 font-italic text-center border">
+            <div class="o_livechat_chatbot_end bg-200 font-italic text-center border" style="display: none;">
                 <span>Conversation ended...</span>
                 <a href="#" class="o_livechat_chatbot_restart">Restart</a>
             </div>


### PR DESCRIPTION
Currently, the block showing that the conversation with the chatbot has ended
is hidden/displayed using bootstrap classes (d-none).

This is an issue because when embedding the livechat in a third-party website,
bootstrap classes are not available and the block is displayed when it should
not be ('d-none' is not available).

To fix the issue, we use standard "display: none" style and jQuery show/hide.

Task-2822240