### PR TITLE
[FIX] account: set default reversal_date

### DIFF
--- a/addons/account/wizard/accrued_orders.py
+++ b/addons/account/wizard/accrued_orders.py
@@ -64,6 +64,7 @@ class AccruedExpenseRevenue(models.TransientModel):
 
     @api.depends('date')
     def _compute_reversal_date(self):
+        self.reversal_date = False
         for record in self:
             if not record.reversal_date or record.reversal_date <= record.date:
                 record.reversal_date = record.date + relativedelta(days=1)


### PR DESCRIPTION
Before this commit, there is traceback on removing
`reversal_date` as method `_compute_reversal_date`
doesn't set any default value for `_compute_reversal_date`

With this commit we set default value for `_compute_reversal_date`

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
