### PR TITLE
[IMP] website: add options for file upload in forms (max size + number)

### DIFF
--- a/addons/web_editor/static/src/js/editor/snippets.options.js
+++ b/addons/web_editor/static/src/js/editor/snippets.options.js
@@ -1215,12 +1215,13 @@ const InputUserValueWidget = UnitUserValueWidget.extend({
         await this._super(...arguments);
 
         const unit = this.el.dataset.unit;
+        const step = this.el.dataset.step;
         this.inputEl = document.createElement('input');
         this.inputEl.setAttribute('type', 'text');
         this.inputEl.setAttribute('autocomplete', 'chrome-off');
         this.inputEl.setAttribute('placeholder', this.el.getAttribute('placeholder') || '');
-        this.inputEl.classList.toggle('text-start', !unit);
-        this.inputEl.classList.toggle('text-end', !!unit);
+        this.inputEl.classList.toggle('text-start', !unit && !step);
+        this.inputEl.classList.toggle('text-end', !!unit || !!step);
         this.containerEl.appendChild(this.inputEl);
 
         var unitEl = document.createElement('span');

--- a/addons/website/static/src/snippets/s_website_form/001.scss
+++ b/addons/website/static/src/snippets/s_website_form/001.scss
@@ -64,6 +64,42 @@
             display: none;
         }
     }
+
+    // File blocks.
+    div.o_files_zone {
+        div.o_file_wrap {
+            border: 1px solid $o-gray-400;
+            border-radius: 0.25rem;
+            font-size: 0.9em;
+            line-height: normal;
+
+            div.o_file_name {
+                overflow: hidden;
+                text-overflow: ellipsis;
+                white-space: nowrap;
+            }
+
+            i.o_file_delete {
+                max-width: 25%;
+                padding: 2px 4px 3px 4px;
+                color: $primary;
+                cursor: pointer;
+
+                &:hover {
+                    color: darken($primary, 7.5%);
+                }
+            }
+        }
+    }
+
+    .o_add_files_button {
+        background-color: $o-gray-200;
+        width: fit-content;
+
+        &:hover {
+            background-color: darken($o-gray-200, 4.5%);
+        }
+    }
 }
 
 body:not(.editor_enable) .s_website_form[data-vcss="001"] {

--- a/addons/website/static/src/snippets/s_website_form/options.js
+++ b/addons/website/static/src/snippets/s_website_form/options.js
@@ -265,6 +265,7 @@ const FieldEditor = FormEditor.extend({
         const classList = this.$target[0].classList;
         const textarea = this.$target[0].querySelector('textarea');
         const input = this.$target[0].querySelector('input[type="text"], input[type="email"], input[type="number"], input[type="tel"], input[type="url"], textarea');
+        const fileInputEl = this.$target[0].querySelector("input[type=file]");
         const description = this.$target[0].querySelector('.s_website_form_field_description');
         field.placeholder = input && input.placeholder;
         if (input) {
@@ -272,6 +273,9 @@ const FieldEditor = FormEditor.extend({
             field.value = input.getAttribute('value') || input.value;
         } else if (field.type === 'boolean') {
             field.value = !!this.$target[0].querySelector('input[type="checkbox"][checked]');
+        } else if (fileInputEl) {
+            field.maxFilesNumber = fileInputEl.dataset.maxFilesNumber;
+            field.maxFileSize = fileInputEl.dataset.maxFileSize;
         }
         // property value is needed for date/datetime (formated date).
         field.propertyValue = input && input.value;
@@ -1070,6 +1074,16 @@ options.registry.WebsiteFieldEditor = FieldEditor.extend({
     setVisibilityDependency(previewMode, widgetValue, params) {
         this._setVisibilityDependency(widgetValue);
     },
+    /**
+     * @override
+     */
+    async selectDataAttribute(previewMode, widgetValue, params) {
+        await this._super(...arguments);
+        if (params.attributeName === "maxFilesNumber") {
+            const allowMultipleFiles = params.activeValue > 1;
+            this.$target[0].toggleAttribute("multiple", allowMultipleFiles);
+        }
+    },
 
     //----------------------------------------------------------------------
     // Private
@@ -1171,6 +1185,13 @@ options.registry.WebsiteFieldEditor = FieldEditor.extend({
             case 'hidden_opt':
             case 'type_opt':
                 return !this.$target[0].classList.contains('s_website_form_model_required');
+            case "max_files_number_opt": {
+                // Do not display the option if only one file is supposed to be
+                // uploaded in the field.
+                const fieldEl = this.$target[0].closest(".s_website_form_field");
+                return fieldEl.classList.contains("s_website_form_custom") ||
+                    ["one2many", "many2many"].includes(fieldEl.dataset.type);
+            }
         }
         return this._super(...arguments);
     },

--- a/addons/website/static/src/xml/website_form.xml
+++ b/addons/website/static/src/xml/website_form.xml
@@ -15,4 +15,14 @@
             <t t-esc="message"/>
         </span>
     </t>
+
+    <!-- A block containing the file name and a cross to delete the file. -->
+    <t t-name="website.file_block">
+        <div class="o_file_block col-4">
+            <div class="o_file_wrap mb-1 px-2 py-1">
+                <div class="o_file_name d-inline-block w-75 pt-1" t-att-title="fileName" t-out="fileName"/>
+                <i class="o_file_delete fa fa-times mt-1 float-end"/>
+            </div>
+        </div>
+    </t>
 </templates>

--- a/addons/website/static/src/xml/website_form_editor.xml
+++ b/addons/website/static/src/xml/website_form_editor.xml
@@ -379,8 +379,10 @@
                 class="form-control s_website_form_input"
                 t-att-name="field.name"
                 t-att-required="field.required || field.modelRequired || None"
-                t-att-multiple="multiple"
+                t-att="field.maxFilesNumber > 1 and {'multiple': ''} or {}"
                 t-att-id="field.id"
+                t-att-data-max-files-number="field.maxFilesNumber or '1'"
+                t-att-data-max-file-size="field.maxFileSize or '1'"
             />
         </t>
     </t>

--- a/addons/website/views/snippets/s_website_form.xml
+++ b/addons/website/views/snippets/s_website_form.xml
@@ -137,6 +137,22 @@
                            data-apply-to=".s_website_form_date input"/>
             <we-checkbox string="Required" data-name="required_opt" data-no-preview="true"
                 data-toggle-required="s_website_form_required"/>
+
+            <we-input data-name="max_files_number_opt"
+                string="Max # of files"
+                title="The maximum number of files that can be uploaded."
+                data-attribute-name="maxFilesNumber"
+                data-select-data-attribute="1"
+                data-apply-to="input[type='file']"
+                data-step="1"/>
+
+            <we-input string="Max file size"
+                title="The maximum size (in MB) an uploaded file can have."
+                data-attribute-name="maxFileSize"
+                data-select-data-attribute="1MB"
+                data-apply-to="input[type='file']"
+                data-unit="MB"/>
+
             <we-select string="Visibility" data-no-preview="true">
                 <we-button data-set-visibility="visible" data-select-class="">Always Visible</we-button>
                 <we-button data-set-visibility="hidden" data-select-class="s_website_form_field_hidden">Hidden</we-button>


### PR DESCRIPTION
[IMP] website: add options for file upload in forms (max size + number)

Currently, we can only upload one file in a form File Upload field and
this file does not have a size limit. (Note that the server can have a
limit to prevent files too large from being uploaded but the file input
itself does not have one.)

This commit adds options to the form file inputs in order to set a
maximum number of files and the maximum file size (in MB) allowed to be
uploaded in these fields. The default values are 1 file and 1 MB. Note
that the option for the number of files is not displayed for the fields
where only one file is supposed to be uploaded.

If the uploaded files do not respect these limits, the form is not sent
and a message is displayed.

task-2798576

---
[IMP] website: manage better the files uploaded in a form

Before this commit, now that multiple files can be uploaded in a form,
we could observe that the file input is not convenient to manage this
situation:

- Clicking again on the input to choose other files replaces the
previously uploaded ones, we can therefore not upload files one by one.
- A file cannot be deleted in an obvious way: we need to cancel a new
upload, as it will replace the file by nothing and therefore delete it.
- When multiple files are uploaded, only the number of files is
displayed and not their name (they are only displayed on hover).

This commit improves these behaviors:

- Clicking again on the input adds additional files instead of replacing
them (unless the number of files allowed is 1);
- The button text content is modified after the upload of files,
displaying "Add Files"/"Replace File" (if multiple/single files are
allowed) to show its role better.
- When files are uploaded, blocks containing each files name and a
cross to delete them are displayed.

In order to make these improvements, the file input is hidden and
replaced by an input of type=`button` when files are uploaded. This was
done for two reasons:
- It is not possible to modify the content of an input of type=`file`
but we can change the value of a button.
- The input did not look good with the file blocks, because it has a
text displaying file informations, which was redundant with the blocks.

task-2798576

---
[IMP] web_editor: align numeric inputs text without units to the right

Before this commit, the input widgets that do not have units have their
text aligned to the left. However, when the content is numeric, it would
be better if the number was on the right, just as when there is a unit.

This commit also considers as numeric an input widget that has the
`data-step` attribute (and not only the `data-unit` attribute) and
forces the text alignment to the right in this case.

task-2798576
