### PR TITLE
[FIX] mail: handle useDragVisibleDropzone/_onDrop in bubble phase

### DIFF
--- a/addons/mail/static/src/models/use_drag_visible_drop_zone.js
+++ b/addons/mail/static/src/models/use_drag_visible_drop_zone.js
@@ -11,7 +11,7 @@ registerModel({
         _created() {
             document.addEventListener('dragenter', this._onDragenterListener, true);
             document.addEventListener('dragleave', this._onDragleaveListener, true);
-            document.addEventListener('drop', this._onDropListener, true);
+            document.addEventListener('drop', this._onDropListener);
 
             // Thoses Events prevent the browser to open or download the file if
             // it's dropped outside of the dropzone
@@ -21,7 +21,7 @@ registerModel({
         _willDelete() {
             document.removeEventListener('dragenter', this._onDragenterListener, true);
             document.removeEventListener('dragleave', this._onDragleaveListener, true);
-            document.removeEventListener('drop', this._onDropListener, true);
+            document.removeEventListener('drop', this._onDropListener);
 
             window.removeEventListener('dragover', ev => ev.preventDefault());
             window.removeEventListener('drop', ev => ev.preventDefault());


### PR DESCRIPTION
Capture phase is problematic because this tells whether the drop zone
is visible or not. The drop of file happens in drop zone in bubble,
so this capture would prevent handling of file dropped.

This works by chance with business logic in component, but it's
definitely gonna break once code is moved to models.

Task-2831082
