### PR TITLE
[FIX] portal: PU can't change their company details

### DIFF
--- a/addons/portal/views/portal_templates.xml
+++ b/addons/portal/views/portal_templates.xml
@@ -376,17 +376,20 @@
                             <div class="clearfix" />
                             <div t-attf-class="form-group mb-1 #{error.get('company_name') and 'o_has_error' or ''} col-xl-6">
                                 <label class="col-form-label label-optional" for="company_name">Company Name</label>
-                                <!-- The <input> is replace by a <p> to avoid sending an unauthorized value on form submit.
+                                <!-- The <input> use "disabled" attribute to avoid sending an unauthorized value on form submit.
                                      The user might not have rights to change company_name but should still be able to see it.
                                 -->
-                                <input type="text" name="company_name" t-attf-class="form-control #{error.get('company_name') and 'is-invalid' or ''}" t-att-value="company_name or partner.commercial_company_name" t-att-readonly="None if partner_can_edit_vat else '1'" />
+                                <input type="text" name="company_name" t-attf-class="form-control #{error.get('company_name') and 'is-invalid' or ''}" t-att-value="company_name or partner.commercial_company_name" t-att-disabled="None if partner_can_edit_vat else '1'" />
                                 <small t-if="not partner_can_edit_vat" class="form-text text-muted d-block d-xl-none">
                                     Changing company name is not allowed once document(s) have been issued for your account. Please contact us directly for this operation.
                                 </small>
                             </div>
                             <div t-attf-class="form-group mb-1 #{error.get('vat') and 'o_has_error' or ''} col-xl-6">
                                 <label class="col-form-label label-optional" for="vat">VAT Number</label>
-                                <input type="text" name="vat" t-attf-class="form-control #{error.get('vat') and 'is-invalid' or ''}" t-att-value="vat or partner.vat" t-att-readonly="None if partner_can_edit_vat else '1'" />
+                                <!-- The <input> use "disabled" attribute to avoid sending an unauthorized value on form submit.
+                                     The user might not have rights to change company_name but should still be able to see it.
+                                -->
+                                <input type="text" name="vat" t-attf-class="form-control #{error.get('vat') and 'is-invalid' or ''}" t-att-value="vat or partner.vat" t-att-disabled="None if partner_can_edit_vat else '1'" />
                                 <small t-if="not partner_can_edit_vat" class="form-text text-muted d-block d-xl-none">Changing VAT number is not allowed once document(s) have been issued for your account. Please contact us directly for this operation.</small>
                             </div>
                             <div t-if="not partner_can_edit_vat" class="col-12 d-none d-xl-block">


### PR DESCRIPTION
A Portal User (PU) cannot edit his company details once they are logged in.

Step to reproduce the issue:
1. Create a new Contact (as an individual) and link him with a company
2. Create an associated PU using the "Action" button on the Contact
3. Retrieve the registration link from the User app and authenticate as the user
4. From the Portal main page, edit the company details.
You will get an error related to the edition of the company_name while no change was done.

Solution: In a previous commit(beb50e8047f4dbe148933edd52cceadb2d5cccde), a change was done
on the `company_name` input. This modification changed the JSON that was sent upon form submission.
Indeed, previously the `company_name` field was not sent (thanks to a `<p>`) but now this field is sent,
causing an error. To mimic the `<p>` behavior and keeping the idea of the first change, the attribute
"disabled" was used in the input, allowing to not send this field upon form submission.

[1]: beb50e8047f4dbe148933edd52cceadb2d5cccde

opw-2754584