### PR TITLE
[IMP] account: Simplify tax_audit computation

### DIFF
--- a/addons/account/models/account_move.py
+++ b/addons/account/models/account_move.py
@@ -620,18 +620,16 @@ class AccountMove(models.Model):
             :return:            The result of the compute_all method.
             '''
             move = base_line.move_id
-
+            tax_type = base_line.tax_ids[0].type_tax_use if base_line.tax_ids else None
+            is_refund = (tax_type == 'sale' and base_line.debit) or (tax_type == 'purchase' and base_line.credit)
             if move.is_invoice(include_receipts=True):
                 handle_price_include = True
                 sign = -1 if move.is_inbound() else 1
                 quantity = base_line.quantity
-                is_refund = move.move_type in ('out_refund', 'in_refund')
                 price_unit_wo_discount = sign * base_line.price_unit * (1 - (base_line.discount / 100.0))
             else:
                 handle_price_include = False
                 quantity = 1.0
-                tax_type = base_line.tax_ids[0].type_tax_use if base_line.tax_ids else None
-                is_refund = (tax_type == 'sale' and base_line.debit) or (tax_type == 'purchase' and base_line.credit)
                 price_unit_wo_discount = base_line.amount_currency
 
             balance_taxes_res = base_line.tax_ids._origin.with_context(force_sign=move._get_tax_force_sign()).compute_all(
@@ -644,14 +642,13 @@ class AccountMove(models.Model):
                 handle_price_include=handle_price_include,
             )
 
-            if move.move_type == 'entry':
-                repartition_field = is_refund and 'refund_repartition_line_ids' or 'invoice_repartition_line_ids'
-                repartition_tags = base_line.tax_ids.flatten_taxes_hierarchy().mapped(repartition_field).filtered(lambda x: x.repartition_type == 'base').tag_ids
-                tags_need_inversion = self._tax_tags_need_inversion(move, is_refund, tax_type)
-                if tags_need_inversion:
-                    balance_taxes_res['base_tags'] = base_line._revert_signed_tags(repartition_tags).ids
-                    for tax_res in balance_taxes_res['taxes']:
-                        tax_res['tag_ids'] = base_line._revert_signed_tags(self.env['account.account.tag'].browse(tax_res['tag_ids'])).ids
+            repartition_field = is_refund and 'refund_repartition_line_ids' or 'invoice_repartition_line_ids'
+            repartition_tags = base_line.tax_ids.flatten_taxes_hierarchy().mapped(repartition_field).filtered(lambda x: x.repartition_type == 'base').tag_ids
+            tags_need_inversion = self._tax_tags_need_inversion(move, is_refund, tax_type)
+            if tags_need_inversion:
+                balance_taxes_res['base_tags'] = base_line._revert_signed_tags(repartition_tags).ids
+                for tax_res in balance_taxes_res['taxes']:
+                    tax_res['tag_ids'] = base_line._revert_signed_tags(self.env['account.account.tag'].browse(tax_res['tag_ids'])).ids
 
             return balance_taxes_res
 

--- a/addons/account/models/account_move.py
+++ b/addons/account/models/account_move.py
@@ -3870,15 +3870,7 @@ class AccountMoveLine(models.Model):
             currency = record.company_id.currency_id
             audit_str = ''
             for tag in record.tax_tag_ids:
-
-                if record.move_id.tax_cash_basis_rec_id:
-                    # Cash basis entries are always treated as misc operations, applying the tag sign directly to the balance
-                    type_multiplicator = 1
-                else:
-                    type_multiplicator = (record.journal_id.type == 'sale' and self._get_not_entry_condition(record) and -1 or 1) * (self._get_refund_tax_audit_condition(record) and -1 or 1)
-
-                tag_amount = type_multiplicator * (tag.tax_negate and -1 or 1) * record.balance
-
+                tag_amount = (tag.tax_negate and -1 or 1) * abs(record.balance)
                 if tag.tax_report_line_ids:
                     #Then, the tag comes from a report line, and hence has a + or - sign (also in its name)
                     for report_line in tag.tax_report_line_ids:

--- a/addons/account/tests/common.py
+++ b/addons/account/tests/common.py
@@ -2,6 +2,7 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 from odoo import fields
 from odoo.tests.common import SavepointCase, HttpSavepointCase, tagged, Form
+from odoo.tools.misc import formatLang
 
 import time
 import base64
@@ -490,6 +491,15 @@ class AccountTestInvoicingCommon(SavepointCase):
         :return:                An instance of etree.
         '''
         return etree.fromstring(xml_tree_str)
+
+    @classmethod
+    def _get_tax_audit_string(cls, move, tag, amount):
+        audit_string = ''
+        separator = '        '
+        for report_line in tag.tax_report_line_ids:
+            audit_string += separator if audit_string else ''
+            audit_string += report_line.tag_name + ': ' + formatLang(cls.env, amount, currency_obj=move.currency_id)
+        return audit_string
 
 
 @tagged('post_install', '-at_install')

--- a/addons/account/tests/test_account_move_in_invoice.py
+++ b/addons/account/tests/test_account_move_in_invoice.py
@@ -588,8 +588,18 @@ class TestAccountMoveInInvoiceOnchanges(AccountTestInvoicingCommon):
             line_form.debit = 800
         with move_form.line_ids.edit(4) as line_form:
             # Custom debit on the second tax line.
-            line_form.debit = 250
+            line_form.debit = 325
         move_form.save()
+        # The invoice contains now :
+        #   - Product A / Price 3000.0 / Tax 15 % / Tax amount 450.0 / Total 3450
+        #   - Product B / Price -500.0 / Tax 15 % + Tax 15% copy / Tax Amount 75.0 + Tax Amount 75.0 / Total -650.0
+        # But the accounting lines :
+        #   - First Tax : Balance 800.0
+        #   - Payable : Balance -3550
+        #   - Product A : Balance 3000.0
+        #   - Product B: Balance -500
+        #   - Second Tax : Balance 325.0
+        #   - First Tax (added line) : Balance -75.0
 
         self.assertInvoiceValues(self.invoice, [
             {
@@ -611,6 +621,14 @@ class TestAccountMoveInInvoiceOnchanges(AccountTestInvoicingCommon):
             },
             {
                 **self.tax_line_vals_1,
+                'price_unit': 325.0,
+                'price_subtotal': 325.0,
+                'price_total': 325.0,
+                'amount_currency': 325.0,
+                'debit': 325.0,
+            },
+            {
+                **self.tax_line_vals_1,
                 'price_unit': 800.0,
                 'price_subtotal': 800.0,
                 'price_total': 800.0,
@@ -619,11 +637,12 @@ class TestAccountMoveInInvoiceOnchanges(AccountTestInvoicingCommon):
             },
             {
                 **self.tax_line_vals_2,
-                'price_unit': 250.0,
-                'price_subtotal': 250.0,
-                'price_total': 250.0,
-                'amount_currency': 250.0,
-                'debit': 250.0,
+                'price_unit': -75.0,
+                'price_subtotal': -75.0,
+                'price_total': -75.0,
+                'amount_currency': -75.0,
+                'credit': 75.0,
+                'debit': 0.0,
             },
             {
                 **self.term_line_vals_1,

--- a/addons/account/tests/test_account_move_in_refund.py
+++ b/addons/account/tests/test_account_move_in_refund.py
@@ -271,7 +271,7 @@ class TestAccountMoveInRefundOnchanges(AccountTestInvoicingCommon):
             line_form.credit = 800
         with move_form.line_ids.edit(4) as line_form:
             # Custom credit on the second tax line.
-            line_form.credit = 250
+            line_form.credit = 325
         move_form.save()
 
         self.assertInvoiceValues(self.invoice, [
@@ -301,12 +301,21 @@ class TestAccountMoveInRefundOnchanges(AccountTestInvoicingCommon):
                 'credit': 800.0,
             },
             {
+                **self.tax_line_vals_1,
+                'price_unit': 325.0,
+                'price_subtotal': 325.0,
+                'price_total': 325.0,
+                'amount_currency': -325.0,
+                'credit': 325.0,
+            },
+            {
                 **self.tax_line_vals_2,
-                'price_unit': 250.0,
-                'price_subtotal': 250.0,
-                'price_total': 250.0,
-                'amount_currency': -250.0,
-                'credit': 250.0,
+                'price_unit': -75.0,
+                'price_subtotal': -75.0,
+                'price_total': -75.0,
+                'amount_currency': 75.0,
+                'credit': 0.0,
+                'debit': 75.0,
             },
             {
                 **self.term_line_vals_1,
@@ -810,11 +819,20 @@ class TestAccountMoveInRefundOnchanges(AccountTestInvoicingCommon):
             {
                 **self.tax_line_vals_1,
                 'price_unit': 24.0,
-                'price_subtotal': 24.001,
-                'price_total': 24.001,
+                'price_total': 24.0,
+                'price_subtotal': 24.0,
                 'currency_id': self.currency_data['currency'].id,
-                'amount_currency': -24.001,
+                'amount_currency': -24.0,
                 'credit': 8.0,
+            },
+            {
+                **self.tax_line_vals_1,
+                'price_unit': 0.001,
+                'price_subtotal': 0.001,
+                'price_total': 0.001,
+                'currency_id': self.currency_data['currency'].id,
+                'amount_currency': -0.001,
+                'credit': 0.0,
             },
             {
                 **self.tax_line_vals_2,
@@ -863,6 +881,14 @@ class TestAccountMoveInRefundOnchanges(AccountTestInvoicingCommon):
                 'price_total': 24.0,
                 'amount_currency': -24.0,
                 'credit': 24.0,
+            },
+            {
+                **self.tax_line_vals_1,
+                'price_unit': 0.001,
+                'price_subtotal': 0.001,
+                'price_total': 0.001,
+                'amount_currency': -0.001,
+                'credit': 0.0,
             },
             self.tax_line_vals_2,
             {

--- a/addons/account/tests/test_account_move_out_invoice.py
+++ b/addons/account/tests/test_account_move_out_invoice.py
@@ -573,7 +573,7 @@ class TestAccountMoveOutInvoiceOnchanges(AccountTestInvoicingCommon):
             line_form.credit = 800
         with move_form.line_ids.edit(4) as line_form:
             # Custom credit on the second tax line.
-            line_form.credit = 250
+            line_form.credit = 325
         move_form.save()
 
         self.assertInvoiceValues(self.invoice, [
@@ -603,12 +603,21 @@ class TestAccountMoveOutInvoiceOnchanges(AccountTestInvoicingCommon):
                 'credit': 800.0,
             },
             {
+                **self.tax_line_vals_1,
+                'price_unit': 325.0,
+                'price_subtotal': 325.0,
+                'price_total': 325.0,
+                'amount_currency': -325.0,
+                'credit': 325.0,
+            },
+            {
                 **self.tax_line_vals_2,
-                'price_unit': 250.0,
-                'price_subtotal': 250.0,
-                'price_total': 250.0,
-                'amount_currency': -250.0,
-                'credit': 250.0,
+                'price_unit': -75.0,
+                'price_subtotal': -75.0,
+                'price_total': -75.0,
+                'amount_currency': 75.0,
+                'credit': 0.0,
+                'debit': 75.0,
             },
             {
                 **self.term_line_vals_1,

--- a/addons/account/tests/test_account_move_out_refund.py
+++ b/addons/account/tests/test_account_move_out_refund.py
@@ -270,7 +270,7 @@ class TestAccountMoveOutRefundOnchanges(AccountTestInvoicingCommon):
             line_form.debit = 800
         with move_form.line_ids.edit(4) as line_form:
             # Custom debit on the second tax line.
-            line_form.debit = 250
+            line_form.debit = 325
         move_form.save()
 
         self.assertInvoiceValues(self.invoice, [
@@ -293,6 +293,14 @@ class TestAccountMoveOutRefundOnchanges(AccountTestInvoicingCommon):
             },
             {
                 **self.tax_line_vals_1,
+                'price_unit': 325.0,
+                'price_subtotal': 325.0,
+                'price_total': 325.0,
+                'amount_currency': 325.0,
+                'debit': 325.0,
+            },
+            {
+                **self.tax_line_vals_1,
                 'price_unit': 800.0,
                 'price_subtotal': 800.0,
                 'price_total': 800.0,
@@ -301,11 +309,12 @@ class TestAccountMoveOutRefundOnchanges(AccountTestInvoicingCommon):
             },
             {
                 **self.tax_line_vals_2,
-                'price_unit': 250.0,
-                'price_subtotal': 250.0,
-                'price_total': 250.0,
-                'amount_currency': 250.0,
-                'debit': 250.0,
+                'price_unit': -75.0,
+                'price_subtotal': -75.0,
+                'price_total': -75.0,
+                'amount_currency': -75.0,
+                'credit': 75.0,
+                'debit': 0.0,
             },
             {
                 **self.term_line_vals_1,
@@ -808,11 +817,20 @@ class TestAccountMoveOutRefundOnchanges(AccountTestInvoicingCommon):
             },
             {
                 **self.tax_line_vals_1,
-                'price_unit': 30.0,
-                'price_subtotal': 30.001,
-                'price_total': 30.001,
+                'price_unit': 0.001,
+                'price_subtotal': 0.001,
+                'price_total': 0.001,
                 'currency_id': self.currency_data['currency'].id,
-                'amount_currency': 30.001,
+                'amount_currency': 0.001,
+                'debit': 0.0,
+            },
+            {
+                **self.tax_line_vals_1,
+                'currency_id': self.currency_data['currency'].id,
+                'amount_currency': 30.0,
+                'price_unit': 30.0,
+                'price_subtotal': 30.0,
+                'price_total': 30.0,
                 'debit': 10.0,
             },
             {
@@ -855,6 +873,14 @@ class TestAccountMoveOutRefundOnchanges(AccountTestInvoicingCommon):
                 'debit': 0.01,
             },
             self.product_line_vals_2,
+            {
+                **self.tax_line_vals_1,
+                'price_unit': 0.001,
+                'price_subtotal': 0.001,
+                'price_total': 0.001,
+                'amount_currency': 0.001,
+                'debit': 0.0,
+            },
             {
                 **self.tax_line_vals_1,
                 'price_unit': 30.0,

--- a/addons/account/tests/test_invoice_taxes.py
+++ b/addons/account/tests/test_invoice_taxes.py
@@ -361,11 +361,11 @@ class TestInvoiceTaxes(AccountTestInvoicingCommon):
             credit_line.credit = 1100.0
 
         move = move_form.save()
-
+        # pylint: disable=C0326 bad-whitespace
         self.assertRecordValues(move.line_ids.sorted('balance'), [
-            {'balance': -1100.0,    'tax_ids': [],              'tax_tag_ids': [],                      'tax_base_amount': 0,       'tax_repartition_line_id': False},
-            {'balance': 100.0,      'tax_ids': [],              'tax_tag_ids': self.tax_tag_neg.ids,    'tax_base_amount': 1000,    'tax_repartition_line_id': ref_tax_rep_ln.id},
-            {'balance': 1000.0,     'tax_ids': sale_tax.ids,    'tax_tag_ids': self.base_tag_neg.ids,   'tax_base_amount': 0,       'tax_repartition_line_id': False},
+            {'balance': -1100.0,    'tax_ids': [],              'tax_tag_ids': [],                      'tax_base_amount': 0,       'tax_repartition_line_id': False,             'tax_audit': False},
+            {'balance': 100.0,      'tax_ids': [],              'tax_tag_ids': self.tax_tag_neg.ids,    'tax_base_amount': 1000,    'tax_repartition_line_id': ref_tax_rep_ln.id, 'tax_audit': self._get_tax_audit_string(move, self.tax_tag_neg, -100.0)},
+            {'balance': 1000.0,     'tax_ids': sale_tax.ids,    'tax_tag_ids': self.base_tag_neg.ids,   'tax_base_amount': 0,       'tax_repartition_line_id': False,             'tax_audit': self._get_tax_audit_string(move, self.base_tag_neg, -1000.0)},
         ])
 
         # === Tax in credit ===
@@ -390,11 +390,11 @@ class TestInvoiceTaxes(AccountTestInvoicingCommon):
             debit_line.debit = 1100.0
 
         move = move_form.save()
-
+        # pylint: disable=C0326 bad-whitespace
         self.assertRecordValues(move.line_ids.sorted('balance'), [
-            {'balance': -1000.0,    'tax_ids': sale_tax.ids,    'tax_tag_ids': self.base_tag_neg.ids,   'tax_base_amount': 0,       'tax_repartition_line_id': False},
-            {'balance': -100.0,     'tax_ids': [],              'tax_tag_ids': self.tax_tag_neg.ids,    'tax_base_amount': 1000,    'tax_repartition_line_id': inv_tax_rep_ln.id},
-            {'balance': 1100.0,     'tax_ids': [],              'tax_tag_ids': [],                      'tax_base_amount': 0,       'tax_repartition_line_id': False},
+            {'balance': -1000.0,    'tax_ids': sale_tax.ids,    'tax_tag_ids': self.base_tag_neg.ids,   'tax_base_amount': 0,       'tax_repartition_line_id': False,               'tax_audit': self._get_tax_audit_string(move, self.base_tag_neg, -1000.0)},
+            {'balance': -100.0,     'tax_ids': [],              'tax_tag_ids': self.tax_tag_neg.ids,    'tax_base_amount': 1000,    'tax_repartition_line_id': inv_tax_rep_ln.id,   'tax_audit': self._get_tax_audit_string(move, self.tax_tag_neg, -100.0)},
+            {'balance': 1100.0,     'tax_ids': [],              'tax_tag_ids': [],                      'tax_base_amount': 0,       'tax_repartition_line_id': False,               'tax_audit': False},
         ])
 
     def test_misc_journal_entry_tax_tags_purchase(self):
@@ -440,7 +440,7 @@ class TestInvoiceTaxes(AccountTestInvoicingCommon):
         # Debit base tax line.
         with move_form.line_ids.new() as credit_line:
             credit_line.name = 'debit_line_1'
-            credit_line.account_id = self.company_data['default_account_revenue']
+            credit_line.account_id = self.company_data['default_account_expense']
             credit_line.debit = 1000.0
             credit_line.tax_ids.clear()
             credit_line.tax_ids.add(purch_tax)
@@ -450,15 +450,15 @@ class TestInvoiceTaxes(AccountTestInvoicingCommon):
         # Balance the journal entry.
         with move_form.line_ids.new() as credit_line:
             credit_line.name = 'balance'
-            credit_line.account_id = self.company_data['default_account_revenue']
+            credit_line.account_id = self.company_data['default_account_expense']
             credit_line.credit = 1100.0
 
         move = move_form.save()
-
+        # pylint: disable=C0326 bad-whitespace
         self.assertRecordValues(move.line_ids.sorted('balance'), [
-            {'balance': -1100.0,    'tax_ids': [],              'tax_tag_ids': [],                      'tax_base_amount': 0,       'tax_repartition_line_id': False},
-            {'balance': 100.0,      'tax_ids': [],              'tax_tag_ids': self.tax_tag_pos.ids,    'tax_base_amount': 1000,    'tax_repartition_line_id': inv_tax_rep_ln.id},
-            {'balance': 1000.0,     'tax_ids': purch_tax.ids,   'tax_tag_ids': self.base_tag_pos.ids,   'tax_base_amount': 0,       'tax_repartition_line_id': False},
+            {'balance': -1100.0,    'tax_ids': [],              'tax_tag_ids': [],                      'tax_base_amount': 0,       'tax_repartition_line_id': False,               'tax_audit': False},
+            {'balance': 100.0,      'tax_ids': [],              'tax_tag_ids': self.tax_tag_pos.ids,    'tax_base_amount': 1000,    'tax_repartition_line_id': inv_tax_rep_ln.id,   'tax_audit': self._get_tax_audit_string(move, self.tax_tag_pos, 100.0)},
+            {'balance': 1000.0,     'tax_ids': purch_tax.ids,   'tax_tag_ids': self.base_tag_pos.ids,   'tax_base_amount': 0,       'tax_repartition_line_id': False,               'tax_audit': self._get_tax_audit_string(move, self.base_tag_pos, 1000.0)},
         ])
 
         # === Tax in credit ===
@@ -469,7 +469,7 @@ class TestInvoiceTaxes(AccountTestInvoicingCommon):
         # Debit base tax line.
         with move_form.line_ids.new() as credit_line:
             credit_line.name = 'debit_line_1'
-            credit_line.account_id = self.company_data['default_account_revenue']
+            credit_line.account_id = self.company_data['default_account_expense']
             credit_line.credit = 1000.0
             credit_line.tax_ids.clear()
             credit_line.tax_ids.add(purch_tax)
@@ -479,11 +479,11 @@ class TestInvoiceTaxes(AccountTestInvoicingCommon):
         # Balance the journal entry.
         with move_form.line_ids.new() as debit_line:
             debit_line.name = 'balance'
-            debit_line.account_id = self.company_data['default_account_revenue']
+            debit_line.account_id = self.company_data['default_account_expense']
             debit_line.debit = 1100.0
 
         move = move_form.save()
-
+        # pylint: disable=C0326 bad-whitespace
         self.assertRecordValues(move.line_ids.sorted('balance'), [
             {'balance': -1000.0,    'tax_ids': purch_tax.ids,   'tax_tag_ids': self.base_tag_pos.ids,   'tax_base_amount': 0,       'tax_repartition_line_id': False},
             {'balance': -100.0,     'tax_ids': [],              'tax_tag_ids': self.tax_tag_pos.ids,    'tax_base_amount': 1000,    'tax_repartition_line_id': ref_tax_rep_ln.id},

--- a/addons/point_of_sale/tests/common.py
+++ b/addons/point_of_sale/tests/common.py
@@ -356,8 +356,20 @@ class TestPoSCommon(ValuationReconciliationTestCommon):
             return cls.env['account.account.tag'].create({
                 'name': name,
                 'applicability': 'taxes',
-                'country_id': cls.env.company.country_id.id
+                'country_id': cls.env.company.country_id.id,
+                'tax_report_line_ids': [
+                    (0, 0, {
+                        'name': name,
+                        'tag_name': name,
+                        'report_id': cls.tax_report.id,
+                        'sequence': 10,
+                    })
+                ]
             })
+        cls.tax_report = cls.env['account.tax.report'].create({
+            'name': "Tax report",
+            'country_id': cls.company_data['company'].country_id.id,
+        })
 
         cls.tax_tag_invoice_base = create_tag('Invoice Base tag')
         cls.tax_tag_invoice_tax = create_tag('Invoice Tax tag')

--- a/addons/point_of_sale/tests/common.py
+++ b/addons/point_of_sale/tests/common.py
@@ -352,11 +352,12 @@ class TestPoSCommon(ValuationReconciliationTestCommon):
         tax10: 10%, included in product price
         tax21: 21%, included in product price
         """
-        def create_tag(name):
+        def create_tag(name, negate=False):
             return cls.env['account.account.tag'].create({
                 'name': name,
                 'applicability': 'taxes',
                 'country_id': cls.env.company.country_id.id,
+                'tax_negate': negate,
                 'tax_report_line_ids': [
                     (0, 0, {
                         'name': name,
@@ -373,8 +374,8 @@ class TestPoSCommon(ValuationReconciliationTestCommon):
 
         cls.tax_tag_invoice_base = create_tag('Invoice Base tag')
         cls.tax_tag_invoice_tax = create_tag('Invoice Tax tag')
-        cls.tax_tag_refund_base = create_tag('Refund Base tag')
-        cls.tax_tag_refund_tax = create_tag('Refund Tax tag')
+        cls.tax_tag_refund_base = create_tag('Refund Base tag', True)
+        cls.tax_tag_refund_tax = create_tag('Refund Tax tag', True)
 
         def create_tax(percentage, price_include=False):
             return cls.env['account.tax'].create({

--- a/addons/point_of_sale/tests/test_pos_products_with_tax.py
+++ b/addons/point_of_sale/tests/test_pos_products_with_tax.py
@@ -329,12 +329,13 @@ class TestPoSProductsWithTax(TestPoSCommon):
         lines = self.pos_session.move_id.line_ids.sorted('balance')
         self.assertEqual(2, len(lines.filtered(lambda l: l.tax_ids)), "Taxes should have been set on 2 lines")
         self.assertEqual(4, len(lines.filtered(lambda l: l.tax_tag_ids)), "Tags should have been set on 4 lines")
+        # pylint: disable=C0326 bad-whitespace
         self.assertRecordValues(lines, [
-            {'account_id': self.sale_account.id,           'balance': -10.0, 'tax_ids': tax_21_incl.ids, 'tax_tag_ids': self.tax_tag_invoice_base.ids},
-            {'account_id': self.tax_received_account.id,   'balance': -2.10, 'tax_ids': [],              'tax_tag_ids': self.tax_tag_invoice_tax.ids},
-            {'account_id': self.tax_received_account.id,   'balance':  1.05, 'tax_ids': [],              'tax_tag_ids': self.tax_tag_refund_tax.ids},
-            {'account_id': self.sale_account.id,           'balance':  5.00, 'tax_ids': tax_21_incl.ids, 'tax_tag_ids': self.tax_tag_refund_base.ids},
-            {'account_id': self.pos_receivable_account.id, 'balance':  6.05, 'tax_ids': [],              'tax_tag_ids': []},
+            {'account_id': self.sale_account.id,           'balance': -10.0, 'tax_ids': tax_21_incl.ids, 'tax_tag_ids': self.tax_tag_invoice_base.ids, 'tax_audit': self._get_tax_audit_string(self.pos_session.move_id, self.tax_tag_invoice_base, 10.0)},
+            {'account_id': self.tax_received_account.id,   'balance': -2.10, 'tax_ids': [],              'tax_tag_ids': self.tax_tag_invoice_tax.ids, 'tax_audit': self._get_tax_audit_string(self.pos_session.move_id, self.tax_tag_invoice_tax, 2.10)},
+            {'account_id': self.tax_received_account.id,   'balance':  1.05, 'tax_ids': [],              'tax_tag_ids': self.tax_tag_refund_tax.ids, 'tax_audit': self._get_tax_audit_string(self.pos_session.move_id, self.tax_tag_refund_tax, -1.05)},
+            {'account_id': self.sale_account.id,           'balance':  5.00, 'tax_ids': tax_21_incl.ids, 'tax_tag_ids': self.tax_tag_refund_base.ids, 'tax_audit': self._get_tax_audit_string(self.pos_session.move_id, self.tax_tag_refund_base, -5.0)},
+            {'account_id': self.pos_receivable_account.id, 'balance':  6.05, 'tax_ids': [],              'tax_tag_ids': [], 'tax_audit': False},
         ])
 
     def test_pos_create_account_move_round_globally(self):


### PR DESCRIPTION
Tax Audit field computation was very odd to understand and reasons code have been added is not obvious.

This is a proposal of simplification in order to use the Tax Negate field in account tags in order to determine the sign value.

Note: I've found the tax negate field help : https://github.com/odoo/odoo/blob/14.0/addons/account/models/account_account_tag.py#L15

I think this is what code does now and surely wanted when refactor done by @smetl there https://github.com/odoo/odoo/commit/7076b4f4d0d933d93b24e8e4c7cf21ef0b0008e5

Tasks:

- [x] Simplify tax audit computation
- [x] Fix tests in point of sale - Create refund taxes with Tax Negate == True
- [x] Fix mixed invoices with normal lines and discount lines - negative quantity or price (those ones have wrong tax tag affected - Note: In a miscellaneous operation, behavior is correct)

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
