### PR TITLE
[FIX] mrp_subcontracting: only add transfer in landed costs views

### DIFF
--- a/addons/mrp_subcontracting/views/mrp_production_views.xml
+++ b/addons/mrp_subcontracting/views/mrp_production_views.xml
@@ -76,6 +76,8 @@
     <record id="mrp_production_subcontracting_tree_view" model="ir.ui.view">
         <field name="name">mrp.production.subcontracting.tree</field>
         <field name="model">mrp.production</field>
+        <field name="mode">primary</field>
+        <field name="priority">1000</field>
         <field name="inherit_id" ref="mrp.mrp_production_tree_view" />
         <field name="arch" type="xml">
             <xpath expr="//field[@name='name']" position="after">
@@ -87,6 +89,8 @@
     <record id="mrp_production_subcontracting_filter" model="ir.ui.view">
         <field name="name">mrp.production.subcontracting.select</field>
         <field name="model">mrp.production</field>
+        <field name="mode">primary</field>
+        <field name="priority">1000</field>
         <field name="inherit_id" ref="mrp.view_mrp_production_filter" />
         <field name="arch" type="xml">
             <xpath expr="//field[@name='name']" position="after">

--- a/addons/mrp_subonctracting_landed_costs/__init__.py
+++ b/addons/mrp_subonctracting_landed_costs/__init__.py
@@ -1,0 +1,2 @@
+# -*- coding: utf-8 -*-
+# Part of Odoo. See LICENSE file for full copyright and licensing details.

--- a/addons/mrp_subonctracting_landed_costs/__manifest__.py
+++ b/addons/mrp_subonctracting_landed_costs/__manifest__.py
@@ -1,0 +1,19 @@
+# -*- coding: utf-8 -*-
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+{
+    'name': 'Landed Costs With Subcontracting order',
+    'version': '1.0',
+    'summary': 'Advanced views to manage landed cost for subcontracting orders',
+    'description': """
+This module allows users to more easily identify subcontracting orders when applying landed costs,
+by also displaying the associated picking reference in the search view.
+    """,
+    'depends': ['stock_landed_costs', 'mrp_subcontracting'],
+    'category': 'Manufacturing/Manufacturing',
+    'data': [
+        'views/stock_landed_cost_views.xml',
+    ],
+    'auto_install': True,
+    'license': 'LGPL-3',
+}

--- a/addons/mrp_subonctracting_landed_costs/views/stock_landed_cost_views.xml
+++ b/addons/mrp_subonctracting_landed_costs/views/stock_landed_cost_views.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<odoo>
+    <record id='view_mrp_landed_costs_form' model='ir.ui.view'>
+        <field name="name">mrp.subcontracting.landed.cost.form</field>
+        <field name="model">stock.landed.cost</field>
+        <field name="inherit_id" ref="mrp_landed_costs.view_mrp_landed_costs_form"/>
+        <field name="arch" type="xml">
+            <field name="mrp_production_ids" position="attributes">
+                <attribute name="context">{'search_view_ref': 'mrp_subcontracting.mrp_production_subcontracting_filter', 'tree_view_ref': 'mrp_subcontracting.mrp_production_subcontracting_tree_view'}</attribute>
+            </field>
+        </field>
+    </record>
+</odoo>


### PR DESCRIPTION
Currently the linked receipt (in case of subcontracting)
is visible in the tree view and search view of every MO.
However we want to limit the feature to landed cost scope
since it's only useful in that case and it adds noise otherwise.

We need a new module since we don't have any bridge between
subcontracting and landed costs
