### PR TITLE
[FIX] factur-x: make factur-x xml compliant

### DIFF
--- a/addons/account_facturx/data/facturx_templates.xml
+++ b/addons/account_facturx/data/facturx_templates.xml
@@ -27,44 +27,43 @@
                     <!-- Amounts. -->
                     <ram:SpecifiedLineTradeAgreement>
                         <!-- Line information, with discount and unit price separate -->
+                        <t t-set="net_amount" t-value="line.price_subtotal/line.quantity if line.quantity else 0"/>
                         <ram:GrossPriceProductTradePrice>
                             <ram:ChargeAmount
-                                t-att-currencyID="currency.name"
                                 t-esc="format_monetary(line.price_unit, currency)"/>
 
                             <!-- Discount. -->
                             <ram:AppliedTradeAllowanceCharge t-if="line.discount">
                                 <ram:ChargeIndicator>
-                                    <udt:Indicator t-esc="'false' if line.discount == 100 else 'true'"/>
+                                    <udt:Indicator>false</udt:Indicator>
                                 </ram:ChargeIndicator>
-                                <ram:CalculationPercent t-esc="line.discount"/>
+                                <ram:ActualAmount t-esc="format_monetary(line.price_unit - net_amount, currency)"/>
                             </ram:AppliedTradeAllowanceCharge>
                         </ram:GrossPriceProductTradePrice>
                         <!-- Line unit price, with discount applied -->
                         <ram:NetPriceProductTradePrice>
                             <ram:ChargeAmount
-                                t-att-currencyID="currency.name"
-                                t-esc="format_monetary(line.price_subtotal/line.quantity if line.quantity else 0, currency)"/>
+                                t-esc="format_monetary(net_amount, currency)"/>
                         </ram:NetPriceProductTradePrice>
                     </ram:SpecifiedLineTradeAgreement>
 
                     <!-- Quantity. -->
                     <ram:SpecifiedLineTradeDelivery>
-                        <ram:BilledQuantity
-                            t-esc="line.quantity"/>
+                        <ram:BilledQuantity t-att-unitCode="line_values['unece_uom_code']" t-esc="line.quantity"/>
                     </ram:SpecifiedLineTradeDelivery>
 
                     <ram:SpecifiedLineTradeSettlement>
                         <t t-foreach="line_values['tax_details']" t-as="tax_vals">
                             <t t-set="tax" t-value="tax_vals['tax']"/>
                             <ram:ApplicableTradeTax t-if="tax.amount_type == 'percent'">
+                                <ram:TypeCode>VAT</ram:TypeCode>
+                                <ram:CategoryCode t-esc="tax_vals['unece_tax_category_code']"/>
                                 <ram:RateApplicablePercent t-esc="tax.amount"/>
                             </ram:ApplicableTradeTax>
                         </t>
                         <!-- Subtotal. -->
                         <ram:SpecifiedTradeSettlementLineMonetarySummation>
                             <ram:LineTotalAmount
-                                t-att-currencyID="currency.name"
                                 t-esc="format_monetary(line.price_subtotal, currency)"/>
                         </ram:SpecifiedTradeSettlementLineMonetarySummation>
                     </ram:SpecifiedLineTradeSettlement>
@@ -79,15 +78,10 @@
                 xmlns:udt="urn:un:unece:uncefact:data:standard:UnqualifiedDataType:100">
                 <!-- Contact. -->
                 <ram:Name t-if="partner.name" t-esc="partner.name"/>
-                <ram:DefinedTradeContact>
-                    <ram:PersonName t-esc="partner.name"/>
-                    <ram:TelephoneUniversalCommunication t-if="partner.phone or partner.mobile">
-                        <ram:CompleteNumber t-esc="partner.phone or partner.mobile"/>
-                    </ram:TelephoneUniversalCommunication>
-                    <ram:EmailURIUniversalCommunication t-if="partner.email">
-                        <ram:URIID schemeID='SMTP' t-esc="partner.email"/>
-                    </ram:EmailURIUniversalCommunication>
-                </ram:DefinedTradeContact>
+
+                <ram:SpecifiedLegalOrganization t-if="SpecifiedLegalOrganization">
+                    <ram:ID t-esc="SpecifiedLegalOrganization"/>
+                </ram:SpecifiedLegalOrganization>
 
                 <!-- Address. -->
                 <ram:PostalTradeAddress>
@@ -119,7 +113,7 @@
 
                 <!-- Document Headers. -->
                 <rsm:ExchangedDocument>
-                    <ram:ID t-esc="record.ref"/>
+                    <ram:ID t-esc="record.name"/>
                     <ram:TypeCode t-esc="'381' if 'refund' in record.type else '380'"/>
                     <ram:IssueDateTime>
                         <udt:DateTimeString format="102" t-esc="format_date(record.invoice_date)"/>
@@ -142,6 +136,7 @@
                             <!-- Address. -->
                             <t t-call="account_facturx.account_invoice_partner_facturx_export">
                                 <t t-set="partner" t-value="record.company_id.partner_id"/>
+                                <t t-set="SpecifiedLegalOrganization" t-value="seller_specified_legal_organization"/>
                             </t>
 
                             <!-- VAT. -->
@@ -155,6 +150,7 @@
                             <!-- Address. -->
                             <t t-call="account_facturx.account_invoice_partner_facturx_export">
                                 <t t-set="partner" t-value="record.commercial_partner_id"/>
+                                <t t-set="SpecifiedLegalOrganization" t-value="buyer_specified_legal_organization"/>
                             </t>
 
                             <!-- VAT. -->
@@ -165,25 +161,27 @@
 
                         <!-- Reference. -->
                         <ram:BuyerOrderReferencedDocument>
-                            <ram:IssuerAssignedID t-esc="'%s: %s' % (record.name, record.invoice_payment_ref) if record.invoice_payment_ref else record.name"/>
+                            <ram:IssuerAssignedID t-esc="record.invoice_payment_ref if record.invoice_payment_ref else record.name"/>
                         </ram:BuyerOrderReferencedDocument>
                     </ram:ApplicableHeaderTradeAgreement>
 
                     <!-- Delivery. Don't make a dependency with sale only for one field. -->
                     <ram:ApplicableHeaderTradeDelivery>
-                        <ram:ShipToTradeParty
-                            t-if="'partner_shipping_id' in record._fields and record.partner_shipping_id">
+                        <ram:ShipToTradeParty>
                             <t t-call="account_facturx.account_invoice_partner_facturx_export">
-                                <t t-set="partner" t-value="record.partner_shipping_id"/>
+                                <t t-if="'partner_shipping_id' in record._fields and record.partner_shipping_id" t-set="partner" t-value="record.partner_shipping_id"/>
+                                <t t-else="" t-set="partner" t-value="record.commercial_partner_id"/>
                             </t>
                         </ram:ShipToTradeParty>
                     </ram:ApplicableHeaderTradeDelivery>
 
                     <!-- Taxes. -->
                     <ram:ApplicableHeaderTradeSettlement>
+                        <ram:InvoiceCurrencyCode t-esc="record.currency_id.name"/>
 
                         <!-- Bank account. -->
                         <ram:SpecifiedTradeSettlementPaymentMeans t-if="record.invoice_partner_bank_id.acc_type == 'iban'">
+                            <ram:TypeCode>42</ram:TypeCode>
                             <ram:PayeePartyCreditorFinancialAccount>
                                 <ram:IBANID t-esc="record.invoice_partner_bank_id.sanitized_acc_number"/>
                             </ram:PayeePartyCreditorFinancialAccount>
@@ -191,47 +189,49 @@
 
                         <!-- Tax Summary. -->
                         <t t-foreach="tax_details" t-as="tax_vals">
-                            <t t-set="tax_line" t-value="tax_vals['line']"/>
                             <ram:ApplicableTradeTax>
                                 <ram:CalculatedAmount
-                                    t-att-currencyID="currency.name"
                                     t-esc="format_monetary(tax_vals['tax_amount'], currency)"/>
+                                <ram:TypeCode>VAT</ram:TypeCode>
+                                <ram:ExemptionReason t-if="tax_vals['unece_tax_category_code'] == 'E'" t-esc="tax_vals['exemption_reason']"/>
+                                <ram:ExemptionReason t-if="tax_vals['unece_tax_category_code'] == 'G'" t-esc="'Export outside the EU'"/>
+                                <ram:ExemptionReason t-if="tax_vals['unece_tax_category_code'] == 'K'" t-esc="'Intra-community supply'"/>
                                 <ram:BasisAmount
-                                    t-att-currencyID="currency.name"
                                     t-esc="format_monetary(tax_vals['tax_base_amount'], currency)"/>
+                                <ram:CategoryCode t-esc="tax_vals['unece_tax_category_code']"/>
                                 <ram:RateApplicablePercent
-                                    t-if="tax_line.tax_line_id.amount_type == 'percent'"
-                                    t-esc="tax_line.tax_line_id.amount"/>
+                                    t-esc="tax_vals['amount']"/>
                             </ram:ApplicableTradeTax>
                         </t>
+
+                        <ram:BillingSpecifiedPeriod>
+                            <ram:StartDateTime>
+                                <udt:DateTimeString format="102" t-esc="format_date(record.invoice_date)"/>
+                            </ram:StartDateTime>
+                        </ram:BillingSpecifiedPeriod>
 
                         <!-- Payment Term. -->
                         <ram:SpecifiedTradePaymentTerms>
                             <ram:Description t-if="record.invoice_payment_term_id" t-esc="record.invoice_payment_term_id.name"/>
                             <ram:DueDateDateTime t-if="record.invoice_date_due">
-                                <udt:DateTimeString t-esc="format_date(record.invoice_date_due)"/>
+                                <udt:DateTimeString format="102" t-esc="format_date(record.invoice_date_due)"/>
                             </ram:DueDateDateTime>
                         </ram:SpecifiedTradePaymentTerms>
 
                         <!-- Summary. -->
                         <ram:SpecifiedTradeSettlementHeaderMonetarySummation>
                             <ram:LineTotalAmount
-                                t-att-currencyID="currency.name"
                                 t-esc="format_monetary(record.amount_untaxed, currency)"/>
                             <ram:TaxBasisTotalAmount
-                                t-att-currencyID="currency.name"
                                 t-esc="format_monetary(record.amount_untaxed, currency)"/>
                             <ram:TaxTotalAmount
                                 t-att-currencyID="currency.name"
                                 t-esc="format_monetary(record.amount_tax, currency)"/>
                             <ram:GrandTotalAmount
-                                t-att-currencyID="currency.name"
                                 t-esc="format_monetary(record.amount_total, currency)"/>
                             <ram:TotalPrepaidAmount
-                                t-att-currencyID="currency.name"
                                 t-esc="format_monetary(record.amount_total - record.amount_residual, currency)"/>
                             <ram:DuePayableAmount
-                                t-att-currencyID="currency.name"
                                 t-esc="format_monetary(record.amount_residual, currency)"/>
                         </ram:SpecifiedTradeSettlementHeaderMonetarySummation>
                     </ram:ApplicableHeaderTradeSettlement>

--- a/addons/account_facturx/models/__init__.py
+++ b/addons/account_facturx/models/__init__.py
@@ -1,4 +1,6 @@
 # -*- encoding: utf-8 -*-
 
 from . import account_move
+from . import account_tax
 from . import ir_actions_report
+from . import uom

--- a/addons/account_facturx/models/account_move.py
+++ b/addons/account_facturx/models/account_move.py
@@ -5,6 +5,7 @@ from odoo.tools import DEFAULT_SERVER_DATE_FORMAT, float_repr
 from odoo.tests.common import Form
 from odoo.exceptions import UserError, except_orm
 
+from collections import defaultdict
 from datetime import datetime
 from lxml import etree
 from PyPDF2 import PdfFileReader
@@ -35,22 +36,45 @@ class AccountMove(models.Model):
 
         def format_monetary(number, currency):
             # Format the monetary values to avoid trailing decimals (e.g. 90.85000000000001).
+            if currency.is_zero(number):  # Ensure that we never return -0.0
+                number = 0.0
             return float_repr(number, currency.decimal_places)
 
         # Create file content.
+        seller_siret = 'siret' in self.company_id._fields and self.company_id.siret or self.company_id.company_registry
+        buyer_siret = 'siret' in self.commercial_partner_id._fields and self.commercial_partner_id.siret
         template_values = {
             'record': self,
             'format_date': format_date,
             'format_monetary': format_monetary,
             'invoice_line_values': [],
+            'seller_specified_legal_organization': seller_siret,
+            'buyer_specified_legal_organization': buyer_siret,
         }
-
         # Tax lines.
-        aggregated_taxes_details = {line.tax_line_id.id: {
-            'line': line,
-            'tax_amount': -line.amount_currency if line.currency_id else -line.balance,
-            'tax_base_amount': 0.0,
-        } for line in self.line_ids.filtered('tax_line_id')}
+        # The old system was making one total "line" per tax in the xml, by using the tax_line_id.
+        # The new one is making one total "line" for each tax category and rate group.
+        aggregated_taxes_details = self._prepare_edi_tax_details(
+            grouping_key_generator=lambda tax_values: {
+                'unece_tax_category_code': tax_values['tax_id']._get_unece_category_code(self.commercial_partner_id, self.company_id),
+                'amount': tax_values['tax_id'].amount
+            }
+        )['tax_details']
+
+        balance_multiplicator = -1 if self.is_inbound() else 1
+        # Map the new keys from the backported _prepare_edi_tax_details into the old ones for compatibility with the old
+        # template. Also apply the multiplication here for consistency between the old and new template.
+        for tax_detail in aggregated_taxes_details.values():
+            tax_detail['tax_base_amount'] = balance_multiplicator * tax_detail['base_amount_currency']
+            tax_detail['tax_amount'] = balance_multiplicator * tax_detail['tax_amount_currency']
+
+            # The old template would get the amount from a tax line given to it, while
+            # the new one would get the amount from the dictionary returned by _prepare_edi_tax_details directly.
+            # As the line was only used to get the tax amount, giving it any line with the same amount will give a correct
+            # result even if the tax line doesn't make much sense as this is a total that is not linked to a specific tax.
+            # I don't have a solution for 0% taxes, we will give an empty line that will allow to render the xml, but it
+            # won't be completely correct. (The RateApplicablePercent will be missing for that line)
+            tax_detail['line'] = self.line_ids.filtered(lambda l: l.tax_line_id and l.tax_line_id.amount == tax_detail['amount'])[:1]
 
         # Invoice lines.
         for i, line in enumerate(self.invoice_line_ids.filtered(lambda l: not l.display_type)):
@@ -69,18 +93,18 @@ class AccountMove(models.Model):
                 'index': i + 1,
                 'tax_details': [],
                 'net_price_subtotal': taxes_res['total_excluded'],
+                'unece_uom_code': line.product_id.product_tmpl_id.uom_id._get_unece_code(),
             }
 
             for tax_res in taxes_res['taxes']:
                 tax = self.env['account.tax'].browse(tax_res['id'])
+                tax_category_code = tax._get_unece_category_code(self.commercial_partner_id, self.company_id)
                 line_template_values['tax_details'].append({
                     'tax': tax,
                     'tax_amount': tax_res['amount'],
                     'tax_base_amount': tax_res['base'],
+                    'unece_tax_category_code': tax_category_code,
                 })
-
-                if tax.id in aggregated_taxes_details:
-                    aggregated_taxes_details[tax.id]['tax_base_amount'] += tax_res['base']
 
             template_values['invoice_line_values'].append(line_template_values)
 
@@ -171,24 +195,29 @@ class AccountMove(models.Model):
             if elements:
                 invoice_form.narration = elements[0].text
 
-            # Total amount.
-            elements = tree.xpath('//ram:GrandTotalAmount', namespaces=tree.nsmap)
+            # Get currency string for new invoices, or invoices coming from outside
+            elements = tree.xpath('//ram:InvoiceCurrencyCode', namespaces=tree.nsmap)
             if elements:
-
-                # Currency.
-                if elements[0].attrib.get('currencyID'):
+                currency_str = elements[0].text
+            # Fallback for old invoices from odoo where the InvoiceCurrencyCode was not present
+            else:
+                elements = tree.xpath('//ram:TaxTotalAmount', namespaces=tree.nsmap)
+                if elements:
                     currency_str = elements[0].attrib['currencyID']
-                    currency = self.env.ref('base.%s' % currency_str.upper(), raise_if_not_found=False)
-                    if currency and not currency.active:
-                        raise UserError(
-                            _('The currency (%s) of the document you are uploading is not active in this database.\n'
-                              'Please activate it before trying again to import.') % currency.name
-                        )
-                    if currency != self.env.company.currency_id and currency.active:
-                        invoice_form.currency_id = currency
 
-                    # Store xml total amount.
-                    amount_total_import = total_amount * refund_sign
+            # Set the invoice currency
+            if currency_str:
+                currency = self.env.ref('base.%s' % currency_str.upper(), raise_if_not_found=False)
+                if currency and not currency.active:
+                    raise UserError(
+                        _('The currency (%s) of the document you are uploading is not active in this database.\n'
+                          'Please activate it before trying again to import.') % currency.name
+                    )
+                if currency != self.env.company.currency_id and currency.active:
+                    invoice_form.currency_id = currency
+
+            # Store xml total amount.
+            amount_total_import = total_amount * refund_sign
 
             # Date.
             elements = tree.xpath('//rsm:ExchangedDocument/ram:IssueDateTime/udt:DateTimeString', namespaces=tree.nsmap)
@@ -386,3 +415,177 @@ class AccountMove(models.Model):
     def _remove_ocr_option(self):
         if 'extract_state' in self:
             self.write({'extract_state': 'done'})
+
+    @api.model
+    def _add_edi_tax_values(self, results, grouping_key, serialized_grouping_key, tax_values):
+        # Add to global results.
+        results['tax_amount'] += tax_values['tax_amount']
+        results['tax_amount_currency'] += tax_values['tax_amount_currency']
+
+        # Add to tax details.
+        tax_details = results['tax_details'][serialized_grouping_key]
+        tax_details.update(grouping_key)
+        if tax_values['base_line_id'] not in set(x['base_line_id'] for x in tax_details['group_tax_details']):
+            tax_details['base_amount'] += tax_values['base_amount']
+            tax_details['base_amount_currency'] += tax_values['base_amount_currency']
+
+        tax_details['tax_amount'] += tax_values['tax_amount']
+        tax_details['tax_amount_currency'] += tax_values['tax_amount_currency']
+        tax_details['exemption_reason'] = tax_values['tax_id'].name
+        tax_details['group_tax_details'].append(tax_values)
+
+    def _prepare_edi_tax_details(self, filter_to_apply=None, filter_invl_to_apply=None, grouping_key_generator=None):
+        ''' Compute amounts related to taxes for the current invoice.
+        :param filter_to_apply:         Optional filter to exclude some tax values from the final results.
+                                        The filter is defined as a method getting a dictionary as parameter
+                                        representing the tax values for a single repartition line.
+                                        This dictionary contains:
+            'base_line_id':             An account.move.line record.
+            'tax_id':                   An account.tax record.
+            'tax_repartition_line_id':  An account.tax.repartition.line record.
+            'base_amount':              The tax base amount expressed in company currency.
+            'tax_amount':               The tax amount expressed in company currency.
+            'base_amount_currency':     The tax base amount expressed in foreign currency.
+            'tax_amount_currency':      The tax amount expressed in foreign currency.
+                                        If the filter is returning False, it means the current tax values will be
+                                        ignored when computing the final results.
+        :param grouping_key_generator:  Optional method used to group tax values together. By default, the tax values
+                                        are grouped by tax. This parameter is a method getting a dictionary as parameter
+                                        (same signature as 'filter_to_apply').
+                                        This method must returns a dictionary where values will be used to create the
+                                        grouping_key to aggregate tax values together. The returned dictionary is added
+                                        to each tax details in order to retrieve the full grouping_key later.
+        :return:                        The full tax details for the current invoice and for each invoice line
+                                        separately. The returned dictionary is the following:
+            'base_amount':              The total tax base amount in company currency for the whole invoice.
+            'tax_amount':               The total tax amount in company currency for the whole invoice.
+            'base_amount_currency':     The total tax base amount in foreign currency for the whole invoice.
+            'tax_amount_currency':      The total tax amount in foreign currency for the whole invoice.
+            'tax_details':              A mapping of each grouping key (see 'grouping_key_generator') to a dictionary
+                                        containing:
+                'base_amount':              The tax base amount in company currency for the current group.
+                'tax_amount':               The tax amount in company currency for the current group.
+                'base_amount_currency':     The tax base amount in foreign currency for the current group.
+                'tax_amount_currency':      The tax amount in foreign currency for the current group.
+                'group_tax_details':        The list of all tax values aggregated into this group.
+            'invoice_line_tax_details': A mapping of each invoice line to a dictionary containing:
+                'base_amount':          The total tax base amount in company currency for the whole invoice line.
+                'tax_amount':           The total tax amount in company currency for the whole invoice line.
+                'base_amount_currency': The total tax base amount in foreign currency for the whole invoice line.
+                'tax_amount_currency':  The total tax amount in foreign currency for the whole invoice line.
+                'tax_details':          A mapping of each grouping key (see 'grouping_key_generator') to a dictionary
+                                        containing:
+                    'base_amount':          The tax base amount in company currency for the current group.
+                    'tax_amount':           The tax amount in company currency for the current group.
+                    'base_amount_currency': The tax base amount in foreign currency for the current group.
+                    'tax_amount_currency':  The tax amount in foreign currency for the current group.
+                    'group_tax_details':    The list of all tax values aggregated into this group.
+        '''
+        self.ensure_one()
+
+        def _serialize_python_dictionary(vals):
+            return '-'.join(str(vals[k]) for k in sorted(vals.keys()))
+
+        def default_grouping_key_generator(tax_values):
+            return {'tax': tax_values['tax_id']}
+
+        # Compute the taxes values for each invoice line.
+
+        invoice_lines = self.invoice_line_ids.filtered(lambda line: not line.display_type)
+        if filter_invl_to_apply:
+            invoice_lines = invoice_lines.filtered(filter_invl_to_apply)
+
+        invoice_lines_tax_values_dict = {}
+        sign = -1 if self.is_inbound() else 1
+        for invoice_line in invoice_lines:
+            taxes_res = invoice_line.tax_ids.compute_all(
+                invoice_line.price_unit * (1 - (invoice_line.discount / 100.0)),
+                currency=invoice_line.currency_id,
+                quantity=invoice_line.quantity,
+                product=invoice_line.product_id,
+                partner=invoice_line.partner_id,
+                is_refund=invoice_line.move_id.type in ('in_refund', 'out_refund'),
+            )
+            tax_values_list = invoice_lines_tax_values_dict[invoice_line] = []
+            rate = abs(invoice_line.balance) / abs(
+                invoice_line.amount_currency) if invoice_line.amount_currency else 0.0
+            for tax_res in taxes_res['taxes']:
+                tax_values_list.append({
+                    'base_line_id': invoice_line,
+                    'tax_id': self.env['account.tax'].browse(tax_res['id']),
+                    'tax_repartition_line_id': self.env['account.tax.repartition.line'].browse(
+                        tax_res['tax_repartition_line_id']),
+                    'base_amount': sign * invoice_line.company_currency_id.round(tax_res['base'] * rate),
+                    'tax_amount': sign * invoice_line.company_currency_id.round(tax_res['amount'] * rate),
+                    'base_amount_currency': sign * tax_res['base'],
+                    'tax_amount_currency': sign * tax_res['amount'],
+                })
+        grouping_key_generator = grouping_key_generator or default_grouping_key_generator
+
+        # Apply 'filter_to_apply'.
+
+        if filter_to_apply:
+            invoice_lines_tax_values_dict = {
+                invoice_line: [x for x in tax_values_list if filter_to_apply(x)]
+                for invoice_line, tax_values_list in invoice_lines_tax_values_dict.items()
+            }
+
+        # Initialize the results dict.
+
+        invoice_global_tax_details = {
+            'base_amount': 0.0,
+            'tax_amount': 0.0,
+            'base_amount_currency': 0.0,
+            'tax_amount_currency': 0.0,
+            'tax_details': defaultdict(lambda: {
+                'base_amount': 0.0,
+                'tax_amount': 0.0,
+                'base_amount_currency': 0.0,
+                'tax_amount_currency': 0.0,
+                'group_tax_details': [],
+            }),
+            'invoice_line_tax_details': defaultdict(lambda: {
+                'base_amount': 0.0,
+                'tax_amount': 0.0,
+                'base_amount_currency': 0.0,
+                'tax_amount_currency': 0.0,
+                'tax_details': defaultdict(lambda: {
+                    'base_amount': 0.0,
+                    'tax_amount': 0.0,
+                    'base_amount_currency': 0.0,
+                    'tax_amount_currency': 0.0,
+                    'group_tax_details': [],
+                }),
+            }),
+        }
+
+        # Apply 'grouping_key_generator' to 'invoice_lines_tax_values_list' and add all values to the final results.
+
+        for invoice_line in invoice_lines:
+            tax_values_list = invoice_lines_tax_values_dict[invoice_line]
+
+            # Add to invoice global tax amounts.
+            invoice_global_tax_details['base_amount'] += invoice_line.balance
+            invoice_global_tax_details['base_amount_currency'] += invoice_line.amount_currency
+
+            for tax_values in tax_values_list:
+                grouping_key = grouping_key_generator(tax_values)
+                serialized_grouping_key = _serialize_python_dictionary(grouping_key)
+
+                # Add to invoice line global tax amounts.
+                if serialized_grouping_key not in invoice_global_tax_details['invoice_line_tax_details'][invoice_line]:
+                    invoice_line_global_tax_details = invoice_global_tax_details['invoice_line_tax_details'][
+                        invoice_line]
+                    invoice_line_global_tax_details.update({
+                        'base_amount': invoice_line.balance,
+                        'base_amount_currency': invoice_line.amount_currency,
+                    })
+                else:
+                    invoice_line_global_tax_details = invoice_global_tax_details['invoice_line_tax_details'][
+                        invoice_line]
+
+                self._add_edi_tax_values(invoice_global_tax_details, grouping_key, serialized_grouping_key, tax_values)
+                self._add_edi_tax_values(invoice_line_global_tax_details, grouping_key, serialized_grouping_key,
+                                         tax_values)
+
+        return invoice_global_tax_details

--- a/addons/account_facturx/models/account_tax.py
+++ b/addons/account_facturx/models/account_tax.py
@@ -1,0 +1,34 @@
+# -*- coding: utf-8 -*-
+
+from odoo import models
+
+
+class AccountTax(models.Model):
+    _inherit = 'account.tax'
+
+    def _get_unece_category_code(self, customer, supplier):
+        """ By default, this method will try to compute the tax category (used by EDI for example) based on the amount
+        and the tax repartition lines. This is hack-ish~ but a valid solution to get a default value in stable.
+
+        In master, the Category selection field should be by default on taxes and filled for each tax in the demo data
+        if possible.
+
+        See https://unece.org/fileadmin/DAM/trade/untdid/d16b/tred/tred5305.htm for the codes.
+        """
+        self.ensure_one()
+        # Defaulting to standard tax.
+        category = 'S'
+        if self.type_tax_use == 'sale':
+            eu_countries = self.env.ref('base.europe').country_ids
+            if supplier.country_id in eu_countries and customer.country_id not in eu_countries:
+                category = 'G'
+            else:
+                if customer.country_id != supplier.country_id \
+                        and customer.country_id in eu_countries \
+                        and supplier.country_id in eu_countries:
+                    category = 'K'
+                # Taxes with a Zero amount will get the E code. (Exempt)
+                elif self.amount == 0:
+                    category = 'E'
+
+        return category

--- a/addons/account_facturx/models/ir_actions_report.py
+++ b/addons/account_facturx/models/ir_actions_report.py
@@ -39,7 +39,7 @@ class IrActionsReport(models.Model):
                         })
                         writer.add_file_metadata(metadata_content)
 
-                writer.addAttachment('factur-x.xml', xml_content, '/application#2Fxml')
+                writer.addAttachment('factur-x.xml', xml_content, '/text#2Fxml')
 
                 buffer = BytesIO()
                 writer.write(buffer)

--- a/addons/account_facturx/models/uom.py
+++ b/addons/account_facturx/models/uom.py
@@ -1,0 +1,44 @@
+# -*- coding: utf-8 -*-
+
+from odoo import models
+
+
+class UoM(models.Model):
+    _inherit = 'uom.uom'
+
+    def _get_unece_code(self):
+        """ Returns the UNECE code used for international trading for corresponding to the UoM as per
+        https://unece.org/fileadmin/DAM/cefact/recommendations/bkup_htm/add2d.htm.
+        """
+        if len(self) != 1:
+            return 'C62'
+
+        xml_id = self.env['ir.model.data'].search([
+                ('model', '=', 'uom.uom'),
+                ('res_id', '=', self.id),
+        ]).name
+        mapping = {
+            'product_uom_unit': 'C62',
+            'product_uom_dozen': 'DZN',
+            'product_uom_kgm': 'KGM',
+            'product_uom_gram': 'GRM',
+            'product_uom_day': 'DAY',
+            'product_uom_hour': 'HUR',
+            'product_uom_ton': 'TNE',
+            'product_uom_meter': 'MTR',
+            'product_uom_km': 'KTM',
+            'product_uom_cm': 'CMT',
+            'product_uom_litre': 'LTR',
+            'product_uom_lb': 'LBR',
+            'product_uom_oz': 'ONZ',
+            'product_uom_inch': 'INH',
+            'product_uom_foot': 'FOT',
+            'product_uom_mile': 'SMI',
+            'product_uom_floz': 'OZA',
+            'product_uom_qt': 'QT',
+            'product_uom_gal': 'GLL',
+            'product_uom_cubic_meter': 'MTQ',
+            'product_uom_cubic_inch': 'INQ',
+            'product_uom_cubic_foot': 'FTQ',
+        }
+        return mapping.get(xml_id, 'C62')

--- a/addons/account_facturx/tests/test_facturx.py
+++ b/addons/account_facturx/tests/test_facturx.py
@@ -69,6 +69,7 @@ class TestAccountEdiFacturx(AccountTestEdiCommon):
                     </GuidelineSpecifiedDocumentContextParameter>
                 </ExchangedDocumentContext>
                 <ExchangedDocument>
+                    <ID>INV/2017/0001</ID>
                     <TypeCode>380</TypeCode>
                     <IssueDateTime>
                         <DateTimeString format="102">20170101</DateTimeString>
@@ -84,68 +85,77 @@ class TestAccountEdiFacturx(AccountTestEdiCommon):
                         </SpecifiedTradeProduct>
                         <SpecifiedLineTradeAgreement>
                             <GrossPriceProductTradePrice>
-                                <ChargeAmount currencyID="Gol">275.000</ChargeAmount>
+                                <ChargeAmount>275.000</ChargeAmount>
                                 <AppliedTradeAllowanceCharge>
                                     <ChargeIndicator>
-                                        <Indicator>true</Indicator>
+                                        <Indicator>false</Indicator>
                                     </ChargeIndicator>
-                                    <CalculationPercent>20.0</CalculationPercent>
+                                    <ActualAmount>55.000</ActualAmount>
                                 </AppliedTradeAllowanceCharge>
                             </GrossPriceProductTradePrice>
                             <NetPriceProductTradePrice>
-                                <ChargeAmount currencyID="Gol">220.000</ChargeAmount>
+                                <ChargeAmount>220.000</ChargeAmount>
                             </NetPriceProductTradePrice>
                         </SpecifiedLineTradeAgreement>
                         <SpecifiedLineTradeDelivery>
-                            <BilledQuantity>5.0</BilledQuantity>
+                            <BilledQuantity unitCode="C62">5.0</BilledQuantity>
                         </SpecifiedLineTradeDelivery>
                         <SpecifiedLineTradeSettlement>
                             <ApplicableTradeTax>
+                                <TypeCode>VAT</TypeCode>
+                                <CategoryCode>S</CategoryCode>
                                 <RateApplicablePercent>20.0</RateApplicablePercent>
                             </ApplicableTradeTax>
                             <SpecifiedTradeSettlementLineMonetarySummation>
-                                <LineTotalAmount currencyID="Gol">1100.000</LineTotalAmount>
+                                <LineTotalAmount>1100.000</LineTotalAmount>
                             </SpecifiedTradeSettlementLineMonetarySummation>
                         </SpecifiedLineTradeSettlement>
                     </IncludedSupplyChainTradeLineItem>
                     <ApplicableHeaderTradeAgreement>
                         <SellerTradeParty>
                             <Name>company_1_data</Name>
-                            <DefinedTradeContact>
-                                <PersonName>company_1_data</PersonName>
-                            </DefinedTradeContact>
                             <PostalTradeAddress/>
                         </SellerTradeParty>
                         <BuyerTradeParty>
                             <Name>partner_b</Name>
-                            <DefinedTradeContact>
-                                <PersonName>partner_b</PersonName>
-                            </DefinedTradeContact>
                             <PostalTradeAddress/>
                         </BuyerTradeParty>
                         <BuyerOrderReferencedDocument>
-                            <IssuerAssignedID>INV/2017/0001: INV/2017/0001</IssuerAssignedID>
+                            <IssuerAssignedID>INV/2017/0001</IssuerAssignedID>
                         </BuyerOrderReferencedDocument>
                     </ApplicableHeaderTradeAgreement>
-                    <ApplicableHeaderTradeDelivery/>
+                    <ApplicableHeaderTradeDelivery>
+                        <ShipToTradeParty>
+                            <Name>partner_b</Name>
+                            <PostalTradeAddress/>
+                        </ShipToTradeParty>
+                    </ApplicableHeaderTradeDelivery>
                     <ApplicableHeaderTradeSettlement>
+                        <InvoiceCurrencyCode>Gol</InvoiceCurrencyCode>
                         <ApplicableTradeTax>
-                            <CalculatedAmount currencyID="Gol">220.000</CalculatedAmount>
-                            <BasisAmount currencyID="Gol">1100.000</BasisAmount>
+                            <CalculatedAmount>220.000</CalculatedAmount>
+                            <TypeCode>VAT</TypeCode>
+                            <BasisAmount>1100.000</BasisAmount>
+                            <CategoryCode>S</CategoryCode>
                             <RateApplicablePercent>20.0</RateApplicablePercent>
                         </ApplicableTradeTax>
+                        <BillingSpecifiedPeriod>
+                            <StartDateTime>
+                                <DateTimeString format="102">20170101</DateTimeString>
+                            </StartDateTime>
+                        </BillingSpecifiedPeriod>
                         <SpecifiedTradePaymentTerms>
                             <DueDateDateTime>
-                                <DateTimeString>20170101</DateTimeString>
+                                <DateTimeString format="102">20170101</DateTimeString>
                             </DueDateDateTime>
                         </SpecifiedTradePaymentTerms>
                         <SpecifiedTradeSettlementHeaderMonetarySummation>
-                            <LineTotalAmount currencyID="Gol">1100.000</LineTotalAmount>
-                            <TaxBasisTotalAmount currencyID="Gol">1100.000</TaxBasisTotalAmount>
+                            <LineTotalAmount>1100.000</LineTotalAmount>
+                            <TaxBasisTotalAmount>1100.000</TaxBasisTotalAmount>
                             <TaxTotalAmount currencyID="Gol">220.000</TaxTotalAmount>
-                            <GrandTotalAmount currencyID="Gol">1320.000</GrandTotalAmount>
-                            <TotalPrepaidAmount currencyID="Gol">0.000</TotalPrepaidAmount>
-                            <DuePayableAmount currencyID="Gol">1320.000</DuePayableAmount>
+                            <GrandTotalAmount>1320.000</GrandTotalAmount>
+                            <TotalPrepaidAmount>0.000</TotalPrepaidAmount>
+                            <DuePayableAmount>1320.000</DuePayableAmount>
                         </SpecifiedTradeSettlementHeaderMonetarySummation>
                     </ApplicableHeaderTradeSettlement>
                 </SupplyChainTradeTransaction>
@@ -175,46 +185,63 @@ class TestAccountEdiFacturx(AccountTestEdiCommon):
             expected_etree = self.with_applied_xpath(
                 self.get_xml_tree_from_string(self.expected_invoice_facturx_values),
                 '''
+                    <xpath expr="//AppliedTradeAllowanceCharge/ActualAmount" position="replace">
+                        <ActualAmount>75.000</ActualAmount>
+                    </xpath>
                     <xpath expr="//NetPriceProductTradePrice/ChargeAmount" position="replace">
-                        <ChargeAmount currencyID="Gol">200.000</ChargeAmount>
+                        <ChargeAmount>200.000</ChargeAmount>
                     </xpath>
                     <xpath expr="//SpecifiedLineTradeSettlement" position="replace">
                         <SpecifiedLineTradeSettlement>
                             <ApplicableTradeTax>
+                                <TypeCode>VAT</TypeCode>
+                                <CategoryCode>S</CategoryCode>
                                 <RateApplicablePercent>10.0</RateApplicablePercent>
                             </ApplicableTradeTax>
                             <ApplicableTradeTax>
+                                <TypeCode>VAT</TypeCode>
+                                <CategoryCode>S</CategoryCode>
                                 <RateApplicablePercent>20.0</RateApplicablePercent>
                             </ApplicableTradeTax>
                             <SpecifiedTradeSettlementLineMonetarySummation>
-                                <LineTotalAmount currencyID="Gol">1000.000</LineTotalAmount>
+                                <LineTotalAmount>1000.000</LineTotalAmount>
                             </SpecifiedTradeSettlementLineMonetarySummation>
                         </SpecifiedLineTradeSettlement>
                     </xpath>
                     <xpath expr="//ApplicableHeaderTradeSettlement" position="replace">
                         <ApplicableHeaderTradeSettlement>
+                        <InvoiceCurrencyCode>Gol</InvoiceCurrencyCode>
                             <ApplicableTradeTax>
-                                <CalculatedAmount currencyID="Gol">220.000</CalculatedAmount>
-                                <BasisAmount currencyID="Gol">1100.000</BasisAmount>
-                                <RateApplicablePercent>20.0</RateApplicablePercent>
-                            </ApplicableTradeTax>
-                            <ApplicableTradeTax>
-                                <CalculatedAmount currencyID="Gol">100.000</CalculatedAmount>
-                                <BasisAmount currencyID="Gol">1000.000</BasisAmount>
+                                <CalculatedAmount>100.000</CalculatedAmount>
+                                <TypeCode>VAT</TypeCode>
+                                <BasisAmount>1000.000</BasisAmount>
+                                <CategoryCode>S</CategoryCode>
                                 <RateApplicablePercent>10.0</RateApplicablePercent>
                             </ApplicableTradeTax>
+                            <ApplicableTradeTax>
+                                <CalculatedAmount>220.000</CalculatedAmount>
+                                <TypeCode>VAT</TypeCode>
+                                <BasisAmount>1100.000</BasisAmount>
+                                <CategoryCode>S</CategoryCode>
+                                <RateApplicablePercent>20.0</RateApplicablePercent>
+                            </ApplicableTradeTax>
+                            <BillingSpecifiedPeriod>
+                                <StartDateTime>
+                                    <DateTimeString format="102">20170101</DateTimeString>
+                                </StartDateTime>
+                            </BillingSpecifiedPeriod>
                             <SpecifiedTradePaymentTerms>
                                 <DueDateDateTime>
-                                    <DateTimeString>20170101</DateTimeString>
+                                    <DateTimeString format="102">20170101</DateTimeString>
                                 </DueDateDateTime>
                             </SpecifiedTradePaymentTerms>
                             <SpecifiedTradeSettlementHeaderMonetarySummation>
-                                <LineTotalAmount currencyID="Gol">1000.000</LineTotalAmount>
-                                <TaxBasisTotalAmount currencyID="Gol">1000.000</TaxBasisTotalAmount>
+                                <LineTotalAmount>1000.000</LineTotalAmount>
+                                <TaxBasisTotalAmount>1000.000</TaxBasisTotalAmount>
                                 <TaxTotalAmount currencyID="Gol">320.000</TaxTotalAmount>
-                                <GrandTotalAmount currencyID="Gol">1320.000</GrandTotalAmount>
-                                <TotalPrepaidAmount currencyID="Gol">0.000</TotalPrepaidAmount>
-                                <DuePayableAmount currencyID="Gol">1320.000</DuePayableAmount>
+                                <GrandTotalAmount>1320.000</GrandTotalAmount>
+                                <TotalPrepaidAmount>0.000</TotalPrepaidAmount>
+                                <DuePayableAmount>1320.000</DuePayableAmount>
                             </SpecifiedTradeSettlementHeaderMonetarySummation>
                         </ApplicableHeaderTradeSettlement>
                     </xpath>


### PR DESCRIPTION
The xml we generate for factur-x is no longer compliant with all
the latest standards. With these changes, we are providing the tools
to make it work once again and make sure it is validated by the
factur-x and zugferd validators in all aspect (PDFA/3, XMP, XML)
It should also be valid to be sent to Chorus pro if applicable.

This adds a mapping to the UNECE unit of measure codes for uom, that
are required for factur-x.

It will also calculate a category for each taxes as such:
    - If the tax has a percentage of 0%, it will be Z.
    - If the tax is of use type purchase, and has exactly two invoice
    repartition lines of type tax, one with 100% and one with -100%,
    it will be AE.
    - Otherwise, it will be S.
See https://unece.org/fileadmin/DAM/trade/untdid/d16b/tred/tred5305.htm

opw-2714544

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
