### PR TITLE
[FIX] stock: select correct preferred route

### DIFF
--- a/addons/stock/models/stock_orderpoint.py
+++ b/addons/stock/models/stock_orderpoint.py
@@ -408,8 +408,9 @@ class StockWarehouseOrderpoint(models.Model):
 
         orderpoints = self.env['stock.warehouse.orderpoint'].with_user(SUPERUSER_ID).create(orderpoint_values_list)
         for orderpoint in orderpoints:
-            orderpoint.route_id = orderpoint.product_id.route_ids[:1]
-        orderpoints.filtered(lambda o: not o.route_id)._set_default_route_id()
+            orderpoint_wh = orderpoint.location_id.get_warehouse()
+            orderpoint.route_id = next((r for r in orderpoint.product_id.route_ids if not r.supplied_wh_id or r.supplied_wh_id == orderpoint_wh), None) \
+                                  or orderpoint._set_default_route_id()
         return action
 
     @api.model


### PR DESCRIPTION
Steps to reproduce:
1 Create two extra warehouses (B and C):
 * Warehouse B: Resupply from San Francisco
 * Warehouse C: Resupply from San Francisco
 
2 Create a new Product:
 * Storable
 * Inventory > Routes: select only Warehouse B and Warehouse C
 
3 Create a new Sale Order:
 * In other Info, select Warehouse C
 * Confirm the SO

Issue:
In replenishment, the defined prefered route will be Warehouse B

Cause:
When the replenishment view is loaded, in
https://github.com/odoo/odoo/blob/5757502a79c920e1aa4c7ca1c581c533907ce674/addons/stock/models/stock_orderpoint.py#L427
The preferred route (route_id) is defined as the first element of the routes defined for the produc which is wrong.

Solution:
Filter the route_ids by selecting the route for which the supplied warehouse is equal to the warehouse selected for the orderpoint.

opw-2815462