### PR TITLE
[FIX] pos_loyalty: fix gift card

### DIFF
--- a/addons/pos_loyalty/__manifest__.py
+++ b/addons/pos_loyalty/__manifest__.py
@@ -12,6 +12,7 @@
     'data': [
         'security/ir.model.access.csv',
         'data/default_barcode_patterns.xml',
+        'data/gift_card_data.xml',
         'views/loyalty_card_views.xml',
         'views/loyalty_mail_views.xml',
         'views/pos_config_views.xml',

--- a/addons/pos_loyalty/data/gift_card_data.xml
+++ b/addons/pos_loyalty/data/gift_card_data.xml
@@ -1,48 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <odoo>
-    <!-- TODO: ?? dunno adapt stuff -->
-    <record id="gift_card_report_pdf" model="ir.actions.report">
-        <field name="name">Gift Card</field>
-        <field name="model">loyalty.card</field>
-        <field name="report_type">qweb-pdf</field>
-        <field name="report_name">sale_loyalty.gift_card_template</field>
-        <field name="binding_type">report</field>
-        <field name="binding_model_id" ref="loyalty.model_loyalty_card"/>
+    <record id="loyalty.gift_card_product_50" model="product.product">
+        <field name="available_in_pos">True</field>
+        <field name="taxes_id" eval="False"/>
     </record>
-
-    <template id="gift_card_template">
-        <t t-call="web.html_container">
-            <t t-foreach="docs" t-as="o">
-                <t t-call="web.external_layout">
-                    <div style="margin:0px; font-size:24px; font-family:arial, 'helvetica neue', helvetica, sans-serif; line-height:36px; color:#333333; text-align: center">
-                        Here is your gift card!
-                    </div>
-                    <div style="padding-top:20px; padding-bottom:20px">
-                        <img src="/gift_card/static/img/gift_card.png" style="display:block; border:0; outline:none; text-decoration:none; margin:auto;" width="300"/>
-                    </div>
-                    <div style="padding:0; margin:0px; padding-top:35px; padding-bottom:35px; text-align:center;">
-                        <h3 style="margin:0px; line-height:48px; font-family:arial, 'helvetica neue', helvetica, sans-serif; font-size:40px; font-style:normal; font-weight:normal; color:#333333; text-align:center">
-                            <strong><span t-field="o.initial_amount"/></strong>
-                        </h3>
-                    </div>
-                    <div style="padding:0; margin:0px; padding-top:35px; padding-bottom:35px; background-color:#efefef; text-align:center;">
-                        <p style="margin:0px; font-size:14px;font-family:arial, 'helvetica neue', helvetica, sans-serif; line-height:21px; color:#333333">
-                            <strong>Gift Card Code</strong>
-                        </p>
-                        <p style="margin:0px; font-size:25px;font-family:arial, 'helvetica neue', helvetica, sans-serif; line-height:38px; color:#A9A9A9">
-                            <span t-field="o.code"/>
-                        </p>
-                    </div>
-                    <div style="padding:0; margin:0px; padding-top:10px; padding-bottom:10px; text-align:center;">
-                        <h3 style="margin:0px; line-height:17px; font-family:arial, 'helvetica neue', helvetica, sans-serif; font-size:14px; font-style:normal; font-weight:normal; color:#A9A9A9; text-align:center">
-                            Card expires <span t-field="o.expired_date"/>
-                        </h3>
-                    </div>
-                    <div style="padding:0; margin:0px; padding-top:10px; padding-bottom:10px; text-align:center;">
-                        <img t-att-src="'/report/barcode/Code128/'+o.code" style="width:200px;height:50px" alt="Barcode"/>
-                    </div>
-                </t>
-            </t>
-        </t>
-    </template>
 </odoo>

--- a/addons/pos_loyalty/static/src/js/Loyalty.js
+++ b/addons/pos_loyalty/static/src/js/Loyalty.js
@@ -1055,6 +1055,7 @@ const PosLoyaltyOrder = (Order) => class PosLoyaltyOrder extends Order {
             pointCost = Math.min(maxDiscount, discountable) / reward.discount;
         }
         // These are considered payments and do not require to be either taxed or split by tax
+        const discountProduct = reward.discount_line_product_id;
         if (['ewallet', 'gift_card'].includes(reward.program_id.program_type)) {
             return [{
                 product: discountProduct,
@@ -1069,7 +1070,6 @@ const PosLoyaltyOrder = (Order) => class PosLoyaltyOrder extends Order {
             }];
         }
         const discountFactor = discountable ? Math.min(1, (maxDiscount / discountable)) : 1;
-        const discountProduct = reward.discount_line_product_id;
         const result = Object.entries(discountablePerTax).reduce((lst, entry) => {
             const taxIds = entry[0] === '' ? [] : entry[0].split(',').map((str) => parseInt(str));
             lst.push({


### PR DESCRIPTION
It was impossible to create a new gift card or pay with a gift card from the front end.

With this fix, it's possible to use a gift card code in the front end and to generate a new gift card. The gift card product is now available in the pos.

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
