### PR TITLE
[FIX] website_slides: avoid loading invalid slide files

### DIFF
--- a/addons/website_slides/static/src/js/slides.js
+++ b/addons/website_slides/static/src/js/slides.js
@@ -41,8 +41,11 @@ return publicWidget.registry.websiteSlides;
 odoo.define('website_slides.slides_embed', function (require) {
 'use strict';
 
+const core = require('web.core');
 var publicWidget = require('web.public.widget');
 require('website_slides.slides');
+
+const _t = core._t;
 
 var SlideSocialEmbed = publicWidget.Widget.extend({
     events: {
@@ -101,6 +104,9 @@ publicWidget.registry.websiteSlidesEmbed = publicWidget.Widget.extend({
     start: function (parent) {
         var defs = [this._super.apply(this, arguments)];
         $('iframe.o_wslides_iframe_viewer').on('ready', this._onIframeViewerReady.bind(this));
+        document.querySelectorAll('iframe.o_wslides_iframe_viewer').forEach(iframe => {
+            iframe.contentDocument.addEventListener('embedexception', this._onEmbedExcpetion.bind(this));
+        });
         return Promise.all(defs);
     },
 
@@ -118,6 +124,18 @@ publicWidget.registry.websiteSlidesEmbed = publicWidget.Widget.extend({
         var $iframe = $(ev.currentTarget);
         var maxPage = $iframe.contents().find('#page_count').val();
         new SlideSocialEmbed(this, maxPage).attachTo($('.oe_slide_js_embed_code_widget'));
+    },
+    /**
+     * @private
+     * @param {Event} ev
+     */
+    _onEmbedExcpetion: function (ev) {
+        this.displayNotification({
+            type: 'danger',
+            title: _t('The document could not be loaded'),
+            message: _t(ev.detail.message),
+            sticky: true,
+        });
     },
 });
 

--- a/addons/website_slides/static/src/js/slides_embed.js
+++ b/addons/website_slides/static/src/js/slides_embed.js
@@ -20,6 +20,8 @@ $(function () {
             this.pdf_viewer = new PDFSlidesViewer(this.slide_url, this.canvas, true);
             this.pdf_viewer.loadDocument().then(function () {
                 self.on_loaded_file();
+            }).catch(function (exception) {
+                document.dispatchEvent(new CustomEvent('embedexception', {detail: exception}));
             });
         };
         EmbeddedViewer.prototype.__proto__ = {


### PR DESCRIPTION
The document and presentation slide types currently only accept pdf files. An end user can still upload other files, however, resulting in a (silent) `InvalidPDFException` on the client side, when trying to view the slide.

No error message is communicated to the end user though, often resulting in confusion. As of this commit:
* An event is emitted by the document containing the `EmbeddedViewer` whenever it encounters an invalid pdf document.
* A message is shown in the backend whenever such an event is detected in the nested iframe holding the `EmbeddeViewer`.
* The slide type is updated when uploading an image file as slide content.
* A `ValidationError` is raised when uploading non-pdf files for document and presentation type slides.

opw-2819105