### PR TITLE
[IMP] payment: allow the public user to tokenize payments

### DIFF
--- a/addons/payment/i18n/payment.pot
+++ b/addons/payment/i18n/payment.pot
@@ -6,8 +6,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 15.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-01-24 08:20+0000\n"
-"PO-Revision-Date: 2022-01-24 08:20+0000\n"
+"POT-Creation-Date: 2022-04-25 15:50+0000\n"
+"PO-Revision-Date: 2022-04-25 15:50+0000\n"
 "Last-Translator: \n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"
@@ -2167,6 +2167,12 @@ msgstr ""
 #: code:addons/payment/models/ir_ui_view.py:0
 #, python-format
 msgid "You cannot delete a view that is used by a payment acquirer."
+msgstr ""
+
+#. module: payment
+#: code:addons/payment/controllers/portal.py:0
+#, python-format
+msgid "You do not have access to this payment token."
 msgstr ""
 
 #. module: payment

--- a/addons/payment/models/payment_acquirer.py
+++ b/addons/payment/models/payment_acquirer.py
@@ -314,13 +314,6 @@ class PaymentAcquirer(models.Model):
             domain = expression.AND([domain, [('allow_tokenization', '=', True)]])
 
         compatible_acquirers = self.env['payment.acquirer'].search(domain)
-
-        # Prevent the public user from saving a token for acquirers that require tokenization.
-        if self.env.user._is_public():
-            compatible_acquirers = compatible_acquirers.filtered(
-                lambda acq: not self._is_tokenization_required(provider=acq.provider, **kwargs)
-            )
-
         return compatible_acquirers
 
     @api.model


### PR DESCRIPTION
Before this commit, the public user would be prevented from creating,
reading, or using payment tokens entirely. This was put in place in an
effort to homogenize the way each application interacts with tokens,
and because it was considered more logical to only create tokens when
you can actually see them afterward. This however led to an undesirable
side effect in Subscriptions where customers would pay while being
logged out, thus preventing the token from being saved and failing the
automatic renewal of the subscription.

With this commit, we enable the public user to create tokens from any
payment flow. This also means that when a token is created, its owner
will not see it until they log in. This commit also reverts 2a084c48
which was intended to hide payments acquirers from the public user if
their payment would end up being tokenized.

opw-2789340

See also:
- https://github.com/odoo/enterprise/pull/26590