### PR TITLE
[FIX] hr_timesheet : round hour spent correctly

### DIFF
--- a/addons/hr_timesheet/models/project.py
+++ b/addons/hr_timesheet/models/project.py
@@ -295,7 +295,7 @@ class Task(models.Model):
     def _compute_effective_hours(self):
         if not any(self._ids):
             for task in self:
-                task.effective_hours = round(sum(task.timesheet_ids.mapped('unit_amount')))
+                task.effective_hours = round(sum(task.timesheet_ids.mapped('unit_amount')), 2)
             return
         timesheet_read_group = self.env['account.analytic.line'].read_group([('task_id', 'in', self.ids)], ['unit_amount', 'task_id'], ['task_id'])
         timesheets_per_task = {res['task_id'][0]: res['unit_amount'] for res in timesheet_read_group}


### PR DESCRIPTION
Steps :
Install project and activate Timesheets.
Go to a task and add a timesheet with 30', then click elsewhere.

Issue :
The hours spent adapts, rounding to integer.

Cause :
The digits are not specified.

Fix :
Specify them.

opw-2822018

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
