### PR TITLE
[FIX] mass_mailing: ensure test templating is true

### DIFF
--- a/addons/mass_mailing/models/mailing.py
+++ b/addons/mass_mailing/models/mailing.py
@@ -85,7 +85,7 @@ class MassMailing(models.Model):
         help="Date at which the mailing was or will be sent.")
     # don't translate 'body_arch', the translations are only on 'body_html'
     body_arch = fields.Html(string='Body', translate=False, sanitize=False)
-    body_html = fields.Html(string='Body converted to be sent by mail', sanitize=False)
+    body_html = fields.Html(string='Body converted to be sent by mail', render_engine='qweb', sanitize=False)
     is_body_empty = fields.Boolean(compute="_compute_is_body_empty",
                                    help='Technical field used to determine if the mail body is empty')
     attachment_ids = fields.Many2many('ir.attachment', 'mass_mailing_ir_attachments_rel',

--- a/addons/test_mass_mailing/tests/test_mailing_test.py
+++ b/addons/test_mass_mailing/tests/test_mailing_test.py
@@ -3,6 +3,7 @@
 import lxml.html
 
 from odoo.addons.test_mass_mailing.tests.common import TestMassMailCommon
+from odoo.fields import Command
 from odoo.tests.common import users
 from odoo.tools import mute_logger
 
@@ -47,7 +48,7 @@ class TestMailingTest(TestMassMailCommon):
         # Test if bad inline_template in the body raises an error
         mailing.write({
             'subject': 'Subject {{ object.name }}',
-            'body_html': '<p>Hello {{ object.name_id.id }}</p>',
+            'body_html': '<p>Hello <t t-out="object.name_id.id"/></p>',
         })
         with self.mock_mail_gateway(), self.assertRaises(Exception):
             mailing_test.send_mail_test()
@@ -59,3 +60,48 @@ class TestMailingTest(TestMassMailCommon):
         })
         with self.mock_mail_gateway(), self.assertRaises(Exception):
             mailing_test.send_mail_test()
+
+    def test_mailing_test_equals_reality(self):
+        """
+        Check that both test and real emails will format the qweb and inline placeholders correctly in body and subject.
+        """
+        contact_list = self.env['mailing.list'].create({
+            'name': 'Testers',
+            'contact_ids': [Command.create({
+                'name': 'Mitchell Admin',
+                'email': 'real@real.com',
+            })],
+        })
+
+        mailing = self.env['mailing.mailing'].create({
+            'name': 'TestButton',
+            'subject': 'Subject {{ object.name }} <t t-out="object.name"/>',
+            'state': 'draft',
+            'mailing_type': 'mail',
+            'body_html': '<p>Hello {{ object.name }} <t t-out="object.name"/></p>',
+            'mailing_model_id': self.env['ir.model']._get('mailing.list').id,
+            'contact_list_ids': [contact_list.id],
+        })
+        mailing_test = self.env['mailing.mailing.test'].create({
+            'email_to': 'test@test.com',
+            'mass_mailing_id': mailing.id,
+        })
+
+        with self.mock_mail_gateway():
+            mailing_test.send_mail_test()
+
+        expected_subject = 'Subject Mitchell Admin <t t-out="object.name"/>'
+        expected_body = 'Hello {{ object.name }} Mitchell Admin'
+
+        self.assertSentEmail(self.env.user.partner_id, ['test@test.com'],
+            subject=expected_subject,
+            body_content=expected_body)
+
+        with self.mock_mail_gateway():
+            # send the mailing
+            mailing.action_launch()
+            self.env.ref('mass_mailing.ir_cron_mass_mailing_queue').method_direct_trigger()
+
+        self.assertSentEmail(self.env.user.partner_id, ['real@real.com'],
+            subject=expected_subject,
+            body_content=expected_body)


### PR DESCRIPTION
When using a template with inline placeholders in the body, the Test button will replace the placeholders, but they will remain in the final body when the mass mailing is sent for real.

This commit fixes this issue by using the correct rendering engine for the Test button too.

[OPW-2819032](https://www.odoo.com/web#model=project.task&id=2819032)
[OPW-2828461](https://www.odoo.com/web#model=project.task&id=2828461)