### PR TITLE
[IMP] website_event: lower footer on default introduction page

### DIFF
--- a/addons/website_event/static/src/scss/event_templates_common.scss
+++ b/addons/website_event/static/src/scss/event_templates_common.scss
@@ -92,13 +92,6 @@
         .o_wevent_online_badge_unpublished{
             opacity: 0.4;
         }
-
-        &.o_wevent_online_bg {
-            @if (color('body') == $o-portal-default-body-bg) {
-                @extend .bg-100;
-            }
-        }
-
         // background color-based for new styling
         .event_color_0 {
             // bg-100 background but DO NOT extend bg-100 as it messes with text-muted colors

--- a/addons/website_event/static/src/scss/event_templates_page.scss
+++ b/addons/website_event/static/src/scss/event_templates_page.scss
@@ -1,4 +1,10 @@
+.o_connected_user .o_wevent_event {
+    min-height: calc(98vh - 110px)
+}
+
 .o_wevent_event {
+    min-height: calc(98vh - 70px);
+    
     // Multi-line event title, even in mobile mode
     nav > div > a.navbar-brand {
         text-overflow: revert;

--- a/addons/website_event_booth/views/event_booth_templates.xml
+++ b/addons/website_event_booth/views/event_booth_templates.xml
@@ -13,24 +13,6 @@
 
                     <div class="container d-flex flex-column flex-grow-1">
                         <h1 class="text-white my-5">Get A Booth</h1>
-                        <div t-if="event.is_finished" class="alert alert-info">
-                            <span>This event is finished. It's no longer possible to book a booth.</span>
-                        </div>
-                        <div t-elif="not event_booths" class="alert alert-info">
-                            <span>This event is not open to exhibitors registration,
-                                <span t-if="request.env.user.has_group('event.group_event_manager')">
-                                    you can
-                                    <a class="text-nowrap" t-attf-href="/web#id=#{event.id}&amp;view_type=form&amp;model=event.event">
-                                        <i class="fa fa-gear mr-1" role="img" aria-label="Configure" title="Configure event booths"/><em>Configure Booths</em>
-                                    </a>
-                                    for this event.
-                                </span>
-                                <span t-else="">
-                                    check our <a href="/event">list of future events</a>.
-                                </span>
-                            </span>
-                        </div>
-
                     </div>
                 </t>
                 <section class="mt-n5">
@@ -40,6 +22,23 @@
                         </div>
                     </div>
                 </section>
+                <div t-if="event.is_finished" class="container d-flex flex-column flex-grow-1">
+                    <span class="alert alert-info">This event is finished. It's no longer possible to book a booth.</span>
+                </div>
+                <div t-elif="not event_booths" class="container d-flex flex-column flex-grow-1">
+                    <span class="alert alert-info">This event is not open to exhibitors registration,
+                        <span t-if="request.env.user.has_group('event.group_event_manager')">
+                            you can
+                            <a class="text-nowrap" t-attf-href="/web#id=#{event.id}&amp;view_type=form&amp;model=event.event">
+                                <i class="fa fa-gear mr-1" role="img" aria-label="Configure" title="Configure event booths"/><em>Configure Booths</em>
+                            </a>
+                            for this event.
+                        </span>
+                        <span t-else="">
+                            check our <a href="/event">list of future events</a>.
+                        </span>
+                    </span>
+                </div>
             </div>
         </t>
     </template>

--- a/addons/website_event_exhibitor/views/event_exhibitor_templates_list.xml
+++ b/addons/website_event_exhibitor/views/event_exhibitor_templates_list.xml
@@ -3,7 +3,7 @@
 
 <template id="event_exhibitors" name="Event Exhibitors">
     <t t-call="website_event.layout">
-        <div class="o_wevent_online o_wevent_online_bg o_wesponsor_index">
+        <div class="o_wevent_online o_wesponsor_index">
             <!-- Topbar -->
             <t t-call="website_event_exhibitor.exhibitors_topbar"/>
             <!-- Drag/Drop Area -->

--- a/addons/website_event_exhibitor/views/event_exhibitor_templates_page.xml
+++ b/addons/website_event_exhibitor/views/event_exhibitor_templates_page.xml
@@ -5,7 +5,7 @@
     <t t-set="no_header" t-value="option_widescreen"/>
     <t t-set="no_footer" t-value="option_widescreen"/>
     <t t-call="website_event.layout">
-        <div class="o_wevent_online o_wevent_online_bg o_wesponsor_index">
+        <div class="o_wevent_online o_wesponsor_index">
             <!-- Options -->
             <t t-set="option_widescreen" t-value="option_widescreen or False"/>
             <!-- Drag/Drop Area -->

--- a/addons/website_event_meet/views/event_meet_templates_list.xml
+++ b/addons/website_event_meet/views/event_meet_templates_list.xml
@@ -3,7 +3,7 @@
 
 <template id="event_meet" name="Meeting Rooms">
     <t t-call="website_event.layout">
-        <div class="o_wevent_online o_wevent_online_bg o_wemeet_index">
+        <div class="o_wevent_online o_wemeet_index">
             <!-- Drag/Drop Area -->
             <div id="oe_structure_website_event_location_1" class="oe_structure"/>
             <!-- Content -->

--- a/addons/website_event_meet/views/event_meet_templates_page.xml
+++ b/addons/website_event_meet/views/event_meet_templates_page.xml
@@ -5,7 +5,7 @@
     <t t-set="no_header" t-value="option_widescreen"/>
     <t t-set="no_footer" t-value="option_widescreen"/>
     <t t-call="website_event.layout">
-        <div class="o_wevent_online o_wevent_online_bg o_wemeet_index">
+        <div class="o_wevent_online o_wemeet_index">
             <!-- Options -->
             <t t-set="option_widescreen" t-value="option_widescreen or False"/>
             <!-- Drag/Drop Area -->

--- a/addons/website_event_track/views/event_track_templates_page.xml
+++ b/addons/website_event_track/views/event_track_templates_page.xml
@@ -3,7 +3,7 @@
 
 <template id="event_track_main" name="Event Exhibitor">
     <t t-call="website_event.layout">
-        <div class="o_wevent_online o_wevent_online_bg o_wesession_index">
+        <div class="o_wevent_online o_wesession_index">
             <!-- Options -->
             <t t-set="option_widescreen" t-value="option_widescreen or False"/>
             <t t-set="option_track_wishlist" t-value="not event.is_done and is_view_active('website_event_track.session_topbar_wishlist')"/>


### PR DESCRIPTION
PURPOSE:

When adding a submenu to an event, a default introduction page
containing only a title is created. Since this page is almost empty,
the footer takes the entire screen.
This commit lowers the footer on this default introduction page so
that it is barely seen.

Task-2831951