### PR TITLE
[FIX] point_of_sale: fix traceback when fast click validate

### DIFF
--- a/addons/point_of_sale/static/src/js/Screens/ClientListScreen/ClientListScreen.js
+++ b/addons/point_of_sale/static/src/js/Screens/ClientListScreen/ClientListScreen.js
@@ -6,6 +6,7 @@ odoo.define('point_of_sale.ClientListScreen', function(require) {
     const Registries = require('point_of_sale.Registries');
     const { useListener } = require('web.custom_hooks');
     const { isConnectionError } = require('point_of_sale.utils');
+    const { useAsyncLockedMethod } = require('point_of_sale.custom_hooks');
 
     /**
      * Render this screen using `showTempScreen` to select client.
@@ -25,9 +26,10 @@ odoo.define('point_of_sale.ClientListScreen', function(require) {
     class ClientListScreen extends PosComponent {
         constructor() {
             super(...arguments);
+            this.lockedSaveChanges = useAsyncLockedMethod(this.saveChanges);
             useListener('click-save', () => this.env.bus.trigger('save-customer'));
             useListener('click-edit', () => this.editClient());
-            useListener('save-changes', this.saveChanges);
+            useListener('save-changes', this.lockedSaveChanges);
 
             // We are not using useState here because the object
             // passed to useState converts the object and its contents

--- a/addons/point_of_sale/static/src/js/Screens/PaymentScreen/PaymentScreen.js
+++ b/addons/point_of_sale/static/src/js/Screens/PaymentScreen/PaymentScreen.js
@@ -3,7 +3,7 @@ odoo.define('point_of_sale.PaymentScreen', function (require) {
 
     const { parse } = require('web.field_utils');
     const PosComponent = require('point_of_sale.PosComponent');
-    const { useErrorHandlers } = require('point_of_sale.custom_hooks');
+    const { useErrorHandlers, useAsyncLockedMethod } = require('point_of_sale.custom_hooks');
     const NumberBuffer = require('point_of_sale.NumberBuffer');
     const { useListener } = require('web.custom_hooks');
     const Registries = require('point_of_sale.Registries');
@@ -21,6 +21,7 @@ odoo.define('point_of_sale.PaymentScreen', function (require) {
             useListener('send-payment-cancel', this._sendPaymentCancel);
             useListener('send-payment-reverse', this._sendPaymentReverse);
             useListener('send-force-done', this._sendForceDone);
+            this.lockedValidateOrder = useAsyncLockedMethod(this.validateOrder);
             NumberBuffer.use({
                 // The numberBuffer listens to this event to update its state.
                 // Basically means 'update the buffer when this event is triggered'
@@ -356,7 +357,7 @@ odoo.define('point_of_sale.PaymentScreen', function (require) {
                         ' ' +
                         this.env._t('? Clicking "Confirm" will validate the payment.'),
                 }).then(({ confirmed }) => {
-                    if (confirmed) this.validateOrder(true);
+                    if (confirmed) this.lockedValidateOrder(true);
                 });
                 return false;
             }

--- a/addons/point_of_sale/static/src/js/custom_hooks.js
+++ b/addons/point_of_sale/static/src/js/custom_hooks.js
@@ -145,5 +145,21 @@ odoo.define('point_of_sale.custom_hooks', function (require) {
         });
     }
 
-    return { useErrorHandlers, useAutoFocusToLast, onChangeOrder, useBarcodeReader };
+    function useAsyncLockedMethod(method) {
+        const component = Component.current;
+        let called = false;
+        return async (...args) => {
+            if (called) {
+                return;
+            }
+            try {
+                called = true;
+                await method.call(component, ...args);
+            } finally {
+                called = false;
+            }
+        };
+    }
+
+    return { useErrorHandlers, useAutoFocusToLast, onChangeOrder, useBarcodeReader, useAsyncLockedMethod };
 });

--- a/addons/point_of_sale/static/src/xml/Screens/PaymentScreen/PaymentScreen.xml
+++ b/addons/point_of_sale/static/src/xml/Screens/PaymentScreen/PaymentScreen.xml
@@ -13,7 +13,7 @@
                         </div>
                         <div class="top-content-center"><h1>Payment</h1></div>
                         <div class="button next" t-att-class="{ highlight: currentOrder.is_paid() and _isValidEmptyOrder() }"
-                              t-on-click="validateOrder(false)">
+                              t-on-click="lockedValidateOrder(false)">
                             <span class="next_text">Validate</span>
                             <i class="fa fa-angle-double-right fa-fw"></i>
                         </div>
@@ -90,7 +90,7 @@
                 </div>
                 <t t-if="env.isMobile">
                     <div class="switchpane">
-                        <button class="btn-switchpane" t-att-class="{ secondary: !(currentOrder.is_paid() and _isValidEmptyOrder()) }" t-on-click="validateOrder(false)">
+                        <button class="btn-switchpane" t-att-class="{ secondary: !(currentOrder.is_paid() and _isValidEmptyOrder()) }" t-on-click="lockedValidateOrder(false)">
                             <h1>Validate</h1>
                         </button>
                         <button class="btn-switchpane secondary" t-on-click="showScreen('ProductScreen', {mobile_pane: 'left'})">


### PR DESCRIPTION
Current behavior:
When clicking multiple times on the validate button in PoS
a traceback appears.
When creating a customer from the PoS, if you click mutliple times
on the create button the customer would be created multiple times
in the Db.

Steps to reproduce issue 1:
- To reproduce you need a slow internet connection, you
  can do that in the developper menu of chrome (F12) and
  in the network tab select 'slow 3G' instead of 'no throttling'
- Go in a PoS session, make an order
- Go in the payment screen
- Press validate multiple times.
- A traceback appears

Steps to reproduce issue 2:
- Go in the customer selection screen
- Go in the create customer screen
- Enter a name, and click multiple times on the create button
- If you check customer list the new customer should appear
  multiple times

opw-2813512
--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
