### PR TITLE
[IMP] mail: move component handlers to models (step 7)

### DIFF
--- a/addons/mail/static/src/components/follower_list_menu/follower_list_menu.js
+++ b/addons/mail/static/src/components/follower_list_menu/follower_list_menu.js
@@ -2,7 +2,7 @@
 
 import { registerMessagingComponent } from '@mail/utils/messaging_component';
 
-const { Component, onMounted, onWillUnmount, useRef, useState } = owl;
+const { Component, onMounted, onWillUnmount, useRef } = owl;
 
 export class FollowerListMenu extends Component {
 
@@ -11,17 +11,10 @@ export class FollowerListMenu extends Component {
      */
     setup() {
         super.setup();
-        this.state = useState({
-            /**
-             * Determine whether the dropdown is open or not.
-             */
-            isDropdownOpen: false,
-        });
         this._dropdownRef = useRef('dropdown');
         this._onClickCaptureGlobal = this._onClickCaptureGlobal.bind(this);
         onMounted(() => this._mounted());
         onWillUnmount(() => this._willUnmount());
-        this._onClickFollower = this._onClickFollower.bind(this);
     }
 
     _mounted() {
@@ -51,31 +44,6 @@ export class FollowerListMenu extends Component {
     }
 
     //--------------------------------------------------------------------------
-    // Private
-    //--------------------------------------------------------------------------
-
-    /**
-     * @private
-     */
-    _hide() {
-        this.state.isDropdownOpen = false;
-    }
-
-    /**
-     * @private
-     * @param {KeyboardEvent} ev
-     */
-    _onKeydown(ev) {
-        ev.stopPropagation();
-        switch (ev.key) {
-            case 'Escape':
-                ev.preventDefault();
-                this._hide();
-                break;
-        }
-    }
-
-    //--------------------------------------------------------------------------
     // Handlers
     //--------------------------------------------------------------------------
 
@@ -85,7 +53,7 @@ export class FollowerListMenu extends Component {
      */
     _onClickAddFollowers(ev) {
         ev.preventDefault();
-        this._hide();
+        this.followerListMenuView.hide();
         this.thread.promptAddPartnerFollower();
     }
 
@@ -98,25 +66,10 @@ export class FollowerListMenu extends Component {
     _onClickCaptureGlobal(ev) {
         // since dropdown is conditionally shown based on state, dropdownRef can be null
         if (this._dropdownRef.el && !this._dropdownRef.el.contains(ev.target)) {
-            this._hide();
+            this.followerListMenuView.hide();
         }
     }
 
-    /**
-     * @private
-     * @param {MouseEvent} ev
-     */
-    _onClickFollowersButton(ev) {
-        this.state.isDropdownOpen = !this.state.isDropdownOpen;
-    }
-
-    /**
-     * @private
-     * @param {MouseEvent} ev
-     */
-    _onClickFollower(ev) {
-        this._hide();
-    }
 }
 
 Object.assign(FollowerListMenu, {

--- a/addons/mail/static/src/components/follower_list_menu/follower_list_menu.xml
+++ b/addons/mail/static/src/components/follower_list_menu/follower_list_menu.xml
@@ -3,14 +3,14 @@
 
     <t t-name="mail.FollowerListMenu" owl="1">
         <t t-if="followerListMenuView and thread">
-            <div class="o_FollowerListMenu position-relative d-flex" t-attf-class="{{ className }}" t-on-keydown="_onKeydown" t-ref="root">
+            <div class="o_FollowerListMenu position-relative d-flex" t-attf-class="{{ className }}" t-on-keydown="followerListMenuView.onKeydown" t-ref="root">
                 <div class="o_FollowerListMenu_followers d-flex" t-ref="dropdown">
-                    <button class="o_FollowerListMenu_buttonFollowers btn btn-link" t-att-disabled="props.isDisabled" t-on-click="_onClickFollowersButton" title="Show Followers" t-att-class="{ 'o_ChatterTopbar_button': props.isChatterButton }">
+                    <button class="o_FollowerListMenu_buttonFollowers btn btn-link" t-att-disabled="props.isDisabled" t-on-click="followerListMenuView.onClickFollowersButton" title="Show Followers" t-att-class="{ 'o_ChatterTopbar_button': props.isChatterButton }">
                         <i class="fa fa-user"/>
                         <span class="o_FollowerListMenu_buttonFollowersCount pl-1" t-esc="thread.followers.length"/>
                     </button>
 
-                    <t t-if="state.isDropdownOpen">
+                    <t t-if="followerListMenuView.isDropdownOpen">
                         <div class="o_FollowerListMenu_dropdown dropdown-menu dropdown-menu-right flex-column d-flex" role="menu">
                             <t t-if="thread.model !== 'channel' and thread.hasWriteAccess">
                                 <a class="o_FollowerListMenu_addFollowersButton dropdown-item" href="#" role="menuitem" t-on-click="_onClickAddFollowers">
@@ -25,7 +25,7 @@
                                     t-foreach="thread.followers" t-as="follower" t-key="follower.localId"
                                     className="'o_FollowerMenu_follower dropdown-item'"
                                     followerLocalId="follower.localId"
-                                    onClick="_onClickFollower"
+                                    onClick="followerListMenuView.onClickFollower"
                                 />
                             </t>
                             <t t-elif="!thread.hasWriteAccess">

--- a/addons/mail/static/src/components/notification_group/notification_group.js
+++ b/addons/mail/static/src/components/notification_group/notification_group.js
@@ -35,37 +35,6 @@ export class NotificationGroup extends Component {
         }
     }
 
-    //--------------------------------------------------------------------------
-    // Handlers
-    //--------------------------------------------------------------------------
-
-    /**
-     * @private
-     * @param {MouseEvent} ev
-     */
-    _onClick(ev) {
-        if (!this.notificationGroupView) {
-            return;
-        }
-        const markAsRead = this.notificationGroupView.markAsReadRef.el;
-        if (markAsRead && markAsRead.contains(ev.target)) {
-            // handled in `_onClickMarkAsRead`
-            return;
-        }
-        this.notificationGroupView.notificationGroup.openDocuments();
-        if (!this.messaging.device.isMobile) {
-            this.messaging.messagingMenu.close();
-        }
-    }
-
-    /**
-     * @private
-     * @param {MouseEvent} ev
-     */
-    _onClickMarkAsRead(ev) {
-        this.notificationGroupView.notificationGroup.notifyCancel();
-    }
-
 }
 
 Object.assign(NotificationGroup, {

--- a/addons/mail/static/src/components/notification_group/notification_group.xml
+++ b/addons/mail/static/src/components/notification_group/notification_group.xml
@@ -3,7 +3,7 @@
 
     <t t-name="mail.NotificationGroup" owl="1">
         <t t-if="notificationGroupView">
-            <div class="o_NotificationGroup" t-attf-class="{{ className }}" t-on-click="_onClick" t-ref="root">
+            <div class="o_NotificationGroup" t-attf-class="{{ className }}" t-on-click="notificationGroupView.onClick" t-ref="root">
                 <div class="o_NotificationGroup_sidebar">
                     <div class="o_NotificationGroup_imageContainer o_NotificationGroup_sidebarItem">
                         <img class="o_NotificationGroup_image rounded-circle" t-att-src="image()" alt="Message delivery failure image"/>
@@ -33,7 +33,7 @@
                             </t>
                         </span>
                         <span class="o-autogrow"/>
-                        <span class="o_NotificationGroup_coreItem o_NotificationGroup_markAsRead fa fa-check" title="Discard message delivery failures" t-on-click="_onClickMarkAsRead" t-ref="markAsRead"/>
+                        <span class="o_NotificationGroup_coreItem o_NotificationGroup_markAsRead fa fa-check" title="Discard message delivery failures" t-on-click="notificationGroupView.onClickMarkAsRead" t-ref="markAsRead"/>
                     </div>
                 </div>
             </div>

--- a/addons/mail/static/src/components/rtc_activity_notice/rtc_activity_notice.js
+++ b/addons/mail/static/src/components/rtc_activity_notice/rtc_activity_notice.js
@@ -4,21 +4,7 @@ import { registerMessagingComponent } from '@mail/utils/messaging_component';
 
 const { Component } = owl;
 
-export class RtcActivityNotice extends Component {
-
-    //--------------------------------------------------------------------------
-    // Handlers
-    //--------------------------------------------------------------------------
-
-    /**
-     * @private
-     * @param {MouseEvent} ev
-     */
-    _onClick(ev) {
-        this.messaging.rtc.channel.open();
-    }
-
-}
+export class RtcActivityNotice extends Component {}
 
 Object.assign(RtcActivityNotice, {
     props: {},

--- a/addons/mail/static/src/components/rtc_activity_notice/rtc_activity_notice.xml
+++ b/addons/mail/static/src/components/rtc_activity_notice/rtc_activity_notice.xml
@@ -7,7 +7,7 @@
                 <RtcInvitations/>
                 <t t-if="messaging.rtc.channel">
                     <t t-set="title">Open conference: <t t-esc="messaging.rtc.channel.displayName"/></t>
-                    <a class="o_RtcActivityNotice_button px-3 user-select-none dropdown-toggle o-no-caret o-dropdown--narrow" t-att-title="title" role="button" t-on-click="_onClick">
+                    <a class="o_RtcActivityNotice_button px-3 user-select-none dropdown-toggle o-no-caret o-dropdown--narrow" t-att-title="title" role="button" t-on-click="messaging.rtc.onClickActivityNoticeButton">
                         <div class="o_RtcActivityNotice_buttonContent d-flex align-items-center">
                             <i class="o_RtcActivityNotice_outputIndicator fa fa-lg" t-att-class="{
                                 'fa-microphone': !messaging.rtc.sendDisplay and !messaging.rtc.sendUserVideo,

--- a/addons/mail/static/src/components/rtc_call_participant_card/rtc_call_participant_card.js
+++ b/addons/mail/static/src/components/rtc_call_participant_card/rtc_call_participant_card.js
@@ -1,10 +1,11 @@
 /** @odoo-module **/
 
+import { useRefToModel } from '@mail/component_hooks/use_ref_to_model';
 import { registerMessagingComponent } from '@mail/utils/messaging_component';
 
 import Popover from "web.Popover";
 
-const { Component, useRef } = owl;
+const { Component } = owl;
 
 export class RtcCallParticipantCard extends Component {
 
@@ -13,7 +14,7 @@ export class RtcCallParticipantCard extends Component {
      */
     setup() {
         super.setup();
-        this._volumeMenuAnchorRef = useRef('volumeMenuAnchor');
+        useRefToModel({ fieldName: 'volumeMenuAnchorRef', modelName: 'RtcCallParticipantCard', refName: 'volumeMenuAnchor' });
     }
 
     //--------------------------------------------------------------------------
@@ -27,24 +28,6 @@ export class RtcCallParticipantCard extends Component {
         return this.messaging.models['RtcCallParticipantCard'].get(this.props.localId);
     }
 
-    //--------------------------------------------------------------------------
-    // Handlers
-    //--------------------------------------------------------------------------
-
-    /**
-     * This listens to the right click event, and used to redirect the event
-     * as a click on the popover.
-     *
-     * @private
-     * @param {Event} ev
-     */
-    async _onContextMenu(ev) {
-        ev.preventDefault();
-        if (!this._volumeMenuAnchorRef || !this._volumeMenuAnchorRef.el) {
-            return;
-        }
-        this._volumeMenuAnchorRef.el.click();
-    }
 }
 
 Object.assign(RtcCallParticipantCard, {

--- a/addons/mail/static/src/components/rtc_call_participant_card/rtc_call_participant_card.xml
+++ b/addons/mail/static/src/components/rtc_call_participant_card/rtc_call_participant_card.xml
@@ -10,7 +10,7 @@
                     'o-isInvitation': callParticipantCard.isInvitation,
                 }"
                 t-attf-class="{{ className }}"
-                t-on-contextmenu="_onContextMenu"
+                t-on-contextmenu="callParticipantCard.onContextMenu"
                 t-ref="root"
             >
                 <div class="o_RtcCallParticipantCard_container align-items-center"

--- a/addons/mail/static/src/components/rtc_call_viewer/rtc_call_viewer.xml
+++ b/addons/mail/static/src/components/rtc_call_viewer/rtc_call_viewer.xml
@@ -51,7 +51,7 @@
             <!-- Dialogs -->
             <t t-if="messaging.userSetting.rtcConfigurationMenu.isOpen">
                 <Dialog size="'small'" title="rtcCallViewer.settingsTitle" onClosed="rtcCallViewer.onRtcSettingsDialogClosed">
-                    <RtcConfigurationMenu/>
+                    <RtcConfigurationMenu localId="messaging.userSetting.rtcConfigurationMenu.localId"/>
                     <t t-set-slot="buttons">
                         <!-- Explicit No buttons -->
                     </t>

--- a/addons/mail/static/src/components/rtc_configuration_menu/rtc_configuration_menu.js
+++ b/addons/mail/static/src/components/rtc_configuration_menu/rtc_configuration_menu.js
@@ -23,52 +23,17 @@ export class RtcConfigurationMenu extends Component {
         this.state.userDevices = await browser.navigator.mediaDevices.enumerateDevices();
     }
 
-    //--------------------------------------------------------------------------
-    // Handlers
-    //--------------------------------------------------------------------------
-
     /**
-     * @private
-     * @param {Event} ev
+     * @returns {RtcConfigurationMenu|undefined}
      */
-    _onChangeDelay(ev) {
-        this.messaging.userSetting.rtcConfigurationMenu.onChangeDelay(ev.target.value);
+    get rtcConfigurationMenu() {
+        return this.messaging && this.messaging.models['RtcConfigurationMenu'].get(this.props.localId);
     }
 
-    /**
-     * @private
-     * @param {Event} ev
-     */
-    _onChangePushToTalk(ev) {
-        this.messaging.userSetting.rtcConfigurationMenu.onChangePushToTalk();
-    }
-
-    /**
-     * @private
-     * @param {Event} ev
-     */
-    _onChangeSelectAudioInput(ev) {
-        this.messaging.userSetting.rtcConfigurationMenu.onChangeSelectAudioInput(ev.target.value);
-    }
-
-    /**
-     * @private
-     * @param {Event} ev
-     */
-    _onChangeThreshold(ev) {
-        this.messaging.userSetting.rtcConfigurationMenu.onChangeThreshold(ev.target.value);
-    }
-
-    /**
-     * @private
-     * @param {MouseEvent} ev
-     */
-    _onClickRegisterKeyButton() {
-        this.messaging.userSetting.rtcConfigurationMenu.onClickRegisterKeyButton();
-    }
 }
 
 Object.assign(RtcConfigurationMenu, {
+    props: { localId: String },
     template: 'mail.RtcConfigurationMenu',
 });
 

--- a/addons/mail/static/src/components/rtc_configuration_menu/rtc_configuration_menu.xml
+++ b/addons/mail/static/src/components/rtc_configuration_menu/rtc_configuration_menu.xml
@@ -7,7 +7,7 @@
                 <label class="o_RtcConfigurationMenu_optionLabel" title="Input device" aria-label="Input device">
                     <span class="o_RtcConfigurationMenu_optionName">Input device</span>
                     <div>
-                        <select name="inputDevice" class="o_RtcConfigurationMenu_optionDeviceSelect" t-att-value="messaging.userSetting.audioInputDeviceId" t-on-change="_onChangeSelectAudioInput">
+                        <select name="inputDevice" class="o_RtcConfigurationMenu_optionDeviceSelect" t-att-value="messaging.userSetting.audioInputDeviceId" t-on-change="rtcConfigurationMenu.onChangeSelectAudioInput">
                             <option value="">Browser default</option>
                             <t t-if="state.userDevices" t-foreach="state.userDevices" t-as="device" t-key="device_index">
                                 <t t-if="device.kind === 'audioinput'">
@@ -21,7 +21,7 @@
             <div class="o_RtcConfigurationMenu_option">
                 <label class="o_RtcConfigurationMenu_optionLabel" title="Use Push-to-talk" aria-label="Use Push-to-talk">
                     <span class="o_RtcConfigurationMenu_optionName">Use Push-to-talk</span>
-                    <input type="checkbox" aria-label="toggle push-to-talk" title="toggle push-to-talk" t-on-change="_onChangePushToTalk" t-att-checked="messaging.userSetting.usePushToTalk ? 'checked' : ''"/>
+                    <input type="checkbox" aria-label="toggle push-to-talk" title="toggle push-to-talk" t-on-change="rtcConfigurationMenu.onChangePushToTalk" t-att-checked="messaging.userSetting.usePushToTalk ? 'checked' : ''"/>
                 </label>
             </div>
             <t t-if="messaging.userSetting.usePushToTalk">
@@ -30,10 +30,10 @@
                         <span class="o_RtcConfigurationMenu_optionName">Push-to-talk key</span>
                         <span class="o_RtcConfigurationMenu_optionPushToTalkGroup">
                             <t t-if="messaging.userSetting.pushToTalkKey">
-                                <span class="o_RtcConfigurationMenu_optionPushToTalkGroupKey" t-att-class="{ 'o-isRegistering': messaging.userSetting.rtcConfigurationMenu.isRegisteringKey }" t-esc="messaging.userSetting.pushToTalkKeyToString()"/>
+                                <span class="o_RtcConfigurationMenu_optionPushToTalkGroupKey" t-att-class="{ 'o-isRegistering': rtcConfigurationMenu.isRegisteringKey }" t-esc="messaging.userSetting.pushToTalkKeyToString()"/>
                             </t>
-                            <button class="o_RtcConfigurationMenu_button" t-on-click="_onClickRegisterKeyButton">
-                                <t t-if="messaging.userSetting.rtcConfigurationMenu.isRegisteringKey">
+                            <button class="o_RtcConfigurationMenu_button" t-on-click="rtcConfigurationMenu.onClickRegisterKeyButton">
+                                <t t-if="rtcConfigurationMenu.isRegisteringKey">
                                     <i title="Cancel" aria-label="Cancel" class="fa fa-2x fa-times-circle"/>
                                 </t>
                                 <t t-else="">
@@ -44,12 +44,12 @@
                     </label>
 
                 </div>
-                <div t-if="messaging.userSetting.rtcConfigurationMenu.isRegisteringKey">Press a key to register it as the push-to-talk shortcut</div>
+                <div t-if="rtcConfigurationMenu.isRegisteringKey">Press a key to register it as the push-to-talk shortcut</div>
                 <div class="o_RtcConfigurationMenu_option">
                     <label class="o_RtcConfigurationMenu_optionLabel" title="Delay after releasing push-to-talk" aria-label="Delay after releasing push-to-talk">
                         <span class="o_RtcConfigurationMenu_optionName">Delay after releasing push-to-talk</span>
                         <div class="o_RtcConfigurationMenu_optionInputGroup">
-                        <input class="o_RtcConfigurationMenu_optionInputGroupInput" type="range" min="1" max="2000" step="1" t-att-value="messaging.userSetting.voiceActiveDuration" t-on-change="_onChangeDelay"/>
+                        <input class="o_RtcConfigurationMenu_optionInputGroupInput" type="range" min="1" max="2000" step="1" t-att-value="messaging.userSetting.voiceActiveDuration" t-on-change="rtcConfigurationMenu.onChangeDelay"/>
                         <span class="o_RtcConfigurationMenu_optionInputGroupValue"><t t-esc="messaging.userSetting.voiceActiveDuration"/>ms</span>
                         </div>
                     </label>
@@ -60,7 +60,7 @@
                     <label class="o_RtcConfigurationMenu_optionLabel" title="Minimum activity for voice detection" aria-label="Minimum activity for voice detection">
                         <span class="o_RtcConfigurationMenu_optionName">Minimum activity for voice detection</span>
                         <div class="o_RtcConfigurationMenu_optionInputGroup">
-                            <input class="o_RtcConfigurationMenu_optionInputGroupInput" type="range" min="0.001" max="1" step="0.001" t-att-value="messaging.userSetting.voiceActivationThreshold" t-on-change="_onChangeThreshold"/>
+                            <input class="o_RtcConfigurationMenu_optionInputGroupInput" type="range" min="0.001" max="1" step="0.001" t-att-value="messaging.userSetting.voiceActivationThreshold" t-on-change="rtcConfigurationMenu.onChangeThreshold"/>
                             <span class="o_RtcConfigurationMenu_optionInputGroupValue"><t t-esc="messaging.userSetting.voiceActivationThreshold"/></span>
                         </div>
                     </label>

--- a/addons/mail/static/src/components/rtc_invitation_card/rtc_invitation_card.js
+++ b/addons/mail/static/src/components/rtc_invitation_card/rtc_invitation_card.js
@@ -17,18 +17,6 @@ export class RtcInvitationCard extends Component {
         return this.messaging.models['RtcInvitationCard'].get(this.props.localId);
     }
 
-    //--------------------------------------------------------------------------
-    // Handlers
-    //--------------------------------------------------------------------------
-
-    /**
-     * @private
-     * @param {MouseEvent} ev
-     */
-    _onClickAvatar(ev) {
-        this.rtcInvitationCard.thread.open();
-    }
-
 }
 
 Object.assign(RtcInvitationCard, {

--- a/addons/mail/static/src/components/rtc_invitation_card/rtc_invitation_card.xml
+++ b/addons/mail/static/src/components/rtc_invitation_card/rtc_invitation_card.xml
@@ -8,7 +8,7 @@
                     <div class="o_RtcInvitationCard_partnerInfo">
                         <img class="o_RtcInvitationCard_partnerInfoImage rounded-circle"
                             t-att-src="rtcInvitationCard.thread.rtcInvitingSession.avatarUrl"
-                            t-on-click="_onClickAvatar"
+                            t-on-click="rtcInvitationCard.onClickAvatar"
                             alt="Avatar"/>
                         <span class="o_RtcInvitationCard_partnerInfoName" t-esc="rtcInvitationCard.thread.rtcInvitingSession.name"/>
                         <span class="o_RtcInvitationCard_partnerInfoText">Incoming Call...</span>

--- a/addons/mail/static/src/models/follower_list_menu_view.js
+++ b/addons/mail/static/src/models/follower_list_menu_view.js
@@ -1,15 +1,47 @@
 /** @odoo-module **/
 
 import { registerModel } from '@mail/model/model_core';
-import { one } from '@mail/model/model_field';
+import { attr, one } from '@mail/model/model_field';
 
 registerModel({
     name: 'FollowerListMenuView',
     identifyingFields: [['chatterOwner']],
+    recordMethods: {
+        hide() {
+            this.update({ isDropdownOpen: false });
+        },
+        /**
+         * @param {MouseEvent} ev
+         */
+        onClickFollower(ev) {
+            this.hide();
+        },
+        /**
+         * @param {MouseEvent} ev
+         */
+        onClickFollowersButton(ev) {
+            this.update({ isDropdownOpen: !this.isDropdownOpen });
+        },
+        /**
+         * @param {KeyboardEvent} ev
+         */
+        onKeydown(ev) {
+            ev.stopPropagation();
+            switch (ev.key) {
+                case 'Escape':
+                    ev.preventDefault();
+                    this.hide();
+                    break;
+            }
+        },
+    },
     fields: {
         chatterOwner: one('Chatter', {
             inverse: 'followerListMenuView',
             readonly: true,
+        }),
+        isDropdownOpen: attr({
+            default: false,
         }),
     },
 });

--- a/addons/mail/static/src/models/notification_group_view.js
+++ b/addons/mail/static/src/models/notification_group_view.js
@@ -6,6 +6,31 @@ import { attr, one } from '@mail/model/model_field';
 registerModel({
     name: 'NotificationGroupView',
     identifyingFields: ['notificationListViewOwner', 'notificationGroup'],
+    recordMethods: {
+        /**
+         * @param {MouseEvent} ev
+         */
+        onClick(ev) {
+            if (!this.exists()) {
+                return;
+            }
+            const markAsRead = this.markAsReadRef.el;
+            if (markAsRead && markAsRead.contains(ev.target)) {
+                // handled in `_onClickMarkAsRead`
+                return;
+            }
+            this.notificationGroup.openDocuments();
+            if (!this.messaging.device.isMobile) {
+                this.messaging.messagingMenu.close();
+            }
+        },
+        /**
+         * @param {MouseEvent} ev
+         */
+        onClickMarkAsRead(ev) {
+            this.notificationGroup.notifyCancel();
+        },
+    },
     fields: {
         /**
          * Reference of the "mark as read" button. Useful to disable the

--- a/addons/mail/static/src/models/rtc.js
+++ b/addons/mail/static/src/models/rtc.js
@@ -148,6 +148,12 @@ registerModel({
             this.messaging.soundEffects.mute.play();
         },
         /**
+         * @param {MouseEvent} ev
+         */
+        onClickActivityNoticeButton(ev) {
+            this.channel.open();
+        },
+        /**
          * Resets the state of the model and cleanly ends all connections and
          * streams.
          *

--- a/addons/mail/static/src/models/rtc_call_participant_card.js
+++ b/addons/mail/static/src/models/rtc_call_participant_card.js
@@ -52,6 +52,19 @@ registerModel({
             markEventHandled(ev, 'CallParticipantCard.clickVolumeAnchor');
         },
         /**
+         * This listens to the right click event, and used to redirect the event
+         * as a click on the popover.
+         *
+         * @param {Event} ev
+         */
+        async onContextMenu(ev) {
+            ev.preventDefault();
+            if (!this.volumeMenuAnchorRef || !this.volumeMenuAnchorRef.el) {
+                return;
+            }
+            this.volumeMenuAnchorRef.el.click();
+        },
+        /**
          * @private
          * @returns {string}
          */
@@ -236,5 +249,6 @@ registerModel({
          * If set, this card represents a rtcSession.
          */
         rtcSession: one('RtcSession'),
+        volumeMenuAnchorRef: attr(),
     },
 });

--- a/addons/mail/static/src/models/rtc_configuration_menu.js
+++ b/addons/mail/static/src/models/rtc_configuration_menu.js
@@ -20,10 +20,10 @@ registerModel({
     },
     recordMethods: {
         /**
-         * @param {String} value
+         * @param {Event} ev
          */
-        onChangeDelay(value) {
-            this.userSetting.setDelayValue(value);
+        onChangeDelay(ev) {
+            this.userSetting.setDelayValue(ev.target.value);
         },
         onChangePushToTalk() {
             if (this.userSetting.usePushToTalk) {
@@ -34,16 +34,16 @@ registerModel({
             this.userSetting.togglePushToTalk();
         },
         /**
-         * @param {String} value
+         * @param {Event} ev
          */
-        onChangeSelectAudioInput(value) {
-            this.userSetting.setAudioInputDevice(value);
+        onChangeSelectAudioInput(ev) {
+            this.userSetting.setAudioInputDevice(ev.target.value);
         },
         /**
-         * @param {String} value
+         * @param {MouseEvent} ev
          */
-        onChangeThreshold(value) {
-            this.userSetting.setThresholdValue(parseFloat(value));
+        onChangeThreshold(ev) {
+            this.userSetting.setThresholdValue(parseFloat(ev.target.value));
         },
         onClickRegisterKeyButton() {
             this.update({

--- a/addons/mail/static/src/models/rtc_invitation_card.js
+++ b/addons/mail/static/src/models/rtc_invitation_card.js
@@ -26,6 +26,12 @@ registerModel({
             }
             await this.thread.toggleCall();
         },
+        /**
+         * @param {MouseEvent} ev
+         */
+        onClickAvatar(ev) {
+            this.thread.open();
+        },
     },
     fields: {
         thread: one('Thread', {


### PR DESCRIPTION
This commit moves some handler methods from components to models,
as a step closer to having most of business code in models.

Having business code in models is desirable so that the code is much more maintainable:
easier to change and more robust code.

Task-2579306

Enterprise: https://github.com/odoo/enterprise/pull/26379
