### PR TITLE
[FIX] pos_gift_card: keep focus on the current input field

### DIFF
--- a/addons/pos_gift_card/static/src/js/GiftCardPopup.js
+++ b/addons/pos_gift_card/static/src/js/GiftCardPopup.js
@@ -22,15 +22,24 @@ odoo.define("pos_gift_card.GiftCardPopup", function (require) {
 
     useAutoFocus(state) {
       const component = useComponent();
+      let hasFocused = false;
       function autofocus() {
-        if (state.showBarcodeGeneration) {
-            const elem = component.el.querySelector(`.giftCardPopupInput`);
-            if (elem)
-                elem.focus();
-        }
+          if (state.showBarcodeGeneration) {
+              // Should autofocus here but only if it hasn't autofocus yet.
+              if (!hasFocused) {
+                  const elem = component.el.querySelector(`.giftCardPopupInput`);
+                  if (elem) {
+                      elem.focus();
+                      hasFocused = true;
+                  }
+              }
+          } else {
+              // When changing showBarcodeGeneration to false, we reset hasFocused.
+              hasFocused = false;
+          }
       }
       onPatched(autofocus);
-    }
+  }
 
     switchBarcodeView() {
       this.state.showBarcodeGeneration = !this.state.showBarcodeGeneration;


### PR DESCRIPTION
Current behavior:
When opening the giftcard popup in a PoS the focus would always
always go back to the first input field after typing in any other
input field.

Steps to reproduce:
- Install PoS and activate gift card
- Activate option "Scan an existing barcode and set a price"
- Start a PoS session
- Access the giftcard popup
- Select "Scan and set price on gift card"
- Type anything in the second input field
- The focus will go back on the first input field

opw-2825163

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
