### PR TITLE
[IMP] survey: add presentator tooltip

### DIFF
--- a/addons/survey/controllers/survey_session_manage.py
+++ b/addons/survey/controllers/survey_session_manage.py
@@ -37,7 +37,7 @@ class UserInputSession(http.Controller):
         right arrow (next slide) icon to the presenter """
         next_question = survey._get_session_next_question(False)
         if show_results and any(answer.answer_score for answer in survey.session_question_id.suggested_answer_ids):
-            return _("Show Results")
+            return _("Show Answers")
         if not is_leaderboard and survey.session_question_id.is_scored_question and survey.session_question_id.scoring_type != 'no_scoring':
             return _('Leaderboard')
         if next_question:

--- a/addons/survey/static/src/js/survey_session_leaderboard.js
+++ b/addons/survey/static/src/js/survey_session_leaderboard.js
@@ -49,7 +49,8 @@ publicWidget.registry.SurveySessionLeaderboard = publicWidget.Widget.extend({
         });
 
         Promise.all([fadeOutPromise, leaderboardPromise]).then(function (results) {
-            var leaderboardResults = results[1];
+            var { leaderboardResults, nextPageTooltip } = results[1];
+            self.trigger_up('update_next_page_tooltip', { nextPageTooltip });
             var $renderedTemplate = $(leaderboardResults);
             self.$('.o_survey_session_leaderboard_container').append($renderedTemplate);
 

--- a/addons/survey/static/src/js/survey_session_manage.js
+++ b/addons/survey/static/src/js/survey_session_manage.js
@@ -183,6 +183,9 @@ publicWidget.registry.SurveySessionManage = publicWidget.Widget.extend(SurveyPre
         }
 
         this.currentScreen = screenToDisplay;
+        if (screenToDisplay === 'userInputs' && this._getNextScreen() == 'results') {
+            this._updateNextPageTooltip({data: {nextPageTooltip: _t('Show Results')}});
+        }
     },
 
     /**
@@ -228,6 +231,9 @@ publicWidget.registry.SurveySessionManage = publicWidget.Widget.extend(SurveyPre
         }
 
         this.currentScreen = screenToDisplay;
+        if (screenToDisplay === 'userInputs' && this._getNextScreen() == 'results') {
+            this._updateNextPageTooltip({data: {nextPageTooltip: _t('Show Results')}});
+        }
     },
 
     /**

--- a/addons/survey/views/survey_templates_user_input_session.xml
+++ b/addons/survey/views/survey_templates_user_input_session.xml
@@ -46,7 +46,7 @@
                         </h2>
                     </div>
                     <a role="button"
-                        class="font-weight-bold fa fa-chevron-right o_survey_session_navigation o_survey_session_navigation_next p-3" />
+                        class="font-weight-bold fa fa-chevron-right o_survey_session_navigation o_survey_session_navigation_next p-3" data-toggle="tooltip" data-placement="left" title="Start"/>
                 </div>
             </div>
         </t>
@@ -109,7 +109,7 @@
                     <div t-field="survey.description_done"/>
                 </div>
                 <a role="button"
-                    class="font-weight-bold fa fa-chevron-right o_survey_session_navigation o_survey_session_navigation_next p-3" />
+                    class="font-weight-bold fa fa-chevron-right o_survey_session_navigation o_survey_session_navigation_next p-3" data-toggle="tooltip" data-placement="left" t-att-title="next_page_tooltip"/>
                 <a role="button"
                     class="font-weight-bold fa fa-chevron-left o_survey_session_navigation o_survey_session_navigation_previous p-3" />
                 <div class="o_survey_session_results flex-column flex-grow-1 mx-5">


### PR DESCRIPTION
Current behavior before PR:

While filling out the survey user don't have any idea about the upcoming
Section/Question.

Desired behavior after PR is merged:

Ease the job of the live speaker by letting them know in advance
what the next slide will be about.
Added a label next to the arrow icon based on what the next slide will be.

Task: https://www.odoo.com/web#id=2791000&cids=2&menu_id=4720&action=4043&model=project.task&view_type=form


--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
