### PR TITLE
[FIX] website: fix Customer Account settings

### DIFF
--- a/addons/website/views/res_config_settings_views.xml
+++ b/addons/website/views/res_config_settings_views.xml
@@ -379,6 +379,11 @@
                         </div>
                     </div>
                 </xpath>
+                <xpath expr="//div[@id='login_documents']/div[hasclass('o_setting_right_pane')]/div[hasclass('mt8')]" position="replace">
+                    <div class="alert alert-info mt-2" role="alert">
+                        As website module is installed, that behavior is handled at the website level. Go to website settings to edit that behavior.
+                    </div>
+                </xpath>
             </field>
         </record>
 


### PR DESCRIPTION
Customer Account settings are present in General Settings and Website
settings when module website is installed.

Steps to reproduce:
1. Install website
2. Create a new company and switch to it
3. Go to Settings and search for 'Customer Account'
4. This option is present in multiple places and trying to change this
setting doesn't save anything because no website is set for the current
company

Solution:
Add an info in General Settings' Customer Account to inform the user
that this setting must be edited from the website settings.

opw-2825823