### PR TITLE
[FIX] base,web,stock: allow PDF header/footer to vary per page (RTL/LTR)

### DIFF
--- a/addons/stock/report/stock_traceability.py
+++ b/addons/stock/report/stock_traceability.py
@@ -226,7 +226,7 @@ class MrpStockReport(models.TransientModel):
 
         return self.env['ir.actions.report']._run_wkhtmltopdf(
             [body],
-            header=header.decode(),
+            headers=[header.decode()],
             landscape=True,
             specific_paperformat_args={'data-report-margin-top': 17, 'data-report-header-spacing': 12}
         )

--- a/addons/web/views/report_templates.xml
+++ b/addons/web/views/report_templates.xml
@@ -265,20 +265,6 @@
                             for (var j=0; j&lt;y.length; ++j)
                                 y[j].textContent = vars[x[i]];
                         }
-
-                        var index = vars['webpage'].split('.', 4)[3];
-                        var header = document.getElementById('minimal_layout_report_headers');
-                        if(header){
-                            var companyHeader = header.children[index];
-                            header.textContent = '';
-                            header.appendChild(companyHeader);
-                        }
-                        var footer = document.getElementById('minimal_layout_report_footers');
-                        if(footer){
-                            var companyFooter = footer.children[index];
-                            footer.textContent = '';
-                            footer.appendChild(companyFooter);
-                        }
                     }
                 </script>
             </head>
@@ -308,7 +294,7 @@
     </template>
 
     <template id="external_layout_striped">
-        <div t-attf-class="o_company_#{company.id}_layout header" t-att-style="report_header_style">
+        <div t-attf-class="o_company_#{company.id}_layout header" t-att-style="report_header_style" t-att-data-oe-lang="o and o.env.context.get('lang')">
             <div class="o_background_header">
             <div class="float-right">
                 <h3 class="mt0 text-right" t-field="company.report_header"/>
@@ -326,7 +312,7 @@
             <t t-out="0"/>
         </div>
 
-        <div t-attf-class="o_company_#{company.id}_layout footer o_background_footer">
+        <div t-attf-class="o_company_#{company.id}_layout footer o_background_footer" t-att-data-oe-lang="o and o.env.context.get('lang')">
             <div class="text-center">
                 <ul class="list-inline">
                     <div t-field="company.report_footer"/>
@@ -342,7 +328,7 @@
     </template>
 
     <template id="external_layout_boxed">
-        <div t-attf-class="header o_company_#{company.id}_layout" t-att-style="report_header_style">
+        <div t-attf-class="header o_company_#{company.id}_layout" t-att-style="report_header_style" t-att-data-oe-lang="o and o.env.context.get('lang')">
             <div class="o_boxed_header">
             <div class="row mb8">
                 <div class="col-6">
@@ -366,7 +352,7 @@
             <t t-out="0"/>
         </div>
 
-        <div t-attf-class="footer o_boxed_footer o_company_#{company.id}_layout">
+        <div t-attf-class="footer o_boxed_footer o_company_#{company.id}_layout" t-att-data-oe-lang="o and o.env.context.get('lang')">
             <div class="text-center">
                 <div t-field="company.report_footer"/>
                 <div t-if="report_type == 'pdf'">
@@ -377,7 +363,7 @@
     </template>
 
     <template id="external_layout_bold">
-        <div t-attf-class="header o_company_#{company.id}_layout" t-att-style="report_header_style">
+        <div t-attf-class="header o_company_#{company.id}_layout" t-att-style="report_header_style" t-att-data-oe-lang="o and o.env.context.get('lang')">
             <div class="o_clean_header">
             <div class="row">
                 <div class="col-6">
@@ -405,7 +391,7 @@
             <t t-out="0"/>
         </div>
 
-        <div t-attf-class="footer o_clean_footer o_company_#{company.id}_layout">
+        <div t-attf-class="footer o_clean_footer o_company_#{company.id}_layout" t-att-data-oe-lang="o and o.env.context.get('lang')">
             <div class="row">
                 <div class="col-4">
                     <span t-field="company.report_footer"/>
@@ -426,7 +412,7 @@
     </template>
 
     <template id="external_layout_standard">
-        <div t-attf-class="header o_company_#{company.id}_layout" t-att-style="report_header_style">
+        <div t-attf-class="header o_company_#{company.id}_layout" t-att-style="report_header_style" t-att-data-oe-lang="o and o.env.context.get('lang')">
             <div class="row">
                 <div class="col-3 mb4">
                     <img t-if="company.logo" t-att-src="image_data_uri(company.logo)" style="max-height: 45px;" alt="Logo"/>
@@ -453,7 +439,7 @@
             <t t-out="0"/>
         </div>
 
-        <div t-attf-class="footer o_standard_footer o_company_#{company.id}_layout">
+        <div t-attf-class="footer o_standard_footer o_company_#{company.id}_layout" t-att-data-oe-lang="o and o.env.context.get('lang')">
             <div class="text-center" style="border-top: 1px solid black;">
                 <ul class="list-inline mb4">
                     <div t-field="company.report_footer"/>


### PR DESCRIPTION
When selecting at least 10 SO with RTL language on the customer, the printing behavior
(the PDF produced) is inconsistent. By inconsistent, we mean some pages are completely
filled with buggy headers making the whole PDF corrupted (on a business point of view).

Step to reproduce the issue:

The customer/vendor on the PO, SO, RFQ has language set to Arabic
The user creating the document has language set to English (US)
Printing out 10+ documents
The resulting PDF document is inconsistent and contains headers issues (as previously stated).
Solution: The problem is that the headers/footers doesn't take into account the language
of the company (RTL or not). In fact, all the headers/footers of a batch print are contained into
a single HTML file (apparently, at the time, wkhtmltopdf did not support multiple headers/footers).
A Javascript script is used to select the appropriate header/footer for each page of the PDF. The issue
is that the CSS file used for these headers/footers is always a LTR CSS file. Moreover, with this design, it
is impossible to combine headers/footers in RTL and LTR into a single PDF file with multiple pages. The complete
solution would be to create a single header/footer file per page in the PDF report (wkhtmltopdf now supports this),
that way we can specify the language (RTL or LTR) for each of the page and have the perfect behavior. However,
this change cannot be applied into a stable version (requires changes in signature of methods, etc.), consequently,
the full solution will only be kept for master.

Enterprise PR: https://github.com/odoo/enterprise/pull/26289
Original PR on stable version: https://github.com/odoo/odoo/pull/88883

opw-2734671