### PR TITLE
[FIX] mrp: Allow user to add manufacturing orders to dashboard

### DIFF
--- a/addons/mrp/views/mrp_production_views.xml
+++ b/addons/mrp/views/mrp_production_views.xml
@@ -603,7 +603,8 @@
                 'search_default_scheduled_date': 2,
                 'search_default_filter_confirmed': True,
                 'search_default_filter_planned': True,
-                'default_company_id': allowed_company_ids[0]
+                'default_company_id': allowed_company_ids[0],
+                'allowed_company_ids': allowed_company_ids
             }</field>
             <field name="help" type="html">
                 <p class="o_view_nocontent_smiling_face">


### PR DESCRIPTION
Currently we can not add Manufacturing orders Report (graph view) to the
board because of missing context keys (`allowed_company_ids`)

We just have to add the key in the context of `mrp_production_report`
opw-2813295