### PR TITLE
[FIX] Format monetary fields value on tracking

### DIFF
--- a/addons/mail/models/mail_thread.py
+++ b/addons/mail/models/mail_thread.py
@@ -626,6 +626,8 @@ class MailThread(models.AbstractModel):
                     tracking_sequence = 100
                 tracking = self.env['mail.tracking.value'].create_tracking_values(initial_value, new_value, col_name, col_info, tracking_sequence)
                 if tracking:
+                    if tracking['field_type'] == 'monetary':
+                        tracking['currency_id'] = getattr(self, col_info.get('currency_field', ''), self.company_id.currency_id).id
                     tracking_value_ids.append([0, 0, tracking])
                 changes.add(col_name)
 

--- a/addons/mail/models/mail_tracking_value.py
+++ b/addons/mail/models/mail_tracking_value.py
@@ -32,6 +32,9 @@ class MailTracking(models.Model):
     new_value_text = fields.Text('New Value Text', readonly=1)
     new_value_datetime = fields.Datetime('New Value Datetime', readonly=1)
 
+    currency_id = fields.Many2one('res.currency', 'Currency', readonly=True, ondelete='set null',
+        help="Used to display the currency when tracking monetary values")
+
     mail_message_id = fields.Many2one('mail.message', 'Message ID', required=True, index=True, ondelete='cascade')
 
     tracking_sequence = fields.Integer('Tracking field sequence', readonly=1, default=100)

--- a/addons/mail/static/src/js/models/messages/message.js
+++ b/addons/mail/static/src/js/models/messages/message.js
@@ -4,6 +4,7 @@ odoo.define('mail.model.Message', function (require) {
 var emojis = require('mail.emojis');
 var AbstractMessage = require('mail.model.AbstractMessage');
 var mailUtils = require('mail.utils');
+var field_utils = require('web.field_utils');
 
 var core = require('web.core');
 var Mixins = require('web.mixins');
@@ -725,6 +726,23 @@ var Message =  AbstractMessage.extend(Mixins.EventDispatcherMixin, ServicesMixin
                             moment(trackingValue.new_value)
                                 .local()
                                 .format('LL');
+                    }
+                } else if (trackingValue.field_type === 'monetary') {
+                    if (trackingValue.old_value) {
+                        trackingValue.old_value = field_utils.format.monetary(trackingValue.old_value, {}, {
+                            currency_id: trackingValue.currency_id
+                                ? session.currencies[value.currency_id]
+                                : undefined,
+                            forceString: true,
+                        });
+                    }
+                    if (trackingValue.new_value) {
+                        trackingValue.new_value = field_utils.format.monetary(trackingValue.new_value, {}, {
+                            currency_id: trackingValue.currency_id
+                                ? session.currencies[value.currency_id]
+                                : undefined,
+                            forceString: true,
+                        });
                     }
                 }
             });


### PR DESCRIPTION
Description of the issue/feature this PR addresses:

Format monetary amount on tracking value.

Current behavior before PR:

Currently, monetary amound isn't well formatted on tracking values.

See https://youtu.be/mx6gBDFxp48

Desired behavior after PR is merged:

Have monetary amount correctly formatted

OPW : 2830027



--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
