### PR TITLE
[FIX] base: performance of has_group()

### DIFF
--- a/odoo/addons/base/models/res_users.py
+++ b/odoo/addons/base/models/res_users.py
@@ -736,8 +736,10 @@ class Users(models.Model):
     def has_group(self, group_ext_id):
         # use singleton's id if called on a non-empty recordset, otherwise
         # context uid
-        uid = self.id or self._uid
-        return self.with_user(uid)._has_group(group_ext_id)
+        uid = self.id
+        if uid and uid != self._uid:
+            self = self.with_user(uid)
+        return self._has_group(group_ext_id)
 
     @api.model
     @tools.ormcache('self._uid', 'group_ext_id')


### PR DESCRIPTION
Description of the issue/feature this PR addresses:

Avoid calling with_user() inside method has_group() when possible, as it
represents a major overhead inside this method which is commonly called. This
sole optimization speeds up the accounting general ledger by about 6%.

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
