### PR TITLE
[FIX] website_hr_recruitment: test application form

### DIFF
--- a/addons/website_hr_recruitment/static/tests/tours/website_hr_recruitment.js
+++ b/addons/website_hr_recruitment/static/tests/tours/website_hr_recruitment.js
@@ -2,39 +2,111 @@ odoo.define('website_hr_recruitment.tour', function(require) {
     'use strict';
 
     var tour = require("web_tour.tour");
+    function applyForAJob(jobName, application) {
+        return [{
+            content: "Select Job",
+            trigger: `.oe_website_jobs h3 span:contains(${jobName})`,
+        }, {
+            content: "Apply",
+            trigger: ".js_hr_recruitment a:contains('Apply')",
+        }, {
+            content: "Complete name",
+            trigger: "input[name=partner_name]",
+            run: `text ${application.name}`,
+        }, {
+            content: "Complete Email",
+            trigger: "input[name=email_from]",
+            run: `text ${application.email}`,
+        }, {
+            content: "Complete phone number",
+            trigger: "input[name=partner_phone]",
+            run: `text ${application.phone}`,
+        }, {
+            content: "Complete Subject",
+            trigger: "textarea[name=description]",
+            run: `text ${application.subject}`,
+        }, { // TODO: Upload a file ?
+            content: "Send the form",
+            trigger: ".s_website_form_send",
+        }, {
+            content: "Check the form is submitted without errors",
+            trigger: ".oe_structure:has(h1:contains('Congratulations'))",
+        }];
+    }
 
     tour.register('website_hr_recruitment_tour', {
         test: true,
         url: '/jobs',
+    }, [
+        ...applyForAJob('Guru', {
+            name: 'John Smith',
+            email: 'john@smith.com',
+            phone: '118.218',
+            subject: '### [GURU] HR RECRUITMENT TEST DATA ###',
+        }),
+        {
+            content: "Go back to the jobs page",
+            trigger: "body",
+            run: () => {
+                window.location.href = '/jobs';
+            },
+        },
+        ...applyForAJob('Internship', {
+            name: 'Jack Doe',
+            email: 'jack@doe.com',
+            phone: '118.712',
+            subject: '### HR [INTERN] RECRUITMENT TEST DATA ###',
+        }),
+    ]);
+
+    tour.register('website_hr_recruitment_tour_edit_form', {
+        test: true,
+        url: '/jobs',
     }, [{
-        content: "Select Job",
-        trigger: ".oe_website_jobs h3 span:contains('A Test Job')"
+        content: 'Go to the Guru job page',
+        trigger: 'a[href*="guru"]',
     }, {
-        content: "Apply",
-        trigger: ".js_hr_recruitment a:contains('Apply')"
+        content: 'Go to the Guru job form',
+        trigger: 'a[href*="apply"]',
     }, {
-        content: "Complete name",
-        trigger: "input[name=partner_name]",
-        run: "text John Smith"
+        content: 'Check if the Guru form is present',
+        trigger: 'form'
     }, {
-        content: "Complete Email",
-        trigger: "input[name=email_from]",
-        run: "text john@smith.com"
+        content: 'Enter in edit mode',
+        trigger: 'a[data-action="edit"]',
     }, {
-        content: "Complete phone number",
-        trigger: "input[name=partner_phone]",
-        run: "text 118.218"
+        content: 'Edit the form',
+        trigger: 'input[type="file"]',
+        extra_trigger: '#oe_snippets.o_loaded',
     }, {
-        content: "Complete Subject",
-        trigger: "textarea[name=description]",
-        run: "text ### HR RECRUITMENT TEST DATA ###"
-    }, { // TODO: Upload a file ?
-        content: "Send the form",
-        trigger: ".s_website_form_send"
+        content: 'Add a new field',
+        trigger: 'we-button[data-add-field]',
     }, {
-        content: "Check the form is submited without errors",
-        trigger: ".oe_structure:has(h1:contains('Congratulations'))"
-    }]);
+        content: 'Save',
+        trigger: 'button[data-action="save"]',
+    }, {
+        content: 'Go back to /jobs page after save',
+        trigger: 'a[data-action="edit"]',
+        run: () => {
+            window.location.href = '/jobs';
+        }
+    }, {
+        content: 'Go to the Internship job page',
+        trigger: 'a[href*="internship"]',
+    }, {
+        content: 'Go to the Internship job form',
+        trigger: 'a[href*="apply"]',
+    }, {
+        content: 'Check that a job_id has been loaded',
+        trigger: 'form',
+        run: () => {
+            const selector = 'input[name="job_id"]:not([value=""])';
+            if (!document.querySelector(selector)) {
+                console.error('The job_id field has a wrong value');
+            }
+        }
+    },
+]);
 
     return {};
 });

--- a/addons/website_hr_recruitment/tests/test_website_hr_recruitment.py
+++ b/addons/website_hr_recruitment/tests/test_website_hr_recruitment.py
@@ -7,16 +7,28 @@ import odoo.tests
 @odoo.tests.tagged('post_install', '-at_install')
 class TestWebsiteHrRecruitmentForm(odoo.tests.HttpCase):
     def test_tour(self):
-        job = self.env['hr.job'].create({
-            'name': 'A Test Job',
+        job_guru = self.env['hr.job'].create({
+            'name': 'Guru',
             'is_published': True,
         })
-
-        self.start_tour("/", 'website_hr_recruitment_tour')
+        job_intern = self.env['hr.job'].create({
+            'name': 'Internship',
+            'is_published': True,
+        })
+        self.start_tour('/', 'website_hr_recruitment_tour_edit_form', login='admin')
+        self.start_tour('/', 'website_hr_recruitment_tour')
 
         # check result
-        record = self.env['hr.applicant'].search([('description', '=', '### HR RECRUITMENT TEST DATA ###')])
-        self.assertEqual(len(record), 1)
-        self.assertEqual(record.partner_name, "John Smith")
-        self.assertEqual(record.email_from, "john@smith.com")
-        self.assertEqual(record.partner_phone, '118.218')
+        guru_applicant = self.env['hr.applicant'].search([('description', '=', '### [GURU] HR RECRUITMENT TEST DATA ###'),
+                                                        ('job_id', '=', job_guru.id),])
+        self.assertEqual(len(guru_applicant), 1)
+        self.assertEqual(guru_applicant.partner_name, 'John Smith')
+        self.assertEqual(guru_applicant.email_from, 'john@smith.com')
+        self.assertEqual(guru_applicant.partner_phone, '118.218')
+
+        internship_applicant = self.env['hr.applicant'].search([('description', '=', '### HR [INTERN] RECRUITMENT TEST DATA ###'),
+                                                                ('job_id', '=', job_intern.id),])
+        self.assertEqual(len(internship_applicant), 1)
+        self.assertEqual(internship_applicant.partner_name, 'Jack Doe')
+        self.assertEqual(internship_applicant.email_from, 'jack@doe.com')
+        self.assertEqual(internship_applicant.partner_phone, '118.712')


### PR DESCRIPTION
This commit adds a test that verifies that the application forms work
correctly even after being edited. Ideally this test should have been
added with [1]. Since we want to make sure that the problem that [1]
solves does not happen again, it is really necessary to have this test.

Details:
The test verifies that the hidden data (the job_id) does not become a
default value after the edition of the form.

[1]: https://github.com/odoo/odoo/commit/04138cc3ad2e23738b4f02f48eec893caa902b9b

**task-2715201**
--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
