### PR TITLE
[FIX] base: allow reports header/footer RTL with LTR user

### DIFF
--- a/odoo/addons/base/models/ir_actions_report.py
+++ b/odoo/addons/base/models/ir_actions_report.py
@@ -366,11 +366,15 @@ class IrActionsReport(models.Model):
             footer_node.append(node)
 
         # Retrieve bodies
+        layout_sections = None
         for node in root.xpath(match_klass.format('article')):
             layout_with_lang = layout
-            # set context language to body language
             if node.get('data-oe-lang'):
+                # context language to body language
                 layout_with_lang = layout_with_lang.with_context(lang=node.get('data-oe-lang'))
+                # set header/lang to body lang prioritizing current user language
+                if not layout_sections or node.get('data-oe-lang') == self.env.lang:
+                    layout_sections = layout_with_lang
             body = layout_with_lang.render(dict(subst=False, body=lxml.html.tostring(node), base_url=base_url, report_xml_id=self.xml_id))
             bodies.append(body)
             if node.get('data-oe-model') == self.model:
@@ -389,8 +393,8 @@ class IrActionsReport(models.Model):
             if attribute[0].startswith('data-report-'):
                 specific_paperformat_args[attribute[0]] = attribute[1]
 
-        header = layout.render(dict(subst=True, body=lxml.html.tostring(header_node), base_url=base_url))
-        footer = layout.render(dict(subst=True, body=lxml.html.tostring(footer_node), base_url=base_url))
+        header = (layout_sections or layout).render(dict(subst=True, body=lxml.html.tostring(header_node), base_url=base_url))
+        footer = (layout_sections or layout).render(dict(subst=True, body=lxml.html.tostring(footer_node), base_url=base_url))
 
         return bodies, res_ids, header, footer, specific_paperformat_args
 


### PR DESCRIPTION
When selecting at least 10 SO with RTL language on the customer, the printing behavior
(the PDF produced) is inconsistent. By inconsistent, we mean some pages are completely
filled with buggy headers making the whole PDF corrupted (on a business point of view).

Step to reproduce the issue:
1. The customer/vendor on the PO, SO, RFQ has language set to Arabic
2. The user creating the document has language set to English (US)
3. Printing out 10+ documents
The resulting PDF document is inconsistent and contains headers issues (as previously stated).

Solution: The problem is that the headers/footers doesn't take into account the language
of the company (RTL or not). In fact, all the headers/footers of a batch print are contained into
a single HTML file (apparently, at the time, `wkhtmltopdf` did not support multiple headers/footers).
A Javascript script is used to select the appropriate header/footer for each page of the PDF. The issue
is that the CSS file used for these headers/footers is always a LTR CSS file. Moreover, with this design, it
is impossible to combine headers/footers in RTL and LTR into a single PDF file with multiple pages. The complete
solution would be to create a single header/footer file per page in the PDF report (`wkhtmltopdf` now supports this),
that way we can specify the language (RTL or LTR) for each of the page and have the perfect behavior. However,
this change cannot be applied into a stable version (requires changes in signature of methods, etc.), consequently,
the full solution will only be kept for `master`. A partial fix would be to use one language on the footer/header, this
would solve the issues when we only print headers/footers in RTL or LTR languages. The fix would not render a perfect
PDF if there is a mix between LTR and RTL in the PDF (only the layout of the header/footer would be non-perfect).
E.G.: in a mix PDF, the logo image would always be to the left side while it should be to the right side for RTL documents.
Nonetheless, this partial fix solve the inconsistent behavior described in the bug which is already an improvement and solve the issue on a business point of view.

opw-2734671