### PR TITLE
[FIX] l10n_it_edi: imap seen flag more compatible


### DIFF
--- a/addons/l10n_it_edi/models/ir_mail_server.py
+++ b/addons/l10n_it_edi/models/ir_mail_server.py
@@ -65,9 +65,9 @@ class FetchmailServer(models.Model):
 
                     # To leave the mail in the state in which they were.
                     if "Seen" not in data[1].decode("utf-8"):
-                        imap_server.uid('STORE', uid, '+FLAGS', '\\Seen')
+                        imap_server.store(uid, '+FLAGS', '\\Seen')
                     else:
-                        imap_server.uid('STORE', uid, '-FLAGS', '\\Seen')
+                        imap_server.store(uid, '-FLAGS', '\\Seen')
 
                     # See details in message_process() in mail_thread.py
                     if isinstance(message, xmlrpclib.Binary):


### PR DESCRIPTION

For an imap "PEC server" we will fetch mail and set \Seen flag according to
current value.

But the way imaplib was used seem to possibly cause an issue on some
particular mail providers.

Mailing RFC* gives example of adding flags with parenthesis around flag:

eg. "A003 STORE 2:4 +FLAGS (\Deleted)"

but we are sending these command wihtout parenthesis (which seems to be
working, but apparently not for some providers).

To fix this issue, we change how we use the API to do the same thing
than in fetchmail module that is a lot more battle tested (and from logs
is sending flags in parenthesis).

* https://datatracker.ietf.org/doc/html/rfc3501#section-6.4.6

fixing #89305
fixing #81443
opw-2714596
