### PR TITLE
[FIX] hw_drivers: sanitize keyboard devices name

### DIFF
--- a/addons/hw_drivers/drivers/KeyboardUSBDriver.py
+++ b/addons/hw_drivers/drivers/KeyboardUSBDriver.py
@@ -8,6 +8,7 @@ import logging
 from lxml import etree
 import os
 from pathlib import Path
+import re
 import subprocess
 import time
 from threading import Lock
@@ -126,7 +127,7 @@ class KeyboardUSBDriver(Driver):
             else:
                 manufacturer = usb.util.get_string(self.dev, self.dev.iManufacturer)
                 product = usb.util.get_string(self.dev, self.dev.iProduct)
-            return ("%s - %s") % (manufacturer, product)
+            return re.sub(r"[^\w \-+/*&]", '', "%s - %s" % (manufacturer, product))
         except ValueError as e:
             _logger.warning(e)
             return _('Unknown input device')


### PR DESCRIPTION
To reproduce:
Synchronise an IoT-box with a device with `\x00` characters in its name
=> ERROR: bad query: UPDATE "iot_device" SET "name"=%s WHERE id IN %s
ERROR: A string literal cannot contain NUL (0x00) characters.

Note that this is pretty rare to have this characters in devices names. But it looks to happen with some Chinese devices like the "TaoTronics 2-in-1 Bluetooth & Wired Barcode Scanner USB Portable Bar Code Scanner"

Original PR:
https://github.com/odoo/enterprise/pull/26471

OPW-2748580

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
