### PR TITLE
[IMP] sale: simplify API of create_product_variant method

### DIFF
--- a/addons/sale/controllers/variant.py
+++ b/addons/sale/controllers/variant.py
@@ -1,6 +1,8 @@
 # -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
+import json
+
 from odoo import http
 from odoo.http import request
 
@@ -29,7 +31,7 @@ class VariantController(http.Controller):
 
     @http.route(['/sale/create_product_variant'], type='json', auth="user", methods=['POST'])
     def create_product_variant(self, product_template_id, product_template_attribute_value_ids, **kwargs):
-        return request.env['product.template'].browse(int(product_template_id)).create_product_variant(product_template_attribute_value_ids)
+        return request.env['product.template'].browse(int(product_template_id)).create_product_variant(json.loads(product_template_attribute_value_ids))
 
     def _get_pricelist(self, pricelist_id, pricelist_fallback=False):
         return request.env['product.pricelist'].browse(int(pricelist_id or 0))

--- a/addons/sale/models/product_template.py
+++ b/addons/sale/models/product_template.py
@@ -115,14 +115,14 @@ class ProductTemplate(models.Model):
 
         :param product_template_attribute_value_ids: the combination for which
             to get or create variant
-        :type product_template_attribute_value_ids: json encoded list of id
+        :type product_template_attribute_value_ids: list of id
             of `product.template.attribute.value`
 
         :return: id of the product variant matching the combination or 0
         :rtype: int
         """
         combination = self.env['product.template.attribute.value'] \
-            .browse(json.loads(product_template_attribute_value_ids))
+            .browse(product_template_attribute_value_ids)
 
         return self._create_product_variant(combination, log_warning=True).id or 0
 


### PR DESCRIPTION
### Current behavior before PR:

The `product.template` model has a nice function `create_product_variant` that unfortunately expects its input to be in JSON.

### Desired behavior after PR is merged:

JSON decoding is moved into the controller, such that the function can be called as expected.

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
