### PR TITLE
[FIX] models: Deduplication occurs when sum two model objects

### DIFF
--- a/odoo/models.py
+++ b/odoo/models.py
@@ -5652,8 +5652,8 @@ Fields:
         for arg in args:
             if not (isinstance(arg, BaseModel) and arg._name == self._name):
                 raise TypeError("Mixing apples and oranges: %s.concat(%s)" % (self, arg))
-            ids.extend(arg._ids)
-        return self.browse(list(set(ids)))
+            ids.extend([id for id in arg._ids if id not in ids])
+        return self.browse(ids)
 
     def __sub__(self, other):
         """ Return the recordset of all the records in ``self`` that are not in

--- a/odoo/models.py
+++ b/odoo/models.py
@@ -5653,7 +5653,7 @@ Fields:
             if not (isinstance(arg, BaseModel) and arg._name == self._name):
                 raise TypeError("Mixing apples and oranges: %s.concat(%s)" % (self, arg))
             ids.extend(arg._ids)
-        return self.browse(ids)
+        return self.browse(list(set(ids)))
 
     def __sub__(self, other):
         """ Return the recordset of all the records in ``self`` that are not in


### PR DESCRIPTION
before:
```python
>>> user
res.users(1,)
>>> user+user
res.users(1, 1)
```

after:
```
>>> user
res.users(1,)
>>> user+user
res.users(1)
```

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
