### PR TITLE
[FIX] typo that prevent to force_company.

### DIFF
--- a/addons/mrp/report/mrp_report_bom_structure.py
+++ b/addons/mrp/report/mrp_report_bom_structure.py
@@ -206,7 +206,7 @@ class ReportBomStructure(models.AbstractModel):
             else:
                 prod_qty = line.product_qty * factor
                 company = bom.company_id or self.env.company
-                not_rounded_price = line.product_id.uom_id._compute_price(line.product_id.with_context(force_comany=company.id).standard_price, line.product_uom_id) * prod_qty
+                not_rounded_price = line.product_id.uom_id._compute_price(line.product_id.with_context(force_company=company.id).standard_price, line.product_uom_id) * prod_qty
                 price += company.currency_id.round(not_rounded_price)
         return price
 


### PR DESCRIPTION
Trivial Patch.

Bug introduced here, 3 years ago : https://github.com/odoo/odoo/commit/96406dc2a9e06595961f6d4bec6b66f27b94e2ff#diff-e8f576a790cd7f3f0976358b9b07f63cee0c6f05b0ba6203fc7bcf91af3ad283R205


Note : bug present in Odoo 13.0 / Odoo 14.0 / Odoo 15.0 and master.

@sle-odoo : could you take a look ? 

thanks ! 


--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
