### PR TITLE
[FIX] mrp: use the fastest workcenter

### DIFF
--- a/addons/mrp/models/mrp_workorder.py
+++ b/addons/mrp/models/mrp_workorder.py
@@ -709,7 +709,8 @@ class MrpWorkorder(models.Model):
             duration_expected_working = (self.duration_expected - self.workcenter_id.time_start - self.workcenter_id.time_stop) * self.workcenter_id.time_efficiency / (100.0 * cycle_number)
             if duration_expected_working < 0:
                 duration_expected_working = 0
-            return alternative_workcenter.time_start + alternative_workcenter.time_stop + cycle_number * duration_expected_working * 100.0 / alternative_workcenter.time_efficiency
+            alternative_wc_cycle_nb = float_round(qty_production / alternative_workcenter.capacity, precision_digits=0, rounding_method='UP')
+            return alternative_workcenter.time_start + alternative_workcenter.time_stop + alternative_wc_cycle_nb * duration_expected_working * 100.0 / alternative_workcenter.time_efficiency
         time_cycle = self.operation_id.time_cycle
         return self.workcenter_id.time_start + self.workcenter_id.time_stop + cycle_number * time_cycle * 100.0 / self.workcenter_id.time_efficiency
 


### PR DESCRIPTION
**Steps to reproduce the bug:**
- Create the workcenter_1:
    - Time Efficiency: 100%
    - Capacity: 2
    - Setup Time: 1
    - Cleanup Time: 1

- Create the workcenter_2:
    - Time Efficiency: 100%
     - Capacity: 4
    - Setup Time: 10
    - Cleanup Time: 5
    - Alternative Work centers: **workcenter_1**

- Create a storable product “**P1**” with BOM:
    - Add any product as component
    - Add operation:
        - Duration: 60
        - Work center: Workcenter_2

- Create a MO:
    - select “P1” as Product
    - Qty to produce: 4
    - Confirm and Plan

**Problem:**
The workcenter_1 is chosen while work_center_2 is faster it can manufacture the 4 units at the same time
while workcenter_1 must do two cycles

As the Time Efficiency = 100%, so:
_Total duration_ = (Setup Time + Cleanup Time) + duration_by_unit * nb_cycle
_Work_center_1_ = (1 + 1) + 60 * 2 = 122
_Work_center_2_ = (10 + 5) + 60 = 75

The calculation is bad because we use the number of cycles necessary for the work_center defined in the BOM
in the calculation for the alternative work center

opw-2821749




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
