### PR TITLE
[MERGE] digest: make digest bioutifoul again

### DIFF
--- a/addons/account/data/digest_data.xml
+++ b/addons/account/data/digest_data.xml
@@ -15,7 +15,7 @@
 <div>
     <p class="tip_title">Tip: No need to print, put in an envelop and post your invoices</p>
     <p class="tip_content">Use the “<i>Send by Post</i>” option to post invoices automatically. For the cost of a local stamp, we do all the manual work: your invoice will be printed in the right country, put in an envelop and sent by snail mail. Use this feature from the list view to post hundreds of invoices in bulk.</p>
-    <img src="https://download.odoocdn.com/digests/account/static/src/img/invoice-stamps.png" class="illustration_border" />
+    <img src="https://download.odoocdn.com/digests/account/static/src/img/invoice-stamps.png" width="540" class="illustration_border" />
 </div>
             </field>
         </record>

--- a/addons/crm/data/digest_data.xml
+++ b/addons/crm/data/digest_data.xml
@@ -34,7 +34,7 @@
 <div>
     <p class="tip_title">Tip: Did you know Odoo has built-in lead mining?</p>
     <p class="tip_content">For a sales team, there is nothing worse than being dry on leads. Fortunately, in just a few clicks, you can generate leads specifically targeted to your needs: company size, industry, etc. To help you test the feature, we offer you 200 credits for free.</p>
-    <img src="https://download.odoocdn.com/digests/crm/static/src/img/generate-leads.gif" class="illustration_border" />
+    <img src="https://download.odoocdn.com/digests/crm/static/src/img/generate-leads.gif" width="540" class="illustration_border" />
 </div>
             </field>
         </record>
@@ -46,7 +46,7 @@
 <div>
     <p class="tip_title">Tip: Opportunity win rate is predicted with AI</p>
     <p class="tip_content">Odoo's artificial intelligence engine predicts the success rate of each opportunity based on your history. You can always update the success rate manually, but if you let Odoo do the job the score is updated while the opportunity moves forward in your sales cycle.</p>
-    <img src="https://download.odoocdn.com/digests/crm/static/src/img/probability-rate.gif" class="illustration_border" />
+    <img src="https://download.odoocdn.com/digests/crm/static/src/img/probability-rate.gif" width="540" class="illustration_border" />
 </div>
             </field>
         </record>
@@ -58,7 +58,7 @@
 <div>
     <p class="tip_title">Tip: Manage your pipeline</p>
     <p class="tip_content">A great tip to boost sales efficiency is to always define a next step on each opportunity. To manage ongoing activities, click on any status of the progress bar to filter opportunities based on their next activities' status. Click on the grey area of the progress bar to see all opportunities that have no next activity.</p>
-    <img src="https://download.odoocdn.com/digests/crm/static/src/img/pipeline-progress.gif" class="illustration_border" />
+    <img src="https://download.odoocdn.com/digests/crm/static/src/img/pipeline-progress.gif" width="540" class="illustration_border" />
 </div>
             </field>
         </record>
@@ -70,7 +70,7 @@
 <div>
     <p class="tip_title">Tip: Do not waste time recording customers' data</p>
     <p class="tip_content">Did you know you can search a company by name or VAT number to instantly fill in all its data? Odoo autocompletes everything for you: logo, address, company size, business information, social media accounts, etc.</p>
-    <img src="https://download.odoocdn.com/digests/crm/static/src/img/autofill.gif" class="illustration_border" />
+    <img src="https://download.odoocdn.com/digests/crm/static/src/img/autofill.gif" width="540" class="illustration_border" />
 </div>
             </field>
         </record>
@@ -82,7 +82,7 @@
 <div>
     <p class="tip_title">Tip: Turn a selection of opportunities into a map</p>
     <p class="tip_content">Did you know you can turn a list of opportunities into a map view, using the top-right map icon? A lot of screens in Odoo can be turned into a map: tasks, contacts, delivery orders, etc.</p>
-    <img src="https://download.odoocdn.com/digests/crm/static/src/img/mapview-toggle.gif" class="illustration_border" />
+    <img src="https://download.odoocdn.com/digests/crm/static/src/img/mapview-toggle.gif" width="540" class="illustration_border" />
 </div>
             </field>
         </record>

--- a/addons/digest/data/digest_data.xml
+++ b/addons/digest/data/digest_data.xml
@@ -10,24 +10,34 @@
         <meta name="format-detection" content="telephone=no"/>
         <meta name="viewport" content="width=device-width; initial-scale=1.0; maximum-scale=1.0; user-scalable=no;"/>
         <meta http-equiv="X-UA-Compatible" content="IE=9; IE=8; IE=7; IE=EDGE" />
-
         <style type="text/css">
             :root {
                 --color-company: <t t-esc="company.secondary_color or '#875a7b'"/>;
             }
+            /* Remove space around the email design. */
+            html,
             body {
-                margin: 0;
-                padding: 0;
+                margin: 0 auto !important;
+                padding: 0 !important;
+                height: 100% !important;
+                width: 100% !important;
                 font-family: Arial, Helvetica, Verdana, sans-serif;
+            }
+            /* Prevent Windows 10 Mail from underlining links. Styles for underlined links should be inline. */
+            a {
+                text-decoration: none;
             }
             #header_background {
                 background-color: var(--color-company);
+                padding-top:70px;
+            }
+            #header {
+                border-start: 1px solid var(--color-company);
+                border-end: 1px solid var(--color-company);
             }
             .global_layout {
-                max-width: 588px;
+                width: 588px;
                 margin: 0 auto;
-                border: 1px solid #eeeeee;
-                border-top: 0;
                 background-color: #ffffff;
             }
             .company_name {
@@ -35,38 +45,45 @@
                 vertical-align: middle;
                 font-weight: bold;
                 color: #8f8f8f;
+                font-size: 25px;
             }
-            .title_subtitle {
+            .header_title {
                 font-weight: bold;
                 color: #282f33;
                 word-break: break-all;
             }
             .button {
-                float: right;
-                background-color: var(--color-company);
                 color: #ffffff;
+            }
+            .td_button {
+                background-color: var(--color-company);
                 border-radius: 5px;
+                white-space: nowrap;
             }
             #button_connect {
-                text-align: center;
+                font-size: 15px;
             }
-            .date {
+            .header_date {
                 color: #8f8f8f;
+                font-size: 12px;
             }
             .tip_title {
                 margin-top: 0;
                 font-weight: bold;
+                font-size: 20px;
             }
             .tip_content {
                 margin: 0 auto;
-                color:#333333;
+                color: #333333;
                 text-align: justify;
                 text-justify: inter-word;
+                margin: 15px auto 0 auto;
+                font-size: 15px;
+                line-height: 25px;
             }
             .tip_button {
                 background-color: var(--color-company);
                 border-radius: 5px;
-                margin: 14px 16px 14px 0px;
                 padding: 10px;
                 text-decoration: none;
             }
@@ -75,43 +92,32 @@
             }
             .illustration_border {
                 width: 100%;
-                border: 1px solid grey;
+                border: 1px solid #808080;
+                margin-top: 20px;
             }
             .kpi_row_footer {
                 padding-bottom: 20px;
             }
             .kpi_header {
-                overflow: auto;
-                padding-bottom: 10px;
-                border-bottom: 1px solid #eeeeee;
                 font-size: 15px;
                 font-weight: bold;
                 color: #282f33;
             }
             #button_open_report {
-                padding: 5px 10px;
                 font-size: 12px;
                 font-weight: normal;
             }
             .kpi_cell {
-                float: left;
                 width: 33%;
                 text-align: center;
                 padding-top: 2px;
-            }
-            .kpi_cell_center {
-                border-top: 2px solid var(--color-company);
-            }
-            .kpi_cell_border {
-                border-top: 2px solid #00A09D;
+                padding: 0;
             }
             .kpi_value {
                 color: #282f33;
                 font-weight: bold;
                 text-decoration: none;
-            }
-            .kpi_center_col {
-                color: var(--color-company);
+                font-size: 30px;
             }
             .kpi_border_col {
                 color: #00A09D;
@@ -123,47 +129,21 @@
                 font-size: 12px;
                 text-transform: uppercase;
             }
-            .kpi_margin {
-                width: 75px;
-                padding: 5px 10px;
-                text-decoration: none;
-                border-radius: 5px;
-            }
-            .positive_kpi_margin {
-                border: 1px solid #c4ecd7;
-                background-color: #d5f1e2;
-                color: #17613a;
-            }
-            .negative_kpi_margin {
-                border: 1px solid #f4cfce;
-                background-color: #f7dddc;
-                color: #712b29;
-            }
-            .kpi_trick {
-                clear: both;
+            .kpi_margin_margin {
+                margin-bottom: 10px;
             }
             .download_app {
-                height: 40px;
                 margin-bottom: 5px;
                 display: inline-block;
-            }
-            .preference_div {
-                clear: both;
-                background-color: #eeeeee;
-                text-align: center;
             }
             .preference {
                 margin-bottom: 15px;
                 color: #6b6d70;
-            }
-            .preference a {
-                text-decoration: none;
+                font-size: 15px;
             }
             .by_odoo {
                 color: #8f8f8f;
-            }
-            .odoo_link {
-                text-decoration: none;
+                font-size: 12px;
             }
             .odoo_link_text {
                 font-weight: bold;
@@ -171,14 +151,31 @@
             }
             .run_business {
                 color: #2d2a26;
+                margin: 15px auto;
+                font-size: 18px;
             }
             #footer {
                 background-color: #eeeeee;
                 color: #8f8f8f;
                 text-align: center;
+                font-size: 20px;
+                border: 1px solid #eeeeee;
+                border-top: 0;
             }
-
+            #stock_tip {
+                overflow: auto;
+                margin-top: 20px;
+            }
+            #stock_div_img {
+                text-align: center;
+            }
+            #stock_img {
+                width: 70%;
+            }
             @media only screen and (max-width: 650px) {
+                .global_layout {
+                    width: 100% !important;
+                }
                 .d-block {
                     display: block !important;
                 }
@@ -189,20 +186,25 @@
                     padding: 15px 20px;
                     border: 1px solid #eeeeee;
                 }
-                .global_layout {
-                    padding: 20px;
-                }
                 .company_name {
                     font-size: 15px;
                 }
-                .title_subtitle {
+                .header_title {
                     margin: 5px auto;
                 }
-                #button_connect {
-                    padding: 4px 10px;
+                .td_button_connect {
+                    padding: 0px 8px !important;
+                    height: 22px !important;
                     font-size: 12px;
                 }
-                .date {
+                .td_button_open_report {
+                    padding: 0px 10px !important;
+                    font-size: 12px;
+                }
+                #button_connect {
+                    font-size: 12px;
+                }
+                .header_date {
                     margin-top: 10px;
                     font-size: 10px;
                 }
@@ -221,13 +223,10 @@
                     font-size: 20px;
                 }
                 .kpi_margin {
-                    font-size: 10px;
+                    font-size: 10px !important;
                 }
                 .kpi_margin_margin {
                     margin-bottom: 5px;
-                }
-                .preference_div {
-                    padding: 15px;
                 }
                 .preference {
                     font-size: 12px;
@@ -245,85 +244,24 @@
                 #powered {
                     margin-top: 15px;
                 }
-            }
-
-            @media only screen and (min-width: 651px) {
-                #header_background {
-                    padding-top: 70px;
-                }
-                #header {
-                    padding: 20px 30px 25px 30px;
-                    border-left: 1px solid var(--color-company);
-                    border-right: 1px solid var(--color-company);
-                }
-                .global_layout {
-                    padding: 25px 30px 30px 30px;
-                }
-                .company_name {
-                    font-size: 25px;
-                }
-                .title_subtitle {
-                    margin: 10px auto;
-                }
-                .button {
-                    padding: 5px 10px;
-                }
-                #button_connect {
-                    padding: 6px 10px;
-                    font-size: 15px;
-                }
-                .date {
+                .tip_twocol {
+                    overflow: auto;
                     margin-top: 15px;
-                    font-size: 12px;
                 }
-                .tip_title {
-                    font-size: 20px;
+                .tip_twocol_left {
+                    text-align: left;
                 }
-                .tip_content {
-                    margin: 15px auto 0 auto;
-                    font-size: 15px;
-                    line-height: 25px;
+                .tip_twocol_img {
+                    width: 90%;
                 }
-                .illustration_border {
-                    margin-top: 20px;
-                }
-                .kpi_value {
-                    font-size: 30px;
-                }
-                .kpi_margin {
-                    font-size: 12px;
-                }
-                .kpi_margin_margin {
-                    margin-bottom: 10px;
-                }
-                .preference_div {
+                .global_td {
                     padding: 20px;
                 }
-                .preference {
-                    font-size: 15px;
-                }
-                .by_odoo {
-                    font-size: 12px;
-                }
-                .run_business {
-                    margin: 15px auto;
-                    font-size: 18px;
-                }
-                #footer {
-                    font-size: 20px;
-                }
-                #stock_tip {
-                    overflow: auto;
-                    margin-top: 20px;
-                }
-                #stock_div_img {
-                    text-align: center;
-                }
-                #stock_img {
-                    width: 70%;
+                .p0 {
+                    padding: 0 !important;
                 }
             }
-         </style>
+        </style>
     </head>
     <body>
         <t t-out="body"/>
@@ -333,117 +271,227 @@
 
     <!-- DIGEST MAIN TEMPLATE -->
     <template id="digest_mail_main">
-<div id="header_background">
-    <div class="global_layout" id="header">
-        <div style="overflow: auto;">
-            <p t-field="company.name" class="company_name" />
-            <a t-att-href="top_button_url" target="_blank"><span t-esc="top_button_label" class="button" id="button_connect" /></a>
-        </div>
-        <div class="title_subtitle">
-            <p t-esc="title" />
-            <p t-if="sub_title" t-esc="sub_title" />
-        </div>
-        <div t-esc="formatted_date" class="date" />
-    </div>
-</div>
-
-<div style="background-color: #eeeeee;">
-<div t-foreach="tips" t-as="tip" t-out="tip" class="global_layout" />
-
-<div t-if="kpi_data" class="global_layout" style="padding-bottom: 0;">
-    <t t-set="kpi_color" t-value="'kpi_border_col'"/>
-    <div t-foreach="kpi_data" t-as="kpi_info" class="kpi_row_footer">
-        <div t-if="kpi_info.get('kpi_col1') or kpi_info.get('kpi_col2') or kpi_info.get('kpi_col3')" t-att-data-field="kpi_info['kpi_name']">
-            <div class="kpi_header">
-                <span t-esc="kpi_info['kpi_fullname']" style="vertical-align: middle;" />
-                <a t-if="kpi_info['kpi_action']" t-att-href="'/web#action=%s' % kpi_info['kpi_action']"><span class="button" id="button_open_report">Open Report</span></a>
-            </div>
-            <div t-if="kpi_info.get('kpi_col1')" class="kpi_cell kpi_cell_border">
-                <div t-call="digest.digest_tool_kpi" >
-                    <t t-set="kpi_value" t-value="kpi_info['kpi_col1']['value']"/>
-                    <t t-set="kpi_margin" t-value="kpi_info['kpi_col1'].get('margin')"/>
-                    <t t-set="kpi_subtitle" t-value="kpi_info['kpi_col1']['col_subtitle']"/>
-                </div>
-            </div>
-            <div t-if="kpi_info.get('kpi_col2')" class="kpi_cell kpi_cell_center">
-                <div t-call="digest.digest_tool_kpi">
-                    <t t-set="kpi_value" t-value="kpi_info['kpi_col2']['value']"/>
-                    <t t-set="kpi_margin" t-value="kpi_info['kpi_col2'].get('margin')"/>
-                    <t t-set="kpi_subtitle" t-value="kpi_info['kpi_col2']['col_subtitle']"/>
-                </div>
-            </div>
-            <div t-if="kpi_info.get('kpi_col3')" class="kpi_cell kpi_cell_border">
-                <div t-call="digest.digest_tool_kpi">
-                    <t t-set="kpi_value" t-value="kpi_info['kpi_col3']['value']"/>
-                    <t t-set="kpi_margin" t-value="kpi_info['kpi_col3'].get('margin')"/>
-                    <t t-set="kpi_subtitle" t-value="kpi_info['kpi_col3']['col_subtitle']"/>
-                </div>
-            </div>
-            <div class="kpi_trick" />
-        </div>
-    </div>
-</div>
-
-<t t-if="body" t-out="body"/>
-
-<div>
-    <div class="global_layout">
-        <div class="preference_div">
-            <div t-if="preferences" t-foreach="preferences" t-as="preference"
-                class="preference">
-                <t t-out="preference"/>
-            </div>
-            <div class="by_odoo">
-                Sent by <a href="https://www.odoo.com" target="_blank" class="odoo_link"><span class="odoo_link_text">Odoo</span></a>
-                <t t-if="unsubscribe_token">
-                    –
-                    <a t-attf-href="/digest/#{object.id}/unsubscribe?token=#{unsubscribe_token}&amp;user_id=#{user.id}"
-                       target="_blank" style="text-decoration: none;">
-                        <span style="color: #8f8f8f;">Unsubscribe</span>
-                    </a>
-                </t>
-                <t t-elif="object and object._name == 'digest.digest'">
-                    –
-                    <a t-att-href="'/web#view_type=form&amp;model=digest.digest&amp;id=%s' % object.id"
-                       target="_blank" style="text-decoration: none;">
-                        <span style="color: #8f8f8f;">Unsubscribe</span>
-                    </a>
-                </t>
-            </div>
-        </div>
-    </div>
-</div>
-
-<div t-if="display_mobile_banner" t-call="digest.digest_section_mobile" />
-
-<div class="global_layout" id="footer">
-    <p style="font-weight: bold;" t-esc="company.name"/>
-    <p class="by_odoo" id="powered">
-        Powered by <a href="https://www.odoo.com" target="_blank" class="odoo_link"><span class="odoo_link_text">Odoo</span></a>
-    </p>
-</div>
-</div>
+<table cellspacing="0" cellpadding="0" style="width: 100%;border: 1px solid #eeeeee;border-bottom: 0;" align="center">
+    <tbody>
+        <tr>
+            <td id="header_background" align="center">
+                <table cellspacing="0" cellpadding="0" border="0" id="header" class="global_layout">
+                    <tbody>
+                        <tr>
+                            <td style="padding: 20px 20px 0px 20px;" class="p0"><p t-field="company.name" class="company_name" /></td>
+                            <td align="right" style="padding: 20px 20px 0px 0px;" class="p0">
+                                <table>
+                                    <tbody>
+                                        <tr>
+                                            <td class="td_button td_button_connect" style="height: 29px;padding: 3px 10px;">
+                                                <a t-att-href="top_button_url" target="_blank">
+                                                    <span t-esc="top_button_label" class="button" id="button_connect" />
+                                                </a>
+                                            </td>
+                                        </tr>
+                                    </tbody>
+                                </table>
+                            </td>
+                        </tr>
+                        <tr>
+                            <td style="padding-left: 20px" class="p0" colspan="2">
+                                <div class="header_title">
+                                    <p t-esc="title"/>
+                                    <p t-if="sub_title" t-esc="sub_title"/>
+                                </div>
+                            </td>
+                        </tr>
+                        <tr>
+                            <td style="padding: 0px 0px 20px 20px;" class="p0" colspan="2">
+                                <span t-esc="formatted_date" class="header_date"/>
+                            </td>
+                        </tr>
+                    </tbody>
+                </table>
+            </td>
+        </tr>
+    </tbody>
+</table>
+<table cellspacing="0" cellpadding="0" border="0" style="width: 100%;background-color: #eeeeee;">
+    <tbody>
+        <tr>
+            <td align="center">
+                <table cellspacing="0" cellpadding="0" border="0" class="global_layout">
+                    <tbody>
+                        <tr t-if="tips" t-foreach="tips" t-as="tip">
+                            <td colspan="3" style="width: 100%;padding: 20px;border: 1px solid #eeeeee;">
+                                <table>
+                                    <tbody>
+                                        <tr>
+                                            <td t-out="tip"></td>
+                                        </tr>
+                                    </tbody>
+                                </table>
+                            </td>
+                        </tr>
+                        <tr t-if="kpi_data">
+                            <td style="padding: 20px 20px 0px 20px;" class='global_td'>
+                                <table t-foreach="kpi_data" t-as="kpi_info" style="width: 100%;" cellspacing="0" cellpadding="0">
+                                    <tr>
+                                        <td style="padding-bottom: 20px;">
+                                            <table t-if="kpi_info.get('kpi_col1') or kpi_info.get('kpi_col2') or kpi_info.get('kpi_col3')"
+                                                    t-att-data-field="kpi_info['kpi_name']" cellspacing="0" cellpadding="10" style="width: 100%;margin-bottom: 5px;">
+                                                <tr class="kpi_header">
+                                                    <td colspan="2" style="padding: 0px 0px 10px 0px;">
+                                                        <span t-esc="kpi_info['kpi_fullname']"  />
+                                                    </td>
+                                                    <td t-if="kpi_info['kpi_action']" align="right" style="padding: 0px 0px 10px 0px;">
+                                                        <table>
+                                                            <tbody>
+                                                                <tr>
+                                                                    <td class="td_button td_button_open_report" style="padding: 1px 10px;height: 24px;">
+                                                                        <a t-att-href="'/web#action=%s' % kpi_info['kpi_action']">
+                                                                            <span class="button" id="button_open_report">Open Report</span>
+                                                                        </a>
+                                                                    </td>
+                                                                </tr>
+                                                            </tbody>
+                                                        </table>
+                                                    </td>
+                                                </tr>
+                                                <tr style="vertical-align: top;">
+                                                    <td t-if="kpi_info.get('kpi_col1')" class="kpi_cell" style="border-top: 2px solid #00A09D;">
+                                                        <div t-call="digest.digest_tool_kpi">
+                                                            <t t-set="kpi_value" t-value="kpi_info['kpi_col1']['value']" />
+                                                            <t t-set="kpi_margin" t-value="kpi_info['kpi_col1'].get('margin')" />
+                                                            <t t-set="kpi_subtitle" t-value="kpi_info['kpi_col1']['col_subtitle']" />
+                                                        </div>
+                                                    </td>
+                                                    <td t-if="kpi_info.get('kpi_col2')" class="kpi_cell" style="border-top: 2px solid var(--color-company)">
+                                                        <div t-call="digest.digest_tool_kpi">
+                                                            <t t-set="kpi_value" t-value="kpi_info['kpi_col2']['value']" />
+                                                            <t t-set="kpi_margin" t-value="kpi_info['kpi_col2'].get('margin')" />
+                                                            <t t-set="kpi_subtitle" t-value="kpi_info['kpi_col2']['col_subtitle']" />
+                                                        </div>
+                                                    </td>
+                                                    <td t-if="kpi_info.get('kpi_col3')" class="kpi_cell" style="border-top: 2px solid #00A09D;">
+                                                        <div t-call="digest.digest_tool_kpi">
+                                                            <t t-set="kpi_value" t-value="kpi_info['kpi_col3']['value']" />
+                                                            <t t-set="kpi_margin" t-value="kpi_info['kpi_col3'].get('margin')" />
+                                                            <t t-set="kpi_subtitle" t-value="kpi_info['kpi_col3']['col_subtitle']" />
+                                                        </div>
+                                                    </td>
+                                                </tr>
+                                            </table>
+                                        </td>
+                                    </tr>
+                                </table>
+                            </td>
+                        </tr>
+                        <tr t-if="body" >
+                            <td style="padding: 20px 20px 0px 20px;" class='global_td'><t t-out="body" /></td>
+                        </tr>
+                    </tbody>
+                    <tfoot>
+                        <tr>
+                            <td style="padding: 20px;border: 1px solid #eeeeee;">
+                                <table border="0" width="100%">
+                                    <tbody>
+                                        <tr style="background-color: #eeeeee;">
+                                            <td align="center" colspan="3" valign="center" style="padding: 15px;">
+                                                <div t-if="preferences" t-foreach="preferences" t-as="preference" class="preference">
+                                                    <t t-out="preference" />
+                                                </div>
+                                                <div class="by_odoo" style="margin-bottom: 15px;">
+                                                    Sent by <a href="https://www.odoo.com" target="_blank">
+                                                    <span class="odoo_link_text">Odoo</span></a>
+                                                    <t t-if="unsubscribe_token">
+                                                        –
+                                                        <a t-attf-href="/digest/#{object.id}/unsubscribe?token=#{unsubscribe_token}&amp;user_id=#{user.id}" target="_blank"
+                                                            style="text-decoration: none;">
+                                                            <span style="color: #8f8f8f;">Unsubscribe</span>
+                                                        </a>
+                                                    </t>
+                                                    <t t-elif="object and object._name == 'digest.digest'">
+                                                        –
+                                                        <a t-att-href="'/web#view_type=form&amp;model=digest.digest&amp;id=%s' % object.id" target="_blank"
+                                                            style="text-decoration: none;">
+                                                            <span style="color: #8f8f8f;">Unsubscribe</span>
+                                                        </a>
+                                                    </t>
+                                                </div>
+                                            </td>
+                                        </tr>
+                                    </tbody>
+                                </table>
+                            </td>
+                        </tr>
+                        <tr t-if="display_mobile_banner" t-call="digest.digest_section_mobile" />
+                    </tfoot>
+                </table>
+            </td>
+        </tr>
+    </tbody>
+    <tfoot>
+        <tr>
+            <td align="center" style="padding: 20px 0px 0px 0px;">
+                <table align="center">
+                    <tbody>
+                        <tr>
+                            <div id="footer">
+                                <p style="font-weight: bold;" t-esc="company.name" />
+                                <p class="by_odoo" id="powered">
+                                    Powered by <a href="https://www.odoo.com" target="_blank" class="odoo_link">
+                                        <span class="odoo_link_text">Odoo</span></a>
+                                </p>
+                            </div>
+                        </tr>
+                    </tbody>
+                </table>
+            </td>
+        </tr>
+    </tfoot>
+</table>
     </template>
-
 
     <!--                     DIGEST PARTS                    -->
 
     <!-- MOBILE BANNER -->
     <template id="digest_section_mobile">
-<div class="global_layout" style="overflow: auto;">
-    <div style="width: 50%; float: left; text-align: right;">
-        <img src="https://www.odoo.com/web/image/24717933/odoo-mobile.png" alt="Odoo Mobile" />
-    </div>
-    <div style="width: 50%; float: left;">
-        <p class="run_business">Run your business from anywhere with <b>Odoo Mobile</b>.</p>
-        <div>
-            <a href="https://play.google.com/store/apps/details?id=com.odoo.mobile" target="_blank"><img class="download_app" src="https://download.odoocdn.com/digests/digest/static/src/img/google_play.png" /></a>
-        </div>
-        <div>
-            <a href="https://itunes.apple.com/us/app/odoo/id1272543640" target="_blank"><img class="download_app" src="https://download.odoocdn.com/digests/digest/static/src/img/app_store.png" /></a>
-        </div>
-    </div>
-</div>
+<td colspan="3" style="padding: 20px;width:100%">
+    <table>
+        <tbody>
+            <tr>
+                <td align="right" style="width: 50%;">
+                    <img src="https://www.odoo.com/web/image/24717933/odoo-mobile.png" alt="Odoo Mobile" />
+                </td>
+                <td align="left" style="width: 50%;">
+                    <table>
+                        <tbody>
+                            <tr>
+                                <td>
+                                    <p class="run_business">Run your business from anywhere with <b>Odoo Mobile</b>.</p>
+                                </td>
+                            </tr>
+                            <tr>
+                                <td>
+                                    <a href="https://play.google.com/store/apps/details?id=com.odoo.mobile"
+                                        target="_blank">
+                                            <img class="download_app" height="40" width="135"
+                                                    src="https://download.odoocdn.com/digests/digest/static/src/img/google_play.png" />
+                                    </a>
+                                </td>
+                            </tr>
+                            <tr>
+                                <td>
+                                    <a href="https://itunes.apple.com/us/app/odoo/id1272543640" target="_blank">
+                                        <img class="download_app" height="40" width="135"
+                                                src="https://download.odoocdn.com/digests/digest/static/src/img/app_store.png" />
+                                    </a>
+                                </td>
+                            </tr>
+                        </tbody>
+                    </table>
+                </td>
+            </tr>
+        </tbody>
+    </table>
+</td>
     </template>
 
 
@@ -451,13 +499,19 @@
 
     <!-- KPI DISPLAY -->
     <template id="digest_tool_kpi">
-<span t-esc="kpi_value" t-att-class="'kpi_value %s' % kpi_color " />
+<span t-esc="kpi_value" style="color: #00A09D;font-weight: bold;text-decoration: none;" class="kpi_value kpi_border_col" />
 <br/>
 <span t-esc="kpi_subtitle" class="kpi_value_label" />
-<div t-if="kpi_margin" class="kpi_margin_margin">
-    <span   t-if="kpi_margin &gt; 0.0" class="kpi_margin positive_kpi_margin">▲ <t t-esc="'%.2f' % kpi_margin"/> %</span>
-    <span t-elif="kpi_margin &lt; 0.0" class="kpi_margin negative_kpi_margin">▼ <t t-esc="'%.2f' % kpi_margin"/> %</span>
-</div>
+<table t-if="kpi_margin" class="kpi_margin_margin" align="center" border="0" cellspacing="0" cellpadding="0">
+    <tr>
+        <td t-if="kpi_margin &gt; 0.0" class="kpi_margin positive_kpi_margin" style="padding: 5px 10px;font-size: 12px;text-decoration: none;border-radius: 5px;border: 1px solid #c4ecd7;border-radius: 5px; background-color: #c4ecd7;color: #17613a;">
+            ▲ <t t-esc="'%.2f' % kpi_margin" /> %
+        </td>
+        <td t-elif="kpi_margin &lt; 0.0" class="kpi_margin negative_kpi_margin" style="padding: 5px 10px;font-size: 12px;text-decoration: none;border-radius: 5px;border: 1px solid #f4cfce;background-color: #f7dddc;color: #712b29;">
+            ▼ <t t-esc="'%.2f' % kpi_margin" /> %
+        </td>
+    </tr>
+</table>
     </template>
 
 </data>

--- a/addons/digest/data/digest_data.xml
+++ b/addons/digest/data/digest_data.xml
@@ -11,9 +11,7 @@
         <meta name="viewport" content="width=device-width; initial-scale=1.0; maximum-scale=1.0; user-scalable=no;"/>
         <meta http-equiv="X-UA-Compatible" content="IE=9; IE=8; IE=7; IE=EDGE" />
         <style type="text/css">
-            :root {
-                --color-company: <t t-esc="company.secondary_color or '#875a7b'"/>;
-            }
+            <t t-set="color_company" t-value="company.secondary_color or '#875a7b'"/>
             /* Remove space around the email design. */
             html,
             body {
@@ -28,12 +26,12 @@
                 text-decoration: none;
             }
             #header_background {
-                background-color: var(--color-company);
+                background-color: <t t-out="color_company"/>;
                 padding-top:70px;
             }
             #header {
-                border-start: 1px solid var(--color-company);
-                border-end: 1px solid var(--color-company);
+                border-start: 1px solid <t t-out="color_company"/>;
+                border-end: 1px solid <t t-out="color_company"/>;
             }
             .global_layout {
                 width: 588px;
@@ -56,7 +54,7 @@
                 color: #ffffff;
             }
             .td_button {
-                background-color: var(--color-company);
+                background-color: <t t-out="color_company"/>;
                 border-radius: 5px;
                 white-space: nowrap;
             }
@@ -82,7 +80,7 @@
                 line-height: 25px;
             }
             .tip_button {
-                background-color: var(--color-company);
+                background-color: <t t-out="color_company"/>;
                 border-radius: 5px;
                 padding: 10px;
                 text-decoration: none;
@@ -147,7 +145,7 @@
             }
             .odoo_link_text {
                 font-weight: bold;
-                color: var(--color-company);
+                color: <t t-out="color_company"/>;
             }
             .run_business {
                 color: #2d2a26;
@@ -362,7 +360,7 @@
                                                             <t t-set="kpi_subtitle" t-value="kpi_info['kpi_col1']['col_subtitle']" />
                                                         </div>
                                                     </td>
-                                                    <td t-if="kpi_info.get('kpi_col2')" class="kpi_cell" style="border-top: 2px solid var(--color-company)">
+                                                    <td t-if="kpi_info.get('kpi_col2')" class="kpi_cell" t-att-style="'border-top: 2px solid ' + (company.secondary_color or  '#875a7b')">
                                                         <div t-call="digest.digest_tool_kpi">
                                                             <t t-set="kpi_value" t-value="kpi_info['kpi_col2']['value']" />
                                                             <t t-set="kpi_margin" t-value="kpi_info['kpi_col2'].get('margin')" />

--- a/addons/digest/data/digest_tips_data.xml
+++ b/addons/digest/data/digest_tips_data.xml
@@ -18,7 +18,7 @@
 <div>
     <p class="tip_title">Tip: Speed up your workflow with shortcuts</p>
     <p class="tip_content">Press ALT in any screen to highlight shortcuts for every button in the screen. It is useful to process multiple documents in batch.</p>
-    <img src="https://download.odoocdn.com/digests/digest/static/src/img/alt-shortcuts.gif" class="illustration_border" />
+    <img src="https://download.odoocdn.com/digests/digest/static/src/img/alt-shortcuts.gif" width="540" class="illustration_border" />
 </div>
             </field>
         </record>
@@ -30,7 +30,7 @@
 <div>
     <p class="tip_title">Tip: Click on an avatar to chat with a user</p>
     <p class="tip_content">Have a question about a document? Click on the responsible user's picture to start a conversation. If his avatar has a green dot, he is online.</p>
-    <img src="https://download.odoocdn.com/digests/digest/static/src/img/avatar.gif" class="illustration_border" />
+    <img src="https://download.odoocdn.com/digests/digest/static/src/img/avatar.gif" width="540" class="illustration_border" />
 </div>
             </field>
         </record>
@@ -42,7 +42,7 @@
 <div>
     <p class="tip_title">Tip: A calculator in Odoo</p>
     <p class="tip_content">When editing a number, you can use formulae by typing the `=` character. This is useful when computing a margin or a discount on a quotation, sale order or invoice.</p>
-    <img src="https://download.odoocdn.com/digests/digest/static/src/img/calculator.gif" class="illustration_border" />
+    <img src="https://download.odoocdn.com/digests/digest/static/src/img/calculator.gif" width="540" class="illustration_border" />
 </div>
             </field>
         </record>
@@ -54,7 +54,7 @@
 <div>
     <p class="tip_title">Tip: How to ping users in internal notes?</p>
     <p class="tip_content">Type "@" to notify someone in a message, or "#" to link to a channel. Try to notify @OdooBot to test the feature.</p>
-    <img src="https://download.odoocdn.com/digests/digest/static/src/img/notifications.gif" class="illustration_border" />
+    <img src="https://download.odoocdn.com/digests/digest/static/src/img/notifications.gif" width="540" class="illustration_border" />
 </div>
             </field>
         </record>
@@ -67,7 +67,7 @@
     <p class="tip_title">Tip: Knowledge is power</p>
     <p class="tip_content">When following documents, use the pencil icon to fine-tune the information you want to receive.
 Follow a project / sales team to keep track of this project's tasks / this team's opportunities.</p>
-    <img src="https://download.odoocdn.com/digests/digest/static/src/img/following.png" class="illustration_border" />
+    <img src="https://download.odoocdn.com/digests/digest/static/src/img/following.png" width="540" class="illustration_border" />
 </div>
             </field>
         </record>

--- a/addons/digest/data/digest_tips_data.xml
+++ b/addons/digest/data/digest_tips_data.xml
@@ -9,7 +9,8 @@
             <field name="kpi_res_users_connected">True</field>
             <field name="kpi_mail_message_total">True</field>
         </record>
-
+    </data>
+    <data noupdate="0">
         <record id="digest_tip_digest_0" model="digest.tip">
             <field name="name">Tip: Speed up your workflow with shortcuts</field>
             <field name="sequence">800</field>

--- a/addons/digest/tests/test_digest.py
+++ b/addons/digest/tests/test_digest.py
@@ -94,7 +94,7 @@ class TestDigest(mail_test.MailCommon):
         self.assertEqual(mail.email_from, self.company_admin.email_formatted)
         self.assertEqual(mail.state, 'outgoing', 'Mail should use the queue')
 
-        kpi_message_values = html.fromstring(mail.body_html).xpath('//div[@data-field="kpi_mail_message_total"]//*[hasclass("kpi_value")]/text()')
+        kpi_message_values = html.fromstring(mail.body_html).xpath('//table[@data-field="kpi_mail_message_total"]//*[hasclass("kpi_value")]/text()')
         self.assertEqual(
             [t.strip() for t in kpi_message_values],
             ['3', '8', '15']

--- a/addons/hr_expense/data/digest_data.xml
+++ b/addons/hr_expense/data/digest_data.xml
@@ -9,7 +9,7 @@
 <div>
     <p class="tip_title">Tip: Snap pictures of your receipts with the remote app</p>
     <p class="tip_content">Do not keep your expense tickets in your pockets any longer. Just snap a picture of your receipt and let Odoo digitalizes it for you. The OCR and Artificial Intelligence will fill the data automatically.</p>
-    <img src="https://download.odoocdn.com/digests/hr_expense/static/src/img/expense.png" class="illustration_border" />
+    <img src="https://download.odoocdn.com/digests/hr_expense/static/src/img/expense.png" width="540" class="illustration_border" />
 </div>
             </field>
         </record>

--- a/addons/hr_timesheet/data/digest_data.xml
+++ b/addons/hr_timesheet/data/digest_data.xml
@@ -9,7 +9,7 @@
 <div>
     <b class="tip_title">Tip: Record your Timesheets faster</b>
     <p class="tip_content">Record your timesheets in an instant by pressing Shift + the corresponding hotkey to add 15min to your projects.</p>
-    <img src="https://download.odoocdn.com/digests/hr_timesheet/static/img/digest_tip_timesheets_hotkeys.gif" class="illustration_border" />
+    <img src="https://download.odoocdn.com/digests/hr_timesheet/static/img/digest_tip_timesheets_hotkeys.gif" width="540" class="illustration_border" />
 </div>
             </field>
         </record>

--- a/addons/im_livechat/data/digest_data.xml
+++ b/addons/im_livechat/data/digest_data.xml
@@ -17,7 +17,7 @@
 <div>
     <p class="tip_title">Tip: Use canned responses to chat faster</p>
     <p class="tip_content">Use canned responses to define templates of messages in the livechat app. To load a canned response, start your sentence with ':' and select the template.</p>
-    <img src="https://download.odoocdn.com/digests/im_livechat/static/src/img/canned-responses.gif" class="illustration_border" />
+    <img src="https://download.odoocdn.com/digests/im_livechat/static/src/img/canned-responses.gif" width="540" class="illustration_border" />
 </div>
             </field>
         </record>

--- a/addons/mass_mailing/data/mailing_data_templates.xml
+++ b/addons/mass_mailing/data/mailing_data_templates.xml
@@ -127,41 +127,39 @@
     </template>
 
     <template id="mass_mailing.mass_mailing_kpi_link_trackers" name="Marketing: mailing link trackers statistic">
-        <div class="global_layout" t-if="link_trackers">
-            <table bgcolor="#ffffff" cellspacing="0" cellpadding="0" width="650" align="center" border="0" style="width: 100%; max-width: 650px;">
-                <tr>
-                    <td style="width: 100%;">
-                        <table cellspacing="0" cellpadding="0" border="0" width="580" align="center" style="width:100%; max-width:580px;">
-                            <tr>
-                                <td align="left">
-                                    <span style="color:#282f33; font-size: 15px; font-weight: bold; line-height: 30px">
-                                        <t t-esc="'Click Rate Report on %i %s Sent' % (object.expected, mailing_type)"/>
-                                    </span>
-                                </td>
-                            </tr>
-                        </table>
-                    </td>
-                </tr>
-                <tr>
-                    <td style="margin: 0; padding:0;">
-                        <table cellspacing="0" cellpadding="0" border="0" width="580" align="center" style="width:100%; max-width:580px;border-collapse: collapse;">
-                            <tr style="color: #875a7b; font-size: 16px; font-weight: 500;">
-                                <td style="width: 70%;padding: 10px 0; text-align: center; border: 1px solid #e7e7e7;">Button Label</td>
-                                <td style="width: 30%;padding: 10px 0; text-align: center; border: 1px solid #e7e7e7;">%Click (Total)</td>
-                            </tr>
-                            <tr t-foreach="link_trackers" t-as="link_tracker" style="color: #888888; font-size: 15px; font-weight: 300;">
-                                <td style="width: 70%;padding: 10px 0; border: 1px solid #e7e7e7;">
-                                    <a t-att-href="link_tracker.absolute_url" target="_blank" style="color: #56b3b5; text-decoration: none;" t-esc="link_tracker.label or link_tracker.url"/>
-                                </td>
-                                <td style="width: 30%;padding: 10px 0; text-align: center;  border: 1px solid #e7e7e7;">
-                                    <t t-esc="int(link_tracker.count * 100 / object.sent) if object.sent else 0"/>% (<t t-esc="link_tracker.count"/>)
-                                </td>
-                            </tr>
-                        </table>
-                    </td>
-                </tr>
-            </table>
-        </div>
+        <table t-if="link_trackers" class="global_table_layout" bgcolor="#ffffff" cellspacing="0" cellpadding="0" align="center" border="0" style="width: 100%;">
+            <tr>
+                <td style="width: 100%;">
+                    <table cellspacing="0" cellpadding="0" border="0" align="center" style="width:100%;">
+                        <tr>
+                            <td align="left">
+                                <span style="color:#282f33; font-size: 15px; font-weight: bold; line-height: 30px">
+                                    <t t-esc="'Click Rate Report on %i %s Sent' % (object.expected, mailing_type)"/>
+                                </span>
+                            </td>
+                        </tr>
+                    </table>
+                </td>
+            </tr>
+            <tr>
+                <td style="margin: 0; padding:0;">
+                    <table cellspacing="0" cellpadding="0" border="0" align="center" style="width:100%; border-collapse: collapse;">
+                        <tr style="color: #875a7b; font-size: 16px; font-weight: 500;">
+                            <td style="width: 70%;padding: 10px 0; text-align: center; border: 1px solid #e7e7e7;">Button Label</td>
+                            <td style="width: 30%;padding: 10px 0; text-align: center; border: 1px solid #e7e7e7;">%Click (Total)</td>
+                        </tr>
+                        <tr t-foreach="link_trackers" t-as="link_tracker" style="color: #888888; font-size: 15px; font-weight: 300;">
+                            <td style="width: 70%;padding: 10px 0; border: 1px solid #e7e7e7;">
+                                <a t-att-href="link_tracker.absolute_url" target="_blank" style="color: #56b3b5; text-decoration: none;" t-esc="link_tracker.label or link_tracker.url"/>
+                            </td>
+                            <td style="width: 30%;padding: 10px 0; text-align: center;  border: 1px solid #e7e7e7;">
+                                <t t-esc="int(link_tracker.count * 100 / object.sent) if object.sent else 0"/>% (<t t-esc="link_tracker.count"/>)
+                            </td>
+                        </tr>
+                    </table>
+                </td>
+            </tr>
+        </table>
     </template>
 </data>
 </odoo>

--- a/addons/mass_mailing/data/mailing_data_templates.xml
+++ b/addons/mass_mailing/data/mailing_data_templates.xml
@@ -144,7 +144,7 @@
             <tr>
                 <td style="margin: 0; padding:0;">
                     <table cellspacing="0" cellpadding="0" border="0" align="center" style="width:100%; border-collapse: collapse;">
-                        <tr style="color: #875a7b; font-size: 16px; font-weight: 500;">
+                        <tr t-att-style="'color: ' + (company.secondary_color or  '#875a7b') + '; font-size: 16px; font-weight: 500;'">
                             <td style="width: 70%;padding: 10px 0; text-align: center; border: 1px solid #e7e7e7;">Button Label</td>
                             <td style="width: 30%;padding: 10px 0; text-align: center; border: 1px solid #e7e7e7;">%Click (Total)</td>
                         </tr>

--- a/addons/mass_mailing/models/mailing.py
+++ b/addons/mass_mailing/models/mailing.py
@@ -1169,6 +1169,7 @@ class MassMailing(models.Model):
             link_trackers_body = self.env['ir.qweb']._render(
                 'mass_mailing.mass_mailing_kpi_link_trackers',
                 {
+                    'company': self.env.user.company_id,
                     'object': mailing,
                     'link_trackers': link_trackers,
                     'mailing_type': mailing_type,

--- a/addons/mrp/data/digest_data.xml
+++ b/addons/mrp/data/digest_data.xml
@@ -9,7 +9,7 @@
 <div>
     <p class="tip_title">Tip: Use tablets in the shop to control manufacturing</p>
     <p class="tip_content">With the Odoo work center control panel, your worker can start work orders in the shop and follow instructions of the worksheet. Quality tests are perfectly integrated into the process. Workers can trigger feedback loops, maintenance alerts, scrap products, etc.</p>
-    <img src="https://download.odoocdn.com/digests/mrp/static/src/img/mrp-tablet.png" style="margin-top: 20px; max-width: 580px" width="100%" />
+    <img src="https://download.odoocdn.com/digests/mrp/static/src/img/mrp-tablet.png" width="540" class="illustration_border" />
 </div>
             </field>
         </record>

--- a/addons/purchase/data/digest_data.xml
+++ b/addons/purchase/data/digest_data.xml
@@ -9,7 +9,7 @@
 <div>
     <p class="tip_title">Tip: How to keep late receipts under control?</p>
     <p class="tip_content">When creating a purchase order, have a look at the vendor's <i>On Time Delivery</i> rate: the percentage of products shipped on time. If it is too low, activate the <i>automated reminders</i>. A few days before the due shipment, Odoo will send the vendor an email to ask confirmation of shipment dates and keep you informed in case of any delays. To get the vendor's performance statistics, click on the OTD rate.</p>
-    <img src="https://download.odoocdn.com/digests/purchase/static/src/img/OTDPurchase.gif" class="illustration_border" />
+    <img src="https://download.odoocdn.com/digests/purchase/static/src/img/OTDPurchase.gif" width="540" class="illustration_border" />
 </div>
             </field>
         </record>

--- a/addons/sale_management/data/digest_data.xml
+++ b/addons/sale_management/data/digest_data.xml
@@ -13,7 +13,7 @@
 <div>
     <p class="tip_title">Tip: Odoo supports configurable products</p>
     <p class="tip_content">Struggling with a complex product catalog? Try out the Product Configurator to help sales configure a product with different options: colors, size, capacity, etc. Make sale orders encoding easier and error-proof.</p>
-    <img src="https://download.odoocdn.com/digests/sale_management/static/src/img/Sales-configure-products.gif" class="illustration_border" />
+    <img src="https://download.odoocdn.com/digests/sale_management/static/src/img/Sales-configure-products.gif" width="540" class="illustration_border" />
 </div>
             </field>
         </record>
@@ -25,7 +25,7 @@
 <div>
     <p class="tip_title">Tip: Sell or buy products in bulk with matrixes</p>
     <p class="tip_content">Selling the same product in different sizes or colors? Try the product grid and populate your orders with multiple quantities of each variant. This feature also exists in the Purchase application.</p>
-    <img src="https://download.odoocdn.com/digests/sale_management/static/src/img/t-shirts.png" class="illustration_border" />
+    <img src="https://download.odoocdn.com/digests/sale_management/static/src/img/t-shirts.png" width="540" class="illustration_border" />
 </div>
             </field>
         </record>

--- a/addons/sale_management/data/digest_data.xml
+++ b/addons/sale_management/data/digest_data.xml
@@ -4,7 +4,8 @@
         <record id="digest.digest_digest_default" model="digest.digest">
             <field name="kpi_all_sale_total">True</field>
         </record>
-
+    </data>
+    <data noupdate="0">
         <record id="digest_tip_sale1_management_0" model="digest.tip">
             <field name="name">Tip: Odoo supports configurable products</field>
             <field name="sequence">2200</field>

--- a/addons/stock/data/digest_data.xml
+++ b/addons/stock/data/digest_data.xml
@@ -6,19 +6,20 @@
             <field name="sequence">1000</field>
             <field name="group_id" ref="stock.group_stock_user" />
             <field name="tip_description" type="html">
-<p class="tip_title">Tip: Speed up inventory operations with barcodes</p>
-<table role="presentation" cellspacing="0" cellpadding="0" border="0" style="width: 100%; margin-top: 5px;">
-    <tbody>
+<div>
+    <p class="tip_title">Tip: Speed up inventory operations with barcodes</p>
+    <table class="tip_twocol">
         <tr>
-            <td width="33%">
-                <img src="https://download.odoocdn.com/digests/stock/static/src/img/barcode.gif" width="100%"/>
+            <td class="tip_twocol_left" style="width: 45%;">
+                <img src="https://download.odoocdn.com/digests/stock/static/src/img/barcode.gif" class="tip_twocol_img" width="240"/>
             </td>
-            <td width="67%" style="padding-left: 20px; vertical-align: text-top;">
-                <p class="tip_content">Enjoy a quick-paced experience with the Odoo barcode app. It is blazing fast and works even without a stable internet connection. It supports all flows: inventory adjustments, batch picking, moving lots or pallets, low inventory checks, etc. Go to the "Apps" menu to activate the barcode interface.</p>
+            <td style="width: 55%;">
+                <p class="tip_content" style="margin: 0;">Enjoy a quick-paced experience with the Odoo barcode app. It is blazing fast and works even without a stable internet connection. It supports all flows: inventory adjustments, batch picking, moving lots or pallets, low inventory checks, etc. Go to the "Apps" menu to activate the barcode interface.</p>
             </td>
         </tr>
-    </tbody>
-</table>
+    </table>
+    <div style="clear: both;" />
+</div>
             </field>
         </record>
     </data>

--- a/addons/test_mass_mailing/tests/test_mailing_statistics.py
+++ b/addons/test_mass_mailing/tests/test_mailing_statistics.py
@@ -66,13 +66,13 @@ class TestMailingStatistics(TestMassMailCommon):
         self.assertEqual(mail.state, 'outgoing')
         # test body content: KPIs
         body_html = html.fromstring(mail.body_html)
-        kpi_values = body_html.xpath('//div[@data-field="mail"]//*[hasclass("kpi_value")]/text()')
+        kpi_values = body_html.xpath('//table[@data-field="mail"]//*[hasclass("kpi_value")]/text()')
         self.assertEqual(
             [t.strip().strip('%') for t in kpi_values],
             ['100', str(mailing.opened_ratio), str(mailing.replied_ratio)]
         )
         # test body content: clicks (a bit hackish but hey we are in stable)
-        kpi_click_values = body_html.xpath('//div[hasclass("global_layout")]/table//tr[contains(@style,"color: #888888")]/td[contains(@style,"width: 30%")]/text()')
+        kpi_click_values = body_html.xpath('//table//tr[contains(@style,"color: #888888")]/td[contains(@style,"width: 30%")]/text()')
         first_link_value = int(kpi_click_values[0].strip().split()[1].strip('()'))
         self.assertEqual(first_link_value, mailing.clicked)
 

--- a/addons/test_mass_mailing/tests/test_mailing_statistics_sms.py
+++ b/addons/test_mass_mailing/tests/test_mailing_statistics_sms.py
@@ -60,12 +60,12 @@ class TestMailingStatistics(TestMassSMSCommon):
         self.assertEqual(mail.state, 'outgoing')
         # test body content: KPIs
         body_html = html.fromstring(mail.body_html)
-        kpi_values = body_html.xpath('//div[@data-field="sms"]//*[hasclass("kpi_value")]/text()')
+        kpi_values = body_html.xpath('//table[@data-field="sms"]//*[hasclass("kpi_value")]/text()')
         self.assertEqual(
             [t.strip().strip('%') for t in kpi_values],
             ['100', str(mailing.opened_ratio), str(mailing.replied_ratio)]
         )
         # test body content: clicks (a bit hackish but hey we are in stable)
-        kpi_click_values = body_html.xpath('//div[hasclass("global_layout")]/table//tr[contains(@style,"color: #888888")]/td[contains(@style,"width: 30%")]/text()')
+        kpi_click_values = body_html.xpath('//table//tr[contains(@style,"color: #888888")]/td[contains(@style,"width: 30%")]/text()')
         first_link_value = int(kpi_click_values[0].strip().split()[1].strip('()'))
         self.assertEqual(first_link_value, mailing.clicked)

--- a/addons/website/data/digest_data.xml
+++ b/addons/website/data/digest_data.xml
@@ -9,7 +9,7 @@
 <div>
     <p class="tip_title">Tip: Engage with visitors to convert them into leads</p>
     <p class="tip_content">Monitor your visitors while they are browsing your website with the Odoo Social app. Engage with them in just a click using a live chat request or a push notification. If they have completed one of your forms, you can send them an SMS, or call them right away while they are browsing your website.</p>
-    <img src="https://download.odoocdn.com/digests/website/static/src/img/website-visitors.gif" class="illustration_border" />
+    <img src="https://download.odoocdn.com/digests/website/static/src/img/website-visitors.gif" width="540" class="illustration_border" />
 </div>
             </field>
         </record>
@@ -21,7 +21,7 @@
 <div>
     <p class="tip_title">Tip: Use royalty-free photos</p>
     <p class="tip_content">Search in the media dialogue when you need photos to illustrate your website. Odoo's integration with Unsplash, featuring millions of royalty free and high quality photos, makes it possible for you to get the perfect picture, in just a few clicks.</p>
-    <img src="https://download.odoocdn.com/digests/website/static/src/img/image-search.gif" class="illustration_border" />
+    <img src="https://download.odoocdn.com/digests/website/static/src/img/image-search.gif" width="540" class="illustration_border" />
 </div>
             </field>
         </record>
@@ -33,7 +33,7 @@
 <div>
     <p class="tip_title">Tip: Search Engine Optimization (SEO)</p>
     <p class="tip_content">To get more visitors, you should target keywords that are often searched in Google. With the built-in SEO tool, once you define a few keywords, Odoo will recommend you the best keywords to target. Then adapt your title and description accordingly to boost your traffic.</p>
-    <img src="https://download.odoocdn.com/digests/website/static/src/img/SEO-keywords.gif" class="illustration_border" />
+    <img src="https://download.odoocdn.com/digests/website/static/src/img/SEO-keywords.gif" width="540" class="illustration_border" />
 </div>
             </field>
         </record>
@@ -45,7 +45,7 @@
 <div>
     <p class="tip_title">Tip: Use illustrations to spice up your website</p>
     <p class="tip_content">Not only can you search for royalty-free illustrations, their colors are also converted so that they always fit your Theme.</p>
-    <img src="https://download.odoocdn.com/digests/website/static/src/img/digest_tip_website_illustrations.gif" class="illustration_border" />
+    <img src="https://download.odoocdn.com/digests/website/static/src/img/digest_tip_website_illustrations.gif" width="540" class="illustration_border" />
 </div>
             </field>
         </record>
@@ -57,7 +57,7 @@
 <div>
     <p class="tip_title">Tip: Add shapes to energize your Website</p>
     <p class="tip_content">More than 90 shapes exist and their colors are picked to match your Theme.</p>
-    <img src="https://download.odoocdn.com/digests/website/static/src/img/digest_tip_website_shapes.gif" class="illustration_border" />
+    <img src="https://download.odoocdn.com/digests/website/static/src/img/digest_tip_website_shapes.gif" width="540" class="illustration_border" />
 </div>
             </field>
         </record>


### PR DESCRIPTION
Digest emails are currently not always correctly displayed on several
email readers. Notably using Outlook feeling is quite bad. This is
notably due to the support of "div" tags in outlook that far from
being perfect. Outlook notably does not support margin nor padding in
div, as well as many "modern" CSS properties.

Digest layout is updated to fix its display. We therefore get back to a
more hardcoded table-based display. It gives a better and more robust
layout cross readers.

This PR fixes the issue by using inline CSS, old CSS, and HTML table tags
to solve the above problem.

This PR also changes the kpi data in various models; update mass mailing
statistics layout;  and adapts test cases in digest and mass mailing models. 

task-2717426
