### PR TITLE
[FIX] hr_holidays: show employee's time off in dashboard

### DIFF
--- a/addons/hr_holidays/static/src/js/time_off_calendar/time_off_calendar_renderer.js
+++ b/addons/hr_holidays/static/src/js/time_off_calendar/time_off_calendar_renderer.js
@@ -40,7 +40,7 @@ export const TimeOffCalendarRenderer = TimeOffPopoverRenderer.extend({
         return await this._rpc({
             model: 'hr.leave.type',
             method: 'get_days_all_request',
-            context: session.user_context,
+            context: this.state.context,
         });
     },
 


### PR DESCRIPTION
Accessing the time off of an employee displays the wrong leave values in
the dashboard

Steps to reproduce:
1. Install Time Off
2. Open the Employees app
3. Open employee 'Anita Oliver'
4. Click on the 'Time Off' smart button
5. The calendar dashboard shows the leaves of the connected user but it
should display the leaves of the employee

Solution:
Use the state context like it was done before [this commit] so the
employee_id will be passed to the rpc call. The call will then do the
query on the correct employee with `_get_contextual_employee_id`.

[this commit]:https://github.com/odoo/odoo/commit/60728a63db141d0fc9f3

opw-2824616