### PR TITLE
[FIX] project : average rating is wrong in tasks analysis

### DIFF
--- a/addons/project/report/project_report.py
+++ b/addons/project/report/project_report.py
@@ -31,7 +31,7 @@ class ReportProjectTaskUser(models.Model):
     working_hours_open = fields.Float(string='Working Hours to Assign', digits=(16, 2), readonly=True, group_operator="avg", help="Number of Working Hours to open the task")
     working_hours_close = fields.Float(string='Working Hours to Close', digits=(16, 2), readonly=True, group_operator="avg", help="Number of Working Hours to close the task")
     rating_last_value = fields.Float('Rating Value (/5)', group_operator="avg", readonly=True, groups="project.group_project_rating")
-    rating_avg = fields.Float('Average Rating', readonly=True)
+    rating_avg = fields.Float('Average Rating', readonly=True, group_operator='avg', groups="project.group_project_rating")
     priority = fields.Selection([
         ('0', 'Low'),
         ('1', 'Normal'),
@@ -111,7 +111,7 @@ class ReportProjectTaskUser(models.Model):
         return f"""
                 project_task t
                     LEFT JOIN project_task_user_rel tu on t.id=tu.task_id
-                    LEFT JOIN rating_rating rt ON rt.parent_res_id = t.id
+                    LEFT JOIN rating_rating rt ON rt.res_id = t.id
                         AND rt.res_model = 'project.task'
                         AND rt.consumed = True
                         AND rt.rating >= {RATING_LIMIT_MIN}

--- a/addons/project/tests/__init__.py
+++ b/addons/project/tests/__init__.py
@@ -21,3 +21,4 @@ from . import test_personal_stages
 from . import test_task_dependencies
 from . import test_task_follow
 from . import test_task_tracking
+from . import test_project_report

--- a/addons/project/tests/test_project_report.py
+++ b/addons/project/tests/test_project_report.py
@@ -1,0 +1,40 @@
+# -*- coding: utf-8 -*-
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from odoo.tests import tagged
+from .test_project_base import TestProjectCommon
+
+@tagged('post_install', '-at_install')
+class TestProjectReport(TestProjectCommon):
+    def test_avg_rating_measure(self):
+        rating_vals = {
+            'res_model_id': self.env['ir.model']._get('project.task').id,
+            'rated_partner_id': self.partner_1.id,
+            'partner_id': self.partner_1.id,
+            'consumed': True,
+        }
+        self.env['rating.rating'].create([
+            {**rating_vals, 'rating': 5, 'res_id': self.task_1.id},
+            {**rating_vals, 'rating': 4, 'res_id': self.task_1.id},
+            {**rating_vals, 'rating': 4.25, 'res_id': self.task_2.id},
+        ])
+        self.assertEqual(self.task_1.rating_avg, 4.5)
+        self.assertEqual(self.task_1.rating_last_value, 5.0)
+
+        self.assertEqual(self.task_2.rating_avg, 4.25)
+        self.assertEqual(self.task_2.rating_last_value, 4.25)
+
+        task_3 = self.env['project.task'].create({
+            'name': 'task 3',
+            'project_id': self.project_pigs.id,
+            'partner_id': self.partner_1.id,
+            'user_ids': self.task_1.user_ids,
+        })
+        self.assertEqual(task_3.rating_avg, 0)
+        self.assertEqual(task_3.rating_last_value, 0)
+
+        tasks = [self.task_1, self.task_2, task_3]
+        for task in tasks:
+            rating_values = task.read(['rating_avg', 'rating_last_value'])[0]
+            task_report = self.env['report.project.task.user'].search_read([('project_id', '=', self.project_pigs.id), ('task_id', '=', task.id)], ['rating_avg', 'rating_last_value'])[0]
+            self.assertDictEqual(task_report, rating_values, 'The rating average and the last rating value for the task 1 should be the same in the report and on the task.')


### PR DESCRIPTION
Before this commit:
- Join between task and rating is made on parent_res_id
- Displayed value is the sum of tasks average_rating
- No Unit test to cover this case
- Measure displayed when customer rating setting is not active
- [Demo data] Each task is rated one time so average_rating and last_rating are the same

After this commit:
- Join is made on res_id which is the task_id
- Displayed value is the avg of tasks average_rating
- Unit test added to cover mesaures calculation
- Measure dusplayed only when setting active
- New demo record added to let average_rating be different from last_rating
