### PR TITLE
[FIX] payment: do not add fee for validation transaction

### DIFF
--- a/addons/payment/models/payment_transaction.py
+++ b/addons/payment/models/payment_transaction.py
@@ -193,11 +193,14 @@ class PaymentTransaction(models.Model):
                 'partner_phone': partner.phone,
             })
 
-            # Compute fees
-            currency = self.env['res.currency'].browse(values.get('currency_id')).exists()
-            values['fees'] = acquirer._compute_fees(
-                values.get('amount', 0), currency, partner.country_id
-            )
+            # Compute fees, for validation transactions fees are zero
+            if values.get('operation') == 'validation':
+                values['fees'] = 0
+            else:
+                currency = self.env['res.currency'].browse(values.get('currency_id')).exists()
+                values['fees'] = acquirer._compute_fees(
+                    values.get('amount', 0), currency, partner.country_id,
+                )
 
             # Include acquirer-specific create values
             values.update(self._get_specific_create_values(acquirer.provider, values))


### PR DESCRIPTION
When making transaction with 'validation' type and where fees
were active, fees were added to the amount  of the transaction. 
This behavior is problematic because
validation operations are used for tokenization for example where
no credit should be charged to the customer.
Now validation operations have no fees even if fees are active
on the acquirer.

Task - 2784765


I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
