### PR TITLE
[FIX] sale: Missing numbers on SO reports

### DIFF
--- a/addons/sale/report/sale_report_templates.xml
+++ b/addons/sale/report/sale_report_templates.xml
@@ -140,7 +140,7 @@
 
             <div class="clearfix" name="so_total_summary">
                 <div id="total" class="row" name="total">
-                    <div t-attf-class="#{'col-4' if report_type != 'html' else 'col-sm-7 col-md-5'} ml-auto">
+                    <div t-attf-class="#{'col-6' if report_type != 'html' else 'col-sm-7 col-md-6'} ml-auto">
                         <table class="table table-sm">
                             <tr class="border-black o_subtotal" style="">
                                 <td name="td_amount_untaxed_label"><strong>Subtotal</strong></td>

--- a/addons/sale/views/sale_portal_templates.xml
+++ b/addons/sale/views/sale_portal_templates.xml
@@ -520,7 +520,7 @@
                 </table>
 
                 <div id="total" class="row" name="total" style="page-break-inside: avoid;">
-                    <div t-attf-class="#{'col-4' if report_type != 'html' else 'col-sm-7 col-md-5'} ml-auto">
+                    <div t-attf-class="#{'col-6' if report_type != 'html' else 'col-sm-7 col-md-6'} ml-auto">
                         <!-- Should be replaced in master by t-call="sale.sale_order_portal_content_totals_table" -->
                         <table class="table table-sm">
                             <tr class="border-black" style="border-bottom:1px solid #dddddd;">


### PR DESCRIPTION
When inputting long numbers in a SO report, some numbers are cutoff.

Step to reproduce the issue:
1) Set paper format to A4
2) Make a SO for at least 100,000,000.00 with TVA
3) Print
The total print cut off on the edge, does not happen on invoices.

Solution: The div was not spanning on enough columns resulting on a overflow.
The solution is similar to what was done on invoices, just increase the col-X.
The same change was done on the portal as the issue would be similar.

opw-2817634