### PR TITLE
[FIX] web_editor: prevent horizontal overflow caused by m2m widget

### DIFF
--- a/addons/web_editor/static/src/scss/wysiwyg_snippets.scss
+++ b/addons/web_editor/static/src/scss/wysiwyg_snippets.scss
@@ -1517,6 +1517,7 @@ body.editor_enable.editor_has_snippets {
         .o_we_m2m {
             we-list, we-list > div, we-list we-select {
                 margin-top: 0;
+                max-width: 100%;
             }
         }
 


### PR DESCRIPTION
When a vertical overflow is triggered in the snippets menu, a vertical
scrollbar is added making the snippets menu slightly smaller. Most
widgets properly adapt their width, however the many2many dropdown
widget does not, causing a horizontal overflow and its associated
scrollbar.

Steps to reproduce the bug :

- Drag and drop the "text-image" snippet in a page.
- Click on the image in this snippet.
- Set the "visibility" option to "Conditionally".
- A horizontal scrollbar appears in the editor panel.

This commit adapts the CSS of the m2m widget to solve the issue.

task-2779530