### PR TITLE
[FIX] sale_coupon: only add program if reward line was created

### DIFF
--- a/addons/sale_coupon/wizard/sale_coupon_apply_code.py
+++ b/addons/sale_coupon/wizard/sale_coupon_apply_code.py
@@ -39,16 +39,22 @@ class SaleCouponApplyCode(models.TransientModel):
                             }
                         }
                 else:  # The program is applied on this order
+                    # Only link the promo program if reward lines were created
+                    order_line_count = len(order.order_line)
                     order._create_reward_line(program)
-                    order.code_promo_program_id = program
+                    if order_line_count < len(order.order_line):
+                        order.code_promo_program_id = program
         else:
             coupon = self.env['sale.coupon'].search([('code', '=', coupon_code)], limit=1)
             if coupon:
                 error_status = coupon._check_coupon_code(order)
                 if not error_status:
+                    # Consume coupon only if reward lines were created
+                    order_line_count = len(order.order_line)
                     order._create_reward_line(coupon.program_id)
-                    order.applied_coupon_ids += coupon
-                    coupon.write({'state': 'used'})
+                    if order_line_count < len(order.order_line):
+                        order.applied_coupon_ids += coupon
+                        coupon.write({'state': 'used'})
             else:
                 error_status = {'not_found': _('The code %s is invalid') % (coupon_code)}
         return error_status


### PR DESCRIPTION
Prior to this commit, a program would be linked regardless of if reward
lines were created while applying it.
It would make it impossible for the order to then unlink that program,
since the usual way to do it is to remove the reward lines from the
order.
It will now only link when the reward lines are created.

