### PR TITLE
[REF] hr_holidays: `PartnerImStatusIcon`, apply correct colors

### DIFF
--- a/addons/hr_holidays/static/src/components/partner_im_status_icon/partner_im_status_icon.xml
+++ b/addons/hr_holidays/static/src/components/partner_im_status_icon/partner_im_status_icon.xml
@@ -6,10 +6,10 @@
                 <i class="o_PartnerImStatusIcon_icon o-online fa fa-plane fa-stack-1x" title="Online" role="img" aria-label="User is online"/>
             </t>
             <t t-if="partner.im_status === 'leave_away'">
-                <i class="o_PartnerImStatusIcon_icon o-away fa fa-plane fa-stack-1x" title="Away" role="img" aria-label="User is away"/>
+                <i class="o_PartnerImStatusIcon_icon o-away fa fa-plane fa-stack-1x text-warning" title="Away" role="img" aria-label="User is away"/>
             </t>
             <t t-if="partner.im_status === 'leave_offline'">
-                <i class="o_PartnerImStatusIcon_icon o-offline fa fa-plane fa-stack-1x" title="Out of office" role="img" aria-label="User is out of office"/>
+                <i class="o_PartnerImStatusIcon_icon o-offline fa fa-plane fa-stack-1x text-700" title="Out of office" role="img" aria-label="User is out of office"/>
             </t>
         </xpath>
     </t>


### PR DESCRIPTION
Prior this commit, status icons colors where applied in scss.
Following this commit ( 67b58d66aac70a60e5de48111d52fe4ae7ac1f6a ), the
colors are now applied by BS classes and it created an issue when
`leave` status is applied at the same time.

After this commit, the right status icons color are applied by BS
classes.

task-2832067

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
