### PR TITLE
[FIX] mail: allow regular users to create mail non-dynamic templates

### DIFF
--- a/addons/mail/i18n/mail.pot
+++ b/addons/mail/i18n/mail.pot
@@ -4869,6 +4869,7 @@ msgstr ""
 #. module: mail
 #: code:addons/mail/models/mail_render_mixin.py:0
 #: code:addons/mail/models/mail_render_mixin.py:0
+#: code:addons/mail/models/mail_render_mixin.py:0
 #, python-format
 msgid "Only users belonging to the \"%s\" group can modify dynamic templates."
 msgstr ""

--- a/addons/mail/models/mail_render_mixin.py
+++ b/addons/mail/models/mail_render_mixin.py
@@ -127,6 +127,23 @@ class MailRenderMixin(models.AbstractModel):
         # allow specifying rendering options directly from field when using the render mixin
         return name in ['render_engine', 'render_options'] or super()._valid_field_parameter(field, name)
 
+    @api.model_create_multi
+    def create(self, values_list):
+        record = super().create(values_list)
+        if self._unrestricted_rendering:
+            # If the rendering is unrestricted (e.g. mail.template),
+            # check the user is part of the mail editor group to create a new template if the template is dynamic
+            record._check_access_right_dynamic_template()
+        return record
+
+    def write(self, vals):
+        super().write(vals)
+        if self._unrestricted_rendering:
+            # If the rendering is unrestricted (e.g. mail.template),
+            # check the user is part of the mail editor group to modify a template if the template is dynamic
+            self._check_access_right_dynamic_template()
+        return True
+
     # ------------------------------------------------------------
     # TOOLS
     # ------------------------------------------------------------
@@ -219,6 +236,46 @@ class MailRenderMixin(models.AbstractModel):
             """).format(preview_markup)
             return tools.prepend_html_content(html, html_preview)
         return html
+
+    # ------------------------------------------------------------
+    # SECURITY
+    # ------------------------------------------------------------
+
+    def _is_dynamic(self):
+        for template in self:
+            for fname, field in template._fields.items():
+                engine = getattr(field, 'render_engine', 'inline_template')
+                if engine in ('qweb', 'qweb_view'):
+                    if self._is_dynamic_template_qweb(template[fname]):
+                        return True
+                else:
+                    if self._is_dynamic_template_inline_template(template[fname]):
+                        return True
+        return False
+
+    @api.model
+    def _is_dynamic_template_qweb(self, template_src):
+        if template_src:
+            try:
+                node = html.fragment_fromstring(template_src, create_parent='div')
+                self.env["ir.qweb"]._compile(node, options={'raise_on_code': True})
+            except QWebCodeFound:
+                return True
+        return False
+
+    @api.model
+    def _is_dynamic_template_inline_template(self, template_txt):
+        if template_txt:
+            template_instructions = parse_inline_template(str(template_txt))
+            if len(template_instructions) > 1 or template_instructions[0][1]:
+                return True
+        return False
+
+    def _check_access_right_dynamic_template(self):
+        if not self.env.su and not self.env.user.has_group('mail.group_mail_template_editor') and self._is_dynamic():
+            group = self.env.ref('mail.group_mail_template_editor')
+            raise AccessError(_('Only users belonging to the "%s" group can modify dynamic templates.', group.name))
+
     # ------------------------------------------------------------
     # RENDERING
     # ------------------------------------------------------------

--- a/addons/mail/security/ir.model.access.csv
+++ b/addons/mail/security/ir.model.access.csv
@@ -31,7 +31,7 @@ access_mail_tracking_value_portal,mail.tracking.value.portal,model_mail_tracking
 access_mail_tracking_value_user,mail.tracking.value.user,model_mail_tracking_value,base.group_user,0,0,0,0
 access_mail_tracking_value_system,mail.tracking.value.system,model_mail_tracking_value,base.group_system,1,1,1,1
 access_publisher_warranty_contract_all,publisher.warranty.contract.all,model_publisher_warranty_contract,,1,1,1,1
-access_mail_template,mail.template,model_mail_template,base.group_user,1,0,0,0
+access_mail_template,mail.template,model_mail_template,base.group_user,1,1,1,1
 access_mail_template_editor,mail.template_editor,model_mail_template,mail.group_mail_template_editor,1,1,1,1
 access_mail_template_system,mail.template_system,model_mail_template,base.group_system,1,1,1,1
 access_mail_shortcode,mail.shortcode,model_mail_shortcode,base.group_user,1,1,1,1

--- a/addons/mail/security/mail_security.xml
+++ b/addons/mail/security/mail_security.xml
@@ -65,6 +65,28 @@
             <field name="perm_unlink" eval="False"/>
         </record>
 
+        <record id="mail_template_employee_rule" model="ir.rule">
+            <field name="name">Employees can only change their own templates</field>
+            <field name="model_id" ref="model_mail_template"/>
+            <field name="domain_force">[('create_uid', '=', user.id)]</field>
+            <field name="groups" eval="[Command.link(ref('base.group_user'))]"/>
+            <field name="perm_create" eval="True"/>
+            <field name="perm_read" eval="False"/>
+            <field name="perm_write" eval="True"/>
+            <field name="perm_unlink" eval="True"/>
+        </record>
+
+        <record id="mail_template_editor_rule" model="ir.rule">
+            <field name="name">Mail Template Editors - Edit All Templates</field>
+            <field name="model_id" ref="model_mail_template"/>
+            <field name="domain_force">[(1, '=', 1)]</field>
+            <field name="groups" eval="[Command.link(ref('group_mail_template_editor')), Command.link(ref('base.group_system'))]"/>
+            <field name="perm_create" eval="True"/>
+            <field name="perm_read" eval="False"/>
+            <field name="perm_write" eval="True"/>
+            <field name="perm_unlink" eval="True"/>
+        </record>
+
         <record id="res_users_settings_rule_admin" model="ir.rule">
             <field name="name">Administrators can access all User Settings.</field>
             <field name="model_id" ref="model_res_users_settings"/>

--- a/addons/mail/wizard/mail_compose_message_views.xml
+++ b/addons/mail/wizard/mail_compose_message_views.xml
@@ -79,8 +79,9 @@
                         <button string="Send" attrs="{'invisible': [('is_log', '=', True)]}" name="action_send_mail" type="object" class="btn-primary o_mail_send" data-hotkey="q"/>
                         <button string="Log" attrs="{'invisible': [('is_log', '=', False)]}" name="action_send_mail" type="object" class="btn-primary" data-hotkey="q"/>
                         <button string="Cancel" class="btn-secondary" special="cancel" data-hotkey="z" />
-                        <button icon="fa-lg fa-save" type="object" groups="mail.group_mail_template_editor"
+                        <button icon="fa-lg fa-save" type="object"
                                 name="action_save_as_template" string="Save as new template"
+                                attrs="{'invisible': [('can_edit_body', '=', False)]}"
                                 class="float-right btn-secondary" help="Save as a new template"/>
                     </footer>
                 </form>


### PR DESCRIPTION
The goal is for regular user (e.g. salesmen) to be able to create their email templates themselves, as long as they do not contain any dynamic code.

Interrogations:
 - The condition to apply this strategy is currently doing it for models having the unrestricted rendering set to True. I wonder if we couldn't apply this for all models inheriting from `mail.render.mixin`, simply.
 - Is this `_unrestricted_rendering` still useful if we do so ? If not, maybe we could remove/refactor this in master.
 - With this, shouldn't we remove the mail editor group from the inherited groups of the employee group ?
 - Is it correct to loop on all fields of the model to check if they are dynamic ? Shouldn't we loop over a restricted set of fields of the model (e.g. `body_html`, `email_to`, ...) that could be given in a global list or in a method that could be overridden by modules ? Or simply force to set a `render_engine` on the attribute of the field to tell this is a field which can be templated/rendered.