### PR TITLE
[FIX] board: filter records according to selected companies

### DIFF
--- a/addons/board/controllers/main.py
+++ b/addons/board/controllers/main.py
@@ -21,6 +21,10 @@ class Board(Controller):
                 xml = ElementTree.fromstring(board['arch'])
                 column = xml.find('./board/column')
                 if column is not None:
+                    # We don't want to save allowed_company_ids
+                    # Otherwise on dashboard, the multi-company widget does not filter the records
+                    if 'allowed_company_ids' in context_to_save:
+                        context_to_save.pop('allowed_company_ids')
                     new_action = ElementTree.Element('action', {
                         'name': str(action_id),
                         'string': name,


### PR DESCRIPTION
Before, when we added view to the dashboard, context was saved too,
including allowed_company_ids. As a result when we checked the same view
from the dashboard, the displayed records corresponded to the active companies
during the time the view was saved and not the current ones - the companies
that are currently ticked from the multi-company widget.

After the fix, the displayed records in dashboard, correspond to the currently active companies.

task - 2809597

