### PR TITLE
[FIX] website_event_sale: check available seats with autoconfirm

### DIFF
--- a/addons/website_event_sale/models/sale_order.py
+++ b/addons/website_event_sale/models/sale_order.py
@@ -81,13 +81,15 @@ class SaleOrder(models.Model):
 
         # case: buying tickets for a sold out ticket
         values = {}
-        if ticket and ticket.seats_limited and ticket.seats_available <= 0:
+        if ticket and ticket.seats_limited and ticket.seats_available <= 0 and \
+                not (ticket.event_id.auto_confirm and len(ticket.registration_id) >= new_qty):
             values['warning'] = _('Sorry, The %(ticket)s tickets for the %(event)s event are sold out.') % {
                 'ticket': ticket.name,
                 'event': ticket.event_id.name}
             new_qty, set_qty, add_qty = 0, 0, -old_qty
         # case: buying tickets, too much attendees
-        elif ticket and ticket.seats_limited and new_qty > ticket.seats_available:
+        elif ticket and ticket.seats_limited and new_qty > ticket.seats_available and \
+                not (ticket.event_id.auto_confirm and len(ticket.registration_id) >= new_qty):
             values['warning'] = _('Sorry, only %(remaining_seats)d seats are still available for the %(ticket)s ticket for the %(event)s event.') % {
                 'remaining_seats': ticket.seats_available,
                 'ticket': ticket.name,


### PR DESCRIPTION
Step to reproduce:
- Create an event with 3 ticket and autoconfirmation
- On the website : Buy 2 ticket for said event
- Continue to payment

Current behaviour:
- On payment the SO change to only 1 ticket
- We checking for the number of available seats, the current
tickets are already removed from the total and can end up in
a configuration to reduce the number of registered ticket even tought
they have already been confirmed.

Behaviour after PR:
- If the event is auto-confirmed, we skip the check is the number
of ticket is = to the number of registration

opw-2824500

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
