### PR TITLE
[IMP] delivery,sale: add method to ease exclusion of line in so amount

### DIFF
--- a/addons/delivery/models/delivery_grid.py
+++ b/addons/delivery/models/delivery_grid.py
@@ -93,15 +93,15 @@ class ProviderGrid(models.Model):
                 continue
             if line.is_delivery:
                 total_delivery += line.price_total
-            if not line.product_id or line.is_delivery:
+            if line._is_not_eligible_for_total():
                 continue
             if line.product_id.type == "service":
                 continue
+            total += line.price_total
             qty = line.product_uom._compute_quantity(line.product_uom_qty, line.product_id.uom_id)
             weight += (line.product_id.weight or 0.0) * qty
             volume += (line.product_id.volume or 0.0) * qty
             quantity += qty
-        total = (order.amount_total or 0.0) - total_delivery
 
         total = self._compute_currency(order, total, 'pricelist_to_company')
 

--- a/addons/delivery/models/sale_order.py
+++ b/addons/delivery/models/sale_order.py
@@ -162,6 +162,16 @@ class SaleOrderLine(models.Model):
     product_qty = fields.Float(compute='_compute_product_qty', string='Product Qty', digits='Product Unit of Measure')
     recompute_delivery_price = fields.Boolean(related='order_id.recompute_delivery_price')
 
+    def _is_not_eligible_for_total(self):
+        """
+        Goal of this function, return True if the line amount should not be added on total
+        For example, i don't want to add service, voucher, ... in the total of my SO for specific use-case
+        Is_delivery = True or _is_not_eligible_for_total = False -> return True -> should not be added
+        Is_delivery = False or _is_not_eligible_for_total = False -> return False -> should be added
+        Is_delivery = False or _is_not_eligible_for_total = True -> return True -> should not be added
+        """
+        return self.is_delivery or super()._is_not_eligible_for_total()
+
     @api.depends('product_id', 'product_uom', 'product_uom_qty')
     def _compute_product_qty(self):
         for line in self:

--- a/addons/sale/models/sale.py
+++ b/addons/sale/models/sale.py
@@ -1951,3 +1951,9 @@ class SaleOrderLine(models.Model):
             name += "\n" + pacv.with_context(lang=self.order_id.partner_id.lang).display_name
 
         return name
+
+    def _is_not_eligible_for_total(self):
+        """
+        Just a prototype, the goal is to override
+        """
+        return not bool(self.product_id)


### PR DESCRIPTION

let's say that you need to exclude some type of product of your so's amount_total,
you can easily surcharge the _is_eligible_for_total method in order to exclude those

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
