### PR TITLE
[IMP] website: hide livechat in edit mode

### DIFF
--- a/addons/website/static/src/js/menu/edit.js
+++ b/addons/website/static/src/js/menu/edit.js
@@ -221,6 +221,7 @@ var EditPageMenu = websiteNavbarData.WebsiteNavbarActionWidget.extend({
         if (this.$welcomeMessage) {
             this.$welcomeMessage.detach(); // detach from the readonly rendering before the clone by wysiwyg.
         }
+        $(".o_livechat_button, .o_thread_window").css("display", "none");
         this.editModeEnable = true;
 
         await this._createWysiwyg();


### PR DESCRIPTION
Currently, when the website editor is opened, the LiveChat window/button is
visible.

After this commit, the LiveChat button/window will be hidden in the website
editor.

TaskID: 2824363

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
