### PR TITLE
[REF] `o-autogrow` scss refactoring

### DIFF
--- a/addons/mail/static/src/components/attachment_viewer/attachment_viewer.xml
+++ b/addons/mail/static/src/components/attachment_viewer/attachment_viewer.xml
@@ -24,7 +24,7 @@
                     <div class="o_AttachmentViewer_headerItem o_AttachmentViewer_name d-flex align-items-center mx-2">
                         <span class="o_AttachmentViewer_nameText text-truncate" t-esc="attachmentViewer.attachment.displayName"/>
                     </div>
-                    <div class="o-autogrow"/>
+                    <div class="flex-grow-1"/>
                     <div class="o_AttachmentViewer_buttonDownload o_AttachmentViewer_headerItem o_AttachmentViewer_headerItemButton d-flex align-items-center px-3 o_cursor_pointer" t-on-click="attachmentViewer.onClickDownload" role="button" title="Download">
                         <i class="o_AttachmentViewer_headerItemButtonIcon fa fa-download fa-fw" t-att-class="{ 'o-hasLabel me-2': messaging.device.sizeClass > env.device.SIZES.MD }" role="img"/>
                         <t t-if="messaging.device.sizeClass > env.device.SIZES.MD">

--- a/addons/mail/static/src/components/chat_window_header/chat_window_header.xml
+++ b/addons/mail/static/src/components/chat_window_header/chat_window_header.xml
@@ -23,7 +23,7 @@
                         (<t t-esc="chatWindow.thread.localMessageUnreadCounter"/>)
                     </div>
                 </t>
-                <div class="o-autogrow"/>
+                <div class="flex-grow-1"/>
                 <div class="o_ChatWindowHeader_item o_ChatWindowHeader_rightArea d-flex align-items-center h-100 ms-1 me-0 my-0" t-att-class="{'opacity-75 opacity-100-hover': !messaging.device.isSmall }">
                     <t t-if="chatWindow.hasCallButtons">
                         <div class="o_ChatWindowHeader_command o_ChatWindowHeader_commandCamera o_cursor_pointer d-flex align-items-center h-100 px-3 py-0 m-0" t-att-class="{ 'o-isDeviceSmall': messaging.device.isSmall, 'opacity-50 opacity-100-hover': !messaging.device.isSmall }" t-att-disabled="chatWindow.thread.hasPendingRtcRequest" t-on-click="chatWindow.onClickCamera" title="Start a Video Call">

--- a/addons/mail/static/src/components/chatter_topbar/chatter_topbar.xml
+++ b/addons/mail/static/src/components/chatter_topbar/chatter_topbar.xml
@@ -41,7 +41,7 @@
                             Schedule activity
                         </button>
                     </t>
-                    <div class="o-autogrow"/>
+                    <div class="flex-grow-1"/>
                         <div class="o_ChatterTopbar_rightSection flex-grow-1 flex-shrink-0 justify-content-end d-flex">
                             <button class="o_ChatterTopbar_button o_ChatterTopbar_buttonAttachments btn btn-link" type="button" t-att-disabled="chatterTopbar.chatter.isDisabled" t-on-click="chatterTopbar.chatter.onClickButtonAttachments" title="Show Attachments">
                                 <i class="fa fa-paperclip"/>

--- a/addons/mail/static/src/components/discuss/discuss.scss
+++ b/addons/mail/static/src/components/discuss/discuss.scss
@@ -2,10 +2,6 @@
 // Layout
 // ------------------------------------------------------------------
 
-.o-autogrow {
-    flex: 1 1 auto;
-}
-
 .o_Discuss {
     display: flex;
     height: map-get($sizes, 100);

--- a/addons/mail/static/src/components/discuss_sidebar_category/discuss_sidebar_category.xml
+++ b/addons/mail/static/src/components/discuss_sidebar_category/discuss_sidebar_category.xml
@@ -10,7 +10,7 @@
                         <i class="o_DiscussSidebarCategory_titleIcon small" t-att-class="category.isOpen ? 'fa fa-chevron-down' : 'fa fa-chevron-right'"/>
                         <span class="o_DiscussSidebarCategory_titleText btn-sm p-0 text-uppercase font-weight-bolder"><t t-esc="category.name"/></span>
                     </div>
-                    <div class="o-autogrow o_DiscussSidebarCategory_headerItem"/>
+                    <div class="o_DiscussSidebarCategory_headerItem flex-grow-1"/>
                     <div class="o_DiscussSidebarCategory_commands o_DiscussSidebarCategory_headerItem d-flex mr-3">
                         <t t-if="category.hasViewCommand">
                             <i t-attf-class="o_DiscussSidebarCategory_command o_DiscussSidebarCategory_commandView fa fa-cog {{ o_DiscussSidebarCategory_hoverItem }}" title="View or join channels" t-on-click="category.onClickCommandView" role="img"/>

--- a/addons/mail/static/src/components/discuss_sidebar_category_item/discuss_sidebar_category_item.xml
+++ b/addons/mail/static/src/components/discuss_sidebar_category_item/discuss_sidebar_category_item.xml
@@ -22,7 +22,7 @@
                 <span class="o_DiscussSidebarCategoryItem_item o_DiscussSidebarCategoryItem_name ms-3 me-2 text-truncate" t-att-class="{ 'o-item-unread font-weight-bolder': categoryItem.isUnread }">
                     <t t-esc="categoryItem.channel.displayName"/>
                 </span>
-                <div class="o-autogrow o_DiscussSidebarCategoryItem_item"/>
+                <div class="o_DiscussSidebarCategoryItem_item flex-grow-1"/>
                 <div t-attf-class="o_DiscussSidebarCategoryItem_item o_DiscussSidebarCategoryItem_commands ms-1 {{ categoryItem.channel and categoryItem.channel.rtcSessions.length ? 'me-1' : 'me-3' }}">
                     <t t-if="categoryItem.hasSettingsCommand">
                         <div t-attf-class="o_DiscussSidebarCategoryItem_command o_DiscussSidebarCategoryItem_commandSettings fa fa-cog {{ o_DiscussSidebarCategoryItem_hoverItem }}" t-on-click="categoryItem.onClickCommandSettings" title="Channel settings" role="img"/>

--- a/addons/mail/static/src/components/discuss_sidebar_mailbox/discuss_sidebar_mailbox.xml
+++ b/addons/mail/static/src/components/discuss_sidebar_mailbox/discuss_sidebar_mailbox.xml
@@ -13,7 +13,7 @@
             <div class="o_DiscussSidebarMailbox_item o_DiscussSidebarMailbox_name me-2 text-truncate">
                 <t t-esc="discussSidebarMailboxView.mailbox.displayName"/>
             </div>
-            <div t-attf-class="o-autogrow o_DiscussSidebarMailbox_item {{ discussSidebarMailboxView.mailbox.counter === 0 ? 'me-3': '' }}"/>
+            <div t-attf-class="o_DiscussSidebarMailbox_item flex-grow-1 {{ discussSidebarMailboxView.mailbox.counter === 0 ? 'me-3': '' }}"/>
             <t t-if="discussSidebarMailboxView.mailbox.counter > 0">
                 <div t-attf-class="o_DiscussSidebarMailbox_counter o_DiscussSidebarMailbox_item badge badge-pill {{ discussSidebarMailboxView.mailbox === messaging.starred ? 'bg-400 text-light' : 'badge-primary' }} ms-1 me-3 border-0">
                     <t t-esc="discussSidebarMailboxView.mailbox.counter"/>

--- a/addons/mail/static/src/components/messaging_menu/messaging_menu.xml
+++ b/addons/mail/static/src/components/messaging_menu/messaging_menu.xml
@@ -30,7 +30,7 @@
                                 <t t-if="messaging.device.isSmall">
                                     <t t-call="mail.MessagingMenu.newMessageButton"/>
                                 </t>
-                                <div class="o-autogrow"/>
+                                <div class="flex-grow-1"/>
                                 <t t-if="!messaging.device.isSmall and !messaging.discuss.discussView">
                                     <t t-call="mail.MessagingMenu.newMessageButton"/>
                                 </t>

--- a/addons/mail/static/src/components/notification_group/notification_group.xml
+++ b/addons/mail/static/src/components/notification_group/notification_group.xml
@@ -19,7 +19,7 @@
                                 (<t t-esc="notificationGroupView.notificationGroup.notifications.length"/>)
                             </span>
                         </t>
-                        <span class="o-autogrow"/>
+                        <span class="flex-grow-1"/>
                         <t t-if="notificationGroupView.notificationGroup.date">
                             <small class="o_NotificationListItem_date o_NotificationGroup_date flex-shrink-0 text-500">
                                 <t t-esc="notificationGroupView.notificationGroup.date.fromNow()"/>
@@ -32,7 +32,7 @@
                                 An error occurred when sending an email.
                             </t>
                         </span>
-                        <span class="o-autogrow"/>
+                        <span class="flex-grow-1"/>
                         <span class="o_NotificationListItem_coreItem o_NotificationListItem_markAsRead o_NotificationGroup_coreItem o_NotificationGroup_markAsRead fa fa-check d-flex flex-shrink-0 ms-2 text-600 opacity-50 opacity-100-hover" title="Discard message delivery failures" t-on-click="notificationGroupView.onClickMarkAsRead" t-ref="markAsRead"/>
                     </div>
                 </div>

--- a/addons/mail/static/src/components/thread_needaction_preview/thread_needaction_preview.xml
+++ b/addons/mail/static/src/components/thread_needaction_preview/thread_needaction_preview.xml
@@ -33,7 +33,7 @@
                                 (<t t-esc="threadNeedactionPreviewView.thread.needactionMessagesAsOriginThread.length"/>)
                             </span>
                         </t>
-                        <span class="o-autogrow"/>
+                        <span class="flex-grow-1"/>
                         <t t-if="threadNeedactionPreviewView.thread.lastNeedactionMessageAsOriginThread and threadNeedactionPreviewView.thread.lastNeedactionMessageAsOriginThread.date">
                             <small class="o_NotificationListItem_date o_ThreadNeedactionPreview_date flex-shrink-0 text-500">
                                 <t t-esc="threadNeedactionPreviewView.thread.lastNeedactionMessageAsOriginThread.date.fromNow()"/>
@@ -47,7 +47,7 @@
                             </t>
                             <t t-esc="inlineLastNeedactionMessageAsOriginThreadBody"/>
                         </span>
-                        <span class="o-autogrow"/>
+                        <span class="flex-grow-1"/>
                         <span class="o_NotificationListItem_coreItem o_NotificationListItem_markAsRead o_ThreadNeedactionPreview_coreItem o_ThreadNeedactionPreview_markAsRead fa fa-check d-flex flex-shrink-0 ms-2 text-600 opacity-50 opacity-100-hover" title="Mark as Read" t-on-click="threadNeedactionPreviewView.onClickMarkAsRead" t-ref="markAsRead"/>
                     </div>
                 </div>

--- a/addons/mail/static/src/components/thread_preview/thread_preview.xml
+++ b/addons/mail/static/src/components/thread_preview/thread_preview.xml
@@ -37,7 +37,7 @@
                         <t t-if="threadPreviewView.thread.rtcSessions.length > 0">
                             <span class="o_ThreadPreview_callIndicator fa fa-volume-up mx-2" t-att-class="{ 'o-isCalling text-danger': threadPreviewView.thread.rtc }"/>
                         </t>
-                        <span class="o-autogrow"/>
+                        <span class="flex-grow-1"/>
                         <t t-if="threadPreviewView.thread.lastMessage and threadPreviewView.thread.lastMessage.date">
                             <small class="o_NotificationListItem_date o_ThreadPreview_date flex-shrink-0 text-500" t-att-class="{ 'o-muted': threadPreviewView.thread.localMessageUnreadCounter === 0 }">
                                 <t t-esc="threadPreviewView.thread.lastMessage.date.fromNow()"/>
@@ -51,7 +51,7 @@
                             </t>
                             <t t-esc="inlineLastMessageBody"/>
                         </span>
-                        <span class="o-autogrow"/>
+                        <span class="flex-grow-1"/>
                         <t t-if="threadPreviewView.thread.localMessageUnreadCounter > 0">
                             <span class="o_NotificationListItem_coreItem o_NotificationListItem_markAsRead o_ThreadPreview_coreItem o_ThreadPreview_markAsRead fa fa-check d-flex flex-shrink-0 ms-2 text-600 opacity-50 opacity-100-hover" title="Mark as Read" t-on-click="threadPreviewView.onClickMarkAsRead" t-ref="markAsRead"/>
                         </t>

--- a/addons/mail/static/src/components/thread_view/thread_view.xml
+++ b/addons/mail/static/src/components/thread_view/thread_view.xml
@@ -34,7 +34,7 @@
                             </div>
                         </t>
                         <t t-elif="threadView.composerView">
-                            <div class="o-autogrow"/>
+                            <div class="flex-grow-1"/>
                         </t>
                         <t t-if="threadView.composerView">
                             <Composer

--- a/addons/mail/static/src/xml/thread.xml
+++ b/addons/mail/static/src/xml/thread.xml
@@ -14,7 +14,7 @@
                     <i class="fa fa-video-camera mr8" t-if="widget.activeAttachment.fileType == 'video'" role="img" aria-label="Video" title="Video"/>
                     <span class="o_viewer_document_name" t-esc="widget.activeAttachment.name"/>
                 </span>
-                <div class="o-autogrow"/>
+                <div class="flex-grow-1"/>
                 <a class="o_download_btn o_document_viewer_topbar_button btn" href="#" title="Download">
                     <i class="fa fa-fw fa-download" role="img" aria-label="Download"/>
                     <span class="d-none d-md-inline ml-2">Download</span>


### PR DESCRIPTION
This commit deletes the class `o-autogrow` and replaces each instance of
it with a global Bootstrap class.

Task-2833725

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
