### PR TITLE
[IMP] mrp: add production capacity in split wizard

### DIFF
--- a/addons/mrp/wizard/mrp_production_split.py
+++ b/addons/mrp/wizard/mrp_production_split.py
@@ -21,6 +21,7 @@ class MrpProductionSplit(models.TransientModel):
     product_id = fields.Many2one(related='production_id.product_id')
     product_qty = fields.Float(related='production_id.product_qty')
     product_uom_id = fields.Many2one(related='production_id.product_uom_id')
+    production_capacity = fields.Float(related='production_id.production_capacity')
     counter = fields.Integer(
         "Split #", default=0, compute="_compute_counter",
         store=True, readonly=False)

--- a/addons/mrp/wizard/mrp_production_split.xml
+++ b/addons/mrp/wizard/mrp_production_split.xml
@@ -13,7 +13,8 @@
                             <field name="production_id"/>
                             <field name="product_id"/>
                             <field name="product_qty"/>
-                            <field name="product_uom_id"/>
+                            <field name="production_capacity"/>
+                            <field name="product_uom_id" groups="uom.group_uom"/>
                             <button name="action_prepare_split" type="object" icon="fa-scissors" width="0.1" title="Split Production"/>
                         </tree>
                     </field>
@@ -35,11 +36,21 @@
                         </group>
                         <group>
                             <field name="product_id"/>
-                            <field name="product_qty"/>
-                            <field name="product_uom_id"/>
+                            <label for="product_qty"/>
+                            <div class="o_row">
+                                <span><field name="product_qty"/></span>
+                                <span><field name="product_uom_id" groups="uom.group_uom"/></span>
+                            </div>
                         </group>
                         <group>
                             <field name="counter"/>
+                        </group>
+                        <group>
+                            <label for="production_capacity"/>
+                            <div class="o_row">
+                                <span><field name="production_capacity"/></span>
+                                <span><field name="product_uom_id" groups="uom.group_uom"/></span>
+                            </div>
                         </group>
                     </group>
                     <field name="production_detailed_vals_ids" attrs="{'invisible': [('counter', '=', 0)]}">


### PR DESCRIPTION
Add in the split wizard the quantity of MO that can be produced using the available quantity of components.

Task-ID: 2773895

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
