### PR TITLE
[FIX] account, sale, purchase : prevent db crash

### DIFF
--- a/addons/account/models/account_move.py
+++ b/addons/account/models/account_move.py
@@ -183,7 +183,7 @@ class AccountMove(models.Model):
     partner_id = fields.Many2one('res.partner', readonly=True, tracking=True,
         states={'draft': [('readonly', False)]},
         check_company=True,
-        string='Partner', change_default=True)
+        string='Partner', change_default=True, auto_join=True)
     commercial_partner_id = fields.Many2one('res.partner', string='Commercial Entity', store=True, readonly=True,
         compute='_compute_commercial_partner_id')
     country_code = fields.Char(related='company_id.country_id.code', readonly=True)
@@ -3174,7 +3174,7 @@ class AccountMoveLine(models.Model):
     date_maturity = fields.Date(string='Due Date', index=True, tracking=True,
         help="This field is used for payable and receivable journal entries. You can put the limit date for the payment of this line.")
     currency_id = fields.Many2one('res.currency', string='Currency', required=True)
-    partner_id = fields.Many2one('res.partner', string='Partner', ondelete='restrict')
+    partner_id = fields.Many2one('res.partner', string='Partner', ondelete='restrict', index=True, auto_join=True)
     product_uom_id = fields.Many2one('uom.uom', string='Unit of Measure', domain="[('category_id', '=', product_uom_category_id)]")
     product_id = fields.Many2one('product.product', string='Product', ondelete='restrict')
     product_uom_category_id = fields.Many2one('uom.category', related='product_id.uom_id.category_id')

--- a/addons/account/views/account_move_views.xml
+++ b/addons/account/views/account_move_views.xml
@@ -319,7 +319,7 @@
                 <search string="Search Journal Items">
                     <field name="name" string="Journal Item" filter_domain="[
                         '|', '|', '|',
-                        ('name', 'ilike', self), ('ref', 'ilike', self), ('account_id', 'ilike', self), ('partner_id', 'ilike', self)]"/>
+                        ('name', 'ilike', self), ('ref', 'ilike', self), ('account_id', 'ilike', self), ('partner_id.display_name', 'ilike', self)]"/>
                     <field name="date"/>
                     <field name="account_id"/>
                     <field name="account_root_id"/>
@@ -327,7 +327,7 @@
                     <field name="partner_id"/>
                     <field name="journal_id"/>
                     <field name="move_id" string="Journal Entry" filter_domain="[
-                        '|', '|', ('move_id.name', 'ilike', self), ('move_id.ref', 'ilike', self), ('move_id.partner_id', 'ilike', self)]"/>
+                        '|', '|', ('move_id.name', 'ilike', self), ('move_id.ref', 'ilike', self), ('move_id.partner_id.display_name', 'ilike', self)]"/>
                     <field name="tax_ids" />
                     <field name="tax_line_id" string="Originator Tax"/>
                     <field name="reconcile_model_id"/>
@@ -1133,7 +1133,7 @@
             <field name="model">account.move</field>
             <field name="arch" type="xml">
                 <search string="Search Move">
-                    <field name="name" string="Journal Entry" filter_domain="['|', '|', ('name', 'ilike', self), ('ref', 'ilike', self), ('partner_id', 'ilike', self)]"/>
+                    <field name="name" string="Journal Entry" filter_domain="['|', '|', ('name', 'ilike', self), ('ref', 'ilike', self), ('partner_id.display_name', 'ilike', self)]"/>
                     <field name="date"/>
                     <field name="partner_id"/>
                     <field name="journal_id"/>
@@ -1173,7 +1173,7 @@
                                 '|', '|' , '|', '|',
                                 ('name', 'ilike', self), ('invoice_origin', 'ilike', self),
                                 ('ref', 'ilike', self), ('payment_reference', 'ilike', self),
-                                ('partner_id', 'child_of', self)]"/>
+                                ('partner_id.display_name', 'ilike', self)]"/>
                     <field name="journal_id"/>
                     <field name="partner_id" operator="child_of"/>
                     <field name="invoice_user_id" string="Salesperson" domain="[('share', '=', False)]"/>

--- a/addons/purchase/models/purchase.py
+++ b/addons/purchase/models/purchase.py
@@ -86,7 +86,7 @@ class PurchaseOrder(models.Model):
     date_order = fields.Datetime('Order Deadline', required=True, states=READONLY_STATES, index=True, copy=False, default=fields.Datetime.now,
         help="Depicts the date within which the Quotation should be confirmed and converted into a purchase order.")
     date_approve = fields.Datetime('Confirmation Date', readonly=1, index=True, copy=False)
-    partner_id = fields.Many2one('res.partner', string='Vendor', required=True, states=READONLY_STATES, change_default=True, tracking=True, domain="['|', ('company_id', '=', False), ('company_id', '=', company_id)]", help="You can find a vendor by its Name, TIN, Email or Internal Reference.")
+    partner_id = fields.Many2one('res.partner', string='Vendor', required=True, states=READONLY_STATES, change_default=True, tracking=True, domain="['|', ('company_id', '=', False), ('company_id', '=', company_id)]", help="You can find a vendor by its Name, TIN, Email or Internal Reference.", auto_join=True)
     dest_address_id = fields.Many2one('res.partner', domain="['|', ('company_id', '=', False), ('company_id', '=', company_id)]", string='Drop Ship Address', states=READONLY_STATES,
         help="Put an address if you want to deliver directly from the vendor to the customer. "
              "Otherwise, keep empty to deliver to your own company.")

--- a/addons/purchase/views/purchase_views.xml
+++ b/addons/purchase/views/purchase_views.xml
@@ -391,7 +391,7 @@
             <field name="arch" type="xml">
                 <search string="Search Purchase Order">
                     <field name="name" string="Order"
-                        filter_domain="['|', '|', ('name', 'ilike', self), ('partner_ref', 'ilike', self), ('partner_id', 'child_of', self)]"/>
+                        filter_domain="['|', '|', ('name', 'ilike', self), ('partner_ref', 'ilike', self), ('partner_id.display_name', 'ilike', self)]"/>
                     <field name="partner_id" operator="child_of"/>
                     <field name="user_id"/>
                     <field name="product_id"/>
@@ -433,7 +433,7 @@
             <field name="arch" type="xml">
                 <search string="Search Purchase Order">
                     <field name="name" string="Order"
-                        filter_domain="['|', '|', ('name', 'ilike', self), ('partner_ref', 'ilike', self), ('partner_id', 'child_of', self)]"/>
+                        filter_domain="['|', '|', ('name', 'ilike', self), ('partner_ref', 'ilike', self), ('partner_id.display_name', 'ilike', self)]"/>
                     <field name="partner_id" operator="child_of"/>
                     <field name="user_id"/>
                     <field name="product_id"/>

--- a/addons/sale/models/sale.py
+++ b/addons/sale/models/sale.py
@@ -189,7 +189,7 @@ class SaleOrder(models.Model):
     partner_id = fields.Many2one(
         'res.partner', string='Customer', readonly=True,
         states={'draft': [('readonly', False)], 'sent': [('readonly', False)]},
-        required=True, change_default=True, index=True, tracking=1,
+        required=True, change_default=True, index=True, tracking=1, auto_join=True,
         domain="['|', ('company_id', '=', False), ('company_id', '=', company_id)]",)
     partner_invoice_id = fields.Many2one(
         'res.partner', string='Invoice Address',

--- a/addons/sale/views/sale_views.xml
+++ b/addons/sale/views/sale_views.xml
@@ -735,7 +735,7 @@
             <field name="priority" eval="15"/>
             <field name="arch" type="xml">
                 <search string="Search Sales Order">
-                    <field name="name" string="Order" filter_domain="['|', '|', ('name', 'ilike', self), ('client_order_ref', 'ilike', self), ('partner_id', 'child_of', self)]"/>
+                    <field name="name" string="Order" filter_domain="['|', '|', ('name', 'ilike', self), ('client_order_ref', 'ilike', self), ('partner_id.display_name', 'ilike', self)]"/>
                     <field name="partner_id" operator="child_of"/>
                     <field name="user_id"/>
                     <field name="team_id" string="Sales Team"/>


### PR DESCRIPTION
**Description of the issue/feature this PR addresses:**
In database with 1 million of partner, when you try to search an invoice, sale, purchase. In the default search there are ('partner_id','child_of',self) in the filter_domain.
But if you search 'a' for exemple the ORM create a very very big query with 'partner_id' in [... very very long list ...]. And you can have very hight load of the database server and can crash.

This PR use the display_name and auto_join the partner table.

@rco-odoo @xmo-odoo @odony 

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
