### PR TITLE
[FIX] pos_gift_card: Increase gift card barcode size

### DIFF
--- a/addons/pos_gift_card/data/gift_card_data.xml
+++ b/addons/pos_gift_card/data/gift_card_data.xml
@@ -44,7 +44,7 @@
                             </h3>
                         </div>
                         <div style="padding:0; margin:0px; padding-top:10px; padding-bottom:10px; text-align:center;">
-                            <img t-att-src="'/report/barcode/Code128/'+o.code" style="width:200px;height:50px" alt="Barcode"/>
+                            <img t-att-src="'/report/barcode/Code128/'+o.code" style="width:400px;height:75px" alt="Barcode"/>
                         </div>
                     </t>
                 </t>


### PR DESCRIPTION
The barcode for gift card is too small for some scanners.
A 2 time width increase make the barcode width similar to the code width in text form.

---

**Before PR:**
![image](https://user-images.githubusercontent.com/29302288/164000353-11133cd5-ef48-4dc0-8e3b-5b6aff6cd572.png)

---

**After PR:**
![image](https://user-images.githubusercontent.com/29302288/164000400-43a91f54-ff6d-4eff-8e4f-2eaa5af1608d.png)

---

OPW-2793423
OPW-2795222

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
