### PR TITLE
[FIX] mrp: start the workorder only once

### DIFF
--- a/addons/mrp/i18n/mrp.pot
+++ b/addons/mrp/i18n/mrp.pot
@@ -4062,6 +4062,12 @@ msgid ""
 msgstr ""
 
 #. module: mrp
+#: code:addons/mrp/models/mrp_workcenter.py:0
+#, python-format
+msgid "The Workoder (%s) cannot be started twice!"
+msgstr ""
+
+#. module: mrp
 #: code:addons/mrp/models/mrp_bom.py:0
 #, python-format
 msgid ""

--- a/addons/mrp/models/mrp_workcenter.py
+++ b/addons/mrp/models/mrp_workcenter.py
@@ -363,6 +363,12 @@ class MrpWorkcenterProductivity(models.Model):
             else:
                 blocktime.duration = 0.0
 
+    @api.constrains('workorder_id')
+    def _check_open_time_ids(self):
+        for workorder in self.workorder_id:
+            if len(workorder.time_ids.filtered(lambda t: t.date_start and not t.date_end)) > 1:
+                raise ValidationError(_('The Workoder (%s) cannot be started twice!', workorder.display_name))
+
     def button_block(self):
         self.ensure_one()
         self.workcenter_id.order_ids.end_all()

--- a/addons/mrp/models/mrp_workorder.py
+++ b/addons/mrp/models/mrp_workorder.py
@@ -526,6 +526,8 @@ class MrpWorkorder(models.Model):
 
     def button_start(self):
         self.ensure_one()
+        if any(time.date_start and not time.date_end for time in self.time_ids):
+            return True
         # As button_start is automatically called in the new view
         if self.state in ('done', 'cancel'):
             return True

--- a/addons/mrp/tests/test_order.py
+++ b/addons/mrp/tests/test_order.py
@@ -2273,3 +2273,23 @@ class TestMrpOrder(TestMrpCommon):
         mo_2.action_confirm()
         mo_2.button_plan()
         self.assertEqual(mo_2.workorder_ids[0].workcenter_id.id, workcenter_2.id, 'workcenter_2 is faster than workcenter_1 to manufacture 4 units')
+
+    def test_starting_wo_twice(self):
+        """
+            Check that the work order is started only once when clicking the start button several times.
+        """
+        production_form = Form(self.env['mrp.production'])
+        production_form.bom_id = self.bom_2
+        production_form.product_qty = 1
+        production = production_form.save()
+        production_form = Form(production)
+        with production_form.workorder_ids.new() as wo:
+            wo.name = 'OP1'
+            wo.workcenter_id = self.workcenter_1
+            wo.duration_expected = 40
+        production = production_form.save()
+        production.action_confirm()
+        production.button_plan()
+        production.workorder_ids[0].button_start()
+        production.workorder_ids[0].button_start()
+        self.assertEqual(len(production.workorder_ids[0].time_ids.filtered(lambda t: t.date_start and not t.date_end)), 1)


### PR DESCRIPTION
**Steps to reproduce the bug:**
- Create a MO with work orders
- Confirm the MO
- Under the tab Work Orders > click on the button start multiple times quickly

**Problem:**
Several `mrp.workcentre.productivity` are created for the work order,
whereas normally the workorder can have only one timer started (without date_end).

**Solution:**
- If the workorder already has a timer running, return true to stop the process
- Add a constraint to block the user when he tries for example to create with an RPC call several `mrp.workcenter.productivity`
without an end date for the same workoder

opw-2802436


https://user-images.githubusercontent.com/78867936/165236935-ce4213d9-5880-48c1-ac69-b933ddb342c8.mp4




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
