### PR TITLE
[FIX] point_of_sale: prevent showing downpayment as discount on receipt

### DIFF
--- a/addons/point_of_sale/static/src/js/models.js
+++ b/addons/point_of_sale/static/src/js/models.js
@@ -3442,6 +3442,9 @@ exports.Order = Backbone.Model.extend({
     },
     get_total_discount: function() {
         return round_pr(this.orderlines.reduce((function(sum, orderLine) {
+            if (orderLine.pos.config.down_payment_product_id[0] === orderLine.product.id) {
+                return 0;
+            }
             sum += (orderLine.get_unit_price() * (orderLine.get_discount()/100) * orderLine.get_quantity());
             if (orderLine.display_discount_policy() === 'without_discount'){
                 sum += ((orderLine.get_lst_price() - orderLine.get_unit_price()) * orderLine.get_quantity());


### PR DESCRIPTION
Current behavior:
When applying a discount and a downpayment on a product in the PoS
the discount line on the receipt would be the sum of the discount
and the downpayment. But the downpayment is not a discount.

Steps to reproduce:
- Install PoS
- Change discount policy to Show public price & discount to the
  customer, in the public pricelist
- Create a promotion program that applies 10% discount
- Use this promotion program in the PoS
- Create a quotation for any product (e.g with a product that cost
  1000$)
- In the PoS go in the quotation/order and apply a downpayment to
  this quotation.
- Pay the downpayment, and go in the quotation/order again. But this
  time settle the order.
- After the payment on the receipt you will see the discount line
  value is not correct. It's the sum of the discount + the downpayment

opw-2792417
--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
