### PR TITLE
[FIX] hr_holidays: set correct default date

### DIFF
--- a/addons/hr_holidays/models/hr_leave_type.py
+++ b/addons/hr_holidays/models/hr_leave_type.py
@@ -232,7 +232,7 @@ class HolidaysType(models.Model):
         ])
 
         if not date:
-            date = self.env.context.get('default_date_from', fields.Date.context_today(self))
+            date = self.env.context.get('default_date_from') or fields.Date.context_today(self)
         allocations = self.env['hr.leave.allocation'].search([
             ('employee_id', 'in', employee_ids),
             ('state', 'in', ['confirm', 'validate1', 'validate']),


### PR DESCRIPTION
Steps to reproduce:
- Go to time off - >New Time Off-> in the list you will see the all the times that are possible to take(that require allocation and not)
- Go to time off->My time off->create
- Select Sick Time Off

Issue:
If you want to select "Paid Time Off" it won't be displayed anymore

Cause:
When selecting a leave_type that does not require allocation the "default_date_from" is False. And so the get(key, default) does not return the default.

opw-2813263
