### PR TITLE
[IMP] mail: turn props into model fields (step 1)

### DIFF
--- a/addons/mail/static/src/components/chat_window/chat_window.js
+++ b/addons/mail/static/src/components/chat_window/chat_window.js
@@ -112,17 +112,7 @@ export class ChatWindow extends Component {
 }
 
 Object.assign(ChatWindow, {
-    defaultProps: {
-        hasCloseAsBackButton: false,
-        isExpandable: false,
-        isFullscreen: false,
-    },
-    props: {
-        localId: String,
-        hasCloseAsBackButton: { type: Boolean, optional: true },
-        isExpandable: { type: Boolean, optional: true },
-        isFullscreen: { type: Boolean, optional: true },
-    },
+    props: { localId: String },
     template: 'mail.ChatWindow',
 });
 

--- a/addons/mail/static/src/components/chat_window/chat_window.xml
+++ b/addons/mail/static/src/components/chat_window/chat_window.xml
@@ -7,7 +7,7 @@
                 t-att-class="{
                     'o-focused': chatWindow.isFocused,
                     'o-folded': chatWindow.isFolded,
-                    'o-fullscreen': props.isFullscreen,
+                    'o-fullscreen': chatWindow.isFullscreen,
                     'o-mobile': messaging.device.isMobile,
                     'o-new-message': !chatWindow.thread,
                 }" t-att-style="chatWindow.componentStyle" t-on-keydown="chatWindow.onKeydown" t-on-focusout="chatWindow.onFocusout" t-att-data-chat-window-local-id="chatWindow.localId" t-att-data-thread-local-id="chatWindow.thread ? chatWindow.thread.localId : ''" t-ref="root"
@@ -15,8 +15,6 @@
                 <ChatWindowHeader
                     className="'o_ChatWindow_header'"
                     chatWindowLocalId="chatWindow.localId"
-                    hasCloseAsBackButton="props.hasCloseAsBackButton"
-                    isExpandable="props.isExpandable"
                     onClicked="chatWindow.onClickHeader"
                 />
                 <t t-if="chatWindow.thread and chatWindow.thread.hasMemberListFeature and chatWindow.isMemberListOpened">
@@ -28,8 +26,6 @@
                 <t t-if="chatWindow.threadView">
                     <ThreadView
                         className="'o_ChatWindow_thread'"
-                        hasComposerCurrentPartnerAvatar="false"
-                        hasComposerSendButton="messaging.device.isMobile"
                         localId="chatWindow.threadView.localId"
                     />
                 </t>

--- a/addons/mail/static/src/components/chat_window_header/chat_window_header.js
+++ b/addons/mail/static/src/components/chat_window_header/chat_window_header.js
@@ -45,20 +45,8 @@ export class ChatWindowHeader extends Component {
 }
 
 Object.assign(ChatWindowHeader, {
-    defaultProps: {
-        hasCloseAsBackButton: false,
-        isExpandable: false,
-    },
     props: {
         chatWindowLocalId: String,
-        hasCloseAsBackButton: {
-            type: Boolean,
-            optional: true,
-        },
-        isExpandable: {
-            type: Boolean,
-            optional: true,
-        },
         onClicked: {
             type: Function,
             optional: true,

--- a/addons/mail/static/src/components/chat_window_header/chat_window_header.xml
+++ b/addons/mail/static/src/components/chat_window_header/chat_window_header.xml
@@ -4,7 +4,7 @@
     <t t-name="mail.ChatWindowHeader" owl="1">
         <t t-if="chatWindow">
             <div class="o_ChatWindowHeader" t-att-class="{ 'o-mobile': messaging.device.isMobile }" t-attf-class="{{ className }}" t-on-click="_onClick" t-ref="root">
-                <t t-if="props.hasCloseAsBackButton">
+                <t t-if="chatWindow.hasCloseAsBackButton">
                     <div class="o_ChatWindowHeader_command o_ChatWindowHeader_commandBack o_ChatWindowHeader_commandClose" t-att-class="{ 'o-mobile': messaging.device.isMobile }" t-on-click="chatWindow.onClickClose" title="Close conversation">
                         <i class="fa fa-arrow-left"/>
                     </div>
@@ -67,12 +67,12 @@
                             <i class="fa fa-angle-right"/>
                         </div>
                     </t>
-                    <t t-if="props.isExpandable">
+                    <t t-if="chatWindow.isExpandable">
                         <div class="o_ChatWindowHeader_command o_ChatWindowHeader_commandExpand" t-att-class="{ 'o-mobile': messaging.device.isMobile }" t-on-click="chatWindow.onClickExpand" title="Open in Discuss">
                             <i class="fa fa-expand"/>
                         </div>
                     </t>
-                    <t t-if="!props.hasCloseAsBackButton">
+                    <t t-if="!chatWindow.hasCloseAsBackButton">
                         <div class="o_ChatWindowHeader_command o_ChatWindowHeader_commandClose" t-att-class="{ 'o-mobile': messaging.device.isMobile }" t-on-click="chatWindow.onClickClose" title="Close chat window">
                             <i class="fa fa-close"/>
                         </div>

--- a/addons/mail/static/src/components/chat_window_manager/chat_window_manager.xml
+++ b/addons/mail/static/src/components/chat_window_manager/chat_window_manager.xml
@@ -9,12 +9,7 @@
                     <ChatWindowHiddenMenu className="'o_ChatWindowManager_hiddenMenu'"/>
                 </t>
                 <t t-foreach="messaging.chatWindowManager.allOrderedVisible" t-as="chatWindow" t-key="chatWindow.localId">
-                    <ChatWindow
-                        localId="chatWindow.localId"
-                        hasCloseAsBackButton="messaging.device.isMobile"
-                        isExpandable="!messaging.device.isMobile and !!chatWindow.thread"
-                        isFullscreen="messaging.device.isMobile"
-                    />
+                    <ChatWindow localId="chatWindow.localId"/>
                 </t>
             </t>
         </div>

--- a/addons/mail/static/src/components/chatter/chatter.xml
+++ b/addons/mail/static/src/components/chatter/chatter.xml
@@ -14,8 +14,6 @@
                             className="'o_Chatter_composer border-bottom'"
                             classNameObj="{ 'o-bordered border-left border-right': chatter.hasExternalBorder }"
                             localId="chatter.composerView.localId"
-                            hasMentionSuggestionsBelowPosition="true"
-                            isExpandable="true"
                         />
                     </t>
                 </div>

--- a/addons/mail/static/src/components/chatter_topbar/chatter_topbar.xml
+++ b/addons/mail/static/src/components/chatter_topbar/chatter_topbar.xml
@@ -53,12 +53,10 @@
                                 </t>
                             </button>
                             <t t-if="chatter.hasFollowers and chatter.thread">
-                                <t t-if="chatter.thread.channel_type !== 'chat'">
+                                <t t-if="chatter.followButtonView">
                                     <FollowButton
                                         className="'o_ChatterTopbar_followButton'"
-                                        isDisabled="chatter.isDisabled"
-                                        threadLocalId="chatter.thread.localId"
-                                        isChatterButton="true"
+                                        localId="chatter.followButtonView.localId"
                                     />
                                 </t>
                                 <FollowerListMenu

--- a/addons/mail/static/src/components/composer/composer.js
+++ b/addons/mail/static/src/components/composer/composer.js
@@ -50,43 +50,7 @@ export class Composer extends Component {
 }
 
 Object.assign(Composer, {
-    defaultProps: {
-        hasCurrentPartnerAvatar: true,
-        hasDiscardButton: false,
-        hasSendButton: true,
-        isExpandable: false,
-    },
-    props: {
-        localId: String,
-        hasCurrentPartnerAvatar: {
-            type: Boolean,
-            optional: true,
-        },
-        hasDiscardButton: {
-            type: Boolean,
-            optional: true,
-        },
-        hasMentionSuggestionsBelowPosition: {
-            type: Boolean,
-            optional: true,
-        },
-        hasSendButton: {
-            type: Boolean,
-            optional: true,
-        },
-        showAttachmentsExtensions: {
-            type: Boolean,
-            optional: true,
-        },
-        showAttachmentsFilenames: {
-            type: Boolean,
-            optional: true,
-        },
-        isExpandable: {
-            type: Boolean,
-            optional: true,
-        },
-    },
+    props: { localId: String },
     template: 'mail.Composer',
 });
 

--- a/addons/mail/static/src/components/composer/composer.xml
+++ b/addons/mail/static/src/components/composer/composer.xml
@@ -6,7 +6,7 @@
             <div class="o_Composer"
                 t-att-class="{
                     'o-focused': composerView.isFocused,
-                    'o-has-current-partner-avatar': props.hasCurrentPartnerAvatar,
+                    'o-has-current-partner-avatar': composerView.hasCurrentPartnerAvatar,
                     'o-has-footer': composerView.hasFooter,
                     'o-has-header': composerView.hasHeader,
                     'o-is-in-thread-view': composerView.threadView,
@@ -52,7 +52,7 @@
                         </t>
                     </div>
                 </t>
-                <t t-if="props.hasCurrentPartnerAvatar">
+                <t t-if="composerView.hasCurrentPartnerAvatar">
                     <div class="o_Composer_sidebarMain">
                         <t t-if="!messaging.currentGuest or composerView.composer.activeThread.model !== 'mail.channel'">
                             <img class="o_Composer_currentPartnerAvatar rounded-circle" t-att-src="composerView.currentPartnerAvatar" alt="Avatar of user"/>
@@ -73,16 +73,15 @@
                         classNameObj="{
                             'o-composer-is-compact': composerView.isCompact,
                             'o_Composer_textInput-mobile': messaging.device.isMobile,
-                            'o-has-current-partner-avatar': props.hasCurrentPartnerAvatar,
+                            'o-has-current-partner-avatar': composerView.hasCurrentPartnerAvatar,
                         }"
                         localId="composerView.localId"
-                        hasMentionSuggestionsBelowPosition="props.hasMentionSuggestionsBelowPosition"
                         t-key="composerView.localId"
                     />
                     <div class="o_Composer_buttons" t-att-class="{ 'o-composer-is-compact': composerView.isCompact, 'o-mobile': messaging.device.isMobile, 'o-messaging-in-editing': composerView and composerView.messageViewInEditing }">
                         <div class="o_Composer_toolButtons"
                             t-att-class="{
-                                'o-composer-has-current-partner-avatar': props.hasCurrentPartnerAvatar,
+                                'o-composer-has-current-partner-avatar': composerView.hasCurrentPartnerAvatar,
                                 'o-composer-is-compact': composerView.isCompact,
                             }">
                             <t t-if="composerView.isCompact">
@@ -103,7 +102,7 @@
                                 <PopoverView t-if="composerView.emojisPopoverView" localId="composerView.emojisPopoverView.localId"/>
                                 <button class="o_Composer_button o_Composer_buttonAttachment o_Composer_toolButton btn btn-light fa fa-paperclip" t-att-class="{ 'o-mobile': messaging.device.isMobile }" title="Add attachment" type="button" t-on-click="composerView.onClickAddAttachment"/>
                             </div>
-                            <t t-if="props.isExpandable">
+                            <t t-if="composerView.isExpandable">
                                 <div class="o_Composer_secondaryToolButtons">
                                     <button class="btn btn-light fa fa-expand o_Composer_button o_Composer_buttonFullComposer o_Composer_toolButton" t-att-class="{ 'o-mobile': messaging.device.isMobile }" title="Full composer" type="button" t-on-click="composerView.onClickFullComposer"/>
                                 </div>
@@ -139,12 +138,12 @@
 
     <t t-name="mail.Composer.actionButtons" owl="1">
         <div class="o_Composer_actionButtons" t-att-class="{ 'o-composer-is-compact': composerView.isCompact }">
-            <t t-if="props.hasSendButton">
+            <t t-if="composerView.hasSendButton">
                 <button class="o_Composer_actionButton o_Composer_button o_Composer_buttonSend btn btn-primary"
                     t-att-class="{
-                        'o-last': messaging.device.isMobile or !props.hasDiscardButton,
+                        'o-last': !composerView.hasDiscardButton,
                         'o-composer-is-compact': composerView.isCompact,
-                        'o-has-current-partner-avatar': props.hasCurrentPartnerAvatar,
+                        'o-has-current-partner-avatar': composerView.hasCurrentPartnerAvatar,
                     }"
                     t-att-disabled="!composerView.composer.canPostMessage ? 'disabled' : ''"
                     type="button"
@@ -154,8 +153,8 @@
                     <t t-else=""><i class="fa fa-paper-plane-o"/></t>
                 </button>
             </t>
-            <t t-if="!messaging.device.isMobile and props.hasDiscardButton">
-                <button class="o_Composer_actionButton o-last o_Composer_button o_Composer_buttonDiscard btn btn-secondary" t-att-class="{ 'o-composer-is-compact': composerView.isCompact, 'o-has-current-partner-avatar': props.hasCurrentPartnerAvatar }" type="button" t-on-click="composerView.onClickDiscard">
+            <t t-if="composerView.hasDiscardButton">
+                <button class="o_Composer_actionButton o-last o_Composer_button o_Composer_buttonDiscard btn btn-secondary" t-att-class="{ 'o-composer-is-compact': composerView.isCompact, 'o-has-current-partner-avatar': composerView.hasCurrentPartnerAvatar }" type="button" t-on-click="composerView.onClickDiscard">
                     Discard
                 </button>
             </t>

--- a/addons/mail/static/src/components/composer_suggestion/composer_suggestion.js
+++ b/addons/mail/static/src/components/composer_suggestion/composer_suggestion.js
@@ -39,7 +39,7 @@ export class ComposerSuggestion extends Component {
             this.composerSuggestion &&
             this.composerSuggestion.composerViewOwner &&
             this.composerSuggestion.composerViewOwner.hasToScrollToActiveSuggestion &&
-            this.props.isActive
+            this.composerSuggestion.isActive
         ) {
             this.root.el.scrollIntoView({
                 block: 'center',
@@ -51,13 +51,7 @@ export class ComposerSuggestion extends Component {
 }
 
 Object.assign(ComposerSuggestion, {
-    defaultProps: {
-        isActive: false,
-    },
-    props: {
-        isActive: { type: Boolean, optional: true },
-        localId: String,
-    },
+    props: { localId: String },
     template: 'mail.ComposerSuggestion',
 });
 

--- a/addons/mail/static/src/components/composer_suggestion/composer_suggestion.xml
+++ b/addons/mail/static/src/components/composer_suggestion/composer_suggestion.xml
@@ -3,7 +3,7 @@
 
     <t t-name="mail.ComposerSuggestion" owl="1">
         <t t-if="composerSuggestion">
-            <a class="o_ComposerSuggestion dropdown-item d-flex w-100 py-2 px-4" t-att-class="{ 'active bg-300': props.isActive }" t-attf-class="{{ className }}" href="#" t-att-title="composerSuggestion.title" role="menuitem" t-on-click="composerSuggestion.onClick" t-ref="root">
+            <a class="o_ComposerSuggestion dropdown-item d-flex w-100 py-2 px-4" t-att-class="{ 'active bg-300': composerSuggestion.isActive }" t-attf-class="{{ className }}" href="#" t-att-title="composerSuggestion.title" role="menuitem" t-on-click="composerSuggestion.onClick" t-ref="root">
                 <t t-if="composerSuggestion.cannedResponse">
                     <strong class="o_ComposerSuggestion_part1 flex-shrink-0 mw-100 pr-2 text-truncate"><t t-esc="composerSuggestion.record.source"/></strong>
                     <em class="o_ComposerSuggestion_part2 text-600 text-truncate"><t t-esc="composerSuggestion.record.substitution"/></em>

--- a/addons/mail/static/src/components/composer_suggestion_list/composer_suggestion_list.xml
+++ b/addons/mail/static/src/components/composer_suggestion_list/composer_suggestion_list.xml
@@ -7,19 +7,13 @@
                 <div class="o_ComposerSuggestionList_drop w-100" t-att-class="{ 'dropdown': props.isBelow, 'dropup': !props.isBelow }">
                     <div class="o_ComposerSuggestionList_list dropdown-menu show w-100 overflow-auto">
                         <t t-foreach="composerView.mainSuggestions" t-as="suggestion" t-key="suggestion.localId">
-                            <ComposerSuggestion
-                                isActive="suggestion === composerView.activeSuggestion"
-                                localId="suggestion.localId"
-                            />
+                            <ComposerSuggestion localId="suggestion.localId"/>
                         </t>
                         <t t-if="composerView.mainSuggestions.length > 0 and composerView.extraSuggestions.length > 0">
                             <div role="separator" class="dropdown-divider"/>
                         </t>
                         <t t-foreach="composerView.extraSuggestions" t-as="suggestion" t-key="suggestion.localId">
-                            <ComposerSuggestion
-                                isActive="suggestion === composerView.activeSuggestion"
-                                localId="suggestion.localId"
-                            />
+                            <ComposerSuggestion localId="suggestion.localId"/>
                         </t>
                     </div>
                 </div>

--- a/addons/mail/static/src/components/composer_text_input/composer_text_input.js
+++ b/addons/mail/static/src/components/composer_text_input/composer_text_input.js
@@ -117,16 +117,7 @@ export class ComposerTextInput extends Component {
 }
 
 Object.assign(ComposerTextInput, {
-    defaultProps: {
-        hasMentionSuggestionsBelowPosition: false,
-    },
-    props: {
-        localId: String,
-        hasMentionSuggestionsBelowPosition: {
-            type: Boolean,
-            optional: true,
-        },
-    },
+    props: { localId: String },
     template: 'mail.ComposerTextInput',
 });
 

--- a/addons/mail/static/src/components/composer_text_input/composer_text_input.xml
+++ b/addons/mail/static/src/components/composer_text_input/composer_text_input.xml
@@ -7,7 +7,7 @@
                 <t t-if="composerView.hasSuggestions">
                     <ComposerSuggestionList
                         composerViewLocalId="composerView.localId"
-                        isBelow="props.hasMentionSuggestionsBelowPosition"
+                        isBelow="composerView.hasMentionSuggestionsBelowPosition"
                     />
                 </t>
                 <textarea class="o_ComposerTextInput_textarea o_ComposerTextInput_textareaStyle" t-att-class="{ 'o-composer-is-compact': composerView.isCompact }" t-esc="composerView.composer.textInputContent" t-att-placeholder="composerView.composer.placeholder" t-on-click="composerView.onClickTextarea" t-on-focusin="composerView.onFocusinTextarea" t-on-focusout="composerView.onFocusoutTextarea" t-on-keydown="composerView.onKeydownTextarea" t-on-keyup="composerView.onKeyupTextarea" t-on-input="_onInputTextarea" t-ref="textarea"/>

--- a/addons/mail/static/src/components/discuss/discuss.xml
+++ b/addons/mail/static/src/components/discuss/discuss.xml
@@ -45,8 +45,6 @@
             <ThreadView
                 className="'o_Discuss_thread'"
                 classNameObj="{ 'o-mobile': messaging.device.isMobile }"
-                hasComposerCurrentPartnerAvatar="!messaging.device.isMobile"
-                hasComposerDiscardButton="discussView.discuss.thread === messaging.inbox"
                 localId="discussView.discuss.threadView.localId"
             />
         </t>

--- a/addons/mail/static/src/components/follow_button/follow_button.js
+++ b/addons/mail/static/src/components/follow_button/follow_button.js
@@ -2,32 +2,19 @@
 
 import { registerMessagingComponent } from '@mail/utils/messaging_component';
 
-const { Component, useState } = owl;
+const { Component } = owl;
 
 export class FollowButton extends Component {
-
-    /**
-     * @override
-     */
-    setup() {
-        super.setup();
-        this.state = useState({
-            /**
-             * Determine whether the unfollow button is highlighted or not.
-             */
-            isUnfollowButtonHighlighted: false,
-        });
-    }
 
     //--------------------------------------------------------------------------
     // Public
     //--------------------------------------------------------------------------
 
     /**
-     * @return {Thread}
+     * @return {FollowButtonView}
      */
-    get thread() {
-        return this.messaging && this.messaging.models['Thread'].get(this.props.threadLocalId);
+    get followButtonView() {
+        return this.messaging && this.messaging.models['FollowButtonView'].get(this.props.localId);
     }
 
     //--------------------------------------------------------------------------
@@ -39,7 +26,10 @@ export class FollowButton extends Component {
      * @param {MouseEvent} ev
      */
     _onMouseLeaveUnfollow(ev) {
-        this.state.isUnfollowButtonHighlighted = false;
+        if (!this.followButtonView) {
+            return;
+        }
+        this.followButtonView.update({ isUnfollowButtonHighlighted: false });
     }
 
     /**
@@ -47,21 +37,16 @@ export class FollowButton extends Component {
      * @param {MouseEvent} ev
      */
     _onMouseEnterUnfollow(ev) {
-        this.state.isUnfollowButtonHighlighted = true;
+        if (!this.followButtonView) {
+            return;
+        }
+        this.followButtonView.update({ isUnfollowButtonHighlighted: true });
     }
 
 }
 
 Object.assign(FollowButton, {
-    defaultProps: {
-        isDisabled: false,
-        isChatterButton: false,
-    },
-    props: {
-        isDisabled: { type: Boolean, optional: true },
-        threadLocalId: String,
-        isChatterButton: { type: Boolean, optional: true },
-    },
+    props: { localId: String },
     template: 'mail.FollowButton',
 });
 

--- a/addons/mail/static/src/components/follow_button/follow_button.xml
+++ b/addons/mail/static/src/components/follow_button/follow_button.xml
@@ -2,11 +2,11 @@
 <templates xml:space="preserve">
 
     <t t-name="mail.FollowButton" owl="1">
-        <t t-if="thread">
+        <t t-if="followButtonView">
             <div class="o_FollowButton d-flex" t-attf-class="{{ className }}" t-ref="root">
-                <t t-if="thread.isCurrentPartnerFollowing">
-                    <button class="o_FollowButton_unfollow btn" t-att-class="{ 'o_ChatterTopbar_button': props.isChatterButton, 'o-following text-success': !state.isUnfollowButtonHighlighted, 'o-unfollow text-warning': state.isUnfollowButtonHighlighted }" t-att-disabled="props.isDisabled" t-on-click="thread.onClickUnfollow" t-on-mouseenter="_onMouseEnterUnfollow" t-on-mouseleave="_onMouseLeaveUnfollow">
-                        <t t-if="state.isUnfollowButtonHighlighted">
+                <t t-if="followButtonView.chatterOwner.thread and followButtonView.chatterOwner.thread.isCurrentPartnerFollowing">
+                    <button class="o_FollowButton_unfollow btn" t-att-class="{ 'o_ChatterTopbar_button': followButtonView.chatterOwner, 'o-following text-success': !followButtonView.isUnfollowButtonHighlighted, 'o-unfollow text-warning': followButtonView.isUnfollowButtonHighlighted }" t-att-disabled="followButtonView.isDisabled" t-on-click="followButtonView.onClickUnfollow" t-on-mouseenter="_onMouseEnterUnfollow" t-on-mouseleave="_onMouseLeaveUnfollow">
+                        <t t-if="followButtonView.isUnfollowButtonHighlighted">
                             <i class="fa fa-times"/> Unfollow
                         </t>
                         <t t-else="">
@@ -15,7 +15,7 @@
                     </button>
                 </t>
                 <t t-else="">
-                    <button class="o_FollowButton_follow btn btn-link text-600" t-att-disabled="props.isDisabled" t-on-click="thread.onClickFollow" t-att-class="{ 'o_ChatterTopbar_button': props.isChatterButton }">
+                    <button class="o_FollowButton_follow btn btn-link text-600" t-att-disabled="followButtonView.isDisabled" t-on-click="followButtonView.onClickFollow" t-att-class="{ 'o_ChatterTopbar_button': followButtonView.chatterOwner }">
                         Follow
                     </button>
                 </t>

--- a/addons/mail/static/src/components/message/message.xml
+++ b/addons/mail/static/src/components/message/message.xml
@@ -132,10 +132,6 @@
                                 <Composer
                                     className="'o_Message_composer mb-1'"
                                     localId="messageView.composerViewInEditing.localId"
-                                    hasCurrentPartnerAvatar="false"
-                                    hasDiscardButton="false"
-                                    hasMentionSuggestionsBelowPosition="false"
-                                    hasSendButton="false"
                                 />
                             </t>
                             <t t-if="messageView.message.subtype_description and !messageView.message.isBodyEqualSubtypeDescription">

--- a/addons/mail/static/src/components/message_list/message_list.js
+++ b/addons/mail/static/src/components/message_list/message_list.js
@@ -364,14 +364,6 @@ Object.assign(MessageList, {
         hasScrollAdjust: true,
     },
     props: {
-        /**
-         * Function returns the exact scrollable element from the parent
-         * to manage proper scroll heights which affects the load more messages.
-         */
-        getScrollableElement: {
-            type: Function,
-            optional: true,
-        },
         hasScrollAdjust: {
             type: Boolean,
             optional: true,

--- a/addons/mail/static/src/components/thread_view/thread_view.js
+++ b/addons/mail/static/src/components/thread_view/thread_view.js
@@ -20,37 +20,12 @@ export class ThreadView extends Component {
 }
 
 Object.assign(ThreadView, {
-    defaultProps: {
-        hasComposerDiscardButton: false,
-        showComposerAttachmentsExtensions: true,
-        showComposerAttachmentsFilenames: true,
-    },
     props: {
-        hasComposerCurrentPartnerAvatar: {
-            type: Boolean,
-            optional: true,
-        },
-        hasComposerDiscardButton: {
-            type: Boolean,
-            optional: true,
-        },
-        hasComposerSendButton: {
-            type: Boolean,
-            optional: true,
-        },
         hasScrollAdjust: {
             type: Boolean,
             optional: true,
         },
         localId: String,
-        showComposerAttachmentsExtensions: {
-            type: Boolean,
-            optional: true,
-        },
-        showComposerAttachmentsFilenames: {
-            type: Boolean,
-            optional: true,
-        },
     },
     template: 'mail.ThreadView',
 });

--- a/addons/mail/static/src/components/thread_view/thread_view.xml
+++ b/addons/mail/static/src/components/thread_view/thread_view.xml
@@ -41,11 +41,6 @@
                             <Composer
                                 className="'o_ThreadView_composer'"
                                 localId="threadView.composerView.localId"
-                                hasCurrentPartnerAvatar="props.hasComposerCurrentPartnerAvatar"
-                                hasDiscardButton="props.hasComposerDiscardButton"
-                                hasSendButton="props.hasComposerSendButton"
-                                showAttachmentsExtensions="props.showComposerAttachmentsExtensions"
-                                showAttachmentsFilenames="props.showComposerAttachmentsFilenames"
                             />
                         </t>
                     </div>

--- a/addons/mail/static/src/models/chat_window.js
+++ b/addons/mail/static/src/models/chat_window.js
@@ -344,6 +344,16 @@ registerModel({
         },
         /**
          * @private
+         * @returns {boolean|FieldCommand}
+         */
+        _computeHasCloseAsBackButton() {
+            if (this.isVisible && this.messaging.device.isMobile) {
+                return true;
+            }
+            return clear();
+        },
+        /**
+         * @private
          * @returns {boolean}
          */
         _computeHasInviteFeature() {
@@ -397,6 +407,16 @@ registerModel({
         },
         /**
          * @private
+         * @returns {boolean|FieldCommand}
+         */
+        _computeIsExpandable() {
+            if (this.isVisible && !this.messaging.device.isMobile && this.thread) {
+                return true;
+            }
+            return clear();
+        },
+        /**
+         * @private
          * @returns {boolean}
          */
         _computeIsFolded() {
@@ -405,6 +425,16 @@ registerModel({
                 return thread.foldState === 'folded';
             }
             return this.isFolded;
+        },
+        /**
+         * @private
+         * @returns {boolean|FieldCommand}
+         */
+        _computeIsFullscreen() {
+            if (this.isVisible && this.messaging.device.isMobile) {
+                return true;
+            }
+            return clear();
         },
         /**
          * @private
@@ -566,6 +596,10 @@ registerModel({
             default: false,
             compute: '_computeHasCallButtons',
         }),
+        hasCloseAsBackButton: attr({
+            compute: '_computeHasCloseAsBackButton',
+            default: false,
+        }),
         /**
          * States whether this chat window has the invite feature.
          */
@@ -601,6 +635,10 @@ registerModel({
         isDoFocus: attr({
             default: false,
         }),
+        isExpandable: attr({
+            default: false,
+            compute: '_computeIsExpandable',
+        }),
         /**
          * States whether `this` is focused. Useful for visual clue.
          */
@@ -612,6 +650,10 @@ registerModel({
          */
         isFolded: attr({
             default: false,
+        }),
+        isFullscreen: attr({
+            default: false,
+            compute: '_computeIsFullscreen',
         }),
         /**
          * Determines whether the member list of this chat window is opened.

--- a/addons/mail/static/src/models/chatter.js
+++ b/addons/mail/static/src/models/chatter.js
@@ -148,6 +148,16 @@ registerModel({
          * @private
          * @returns {FieldCommand}
          */
+        _computeFollowButtonView() {
+            if (this.hasFollowers && this.thread && this.thread.channel_type !== 'chat') {
+                return insertAndReplace();
+            }
+            return clear();
+        },
+        /**
+         * @private
+         * @returns {FieldCommand}
+         */
         _computeFollowerListMenuView() {
             if (this.hasFollowers && this.thread) {
                 return insertAndReplace();
@@ -291,6 +301,11 @@ registerModel({
         }),
         context: attr({
             default: {},
+        }),
+        followButtonView: one('FollowButtonView', {
+            compute: '_computeFollowButtonView',
+            inverse: 'chatterOwner',
+            isCausal: true,
         }),
         followerListMenuView: one('FollowerListMenuView', {
             compute: '_computeFollowerListMenuView',

--- a/addons/mail/static/src/models/composer_suggestion.js
+++ b/addons/mail/static/src/models/composer_suggestion.js
@@ -36,6 +36,19 @@ registerModel({
         },
         /**
          * @private
+         * @returns {boolean|FieldCommand}
+         */
+        _computeIsActive() {
+            if (this.composerViewOwnerAsMainSuggestion && this === this.composerViewOwnerAsMainSuggestion.activeSuggestion) {
+                return true;
+            }
+            if (this.composerViewOwnerAsExtraSuggestion && this === this.composerViewOwnerAsExtraSuggestion.activeSuggestion) {
+                return true;
+            }
+            return clear();
+        },
+        /**
+         * @private
          * @returns {string}
          */
         _computeMentionText() {
@@ -111,6 +124,10 @@ registerModel({
         composerViewOwnerAsMainSuggestion: one('ComposerView', {
             inverse: 'mainSuggestions',
             readonly: true,
+        }),
+        isActive: attr({
+            compute: '_computeIsActive',
+            default: true,
         }),
         /**
          * The text that identifies this suggestion in a mention.

--- a/addons/mail/static/src/models/composer_view.js
+++ b/addons/mail/static/src/models/composer_view.js
@@ -838,6 +838,25 @@ registerModel({
             return '/web/static/img/user_menu_avatar.png';
         },
         /**
+         * @private
+         * @returns {boolean|FieldCommand}
+         */
+        _computeHasDiscardButton() {
+            if (this.messageViewInEditing) {
+                return false;
+            }
+            if (this.messaging.device.isMobile) {
+                return false;
+            }
+            if (!this.threadView) {
+                return clear();
+            }
+            if (this.threadView.threadViewer.discuss) {
+                return this.threadView.threadViewer.discuss.thread === this.messaging.inbox;
+            }
+            return clear();
+        },
+        /**
          * Clears the extra suggestions on closing mentions, and ensures
          * the extra list does not contain any element already present in the
          * main list, which is a requirement for the navigation process.
@@ -850,6 +869,25 @@ registerModel({
                 return clear();
             }
             return unlink(this.mainSuggestions);
+        },
+        /**
+         * @private
+         * @returns {boolean|FieldCommand}
+         */
+        _computeHasCurrentPartnerAvatar() {
+            if (this.messageViewInEditing) {
+                return false;
+            }
+            if (!this.threadView) {
+                return clear();
+            }
+            if (this.threadView.threadViewer.chatWindow) {
+                return false;
+            }
+            if (this.threadView.threadViewer.discuss) {
+                return !this.messaging.device.isMobile;
+            }
+            return clear();
         },
         /**
          * @private
@@ -886,6 +924,19 @@ registerModel({
         },
         /**
          * @private
+         * @returns {boolean|FieldCommand}
+         */
+        _computeHasMentionSuggestionsBelowPosition() {
+            if (this.threadView && this.threadView.threadViewer.chatter) {
+                return true;
+            }
+            if (this.messageViewInEditing) {
+                return false;
+            }
+            return clear();
+        },
+        /**
+         * @private
          * @return {boolean}
          */
         _computeHasSuggestions() {
@@ -910,6 +961,29 @@ registerModel({
                 return false;
             }
             if (this.messageViewInEditing) {
+                return true;
+            }
+            return clear();
+        },
+        /**
+         * @private
+         * @returns {boolean|FieldCommand}
+         */
+        _computeHasSendButton() {
+            if (this.messageViewInEditing) {
+                return false;
+            }
+            if (this.threadView && this.threadView.threadViewer.chatWindow) {
+                return this.messaging.device.isMobile;
+            }
+            return clear();
+        },
+        /**
+         * @private
+         * @returns {boolean|FieldCommand}
+         */
+        _computeIsExpandable() {
+            if (this.chatter) {
                 return true;
             }
             return clear();
@@ -1373,6 +1447,14 @@ registerModel({
             readonly: true,
             required: true,
         }),
+        hasCurrentPartnerAvatar: attr({
+            default: true,
+            compute: '_computeHasCurrentPartnerAvatar',
+        }),
+        hasDiscardButton: attr({
+            compute: '_computeHasDiscardButton',
+            default: false,
+        }),
         hasFollowers: attr({
             compute: '_computeHasFollowers',
             default: false,
@@ -1388,6 +1470,14 @@ registerModel({
          */
         hasHeader: attr({
             compute: '_computeHasHeader',
+        }),
+        hasMentionSuggestionsBelowPosition: attr({
+            compute: '_computeHasMentionSuggestionsBelowPosition',
+            default: false,
+        }),
+        hasSendButton: attr({
+            compute: '_computeHasSendButton',
+            default: true,
         }),
         /**
          * States whether there is any result currently found for the current
@@ -1425,6 +1515,10 @@ registerModel({
         isCompact: attr({
             compute: '_computeIsCompact',
             default: true,
+        }),
+        isExpandable: attr({
+            compute: '_computeIsExpandable',
+            default: false,
         }),
         isFocused: attr({
             default: false,

--- a/addons/mail/static/src/models/follow_button_view.js
+++ b/addons/mail/static/src/models/follow_button_view.js
@@ -1,0 +1,58 @@
+/** @odoo-module **/
+
+import { registerModel } from '@mail/model/model_core';
+import { attr, one } from '@mail/model/model_field';
+import { clear } from '@mail/model/model_field_command';
+
+registerModel({
+    name: 'FollowButtonView',
+    identifyingFields: [['chatterOwner']],
+    recordMethods: {
+        /**
+         * @private
+         * @returns {boolean|FieldCommand}
+         */
+        _computeIsDisabled() {
+            if (!this.chatterOwner) {
+                return clear();
+            }
+            return this.chatterOwner.isDisabled;
+        },
+        /**
+         * @param {MouseEvent} ev 
+         */
+        onClickFollow(ev) {
+            if (!this.exists()) {
+                return;
+            }
+            if (!this.chatterOwner || !this.chatterOwner.thread) {
+                return;
+            }
+            this.chatterOwner.thread.follow();
+        },
+        /**
+         * @param {MouseEvent} ev
+         */
+        onClickUnfollow(ev) {
+            if (!this.exists()) {
+                return;
+            }
+            if (!this.chatterOwner || !this.chatterOwner.thread) {
+                return;
+            }
+            this.chatterOwner.thread.unfollow();
+        },
+    },
+    fields: {
+        chatterOwner: one('Chatter', {
+            inverse: 'followButtonView',
+            readonly: true,
+        }),
+        isDisabled: attr({
+            compute: '_computeIsDisabled',
+        }),
+        isUnfollowButtonHighlighted: attr({
+            default: false,
+        }),
+    },
+});

--- a/addons/mail/static/src/models/thread.js
+++ b/addons/mail/static/src/models/thread.js
@@ -894,12 +894,6 @@ registerModel({
             });
         },
         /**
-         * @param {MouseEvent} ev
-         */
-        onClickFollow(ev) {
-            this.follow();
-        },
-        /**
          * Handles click on the avatar of the given member in the member list of
          * this channel.
          *
@@ -916,12 +910,6 @@ registerModel({
          */
         onClickMemberName(member) {
             member.openProfile();
-        },
-        /**
-         * @param {MouseEvent} ev
-         */
-        onClickUnfollow(ev) {
-            this.unfollow();
         },
         /**
          * Opens this thread either as form view, in discuss app, or as a chat

--- a/addons/mail/static/tests/helpers/mock_server.js
+++ b/addons/mail/static/tests/helpers/mock_server.js
@@ -1856,8 +1856,20 @@ MockServer.include({
      * @returns {boolean}
      */
     _mockMailThreadMessageSubscribe(model, ids, partner_ids, subtype_ids) {
-        // message_subscribe is too complex for a generic mock.
-        // mockRPC should be considered for a specific result.
+        for (const id of ids) {
+            for (const partner_id of partner_ids) {
+                const followerId = this._mockCreate('mail.followers', {
+                    is_active: true,
+                    partner_id,
+                    res_id: id,
+                    res_model: model,
+                    subtype_ids: subtype_ids,
+                });
+                this._mockWrite('res.partner', [[partner_id], {
+                    message_follower_ids: [followerId],
+                }]);
+            }
+        }
     },
     /**
      * Simulates `_notify_thread` on `mail.thread`.


### PR DESCRIPTION
This commit moves some business logic from components to models,
as a step to move further to having essentially all business code in models.

Having code in models is desirable to have very maintainable code, thanks to
robust and declarative code with an ORM-like architecture.

Task-2826823
