### PR TITLE
[REF] mail: change scheduled_date type to Datetime

### DIFF
--- a/addons/mail/__manifest__.py
+++ b/addons/mail/__manifest__.py
@@ -2,7 +2,7 @@
 
 {
     'name': 'Discuss',
-    'version': '1.8',
+    'version': '1.9',
     'category': 'Productivity/Discuss',
     'sequence': 145,
     'summary': 'Chat, mail gateway and private channels',

--- a/addons/mail/models/mail_mail.py
+++ b/addons/mail/models/mail_mail.py
@@ -78,15 +78,19 @@ class MailMail(models.Model):
     auto_delete = fields.Boolean(
         'Auto Delete',
         help="This option permanently removes any track of email after it's been sent, including from the Technical menu in the Settings, in order to preserve storage space of your Odoo database.")
-    scheduled_date = fields.Char('Scheduled Send Date',
+    scheduled_date = fields.Datetime('Scheduled Send Date',
         help="If set, the queue manager will send the email after the date. If not set, the email will be send as soon as possible.")
 
     @api.model_create_multi
     def create(self, values_list):
-        # notification field: if not set, set if mail comes from an existing mail.message
         for values in values_list:
+            # notification field: if not set, set if mail comes from an existing mail.message
             if 'is_notification' not in values and values.get('mail_message_id'):
                 values['is_notification'] = True
+            # scheduled_date field: if not set in mail_template, set its value to False
+            # this line is required to avoid casting problem when create is triggered in mail_template
+            if 'scheduled_date' in values and not values['scheduled_date']:
+                values['scheduled_date'] = False
 
         new_mails = super(MailMail, self).create(values_list)
 

--- a/addons/mail/models/mail_template.py
+++ b/addons/mail/models/mail_template.py
@@ -61,7 +61,7 @@ class MailTemplate(models.Model):
     mail_server_id = fields.Many2one('ir.mail_server', 'Outgoing Mail Server', readonly=False,
                                      help="Optional preferred server for outgoing mails. If not set, the highest "
                                           "priority one will be used.")
-    scheduled_date = fields.Char('Scheduled Date', help="If set, the queue manager will send the email after the date. If not set, the email will be send as soon as possible. You can use dynamic expressions expression.")
+    scheduled_date = fields.Char('Scheduled Date', help="If set, the queue manager will send the email after the date. If not set, the email will be send as soon as possible. You can use a dynamic expression.")
     auto_delete = fields.Boolean(
         'Auto Delete', default=True,
         help="This option permanently removes any track of email after it's been sent, including from the Technical menu in the Settings, in order to preserve storage space of your Odoo database.")

--- a/addons/mail/wizard/mail_template_preview.py
+++ b/addons/mail/wizard/mail_template_preview.py
@@ -3,6 +3,7 @@
 
 from odoo import api, fields, models
 from odoo.exceptions import UserError
+from dateutil import parser
 
 
 class MailTemplatePreview(models.TransientModel):
@@ -43,7 +44,7 @@ class MailTemplatePreview(models.TransientModel):
                            help="Comma-separated recipient addresses")
     email_cc = fields.Char('Cc', compute='_compute_mail_template_fields', help="Carbon copy recipients")
     reply_to = fields.Char('Reply-To', compute='_compute_mail_template_fields', help="Preferred response address")
-    scheduled_date = fields.Char('Scheduled Date', compute='_compute_mail_template_fields',
+    scheduled_date = fields.Datetime('Scheduled Date', compute='_compute_mail_template_fields',
                                  help="The queue manager will send the email after the date")
     body_html = fields.Html('Body', compute='_compute_mail_template_fields', sanitize=False)
     attachment_ids = fields.Many2many('ir.attachment', 'Attachments', compute='_compute_mail_template_fields')
@@ -82,5 +83,7 @@ class MailTemplatePreview(models.TransientModel):
     def _set_mail_attributes(self, values=None):
         for field in self._MAIL_TEMPLATE_FIELDS:
             field_value = values.get(field, False) if values else self.mail_template_id[field]
+            if field == 'scheduled_date' and field_value:
+                field_value = parser.parse(field_value)
             self[field] = field_value
         self.partner_ids = values.get('partner_ids', False) if values else False


### PR DESCRIPTION
- Change schedule_date data type from char to Datetime.

- The field should accept DateTime format in both models
mail_mail and mail_template_preview

- The reason for this change is to have more code consistency
since storing date in a char format is deprecated.

- The model mail_template was excluded and it will be kept as Char
for the reason that it needs to support dynamic expressions.

- Task id: #2826699

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
