### PR TITLE
[FIX] mail: fix race condition in chat window scroll restore test

### DIFF
--- a/addons/mail/static/src/components/chat_window/chat_window.js
+++ b/addons/mail/static/src/components/chat_window/chat_window.js
@@ -6,6 +6,7 @@ const components = {
     ChatWindowHeader: require('mail/static/src/components/chat_window_header/chat_window_header.js'),
     ThreadView: require('mail/static/src/components/thread_view/thread_view.js'),
 };
+const useComponentToModel = require('mail/static/src/component_hooks/use_component_to_model/use_component_to_model.js');
 const useShouldUpdateBasedOnProps = require('mail/static/src/component_hooks/use_should_update_based_on_props/use_should_update_based_on_props.js');
 const useStore = require('mail/static/src/component_hooks/use_store/use_store.js');
 const useUpdate = require('mail/static/src/component_hooks/use_update/use_update.js');
@@ -67,7 +68,6 @@ class ChatWindow extends Component {
         // the following are passed as props to children
         this._onAutocompleteSelect = this._onAutocompleteSelect.bind(this);
         this._onAutocompleteSource = this._onAutocompleteSource.bind(this);
-        this._saveThreadScrollTop = this._saveThreadScrollTop.bind(this);
         this._constructor(...args);
     }
 
@@ -75,6 +75,10 @@ class ChatWindow extends Component {
      * Allows patching constructor.
      */
     _constructor() {}
+
+    setup() {
+        useComponentToModel({ fieldName: 'component', modelName: 'mail.chat_window', propNameAsRecordLocalId: 'chatWindowLocalId' });
+    }
 
     mounted() {
         this.env.messagingBus.on('will_hide_home_menu', this, this._onWillHideHomeMenu);

--- a/addons/mail/static/src/components/chat_window/chat_window.xml
+++ b/addons/mail/static/src/components/chat_window/chat_window.xml
@@ -17,7 +17,6 @@
                     chatWindowLocalId="chatWindow.localId"
                     hasCloseAsBackButton="props.hasCloseAsBackButton"
                     isExpandable="props.isExpandable"
-                    saveThreadScrollTop="_saveThreadScrollTop"
                     t-on-o-clicked="_onClickedHeader"
                     t-ref="header"
                 />

--- a/addons/mail/static/src/components/chat_window_header/chat_window_header.js
+++ b/addons/mail/static/src/components/chat_window_header/chat_window_header.js
@@ -85,9 +85,6 @@ class ChatWindowHeader extends Component {
      */
     _onClickShiftLeft(ev) {
         ev.stopPropagation();
-        if (this.props.saveThreadScrollTop) {
-            this.props.saveThreadScrollTop();
-        }
         this.chatWindow.shiftLeft();
     }
 
@@ -97,9 +94,6 @@ class ChatWindowHeader extends Component {
      */
     _onClickShiftRight(ev) {
         ev.stopPropagation();
-        if (this.props.saveThreadScrollTop) {
-            this.props.saveThreadScrollTop();
-        }
         this.chatWindow.shiftRight();
     }
 
@@ -115,10 +109,6 @@ Object.assign(ChatWindowHeader, {
         chatWindowLocalId: String,
         hasCloseAsBackButton: Boolean,
         isExpandable: Boolean,
-        saveThreadScrollTop: {
-            type: Function,
-            optional: true,
-        },
     },
     template: 'mail.ChatWindowHeader',
 });

--- a/addons/mail/static/src/components/chat_window_manager/chat_window_manager_tests.js
+++ b/addons/mail/static/src/components/chat_window_manager/chat_window_manager_tests.js
@@ -2443,34 +2443,41 @@ QUnit.test('chat window scroll position should remain the same after switching l
     }
     await this.start();
 
-    const thread1LocalId = this.env.models['mail.thread'].findFromIdentifyingData({
+    const thread1 = this.env.models['mail.thread'].findFromIdentifyingData({
         id: 20,
         model: 'mail.channel',
-    }).localId;
-    const thread2LocalId = this.env.models['mail.thread'].findFromIdentifyingData({
+    });
+    const thread2 = this.env.models['mail.thread'].findFromIdentifyingData({
         id: 21,
         model: 'mail.channel',
-    }).localId;
-    document.querySelector(`.o_ChatWindow[data-thread-local-id="${thread1LocalId}"] .o_ThreadView_messageList`).scrollTop = 100;
-    document.querySelector(`.o_ChatWindow[data-thread-local-id="${thread2LocalId}"] .o_ThreadView_messageList`).scrollTop = 110;
-
-    await this.afterEvent({
-        eventName: 'o-thread-view-hint-processed',
-        func: () => document.querySelector('.o_ChatWindowHeader_commandShiftLeft').click(),
-        message: "Should wait until the scroll is adjusted after a command shift.",
-        predicate: ({ hint }) => {
-            return hint.type === 'adjust-scroll';
-        },
     });
+    document.querySelector(`.o_ChatWindow[data-thread-local-id="${thread1.localId}"] .o_ThreadView_messageList`).scrollTop = 100;
+    document.querySelector(`.o_ChatWindow[data-thread-local-id="${thread2.localId}"] .o_ThreadView_messageList`).scrollTop = 110;
+
+    await afterNextRender(() => this.afterEvent({
+        eventName: 'o-thread-view-hint-processed',
+        func: () => this.afterEvent({
+            eventName: 'o-thread-view-hint-processed',
+            func: () => document.querySelector('.o_ChatWindowHeader_commandShiftLeft').click(),
+            message: "Should wait until the scroll is adjusted on 1st thread after a command shift left.",
+            predicate: ({ hint, threadViewer }) => {
+                return hint.type === 'adjust-scroll' && threadViewer.thread === thread1;
+            },
+        }),
+        message: "Should wait until the scroll is adjusted on 2nd thread after a command shift left.",
+        predicate: ({ hint, threadViewer }) => {
+            return hint.type === 'adjust-scroll' && threadViewer.thread === thread2;
+        },
+    }));
     assert.strictEqual(
-        document.querySelector(`.o_ChatWindow[data-thread-local-id="${thread2LocalId}"] .o_ThreadView_messageList`).scrollTop,
+        document.querySelector(`.o_ChatWindow[data-thread-local-id="${thread2.localId}"] .o_ThreadView_messageList`).scrollTop,
         110,
-        "Scroll position should remain the same after a chat window shift"
+        "Scroll position of 2nd thread should remain the same after a chat window shift left"
     );
     assert.strictEqual(
-        document.querySelector(`.o_ChatWindow[data-thread-local-id="${thread1LocalId}"] .o_ThreadView_messageList`).scrollTop,
+        document.querySelector(`.o_ChatWindow[data-thread-local-id="${thread1.localId}"] .o_ThreadView_messageList`).scrollTop,
         100,
-        "Scroll position should remain the same after a chat window shift"
+        "Scroll position of 1st thread should remain the same after a chat window shift left"
     );
 });
 
@@ -2500,34 +2507,41 @@ QUnit.test('chat window scroll position should remain the same after switching r
         });
     }
     await this.start();
-    const thread1LocalId = this.env.models['mail.thread'].findFromIdentifyingData({
+    const thread1 = this.env.models['mail.thread'].findFromIdentifyingData({
         id: 20,
         model: 'mail.channel',
-    }).localId;
-    const thread2LocalId = this.env.models['mail.thread'].findFromIdentifyingData({
+    });
+    const thread2 = this.env.models['mail.thread'].findFromIdentifyingData({
         id: 21,
         model: 'mail.channel',
-    }).localId;
-    document.querySelector(`.o_ChatWindow[data-thread-local-id="${thread1LocalId}"] .o_ThreadView_messageList`).scrollTop = 100;
-    document.querySelector(`.o_ChatWindow[data-thread-local-id="${thread2LocalId}"] .o_ThreadView_messageList`).scrollTop = 110;
-
-    await this.afterEvent({
-        eventName: 'o-thread-view-hint-processed',
-        func: () => document.querySelector('.o_ChatWindowHeader_commandShiftRight').click(),
-        message: "Should wait until the scroll is adjusted after a command shift.",
-        predicate: ({ hint }) => {
-            return hint.type === 'adjust-scroll';
-        },
     });
+    document.querySelector(`.o_ChatWindow[data-thread-local-id="${thread1.localId}"] .o_ThreadView_messageList`).scrollTop = 100;
+    document.querySelector(`.o_ChatWindow[data-thread-local-id="${thread2.localId}"] .o_ThreadView_messageList`).scrollTop = 110;
+
+    await afterNextRender(() => this.afterEvent({
+        eventName: 'o-thread-view-hint-processed',
+        func: () => this.afterEvent({
+            eventName: 'o-thread-view-hint-processed',
+            func: () => document.querySelector('.o_ChatWindowHeader_commandShiftRight').click(),
+            message: "Should wait until the scroll is adjusted on 1st thread after a command shift right.",
+            predicate: ({ hint, threadViewer }) => {
+                return hint.type === 'adjust-scroll' && threadViewer.thread === thread1;
+            },
+        }),
+        message: "Should wait until the scroll is adjusted on 2nd thread after a command shift right.",
+        predicate: ({ hint, threadViewer }) => {
+            return hint.type === 'adjust-scroll' && threadViewer.thread === thread2;
+        },
+    }));
     assert.strictEqual(
-        document.querySelector(`.o_ChatWindow[data-thread-local-id="${thread2LocalId}"] .o_ThreadView_messageList`).scrollTop,
+        document.querySelector(`.o_ChatWindow[data-thread-local-id="${thread2.localId}"] .o_ThreadView_messageList`).scrollTop,
         110,
-        "Scroll position should remain the same after a chat window shift"
+        "Scroll position of 2nd thread should remain the same after a chat window shift right"
     );
     assert.strictEqual(
-        document.querySelector(`.o_ChatWindow[data-thread-local-id="${thread1LocalId}"] .o_ThreadView_messageList`).scrollTop,
+        document.querySelector(`.o_ChatWindow[data-thread-local-id="${thread1.localId}"] .o_ThreadView_messageList`).scrollTop,
         100,
-        "Scroll position should remain the same after a chat window shift"
+        "Scroll position of 1st thread should remain the same after a chat window shift right"
     );
 });
 

--- a/addons/mail/static/src/components/message_list/message_list.js
+++ b/addons/mail/static/src/components/message_list/message_list.js
@@ -525,6 +525,7 @@ class MessageList extends Component {
      */
     _onScrollThrottled(ev) {
         const {
+            componentHintList,
             order,
             orderedMessages,
             thread,
@@ -554,7 +555,19 @@ class MessageList extends Component {
                 : scrollTop <= margin;
             threadView.update({ hasAutoScrollOnMessageReceived });
         }
-        if (threadViewer && threadViewer.exists()) {
+        /**
+         * Determines whether the current scroll position is considered
+         * acceptable to be saved in the models.
+         * If the value is 0 (which would be the default value when first
+         * rendering), and there are pending hints to adapt it, this should
+         * prevent from overriding the soon to be restored value by 0.
+         * This case could happen in particular if there is a scroll event made
+         * by the user, followed by a render from another action (example chat
+         * window swap), which itself adds a hint to restore the previous scroll
+         * position.
+         */
+        const isScrollAcceptable = scrollTop !== 0 || componentHintList.length === 0;
+        if (isScrollAcceptable && threadViewer && threadViewer.exists()) {
             threadViewer.saveThreadCacheScrollHeightAsInitial(this._getScrollableElement().scrollHeight, threadCache);
             threadViewer.saveThreadCacheScrollPositionsAsInitial(scrollTop, threadCache);
         }

--- a/addons/mail/static/src/models/chat_window/chat_window.js
+++ b/addons/mail/static/src/models/chat_window/chat_window.js
@@ -130,6 +130,12 @@ function factory(dependencies) {
             this.manager.swap(this, lastVisible);
         }
 
+        saveThreadScrollTop() {
+            if (this.component) {
+                this.component._saveThreadScrollTop();
+            }
+        }
+
         /**
          * Shift this chat window to the left on screen.
          */
@@ -347,6 +353,7 @@ function factory(dependencies) {
     }
 
     ChatWindow.fields = {
+        component: attr(),
         /**
          * Determines whether "new message form" should be displayed.
          */

--- a/addons/mail/static/src/models/chat_window_manager/chat_window_manager.js
+++ b/addons/mail/static/src/models/chat_window_manager/chat_window_manager.js
@@ -156,6 +156,8 @@ function factory(dependencies) {
                 return;
             }
             const otherChatWindow = chatWindows[index + 1];
+            chatWindow.saveThreadScrollTop();
+            otherChatWindow.saveThreadScrollTop();
             const _newOrdered = [...this._ordered];
             _newOrdered[index] = otherChatWindow.localId;
             _newOrdered[index + 1] = chatWindow.localId;
@@ -181,6 +183,8 @@ function factory(dependencies) {
                 return;
             }
             const otherChatWindow = chatWindows[index - 1];
+            chatWindow.saveThreadScrollTop();
+            otherChatWindow.saveThreadScrollTop();
             const _newOrdered = [...this._ordered];
             _newOrdered[index] = otherChatWindow.localId;
             _newOrdered[index - 1] = chatWindow.localId;
@@ -204,6 +208,8 @@ function factory(dependencies) {
             if (index1 === -1 || index2 === -1) {
                 return;
             }
+            chatWindow1.saveThreadScrollTop();
+            chatWindow2.saveThreadScrollTop();
             const _newOrdered = [...this._ordered];
             _newOrdered[index1] = chatWindow2.localId;
             _newOrdered[index2] = chatWindow1.localId;


### PR DESCRIPTION
1. the scroll position needs to be saved before swap on both chat windows
2. the test needs to wait for the restore to happen on both chat windows
3. an obsolete scroll event should not override a pending hint

task-2829626