### PR TITLE
[FIX] project: improve visibility of alias_def

### DIFF
--- a/addons/project/views/project_views.xml
+++ b/addons/project/views/project_views.xml
@@ -371,16 +371,15 @@
                                     <field name="privacy_visibility" widget="radio"/>
                                 </group>
                                 <group>
-                                    <div name="alias_def" colspan="2" attrs="{'invisible': [('alias_domain', '=', False)]}">
+                                    <div name="alias_def" colspan="2" class="pb-2" attrs="{'invisible': [('alias_domain', '=', False)]}">
                                         <!-- Always display the whole alias in edit mode. It depends in read only -->
                                         <field name="alias_enabled" invisible="1"/>
-                                        <span class="oe_read_only" attrs="{'invisible': [('alias_name', '!=', False)]}">Create tasks by sending an email to </span>
-                                        <span class="font-weight-bold oe_read_only" attrs="{'invisible': [('alias_name', '=', False)]}">Create tasks by sending an email to </span>
-                                        <span class="font-weight-bold oe_edit_only">Create tasks by sending an email to </span>
+                                        <span class="font-weight-bold oe_read_only" attrs="{'invisible': [('alias_name', '!=', False)]}" style="opacity: 0.7;">Create tasks by sending an email to </span>
+                                        <span class="font-weight-bold oe_read_only text-dark" attrs="{'invisible': [('alias_name', '=', False)]}">Create tasks by sending an email to </span>
+                                        <span class="font-weight-bold oe_edit_only text-dark">Create tasks by sending an email to </span>
                                             <field name="alias_value" class="oe_read_only d-inline" readonly="1" widget="email" attrs="{'invisible':  [('alias_name', '=', False)]}" />
                                             <span class="oe_edit_only">
-                                                <field name="alias_name" class="oe_inline"/>@
-                                                <field name="alias_domain" class="oe_inline" readonly="1"/>
+                                                <field name="alias_name" class="oe_inline"/>@<field name="alias_domain" class="oe_inline" readonly="1"/>
                                             </span>
                                     </div>
                                     <!-- the alias contact must appear when the user start typing and it must disappear


### PR DESCRIPTION
related to 956f7f81d12bf030b572b94e7ad09924ed01ef9c and 14e9f3d5e83909d4a61aded0c125c6330379a756 since the first fix was not compliant with the stable policy.

before this commit,
in project form view alias_name field label color and padding are
different then other fields.

after this commit,
alias_name field label color and padding will be same as other.
field' label color and padding.

task-2758779

Related: #85098

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
