### PR TITLE
[MERGE][FIX] event_booth_sale: Allow confirm sale order with event booth

### DIFF
--- a/addons/event_booth/tests/test_event_booth_internals.py
+++ b/addons/event_booth/tests/test_event_booth_internals.py
@@ -5,9 +5,10 @@ from datetime import datetime, timedelta
 
 from odoo.addons.event_booth.tests.common import TestEventBoothCommon
 from odoo.fields import Datetime as FieldsDatetime
-from odoo.tests.common import users
+from odoo.tests.common import users, tagged
 
 
+@tagged('post_install', '-at_install', 'event_booth')
 class TestEventData(TestEventBoothCommon):
 
     @users('user_eventmanager')

--- a/addons/event_booth/tests/test_event_internals.py
+++ b/addons/event_booth/tests/test_event_internals.py
@@ -6,11 +6,14 @@ from datetime import datetime, timedelta
 from odoo import Command
 from odoo.addons.event_booth.tests.common import TestEventBoothCommon
 from odoo.fields import Datetime as FieldsDatetime
-from odoo.tests.common import users, Form
+from odoo.tests.common import users, Form, tagged
+from odoo.tools import mute_logger
 
 
+@tagged('post_install', '-at_install')
 class TestEventData(TestEventBoothCommon):
 
+    @mute_logger('odoo.models.unlink')
     @users('user_eventmanager')
     def test_event_configuration_booths_from_type(self):
         """ Test data computation (related to booths) of event coming from its event.type template. """

--- a/addons/event_booth_sale/models/event_booth.py
+++ b/addons/event_booth_sale/models/event_booth.py
@@ -26,7 +26,7 @@ class EventBooth(models.Model):
 
     @api.ondelete(at_uninstall=False)
     def _unlink_except_linked_sale_order(self):
-        booth_with_so = self.filtered('sale_order_id')
+        booth_with_so = self.sudo().filtered('sale_order_id')
         if booth_with_so:
             raise UserError(_(
                 'You can\'t delete the following booths as they are linked to sales orders: '

--- a/addons/event_booth_sale/models/sale_order_line.py
+++ b/addons/event_booth_sale/models/sale_order_line.py
@@ -77,9 +77,9 @@ class SaleOrderLine(models.Model):
                     raise ValidationError(
                         _('The following booths are unavailable, please remove them to continue : %(booth_names)s',
                           booth_names=''.join('\n\t- %s' % booth.display_name for booth in unavailable)))
-                so_line.event_booth_registration_ids.action_confirm()
+                so_line.event_booth_registration_ids.sudo().action_confirm()
             if so_line.event_booth_ids and set_paid:
-                so_line.event_booth_ids.action_set_paid()
+                so_line.event_booth_ids.sudo().action_set_paid()
         return True
 
     def get_sale_order_line_multiline_description_sale(self, product):

--- a/addons/event_booth_sale/tests/common.py
+++ b/addons/event_booth_sale/tests/common.py
@@ -21,3 +21,12 @@ class TestEventBoothSaleCommon(TestEventBoothCommon, TestEventSaleCommon):
         (cls.event_booth_category_1 + cls.event_booth_category_2).write({
             'product_id': cls.event_booth_product.id,
         })
+
+        cls.tax_10 = cls.env['account.tax'].sudo().create({
+            'name': 'Tax 10',
+            'amount': 10,
+        })
+
+        cls.test_pricelist = cls.env['product.pricelist'].sudo().create({
+            'name': 'Test Pricelist',
+        })

--- a/addons/event_booth_sale/tests/test_event_booth_sale.py
+++ b/addons/event_booth_sale/tests/test_event_booth_sale.py
@@ -3,27 +3,28 @@
 
 from odoo import Command
 from odoo.addons.event_booth_sale.tests.common import TestEventBoothSaleCommon
-from odoo.tests.common import users
+from odoo.addons.sale.tests.common import TestSaleCommon
+from odoo.tests.common import tagged, users
 from odoo.tools import float_compare
 
 
-class TestEventBoothSale(TestEventBoothSaleCommon):
+class TestEventBoothSaleWData(TestEventBoothSaleCommon):
 
     @classmethod
     def setUpClass(cls):
-        super(TestEventBoothSale, cls).setUpClass()
+        super(TestEventBoothSaleWData, cls).setUpClass()
 
-        cls.booth_1 = cls.env['event.booth'].create({
-            'name': 'Test Booth 1',
-            'booth_category_id': cls.event_booth_category_1.id,
-            'event_id': cls.event_0.id,
-        })
-
-        cls.booth_2 = cls.env['event.booth'].create({
-            'name': 'Test Booth 2',
-            'booth_category_id': cls.event_booth_category_1.id,
-            'event_id': cls.event_0.id,
-        })
+        cls.booth_1, cls.booth_2 = cls.env['event.booth'].create([
+            {
+                'name': 'Test Booth 1',
+                'booth_category_id': cls.event_booth_category_1.id,
+                'event_id': cls.event_0.id,
+            }, {
+                'name': 'Test Booth 2',
+                'booth_category_id': cls.event_booth_category_1.id,
+                'event_id': cls.event_0.id,
+            }
+        ])
 
         cls.tax_10 = cls.env['account.tax'].sudo().create({
             'name': 'Tax 10',
@@ -34,9 +35,13 @@ class TestEventBoothSale(TestEventBoothSaleCommon):
             'name': 'Test Pricelist',
         })
 
+        cls.event_booth_product.taxes_id = cls.tax_10
+
+
+class TestEventBoothSale(TestEventBoothSaleWData):
+
     @users('user_sales_salesman')
     def test_event_booth_prices_with_sale_order(self):
-        self.event_booth_product.taxes_id = self.tax_10
         sale_order = self.env['sale.order'].create({
             'partner_id': self.event_customer.id,
             'pricelist_id': self.pricelist.id,
@@ -72,3 +77,88 @@ class TestEventBoothSale(TestEventBoothSaleCommon):
                          "Untaxed amount should be the sum of the booths prices ($200.0).")
         self.assertEqual(float_compare(sale_order.amount_total, 220.0, precision_rounding=0.1), 0,
                          "Total amount should be the sum of the booths prices with 10% taxes ($200.0 + $20.0).")
+
+        # Confirm the SO.
+        sale_order.action_confirm()
+
+        for booth in self.booth_1 + self.booth_2:
+            self.assertEqual(
+                booth.sale_order_id.id, sale_order.id,
+                "Booth sale order should be the same as the original sale order.")
+            self.assertEqual(
+                booth.sale_order_line_id.id, sale_order.order_line[0].id,
+                "Booth sale order line should the same as the order line in the original sale order.")
+            self.assertEqual(
+                booth.partner_id.id, self.event_customer.id,
+                "Booth partner should be the same as sale order customer.")
+            self.assertEqual(
+                booth.contact_email, self.event_customer.email,
+                "Booth contact email should be the same as sale order customer email.")
+            self.assertEqual(
+                booth.contact_name, self.event_customer.name,
+                "Booth contact name should be the same as sale order customer name.")
+            self.assertEqual(
+                booth.contact_mobile, self.event_customer.mobile,
+                "Booth contact mobile should be the same as sale order customer mobile.")
+            self.assertEqual(
+                booth.contact_phone, self.event_customer.phone,
+                "Booth contact phone should be the same as sale order customer phone.")
+            self.assertEqual(
+                booth.state, 'unavailable',
+                "Booth should not be available anymore.")
+
+
+@tagged('post_install', '-at_install')
+class TestEventBoothSaleInvoice(TestSaleCommon, TestEventBoothSaleWData):
+
+    @classmethod
+    def setUpClass(cls):
+        super(TestEventBoothSaleInvoice, cls).setUpClass()
+
+        # Add group `group_account_invoice` to user_sales_salesman to allow to pay the invoice
+        cls.user_sales_salesman.groups_id += cls.env.ref('account.group_account_invoice')
+
+    @users('user_sales_salesman')
+    def test_event_booth_with_invoice(self):
+        booth = self.booth_1.with_env(self.env)
+        self.assertEqual(booth.state, 'available')
+
+        sale_order = self.env['sale.order'].create({
+            'partner_id': self.event_customer.id,
+            'pricelist_id': self.pricelist.id,
+            'order_line': [
+                Command.create({
+                    'product_id': self.event_booth_product.id,
+                    'event_id': self.event_0.id,
+                    'event_booth_pending_ids': booth.ids
+                })
+            ]
+        })
+        sale_order.action_confirm()
+        self.assertEqual(booth.state, 'unavailable')
+        self.assertFalse(booth.is_paid)
+
+        # Create and check that the invoice was created
+        invoice = sale_order._create_invoices()
+        self.assertEqual(len(sale_order.invoice_ids), 1, "Invoice not created.")
+
+        # Confirm the invoice and check SO invoice status
+        invoice.action_post()
+        self.assertEqual(
+            sale_order.invoice_status, 'invoiced',
+            f"Order is in '{sale_order.invoice_status}' status while it should be 'invoiced'.")
+        # Pay the invoice.
+        journal = self.env['account.journal'].search([('type', '=', 'cash'), ('company_id', '=', sale_order.company_id.id)], limit=1)
+
+        register_payments = self.env['account.payment.register'].with_context(active_model='account.move', active_ids=invoice.ids).create({
+            'journal_id': journal.id,
+        })
+        register_payments._create_payments()
+
+        # Check the invoice payment state after paying the invoice
+        in_payment_state = invoice._get_invoice_in_payment_state()
+        self.assertEqual(invoice.payment_state, in_payment_state,
+            f"Invoice payment is in '{invoice.payment_state}' status while it should be '{in_payment_state}'.")
+
+        self.assertEqual(booth.state, 'unavailable')
+        self.assertTrue(booth.is_paid)

--- a/addons/event_booth_sale/tests/test_event_booth_sale.py
+++ b/addons/event_booth_sale/tests/test_event_booth_sale.py
@@ -26,15 +26,6 @@ class TestEventBoothSaleWData(TestEventBoothSaleCommon):
             }
         ])
 
-        cls.tax_10 = cls.env['account.tax'].sudo().create({
-            'name': 'Tax 10',
-            'amount': 10,
-        })
-
-        cls.pricelist = cls.env['product.pricelist'].sudo().create({
-            'name': 'Test Pricelist',
-        })
-
         cls.event_booth_product.taxes_id = cls.tax_10
 
 
@@ -44,7 +35,7 @@ class TestEventBoothSale(TestEventBoothSaleWData):
     def test_event_booth_prices_with_sale_order(self):
         sale_order = self.env['sale.order'].create({
             'partner_id': self.event_customer.id,
-            'pricelist_id': self.pricelist.id,
+            'pricelist_id': self.test_pricelist.id,
             'order_line': [
                 Command.create({
                     'product_id': self.event_booth_product.id,
@@ -57,7 +48,7 @@ class TestEventBoothSale(TestEventBoothSaleWData):
 
         self.assertEqual(self.booth_1.price, self.event_booth_product.list_price,
                          "Booth price should be equal from product price.")
-        self.assertEqual(self.event_booth_category_1.with_context(pricelist=self.pricelist.id).price_reduce_taxinc, 22.0,
+        self.assertEqual(self.event_booth_category_1.with_context(pricelist=self.test_pricelist.id).price_reduce_taxinc, 22.0,
                          "Booth price reduce tax should be equal to its price with 10% taxes ($20.0 + $2.0)")
         # Here we expect the price to be the sum of the booth ($40.0)
         self.assertEqual(float_compare(sale_order.amount_untaxed, 40.0, precision_rounding=0.1), 0,
@@ -70,7 +61,7 @@ class TestEventBoothSale(TestEventBoothSaleWData):
 
         self.assertNotEqual(self.booth_1.price, self.event_booth_product.list_price,
                             "Booth price should be different from product price.")
-        self.assertEqual(self.event_booth_category_1.with_context(pricelist=self.pricelist.id).price_reduce_taxinc, 110.0,
+        self.assertEqual(self.event_booth_category_1.with_context(pricelist=self.test_pricelist.id).price_reduce_taxinc, 110.0,
                          "Booth price reduce tax should be equal to its price with 10% taxes ($100.0 + $10.0)")
         # Here we expect the price to be the sum of the booth ($200.0)
         self.assertEqual(float_compare(sale_order.amount_untaxed, 200.0, precision_rounding=0.1), 0,
@@ -125,7 +116,7 @@ class TestEventBoothSaleInvoice(TestSaleCommon, TestEventBoothSaleWData):
 
         sale_order = self.env['sale.order'].create({
             'partner_id': self.event_customer.id,
-            'pricelist_id': self.pricelist.id,
+            'pricelist_id': self.test_pricelist.id,
             'order_line': [
                 Command.create({
                     'product_id': self.event_booth_product.id,


### PR DESCRIPTION
Steps to Reproduce:

  - Connect as Admin
  - Install event_booth_sale module
  - Give only sales right to Demo user
    (get rid of everything else (especially event)
  - Connect as Demo
  - Create a new SO
  - Add an event_booth as product to the SO
  - Try to confirm the SO

Issue:

  Access error.

Cause:

  When confirming the SO, we also update the selected event_booth
  while the sales right are not enough to update event_booth model.

Solution:

  Use sudo to update event_booth, since SO already confirmed.

Also fix unlink of booth, for the same reason.

opw-2823555
Task-2842621