### PR TITLE
[FIX] web_editor: properly display colorpickers in all languages

### DIFF
--- a/addons/web_editor/static/src/scss/wysiwyg.scss
+++ b/addons/web_editor/static/src/scss/wysiwyg.scss
@@ -76,12 +76,12 @@ $o-we-toolbar-color-clickable-active: $o-we-bg-darkest;
         box-shadow: inset 0 1px 0 var(--tab-border-top);
     }
 
-    .o_we_colorpicker_switch_pane_btn {
+    .o_we_colorpicker_switch_pane_btn, .o_colorpicker_reset {
         flex: 0 0 auto;
     }
-
     .o_colorpicker_reset {
-        max-width: 40%;
+        // TODO in master, review XML definition
+        margin-left: auto !important;
     }
 
     .o_colorpicker_sections {
@@ -122,6 +122,7 @@ $o-we-toolbar-color-clickable-active: $o-we-bg-darkest;
             border: 1px solid var(--bg);
 
             &.o_colorpicker_reset {
+                // TODO dead code, remove me in master
                 background-color: transparent;
 
                 &::before {

--- a/addons/web_editor/static/src/scss/wysiwyg_snippets.scss
+++ b/addons/web_editor/static/src/scss/wysiwyg_snippets.scss
@@ -176,16 +176,17 @@ body.editor_enable.editor_has_snippets {
 
 %we-generic-tab-button {
     @extend %we-generic-link;
-    @include o-text-overflow(inline-flex);
+    display: inline-flex;
     flex: 1 1 auto;
     justify-content: center;
+    min-width: 0;
     border: none;
     background-color: transparent;
     color: inherit;
     font-weight: normal;
 
     > span {
-        display: inline-block;
+        @include o-text-overflow(inline-block);
         $-r: $o-we-sidebar-tabs-size-ratio;
         padding: (0.6em * $-r) (0.4em * $-r) (0.5em * $-r);
     }
@@ -576,6 +577,7 @@ body.editor_enable.editor_has_snippets {
             }
 
             #colorInputButtonGroup {
+                position: static;
                 grid-area: colors;
 
                 .dropdown-toggle:after {
@@ -585,7 +587,7 @@ body.editor_enable.editor_has_snippets {
                 .colorpicker-group {
                     display: flex;
                     align-items: stretch;
-                    position: initial;
+                    position: static;
                 }
 
                 #oe-text-color {
@@ -667,12 +669,17 @@ body.editor_enable.editor_has_snippets {
             }
 
             .dropdown-menu.colorpicker-menu {
+                min-width: 0;
                 max-height: none;
-                left: auto;
-                right: 0;
+                left: $o-we-sidebar-content-indent;
+                right: $o-we-sidebar-content-padding-base;
                 border: $o-we-sidebar-content-field-dropdown-border-width solid $o-we-sidebar-content-field-dropdown-border-color;
                 border-radius: $o-we-item-border-radius;
                 padding: 0;
+            }
+
+            :not(.dropup) > .dropdown-menu.colorpicker-menu {
+                top: 2em; // TODO Ugly and not precise, conflict with row-gap of grid
             }
         }
 
@@ -1745,6 +1752,7 @@ body.editor_enable.editor_has_snippets {
 
     .o_we_colorpicker_switch_pane_btn {
         @extend %we-generic-tab-button;
+        flex: 0 1 auto;
     }
     .o_colorpicker_reset {
         @extend %we-generic-button;

--- a/addons/web_editor/static/src/xml/snippets.xml
+++ b/addons/web_editor/static/src/xml/snippets.xml
@@ -47,13 +47,13 @@
     <!-- options -->
     <div t-name="web_editor.snippet.option.colorpicker" class="colorpicker">
         <div class="o_we_colorpicker_switch_panel d-flex justify-content-end px-2">
-            <button type="button" tabindex="1" class="o_we_colorpicker_switch_pane_btn" t-attf-data-target="#{widget.withCombinations? 'color-combinations' : 'theme-colors'}">
+            <button type="button" tabindex="1" class="o_we_colorpicker_switch_pane_btn" t-attf-data-target="#{widget.withCombinations? 'color-combinations' : 'theme-colors'}" title="Theme">
                 <span>Theme</span>
             </button>
-            <button type="button" tabindex="2" class="o_we_colorpicker_switch_pane_btn" data-target="custom-colors">
+            <button type="button" tabindex="2" class="o_we_colorpicker_switch_pane_btn" data-target="custom-colors" title="Solid">
                 <span>Solid</span>
             </button>
-            <button type="button" tabindex="3" class="o_we_colorpicker_switch_pane_btn" data-target="gradients">
+            <button type="button" tabindex="3" class="o_we_colorpicker_switch_pane_btn" data-target="gradients" title="Gradient">
                 <span>Gradient</span>
             </button>
             <t t-if="widget.resetButton">


### PR DESCRIPTION
Before this commit, the tab labels of the colorpickers were too long
in some languages (e.g. German) making them overflow and making the UI
impossible to use in some cases. Indeed, the bug was different depending
on where the colorpicker was:

- In the text tools, the colorpicker overflew the whole panel, making it
  impossible to use

- In the snippet options, the colorpicker buttons were cropped without
  ellipsis making them impossible to read

- In the backend, as the toolbar is floating, it was ok but the code was
  quite dependent of the other colorpicker-related scss

This commit solves those problems and unifies the way colorpickers look
independently of their position (always full width, the buttons fill the
available space, if the buttons are too long they are cropped with
ellipsis, they have a title on hover and are always aligned on the
left of the tabs area).

opw-2786778
