### PR TITLE
[FIX] mail: ensure a user can leave a private channel + test

### DIFF
--- a/addons/mail/tests/test_mail_channel.py
+++ b/addons/mail/tests/test_mail_channel.py
@@ -408,6 +408,16 @@ class TestChannelInternals(MailCommon):
         self.assertEqual(self.test_channel.channel_partner_ids, self.user_employee.partner_id | test_partner)
         self.assertEqual(test_chat.channel_partner_ids, self.user_employee.partner_id | test_partner)
 
+    @users('employee')
+    def test_channel_private_unfollow(self):
+        """ Test that a partner can leave (unfollow) a private channel. """
+        channel_private = self.env['mail.channel'].create({
+            'name': 'Winden caves',
+            'public': 'private',
+        })
+        channel_private.action_unfollow()
+        self.assertEqual(channel_private.channel_partner_ids, self.env['res.partner'])
+
     def test_channel_unfollow_should_not_post_message_if_the_partner_has_been_removed(self):
         '''
         When a partner leaves a channel, the system will help post a message under


### PR DESCRIPTION
Steps to reproduce:

  - Go to discuss app and click on `Start a meeting`
  - Disconnect from the meeting (red phone button)
  - On the left sidebar, hover the channel and click on the cross to
    leave the channel, then confirm.

Issue:

  Access error.

Solution:

  Use `_action_remove_members` method to remove member from the channel;
  it is done as sudo to avoid ACLs issues with channel partners.

opw-2820449