### PR TITLE
[FIX] sale_loyalty: fix pricing on free products

### DIFF
--- a/addons/sale_loyalty/models/sale_order.py
+++ b/addons/sale_loyalty/models/sale_order.py
@@ -139,7 +139,7 @@ class SaleOrder(models.Model):
         return [{
             'name': _("Free Product - %(product)s", product=product.name),
             'product_id': product.id,
-            'price_unit': 0,
+            'discount': 100,
             'product_uom_qty': reward.reward_product_qty * claimable_count,
             'reward_id': reward.id,
             'coupon_id': coupon.id,

--- a/addons/sale_loyalty/models/sale_order_line.py
+++ b/addons/sale_loyalty/models/sale_order_line.py
@@ -40,7 +40,7 @@ class SaleOrderLine(models.Model):
     def _get_display_price(self):
         # A product created from a promotion does not have a list_price.
         # The price_unit of a reward order line is computed by the promotion, so it can be used directly
-        if self.is_reward_line:
+        if self.is_reward_line and self.reward_id.reward_type != 'product':
             return self.price_unit
         return super()._get_display_price()
 


### PR DESCRIPTION
Previously free products from loyalty programs were given as the product
with a price_unit of 0, it will now have the complete price but with a
100% discount instead.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
