### PR TITLE
[IMP] website: hide livechat in edit mode

### DIFF
--- a/addons/website_livechat/__manifest__.py
+++ b/addons/website_livechat/__manifest__.py
@@ -36,6 +36,9 @@ Allow website visitors to chat with the collaborators. This module also brings a
             'website_livechat/static/src/legacy/website_livechat_chatbot_test_script.js',
             'website_livechat/static/src/legacy/public_livechat.scss',
         ],
+        'website.assets_wysiwyg': [
+            'website_livechat/static/src/scss/website_livechat.edit_mode.scss',
+        ],
         'website.assets_editor': [
             'website_livechat/static/src/js/systray_items/*.js',
         ],

--- a/addons/website_livechat/static/src/scss/website_livechat.edit_mode.scss
+++ b/addons/website_livechat/static/src/scss/website_livechat.edit_mode.scss
@@ -1,0 +1,5 @@
+body.editor_enable {
+    .o_livechat_button, .o_thread_window {
+        display: none;
+    }
+}


### PR DESCRIPTION
Currently, when the website editor is opened, the LiveChat window/button is
visible.

After this PR, the LiveChat button/window will be hidden in the website
editor.

TaskID: 2824363