### PR TITLE
[FIX] l10n_it_edi: wrong condition for contact form vat

### DIFF
--- a/addons/l10n_it_edi/models/res_partner.py
+++ b/addons/l10n_it_edi/models/res_partner.py
@@ -38,7 +38,7 @@ class ResPartner(models.Model):
 
     @api.onchange('vat', 'country_id')
     def _l10n_it_onchange_vat(self):
-        if not self.l10n_it_codice_fiscale and (self.country_id.code == "IT" or (self.vat and self.vat.startswith("IT"))):
+        if not self.l10n_it_codice_fiscale and self.vat and (self.country_id.code == "IT" or self.vat.startswith("IT")):
             self.l10n_it_codice_fiscale = self._l10n_it_normalize_codice_fiscale(self.vat)
         elif self.country_id.code not in [False, "IT"]:
             self.l10n_it_codice_fiscale = ""


### PR DESCRIPTION
Step to reproduce :
	-set your company country in Italy
	-install accounting
	-install contacts
	-create a new individual contact
	-set the country address of this contact to Italy

Expected Behavior:
No problem

Current behavior:
Error message in function _l10n_it_normalize_codice_fiscale

Explanation:
In this fix commit https://github.com/odoo/odoo/commit/702c01661f255fe9ebbfc04c90b2cd0fa194d1e8
the case where vat is unset but the country is Italy is not rejected
anymore and a unset value is passed in _l10n_it_normalize_codice_fiscale

opw-2822259