### PR TITLE
[FIX] web_editor: remove command /image for portal users

### DIFF
--- a/addons/web/static/src/legacy/js/core/session.js
+++ b/addons/web/static/src/legacy/js/core/session.js
@@ -133,7 +133,8 @@ var Session = core.Class.extend(mixins.EventDispatcherMixin, {
         return this.rpc("/web/session/destroy", {});
     },
     user_has_group: function (group) {
-        if (!this.uid) {
+        // the frontend session info has no `uid` but an `user_id`
+        if (!this.uid && !this.user_id) {
             return Promise.resolve(false);
         }
         var def = this._groups_def[group];

--- a/addons/web_editor/static/src/js/wysiwyg/wysiwyg.js
+++ b/addons/web_editor/static/src/js/wysiwyg/wysiwyg.js
@@ -3,6 +3,7 @@ odoo.define('web_editor.wysiwyg', function (require) {
 
 const dom = require('web.dom');
 const core = require('web.core');
+const session = require('web.session');
 const Widget = require('web.Widget');
 const Dialog = require('web.Dialog');
 const customColors = require('web_editor.custom_colors');
@@ -96,6 +97,7 @@ const Wysiwyg = Widget.extend({
 
         var options = this._editorOptions();
         this._value = options.value;
+        this.options.isInternalUser = await session.user_has_group('base.group_user');
 
         this.$editable = this.$editable || this.$el;
         this.$editable.html(this._value);
@@ -1776,7 +1778,9 @@ const Wysiwyg = Widget.extend({
                     }, 150);
                 },
             },
-            {
+        ];
+        if (options.isInternalUser) {
+            commands.push({
                 groupName: 'Medias',
                 title: 'Image',
                 description: 'Insert an image.',
@@ -1784,8 +1788,8 @@ const Wysiwyg = Widget.extend({
                 callback: () => {
                     this.openMediaDialog();
                 },
-            },
-        ];
+            });
+        }
         if (options.allowCommandVideo) {
             commands.push({
                 groupName: 'Medias',


### PR DESCRIPTION
The command `/image` used by portal users (in a forum post for example)
throws an access error. This fix removes this command for portal users
until master. In master, the command is reintroduced [here].

Indeed, before the new editor in v15, those restricted users could
insert an image as we were using an "in place" image upload dialog
from summernote resulting in simple base64 image added in the image tag.
This allowed to add image without creating an attachment.
But with the new editor, there is no such base64 image upload, and it
would be too tedious / risky to introduce one in stable.

[here]: https://github.com/odoo/odoo/pull/82612

opw-2648770