### PR TITLE
[FIX] web_editor, *: prevent dropping unsafe snippets in model fields

### DIFF
--- a/addons/web_editor/i18n/web_editor.pot
+++ b/addons/web_editor/i18n/web_editor.pot
@@ -612,6 +612,13 @@ msgstr ""
 
 #. module: web_editor
 #. openerp-web
+#: code:addons/web_editor/static/src/js/editor/snippets.editor.js:0
+#, python-format
+msgid "For technical reasons, this block cannot be dropped here"
+msgstr ""
+
+#. module: web_editor
+#. openerp-web
 #: code:addons/web_editor/static/src/xml/ace.xml:0
 #, python-format
 msgid "Format"

--- a/addons/web_editor/models/ir_qweb.py
+++ b/addons/web_editor/models/ir_qweb.py
@@ -53,9 +53,11 @@ class QWeb(models.AbstractModel):
         view_id = View.get_view_id(el.attrib.get('t-call'))
         name = View.browse(view_id).name
         thumbnail = el.attrib.pop('t-thumbnail', "oe-thumbnail")
-        div = u'<div name="%s" data-oe-type="snippet" data-oe-thumbnail="%s">' % (
+        forbid_sanitize = el.attrib.get('t-forbid-sanitize')
+        div = u'<div name="%s" data-oe-type="snippet" data-oe-thumbnail="%s" %s>' % (
             escape(pycompat.to_text(name)),
-            escape(pycompat.to_text(thumbnail))
+            escape(pycompat.to_text(thumbnail)),
+            'data-oe-forbid-sanitize="true"' if forbid_sanitize else '',
         )
         return [self._append(ast.Str(div))] + self._compile_node(el, options) + [self._append(ast.Str(u'</div>'))]
 
@@ -326,6 +328,15 @@ class HTML(models.AbstractModel):
     _name = 'ir.qweb.field.html'
     _description = 'Qweb Field HTML'
     _inherit = 'ir.qweb.field.html'
+
+    @api.model
+    def attributes(self, record, field_name, options, values=None):
+        attrs = super().attributes(record, field_name, options, values)
+        if options.get('inherit_branding'):
+            field = record._fields[field_name]
+            if field.sanitize:
+                attrs['data-oe-sanitize'] = 1
+        return attrs
 
     @api.model
     def from_html(self, model, field, element):

--- a/addons/web_editor/static/src/scss/wysiwyg_snippets.scss
+++ b/addons/web_editor/static/src/scss/wysiwyg_snippets.scss
@@ -430,6 +430,11 @@ body.editor_enable.editor_has_snippets {
             margin: 0 (-$o-we-dropzone-size/2);
         }
     }
+    &.oe_drop_zone_danger {
+        background-color: rgba($o-we-color-danger, 0.15);
+        color: $o-we-color-danger;
+        border-color: $o-we-color-danger;
+    }
 }
 
 // MANIPULATORS

--- a/addons/website_form/views/snippets.xml
+++ b/addons/website_form/views/snippets.xml
@@ -19,7 +19,9 @@
 
         <template id="register_s_website_form" inherit_id="website.snippets" name="Snippet Form Builder">
             <xpath expr="//div[@id='snippet_feature']//t[@t-snippet][last()]" position="after">
-                <t t-snippet="website_form.s_website_form" t-thumbnail="/website/static/src/img/s_website_form.png"/>
+                <!-- This snippet cannot be used in sanitized fields -->
+                <!-- because it contains inputs that would be removed -->
+                <t t-snippet="website_form.s_website_form" t-thumbnail="/website/static/src/img/s_website_form.png" t-forbid-sanitize="true"/>
             </xpath>
         </template>
 

--- a/addons/website_sale/views/snippets.xml
+++ b/addons/website_sale/views/snippets.xml
@@ -41,11 +41,15 @@
 
 <template id="snippets" inherit_id="website.snippets" name="e-commerce snippets">
     <xpath expr="//div[@id='snippet_feature']//t[@t-snippet][last()]" position="after">
-        <t t-snippet="website_sale.s_products_searchbar" t-thumbnail="/website/static/src/img/snippets_thumbs/s_products_searchbar.png"/>
+        <!-- This snippet cannot be used in sanitized fields because it -->
+        <!-- contains an input that would be removed -->
+        <t t-snippet="website_sale.s_products_searchbar" t-thumbnail="/website/static/src/img/snippets_thumbs/s_products_searchbar.png" t-forbid-sanitize="true"/>
         <t t-snippet="website_sale.s_products_recently_viewed" t-thumbnail="/website/static/src/img/snippets_thumbs/s_products_recently_viewed.png"/>
     </xpath>
     <xpath expr="//div[@id='snippet_content']//t[@t-snippet][last()]" position="after">
-        <t t-snippet="website_sale.s_products_searchbar_input" t-thumbnail="/website/static/src/img/snippets_thumbs/s_products_searchbar.png"/>
+        <!-- This snippet cannot be used in sanitized fields because it -->
+        <!-- contains an input that would be removed -->
+        <t t-snippet="website_sale.s_products_searchbar_input" t-thumbnail="/website/static/src/img/snippets_thumbs/s_products_searchbar.png" t-forbid-sanitize="true"/>
     </xpath>
 </template>
 


### PR DESCRIPTION
*: website_form, website_sale

When an unsafe snippet is dropped into a sanitized HTML model field, its
unsafe content gets removed on save.

This commit prevents unsafe snippets from being dropped into sanitized
HTML model fields.
The "Form Builder", "Product Search" and "Product Search Input" blocks
are now prevented from being dropped or moved into sanitized HTML model
fields.

Steps to reproduce:
- Go to a product page
- Drop a "Product Search" snippet into the product-specific section of the
product
- Save
=> The form was removed.

task-2829961

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
