### PR TITLE
[FIX] base: overcome self being a NewId

### DIFF
--- a/odoo/models.py
+++ b/odoo/models.py
@@ -3104,10 +3104,11 @@ Fields:
                 if field.deprecated:
                     _logger.warning('Field %s is deprecated: %s', field, field.deprecated)
 
-        # possibly raise exception for the records that could not be read
-        missing = self - fetched
+        # possibly raise exception for the records that could not be read and flatten
+        records = self.env[self._name].browse(self.ids)
+        missing = records - fetched
         if missing:
-            extras = fetched - self
+            extras = fetched - records
             if extras:
                 raise AccessError(
                     _("Database fetch misses ids ({}) and has extra ids ({}), may be caused by a type incoherence in a previous request").format(


### PR DESCRIPTION
**Description of the issue/feature this PR addresses:**
https://github.com/odoo/odoo/commit/311756d2f55dabee100fa4e0c6c7e00b80399f6b#comments

Having a `Many2many` list in the partner object (in my case product.product) will stop me saving as it does not get the equality between a `NewId` with the proper origin and the Database `id` even though it is the same and produces a miserable showstopper.

**Current behavior before PR:**
Incorrect AccessError

**Desired behavior after PR is merged:**
No incorrect AccessError

Info: @wt-io-it

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
