### PR TITLE
[FIX] account_facturx: fix discount amount calculation

### DIFF
--- a/addons/account_facturx/data/facturx_templates.xml
+++ b/addons/account_facturx/data/facturx_templates.xml
@@ -37,7 +37,7 @@
                                 <ram:ChargeIndicator>
                                     <udt:Indicator>false</udt:Indicator>
                                 </ram:ChargeIndicator>
-                                <ram:ActualAmount t-esc="format_monetary(line.price_unit - net_amount, currency)"/>
+                                <ram:ActualAmount t-esc="format_monetary(line_values['price_discount_unit'], currency)"/>
                             </ram:AppliedTradeAllowanceCharge>
                         </ram:GrossPriceProductTradePrice>
                         <!-- Line unit price, with discount applied -->

--- a/addons/account_facturx/models/account_move.py
+++ b/addons/account_facturx/models/account_move.py
@@ -88,11 +88,16 @@ class AccountMove(models.Model):
                 is_refund=line.move_id.type in ('in_refund', 'out_refund'),
             )
 
+            if line.discount == 100.0:
+                gross_price_subtotal = line.currency_id.round(line.price_unit * line.quantity)
+            else:
+                gross_price_subtotal = line.currency_id.round(line.price_subtotal / (1 - (line.discount / 100.0)))
             line_template_values = {
                 'line': line,
                 'index': i + 1,
                 'tax_details': [],
                 'net_price_subtotal': taxes_res['total_excluded'],
+                'price_discount_unit': (gross_price_subtotal - line.price_subtotal) / line.quantity if line.quantity else 0.0,
                 'unece_uom_code': line.product_id.product_tmpl_id.uom_id._get_unece_code(),
             }
 

--- a/addons/account_facturx/tests/test_facturx.py
+++ b/addons/account_facturx/tests/test_facturx.py
@@ -186,7 +186,7 @@ class TestAccountEdiFacturx(AccountTestEdiCommon):
                 self.get_xml_tree_from_string(self.expected_invoice_facturx_values),
                 '''
                     <xpath expr="//AppliedTradeAllowanceCharge/ActualAmount" position="replace">
-                        <ActualAmount>75.000</ActualAmount>
+                        <ActualAmount>50.000</ActualAmount>
                     </xpath>
                     <xpath expr="//NetPriceProductTradePrice/ChargeAmount" position="replace">
                         <ChargeAmount>200.000</ChargeAmount>


### PR DESCRIPTION
The discount inside a facturx document has recently changed to include
the amount instead of the percent.
In the process, there is an issue when using tax_included where
the discount would be computed not based on the amount without tax
but on the amount taxed.

This change will align the discount computation on what will be
used in 15.0+

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
