### PR TITLE
[FIX] calendar: allow to schedule meetings/calls when already created

### DIFF
--- a/addons/calendar/views/mail_activity_views.xml
+++ b/addons/calendar/views/mail_activity_views.xml
@@ -25,11 +25,12 @@
                   <attribute name="attrs">{'invisible': [('activity_category', '=', 'meeting')]}</attribute>
             </xpath>
             <xpath expr="//button[@name='action_close_dialog']" position="before">
-                <button string="Open Calendar"
-                    attrs="{'invisible': ['|', ('activity_category', 'not in', ['meeting', 'phonecall']), ('id', '!=', False)]}"
-                    name="action_create_calendar_event"
-                    type="object"
-                    class="btn-primary"/>
+                  <field name="calendar_event_id" invisible="1" />
+                  <button string="Open Calendar"
+                        attrs="{'invisible': ['|', ('activity_category', 'not in', ['meeting', 'phonecall']), ('calendar_event_id', '!=', False)]}"
+                        name="action_create_calendar_event"
+                        type="object"
+                        class="btn-primary"/>
             </xpath>
         </field>
     </record>


### PR DESCRIPTION
When a an activity was already created, it is no longer to schedule it
when we change the type to a call or a meeting.

Step to reproduce the issue:
1. Create any activity (without scheduling it) on for example a Quotation
2. Edit this activity and change its type to meeting/call
There are no longer a Open Calendar Button, thus we can't schedule it.

Solution: The issue is simply that the Open Calendar button is only displayed
when the activity is not yet created (and if we have the appropriate category).
Instead of this condition, we should display this button if there are no event
already created.

opw-2824396