### PR TITLE
[FIX] point_of_sale,pos_{sale,gift_card}: product taken in total disc…

### DIFF
--- a/addons/point_of_sale/static/src/js/models.js
+++ b/addons/point_of_sale/static/src/js/models.js
@@ -3440,17 +3440,16 @@ exports.Order = Backbone.Model.extend({
             return sum + orderLine.get_price_without_tax();
         }), 0), this.pos.currency.rounding);
     },
+    _reduce_total_discount_callback: function(sum, orderLine) {
+        sum += (orderLine.get_unit_price() * (orderLine.get_discount()/100) * orderLine.get_quantity());
+        if (orderLine.display_discount_policy() === 'without_discount'){
+            sum += ((orderLine.get_lst_price() - orderLine.get_unit_price()) * orderLine.get_quantity());
+        }
+        return sum;
+    },
     get_total_discount: function() {
-        return round_pr(this.orderlines.reduce((function(sum, orderLine) {
-            if (orderLine.pos.config.down_payment_product_id[0] === orderLine.product.id) {
-                return 0;
-            }
-            sum += (orderLine.get_unit_price() * (orderLine.get_discount()/100) * orderLine.get_quantity());
-            if (orderLine.display_discount_policy() === 'without_discount'){
-                sum += ((orderLine.get_lst_price() - orderLine.get_unit_price()) * orderLine.get_quantity());
-            }
-            return sum;
-        }), 0), this.pos.currency.rounding);
+        const reduce_callback = this._reduce_total_discount_callback.bind(this);
+        return round_pr(this.orderlines.reduce(reduce_callback, 0), this.pos.currency.rounding);
     },
     get_total_tax: function() {
         if (this.pos.company.tax_calculation_rounding_method === "round_globally") {

--- a/addons/pos_gift_card/static/src/js/models.js
+++ b/addons/pos_gift_card/static/src/js/models.js
@@ -28,6 +28,7 @@ odoo.define("pos_gift_card.gift_card", function (require) {
 
   var _order_super = models.Order.prototype;
   models.Order = models.Order.extend({
+    //@override
     set_orderline_options: function (orderline, options) {
       _order_super.set_orderline_options.apply(this, [orderline, options]);
       if (options && options.generated_gift_card_ids) {
@@ -37,6 +38,7 @@ odoo.define("pos_gift_card.gift_card", function (require) {
         orderline.gift_card_id = options.gift_card_id;
       }
     },
+    //@override
     wait_for_push_order: function () {
         if(this.pos.config.use_gift_card) {
             let giftProduct = this.pos.db.product_by_id[this.pos.config.gift_card_product_id[0]];
@@ -47,6 +49,14 @@ odoo.define("pos_gift_card.gift_card", function (require) {
         }
         return _order_super.wait_for_push_order.apply(this, arguments);
     },
+    //@override
+    _reduce_total_discount_callback: function(sum, orderLine) {
+        if (this.pos.config.gift_card_product_id[0] === orderLine.product.id) {
+            return sum;
+        }
+        return _order_super._reduce_total_discount_callback.apply(this, arguments);
+    },
+
   });
 
   var _super_orderline = models.Orderline;

--- a/addons/pos_sale/static/src/js/models.js
+++ b/addons/pos_sale/static/src/js/models.js
@@ -22,6 +22,17 @@ models.load_models([{
 
 models.load_fields("product.product", ["invoice_policy", "type"]);
 
+const super_order_model = models.Order.prototype;
+models.Order = models.Order.extend({
+    //@override
+    _reduce_total_discount_callback: function(sum, orderLine) {
+        if (this.pos.config.down_payment_product_id[0] === orderLine.product.id) {
+            return sum;
+        }
+        return super_order_model._reduce_total_discount_callback.apply(this, arguments);
+    },
+})
+
 var super_order_line_model = models.Orderline.prototype;
 models.Orderline = models.Orderline.extend({
   initialize: function (attributes, options) {


### PR DESCRIPTION
…ount

When showing the discount the to the public, the down payment and gift card products were taken into account in the discount computation shown in the receipt.

This also fix a mistake made in fc546e0481ae0159e67791240833bc1e38a4440f where it was implemented in the wrong place and returning a wrong value in a reduce callback.

related pr: https://github.com/odoo/odoo/pull/89028