### PR TITLE
[FIX] payment_ogone: allow any key size

### DIFF
--- a/addons/payment_ogone/models/payment_acquirer.py
+++ b/addons/payment_ogone/models/payment_acquirer.py
@@ -27,9 +27,9 @@ class PaymentAcquirer(models.Model):
     ogone_password = fields.Char(
         string="API User Password", required_if_provider='ogone', groups='base.group_system')
     ogone_shakey_in = fields.Char(
-        string="SHA Key IN", size=32, required_if_provider='ogone', groups='base.group_system')
+        string="SHA Key IN", required_if_provider='ogone', groups='base.group_system')
     ogone_shakey_out = fields.Char(
-        string="SHA Key OUT", size=32, required_if_provider='ogone', groups='base.group_system')
+        string="SHA Key OUT", required_if_provider='ogone', groups='base.group_system')
 
     @api.model
     def _get_compatible_acquirers(self, *args, is_validation=False, **kwargs):


### PR DESCRIPTION
Since odoo/odoo#85759 we are allowed to use other hashing algorithm
with OGONE's payment acquierer.

The V15 fw-port of this PR missed to unlock the max key size.
The goal of this PR is to fix the issue where 32+ length key
were not accepted in V15 and later.

opw-2766648

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
