### PR TITLE
[FIX] mail: fix url redirection in case of non-logged user

### DIFF
--- a/addons/mail/controllers/mail.py
+++ b/addons/mail/controllers/mail.py
@@ -97,7 +97,17 @@ class MailController(http.Controller):
         else:
             record_action = record_sudo.get_access_action()
             if record_action['type'] == 'ir.actions.act_url' and record_action.get('target_type') != 'public':
-                return cls._redirect_to_messaging()
+                url_params = {
+                    'model': model,
+                    'id': res_id,
+                    'active_id': res_id,
+                    'action': record_action.get('id'),
+                }
+                view_id = record_sudo.get_formview_id()
+                if view_id:
+                    url_params['view_id'] = view_id
+                url = '/web/login?redirect=#%s' % url_encode(url_params)
+                return request.redirect(url)
 
         record_action.pop('target_type', None)
         # the record has an URL redirection: use it directly


### PR DESCRIPTION
### Observed Behaviour

When assigning someone to a task (in project), the employee will receive a link be email. If he opens this link in a
browser where he isn't already logged, he will be redirected to the logging page and, after have successfully logged in,
he will be redirected to the Odoo mail module

### Expected Behaviour
After a successful loggin, the user should be redirected to the task view

### Reproducibility
This issue can be reproduced with the following steps:
1. Connect as Mitchell Admin
2. Go to the project module
3. Create a new task and assign it to Marc Demo
4. Go to Mark Demo's email and open the related mail
5. Open the link in the mail in an incognito window
6. Log in as Marc Demo

### Fix Description
The issue is coming from the fact that, when no user is logged in and if the url isn't public, we redirect the
url to the connection page without ensuring we have the correct redirection after the loggin. This is fixed by
editing the url to web/login?redirect= + target url

### Related Issues/PR
 - opw-2802439

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
