### PR TITLE
[IMP] mail: introduce AutocompleteInputView (step 2)

### DIFF
--- a/addons/mail/static/src/components/autocomplete_input/autocomplete_input.js
+++ b/addons/mail/static/src/components/autocomplete_input/autocomplete_input.js
@@ -57,6 +57,13 @@ export class AutocompleteInput extends Component {
         $(this.root.el).autocomplete('destroy');
     }
 
+    /**
+     * @returns {AutocompleteInputView}
+     */
+     get autocompleteInputView() {
+        return this.messaging && this.messaging.models['AutocompleteInputView'].get(this.props.localId);
+    }
+
     //--------------------------------------------------------------------------
     // Public
     //--------------------------------------------------------------------------
@@ -154,8 +161,6 @@ Object.assign(AutocompleteInput, {
     defaultProps: {
         isFocusOnMount: false,
         isHtml: false,
-        placeholder: '',
-        onFocusin: () => {},
     },
     props: {
         customClass: {
@@ -174,10 +179,7 @@ Object.assign(AutocompleteInput, {
             type: Boolean,
             optional: true,
         },
-        onFocusin: {
-            type: Function,
-            optional: true,
-        },
+        localId: String,
         onHide: {
             type: Function,
             optional: true,

--- a/addons/mail/static/src/components/autocomplete_input/autocomplete_input.xml
+++ b/addons/mail/static/src/components/autocomplete_input/autocomplete_input.xml
@@ -2,7 +2,7 @@
 <templates xml:space="preserve">
 
     <t t-name="mail.AutocompleteInput" owl="1">
-        <input class="o_AutocompleteInput" t-attf-class="{{ className }}" t-on-blur="_onBlur" t-on-focusin="props.onFocusin" t-on-keydown="_onKeydown" t-att-placeholder="props.placeholder" t-ref="root"/>
+        <input class="o_AutocompleteInput" t-attf-class="{{ className }}" t-on-blur="_onBlur" t-on-focusin="autocompleteInputView.onFocusin" t-on-keydown="_onKeydown" t-att-placeholder="autocompleteInputView.placeholder" t-ref="root"/>
     </t>
 
 </templates>

--- a/addons/mail/static/src/components/chat_window/chat_window.xml
+++ b/addons/mail/static/src/components/chat_window/chat_window.xml
@@ -41,10 +41,9 @@
                         </span>
                         <AutocompleteInput
                             className="'o_ChatWindow_newMessageFormInput'"
-                            placeholder="chatWindow.newMessageFormInputPlaceholder"
+                            localId="chatWindow.newMessageAutocompleteInputView.localId"
                             select="_onAutocompleteSelect"
                             source="_onAutocompleteSource"
-                            onFocusin="chatWindow.onFocusInNewMessageFormInput"
                             inputRef="_inputRef"
                         />
                     </div>

--- a/addons/mail/static/src/components/discuss/discuss.js
+++ b/addons/mail/static/src/components/discuss/discuss.js
@@ -12,7 +12,6 @@ export class Discuss extends LegacyComponent {
     setup() {
         this._updateLocalStoreProps();
         // bind since passed as props
-        this._onMobileAddItemHeaderInputSelect = this._onMobileAddItemHeaderInputSelect.bind(this);
         this._onMobileAddItemHeaderInputSource = this._onMobileAddItemHeaderInputSource.bind(this);
         useUpdate({ func: () => this._update() });
         this._onHideMobileAddItemHeader = this._onHideMobileAddItemHeader.bind(this);
@@ -91,25 +90,6 @@ export class Discuss extends LegacyComponent {
             return;
         }
         this.discussView.discuss.clearIsAddingItem();
-    }
-
-    /**
-     * @private
-     * @param {Event} ev
-     * @param {Object} ui
-     * @param {Object} ui.item
-     * @param {integer} ui.item.id
-     */
-    _onMobileAddItemHeaderInputSelect(ev, ui) {
-        if (!this.discussView) {
-            return;
-        }
-        const discuss = this.discussView.discuss;
-        if (discuss.isAddingChannel) {
-            discuss.handleAddChannelAutocompleteSelect(ev, ui);
-        } else {
-            discuss.handleAddChatAutocompleteSelect(ev, ui);
-        }
     }
 
     /**

--- a/addons/mail/static/src/components/discuss/discuss.xml
+++ b/addons/mail/static/src/components/discuss/discuss.xml
@@ -33,8 +33,8 @@
                     className="'o_Discuss_mobileAddItemHeaderInput'"
                     isFocusOnMount="true"
                     isHtml="discussView.discuss.isAddingChannel"
-                    placeholder="discussView.discuss.isAddingChannel ? discussView.discuss.addChannelInputPlaceholder : discussView.discuss.addChatInputPlaceholder"
-                    select="_onMobileAddItemHeaderInputSelect"
+                    localId="discussView.mobileAddItemHeaderAutocompleteInputView.localId"
+                    select="discussView.onMobileAddItemHeaderInputSelect"
                     source="_onMobileAddItemHeaderInputSource"
                     onHide="_onHideMobileAddItemHeader"
                 />

--- a/addons/mail/static/src/components/discuss_sidebar_category/discuss_sidebar_category.xml
+++ b/addons/mail/static/src/components/discuss_sidebar_category/discuss_sidebar_category.xml
@@ -31,9 +31,9 @@
                                 <AutocompleteInput
                                     className="'o_DiscussSidebarCategory_addingItemInput flex-grow-1'"
                                     customClass="category === messaging.discuss.categoryChannel ? 'o_DiscussSidebarCategory_newChannelAutocompleteSuggestions' : False"
+                                    localId="category.addingItemAutocompleteInputView.localId"
                                     isFocusOnMount="true"
                                     isHtml="category === messaging.discuss.categoryChannel ? true : False"
-                                    placeholder="category.newItemPlaceholderText"
                                     select="category.onAddItemAutocompleteSelect"
                                     source="category.onAddItemAutocompleteSource"
                                     onHide="category.onHideAddingItem"

--- a/addons/mail/static/src/components/messaging_menu/messaging_menu.js
+++ b/addons/mail/static/src/components/messaging_menu/messaging_menu.js
@@ -21,7 +21,6 @@ export class MessagingMenu extends Component {
         this._onMobileNewMessageInputSelect = this._onMobileNewMessageInputSelect.bind(this);
         this._onMobileNewMessageInputSource = this._onMobileNewMessageInputSource.bind(this);
         this._onClickCaptureGlobal = this._onClickCaptureGlobal.bind(this);
-        this._onHideMobileNewMessage = this._onHideMobileNewMessage.bind(this);
         onMounted(() => this._mounted());
         onWillUnmount(() => this._willUnmount());
     }
@@ -65,13 +64,6 @@ export class MessagingMenu extends Component {
         }
         // in all other cases: close the messaging menu when clicking outside
         this.messagingMenu.close();
-    }
-
-    /**
-     * @private
-     */
-    _onHideMobileNewMessage() {
-        this.messagingMenu.toggleMobileNewMessage();
     }
 
     /**

--- a/addons/mail/static/src/components/messaging_menu/messaging_menu.xml
+++ b/addons/mail/static/src/components/messaging_menu/messaging_menu.xml
@@ -43,10 +43,10 @@
                                         className="'o_MessagingMenu_mobileNewMessageInput'"
                                         customClass="id + '_mobileNewMessageInputAutocomplete'"
                                         isFocusOnMount="true"
-                                        placeholder="messagingMenu.mobileNewMessageInputPlaceholder"
+                                        localId="messagingMenu.mobileNewMessageAutocompleteInputView.localId"
                                         select="_onMobileNewMessageInputSelect"
                                         source="_onMobileNewMessageInputSource"
-                                        onHide="_onHideMobileNewMessage"
+                                        onHide="messagingMenu.onHideMobileNewMessage"
                                     />
                                 </t>
                             </div>

--- a/addons/mail/static/src/models/autocomplete_input_view.js
+++ b/addons/mail/static/src/models/autocomplete_input_view.js
@@ -1,7 +1,8 @@
 /** @odoo-module **/
 
 import { registerModel } from '@mail/model/model_core';
-import { one } from '@mail/model/model_field';
+import { attr, one } from '@mail/model/model_field';
+import { clear } from '@mail/model/model_field_command';
 
 registerModel({
     name: 'AutocompleteInputView',
@@ -11,6 +12,40 @@ registerModel({
         'discussViewOwnerAsMobileAddItemHeader',
         'messagingMenuOwnerAsMobileNewMessageInput',
     ]],
+    recordMethods: {
+        /**
+         * @param {FocusEvent} ev
+         */
+        onFocusin(ev) {
+            if (this.chatWindowOwnerAsNewMessage) {
+                this.chatWindowOwnerAsNewMessage.onFocusInNewMessageFormInput(ev);
+                return;
+            }
+        },
+        /**
+         * @private
+         * @returns {string}
+         */
+        _computePlaceholder() {
+            if (this.chatWindowOwnerAsNewMessage) {
+                return this.chatWindowOwnerAsNewMessage.newMessageFormInputPlaceholder;
+            }
+            if (this.discussViewOwnerAsMobileAddItemHeader) {
+                if (this.discussViewOwnerAsMobileAddItemHeader.discuss.isAddingChannel) {
+                    return this.discussViewOwnerAsMobileAddItemHeader.discuss.addChannelInputPlaceholder;
+                } else {
+                    return this.discussViewOwnerAsMobileAddItemHeader.discuss.addChatInputPlaceholder;
+                }
+            }
+            if (this.discussSidebarCategoryOwnerAsAddingItem) {
+                return this.discussSidebarCategoryOwnerAsAddingItem.newItemPlaceholderText;
+            }
+            if (this.messagingMenuOwnerAsMobileNewMessageInput) {
+                return this.messagingMenuOwnerAsMobileNewMessageInput.mobileNewMessageInputPlaceholder;
+            }
+            return clear();
+        },
+    },
     fields: {
         chatWindowOwnerAsNewMessage: one('ChatWindow', {
             inverse: 'newMessageAutocompleteInputView',
@@ -27,6 +62,9 @@ registerModel({
         messagingMenuOwnerAsMobileNewMessageInput: one('MessagingMenu', {
             inverse: 'mobileNewMessageAutocompleteInputView',
             readonly: true,
+        }),
+        placeholder: attr({
+            compute: '_computePlaceholder',
         }),
     },
 });

--- a/addons/mail/static/src/models/discuss_view.js
+++ b/addons/mail/static/src/models/discuss_view.js
@@ -60,6 +60,22 @@ registerModel({
             mailbox.open();
         },
         /**
+         * @param {Event} ev
+         * @param {Object} ui
+         * @param {Object} ui.item
+         * @param {integer} ui.item.id
+         */
+        onMobileAddItemHeaderInputSelect(ev, ui) {
+            if (!this.exists()) {
+                return;
+            }
+            if (this.discuss.isAddingChannel) {
+                this.discuss.handleAddChannelAutocompleteSelect(ev, ui);
+            } else {
+                this.discuss.handleAddChatAutocompleteSelect(ev, ui);
+            }
+        },
+        /**
          * @private
          * @returns {FieldCommand}
          */

--- a/addons/mail/static/src/models/messaging_menu.js
+++ b/addons/mail/static/src/models/messaging_menu.js
@@ -42,6 +42,9 @@ registerModel({
             }
             this.toggleOpen();
         },
+        onHideMobileNewMessage() {
+            this.update({ isMobileNewMessageToggled: false });
+        },
         /**
          * Toggle the visibility of the messaging menu "new message" input in
          * mobile.


### PR DESCRIPTION
This commit moves some business logic from component AutocompleteInput
To model AutocompleteInputView, as a step to move further to having essentially
all business code in models.

Having code in models is desirable to have very maintainable code, thanks to
robust and declarative code with an ORM-like architecture.

Task-2817076
