### PR TITLE
[FIX] website: restore video loading on page load

### DIFF
--- a/addons/website/static/src/js/content/snippets.animation.js
+++ b/addons/website/static/src/js/content/snippets.animation.js
@@ -759,11 +759,13 @@ registry.mediaVideo = publicWidget.Widget.extend(MobileYoutubeAutoplayMixin, {
             // Unsupported domain, don't inject iframe
             return;
         }
-        return this.$target.append($('<iframe/>', {
+        const iframeEl = $('<iframe/>', {
             src: src,
             frameborder: '0',
             allowfullscreen: 'allowfullscreen',
-        }))[0];
+        })[0];
+        this.$target.append(iframeEl);
+        return iframeEl;
     },
 });
 


### PR DESCRIPTION
Commit [1] broke the building of iframes in existing databases.

[1]: https://github.com/odoo/odoo/commit/b9b29bac14242eb88fc83a1fe5ba2472b64c24ea

opw-2832238
