### PR TITLE
[IMP] mail: remove obsolete method _action_remove_members

### DIFF
--- a/addons/mail/models/mail_channel.py
+++ b/addons/mail/models/mail_channel.py
@@ -448,15 +448,6 @@ class Channel(models.Model):
                     current_channel_partner._rtc_invite_members(partner_ids=partners.ids, guest_ids=guests.ids)
         self.env['bus.bus']._sendmany(notifications)
 
-    def _action_remove_members(self, partners):
-        """ Private implementation to remove members from channels. Done as sudo
-        to avoid ACLs issues with channel partners. """
-        self.env['mail.channel.partner'].sudo().search([
-            ('partner_id', 'in', partners.ids),
-            ('channel_id', 'in', self.ids)
-        ]).unlink()
-        self.invalidate_cache(fnames=['channel_partner_ids', 'channel_last_seen_partner_ids'])
-
     def _can_invite(self, partner_id):
         """Return True if the current user can invite the partner to the channel.
 

--- a/addons/mail/tests/test_mail_channel.py
+++ b/addons/mail/tests/test_mail_channel.py
@@ -194,7 +194,10 @@ class TestChannelInternals(MailCommon):
         self.assertEqual(channel.message_partner_ids, self.env['res.partner'])
         self.assertEqual(channel.channel_partner_ids, self.test_partner)
 
-        channel._action_remove_members(self.test_partner)
+        self.env['mail.channel.partner'].sudo().search([
+            ('partner_id', 'in', self.test_partner.ids),
+            ('channel_id', 'in', channel.ids)
+        ]).unlink()
         self.assertEqual(channel.message_partner_ids, self.env['res.partner'])
         self.assertEqual(channel.channel_partner_ids, self.env['res.partner'])
 


### PR DESCRIPTION
**Current behavior before PR:**

There is an obsolete method `_action_remove_members` in tests which is not
needed now

**Desired behavior after PR is merged:**

Removed this obsolete method

Task-2824921

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
