### PR TITLE
[IMP] mail: move component handlers to models (step 6)

### DIFF
--- a/addons/mail/static/src/components/chat_window/chat_window.js
+++ b/addons/mail/static/src/components/chat_window/chat_window.js
@@ -22,7 +22,6 @@ export class ChatWindow extends Component {
         // the following are passed as props to children
         this._onAutocompleteSelect = this._onAutocompleteSelect.bind(this);
         this._onAutocompleteSource = this._onAutocompleteSource.bind(this);
-        this._onFocusinThread = this._onFocusinThread.bind(this);
     }
 
     //--------------------------------------------------------------------------
@@ -108,19 +107,6 @@ export class ChatWindow extends Component {
             keyword: _.escape(req.term),
             limit: 10,
         });
-    }
-
-    /**
-     * Called when an element in the thread becomes focused.
-     *
-     * @private
-     */
-    _onFocusinThread() {
-        if (!this.chatWindow) {
-            // prevent crash on destroy
-            return;
-        }
-        this.chatWindow.update({ isFocused: true });
     }
 
 }

--- a/addons/mail/static/src/components/chat_window/chat_window.xml
+++ b/addons/mail/static/src/components/chat_window/chat_window.xml
@@ -31,7 +31,6 @@
                         hasComposerCurrentPartnerAvatar="false"
                         hasComposerSendButton="messaging.device.isMobile"
                         localId="chatWindow.threadView.localId"
-                        onFocusin="_onFocusinThread"
                     />
                 </t>
                 <t t-if="chatWindow.newMessageAutocompleteInputView">

--- a/addons/mail/static/src/components/notification_group/notification_group.js
+++ b/addons/mail/static/src/components/notification_group/notification_group.js
@@ -1,8 +1,9 @@
 /** @odoo-module **/
 
+import { useRefToModel } from '@mail/component_hooks/use_ref_to_model';
 import { registerMessagingComponent } from '@mail/utils/messaging_component';
 
-const { Component, useRef } = owl;
+const { Component } = owl;
 
 export class NotificationGroup extends Component {
 
@@ -11,11 +12,7 @@ export class NotificationGroup extends Component {
      */
     setup() {
         super.setup();
-        /**
-         * Reference of the "mark as read" button. Useful to disable the
-         * top-level click handler when clicking on this specific button.
-         */
-        this._markAsReadRef = useRef('markAsRead');
+        useRefToModel({ fieldName: 'markAsReadRef', modelName: 'NotificationGroupView', refName: 'markAsRead' });
     }
 
     //--------------------------------------------------------------------------
@@ -47,7 +44,10 @@ export class NotificationGroup extends Component {
      * @param {MouseEvent} ev
      */
     _onClick(ev) {
-        const markAsRead = this._markAsReadRef.el;
+        if (!this.notificationGroupView) {
+            return;
+        }
+        const markAsRead = this.notificationGroupView.markAsReadRef.el;
         if (markAsRead && markAsRead.contains(ev.target)) {
             // handled in `_onClickMarkAsRead`
             return;

--- a/addons/mail/static/src/components/rtc_invitation_card/rtc_invitation_card.js
+++ b/addons/mail/static/src/components/rtc_invitation_card/rtc_invitation_card.js
@@ -11,10 +11,10 @@ export class RtcInvitationCard extends Component {
     //--------------------------------------------------------------------------
 
     /**
-     * @returns {Thread}
+     * @returns {RtcInvitationCard|undefined}
      */
-    get thread() {
-        return this.messaging.models['Thread'].get(this.props.threadLocalId);
+    get rtcInvitationCard() {
+        return this.messaging.models['RtcInvitationCard'].get(this.props.localId);
     }
 
     //--------------------------------------------------------------------------
@@ -25,37 +25,14 @@ export class RtcInvitationCard extends Component {
      * @private
      * @param {MouseEvent} ev
      */
-    async _onClickAccept(ev) {
-        this.thread.open();
-        if (this.thread.hasPendingRtcRequest) {
-            return;
-        }
-        await this.thread.toggleCall();
-    }
-
-    /**
-     * @private
-     * @param {MouseEvent} ev
-     */
     _onClickAvatar(ev) {
-        this.thread.open();
-    }
-
-    /**
-     * @private
-     * @param {MouseEvent} ev
-     */
-    _onClickRefuse(ev) {
-        if (this.thread.hasPendingRtcRequest) {
-            return;
-        }
-        this.thread.leaveCall();
+        this.rtcInvitationCard.thread.open();
     }
 
 }
 
 Object.assign(RtcInvitationCard, {
-    props: { threadLocalId: String },
+    props: { localId: String },
     template: 'mail.RtcInvitationCard',
 });
 

--- a/addons/mail/static/src/components/rtc_invitation_card/rtc_invitation_card.xml
+++ b/addons/mail/static/src/components/rtc_invitation_card/rtc_invitation_card.xml
@@ -2,15 +2,15 @@
 <templates xml:space="preserve">
 
     <t t-name="mail.RtcInvitationCard" owl="1">
-        <t t-if="thread">
+        <t t-if="rtcInvitationCard">
             <div class="o_RtcInvitationCard" t-attf-class="{{ className }}" t-ref="root">
-                <t t-if="thread.rtcInvitingSession">
+                <t t-if="rtcInvitationCard.thread.rtcInvitingSession">
                     <div class="o_RtcInvitationCard_partnerInfo">
                         <img class="o_RtcInvitationCard_partnerInfoImage rounded-circle"
-                            t-att-src="thread.rtcInvitingSession.avatarUrl"
+                            t-att-src="rtcInvitationCard.thread.rtcInvitingSession.avatarUrl"
                             t-on-click="_onClickAvatar"
                             alt="Avatar"/>
-                        <span class="o_RtcInvitationCard_partnerInfoName" t-esc="thread.rtcInvitingSession.name"/>
+                        <span class="o_RtcInvitationCard_partnerInfoName" t-esc="rtcInvitationCard.thread.rtcInvitingSession.name"/>
                         <span class="o_RtcInvitationCard_partnerInfoText">Incoming Call...</span>
                     </div>
                 </t>
@@ -18,13 +18,13 @@
                     <div class="o_RtcInvitationCard_buttonListButton o_RtcInvitationCard_buttonListRefuse"
                         aria-label="Refuse"
                         title="Refuse"
-                        t-on-click="_onClickRefuse">
+                        t-on-click="rtcInvitationCard.onClickRefuse">
                         <i class="o_RtcInvitationCard_buttonListButtonIcon fa fa-lg fa-times"/>
                     </div>
                     <div class="o_RtcInvitationCard_buttonListButton o_RtcInvitationCard_buttonListAccept"
                         aria-label="Accept"
                         title="Accept"
-                        t-on-click="_onClickAccept">
+                        t-on-click="rtcInvitationCard.onClickAccept">
                         <i class="o_RtcInvitationCard_buttonListButtonIcon fa fa-lg fa-phone"/>
                     </div>
                 </div>

--- a/addons/mail/static/src/components/rtc_invitations/rtc_invitations.xml
+++ b/addons/mail/static/src/components/rtc_invitations/rtc_invitations.xml
@@ -4,8 +4,8 @@
     <t t-name="mail.RtcInvitations" owl="1">
         <div class="o_RtcInvitations" t-attf-class="{{ className }}" t-ref="root">
             <t t-if="messaging.ringingThreads">
-                <t t-foreach="messaging.ringingThreads" t-as="thread" t-key="thread.localId">
-                    <RtcInvitationCard threadLocalId="thread.localId"/>
+                <t t-foreach="messaging.rtcInvitationCards" t-as="rtcInvitationCard" t-key="rtcInvitationCard.localId">
+                    <RtcInvitationCard localId="rtcInvitationCards.localId"/>
                 </t>
             </t>
         </div>

--- a/addons/mail/static/src/components/rtc_video/rtc_video.js
+++ b/addons/mail/static/src/components/rtc_video/rtc_video.js
@@ -54,28 +54,6 @@ export class RtcVideo extends Component {
         this.root.el.load();
     }
 
-    //--------------------------------------------------------------------------
-    // Handlers
-    //--------------------------------------------------------------------------
-
-    /**
-     * Plays the video as some browsers may not support or block autoplay.
-     *
-     * @private
-     * @param {Event} ev
-     */
-    async _onVideoLoadedMetaData(ev) {
-        try {
-            await ev.target.play();
-        } catch (error) {
-            if (typeof error === 'object' && error.name === 'NotAllowedError') {
-                // Ignored as some browsers may reject play() calls that do not
-                // originate from a user input.
-                return;
-            }
-            throw error;
-        }
-    }
 }
 
 Object.assign(RtcVideo, {

--- a/addons/mail/static/src/components/rtc_video/rtc_video.xml
+++ b/addons/mail/static/src/components/rtc_video/rtc_video.xml
@@ -8,7 +8,7 @@
                 playsinline="true"
                 autoplay="true"
                 muted="true"
-                t-on-loadedmetadata="_onVideoLoadedMetaData"
+                t-on-loadedmetadata="rtcSession.onVideoLoadedMetaData"
                 t-ref="root"
             />
         </t>

--- a/addons/mail/static/src/components/thread_needaction_preview/thread_needaction_preview.js
+++ b/addons/mail/static/src/components/thread_needaction_preview/thread_needaction_preview.js
@@ -2,9 +2,10 @@
 
 import * as mailUtils from '@mail/js/utils';
 
+import { useRefToModel } from '@mail/component_hooks/use_ref_to_model';
 import { registerMessagingComponent } from '@mail/utils/messaging_component';
 
-const { Component, useRef } = owl;
+const { Component } = owl;
 
 export class ThreadNeedactionPreview extends Component {
 
@@ -13,11 +14,7 @@ export class ThreadNeedactionPreview extends Component {
      */
     setup() {
         super.setup();
-        /**
-         * Reference of the "mark as read" button. Useful to disable the
-         * top-level click handler when clicking on this specific button.
-         */
-        this._markAsReadRef = useRef('markAsRead');
+        useRefToModel({ fieldName: 'markAsReadRef', modelName: 'ThreadNeedactionPreviewView', refName: 'markAsRead' });
     }
 
     //--------------------------------------------------------------------------
@@ -59,37 +56,6 @@ export class ThreadNeedactionPreview extends Component {
      */
     get threadNeedactionPreviewView() {
         return this.messaging && this.messaging.models['ThreadNeedactionPreviewView'].get(this.props.localId);
-    }
-
-    //--------------------------------------------------------------------------
-    // Handlers
-    //--------------------------------------------------------------------------
-
-    /**
-     * @private
-     * @param {MouseEvent} ev
-     */
-    _onClick(ev) {
-        const markAsRead = this._markAsReadRef.el;
-        if (markAsRead && markAsRead.contains(ev.target)) {
-            // handled in `_onClickMarkAsRead`
-            return;
-        }
-        this.threadNeedactionPreviewView.thread.open();
-        if (!this.messaging.device.isMobile) {
-            this.messaging.messagingMenu.close();
-        }
-    }
-
-    /**
-     * @private
-     * @param {MouseEvent} ev
-     */
-    _onClickMarkAsRead(ev) {
-        this.messaging.models['Message'].markAllAsRead([
-            ['model', '=', this.threadNeedactionPreviewView.thread.model],
-            ['res_id', '=', this.threadNeedactionPreviewView.thread.id],
-        ]);
     }
 
 }

--- a/addons/mail/static/src/components/thread_needaction_preview/thread_needaction_preview.xml
+++ b/addons/mail/static/src/components/thread_needaction_preview/thread_needaction_preview.xml
@@ -7,7 +7,7 @@
                 The preview template is used by the discuss in mobile, and by the systray
                 menu in order to show preview of threads.
             -->
-            <div class="o_ThreadNeedactionPreview" t-attf-class="{{ className }}" t-on-click="_onClick" t-att-data-thread-local-id="threadNeedactionPreviewView.thread.localId" t-ref="root">
+            <div class="o_ThreadNeedactionPreview" t-attf-class="{{ className }}" t-on-click="threadNeedactionPreviewView.onClick" t-att-data-thread-local-id="threadNeedactionPreviewView.thread.localId" t-ref="root">
                 <div class="o_ThreadNeedactionPreview_sidebar">
                     <div class="o_ThreadNeedactionPreview_imageContainer o_ThreadNeedactionPreview_sidebarItem">
                         <img class="o_ThreadNeedactionPreview_image" t-att-src="image()" alt="Thread Image"/>
@@ -47,7 +47,7 @@
                             <t t-esc="inlineLastNeedactionMessageAsOriginThreadBody"/>
                         </span>
                         <span class="o-autogrow"/>
-                        <span class="o_ThreadNeedactionPreview_coreItem o_ThreadNeedactionPreview_markAsRead fa fa-check" title="Mark as Read" t-on-click="_onClickMarkAsRead" t-ref="markAsRead"/>
+                        <span class="o_ThreadNeedactionPreview_coreItem o_ThreadNeedactionPreview_markAsRead fa fa-check" title="Mark as Read" t-on-click="threadNeedactionPreviewView.onClickMarkAsRead" t-ref="markAsRead"/>
                     </div>
                 </div>
             </div>

--- a/addons/mail/static/src/components/thread_preview/thread_preview.js
+++ b/addons/mail/static/src/components/thread_preview/thread_preview.js
@@ -2,9 +2,10 @@
 
 import * as mailUtils from '@mail/js/utils';
 
+import { useRefToModel } from '@mail/component_hooks/use_ref_to_model';
 import { registerMessagingComponent } from '@mail/utils/messaging_component';
 
-const { Component, useRef } = owl;
+const { Component } = owl;
 
 export class ThreadPreview extends Component {
 
@@ -13,11 +14,7 @@ export class ThreadPreview extends Component {
      */
     setup() {
         super.setup();
-        /**
-         * Reference of the "mark as read" button. Useful to disable the
-         * top-level click handler when clicking on this specific button.
-         */
-        this._markAsReadRef = useRef('markAsRead');
+        useRefToModel({ fieldName: 'markAsReadRef', modelName: 'ThreadPreviewView', refName: 'markAsRead' });
     }
 
     //--------------------------------------------------------------------------
@@ -53,36 +50,6 @@ export class ThreadPreview extends Component {
      */
     get threadPreviewView() {
         return this.messaging && this.messaging.models['ThreadPreviewView'].get(this.props.localId);
-    }
-
-    //--------------------------------------------------------------------------
-    // Handlers
-    //--------------------------------------------------------------------------
-
-    /**
-     * @private
-     * @param {MouseEvent} ev
-     */
-    _onClick(ev) {
-        const markAsRead = this._markAsReadRef.el;
-        if (markAsRead && markAsRead.contains(ev.target)) {
-            // handled in `_onClickMarkAsRead`
-            return;
-        }
-        this.threadPreviewView.thread.open();
-        if (!this.messaging.device.isMobile) {
-            this.messaging.messagingMenu.close();
-        }
-    }
-
-    /**
-     * @private
-     * @param {MouseEvent} ev
-     */
-    _onClickMarkAsRead(ev) {
-        if (this.threadPreviewView.thread.lastNonTransientMessage) {
-            this.threadPreviewView.thread.markAsSeen(this.threadPreviewView.thread.lastNonTransientMessage);
-        }
     }
 
 }

--- a/addons/mail/static/src/components/thread_preview/thread_preview.xml
+++ b/addons/mail/static/src/components/thread_preview/thread_preview.xml
@@ -7,7 +7,7 @@
                 The preview template is used by the discuss in mobile, and by the systray
                 menu in order to show preview of threads.
             -->
-            <div class="o_ThreadPreview" t-att-class="{ 'o-muted': threadPreviewView.thread.localMessageUnreadCounter === 0 }" t-attf-class="{{ className }}" t-on-click="_onClick" t-att-data-thread-local-id="threadPreviewView.thread.localId" t-ref="root">
+            <div class="o_ThreadPreview" t-att-class="{ 'o-muted': threadPreviewView.thread.localMessageUnreadCounter === 0 }" t-attf-class="{{ className }}" t-on-click="threadPreviewView.onClick" t-att-data-thread-local-id="threadPreviewView.thread.localId" t-ref="root">
                 <div class="o_ThreadPreview_sidebar">
                     <div class="o_ThreadPreview_imageContainer o_ThreadPreview_sidebarItem">
                         <img class="o_ThreadPreview_image rounded-circle" t-att-src="image()" alt="Thread Image"/>
@@ -52,7 +52,7 @@
                         </span>
                         <span class="o-autogrow"/>
                         <t t-if="threadPreviewView.thread.localMessageUnreadCounter > 0">
-                            <span class="o_ThreadPreview_coreItem o_ThreadPreview_markAsRead fa fa-check" title="Mark as Read" t-on-click="_onClickMarkAsRead" t-ref="markAsRead"/>
+                            <span class="o_ThreadPreview_coreItem o_ThreadPreview_markAsRead fa fa-check" title="Mark as Read" t-on-click="threadPreviewView.onClickMarkAsRead" t-ref="markAsRead"/>
                         </t>
                     </div>
                 </div>

--- a/addons/mail/static/src/components/thread_view/thread_view.js
+++ b/addons/mail/static/src/components/thread_view/thread_view.js
@@ -17,23 +17,6 @@ export class ThreadView extends Component {
         return this.messaging && this.messaging.models['ThreadView'].get(this.props.localId);
     }
 
-    //--------------------------------------------------------------------------
-    // Handlers
-    //--------------------------------------------------------------------------
-
-    /**
-     * @private
-     */
-    _onClickRetryLoadMessages() {
-        if (!this.threadView) {
-            return;
-        }
-        if (!this.threadView.threadCache) {
-            return;
-        }
-        this.threadView.threadCache.update({ hasLoadingFailed: false });
-    }
-
 }
 
 Object.assign(ThreadView, {
@@ -41,7 +24,6 @@ Object.assign(ThreadView, {
         hasComposerDiscardButton: false,
         showComposerAttachmentsExtensions: true,
         showComposerAttachmentsFilenames: true,
-        onFocusin: () => {},
     },
     props: {
         hasComposerCurrentPartnerAvatar: {
@@ -61,10 +43,6 @@ Object.assign(ThreadView, {
             optional: true,
         },
         localId: String,
-        onFocusin: {
-            type: Function,
-            optional: true,
-        },
         showComposerAttachmentsExtensions: {
             type: Boolean,
             optional: true,

--- a/addons/mail/static/src/components/thread_view/thread_view.xml
+++ b/addons/mail/static/src/components/thread_view/thread_view.xml
@@ -3,7 +3,7 @@
 
     <t t-name="mail.ThreadView" owl="1">
         <t t-if="threadView">
-            <div class="o_ThreadView" t-att-class="threadView.extraClass" t-attf-class="{{ className }}" t-att-data-correspondent-id="threadView.thread and threadView.thread.correspondent and threadView.thread.correspondent.id" t-att-data-thread-local-id="threadView.thread and threadView.thread.localId" t-on-focusin="props.onFocusin" t-ref="root">
+            <div class="o_ThreadView" t-att-class="threadView.extraClass" t-attf-class="{{ className }}" t-att-data-correspondent-id="threadView.thread and threadView.thread.correspondent and threadView.thread.correspondent.id" t-att-data-thread-local-id="threadView.thread and threadView.thread.localId" t-on-focusin="threadView.onFocusin" t-ref="root">
                 <t t-if="threadView.topbar">
                     <ThreadViewTopbar className="'border-bottom'" localId="threadView.topbar.localId"/>
                 </t>
@@ -29,7 +29,7 @@
                                 <div class="o_ThreadView_loadingFailedText">
                                     An error occurred while fetching messages.
                                 </div>
-                                <button class="o_ThreadView_loadingFailedRetryButton btn btn-link" t-on-click="_onClickRetryLoadMessages">
+                                <button class="o_ThreadView_loadingFailedRetryButton btn btn-link" t-on-click="threadView.onClickRetryLoadMessages">
                                     Click here to retry
                                 </button>
                             </div>

--- a/addons/mail/static/src/components/thread_view_topbar/thread_view_topbar.js
+++ b/addons/mail/static/src/components/thread_view_topbar/thread_view_topbar.js
@@ -31,34 +31,6 @@ export class ThreadViewTopbar extends Component {
         return this.messaging && this.messaging.models['ThreadViewTopbar'].get(this.props.localId);
     }
 
-    //--------------------------------------------------------------------------
-    // Handlers
-    //--------------------------------------------------------------------------
-
-    /**
-     * @private
-     * @param {MouseEvent} ev
-     */
-    async _onClickPhone(ev) {
-        if (this.threadViewTopbar.thread.hasPendingRtcRequest) {
-            return;
-        }
-        await this.threadViewTopbar.thread.toggleCall();
-    }
-
-    /**
-     * @private
-     * @param {MouseEvent} ev
-     */
-    async _onClickCamera(ev) {
-        if (this.threadViewTopbar.thread.hasPendingRtcRequest) {
-            return;
-        }
-        await this.threadViewTopbar.thread.toggleCall({
-            startWithVideo: true,
-        });
-    }
-
 }
 
 Object.assign(ThreadViewTopbar, {

--- a/addons/mail/static/src/components/thread_view_topbar/thread_view_topbar.xml
+++ b/addons/mail/static/src/components/thread_view_topbar/thread_view_topbar.xml
@@ -50,10 +50,10 @@
                         <button class="o_ThreadViewTopbar_unstarAllButton btn btn-secondary" t-att-disabled="threadViewTopbar.threadView.messages.length === 0" t-on-click="threadViewTopbar.onClickUnstarAll">Unstar all</button>
                     </t>
                     <t t-if="threadViewTopbar.thread and threadViewTopbar.thread.hasCallFeature and threadViewTopbar.thread.rtcSessions.length === 0">
-                        <button class="o_ThreadViewTopbar_callButton o_ThreadViewTopbar_button o-active" t-att-disabled="threadViewTopbar.thread.hasPendingRtcRequest" title="Start a Call" t-on-click="_onClickPhone">
+                        <button class="o_ThreadViewTopbar_callButton o_ThreadViewTopbar_button o-active" t-att-disabled="threadViewTopbar.thread.hasPendingRtcRequest" title="Start a Call" t-on-click="threadViewTopbar.onClickPhone">
                             <i class="fa fa-lg fa-phone"/>
                         </button>
-                        <button class="o_ThreadViewTopbar_callButton o_ThreadViewTopbar_button o-active" t-att-disabled="threadViewTopbar.thread.hasPendingRtcRequest" title="Start a Video Call" t-on-click="_onClickCamera">
+                        <button class="o_ThreadViewTopbar_callButton o_ThreadViewTopbar_button o-active" t-att-disabled="threadViewTopbar.thread.hasPendingRtcRequest" title="Start a Video Call" t-on-click="threadViewTopbar.onClickCamera">
                             <i class="fa fa-lg fa-video-camera"/>
                         </button>
                     </t>

--- a/addons/mail/static/src/models/messaging.js
+++ b/addons/mail/static/src/models/messaging.js
@@ -3,7 +3,7 @@
 import { registerModel } from '@mail/model/model_core';
 import { attr, many, one } from '@mail/model/model_field';
 import { OnChange } from '@mail/model/model_onchange';
-import { insertAndReplace, link, unlink } from '@mail/model/model_field_command';
+import { clear, insertAndReplace, link, replace, unlink } from '@mail/model/model_field_command';
 import { makeDeferred } from '@mail/utils/deferred';
 
 const { EventBus } = owl;
@@ -208,6 +208,16 @@ registerModel({
         },
         /**
          * @private
+         * @returns {FieldCommand}
+         */
+        _computeRtcInvitationCards() {
+            if (this.ringingThreads.length === 0) {
+                return clear();
+            }
+            return replace(this.ringingThreads.map(thread => thread.rtcInvitationCard));
+        },
+        /**
+         * @private
          */
         _handleGlobalWindowFocus() {
             this.update({ outOfFocusUnreadMessageCounter: 0 });
@@ -372,6 +382,10 @@ registerModel({
             default: insertAndReplace(),
             isCausal: true,
             readonly: true,
+        }),
+        rtcInvitationCards: many('RtcInvitationCard', {
+            compute: '_computeRtcInvitationCards',
+            isCausal: true,
         }),
         soundEffects: one('SoundEffects', {
             default: insertAndReplace(),

--- a/addons/mail/static/src/models/notification_group_view.js
+++ b/addons/mail/static/src/models/notification_group_view.js
@@ -1,12 +1,17 @@
 /** @odoo-module **/
 
 import { registerModel } from '@mail/model/model_core';
-import { one } from '@mail/model/model_field';
+import { attr, one } from '@mail/model/model_field';
 
 registerModel({
     name: 'NotificationGroupView',
     identifyingFields: ['notificationListViewOwner', 'notificationGroup'],
     fields: {
+        /**
+         * Reference of the "mark as read" button. Useful to disable the
+         * top-level click handler when clicking on this specific button.
+         */
+        markAsReadRef: attr(),
         notificationGroup: one('NotificationGroup', {
             inverse: 'notificationGroupViews',
             readonly: true,

--- a/addons/mail/static/src/models/rtc_invitation_card.js
+++ b/addons/mail/static/src/models/rtc_invitation_card.js
@@ -1,0 +1,37 @@
+/** @odoo-module **/
+
+import { registerModel } from '@mail/model/model_core';
+import { one } from '@mail/model/model_field';
+
+registerModel({
+    name: 'RtcInvitationCard',
+    identifyingFields: ['thread'],
+    recordMethods: {
+        /**
+         * @param {MouseEvent} ev
+         */
+        onClickRefuse(ev) {
+            if (this.thread.hasPendingRtcRequest) {
+                return;
+            }
+            this.thread.leaveCall();
+        },
+        /**
+         * @param {MouseEvent} ev
+         */
+        async onClickAccept(ev) {
+            this.thread.open();
+            if (this.thread.hasPendingRtcRequest) {
+                return;
+            }
+            await this.thread.toggleCall();
+        },
+    },
+    fields: {
+        thread: one('Thread', {
+            inverse: 'rtcInvitationCard',
+            readonly: true,
+            required: true,
+        }),
+    },
+});

--- a/addons/mail/static/src/models/rtc_session.js
+++ b/addons/mail/static/src/models/rtc_session.js
@@ -14,6 +14,23 @@ registerModel({
     },
     recordMethods: {
         /**
+         * Plays the video as some browsers may not support or block autoplay.
+         *
+         * @param {Event} ev
+         */
+        async onVideoLoadedMetaData(ev) {
+            try {
+                await ev.target.play();
+            } catch (error) {
+                if (typeof error === 'object' && error.name === 'NotAllowedError') {
+                    // Ignored as some browsers may reject play() calls that do not
+                    // originate from a user input.
+                    return;
+                }
+                throw error;
+            }
+        },
+        /**
          * restores the session to its default values
          */
         reset() {

--- a/addons/mail/static/src/models/thread.js
+++ b/addons/mail/static/src/models/thread.js
@@ -1627,6 +1627,16 @@ registerModel({
         },
         /**
          * @private
+         * @returns {FieldCommand}
+         */
+        _computeRtcInvitationCard() {
+            if (this.rtcInvitingSession) {
+                return insertAndReplace();
+            }
+            return clear();
+        },
+        /**
+         * @private
          * @returns {Activity[]}
          */
         _computeTodayActivities() {
@@ -2321,6 +2331,11 @@ registerModel({
          */
         rtc: one('Rtc', {
             inverse: 'channel',
+        }),
+        rtcInvitationCard: one('RtcInvitationCard', {
+            compute: '_computeRtcInvitationCard',
+            inverse: 'thread',
+            isCausal: true,
         }),
         /**
          * The session that invited the current user, it is only set when the

--- a/addons/mail/static/src/models/thread_needaction_preview_view.js
+++ b/addons/mail/static/src/models/thread_needaction_preview_view.js
@@ -1,13 +1,39 @@
 /** @odoo-module **/
 
 import { registerModel } from '@mail/model/model_core';
-import { one } from '@mail/model/model_field';
+import { attr, one } from '@mail/model/model_field';
 import { clear, insertAndReplace } from '@mail/model/model_field_command';
 
 registerModel({
     name: 'ThreadNeedactionPreviewView',
     identifyingFields: ['notificationListViewOwner', 'thread'],
     recordMethods: {
+        /**
+         * @param {MouseEvent} ev
+         */
+        onClick(ev) {
+            if (!this.exists()) {
+                return;
+            }
+            const markAsRead = this.markAsReadRef.el;
+            if (markAsRead && markAsRead.contains(ev.target)) {
+                // handled in `_onClickMarkAsRead`
+                return;
+            }
+            this.thread.open();
+            if (!this.messaging.device.isMobile) {
+                this.messaging.messagingMenu.close();
+            }
+        },
+        /**
+         * @param {MouseEvent} ev
+         */
+        onClickMarkAsRead(ev) {
+            this.messaging.models['Message'].markAllAsRead([
+                ['model', '=', this.thread.model],
+                ['res_id', '=', this.thread.id],
+            ]);
+        },
         /**
          * @private
          * @returns {FieldCommand}
@@ -23,6 +49,11 @@ registerModel({
         },
     },
     fields: {
+        /**
+         * Reference of the "mark as read" button. Useful to disable the
+         * top-level click handler when clicking on this specific button.
+         */
+        markAsReadRef: attr(),
         messageAuthorPrefixView: one('MessageAuthorPrefixView', {
             compute: '_computeMessageAuthorPrefixView',
             inverse: 'threadNeedactionPreviewViewOwner',

--- a/addons/mail/static/src/models/thread_preview_view.js
+++ b/addons/mail/static/src/models/thread_preview_view.js
@@ -1,13 +1,38 @@
 /** @odoo-module **/
 
 import { registerModel } from '@mail/model/model_core';
-import { one } from '@mail/model/model_field';
+import { attr, one } from '@mail/model/model_field';
 import { clear, insertAndReplace } from '@mail/model/model_field_command';
 
 registerModel({
     name: 'ThreadPreviewView',
     identifyingFields: ['notificationListViewOwner', 'thread'],
     recordMethods: {
+        /**
+         * @param {MouseEvent} ev
+         */
+        onClick(ev) {
+            if (!this.exists()) {
+                return;
+            }
+            const markAsRead = this.markAsReadRef.el;
+            if (markAsRead && markAsRead.contains(ev.target)) {
+                // handled in `_onClickMarkAsRead`
+                return;
+            }
+            this.thread.open();
+            if (!this.messaging.device.isMobile) {
+                this.messaging.messagingMenu.close();
+            }
+        },
+        /**
+         * @param {MouseEvent} ev 
+         */
+        onClickMarkAsRead(ev) {
+            if (this.thread.lastNonTransientMessage) {
+                this.thread.markAsSeen(this.thread.lastNonTransientMessage);
+            }
+        },
         /**
          * @private
          * @returns {FieldCommand}
@@ -23,6 +48,11 @@ registerModel({
         },
     },
     fields: {
+        /**
+         * Reference of the "mark as read" button. Useful to disable the
+         * top-level click handler when clicking on this specific button.
+         */
+        markAsReadRef: attr(),
         messageAuthorPrefixView: one('MessageAuthorPrefixView', {
             compute: '_computeMessageAuthorPrefixView',
             inverse: 'threadPreviewViewOwner',

--- a/addons/mail/static/src/models/thread_view.js
+++ b/addons/mail/static/src/models/thread_view.js
@@ -53,6 +53,27 @@ registerModel({
                 threadViewer: this.threadViewer,
             });
         },
+        onClickRetryLoadMessages() {
+            if (!this.exists()) {
+                return;
+            }
+            if (!this.threadCache) {
+                return;
+            }
+            this.threadCache.update({ hasLoadingFailed: false });
+        },
+        /**
+         * Called when an element in the thread becomes focused.
+         */
+        onFocusin() {
+            if (!this.exists()) {
+                // prevent crash on destroy
+                return;
+            }
+            if (this.threadViewer.chatWindow) {
+                this.threadViewer.chatWindow.update({ isFocused: true });
+            }
+        },
         /**
          * Starts editing the last message of this thread from the current user.
          */

--- a/addons/mail/static/src/models/thread_view_topbar.js
+++ b/addons/mail/static/src/models/thread_view_topbar.js
@@ -17,6 +17,17 @@ registerModel({
     },
     recordMethods: {
         /**
+         * @param {MouseEvent} ev
+         */
+        async onClickCamera(ev) {
+            if (this.thread.hasPendingRtcRequest) {
+                return;
+            }
+            await this.thread.toggleCall({
+                startWithVideo: true,
+            });
+        },
+        /**
          * Handles click on the "hide member list" button.
          *
          * @param {Event} ev
@@ -44,6 +55,15 @@ registerModel({
             } else {
                 this.openInvitePopoverView();
             }
+        },
+        /**
+         * @param {MouseEvent} ev
+         */
+        async onClickPhone(ev) {
+            if (this.thread.hasPendingRtcRequest) {
+                return;
+            }
+            await this.thread.toggleCall();
         },
         /**
          * Handles click on the "show member list" button.


### PR DESCRIPTION
This commit moves some handler methods from components to models,
as a step closer to having most of business code in models.

Having business code in models is desirable so that the code is much more maintainable:
easier to change and more robust code.

Task-2579306