### PR TITLE
[FIX] purchase_stock: create new POL if different RR

### DIFF
--- a/addons/purchase_stock/models/purchase.py
+++ b/addons/purchase_stock/models/purchase.py
@@ -528,7 +528,7 @@ class PurchaseOrderLine(models.Model):
             description_picking = values['product_description_variants']
         lines = self.filtered(
             lambda l: l.propagate_cancel == values['propagate_cancel']
-            and ((values['orderpoint_id'] and not values['move_dest_ids']) and l.orderpoint_id == values['orderpoint_id'] or True)
+            and (l.orderpoint_id == values['orderpoint_id'] if values['orderpoint_id'] and not values['move_dest_ids'] else True)
         )
 
         # In case 'product_description_variants' is in the values, we also filter on the PO line

--- a/addons/purchase_stock/tests/test_reordering_rule.py
+++ b/addons/purchase_stock/tests/test_reordering_rule.py
@@ -637,3 +637,49 @@ class TestReorderingRule(SavepointCase):
             [("product_id", "=", product.id)])
         self.assertTrue(po_line)
         self.assertEqual("[A] product TEST", po_line.name)
+
+    def test_multi_locations_and_reordering_rule(self):
+        """
+        Suppose two orderpoints for the same product, each one to a different location
+        If the user triggers each orderpoint separately, it should still produce two
+        different purchase order lines (one for each orderpoint)
+        """
+        warehouse = self.env['stock.warehouse'].search([('company_id', '=', self.env.user.id)], limit=1)
+        stock_location = warehouse.lot_stock_id
+        sub_location = self.env['stock.location'].create({'name': 'subloc_1', 'location_id': stock_location.id})
+
+        orderpoint_form = Form(self.env['stock.warehouse.orderpoint'])
+        orderpoint_form.warehouse_id = warehouse
+        orderpoint_form.location_id = stock_location
+        orderpoint_form.product_id = self.product_01
+        orderpoint_form.product_min_qty = 1
+        orderpoint_form.product_max_qty = 1
+        stock_op = orderpoint_form.save()
+
+        orderpoint_form = Form(self.env['stock.warehouse.orderpoint'])
+        orderpoint_form.warehouse_id = warehouse
+        orderpoint_form.location_id = sub_location
+        orderpoint_form.product_id = self.product_01
+        orderpoint_form.product_min_qty = 2
+        orderpoint_form.product_max_qty = 2
+        sub_op = orderpoint_form.save()
+
+        stock_op.action_replenish()
+        sub_op.action_replenish()
+
+        po = self.env['purchase.order'].search([('partner_id', '=', self.partner.id)])
+        self.assertRecordValues(po.order_line, [
+            {'product_id': self.product_01.id, 'product_qty': 1.0, 'orderpoint_id': stock_op.id},
+            {'product_id': self.product_01.id, 'product_qty': 2.0, 'orderpoint_id': sub_op.id},
+        ])
+
+        po.button_confirm()
+        picking = po.picking_ids
+        action = picking.button_validate()
+        wizard = Form(self.env[(action.get('res_model'))].with_context(action['context'])).save()
+        wizard.process()
+
+        self.assertRecordValues(picking.move_line_ids, [
+            {'product_id': self.product_01.id, 'qty_done': 1.0, 'state': 'done', 'location_dest_id': stock_location.id},
+            {'product_id': self.product_01.id, 'qty_done': 2.0, 'state': 'done', 'location_dest_id': sub_location.id},
+        ])


### PR DESCRIPTION
If the user triggers several orderpoints one by one, some purchase order
lines may be merged while they shouldn't.

To reproduce the issue:
1. In Settings, enable "Storage Locations"
2. Create a product P:
    - Type: Storable
    - With a vendor V
    - Route: Buy
3. Add two reordering rules to P:
    - Min=Max=1 at WH/Stock
    - Min=Max=2 at WH/Stock/Shelf 1
4. Inventory > Operations > Replenishment, trigger the orderpoints of P
(one by one)
5. Open the generated PO

Error: There is only one line with 3 x P, there should be two lines (1 x
P + 2 x P, one for each orderpoint). If the user confirms the PO and
receives the products, the destination location will be Stock or Shelf 1
(depending on the last orderpoint triggered)

Running the orderpoint leads to `_run_buy`, where we try to find an
existing PO line so we can update it (else we will create a new one):
https://github.com/odoo/odoo/blob/5b34adb51eda978aa9ef1a434ab77257d73b9594/addons/purchase_stock/models/stock_rule.py#L122-L129

Here is the issue: the filter in `_find_candidate` contains an `or True`
that makes a whole condition useless.

Considering [1], the condition on `move_dest_ids` is only relevant when
an orderpoint is defined. Therefore, we can remove the `or True` and
improve the condition

[1] 63fffa0beeb83f1cb857929959e72ff72a481304

OPW-2720868