### PR TITLE
[FIX] project : average rating is wrong in tasks analysis

### DIFF
--- a/addons/project/data/project_demo.xml
+++ b/addons/project/data/project_demo.xml
@@ -1256,6 +1256,16 @@ Send it ASAP, its urgent.</field>
         <function model="project.task" name="rating_apply"
             eval="([ref('project.project_1_task_4')], 5, 'PROJECT_3', None, 'Exactly what I asked for, thank you!')"/>
 
+        <record id="rating_task_3_part2" model="rating.rating">
+            <field name="access_token">PROJECT_3_part2</field>
+            <field name="res_model_id" ref="project.model_project_task"/>
+            <field name="rated_partner_id" ref="base.partner_root"/>
+            <field name="partner_id" ref="base.partner_demo_portal"/>
+            <field name="res_id" ref="project.project_1_task_4"/>
+        </record>
+        <function model="project.task" name="rating_apply"
+            eval="([ref('project.project_1_task_4')], 4, 'PROJECT_3_part2', None, 'Exactly what I asked for, but one day late from the deadline')"/>
+
         <record id="rating_task_4" model="rating.rating">
             <field name="access_token">PROJECT_4</field>
             <field name="res_model_id" ref="project.model_project_task"/>

--- a/addons/project/report/project_report.py
+++ b/addons/project/report/project_report.py
@@ -31,7 +31,7 @@ class ReportProjectTaskUser(models.Model):
     working_hours_open = fields.Float(string='Working Hours to Assign', digits=(16, 2), readonly=True, group_operator="avg", help="Number of Working Hours to open the task")
     working_hours_close = fields.Float(string='Working Hours to Close', digits=(16, 2), readonly=True, group_operator="avg", help="Number of Working Hours to close the task")
     rating_last_value = fields.Float('Rating Value (/5)', group_operator="avg", readonly=True, groups="project.group_project_rating")
-    rating_avg = fields.Float('Average Rating', readonly=True)
+    rating_avg = fields.Float('Average Rating', group_operator='avg', readonly=True, groups="project.group_project_rating")
     priority = fields.Selection([
         ('0', 'Low'),
         ('1', 'Normal'),
@@ -111,7 +111,7 @@ class ReportProjectTaskUser(models.Model):
         return f"""
                 project_task t
                     LEFT JOIN project_task_user_rel tu on t.id=tu.task_id
-                    LEFT JOIN rating_rating rt ON rt.parent_res_id = t.id
+                    LEFT JOIN rating_rating rt ON rt.res_id = t.id
                         AND rt.res_model = 'project.task'
                         AND rt.consumed = True
                         AND rt.rating >= {RATING_LIMIT_MIN}


### PR DESCRIPTION
Before this commit:
- Join between task and rating is made on parent_res_id
- Displayed value is the sum of tasks average_rating
- No Unit test to detect this anomalie
- Each task is rated one time so average_rating and last_rating are the same

After this commit:
- Join is made on res_id which is the task_id
- Displayed value is the avg of tasks average_rating
- Unit test added to cover mesaures calculation
- New demo record added to let average_rating be different from last_rating

