### PR TITLE
[FIX] project_timesheet_holidays: remove timesheets when time off is canceled

### DIFF
--- a/addons/hr_holidays/models/hr_leave.py
+++ b/addons/hr_holidays/models/hr_leave.py
@@ -971,8 +971,8 @@ class HolidaysRequest(models.Model):
         return holidays
 
     def write(self, values):
-        if 'active' in values and not values['active'] and not self.env.context.get('from_cancel_wizard'):
-            raise UserError(_("You can't manually archive a time off."))
+        if 'active' in values and not self.env.context.get('from_cancel_wizard'):
+            raise UserError(_("You can't manually archive/unarchive a time off."))
 
         is_officer = self.env.user.has_group('hr_holidays.group_hr_holidays_user') or self.env.is_superuser()
         if not is_officer and values.keys() - {'supported_attachment_ids', 'message_main_attachment_id'}:
@@ -1352,6 +1352,19 @@ class HolidaysRequest(models.Model):
 
         self.activity_update()
         return True
+
+    def _action_user_cancel(self, reason):
+        self.ensure_one()
+        if not self.can_cancel:
+            raise ValidationError(_('This time off cannot be canceled.'))
+
+        self.message_post(
+            body=_('The time off has been canceled: %s', reason)
+        )
+
+        leave_sudo = self.sudo()
+        leave_sudo.with_context(from_cancel_wizard=True).active = False
+        leave_sudo._remove_resource_leave()
 
     def action_documents(self):
         domain = [('id', 'in', self.attachment_ids.ids)]

--- a/addons/hr_holidays/tests/__init__.py
+++ b/addons/hr_holidays/tests/__init__.py
@@ -5,6 +5,7 @@ from . import test_access_rights
 from . import test_automatic_leave_dates
 from . import test_allocation_access_rights
 from . import test_holidays_flow
+from . import test_hr_holidays_cancel_leave
 from . import test_hr_leave_type
 from . import test_accrual_allocations
 from . import test_change_department

--- a/addons/hr_holidays/tests/test_hr_holidays_cancel_leave.py
+++ b/addons/hr_holidays/tests/test_hr_holidays_cancel_leave.py
@@ -1,0 +1,65 @@
+# -*- coding: utf-8 -*-
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from datetime import datetime
+from dateutil.relativedelta import relativedelta
+from freezegun import freeze_time
+
+from odoo.exceptions import UserError, ValidationError
+
+from .common import TestHrHolidaysCommon
+
+
+class TestHrHolidaysCancelLeave(TestHrHolidaysCommon):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+
+        leave_start_datetime = datetime(2018, 2, 5, 7, 0, 0, 0)  # this is monday
+        leave_end_datetime = leave_start_datetime + relativedelta(days=3)
+
+        cls.hr_leave_type = cls.env['hr.leave.type'].with_user(cls.user_hrmanager).create({
+            'name': 'Leave Type',
+            'requires_allocation': 'no',
+        })
+        cls.holiday = cls.env['hr.leave'].with_context(mail_create_nolog=True, mail_notrack=True).with_user(cls.user_employee).create({
+            'name': 'Leave 1',
+            'employee_id': cls.employee_emp.id,
+            'holiday_status_id': cls.hr_leave_type.id,
+            'date_from': leave_start_datetime,
+            'date_to': leave_end_datetime,
+            'number_of_days': (leave_end_datetime - leave_start_datetime).days,
+        })
+        cls.holiday.with_user(cls.user_hrmanager).action_validate()
+
+    @freeze_time('2018-02-05')  # useful to be able to cancel the validated time off
+    def test_action_cancel_leave(self):
+        self.assertTrue(self.holiday.with_user(self.user_employee).can_cancel)
+        self.env['hr.holidays.cancel.leave'].with_user(self.user_employee).with_context(default_leave_id=self.holiday.id) \
+            .new({'reason': 'Test remove holiday'}) \
+            .action_cancel_leave()
+        self.assertFalse(self.holiday.active, 'The validated leave should be canceled, that is archived.')
+
+    def test_action_cancel_leave_in_past(self):
+        """ Test if the user may cancel a validated leave in the past. """
+        with self.assertRaises(ValidationError, msg='The leave could not be cancel since it is leave in the past.'):
+            self.env['hr.holidays.cancel.leave'].with_user(self.user_employee).with_context(default_leave_id=self.holiday.id) \
+                .new({'reason': 'Test remove holiday'}) \
+                .action_cancel_leave()
+
+    def test_action_cancel_leave_from_another_person(self):
+        """ Test if the user may cancel a validated leave from another person. """
+        self.assertFalse(self.holiday.with_user(self.user_hruser).can_cancel, 'The user should not be able to cancel the leave from another one.')
+        with self.assertRaises(ValidationError, msg='The leave could not be cancel since it is leave in the past.'):
+            self.env['hr.holidays.cancel.leave'].with_user(self.user_hruser).with_context(default_leave_id=self.holiday.id) \
+                .new({'reason': 'Test remove holiday'}) \
+                .action_cancel_leave()
+
+    @freeze_time('2018-02-05')  # useful to be able to cancel the validated time off
+    def test_user_cannot_unarchive_leave(self):
+        """ Test the user cannot manually unarchive a canceled leave """
+        self.env['hr.holidays.cancel.leave'].with_user(self.user_employee).with_context(default_leave_id=self.holiday.id) \
+            .new({'reason': 'Test remove holiday'}) \
+            .action_cancel_leave()
+        with self.assertRaises(UserError, msg='The user should not be able to manually unarchive the leave.'):
+            self.holiday.with_user(self.user_employee).write({'active': False})

--- a/addons/hr_holidays/wizard/hr_holidays_cancel_leave.py
+++ b/addons/hr_holidays/wizard/hr_holidays_cancel_leave.py
@@ -15,16 +15,7 @@ class HrHolidaysCancelLeave(models.TransientModel):
     def action_cancel_leave(self):
         self.ensure_one()
 
-        if not self.leave_id.can_cancel:
-            raise ValidationError(_('This time off cannot be canceled.'))
-
-        self.leave_id.message_post(
-            body=_('The time off has been canceled: %s', self.reason)
-        )
-
-        leave_sudo = self.leave_id.sudo()
-        leave_sudo.with_context(from_cancel_wizard=True).active = False
-        leave_sudo._remove_resource_leave()
+        self.leave_id._action_user_cancel(self.reason)
 
         return {
             'type': 'ir.actions.client',

--- a/addons/project_timesheet_holidays/models/hr_holidays.py
+++ b/addons/project_timesheet_holidays/models/hr_holidays.py
@@ -113,3 +113,10 @@ class Holidays(models.Model):
         timesheets.write({'holiday_id': False})
         timesheets.unlink()
         return result
+
+    def _action_user_cancel(self, reason):
+        res = super()._action_user_cancel(reason)
+        timesheets = self.sudo().timesheet_ids
+        timesheets.write({'holiday_id': False})
+        timesheets.unlink()
+        return res


### PR DESCRIPTION
Before this commit, when the user cancels his validated time off planned
in the future, the timesheets generated for this time off are not
deleted. The problem is since the timesheets are not removed we could
have duplicated timesheets if the user adds a new time off in the same days
for instance, because the newest timesheets are generated and thus we have
duplicated timesheets generated instead of having only timesheets generated
for the newest time off.

This commit removes the timesheets generated for the time off when this
time off is canceled (=archived). Also, if the user unarchives the time
off then the timehseets will be regenerated for this time off.

Related PR: #76722

Part of task-2791386

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
