### PR TITLE
[FIX] core, base_address_extended: manage special characters in street_split

### DIFF
--- a/addons/base_address_extended/tests/test_street_fields.py
+++ b/addons/base_address_extended/tests/test_street_fields.py
@@ -19,7 +19,9 @@ class TestStreetFields(TransactionCase):
             ['Chaussee de Namur 1', 'Chaussee de Namur', '1', ''],
             ['40 Chaussee de Namur', '40 Chaussee de Namur', '', ''],
             ['Chaussee de Namur, 40 - Apt 2b', 'Chaussee de Namur,', '40', 'Apt 2b'],
-            ['header Chaussee de Namur, 40 trailer', 'header Chaussee de Namur, 40 trailer', '', ''],
+            ['header Chaussee de Namur, 40 trailer ', 'header Chaussee de Namur, 40 trailer', '', ''],
+            ['\nCl 53\n # 43 - 81', 'Cl 53\n #', '43', '81'],
+            ['Street Line 1\nNumber Line 2 44 76', 'Street Line 1\nNumber Line 2 44', '76', ''],
         ]
 
         for street, name, number, number2 in values:
@@ -33,4 +35,4 @@ class TestStreetFields(TransactionCase):
             partner.street_number2 = number2
             partner.street_number = number
             partner.street_name = name
-            self.assertEqual(partner.street, street, 'Wrongly formatted street: expected %s, received %s' % (street, partner.street))
+            self.assertEqual(partner.street, street.strip(), 'Wrongly formatted street: expected %s, received %s' % (street, partner.street))

--- a/odoo/tools/misc.py
+++ b/odoo/tools/misc.py
@@ -1640,11 +1640,12 @@ def hmac(env, scope, message, hash_function=hashlib.sha256):
     ).hexdigest()
 
 
-ADDRESS_REGEX = re.compile(r'^(.*?)(\s[0-9][0-9\S]*)?( - (.+))?$')
+ADDRESS_REGEX = re.compile(r'^(.*?)(\s[0-9][0-9\S]*)?(?: - (.+))?$', flags=re.DOTALL)
 def street_split(street):
-    results = ADDRESS_REGEX.match(street or '').groups('')
+    match = ADDRESS_REGEX.match(street or '')
+    results = match.groups('') if match else ('', '', '')
     return {
         'street_name': results[0].strip(),
         'street_number': results[1].strip(),
-        'street_number2': results[3]
+        'street_number2': results[2],
     }


### PR DESCRIPTION
A traceback is caused when migrating/upgrading certain databases. It seems to be caused by special characters in the `street` field.
When there are `newline` characters the regex match function returns None.
This fix improves the REGEX with DOTALL mode and also checks if the Regular Expression match function succeeds or provides a fallback

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
