### PR TITLE
[IMP] im_livechat: shorten method name in legacy livechat files

### DIFF
--- a/addons/im_livechat/static/src/legacy/models/abstract_message.js
+++ b/addons/im_livechat/static/src/legacy/models/abstract_message.js
@@ -36,7 +36,7 @@ var AbstractMessage = Class.extend({
      * @param {boolean} [data.is_notification = false]
      * @param {string} [data.message_type = undefined]
      */
-    init: function (parent, data) {
+    init(parent, data) {
         this._attachmentIDs = data.attachment_ids || [];
         this._body = data.body || "";
         // by default: current datetime
@@ -63,7 +63,7 @@ var AbstractMessage = Class.extend({
      *
      * @return {Object[]}
      */
-    getAttachments: function () {
+    getAttachments() {
         return this._attachmentIDs;
     },
     /**
@@ -72,7 +72,7 @@ var AbstractMessage = Class.extend({
      *
      * @return {integer}
      */
-    getAuthorID: function () {
+    getAuthorID() {
         if (!this.hasAuthor()) {
             return -1;
         }
@@ -83,7 +83,7 @@ var AbstractMessage = Class.extend({
      *
      * @return {undefined}
      */
-    getAuthorImStatus: function () {
+    getAuthorImStatus() {
         return undefined;
     },
     /**
@@ -92,7 +92,7 @@ var AbstractMessage = Class.extend({
      * @abstract
      * @return {string}
      */
-    getAvatarSource: function () {
+    getAvatarSource() {
         if (this.hasAuthor()) {
             return '/web/image/res.partner/' + this.getAuthorID() + '/avatar_128';
         }
@@ -102,13 +102,13 @@ var AbstractMessage = Class.extend({
      *
      * @return {string}
      */
-    getBody: function () {
+    getBody() {
         return this._body;
     },
     /**
      * @return {moment}
      */
-    getDate: function () {
+    getDate() {
         return this._date;
     },
     /**
@@ -116,7 +116,7 @@ var AbstractMessage = Class.extend({
      *
      * @return {string}
      */
-    getDateDay: function () {
+    getDateDay() {
         var date = this.getDate().format('YYYY-MM-DD');
         if (date === moment().format('YYYY-MM-DD')) {
             return _t("Today");
@@ -131,7 +131,7 @@ var AbstractMessage = Class.extend({
      *
      * @return {string}
      */
-    getDisplayedAuthor: function () {
+    getDisplayedAuthor() {
         return this.hasAuthor() ? this._getAuthorName() : null;
     },
     /**
@@ -140,7 +140,7 @@ var AbstractMessage = Class.extend({
      * @override
      * @return {integer}
      */
-    getID: function () {
+    getID() {
         return this._id;
     },
     /**
@@ -149,7 +149,7 @@ var AbstractMessage = Class.extend({
      *
      * @return {Object[]}
      */
-    getImageAttachments: function () {
+    getImageAttachments() {
         return _.filter(this.getAttachments(), function (attachment) {
             return attachment.mimetype && attachment.mimetype.split('/')[0] === 'image';
         });
@@ -160,7 +160,7 @@ var AbstractMessage = Class.extend({
      *
      * @return {Object[]}
      */
-    getNonImageAttachments: function () {
+    getNonImageAttachments() {
         return _.difference(this.getAttachments(), this.getImageAttachments());
     },
     /**
@@ -196,7 +196,7 @@ var AbstractMessage = Class.extend({
      *
      * @return {string}
      */
-    getTimeElapsed: function () {
+    getTimeElapsed() {
         return mailUtils.timeFromNow(this.getDate());
     },
     /**
@@ -206,7 +206,7 @@ var AbstractMessage = Class.extend({
      * @override
      * @return {string|undefined}
      */
-    getType: function () {
+    getType() {
         return this._type;
     },
     /**
@@ -215,7 +215,7 @@ var AbstractMessage = Class.extend({
      * @override
      * @return {boolean}
      */
-    hasAttachments: function () {
+    hasAttachments() {
         return this.getAttachments().length > 0;
     },
     /**
@@ -223,7 +223,7 @@ var AbstractMessage = Class.extend({
      *
      * @return {boolean}
      */
-    hasAuthor: function () {
+    hasAuthor() {
         return !!(this._serverAuthorID && this._serverAuthorID[0]);
     },
     /**
@@ -232,7 +232,7 @@ var AbstractMessage = Class.extend({
      *
      * @return {string}
      */
-    hasEmailFrom: function () {
+    hasEmailFrom() {
         return false;
     },
     /**
@@ -240,7 +240,7 @@ var AbstractMessage = Class.extend({
      *
      * @return {boolean}
      */
-    hasImageAttachments: function () {
+    hasImageAttachments() {
         return _.some(this.getAttachments(), function (attachment) {
             return attachment.mimetype && attachment.mimetype.split('/')[0] === 'image';
         });
@@ -250,7 +250,7 @@ var AbstractMessage = Class.extend({
      *
      * @return {boolean}
      */
-    hasNonImageAttachments: function () {
+    hasNonImageAttachments() {
         return _.some(this.getAttachments(), function (attachment) {
             return !(attachment.mimetype && attachment.mimetype.split('/')[0] === 'image');
         });
@@ -281,7 +281,7 @@ var AbstractMessage = Class.extend({
      * @override
      * @return {boolean}
      */
-    originatesFromChannel: function () {
+    originatesFromChannel() {
         return false;
     },
     /**
@@ -290,7 +290,7 @@ var AbstractMessage = Class.extend({
      *
      * @return {boolean}
      */
-    hasSubject: function () {
+    hasSubject() {
         return false;
     },
     /**
@@ -298,7 +298,7 @@ var AbstractMessage = Class.extend({
      *
      * @return {boolean}
      */
-    isEmpty: function () {
+    isEmpty() {
         return !this.hasTrackingValues() &&
         !this.hasAttachments() &&
         !this.getBody();
@@ -308,7 +308,7 @@ var AbstractMessage = Class.extend({
      *
      * @return {boolean}
      */
-    hasSubtypeDescription: function () {
+    hasSubtypeDescription() {
         return false;
     },
     /**
@@ -317,7 +317,7 @@ var AbstractMessage = Class.extend({
      *
      * @return {boolean}
      */
-    hasTrackingValues: function () {
+    hasTrackingValues() {
         return false;
     },
     /**
@@ -325,7 +325,7 @@ var AbstractMessage = Class.extend({
      *
      * @return {boolean}
      */
-    isDiscussion: function () {
+    isDiscussion() {
         return this._isDiscussion;
     },
     /**
@@ -334,7 +334,7 @@ var AbstractMessage = Class.extend({
      *
      * @return {boolean}
      */
-    isLinkedToDocumentThread: function () {
+    isLinkedToDocumentThread() {
         return false;
     },
     /**
@@ -343,7 +343,7 @@ var AbstractMessage = Class.extend({
      *
      * @return {boolean}
      */
-    isNeedaction: function () {
+    isNeedaction() {
         return false;
     },
     /**
@@ -351,7 +351,7 @@ var AbstractMessage = Class.extend({
      *
      * @return {boolean}
      */
-    isNote: function () {
+    isNote() {
         return this._isNote;
     },
     /**
@@ -367,7 +367,7 @@ var AbstractMessage = Class.extend({
      *
      * @returns {boolean}
      */
-    isNotification: function () {
+    isNotification() {
         return this._isNotification;
     },
     /**
@@ -376,7 +376,7 @@ var AbstractMessage = Class.extend({
      *
      * @return {boolean}
      */
-    isStarred: function () {
+    isStarred() {
         return false;
     },
     /**
@@ -386,7 +386,7 @@ var AbstractMessage = Class.extend({
      * @override
      * @return {boolean}
      */
-    isSystemNotification: function () {
+    isSystemNotification() {
         return false;
     },
     /**
@@ -395,13 +395,13 @@ var AbstractMessage = Class.extend({
      *
      * @returns {boolean}
      */
-    needsModeration: function () {
+    needsModeration() {
         return false;
     },
     /**
      * @params {integer[]} attachmentIDs
      */
-    removeAttachments: function (attachmentIDs) {
+    removeAttachments(attachmentIDs) {
         this._attachmentIDs = _.reject(this._attachmentIDs, function (attachment) {
             return _.contains(attachmentIDs, attachment.id);
         });
@@ -414,7 +414,7 @@ var AbstractMessage = Class.extend({
      *
      * @return {boolean}
      */
-    shouldRedirectToAuthor: function () {
+    shouldRedirectToAuthor() {
         return !this._isMyselfAuthor();
     },
 
@@ -429,7 +429,7 @@ var AbstractMessage = Class.extend({
      * @private
      * @returns {string}
      */
-    _getAuthorName: function () {
+    _getAuthorName() {
         if (!this.hasAuthor()) {
             return "";
         }
@@ -441,7 +441,7 @@ var AbstractMessage = Class.extend({
      * @private
      * @return {boolean}
      */
-    _isMyselfAuthor: function () {
+    _isMyselfAuthor() {
         return this.hasAuthor() && (this.getAuthorID() === session.partner_id);
     },
     /**
@@ -449,7 +449,7 @@ var AbstractMessage = Class.extend({
      *
      * @private
      */
-    _processAttachmentURL: function () {
+    _processAttachmentURL() {
         _.each(this.getAttachments(), function (attachment) {
             attachment.url = '/web/content/' + attachment.id + '?download=true';
         });

--- a/addons/im_livechat/static/src/legacy/models/abstract_thread.js
+++ b/addons/im_livechat/static/src/legacy/models/abstract_thread.js
@@ -20,7 +20,7 @@ var AbstractThread = Class.extend(Mixins.EventDispatcherMixin, {
      * @param {Object} params.parent Object with the event-dispatcher mixin
      *   (@see {web.mixins.EventDispatcherMixin})
      */
-    init: function (params) {
+    init(params) {
         Mixins.EventDispatcherMixin.init.call(this, arguments);
         this.setParent(params.parent);
 
@@ -40,7 +40,7 @@ var AbstractThread = Class.extend(Mixins.EventDispatcherMixin, {
      *
      * @param {im_livechat.legacy.mail.model.AbstractMessage} message
      */
-    addMessage: function (message) {
+    addMessage(message) {
         this._addMessage.apply(this, arguments);
         this.trigger('message_added', message);
     },
@@ -49,7 +49,7 @@ var AbstractThread = Class.extend(Mixins.EventDispatcherMixin, {
      *
      * @param {boolean} folded
      */
-    fold: function (folded) {
+    fold(folded) {
         this._folded = folded;
     },
     /**
@@ -57,21 +57,21 @@ var AbstractThread = Class.extend(Mixins.EventDispatcherMixin, {
      *
      * @returns {integer|string}
      */
-    getID: function () {
+    getID() {
         return this._id;
     },
     /**
      * @abstract
      * @returns {im_livechat.legacy.mail.model.AbstractMessage[]}
      */
-    getMessages: function () {},
+    getMessages() {},
     /**
      * Get the name of this thread. If the name of the thread has been created
      * by the user from an input, it may be escaped.
      *
      * @returns {string}
      */
-    getName: function () {
+    getName() {
         return this._name;
     },
     /**
@@ -79,7 +79,7 @@ var AbstractThread = Class.extend(Mixins.EventDispatcherMixin, {
      *
      * @returns {string}
      */
-    getStatus: function () {
+    getStatus() {
         return this._status;
     },
     /**
@@ -87,20 +87,20 @@ var AbstractThread = Class.extend(Mixins.EventDispatcherMixin, {
      *
      * @returns {string} the name of the thread by default (see @getName)
      */
-    getTitle: function () {
+    getTitle() {
         return this.getName();
     },
-    getType: function () {},
+    getType() {},
     /**
      * @returns {integer}
      */
-    getUnreadCounter: function () {
+    getUnreadCounter() {
         return this._unreadCounter;
     },
     /**
      * @returns {boolean}
      */
-    hasMessages: function () {
+    hasMessages() {
         return !_.isEmpty(this.getMessages());
     },
     /**
@@ -108,7 +108,7 @@ var AbstractThread = Class.extend(Mixins.EventDispatcherMixin, {
      *
      * @return {boolean}
      */
-    isFolded: function () {
+    isFolded() {
         return this._folded;
     },
     /**
@@ -117,7 +117,7 @@ var AbstractThread = Class.extend(Mixins.EventDispatcherMixin, {
      *
      * @returns {Promise}
      */
-    markAsRead: function () {
+    markAsRead() {
         if (this._unreadCounter > 0) {
             return this._markAsRead();
         }
@@ -129,14 +129,14 @@ var AbstractThread = Class.extend(Mixins.EventDispatcherMixin, {
      * @returns {Promise} resolved with the message object to be sent to the
      *   server
      */
-    postMessage: function () {
+    postMessage() {
         return this._postMessage.apply(this, arguments)
                                 .then(this.trigger.bind(this, 'message_posted'));
     },
     /**
      * Resets the unread counter of this thread to 0.
      */
-    resetUnreadCounter: function () {
+    resetUnreadCounter() {
         this._unreadCounter = 0;
         this._warnUpdatedUnreadCounter();
     },
@@ -152,13 +152,13 @@ var AbstractThread = Class.extend(Mixins.EventDispatcherMixin, {
      * @private
      * @param {im_livechat.legacy.mail.model.AbstractMessage} message
      */
-    _addMessage: function (message) {},
+    _addMessage(message) {},
     /**
      * Increments the unread counter of this thread by 1 unit.
      *
      * @private
      */
-    _incrementUnreadCounter: function () {
+    _incrementUnreadCounter() {
         this._unreadCounter++;
     },
     /**
@@ -167,7 +167,7 @@ var AbstractThread = Class.extend(Mixins.EventDispatcherMixin, {
      * @private
      * @returns {Promise}
      */
-    _markAsRead: function () {
+    _markAsRead() {
         this.resetUnreadCounter();
         return Promise.resolve();
     },
@@ -179,7 +179,7 @@ var AbstractThread = Class.extend(Mixins.EventDispatcherMixin, {
      * @returns {Promise} resolved with the message object to be sent to the
      *   server
      */
-    _postMessage: function () {
+    _postMessage() {
         return Promise.resolve();
     },
     /**
@@ -189,7 +189,7 @@ var AbstractThread = Class.extend(Mixins.EventDispatcherMixin, {
      * @abstract
      * @private
      */
-    _warnUpdatedUnreadCounter: function () {},
+    _warnUpdatedUnreadCounter() {},
 });
 
 return AbstractThread;

--- a/addons/im_livechat/static/src/legacy/models/cc_throttle_function_object.js
+++ b/addons/im_livechat/static/src/legacy/models/cc_throttle_function_object.js
@@ -17,7 +17,7 @@ var CCThrottleFunctionObject = Class.extend({
      * @param {function} params.func provided function for making the CC
      *   throttled version.
      */
-    init: function (params) {
+    init(params) {
         this._arguments = undefined;
         this._cooldownTimeout = undefined;
         this._duration = params.duration;
@@ -32,7 +32,7 @@ var CCThrottleFunctionObject = Class.extend({
     /**
      * Cancel any buffered function call, but keep the cooldown phase running.
      */
-    cancel: function () {
+    cancel() {
         this._arguments = undefined;
         this._shouldCallFunctionAfterCD = false;
     },
@@ -40,7 +40,7 @@ var CCThrottleFunctionObject = Class.extend({
      * Clear the internal throttle timer, so that the following function call
      * is immediate. For instance, if there is a cooldown stage, it is aborted.
      */
-    clear: function () {
+    clear() {
         if (this._cooldownTimeout) {
             clearTimeout(this._cooldownTimeout);
             this._onCooldownTimeout();
@@ -59,7 +59,7 @@ var CCThrottleFunctionObject = Class.extend({
      * Note that after the cooldown stage, only the last attempted function
      * call will be considered.
      */
-    do: function () {
+    do() {
         this._arguments = Array.prototype.slice.call(arguments);
         if (this._cooldownTimeout === undefined) {
             this._callFunction();
@@ -78,7 +78,7 @@ var CCThrottleFunctionObject = Class.extend({
      *
      * @private
      */
-    _callFunction: function () {
+    _callFunction() {
         this._func.apply(null, this._arguments);
         this._cooldown();
     },
@@ -89,7 +89,7 @@ var CCThrottleFunctionObject = Class.extend({
      *
      * @private
      */
-    _cooldown: function () {
+    _cooldown() {
         this.cancel();
         this._cooldownTimeout = setTimeout(
             this._onCooldownTimeout.bind(this),
@@ -107,7 +107,7 @@ var CCThrottleFunctionObject = Class.extend({
      *
      * @private
      */
-    _onCooldownTimeout: function () {
+    _onCooldownTimeout() {
         if (this._shouldCallFunctionAfterCD) {
             this._callFunction();
         } else {

--- a/addons/im_livechat/static/src/legacy/models/thread_typing_mixin.js
+++ b/addons/im_livechat/static/src/legacy/models/thread_typing_mixin.js
@@ -29,7 +29,7 @@ var ThreadTypingMixin = {
      *     possibility to immediately notify if he types something right away,
      *     instead of waiting for a throttle behaviour.
      */
-    init: function () {
+    init() {
         // Store the last "myself typing" status that has been sent to the
         // server. This is useful in order to not notify the same typing
         // status multiple times.
@@ -116,7 +116,7 @@ var ThreadTypingMixin = {
      * @returns {string} list of members that are typing something on the thread
      *   (excluding the current user).
      */
-    getTypingMembersToText: function () {
+    getTypingMembersToText() {
         var typingPartnerIDs = this._typingPartnerIDs;
         var typingMembers = _.filter(this._members, function (member) {
             return _.contains(typingPartnerIDs, member.id);
@@ -145,7 +145,7 @@ var ThreadTypingMixin = {
      *
      * @returns {boolean}
      */
-    hasTypingNotification: function () {
+    hasTypingNotification() {
         return true;
     },
     /**
@@ -154,7 +154,7 @@ var ThreadTypingMixin = {
      *
      * @returns {boolean}
      */
-    isSomeoneTyping: function () {
+    isSomeoneTyping() {
         return !(_.isEmpty(this._typingPartnerIDs));
     },
     /**
@@ -168,7 +168,7 @@ var ThreadTypingMixin = {
      * @param {integer} params.partnerID ID of the partner linked to the user
      *   currently typing something on the thread.
      */
-    registerTyping: function (params) {
+    registerTyping(params) {
         if (this._isTypingMyselfInfo(params)) {
             return;
         }
@@ -190,7 +190,7 @@ var ThreadTypingMixin = {
      * @param {Object} params
      * @param {boolean} params.typing tell whether the current is typing or not.
      */
-    setMyselfTyping: function (params) {
+    setMyselfTyping(params) {
         var typing = params.typing;
         if (this._lastNotifiedMyselfTyping === typing) {
             this._throttleNotifyMyselfTyping.cancel();
@@ -211,7 +211,7 @@ var ThreadTypingMixin = {
      * @param {integer} params.partnerID ID of the partner related to the user
      *   that is currently typing something
      */
-    unregisterTyping: function (params) {
+    unregisterTyping(params) {
         var partnerID = params.partnerID;
         this._othersTypingTimers.unregisterTimer({ timerID: partnerID });
         if (!_.contains(this._typingPartnerIDs, partnerID)) {
@@ -236,7 +236,7 @@ var ThreadTypingMixin = {
      * @param {Object} params
      * @param {integer} params.partner ID of partner to check
      */
-    _isTypingMyselfInfo: function (params) {
+    _isTypingMyselfInfo(params) {
         return false;
     },
     /**
@@ -250,7 +250,7 @@ var ThreadTypingMixin = {
      * @returns {Promise} resolved if the server is notified, rejected
      *   otherwise
      */
-    _notifyMyselfTyping: function (params) {
+    _notifyMyselfTyping(params) {
         return Promise.resolve();
     },
     /**
@@ -260,7 +260,7 @@ var ThreadTypingMixin = {
      * @abstract
      * @private
      */
-    _warnUpdatedTypingPartners: function () {},
+    _warnUpdatedTypingPartners() {},
 
     //--------------------------------------------------------------------------
     // Handlers
@@ -273,7 +273,7 @@ var ThreadTypingMixin = {
      *
      * @private
      */
-    _onMyselfLongTypingTimeout: function () {
+    _onMyselfLongTypingTimeout() {
         this._throttleNotifyMyselfTyping.clear();
         this._throttleNotifyMyselfTyping({ typing: true });
     },
@@ -284,7 +284,7 @@ var ThreadTypingMixin = {
      *
      * @private
      */
-    _onMyselfTypingInactivityTimeout: function () {
+    _onMyselfTypingInactivityTimeout() {
         this._throttleNotifyMyselfTyping.clear();
         this._throttleNotifyMyselfTyping({ typing: false });
     },
@@ -299,7 +299,7 @@ var ThreadTypingMixin = {
      * @param {Object} params
      * @param {boolean} params.typing whether we are typing something or not.
      */
-    _onNotifyMyselfTyping: function (params) {
+    _onNotifyMyselfTyping(params) {
         var typing = params.typing;
         this._lastNotifiedMyselfTyping = typing;
         this._notifyMyselfTyping(params);
@@ -318,7 +318,7 @@ var ThreadTypingMixin = {
      * @param {integer} partnerID partnerID of the person we assume he is no
      *   longer typing something.
      */
-    _onOthersTypingTimeout: function (partnerID) {
+    _onOthersTypingTimeout(partnerID) {
         this.unregisterTyping({ partnerID: partnerID });
     },
     /**
@@ -329,7 +329,7 @@ var ThreadTypingMixin = {
      * @private
      * @param {mail.model.AbstractMessage} message
      */
-    _onTypingMessageAdded: function (message) {
+    _onTypingMessageAdded(message) {
         var partnerID = message.hasAuthor() ?
                         message.getAuthorID() :
                         this._DEFAULT_TYPING_PARTNER_ID;
@@ -348,7 +348,7 @@ var ThreadTypingMixin = {
      *
      * @private
      */
-    _onTypingMessagePosted: function () {
+    _onTypingMessagePosted() {
         this._lastNotifiedMyselfTyping = false;
         this._throttleNotifyMyselfTyping.clear();
         this._myselfLongTypingTimer.clear();

--- a/addons/im_livechat/static/src/legacy/models/timer.js
+++ b/addons/im_livechat/static/src/legacy/models/timer.js
@@ -18,7 +18,7 @@ var Timer = Class.extend({
      * @param {function} params.onTimeout function that is called when the
      *   timer times out.
      */
-    init: function (params) {
+    init(params) {
         this._duration = params.duration;
         this._timeout = undefined;
         this._timeoutCallback = params.onTimeout;
@@ -31,13 +31,13 @@ var Timer = Class.extend({
     /**
      * Clears the countdown of the timer.
      */
-    clear: function () {
+    clear() {
         clearTimeout(this._timeout);
     },
     /**
      * Resets the timer, i.e. resets its duration.
      */
-    reset: function () {
+    reset() {
         this.clear();
         this.start();
     },
@@ -45,7 +45,7 @@ var Timer = Class.extend({
      * Starts the timer, i.e. after a certain duration, it times out and calls
      * a function back.
      */
-    start: function () {
+    start() {
         this._timeout = setTimeout(this._onTimeout.bind(this), this._duration);
     },
 
@@ -58,7 +58,7 @@ var Timer = Class.extend({
      *
      * @private
      */
-    _onTimeout: function () {
+    _onTimeout() {
         this._timeoutCallback();
     },
 

--- a/addons/im_livechat/static/src/legacy/models/timers.js
+++ b/addons/im_livechat/static/src/legacy/models/timers.js
@@ -19,7 +19,7 @@ var Timers = Class.extend({
      * @param {function} params.onTimeout a function to call back for underlying
      *   timers on timeout.
      */
-    init: function (params) {
+    init(params) {
         this._duration = params.duration;
         this._timeoutCallback = params.onTimeout;
         this._timers = {};
@@ -40,7 +40,7 @@ var Timers = Class.extend({
      * @param {Array} [params.timeoutCallbackArguments]
      * @param {integer} params.timerID
      */
-    registerTimer: function (params) {
+    registerTimer(params) {
         var timerID = params.timerID;
         if (this._timers[timerID]) {
             this._timers[timerID].clear();
@@ -67,7 +67,7 @@ var Timers = Class.extend({
      * @param {Object} params
      * @param {integer} params.timerID
      */
-    unregisterTimer: function (params) {
+    unregisterTimer(params) {
         var timerID = params.timerID;
         if (this._timers[timerID]) {
             this._timers[timerID].clear();

--- a/addons/im_livechat/static/src/legacy/models/website_livechat.js
+++ b/addons/im_livechat/static/src/legacy/models/website_livechat.js
@@ -30,7 +30,7 @@ var WebsiteLivechat = AbstractThread.extend(ThreadTypingMixin, {
      * @param {string} params.data.uuid the UUID of this livechat.
      * @param {im_livechat.legacy.im_livechat.LivechatButton} params.parent
      */
-    init: function (params) {
+    init(params) {
         this._super.apply(this, arguments);
         ThreadTypingMixin.init.call(this, arguments);
 
@@ -64,19 +64,19 @@ var WebsiteLivechat = AbstractThread.extend(ThreadTypingMixin, {
      * @override
      * @returns {im_livechat.legacy.im_livechat.model.WebsiteLivechatMessage[]}
      */
-    getMessages: function () {
+    getMessages() {
         return this._messages;
     },
     /**
      * @returns {Array}
      */
-    getOperatorPID: function () {
+    getOperatorPID() {
         return this._operatorPID;
     },
     /**
      * @returns {string}
      */
-    getUUID: function () {
+    getUUID() {
         return this._uuid;
     },
     /**
@@ -86,7 +86,7 @@ var WebsiteLivechat = AbstractThread.extend(ThreadTypingMixin, {
      * for website livechat is external. This method should be dropped when
      * this class handles messages by itself.
      */
-    incrementUnreadCounter: function () {
+    incrementUnreadCounter() {
         this._incrementUnreadCounter();
     },
     /**
@@ -94,13 +94,13 @@ var WebsiteLivechat = AbstractThread.extend(ThreadTypingMixin, {
      *
      * @param {im_livechat.legacy.im_livechat.model.WebsiteLivechatMessage[]} messages
      */
-    setMessages: function (messages) {
+    setMessages(messages) {
         this._messages = messages;
     },
     /**
      * @returns {Object}
      */
-    toData: function () {
+    toData() {
         return {
             folded: this.isFolded(),
             id: this.getID(),
@@ -122,7 +122,7 @@ var WebsiteLivechat = AbstractThread.extend(ThreadTypingMixin, {
      * @param {boolean} params.isWebsiteUser
      * @returns {boolean}
      */
-    _isTypingMyselfInfo: function (params) {
+    _isTypingMyselfInfo(params) {
         return params.isWebsiteUser;
     },
     /**
@@ -132,7 +132,7 @@ var WebsiteLivechat = AbstractThread.extend(ThreadTypingMixin, {
      * @param {boolean} params.typing
      * @returns {Promise}
      */
-    _notifyMyselfTyping: function (params) {
+    _notifyMyselfTyping(params) {
         return session.rpc('/im_livechat/notify_typing', {
             uuid: this.getUUID(),
             is_typing: params.typing,
@@ -145,7 +145,7 @@ var WebsiteLivechat = AbstractThread.extend(ThreadTypingMixin, {
      * @override {mail.model.ThreadTypingMixin}
      * @private
      */
-    _warnUpdatedTypingPartners: function () {
+    _warnUpdatedTypingPartners() {
         this.trigger_up('updated_typing_partners');
     },
     /**
@@ -154,7 +154,7 @@ var WebsiteLivechat = AbstractThread.extend(ThreadTypingMixin, {
      * @override
      * @private
      */
-    _warnUpdatedUnreadCounter: function () {
+    _warnUpdatedUnreadCounter() {
         this.trigger_up('updated_unread_counter');
     },
 
@@ -173,7 +173,7 @@ var WebsiteLivechat = AbstractThread.extend(ThreadTypingMixin, {
      * @private
      * @param {mail.model.AbstractMessage} message
      */
-    _onTypingMessageAdded: function (message) {
+    _onTypingMessageAdded(message) {
         var operatorID = this.getOperatorPID()[0];
         if (message.hasAuthor() && message.getAuthorID() === operatorID) {
             this.unregisterTyping({ partnerID: operatorID });

--- a/addons/im_livechat/static/src/legacy/models/website_livechat_message.js
+++ b/addons/im_livechat/static/src/legacy/models/website_livechat_message.js
@@ -19,7 +19,7 @@ var WebsiteLivechatMessage = AbstractMessage.extend({
      * @param {string} options.default_username
      * @param {string} options.serverURL
      */
-    init: function (parent, data, options) {
+    init(parent, data, options) {
         this._super.apply(this, arguments);
 
         this._defaultUsername = options.default_username;
@@ -36,7 +36,7 @@ var WebsiteLivechatMessage = AbstractMessage.extend({
      * @override
      * @return {string}
      */
-    getAvatarSource: function () {
+    getAvatarSource() {
         var source = this._serverURL;
         if (this.hasAuthor()) {
             source += `/im_livechat/operator/${this.getAuthorID()}/avatar`;
@@ -55,7 +55,7 @@ var WebsiteLivechatMessage = AbstractMessage.extend({
      * @override
      * @return {string}
      */
-    getDisplayedAuthor: function () {
+    getDisplayedAuthor() {
         return this._super.apply(this, arguments) || this._defaultUsername;
     },
 

--- a/addons/im_livechat/static/src/legacy/models/website_livechat_window.js
+++ b/addons/im_livechat/static/src/legacy/models/website_livechat_window.js
@@ -46,7 +46,7 @@ var LivechatWindow = AbstractThreadWindow.extend({
     /**
      * @override
      */
-    close: function () {
+    close() {
         this.trigger_up('close_chat_window');
     },
     /**
@@ -54,7 +54,7 @@ var LivechatWindow = AbstractThreadWindow.extend({
      *
      * @param {$.Element} $element
      */
-    replaceContentWith: function ($element) {
+    replaceContentWith($element) {
         $element.replace(this._threadWidget.$el);
     },
     /**
@@ -63,7 +63,7 @@ var LivechatWindow = AbstractThreadWindow.extend({
      * @override
      * @param {boolean} folded
      */
-    toggleFold: function () {
+    toggleFold() {
         this._super.apply(this, arguments);
         this.trigger_up('save_chat_window');
         this.updateVisualFoldState();
@@ -78,7 +78,7 @@ var LivechatWindow = AbstractThreadWindow.extend({
      * @private
      * @param {Object} messageData
      */
-    _postMessage: function (messageData) {
+    _postMessage(messageData) {
         this.trigger_up('post_message_chat_window', { messageData: messageData });
         this._super.apply(this, arguments);
     },
@@ -92,7 +92,7 @@ var LivechatWindow = AbstractThreadWindow.extend({
      *
      * @private
      */
-    _onInput: function () {
+    _onInput() {
         if (this.hasThread() && this._thread.hasTypingNotification()) {
             var isTyping = this.$input.val().length > 0;
             this._thread.setMyselfTyping({ typing: isTyping });

--- a/addons/im_livechat/static/src/legacy/public_livechat_chatbot.js
+++ b/addons/im_livechat/static/src/legacy/public_livechat_chatbot.js
@@ -20,7 +20,7 @@ const QWeb = core.qweb;
  *   message for a couple seconds and then trigger the next step of the script
  */
  LivechatButton.include({
-    init: function () {
+    init() {
         this._super(...arguments);
 
         this._chatbotMessageDelay = 3500;  // in milliseconds
@@ -49,7 +49,7 @@ const QWeb = core.qweb;
      *
      * @override
      */
-    willStart: async function () {
+    async willStart() {
         const superResult = await this._super(...arguments);
 
         this._isChatbot = false;
@@ -122,7 +122,7 @@ const QWeb = core.qweb;
      *
      * It also helps while running test tours since those don't have the bus enabled.
      */
-    _chatbotAddMessage: function (message, options) {
+    _chatbotAddMessage(message, options) {
         message.body = utils.Markup(message.body);
         this._addMessage(message, options);
         if (this._chatWindow.isFolded() || !this._chatWindow.isAtBottom()) {
@@ -147,7 +147,7 @@ const QWeb = core.qweb;
      * First we check if the last message was sent by the user, to make sure we always let him type
      * at least one message before moving on.
      */
-    _chatbotAwaitUserInput: function () {
+    _chatbotAwaitUserInput() {
         if (this._isLastMessageFromCustomer()) {
             if (this._chatbotShouldEndScript()) {
                 this._chatbotEndScript();
@@ -172,7 +172,7 @@ const QWeb = core.qweb;
      * It also allows tying any first response / question_selection choice to a chatbot.message
      * that has a linked mail.message.
      */
-    _chatbotPostWelcomeMessages: async function () {
+    async _chatbotPostWelcomeMessages() {
         const welcomeMessages = this._getWelcomeMessages();
 
         if (welcomeMessages.length === 0) {
@@ -207,7 +207,7 @@ const QWeb = core.qweb;
      *
      * @private
      */
-    _chatbotDisableInput: function (disableText) {
+    _chatbotDisableInput(disableText) {
         this._chatWindow.$('.o_composer_text_field')
             .prop('disabled', true)
             .addClass('text-center font-italic bg-200')
@@ -217,7 +217,7 @@ const QWeb = core.qweb;
     /**
      * @private
      */
-    _chatbotEnableInput: function () {
+    _chatbotEnableInput() {
         const $composerTextField = this._chatWindow.$('.o_composer_text_field');
         $composerTextField
             .prop('disabled', false)
@@ -240,7 +240,7 @@ const QWeb = core.qweb;
      *
      * @private
      */
-    _chatbotEndScript: function () {
+    _chatbotEndScript() {
         this._chatWindow.$('.o_composer_text_field').addClass('d-none');
         this._chatWindow.$('.o_livechat_chatbot_end').show();
         this._chatWindow.$('.o_livechat_chatbot_restart').one('click',
@@ -255,7 +255,7 @@ const QWeb = core.qweb;
      *
      * @private
      */
-    _chatbotDisplayRestartButton: function () {
+    _chatbotDisplayRestartButton() {
         return this._isChatbot && (!this._chatbotCurrentStep ||
             (this._chatbotCurrentStep.chatbot_step_type !== 'forward_operator' ||
              !this._chatbotCurrentStep.chatbot_operator_found));
@@ -265,7 +265,7 @@ const QWeb = core.qweb;
      *
      * @private
      */
-    _chatbotIsExpectingUserInput: function () {
+    _chatbotIsExpectingUserInput() {
         return [
             'question_phone',
             'question_email',
@@ -300,7 +300,7 @@ const QWeb = core.qweb;
      *
      * @private
      */
-    _chatbotProcessStep: function () {
+    _chatbotProcessStep() {
         if (this._chatbotShouldEndScript()) {
             this._chatbotEndScript();
         } else if (this._chatbotCurrentStep.chatbot_step_type === 'forward_operator'
@@ -358,7 +358,7 @@ const QWeb = core.qweb;
       *
       * @private
       */
-    _chatbotRestoreSession: function (sessionCookie) {
+    _chatbotRestoreSession(sessionCookie) {
         const sessionKey = 'im_livechat.chatbot.state.uuid_' + JSON.parse(sessionCookie).uuid;
         const browserLocalStorage = window.localStorage;
         if (browserLocalStorage && browserLocalStorage.length) {
@@ -388,7 +388,7 @@ const QWeb = core.qweb;
      *
      * @private
      */
-    _chatbotSaveSession: function () {
+    _chatbotSaveSession() {
         const chatUuid = this._livechat.toData().uuid;
         localStorage.setItem('im_livechat.chatbot.state.uuid_' + chatUuid, JSON.stringify({
             '_chatbot': this._chatbot,
@@ -400,7 +400,7 @@ const QWeb = core.qweb;
      *
      * @private
      */
-    _chatbotSetIsTyping: function (isWelcomeMessage=false) {
+    _chatbotSetIsTyping(isWelcomeMessage=false) {
         if (this.isTypingTimeout) {
             clearTimeout(this.isTypingTimeout);
         }
@@ -431,7 +431,7 @@ const QWeb = core.qweb;
      * @returns {Boolean}
      * @private
      */
-    _chatbotShouldEndScript: function () {
+    _chatbotShouldEndScript() {
         if (this._chatbotCurrentStep.chatbot_step_is_last &&
             (this._chatbotCurrentStep.chatbot_step_type !== 'forward_operator' ||
              !this._chatbotCurrentStep.chatbot_operator_found)) {
@@ -469,7 +469,7 @@ const QWeb = core.qweb;
      *
      * @private
      */
-    _chatbotValidateEmail: async function () {
+    async _chatbotValidateEmail() {
         let emailValidResult = await session.rpc('/chatbot/step/validate_email', {
             channel_uuid: this._livechat.getUUID(),
         });
@@ -495,7 +495,7 @@ const QWeb = core.qweb;
      *
      * @private
      */
-    _chatbotTriggerNextStep: async function () {
+    async _chatbotTriggerNextStep() {
         let triggerNextStep = true;
         if (this._chatbotCurrentStep && this._chatbotCurrentStep.chatbot_step_type === 'question_email') {
             triggerNextStep = await this._chatbotValidateEmail();
@@ -535,7 +535,7 @@ const QWeb = core.qweb;
      *
      * @private
      */
-    _getWelcomeMessages: function () {
+    _getWelcomeMessages() {
         return this._messages.filter((message) => {
             return message._id && typeof message._id === 'string' && message._id.startsWith('_welcome_');
         });
@@ -545,7 +545,7 @@ const QWeb = core.qweb;
      *
      * @private
      */
-    _isLastMessageFromCustomer: function () {
+    _isLastMessageFromCustomer() {
         const lastMessage = this._messages.length !== 0 ? this._messages[this._messages.length - 1] : null;
         return lastMessage && lastMessage.getAuthorID() !== this._livechat.getOperatorPID()[0];
     },
@@ -561,7 +561,7 @@ const QWeb = core.qweb;
      * @override
      * @private
      */
-     _askFeedback: function () {
+     _askFeedback() {
         this._super(...arguments);
 
         this._chatWindow.$('.o_livechat_chatbot_main_restart').addClass('d-none');
@@ -581,7 +581,7 @@ const QWeb = core.qweb;
      * @private
      * @override
      */
-    _openChatWindow: function () {
+    _openChatWindow() {
         return this._super(...arguments).then(() => {
             window.addEventListener('resize', () => {
                 if (this._chatWindow) {
@@ -598,7 +598,7 @@ const QWeb = core.qweb;
      * @private
      * @override
      */
-    _prepareGetSessionParameters: function () {
+    _prepareGetSessionParameters() {
         const parameters = this._super(...arguments);
 
         if (this._isChatbot) {
@@ -610,7 +610,7 @@ const QWeb = core.qweb;
     /**
      * @private
      */
-    _renderMessages: function () {
+    _renderMessages() {
         this._super(...arguments);
 
         var self = this;
@@ -648,7 +648,7 @@ const QWeb = core.qweb;
      *
      * @private
      */
-    _sendMessage: async function (message) {
+    async _sendMessage(message) {
         const superArguments = arguments;
         const superMethod = this._super;
 
@@ -683,7 +683,7 @@ const QWeb = core.qweb;
      * Small override to handle chatbot welcome message(s).
      * @private
      */
-    _sendWelcomeMessage: function () {
+    _sendWelcomeMessage() {
         if (this._isChatbot) {
             this._sendWelcomeChatbotMessage(
                 0,
@@ -714,7 +714,7 @@ const QWeb = core.qweb;
      *
      * @private
      */
-    _sendWelcomeChatbotMessage: function (stepIndex, welcomeMessageDelay) {
+    _sendWelcomeChatbotMessage(stepIndex, welcomeMessageDelay) {
         const chatbotStep = this._chatbot.chatbot_welcome_steps[stepIndex];
         this._chatbotCurrentStep = chatbotStep;
 
@@ -768,7 +768,7 @@ const QWeb = core.qweb;
      *
      * @private
      */
-    _onChatbotRestartScript: async function (ev) {
+    async _onChatbotRestartScript(ev) {
         this._chatWindow.$('.o_composer_text_field').removeClass('d-none');
         this._chatWindow.$('.o_livechat_chatbot_end').hide();
 
@@ -795,7 +795,7 @@ const QWeb = core.qweb;
             this._chatbotTriggerNextStep.bind(this), this._chatbotMessageDelay);
     },
 
-    _onChatbotInputKeyDown: function () {
+    _onChatbotInputKeyDown() {
         if (this._chatbotCurrentStep &&
             this._chatbotCurrentStep.chatbot_step_type === 'free_input_multi') {
             this._debouncedChatbotAwaitUserInput();
@@ -813,7 +813,7 @@ const QWeb = core.qweb;
      * @param {MouseEvent} ev
      * @private
      */
-    _onChatbotOptionClicked: async function (ev) {
+    async _onChatbotOptionClicked(ev) {
         ev.stopPropagation();
 
         const $target = $(ev.currentTarget);

--- a/addons/im_livechat/static/src/legacy/website_livechat_message_chatbot.js
+++ b/addons/im_livechat/static/src/legacy/website_livechat_message_chatbot.js
@@ -16,7 +16,7 @@ WebsiteLivechatMessage.include({
      * @param {string} options.default_username
      * @param {string} options.serverURL
      */
-    init: function (parent, data, options) {
+    init(parent, data, options) {
         this._super(...arguments);
 
         if (parent._isChatbot) {
@@ -39,7 +39,7 @@ WebsiteLivechatMessage.include({
      *
      * @return {string}
      */
-    getChatbotStepId: function () {
+    getChatbotStepId() {
         return this._chatbotStepId;
     },
     /**
@@ -47,7 +47,7 @@ WebsiteLivechatMessage.include({
      *
      * @return {string}
      */
-    getChatbotStepAnswers: function () {
+    getChatbotStepAnswers() {
         return this._chatbotStepAnswers;
     },
     /**
@@ -55,13 +55,13 @@ WebsiteLivechatMessage.include({
      *
      * @return {string}
      */
-    getChatbotStepAnswerId: function () {
+    getChatbotStepAnswerId() {
         return this._chatbotStepAnswerId;
     },
     /**
      * @override
      */
-    setChatbotStepAnswerId: function (chatbotStepAnswerId) {
+    setChatbotStepAnswerId(chatbotStepAnswerId) {
         this._chatbotStepAnswerId = chatbotStepAnswerId;
     }
 });

--- a/addons/im_livechat/static/src/legacy/widgets/abstract_thread_window.js
+++ b/addons/im_livechat/static/src/legacy/widgets/abstract_thread_window.js
@@ -44,7 +44,7 @@ var AbstractThreadWindow = Widget.extend({
      * @param {Object} [options={}]
      * @param {im_livechat.legacy.mail.model.AbstractThread} [options.thread]
      */
-    init: function (parent, thread, options) {
+    init(parent, thread, options) {
         this._super(parent);
 
         this.options = _.defaults(options || {}, {
@@ -65,7 +65,7 @@ var AbstractThreadWindow = Widget.extend({
             this._folded = false;
         }
     },
-    start: function () {
+    start() {
         var self = this;
         this.$input = this.$('.o_composer_text_field');
         this.$header = this.$('.o_thread_window_header');
@@ -97,21 +97,21 @@ var AbstractThreadWindow = Widget.extend({
     /**
      * @override
      */
-    do_hide: function () {
+    do_hide() {
         this._hidden = true;
         this._super.apply(this, arguments);
     },
     /**
      * @override
      */
-    do_show: function () {
+    do_show() {
         this._hidden = false;
         this._super.apply(this, arguments);
     },
     /**
      * @override
      */
-    do_toggle: function (display) {
+    do_toggle(display) {
         this._hidden = _.isBoolean(display) ? !display : !this._hidden;
         this._super.apply(this, arguments);
     },
@@ -125,20 +125,20 @@ var AbstractThreadWindow = Widget.extend({
      *
      * @abstract
      */
-    close: function () {},
+    close() {},
     /**
      * Get the ID of the thread window, which is equivalent to the ID of the
      * thread related to this window
      *
      * @returns {integer|string}
      */
-    getID: function () {
+    getID() {
         return this._getThreadID();
     },
     /**
      * @returns {mail.model.Thread|undefined}
      */
-    getThread: function () {
+    getThread() {
         if (!this.hasThread()) {
             return undefined;
         }
@@ -151,7 +151,7 @@ var AbstractThreadWindow = Widget.extend({
      *
      * @returns {string|undefined}
      */
-    getThreadStatus: function () {
+    getThreadStatus() {
         if (!this.hasThread()) {
             return undefined;
         }
@@ -163,7 +163,7 @@ var AbstractThreadWindow = Widget.extend({
      *
      * @returns {string}
      */
-    getTitle: function () {
+    getTitle() {
         if (!this.hasThread()) {
             return _t("Undefined");
         }
@@ -175,7 +175,7 @@ var AbstractThreadWindow = Widget.extend({
      *
      * @returns {integer}
      */
-    getUnreadCounter: function () {
+    getUnreadCounter() {
         if (!this.hasThread()) {
             return 0;
         }
@@ -190,7 +190,7 @@ var AbstractThreadWindow = Widget.extend({
      *
      * @returns {boolean}
      */
-    hasThread: function () {
+    hasThread() {
         return !! this._thread;
     },
     /**
@@ -199,7 +199,7 @@ var AbstractThreadWindow = Widget.extend({
      *
      * @returns {boolean}
      */
-    isAtBottom: function () {
+    isAtBottom() {
         return this._threadWidget.isAtBottom();
     },
     /**
@@ -209,7 +209,7 @@ var AbstractThreadWindow = Widget.extend({
      *
      * @returns {boolean}
      */
-    isFolded: function () {
+    isFolded() {
         if (!this.hasThread()) {
             return this._folded;
         }
@@ -221,7 +221,7 @@ var AbstractThreadWindow = Widget.extend({
      *
      * @returns {boolean}
      */
-    isMobile: function () {
+    isMobile() {
         return config.device.isMobile;
     },
     /**
@@ -229,7 +229,7 @@ var AbstractThreadWindow = Widget.extend({
      *
      * @returns {boolean}
      */
-    isHidden: function () {
+    isHidden() {
         return this._hidden;
     },
     /**
@@ -238,13 +238,13 @@ var AbstractThreadWindow = Widget.extend({
      *
      * @returns {boolean}
      */
-    needsComposer: function () {
+    needsComposer() {
         return this.hasThread();
     },
     /**
      * Render the thread window
      */
-    render: function () {
+    render() {
         this.renderHeader();
         if (this.hasThread()) {
             this._threadWidget.render(this._thread, { displayLoadMore: false });
@@ -257,7 +257,7 @@ var AbstractThreadWindow = Widget.extend({
      *
      * @private
      */
-    renderHeader: function () {
+    renderHeader() {
         var options = this._getHeaderRenderingOptions();
         this.$header.html(
             QWeb.render('im_livechat.legacy.mail.AbstractThreadWindow.HeaderContent', options));
@@ -265,7 +265,7 @@ var AbstractThreadWindow = Widget.extend({
     /**
      * Scroll to the bottom of the thread in the thread window
      */
-    scrollToBottom: function () {
+    scrollToBottom() {
         this._threadWidget.scrollToBottom();
     },
     /**
@@ -276,7 +276,7 @@ var AbstractThreadWindow = Widget.extend({
      * @param {boolean} [folded] if not a boolean, toggle the fold state.
      *   Otherwise, fold/unfold the window if set/unset.
      */
-    toggleFold: function (folded) {
+    toggleFold(folded) {
         if (!_.isBoolean(folded)) {
             folded = !this.isFolded();
         }
@@ -287,7 +287,7 @@ var AbstractThreadWindow = Widget.extend({
      * fold state. This is useful in case the related thread has its fold state
      * that has been changed.
      */
-    updateVisualFoldState: function () {
+    updateVisualFoldState() {
         if (!this.isFolded()) {
             this._threadWidget.scrollToBottom();
             if (this.options.autofocus) {
@@ -309,7 +309,7 @@ var AbstractThreadWindow = Widget.extend({
      * @private
      * Set the focus on the input of the window
      */
-    _focusInput: function () {
+    _focusInput() {
         if (
             config.device.touch &&
             config.device.size_class <= config.device.SIZES.SM
@@ -324,7 +324,7 @@ var AbstractThreadWindow = Widget.extend({
      * @private
      * @returns {Object}
      */
-    _getHeaderRenderingOptions: function () {
+    _getHeaderRenderingOptions() {
         return {
             status: this.getThreadStatus(),
             thread: this.getThread(),
@@ -342,7 +342,7 @@ var AbstractThreadWindow = Widget.extend({
      * @returns {integer|string} the threadID, or '_blank' for the window that
      *   is not related to any thread.
      */
-    _getThreadID: function () {
+    _getThreadID() {
         if (!this.hasThread()) {
             return '_blank';
         }
@@ -355,7 +355,7 @@ var AbstractThreadWindow = Widget.extend({
      * @private
      * @returns {boolean}
      */
-    _hasFocus: function () {
+    _hasFocus() {
         return this.$input.is(':focus');
     },
     /**
@@ -365,7 +365,7 @@ var AbstractThreadWindow = Widget.extend({
      * @private
      * @param {Object} messageData
      */
-    _postMessage: function (messageData) {
+    _postMessage(messageData) {
         var self = this;
         if (!this.hasThread()) {
             return;
@@ -385,7 +385,7 @@ var AbstractThreadWindow = Widget.extend({
      * @private
      * @param {boolean} folded
      */
-    _updateThreadFoldState: function (folded) {
+    _updateThreadFoldState(folded) {
         if (this.hasThread()) {
             this._thread.fold(folded);
         } else {
@@ -405,7 +405,7 @@ var AbstractThreadWindow = Widget.extend({
      * @private
      * @param {MouseEvent} ev
      */
-    _onClickClose: function (ev) {
+    _onClickClose(ev) {
         ev.stopPropagation();
         ev.preventDefault();
         if (
@@ -423,7 +423,7 @@ var AbstractThreadWindow = Widget.extend({
      *
      * @private
      */
-    _onClickFold: function () {
+    _onClickFold() {
         if (!config.device.isMobile) {
             this.toggleFold();
         }
@@ -435,7 +435,7 @@ var AbstractThreadWindow = Widget.extend({
      * @private
      * @param {Event} ev
      */
-    _onComposerClick: function (ev) {
+    _onComposerClick(ev) {
         if ($(ev.target).closest('a, button').length) {
             return;
         }
@@ -444,7 +444,7 @@ var AbstractThreadWindow = Widget.extend({
     /**
      * @private
      */
-    _onDocumentViewerClose: function () {
+    _onDocumentViewerClose() {
         this._focusInput();
     },
     /**
@@ -453,7 +453,7 @@ var AbstractThreadWindow = Widget.extend({
      * @private
      * @param {KeyboardEvent} ev
      */
-    _onKeydown: function (ev) {
+    _onKeydown(ev) {
         ev.stopPropagation(); // to prevent jquery's blockUI to cancel event
         // ENTER key (avoid requiring jquery ui for external livechat)
         if (ev.which === 13) {
@@ -473,13 +473,13 @@ var AbstractThreadWindow = Widget.extend({
      * @private
      * @param {KeyboardEvent} ev
      */
-    _onKeypress: function (ev) {
+    _onKeypress(ev) {
         ev.stopPropagation(); // to prevent jquery's blockUI to cancel event
     },
     /**
      * @private
      */
-    _onScroll: function () {
+    _onScroll() {
         if (this.hasThread() && this.isAtBottom()) {
             this._thread.markAsRead();
         }
@@ -490,7 +490,7 @@ var AbstractThreadWindow = Widget.extend({
      *
      * @private
      */
-    _onThreadWindowClicked: function () {
+    _onThreadWindowClicked() {
         var selectObj = window.getSelection();
         if (selectObj.anchorOffset === selectObj.focusOffset) {
             this.$input.focus();

--- a/addons/im_livechat/static/src/legacy/widgets/document_viewer.js
+++ b/addons/im_livechat/static/src/legacy/widgets/document_viewer.js
@@ -41,7 +41,7 @@ var DocumentViewer = Widget.extend({
      * @param {Array<Object>} attachments list of attachments
      * @param {integer} activeAttachmentID
      */
-    init: function (parent, attachments, activeAttachmentID) {
+    init(parent, attachments, activeAttachmentID) {
         this._super.apply(this, arguments);
         this.attachment = _.filter(attachments, function (attachment) {
             var match = attachment.type === 'url' ? attachment.url.match("(youtu|.png|.jpg|.gif)") : attachment.mimetype.match("(image|video|application/pdf|text)");
@@ -73,7 +73,7 @@ var DocumentViewer = Widget.extend({
      * Open a modal displaying the active attachment
      * @override
      */
-    start: function () {
+    start() {
         this.$el.modal('show');
         this.$el.on('hidden.bs.modal', _.bind(this._onDestroy, this));
         this.$('.o_viewer_img').on("load", _.bind(this._onImageLoaded, this));
@@ -83,7 +83,7 @@ var DocumentViewer = Widget.extend({
     /**
      * @override
      */
-    destroy: function () {
+    destroy() {
         if (this.isDestroyed()) {
             return;
         }
@@ -100,7 +100,7 @@ var DocumentViewer = Widget.extend({
     /**
      * @private
      */
-    _next: function () {
+    _next() {
         var index = _.findIndex(this.attachment, this.activeAttachment);
         index = (index + 1) % this.attachment.length;
         this.activeAttachment = this.attachment[index];
@@ -109,7 +109,7 @@ var DocumentViewer = Widget.extend({
     /**
      * @private
      */
-    _previous: function () {
+    _previous() {
         var index = _.findIndex(this.attachment, this.activeAttachment);
         index = index === 0 ? this.attachment.length - 1 : index - 1;
         this.activeAttachment = this.attachment[index];
@@ -118,7 +118,7 @@ var DocumentViewer = Widget.extend({
     /**
      * @private
      */
-    _reset: function () {
+    _reset() {
         this.scale = 1;
         this.dragStartX = this.dragstopX = 0;
         this.dragStartY = this.dragstopY = 0;
@@ -128,7 +128,7 @@ var DocumentViewer = Widget.extend({
      *
      * @private
      */
-    _updateContent: function () {
+    _updateContent() {
         this.$('.o_viewer_content').html(QWeb.render('im_livechat.legacy.mail.DocumentViewer.Content', {
             widget: this
         }));
@@ -146,7 +146,7 @@ var DocumentViewer = Widget.extend({
      * @param {float} scale
      * @param {float} angle
      */
-    _getTransform: function (scale, angle) {
+    _getTransform(scale, angle) {
         return 'scale3d(' + scale + ', ' + scale + ', 1) rotate(' + angle + 'deg)';
     },
     /**
@@ -155,7 +155,7 @@ var DocumentViewer = Widget.extend({
      * @private
      * @param {float} angle
      */
-    _rotate: function (angle) {
+    _rotate(angle) {
         this._reset();
         var new_angle = (this.angle || 0) + angle;
         this.$('.o_viewer_img').css('transform', this._getTransform(this.scale, new_angle));
@@ -169,7 +169,7 @@ var DocumentViewer = Widget.extend({
      * @private
      * @param {integer} scale
      */
-    _zoom: function (scale) {
+    _zoom(scale) {
         if (scale > 0.5) {
             this.$('.o_viewer_img').css('transform', this._getTransform(scale, this.angle || 0));
             this.scale = scale;
@@ -185,7 +185,7 @@ var DocumentViewer = Widget.extend({
      * @private
      * @param {MouseEvent} e
      */
-    _onClose: function (e) {
+    _onClose(e) {
         e.preventDefault();
         this.destroy();
     },
@@ -194,14 +194,14 @@ var DocumentViewer = Widget.extend({
      *
      * @private
      */
-    _onDestroy: function () {
+    _onDestroy() {
         this.destroy();
     },
     /**
      * @private
      * @param {MouseEvent} e
      */
-    _onDownload: function (e) {
+    _onDownload(e) {
         e.preventDefault();
         window.location = '/web/content/' + this.modelName + '/' + this.activeAttachment.id + '/' + 'datas' + '?download=true';
     },
@@ -209,7 +209,7 @@ var DocumentViewer = Widget.extend({
      * @private
      * @param {MouseEvent} e
      */
-    _onDrag: function (e) {
+    _onDrag(e) {
         e.preventDefault();
         if (this.enableDrag) {
             var $image = this.$('.o_viewer_img');
@@ -224,7 +224,7 @@ var DocumentViewer = Widget.extend({
      * @private
      * @param {MouseEvent} e
      */
-    _onEndDrag: function (e) {
+    _onEndDrag(e) {
         e.preventDefault();
         if (this.enableDrag) {
             this.enableDrag = false;
@@ -239,14 +239,14 @@ var DocumentViewer = Widget.extend({
      * @private
      * @param {MouseEvent} e
      */
-    _onImageClicked: function (e) {
+    _onImageClicked(e) {
         e.stopPropagation();
     },
     /**
      * Remove loading indicator when image loaded
      * @private
      */
-    _onImageLoaded: function () {
+    _onImageLoaded() {
         this.$('.o_loading_img').hide();
     },
     /**
@@ -255,7 +255,7 @@ var DocumentViewer = Widget.extend({
      * @private
      * @param {KeyEvent} e
      */
-    _onKeydown: function (e) {
+    _onKeydown(e) {
         switch (e.which) {
             case $.ui.keyCode.RIGHT:
                 e.preventDefault();
@@ -273,7 +273,7 @@ var DocumentViewer = Widget.extend({
      * @private
      * @param {KeyEvent} e
      */
-    _onKeyUp: function (e) {
+    _onKeyUp(e) {
         switch (e.which) {
             case $.ui.keyCode.ESCAPE:
                 e.preventDefault();
@@ -285,7 +285,7 @@ var DocumentViewer = Widget.extend({
      * @private
      * @param {MouseEvent} e
      */
-    _onNext: function (e) {
+    _onNext(e) {
         e.preventDefault();
         this._next();
     },
@@ -293,7 +293,7 @@ var DocumentViewer = Widget.extend({
      * @private
      * @param {MouseEvent} e
      */
-    _onPrevious: function (e) {
+    _onPrevious(e) {
         e.preventDefault();
         this._previous();
     },
@@ -301,7 +301,7 @@ var DocumentViewer = Widget.extend({
      * @private
      * @param {MouseEvent} e
      */
-    _onPrint: function (e) {
+    _onPrint(e) {
         e.preventDefault();
         var src = this.$('.o_viewer_img').prop('src');
         var script = QWeb.render('im_livechat.legacy.mail.PrintImage', {
@@ -318,7 +318,7 @@ var DocumentViewer = Widget.extend({
      * @private
      * @param {MouseEvent} e
      */
-    _onScroll: function (e) {
+    _onScroll(e) {
         var scale;
         if (e.originalEvent.wheelDelta > 0 || e.originalEvent.detail < 0) {
             scale = this.scale + SCROLL_ZOOM_STEP;
@@ -332,7 +332,7 @@ var DocumentViewer = Widget.extend({
      * @private
      * @param {MouseEvent} e
      */
-    _onStartDrag: function (e) {
+    _onStartDrag(e) {
         e.preventDefault();
         this.enableDrag = true;
         this.dragStartX = e.clientX - (this.dragstopX || 0);
@@ -345,7 +345,7 @@ var DocumentViewer = Widget.extend({
      * @private
      * @param {MouseEvent} e
      */
-    _onVideoClicked: function (e) {
+    _onVideoClicked(e) {
         e.stopPropagation();
         var videoElement = e.target;
         if (videoElement.paused) {
@@ -358,7 +358,7 @@ var DocumentViewer = Widget.extend({
      * @private
      * @param {MouseEvent} e
      */
-    _onRotate: function (e) {
+    _onRotate(e) {
         e.preventDefault();
         this._rotate(90);
     },
@@ -366,7 +366,7 @@ var DocumentViewer = Widget.extend({
      * @private
      * @param {MouseEvent} e
      */
-    _onZoomIn: function (e) {
+    _onZoomIn(e) {
         e.preventDefault();
         var scale = this.scale + ZOOM_STEP;
         this._zoom(scale);
@@ -375,7 +375,7 @@ var DocumentViewer = Widget.extend({
      * @private
      * @param {MouseEvent} e
      */
-    _onZoomOut: function (e) {
+    _onZoomOut(e) {
         e.preventDefault();
         var scale = this.scale - ZOOM_STEP;
         this._zoom(scale);
@@ -384,7 +384,7 @@ var DocumentViewer = Widget.extend({
      * @private
      * @param {MouseEvent} e
      */
-    _onZoomReset: function (e) {
+    _onZoomReset(e) {
         e.preventDefault();
         this.$('.o_viewer_zoomer').css("transform", "");
         this._zoom(1);

--- a/addons/im_livechat/static/src/legacy/widgets/feedback.js
+++ b/addons/im_livechat/static/src/legacy/widgets/feedback.js
@@ -31,7 +31,7 @@ var Feedback = Widget.extend({
      * @param {?} parent
      * @param {im_livechat.legacy.im_livechat.model.WebsiteLivechat} livechat
      */
-    init: function (parent, livechat) {
+    init(parent, livechat) {
         this._super(parent);
         this._livechat = livechat;
         this.server_origin = session.origin;
@@ -47,7 +47,7 @@ var Feedback = Widget.extend({
      * @private
      * @param {Object} options
      */
-    _sendFeedback: function (reason) {
+    _sendFeedback(reason) {
         var self = this;
         var args = {
             uuid: this._livechat.getUUID(),
@@ -68,7 +68,7 @@ var Feedback = Widget.extend({
     /**
     * @private
     */
-    _showThanksMessage: function () {
+    _showThanksMessage() {
         this.$('.o_livechat_rating_box').empty().append($('<div />', {
             text: _t('Thank you for your feedback'),
             class: 'text-muted'
@@ -82,13 +82,13 @@ var Feedback = Widget.extend({
     /**
      * @private
      */
-    _onClickNoFeedback: function () {
+    _onClickNoFeedback() {
         this.trigger('feedback_sent'); // will close the chat
     },
     /**
      * @private
      */
-    _onClickSend: function () {
+    _onClickSend() {
         this.$('.o_livechat_rating_reason').hide();
         this._showThanksMessage();
         if (_.isNumber(this.rating)) {
@@ -99,7 +99,7 @@ var Feedback = Widget.extend({
      * @private
      * @param {MouseEvent} ev
      */
-    _onClickSmiley: function (ev) {
+    _onClickSmiley(ev) {
         this.rating = parseInt($(ev.currentTarget).data('value'));
         this.$('.o_livechat_rating_choices img').removeClass('selected');
         this.$('.o_livechat_rating_choices img[data-value="' + this.rating + '"]').addClass('selected');
@@ -117,7 +117,7 @@ var Feedback = Widget.extend({
     /**
     * @private
     */
-    _onEmailChat: function () {
+    _onEmailChat() {
         var self = this;
         var $email = this.$('#o_email');
 
@@ -143,7 +143,7 @@ var Feedback = Widget.extend({
     /**
     * @private
     */
-    _onTryAgain: function () {
+    _onTryAgain() {
         this.$('#o_email').prop('disabled', false);
         this.$('.o_email_chat_button').prop('disabled', false);
         this.$('.o_livechat_email_error').hide();

--- a/addons/im_livechat/static/src/legacy/widgets/livechat_button.js
+++ b/addons/im_livechat/static/src/legacy/widgets/livechat_button.js
@@ -29,7 +29,7 @@ var LivechatButton = Widget.extend({
     events: {
         'click': '_openChat'
     },
-    init: function (parent, serverURL, options) {
+    init(parent, serverURL, options) {
         this._super(parent);
         this.options = _.defaults(options || {}, {
             input_placeholder: _t("Ask something ..."),
@@ -61,7 +61,7 @@ var LivechatButton = Widget.extend({
         }
         return this._loadQWebTemplate();
     },
-    start: function () {
+    start() {
         this.$el.text(this.options.button_text);
         if (this._history) {
             this._history.forEach(m => this._addMessage(m));
@@ -100,7 +100,7 @@ var LivechatButton = Widget.extend({
      * @param {Object} data
      * @param {Object} [options={}]
      */
-    _addMessage: function (data, options) {
+    _addMessage(data, options) {
         options = _.extend({}, this.options, options, {
             serverURL: this._serverURL,
         });
@@ -126,7 +126,7 @@ var LivechatButton = Widget.extend({
     /**
      * @private
      */
-    _askFeedback: function () {
+    _askFeedback() {
         this._chatWindow.$('.o_thread_composer input').prop('disabled', true);
 
         var feedback = new Feedback(this, this._livechat);
@@ -138,7 +138,7 @@ var LivechatButton = Widget.extend({
     /**
      * @private
      */
-    _closeChat: function () {
+    _closeChat() {
         this._chatWindow.destroy();
         utils.set_cookie('im_livechat_session', "", -1); // remove cookie
     },
@@ -148,7 +148,7 @@ var LivechatButton = Widget.extend({
      * @param {Object} notification.payload
      * @param {string} notification.type
      */
-    _handleNotification: function ({ payload, type }) {
+    _handleNotification({ payload, type }) {
         switch (type) {
             case 'im_livechat.history_command': {
                 if (payload.id !== this._livechat._id) {
@@ -201,7 +201,7 @@ var LivechatButton = Widget.extend({
     /**
      * @private
      */
-    _loadQWebTemplate: function () {
+    _loadQWebTemplate() {
         return session.rpc('/im_livechat/load_templates').then(function (templates) {
             _.each(templates, function (template) {
                 QWeb.add_template(template);
@@ -287,7 +287,7 @@ var LivechatButton = Widget.extend({
      * @private
      * @return {integer} operator_id.partner_id.id if the cookie is set
      */
-    _get_previous_operator_id: function () {
+    _get_previous_operator_id() {
         var cookie = utils.get_cookie('im_livechat_previous_operator_pid');
         if (cookie) {
             return cookie;
@@ -299,7 +299,7 @@ var LivechatButton = Widget.extend({
      * @private
      * @return {Promise}
      */
-    _openChatWindow: function () {
+    _openChatWindow() {
         var self = this;
         var options = {
             displayStars: false,
@@ -318,7 +318,7 @@ var LivechatButton = Widget.extend({
     /**
      * @private
      */
-    _prepareGetSessionParameters: function () {
+    _prepareGetSessionParameters() {
         return {
             channel_id: this.options.channel_id,
             anonymous_name: this.options.default_username,
@@ -328,7 +328,7 @@ var LivechatButton = Widget.extend({
     /**
      * @private
      */
-    _renderMessages: function () {
+    _renderMessages() {
         var shouldScroll = !this._chatWindow.isFolded() && this._chatWindow.isAtBottom();
         this._livechat.setMessages(this._messages);
         this._chatWindow.render();
@@ -341,7 +341,7 @@ var LivechatButton = Widget.extend({
      * @param {Object} message
      * @return {Promise}
      */
-    _sendMessage: function (message) {
+    _sendMessage(message) {
         var self = this;
         this._livechat._notifyMyselfTyping({ typing: false });
         return session
@@ -372,7 +372,7 @@ var LivechatButton = Widget.extend({
     /**
      * @private
      */
-    _sendWelcomeMessage: function () {
+    _sendWelcomeMessage() {
         if (this.options.default_message) {
             this._addMessage({
                 id: '_welcome',
@@ -394,7 +394,7 @@ var LivechatButton = Widget.extend({
      * @private
      * @param {OdooEvent} ev
      */
-    _onCloseChatWindow: function (ev) {
+    _onCloseChatWindow(ev) {
         ev.stopPropagation();
         var isComposerDisabled = this._chatWindow.$('.o_thread_composer input').prop('disabled');
         var shouldAskFeedback = !isComposerDisabled && _.find(this._messages, function (message) {
@@ -412,7 +412,7 @@ var LivechatButton = Widget.extend({
      * @private
      * @param {Array[]} notifications
      */
-    _onNotification: function (notifications) {
+    _onNotification(notifications) {
         var self = this;
         _.each(notifications, function (notification) {
             self._handleNotification(notification);
@@ -423,7 +423,7 @@ var LivechatButton = Widget.extend({
      * @param {OdooEvent} ev
      * @param {Object} ev.data.messageData
      */
-    _onPostMessageChatWindow: function (ev) {
+    _onPostMessageChatWindow(ev) {
         ev.stopPropagation();
         var self = this;
         var messageData = ev.data.messageData;
@@ -436,7 +436,7 @@ var LivechatButton = Widget.extend({
      * @private
      * @param {OdooEvent} ev
      */
-    _onSaveChatWindow: function (ev) {
+    _onSaveChatWindow(ev) {
         ev.stopPropagation();
         utils.set_cookie('im_livechat_session', utils.unaccent(JSON.stringify(this._livechat.toData()), true), 60 * 60);
     },
@@ -452,7 +452,7 @@ var LivechatButton = Widget.extend({
      * @private
      * @param {OdooEvent} ev
      */
-    _onUpdatedUnreadCounter: function (ev) {
+    _onUpdatedUnreadCounter(ev) {
         ev.stopPropagation();
         this._chatWindow.renderHeader();
     },
@@ -461,7 +461,7 @@ var LivechatButton = Widget.extend({
      * Called when the visitor leaves the livechat chatter the first time (first click on X button)
      * this will deactivate the mail_channel, notify operator that visitor has left the channel.
      */
-    _visitorLeaveSession: function () {
+    _visitorLeaveSession() {
         var cookie = utils.get_cookie('im_livechat_session');
         if (cookie) {
             var channel = JSON.parse(cookie);

--- a/addons/im_livechat/static/src/legacy/widgets/thread.js
+++ b/addons/im_livechat/static/src/legacy/widgets/thread.js
@@ -51,7 +51,7 @@ var ThreadWidget = Widget.extend({
      * @param {widget} parent
      * @param {Object} options
      */
-    init: function (parent, options) {
+    init(parent, options) {
         this._super.apply(this, arguments);
         this.attachments = [];
         // options when the thread is enabled (e.g. can send message,
@@ -93,7 +93,7 @@ var ThreadWidget = Widget.extend({
      *
      * @override
      */
-    destroy: function () {
+    destroy() {
         clearInterval(this._updateTimestampsInterval);
         if (this._messageMailPopover) {
             this._messageMailPopover.popover('hide');
@@ -114,7 +114,7 @@ var ThreadWidget = Widget.extend({
      * @param {boolean} [options.scrollToBottom=false]
      * @param {boolean} [options.squashCloseMessages]
      */
-    render: function (thread, options) {
+    render(thread, options) {
         var self = this;
 
         var shouldScrollToBottomAfterRendering = false;
@@ -213,7 +213,7 @@ var ThreadWidget = Widget.extend({
      * Render thread widget when loading, i.e. when messaging is not yet ready.
      * @see /mail/init_messaging
      */
-    renderLoading: function () {
+    renderLoading() {
         this.$el.html(QWeb.render('im_livechat.legacy.mail.widget.ThreadLoading'));
     },
 
@@ -221,7 +221,7 @@ var ThreadWidget = Widget.extend({
     // Public
     //--------------------------------------------------------------------------
 
-    getScrolltop: function () {
+    getScrolltop() {
         return this.$el.scrollTop();
     },
     /**
@@ -230,7 +230,7 @@ var ThreadWidget = Widget.extend({
      *
      * @return {boolean}
      */
-    isAtBottom: function () {
+    isAtBottom() {
         var fullHeight = this.el.scrollHeight;
         var topHiddenHeight = this.$el.scrollTop();
         var visibleHeight = this.$el.outerHeight();
@@ -246,13 +246,13 @@ var ThreadWidget = Widget.extend({
      *   `messageID`).
      * @param {Object} [options] options for the thread rendering
      */
-    removeMessageAndRender: function (messageID, thread, options) {
+    removeMessageAndRender(messageID, thread, options) {
         var self = this;
         this._currentThreadID = thread.getID();
         return new Promise(function (resolve, reject) {
             self.$('.o_thread_message[data-message-id="' + messageID + '"]')
             .fadeOut({
-                done: function () {
+                done() {
                     if (self._currentThreadID === thread.getID()) {
                         self.render(thread, options);
                     }
@@ -265,7 +265,7 @@ var ThreadWidget = Widget.extend({
     /**
      * Scroll to the bottom of the thread
      */
-    scrollToBottom: function () {
+    scrollToBottom() {
         this.$el.scrollTop(this.el.scrollHeight);
     },
     /**
@@ -275,7 +275,7 @@ var ThreadWidget = Widget.extend({
      * @param {integer} [options.duration]
      * @param {boolean} [options.onlyIfNecessary]
      */
-    scrollToMessage: function (options) {
+    scrollToMessage(options) {
         var $target = this.$('.o_thread_message[data-message-id="' + options.messageID + '"]');
         if (options.onlyIfNecessary) {
             var delta = $target.parent().height() - $target.height();
@@ -296,7 +296,7 @@ var ThreadWidget = Widget.extend({
      * @param {integer} [position] distance from top to position in pixels.
      *    If not provided, scroll to the bottom.
      */
-    scrollToPosition: function (position) {
+    scrollToPosition(position) {
         if (position) {
             this.$el.scrollTop(position);
         } else {
@@ -309,13 +309,13 @@ var ThreadWidget = Widget.extend({
      * @param {boolean} checked if true, check the boxes,
      *      otherwise uncheck them.
      */
-    toggleModerationCheckboxes: function (checked) {
+    toggleModerationCheckboxes(checked) {
         this.$('.moderation_checkbox').prop('checked', checked);
     },
     /**
      * Unselect the selected message
      */
-    unselectMessage: function () {
+    unselectMessage() {
         this.$('.o_thread_message').removeClass('o_thread_selected_message');
         this._selectedMessageID = null;
     },
@@ -334,7 +334,7 @@ var ThreadWidget = Widget.extend({
      * @private
      * @param {jQuery} $element
      */
-    _insertReadMore: function ($element) {
+    _insertReadMore($element) {
         var self = this;
 
         var groups = [];
@@ -410,7 +410,7 @@ var ThreadWidget = Widget.extend({
     * @private
     * @param {MouseEvent} ev
     */
-    _onDeleteAttachment: function (ev) {
+    _onDeleteAttachment(ev) {
         ev.stopPropagation();
         var $target = $(ev.currentTarget);
         this.trigger_up('delete_attachment', {
@@ -455,7 +455,7 @@ var ThreadWidget = Widget.extend({
             placement: 'auto',
             trigger: 'hover',
             offset: '0, 1',
-            content: function () {
+            content() {
                 var messageID = $(this).data('message-id');
                 var message = _.find(messages, function (message) {
                     return message.getID() === messageID;
@@ -469,7 +469,7 @@ var ThreadWidget = Widget.extend({
     /**
      * @private
      */
-    _updateTimestamps: function () {
+    _updateTimestamps() {
         var isAtBottom = this.isAtBottom();
         this.$('.o_mail_timestamp').each(function () {
             var date = $(this).data('date');
@@ -488,14 +488,14 @@ var ThreadWidget = Widget.extend({
      * @private
      * @param {MouseEvent} event
      */
-    _onAttachmentDownload: function (event) {
+    _onAttachmentDownload(event) {
         event.stopPropagation();
     },
     /**
      * @private
      * @param {MouseEvent} event
      */
-    _onAttachmentView: function (event) {
+    _onAttachmentView(event) {
         event.stopPropagation();
         var activeAttachmentID = $(event.currentTarget).data('id');
         if (activeAttachmentID) {
@@ -507,13 +507,13 @@ var ThreadWidget = Widget.extend({
      * @private
      * @param {MouseEvent} ev
      */
-    _onChangeModerationCheckbox: function (ev) {
+    _onChangeModerationCheckbox(ev) {
         this.trigger_up('update_moderation_buttons');
     },
     /**
      * @private
      */
-    _onClick: function () {
+    _onClick() {
         if (this._selectedMessageID) {
             this.unselectMessage();
             this.trigger('unselect_message');
@@ -523,21 +523,21 @@ var ThreadWidget = Widget.extend({
      * @private
      * @param {MouseEvent} ev
      */
-    _onClickMailExpand: function (ev) {
+    _onClickMailExpand(ev) {
         ev.preventDefault();
     },
     /**
      * @private
      * @param {MouseEvent} ev
      */
-    _onClickMessage: function (ev) {
+    _onClickMessage(ev) {
         $(ev.currentTarget).toggleClass('o_thread_selected_message');
     },
     /**
      * @private
      * @param {MouseEvent} ev
      */
-    _onClickMessageNeedaction: function (ev) {
+    _onClickMessageNeedaction(ev) {
         var messageID = $(ev.currentTarget).data('message-id');
         this.trigger('mark_as_read', messageID);
     },
@@ -557,7 +557,7 @@ var ThreadWidget = Widget.extend({
      * @private
      * @param {MouseEvent} ev
      */
-    _onClickMessageReply: function (ev) {
+    _onClickMessageReply(ev) {
         this._selectedMessageID = $(ev.currentTarget).data('message-id');
         this.$('.o_thread_message').removeClass('o_thread_selected_message');
         this.$('.o_thread_message[data-message-id="' + this._selectedMessageID + '"]')
@@ -569,7 +569,7 @@ var ThreadWidget = Widget.extend({
      * @private
      * @param {MouseEvent} ev
      */
-    _onClickMessageStar: function (ev) {
+    _onClickMessageStar(ev) {
         var messageID = $(ev.currentTarget).data('message-id');
         this.trigger('toggle_star_status', messageID);
     },
@@ -577,7 +577,7 @@ var ThreadWidget = Widget.extend({
      * @private
      * @param {MouseEvent} ev
      */
-    _onClickMessageModeration: function (ev) {
+    _onClickMessageModeration(ev) {
         var $button = $(ev.currentTarget);
         var messageID = $button.data('message-id');
         var decision = $button.data('decision');
@@ -590,7 +590,7 @@ var ThreadWidget = Widget.extend({
      * @private
      * @param {MouseEvent} ev
      */
-    _onClickRedirect: function (ev) {
+    _onClickRedirect(ev) {
         // ignore inherited branding
         if ($(ev.target).data('oe-field') !== undefined) {
             return;
@@ -614,7 +614,7 @@ var ThreadWidget = Widget.extend({
     /**
      * @private
      */
-    _onClickShowMore: function () {
+    _onClickShowMore() {
         this.trigger('load_more_messages');
     },
 });


### PR DESCRIPTION
The method names in legacy livechat files can be shortened

`method: function(param){` can be shortened to `method(param){`
and
`method: async function(param){` can be shortened to `async method(param){`

task-2825104