### PR TITLE
[FIX] website_sale: address edit error

### DIFF
--- a/addons/website_sale/controllers/main.py
+++ b/addons/website_sale/controllers/main.py
@@ -720,6 +720,10 @@ class WebsiteSale(http.Controller):
                 values = kw
             else:
                 partner_id = self._checkout_form_save(mode, post, kw)
+                # We need to validate _checkout_form_save return, because when partner_id not in shippings
+                # it returns Forbidden() instead the partner_id
+                if isinstance(partner_id, Forbidden):
+                    return partner_id
                 if mode[1] == 'billing':
                     order.partner_id = partner_id
                     order.with_context(not_self_saleperson=True).onchange_partner_id()


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
https://github.com/odoo/odoo/blob/7f3f6902c57428eee9aba7034725949c3b38cc95/addons/website_sale/controllers/main.py#L835

 The value of _checkout_form_save was validated because
 in some cases the method returns Forbidden()
 and this value is set directly to the order

https://github.com/odoo/odoo/blob/7f3f6902c57428eee9aba7034725949c3b38cc95/addons/website_sale/controllers/main.py#L742

Current behavior before PR:
![image](https://user-images.githubusercontent.com/35231827/165155114-361108b6-4870-4ecd-b235-64ef0d106312.png)


Desired behavior after PR is merged:
![image](https://user-images.githubusercontent.com/35231827/165153624-887b16a5-8792-4bfd-9314-029f4f2a59d0.png)




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
