### PR TITLE
[IMP] l10n_ar: change message error

### DIFF
--- a/addons/l10n_ar/i18n/es.po
+++ b/addons/l10n_ar/i18n/es.po
@@ -1147,10 +1147,9 @@ msgstr "El dígito de validación no es válido para \"%s\""
 #. module: l10n_ar
 #: code:addons/l10n_ar/models/account_move.py:0
 #, python-format
-msgid "There must be one and only one VAT tax per line. Check line \"%s\""
+msgid "There should be a single tax from the \"VAT\" tax group per line, add it to \"%s\". If you already have it, please check the tax configuration, in advanced options, in the corresponding field \"Tax Group\"."
 msgstr ""
-"Debe haber un único y solo un impuesto de IVA por línea. Revise la línea "
-"\"%s\""
+"Debe haber un único impuesto del grupo de impuestos \"IVA\" por línea, agréguelo a \"%s\". En caso de tenerlo, revise la configuración del impuesto, en opciones avanzadas, en el campo correspondiente \"Grupo de Impuestos\"."
 
 #. module: l10n_ar
 #: model:ir.model.fields,help:l10n_ar.field_res_country__l10n_ar_afip_code

--- a/addons/l10n_ar/i18n/l10n_ar.pot
+++ b/addons/l10n_ar/i18n/l10n_ar.pot
@@ -1102,7 +1102,7 @@ msgstr ""
 #. module: l10n_ar
 #: code:addons/l10n_ar/models/account_move.py:0
 #, python-format
-msgid "There must be one and only one VAT tax per line. Check line \"%s\""
+msgid "There should be a single tax from the \"VAT\" tax group per line, add it to \"%s\". If you already have it, please check the tax configuration, in advanced options, in the corresponding field \"Tax Group\"."
 msgstr ""
 
 #. module: l10n_ar

--- a/addons/l10n_ar/models/account_move.py
+++ b/addons/l10n_ar/models/account_move.py
@@ -119,7 +119,7 @@ class AccountMove(models.Model):
             for line in inv.mapped('invoice_line_ids').filtered(lambda x: x.display_type not in ('line_section', 'line_note')):
                 vat_taxes = line.tax_ids.filtered(lambda x: x.tax_group_id.l10n_ar_vat_afip_code)
                 if len(vat_taxes) != 1:
-                    raise UserError(_('There must be one and only one VAT tax per line. Check line "%s"') % line.name)
+                    raise UserError(_('There should be a single tax from the "VAT" tax group per line, add it to "%s". If you already have it, please check the tax configuration, in advanced options, in the corresponding field "Tax Group".') % line.name)
                 elif purchase_aliquots == 'zero' and vat_taxes.tax_group_id.l10n_ar_vat_afip_code != '0':
                     raise UserError(_('On invoice id "%s" you must use VAT Not Applicable on every line.')  % inv.id)
                 elif purchase_aliquots == 'not_zero' and vat_taxes.tax_group_id.l10n_ar_vat_afip_code == '0':

--- a/doc/cla/corporate/adhoc.md
+++ b/doc/cla/corporate/adhoc.md
@@ -19,3 +19,4 @@ Bruno Zanotti bz@adhoc.com.ar https://github.com/Bruno-Zanotti
 Pablo Santiago Paez Sheridan pp@adhoc.com.ar https://github.com/PabloPaezSheridan
 Augusto Weiss awe@adhoc.com.ar https://github.com/augusto-weiss
 Pablo Montenegro pam@adhoc.com.ar https://github.com/pablohmontenegro
+Ignacio Cainelli ica@adhoc.com.ar https://github.com/ica-adhoc


### PR DESCRIPTION
The error message now shows that a VAT tax must be added to that line
and that if it is already added, it may be misconfigured. This improves
the functionality since previously it showed that there should only be
one VAT tax and that could generate confusion in some cases

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
