### PR TITLE
[FIX] sale_coupon: only add program if reward line was created

### DIFF
--- a/addons/sale_coupon/wizard/sale_coupon_apply_code.py
+++ b/addons/sale_coupon/wizard/sale_coupon_apply_code.py
@@ -40,7 +40,8 @@ class SaleCouponApplyCode(models.TransientModel):
                         }
                 else:  # The program is applied on this order
                     order._create_reward_line(program)
-                    order.code_promo_program_id = program
+                    if order._get_reward_lines():
+                        order.code_promo_program_id = program
         else:
             coupon = self.env['sale.coupon'].search([('code', '=', coupon_code)], limit=1)
             if coupon:


### PR DESCRIPTION
**Description of the issue/feature this PR addresses:**

- Create a sale order
- Add a line with a subtotal of zero
- Apply coupon with promo code
- Add some price to the line with a subtotal of zero to have something to be applied for a coupon
- Try to apply the coupon again to actually create a reward line -> Coupon has already been applied because it was linked before without effect on the `sale.order`

**Current behavior before PR:**
Coupon is saved although no reward line was created

**Desired behavior after PR is merged:**
Coupon is only linked in case an actual reward line was created

Info: @wt-io-it



--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
