### PR TITLE
[FIX] base: do not force creating preexisting mail.default.from

### DIFF
--- a/odoo/addons/base/data/ir_config_parameter_data.xml
+++ b/odoo/addons/base/data/ir_config_parameter_data.xml
@@ -14,7 +14,7 @@
         </record>
 
         <!-- Notifications -->
-        <record id="icp_mail_default_from" model="ir.config_parameter">
+        <record id="icp_mail_default_from" model="ir.config_parameter" forcecreate="False">
             <field name="key">mail.default.from</field>
             <field name="value">notifications</field>
         </record>


### PR DESCRIPTION
This parameter was already supported by Odoo v14. However, it was not precreated. So it's very likely that a database contains the parameter already.

When migrating a database, upgrading `base` module would fail because it couldn't create this data.

Adding forcecreate=false to fix it, just like with a7c774849c000a7910d4db3d026cb9569297dc21.

OPW-2826875

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
