### PR TITLE
[FIX] account: not to reconcile with unposted payment

### DIFF
--- a/addons/account/wizard/account_payment_register.py
+++ b/addons/account/wizard/account_payment_register.py
@@ -623,6 +623,10 @@ class AccountPaymentRegister(models.TransientModel):
         """
         domain = [('account_internal_type', 'in', ('receivable', 'payable')), ('reconciled', '=', False)]
         for vals in to_process:
+            # When using the payment tokens, the payment could not be posted at this point (e.g. the transaction failed)
+            # and then, we can't perform the reconciliation.
+            if vals['payment'].state != 'posted':
+                continue
             payment_lines = vals['payment'].line_ids.filtered_domain(domain)
             lines = vals['to_reconcile']
 


### PR DESCRIPTION
After 64b2580, this condition check is removed which will cause a
problem when a payment is registered, which triggers transaction
processing and happen to fail. This commit re-add the checking condition
to allow transaction taking place but not to reconcile transaction's
payment with invoice if fail.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
