### PR TITLE
[FIX] web: list: Button confirmation message not show in list view

### DIFF
--- a/addons/web/static/src/js/views/list/list_controller.js
+++ b/addons/web/static/src/js/views/list/list_controller.js
@@ -738,7 +738,13 @@ var ListController = BasicController.extend({
      */
     _onButtonClicked: function (ev) {
         ev.stopPropagation();
-        this._callButtonAction(ev.data.attrs, ev.data.record);
+        if (ev.data.attrs.confirm) {
+            Dialog.confirm(this, ev.data.attrs.confirm, {
+                confirm_callback: this._callButtonAction.bind(this, ev.data.attrs, ev.data.record),
+            });
+        } else {
+            this._callButtonAction(ev.data.attrs, ev.data.record);
+        }
     },
     /**
      * When the user clicks on the 'create' button, two things can happen. We


### PR DESCRIPTION
The confirmation message stored in <confirm> tag of the buttons is not showing in tree views.

**Impacted versions:**
14.0
15.0

**Current behavior:**
When a button that has a "confirm" attribute with a message is clicked, this message is never displayed and performs an action directly

**Expected behavior:**
Show the confirmation message before executing the action

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
