### PR TITLE
[FIX] l10n_it_edi: bank required for DatiPagamento

### DIFF
--- a/addons/l10n_it_edi/data/invoice_it_template.xml
+++ b/addons/l10n_it_edi/data/invoice_it_template.xml
@@ -184,13 +184,13 @@
                             </DatiRiepilogo>
                         </t>
                     </DatiBeniServizi>
-                    <DatiPagamento t-if="record.type != 'out_refund'">
+                    <t t-set="company_bank_account" t-value="record.invoice_partner_bank_id"/>
+                    <DatiPagamento t-if="company_bank_account and record.type != 'out_refund'">
                         <t t-set="payments" t-value="record.line_ids.filtered(lambda line: line.account_id.user_type_id.type in ('receivable', 'payable'))"/>
                         <CondizioniPagamento><t t-if="len(payments) == 1">TP02</t><t t-else="">TP01</t></CondizioniPagamento>
                         <t t-foreach="payments" t-as="payment">
                             <DettaglioPagamento>
-                                <t t-set="company_bank_account" t-value="record.invoice_partner_bank_id"/>
-                                <ModalitaPagamento t-if="company_bank_account">MP05</ModalitaPagamento>
+                                <ModalitaPagamento>MP05</ModalitaPagamento>
                                 <DataScadenzaPagamento t-esc="format_date(payment.date_maturity)"/>
                                 <ImportoPagamento t-esc="format_monetary(abs(payment.price_total), currency)"/>
                                 <IstitutoFinanziario t-if="company_bank_account.bank_id" t-esc="company_bank_account.bank_id.name[:80]"/>


### PR DESCRIPTION
Due to changes in the previous commit ceeae85 the DatiPagamento section
is no longer mandatory. However if it is present two fields are
mandatory. 'ImportoPagamento' specifies the amounts, and
'ModalitaPagamento' specifies the type of transaction.

Currently there is a t-if on the ModalitaPagamento field, which is
required by the edi (if the DatiPagamento exists). Since we aren't
adapting the logic much, the type will be fixed at MP05 (bank
transaction), and we will require the invoice to have a partner_bank_id
in order for the DatiPagamento to appear in the xml.

task-id: 2824254