### PR TITLE
[FIX] pos_hr: save cashier correctly in db

### DIFF
--- a/addons/point_of_sale/models/pos_order.py
+++ b/addons/point_of_sale/models/pos_order.py
@@ -102,6 +102,9 @@ class PosOrder(models.Model):
 
         return new_session
 
+    def _get_fields_for_draft_order(self):
+        """This method is here to be overridden in order to add fields that are required for draft orders."""
+        return []
 
     @api.model
     def _process_order(self, order, draft, existing_order):

--- a/addons/pos_hr/models/pos_order.py
+++ b/addons/pos_hr/models/pos_order.py
@@ -28,3 +28,8 @@ class PosOrder(models.Model):
             'employee_id': order.employee_id.id,
         })
         return result
+
+    def _get_fields_for_draft_order(self):
+        fields = super(PosOrder, self)._get_fields_for_draft_order()
+        fields.append('employee_id')
+        return fields

--- a/addons/pos_hr/static/src/js/models.js
+++ b/addons/pos_hr/static/src/js/models.js
@@ -81,7 +81,7 @@ models.Order = models.Order.extend({
     },
     init_from_JSON: function (json) {
         super_order_model.init_from_JSON.apply(this, arguments);
-        if (this.pos.config.module_pos_hr) {
+        if (this.pos.config.module_pos_hr && json.employee_id) {
             this.employee = this.pos.employee_by_id[json.employee_id];
         }
     },

--- a/addons/pos_restaurant/models/pos_order.py
+++ b/addons/pos_restaurant/models/pos_order.py
@@ -124,7 +124,8 @@ class PosOrder(models.Model):
             next(order for order in orders if order['id'] == order_id[0])['statement_ids'] = list(payment_lines)
 
     def _get_fields_for_draft_order(self):
-        return [
+        fields = super(PosOrder, self)._get_fields_for_draft_order()
+        fields.extend([
                     'id',
                     'pricelist_id',
                     'partner_id',
@@ -138,7 +139,8 @@ class PosOrder(models.Model):
                     'table_id',
                     'to_invoice',
                     'multiprint_resume',
-                    ]
+                    ])
+        return fields
 
     @api.model
     def get_table_draft_orders(self, table_id):
@@ -152,8 +154,8 @@ class PosOrder(models.Model):
         :returns: list -- list of dict representing the table orders
         """
         table_orders = self.search_read(
-                domain = [('state', '=', 'draft'), ('table_id', '=', table_id)],
-                fields = self._get_fields_for_draft_order())
+                domain=[('state', '=', 'draft'), ('table_id', '=', table_id)],
+                fields=self._get_fields_for_draft_order())
 
         self._get_order_lines(table_orders)
         self._get_payment_lines(table_orders)
@@ -172,6 +174,8 @@ class PosOrder(models.Model):
                 order['partner_id'] = order['partner_id'][0]
             if order['table_id']:
                 order['table_id'] = order['table_id'][0]
+            if order['employee_id']:
+                order['employee_id'] = order['employee_id'][0] if order['employee_id'] else False
 
             if not 'lines' in order:
                 order['lines'] = []


### PR DESCRIPTION
Current behavior:
In PoS restaurant cashier were not saved correctly in db if you
switched table before making the payment of the order.

Steps to reproduce:
- Install PoS
- Activate restaurant on one of your PoS
- Activate Authorized employee
- Start a PoS session, and select a cashier
- Create an order on a table
- Leave the table and comeback to it
- Make the payment for the order
- Go in the PoS orders, the cashier wasn't saved

opw-2794574
--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
