### PR TITLE
[FIX] web: Remove offset only for datetime field, not date

### DIFF
--- a/addons/web/static/src/js/fields/basic_fields.js
+++ b/addons/web/static/src/js/fields/basic_fields.js
@@ -934,7 +934,9 @@ var FieldDate = InputField.extend({
             let value = this.$input.val();
             try {
                 value = this._parseValue(value);
-                value.add(-this.getSession().getTZOffset(value), "minutes");
+                if (this.field.type === "datetime") {
+                    value.add(-this.getSession().getTZOffset(value), "minutes");
+                }
             } catch (err) {}
             await this._setValue(value);
             this._render();

--- a/addons/web/static/tests/fields/basic_fields_tests.js
+++ b/addons/web/static/tests/fields/basic_fields_tests.js
@@ -4243,6 +4243,11 @@ QUnit.module('basic_fields', {
             viewOptions: {
                 mode: 'edit',
             },
+            session: {
+                getTZOffset: function () {
+                    return 120;
+                },
+            },
         });
 
         const year = (new Date()).getFullYear();


### PR DESCRIPTION
Since https://github.com/odoo/odoo/pull/87584

with `date` field, pressing enter will removes 1 day to the value.
To fix it we have to ignore the offset suppression used for `datetime`

opw-2818927