### PR TITLE
[FIX] website_forum: fix crash when clicking on the vote button

### DIFF
--- a/addons/website_forum/static/src/js/website_forum.js
+++ b/addons/website_forum/static/src/js/website_forum.js
@@ -358,7 +358,7 @@ publicWidget.registry.websiteForum = publicWidget.Widget.extend({
                 } else if (data.error === 'anonymous_user') {
                     message = _t('Sorry you must be logged to vote');
                 }
-                this.displayNotification({
+                self.displayNotification({
                     message: message,
                     title: _t("Access Denied"),
                     sticky: false,


### PR DESCRIPTION
**Current behavior before PR:**
Crash when clicking on the vote button
**Steps to reproduce:**
 Vote own post (in case enough karma)




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
