### PR TITLE
[FIX] purchase_stock: decrease the sale qty without creating a return

### DIFF
--- a/addons/purchase_stock/models/purchase.py
+++ b/addons/purchase_stock/models/purchase.py
@@ -109,7 +109,7 @@ class PurchaseOrder(models.Model):
                         move_dest_ids = order_line.move_dest_ids
                         if order_line.propagate_cancel:
                             move_dest_ids._action_cancel()
-                        else:
+                        elif order_line.move_ids:
                             move_dest_ids.write({'procure_method': 'make_to_stock'})
                             move_dest_ids._recompute_state()
 


### PR DESCRIPTION
Steps to reproduce the bug:
- Activate the multistep route
- Unarchive the "Replenish on Order (MTO)" route
- Create the Product “P1” with buy and MTO route
- Create a SO with 3 qty of the product “P1” > confirm
- A purchase order and picking  are created
- Reduce the quantities sold to 1
- The qty in the delivery and the PO are updated
- Cancel the PO
- Reduce the quantities sold to 1
- A return picking is created

Problem:
The delivery should be decreased in the same way instead of creating a return

When the PO is not cancelled, as we are in MTO > the `run_pull` rule creates a new `stock.move` with `procure_method="Make to order"`
and as the first `stock_move` was also created with a `procure_method = "Make to order"` and the other fields are similar too.
Both `stock.moves` can be merged:

https://github.com/odoo/odoo/blob/dda9700d8236091626cbd78efc0ca4116e1e1acd/addons/stock/models/stock_move.py#L869-L881

However, when cancelling the PO, The move is not canceled and its `procure_method` is updated to `“Make to stock”`:
https://github.com/odoo/odoo/blob/dabe59df9c84d5dbb7109decb193606b8cc2efe0/addons/purchase_stock/models/purchase.py#L104

So, now when we reduce the qty in the SO > the run_pull rule creates a new `stock.move` with procure_method="Make to order"
then, we try to merge with the first stock_move > not possible because they don't have the same `procure_method`
so it creates a new return picking.

Solution:
If there are no move_ids to cancel for the order_lines, then there is no point in changing the procure method
from purchase to MTS to link the move's chain

opw-2802485




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
