### PR TITLE
[FIX] website_sale : display whole popover when large cart

### DIFF
--- a/addons/website_sale/static/src/scss/website_sale.scss
+++ b/addons/website_sale/static/src/scss/website_sale.scss
@@ -421,9 +421,12 @@ ul.wizard {
 .mycart-popover {
     max-width: 500px;
     min-width: 250px;
+    max-height: 90%;
+    overflow: auto;
 
     .cart_line {
         border-bottom: 1px #EEE solid;
+        max-width: 90%;
     }
 }
 


### PR DESCRIPTION
Steps :
In eShop, add >12 items to cart.
Hover the cart icon.

Issue :
The list pops, but you do not see :
	> the next items,
	> the totals,
	> the View Cart button.

Cause :
Nothing is precised for that case in the stylesheet.

Fix :
Set popover's max height to 90%,
add a scrollbar if needed,
set its line's wdth to 90% to make room for the scrollbar.

opw-2781715

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
