### PR TITLE
[FIX] product: update attribute's related products

### DIFF
--- a/addons/product/models/product_attribute.py
+++ b/addons/product/models/product_attribute.py
@@ -39,7 +39,7 @@ class ProductAttribute(models.Model):
     @api.depends('attribute_line_ids.active', 'attribute_line_ids.product_tmpl_id')
     def _compute_products(self):
         for pa in self:
-            pa.product_tmpl_ids = pa.attribute_line_ids.product_tmpl_id
+            pa.with_context(active_test=False).product_tmpl_ids = pa.attribute_line_ids.product_tmpl_id
 
     def _without_no_variant_attributes(self):
         return self.filtered(lambda pa: pa.create_variant != 'no_variant')

--- a/addons/product/tests/test_product_attribute_value_config.py
+++ b/addons/product/tests/test_product_attribute_value_config.py
@@ -662,3 +662,34 @@ class TestProductAttributeValueConfig(TestProductAttributeValueSetup):
                 'name': '32 GB',
                 'attribute_id': self.ram_attribute.id,
             })
+
+    def test_inactive_related_product_update(self):
+        """
+            Create a product and give it a product attribute then archive it, delete the product attribute,
+            unarchive the product and check that the product is not related to the product attribute.
+        """
+        product_attribut = self.env['product.attribute'].create({
+            'name': 'PA',
+            'sequence': 1,
+            'create_variant': 'no_variant',
+        })
+        a1 = self.env['product.attribute.value'].create({
+            'name': 'pa_value',
+            'attribute_id': product_attribut.id,
+            'sequence': 1,
+        })
+        product = self.env['product.template'].create({
+            'name': 'P1',
+            'type': 'product',
+            'attribute_line_ids': [(0, 0, {
+                'attribute_id': product_attribut.id,
+                'value_ids': [(6, 0, [a1.id])],
+            })]
+        })
+        self.assertTrue(product_attribut.is_used_on_products, 'The product attribute must have an associated product')
+        product.action_archive()
+        self.assertFalse(product.active, 'The product should be archived.')
+        product.write({'attribute_line_ids': [[5, 0, 0]]})
+        product.action_unarchive()
+        self.assertTrue(product.active, 'The product should be unarchived.')
+        self.assertFalse(product_attribut.is_used_on_products, 'The product attribute must not have an associated product')


### PR DESCRIPTION
**Steps to reproduce the bug:**
- Create a product attribute “PA”:
    - Variants Creation Mode: Never
    - Value: “PA1”

- Create a storable product “test”:
    - Add the attribute “PA“ and the variant “PA1”
    - Save

- Archive the product and then remove the attribute from the product
- Unarchive the product

So the product has no longer the attribute line but if we check the
attribute itself, it is still having the product as a related one.

**Problem:**
When we remove the line attribute, the `_compute_products` is called,
but as the product “test” is archived, when we try to access the
related products of the product attribute, it returns an empty recordset
because the ORM only returns active records.
Since the attribute `product_tmpl_ids` seems empty and we try to update
it with an empty value, the ORM considers there is no change and so, it
does not update the field value in the DB.

**Solution:**
We must use `active_test=False` when accessing the related products, so
the ORM returns all records, active or archived.
And since there is indeed a linked product and we are trying to
overwrite it with an empty recordset, the change will be effective.

opw-[2806316](https://www.odoo.com/web#id=2806316&view_type=form&model=project.task)




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
