### PR TITLE
[FIX] website_sale: Ribbon Tree View by Default

### DIFF
--- a/addons/website_sale/i18n/website_sale.pot
+++ b/addons/website_sale/i18n/website_sale.pot
@@ -1612,6 +1612,7 @@ msgstr ""
 #: model:ir.model.fields,field_description:website_sale.field_product_image__name
 #: model:ir.model.fields,field_description:website_sale.field_product_public_category__name
 #: model_terms:ir.ui.view,arch_db:website_sale.address
+#: model_terms:ir.ui.view,arch_db:website_sale.product_ribbon_view_tree
 #, python-format
 msgid "Name"
 msgstr ""

--- a/addons/website_sale/views/product_views.xml
+++ b/addons/website_sale/views/product_views.xml
@@ -101,7 +101,7 @@
                             <field name="public_categ_ids" widget="many2many_tags" string="Categories"/>
                             <field name="alternative_product_ids" widget="many2many_tags" domain="[('id', '!=', active_id), '|', ('company_id', '=', company_id), ('company_id', '=', False)]"/>
                             <field name="accessory_product_ids" widget="many2many_tags"/>
-                            <field name="website_ribbon_id" groups="base.group_no_one"/>
+                            <field name="website_ribbon_id" groups="base.group_no_one" options="{'no_quick_create': True'}"/>
                         </group>
                     </group>
                     <group name="product_template_images" string="Extra Product Media">
@@ -170,6 +170,16 @@
             Categories are used to browse your products through the
             touchscreen interface.
           </p>
+        </field>
+    </record>
+
+    <record id="product_ribbon_view_tree" model="ir.ui.view">
+        <field name="name">product.ribbon.tree</field>
+        <field name="model">product.ribbon</field>
+        <field name="arch" type="xml">
+            <tree string="Products Ribbon">
+                <field name="html" string="Name"/>
+            </tree>
         </field>
     </record>
 


### PR DESCRIPTION
When clicking on "Search More" on the Ribbon field on a Product,
we find a list of all the ribbons but only their ID are displayed.

Step to reproduce the issue:
1. Activate developer mode
2. Create enough Ribbons to have the "Search" option displayed (10 should do the trick)
3. Click on the "Search More", the list of all ribbons appears but we only see their IDs

Solution: There were no tree_view for the product.ribbon model. The default view was
thus rendered (default view with only the ID present). Jumped on the occasion to disable
the "Quick Create" button of the Ribbon as we cannot directly create a Ribbon from a bare field,
we need a form. Indeed, the `html_class` and `html` fields are both required.

opw-2820247