### PR TITLE
[FIX] web: fix ComponentWrapper lifecycle on out-of-DOM updates

### DIFF
--- a/addons/web/static/src/legacy/js/owl_compatibility.js
+++ b/addons/web/static/src/legacy/js/owl_compatibility.js
@@ -626,6 +626,9 @@ odoo.define('web.OwlCompatibility', function (require) {
         }
 
         render() {
+            if (this.status !== "mounted") {
+                return;
+            }
             if (this.renderProm) {
                 this.node.render(true);
                 return this.renderProm;

--- a/addons/web/static/tests/legacy/owl_compatibility_tests.js
+++ b/addons/web/static/tests/legacy/owl_compatibility_tests.js
@@ -1007,7 +1007,7 @@ odoo.define('web.OwlCompatibilityTests', function (require) {
         });
 
         QUnit.test("lifecycle mount in fragment", async function (assert) {
-            assert.expect(17);
+            assert.expect(18);
 
             class MyChildComponent extends LegacyComponent {
                 setup() {
@@ -1024,8 +1024,8 @@ odoo.define('web.OwlCompatibilityTests', function (require) {
             MyComponent.components = { MyChildComponent };
             const MyWidget = WidgetAdapter.extend({
                 start() {
-                    let component = new ComponentWrapper(this, MyComponent, {});
-                    return component.mount(this.el);
+                    this.component = new ComponentWrapper(this, MyComponent, {});
+                    return this.component.mount(this.el);
                 }
             });
 
@@ -1043,6 +1043,9 @@ odoo.define('web.OwlCompatibilityTests', function (require) {
                 "onWillRender MyChildComponent",
                 "onRendered MyChildComponent",
             ]);
+
+            await widget.component.update({});
+            assert.verifySteps([]); // Out of DOM: shouldn't do anything.
 
             widget.$el.appendTo(target);
             widget.on_attach_callback();


### PR DESCRIPTION
Previously, updating a component that was mounted out of the DOM would
rerender it and patch it. In owl 1, patched was not called when a
component was mounted outside of the document. This caused crashes when
something done in onPatched depended on something done in onMounted (as
mounted is also not called when not it the DOM, which was handled
correctly by the compatibility layer).

This commit fixes that by ignoring requests to render a component that
is not yet in the DOM as a new render will be initiated anyway when
mounting the component in the document for real.
