### PR TITLE
[FIX] mail: broken email scheduled date

### DIFF
--- a/addons/mail/i18n/mail.pot
+++ b/addons/mail/i18n/mail.pot
@@ -7468,6 +7468,11 @@ msgid "Wrong operation name (%s)"
 msgstr ""
 
 #. module: mail
+#: model_terms:ir.ui.view,arch_db:mail.view_mail_form
+msgid "YYYY-MM-DD HH:MM:SS"
+msgstr ""
+
+#. module: mail
 #. openerp-web
 #: code:addons/mail/static/src/js/activity.js:0
 #: code:addons/mail/static/src/models/message/message.js:0

--- a/addons/mail/views/mail_mail_views.xml
+++ b/addons/mail/views/mail_mail_views.xml
@@ -27,7 +27,7 @@
                             <field name="recipient_ids" widget="many2many_tags"/>
                             <field name="email_cc"/>
                             <field name="reply_to"/>
-                            <field name="scheduled_date"/>
+                            <field name="scheduled_date" placeholder="YYYY-MM-DD HH:MM:SS"/>
                         </group>
                         <notebook>
                             <page string="Body" name="body">


### PR DESCRIPTION
Step to reproduce:
	activate the developer mode
	go to settings - technical - emails
	create a new email and set the Scheduled Send Date in the future
	run the scheduled action Mail: Email Queue Manager

Current behavior:
the email is sent and the action does not consider the filter

Expected behavior:
the email is not sent and will only be sent when the scheduler detects
that scheduled_date exceeds the current time.

Issue description:
The scheduled_date field of the mail is of type char and contains
the time in local time. We need to set "now" with the right format and
timezone for the filter to compare the two correctly.

Note for RD sm:
The field scheduled_date should be updated to field.Datetime and it should
be stored in UTC in db. 

opw-2823106