### PR TITLE
[IMP] web, web_editor: exclude assets from documents

### DIFF
--- a/addons/web/static/src/legacy/js/core/utils.js
+++ b/addons/web/static/src/legacy/js/core/utils.js
@@ -1129,24 +1129,6 @@ var utils = Object.assign({
         }
         return curr;
     },
-    /**
-     * Returns the domain targeting assets files.
-     *
-     * @returns {Array} Domain of assets files
-     */
-    assetsDomain: function () {
-        return [
-            '&',
-            ['res_model', '=', 'ir.ui.view'],
-            '|',
-            '|',
-            '|',
-            ['name', '=like', '%.assets\_%.css'],
-            ['name', '=like', '%.assets\_%.js'],
-            ['name', '=like', '%.report_assets\_%.css'],
-            ['name', '=like', '%.assets\_%.map'],
-        ];
-    },
 }, cookieUtils);
 
 return utils;

--- a/addons/web_editor/static/src/js/wysiwyg/widgets/media.js
+++ b/addons/web_editor/static/src/js/wysiwyg/widgets/media.js
@@ -1069,8 +1069,9 @@ var DocumentWidget = FileWidget.extend({
      */
     _getAttachmentsDomain: function (needle) {
         var domain = this._super.apply(this, arguments);
-        // the assets should not be part of the documents
-        return domain.concat('!', utils.assetsDomain());
+        // The assets should not be part of the documents.
+        // All assets begin with '/web/assets/', see _get_asset_template_url().
+        return ['&', '|', ['url', '=', null], '!', ['url', '=like', '/web/assets/%']].concat(domain);
     },
 });
 


### PR DESCRIPTION
Currently only the `*.assets_*` CSS and JS files are considered as
assets. Because of this some assets from `web_studio`, `pos` and
`document_spreadsheet` become available for selection as documents.

This commit replaces the existing blacklist by a check on whether the
URL matches `/web/assets/*`.

Steps to reproduce:
- Install website, web_studio and pos.
- Drop a Text - Image block in the home page.
- Replace the Image.
- Go to the Documents tab.
=> Some JS/CSS/map assets were available for selection.

task-2799866


Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
