### PR TITLE
[FIX] mrp: fix double document creation on mrp.document copy

### DIFF
--- a/addons/mrp/models/mrp_document.py
+++ b/addons/mrp/models/mrp_document.py
@@ -20,7 +20,7 @@ class MrpDocument(models.Model):
         if ir_default:
             ir_fields = list(self.env['ir.attachment']._fields)
             ir_default = {field : default[field] for field in default.keys() if field in ir_fields}
-        new_attach = self.ir_attachment_id.copy(ir_default)
+        new_attach = self.ir_attachment_id.with_context(no_document=True).copy(ir_default)
         return super().copy(dict(default, ir_attachment_id=new_attach.id))
 
     ir_attachment_id = fields.Many2one('ir.attachment', string='Related attachment', required=True, ondelete='cascade')


### PR DESCRIPTION

**Description of the issue/feature this PR addresses**

This PR fix the "This attachment is already a document" Error when clicking on the "Apply Changes" button of a mrp.eco (Engineering Change Orders) in the PLM App.
Issue introduced by this PR: https://github.com/odoo/odoo/pull/86901

---
**How To Reproduce**

- On Runbot 13/14/15
- With PLM and Document Apps installed
- In Document Setting, activate option "Product: Centralize files attached to products"
- Go to PLM > Changes > Create (use any product) > Start New Revision
- Click On 'Update Documents' and upload any document
- Set state to 'Validated', then click on 'Apply Changes'
=> Error appear: "This attachment is already a document"
![image](https://user-images.githubusercontent.com/29302288/163959774-d3ee3d96-5c01-4048-90c7-3b2c09a9cb09.png)

With the Documents App installed and the "Product: Centralize files attached to products" document setting activated, copying the attachment will also copy the document.
Then when we try to copy the current document and link it to the new attachment, the above mentioned error appear.

---
**Desired behavior after PR is merged**

The context no_document=True prevent the document copy during the attachment copy.
The document is then copied only once.

---
OPW-2762448



--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
