### PR TITLE
[FIX] sale: various improvements

### DIFF
--- a/addons/sale/models/res_partner.py
+++ b/addons/sale/models/res_partner.py
@@ -1,9 +1,9 @@
 # -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
-from odoo import fields, models
+from odoo import api, fields, models
 from odoo.addons.base.models.res_partner import WARNING_MESSAGE, WARNING_HELP
-
+from odoo.osv import expression
 
 class ResPartner(models.Model):
     _inherit = 'res.partner'
@@ -13,13 +13,17 @@ class ResPartner(models.Model):
     sale_warn = fields.Selection(WARNING_MESSAGE, 'Sales Warnings', default='no-message', help=WARNING_HELP)
     sale_warn_msg = fields.Text('Message for Sales Order')
 
+    @api.model
+    def _get_sale_order_domain_count(self):
+        return []
+
     def _compute_sale_order_count(self):
         # retrieve all children partners and prefetch 'parent_id' on them
         all_partners = self.with_context(active_test=False).search([('id', 'child_of', self.ids)])
         all_partners.read(['parent_id'])
 
         sale_order_groups = self.env['sale.order']._read_group(
-            domain=[('partner_id', 'in', all_partners.ids)],
+            domain=expression.AND([self._get_sale_order_domain_count(), [('partner_id', 'in', all_partners.ids)]]),
             fields=['partner_id'], groupby=['partner_id']
         )
         partners = self.browse()

--- a/addons/sale/static/src/js/sale_order_controller.js
+++ b/addons/sale/static/src/js/sale_order_controller.js
@@ -23,13 +23,19 @@ odoo.define('sale.SaleOrderFormController', function (require) {
          *  (3) value is the same in all other sale order line
          */
         _onOpenUpdateAllWizard(ev) {
-            const orderLines = this._DialogReady(ev, 'normal')
+            const orderLines = this._DialogReady(ev, 'normal');
+            const customValuesCommands = [];
             const confirmCallback = () => {
                 orderLines.slice(1).forEach((line) => {
-                    this.trigger_up('field_changed', {
-                        dataPointID: this.renderer.state.id,
-                        changes: {order_line: {operation: "UPDATE", id: line.id, data: {[ev.data.fieldName]: ev.data.value}}},
+                    customValuesCommands.push({
+                        operation: "UPDATE",
+                        id: line.id,
+                        data: {[ev.data.fieldName]: ev.data.value},
                     });
+                });
+                this.trigger_up('field_changed', {
+                            dataPointID: this.renderer.state.id,
+                            changes: {order_line: {operation: "MULTI", commands: customValuesCommands}},
                 });
             };
             if (orderLines) {


### PR DESCRIPTION
Before this commit, when user updated all column values in sale order all the changes were applied to the line one by one.
The domain used to count the number of SO of a partner was not easlily overridable in the compute method.

Description of the issue/feature this PR addresses:






--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
