### PR TITLE
[FIX] typo in odoo/odoo/release.py odoo#88866

### DIFF
--- a/doc/cla/individual/dsbenton.md
+++ b/doc/cla/individual/dsbenton.md
@@ -1,0 +1,11 @@
+United States, 2022-04-16
+
+I hereby agree to the terms of the Odoo Individual Contributor License
+Agreement v1.0.
+
+I declare that I am authorized and able to make this agreement and sign this
+declaration.
+
+Signed,
+
+Dejanae Benton dsbenton@umich.edu https://github.com/dsbenton

--- a/odoo/release.py
+++ b/odoo/release.py
@@ -9,7 +9,7 @@ RELEASE_LEVELS_DISPLAY = {ALPHA: ALPHA,
 
 # version_info format: (MAJOR, MINOR, MICRO, RELEASE_LEVEL, SERIAL)
 # inspired by Python's own sys.version_info, in order to be
-# properly comparable using normal operarors, for example:
+# properly comparable using normal operators, for example:
 #  (6,1,0,'beta',0) < (6,1,0,'candidate',1) < (6,1,0,'candidate',2)
 #  (6,1,0,'candidate',2) < (6,1,0,'final',0) < (6,1,2,'final',0)
 version_info = (15, 0, 0, FINAL, 0, '')


### PR DESCRIPTION
Description of the issue/feature this PR addresses: https://github.com/odoo/odoo/issues/88866 typo in odoo/odoo/release.py

Steps to reproduce:

Current behavior before PR:
Line 12, word 5: operarors

Desired behavior after PR is merged:
The word will now be "operators"

--
I confirm I have signed the CLA and read the PR guidelines at [www.odoo.com/submit-pr](http://www.odoo.com/submit-pr)