### PR TITLE
[IMP] base: remove unused fields in ir_module

### DIFF
--- a/odoo/addons/base/data/base_data.sql
+++ b/odoo/addons/base/data/base_data.sql
@@ -70,10 +70,6 @@ CREATE TABLE ir_module_module (
 
 CREATE TABLE ir_module_module_dependency (
     id serial NOT NULL,
-    create_uid integer, -- references res_users on delete set null,
-    create_date timestamp without time zone,
-    write_date timestamp without time zone,
-    write_uid integer, -- references res_users on delete set null,
     name character varying,
     module_id integer REFERENCES ir_module_module ON DELETE cascade,
     auto_install_required boolean DEFAULT true,

--- a/odoo/addons/base/models/ir_module.py
+++ b/odoo/addons/base/models/ir_module.py
@@ -1030,6 +1030,7 @@ DEP_STATES = STATES + [('unknown', 'Unknown')]
 class ModuleDependency(models.Model):
     _name = "ir.module.module.dependency"
     _description = "Module dependency"
+    _log_access = False  # inserts are done manually, create and write uid, dates are always null
 
     # the dependency name
     name = fields.Char(index=True)


### PR DESCRIPTION
The table ir_module was created manually with tracking fields, but the
CRUD was done manually, without the ORM.
Removing the fields that are always null will not have any impact
whatsoever but we should still do it to be correct.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
