### PR TITLE
[FIX] mass_mailing: compute schedule_type/date correctly

### DIFF
--- a/addons/mass_mailing/models/mailing.py
+++ b/addons/mass_mailing/models/mailing.py
@@ -77,10 +77,11 @@ class MassMailing(models.Model):
 
     schedule_type = fields.Selection([('now', 'Send now'), ('scheduled', 'Send on')], string='Schedule',
                                      default='now', required=True, readonly=True,
-                                     states={'draft': [('readonly', False)], 'in_queue': [('readonly', False)]})
+                                     states={'draft': [('readonly', False)], 'in_queue': [('readonly', False)]},
+                                     copy=False)
     schedule_date = fields.Datetime(string='Scheduled for', tracking=True, readonly=True,
                                     states={'draft': [('readonly', False)], 'in_queue': [('readonly', False)]},
-                                    compute='_compute_schedule_date', store=True, copy=True)
+                                    compute='_compute_schedule_date', store=True)
     calendar_date = fields.Datetime('Calendar Date', compute='_compute_calendar_date', store=True, copy=False,
         help="Date at which the mailing was or will be sent.")
     # don't translate 'body_arch', the translations are only on 'body_html'


### PR DESCRIPTION
Steps to Reproduce:
- Create Mass Mailing and Schedule it on Date.
- Copy it.

Bug:
- New copied Mass Mailing has set `schedule_type` as `scheduled`
  instead of default value `now`.
- It has `schedule_date` from old original record while it has to be `False`

Fix:
- Fields `schedule_type` and `schedule_date` should not be copied.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
