### PR TITLE
[FIX] website: fix animation in mega menu

### DIFF
--- a/addons/website/static/src/js/content/snippets.animation.js
+++ b/addons/website/static/src/js/content/snippets.animation.js
@@ -1183,6 +1183,10 @@ registry.WebsiteAnimate = publicWidget.Widget.extend({
         // Render elements and trigger the animation then pause it in state 0.
         this.$animatedElements = this.$target.find('.o_animate');
         _.each(this.$animatedElements, el => {
+            if (el.closest('.dropdown')) {
+                el.classList.add('o_animate_in_dropdown');
+                return;
+            }
             this._resetAnimation($(el));
         });
         // Then we render all the elements, the ones which are invisible
@@ -1196,14 +1200,9 @@ registry.WebsiteAnimate = publicWidget.Widget.extend({
         this.__onScrollWebsiteAnimate = _.throttle(this._onScrollWebsiteAnimate.bind(this), 200);
         this.$scrollingElement[0].addEventListener('scroll', this.__onScrollWebsiteAnimate, {capture: true});
 
-        $(window).on('resize.o_animate, shown.bs.modal.o_animate, slid.bs.carousel.o_animate, shown.bs.dropdown.o_animate', () => {
+        $(window).on('resize.o_animate, shown.bs.modal.o_animate, slid.bs.carousel.o_animate', () => {
             this.windowsHeight = $(window).height();
-            let $scrollingElement = this.$scrollingElement;
-            const $openDropdown = $('.dropdown-menu.show:has(.o_animate)');
-            if ($openDropdown.length) {
-                $scrollingElement = $openDropdown;
-            }
-            this._scrollWebsiteAnimate($scrollingElement[0]);
+            this._scrollWebsiteAnimate(this.$scrollingElement[0]);
         }).trigger("resize");
 
         return this._super(...arguments);
@@ -1214,7 +1213,7 @@ registry.WebsiteAnimate = publicWidget.Widget.extend({
     destroy() {
         this._super(...arguments);
         this.$target.find('.o_animate')
-            .removeClass('o_animating o_animated o_animate_preview')
+            .removeClass('o_animating o_animated o_animate_preview o_animate_in_dropdown')
             .css({
                 'animation-name': '',
                 'animation-play-state': '',
@@ -1301,7 +1300,7 @@ registry.WebsiteAnimate = publicWidget.Widget.extend({
         const direction = (scroll < this.lastScroll) ? -1 : 1;
         this.lastScroll = scroll;
 
-        _.each(this.$target.find('.o_animate'), el => {
+        _.each(this.$target.find('.o_animate:not(.o_animate_in_dropdown)'), el => {
             const $el = $(el);
             const elHeight = $el.height();
             const elOffset = direction * Math.max((elHeight * this.offsetRatio), this.offsetMin);

--- a/addons/website/static/src/scss/website.scss
+++ b/addons/website/static/src/scss/website.scss
@@ -1553,7 +1553,7 @@ ul.o_checklist > li.o_checked::after {
     text-rendering: geometricPrecision; // take care of animated titles
     visibility: hidden;
 
-    &:not(.o_animating) {
+    &:not(.o_animating):not(.o_animate_in_dropdown) {
         transform: none !important;
     }
 }


### PR DESCRIPTION
Before this commit, the animations were never launched in a mega menu
with the navbar option "sub menus = on hover" enabled.

Indeed the animations are launched when the element to be animated
appears in the viewport according to the scroll. But in the case of a
mega menu we just want the animation to start when the mega menu is
opened. For that we don't need all the code that checks the scroll, etc.
The animation starts by itself when the element inside the mega menu is
made visible in CSS.

A first attempt to fix this was made by this commit [1], but this fix
was wrong. Indeed, as explained above, animations in a dropdown do not
need to be triggered on scroll. And moreover, it didn't work properly
because the animations were never reset when the dropdown was closed.

This commit also hides the "Each time it becomes visible" option for
an element animated in a mega menu. This was already done in the
"_computeWidgetVisibility" but by mistake, there were 2
"_computeWidgetVisibility" in the js code of "websiteAnimate", which
meant that the one hiding this option was not taken into account.

[1]: https://github.com/odoo/odoo/commit/7a96557b839a69a9d44aac4242af2d21bc7f0e38

task-2764895

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
