### PR TITLE
[FIX] mrp_subcontracting: remove transfer list from global MO tree view

### DIFF
--- a/addons/mrp_subcontracting/views/mrp_production_views.xml
+++ b/addons/mrp_subcontracting/views/mrp_production_views.xml
@@ -79,7 +79,7 @@
         <field name="inherit_id" ref="mrp.mrp_production_tree_view" />
         <field name="arch" type="xml">
             <xpath expr="//field[@name='name']" position="after">
-                <field name="incoming_picking"/>
+                <field name="incoming_picking" invisible="1"/>
             </xpath>
         </field>
     </record>


### PR DESCRIPTION
The purpose is only for landed cost, hide it in this version and create
new views for saas-15.4

opw-2667152
