### PR TITLE
[IMP] mail: remove alias mixin from channel

### DIFF
--- a/addons/mail/tests/test_mail_channel.py
+++ b/addons/mail/tests/test_mail_channel.py
@@ -158,7 +158,6 @@ class TestChannelInternals(MailCommon):
             'name': 'Test',
             'channel_type': 'channel',
             'description': 'Description',
-            'alias_name': 'test',
             'public': 'public',
         })
         cls.test_partner = cls.env['res.partner'].with_context(cls._test_context).create({
@@ -259,7 +258,6 @@ class TestChannelInternals(MailCommon):
     @mute_logger('odoo.addons.mail.models.mail_mail', 'odoo.models.unlink')
     def test_channel_recipients_mention(self):
         """ Posting a message on a classic channel should support mentioning somebody """
-        self.test_channel.write({'alias_name': False})
         with self.mock_mail_gateway():
             self.test_channel.message_post(
                 body="Test", partner_ids=self.test_partner.ids,

--- a/addons/mail/views/mail_channel_views.xml
+++ b/addons/mail/views/mail_channel_views.xml
@@ -57,17 +57,6 @@
                             <field name="active" invisible="1"/>
                             <field name="description" placeholder="Topics discussed in this group..."/>
                         </group>
-                        <group name="group_alias" attrs="{'invisible': [('alias_domain', '=', False)]}">
-                            <label for="alias_id" string=" " class="fa fa-envelope-o" style="min-width: 20px;" aria-label="Email" title="Email" role="img"/>
-                            <div name="alias_def">
-                                <field name="alias_id" class="oe_read_only oe_inline"
-                                        string="Email Alias" required="0"/>
-                                <div class="oe_edit_only oe_inline" name="edit_alias" style="display: inline;" >
-                                    <field name="alias_name" class="oe_inline"/>@<field name="alias_domain" class="oe_inline" readonly="1"/>
-                                </div>
-                            </div>
-                            <field name="alias_contact" class="oe_inline" invisible="1"/>
-                        </group>
                         <notebook>
                             <page string="Privacy" name="privacy">
                                 <group class="o_label_nowrap">


### PR DESCRIPTION
**Current behavior before PR:**

`mail.alias.mixin` is being used in `mail.channel`

**Desired behavior after PR is merged:**

removed `mail.alias.mixin` with all of its uses in `mail.channel`

Task-2823691

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
