### PR TITLE
[FIX] web_editor: prevent website changes to break the backend assets

### DIFF
--- a/addons/web_editor/static/src/scss/bootstrap_overridden.scss
+++ b/addons/web_editor/static/src/scss/bootstrap_overridden.scss
@@ -7,16 +7,18 @@ $colors: () !default;
     $colors: map-merge(('#{$name}': o-color($color)), $colors);
 }
 
-$o-btn-bg-colors: () !default;
-$o-btn-bg-colors: map-merge((
-    'primary': o-color('o-cc1-btn-primary'),
-    'secondary': o-color('o-cc1-btn-secondary'),
-), $o-btn-bg-colors);
-$o-btn-border-colors: () !default;
-$o-btn-border-colors: map-merge((
-    'primary': o-color('o-cc1-btn-primary-border'),
-    'secondary': o-color('o-cc1-btn-secondary-border'),
-), $o-btn-border-colors);
+@if not (variable-exists('prevent-backend-colors-alteration') and $prevent-backend-colors-alteration) {
+    $o-btn-bg-colors: () !default;
+    $o-btn-bg-colors: map-merge((
+        'primary': o-color('o-cc1-btn-primary'),
+        'secondary': o-color('o-cc1-btn-secondary'),
+    ), $o-btn-bg-colors);
+    $o-btn-border-colors: () !default;
+    $o-btn-border-colors: map-merge((
+        'primary': o-color('o-cc1-btn-primary-border'),
+        'secondary': o-color('o-cc1-btn-secondary-border'),
+    ), $o-btn-border-colors);
+}
 
 // Automatically extend bootstrap to create theme background/text/button classes
 $theme-colors: () !default;
@@ -29,6 +31,13 @@ $theme-colors: () !default;
 $grays: () !default;
 @each $name, $color in $o-gray-color-palette {
     $grays: map-merge(('#{$name}': o-color($color)), $grays);
+}
+
+// Detach colors that are used for backend UI (see comment linked to the
+// prevent-backend-colors-alteration for more information)
+@if variable-exists('prevent-backend-colors-alteration') and $prevent-backend-colors-alteration {
+    $theme-colors: map-remove($theme-colors, 'primary', 'secondary', 'success', 'info', 'warning', 'danger', 'light', 'dark');
+    $grays: map-remove($grays, '100', '200', '300', '400', '500', '600', '700', '800', '900');
 }
 
 // Bootstrap use standard variables to define individual colors which are then

--- a/addons/web_editor/static/src/scss/bootstrap_overridden_backend.scss
+++ b/addons/web_editor/static/src/scss/bootstrap_overridden_backend.scss
@@ -1,14 +1,15 @@
-
-$o-theme-color-palette: map-remove($o-theme-color-palette, 'primary', 'secondary', 'success', 'info', 'warning', 'danger', 'light', 'dark');
-$o-gray-color-palette: map-remove($o-gray-color-palette, '100', '200', '300', '400', '500', '600', '700', '800', '900');
-
-$o-btn-bg-colors: () !default;
-$o-btn-bg-colors: map-merge((
-    'primary': null,
-    'secondary': null,
-), $o-btn-bg-colors);
-$o-btn-border-colors: () !default;
-$o-btn-border-colors: map-merge((
-    'primary': null,
-    'secondary': null,
-), $o-btn-border-colors);
+// TODO the code linked to this variable should not be needed, this needs a lot
+// of refactoring. Basically, "frontend" color (complex) maps are available
+// in all assets (via the variables parts that all assets have in common). The
+// original plan was for them to be used in shared "frontend" environment like
+// the mass_mailing application. The web_editor SCSS generation uses those
+// variables to customize bootstrap variables... but it conflicts with the
+// backend also customizing those. In master it should be reviewed so that the
+// web_editor probably does not touch any bootstrap variable when in a backend
+// environment and/or some code should simply be moved to the website app only.
+// In stable, this next code was made to "clean" what the web_editor alters when
+// in a backend environment.
+// See also web_editor.common.scss where many CSS rules depends on this and are
+// available in the backend... while they probably should not. But in stable,
+// we wanted to avoid changing too many things.
+$prevent-backend-colors-alteration: true;

--- a/addons/web_editor/static/src/scss/web_editor.common.scss
+++ b/addons/web_editor/static/src/scss/web_editor.common.scss
@@ -1,5 +1,9 @@
 ///
-/// This file regroups basic style rules for web_editor enable page edition and backend utils.
+/// This file regroups basic style rules for web_editor enable page edition and
+/// backend utils.
+/// TODO many of those rules should probably not be declared for the backend.
+/// in particular the o_ccX rules, see code linked to the variable named
+/// 'prevent-backend-colors-alteration'.
 ///
 
 :root {


### PR DESCRIPTION
This commit fixes a symptom of a more general problem which will be
investigated later.

Steps to reproduce:
- Go to apps
- Install website
- Follow the configurator flow up to entering edit mode
- Go to the 3rd tab of the editor panel
- Change the "background" color of the third color combination and
  choose one of the gray colors
- Go to the backend => SCSS compilation crash

Basically, "frontend" color (complex) maps are available in all assets
(via the variables parts that all assets have in common). The original
plan was for them to be used in shared "frontend" environment like the
mass_mailing application. The web_editor SCSS generation uses those
variables to customize bootstrap variables... but it conflicts with the
backend also customizing those. That's why there is code to "clean" what
the web_editor app does when you are in the backend environment. The
problem after the mentioned steps is that this "cleaning" is done too
soon: gray colors are removed from maps to not alter backend grays and
a web_editor css rules wants to access those gray values if configured
to be used liked mentioned in the steps to reproduce. This commit
basically reviews what was done at [1].

In master it should be reviewed so that the web_editor probably does not
touch any bootstrap variable when in a backend environment and/or some
code should simply be moved to the website app only. See also
web_editor.common.scss where many CSS rules depends on this and are
available in the backend... while they probably should not (like the one
which tried to use that gray value like explained above). But in stable,
we wanted to avoid changing too many things.

However, this was only a symptom of the problem: the fact that some
CSS rules should not be loaded in the backend is not a critical issue.
The real problem is that those CSS rules were breaking because the
backend assets are actually generated using website-specific assets
while the backend is supposed to be website-independant. That's probably
a bug introduced with the new assets system (ir.asset) which would
explain why this bug cannot be reproduced in 14.0. This will be looked
into in a future update. Also, this could be backported later if judged
necessary or if a traceback is actually found.

[1]: https://github.com/odoo/odoo/commit/70f35620babdfdf43e2c603efbf37f2cf7399240

opw-2735123
