### PR TITLE
[FIX] hr_holidays: correctly compute accrual days when no cap

### DIFF
--- a/addons/hr_holidays/models/hr_leave_allocation.py
+++ b/addons/hr_holidays/models/hr_leave_allocation.py
@@ -443,9 +443,9 @@ class HolidaysAllocation(models.Model):
                 allocation.lastcall = allocation.nextcall
                 allocation.nextcall = nextcall
             if days_added_per_level:
-                number_of_days_to_add = sum(days_added_per_level.values())
+                number_of_days_to_add = allocation.number_of_days + sum(days_added_per_level.values())
                 # Let's assume the limit of the last level is the correct one
-                allocation.write({'number_of_days': min(allocation.number_of_days + number_of_days_to_add, current_level.maximum_leave)})
+                allocation.number_of_days = min(number_of_days_to_add, current_level.maximum_leave + allocation.leaves_taken) if current_level.maximum_leave > 0 else number_of_days_to_add
 
     @api.model
     def _update_accrual(self):

--- a/addons/hr_holidays/tests/test_accrual_allocations.py
+++ b/addons/hr_holidays/tests/test_accrual_allocations.py
@@ -625,3 +625,104 @@ class TestAccrualAllocations(TestHrHolidaysCommon):
         with freeze_time('2022-4-4'):
             allocation._update_accrual()
         self.assertEqual(allocation.number_of_days, 3, "Invalid number of days")
+
+    def test_accrual_maximum_leaves(self):
+        accrual_plan = self.env['hr.leave.accrual.plan'].with_context(tracking_disable=True).create({
+            'name': 'Accrual Plan For Test',
+            'level_ids': [(0, 0, {
+                'start_count': 1,
+                'start_type': 'day',
+                'added_value': 1,
+                'added_value_type': 'days',
+                'frequency': 'daily',
+                'maximum_leave': 5,
+            })],
+        })
+        allocation = self.env['hr.leave.allocation'].with_user(self.user_hrmanager_id).with_context(tracking_disable=True).create({
+            'name': 'Accrual allocation for employee',
+            'accrual_plan_id': accrual_plan.id,
+            'employee_id': self.employee_emp.id,
+            'holiday_status_id': self.leave_type.id,
+            'number_of_days': 0,
+            'allocation_type': 'accrual',
+            'date_from': '2021-09-03',
+        })
+
+        with freeze_time(datetime.date(2021, 10, 3)):
+            allocation.action_confirm()
+            allocation.action_validate()
+            allocation._update_accrual()
+
+            self.assertEqual(allocation.number_of_days, 5, "Should accrue maximum 5 days")
+
+    def test_accrual_maximum_leaves_no_limit(self):
+        accrual_plan = self.env['hr.leave.accrual.plan'].with_context(tracking_disable=True).create({
+            'name': 'Accrual Plan For Test',
+            'level_ids': [(0, 0, {
+                'start_count': 1,
+                'start_type': 'day',
+                'added_value': 1,
+                'added_value_type': 'days',
+                'frequency': 'daily',
+                'maximum_leave': 0,
+            })],
+        })
+        allocation = self.env['hr.leave.allocation'].with_user(self.user_hrmanager_id).with_context(tracking_disable=True).create({
+            'name': 'Accrual allocation for employee',
+            'accrual_plan_id': accrual_plan.id,
+            'employee_id': self.employee_emp.id,
+            'holiday_status_id': self.leave_type.id,
+            'number_of_days': 0,
+            'allocation_type': 'accrual',
+            'date_from': '2021-09-03',
+        })
+
+        with freeze_time(datetime.date(2021, 10, 3)):
+            allocation.action_confirm()
+            allocation.action_validate()
+            allocation._update_accrual()
+
+            self.assertEqual(allocation.number_of_days, 29, "No limits for accrued days")
+
+    def test_accrual_leaves_taken_maximum(self):
+        accrual_plan = self.env['hr.leave.accrual.plan'].with_context(tracking_disable=True).create({
+            'name': 'Accrual Plan For Test',
+            'level_ids': [(0, 0, {
+                'start_count': 0,
+                'start_type': 'day',
+                'added_value': 1,
+                'added_value_type': 'days',
+                'frequency': 'weekly',
+                'week_day': 'mon',
+                'maximum_leave': 5,
+            })],
+        })
+        allocation = self.env['hr.leave.allocation'].with_user(self.user_hrmanager_id).with_context(tracking_disable=True).create({
+            'name': 'Accrual allocation for employee',
+            'accrual_plan_id': accrual_plan.id,
+            'employee_id': self.employee_emp.id,
+            'holiday_status_id': self.leave_type.id,
+            'number_of_days': 0,
+            'allocation_type': 'accrual',
+            'date_from': '2022-01-01',
+        })
+        allocation.action_confirm()
+        allocation.action_validate()
+
+        with freeze_time(datetime.date(2022, 3, 2)):
+            allocation._update_accrual()
+
+        self.assertEqual(allocation.number_of_days, 5, "Maximum of 5 days accrued")
+
+        leave = self.env['hr.leave'].create({
+            'name': 'leave',
+            'employee_id': self.employee_emp.id,
+            'holiday_status_id': self.leave_type.id,
+            'date_from': '2022-03-07 00:00:00',
+            'date_to': '2022-03-11 23:59:59',
+        })
+        leave.action_validate()
+
+        with freeze_time(datetime.date(2022, 6, 1)):
+            allocation._update_accrual()
+        self.assertEqual(allocation.number_of_days, 10, "Should accrue 5 additional days")


### PR DESCRIPTION
Having a value of 0 for `maximum_leave` means 'no limit', but it was
considered as a limit of 0 - thus no days were accrued.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
