### PR TITLE
[FIX] mail: `Message`, MessageActionList in front of Composer

### DIFF
--- a/addons/mail/static/src/components/message/message.scss
+++ b/addons/mail/static/src/components/message/message.scss
@@ -4,7 +4,8 @@
 
 .o_Message_actionListContainer {
     @include o-position-absolute($top: - map-get($spacers, 3), $right: 0);
-
+    z-index: 10; // Place the element in front of the Composer when they overlap
+    
     &.o-squashed {
         @include o-position-absolute($top: - map-get($spacers, 4), $right: 0);
     }


### PR DESCRIPTION
Prior this commit, the MessageActionList was behind and partly hidden by
the Composer when we edit small messages.

After this commit, the MessageActionList is in front of the Composer.

task-2819763

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
