### PR TITLE
[FIX] stock: cancel picking with scrapped SM

### DIFF
--- a/addons/stock/models/stock_picking.py
+++ b/addons/stock/models/stock_picking.py
@@ -420,7 +420,7 @@ class Picking(models.Model):
         '''
         picking_moves_state_map = defaultdict(dict)
         picking_move_lines = defaultdict(set)
-        for move in self.env['stock.move'].search([('picking_id', 'in', self.ids)]):
+        for move in self.env['stock.move'].search([('picking_id', 'in', self.ids), ('scrapped', '=', False)]):
             picking_id = move.picking_id
             move_state = move.state
             picking_moves_state_map[picking_id.id].update({

--- a/addons/stock/tests/test_stock_flow.py
+++ b/addons/stock/tests/test_stock_flow.py
@@ -1998,3 +1998,43 @@ class TestStockFlow(TestStockCommon):
 
         picking.write({'partner_id': partner_2.id})
         self.assertEqual(picking.move_lines.partner_id, partner_2)
+
+    def test_cancel_picking_with_scrapped_products(self):
+        """
+        The user scraps some products of a picking, then cancel this picking
+        The test ensures that the scrapped SM is not cancelled
+        """
+        stock_location = self.env['stock.location'].browse(self.stock_location)
+        self.env['stock.quant']._update_available_quantity(self.productA, stock_location, 10)
+
+        picking = self.env['stock.picking'].create({
+            'picking_type_id': self.picking_type_out,
+            'location_id': self.supplier_location,
+            'location_dest_id': self.stock_location,
+        })
+        move = self.env['stock.move'].create({
+            'name': self.productA.name,
+            'product_id': self.productA.id,
+            'product_uom_qty': 1,
+            'product_uom': self.productA.uom_id.id,
+            'picking_id': picking.id,
+            'location_id': self.supplier_location,
+            'location_dest_id': self.stock_location,
+        })
+
+        picking.action_confirm()
+        picking.action_assign()
+
+        scrap = self.env['stock.scrap'].create({
+            'picking_id': picking.id,
+            'product_id': self.productA.id,
+            'product_uom_id': self.productA.uom_id.id,
+            'scrap_qty': 1.0,
+        })
+        scrap.do_scrap()
+
+        picking.action_cancel()
+
+        self.assertEqual(picking.state, 'cancel')
+        self.assertEqual(move.state, 'cancel')
+        self.assertEqual(scrap.move_id.state, 'done')


### PR DESCRIPTION
Cancelling a picking with scrapped and done SM will cancel this SM too.

To reproduce the issue:
1. In Settings, enable "Storage Locations"
2. Create a storable product P
3. Update the quantity of P: 10 in WH/Stock
4. Create a planned delivery order DO with 2 x P
5. Mark DO as todo, Check availability
6. Scrap 2 x P
7. Cancel DO
8. Open the SM of the scrapping

Error: The SM is cancelled. This is incorrect: the move was done, so
there is a quant with 2 x P in scrap location. There is now an
incoherence between quants and SMs report.

OPW-2805604