### PR TITLE
[FIX] web: fix modal title display when too long

### DIFF
--- a/addons/web/static/src/scss/modal.scss
+++ b/addons/web/static/src/scss/modal.scss
@@ -8,7 +8,9 @@
         }
 
         .modal-header .modal-title {
-            word-break: break-word;
+            overflow: hidden;
+            white-space: nowrap;
+            text-overflow: ellipsis;
         }
 
         .modal-body {


### PR DESCRIPTION
Description of the issue/feature this PR addresses:

Steps to reproduce the issues:

Issues found using a mobile device only.

On the planning module, go to the gantt view and select a shift with a long name.
The title of the modal that appears will be displayed in three separate lines, and
not all the information is visible. This was fixed globally to avoid having the same
issues in other modules as well.

On the industry fsm module, since 14.0, the worksheet info when signing a document is now
correctly structured.

task-2755200


--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
