### PR TITLE
[FIX] core: manage special characters in street_split

### DIFF
--- a/odoo/tools/misc.py
+++ b/odoo/tools/misc.py
@@ -1640,9 +1640,10 @@ def hmac(env, scope, message, hash_function=hashlib.sha256):
     ).hexdigest()
 
 
-ADDRESS_REGEX = re.compile(r'^(.*?)(\s[0-9][0-9\S]*)?( - (.+))?$')
+ADDRESS_REGEX = re.compile(r'^(.*?)(\s[0-9][0-9\S]*)?( - (.+))?$', re.S)
 def street_split(street):
-    results = ADDRESS_REGEX.match(street or '').groups('')
+    rematch = ADDRESS_REGEX.match(street or '')
+    results = rematch.groups('') if rematch else ('', '', '', '')
     return {
         'street_name': results[0].strip(),
         'street_number': results[1].strip(),


### PR DESCRIPTION
A traceback is caused when migrating/upgrading certain databases. It seems to be caused by special characters in the `street` field.
This fix checks if the Regular Expression match function succeeds or provides a fallback

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
