### PR TITLE
[IMP] mail: make field name easier to trace 

### DIFF
--- a/addons/hr/static/src/models/employee.js
+++ b/addons/hr/static/src/models/employee.js
@@ -6,7 +6,7 @@ import { clear, insert } from '@mail/model/model_field_command';
 
 registerModel({
     name: 'Employee',
-    identifyingFields: ['id'],
+    identifyingFields: ['Employee/id'],
     modelMethods: {
         /**
          * @param {Object} data
@@ -163,7 +163,7 @@ registerModel({
          */
         partner: one('Partner', {
             inverse: 'employee',
-            related: 'user.partner',
+            related: 'Employee/user.User/partner',
         }),
         /**
          * User related to this employee.

--- a/addons/im_livechat/static/src/models/discuss_sidebar_category.js
+++ b/addons/im_livechat/static/src/models/discuss_sidebar_category.js
@@ -13,5 +13,5 @@ addFields('DiscussSidebarCategory', {
 });
 
 patchIdentifyingFields('DiscussSidebarCategory', identifyingFields => {
-    identifyingFields[0].push('discussAsLivechat');
+    identifyingFields[0].push('DiscussSidebarCategory/discussAsLivechat');
 });

--- a/addons/mail/static/src/components/activity/activity.js
+++ b/addons/mail/static/src/components/activity/activity.js
@@ -13,7 +13,7 @@ export class Activity extends LegacyComponent {
      */
      setup() {
         super.setup();
-        useComponentToModel({ fieldName: 'component', modelName: 'ActivityView' });
+        useComponentToModel({ fieldName: 'ActivityView/component', modelName: 'ActivityView' });
     }
 
     /**

--- a/addons/mail/static/src/components/activity/activity.js
+++ b/addons/mail/static/src/components/activity/activity.js
@@ -23,6 +23,10 @@ export class Activity extends LegacyComponent {
         return this.messaging && this.messaging.models['ActivityView'].get(this.props.localId);
     }
 
+    get(name) {
+        return this.activityView.get(name);
+    }
+
 }
 
 Object.assign(Activity, {

--- a/addons/mail/static/src/components/activity/activity.xml
+++ b/addons/mail/static/src/components/activity/activity.xml
@@ -6,17 +6,17 @@
             <div class="o_Activity d-flex p-2" t-attf-class="{{ className }}" t-on-click="activityView.onClickActivity" t-ref="root">
                 <div class="o_Activity_sidebar mr-3">
                     <div class="o_Activity_user position-relative h-100 w-100">
-                        <t t-if="activityView.activity.assignee">
-                            <img class="o_Activity_userAvatar rounded-circle h-100 w-100 o_object_fit_cover" t-attf-src="/web/image/res.users/{{ activityView.activity.assignee.id }}/avatar_128" t-att-alt="activityView.activity.assignee.nameOrDisplayName"/>
+                        <t t-if="activityView['ActivityView/activity']['Activity/assignee']">
+                            <img class="o_Activity_userAvatar rounded-circle h-100 w-100 o_object_fit_cover" t-attf-src="/web/image/res.users/{{ activityView['ActivityView/activity']['Activity/assignee']['User/id'] }}/avatar_128" t-att-alt="activityView['ActivityView/activity']['Activity/assignee']['User/nameOrDisplayName']"/>
                         </t>
                         <div class="o_Activity_iconContainer d-flex align-items-center justify-content-center rounded-circle w-50 h-50 text-white"
                             t-att-class="{
-                                'bg-success': activityView.activity.state === 'planned',
-                                'bg-warning': activityView.activity.state === 'today',
-                                'bg-danger': activityView.activity.state === 'overdue',
+                                'bg-success': activityView['ActivityView/activity']['Activity/state'] === 'planned',
+                                'bg-warning': activityView['ActivityView/activity']['Activity/state'] === 'today',
+                                'bg-danger': activityView['ActivityView/activity']['Activity/state'] === 'overdue',
                             }"
                         >
-                            <i class="o_Activity_icon fa small" t-attf-class="{{ activityView.activity.icon }}"/>
+                            <i class="o_Activity_icon fa small" t-attf-class="{{ activityView['ActivityView/activity']['Activity/icon'] }}"/>
                         </div>
                     </div>
                 </div>
@@ -24,31 +24,31 @@
                     <div class="o_Activity_info d-flex align-items-baseline">
                         <div class="o_Activity_dueDateText me-2"
                             t-att-class="{
-                                'text-danger': activityView.activity.state === 'overdue',
-                                'text-success': activityView.activity.state === 'planned',
-                                'text-warning': activityView.activity.state === 'today',
+                                'text-danger': activityView['ActivityView/activity']['Activity/state'] === 'overdue',
+                                'text-success': activityView['ActivityView/activity']['Activity/state'] === 'planned',
+                                'text-warning': activityView['ActivityView/activity']['Activity/state'] === 'today',
                             }"
                         >
-                            <b t-esc="activityView.delayLabel"/>
+                            <b t-esc="activityView['ActivityView/delayLabel']"/>
                         </div>
-                        <t t-if="activityView.activity.summary">
+                        <t t-if="activityView['ActivityView/activity']['Activity/summary']">
                             <b class="o_Activity_summary text-900 me-2">
-                                <t t-esc="activityView.summary"/>
+                                <t t-esc="activityView['ActivityView/summary']"/>
                             </b>
                         </t>
-                        <t t-elif="activityView.activity.type">
+                        <t t-elif="activityView['ActivityView/activity']['Activity/type']">
                             <b class="o_Activity_summary o_Activity_type text-900 me-2">
-                                <t t-esc="activityView.activity.type.displayName"/>
+                                <t t-esc="activityView['ActivityView/activity']['Activity/type']['ActivityType/displayName']"/>
                             </b>
                         </t>
-                        <t t-if="activityView.activity.assignee">
+                        <t t-if="activityView['ActivityView/activity']['Activity/assignee']">
                             <div class="o_Activity_userName">
-                                <t t-esc="activityView.assignedUserText"/>
+                                <t t-esc="activityView['ActivityView/assignedUserText']"/>
                             </div>
                         </t>
                         <a
                             class="o_Activity_detailsButton btn py-0"
-                            t-att-class="activityView.areDetailsVisible ? 'text-primary' : 'btn-link btn-primary'"
+                            t-att-class="activityView['ActivityView/areDetailsVisible'] ? 'text-primary' : 'btn-link btn-primary'"
                             t-on-click="activityView.onClickDetailsButton"
                             role="button"
                         >
@@ -56,30 +56,30 @@
                         </a>
                     </div>
 
-                    <t t-if="activityView.areDetailsVisible">
+                    <t t-if="activityView['ActivityView/areDetailsVisible']">
                         <div class="o_Activity_details">
                             <div class="d-md-table table table-sm mt-2 mb-3">
-                                <div t-if="activityView.activity.type" class="d-md-table-row mb-3">
+                                <div t-if="activityView['ActivityView/activity']['Activity/type']" class="d-md-table-row mb-3">
                                     <div class="d-md-table-cell font-weight-bold text-md-right m-0 py-md-1 px-md-4">Activity type</div>
                                     <div class="o_Activity_type d-md-table-cell py-md-1 pr-4">
-                                        <t t-esc="activityView.activity.type.displayName"/>
+                                        <t t-esc="activityView['ActivityView/activity']['Activity/type']['ActivityType/displayName']"/>
                                     </div>
                                 </div>
-                                <div t-if="activityView.activity.creator" class="d-md-table-row mb-3">
+                                <div t-if="activityView['ActivityView/activity']['Activity/creator']" class="d-md-table-row mb-3">
                                     <div class="d-md-table-cell font-weight-bold text-md-right m-0 py-md-1 px-md-4">Created</div>
                                     <div class="o_Activity_detailsCreation d-md-table-cell py-md-1 pr-4">
-                                        <t t-esc="activityView.formattedCreateDatetime"/>, <br t-if="messaging.device.isSmall"/>by
-                                        <img class="o_Activity_detailsUserAvatar o_Activity_detailsCreatorAvatar ms-1 me-1 rounded-circle align-text-bottom" t-attf-src="/web/image/res.users/{{ activityView.activity.creator.id }}/avatar_128" t-att-title="activityView.activity.creator.nameOrDisplayName" t-att-alt="activityView.activity.creator.nameOrDisplayName"/>
+                                        <t t-esc="activityView['ActivityView/formattedCreateDatetime']"/>, <br t-if="messaging.device.isSmall"/>by
+                                        <img class="o_Activity_detailsUserAvatar o_Activity_detailsCreatorAvatar ms-1 me-1 rounded-circle align-text-bottom" t-attf-src="/web/image/res.users/{{ activityView['ActivityView/activity']['Activity/creator']['User/id'] }}/avatar_128" t-att-title="activityView['ActivityView/activity']['Activity/creator']['User/nameOrDisplayName']" t-att-alt="activityView['ActivityView/activity']['Activity/creator']['User/nameOrDisplayName']"/>
                                         <b class="o_Activity_detailsCreator">
-                                            <t t-esc="activityView.activity.creator.nameOrDisplayName"/>
+                                            <t t-esc="activityView['ActivityView/activity']['Activity/creator']['User/nameOrDisplayName']"/>
                                         </b>
                                     </div>
                                 </div>
-                                <div t-if="activityView.activity.assignee" class="d-md-table-row mb-3">
+                                <div t-if="activityView['ActivityView/activity']['Activity/assignee']" class="d-md-table-row mb-3">
                                     <div class="d-md-table-cell font-weight-bold text-md-right m-0 py-md-1 px-md-4">Assigned to</div>
                                     <div class="o_Activity_detailsAssignation d-md-table-cell py-md-1 pr-4">
-                                        <img class="o_Activity_detailsUserAvatar o_Activity_detailsAssignationUserAvatar me-1 rounded-circle align-text-bottom" t-attf-src="/web/image/res.users/{{ activityView.activity.assignee.id }}/avatar_128" t-att-title="activityView.activity.assignee.nameOrDisplayName" t-att-alt="activityView.activity.assignee.nameOrDisplayName"/>
-                                        <b t-esc="activityView.activity.assignee.nameOrDisplayName"/>
+                                        <img class="o_Activity_detailsUserAvatar o_Activity_detailsAssignationUserAvatar me-1 rounded-circle align-text-bottom" t-attf-src="/web/image/res.users/{{ activityView['ActivityView/activity']['Activity/assignee']['User/id'] }}/avatar_128" t-att-title="activityView['ActivityView/activity']['Activity/assignee']['User/nameOrDisplayName']" t-att-alt="activityView['ActivityView/activity']['Activity/assignee']['User/nameOrDisplayName']"/>
+                                        <b t-esc="activityView['ActivityView/activity']['Activity/assignee']['User/nameOrDisplayName']"/>
                                     </div>
                                 </div>
                                 <div class="d-md-table-row">
@@ -87,12 +87,12 @@
                                     <div class="o_Activity_detailsDueDate d-md-table-cell py-md-1 pr-4">
                                         <span class="o_Activity_deadlineDateText"
                                             t-att-class="{
-                                                'text-danger': activityView.activity.state === 'overdue',
-                                                'text-success': activityView.activity.state === 'planned',
-                                                'text-warning': activityView.activity.state === 'today',
+                                                'text-danger': activityView['ActivityView/activity']['Activity/state'] === 'overdue',
+                                                'text-success': activityView['ActivityView/activity']['Activity/state'] === 'planned',
+                                                'text-warning': activityView['ActivityView/activity']['Activity/state'] === 'today',
                                             }"
                                         >
-                                            <t t-esc="activityView.formattedDeadlineDate"/>
+                                            <t t-esc="activityView['ActivityView/formattedDeadlineDate']"/>
                                         </span>
                                     </div>
                                 </div>
@@ -100,15 +100,15 @@
                         </div>
                     </t>
 
-                    <t t-if="activityView.activity.note">
+                    <t t-if="activityView['ActivityView/activity']['Activity/note']">
                         <div class="o_Activity_note">
-                            <t t-out="activityView.activity.noteAsMarkup"/>
+                            <t t-out="activityView['ActivityView/activity']['Activity/noteAsMarkup']"/>
                         </div>
                     </t>
 
-                    <t t-if="activityView.mailTemplateViews.length > 0">
+                    <t t-if="activityView['ActivityView/mailTemplateViews'].length > 0">
                         <div class="o_Activity_mailTemplates">
-                            <t t-foreach="activityView.mailTemplateViews" t-as="mailTemplateView" t-key="mailTemplateView.localId">
+                            <t t-foreach="activityView['ActivityView/mailTemplateViews']" t-as="mailTemplateView" t-key="mailTemplateView.localId">
                                 <MailTemplate
                                     className="'o_Activity_mailTemplate'"
                                     localId="mailTemplateView.localId"
@@ -117,19 +117,19 @@
                         </div>
                     </t>
 
-                    <t t-if="activityView.activity.canWrite">
+                    <t t-if="activityView['ActivityView/activity']['Activity/canWrite']">
                         <div name="tools" class="o_Activity_tools d-flex">
-                            <t t-if="!activityView.fileUploader">
-                                <Popover position="'right'" title="activityView.markDoneText">
-                                    <button class="o_Activity_toolButton o_Activity_markDoneButton btn btn-link btn-primary pt-0 pl-0" t-att-title="activityView.markDoneText">
+                            <t t-if="!activityView['ActivityView/fileUploader']">
+                                <Popover position="'right'" title="activityView['ActivityView/markDoneText']">
+                                    <button class="o_Activity_toolButton o_Activity_markDoneButton btn btn-link btn-primary pt-0 pl-0" t-att-title="activityView['ActivityView/markDoneText']">
                                         <i class="fa fa-check"/> Mark Done
                                     </button>
                                     <t t-set-slot="opened">
-                                        <ActivityMarkDonePopover localId="activityView.activityMarkDonePopoverView.localId"/>
+                                        <ActivityMarkDonePopover localId="activityView['ActivityView/activityMarkDonePopoverView'].localId"/>
                                     </t>
                                 </Popover>
                             </t>
-                            <t t-if="activityView.fileUploader">
+                            <t t-if="activityView['ActivityView/fileUploader']">
                                 <button class="o_Activity_toolButton o_Activity_uploadButton btn btn-link btn-primary pt-0 pl-0" t-on-click="activityView.onClickUploadDocument">
                                     <i class="fa fa-upload"/> Upload Document
                                 </button>

--- a/addons/mail/static/src/components/activity/activity.xml
+++ b/addons/mail/static/src/components/activity/activity.xml
@@ -6,17 +6,17 @@
             <div class="o_Activity d-flex p-2" t-attf-class="{{ className }}" t-on-click="activityView.onClickActivity" t-ref="root">
                 <div class="o_Activity_sidebar mr-3">
                     <div class="o_Activity_user position-relative h-100 w-100">
-                        <t t-if="activityView['ActivityView/activity']['Activity/assignee']">
-                            <img class="o_Activity_userAvatar rounded-circle h-100 w-100 o_object_fit_cover" t-attf-src="/web/image/res.users/{{ activityView['ActivityView/activity']['Activity/assignee']['User/id'] }}/avatar_128" t-att-alt="activityView['ActivityView/activity']['Activity/assignee']['User/nameOrDisplayName']"/>
+                        <t t-if="get('ActivityView/activity').get('Activity/assignee')">
+                            <img class="o_Activity_userAvatar rounded-circle h-100 w-100 o_object_fit_cover" t-attf-src="/web/image/res.users/{{ get('ActivityView/activity').get('Activity/assignee').get('User/id') }}/avatar_128" t-att-alt="get('ActivityView/activity').get('Activity/assignee').get('User/nameOrDisplayName')"/>
                         </t>
                         <div class="o_Activity_iconContainer d-flex align-items-center justify-content-center rounded-circle w-50 h-50 text-white"
                             t-att-class="{
-                                'bg-success': activityView['ActivityView/activity']['Activity/state'] === 'planned',
-                                'bg-warning': activityView['ActivityView/activity']['Activity/state'] === 'today',
-                                'bg-danger': activityView['ActivityView/activity']['Activity/state'] === 'overdue',
+                                'bg-success': get('ActivityView/activity').get('Activity/state') === 'planned',
+                                'bg-warning': get('ActivityView/activity').get('Activity/state') === 'today',
+                                'bg-danger': get('ActivityView/activity').get('Activity/state') === 'overdue',
                             }"
                         >
-                            <i class="o_Activity_icon fa small" t-attf-class="{{ activityView['ActivityView/activity']['Activity/icon'] }}"/>
+                            <i class="o_Activity_icon fa small" t-attf-class="{{ get('ActivityView/activity').get('Activity/icon') }}"/>
                         </div>
                     </div>
                 </div>
@@ -24,31 +24,31 @@
                     <div class="o_Activity_info d-flex align-items-baseline">
                         <div class="o_Activity_dueDateText me-2"
                             t-att-class="{
-                                'text-danger': activityView['ActivityView/activity']['Activity/state'] === 'overdue',
-                                'text-success': activityView['ActivityView/activity']['Activity/state'] === 'planned',
-                                'text-warning': activityView['ActivityView/activity']['Activity/state'] === 'today',
+                                'text-danger': get('ActivityView/activity').get('Activity/state') === 'overdue',
+                                'text-success': get('ActivityView/activity').get('Activity/state') === 'planned',
+                                'text-warning': get('ActivityView/activity').get('Activity/state') === 'today',
                             }"
                         >
-                            <b t-esc="activityView['ActivityView/delayLabel']"/>
+                            <b t-esc="get('ActivityView/delayLabel')"/>
                         </div>
-                        <t t-if="activityView['ActivityView/activity']['Activity/summary']">
+                        <t t-if="get('ActivityView/activity').get('Activity/summary')">
                             <b class="o_Activity_summary text-900 me-2">
-                                <t t-esc="activityView['ActivityView/summary']"/>
+                                <t t-esc="get('ActivityView/summary')"/>
                             </b>
                         </t>
-                        <t t-elif="activityView['ActivityView/activity']['Activity/type']">
+                        <t t-elif="get('ActivityView/activity').get('Activity/type')">
                             <b class="o_Activity_summary o_Activity_type text-900 me-2">
-                                <t t-esc="activityView['ActivityView/activity']['Activity/type']['ActivityType/displayName']"/>
+                                <t t-esc="get('ActivityView/activity').get('Activity/type').get('ActivityType/displayName')"/>
                             </b>
                         </t>
-                        <t t-if="activityView['ActivityView/activity']['Activity/assignee']">
+                        <t t-if="get('ActivityView/activity').get('Activity/assignee')">
                             <div class="o_Activity_userName">
-                                <t t-esc="activityView['ActivityView/assignedUserText']"/>
+                                <t t-esc="get('ActivityView/assignedUserText')"/>
                             </div>
                         </t>
                         <a
                             class="o_Activity_detailsButton btn py-0"
-                            t-att-class="activityView['ActivityView/areDetailsVisible'] ? 'text-primary' : 'btn-link btn-primary'"
+                            t-att-class="get('ActivityView/areDetailsVisible') ? 'text-primary' : 'btn-link btn-primary'"
                             t-on-click="activityView.onClickDetailsButton"
                             role="button"
                         >
@@ -56,30 +56,30 @@
                         </a>
                     </div>
 
-                    <t t-if="activityView['ActivityView/areDetailsVisible']">
+                    <t t-if="get('ActivityView/areDetailsVisible')">
                         <div class="o_Activity_details">
                             <div class="d-md-table table table-sm mt-2 mb-3">
-                                <div t-if="activityView['ActivityView/activity']['Activity/type']" class="d-md-table-row mb-3">
+                                <div t-if="get('ActivityView/activity').get('Activity/type')" class="d-md-table-row mb-3">
                                     <div class="d-md-table-cell font-weight-bold text-md-right m-0 py-md-1 px-md-4">Activity type</div>
                                     <div class="o_Activity_type d-md-table-cell py-md-1 pr-4">
-                                        <t t-esc="activityView['ActivityView/activity']['Activity/type']['ActivityType/displayName']"/>
+                                        <t t-esc="get('ActivityView/activity').get('Activity/type').get('ActivityType/displayName')"/>
                                     </div>
                                 </div>
-                                <div t-if="activityView['ActivityView/activity']['Activity/creator']" class="d-md-table-row mb-3">
+                                <div t-if="get('ActivityView/activity').get('Activity/creator')" class="d-md-table-row mb-3">
                                     <div class="d-md-table-cell font-weight-bold text-md-right m-0 py-md-1 px-md-4">Created</div>
                                     <div class="o_Activity_detailsCreation d-md-table-cell py-md-1 pr-4">
-                                        <t t-esc="activityView['ActivityView/formattedCreateDatetime']"/>, <br t-if="messaging.device.isSmall"/>by
-                                        <img class="o_Activity_detailsUserAvatar o_Activity_detailsCreatorAvatar ms-1 me-1 rounded-circle align-text-bottom" t-attf-src="/web/image/res.users/{{ activityView['ActivityView/activity']['Activity/creator']['User/id'] }}/avatar_128" t-att-title="activityView['ActivityView/activity']['Activity/creator']['User/nameOrDisplayName']" t-att-alt="activityView['ActivityView/activity']['Activity/creator']['User/nameOrDisplayName']"/>
+                                        <t t-esc="get('ActivityView/formattedCreateDatetime')"/>, <br t-if="messaging.device.isSmall"/>by
+                                        <img class="o_Activity_detailsUserAvatar o_Activity_detailsCreatorAvatar ms-1 me-1 rounded-circle align-text-bottom" t-attf-src="/web/image/res.users/{{ get('ActivityView/activity').get('Activity/creator').get('User/id') }}/avatar_128" t-att-title="get('ActivityView/activity').get('Activity/creator').get('User/nameOrDisplayName')" t-att-alt="get('ActivityView/activity').get('Activity/creator').get('User/nameOrDisplayName')"/>
                                         <b class="o_Activity_detailsCreator">
-                                            <t t-esc="activityView['ActivityView/activity']['Activity/creator']['User/nameOrDisplayName']"/>
+                                            <t t-esc="get('ActivityView/activity').get('Activity/creator').get('User/nameOrDisplayName')"/>
                                         </b>
                                     </div>
                                 </div>
-                                <div t-if="activityView['ActivityView/activity']['Activity/assignee']" class="d-md-table-row mb-3">
+                                <div t-if="get('ActivityView/activity').get('Activity/assignee')" class="d-md-table-row mb-3">
                                     <div class="d-md-table-cell font-weight-bold text-md-right m-0 py-md-1 px-md-4">Assigned to</div>
                                     <div class="o_Activity_detailsAssignation d-md-table-cell py-md-1 pr-4">
-                                        <img class="o_Activity_detailsUserAvatar o_Activity_detailsAssignationUserAvatar me-1 rounded-circle align-text-bottom" t-attf-src="/web/image/res.users/{{ activityView['ActivityView/activity']['Activity/assignee']['User/id'] }}/avatar_128" t-att-title="activityView['ActivityView/activity']['Activity/assignee']['User/nameOrDisplayName']" t-att-alt="activityView['ActivityView/activity']['Activity/assignee']['User/nameOrDisplayName']"/>
-                                        <b t-esc="activityView['ActivityView/activity']['Activity/assignee']['User/nameOrDisplayName']"/>
+                                        <img class="o_Activity_detailsUserAvatar o_Activity_detailsAssignationUserAvatar me-1 rounded-circle align-text-bottom" t-attf-src="/web/image/res.users/{{ get('ActivityView/activity').get('Activity/assignee').get('User/id') }}/avatar_128" t-att-title="get('ActivityView/activity').get('Activity/assignee').get('User/nameOrDisplayName')" t-att-alt="get('ActivityView/activity').get('Activity/assignee').get('User/nameOrDisplayName')"/>
+                                        <b t-esc="get('ActivityView/activity').get('Activity/assignee').get('User/nameOrDisplayName')"/>
                                     </div>
                                 </div>
                                 <div class="d-md-table-row">
@@ -87,12 +87,12 @@
                                     <div class="o_Activity_detailsDueDate d-md-table-cell py-md-1 pr-4">
                                         <span class="o_Activity_deadlineDateText"
                                             t-att-class="{
-                                                'text-danger': activityView['ActivityView/activity']['Activity/state'] === 'overdue',
-                                                'text-success': activityView['ActivityView/activity']['Activity/state'] === 'planned',
-                                                'text-warning': activityView['ActivityView/activity']['Activity/state'] === 'today',
+                                                'text-danger': get('ActivityView/activity').get('Activity/state') === 'overdue',
+                                                'text-success': get('ActivityView/activity').get('Activity/state') === 'planned',
+                                                'text-warning': get('ActivityView/activity').get('Activity/state') === 'today',
                                             }"
                                         >
-                                            <t t-esc="activityView['ActivityView/formattedDeadlineDate']"/>
+                                            <t t-esc="get('ActivityView/formattedDeadlineDate')"/>
                                         </span>
                                     </div>
                                 </div>
@@ -100,15 +100,15 @@
                         </div>
                     </t>
 
-                    <t t-if="activityView['ActivityView/activity']['Activity/note']">
+                    <t t-if="get('ActivityView/activity').get('Activity/note')">
                         <div class="o_Activity_note">
-                            <t t-out="activityView['ActivityView/activity']['Activity/noteAsMarkup']"/>
+                            <t t-out="get('ActivityView/activity').get('Activity/noteAsMarkup')"/>
                         </div>
                     </t>
 
-                    <t t-if="activityView['ActivityView/mailTemplateViews'].length > 0">
+                    <t t-if="get('ActivityView/mailTemplateViews').length > 0">
                         <div class="o_Activity_mailTemplates">
-                            <t t-foreach="activityView['ActivityView/mailTemplateViews']" t-as="mailTemplateView" t-key="mailTemplateView.localId">
+                            <t t-foreach="get('ActivityView/mailTemplateViews')" t-as="mailTemplateView" t-key="mailTemplateView.localId">
                                 <MailTemplate
                                     className="'o_Activity_mailTemplate'"
                                     localId="mailTemplateView.localId"
@@ -117,19 +117,19 @@
                         </div>
                     </t>
 
-                    <t t-if="activityView['ActivityView/activity']['Activity/canWrite']">
+                    <t t-if="get('ActivityView/activity').get('Activity/canWrite')">
                         <div name="tools" class="o_Activity_tools d-flex">
-                            <t t-if="!activityView['ActivityView/fileUploader']">
-                                <Popover position="'right'" title="activityView['ActivityView/markDoneText']">
-                                    <button class="o_Activity_toolButton o_Activity_markDoneButton btn btn-link btn-primary pt-0 pl-0" t-att-title="activityView['ActivityView/markDoneText']">
+                            <t t-if="!get('ActivityView/fileUploader')">
+                                <Popover position="'right'" title="get('ActivityView/markDoneText')">
+                                    <button class="o_Activity_toolButton o_Activity_markDoneButton btn btn-link btn-primary pt-0 pl-0" t-att-title="get('ActivityView/markDoneText')">
                                         <i class="fa fa-check"/> Mark Done
                                     </button>
                                     <t t-set-slot="opened">
-                                        <ActivityMarkDonePopover localId="activityView['ActivityView/activityMarkDonePopoverView'].localId"/>
+                                        <ActivityMarkDonePopover localId="get('ActivityView/activityMarkDonePopoverView').localId"/>
                                     </t>
                                 </Popover>
                             </t>
-                            <t t-if="activityView['ActivityView/fileUploader']">
+                            <t t-if="get('ActivityView/fileUploader')">
                                 <button class="o_Activity_toolButton o_Activity_uploadButton btn btn-link btn-primary pt-0 pl-0" t-on-click="activityView.onClickUploadDocument">
                                     <i class="fa fa-upload"/> Upload Document
                                 </button>

--- a/addons/mail/static/src/models/activity.js
+++ b/addons/mail/static/src/models/activity.js
@@ -8,7 +8,7 @@ const { markup } = owl;
 
 registerModel({
     name: 'Activity',
-    identifyingFields: ['id'],
+    identifyingFields: ['Activity/id'],
     modelMethods: {
         /**
          * @param {Object} data
@@ -17,83 +17,83 @@ registerModel({
         convertData(data) {
             const data2 = {};
             if ('activity_category' in data) {
-                data2.category = data.activity_category;
+                data2['Activity/category'] = data.activity_category;
             }
             if ('can_write' in data) {
-                data2.canWrite = data.can_write;
+                data2['Activity/canWrite'] = data.can_write;
             }
             if ('create_date' in data) {
-                data2.dateCreate = data.create_date;
+                data2['Activity/dateCreate'] = data.create_date;
             }
             if ('date_deadline' in data) {
-                data2.dateDeadline = data.date_deadline;
+                data2['Activity/dateDeadline'] = data.date_deadline;
             }
             if ('chaining_type' in data) {
-                data2.chaining_type = data.chaining_type;
+                data2['Activity/chaining_type'] = data.chaining_type;
             }
             if ('icon' in data) {
-                data2.icon = data.icon;
+                data2['Activity/icon'] = data.icon;
             }
             if ('id' in data) {
-                data2.id = data.id;
+                data2['Activity/id'] = data.id;
             }
             if ('note' in data) {
-                data2.note = data.note;
+                data2['Activity/note'] = data.note;
             }
             if ('state' in data) {
-                data2.state = data.state;
+                data2['Activity/state'] = data.state;
             }
             if ('summary' in data) {
-                data2.summary = data.summary;
+                data2['Activity/summary'] = data.summary;
             }
 
             // relation
             if ('activity_type_id' in data) {
                 if (!data.activity_type_id) {
-                    data2.type = clear();
+                    data2['Activity/type'] = clear();
                 } else {
-                    data2.type = insert({
-                        displayName: data.activity_type_id[1],
-                        id: data.activity_type_id[0],
+                    data2['Activity/type'] = insert({
+                        'ActivityType/displayName': data.activity_type_id[1],
+                        'ActivityType/id': data.activity_type_id[0],
                     });
                 }
             }
             if ('create_uid' in data) {
                 if (!data.create_uid) {
-                    data2.creator = clear();
+                    data2['Activity/creator'] = clear();
                 } else {
-                    data2.creator = insert({
-                        id: data.create_uid[0],
-                        display_name: data.create_uid[1],
+                    data2['Activity/creator'] = insert({
+                        'User/id': data.create_uid[0],
+                        'User/display_name': data.create_uid[1],
                     });
                 }
             }
             if ('mail_template_ids' in data) {
-                data2.mailTemplates = insert(data.mail_template_ids);
+                data2['Activity/mailTemplates'] = insert(data.mail_template_ids);
             }
             if ('res_id' in data && 'res_model' in data) {
-                data2.thread = insert({
-                    id: data.res_id,
-                    model: data.res_model,
+                data2['Activity/thread'] = insert({
+                    'Thread/id': data.res_id,
+                    'Thread/model': data.res_model,
                 });
             }
             if ('user_id' in data) {
                 if (!data.user_id) {
-                    data2.assignee = clear();
+                    data2['Activity/assignee'] = clear();
                 } else {
-                    data2.assignee = insert({
-                        id: data.user_id[0],
-                        display_name: data.user_id[1],
+                    data2['Activity/assignee'] = insert({
+                        'User/id': data.user_id[0],
+                        'User/display_name': data.user_id[1],
                     });
                 }
             }
             if ('request_partner_id' in data) {
                 if (!data.request_partner_id) {
-                    data2.requestingPartner = clear();
+                    data2['Activity/requestingPartner'] = clear();
                 } else {
-                    data2.requestingPartner = insert({
-                        id: data.request_partner_id[0],
-                        display_name: data.request_partner_id[1],
+                    data2['Activity/requestingPartner'] = insert({
+                        'Partner/id': data.request_partner_id[0],
+                        'Partner/display_name': data.request_partner_id[1],
                     });
                 }
             }
@@ -106,10 +106,10 @@ registerModel({
          * Delete the record from database and locally.
          */
         async deleteServerRecord() {
-            await this.async(() => this.messaging.rpc({
+            await this.async(() => this['Record/messaging'].rpc({
                 model: 'mail.activity',
                 method: 'unlink',
-                args: [[this.id]],
+                args: [[this['Activity/id']]],
             }));
             this.delete();
         },
@@ -126,10 +126,10 @@ registerModel({
                 views: [[false, 'form']],
                 target: 'new',
                 context: {
-                    default_res_id: this.thread.id,
-                    default_res_model: this.thread.model,
+                    default_res_id: this['Activity/thread']['Thread/id'],
+                    default_res_model: this['Activity/thread']['Thread/model'],
                 },
-                res_id: this.id,
+                res_id: this['Activity/id'],
             };
             this.env.bus.trigger('do-action', {
                 action,
@@ -137,10 +137,10 @@ registerModel({
             });
         },
         async fetchAndUpdate() {
-            const [data] = await this.messaging.rpc({
+            const [data] = await this['Record/messaging'].rpc({
                 model: 'mail.activity',
                 method: 'activity_format',
-                args: [this.id],
+                args: [this['Activity/id']],
             }, { shadow: true }).catch(e => {
                 const errorName = e.message && e.message.data && e.message.data.name;
                 if (errorName === 'odoo.exceptions.MissingError') {
@@ -155,7 +155,7 @@ registerModel({
             } else {
                 shouldDelete = true;
             }
-            this.thread.fetchData(['activities', 'attachments', 'messages']);
+            this['Activity/thread'].fetchData(['activities', 'attachments', 'messages']);
             if (shouldDelete) {
                 this.delete();
             }
@@ -166,17 +166,17 @@ registerModel({
          * @param {string|boolean} [param0.feedback=false]
          */
         async markAsDone({ attachments = [], feedback = false }) {
-            const attachmentIds = attachments.map(attachment => attachment.id);
-            await this.async(() => this.messaging.rpc({
+            const attachmentIds = attachments.map(attachment => attachment['Attachment.id']);
+            await this.async(() => this['Record/messaging'].rpc({
                 model: 'mail.activity',
                 method: 'action_feedback',
-                args: [[this.id]],
+                args: [[this['Activity/id']]],
                 kwargs: {
                     attachment_ids: attachmentIds,
                     feedback,
                 },
             }));
-            this.thread.fetchData(['attachments', 'messages']);
+            this['Activity/thread'].fetchData(['attachments', 'messages']);
             this.delete();
         },
         /**
@@ -185,14 +185,14 @@ registerModel({
          * @returns {Object}
          */
         async markAsDoneAndScheduleNext({ feedback }) {
-            const action = await this.async(() => this.messaging.rpc({
+            const action = await this.async(() => this['Record/messaging'].rpc({
                 model: 'mail.activity',
                 method: 'action_feedback_schedule_next',
-                args: [[this.id]],
+                args: [[this['Activity/id']]],
                 kwargs: { feedback },
             }));
-            this.thread.fetchData(['activities', 'attachments', 'messages']);
-            const thread = this.thread;
+            this['Activity/thread'].fetchData(['activities', 'attachments', 'messages']);
+            const thread = this['Activity/thread'];
             this.delete();
             if (!action) {
                 return;
@@ -211,10 +211,14 @@ registerModel({
          * @returns {boolean}
          */
         _computeIsCurrentPartnerAssignee() {
-            if (!this.assignee || !this.assignee.partner || !this.messaging.currentPartner) {
+            if (
+                !this['Activity/assignee'] ||
+                !this['Activity/assignee']['User/partner'] ||
+                !this['Record/messaging']['Messaging/currentPartner']
+            ) {
                 return false;
             }
-            return this.assignee.partner === this.messaging.currentPartner;
+            return this['Activity/assignee']['User/partner'] === this['Record/messaging']['Messaging/currentPartner'];
         },
         /**
          * Wysiwyg editor put `<p><br></p>` even without a note on the activity.
@@ -225,55 +229,55 @@ registerModel({
          * @returns {string|undefined}
          */
         _computeNote() {
-            if (this.note === '<p><br></p>') {
+            if (this['Activity/note'] === '<p><br></p>') {
                 return clear();
             }
-            return this.note;
+            return this['Activity/note'];
         },
         /**
          * @private
          * @returns {Markup}
          */
         _computeNoteAsMarkup() {
-            return markup(this.note);
+            return markup(this['Activity/note']);
         },
     },
     fields: {
-        activityViews: many('ActivityView', {
-            inverse: 'activity',
+        'Activity/activityViews': many('ActivityView', {
+            inverse: 'ActivityView/activity',
             isCausal: true,
         }),
-        assignee: one('User'),
-        attachments: many('Attachment', {
+        'Activity/assignee': one('User'),
+        'Activity/attachments': many('Attachment', {
             inverse: 'activities',
         }),
-        canWrite: attr({
+        'Activity/canWrite': attr({
             default: false,
         }),
-        category: attr(),
-        creator: one('User'),
-        dateCreate: attr(),
-        dateDeadline: attr(),
+        'Activity/category': attr(),
+        'Activity/creator': one('User'),
+        'Activity/dateCreate': attr(),
+        'Activity/dateDeadline': attr(),
         /**
          * Backup of the feedback content of an activity to be marked as done in the popover.
          * Feature-specific to restoring the feedback content when component is re-mounted.
          * In all other cases, this field value should not be trusted.
          */
-        feedbackBackup: attr(),
-        chaining_type: attr({
+        'Activity/feedbackBackup': attr(),
+        'Activity/chaining_type': attr({
             default: 'suggest',
         }),
-        icon: attr(),
-        id: attr({
+        'Activity/icon': attr(),
+        'Activity/id': attr({
             readonly: true,
             required: true,
         }),
-        isCurrentPartnerAssignee: attr({
+        'Activity/isCurrentPartnerAssignee': attr({
             compute: '_computeIsCurrentPartnerAssignee',
             default: false,
         }),
-        mailTemplates: many('MailTemplate', {
-            inverse: 'activities',
+        'Activity/mailTemplates': many('MailTemplate', {
+            inverse: 'MailTemplate/activities',
         }),
         /**
          * This value is meant to be returned by the server
@@ -281,10 +285,10 @@ registerModel({
          * Do not use this value in a 't-raw' if the activity has been created
          * directly from user input and not from server data as it's not escaped.
          */
-        note: attr({
+        'Activity/note': attr({
             compute: '_computeNote',
         }),
-        noteAsMarkup: attr({
+        'Activity/noteAsMarkup': attr({
             compute: '_computeNoteAsMarkup',
         }),
         /**
@@ -294,18 +298,18 @@ registerModel({
          * Also, be useful when the assigned user is different from the
          * "source" or "requesting" partner.
          */
-        requestingPartner: one('Partner'),
-        state: attr(),
-        summary: attr(),
+        'Activity/requestingPartner': one('Partner'),
+        'Activity/state': attr(),
+        'Activity/summary': attr(),
         /**
          * Determines to which "thread" (using `mail.activity.mixin` on the
          * server) `this` belongs to.
          */
-        thread: one('Thread', {
-            inverse: 'activities',
+        'Activity/thread': one('Thread', {
+            inverse: 'Thread/activities',
         }),
-        type: one('ActivityType', {
-            inverse: 'activities',
+        'Activity/type': one('ActivityType', {
+            inverse: 'ActivityType/activities',
         }),
     },
 });

--- a/addons/mail/static/src/models/activity.js
+++ b/addons/mail/static/src/models/activity.js
@@ -106,10 +106,10 @@ registerModel({
          * Delete the record from database and locally.
          */
         async deleteServerRecord() {
-            await this.async(() => this['Record/messaging'].rpc({
+            await this.async(() => this.get('Record/messaging').rpc({
                 model: 'mail.activity',
                 method: 'unlink',
-                args: [[this['Activity/id']]],
+                args: [[this.get('Activity/id')]],
             }));
             this.delete();
         },
@@ -126,10 +126,10 @@ registerModel({
                 views: [[false, 'form']],
                 target: 'new',
                 context: {
-                    default_res_id: this['Activity/thread']['Thread/id'],
-                    default_res_model: this['Activity/thread']['Thread/model'],
+                    default_res_id: this.get('Activity/thread').get('Thread/id'),
+                    default_res_model: this.get('Activity/thread').get('Thread/model'),
                 },
-                res_id: this['Activity/id'],
+                res_id: this.get('Activity/id'),
             };
             this.env.bus.trigger('do-action', {
                 action,
@@ -137,10 +137,10 @@ registerModel({
             });
         },
         async fetchAndUpdate() {
-            const [data] = await this['Record/messaging'].rpc({
+            const [data] = await this.get('Record/messaging').rpc({
                 model: 'mail.activity',
                 method: 'activity_format',
-                args: [this['Activity/id']],
+                args: [this.get('Activity/id')],
             }, { shadow: true }).catch(e => {
                 const errorName = e.message && e.message.data && e.message.data.name;
                 if (errorName === 'odoo.exceptions.MissingError') {
@@ -155,7 +155,7 @@ registerModel({
             } else {
                 shouldDelete = true;
             }
-            this['Activity/thread'].fetchData(['activities', 'attachments', 'messages']);
+            this.get('Activity/thread').fetchData(['activities', 'attachments', 'messages']);
             if (shouldDelete) {
                 this.delete();
             }
@@ -166,17 +166,17 @@ registerModel({
          * @param {string|boolean} [param0.feedback=false]
          */
         async markAsDone({ attachments = [], feedback = false }) {
-            const attachmentIds = attachments.map(attachment => attachment['Attachment.id']);
-            await this.async(() => this['Record/messaging'].rpc({
+            const attachmentIds = attachments.map(attachment => attachment.get('Attachment/id'));
+            await this.async(() => this.get('Record/messaging').rpc({
                 model: 'mail.activity',
                 method: 'action_feedback',
-                args: [[this['Activity/id']]],
+                args: [[this.get('Activity/id')]],
                 kwargs: {
                     attachment_ids: attachmentIds,
                     feedback,
                 },
             }));
-            this['Activity/thread'].fetchData(['attachments', 'messages']);
+            this.get('Activity/thread').fetchData(['attachments', 'messages']);
             this.delete();
         },
         /**
@@ -185,14 +185,14 @@ registerModel({
          * @returns {Object}
          */
         async markAsDoneAndScheduleNext({ feedback }) {
-            const action = await this.async(() => this['Record/messaging'].rpc({
+            const action = await this.async(() => this.get('Record/messaging').rpc({
                 model: 'mail.activity',
                 method: 'action_feedback_schedule_next',
-                args: [[this['Activity/id']]],
+                args: [[this.get('Activity/id')]],
                 kwargs: { feedback },
             }));
-            this['Activity/thread'].fetchData(['activities', 'attachments', 'messages']);
-            const thread = this['Activity/thread'];
+            this.get('Activity/thread').fetchData(['activities', 'attachments', 'messages']);
+            const thread = this.get('Activity/thread');
             this.delete();
             if (!action) {
                 return;
@@ -212,13 +212,13 @@ registerModel({
          */
         _computeIsCurrentPartnerAssignee() {
             if (
-                !this['Activity/assignee'] ||
-                !this['Activity/assignee']['User/partner'] ||
-                !this['Record/messaging']['Messaging/currentPartner']
+                !this.get('Activity/assignee') ||
+                !this.get('Activity/assignee').get('User/partner') ||
+                !this.get('Record/messaging').get('Messaging/currentPartner')
             ) {
                 return false;
             }
-            return this['Activity/assignee']['User/partner'] === this['Record/messaging']['Messaging/currentPartner'];
+            return this.get('Activity/assignee').get('User/partner') === this.get('Record/messaging').get('Messaging/currentPartner');
         },
         /**
          * Wysiwyg editor put `<p><br></p>` even without a note on the activity.
@@ -229,17 +229,17 @@ registerModel({
          * @returns {string|undefined}
          */
         _computeNote() {
-            if (this['Activity/note'] === '<p><br></p>') {
+            if (this.get('Activity/note') === '<p><br></p>') {
                 return clear();
             }
-            return this['Activity/note'];
+            return this.get('Activity/note');
         },
         /**
          * @private
          * @returns {Markup}
          */
         _computeNoteAsMarkup() {
-            return markup(this['Activity/note']);
+            return markup(this.get('Activity/note'));
         },
     },
     fields: {

--- a/addons/mail/static/src/models/activity_box_view.js
+++ b/addons/mail/static/src/models/activity_box_view.js
@@ -6,7 +6,7 @@ import { insertAndReplace, replace } from '@mail/model/model_field_command';
 
 registerModel({
     name: 'ActivityBoxView',
-    identifyingFields: ['chatter'],
+    identifyingFields: ['ActivityBoxView/chatter'],
     recordMethods: {
         /**
          * Handles click on activity box title.

--- a/addons/mail/static/src/models/activity_mark_done_popover_view.js
+++ b/addons/mail/static/src/models/activity_mark_done_popover_view.js
@@ -5,7 +5,7 @@ import { attr, one } from '@mail/model/model_field';
 
 registerModel({
     name: 'ActivityMarkDonePopoverView',
-    identifyingFields: ['activityViewOwner'],
+    identifyingFields: ['ActivityMarkDonePopoverView/activityViewOwner'],
     recordMethods: {
         /**
          * Handles blur on this feedback textarea.

--- a/addons/mail/static/src/models/activity_type.js
+++ b/addons/mail/static/src/models/activity_type.js
@@ -5,7 +5,7 @@ import { attr, many } from '@mail/model/model_field';
 
 registerModel({
     name: 'ActivityType',
-    identifyingFields: ['id'],
+    identifyingFields: ['ActivityType/id'],
     fields: {
         activities: many('Activity', {
             inverse: 'type',

--- a/addons/mail/static/src/models/activity_view.js
+++ b/addons/mail/static/src/models/activity_view.js
@@ -9,7 +9,7 @@ import { sprintf } from '@web/core/utils/strings';
 
 registerModel({
     name: 'ActivityView',
-    identifyingFields: ['activityBoxView', 'activity'],
+    identifyingFields: ['ActivityView/activityBoxView', 'ActivityView/activity'],
     recordMethods: {
         /**
          * Handles the click on a link inside the activity.

--- a/addons/mail/static/src/models/attachment.js
+++ b/addons/mail/static/src/models/attachment.js
@@ -6,7 +6,7 @@ import { clear, insert } from '@mail/model/model_field_command';
 
 registerModel({
     name: 'Attachment',
-    identifyingFields: ['id'],
+    identifyingFields: ['Attachment/id'],
     modelMethods: {
         /**
          * @static

--- a/addons/mail/static/src/models/attachment_box_view.js
+++ b/addons/mail/static/src/models/attachment_box_view.js
@@ -6,7 +6,7 @@ import { clear, insertAndReplace } from '@mail/model/model_field_command';
 
 registerModel({
     name: 'AttachmentBoxView',
-    identifyingFields: ['chatter'],
+    identifyingFields: ['AttachmentBoxView/chatter'],
     recordMethods: {
         /**
          * Handles click on the "add attachment" button.

--- a/addons/mail/static/src/models/attachment_card.js
+++ b/addons/mail/static/src/models/attachment_card.js
@@ -6,7 +6,7 @@ import { insertAndReplace, replace } from '@mail/model/model_field_command';
 
 registerModel({
     name: 'AttachmentCard',
-    identifyingFields: ['attachmentList', 'attachment'],
+    identifyingFields: ['AttachmentCard/attachmentList', 'AttachmentCard/attachment'],
     recordMethods: {
         /**
          * Opens the attachment viewer when clicking on viewable attachment.

--- a/addons/mail/static/src/models/attachment_delete_confirm_view.js
+++ b/addons/mail/static/src/models/attachment_delete_confirm_view.js
@@ -7,7 +7,7 @@ import { sprintf } from '@web/core/utils/strings';
 
 registerModel({
     name: 'AttachmentDeleteConfirmView',
-    identifyingFields: ['dialogOwner'],
+    identifyingFields: ['AttachmentDeleteConfirmView/dialogOwner'],
     recordMethods: {
         /**
          * Returns whether the given html element is inside this attachment delete confirm view.

--- a/addons/mail/static/src/models/attachment_image.js
+++ b/addons/mail/static/src/models/attachment_image.js
@@ -6,7 +6,7 @@ import { clear, insertAndReplace, replace } from '@mail/model/model_field_comman
 
 registerModel({
     name: 'AttachmentImage',
-    identifyingFields: ['attachmentList', 'attachment'],
+    identifyingFields: ['AttachmentImage/attachmentList', 'AttachmentImage/attachment'],
     recordMethods: {
         /**
          * Opens the attachment viewer when clicking on viewable attachment.

--- a/addons/mail/static/src/models/attachment_list.js
+++ b/addons/mail/static/src/models/attachment_list.js
@@ -6,7 +6,7 @@ import { clear, insertAndReplace, replace } from '@mail/model/model_field_comman
 
 registerModel({
     name: 'AttachmentList',
-    identifyingFields: [['composerViewOwner', 'messageViewOwner', 'attachmentBoxViewOwner']],
+    identifyingFields: [['AttachmentList/composerViewOwner', 'AttachmentList/messageViewOwner', 'AttachmentList/attachmentBoxViewOwner']],
     recordMethods: {
         /**
          * Select the next attachment.

--- a/addons/mail/static/src/models/attachment_viewer.js
+++ b/addons/mail/static/src/models/attachment_viewer.js
@@ -5,7 +5,7 @@ import { attr, many, one } from '@mail/model/model_field';
 
 registerModel({
     name: 'AttachmentViewer',
-    identifyingFields: ['dialogOwner'],
+    identifyingFields: ['AttachmentViewer/dialogOwner'],
     recordMethods: {
         /**
          * Close the dialog with this attachment viewer.
@@ -222,14 +222,14 @@ registerModel({
             default: 0,
         }),
         attachment: one('Attachment', {
-            related: 'attachmentList.selectedAttachment',
+            related: 'AttachmentViewer/attachmentList.AttachmentList/selectedAttachment',
         }),
         attachmentList: one('AttachmentList', {
-            related: 'dialogOwner.attachmentListOwnerAsAttachmentView',
+            related: 'AttachmentViewer/dialogOwner.Dialog/attachmentListOwnerAsAttachmentView',
             required: true,
         }),
         attachments: many('Attachment', {
-            related: 'attachmentList.viewableAttachments',
+            related: 'AttachmentViewer/attachmentList.AttachmentList/viewableAttachments',
         }),
         /**
          * States the OWL component of this attachment viewer.

--- a/addons/mail/static/src/models/autocomplete_input_view.js
+++ b/addons/mail/static/src/models/autocomplete_input_view.js
@@ -7,10 +7,10 @@ import { clear } from '@mail/model/model_field_command';
 registerModel({
     name: 'AutocompleteInputView',
     identifyingFields: [[
-        'chatWindowOwnerAsNewMessage',
-        'discussSidebarCategoryOwnerAsAddingItem',
-        'discussViewOwnerAsMobileAddItemHeader',
-        'messagingMenuOwnerAsMobileNewMessageInput',
+        'AutocompleteInputView/chatWindowOwnerAsNewMessage',
+        'AutocompleteInputView/discussSidebarCategoryOwnerAsAddingItem',
+        'AutocompleteInputView/discussViewOwnerAsMobileAddItemHeader',
+        'AutocompleteInputView/messagingMenuOwnerAsMobileNewMessageInput',
     ]],
     recordMethods: {
         /**

--- a/addons/mail/static/src/models/canned_response.js
+++ b/addons/mail/static/src/models/canned_response.js
@@ -6,7 +6,7 @@ import { cleanSearchTerm } from '@mail/utils/utils';
 
 registerModel({
     name: 'CannedResponse',
-    identifyingFields: ['id'],
+    identifyingFields: ['CannedResponse/id'],
     modelMethods: {
         /**
          * Fetches canned responses matching the given search term to extend the

--- a/addons/mail/static/src/models/channel_command.js
+++ b/addons/mail/static/src/models/channel_command.js
@@ -6,7 +6,7 @@ import { cleanSearchTerm } from '@mail/utils/utils';
 
 registerModel({
     name: 'ChannelCommand',
-    identifyingFields: ['name'],
+    identifyingFields: ['ChannelCommand/name'],
     modelMethods: {
         /**
          * Fetches channel commands matching the given search term to extend the

--- a/addons/mail/static/src/models/channel_invitation_form.js
+++ b/addons/mail/static/src/models/channel_invitation_form.js
@@ -7,7 +7,7 @@ import { cleanSearchTerm } from '@mail/utils/utils';
 
 registerModel({
     name: 'ChannelInvitationForm',
-    identifyingFields: [['chatWindow', 'popoverViewOwner']],
+    identifyingFields: [['ChannelInvitationForm/chatWindow', 'ChannelInvitationForm/popoverViewOwner']],
     recordMethods: {
         /**
          * Handles click on the "copy" button.

--- a/addons/mail/static/src/models/channel_member_list_view.js
+++ b/addons/mail/static/src/models/channel_member_list_view.js
@@ -6,7 +6,7 @@ import { clear, replace } from '@mail/model/model_field_command';
 
 registerModel({
     name: 'ChannelMemberListView',
-    identifyingFields: [['chatWindowOwner', 'threadViewOwner']],
+    identifyingFields: [['ChannelMemberListView/chatWindowOwner', 'ChannelMemberListView/threadViewOwner']],
     recordMethods: {
         /**
          * @private

--- a/addons/mail/static/src/models/chat_window.js
+++ b/addons/mail/static/src/models/chat_window.js
@@ -7,7 +7,7 @@ import { isEventHandled, markEventHandled } from '@mail/utils/utils';
 
 registerModel({
     name: 'ChatWindow',
-    identifyingFields: ['manager', ['thread', 'managerAsNewMessage']],
+    identifyingFields: ['ChatWindow/manager', ['ChatWindow/thread', 'ChatWindow/managerAsNewMessage']],
     recordMethods: {
         /**
          * Close this chat window.
@@ -731,7 +731,7 @@ registerModel({
          * States the `ThreadView` displaying `this.thread`.
          */
         threadView: one('ThreadView', {
-            related: 'threadViewer.threadView',
+            related: 'ChatWindow/threadViewer.ThreadViewer/threadView',
         }),
         /**
          * Determines the `ThreadViewer` managing the display of `this.thread`.

--- a/addons/mail/static/src/models/chat_window_header_view.js
+++ b/addons/mail/static/src/models/chat_window_header_view.js
@@ -5,7 +5,7 @@ import { one } from '@mail/model/model_field';
 
 registerModel({
     name: 'ChatWindowHeaderView',
-    identifyingFields: ['chatWindowOwner'],
+    identifyingFields: ['ChatWindowHeaderView/chatWindowOwner'],
     fields: {
         chatWindowOwner: one('ChatWindow', {
             inverse: 'chatWindowHeaderView',

--- a/addons/mail/static/src/models/chat_window_manager.js
+++ b/addons/mail/static/src/models/chat_window_manager.js
@@ -48,7 +48,7 @@ const BASE_VISUAL = {
 
 registerModel({
     name: 'ChatWindowManager',
-    identifyingFields: ['messaging'],
+    identifyingFields: ['Record/messaging'],
     recordMethods: {
         /**
          * Close all chat windows.

--- a/addons/mail/static/src/models/chatter.js
+++ b/addons/mail/static/src/models/chatter.js
@@ -23,7 +23,7 @@ const getMessageNextTemporaryId = (function () {
 
 registerModel({
     name: 'Chatter',
-    identifyingFields: ['id'],
+    identifyingFields: ['Chatter/id'],
     lifecycleHooks: {
         _willDelete() {
             this.messaging.browser.clearTimeout(this.attachmentsLoaderTimeout);
@@ -398,7 +398,7 @@ registerModel({
          * States the `ThreadView` displaying `this.thread`.
          */
         threadView: one('ThreadView', {
-            related: 'threadViewer.threadView',
+            related: 'Chatter/threadViewer.ThreadViewer/threadView',
         }),
         /**
          * Determines the `ThreadViewer` managing the display of `this.thread`.
@@ -413,11 +413,11 @@ registerModel({
     },
     onChanges: [
         new OnChange({
-            dependencies: ['threadId', 'threadModel'],
+            dependencies: ['Chatter/threadId', 'Chatter/threadModel'],
             methodName: '_onThreadIdOrThreadModelChanged',
         }),
         new OnChange({
-            dependencies: ['thread.isLoadingAttachments'],
+            dependencies: ['Chatter/thread.Thread/isLoadingAttachments'],
             methodName: '_onThreadIsLoadingAttachmentsChanged',
         }),
     ],

--- a/addons/mail/static/src/models/clock.js
+++ b/addons/mail/static/src/models/clock.js
@@ -9,7 +9,7 @@ import { OnChange } from '@mail/model/model_onchange';
  */
 registerModel({
     name: 'Clock',
-    identifyingFields: ['frequency'],
+    identifyingFields: ['Clock/frequency'],
     lifecycleHooks: {
         _willDelete() {
             this.messaging.browser.clearInterval(this.tickInterval);
@@ -68,7 +68,7 @@ registerModel({
     },
     onChanges: [
         new OnChange({
-            dependencies: ['watchers'],
+            dependencies: ['Clock/watchers'],
             methodName: '_onChangeWatchers',
         }),
     ],

--- a/addons/mail/static/src/models/clock_watcher.js
+++ b/addons/mail/static/src/models/clock_watcher.js
@@ -8,7 +8,7 @@ import { one } from '@mail/model/model_field';
  */
 registerModel({
     name: 'ClockWatcher',
-    identifyingFields: [['activityViewOwner']],
+    identifyingFields: [['ClockWatcher/activityViewOwner']],
     fields: {
         activityViewOwner: one('ActivityView', {
             inverse: 'clockWatcher',

--- a/addons/mail/static/src/models/composer.js
+++ b/addons/mail/static/src/models/composer.js
@@ -7,7 +7,7 @@ import { sprintf } from '@web/core/utils/strings';
 
 registerModel({
     name: 'Composer',
-    identifyingFields: [['thread', 'messageViewInEditing']],
+    identifyingFields: [['Composer/thread', 'Composer/messageViewInEditing']],
     recordMethods: {
         /**
          * @private

--- a/addons/mail/static/src/models/composer_suggested_recipient_list_view.js
+++ b/addons/mail/static/src/models/composer_suggested_recipient_list_view.js
@@ -6,7 +6,7 @@ import { replace } from '@mail/model/model_field_command';
 
 registerModel({
     name: 'ComposerSuggestedRecipientListView',
-    identifyingFields: ['composerViewOwner'],
+    identifyingFields: ['ComposerSuggestedRecipientListView/composerViewOwner'],
     recordMethods: {
         /**
          * @param {MouseEvent} ev

--- a/addons/mail/static/src/models/composer_suggestion.js
+++ b/addons/mail/static/src/models/composer_suggestion.js
@@ -13,7 +13,10 @@ import { sprintf } from '@web/core/utils/strings';
  */
 registerModel({
     name: 'ComposerSuggestion',
-    identifyingFields: [['composerViewOwnerAsExtraSuggestion', 'composerViewOwnerAsMainSuggestion'], ['cannedResponse', 'channelCommand', 'partner', 'thread']],
+    identifyingFields: [
+        ['ComposerSuggestion/composerViewOwnerAsExtraSuggestion', 'ComposerSuggestion/composerViewOwnerAsMainSuggestion'],
+        ['ComposerSuggestion/cannedResponse', 'ComposerSuggestion/channelCommand', 'ComposerSuggestion/partner', 'ComposerSuggestion/thread'],
+    ],
     recordMethods: {
         /**
          * @param {Event} ev

--- a/addons/mail/static/src/models/composer_view.js
+++ b/addons/mail/static/src/models/composer_view.js
@@ -12,7 +12,7 @@ import { escape, sprintf } from '@web/core/utils/strings';
 
 registerModel({
     name: 'ComposerView',
-    identifyingFields: [['threadView', 'messageViewInEditing', 'chatter']],
+    identifyingFields: [['ComposerView/threadView', 'ComposerView/messageViewInEditing', 'ComposerView/chatter']],
     lifecycleHooks: {
         _created() {
             document.addEventListener('click', this.onClickCaptureGlobal, true);
@@ -1639,15 +1639,15 @@ registerModel({
     },
     onChanges: [
         new OnChange({
-            dependencies: ['composer'],
+            dependencies: ['ComposerView/composer'],
             methodName: '_onChangeComposer',
         }),
         new OnChange({
-            dependencies: ['composer.textInputContent', 'composer.textInputCursorEnd', 'composer.textInputCursorStart'],
+            dependencies: ['ComposerView/composer.Composer/textInputContent', 'ComposerView/composer.Composer/textInputCursorEnd', 'ComposerView/composer.Composer/textInputCursorStart'],
             methodName: '_onChangeDetectSuggestionDelimiterPosition',
         }),
         new OnChange({
-            dependencies: ['suggestionDelimiterPosition', 'suggestionModelName', 'suggestionSearchTerm', 'composer.activeThread'],
+            dependencies: ['ComposerView/suggestionDelimiterPosition', 'ComposerView/suggestionModelName', 'ComposerView/suggestionSearchTerm', 'ComposerView/composer.Composer/activeThread'],
             methodName: '_onChangeUpdateSuggestionList',
         }),
     ],

--- a/addons/mail/static/src/models/country.js
+++ b/addons/mail/static/src/models/country.js
@@ -6,7 +6,7 @@ import { clear } from '@mail/model/model_field_command';
 
 registerModel({
     name: 'Country',
-    identifyingFields: ['id'],
+    identifyingFields: ['Country/id'],
     recordMethods: {
         /**
          * @private

--- a/addons/mail/static/src/models/delete_message_confirm_view.js
+++ b/addons/mail/static/src/models/delete_message_confirm_view.js
@@ -6,7 +6,7 @@ import { clear, insertAndReplace, replace } from '@mail/model/model_field_comman
 
 registerModel({
     name: 'DeleteMessageConfirmView',
-    identifyingFields: ['dialogOwner'],
+    identifyingFields: ['DeleteMessageConfirmView/dialogOwner'],
     recordMethods: {
         /**
          * Returns whether the given html element is inside this delete message confirm view.

--- a/addons/mail/static/src/models/device.js
+++ b/addons/mail/static/src/models/device.js
@@ -6,7 +6,7 @@ import { browser } from "@web/core/browser/browser";
 
 registerModel({
     name: 'Device',
-    identifyingFields: ['messaging'],
+    identifyingFields: ['Record/messaging'],
     lifecycleHooks: {
         _created() {
             this._refresh();

--- a/addons/mail/static/src/models/dialog.js
+++ b/addons/mail/static/src/models/dialog.js
@@ -7,11 +7,11 @@ import { clear, insertAndReplace, replace } from '@mail/model/model_field_comman
 registerModel({
     name: 'Dialog',
     identifyingFields: [[
-        'attachmentCardOwnerAsAttachmentDeleteConfirm',
-        'attachmentImageOwnerAsAttachmentDeleteConfirm',
-        'attachmentListOwnerAsAttachmentView',
-        'followerOwnerAsSubtypeList',
-        'messageActionListOwnerAsDeleteConfirm',
+        'Dialog/attachmentCardOwnerAsAttachmentDeleteConfirm',
+        'Dialog/attachmentImageOwnerAsAttachmentDeleteConfirm',
+        'Dialog/attachmentListOwnerAsAttachmentView',
+        'Dialog/followerOwnerAsSubtypeList',
+        'Dialog/messageActionListOwnerAsDeleteConfirm',
     ]],
     lifecycleHooks: {
         _created() {

--- a/addons/mail/static/src/models/dialog_manager.js
+++ b/addons/mail/static/src/models/dialog_manager.js
@@ -5,7 +5,7 @@ import { many } from '@mail/model/model_field';
 
 registerModel({
     name: 'DialogManager',
-    identifyingFields: ['messaging'],
+    identifyingFields: ['Record/messaging'],
     fields: {
         // FIXME: dependent on implementation that uses insert order in relations!!
         dialogs: many('Dialog', {

--- a/addons/mail/static/src/models/discuss.js
+++ b/addons/mail/static/src/models/discuss.js
@@ -7,7 +7,7 @@ import { escape, sprintf } from '@web/core/utils/strings';
 
 registerModel({
     name: 'Discuss',
-    identifyingFields: ['messaging'],
+    identifyingFields: ['Record/messaging'],
     recordMethods: {
         clearIsAddingItem() {
             this.update({
@@ -462,7 +462,7 @@ registerModel({
          * States the `ThreadView` displaying `this.thread`.
          */
         threadView: one('ThreadView', {
-            related: 'threadViewer.threadView',
+            related: 'Discuss/threadViewer.ThreadViewer/threadView',
         }),
         /**
          * Determines the `ThreadViewer` managing the display of `this.thread`.

--- a/addons/mail/static/src/models/discuss_public_view.js
+++ b/addons/mail/static/src/models/discuss_public_view.js
@@ -6,7 +6,7 @@ import { clear, insertAndReplace, replace } from '@mail/model/model_field_comman
 
 registerModel({
     name: 'DiscussPublicView',
-    identifyingFields: ['messaging'],
+    identifyingFields: ['Record/messaging'],
     recordMethods: {
         /**
          * Creates and displays the thread view and clears the welcome view.
@@ -74,7 +74,7 @@ registerModel({
          */
         threadView: one('ThreadView', {
             readonly: true,
-            related: 'threadViewer.threadView',
+            related: 'DiscussPublicView/threadViewer.ThreadViewer/threadView',
         }),
         /**
          * States the thread viewer linked to this discuss public view.

--- a/addons/mail/static/src/models/discuss_sidebar_category.js
+++ b/addons/mail/static/src/models/discuss_sidebar_category.js
@@ -7,7 +7,7 @@ import { OnChange } from '@mail/model/model_onchange';
 
 registerModel({
     name: 'DiscussSidebarCategory',
-    identifyingFields: [['discussAsChannel', 'discussAsChat']],
+    identifyingFields: [['DiscussSidebarCategory/discussAsChannel', 'DiscussSidebarCategory/discussAsChat']],
     modelMethods: {
         /**
          * Performs the `set_res_users_settings` RPC on `res.users.settings`.
@@ -104,17 +104,17 @@ registerModel({
             switch (this.sortComputeMethod) {
                 case 'name':
                     return [
-                        ['defined-first', 'channel'],
-                        ['defined-first', 'channel.displayName'],
-                        ['case-insensitive-asc', 'channel.displayName'],
-                        ['smaller-first', 'channel.id'],
+                        ['defined-first', 'DiscussSidebarCategoryItem/channel'],
+                        ['defined-first', 'DiscussSidebarCategoryItem/channel.Thread/displayName'],
+                        ['case-insensitive-asc', 'DiscussSidebarCategoryItem/channel.Thread/displayName'],
+                        ['smaller-first', 'DiscussSidebarCategoryItem/channel.Thread/id'],
                     ];
                 case 'last_action':
                     return [
-                        ['defined-first', 'channel'],
-                        ['defined-first', 'channel.lastInterestDateTime'],
-                        ['greater-first', 'channel.lastInterestDateTime'],
-                        ['greater-first', 'channel.id'],
+                        ['defined-first', 'DiscussSidebarCategoryItem/channel'],
+                        ['defined-first', 'DiscussSidebarCategoryItem/channel.Thread/lastInterestDateTime'],
+                        ['greater-first', 'DiscussSidebarCategoryItem/channel.Thread/lastInterestDateTime'],
+                        ['greater-first', 'DiscussSidebarCategoryItem/channel.Thread/id'],
                     ];
             }
         },
@@ -236,7 +236,7 @@ registerModel({
         counter: attr({
             default: 0,
             readonly: true,
-            sum: 'categoryItems.categoryCounterContribution',
+            sum: 'DiscussSidebarCategory/categoryItems.DiscussSidebarCategoryItem/categoryCounterContribution',
         }),
         discussAsChannel: one('Discuss', {
             inverse: 'categoryChannel',
@@ -322,7 +322,7 @@ registerModel({
     },
     onChanges: [
         new OnChange({
-            dependencies: ['isServerOpen'],
+            dependencies: ['DiscussSidebarCategory/isServerOpen'],
             methodName: ['_onIsServerOpenChanged'],
         }),
     ],

--- a/addons/mail/static/src/models/discuss_sidebar_category_item.js
+++ b/addons/mail/static/src/models/discuss_sidebar_category_item.js
@@ -8,7 +8,7 @@ import Dialog from 'web.Dialog';
 
 registerModel({
     name: 'DiscussSidebarCategoryItem',
-    identifyingFields: ['category', 'channel'],
+    identifyingFields: ['DiscussSidebarCategoryItem/category', 'DiscussSidebarCategoryItem/channel'],
     recordMethods: {
         /**
          * @private
@@ -279,7 +279,7 @@ registerModel({
          * Type of the related channel thread.
          */
         channelType: attr({
-            related: 'channel.channel_type',
+            related: 'DiscussSidebarCategoryItem/channel.Thread/channel_type',
         }),
     },
 });

--- a/addons/mail/static/src/models/discuss_view.js
+++ b/addons/mail/static/src/models/discuss_view.js
@@ -6,7 +6,7 @@ import { clear, insertAndReplace } from '@mail/model/model_field_command';
 
 registerModel({
     name: 'DiscussView',
-    identifyingFields: ['discuss'],
+    identifyingFields: ['DiscussView/discuss'],
     recordMethods: {
         /**
          * Handles click on the mobile "new channel" button.

--- a/addons/mail/static/src/models/drop_zone_view.js
+++ b/addons/mail/static/src/models/drop_zone_view.js
@@ -6,7 +6,7 @@ import { decrement, increment } from '@mail/model/model_field_command';
 
 registerModel({
     name: 'DropZoneView',
-    identifyingFields: [['attachmentBoxViewOwner', 'composerViewOwner']],
+    identifyingFields: [['DropZoneView/attachmentBoxViewOwner', 'DropZoneView/composerViewOwner']],
     recordMethods: {
         /**
          * Shows a visual drop effect when dragging inside the dropzone.

--- a/addons/mail/static/src/models/emoji_list_view.js
+++ b/addons/mail/static/src/models/emoji_list_view.js
@@ -5,7 +5,7 @@ import { one } from '@mail/model/model_field';
 
 registerModel({
     name: 'EmojiListView',
-    identifyingFields: ['popoverViewOwner'],
+    identifyingFields: ['EmojiListView/popoverViewOwner'],
     recordMethods: {
         /**
          * @param {MouseEvent} ev

--- a/addons/mail/static/src/models/file_uploader.js
+++ b/addons/mail/static/src/models/file_uploader.js
@@ -16,7 +16,7 @@ const getAttachmentNextTemporaryId = (function () {
 
 registerModel({
     name: 'FileUploader',
-    identifyingFields: [['activityView', 'attachmentBoxView', 'composerView']],
+    identifyingFields: [['FileUploader/activityView', 'FileUploader/attachmentBoxView', 'FileUploader/composerView']],
     recordMethods: {
         openBrowserFileUploader() {
             this.fileInput.click();

--- a/addons/mail/static/src/models/follow_button_view.js
+++ b/addons/mail/static/src/models/follow_button_view.js
@@ -6,7 +6,7 @@ import { clear } from '@mail/model/model_field_command';
 
 registerModel({
     name: 'FollowButtonView',
-    identifyingFields: [['chatterOwner']],
+    identifyingFields: [['FollowButtonView/chatterOwner']],
     recordMethods: {
         /**
          * @private

--- a/addons/mail/static/src/models/follower.js
+++ b/addons/mail/static/src/models/follower.js
@@ -6,7 +6,7 @@ import { clear, insert, insertAndReplace, link, unlink } from '@mail/model/model
 
 registerModel({
     name: 'Follower',
-    identifyingFields: ['id'],
+    identifyingFields: ['Follower/id'],
     modelMethods: {
         /**
          * @param {Object} data

--- a/addons/mail/static/src/models/follower_list_menu_view.js
+++ b/addons/mail/static/src/models/follower_list_menu_view.js
@@ -5,7 +5,7 @@ import { attr, one } from '@mail/model/model_field';
 
 registerModel({
     name: 'FollowerListMenuView',
-    identifyingFields: [['chatterOwner']],
+    identifyingFields: [['FollowerListMenuView/chatterOwner']],
     recordMethods: {
         hide() {
             this.update({ isDropdownOpen: false });

--- a/addons/mail/static/src/models/follower_subtype.js
+++ b/addons/mail/static/src/models/follower_subtype.js
@@ -5,7 +5,7 @@ import { attr, many } from '@mail/model/model_field';
 
 registerModel({
     name: 'FollowerSubtype',
-    identifyingFields: ['id'],
+    identifyingFields: ['FollowerSubtype/id'],
     modelMethods: {
         /**
          * @param {Object} data

--- a/addons/mail/static/src/models/follower_subtype_list.js
+++ b/addons/mail/static/src/models/follower_subtype_list.js
@@ -6,7 +6,7 @@ import { clear, insertAndReplace, replace } from '@mail/model/model_field_comman
 
 registerModel({
     name: 'FollowerSubtypeList',
-    identifyingFields: ['dialogOwner'],
+    identifyingFields: ['FollowerSubtypeList/dialogOwner'],
     recordMethods: {
         /**
          * Returns whether the given html element is inside this follower subtype list.
@@ -49,7 +49,7 @@ registerModel({
          */
         _sortFollowerSubtypeViews() {
             return [
-                ['smaller-first', 'subtype.id'],
+                ['smaller-first', 'FollowerSubtypeView/subtype.FollowerSubtype/id'],
             ];
         },
     },
@@ -67,7 +67,7 @@ registerModel({
             readonly: true,
         }),
         follower: one('Follower', {
-            related: 'dialogOwner.followerOwnerAsSubtypeList',
+            related: 'FollowerSubtypeList/dialogOwner.Dialog/followerOwnerAsSubtypeList',
             required: true,
         }),
         followerSubtypeViews: many('FollowerSubtypeView', {

--- a/addons/mail/static/src/models/follower_subtype_view.js
+++ b/addons/mail/static/src/models/follower_subtype_view.js
@@ -5,7 +5,7 @@ import { one } from '@mail/model/model_field';
 
 registerModel({
     name: 'FollowerSubtypeView',
-    identifyingFields: ['followerSubtypeListOwner', 'subtype'],
+    identifyingFields: ['FollowerSubtypeView/followerSubtypeListOwner', 'FollowerSubtypeView/subtype'],
     recordMethods: {
         /**
          * Called when clicking on cancel button.
@@ -22,7 +22,7 @@ registerModel({
     },
     fields: {
         follower: one('Follower', {
-            related: 'followerSubtypeListOwner.follower',
+            related: 'FollowerSubtypeView/followerSubtypeListOwner.FollowerSubtypeList/follower',
         }),
         followerSubtypeListOwner: one('FollowerSubtypeList', {
             inverse: 'followerSubtypeViews',

--- a/addons/mail/static/src/models/guest.js
+++ b/addons/mail/static/src/models/guest.js
@@ -5,7 +5,7 @@ import { registerModel } from '@mail/model/model_core';
 
 registerModel({
     name: 'Guest',
-    identifyingFields: ['id'],
+    identifyingFields: ['Guest/id'],
     modelMethods: {
         /**
          * @param {Object} param0

--- a/addons/mail/static/src/models/locale.js
+++ b/addons/mail/static/src/models/locale.js
@@ -5,7 +5,7 @@ import { attr } from '@mail/model/model_field';
 
 registerModel({
     name: 'Locale',
-    identifyingFields: ['messaging'],
+    identifyingFields: ['Record/messaging'],
     recordMethods: {
         /**
          * @private

--- a/addons/mail/static/src/models/mail_template.js
+++ b/addons/mail/static/src/models/mail_template.js
@@ -5,7 +5,7 @@ import { attr, many } from '@mail/model/model_field';
 
 registerModel({
     name: 'MailTemplate',
-    identifyingFields: ['id'],
+    identifyingFields: ['MailTemplate/id'],
     recordMethods: {
         /**
          * @param {Activity} activity

--- a/addons/mail/static/src/models/mail_template_view.js
+++ b/addons/mail/static/src/models/mail_template_view.js
@@ -5,7 +5,7 @@ import { one } from '@mail/model/model_field';
 
 registerModel({
     name: 'MailTemplateView',
-    identifyingFields: ['activityViewOwner', 'mailTemplate'],
+    identifyingFields: ['MailTemplateView/activityViewOwner', 'MailTemplateView/mailTemplate'],
     recordMethods: {
         /**
          * @param {MouseEvent} ev

--- a/addons/mail/static/src/models/media_preview.js
+++ b/addons/mail/static/src/models/media_preview.js
@@ -5,7 +5,7 @@ import { registerModel } from '@mail/model/model_core';
 
 registerModel({
     name: 'MediaPreview',
-    identifyingFields: ['welcomeView'],
+    identifyingFields: ['MediaPreview/welcomeView'],
     modelMethods: {
         /**
          * Iterates tracks of the provided MediaStream, calling the `stop`

--- a/addons/mail/static/src/models/message.js
+++ b/addons/mail/static/src/models/message.js
@@ -16,7 +16,7 @@ const { markup } = owl;
 
 registerModel({
     name: 'Message',
-    identifyingFields: ['id'],
+    identifyingFields: ['Message/id'],
     modelMethods: {
         /**
          * @param {Object} data

--- a/addons/mail/static/src/models/message_action_list.js
+++ b/addons/mail/static/src/models/message_action_list.js
@@ -7,7 +7,7 @@ import { markEventHandled } from '@mail/utils/utils';
 
 registerModel({
     name: 'MessageActionList',
-    identifyingFields: ['messageView'],
+    identifyingFields: ['MessageActionList/messageView'],
     recordMethods: {
         /**
          * @private
@@ -133,7 +133,7 @@ registerModel({
          * States the message on which this action message list operates.
          */
         message: one('Message', {
-            related: 'messageView.message',
+            related: 'MessageActionList/messageView.MessageView/message',
         }),
         /**
          * States the message view that controls this message action list.

--- a/addons/mail/static/src/models/message_author_prefix_view.js
+++ b/addons/mail/static/src/models/message_author_prefix_view.js
@@ -6,7 +6,7 @@ import { clear, replace } from '@mail/model/model_field_command';
 
 registerModel({
     name: 'MessageAuthorPrefixView',
-    identifyingFields: [['threadNeedactionPreviewViewOwner', 'threadPreviewViewOwner']],
+    identifyingFields: [['MessageAuthorPrefixView/threadNeedactionPreviewViewOwner', 'MessageAuthorPrefixView/threadPreviewViewOwner']],
     recordMethods: {
         /**
          * @private

--- a/addons/mail/static/src/models/message_in_reply_to_view.js
+++ b/addons/mail/static/src/models/message_in_reply_to_view.js
@@ -7,7 +7,7 @@ import { markEventHandled } from '@mail/utils/utils';
 
 registerModel({
     name: 'MessageInReplyToView',
-    identifyingFields: ['messageView'],
+    identifyingFields: ['MessageInReplyToView/messageView'],
     recordMethods: {
         /**
          * @private

--- a/addons/mail/static/src/models/message_list_view.js
+++ b/addons/mail/static/src/models/message_list_view.js
@@ -6,7 +6,7 @@ import { clear } from '@mail/model/model_field_command';
 
 registerModel({
     name: 'MessageListView',
-    identifyingFields: ['threadViewOwner'],
+    identifyingFields: ['MessageListView/threadViewOwner'],
     recordMethods: {
         /**
          * @returns {Element|undefined}

--- a/addons/mail/static/src/models/message_reaction_group.js
+++ b/addons/mail/static/src/models/message_reaction_group.js
@@ -8,7 +8,7 @@ import { sprintf } from '@web/core/utils/strings';
 
 registerModel({
     name: 'MessageReactionGroup',
-    identifyingFields: ['message', 'content'],
+    identifyingFields: ['MessageReactionGroup/message', 'MessageReactionGroup/content'],
     recordMethods: {
         /**
          * Handles click on the reaction group.

--- a/addons/mail/static/src/models/message_seen_indicator.js
+++ b/addons/mail/static/src/models/message_seen_indicator.js
@@ -7,7 +7,7 @@ import { sprintf } from '@web/core/utils/strings';
 
 registerModel({
     name: 'MessageSeenIndicator',
-    identifyingFields: ['thread', 'message'],
+    identifyingFields: ['MessageSeenIndicator/thread', 'MessageSeenIndicator/message'],
     recordMethods: {
         /**
          * Manually called as not always called when necessary

--- a/addons/mail/static/src/models/message_seen_indicator_view.js
+++ b/addons/mail/static/src/models/message_seen_indicator_view.js
@@ -6,7 +6,7 @@ import { clear, insertAndReplace, replace } from '@mail/model/model_field_comman
 
 registerModel({
     name: 'MessageSeenIndicatorView',
-    identifyingFields: ['messageViewOwner'],
+    identifyingFields: ['MessageSeenIndicatorView/messageViewOwner'],
     recordMethods: {
         /**
          * @private

--- a/addons/mail/static/src/models/message_view.js
+++ b/addons/mail/static/src/models/message_view.js
@@ -7,7 +7,7 @@ import { isEventHandled, markEventHandled } from '@mail/utils/utils';
 
 registerModel({
     name: 'MessageView',
-    identifyingFields: [['threadView', 'deleteMessageConfirmViewOwner'], 'message'],
+    identifyingFields: [['MessageView/threadView', 'MessageView/deleteMessageConfirmViewOwner'], 'MessageView/message'],
     recordMethods: {
         /**
          * Briefly highlights the message.

--- a/addons/mail/static/src/models/messaging.js
+++ b/addons/mail/static/src/models/messaging.js
@@ -272,8 +272,8 @@ registerModel({
          * Inverse of the messaging field present on all models. This field
          * therefore contains all existing records.
          */
-        allRecords: many('Record', {
-            inverse: 'messaging',
+        'Messaging/allRecords': many('Record', {
+            inverse: 'Record/messaging',
             isCausal: true,
         }),
         /**
@@ -427,11 +427,11 @@ registerModel({
     },
     onChanges: [
         new OnChange({
-            dependencies: ['ringingThreads'],
+            dependencies: ['Messaging/ringingThreads'],
             methodName: '_onChangeRingingThreads',
         }),
         new OnChange({
-            dependencies: ['focusedRtcSession'],
+            dependencies: ['Messaging/focusedRtcSession'],
             methodName: '_onChangeFocusedRtcSession',
         }),
     ],

--- a/addons/mail/static/src/models/messaging_initializer.js
+++ b/addons/mail/static/src/models/messaging_initializer.js
@@ -6,7 +6,7 @@ import { link, insert, insertAndReplace, replace } from '@mail/model/model_field
 
 registerModel({
     name: 'MessagingInitializer',
-    identifyingFields: ['messaging'],
+    identifyingFields: ['Record/messaging'],
     recordMethods: {
         /**
          * Fetch messaging data initially to populate the store specifically for

--- a/addons/mail/static/src/models/messaging_menu.js
+++ b/addons/mail/static/src/models/messaging_menu.js
@@ -6,7 +6,7 @@ import { clear, insertAndReplace } from '@mail/model/model_field_command';
 
 registerModel({
     name: 'MessagingMenu',
-    identifyingFields: ['messaging'],
+    identifyingFields: ['Record/messaging'],
     recordMethods: {
         /**
          * Close the messaging menu. Should reset its internal state.

--- a/addons/mail/static/src/models/messaging_notification_handler.js
+++ b/addons/mail/static/src/models/messaging_notification_handler.js
@@ -13,7 +13,7 @@ const PREVIEW_MSG_MAX_SIZE = 350; // optimal for native English speakers
 
 registerModel({
     name: 'MessagingNotificationHandler',
-    identifyingFields: ['messaging'],
+    identifyingFields: ['Record/messaging'],
     lifecycleHooks: {
         _willDelete() {
             if (this.env.services['bus_service']) {

--- a/addons/mail/static/src/models/mobile_messaging_navbar_view.js
+++ b/addons/mail/static/src/models/mobile_messaging_navbar_view.js
@@ -6,7 +6,7 @@ import { clear, replace } from '@mail/model/model_field_command';
 
 registerModel({
     name: 'MobileMessagingNavbarView',
-    identifyingFields: [['discuss', 'messagingMenu']],
+    identifyingFields: [['MobileMessagingNavbarView/discuss', 'MobileMessagingNavbarView/messagingMenu']],
     recordMethods: {
         /**
          * @param {string} tabId

--- a/addons/mail/static/src/models/notification.js
+++ b/addons/mail/static/src/models/notification.js
@@ -6,7 +6,7 @@ import { clear, insert, insertAndReplace } from '@mail/model/model_field_command
 
 registerModel({
     name: 'Notification',
-    identifyingFields: ['id'],
+    identifyingFields: ['Notification/id'],
     modelMethods: {
         /**
          * @param {Object} data

--- a/addons/mail/static/src/models/notification_group.js
+++ b/addons/mail/static/src/models/notification_group.js
@@ -7,7 +7,7 @@ import { OnChange } from '@mail/model/model_onchange';
 
 registerModel({
     name: 'NotificationGroup',
-    identifyingFields: ['res_model', 'res_id', 'notification_type'],
+    identifyingFields: ['NotificationGroup/res_model', 'NotificationGroup/res_id', 'NotificationGroup/notification_type'],
     recordMethods: {
         /**
          * Cancel notifications of the group.
@@ -147,7 +147,7 @@ registerModel({
     },
     onChanges: [
         new OnChange({
-            dependencies: ['notifications'],
+            dependencies: ['NotificationGroup/notifications'],
             methodName: '_onChangeNotifications',
         }),
     ],

--- a/addons/mail/static/src/models/notification_group_view.js
+++ b/addons/mail/static/src/models/notification_group_view.js
@@ -5,7 +5,7 @@ import { attr, one } from '@mail/model/model_field';
 
 registerModel({
     name: 'NotificationGroupView',
-    identifyingFields: ['notificationListViewOwner', 'notificationGroup'],
+    identifyingFields: ['NotificationGroupView/notificationListViewOwner', 'NotificationGroupView/notificationGroup'],
     recordMethods: {
         /**
          * @param {MouseEvent} ev

--- a/addons/mail/static/src/models/notification_list_view.js
+++ b/addons/mail/static/src/models/notification_list_view.js
@@ -6,7 +6,7 @@ import { clear, insertAndReplace, replace } from '@mail/model/model_field_comman
 
 registerModel({
     name: 'NotificationListView',
-    identifyingFields: [['discussOwner', 'messagingMenuOwner']],
+    identifyingFields: [['NotificationListView/discussOwner', 'NotificationListView/messagingMenuOwner']],
     recordMethods: {
         /**
          * @private

--- a/addons/mail/static/src/models/notification_request_view.js
+++ b/addons/mail/static/src/models/notification_request_view.js
@@ -5,7 +5,7 @@ import { one } from '@mail/model/model_field';
 
 registerModel({
     name: 'NotificationRequestView',
-    identifyingFields: ['notificationListViewOwner'],
+    identifyingFields: ['NotificationRequestView/notificationListViewOwner'],
     fields: {
         notificationListViewOwner: one('NotificationListView', {
             inverse: 'notificationRequestView',

--- a/addons/mail/static/src/models/partner.js
+++ b/addons/mail/static/src/models/partner.js
@@ -7,7 +7,7 @@ import { cleanSearchTerm } from '@mail/utils/utils';
 
 registerModel({
     name: 'Partner',
-    identifyingFields: ['id'],
+    identifyingFields: ['Partner/id'],
     modelMethods: {
         /**
          * @param {Object} data

--- a/addons/mail/static/src/models/popover_view.js
+++ b/addons/mail/static/src/models/popover_view.js
@@ -6,7 +6,7 @@ import { clear, insertAndReplace, replace } from '@mail/model/model_field_comman
 
 registerModel({
     name: 'PopoverView',
-    identifyingFields: [['composerViewOwnerAsEmoji', 'messageActionListOwnerAsReaction', 'threadViewTopbarOwnerAsInvite']],
+    identifyingFields: [['PopoverView/composerViewOwnerAsEmoji', 'PopoverView/messageActionListOwnerAsReaction', 'PopoverView/threadViewTopbarOwnerAsInvite']],
     lifecycleHooks: {
         _created() {
             document.addEventListener('click', this._onClickCaptureGlobal, true);

--- a/addons/mail/static/src/models/record.js
+++ b/addons/mail/static/src/models/record.js
@@ -191,6 +191,15 @@ registerModel({
             return this.modelManager.exists(this.constructor, this);
         },
         /**
+         * Gets the value of the given fieldName.
+         *
+         * @param {string} fieldName
+         * @returns {any}
+         */
+        get(fieldName) {
+            return this[fieldName];
+        },
+        /**
          * Returns a string representation of this record.
          */
         toString() {

--- a/addons/mail/static/src/models/record.js
+++ b/addons/mail/static/src/models/record.js
@@ -24,7 +24,7 @@ registerModel({
      * and each element of the same sub-list will be parsed as "or". If there
      * is no identifying fields, this model generates a singleton.
      */
-    identifyingFields: ['messaging'],
+    identifyingFields: ['Record/messaging'],
     lifecycleHooks: {
         /**
          * This function is called after the record has been created, more
@@ -245,9 +245,9 @@ registerModel({
          * States the messaging singleton. Automatically assigned by the model
          * manager at creation.
          */
-        messaging: one('Messaging', {
+        'Record/messaging': one('Messaging', {
             default: insertAndReplace(),
-            inverse: 'allRecords',
+            inverse: 'Messaging/allRecords',
             readonly: true,
             required: true,
         }),

--- a/addons/mail/static/src/models/rtc.js
+++ b/addons/mail/static/src/models/rtc.js
@@ -24,7 +24,7 @@ const getRTCPeerNotificationNextTemporaryId = (function () {
 
 registerModel({
     name: 'Rtc',
-    identifyingFields: ['messaging'],
+    identifyingFields: ['Record/messaging'],
     lifecycleHooks: {
         _created() {
             browser.addEventListener('keydown', this._onKeyDown);

--- a/addons/mail/static/src/models/rtc_call_participant_card.js
+++ b/addons/mail/static/src/models/rtc_call_participant_card.js
@@ -8,7 +8,7 @@ import { sprintf } from '@web/core/utils/strings';
 
 registerModel({
     name: 'RtcCallParticipantCard',
-    identifyingFields: ['relationalId'],
+    identifyingFields: ['RtcCallParticipantCard/relationalId'],
     recordMethods: {
         /**
          * @param {Event} ev

--- a/addons/mail/static/src/models/rtc_call_viewer.js
+++ b/addons/mail/static/src/models/rtc_call_viewer.js
@@ -11,7 +11,7 @@ import { isEventHandled, markEventHandled } from '@mail/utils/utils';
 
 registerModel({
     name: 'RtcCallViewer',
-    identifyingFields: ['threadView'],
+    identifyingFields: ['RtcCallViewer/threadView'],
     lifecycleHooks: {
         _created() {
             browser.addEventListener('fullscreenchange', this._onFullScreenChange);
@@ -395,11 +395,11 @@ registerModel({
     },
     onChanges: [
         new OnChange({
-            dependencies: ['threadView.thread.rtc'],
+            dependencies: ['RtcCallViewer/threadView.ThreadView/thread.Thread/rtc'],
             methodName: '_onChangeRtcChannel',
         }),
         new OnChange({
-            dependencies: ['threadView.thread.videoCount'],
+            dependencies: ['RtcCallViewer/threadView.ThreadView/thread.Thread/videoCount'],
             methodName: '_onChangeVideoCount',
         }),
     ],

--- a/addons/mail/static/src/models/rtc_configuration_menu.js
+++ b/addons/mail/static/src/models/rtc_configuration_menu.js
@@ -7,7 +7,7 @@ import { attr, one } from '@mail/model/model_field';
 
 registerModel({
     name: 'RtcConfigurationMenu',
-    identifyingFields: ['userSetting'],
+    identifyingFields: ['RtcConfigurationMenu/userSetting'],
     lifecycleHooks: {
         _created() {
             browser.addEventListener('keydown', this._onKeyDown);

--- a/addons/mail/static/src/models/rtc_controller.js
+++ b/addons/mail/static/src/models/rtc_controller.js
@@ -6,7 +6,7 @@ import { insertAndReplace } from '@mail/model/model_field_command';
 
 registerModel({
     name: 'RtcController',
-    identifyingFields: ['callViewer'],
+    identifyingFields: ['RtcController/callViewer'],
     recordMethods: {
         /**
          * @param {MouseEvent} ev

--- a/addons/mail/static/src/models/rtc_data_channel.js
+++ b/addons/mail/static/src/models/rtc_data_channel.js
@@ -5,7 +5,7 @@ import { attr, one } from '@mail/model/model_field';
 
 registerModel({
     name: 'RtcDataChannel',
-    identifyingFields: ['rtcSession'],
+    identifyingFields: ['RtcDataChannel/rtcSession'],
     lifecycleHooks: {
         _willDelete() {
             this.dataChannel.close();

--- a/addons/mail/static/src/models/rtc_invitation_card.js
+++ b/addons/mail/static/src/models/rtc_invitation_card.js
@@ -5,7 +5,7 @@ import { one } from '@mail/model/model_field';
 
 registerModel({
     name: 'RtcInvitationCard',
-    identifyingFields: ['thread'],
+    identifyingFields: ['RtcInvitationCard/thread'],
     recordMethods: {
         /**
          * @param {MouseEvent} ev

--- a/addons/mail/static/src/models/rtc_layout_menu.js
+++ b/addons/mail/static/src/models/rtc_layout_menu.js
@@ -6,7 +6,7 @@ import { clear } from '@mail/model/model_field_command';
 
 registerModel({
     name: 'RtcLayoutMenu',
-    identifyingFields: ['callViewer'],
+    identifyingFields: ['RtcLayoutMenu/callViewer'],
     recordMethods: {
         /**
          * @param {MouseEvent} ev

--- a/addons/mail/static/src/models/rtc_option_list.js
+++ b/addons/mail/static/src/models/rtc_option_list.js
@@ -5,7 +5,7 @@ import { attr, one } from '@mail/model/model_field';
 
 registerModel({
     name: 'RtcOptionList',
-    identifyingFields: ['rtcController'],
+    identifyingFields: ['RtcOptionList/rtcController'],
     recordMethods: {
         /**
          * Creates and download a file that contains the logs of the current RTC call.

--- a/addons/mail/static/src/models/rtc_peer_connection.js
+++ b/addons/mail/static/src/models/rtc_peer_connection.js
@@ -5,7 +5,7 @@ import { attr, one } from '@mail/model/model_field';
 
 registerModel({
     name: 'RtcPeerConnection',
-    identifyingFields: ['rtcSession'],
+    identifyingFields: ['RtcPeerConnection/rtcSession'],
     lifecycleHooks: {
         _willDelete() {
             this.peerConnection.close();

--- a/addons/mail/static/src/models/rtc_peer_notification.js
+++ b/addons/mail/static/src/models/rtc_peer_notification.js
@@ -5,7 +5,7 @@ import { attr } from '@mail/model/model_field';
 
 registerModel({
     name: 'RtcPeerNotification',
-    identifyingFields: ['id'],
+    identifyingFields: ['RtcPeerNotification/id'],
     fields: {
         channelId: attr({
             readonly: true,

--- a/addons/mail/static/src/models/rtc_session.js
+++ b/addons/mail/static/src/models/rtc_session.js
@@ -6,7 +6,7 @@ import { clear, replace } from '@mail/model/model_field_command';
 
 registerModel({
     name: 'RtcSession',
-    identifyingFields: ['id'],
+    identifyingFields: ['RtcSession/id'],
     lifecycleHooks: {
         _willDelete() {
             this.reset();

--- a/addons/mail/static/src/models/sound_effect.js
+++ b/addons/mail/static/src/models/sound_effect.js
@@ -5,7 +5,7 @@ import { attr } from '@mail/model/model_field';
 
 registerModel({
     name: 'SoundEffect',
-    identifyingFields: ['path', 'filename'],
+    identifyingFields: ['SoundEffect/path', 'SoundEffect/filename'],
     recordMethods: {
         /**
          * @param {Object} param0

--- a/addons/mail/static/src/models/sound_effects.js
+++ b/addons/mail/static/src/models/sound_effects.js
@@ -6,54 +6,54 @@ import { insertAndReplace } from '@mail/model/model_field_command';
 
 registerModel({
     name: 'SoundEffects',
-    identifyingFields: ['messaging'],
+    identifyingFields: ['Record/messaging'],
     fields: {
         channelJoin: one('SoundEffect', {
-            default: insertAndReplace({ defaultVolume: 0.3, filename: 'channel_01_in' }),
+            default: insertAndReplace({ 'SoundEffect/defaultVolume': 0.3, 'SoundEffect/filename': 'channel_01_in' }),
             isCausal: true,
         }),
         channelLeave: one('SoundEffect', {
-            default: insertAndReplace({ filename: 'channel_04_out' }),
+            default: insertAndReplace({ 'SoundEffect/filename': 'channel_04_out' }),
             isCausal: true,
         }),
         deafen: one('SoundEffect', {
-            default: insertAndReplace({ defaultVolume: 0.15, filename: 'deafen_new_01' }),
+            default: insertAndReplace({ 'SoundEffect/defaultVolume': 0.15, 'SoundEffect/filename': 'deafen_new_01' }),
             isCausal: true,
         }),
         incomingCall: one('SoundEffect', {
-            default: insertAndReplace({ defaultVolume: 0.15, filename: 'call_02_in_' }),
+            default: insertAndReplace({ 'SoundEffect/defaultVolume': 0.15, 'SoundEffect/filename': 'call_02_in_' }),
             isCausal: true,
         }),
         memberLeave: one('SoundEffect', {
-            default: insertAndReplace({ defaultVolume: 0.5, filename: 'channel_01_out' }),
+            default: insertAndReplace({ 'SoundEffect/defaultVolume': 0.5, 'SoundEffect/filename': 'channel_01_out' }),
             isCausal: true,
         }),
         mute: one('SoundEffect', {
-            default: insertAndReplace({ defaultVolume: 0.2, filename: 'mute_1' }),
+            default: insertAndReplace({ 'SoundEffect/defaultVolume': 0.2, 'SoundEffect/filename': 'mute_1' }),
             isCausal: true,
         }),
         newMessage: one('SoundEffect', {
-            default: insertAndReplace({ filename: 'dm_02' }),
+            default: insertAndReplace({ 'SoundEffect/filename': 'dm_02' }),
             isCausal: true,
         }),
         pushToTalkOn: one('SoundEffect', {
-            default: insertAndReplace({ defaultVolume: 0.05, filename: 'ptt_push_1' }),
+            default: insertAndReplace({ 'SoundEffect/defaultVolume': 0.05, 'SoundEffect/filename': 'ptt_push_1' }),
             isCausal: true,
         }),
         pushToTalkOff: one('SoundEffect', {
-            default: insertAndReplace({ defaultVolume: 0.05, filename: 'ptt_release_1' }),
+            default: insertAndReplace({ 'SoundEffect/defaultVolume': 0.05, 'SoundEffect/filename': 'ptt_release_1' }),
             isCausal: true,
         }),
         screenSharing: one('SoundEffect', {
-            default: insertAndReplace({ defaultVolume: 0.5, filename: 'share_02' }),
+            default: insertAndReplace({ 'SoundEffect/defaultVolume': 0.5, 'SoundEffect/filename': 'share_02' }),
             isCausal: true,
         }),
         undeafen: one('SoundEffect', {
-            default: insertAndReplace({ defaultVolume: 0.15, filename: 'undeafen_new_01' }),
+            default: insertAndReplace({ 'SoundEffect/defaultVolume': 0.15, 'SoundEffect/filename': 'undeafen_new_01' }),
             isCausal: true,
         }),
         unmute: one('SoundEffect', {
-            default: insertAndReplace({ defaultVolume: 0.2, filename: 'unmute_1' }),
+            default: insertAndReplace({ 'SoundEffect/defaultVolume': 0.2, 'SoundEffect/filename': 'unmute_1' }),
             isCausal: true,
         }),
     },

--- a/addons/mail/static/src/models/suggested_recipient_info.js
+++ b/addons/mail/static/src/models/suggested_recipient_info.js
@@ -7,7 +7,7 @@ import { sprintf } from '@web/core/utils/strings';
 
 registerModel({
     name: 'SuggestedRecipientInfo',
-    identifyingFields: ['id'],
+    identifyingFields: ['SuggestedRecipientInfo/id'],
     recordMethods: {
         /**
          * @private

--- a/addons/mail/static/src/models/thread.js
+++ b/addons/mail/static/src/models/thread.js
@@ -22,7 +22,7 @@ const getSuggestedRecipientInfoNextTemporaryId = (function () {
 
 registerModel({
     name: 'Thread',
-    identifyingFields: ['model', 'id'],
+    identifyingFields: ['Thread/model', 'Thread/id'],
     lifecycleHooks: {
         _created() {
             /**
@@ -1619,7 +1619,7 @@ registerModel({
          */
         _computeTypingStatusText() {
             if (this.orderedOtherTypingMembers.length === 0) {
-                return this.constructor.fields.typingStatusText.default;
+                return clear();
             }
             if (this.orderedOtherTypingMembers.length === 1) {
                 return sprintf(
@@ -1785,8 +1785,8 @@ registerModel({
          */
         _sortGuestMembers() {
             return [
-                ['defined-first', 'name'],
-                ['case-insensitive-asc', 'name'],
+                ['defined-first', 'Guest/name'],
+                ['case-insensitive-asc', 'Guest/name'],
             ];
         },
         /**
@@ -1795,8 +1795,8 @@ registerModel({
          */
         _sortPartnerMembers() {
             return [
-                ['defined-first', 'nameOrDisplayName'],
-                ['case-insensitive-asc', 'nameOrDisplayName'],
+                ['defined-first', 'Partner/nameOrDisplayName'],
+                ['case-insensitive-asc', 'Partner/nameOrDisplayName'],
             ];
         },
         /**
@@ -1952,7 +1952,7 @@ registerModel({
             compute: '_computeFetchMessagesUrl',
         }),
         followersPartner: many('Partner', {
-            related: 'followers.partner',
+            related: 'Thread/followers.Follower/partner',
         }),
         followers: many('Follower', {
             inverse: 'followedThread',
@@ -2443,15 +2443,15 @@ registerModel({
     },
     onChanges: [
         new OnChange({
-            dependencies: ['lastSeenByCurrentPartnerMessageId'],
+            dependencies: ['Thread/lastSeenByCurrentPartnerMessageId'],
             methodName: '_onChangeLastSeenByCurrentPartnerMessageId',
         }),
         new OnChange({
-            dependencies: ['isServerPinned'],
+            dependencies: ['Thread/isServerPinned'],
             methodName: '_onIsServerPinnedChanged',
         }),
         new OnChange({
-            dependencies: ['serverFoldState'],
+            dependencies: ['Thread/serverFoldState'],
             methodName: '_onServerFoldStateChanged',
         }),
     ],

--- a/addons/mail/static/src/models/thread_cache.js
+++ b/addons/mail/static/src/models/thread_cache.js
@@ -7,7 +7,7 @@ import { OnChange } from '@mail/model/model_onchange';
 
 registerModel({
     name: 'ThreadCache',
-    identifyingFields: ['thread'],
+    identifyingFields: ['ThreadCache/thread'],
     recordMethods: {
         async loadMoreMessages() {
             if (this.isAllHistoryLoaded || this.isLoading) {
@@ -415,15 +415,15 @@ registerModel({
     },
     onChanges: [
         new OnChange({
-            dependencies: ['hasLoadingFailed', 'isCacheRefreshRequested', 'isLoaded', 'isLoading', 'thread.isTemporary', 'threadViews'],
+            dependencies: ['ThreadCache/hasLoadingFailed', 'ThreadCache/isCacheRefreshRequested', 'ThreadCache/isLoaded', 'ThreadCache/isLoading', 'ThreadCache/thread.Thread/isTemporary', 'ThreadCache/threadViews'],
             methodName: '_onChangeForHasToLoadMessages',
         }),
         new OnChange({
-            dependencies: ['isLoaded', 'isLoading', 'isMarkAllAsReadRequested', 'thread.isTemporary', 'thread.model', 'threadViews'],
+            dependencies: ['ThreadCache/isLoaded', 'ThreadCache/isLoading', 'ThreadCache/isMarkAllAsReadRequested', 'ThreadCache/thread.Thread/isTemporary', 'ThreadCache/thread.Thread/model', 'ThreadCache/threadViews'],
             methodName: '_onChangeMarkAllAsRead',
         }),
         new OnChange({
-            dependencies: ['hasToLoadMessages'],
+            dependencies: ['ThreadCache/hasToLoadMessages'],
             methodName: '_onHasToLoadMessagesChanged',
         }),
     ],

--- a/addons/mail/static/src/models/thread_needaction_preview_view.js
+++ b/addons/mail/static/src/models/thread_needaction_preview_view.js
@@ -6,7 +6,7 @@ import { clear, insertAndReplace } from '@mail/model/model_field_command';
 
 registerModel({
     name: 'ThreadNeedactionPreviewView',
-    identifyingFields: ['notificationListViewOwner', 'thread'],
+    identifyingFields: ['ThreadNeedactionPreviewView/notificationListViewOwner', 'ThreadNeedactionPreviewView/thread'],
     recordMethods: {
         /**
          * @param {MouseEvent} ev

--- a/addons/mail/static/src/models/thread_partner_seen_info.js
+++ b/addons/mail/static/src/models/thread_partner_seen_info.js
@@ -5,7 +5,7 @@ import { one } from '@mail/model/model_field';
 
 registerModel({
     name: 'ThreadPartnerSeenInfo',
-    identifyingFields: ['thread', 'partner'],
+    identifyingFields: ['ThreadPartnerSeenInfo/thread', 'ThreadPartnerSeenInfo/partner'],
     fields: {
         lastFetchedMessage: one('Message'),
         lastSeenMessage: one('Message'),

--- a/addons/mail/static/src/models/thread_preview_view.js
+++ b/addons/mail/static/src/models/thread_preview_view.js
@@ -6,7 +6,7 @@ import { clear, insertAndReplace } from '@mail/model/model_field_command';
 
 registerModel({
     name: 'ThreadPreviewView',
-    identifyingFields: ['notificationListViewOwner', 'thread'],
+    identifyingFields: ['ThreadPreviewView/notificationListViewOwner', 'ThreadPreviewView/thread'],
     recordMethods: {
         /**
          * @param {MouseEvent} ev

--- a/addons/mail/static/src/models/thread_view.js
+++ b/addons/mail/static/src/models/thread_view.js
@@ -8,7 +8,7 @@ import { OnChange } from '@mail/model/model_onchange';
 
 registerModel({
     name: 'ThreadView',
-    identifyingFields: ['threadViewer'],
+    identifyingFields: ['ThreadView/threadViewer'],
     lifecycleHooks: {
         _willDelete() {
             this.messaging.browser.clearTimeout(this.loaderTimeout);
@@ -355,7 +355,7 @@ registerModel({
             isCausal: true,
         }),
         compact: attr({
-            related: 'threadViewer.compact',
+            related: 'ThreadView/threadViewer.ThreadViewer/compact',
         }),
         /**
          * List of component hints. Hints contain information that help
@@ -387,14 +387,14 @@ registerModel({
          * Determines which extra class this thread view component should have.
          */
         extraClass: attr({
-            related: 'threadViewer.extraClass',
+            related: 'ThreadView/threadViewer.ThreadViewer/extraClass',
         }),
         /**
          * Determines whether this thread viewer has a member list.
          * Only makes sense if thread.hasMemberListFeature is true.
          */
         hasMemberList: attr({
-            related: 'threadViewer.hasMemberList',
+            related: 'ThreadView/threadViewer.ThreadViewer/hasMemberList',
         }),
         /**
          * Determines whether this thread view should squash close messages.
@@ -408,10 +408,10 @@ registerModel({
          * Determines whether this thread view has a top bar.
          */
         hasTopbar: attr({
-            related: 'threadViewer.hasTopbar',
+            related: 'ThreadView/threadViewer.ThreadViewer/hasTopbar',
         }),
         isComposerFocused: attr({
-            related: 'composerView.isFocused',
+            related: 'ThreadView/composerView.ComposerView/isFocused',
         }),
         /**
          * States whether `this.threadCache` is currently loading messages.
@@ -470,7 +470,7 @@ registerModel({
          * Last message in the context of the currently displayed thread cache.
          */
         lastMessage: one('Message', {
-            related: 'thread.lastMessage',
+            related: 'ThreadView/thread.Thread/lastMessage',
         }),
         lastMessageView: one('MessageView', {
             compute: '_computeLastMessageView',
@@ -489,7 +489,7 @@ registerModel({
             isCausal: true,
         }),
         messages: many('Message', {
-            related: 'threadCache.messages',
+            related: 'ThreadView/threadCache.ThreadCache/messages',
         }),
         /**
          * States the message views used to display this messages.
@@ -504,7 +504,7 @@ registerModel({
          * Either 'asc', or 'desc'.
          */
         order: attr({
-            related: 'threadViewer.order',
+            related: 'ThreadView/threadViewer.ThreadViewer/order',
         }),
         /**
          * Determines the message that's currently being replied to.
@@ -525,7 +525,7 @@ registerModel({
         thread: one('Thread', {
             inverse: 'threadViews',
             readonly: true,
-            related: 'threadViewer.thread',
+            related: 'ThreadView/threadViewer.ThreadViewer/thread',
         }),
         /**
          * States the `ThreadCache` currently displayed by `this`.
@@ -533,7 +533,7 @@ registerModel({
         threadCache: one('ThreadCache', {
             inverse: 'threadViews',
             readonly: true,
-            related: 'threadViewer.threadCache',
+            related: 'ThreadView/threadViewer.ThreadViewer/threadCache',
         }),
         threadCacheInitialScrollHeight: attr({
             compute: '_computeThreadCacheInitialScrollHeight',
@@ -546,14 +546,14 @@ registerModel({
          */
         threadCacheInitialScrollHeights: attr({
             default: {},
-            related: 'threadViewer.threadCacheInitialScrollHeights',
+            related: 'ThreadView/threadViewer.ThreadViewer/threadCacheInitialScrollHeights',
         }),
         /**
          * List of saved initial scroll positions of thread caches.
          */
         threadCacheInitialScrollPositions: attr({
             default: {},
-            related: 'threadViewer.threadCacheInitialScrollPositions',
+            related: 'ThreadView/threadViewer.ThreadViewer/threadCacheInitialScrollPositions',
         }),
         /**
          * Determines the `ThreadViewer` currently managing `this`.
@@ -575,15 +575,15 @@ registerModel({
     },
     onChanges: [
         new OnChange({
-            dependencies: ['threadCache'],
+            dependencies: ['ThreadView/threadCache'],
             methodName: '_onThreadCacheChanged',
         }),
         new OnChange({
-            dependencies: ['threadCache.isLoading'],
+            dependencies: ['ThreadView/threadCache.ThreadCache/isLoading'],
             methodName: '_onThreadCacheIsLoadingChanged',
         }),
         new OnChange({
-            dependencies: ['isComposerFocused', 'lastMessage', 'thread.lastNonTransientMessage', 'lastVisibleMessage', 'threadCache'],
+            dependencies: ['ThreadView/isComposerFocused', 'ThreadView/lastMessage', 'ThreadView/thread.Thread/lastNonTransientMessage', 'ThreadView/lastVisibleMessage', 'ThreadView/threadCache'],
             methodName: '_computeThreadShouldBeSetAsSeen',
         }),
     ],

--- a/addons/mail/static/src/models/thread_view_topbar.js
+++ b/addons/mail/static/src/models/thread_view_topbar.js
@@ -6,7 +6,7 @@ import { clear, insertAndReplace } from '@mail/model/model_field_command';
 
 registerModel({
     name: 'ThreadViewTopbar',
-    identifyingFields: ['threadView'],
+    identifyingFields: ['ThreadViewTopbar/threadView'],
     lifecycleHooks: {
         _created() {
             document.addEventListener('click', this._onClickCaptureGlobal, true);
@@ -677,7 +677,7 @@ registerModel({
          * States the thread that is displayed by this top bar.
          */
         thread: one('Thread', {
-            related: 'threadView.thread',
+            related: 'ThreadViewTopbar/threadView.ThreadView/thread',
         }),
         /**
          * States the OWL ref of the "thread name" input of this top bar.

--- a/addons/mail/static/src/models/thread_viewer.js
+++ b/addons/mail/static/src/models/thread_viewer.js
@@ -6,7 +6,7 @@ import { clear, insertAndReplace } from '@mail/model/model_field_command';
 
 registerModel({
     name: 'ThreadViewer',
-    identifyingFields: [['chatter', 'chatWindow', 'discuss', 'discussPublicView']],
+    identifyingFields: [['ThreadViewer/chatter', 'ThreadViewer/chatWindow', 'ThreadViewer/discuss', 'ThreadViewer/discussPublicView']],
     recordMethods: {
         /**
          * @param {integer} scrollHeight
@@ -133,7 +133,7 @@ registerModel({
          * States the `ThreadCache` that should be displayed by `this`.
          */
         threadCache: one('ThreadCache', {
-            related: 'thread.cache',
+            related: 'ThreadViewer/thread.Thread/cache',
         }),
         /**
          * Determines the initial scroll height of thread caches, which is the

--- a/addons/mail/static/src/models/use_drag_visible_drop_zone.js
+++ b/addons/mail/static/src/models/use_drag_visible_drop_zone.js
@@ -6,7 +6,7 @@ import { decrement, increment } from '@mail/model/model_field_command';
 
 registerModel({
     name: 'UseDragVisibleDropZone',
-    identifyingFields: [['attachmentBoxViewOwner', 'composerViewOwner']],
+    identifyingFields: [['UseDragVisibleDropZone/attachmentBoxViewOwner', 'UseDragVisibleDropZone/composerViewOwner']],
     lifecycleHooks: {
         _created() {
             document.addEventListener('dragenter', this._onDragenterListener, true);

--- a/addons/mail/static/src/models/user.js
+++ b/addons/mail/static/src/models/user.js
@@ -6,7 +6,7 @@ import { clear, insert } from '@mail/model/model_field_command';
 
 registerModel({
     name: 'User',
-    identifyingFields: ['id'],
+    identifyingFields: ['User/id'],
     modelMethods: {
         /**
          * @param {Object} data

--- a/addons/mail/static/src/models/user_setting.js
+++ b/addons/mail/static/src/models/user_setting.js
@@ -8,7 +8,7 @@ import { clear, insertAndReplace } from '@mail/model/model_field_command';
 
 registerModel({
     name: 'UserSetting',
-    identifyingFields: ['id'],
+    identifyingFields: ['UserSetting/id'],
     lifecycleHooks: {
         _created() {
             this._loadLocalSettings();

--- a/addons/mail/static/src/models/volume_setting.js
+++ b/addons/mail/static/src/models/volume_setting.js
@@ -6,7 +6,7 @@ import { OnChange } from '@mail/model/model_onchange';
 
 registerModel({
     name: 'VolumeSetting',
-    identifyingFields: ['id'],
+    identifyingFields: ['VolumeSetting/id'],
     recordMethods: {
         /**
          * @private
@@ -48,7 +48,7 @@ registerModel({
     },
     onChanges: [
         new OnChange({
-            dependencies: ['volume'],
+            dependencies: ['VolumeSetting/volume'],
             methodName: '_onChangeVolume',
         }),
     ],

--- a/addons/mail/static/src/models/welcome_view.js
+++ b/addons/mail/static/src/models/welcome_view.js
@@ -11,7 +11,7 @@ const getNextGuestNameInputId = (function () {
 
 registerModel({
     name: 'WelcomeView',
-    identifyingFields: ['discussPublicView'],
+    identifyingFields: ['WelcomeView/discussPublicView'],
     recordMethods: {
         /**
          * Updates guest if needed then displays the thread view instead of the

--- a/addons/mail/static/tests/models/clock_watcher_qunit_tests.js
+++ b/addons/mail/static/tests/models/clock_watcher_qunit_tests.js
@@ -6,7 +6,7 @@ import { one } from '@mail/model/model_field';
 import '@mail/models/clock_watcher';
 
 patchIdentifyingFields('ClockWatcher', identifyingFields => {
-    identifyingFields[0].push('qunitTestOwner');
+    identifyingFields[0].push('ClockWatcher/qunitTestOwner');
 });
 
 addFields('ClockWatcher', {

--- a/addons/mail/static/tests/models/composer_view_qunit_tests.js
+++ b/addons/mail/static/tests/models/composer_view_qunit_tests.js
@@ -23,5 +23,5 @@ addFields('ComposerView', {
 });
 
 patchIdentifyingFields('ComposerView', identifyingFields => {
-    identifyingFields[0].push('qunitTest');
+    identifyingFields[0].push('ComposerView/qunitTest');
 });

--- a/addons/mail/static/tests/models/follower_list_menu_view_qunit_tests.js
+++ b/addons/mail/static/tests/models/follower_list_menu_view_qunit_tests.js
@@ -13,5 +13,5 @@ addFields('FollowerListMenuView', {
 });
 
 patchIdentifyingFields('FollowerListMenuView', identifyingFields => {
-    identifyingFields[0].push('qunitTest');
+    identifyingFields[0].push('FollowerListMenuView/qunitTest');
 });

--- a/addons/mail/static/tests/models/message_view_qunit_tests.js
+++ b/addons/mail/static/tests/models/message_view_qunit_tests.js
@@ -13,5 +13,5 @@ addFields('MessageView', {
 });
 
 patchIdentifyingFields('MessageView', identifyingFields => {
-    identifyingFields[0].push('qunitTest');
+    identifyingFields[0].push('MessageView/qunitTest');
 });

--- a/addons/mail/static/tests/models/notification_list_view_qunit_tests.js
+++ b/addons/mail/static/tests/models/notification_list_view_qunit_tests.js
@@ -12,7 +12,7 @@ addFields('NotificationListView', {
 });
 
 patchIdentifyingFields('NotificationListView', identifyingFields => {
-    identifyingFields[0].push('qunitTestOwner');
+    identifyingFields[0].push('NotificationListView/qunitTestOwner');
 });
 
 patchRecordMethods('NotificationListView', {

--- a/addons/mail/static/tests/models/test_models.js
+++ b/addons/mail/static/tests/models/test_models.js
@@ -6,7 +6,7 @@ import { insertAndReplace } from '@mail/model/model_field_command';
 
 registerModel({
     name: 'TestAddress',
-    identifyingFields: ['id'],
+    identifyingFields: ['TestAddress/id'],
     fields: {
         id: attr({
             readonly: true,
@@ -21,7 +21,7 @@ registerModel({
 
 registerModel({
     name: 'TestContact',
-    identifyingFields: ['id'],
+    identifyingFields: ['TestContact/id'],
     fields: {
         id: attr({
             readonly: true,
@@ -47,7 +47,7 @@ registerModel({
 
 registerModel({
     name: 'TestHobby',
-    identifyingFields: ['description'],
+    identifyingFields: ['TestHobby/description'],
     fields: {
         description: attr({
             readonly: true,
@@ -58,7 +58,7 @@ registerModel({
 
 registerModel({
     name: 'TestTask',
-    identifyingFields: ['id'],
+    identifyingFields: ['TestTask/id'],
     fields: {
         id: attr({
             readonly: true,

--- a/addons/mail/static/tests/models/thread_viewer_qunit_tests.js
+++ b/addons/mail/static/tests/models/thread_viewer_qunit_tests.js
@@ -13,5 +13,5 @@ addFields('ThreadViewer', {
 });
 
 patchIdentifyingFields('ThreadViewer', identifyingFields => {
-    identifyingFields[0].push('qunitTest');
+    identifyingFields[0].push('ThreadViewer/qunitTest');
 });

--- a/addons/snailmail/static/src/models/dialog.js
+++ b/addons/snailmail/static/src/models/dialog.js
@@ -7,7 +7,7 @@ import { clear, insertAndReplace, replace } from '@mail/model/model_field_comman
 import '@mail/models/dialog';
 
 patchIdentifyingFields('Dialog', identifyingFields => {
-    identifyingFields[0].push('messageViewOwnerAsSnailmailError');
+    identifyingFields[0].push('Dialog/messageViewOwnerAsSnailmailError');
 });
 
 addFields('Dialog', {

--- a/addons/snailmail/static/src/models/snailmail_error_view.js
+++ b/addons/snailmail/static/src/models/snailmail_error_view.js
@@ -6,7 +6,7 @@ import { replace } from '@mail/model/model_field_command';
 
 registerModel({
     name: 'SnailmailErrorView',
-    identifyingFields: ['dialogOwner'],
+    identifyingFields: ['SnailmailErrorView/dialogOwner'],
     recordMethods: {
         /**
          * Returns whether the given html element is inside this snailmail error view.

--- a/addons/website_livechat/static/src/models/visitor.js
+++ b/addons/website_livechat/static/src/models/visitor.js
@@ -6,7 +6,7 @@ import { clear, insert, replace } from '@mail/model/model_field_command';
 
 registerModel({
     name: 'Visitor',
-    identifyingFields: ['id'],
+    identifyingFields: ['Visitor/id'],
     modelMethods: {
         convertData(data) {
             const data2 = {};


### PR DESCRIPTION
Note: solution in this PR is not really satisfactory for now... Serves as POC/highlighting the problem I guess.

---

The code is slightly more annoying to type, but much easier to maintain :

- reading the code it is now immediately clear which field is accessed without
  having to check the context (where the `this` keyword or where the current
  variable is defined, which sometimes is through a long chain).
- finding occurrences of a specific field becomes trivial, which will help
  immensely whenever debugging or refactoring.
- it opens the possibility of introducing mixin/trait.
- it opens the possibility of simplifying field names as a follow up step (when
  name already contained too much context, it is now part of the model).

Done:

- support for the syntax with backwards compatibility on read/update
- converted identifyingFields
- converted onChanges
- converted related field
- converted sum field
- converted sort field
- converted activity model file
- converted activity component files

task-2745465