### PR TITLE
[FIX] sale : select incompatible variant (pill)

### DIFF
--- a/addons/sale/static/src/scss/product_configurator.scss
+++ b/addons/sale/static/src/scss/product_configurator.scss
@@ -196,9 +196,6 @@ label.css_attribute_color.css_not_available {
             color: gray('600');
             background-color: gray('200');
         }
-        &.css_not_available {
-            pointer-events: none;
-        }
     }
 }
 


### PR DESCRIPTION
Steps :
Create a Product with 2 attributes (2 values each) :
	> Color : black and white
	> Size  : small and large
Set them display type to Pills.
Configure them so that only 2 combinations are possible :
	> black - small
	> white - large
Go to Website (product configurator).
The first combination is set. Try to set the otherone.

Issue :
It is impossible to change neither attributes
and, therefore, to change the combination.
With other display types, you can change one attribute,
even if it creates an unavailable combination.
You are warned of this fact,
but you can change the other attribute and, by doing so,
get back on another available combination.

Cause :
The stylesheet does not allow to click on
an incompatible variant (attribute value).

Fix :
Delete this property.

opw-2762514

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
