### PR TITLE
[FIX] sale_coupon: coupon codes are not filtered by website

### DIFF
--- a/addons/sale_coupon/models/sale_order.py
+++ b/addons/sale_coupon/models/sale_order.py
@@ -133,6 +133,9 @@ class SaleOrder(models.Model):
         else:
             return fixed_amount
 
+    def _get_coupon_program_domain(self):
+        return []
+
     def _get_cheapest_line(self):
         # Unit prices tax included
         return min(self.order_line.filtered(lambda x: not x.is_reward_line and x.price_reduce > 0), key=lambda x: x['price_reduce'])

--- a/addons/sale_coupon/wizard/sale_coupon_apply_code.py
+++ b/addons/sale_coupon/wizard/sale_coupon_apply_code.py
@@ -2,6 +2,7 @@
 
 from odoo import api, fields, models, _
 from odoo.exceptions import UserError
+from odoo.osv import expression
 
 
 class SaleCouponApplyCode(models.TransientModel):
@@ -24,7 +25,9 @@ class SaleCouponApplyCode(models.TransientModel):
 
     def apply_coupon(self, order, coupon_code):
         error_status = {}
-        program = self.env['sale.coupon.program'].search([('promo_code', '=', coupon_code)])
+        program_domain = order._get_coupon_program_domain()
+        program_domain = expression.AND([program_domain, [('promo_code', '=', coupon_code)]])
+        program = self.env['sale.coupon.program'].search(program_domain)
         if program:
             error_status = program._check_promo_code(order, coupon_code)
             if not error_status:

--- a/addons/website_sale_coupon/models/sale_order.py
+++ b/addons/website_sale_coupon/models/sale_order.py
@@ -63,6 +63,9 @@ class SaleOrder(models.Model):
             request.session.pop('error_promo_code')
         return error
 
+    def _get_coupon_program_domain(self):
+        return [('website_id', 'in', [False, self.website_id.id])]
+
     def _cart_update(self, product_id=None, line_id=None, add_qty=0, set_qty=0, **kwargs):
         res = super(SaleOrder, self)._cart_update(product_id=product_id, line_id=line_id, add_qty=add_qty, set_qty=set_qty, **kwargs)
         self.recompute_coupon_lines()


### PR DESCRIPTION
If applied, this commit will fix the following bug by adding
the website to the filtering domain when selecting the program
to apply

Steps to reproduce:

1- install website, sales, sale_coupon_delivery
2- create 2 promotion programs p1, p2 with the same promo code
3- assign p1 to website 1 and p2 to website 2
4- try the promo code with any product in cart
5- the promotion is not applied

Bug:

the search domain uses only the promo_code thus returning 2 programs

Fix:

add website_id to the search domain

OPW-2812707
