### PR TITLE
[REV] expression: revert performance search one2many commit

### DIFF
--- a/odoo/addons/base/tests/test_expression.py
+++ b/odoo/addons/base/tests/test_expression.py
@@ -1591,10 +1591,9 @@ class TestOne2many(TransactionCase):
         with self.assertQueries(['''
             SELECT "res_partner".id
             FROM "res_partner"
-            WHERE EXISTS (
-                SELECT 1 FROM "res_partner_bank" AS "res_partner__bank_ids"
-                WHERE "res_partner__bank_ids"."partner_id" = "res_partner".id
-            )
+            WHERE ("res_partner"."id" IN (
+                SELECT "partner_id" FROM "res_partner_bank" WHERE "partner_id" IS NOT NULL
+            ))
             ORDER BY "res_partner"."id"
         ''']):
             self.Partner.search([('bank_ids', '!=', False)], order='id')
@@ -1602,10 +1601,9 @@ class TestOne2many(TransactionCase):
         with self.assertQueries(['''
             SELECT "res_partner".id
             FROM "res_partner"
-            WHERE NOT EXISTS (
-                SELECT 1 FROM "res_partner_bank" AS "res_partner__bank_ids"
-                WHERE "res_partner__bank_ids"."partner_id" = "res_partner".id
-            )
+            WHERE ("res_partner"."id" NOT IN (
+                SELECT "partner_id" FROM "res_partner_bank" WHERE "partner_id" IS NOT NULL
+            ))
             ORDER BY "res_partner"."id"
         ''']):
             self.Partner.search([('bank_ids', '=', False)], order='id')

--- a/odoo/osv/expression.py
+++ b/odoo/osv/expression.py
@@ -786,14 +786,9 @@ class expression(object):
                 else:
                     if inverse_field.store and not (inverse_is_int and domain):
                         # rewrite condition to match records with/without lines
-                        exists = 'EXISTS' if operator in NEGATIVE_TERM_OPERATORS else 'NOT EXISTS'
-                        rel_alias = _generate_table_alias(alias, field.name)
-                        push_result(f"""
-                            {exists} (
-                                SELECT 1 FROM "{comodel._table}" AS "{rel_alias}"
-                                WHERE "{rel_alias}"."{inverse_field.name}" = "{alias}".id
-                            )
-                        """, [])
+                        op1 = 'inselect' if operator in NEGATIVE_TERM_OPERATORS else 'not inselect'
+                        subquery = f'SELECT "{inverse_field.name}" FROM "{comodel._table}" WHERE "{inverse_field.name}" IS NOT NULL'
+                        push(('id', op1, (subquery, [])), model, alias, internal=True)
                     else:
                         comodel_domain = [(inverse_field.name, '!=', False)]
                         if inverse_is_int and domain:


### PR DESCRIPTION
Reverts commit 54cd73a4f4 (#78607) as it prevents customers from closing
their pos sessions without timeouting. 

It also seems to impact stock.move operations.


tickets impacted: 

- 2822674
- 2822956
- 2805087
- 2822330
- 2821836
- 2821782


When name_searching products, using `EXISTS` here speeds up the leaf `product_variant_ids = False`.
However, it seems that when doing read_groups, the `EXISTS` condition prevents the planner
to go for a Hash Join. Instead, it performs multiple Nested Loop + index scan, which is much
slower when the tables become bigger.

Plan with EXISTS to retrieve grouped by purchase_order_line data: https://explain.dalibo.com/plan/8vJ

Plan without EXISTS: https://explain.dalibo.com/plan/niG


--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
