### PR TITLE
[FIX] core: always close cursors at the exit of context managers 

### DIFF
--- a/addons/stock/models/stock_rule.py
+++ b/addons/stock/models/stock_rule.py
@@ -650,18 +650,12 @@ class ProcurementGroup(models.Model):
                             else:
                                 raise
 
-            try:
-                if use_new_cursor:
-                    cr.commit()
-            except OperationalError:
-                if use_new_cursor:
-                    cr.rollback()
-                    continue
-                else:
-                    raise
-
             if use_new_cursor:
-                cr.commit()
-                cr.close()
+                try:
+                    cr.commit()
+                except OperationalError:
+                    cr.rollback()
+                finally:
+                    cr.close()
 
         return {}

--- a/addons/stock/wizard/stock_scheduler_compute.py
+++ b/addons/stock/wizard/stock_scheduler_compute.py
@@ -19,9 +19,8 @@ class StockSchedulerCompute(models.TransientModel):
     _description = 'Run Scheduler Manually'
 
     def _procure_calculation_orderpoint(self):
-        with api.Environment.manage():
-            # As this function is in a new thread, I need to open a new cursor, because the old one may be closed
-            new_cr = self.pool.cursor()
+        # As this function is in a new thread, I need to open a new cursor, because the old one may be closed
+        with api.Environment.manage(), self.pool.cursor() as new_cr:
             self = self.with_env(self.env(cr=new_cr))
             scheduler_cron = self.sudo().env.ref('stock.ir_cron_scheduler_action')
             # Avoid to run the scheduler multiple times in the same time
@@ -39,7 +38,6 @@ class StockSchedulerCompute(models.TransientModel):
                 self.env['procurement.group'].with_context(allowed_company_ids=cids).run_scheduler(
                     use_new_cursor=self._cr.dbname,
                     company_id=company.id)
-            new_cr.close()
             return {}
 
     def procure_calculation(self):

--- a/odoo/sql_db.py
+++ b/odoo/sql_db.py
@@ -429,9 +429,11 @@ class Cursor(object):
         return self
 
     def __exit__(self, exc_type, exc_value, traceback):
-        if exc_type is None:
-            self.commit()
-        self.close()
+        try:
+            if exc_type is None:
+                self.commit()
+        finally:
+            self.close()
 
     @contextmanager
     @check
@@ -515,9 +517,11 @@ class TestCursor(object):
         return self
 
     def __exit__(self, exc_type, exc_value, traceback):
-        if exc_type is None:
-            self.commit()
-        self.close()
+        try:
+            if exc_type is None:
+                self.commit()
+        finally:
+            self.close()
 
     def __getattr__(self, name):
         value = getattr(self._cursor, name)


### PR DESCRIPTION
The call to `commit()` can fail during the flush of the environment
and raise an exception before the actual `COMMIT;`, leaving the
cursor unclosed.

This leaked cursor may hold locks that only be released when the GC
collects it. On low-traffic workers like the CronWorker, this can
lock usual database usages.