### PR TITLE
[FIX] web_editor: typography adaptations

### DIFF
--- a/addons/web_editor/static/src/scss/web_editor.backend.scss
+++ b/addons/web_editor/static/src/scss/web_editor.backend.scss
@@ -14,15 +14,8 @@
         font-family: inherit !important;
         line-height: inherit !important;
         color: inherit !important;
+    }
 
-        p, div {
-            font-family: 'Lucida Grande', Helvetica, Verdana, Arial, sans-serif;
-            font-size: 13px;
-        }
-    }
-    ul > li > p, p {
-        margin: 0px;
-    }
     > iframe {
         display: block;
         width: 100%;


### PR DESCRIPTION
Prior of this commit the paragraph margin-bottom was forced to '0'
braking the typography's vertical rhythm.

This commit will remove the customization rules restoring bootstrap
default values for the backend.

Backport of #86740






--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
