### PR TITLE
[FIX] account: unbalanced entry with price_unit 0

### DIFF
--- a/addons/account/models/account_move.py
+++ b/addons/account/models/account_move.py
@@ -3112,6 +3112,7 @@ class AccountMoveLine(models.Model):
                 if tax.price_include:
                     balance += tax_res['amount']
 
+        tax_included_division_is_zero = any(tax.price_include and tax.amount == 100 and tax.amount_type == 'division' for tax in taxes) and balance == 0
         discount_factor = 1 - (discount / 100.0)
         if balance and discount_factor:
             # discount != 100%
@@ -3126,8 +3127,9 @@ class AccountMoveLine(models.Model):
                 'discount': 0.0,
                 'price_unit': balance / (quantity or 1.0),
             }
-        elif not discount_factor:
-            # balance of line is 0, but discount  == 100% so we display the normal unit_price
+        elif not discount_factor or tax_included_division_is_zero:
+            # balance of line is 0, but discount == 100% or taxes (price included) == 100%,
+            # so we display the normal unit_price
             vals = {}
         else:
             # balance is 0, so unit price is 0 as well

--- a/addons/account/tests/test_account_move_out_invoice.py
+++ b/addons/account/tests/test_account_move_out_invoice.py
@@ -3139,3 +3139,19 @@ class TestAccountMoveOutInvoiceOnchanges(AccountTestInvoicingCommon):
                 'credit': value['debit'],
             })
         self.assertRecordValues(reversed_caba_move.line_ids, expected_values)
+
+    def test_changeprice_unit_to_zero(self):
+        move_form = Form(self.env['account.move'].with_context(default_type='out_invoice'))
+        move_form.partner_id = self.partner_a
+        move_form.invoice_date = fields.Date.from_string('2017-01-01')
+        with move_form.invoice_line_ids.new() as line_form:
+            line_form.product_id = self.product_a
+            line_form.tax_ids.clear()
+        with move_form.invoice_line_ids.edit(0) as line_form:
+            line_form.price_unit = 0
+
+        move = move_form.save()
+
+        self.assertRecordValues(move.invoice_line_ids, [
+            {'price_unit': 0}
+        ])

--- a/addons/account/tests/test_invoice_taxes.py
+++ b/addons/account/tests/test_invoice_taxes.py
@@ -706,3 +706,41 @@ class TestInvoiceTaxes(AccountTestInvoicingCommon):
         self.assertRecordValues(invoice.line_ids.filtered(lambda l: l.account_id.internal_type == 'receivable'), [{
             'balance': 686.54
         }])
+
+    def test_invoice_with_100_percent_division_tax_incl(self):
+        """
+        Check if the price unit remain the same after affecting a tax
+        100%, price_include and amount_type 'division'
+        """
+        invoice = self.env['account.move'].create({
+            'type': 'out_invoice',
+            'partner_id': self.partner_a.id,
+            'currency_id': self.currency_data['currency'].id,
+            'invoice_date': '2018-01-01',
+            'date': '2018-01-01',
+            'invoice_line_ids': [(0, 0, {
+                'name': 'xxxx',
+                'quantity': 1,
+                'price_unit': 500,
+            })]
+        })
+
+        division_tax_4_incl = self.env['account.tax'].create({
+            'name': '100% incl',
+            'amount_type': 'division',
+            'amount': 100,
+            'price_include': True,
+            'include_base_amount': True,
+            'sequence': 50,
+        })
+
+        self.assertRecordValues(invoice.invoice_line_ids, [
+            {'price_unit': 500}
+        ])
+        with Form(invoice) as inv_form:
+            with inv_form.invoice_line_ids.edit(0) as line_form:
+                line_form.tax_ids.add(division_tax_4_incl)
+
+        self.assertRecordValues(invoice.invoice_line_ids, [
+            {'price_unit': 500}
+        ])


### PR DESCRIPTION
Steps to reproduce:

- Create invoice for a prudict at price X > 0
- Change the price to 0 before saving
- Then save it
-> Error : Cannot create unbalanced journal entry

This bug was introduced in 14.0 with this commit fe7d56dc32c71e04b54de9dbd756a48942a832f4
The reason is, if a line is an invoice_line, there is no
amount_currency, therefore we enter in the wrong condition.
Fix the initial bug in 13.0, but for the backport in 13.0,
we check the balance instead of the amount_currency.

opw-2822635

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
