### PR TITLE
[FIX] product, point_of_sale: min, max margins not applied correctly

### DIFF
--- a/addons/point_of_sale/static/src/js/models.js
+++ b/addons/point_of_sale/static/src/js/models.js
@@ -1559,7 +1559,7 @@ exports.Product = Backbone.Model.extend({
                 price = price - (price * (rule.percent_price / 100));
                 return true;
             } else {
-                var price_limit = price;
+                var price_limit = self.standard_price;
                 price = price - (price * (rule.price_discount / 100));
                 if (rule.price_round) {
                     price = round_pr(price, rule.price_round);

--- a/addons/product/models/product_pricelist.py
+++ b/addons/product/models/product_pricelist.py
@@ -593,7 +593,7 @@ class PricelistItem(models.Model):
             price = (price - (price * (self.percent_price / 100))) or 0.0
         else:
             # complete formula
-            price_limit = price
+            price_limit = product.standard_price
             price = (price - (price * (self.price_discount / 100))) or 0.0
             if self.base == 'standard_price':
                 price_currency = product.cost_currency_id

--- a/addons/product/tests/test_product_pricelist.py
+++ b/addons/product/tests/test_product_pricelist.py
@@ -168,7 +168,7 @@ class TestProductPricelist(TransactionCase):
             'pricelist': pricelist.id, 'quantity': 1
         })
         # product price use the currency of the pricelist
-        self.assertEqual(product.price, 4510)
+        self.assertEqual(product.price, 3100)
 
     def test_22_price_diff_cur_max_margin_pricelist(self):
         pricelist = self.ProductPricelist.create({
@@ -185,4 +185,4 @@ class TestProductPricelist(TransactionCase):
             'pricelist': pricelist.id, 'quantity': 1
         })
         # product price use the currency of the pricelist
-        self.assertEqual(product.price, 4590)
+        self.assertEqual(product.price, 3090)


### PR DESCRIPTION
If applied, this commit will fix the following bug by using the cost of
 the product instead of the sale price

Steps to reproduce:

1- install sales
2- enable discounts, pricelists with a formula
3- create a new pricelist pl with the item i
4- set i to apply discount pr% with min margin x
5- select pl in a quotation with a product p
6- the minimum margin calculation is not respected

for example when:
p.price = 100
p.standard_price = 20
pr = 35
x = 60

the correct price on sales order should be:
max(p.price*(1-pr), p.standard_price + x)
max(65,80) = 80

the current behavior results in a price of 160

Bug:

the price is used instead of the standard_price

Fix:

use standard price

OPW-2811271
