### PR TITLE
[FIX] sale_{purchase,stock}, stock: decreasing the ordered qty

### DIFF
--- a/addons/sale_stock/models/sale_order.py
+++ b/addons/sale_stock/models/sale_order.py
@@ -86,7 +86,7 @@ class SaleOrder(models.Model):
             for order in self:
                 to_log = {}
                 for order_line in order.order_line:
-                    if float_compare(order_line.product_uom_qty, pre_order_line_qty.get(order_line, 0.0), order_line.product_uom.rounding) < 0:
+                    if float_compare(order_line.product_uom_qty, pre_order_line_qty.get(order_line, 0.0), precision_rounding=order_line.product_uom.rounding) < 0:
                         to_log[order_line] = (order_line.product_uom_qty, pre_order_line_qty.get(order_line, 0.0))
                 if to_log:
                     documents = self.env['stock.picking']._log_activity_get_documents(to_log, 'move_ids', 'UP')

--- a/addons/stock/models/stock_picking.py
+++ b/addons/stock/models/stock_picking.py
@@ -1143,7 +1143,7 @@ class Picking(models.Model):
         """
         for (parent, responsible), rendering_context in documents.items():
             note = render_method(rendering_context)
-            parent.activity_schedule(
+            parent.sudo().activity_schedule(
                 'mail.mail_activity_data_warning',
                 date.today(),
                 note=note,


### PR DESCRIPTION
In a MTO case, when a salesman decreases the ordered quantity, it can
lead to an access error

To reproduce the issue:
(Use demo data)
1. In Users, edit Marc Demo:
    - Invoicing: None
    - Purchase: None
2. Create a product P:
    - Type: Storable
    - Add a vendor V
    - Routes:
        - MTO
        - Buy
3. Log in as Marc Demo
4. Create a sale order SO with 2 x P
5. Confirm SO
6. Edit SO:
    - Set the qty of P to 1
    - ignore the warning
7. Save the SO

Error: There is an access error ("create" on "Activity" (mail.activity))

Because the user decreases the quantity, we want to log this decreasing
on the related documents:
https://github.com/odoo/odoo/blob/ee9ea35ad218be87564de484470f1c4e9c433977/addons/sale_stock/models/sale_order.py#L91-L94
In the above case, it leads to a write operation on the generated
purchase order. However, Marc Demo hasn't any right to perform such an
operation.

We should bypass the rights checking in such situation.

Note: in `/sale_stock:SaleOrder.write`: we need to specify what kind of
precision we are using.

OPW-2745317