### PR TITLE
[IMP] core: populate UI

### DIFF
--- a/odoo/cli/populate.py
+++ b/odoo/cli/populate.py
@@ -10,19 +10,38 @@ import odoo
 from . import Command
 _logger = logging.getLogger(__name__)
 
+# NB: sibling options (same group) are still valid but not shown by --help,
+#     other groups are completely removed
+STANDARD_OPTIONS_TO_KEEP = {
+    '--config', '--database', '--addons-path',
+    '--log-level', '--log-handler', '--logfile',
+}
 
 class Populate(Command):
 
     def run(self, cmdargs):
         parser = odoo.tools.config.parser
+
+        groups_to_keep = []
+        for group in parser.option_groups:
+            if not any(group.has_option(opt) for opt in STANDARD_OPTIONS_TO_KEEP):
+                continue
+
+            groups_to_keep.append(group)
+            for opt in group.option_list:
+                if opt.get_opt_string() not in STANDARD_OPTIONS_TO_KEEP:
+                    opt.help = optparse.SUPPRESS_HELP
+        parser.option_groups = groups_to_keep
+
         group = optparse.OptionGroup(parser, "Populate Configuration")
         group.add_option("--size", dest="population_size",
                         help="Populate database with auto-generated data. Value should be the population size: small, medium or large",
                         default='small')
         group.add_option("--models",
                          dest='populate_models',
-                         help="Comma separated list of model or pattern (fnmatch)")
+                         help="Comma separated list of model or glob pattern")
         parser.add_option_group(group)
+
         opt = odoo.tools.config.parse_config(cmdargs)
         populate_models = opt.populate_models and set(opt.populate_models.split(','))
         population_size = opt.population_size
@@ -37,16 +56,22 @@ class Populate(Command):
     @classmethod
     def populate(cls, env, size, model_patterns=False):
         registry = env.registry
-        populated_models = None
         try:
             registry.populated_models = {}  # todo master, initialize with already populated models
             ordered_models = cls._get_ordered_models(env, model_patterns)
 
             _logger.log(25, 'Populating database')
             for model in ordered_models:
-                _logger.info('Populating database for model %s', model._name)
                 t0 = time.time()
-                registry.populated_models[model._name] = model._populate(size).ids
+                ids = registry.populated_models[model._name] = model._populate(size).ids
+                if not ids:
+                    # if no record could be generated, if the model was
+                    # requested exactly log a warning otherwise just an info
+                    if model_patterns and model._name in model_patterns:
+                        log = _logger.warning
+                    else:
+                        log = _logger.info
+                    log("No population factory for model %s, ignoring", model._name)
                 # todo indicate somewhere that model is populated
                 env.cr.commit()
                 model_time = time.time() - t0

--- a/odoo/models.py
+++ b/odoo/models.py
@@ -6372,7 +6372,8 @@ Fields:
         field_generators = self._populate_factories()
         if not field_generators:
             return self.browse() # maybe create an automatic generator?
-            
+
+        _logger.info('Populating database for model %s', self._name)
         records_batches = []
         generator = populate.chain_factories(field_generators, self._name)
         while record_count <= min_size or not complete:


### PR DESCRIPTION
- clearly print out when the model does not support population
- don't show most of the "standard" options as they don't generally
  apply to populate calls
