### PR TITLE
[FIX] web_editor, website, mass_mailing: fix click on theme tab tests

### DIFF
--- a/addons/mass_mailing/static/src/js/tours/mass_mailing_snippets_menu_tabs.js
+++ b/addons/mass_mailing/static/src/js/tours/mass_mailing_snippets_menu_tabs.js
@@ -32,6 +32,7 @@ tour.register('mass_mailing_snippets_menu_tabs', {
     },
     {
         content: "Verify that the customize panel is not empty.",
+        extra_trigger: 'iframe .o_we_customize_design_btn.active',
         trigger: 'iframe .o_we_customize_panel .snippet-option-DesignTab',
         run: () => null, // it's a check
     },
@@ -45,6 +46,7 @@ tour.register('mass_mailing_snippets_menu_tabs', {
     },
     {
         content: "Verify that the customize panel is not empty.",
+        extra_trigger: 'iframe .o_we_customize_design_btn.active',
         trigger: 'iframe .o_we_customize_panel .snippet-option-DesignTab',
         run: () => null, // it's a check
     },

--- a/addons/website/static/tests/tours/website_snippets_menu_tabs.js
+++ b/addons/website/static/tests/tours/website_snippets_menu_tabs.js
@@ -17,6 +17,7 @@ tour.register("website_snippets_menu_tabs", {
     wTourUtils.goToTheme(),
     {
         content: "Verify that the customize panel is not empty.",
+        extra_trigger: '.o_we_customize_theme_btn.active',
         trigger: '.o_we_customize_panel > we-customizeblock-options',
         run: () => null, // it's a check
     },
@@ -27,6 +28,7 @@ tour.register("website_snippets_menu_tabs", {
     wTourUtils.goToTheme(),
     {
         content: "Verify that the customize panel is not empty.",
+        extra_trigger: '.o_we_customize_theme_btn.active',
         trigger: '.o_we_customize_panel > we-customizeblock-options',
         run: () => null, // it's a check
     },


### PR DESCRIPTION
Since this commit [1], the click on theme tab test in mass_mailing
failed sometimes on runbot. It looks like the step to wait for the theme
tab is filled requires an extra trigger to be sure it is not yet empty.

This commit also adds this extra trigger in the website test, even if
that one didn't cause any problems.

[1]: https://github.com/odoo/odoo/pull/88497/commits/119032151a45d264bf3a8f0018eb95ae24805909

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
