### PR TITLE
[FIX] sale_timesheet: fix computation of allocated_hours field

### DIFF
--- a/addons/sale_timesheet/models/project.py
+++ b/addons/sale_timesheet/models/project.py
@@ -200,15 +200,13 @@ class Project(models.Model):
         uoms_dict = {uom.id: uom for uom in self.env['uom.uom'].browse(uom_ids)}
 
         for project in self:
-            if not project.sale_line_id:
-                project.allocated_hours = 0
-                continue
+            project_id = project.id or project._origin.id
             # sale order line may be stored in a different unit of measure, so first
             # we convert all of them to the reference unit
             # if the sol has no product_uom_id then we take the one of the project
             allocated_hours = sum([
                 product_uom_qty * uoms_dict.get(product_uom, project.timesheet_encode_uom_id.id).factor_inv
-                for product_uom, product_uom_qty in sol_qty_dict[project.id]
+                for product_uom, product_uom_qty in sol_qty_dict[project_id]
             ], 0.0)
             # Now convert to the unit of measure to hours
             allocated_hours *= uom_hour.factor


### PR DESCRIPTION
This commit fix the computation of allocated_hours field when
there is origin id instead of id of project.

task-2788878

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
