### PR TITLE
[IMP] mail: introduce MessageSeenIndicatorView

### DIFF
--- a/addons/mail/static/src/components/message/message.xml
+++ b/addons/mail/static/src/components/message/message.xml
@@ -49,8 +49,8 @@
                                     <t t-esc="messageView.message.shortTime"/>
                                 </div>
                             </t>
-                            <t t-if="!messageView.isActive and messageView.message.isCurrentUserOrGuestAuthor and messageView.threadView and messageView.threadView.thread and messageView.threadView.thread.hasSeenIndicators">
-                                <MessageSeenIndicator className="'o_Message_seenIndicator'" messageLocalId="messageView.message.localId" threadLocalId="messageView.threadView.thread.localId"/>
+                            <t t-if="!messageView.isActive and messageView.messageSeenIndicatorView">
+                                <MessageSeenIndicator className="'o_Message_seenIndicator'" localId="messageView.messageSeenIndicatorView.localId"/>
                             </t>
                         </t>
                     </div>
@@ -87,8 +87,8 @@
                                         - <t t-esc="messageView.message.dateFromNow"/>
                                     </div>
                                 </t>
-                                <t t-if="messageView.message.isCurrentUserOrGuestAuthor and messageView.threadView and messageView.threadView.thread and messageView.threadView.thread.hasSeenIndicators">
-                                    <MessageSeenIndicator className="'o_Message_seenIndicator'" messageLocalId="messageView.message.localId" threadLocalId="messageView.threadView.thread.localId"/>
+                                <t t-if="messageView.messageSeenIndicatorView">
+                                    <MessageSeenIndicator className="'o_Message_seenIndicator'" localId="messageView.messageSeenIndicatorView.localId"/>
                                 </t>
                                 <t t-if="messageView.threadView and messageView.message.originThread and messageView.message.originThread !== messageView.threadView.thread">
                                     <div class="o_Message_originThread" t-att-class="{ 'o-message-selected': messageView.isSelected }">

--- a/addons/mail/static/src/components/message_seen_indicator/message_seen_indicator.js
+++ b/addons/mail/static/src/components/message_seen_indicator/message_seen_indicator.js
@@ -11,38 +11,15 @@ export class MessageSeenIndicator extends Component {
     //--------------------------------------------------------------------------
 
     /**
-     * @returns {Message}
-     */
-    get message() {
-        return this.messaging && this.messaging.models['Message'].get(this.props.messageLocalId);
-    }
-
-    /**
      * @returns {MessageSeenIndicator}
      */
-    get messageSeenIndicator() {
-        if (!this.thread || this.thread.model !== 'mail.channel') {
-            return undefined;
-        }
-        return this.messaging.models['MessageSeenIndicator'].findFromIdentifyingData({
-            message: this.message,
-            thread: this.thread,
-        });
-    }
-
-    /**
-     * @returns {Thread}
-     */
-    get thread() {
-        return this.messaging && this.messaging.models['Thread'].get(this.props.threadLocalId);
+     get messageSeenIndicatorView() {
+        return this.messaging && this.messaging.models['MessageSeenIndicatorView'].get(this.props.localId);
     }
 }
 
 Object.assign(MessageSeenIndicator, {
-    props: {
-        messageLocalId: String,
-        threadLocalId: String,
-    },
+    props: { localId: String },
     template: 'mail.MessageSeenIndicator',
 });
 

--- a/addons/mail/static/src/components/message_seen_indicator/message_seen_indicator.xml
+++ b/addons/mail/static/src/components/message_seen_indicator/message_seen_indicator.xml
@@ -2,13 +2,13 @@
 <templates xml:space="preserve">
 
     <t t-name="mail.MessageSeenIndicator" owl="1">
-        <t t-if="messageSeenIndicator">
-            <span class="o_MessageSeenIndicator" t-att-class="{ 'o-all-seen': messageSeenIndicator.hasEveryoneSeen }" t-attf-class="{{ className }}" t-att-title="messageSeenIndicator.text" t-ref="root">
-                <t t-if="!messageSeenIndicator.isMessagePreviousToLastCurrentPartnerMessageSeenByEveryone">
-                    <t t-if="messageSeenIndicator.hasSomeoneFetched or messageSeenIndicator.hasSomeoneSeen">
+        <t t-if="messageSeenIndicatorView">
+            <span class="o_MessageSeenIndicator" t-att-class="{ 'o-all-seen': messageSeenIndicatorView.messageSeenIndicator.hasEveryoneSeen }" t-attf-class="{{ className }}" t-att-title="messageSeenIndicatorView.messageSeenIndicator.text" t-ref="root">
+                <t t-if="!messageSeenIndicatorView.messageSeenIndicator.isMessagePreviousToLastCurrentPartnerMessageSeenByEveryone">
+                    <t t-if="messageSeenIndicatorView.messageSeenIndicator.hasSomeoneFetched or messageSeenIndicatorView.messageSeenIndicator.hasSomeoneSeen">
                         <i class="o_MessageSeenIndicator_icon o-first fa fa-check"/>
                     </t>
-                    <t t-if="messageSeenIndicator.hasSomeoneSeen">
+                    <t t-if="messageSeenIndicatorView.messageSeenIndicator.hasSomeoneSeen">
                         <i class="o_MessageSeenIndicator_icon o-second fa fa-check"/>
                     </t>
                 </t>

--- a/addons/mail/static/src/models/message_seen_indicator_view.js
+++ b/addons/mail/static/src/models/message_seen_indicator_view.js
@@ -1,0 +1,35 @@
+/** @odoo-module **/
+
+import { registerModel } from '@mail/model/model_core';
+import { one } from '@mail/model/model_field';
+import { clear, insertAndReplace, replace } from '@mail/model/model_field_command';
+
+registerModel({
+    name: 'MessageSeenIndicatorView',
+    identifyingFields: ['messageViewOwner'],
+    recordMethods: {
+        /**
+         * @private
+         * @returns {FieldCommand}
+         */
+        _computeMessageSeenIndicator() {
+            if (this.messageViewOwner.threadView && this.messageViewOwner.threadView.thread) {
+                return insertAndReplace({
+                    message: replace(this.messageViewOwner.message),
+                    thread: replace(this.messageViewOwner.threadView.thread),
+                });
+            }
+            return clear();
+        },
+    },
+    fields: {
+        messageViewOwner: one('MessageView', {
+            inverse: 'messageSeenIndicatorView',
+            readonly: true,
+            required: true,
+        }),
+        messageSeenIndicator: one('MessageSeenIndicator', {
+            compute: '_computeMessageSeenIndicator',
+        }),
+    },
+});

--- a/addons/mail/static/src/models/message_view.js
+++ b/addons/mail/static/src/models/message_view.js
@@ -196,6 +196,21 @@ registerModel({
                 this.message.parentMessage
             ) ? insertAndReplace() : clear();
         },
+        /**
+         * @private
+         * @retuns {FieldCommand}
+         */
+        _computeMessageSeenIndicatorView() {
+            if (
+                this.message.isCurrentUserOrGuestAuthor &&
+                this.threadView &&
+                this.threadView.thread &&
+                this.threadView.thread.hasSeenIndicators
+            ) {
+                return insertAndReplace();
+            }
+            return clear();
+        },
     },
     fields: {
         /**
@@ -321,6 +336,11 @@ registerModel({
             inverse: 'messageView',
             isCausal: true,
             readonly: true,
+        }),
+        messageSeenIndicatorView: one('MessageSeenIndicatorView', {
+            compute: '_computeMessageSeenIndicatorView',
+            inverse: 'messageViewOwner',
+            isCausal: true,
         }),
         /**
          * States the thread view that is displaying this messages (if any).


### PR DESCRIPTION
This commit introduce the MessageSeenIndicatorView model,
in order to move business code from MessageSeenIndicator
component to MessageSeenIndicatorViews.

Code that are not in modelling are hacky, hard to maintain,
and very prone to bug. That's why it's important to move most
code in components to models.

Task-2793280
