### PR TITLE
[FIX] sale_project : set project's aa on sol

### DIFF
--- a/addons/sale_project/models/sale_order.py
+++ b/addons/sale_project/models/sale_order.py
@@ -355,8 +355,9 @@ class SaleOrderLine(models.Model):
         """
         values = super(SaleOrderLine, self)._prepare_invoice_line(**optional_values)
         if not values.get('analytic_account_id'):
-            if self.task_id.analytic_account_id:
-                values['analytic_account_id'] = self.task_id._get_task_analytic_account_id().id
+            task_analytic_account = self.task_id._get_task_analytic_account_id() if self.task_id else False
+            if task_analytic_account:
+                values['analytic_account_id'] = task_analytic_account.id
             elif self.project_id.analytic_account_id:
                 values['analytic_account_id'] = self.project_id.analytic_account_id.id
             elif self.is_service and not self.is_expense:


### PR DESCRIPTION
Steps :
Create a Project (P) :
	> Analytic Account : AA
Create a Product (A) :
	> Product Type : Service
	> Create on Order : Task
	> Project : P
Create a Product (B) :
	> Product Type : Consumable
Create and confirm a Quotation :
	> SOL > Product : A
Go to the Task consequently created.
Add B to the products.
Go back to the Quotation and create invoice.

Issue :
See Invoice Lines:
	> INVL(A)'s analytic account is AA.
	> INVL(B)'s is not set.

Cause :
To set the aa on the SOL, we use
SOL.task_id._get_task_analytic_account_id(),
which returns the task's aa or its project's.
Yet we do that only if the task has an aa.

Fix :
Call the method. If it returns something, set it on SOL.

opw-2817811

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
