### PR TITLE
[IMP] partner_autocomplete: use same author name as all other apps

### DIFF
--- a/addons/partner_autocomplete/__manifest__.py
+++ b/addons/partner_autocomplete/__manifest__.py
@@ -9,7 +9,7 @@
     'description': """
        Auto-complete partner companies' data
     """,
-    'author': "Odoo SA",
+    'author': "Odoo S.A.",
     'category': 'Hidden/Tools',
     'depends': [
         'iap_mail',


### PR DESCRIPTION
Currently all apps across Odoo are licensed under "Odoo S.A." besides of this one, which is licensed under "Odoo SA".
This PR put's it into sync with all other apps:
![image](https://user-images.githubusercontent.com/6352350/164167621-1c851c74-ea2e-4f62-bcfe-3814641d9495.png)
