### PR TITLE
[FIX] web: Only generate latin-numbered date-time

### DIFF
--- a/addons/web/static/src/views/helpers/sample_server.js
+++ b/addons/web/static/src/views/helpers/sample_server.js
@@ -309,7 +309,7 @@ export class SampleServer {
      */
     _getRandomDate(format) {
         const delta = Math.floor((Math.random() - Math.random()) * SampleServer.DATE_DELTA);
-        return luxon.DateTime.local().plus({ hours: delta }).toFormat(format);
+        return luxon.DateTime.local().reconfigure({ numberingSystem: "latn" }).plus({ hours: delta }).toFormat(format);
     }
 
     /**


### PR DESCRIPTION
Step to reproduce:
- Create a db with no demo data and default language arabic
- Install website_sale
- Try to access website_sale

Current Behaviour:
- Traceback
- mock RPC generate datetime in withe the arab numbering system
 which is not supported by the dateparser.

Behaviour after PR:
- Force numbering of generated datetime to latin

opw-2810437

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
