### PR TITLE
[FIX] auth_signup: translations are fixed for spanish

### DIFF
--- a/addons/auth_signup/i18n/es.po
+++ b/addons/auth_signup/i18n/es.po
@@ -765,7 +765,7 @@ msgstr ""
 #. module: auth_signup
 #: model:ir.model.fields.selection,name:auth_signup.selection__res_config_settings__auth_signup_uninvited__b2c
 msgid "Free sign up"
-msgstr "Registro gatris"
+msgstr "Registro gratis"
 
 #. module: auth_signup
 #: model:ir.model,name:auth_signup.model_ir_http

--- a/addons/auth_signup/i18n/es_MX.po
+++ b/addons/auth_signup/i18n/es_MX.po
@@ -764,7 +764,7 @@ msgstr ""
 #. module: auth_signup
 #: model:ir.model.fields.selection,name:auth_signup.selection__res_config_settings__auth_signup_uninvited__b2c
 msgid "Free sign up"
-msgstr "Registro gatris"
+msgstr "Registro gratis"
 
 #. module: auth_signup
 #: model:ir.model,name:auth_signup.model_ir_http

--- a/doc/cla/individual/fnaquira.md
+++ b/doc/cla/individual/fnaquira.md
@@ -1,0 +1,11 @@
+Perú, 2022-04-21
+
+I hereby agree to the terms of the Odoo Individual Contributor License
+Agreement v1.0.
+
+I declare that I am authorized and able to make this agreement and sign this
+declaration.
+
+Signed,
+
+Favio Náquira fnaquiravargas@gmail.com https://github.com/fnaquira

--- a/doc/cla/individual/fnaquira.md
+++ b/doc/cla/individual/fnaquira.md
@@ -8,4 +8,4 @@ declaration.
 
 Signed,
 
-Favio Náquira fnaquiravargas@gmail.com https://github.com/fnaquira
+Favio Náquira Vargas fnaquiravargas@gmail.com https://github.com/fnaquira


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
Terms "Free sign up" are translated in a wrong way.
Current behavior before PR:
Translation are wrong
Desired behavior after PR is merged:
Translation will be ok



--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
