### PR TITLE
[IMP] hr: sudo no longer used to show users' preferences

### DIFF
--- a/doc/cla/individual/crazybolillo.md
+++ b/doc/cla/individual/crazybolillo.md
@@ -1,0 +1,11 @@
+Mexico, 2022-04-24
+
+I hereby agree to the terms of the Odoo Individual Contributor License
+Agreement v1.0.
+
+I declare that I am authorized and able to make this agreement and sign this
+declaration.
+
+Signed,
+
+Antonio antonio@zoftko.com https://github.com/crazybolillo


### PR DESCRIPTION
**Description of the issue/feature this PR addresses:**
The `hr` module lets users write their own profile data, in order to do this users must be able to read fields they don't normally have access to, this is currently done by getting the view as `sudo`, with the side effects that users can skip all security checks and see all fields, even if other module developers did not design it to be that way.

**Current behavior before PR:**
If I add a field to `res.users` and want to restrict its visibility based on the user's groups, I can't do it, because the `hr` module skips over all those checks.

**Desired behavior after PR is merged:**
If I add a field to 'res.users' I can restrict its visibility based on the user's groups, and users can still see all HR related fields and edit them (if allowed).




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
