### PR TITLE
[FIX] sale_margin: fix compute_purchase_price with use case timesheet_margin

### DIFF
--- a/addons/sale_timesheet_margin/__init__.py
+++ b/addons/sale_timesheet_margin/__init__.py
@@ -2,3 +2,4 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 from . import models
+from . import tests

--- a/addons/sale_timesheet_margin/models/sale_order_line.py
+++ b/addons/sale_timesheet_margin/models/sale_order_line.py
@@ -11,7 +11,11 @@ class SaleOrderLine(models.Model):
             lambda sol: sol.qty_delivered_method == 'timesheet' and not sol.product_id.standard_price and not sol.product_id.service_policy == 'ordered_timesheet'
         )
         already_computed_service = self.filtered(lambda sol: sol.create_date is not False and sol.product_id.service_policy == 'ordered_timesheet')
-        super(SaleOrderLine, self - timesheet_sols - already_computed_service)._compute_purchase_price()
+        manual_purchase_price = self.filtered(
+            lambda sol: sol.purchase_price != sol._convert_price(sol.product_id.standard_price, sol.product_id.uom_id)
+                        and sol.purchase_price != 0 != sol.product_id.standard_price
+        )
+        super(SaleOrderLine, self - timesheet_sols - already_computed_service - manual_purchase_price)._compute_purchase_price()
         if timesheet_sols:
             group_amount = self.env['account.analytic.line'].read_group(
                 [('so_line', 'in', timesheet_sols.ids), ('project_id', '!=', False)],

--- a/addons/sale_timesheet_margin/tests/__init__.py
+++ b/addons/sale_timesheet_margin/tests/__init__.py
@@ -1,0 +1,4 @@
+# # -*- coding: utf-8 -*-
+# # Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from . import test_sale_order

--- a/addons/sale_timesheet_margin/tests/test_sale_order.py
+++ b/addons/sale_timesheet_margin/tests/test_sale_order.py
@@ -1,0 +1,51 @@
+# -*- coding: utf-8 -*-
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from odoo.addons.stock_account.tests.test_stockvaluationlayer import TestStockValuationCommon
+
+
+class TestSaleTimesheetMargin(TestStockValuationCommon):
+
+    @classmethod
+    def setUpClass(cls):
+        super(TestSaleTimesheetMargin, cls).setUpClass()
+
+    def _create_sale_order(self):
+        return self.env['sale.order'].create({
+            'name': 'Sale order',
+            'partner_id': self.env.ref('base.partner_admin').id,
+            'partner_invoice_id': self.env.ref('base.partner_admin').id,
+        })
+
+    def _create_sale_order_line(self, sale_order, product, quantity, price_unit=0):
+        return self.env['sale.order.line'].create({
+            'name': 'Sale order',
+            'order_id': sale_order.id,
+            'price_unit': price_unit,
+            'product_id': product.id,
+            'product_uom_qty': quantity,
+            'product_uom': self.env.ref('uom.product_uom_unit').id,
+        })
+
+    def _create_product(self):
+        product_template = self.env['product.template'].create({
+            'name': 'Super product',
+            'type': 'product',
+        })
+        product_template.categ_id.property_cost_method = 'fifo'
+        return product_template.product_variant_ids
+
+    def test_manual_purchase_price(self):
+        product = self._create_product()
+        product.standard_price = 100
+        so = self._create_sale_order()
+        self._create_sale_order_line(so, product, 1)
+        self.assertEqual(so.order_line.purchase_price, 100)
+        so.order_line.purchase_price = 10
+        self.assertEqual(so.order_line.purchase_price, 10)
+
+        # send quotation
+        email_act = so.action_quotation_send()
+        email_ctx = email_act.get('context', {})
+        so.with_context(**email_ctx).message_post_with_template(email_ctx.get('default_template_id'))
+        self.assertEqual(so.order_line.purchase_price, 10, 'The purchase_price should be 10 and not 100')


### PR DESCRIPTION
Steps to reproduce:
(sale_timesheet_margin, sale_stock_margin, sale_margin)
1. Sales -> configuration -> setting -> Activated the “Margin”.
2. Create a Product. ( Test Product)
- Define Sales Price, cost
- Product category select “Costing Method: Average Cost (AVCO)” and “Inventory Valuation: Automated”
3. Sales quotation
- select Product “Test Product”.
- Change the “Cost” value.
- Click on “Send by Email” (don’t click on the save button).
- Send an email.

Issue:
-> The cost has been reinitialised to its standard_price value.

Cause:
Everything's okay until you install `sale_timesheet_margin` in which case, whenever you send an email`you will compute the fields of the sale order and by extension the analytic_line which in turn triggers the `_compute_purchase_price` method from the sale_timesheet_margin
https://github.com/odoo/odoo/blob/e260a97392e698c88741be713a6b8cc2dc3c74a1/addons/sale_timesheet_margin/models/sale_order_line.py#L8-L9
And in
https://github.com/odoo/odoo/blob/e260a97392e698c88741be713a6b8cc2dc3c74a1/addons/sale_timesheet_margin/models/sale_order_line.py#L14

The method called in `sale_margin` has no case to keep the `purchase_price` if it has been set.

opw-2812360