### PR TITLE
[FIX] mail: allow customized OdooBot avatar

### DIFF
--- a/addons/mail/static/src/components/message/message.js
+++ b/addons/mail/static/src/components/message/message.js
@@ -147,12 +147,7 @@ class Message extends Component {
      * @returns {string}
      */
     get avatar() {
-        if (
-            this.message.author &&
-            this.message.author === this.env.messaging.partnerRoot
-        ) {
-            return '/mail/static/src/img/odoobot.png';
-        } else if (this.message.author) {
+        if (this.message.author) {
             // TODO FIXME for public user this might not be accessible. task-2223236
             // we should probably use the correspondig attachment id + access token
             // or create a dedicated route to get message image, checking the access right of the message

--- a/addons/mail/static/src/components/notification_request/notification_request.xml
+++ b/addons/mail/static/src/components/notification_request/notification_request.xml
@@ -5,7 +5,7 @@
         <div class="o_NotificationRequest" t-on-click="_onClick">
             <div class="o_NotificationRequest_sidebar">
                 <div class="o_NotificationRequest_imageContainer o_NotificationRequest_sidebarItem">
-                    <img class="o_NotificationRequest_image rounded-circle" src="/mail/static/src/img/odoobot.png" alt="Avatar of OdooBot"/>
+                    <img class="o_NotificationRequest_image rounded-circle" t-att-src="env.messaging.partnerRoot.avatarUrl" alt="Avatar of OdooBot"/>
                     <PartnerImStatusIcon
                         class="o_NotificationRequest_partnerImStatusIcon"
                         t-att-class="{ 'o-mobile': env.messaging.device.isMobile }"


### PR DESCRIPTION
Since refactoring to OWL, the bot's avatar was hardcoded, while previous Odoo
release (v13) allowed to custome it.

STEPS:
* open OdooBot profile (user_id=1)
* change avatar to a custom one
* open any record with a message from the bot

BEFORE: always the same avatar
AFTER:  the custom avatar is shown

---

opw-2827424

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
