### PR TITLE
[13.0][IMP] account: Usage of registration payment wizard should depend on partner count

### DIFF
--- a/addons/account/models/account_payment.py
+++ b/addons/account/models/account_payment.py
@@ -404,12 +404,12 @@ class account_payment(models.Model):
         active_ids = self.env.context.get('active_ids')
         if not active_ids:
             return ''
-
+        partners = self.env["account.move"].browse(active_ids).partner_id
         return {
             'name': _('Register Payment'),
-            'res_model': len(active_ids) == 1 and 'account.payment' or 'account.payment.register',
+            'res_model': len(partners) == 1 and 'account.payment' or 'account.payment.register',
             'view_mode': 'form',
-            'view_id': len(active_ids) != 1 and self.env.ref('account.view_account_payment_form_multi').id or self.env.ref('account.view_account_payment_invoice_form').id,
+            'view_id': len(partners) != 1 and self.env.ref('account.view_account_payment_form_multi').id or self.env.ref('account.view_account_payment_invoice_form').id,
             'context': self.env.context,
             'target': 'new',
             'type': 'ir.actions.act_window',


### PR DESCRIPTION
Usage of registration payment wizard should depend on partner count instead of invoice count.
The code is prepared to handle several invoices from the same client:
https://github.com/odoo/odoo/blob/cf13ca1fa7825068bbc6ec5c830e9dac5133bd76/addons/account/models/account_payment.py#L101-L125

Description of the issue/feature this PR addresses:
Use of registration payment wizard is not needed when all selected invoices have the same partner.

Current behavior before PR:
Registration payment wizard is showed when more than one invoice is selected 

Desired behavior after PR is merged:
Registration payment wizard only is showed if selected invoces have distinct partners

@Tecnativa TT35197

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
