### PR TITLE
[FIX] stock_account: wrong accounts for manual valuation

### DIFF
--- a/addons/stock_account/models/product.py
+++ b/addons/stock_account/models/product.py
@@ -755,7 +755,7 @@ class ProductCategory(models.Model):
                 raise ValidationError(_('The Stock Input and/or Output accounts cannot be the same as the Stock Valuation account.'))
 
     @api.onchange('property_cost_method')
-    def onchange_property_valuation(self):
+    def onchange_property_cost(self):
         if not self._origin:
             # don't display the warning when creating a product category
             return
@@ -819,3 +819,16 @@ class ProductCategory(models.Model):
             account_moves = self.env['account.move'].sudo().create(move_vals_list)
             account_moves._post()
         return res
+
+    @api.onchange('property_valuation')
+    def onchange_property_valuation(self):
+        # Remove or set the account stock properties if necessary
+        if self.property_valuation == 'manual_periodic':
+            self.property_stock_account_input_categ_id = False
+            self.property_stock_account_output_categ_id = False
+            self.property_stock_valuation_account_id = False
+        if self.property_valuation == 'real_time':
+            company_id = self.env.company
+            self.property_stock_account_input_categ_id = company_id.property_stock_account_input_categ_id
+            self.property_stock_account_output_categ_id = company_id.property_stock_account_output_categ_id
+            self.property_stock_valuation_account_id = company_id.property_stock_valuation_account_id


### PR DESCRIPTION
Step to reproduce:
Install purchase, stock and accounting
Create a product in a database with USA localization.
Create a new product category and select the manual valuation option.
Purchase the item, receive the item and create the Vendor bill

Current Behavior
On the journal entries you will see that the stock interim accounts
are impacted (the accounts uase for an automated stock valuation)

Expected Behavior
The used account is expenses

Explanation:
The problem comes from the fact that we don't set/reset the accounts when
we change the valuation type.
 

opw-2746384