### PR TITLE
[FIX] account: show invoices of archived contact in "Invoiced" button

### DIFF
--- a/addons/account/models/partner.py
+++ b/addons/account/models/partner.py
@@ -477,7 +477,13 @@ class ResPartner(models.Model):
             ('type', 'in', ('out_invoice', 'out_refund')),
             ('partner_id', 'child_of', self.id),
         ]
-        action['context'] = {'default_type':'out_invoice', 'type':'out_invoice', 'journal_type': 'sale', 'search_default_unpaid': 1}
+        action['context'] = {
+            'default_type':'out_invoice',
+            'type':'out_invoice',
+            'journal_type': 'sale',
+            'search_default_unpaid': 1,
+            'active_test': False,
+            }
         return action
 
     @api.onchange('company_id', 'parent_id')


### PR DESCRIPTION
When going from the res.partner form view to the smart button
"Invoiced", we currently do not show in the list the invoices where the
partner set on it is archived. This is misleading as the value in the
smart button itself is computed by including them. We should show these
invoices as well to keep things consistent.

Description of the issue/feature this PR addresses:
opw-2801337

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
