### PR TITLE
[FIX] l10n_ch: fix preview on email templates

### DIFF
--- a/addons/l10n_ch/models/mail_template.py
+++ b/addons/l10n_ch/models/mail_template.py
@@ -47,9 +47,10 @@ class MailTemplate(models.Model):
                     qr_pdf = base64.b64encode(qr_pdf)
                     new_attachments.append((qr_report_name, qr_pdf))
 
-                attachments_list = multi_mode and rslt[res_id].get('attachments', False) or rslt.get('attachments', False)
+                record_dict = multi_mode and rslt[res_id] or rslt
+                attachments_list = record_dict.get('attachments', False)
                 if attachments_list:
                     attachments_list.extend(new_attachments)
                 else:
-                    rslt[res_id]['attachments'] = new_attachments
+                    record_dict['attachments'] = new_attachments
         return rslt


### PR DESCRIPTION
Steps to reproduce:

  - Intall l10n_ch module
  - Go to Settings -> Technical -> Email -> Templates
  - Create a new one
  - Set 'Applies to' to 'Journal Entries' then save
  - Click on 'Preview' button

Issue:

  Traceback raised.

Cause:

  Trying to get record from rslt while it's already the dict of the rec.
  If in multi_mode (res_ids is an integer), rslt will be directly a dict
  of the record (opposite to NOT multi_mode where rslt will be a list of
  dicts).

opw-2694396