### PR TITLE
[FIX] cloc: empty string in demo(_xml) or cloc_exclude

### DIFF
--- a/odoo/tools/cloc.py
+++ b/odoo/tools/cloc.py
@@ -99,7 +99,7 @@ class Cloc(object):
                 pass
         if not exclude:
             exclude = set()
-        for i in exclude_list:
+        for i in filter(None, exclude_list):
             exclude.update(str(p) for p in pathlib.Path(path).glob(i))
 
         module_name = os.path.basename(path)


### PR DESCRIPTION
Before this commit:
calling `odoo-bin cloc -P <path_to_a_module>` when the manifest of a
module includes an empty string in the demo, demo_xml or cloc_exclude
entries, would result in a crash because an empty string is not an
acceptable pattern for Path.glob


opw-2829886