### PR TITLE
[FIX] point_of_sale: price at 0, fixed tax price include

### DIFF
--- a/addons/point_of_sale/models/pos_session.py
+++ b/addons/point_of_sale/models/pos_session.py
@@ -694,7 +694,7 @@ class PosSession(models.Model):
         # may arise in 'Round Globally'.
         check_refund = lambda x: x.qty * x.price_unit < 0
         is_refund = check_refund(order_line)
-        tax_data = tax_ids.compute_all(price_unit=price, quantity=abs(order_line.qty), currency=self.currency_id, is_refund=is_refund)
+        tax_data = tax_ids.with_context(force_sign=sign).compute_all(price_unit=price, quantity=abs(order_line.qty), currency=self.currency_id, is_refund=is_refund)
         taxes = tax_data['taxes']
         # For Cash based taxes, use the account from the repartition line immediately as it has been paid already
         for tax in taxes:


### PR DESCRIPTION
Have a product with:
* Fixed tax (i.e. 1$) included
* Standard 15% sales tax included
in this order
Open pos session, add the product to order, make a 100% discount,
confirm and pay
Close session and validate

Journal entries will report:

|Account            |Debit|Credit|
|-------------------|-----|------|
|Tax Received       |1    |0     |
|Product Sales      |1    |0     |
|Account Receivable |0    |2     |

After 5b45c232fbb7036c255ef1feec8d94d89ec2fe31
fixed situations with a 0.00 price and a fixed
tax included.
doing the same operation in account app will get

|Account            |Debit|Credit|
|-------------------|-----|------|
|Tax Received       |0    |1     |
|Product Sales      |1    |0     |
|Account Receivable |0    |0     |

This commit align the behavior of POS to the account app, by forcing the
sign when computing the tax vals

opw-2637512

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
