### PR TITLE
[13.0][FIX] purchase: Description is changed after quantity is modified if seller is set

### DIFF
--- a/addons/purchase/models/purchase.py
+++ b/addons/purchase/models/purchase.py
@@ -729,7 +729,8 @@ class PurchaseOrderLine(models.Model):
 
         self.price_unit = price_unit
         product_ctx = {'seller_id': seller.id, 'lang': get_lang(self.env, self.partner_id.lang).code}
-        self.name = self._get_product_purchase_description(self.product_id.with_context(**product_ctx))
+        if seller.product_name:
+            self.name = self._get_product_purchase_description(self.product_id.with_context(**product_ctx))
 
     @api.depends('product_uom', 'product_qty', 'product_id.uom_id')
     def _compute_product_uom_qty(self):


### PR DESCRIPTION

![purchase_description_lost_if_change_qty](https://user-images.githubusercontent.com/7701001/163989067-82e17195-f3db-4e01-8196-547b1d93e225.gif)


Description of the issue/feature this PR addresses:
Description is changed after quantity is modified if seller is set

Current behavior before PR:
Description is changed after quantity is modified if seller is set

Desired behavior after PR is merged:
Avoid change description if seller don't have specific description 


@Tecnativa TT36008


--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
