### PR TITLE
[FIX] sale: translate warning message title

### DIFF
--- a/addons/sale/models/sale.py
+++ b/addons/sale/models/sale.py
@@ -433,7 +433,7 @@ class SaleOrder(models.Model):
             # Block if partner only has warning but parent company is blocked
             if partner.sale_warn != 'block' and partner.parent_id and partner.parent_id.sale_warn == 'block':
                 partner = partner.parent_id
-            title = ("Warning for %s") % partner.name
+            title = _("Warning for %s") % partner.name
             message = partner.sale_warn_msg
             warning = {
                     'title': title,


### PR DESCRIPTION
Reproduction:
1. enable sale warnings,
2. set a warning on a partner
3. switch profile language (non-english))
4. create quotation-> select the partner
5. warning appears in English

Reason: The title isn’t translated

Fix: added translation function around the title

opw-2821521

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
