### PR TITLE
[FIX] purchase_stock: removes `filtered`

### DIFF
--- a/addons/purchase_stock/models/account_invoice.py
+++ b/addons/purchase_stock/models/account_invoice.py
@@ -41,8 +41,7 @@ class AccountMove(models.Model):
             if move.type not in ('in_invoice', 'in_refund', 'in_receipt') or not move.company_id.anglo_saxon_accounting:
                 continue
 
-            for line in move.invoice_line_ids.filtered(lambda line: line.product_id.type == 'product' and line.product_id.valuation == 'real_time'):
-
+            for line in move.invoice_line_ids:
                 # Filter out lines being not eligible for price difference.
                 if line.product_id.type != 'product' or line.product_id.valuation != 'real_time':
                     continue


### PR DESCRIPTION
In the `_stock_account_prepare_anglo_saxon_in_lines_vals` method, we loop the moves' invoice lines but we called `filtered` on it to remove ineligible lines.
That said, we have a conditional `continue` at the beginning of the loop precisely for the same reason, which is redundant.

As it's better to filter out inside a loop instead of call `filtered` (one loop instead of two), this commit removes the call to `filtered`.