### PR TITLE
[FIX] pos_hr: keep login screen open in idle

### DIFF
--- a/addons/pos_hr/static/src/js/Chrome.js
+++ b/addons/pos_hr/static/src/js/Chrome.js
@@ -20,6 +20,9 @@ odoo.define('pos_hr.chrome', function (require) {
             shouldShowCashControl() {
                 return super.shouldShowCashControl() && this.env.pos.hasLoggedIn;
             }
+            _shouldResetIdleTimer() {
+                return super._shouldResetIdleTimer() && this.tempScreen.name !== 'LoginScreen';
+            }
         };
 
     Registries.Component.extend(Chrome, PosHrChrome);


### PR DESCRIPTION
Current behavior:
When authorized employees is activated is activated for a PoS if you
go back to the login screen and do nothing for like 1 minutes you would
go back to the PoS logged as the previous employee

Steps to reproduce:
- Have PoS installed, create a PoS restaurant wiht authorized employee
- Start a PoS session
- Click on the lock button to go back to the login screen
- Wait for 1 minute
- The screen go back to the PoS

opw-2792531
--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
