### PR TITLE
[FIX] website: fix cookiebar responsiveness

### DIFF
--- a/addons/website/static/src/scss/website.scss
+++ b/addons/website/static/src/scss/website.scss
@@ -1442,6 +1442,13 @@ $ribbon-padding: 100px;
     :not(.o_cookies_popup) {
         bottom: 0;
     }
+    .o_cookies_discrete {
+        .js_close_popup.o_cookies_bar_text_button, .o_cookies_bar_text_policy {
+            @include media-breakpoint-down(md) {
+                margin-bottom: 1rem;
+            }
+        }
+    }
 }
 
 .o_website_btn_loading {

--- a/addons/website/static/src/snippets/s_popup/001.scss
+++ b/addons/website/static/src/snippets/s_popup/001.scss
@@ -10,6 +10,9 @@
     .modal-dialog {
         height: auto;
         min-height: 100%;
+        @include media-breakpoint-down(xs) {
+            min-height: calc(100% - 2 * #{$modal-dialog-margin});
+        }
     }
 
     // Close icon


### PR DESCRIPTION
### Current behavior
Cookie bar is slightly shifted during mobile browsing, which complicates the acceptation and prevents navigation through the site (which is not the case during a "desktop" browsing)

### Steps
- Install Website
- Enable cookie bar in the Settings
- Go on the Website with a mobile screen width

OPW-2784233