### PR TITLE
[FIX] mass_mailing: add background image options for masonry

### DIFF
--- a/addons/mass_mailing/static/src/js/mass_mailing_snippets.js
+++ b/addons/mass_mailing/static/src/js/mass_mailing_snippets.js
@@ -171,4 +171,19 @@ options.registry.ImageOptimize.include({
     },
 });
 
+options.registry.Parallax = options.Class.extend({
+
+    //--------------------------------------------------------------------------
+    // Private
+    //--------------------------------------------------------------------------
+
+    /**
+     * @override
+     */
+    async _computeWidgetVisibility(widgetName, params) {
+        // Parallax is not supported in emails.
+        return false;
+    },
+});
+
 });

--- a/addons/mass_mailing/views/snippets_themes.xml
+++ b/addons/mass_mailing/views/snippets_themes.xml
@@ -956,6 +956,12 @@
             data-color-prefix="bg-"/>
     </div>
 
+    <!-- Allow changing background images in Masonry -->
+    <t t-call="web_editor.snippet_options_background_options">
+        <t t-set="selector" t-value="'.s_masonry_block .row > div'"/>
+        <t t-set="with_images" t-value="True"/>
+    </t>
+
     <!-- COLOR | .s_three_columns | .s_comparisons -->
     <div data-js="Box"
          data-selector=".s_three_columns .row > div, .s_comparisons .row > div"


### PR DESCRIPTION
The masonry snippet was recently imported from website into mass_mailing but its background image options were omitted, making it impossible to changes these images.

task-2824014

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
