### PR TITLE
[FIX] web_editor : fix paste behaviors

### DIFF
--- a/addons/web_editor/static/lib/odoo-editor/src/OdooEditor.js
+++ b/addons/web_editor/static/lib/odoo-editor/src/OdooEditor.js
@@ -1287,7 +1287,9 @@ export class OdooEditor extends EventTarget {
         let start = range.startContainer;
         let end = range.endContainer;
         // Let the DOM split and delete the range.
-        const doJoin = closestBlock(start) !== closestBlock(range.commonAncestorContainer);
+        const doJoin =
+            closestBlock(start) !== closestBlock(range.commonAncestorContainer) ||
+            closestBlock(end) !== closestBlock(range.commonAncestorContainer) ;
         let next = nextLeaf(end, this.editable);
         const splitEndTd = closestElement(end, 'td') && end.nextSibling;
         const contents = range.extractContents();

--- a/addons/web_editor/static/lib/odoo-editor/src/OdooEditor.js
+++ b/addons/web_editor/static/lib/odoo-editor/src/OdooEditor.js
@@ -79,7 +79,7 @@ const CLIPBOARD_BLACKLISTS = {
     unwrap: ['.Apple-interchange-newline', 'DIV'], // These elements' children will be unwrapped.
     remove: ['META', 'STYLE', 'SCRIPT'], // These elements will be removed along with their children.
 };
-const CLIPBOARD_WHITELISTS = {
+export const CLIPBOARD_WHITELISTS = {
     nodes: [
         // Style
         'P',

--- a/addons/web_editor/static/lib/odoo-editor/src/OdooEditor.js
+++ b/addons/web_editor/static/lib/odoo-editor/src/OdooEditor.js
@@ -2924,6 +2924,7 @@ export class OdooEditor extends EventTarget {
      */
     _onPaste(ev) {
         ev.preventDefault();
+        const sel = this.document.getSelection();
         const files = getImageFiles(ev.clipboardData);
         const clipboardHtml = ev.clipboardData.getData('text/html');
         if (files.length) {
@@ -2934,15 +2935,18 @@ export class OdooEditor extends EventTarget {
             const text = ev.clipboardData.getData('text/plain');
             const splitAroundUrl = text.split(URL_REGEX);
             const linkAttributes = this.options.defaultLinkAttributes || {};
+            const selectionIsInsideALink = !!closestElement(sel.anchorNode, 'a');
 
             for (let i = 0; i < splitAroundUrl.length; i++) {
+                const url = /^https?:\/\//gi.test(splitAroundUrl[i])
+                    ? splitAroundUrl[i]
+                    : 'https://' + splitAroundUrl[i];
+                const youtubeUrl = YOUTUBE_URL_GET_VIDEO_ID.exec(url);
+                const urlFileExtention = url.split('.').pop();
+                const isImageUrl = ['jpg', 'jpeg', 'png', 'gif'].includes(urlFileExtention.toLowerCase());
                 // Even indexes will always be plain text, and odd indexes will always be URL.
-                if (i % 2) {
-                    const url = /^https?:\/\//gi.test(splitAroundUrl[i])
-                        ? splitAroundUrl[i]
-                        : 'https://' + splitAroundUrl[i];
-                    const youtubeUrl = YOUTUBE_URL_GET_VIDEO_ID.exec(url);
-                    const urlFileExtention = url.split('.').pop();
+                // only allow images emebed inside an existing link. No other url or video embed.
+                if (i % 2 && (isImageUrl || !selectionIsInsideALink)) {
                     const baseEmbedCommand = [
                         {
                             groupName: 'paste',
@@ -2958,6 +2962,9 @@ export class OdooEditor extends EventTarget {
                                 }
                                 link.innerText = splitAroundUrl[i];
                                 const sel = this.document.getSelection();
+                                if (!sel.isCollapsed) {
+                                    this.deleteRange(sel);
+                                }
                                 if (sel.rangeCount) {
                                     sel.getRangeAt(0).insertNode(link);
                                     sel.collapseToEnd();
@@ -2983,7 +2990,7 @@ export class OdooEditor extends EventTarget {
                         this.historyStep(true);
                     };
 
-                    if (['jpg', 'jpeg', 'png', 'gif'].includes(urlFileExtention)) {
+                    if (isImageUrl) {
                         const stepIndexBeforeInsert = this._historySteps.length - 1;
                         this.execCommand('insertText', splitAroundUrl[i]);
                         this.commandBar.open({
@@ -2999,6 +3006,9 @@ export class OdooEditor extends EventTarget {
                                             const img = document.createElement('IMG');
                                             img.setAttribute('src', url);
                                             const sel = this.document.getSelection();
+                                            if (!sel.isCollapsed) {
+                                                this.deleteRange(sel);
+                                            }
                                             if (sel.rangeCount) {
                                                 sel.getRangeAt(0).insertNode(img);
                                                 sel.collapseToEnd();
@@ -3041,6 +3051,9 @@ export class OdooEditor extends EventTarget {
                                                 videoElement.setAttribute('allowfullscreen', '1');
                                             }
                                             const sel = this.document.getSelection();
+                                            if (!sel.isCollapsed) {
+                                                this.deleteRange(sel);
+                                            }
                                             if (sel.rangeCount) {
                                                 sel.getRangeAt(0).insertNode(videoElement);
                                                 sel.collapseToEnd();
@@ -3058,6 +3071,9 @@ export class OdooEditor extends EventTarget {
                         }
                         link.innerText = splitAroundUrl[i];
                         const sel = this.document.getSelection();
+                        if (!sel.isCollapsed) {
+                            this.deleteRange(sel);
+                        }
                         if (sel.rangeCount) {
                             sel.getRangeAt(0).insertNode(link);
                             sel.collapseToEnd();

--- a/addons/web_editor/static/lib/odoo-editor/src/OdooEditor.js
+++ b/addons/web_editor/static/lib/odoo-editor/src/OdooEditor.js
@@ -169,7 +169,7 @@ function getImageUrl (file) {
                 return reject(reader.error);
             }
             resolve(e.target.result);
-        }
+        };
     });
 }
 export class OdooEditor extends EventTarget {
@@ -2077,7 +2077,7 @@ export class OdooEditor extends EventTarget {
 
         for (const tableElement of container.querySelectorAll('table')) {
             tableElement.classList.add('table', 'table-bordered');
-        };
+        }
 
         for (const child of [...container.childNodes]) {
             this._cleanForPaste(child);
@@ -2948,7 +2948,7 @@ export class OdooEditor extends EventTarget {
                         callback();
 
                         this.historyStep(true);
-                    }
+                    };
 
                     if (['jpg', 'jpeg', 'png', 'gif'].includes(urlFileExtention)) {
                         const stepIndexBeforeInsert = this._historySteps.length - 1;

--- a/addons/web_editor/static/lib/odoo-editor/src/commands/commands.js
+++ b/addons/web_editor/static/lib/odoo-editor/src/commands/commands.js
@@ -48,75 +48,130 @@ const BG_CLASSES_REGEX = /\bbg-[^\s]*\b/g;
 function insert(editor, data, isText = true) {
     const selection = editor.document.getSelection();
     const range = selection.getRangeAt(0);
-    let startNode;
+    let currentNode;
     let insertBefore = false;
     if (selection.isCollapsed) {
         if (range.startContainer.nodeType === Node.TEXT_NODE) {
             insertBefore = !range.startOffset;
             splitTextNode(range.startContainer, range.startOffset, DIRECTIONS.LEFT);
-            startNode = range.startContainer;
+            currentNode = range.startContainer;
         }
     } else {
         editor.deleteRange(selection);
     }
-    startNode = startNode || editor.document.getSelection().anchorNode;
-    if (startNode.nodeType === Node.ELEMENT_NODE) {
+    currentNode = currentNode || editor.document.getSelection().anchorNode;
+    if (currentNode.nodeType === Node.ELEMENT_NODE) {
         if (selection.anchorOffset === 0) {
-            startNode.prepend(editor.document.createTextNode(''));
-            startNode = startNode.firstChild;
+            currentNode.prepend(editor.document.createTextNode(''));
+            currentNode = currentNode.firstChild;
         } else {
-            startNode = startNode.childNodes[selection.anchorOffset - 1];
+            currentNode = currentNode.childNodes[selection.anchorOffset - 1];
         }
     }
 
     const fakeEl = document.createElement('fake-element');
+    const fakeElFirstChild = document.createElement('fake-element-fc');
+    const fakeElLastChild = document.createElement('fake-element-lc');
     if (isText) {
         fakeEl.innerText = data;
     } else {
         fakeEl.innerHTML = data;
     }
+
+    // In case the html inserted is all contained in a single root <P> tag,
+    // we take the all content of the <p> and avoid inserting the <p>.
+    if (fakeEl.firstChild === fakeEl.lastChild && fakeEl.firstChild.nodeName === 'P') {
+        const p = fakeEl.firstElementChild;
+        fakeEl.replaceChildren(...p.childNodes);
+    } else if (fakeEl.childElementCount > 1) {
+        // Grab the content of the first child block and isolate it.
+        if (isBlock(fakeEl.firstChild)) {
+            fakeElFirstChild.replaceChildren(...fakeEl.firstElementChild.childNodes);
+            fakeEl.firstElementChild.remove();
+        }
+        // Grab the content of the last child block and isolate it.
+        if (isBlock(fakeEl.lastChild)) {
+            fakeElLastChild.replaceChildren(...fakeEl.lastElementChild.childNodes);
+            fakeEl.lastElementChild.remove();
+        }
+    }
+
+    // if we have isolated block content,
+    // first we split the current focus element if it's a block
+    // then we insert the content in the right places
+    let lastChildNode = false;
+    if (fakeElLastChild.hasChildNodes()) {
+        let tempCurrentNode = currentNode;
+        for (const n of [...fakeElLastChild.childNodes]) {
+            tempCurrentNode.after(n);
+            tempCurrentNode = n;
+        }
+        lastChildNode = tempCurrentNode;
+    }
+
+    if (fakeElFirstChild.hasChildNodes()) {
+        for (const n of [...fakeElFirstChild.childNodes]) {
+            currentNode.after(n);
+            currentNode = n;
+        }
+    }
+
+    // If all the Html have been isolated, We force a split of the parent element
+    // to have the need new line in the final result
+    if (!fakeEl.hasChildNodes()) {
+        if (isUnbreakable(closestBlock(currentNode.nextSibling))) {
+            currentNode.nextSibling.oShiftEnter(0);
+        } else {
+            // If we arrive here, the o_enter index should always be 0.
+            const parent = currentNode.nextSibling.parentElement;
+            const index = [...parent.childNodes].indexOf(currentNode.nextSibling);
+            currentNode.nextSibling.parentElement.oEnter(index);
+        }
+    }
+
     let nodeToInsert;
     const insertedNodes = [...fakeEl.childNodes];
     while ((nodeToInsert = fakeEl.childNodes[0])) {
-        if (isBlock(nodeToInsert) && !allowsParagraphRelatedElements(startNode)) {
+        if (isBlock(nodeToInsert) && !allowsParagraphRelatedElements(currentNode)) {
             // Split blocks at the edges if inserting new blocks (preventing
             // <p><p>text</p></p> scenarios).
             while (
-                startNode.parentElement !== editor.editable &&
-                !allowsParagraphRelatedElements(startNode.parentElement)
+                currentNode.parentElement !== editor.editable &&
+                !allowsParagraphRelatedElements(currentNode.parentElement)
             ) {
-                if (isUnbreakable(startNode.parentElement)) {
+                if (isUnbreakable(currentNode.parentElement)) {
                     makeContentsInline(fakeEl);
                     nodeToInsert = fakeEl.childNodes[0];
                     break;
                 }
-                let offset = childNodeIndex(startNode);
+                let offset = childNodeIndex(currentNode);
                 if (!insertBefore) {
                     offset += 1;
                 }
                 if (offset) {
-                    const [left, right] = splitElement(startNode.parentElement, offset);
-                    startNode = insertBefore ? right : left;
+                    const [left, right] = splitElement(currentNode.parentElement, offset);
+                    currentNode = insertBefore ? right : left;
                 } else {
-                    startNode = startNode.parentElement;
+                    currentNode = currentNode.parentElement;
                 }
             }
         }
         if (insertBefore) {
-            startNode.before(nodeToInsert);
+            currentNode.before(nodeToInsert);
             insertBefore = false;
         } else {
-            startNode.after(nodeToInsert);
+            currentNode.after(nodeToInsert);
         }
-        if (startNode.tagName !== 'BR' && isShrunkBlock(startNode)) {
-            startNode.remove();
+        if (currentNode.tagName !== 'BR' && isShrunkBlock(currentNode)) {
+            currentNode.remove();
         }
-        startNode = nodeToInsert;
+        currentNode = nodeToInsert;
     }
 
+    currentNode = lastChildNode || currentNode;
     selection.removeAllRanges();
     const newRange = new Range();
-    const lastPosition = rightPos(startNode);
+    const lastPosition = rightPos(currentNode);
     newRange.setStart(lastPosition[0], lastPosition[1]);
     newRange.setEnd(lastPosition[0], lastPosition[1]);
     selection.addRange(newRange);

--- a/addons/web_editor/static/lib/odoo-editor/src/powerbox/Powerbox.js
+++ b/addons/web_editor/static/lib/odoo-editor/src/powerbox/Powerbox.js
@@ -12,6 +12,7 @@ function cycle(num, max) {
 
 export class Powerbox {
     constructor(options = {}) {
+        this._active = false;
         this.options = options;
         this.options.width = this.options.width || 340;
         if (!this.options._t) this.options._t = string => string;

--- a/addons/web_editor/static/lib/odoo-editor/src/utils/utils.js
+++ b/addons/web_editor/static/lib/odoo-editor/src/utils/utils.js
@@ -1444,7 +1444,7 @@ export function splitAroundUntil(elements, limitAncestor) {
 }
 
 export function insertText(sel, content) {
-    if (sel.anchorNode.nodeType == Node.TEXT_NODE) {
+    if (sel.anchorNode.nodeType === Node.TEXT_NODE) {
         const pos = [sel.anchorNode.parentElement, splitTextNode(sel.anchorNode, sel.anchorOffset)];
         setSelection(...pos, ...pos, false);
     }

--- a/addons/web_editor/static/lib/odoo-editor/test/editor-test.js
+++ b/addons/web_editor/static/lib/odoo-editor/test/editor-test.js
@@ -2,6 +2,7 @@ import './spec/utils.test.js';
 import './spec/align.test.js';
 import './spec/color.test.js';
 import './spec/editor.test.js';
+import './spec/copyPaste.test.js';
 import './spec/list.test.js';
 import './spec/link.test.js';
 import './spec/fontSize.test.js';

--- a/addons/web_editor/static/lib/odoo-editor/test/spec/copyPaste.test.js
+++ b/addons/web_editor/static/lib/odoo-editor/test/spec/copyPaste.test.js
@@ -1,0 +1,1284 @@
+import {
+    BasicEditor, customErrorMessage,
+    testEditor
+} from "../utils.js";
+import {CLIPBOARD_WHITELISTS} from "../../src/OdooEditor.js";
+
+// Mock an paste event and send it to the editor.
+const pasteData = async function (editor, text, type) {
+    var mockEvent = {
+        dataType: 'text/plain',
+        data: text,
+        clipboardData: {
+            getData: (datatype) => type === datatype ? text : null,
+            files: [],
+            items: [],
+        },
+        preventDefault: () => {},
+    };
+    await editor._onPaste(mockEvent);
+};
+
+const pasteText = async (editor, text) => pasteData(editor, text, 'text/plain');
+const pasteHtml = async (editor, html) => pasteData(editor, html, 'text/html');
+
+describe('Copy and paste', () => {
+    describe('Html Paste cleaning', () => {
+        describe('whitelist', async () => {
+            it('should keep whitelisted Tags tag', async () => {
+                const tagsToKeep = [
+                    'a<img src="http://www.imgurl.com/img.jpg">d', // img tag
+                    'a<br>b' // br tags
+                ];
+
+                for (const node of CLIPBOARD_WHITELISTS.nodes) {
+                    if (!['TABLE', 'THEAD', 'TH', 'TBODY', 'TR', 'TD', 'IMG', 'BR', '.fa'].includes(node)) {
+                        tagsToKeep.push(`a<${node.toLowerCase()}>b</${node.toLowerCase()}>c`);
+                    }
+                }
+
+                for (const tagToKeep of tagsToKeep) {
+                    await testEditor(BasicEditor, {
+                        contentBefore: '123[]',
+                        stepFunction: async editor => {
+                            await pasteHtml(editor, tagToKeep);
+                        },
+                        contentAfter: '123' + tagToKeep + '[]',
+                    });
+                }
+            });
+            it('should keep tables Tags tag and add classes', async () => {
+                await testEditor(BasicEditor, {
+                    contentBefore: '123[]',
+                    stepFunction: async editor => {
+                        await pasteHtml(editor, 'a<table><thead><tr><th>h</th></tr></thead><tbody><tr><td>b</td></tr></tbody></table>d');
+                    },
+                    contentAfter: '123a<table class="table table-bordered"><thead><tr><th>h</th></tr></thead><tbody><tr><td>b</td></tr></tbody></table>d[]',
+                });
+            });
+            it('should not keep span', async () => {
+                await testEditor(BasicEditor, {
+                    contentBefore: '123[]',
+                    stepFunction: async editor => {
+                        await pasteHtml(editor, 'a<span>bc</span>d');
+                    },
+                    contentAfter: '123abcd[]',
+                });
+            });
+            it('should keep styled span', async () => {
+                await testEditor(BasicEditor, {
+                    contentBefore: '123[]',
+                    stepFunction: async editor => {
+                        await pasteHtml(editor, 'a<span style="text-decoration: underline">bc</span>d');
+                    },
+                    contentAfter: '123a<span style="text-decoration: underline">bc</span>d[]',
+                });
+            });
+        });
+    });
+    describe('Simple text', () => {
+        describe('range collapsed', async () => {
+            it('should paste a text in a p', async () => {
+                await testEditor(BasicEditor, {
+                    contentBefore: '<p>ab[]cd</p>',
+                    stepFunction: async editor => {
+                        await pasteText(editor, 'x');
+                    },
+                    contentAfter: '<p>abx[]cd</p>',
+                });
+                await testEditor(BasicEditor, {
+                    contentBefore: '<p>ab[]cd</p>',
+                    stepFunction: async editor => {
+                        await pasteText(editor, 'xyz 123');
+                    },
+                    contentAfter: '<p>abxyz 123[]cd</p>',
+                });
+                await testEditor(BasicEditor, {
+                    contentBefore: '<p>ab[]cd</p>',
+                    stepFunction: async editor => {
+                        await pasteText(editor, 'x    y');
+                    },
+                    contentAfter: '<p>abx    y[]cd</p>',
+                });
+            });
+            it('should paste a text in a span', async () => {
+                await testEditor(BasicEditor, {
+                    contentBefore: '<p>a<span>b[]c</span>d</p>',
+                    stepFunction: async editor => {
+                        await pasteText(editor, 'x');
+                    },
+                    contentAfter: '<p>a<span>bx[]c</span>d</p>',
+                });
+            });
+        });
+        describe('range not collapsed', async () => {
+            it('should paste a text in a p', async () => {
+                await testEditor(BasicEditor, {
+                    contentBefore: '<p>a[bc]d</p>',
+                    stepFunction: async editor => {
+                        await pasteText(editor, 'x');
+                    },
+                    contentAfter: '<p>ax[]d</p>',
+                });
+                await testEditor(BasicEditor, {
+                    contentBefore: '<p>a[bc]d</p>',
+                    stepFunction: async editor => {
+                        await pasteText(editor, 'xyz 123');
+                    },
+                    contentAfter: '<p>axyz 123[]d</p>',
+                });
+                await testEditor(BasicEditor, {
+                    contentBefore: '<p>a[bc]d</p>',
+                    stepFunction: async editor => {
+                        await pasteText(editor, 'x    y');
+                    },
+                    contentAfter: '<p>ax    y[]d</p>',
+                });
+            });
+            it('should paste a text in a span', async () => {
+                await testEditor(BasicEditor, {
+                    contentBefore: '<p>a<span>b[cd]e</span>f</p>',
+                    stepFunction: async editor => {
+                        await pasteText(editor, 'x');
+                    },
+                    contentAfter: '<p>a<span>bx[]e</span>f</p>',
+                });
+            });
+            it('should paste a text when selection across two span', async () => {
+                await testEditor(BasicEditor, {
+                    contentBefore: '<p>a<span>b[c</span><span>d]e</span>f</p>',
+                    stepFunction: async editor => {
+                        await pasteText(editor, 'x');
+                    },
+                    contentAfter: '<p>a<span>bx[]e</span>f</p>',
+                });
+                await testEditor(BasicEditor, {
+                    contentBefore: '<p>a<span>b[c</span>- -<span>d]e</span>f</p>',
+                    stepFunction: async editor => {
+                        await pasteText(editor, 'y');
+                    },
+                    contentAfter: '<p>a<span>by[]e</span>f</p>',
+                });
+            });
+            it('should paste a text when selection across two p', async () => {
+                await testEditor(BasicEditor, {
+                    contentBefore: '<div>a<p>b[c</p><p>d]e</p>f</div>',
+                    stepFunction: async editor => {
+                        await pasteText(editor, 'x');
+                    },
+                    contentAfter: '<div>a<p>bx[]e</p>f</div>',
+                });
+                await testEditor(BasicEditor, {
+                    contentBefore: '<div>a<p>b[c</p>- -<p>d]e</p>f</div>',
+                    stepFunction: async editor => {
+                        await pasteText(editor, 'y');
+                    },
+                    contentAfter: '<div>a<p>by[]e</p>f</div>',
+                });
+            });
+            it('should paste a text when selection leave a span', async () => {
+                await testEditor(BasicEditor, {
+                    contentBefore: '<div>ab<span>c[d</span>e]f</div>',
+                    stepFunction: async editor => {
+                        await pasteText(editor, 'x');
+                    },
+                    contentAfter: '<div>ab<span>cx[]</span>f</div>',
+                });
+                await testEditor(BasicEditor, {
+                    contentBefore: '<div>a[b<span>c]d</span>ef</div>',
+                    stepFunction: async editor => {
+                        await pasteText(editor, 'y');
+                    },
+                    contentAfter: '<div>ay[]<span>d</span>ef</div>',
+                });
+            });
+            it('should paste a text when selection across two element', async () => {
+                await testEditor(BasicEditor, {
+                    contentBefore: '<div>1a<p>b[c</p><span>d]e</span>f</div>',
+                    stepFunction: async editor => {
+                        await pasteText(editor, 'x');
+                    },
+                    contentAfter: '<div>1a<p>bx[]<span>e</span>f</p></div>',
+                });
+                await testEditor(BasicEditor, {
+                    contentBefore: '<div>2a<span>b[c</span><p>d]e</p>f</div>',
+                    stepFunction: async editor => {
+                        await pasteText(editor, 'x');
+                    },
+                    contentAfter: '<div>2a<span>bx[]</span>e<br>f</div>',
+                });
+            });
+        });
+    });
+    describe('Simple html span', () => {
+        const simpleHtmlCharX = '<span style="color: rgb(0, 0, 0); font-family: -apple-system, BlinkMacSystemFont, &quot;Segoe UI&quot;, Roboto, &quot;Helvetica Neue&quot;, Arial, &quot;Noto Sans&quot;, sans-serif, &quot;Apple Color Emoji&quot;, &quot;Segoe UI Emoji&quot;, &quot;Segoe UI Symbol&quot;, &quot;Noto Color Emoji&quot;; font-size: 16px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: left; text-indent: 0px; text-transform: none; white-space: normal; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; background-color: rgb(255, 255, 255); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial; display: inline !important; float: none;">x</span>';
+        describe('range collapsed', async () => {
+            it('should paste a text in a p', async () => {
+                await testEditor(BasicEditor, {
+                    contentBefore: '<p>ab[]cd</p>',
+                    stepFunction: async editor => {
+                        await pasteHtml(editor, simpleHtmlCharX);
+                    },
+                    contentAfter: '<p>abx[]cd</p>',
+                });
+            });
+            it('should paste a text in a span', async () => {
+                await testEditor(BasicEditor, {
+                    contentBefore: '<p>a<span>b[]c</span>d</p>',
+                    stepFunction: async editor => {
+                        await pasteHtml(editor, simpleHtmlCharX);
+                    },
+                    contentAfter: '<p>a<span>bx[]c</span>d</p>',
+                });
+            });
+        });
+        describe('range not collapsed', async () => {
+            it('should paste a text in a p', async () => {
+                await testEditor(BasicEditor, {
+                    contentBefore: '<p>a[bc]d</p>',
+                    stepFunction: async editor => {
+                        await pasteHtml(editor, simpleHtmlCharX);
+                    },
+                    contentAfter: '<p>ax[]d</p>',
+                });
+            });
+            it('should paste a text in a span', async () => {
+                await testEditor(BasicEditor, {
+                    contentBefore: '<p>a<span>b[cd]e</span>f</p>',
+                    stepFunction: async editor => {
+                        await pasteHtml(editor, simpleHtmlCharX);
+                    },
+                    contentAfter: '<p>a<span>bx[]e</span>f</p>',
+                });
+            });
+            it('should paste a text when selection across two span', async () => {
+                await testEditor(BasicEditor, {
+                    contentBefore: '<p>a<span>b[c</span><span>d]e</span>f</p>',
+                    stepFunction: async editor => {
+                        await pasteHtml(editor, simpleHtmlCharX);
+                    },
+                    contentAfter: '<p>a<span>bx[]e</span>f</p>',
+                });
+                await testEditor(BasicEditor, {
+                    contentBefore: '<p>a<span>b[c</span>- -<span>d]e</span>f</p>',
+                    stepFunction: async editor => {
+                        await pasteHtml(editor, simpleHtmlCharX);
+                    },
+                    contentAfter: '<p>a<span>bx[]e</span>f</p>',
+                });
+            });
+            it('should paste a text when selection across two p', async () => {
+                await testEditor(BasicEditor, {
+                    contentBefore: '<div>1a<p>b[c</p><p>d]e</p>f</div>',
+                    stepFunction: async editor => {
+                        await pasteHtml(editor, simpleHtmlCharX);
+                    },
+                    contentAfter: '<div>1a<p>bx[]e</p>f</div>',
+                });
+                await testEditor(BasicEditor, {
+                    contentBefore: '<div>2a<p>b[c</p>- -<p>d]e</p>f</div>',
+                    stepFunction: async editor => {
+                        await pasteHtml(editor, simpleHtmlCharX);
+                    },
+                    contentAfter: '<div>2a<p>bx[]e</p>f</div>',
+                });
+            });
+            it('should paste a text when selection leave a span', async () => {
+                await testEditor(BasicEditor, {
+                    contentBefore: '<div>ab<span>c[d</span>e]f</div>',
+                    stepFunction: async editor => {
+                        await pasteHtml(editor, simpleHtmlCharX);
+                    },
+                    contentAfter: '<div>ab<span>cx[]</span>f</div>',
+                });
+                await testEditor(BasicEditor, {
+                    contentBefore: '<div>a[b<span>c]d</span>ef</div>',
+                    stepFunction: async editor => {
+                        await pasteHtml(editor, simpleHtmlCharX);
+                    },
+                    contentAfter: '<div>ax[]<span>d</span>ef</div>',
+                });
+            });
+            it('should paste a text when selection across two element', async () => {
+                await testEditor(BasicEditor, {
+                    contentBefore: '<div>1a<p>b[c</p><span>d]e</span>f</div>',
+                    stepFunction: async editor => {
+                        await pasteHtml(editor, simpleHtmlCharX);
+                    },
+                    contentAfter: '<div>1a<p>bx[]<span>e</span>f</p></div>',
+                });
+                await testEditor(BasicEditor, {
+                    contentBefore: '<div>2a<span>b[c</span><p>d]e</p>f</div>',
+                    stepFunction: async editor => {
+                        await pasteHtml(editor, simpleHtmlCharX);
+                    },
+                    contentAfter: '<div>2a<span>bx[]</span>e<br>f</div>',
+                });
+                await testEditor(BasicEditor, {
+                    contentBefore: '<div>3a<p>b[c</p><p>d]e</p>f</div>',
+                    stepFunction: async editor => {
+                        await pasteHtml(editor, simpleHtmlCharX);
+                    },
+                    contentAfter: '<div>3a<p>bx[]e</p>f</div>',
+                });
+            });
+        });
+    });
+    describe('Simple html p', () => {
+        const simpleHtmlCharX = '<p>x</p>';
+        describe('range collapsed', async () => {
+            it('should paste a text in a p', async () => {
+                await testEditor(BasicEditor, {
+                    contentBefore: '<p>ab[]cd</p>',
+                    stepFunction: async editor => {
+                        await pasteHtml(editor, simpleHtmlCharX);
+                    },
+                    contentAfter: '<p>abx[]cd</p>',
+                });
+            });
+            it('should paste a text in a span', async () => {
+                await testEditor(BasicEditor, {
+                    contentBefore: '<p>a<span>b[]c</span>d</p>',
+                    stepFunction: async editor => {
+                        await pasteHtml(editor, simpleHtmlCharX);
+                    },
+                    contentAfter: '<p>a<span>bx[]c</span>d</p>',
+                });
+            });
+        });
+        describe('range not collapsed', async () => {
+            it('should paste a text in a p', async () => {
+                await testEditor(BasicEditor, {
+                    contentBefore: '<p>a[bc]d</p>',
+                    stepFunction: async editor => {
+                        await pasteHtml(editor, simpleHtmlCharX);
+                    },
+                    contentAfter: '<p>ax[]d</p>',
+                });
+            });
+            it('should paste a text in a span', async () => {
+                await testEditor(BasicEditor, {
+                    contentBefore: '<p>a<span>b[cd]e</span>f</p>',
+                    stepFunction: async editor => {
+                        await pasteHtml(editor, simpleHtmlCharX);
+                    },
+                    contentAfter: '<p>a<span>bx[]e</span>f</p>',
+                });
+            });
+            it('should paste a text when selection across two span', async () => {
+                await testEditor(BasicEditor, {
+                    contentBefore: '<p>a<span>b[c</span><span>d]e</span>f</p>',
+                    stepFunction: async editor => {
+                        await pasteHtml(editor, simpleHtmlCharX);
+                    },
+                    contentAfter: '<p>a<span>bx[]e</span>f</p>',
+                });
+                await testEditor(BasicEditor, {
+                    contentBefore: '<p>a<span>b[c</span>- -<span>d]e</span>f</p>',
+                    stepFunction: async editor => {
+                        await pasteHtml(editor, simpleHtmlCharX);
+                    },
+                    contentAfter: '<p>a<span>bx[]e</span>f</p>',
+                });
+            });
+            it('should paste a text when selection across two p', async () => {
+                await testEditor(BasicEditor, {
+                    contentBefore: '<div>1a<p>b[c</p><p>d]e</p>f</div>',
+                    stepFunction: async editor => {
+                        await pasteHtml(editor, simpleHtmlCharX);
+                    },
+                    contentAfter: '<div>1a<p>bx[]e</p>f</div>',
+                });
+                await testEditor(BasicEditor, {
+                    contentBefore: '<div>2a<p>b[c</p>- -<p>d]e</p>f</div>',
+                    stepFunction: async editor => {
+                        await pasteHtml(editor, simpleHtmlCharX);
+                    },
+                    contentAfter: '<div>2a<p>bx[]e</p>f</div>',
+                });
+            });
+            it('should paste a text when selection leave a span', async () => {
+                await testEditor(BasicEditor, {
+                    contentBefore: '<div>ab<span>c[d</span>e]f</div>',
+                    stepFunction: async editor => {
+                        await pasteHtml(editor, simpleHtmlCharX);
+                    },
+                    contentAfter: '<div>ab<span>cx[]</span>f</div>',
+                });
+                await testEditor(BasicEditor, {
+                    contentBefore: '<div>a[b<span>c]d</span>ef</div>',
+                    stepFunction: async editor => {
+                        await pasteHtml(editor, simpleHtmlCharX);
+                    },
+                    contentAfter: '<div>ax[]<span>d</span>ef</div>',
+                });
+            });
+            it('should paste a text when selection across two element', async () => {
+                await testEditor(BasicEditor, {
+                    contentBefore: '<div>1a<p>b[c</p><span>d]e</span>f</div>',
+                    stepFunction: async editor => {
+                        await pasteHtml(editor, simpleHtmlCharX);
+                    },
+                    contentAfter: '<div>1a<p>bx[]<span>e</span>f</p></div>',
+                });
+                await testEditor(BasicEditor, {
+                    contentBefore: '<div>2a<span>b[c</span><p>d]e</p>f</div>',
+                    stepFunction: async editor => {
+                        await pasteHtml(editor, simpleHtmlCharX);
+                    },
+                    contentAfter: '<div>2a<span>bx[]</span>e<br>f</div>',
+                });
+                await testEditor(BasicEditor, {
+                    contentBefore: '<div>3a<p>b[c</p><p>d]e</p>f</div>',
+                    stepFunction: async editor => {
+                        await pasteHtml(editor, simpleHtmlCharX);
+                    },
+                    contentAfter: '<div>3a<p>bx[]e</p>f</div>',
+                });
+            });
+        });
+    });
+    describe('Complex html span', () => {
+        const complexHtmlData = '<span style="color: rgb(0, 0, 0); font-family: -apple-system, BlinkMacSystemFont, &quot;Segoe UI&quot;, Roboto, &quot;Helvetica Neue&quot;, Arial, &quot;Noto Sans&quot;, sans-serif, &quot;Apple Color Emoji&quot;, &quot;Segoe UI Emoji&quot;, &quot;Segoe UI Symbol&quot;, &quot;Noto Color Emoji&quot;; font-size: 16px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: left; text-indent: 0px; text-transform: none; white-space: normal; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; background-color: rgb(255, 255, 255); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial; display: inline !important; float: none;">1</span><b style="box-sizing: border-box; font-weight: bolder; color: rgb(0, 0, 0); font-family: -apple-system, BlinkMacSystemFont, &quot;Segoe UI&quot;, Roboto, &quot;Helvetica Neue&quot;, Arial, &quot;Noto Sans&quot;, sans-serif, &quot;Apple Color Emoji&quot;, &quot;Segoe UI Emoji&quot;, &quot;Segoe UI Symbol&quot;, &quot;Noto Color Emoji&quot;; font-size: 16px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; letter-spacing: normal; orphans: 2; text-align: left; text-indent: 0px; text-transform: none; white-space: normal; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; background-color: rgb(255, 255, 255); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">23</b><span style="color: rgb(0, 0, 0); font-family: -apple-system, BlinkMacSystemFont, &quot;Segoe UI&quot;, Roboto, &quot;Helvetica Neue&quot;, Arial, &quot;Noto Sans&quot;, sans-serif, &quot;Apple Color Emoji&quot;, &quot;Segoe UI Emoji&quot;, &quot;Segoe UI Symbol&quot;, &quot;Noto Color Emoji&quot;; font-size: 16px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: left; text-indent: 0px; text-transform: none; white-space: normal; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; background-color: rgb(255, 255, 255); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial; display: inline !important; float: none;"><span> </span>4</span>';
+        describe('range collapsed', async () => {
+            it('should paste a text in a p', async () => {
+                await testEditor(BasicEditor, {
+                    contentBefore: '<p>ab[]cd</p>',
+                    stepFunction: async editor => {
+                        await pasteHtml(editor, complexHtmlData);
+                    },
+                    contentAfter: '<p>ab1<b>23</b>&nbsp;4[]cd</p>',
+                });
+            });
+            it('should paste a text in a span', async () => {
+                await testEditor(BasicEditor, {
+                    contentBefore: '<p>a<span>b[]c</span>d</p>',
+                    stepFunction: async editor => {
+                        await pasteHtml(editor, complexHtmlData);
+                    },
+                    contentAfter: '<p>a<span>b1<b>23</b>&nbsp;4[]c</span>d</p>',
+                });
+            });
+        });
+        describe('range not collapsed', async () => {
+            it('should paste a text in a p', async () => {
+                await testEditor(BasicEditor, {
+                    contentBefore: '<p>a[bc]d</p>',
+                    stepFunction: async editor => {
+                        await pasteHtml(editor, complexHtmlData);
+                    },
+                    contentAfter: '<p>a1<b>23</b>&nbsp;4[]d</p>',
+                });
+            });
+            it('should paste a text in a span', async () => {
+                await testEditor(BasicEditor, {
+                    contentBefore: '<p>a<span>b[cd]e</span>f</p>',
+                    stepFunction: async editor => {
+                        await pasteHtml(editor, complexHtmlData);
+                    },
+                    contentAfter: '<p>a<span>b1<b>23</b>&nbsp;4[]e</span>f</p>',
+                });
+            });
+            it('should paste a text when selection across two span', async () => {
+                await testEditor(BasicEditor, {
+                    contentBefore: '<p>a<span>b[c</span><span>d]e</span>f</p>',
+                    stepFunction: async editor => {
+                        await pasteHtml(editor, complexHtmlData);
+                    },
+                    contentAfter: '<p>a<span>b1<b>23</b>&nbsp;4[]e</span>f</p>',
+                });
+                await testEditor(BasicEditor, {
+                    contentBefore: '<p>a<span>b[c</span>- -<span>d]e</span>f</p>',
+                    stepFunction: async editor => {
+                        await pasteHtml(editor, complexHtmlData);
+                    },
+                    contentAfter: '<p>a<span>b1<b>23</b>&nbsp;4[]e</span>f</p>',
+                });
+            });
+            it('should paste a text when selection across two p', async () => {
+                await testEditor(BasicEditor, {
+                    contentBefore: '<div>a<p>b[c</p><p>d]e</p>f</div>',
+                    stepFunction: async editor => {
+                        await pasteHtml(editor, complexHtmlData);
+                    },
+                    contentAfter: '<div>a<p>b1<b>23</b>&nbsp;4[]e</p>f</div>',
+                });
+                await testEditor(BasicEditor, {
+                    contentBefore: '<div>a<p>b[c</p>- -<p>d]e</p>f</div>',
+                    stepFunction: async editor => {
+                        await pasteHtml(editor, complexHtmlData);
+                    },
+                    contentAfter: '<div>a<p>b1<b>23</b>&nbsp;4[]e</p>f</div>',
+                });
+            });
+            it('should paste a text when selection leave a span', async () => {
+                await testEditor(BasicEditor, {
+                    contentBefore: '<div>ab<span>c[d</span>e]f</div>',
+                    stepFunction: async editor => {
+                        await pasteHtml(editor, complexHtmlData);
+                    },
+                    contentAfter: '<div>ab<span>c1<b>23</b>&nbsp;4[]</span>f</div>',
+                });
+                await testEditor(BasicEditor, {
+                    contentBefore: '<div>a[b<span>c]d</span>ef</div>',
+                    stepFunction: async editor => {
+                        await pasteHtml(editor, complexHtmlData);
+                    },
+                    contentAfter: '<div>a1<b>23</b>&nbsp;4[]<span>d</span>ef</div>',
+                });
+            });
+            it('should paste a text when selection across two element', async () => {
+                await testEditor(BasicEditor, {
+                    contentBefore: '<div>1a<p>b[c</p><span>d]e</span>f</div>',
+                    stepFunction: async editor => {
+                        await pasteHtml(editor, complexHtmlData);
+                    },
+                    contentAfter: '<div>1a<p>b1<b>23</b>&nbsp;4[]<span>e</span>f</p></div>',
+                });
+                await testEditor(BasicEditor, {
+                    contentBefore: '<div>2a<span>b[c</span><p>d]e</p>f</div>',
+                    stepFunction: async editor => {
+                        await pasteHtml(editor, complexHtmlData);
+                    },
+                    contentAfter: '<div>2a<span>b1<b>23</b>&nbsp;4[]</span>e<br>f</div>',
+                });
+                await testEditor(BasicEditor, {
+                    contentBefore: '<div>3a<p>b[c</p><p>d]e</p>f</div>',
+                    stepFunction: async editor => {
+                        await pasteHtml(editor, complexHtmlData);
+                    },
+                    contentAfter: '<div>3a<p>b1<b>23</b>&nbsp;4[]e</p>f</div>',
+                });
+            });
+        });
+    });
+    describe('Complex html p', () => {
+        const complexHtmlData = '<p style="box-sizing: border-box; margin-top: 0px; margin-bottom: 1rem; color: rgb(0, 0, 0); font-family: -apple-system, BlinkMacSystemFont, &quot;Segoe UI&quot;, Roboto, &quot;Helvetica Neue&quot;, Arial, &quot;Noto Sans&quot;, sans-serif, &quot;Apple Color Emoji&quot;, &quot;Segoe UI Emoji&quot;, &quot;Segoe UI Symbol&quot;, &quot;Noto Color Emoji&quot;; font-size: 16px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: left; text-indent: 0px; text-transform: none; white-space: normal; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; background-color: rgb(255, 255, 255); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">12</p><p style="box-sizing: border-box; margin-top: 0px; margin-bottom: 1rem; color: rgb(0, 0, 0); font-family: -apple-system, BlinkMacSystemFont, &quot;Segoe UI&quot;, Roboto, &quot;Helvetica Neue&quot;, Arial, &quot;Noto Sans&quot;, sans-serif, &quot;Apple Color Emoji&quot;, &quot;Segoe UI Emoji&quot;, &quot;Segoe UI Symbol&quot;, &quot;Noto Color Emoji&quot;; font-size: 16px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: left; text-indent: 0px; text-transform: none; white-space: normal; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; background-color: rgb(255, 255, 255); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">34</p>';
+        describe('range collapsed', async () => {
+            it('should paste a text in a p', async () => {
+                await testEditor(BasicEditor, {
+                    contentBefore: '<p>ab[]cd</p>',
+                    stepFunction: async editor => {
+                        await pasteHtml(editor, complexHtmlData);
+                    },
+                    contentAfter: '<p>ab12</p><p>34[]cd</p>',
+                });
+            });
+            it('should paste a text in a span', async () => {
+                await testEditor(BasicEditor, {
+                    contentBefore: '<p>a<span>b[]c</span>d</p>',
+                    stepFunction: async editor => {
+                        await pasteHtml(editor, complexHtmlData);
+                    },
+                    contentAfter: '<p>a<span>b12</span></p><p><span>34[]c</span>d</p>',
+                });
+            });
+        });
+        describe('range not collapsed', async () => {
+            it('should paste a text in a p', async () => {
+                await testEditor(BasicEditor, {
+                    contentBefore: '<p>a[bc]d</p>',
+                    stepFunction: async editor => {
+                        await pasteHtml(editor, complexHtmlData);
+                    },
+                    contentAfter: '<p>a12</p><p>34[]d</p>',
+                });
+            });
+            it('should paste a text in a span', async () => {
+                await testEditor(BasicEditor, {
+                    contentBefore: '<p>a<span>b[cd]e</span>f</p>',
+                    stepFunction: async editor => {
+                        await pasteHtml(editor, complexHtmlData);
+                    },
+                    contentAfter: '<p>a<span>b12</span></p><p><span>34[]e</span>f</p>',
+                });
+            });
+            it('should paste a text when selection across two span (1)', async () => {
+                await testEditor(BasicEditor, {
+                    contentBefore: '<p>1a<span>b[c</span><span>d]e</span>f</p>',
+                    stepFunction: async editor => {
+                        await pasteHtml(editor, complexHtmlData);
+                    },
+                    contentAfter: '<p>1a<span>b12</span></p><p><span>34[]e</span>f</p>',
+                });
+            });
+            it('should paste a text when selection across two span (2)', async () => {
+                await testEditor(BasicEditor, {
+                    contentBefore: '<p>2a<span>b[c</span>- -<span>d]e</span>f</p>',
+                    stepFunction: async editor => {
+                        await pasteHtml(editor, complexHtmlData);
+                    },
+                    contentAfter: '<p>2a<span>b12</span></p><p><span>34[]e</span>f</p>',
+                });
+            });
+            it('should paste a text when selection across two p', async () => {
+                await testEditor(BasicEditor, {
+                    contentBefore: '<div>a<p>b[c</p><p>d]e</p>f</div>',
+                    stepFunction: async editor => {
+                        await pasteHtml(editor, complexHtmlData);
+                    },
+                    contentAfter: '<div>a<p>b12</p><p>34[]e</p>f</div>',
+                });
+                await testEditor(BasicEditor, {
+                    contentBefore: '<div>a<p>b[c</p>- -<p>d]e</p>f</div>',
+                    stepFunction: async editor => {
+                        await pasteHtml(editor, complexHtmlData);
+                    },
+                    contentAfter: '<div>a<p>b12</p><p>34[]e</p>f</div>',
+                });
+            });
+            it('should paste a text when selection leave a span (1)', async () => {
+                await testEditor(BasicEditor, {
+                    contentBefore: '<div>1ab<span>c[d</span>e]f</div>',
+                    stepFunction: async editor => {
+                        await pasteHtml(editor, complexHtmlData);
+                    },
+                    contentAfter: '<div>1ab<span>c12<br>34[]</span>f</div>',
+                });
+                await testEditor(BasicEditor, {
+                    contentBefore: '<div>2a[b<span>c]d</span>ef</div>',
+                    stepFunction: async editor => {
+                        await pasteHtml(editor, complexHtmlData);
+                    },
+                    contentAfter: '<div>2a12<br>34[]<span>d</span>ef</div>',
+                });
+            });
+            it('should paste a text when selection leave a span (2)', async () => {
+                await testEditor(BasicEditor, {
+                    contentBefore: '<p>1ab<span>c[d</span>e]f</p>',
+                    stepFunction: async editor => {
+                        await pasteHtml(editor, complexHtmlData);
+                    },
+                    contentAfter: '<p>1ab<span>c12</span></p><p><span>34[]</span>f</p>',
+                });
+                await testEditor(BasicEditor, {
+                    contentBefore: '<p>2a[b<span>c]d</span>ef</p>',
+                    stepFunction: async editor => {
+                        await pasteHtml(editor, complexHtmlData);
+                    },
+                    contentAfter: '<p>2a12</p><p>34[]<span>d</span>ef</p>',
+                });
+            });
+            it('should paste a text when selection across two element (1)', async () => {
+                await testEditor(BasicEditor, {
+                    contentBefore: '<div>1a<p>b[c</p><span>d]e</span>f</div>',
+                    stepFunction: async editor => {
+                        await pasteHtml(editor, complexHtmlData);
+                    },
+                    // FIXME: Bringing `e` and `f` into the `<p>` is a tradeOff
+                    // Should we change it ? How ? Might warrant a discution.
+                    // possible alt contentAfter : <div>1a<p>b12</p>34[]<span>e</span>f</div>
+                    contentAfter: '<div>1a<p>b12</p><p>34[]<span>e</span>f</p></div>',
+                });
+            });
+            it('should paste a text when selection across two element (2)', async () => {
+                await testEditor(BasicEditor, {
+                    contentBefore: '<div>2a<span>b[c</span><p>d]e</p>f</div>',
+                    stepFunction: async editor => {
+                        await pasteHtml(editor, complexHtmlData);
+                    },
+                    contentAfter: '<div>2a<span>b12<br>34[]</span>e<br>f</div>',
+                });
+            });
+        });
+    });
+     describe('Complex html 3 p', () => {
+        const complexHtmlData = '<p>1<i>X</i>2</p><p>3<i>X</i>4</p><p>5<i>X</i>6</p>';
+        describe('range collapsed', async () => {
+            it('should paste a text in a p', async () => {
+                await testEditor(BasicEditor, {
+                    contentBefore: '<p>ab[]cd</p>',
+                    stepFunction: async editor => {
+                        await pasteHtml(editor, complexHtmlData);
+                    },
+                    contentAfter: '<p>ab1<i>X</i>2</p><p>3<i>X</i>4</p><p>5<i>X</i>6[]cd</p>',
+                });
+            });
+            it('should paste a text in a span', async () => {
+                await testEditor(BasicEditor, {
+                    contentBefore: '<p>a<span>b[]c</span>d</p>',
+                    stepFunction: async editor => {
+                        await pasteHtml(editor, complexHtmlData);
+                    },
+                    contentAfter: '<p>a<span>b1<i>X</i>2</span></p><p>3<i>X</i>4</p><p><span>5<i>X</i>6[]c</span>d</p>',
+                });
+            });
+        });
+        describe('range not collapsed', async () => {
+            it('should paste a text in a p', async () => {
+                await testEditor(BasicEditor, {
+                    contentBefore: '<p>a[bc]d</p>',
+                    stepFunction: async editor => {
+                        await pasteHtml(editor, complexHtmlData);
+                    },
+                    contentAfter: '<p>a1<i>X</i>2</p><p>3<i>X</i>4</p><p>5<i>X</i>6[]d</p>',
+                });
+            });
+            it('should paste a text in a span', async () => {
+                await testEditor(BasicEditor, {
+                    contentBefore: '<p>a<span>b[cd]e</span>f</p>',
+                    stepFunction: async editor => {
+                        await pasteHtml(editor, complexHtmlData);
+                    },
+                    contentAfter: '<p>a<span>b1<i>X</i>2</span></p><p>3<i>X</i>4</p><p><span>5<i>X</i>6[]e</span>f</p>',
+                });
+            });
+            it('should paste a text when selection across two span (1)', async () => {
+                await testEditor(BasicEditor, {
+                    contentBefore: '<p>1a<span>b[c</span><span>d]e</span>f</p>',
+                    stepFunction: async editor => {
+                        await pasteHtml(editor, complexHtmlData);
+                    },
+                    contentAfter: '<p>1a<span>b1<i>X</i>2</span></p><p>3<i>X</i>4</p><p><span>5<i>X</i>6[]e</span>f</p>',
+                });
+            });
+            it('should paste a text when selection across two span (2)', async () => {
+                await testEditor(BasicEditor, {
+                    contentBefore: '<p>2a<span>b[c</span>- -<span>d]e</span>f</p>',
+                    stepFunction: async editor => {
+                        await pasteHtml(editor, complexHtmlData);
+                    },
+                    contentAfter: '<p>2a<span>b1<i>X</i>2</span></p><p>3<i>X</i>4</p><p><span>5<i>X</i>6[]e</span>f</p>',
+                });
+            });
+            it('should paste a text when selection across two p', async () => {
+                await testEditor(BasicEditor, {
+                    contentBefore: '<div>a<p>b[c</p><p>d]e</p>f</div>',
+                    stepFunction: async editor => {
+                        await pasteHtml(editor, complexHtmlData);
+                    },
+                    contentAfter: '<div>a<p>b1<i>X</i>2</p><p>3<i>X</i>4</p><p>5<i>X</i>6[]e</p>f</div>',
+                });
+                await testEditor(BasicEditor, {
+                    contentBefore: '<div>a<p>b[c</p>- -<p>d]e</p>f</div>',
+                    stepFunction: async editor => {
+                        await pasteHtml(editor, complexHtmlData);
+                    },
+                    contentAfter: '<div>a<p>b1<i>X</i>2</p><p>3<i>X</i>4</p><p>5<i>X</i>6[]e</p>f</div>',
+                });
+            });
+            it('should paste a text when selection leave a span (1)', async () => {
+                await testEditor(BasicEditor, {
+                    contentBefore: '<div>1ab<span>c[d</span>e]f</div>',
+                    stepFunction: async editor => {
+                        await pasteHtml(editor, complexHtmlData);
+                    },
+                    contentAfter: '<div>1ab<span>c1<i>X</i>2</span><p>3<i>X</i>4</p><span>5<i>X</i>6[]</span>f</div>',
+                });
+                await testEditor(BasicEditor, {
+                    contentBefore: '<div>2a[b<span>c]d</span>ef</div>',
+                    stepFunction: async editor => {
+                        await pasteHtml(editor, complexHtmlData);
+                    },
+                    contentAfter: '<div>2a1<i>X</i>2<p>3<i>X</i>4</p>5<i>X</i>6[]<span>d</span>ef</div>',
+                });
+            });
+            it('should paste a text when selection leave a span (2)', async () => {
+                await testEditor(BasicEditor, {
+                    contentBefore: '<p>1ab<span>c[d</span>e]f</p>',
+                    stepFunction: async editor => {
+                        await pasteHtml(editor, complexHtmlData);
+                    },
+                    contentAfter: '<p>1ab<span>c1<i>X</i>2</span></p><p>3<i>X</i>4</p><p><span>5<i>X</i>6[]</span>f</p>',
+                });
+                await testEditor(BasicEditor, {
+                    contentBefore: '<p>2a[b<span>c]d</span>ef</p>',
+                    stepFunction: async editor => {
+                        await pasteHtml(editor, complexHtmlData);
+                    },
+                    contentAfter: '<p>2a1<i>X</i>2</p><p>3<i>X</i>4</p><p>5<i>X</i>6[]<span>d</span>ef</p>',
+                });
+            });
+            it('should paste a text when selection across two element (1)', async () => {
+                await testEditor(BasicEditor, {
+                    contentBefore: '<div>1a<p>b[c</p><span>d]e</span>f</div>',
+                    stepFunction: async editor => {
+                        await pasteHtml(editor, complexHtmlData);
+                    },
+                    contentAfter: '<div>1a<p>b1<i>X</i>2</p><p>3<i>X</i>4</p><p>5<i>X</i>6[]<span>e</span>f</p></div>',
+                });
+            });
+            it('should paste a text when selection across two element (2)', async () => {
+                await testEditor(BasicEditor, {
+                    contentBefore: '<div>2a<span>b[c</span><p>d]e</p>f</div>',
+                    stepFunction: async editor => {
+                        await pasteHtml(editor, complexHtmlData);
+                    },
+                    contentAfter: '<div>2a<span>b1<i>X</i>2</span><p>3<i>X</i>4</p><span>5<i>X</i>6[]</span>e<br>f</div>',
+                });
+            });
+        });
+    });
+    describe('Complex html p+i', () => {
+        const complexHtmlData = '<p style="box-sizing: border-box; margin-top: 0px; margin-bottom: 1rem; color: rgb(0, 0, 0); font-family: -apple-system, BlinkMacSystemFont, &quot;Segoe UI&quot;, Roboto, &quot;Helvetica Neue&quot;, Arial, &quot;Noto Sans&quot;, sans-serif, &quot;Apple Color Emoji&quot;, &quot;Segoe UI Emoji&quot;, &quot;Segoe UI Symbol&quot;, &quot;Noto Color Emoji&quot;; font-size: 16px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: left; text-indent: 0px; text-transform: none; white-space: normal; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; background-color: rgb(255, 255, 255); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">12</p><p style="box-sizing: border-box; margin-top: 0px; margin-bottom: 1rem; color: rgb(0, 0, 0); font-family: -apple-system, BlinkMacSystemFont, &quot;Segoe UI&quot;, Roboto, &quot;Helvetica Neue&quot;, Arial, &quot;Noto Sans&quot;, sans-serif, &quot;Apple Color Emoji&quot;, &quot;Segoe UI Emoji&quot;, &quot;Segoe UI Symbol&quot;, &quot;Noto Color Emoji&quot;; font-size: 16px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: left; text-indent: 0px; text-transform: none; white-space: normal; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; background-color: rgb(255, 255, 255); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;"><i style="box-sizing: border-box;">ii</i></p>';
+        describe('range collapsed', async () => {
+            it('should paste a text in a p', async () => {
+                await testEditor(BasicEditor, {
+                    contentBefore: '<p>ab[]cd</p>',
+                    stepFunction: async editor => {
+                        await pasteHtml(editor, complexHtmlData);
+                    },
+                    contentAfter: '<p>ab12</p><p><i>ii</i>[]cd</p>',
+                });
+            });
+            it('should paste a text in a span', async () => {
+                await testEditor(BasicEditor, {
+                    contentBefore: '<p>a<span>b[]c</span>d</p>',
+                    stepFunction: async editor => {
+                        await pasteHtml(editor, complexHtmlData);
+                    },
+                    contentAfter: '<p>a<span>b12</span></p><p><span><i>ii</i>[]c</span>d</p>',
+                });
+            });
+        });
+        describe('range not collapsed', async () => {
+            it('should paste a text in a p', async () => {
+                await testEditor(BasicEditor, {
+                    contentBefore: '<p>a[bc]d</p>',
+                    stepFunction: async editor => {
+                        await pasteHtml(editor, complexHtmlData);
+                    },
+                    contentAfter: '<p>a12</p><p><i>ii</i>[]d</p>',
+                });
+            });
+            it('should paste a text in a span', async () => {
+                await testEditor(BasicEditor, {
+                    contentBefore: '<p>a<span>b[cd]e</span>f</p>',
+                    stepFunction: async editor => {
+                        await pasteHtml(editor, complexHtmlData);
+                    },
+                    contentAfter: '<p>a<span>b12</span></p><p><span><i>ii</i>[]e</span>f</p>',
+                });
+            });
+            it('should paste a text when selection across two span', async () => {
+                await testEditor(BasicEditor, {
+                    contentBefore: '<p>a<span>b[c</span><span>d]e</span>f</p>',
+                    stepFunction: async editor => {
+                        await pasteHtml(editor, complexHtmlData);
+                    },
+                    contentAfter: '<p>a<span>b12</span></p><p><span><i>ii</i>[]e</span>f</p>',
+                });
+                await testEditor(BasicEditor, {
+                    contentBefore: '<p>a<span>b[c</span>- -<span>d]e</span>f</p>',
+                    stepFunction: async editor => {
+                        await pasteHtml(editor, complexHtmlData);
+                    },
+                    contentAfter: '<p>a<span>b12</span></p><p><span><i>ii[]</i>e</span>f</p>',
+                });
+            });
+            it('should paste a text when selection across two p', async () => {
+                await testEditor(BasicEditor, {
+                    contentBefore: '<div>a<p>b[c</p><p>d]e</p>f</div>',
+                    stepFunction: async editor => {
+                        await pasteHtml(editor, complexHtmlData);
+                    },
+                    contentAfter: '<div>a<p>b12</p><p><i>ii</i>[]e</p>f</div>',
+                });
+                await testEditor(BasicEditor, {
+                    contentBefore: '<div>a<p>b[c</p>- -<p>d]e</p>f</div>',
+                    stepFunction: async editor => {
+                        await pasteHtml(editor, complexHtmlData);
+                    },
+                    contentAfter: '<div>a<p>b12</p><p><i>ii</i>[]e</p>f</div>',
+                });
+            });
+            it('should paste a text when selection leave a span (1)', async () => {
+                await testEditor(BasicEditor, {
+                    contentBefore: '<div>1ab<span>c[d</span>e]f</div>',
+                    stepFunction: async editor => {
+                        await pasteHtml(editor, complexHtmlData);
+                    },
+                    contentAfter: '<div>1ab<span>c12<i><br>ii</i>[]</span>f</div>',
+                });
+                await testEditor(BasicEditor, {
+                    contentBefore: '<div>2a[b<span>c]d</span>ef</div>',
+                    stepFunction: async editor => {
+                        await pasteHtml(editor, complexHtmlData);
+                    },
+                    contentAfter: '<div>2a12<i><br>ii</i>[]<span>d</span>ef</div>',
+                });
+            });
+            it('should paste a text when selection leave a span (2)', async () => {
+                await testEditor(BasicEditor, {
+                    contentBefore: '<p>1ab<span>c[d</span>e]f</p>',
+                    stepFunction: async editor => {
+                        await pasteHtml(editor, complexHtmlData);
+                    },
+                    contentAfter: '<p>1ab<span>c12</span></p><p><span><i>ii</i>[]</span>f</p>',
+                });
+                await testEditor(BasicEditor, {
+                    contentBefore: '<p>2a[b<span>c]d</span>ef</p>',
+                    stepFunction: async editor => {
+                        await pasteHtml(editor, complexHtmlData);
+                    },
+                    contentAfter: '<p>2a12</p><p><i>ii</i>[]<span>d</span>ef</p>',
+                });
+            });
+            it('should paste a text when selection across two element (1)', async () => {
+                await testEditor(BasicEditor, {
+                    contentBefore: '<div>1a<p>b[c</p><span>d]e</span>f</div>',
+                    stepFunction: async editor => {
+                        await pasteHtml(editor, complexHtmlData);
+                    },
+                    contentAfter: '<div>1a<p>b12</p><p><i>ii</i>[]<span>e</span>f</p></div>',
+                });
+            });
+            it('should paste a text when selection across two element (2)', async () => {
+                await testEditor(BasicEditor, {
+                    contentBefore: '<div>2a<span>b[c</span><p>d]e</p>f</div>',
+                    stepFunction: async editor => {
+                        await pasteHtml(editor, complexHtmlData);
+                    },
+                    contentAfter: '<div>2a<span>b12<i><br>ii</i>[]</span>e<br>f</div>',
+                });
+            });
+        });
+    });
+    describe('Complex html 3p+b', () => {
+        const complexHtmlData = '<p>1<b>23</b></p><p>zzz</p><p>45<b>6</b>7</p>';
+        describe('range collapsed', async () => {
+            it('should paste a text in a p', async () => {
+                await testEditor(BasicEditor, {
+                    contentBefore: '<p>ab[]cd</p>',
+                    stepFunction: async editor => {
+                        await pasteHtml(editor, complexHtmlData);
+                    },
+                    contentAfter: '<p>ab1<b>23</b></p><p>zzz</p><p>45<b>6</b>7[]cd</p>',
+                });
+            });
+            it('should paste a text in a span', async () => {
+                await testEditor(BasicEditor, {
+                    contentBefore: '<p>a<span>b[]c</span>d</p>',
+                    stepFunction: async editor => {
+                        await pasteHtml(editor, complexHtmlData);
+                    },
+                    contentAfter: '<p>a<span>b1<b>23</b></span></p><p>zzz</p><p><span>45<b>6</b>7[]c</span>d</p>',
+                });
+            });
+        });
+        describe('range not collapsed', async () => {
+            it('should paste a text in a p', async () => {
+                await testEditor(BasicEditor, {
+                    contentBefore: '<p>a[bc]d</p>',
+                    stepFunction: async editor => {
+                        await pasteHtml(editor, complexHtmlData);
+                    },
+                    contentAfter: '<p>a1<b>23</b></p><p>zzz</p><p>45<b>6</b>7[]d</p>',
+                });
+            });
+            it('should paste a text in a span', async () => {
+                await testEditor(BasicEditor, {
+                    contentBefore: '<p>a<span>b[cd]e</span>f</p>',
+                    stepFunction: async editor => {
+                        await pasteHtml(editor, complexHtmlData);
+                    },
+                    contentAfter: '<p>a<span>b1<b>23</b></span></p><p>zzz</p><p><span>45<b>6</b>7[]e</span>f</p>',
+                });
+            });
+            it('should paste a text when selection across two span', async () => {
+                await testEditor(BasicEditor, {
+                    contentBefore: '<p>a<span>b[c</span><span>d]e</span>f</p>',
+                    stepFunction: async editor => {
+                        await pasteHtml(editor, complexHtmlData);
+                    },
+                    contentAfter: '<p>a<span>b1<b>23</b></span></p><p>zzz</p><p><span>45<b>6</b>7[]e</span>f</p>',
+                });
+                await testEditor(BasicEditor, {
+                    contentBefore: '<p>a<span>b[c</span>- -<span>d]e</span>f</p>',
+                    stepFunction: async editor => {
+                        await pasteHtml(editor, complexHtmlData);
+                    },
+                    contentAfter: '<p>a<span>b1<b>23</b></span></p><p>zzz</p><p><span>45<b>6</b>7[]e</span>f</p>',
+                });
+            });
+            it('should paste a text when selection across two p', async () => {
+                await testEditor(BasicEditor, {
+                    contentBefore: '<div>a<p>b[c</p><p>d]e</p>f</div>',
+                    stepFunction: async editor => {
+                        await pasteHtml(editor, complexHtmlData);
+                    },
+                    contentAfter: '<div>a<p>b1<b>23</b></p><p>zzz</p><p>45<b>6</b>7[]e</p>f</div>',
+                });
+                await testEditor(BasicEditor, {
+                    contentBefore: '<div>a<p>b[c</p>- -<p>d]e</p>f</div>',
+                    stepFunction: async editor => {
+                        await pasteHtml(editor, complexHtmlData);
+                    },
+                    contentAfter: '<div>a<p>b1<b>23</b></p><p>zzz</p><p>45<b>6</b>7[]e</p>f</div>',
+                });
+            });
+            it('should paste a text when selection leave a span (1)', async () => {
+                await testEditor(BasicEditor, {
+                    contentBefore: '<div>1ab<span>c[d</span>e]f</div>',
+                    stepFunction: async editor => {
+                        await pasteHtml(editor, complexHtmlData);
+                    },
+                    contentAfter: '<div>1ab<span>c1<b>23</b></span><p>zzz</p><span>45<b>6</b>7[]</span>f</div>',
+                });
+                await testEditor(BasicEditor, {
+                    contentBefore: '<div>2a[b<span>c]d</span>ef</div>',
+                    stepFunction: async editor => {
+                        await pasteHtml(editor, complexHtmlData);
+                    },
+                    contentAfter: '<div>2a1<b>23</b><p>zzz</p>45<b>6</b>7[]<span>d</span>ef</div>',
+                });
+            });
+            it('should paste a text when selection across two element (1)', async () => {
+                await testEditor(BasicEditor, {
+                    contentBefore: '<div>1a<p>b[c</p><span>d]e</span>f</div>',
+                    stepFunction: async editor => {
+                        await pasteHtml(editor, complexHtmlData);
+                    },
+                    contentAfter: '<div>1a<p>b1<b>23</b></p><p>zzz</p><p>45<b>6</b>7[]<span>e</span>f</p></div>',
+                });
+            });
+            it('should paste a text when selection across two element (2)', async () => {
+                await testEditor(BasicEditor, {
+                    contentBefore: '<div>2a<span>b[c</span><p>d]e</p>f</div>',
+                    stepFunction: async editor => {
+                        await pasteHtml(editor, complexHtmlData);
+                    },
+                    contentAfter: '<div>2a<span>b1<b>23</b></span><p>zzz</p><span>45<b>6</b>7[]</span>e<br>f</div>',
+                });
+            });
+        });
+    });
+    describe('Special cases', () => {
+        describe('lists', async () => {
+            it('should paste a list in a p', async () => {
+                await testEditor(BasicEditor, {
+                    contentBefore: '<p>12[]34</p>',
+                    stepFunction: async editor => {
+                        await pasteHtml(editor, '<ul><li>abc</li><li>def</li><li>ghi</li></ul>');
+                    },
+                    contentAfter: '<p>12</p><ul><li>abc</li><li>def</li><li>ghi</li></ul>[]<p>34</p>',
+                });
+            });
+        });
+    });
+
+    describe('link', () => {
+        describe('range collapsed', async () => {
+            it('should paste and transform an URL in a p', async () => {
+                await testEditor(BasicEditor, {
+                    contentBefore: '<p>ab[]cd</p>',
+                    stepFunction: async editor => {
+                        await pasteText(editor, 'http://www.xyz.com');
+                    },
+                    contentAfter: '<p>ab<a href="http://www.xyz.com">http://www.xyz.com</a>[]cd</p>',
+                });
+            });
+            it('should paste and transform an URL in a span', async () => {
+                await testEditor(BasicEditor, {
+                    contentBefore: '<p>a<span>b[]c</span>d</p>',
+                    stepFunction: async editor => {
+                        await pasteText(editor, 'http://www.xyz.com');
+                    },
+                    contentAfter: '<p>a<span>b<a href="http://www.xyz.com">http://www.xyz.com</a>[]c</span>d</p>',
+                });
+            });
+            it('should paste and not transform an URL in a existing link', async () => {
+                await testEditor(BasicEditor, {
+                    contentBefore: '<p>a<a href="http://existing.com">b[]c</a>d</p>',
+                    stepFunction: async editor => {
+                        await pasteText(editor, 'http://www.xyz.com');
+                    },
+                    contentAfter: '<p>a<a href="http://existing.com">bhttp://www.xyz.com[]c</a>d</p>',
+                });
+            });
+        });
+        describe('range not collapsed', async () => {
+            it('should paste and transform an URL in a p', async () => {
+                await testEditor(BasicEditor, {
+                    contentBefore: '<p>ab[xxx]cd</p>',
+                    stepFunction: async editor => {
+                        await pasteText(editor, 'http://www.xyz.com');
+                    },
+                    contentAfter: '<p>ab<a href="http://www.xyz.com">http://www.xyz.com</a>[]cd</p>',
+                });
+            });
+            it('should paste and transform an URL in a span', async () => {
+                await testEditor(BasicEditor, {
+                    contentBefore: '<p>a<span>b[x<a href="http://existing.com">546</a>x]c</span>d</p>',
+                    stepFunction: async editor => {
+                        await pasteText(editor, 'http://www.xyz.com');
+                    },
+                    contentAfter: '<p>a<span>b<a href="http://www.xyz.com">http://www.xyz.com</a>[]c</span>d</p>',
+                });
+            });
+            it('should paste and not transform an URL in a existing link', async () => {
+                await testEditor(BasicEditor, {
+                    contentBefore: '<p>a<a href="http://existing.com">b[qsdqsd]c</a>d</p>',
+                    stepFunction: async editor => {
+                        await pasteText(editor, 'http://www.xyz.com');
+                    },
+                    contentAfter: '<p>a<a href="http://existing.com">bhttp://www.xyz.com[]c</a>d</p>',
+                });
+            });
+        });
+    });
+    describe('images', () => {
+        describe('range collapsed', async () => {
+            it('should paste and transform an image URL in a p', async () => {
+                await testEditor(BasicEditor, {
+                    contentBefore: '<p>ab[]cd</p>',
+                    stepFunction: async editor => {
+                        await pasteText(editor, 'https://download.odoocdn.com/icons/website/static/description/icon.png');
+                        // Ensure the powerbox is active
+                        window.chai.expect(editor.commandBar._active).to.be.true;
+                        // Force commandBar validation on the default first choice
+                        await editor.commandBar._currentValidate();
+                    },
+                    contentAfter: '<p>ab<img src="https://download.odoocdn.com/icons/website/static/description/icon.png">[]cd</p>',
+                });
+            });
+            it('should paste and transform an image URL in a span', async () => {
+                await testEditor(BasicEditor, {
+                    contentBefore: '<p>a<span>b[]c</span>d</p>',
+                    stepFunction: async editor => {
+                        await pasteText(editor, 'https://download.odoocdn.com/icons/website/static/description/icon.png');
+                        // Ensure the powerbox is active
+                        window.chai.expect(editor.commandBar._active).to.be.true;
+                        // Force commandBar validation on the default first choice
+                        await editor.commandBar._currentValidate();
+                    },
+                    contentAfter: '<p>a<span>b<img src="https://download.odoocdn.com/icons/website/static/description/icon.png">[]c</span>d</p>',
+                });
+            });
+            it('should paste and transform an image URL in an existing link', async () => {
+                await testEditor(BasicEditor, {
+                    contentBefore: '<p>a<a href="http://existing.com">b[]c</a>d</p>',
+                    stepFunction: async editor => {
+                        await pasteText(editor, 'https://download.odoocdn.com/icons/website/static/description/icon.png');
+                        // Ensure the powerbox is active
+                        window.chai.expect(editor.commandBar._active).to.be.true;
+                        // Force commandBar validation on the default first choice
+                        await editor.commandBar._currentValidate();
+                    },
+                    contentAfter: '<p>a<a href="http://existing.com">b<img src="https://download.odoocdn.com/icons/website/static/description/icon.png">[]c</a>d</p>',
+                });
+            });
+        });
+        describe('range not collapsed', async () => {
+            it('should paste and transform an image URL in a p', async () => {
+                await testEditor(BasicEditor, {
+                    contentBefore: '<p>ab[xxx]cd</p>',
+                    stepFunction: async editor => {
+                        await pasteText(editor, 'https://download.odoocdn.com/icons/website/static/description/icon.png');
+                        // Ensure the powerbox is active
+                        window.chai.expect(editor.commandBar._active).to.be.true;
+                        // Force commandBar validation on the default first choice
+                        await editor.commandBar._currentValidate();
+                    },
+                    contentAfter: '<p>ab<img src="https://download.odoocdn.com/icons/website/static/description/icon.png">[]cd</p>',
+                });
+            });
+            it('should paste and transform an image URL in a span', async () => {
+                await testEditor(BasicEditor, {
+                    contentBefore: '<p>a<span>b[x<a href="http://existing.com">546</a>x]c</span>d</p>',
+                    stepFunction: async editor => {
+                        await pasteText(editor, 'https://download.odoocdn.com/icons/website/static/description/icon.png');
+                        // Ensure the powerbox is active
+                        window.chai.expect(editor.commandBar._active).to.be.true;
+                        // Force commandBar validation on the default first choice
+                        await editor.commandBar._currentValidate();
+                    },
+                    contentAfter: '<p>a<span>b<img src="https://download.odoocdn.com/icons/website/static/description/icon.png">[]c</span>d</p>',
+                });
+            });
+            it('should paste and transform an image URL inside an existing link', async () => {
+                await testEditor(BasicEditor, {
+                    contentBefore: '<p>a<a href="http://existing.com">b[qsdqsd]c</a>d</p>',
+                    stepFunction: async editor => {
+                        await pasteText(editor, 'https://download.odoocdn.com/icons/website/static/description/icon.png');
+                        // Ensure the powerbox is active
+                        window.chai.expect(editor.commandBar._active).to.be.true;
+                        // Force commandBar validation on the default first choice
+                        await editor.commandBar._currentValidate();
+                    },
+                    contentAfter: '<p>a<a href="http://existing.com">b<img src="https://download.odoocdn.com/icons/website/static/description/icon.png">[]c</a>d</p>',
+                });
+            });
+        });
+    });
+    describe('youtube video', () => {
+        describe('range collapsed', async () => {
+            it('should paste and transform a youtube URL in a p', async () => {
+                await testEditor(BasicEditor, {
+                    contentBefore: '<p>ab[]cd</p>',
+                    stepFunction: async editor => {
+                        await pasteText(editor, 'https://www.youtube.com/watch?v=dQw4w9WgXcQ');
+                        // Ensure the powerbox is active
+                        window.chai.expect(editor.commandBar._active).to.be.true;
+                        // Force commandBar validation on the default first choice
+                        await editor.commandBar._currentValidate();
+                    },
+                    contentAfter: '<p>ab<iframe width="560" height="315" src="https://www.youtube.com/embed/dQw4w9WgXcQ" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen="1"></iframe>[]cd</p>',
+                });
+            });
+            it('should paste and transform a youtube URL in a span', async () => {
+                await testEditor(BasicEditor, {
+                    contentBefore: '<p>a<span>b[]c</span>d</p>',
+                    stepFunction: async editor => {
+                        await pasteText(editor, 'https://youtu.be/dQw4w9WgXcQ');
+                        // Ensure the powerbox is active
+                        window.chai.expect(editor.commandBar._active).to.be.true;
+                        // Force commandBar validation on the default first choice
+                        await editor.commandBar._currentValidate();
+                    },
+                    contentAfter: '<p>a<span>b<iframe width="560" height="315" src="https://www.youtube.com/embed/dQw4w9WgXcQ" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen="1"></iframe>[]c</span>d</p>',
+                });
+            });
+            it('should paste and not transform a youtube  URL in a existing link', async () => {
+                await testEditor(BasicEditor, {
+                    contentBefore: '<p>a<a href="http://existing.com">b[]c</a>d</p>',
+                    stepFunction: async editor => {
+                        await pasteText(editor, 'https://youtu.be/dQw4w9WgXcQ');
+                        // Ensure the powerbox is not active
+                        window.chai.expect(editor.commandBar._active).to.be.false;
+                    },
+                    contentAfter: '<p>a<a href="http://existing.com">bhttps://youtu.be/dQw4w9WgXcQ[]c</a>d</p>',
+                });
+            });
+        });
+        describe('range not collapsed', async () => {
+            it('should paste and transform a youtube URL in a p', async () => {
+                await testEditor(BasicEditor, {
+                    contentBefore: '<p>ab[xxx]cd</p>',
+                    stepFunction: async editor => {
+                        await pasteText(editor, 'https://youtu.be/dQw4w9WgXcQ');
+                        // Ensure the powerbox is active
+                        window.chai.expect(editor.commandBar._active).to.be.true;
+                        // Force commandBar validation on the default first choice
+                        await editor.commandBar._currentValidate();
+                    },
+                    contentAfter: '<p>ab<iframe width="560" height="315" src="https://www.youtube.com/embed/dQw4w9WgXcQ" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen="1"></iframe>[]cd</p>',
+                });
+            });
+            it('should paste and transform a youtube URL in a span', async () => {
+                await testEditor(BasicEditor, {
+                    contentBefore: '<p>a<span>b[x<a href="http://existing.com">546</a>x]c</span>d</p>',
+                    stepFunction: async editor => {
+                        await pasteText(editor, 'https://www.youtube.com/watch?v=dQw4w9WgXcQ');
+                        // Ensure the powerbox is active
+                        window.chai.expect(editor.commandBar._active).to.be.true;
+                        // Force commandBar validation on the default first choice
+                        await editor.commandBar._currentValidate();
+                    },
+                    contentAfter: '<p>a<span>b<iframe width="560" height="315" src="https://www.youtube.com/embed/dQw4w9WgXcQ" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen="1"></iframe>[]c</span>d</p>',
+                });
+            });
+            it('should paste and not transform a youtube URL in a existing link', async () => {
+                await testEditor(BasicEditor, {
+                    contentBefore: '<p>a<a href="http://existing.com">b[qsdqsd]c</a>d</p>',
+                    stepFunction: async editor => {
+                        await pasteText(editor, 'https://www.youtube.com/watch?v=dQw4w9WgXcQ');
+                        // Ensure the powerbox is not active
+                        window.chai.expect(editor.commandBar._active).to.be.false;
+                    },
+                    contentAfter: '<p>a<a href="http://existing.com">bhttps://www.youtube.com/watch?v=dQw4w9WgXcQ[]c</a>d</p>',
+                });
+            });
+        });
+    });
+});

--- a/addons/web_editor/static/lib/odoo-editor/test/spec/editor.test.js
+++ b/addons/web_editor/static/lib/odoo-editor/test/spec/editor.test.js
@@ -86,6 +86,34 @@ describe('Editor', () => {
                         contentAfter: '<p>[]abc</p>',
                     });
                 });
+                it('should merge P node correctly ', async () => {
+                    await testEditor(BasicEditor, {
+                        contentBefore: '<div>a<p>b[]</p><p>c</p>d</div>',
+                        stepFunction: deleteForward,
+                        contentAfter: '<div>a<p>b[]c</p>d</div>',
+                    });
+                });
+                it('should merge node correctly', async () => {
+                    await testEditor(BasicEditor, {
+                        contentBefore: '<div>a<span>b[]</span><p>c</p>d</div>',
+                        stepFunction: deleteForward,
+                        contentAfter: '<div>a<span>b[]</span>c<br>d</div>',
+                    });
+                });
+                it('should merge SPAN node correctly ', async () => {
+                    await testEditor(BasicEditor, {
+                        contentBefore: '<div>a<span>bc[]</span><span>de</span>f</div>',
+                        stepFunction: deleteForward,
+                        contentAfter: '<div>a<span>bc[]e</span>f</div>',
+                    });
+                });
+                it('should merge diferent element correctly', async () => {
+                    await testEditor(BasicEditor, {
+                        contentBefore: '<div>a<span>b[]</span><p>c</p>d</div>',
+                        stepFunction: deleteForward,
+                        contentAfter: '<div>a<span>b[]</span>c<br>d</div>',
+                    });
+                });
                 it('should ignore ZWS', async () => {
                     await testEditor(BasicEditor, {
                         contentBefore: '<p>ab[]\u200Bc</p>',
@@ -829,6 +857,27 @@ X[]
                     contentAfter: '<p>ab[]ef</p>',
                 });
             });
+            it('should merge node correctly', async () => {
+                await testEditor(BasicEditor, {
+                    contentBefore: '<div>a<span>b[c</span><p>d]e</p>f</div>',
+                    stepFunction: deleteForward,
+                    contentAfter: '<div>a<span>b[]</span>e<br>f</div>',
+                });
+            });
+            it('should delete part of the text across two paragraphs', async () => {
+                // Forward selection
+                await testEditor(BasicEditor, {
+                    contentBefore: '<div>a<p>b[c</p><p>d]e</p>f</div>',
+                    stepFunction: deleteForward,
+                    contentAfter: '<div>a<p>b[]e</p>f</div>',
+                });
+                // Backward selection
+                await testEditor(BasicEditor, {
+                    contentBefore: '<div>a<p>b]c</p><p>d[e</p>f</div>',
+                    stepFunction: deleteForward,
+                    contentAfter: '<div>a<p>b[]e</p>f</div>',
+                });
+            });
             it('should delete empty nodes ', async () => {
                 // Forward selection
                 await testEditor(BasicEditor, {
@@ -1087,6 +1136,13 @@ X[]
                         contentBefore: '<p><br></p><p>[]abc</p>',
                         stepFunction: deleteBackward,
                         contentAfter: '<p>[]abc</p>',
+                    });
+                });
+                it('should merge node correctly', async () => {
+                    await testEditor(BasicEditor, {
+                        contentBefore: '<div>a<span>b</span><p>[]c</p>d</div>',
+                        stepFunction: deleteBackward,
+                        contentAfter: '<div>a<span>b[]</span>c<br>d</div>',
                     });
                 });
                 it('should ignore ZWS', async () => {
@@ -1750,7 +1806,7 @@ X[]
                     await testEditor(BasicEditor, {
                         contentBefore: 'ab<p>[]cd</p>ef',
                         stepFunction: deleteBackward,
-                        contentAfter: 'ab[]cdef', // FIXME for me this is wrong, I would expect ab[]cd<p>ef</p> or something like that ?
+                        contentAfter: 'ab[]cd<br>ef',
                     });
                 });
             });
@@ -2042,6 +2098,23 @@ X[]
                     contentAfter: '<div><p>ab <span class="style">x[]</span> f</p></div>',
                 });
             });
+            it('should merge node correctly (1)', async () => {
+                await testEditor(BasicEditor, {
+                    contentBefore: '<div>a<span>b[c</span><p>d]e</p>f<br>g</div>',
+                    stepFunction: deleteBackward,
+                    // FIXME ?? : Maybe this should bing the content inside the <p>
+                    // Instead of removing the <p>,
+                    // ex : <div><p>a<span>b[]</span>e</p>f<br>g</div>
+                    contentAfter: '<div>a<span>b[]</span>e<br>f<br>g</div>',
+                });
+            });
+            it('should merge node correctly (2)', async () => {
+                await testEditor(BasicEditor, {
+                    contentBefore: '<div>a<p>b[c</p><span>d]e</span>f<p>xxx</p></div>',
+                    stepFunction: deleteBackward,
+                    contentAfter: '<div>a<p>b[]<span>e</span>f</p><p>xxx</p></div>',
+                });
+            });
             it('should delete part of the text within a paragraph', async () => {
                 // Forward selection
                 await testEditor(BasicEditor, {
@@ -2068,6 +2141,20 @@ X[]
                     contentBefore: '<p>ab]cd</p><p>ef[gh</p>',
                     stepFunction: deleteBackward,
                     contentAfter: '<p>ab[]gh</p>',
+                });
+            });
+            it('should delete part of the text across two paragraphs', async () => {
+                // Forward selection
+                await testEditor(BasicEditor, {
+                    contentBefore: '<div>a<p>b[c</p><p>d]e</p>f</div>',
+                    stepFunction: deleteBackward,
+                    contentAfter: '<div>a<p>b[]e</p>f</div>',
+                });
+                // Backward selection
+                await testEditor(BasicEditor, {
+                    contentBefore: '<div>a<p>b]c</p><p>d[e</p>f</div>',
+                    stepFunction: deleteBackward,
+                    contentAfter: '<div>a<p>b[]e</p>f</div>',
                 });
             });
             it('should delete all the text in a paragraph', async () => {

--- a/addons/web_editor/static/lib/odoo-editor/test/spec/insertHTML.test.js
+++ b/addons/web_editor/static/lib/odoo-editor/test/spec/insertHTML.test.js
@@ -62,7 +62,7 @@ describe('insetHTML', () => {
                 stepFunction: async editor => {
                     await editor.execCommand('insertHTML', '<p>b</p><p>c</p><p>d</p>');
                 },
-                contentAfter: 'a<p>b</p><p>c</p><p>d</p>[]e<br>',
+                contentAfter: 'ab<p>c</p>d[]e<br>',
             });
         });
     });

--- a/addons/web_editor/static/lib/odoo-editor/test/utils.js
+++ b/addons/web_editor/static/lib/odoo-editor/test/utils.js
@@ -264,7 +264,7 @@ export function customErrorMessage(assertLocation, value, expected) {
     value = value.replace('\u200B', zws);
     expected = expected.replace('\u200B', zws);
 
-    return `[${assertLocation}}]\nactual  : '${value}'\nexpected: '${expected}'\n\nStackTrace `;
+    return `[${assertLocation}]\nactual  : '${value}'\nexpected: '${expected}'\n\nStackTrace `;
 }
 
 export async function testEditor(Editor = OdooEditor, spec) {


### PR DESCRIPTION
Multiple fixes on HTML paste behaviors.
Some fixes on DeleteBackward and DeleteRange.
Few fixes on URL transform and image / video embed on paste.
Couple of linting fixes.
One minor PowerBox fix.

+ Add some test coverage.

See Commits for more in depth descriptions.

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
