### PR TITLE
[FIX] project: readd token value in portal.message_thread template call

### DIFF
--- a/addons/project/views/project_portal_templates.xml
+++ b/addons/project/views/project_portal_templates.xml
@@ -310,7 +310,9 @@
 
                     <div class="mt32" id="task_chat" data-anchor="true">
                         <h4><strong>Message and communication history</strong></h4>
-                        <t t-call="portal.message_thread"/>
+                        <t t-call="portal.message_thread">
+                            <t t-set="token" t-value="task.access_token"/>
+                        </t>
                     </div>
                 </div>
             </div>


### PR DESCRIPTION
A change introduced in https://github.com/odoo/odoo/pull/84644 removed the 'token' variable from a call to the `portal.message_thread` template, which created a bug where a portal user trying to submit a comment to a task would encounter an "Access Denied" error.

This PR reverts that change.

Task-2832688