### PR TITLE
[FIX] hr_holidays : give days to accrual allocation unused lost

### DIFF
--- a/addons/hr_holidays/models/hr_leave_allocation.py
+++ b/addons/hr_holidays/models/hr_leave_allocation.py
@@ -426,7 +426,7 @@ class HolidaysAllocation(models.Model):
                 # If accruals are lost at the beginning of year, skip accrual until beginning of this year
                 if current_level.action_with_unused_accruals == 'lost':
                     this_year_first_day = today + relativedelta(day=1, month=1)
-                    if period_end < this_year_first_day or period_start < period_end:
+                    if period_end < this_year_first_day:
                         allocation.lastcall = allocation.nextcall
                         allocation.nextcall = nextcall
                         continue
@@ -443,9 +443,7 @@ class HolidaysAllocation(models.Model):
                 allocation.lastcall = allocation.nextcall
                 allocation.nextcall = nextcall
             if days_added_per_level:
-                number_of_days_to_add = 0
-                for value in days_added_per_level.values():
-                    number_of_days_to_add += value
+                number_of_days_to_add = sum(days_added_per_level.values())
                 # Let's assume the limit of the last level is the correct one
                 allocation.write({'number_of_days': min(allocation.number_of_days + number_of_days_to_add, current_level.maximum_leave)})
 

--- a/addons/hr_holidays/tests/test_accrual_allocations.py
+++ b/addons/hr_holidays/tests/test_accrual_allocations.py
@@ -593,3 +593,35 @@ class TestAccrualAllocations(TestHrHolidaysCommon):
         with freeze_time('2022-1-10'):
             allocation._update_accrual()
         self.assertAlmostEqual(allocation.number_of_days, 30.79, 2, "Invalid number of days")
+
+    def test_accrual_lost(self):
+        # Test that when an allocation is made in the past and the second level is technically reached
+        #  that the first level is not skipped completely.
+        accrual_plan = self.env['hr.leave.accrual.plan'].with_context(tracking_disable=True).create({
+            'name': 'Accrual Plan For Test',
+            'level_ids': [
+                (0, 0, {
+                'start_count': 0,
+                'start_type': 'day',
+                'added_value': 1,
+                'added_value_type': 'days',
+                'frequency': 'monthly',
+                'maximum_leave': 100,
+                'action_with_unused_accruals': 'lost',
+                }),
+            ],
+        })
+        allocation = self.env['hr.leave.allocation'].with_user(self.user_hrmanager_id).with_context(tracking_disable=True).create({
+            'name': 'Accrual Allocation - Test',
+            'accrual_plan_id': accrual_plan.id,
+            'employee_id': self.employee_emp.id,
+            'holiday_status_id': self.leave_type.id,
+            'number_of_days': 0,
+            'allocation_type': 'accrual',
+            'date_from': datetime.date(2022, 1, 1),
+        })
+        allocation.action_confirm()
+        allocation.action_validate()
+        with freeze_time('2022-4-4'):
+            allocation._update_accrual()
+        self.assertEqual(allocation.number_of_days, 3, "Invalid number of days")


### PR DESCRIPTION
Steps :
Create an accrual plan with one level :
	> Starts after : 0 days
	> Rate : 1 day/month on the 1st of the month
	> Unused time at the end of the year : Lost.
Create an allocation :
	> Type : accrual
	> Plan : this plan
	> Start Date : 1/1/this year
Confirm and validate allocation.
Manually set nextcall at the beginning of the month
and lastcall one month before.
Run the appropriate scheduled action.

Issue :
You do not receive a day for the allocation.

Cause :
What we want is, if the period is not in the good year,
or is "negative" (start after end),
we do not add leaves and go to next period.
However, we check that the period is "positive".

Fix :
Check that it is negative.

Also simplified a loop.

opw-2793840

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
