### PR TITLE
[FIX] hr_holidays: No limit accrual

### DIFF
--- a/addons/hr_holidays/models/hr_leave_allocation.py
+++ b/addons/hr_holidays/models/hr_leave_allocation.py
@@ -445,8 +445,10 @@ class HolidaysAllocation(models.Model):
             if days_added_per_level:
                 number_of_days_to_add = sum(days_added_per_level.values())
                 # Let's assume the limit of the last level is the correct one
-                allocation.write({'number_of_days': min(allocation.number_of_days + number_of_days_to_add, current_level.maximum_leave)})
-
+                allocation.write({
+                    'number_of_days': allocation.number_of_days + number_of_days_to_add if not current_level.maximum_leave else
+                                    min(allocation.number_of_days + number_of_days_to_add, current_level.maximum_leave)
+                })
     @api.model
     def _update_accrual(self):
         """


### PR DESCRIPTION
Step to reproduce:
- Create an accrual Plan with a level L
- In level L, set limit = 0
- Create an accrual allocation for this Plan which should result
in number_of_days > 0
- Run the scheduled action for time off

Current behaviour:
- Allocation's number of day is stuck to 0

Behaviour after PR:
- Allocation number of day is correctly updated

opw-2806826

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
