### PR TITLE
[IMP] fleet: add category_id to the vehicle from model

### DIFF
--- a/addons/fleet/data/fleet_demo.xml
+++ b/addons/fleet/data/fleet_demo.xml
@@ -411,24 +411,20 @@
         <field name="color" eval="4"/>
       </record>
 
-      <record id="vehicle_tag_compact" model="fleet.vehicle.tag" >
-        <field name="name">Compact</field>
-        <field name="color" eval="5"/>
-      </record>
-
-      <record id="vehicle_tag_sedan" model="fleet.vehicle.tag" >
-        <field name="name">Sedan</field>
-        <field name="color" eval="6"/>
-      </record>
-
-      <record id="vehicle_tag_convertible" model="fleet.vehicle.tag" >
-        <field name="name">Convertible</field>
-        <field name="color" eval="7"/>
-      </record>
-
-      <record id="vehicle_tag_break" model="fleet.vehicle.tag" >
+      <record id="model_category_1" model="fleet.vehicle.model.category">
         <field name="name">Break</field>
-        <field name="color" eval="8"/>
+      </record>
+
+      <record id="model_category_2" model="fleet.vehicle.model.category">
+        <field name="name">SUV</field>
+      </record>
+
+      <record id="model_category_3" model="fleet.vehicle.model.category">
+        <field name="name">Sport Car</field>
+      </record>
+
+      <record id="model_category_4" model="fleet.vehicle.model.category">
+        <field name="name">Compact</field>
       </record>
 
       <record id="vehicle_1" model="fleet.vehicle">
@@ -443,7 +439,7 @@
           <field name="state_id" ref="fleet_vehicle_state_registered"/>
           <field name="odometer_unit">kilometers</field>
           <field name="car_value">20000</field>
-          <field eval="[(6,0,[ref('vehicle_tag_leasing'),ref('fleet.vehicle_tag_break'),ref('fleet.vehicle_tag_senior')])]" name="tag_ids"/>
+          <field eval="[(6,0,[ref('vehicle_tag_leasing'),ref('fleet.vehicle_tag_purchased'),ref('fleet.vehicle_tag_senior')])]" name="tag_ids"/>
       </record>
 
       <record id="vehicle_2" model="fleet.vehicle">
@@ -458,7 +454,7 @@
           <field name="state_id" ref="fleet_vehicle_state_downgraded"/>
           <field name="odometer_unit">kilometers</field>
           <field name="car_value">16000</field>
-          <field eval="[(6,0,[ref('vehicle_tag_leasing'),ref('fleet.vehicle_tag_compact'),ref('fleet.vehicle_tag_junior')])]" name="tag_ids"/>
+          <field eval="[(6,0,[ref('vehicle_tag_leasing'),ref('fleet.vehicle_tag_purchased'),ref('fleet.vehicle_tag_junior')])]" name="tag_ids"/>
       </record>
 
       <record id="vehicle_3" model="fleet.vehicle">
@@ -473,7 +469,7 @@
           <field name="state_id" ref="fleet_vehicle_state_registered"/>
           <field name="odometer_unit">kilometers</field>
           <field name="car_value">20000</field>
-          <field eval="[(6,0,[ref('vehicle_tag_leasing'),ref('fleet.vehicle_tag_compact'),ref('fleet.vehicle_tag_senior')])]" name="tag_ids"/>
+          <field eval="[(6,0,[ref('vehicle_tag_leasing'),ref('fleet.vehicle_tag_purchased'),ref('fleet.vehicle_tag_senior')])]" name="tag_ids"/>
       </record>
 
        <record id="vehicle_4" model="fleet.vehicle">
@@ -488,7 +484,7 @@
           <field name="state_id" ref="fleet_vehicle_state_registered"/>
           <field name="odometer_unit">kilometers</field>
           <field name="car_value">20000</field>
-          <field eval="[(6,0,[ref('vehicle_tag_leasing'),ref('fleet.vehicle_tag_compact'),ref('fleet.vehicle_tag_senior')])]" name="tag_ids"/>
+          <field eval="[(6,0,[ref('vehicle_tag_leasing'),ref('fleet.vehicle_tag_purchased'),ref('fleet.vehicle_tag_senior')])]" name="tag_ids"/>
       </record>
 
       <record id="vehicle_5" model="fleet.vehicle">
@@ -503,7 +499,7 @@
           <field name="state_id" ref="fleet_vehicle_state_registered"/>
           <field name="odometer_unit">kilometers</field>
           <field name="car_value">18000</field>
-          <field eval="[(6,0,[ref('vehicle_tag_leasing'),ref('fleet.vehicle_tag_compact'),ref('fleet.vehicle_tag_senior')])]" name="tag_ids"/>
+          <field eval="[(6,0,[ref('vehicle_tag_leasing'),ref('fleet.vehicle_tag_purchased'),ref('fleet.vehicle_tag_senior')])]" name="tag_ids"/>
       </record>
 
       <record id="log_odometer_1" model="fleet.vehicle.odometer">

--- a/addons/fleet/models/fleet_vehicle.py
+++ b/addons/fleet/models/fleet_vehicle.py
@@ -14,7 +14,7 @@ MODEL_FIELDS_TO_VEHICLE = {
     'transmission': 'transmission', 'model_year': 'model_year', 'electric_assistance': 'electric_assistance',
     'color': 'color', 'seats': 'seats', 'doors': 'doors', 'trailer_hook': 'trailer_hook',
     'default_co2': 'co2', 'co2_standard': 'co2_standard', 'default_fuel_type': 'fuel_type',
-    'power': 'power', 'horsepower': 'horsepower', 'horsepower_tax': 'horsepower_tax',
+    'power': 'power', 'horsepower': 'horsepower', 'horsepower_tax': 'horsepower_tax', 'category_id': 'category_id',
 }
 
 class FleetVehicle(models.Model):
@@ -89,6 +89,7 @@ class FleetVehicle(models.Model):
     power = fields.Integer('Power', help='Power in kW of the vehicle', compute='_compute_model_fields', store=True, readonly=False)
     co2 = fields.Float('CO2 Emissions', help='CO2 emissions of the vehicle', compute='_compute_model_fields', store=True, readonly=False, tracking=True)
     co2_standard = fields.Char(compute='_compute_model_fields', store=True, readonly=False)
+    category_id = fields.Many2one('fleet.vehicle.model.category', 'Category', compute='_compute_model_fields', store=True, readonly=False)
     image_128 = fields.Image(related='model_id.image_128', readonly=True)
     contract_renewal_due_soon = fields.Boolean(compute='_compute_contract_reminder', search='_search_contract_renewal_due_soon',
         string='Has Contracts to renew')

--- a/addons/fleet/views/fleet_vehicle_views.xml
+++ b/addons/fleet/views/fleet_vehicle_views.xml
@@ -73,8 +73,10 @@
                             <field name="plan_to_change_car" groups="fleet.fleet_group_manager" attrs="{'invisible': [('vehicle_type', '!=', 'car')]}"/>
                             <field name="plan_to_change_bike" groups="fleet.fleet_group_manager"  attrs="{'invisible': [('vehicle_type', '!=', 'bike')]}"/>
                             <field name="next_assignation_date"/>
+                            <field name="company_id" groups="base.group_multi_company"/>
                         </group>
                         <group string="Vehicle">
+                            <field name="category_id"/>
                             <field name="acquisition_date" attrs="{'invisible': [('vehicle_type', '!=', 'car')]}"/>
                             <field name="write_off_date" attrs="{'invisible': [('vehicle_type', '!=', 'car')]}"/>
                             <field name="vin_sn"/>
@@ -85,7 +87,6 @@
                             </div>
                             <field name="manager_id" domain="[('share', '=', False)]"/>
                             <field name="location"/>
-                            <field name="company_id" groups="base.group_multi_company"/>
                         </group>
                     </group>
                     <notebook>
@@ -159,6 +160,7 @@
                 <field name="active" invisible="1"/>
                 <field name="license_plate" readonly="1"/>
                 <field name="model_id" widget="many2one_avatar" readonly="1"/>
+                <field name="category_id"/>
                 <field name="manager_id" optional="hide"/>
                 <field name="driver_id" widget="many2one_avatar" readonly="1"/>
                 <field name="future_driver_id"  widget="many2one_avatar" readonly="1"/>


### PR DESCRIPTION
category_id field is populated from the model, but it can be edited.

task - 2828459

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
