### PR TITLE
[FIX] sale_management: copy sequence from quotation template

### DIFF
--- a/addons/sale_management/models/sale_order.py
+++ b/addons/sale_management/models/sale_order.py
@@ -58,6 +58,7 @@ class SaleOrder(models.Model):
 
     def _compute_line_data_for_template_change(self, line):
         return {
+            'sequence': line.sequence,
             'display_type': line.display_type,
             'name': line.name,
             'state': 'draft',


### PR DESCRIPTION
When selecting a quotation template for a quotation all the template lines are copied into the quotation. However, the sequence field is omitted when adding the lines. As a result all quotation lines have, by default, the same sequence number.

This should not be a problem, since the lines are still shown in order in the frontend quotation view. Once the lines are shown, the user can freely reorder the lines, while the frontend takes care of reordering the sequence numbers.

However, there is an interaction with an existing problem in One2Many and Many2Many fields. When these fields are paginated a sequence update will only update the sequence numbers on the first page. This means that, before this commit, when we move around a line on the first page, all the lines on the second page will be inserted at the second position on the first page (because of the way `_onResequenceRecords` is implemented).

This commit does include the sequence number in the copied quotation lines, resolving the problem described above.

Note: It is still possible to insert new lines in the first page, extending the sequence numbers at the end of the page. Since the sequence numbers on the second page still remain the same, there are now lines on the first and second page having the same sequence numbers, resulting in a similar bug.

opw-2730746