### PR TITLE
[IMP] account_*: simpler domains to avoid a join

### DIFF
--- a/addons/account/models/account_analytic_line.py
+++ b/addons/account/models/account_analytic_line.py
@@ -33,7 +33,7 @@ class AccountAnalyticAccount(models.Model):
     def _compute_invoice_count(self):
         sale_types = self.env['account.move'].get_sale_types()
         domain = [
-            ('move_id.state', '=', 'posted'),
+            ('parent_state', '=', 'posted'),
             ('move_id.move_type', 'in', sale_types),
             ('analytic_account_id', 'in', self.ids)
         ]
@@ -46,7 +46,7 @@ class AccountAnalyticAccount(models.Model):
     def _compute_vendor_bill_count(self):
         purchase_types = self.env['account.move'].get_purchase_types()
         domain = [
-            ('move_id.state', '=', 'posted'),
+            ('parent_state', '=', 'posted'),
             ('move_id.move_type', 'in', purchase_types),
             ('analytic_account_id', 'in', self.ids)
         ]

--- a/addons/l10n_it_stock_ddt/models/account_invoice.py
+++ b/addons/l10n_it_stock_ddt/models/account_invoice.py
@@ -31,7 +31,7 @@ class AccountMove(models.Model):
                     invoice_line_pickings.setdefault(done_moves_related.picking_id, []).append(line_count)
             else:
                 total_invoices = done_moves_related.mapped('sale_line_id.invoice_lines').filtered(
-                    lambda l: l.move_id.state == 'posted' and l.move_id.move_type == 'out_invoice').sorted(lambda l: l.move_id.invoice_date)
+                    lambda l: l.parent_state == 'posted' and l.move_id.move_type == 'out_invoice').sorted(lambda l: l.move_id.invoice_date)
                 total_invs = [(i.product_uom_id._compute_quantity(i.quantity, i.product_id.uom_id), i) for i in total_invoices]
                 inv = total_invs.pop(0)
                 # Match all moves and related invoice lines FIFO looking for when the matched invoice_line matches line

--- a/addons/purchase/models/purchase.py
+++ b/addons/purchase/models/purchase.py
@@ -1005,7 +1005,7 @@ class PurchaseOrderLine(models.Model):
             # compute qty_invoiced
             qty = 0.0
             for inv_line in line._get_invoice_lines():
-                if inv_line.move_id.state not in ['cancel']:
+                if inv_line.parent_state not in ['cancel']:
                     if inv_line.move_id.move_type == 'in_invoice':
                         qty += inv_line.product_uom_id._compute_quantity(inv_line.quantity, line.product_uom)
                     elif inv_line.move_id.move_type == 'in_refund':

--- a/addons/sale/models/sale_order_line.py
+++ b/addons/sale/models/sale_order_line.py
@@ -707,7 +707,7 @@ class SaleOrderLine(models.Model):
         for line in self:
             qty_invoiced = 0.0
             for invoice_line in line._get_invoice_lines():
-                if invoice_line.move_id.state != 'cancel':
+                if invoice_line.parent_state != 'cancel':
                     if invoice_line.move_id.move_type == 'out_invoice':
                         qty_invoiced += invoice_line.product_uom_id._compute_quantity(invoice_line.quantity, line.product_uom)
                     elif invoice_line.move_id.move_type == 'out_refund':
@@ -782,7 +782,7 @@ class SaleOrderLine(models.Model):
         for line in self:
             amount_invoiced = 0.0
             for invoice_line in line._get_invoice_lines():
-                if invoice_line.move_id.state == 'posted':
+                if invoice_line.parent_state == 'posted':
                     invoice_date = invoice_line.move_id.invoice_date or fields.Date.today()
                     if invoice_line.move_id.move_type == 'out_invoice':
                         amount_invoiced += invoice_line.currency_id._convert(invoice_line.price_subtotal, line.currency_id, line.company_id, invoice_date)

--- a/addons/sale_mrp/models/account_move.py
+++ b/addons/sale_mrp/models/account_move.py
@@ -17,7 +17,7 @@ class AccountMoveLine(models.Model):
             if bom and bom.type == 'phantom':
                 is_line_reversing = bool(self.move_id.reversed_entry_id)
                 qty_to_invoice = self.product_uom_id._compute_quantity(self.quantity, self.product_id.uom_id)
-                posted_invoice_lines = so_line.invoice_lines.filtered(lambda l: l.move_id.state == 'posted' and bool(l.move_id.reversed_entry_id) == is_line_reversing)
+                posted_invoice_lines = so_line.invoice_lines.filtered(lambda l: l.parent_state == 'posted' and bool(l.move_id.reversed_entry_id) == is_line_reversing)
                 qty_invoiced = sum([x.product_uom_id._compute_quantity(x.quantity, x.product_id.uom_id) for x in posted_invoice_lines])
                 moves = so_line.move_ids
                 average_price_unit = 0

--- a/addons/sale_stock/models/account_move.py
+++ b/addons/sale_stock/models/account_move.py
@@ -125,7 +125,7 @@ class AccountMoveLine(models.Model):
         if so_line:
             is_line_reversing = bool(self.move_id.reversed_entry_id)
             qty_to_invoice = self.product_uom_id._compute_quantity(self.quantity, self.product_id.uom_id)
-            posted_invoice_lines = so_line.invoice_lines.filtered(lambda l: l.move_id.state == 'posted' and bool(l.move_id.reversed_entry_id) == is_line_reversing)
+            posted_invoice_lines = so_line.invoice_lines.filtered(lambda l: l.parent_state == 'posted' and bool(l.move_id.reversed_entry_id) == is_line_reversing)
             qty_invoiced = sum([x.product_uom_id._compute_quantity(x.quantity, x.product_id.uom_id) for x in posted_invoice_lines])
 
             product = self.product_id.with_company(self.company_id)

--- a/addons/sale_timesheet/models/account_move.py
+++ b/addons/sale_timesheet/models/account_move.py
@@ -100,7 +100,7 @@ class AccountMoveLine(models.Model):
     def unlink(self):
         move_line_read_group = self.env['account.move.line'].search_read([
             ('move_id.move_type', '=', 'out_invoice'),
-            ('move_id.state', '=', 'draft'),
+            ('parent_state', '=', 'draft'),
             ('sale_line_ids.product_id.invoice_policy', '=', 'delivery'),
             ('sale_line_ids.product_id.service_type', '=', 'timesheet'),
             ('id', 'in', self.ids)],


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
We often use a JOIN on `account.move` to read the state of the move but it could be avoided as `parent_move` is already available on `account.move.line`. This is particularly critical for accounting reports.

This PR replaces `move_id.state` with `parent_state` and adds a new index on `parent_move`.

Current behavior before PR:
Slower queries

Desired behavior after PR is merged:
Faster queries



--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
