### PR TITLE
[FIX] web_editor: fix content_changed trigger

### DIFF
--- a/addons/web_editor/static/lib/odoo-editor/src/OdooEditor.js
+++ b/addons/web_editor/static/lib/odoo-editor/src/OdooEditor.js
@@ -489,6 +489,7 @@ export class OdooEditor extends EventTarget {
             this.observer = new MutationObserver(records => {
                 records = this.filterMutationRecords(records);
                 if (!records.length) return;
+                this.dispatchEvent(new Event('contentChanged'));
                 clearTimeout(this.observerTimeout);
                 if (this._observerTimeoutUnactive.size === 0) {
                     this.observerTimeout = setTimeout(() => {
@@ -721,7 +722,6 @@ export class OdooEditor extends EventTarget {
         this._checkStepUnbreakable = true;
         this._recordHistorySelection();
         this.dispatchEvent(new Event('historyStep'));
-        this.dispatchEvent(new Event('contentChanged'));
         this.multiselectionRefresh();
     }
     // apply changes according to some records


### PR DESCRIPTION
We had a conflict when forward porting https://github.com/odoo/odoo/pull/85411.

We thought we chose the right way to solve the conflict in https://github.com/odoo/odoo/pull/89272.

In light of the fact that freezes can happen in hr_appraisal because of
the original change, it appears we chose poorly. We tested in other
modules but not in hr_appraisal indeed.

This commit solves the original conflict the other away around and is
therefore a partial revert of 7dd6b8ff39b9a35cd4c159fb9bcd68b752c8475b.

task-2832078
