### PR TITLE
[FIX] account_edi: avoid accidental deactivation of the EDI cron on u…

### DIFF
--- a/addons/account_edi/data/cron.xml
+++ b/addons/account_edi/data/cron.xml
@@ -1,4 +1,4 @@
-<odoo>
+<odoo noupdate="1">
     <record id="ir_cron_edi_network" model="ir.cron">
         <field name="name">EDI : Perform web services operations</field>
         <field name="model_id" ref="model_account_edi_document"/>


### PR DESCRIPTION
…pdate

The problem is that when we update the account_edi, e.g. by updating the
base module, the cron gets deactivated because initially the ir.cron
record is set to active False and we activate it when we have an
edi format that requires web services.

By setting the record to noupdate, it will not execute setting it to
False again when updating the module.  (It will however not update
the record to noupdate)

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
