### PR TITLE
[FIX] website_hr_recruitment: allow portal users to filter by department

### DIFF
--- a/addons/website_hr_recruitment/security/ir.model.access.csv
+++ b/addons/website_hr_recruitment/security/ir.model.access.csv
@@ -1,3 +1,3 @@
 id,name,model_id:id,group_id:id,perm_read,perm_write,perm_create,perm_unlink
 access_hr_job_public,hr.job.public,hr.model_hr_job,,1,0,0,0
-access_hr_department_public,hr.department.public,hr.model_hr_department,base.group_public,1,0,0,0
+access_hr_department_public,hr.department.public,hr.model_hr_department,,1,0,0,0


### PR DESCRIPTION
Currently, only a public user or an internal user can access HR
department information. This is causing an access rights error when
trying to filter job offers on the website if connected with a portal
user, while there is no error if not connected (public user). We should
have the same behavior for the two cases.

Description of the issue/feature this PR addresses:
opw-2819632

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
