### PR TITLE
[FIX] project: avoid filtering burndown chart records for project manager

### DIFF
--- a/addons/project/security/project_security.xml
+++ b/addons/project/security/project_security.xml
@@ -275,6 +275,13 @@
         <field name="groups" eval="[(4,ref('project.group_project_user'))]"/>
     </record>
 
+    <record model="ir.rule" id="burndown_chart_project_manager_rule">
+        <field name="name">Burndown chart: project visibility User</field>
+        <field name="model_id" ref="model_project_task_burndown_chart_report"/>
+        <field name="domain_force">[(1, '=', 1)]</field>
+        <field name="groups" eval="[(4,ref('project.group_project_manager'))]"/>
+    </record>
+
     <record model="ir.rule" id="milestone_comp_rule">
         <field name="name">Project/Milestone: multi-company</field>
         <field name="model_id" ref="model_project_milestone"/>


### PR DESCRIPTION
Before this commit, when the Project Manager wants to see the burndown
chart report, he cannot see all the tasks if the project visibility is
follower and he do not follow the project. Indeed, he can only see the
ones in which he is assigned or follower. This behaviour is not expected
for a project manager but only expected for a project user.

This commit adds a rule to avoid filtering the records from burndown
chart report when the current user is a Project Manager.

Related PR: #82634

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
