### PR TITLE
[FIX] web_editor: fix form not saved

### DIFF
--- a/addons/web_editor/static/src/js/wysiwyg/widgets/link_tools.js
+++ b/addons/web_editor/static/src/js/wysiwyg/widgets/link_tools.js
@@ -49,7 +49,6 @@ const LinkTools = Link.extend({
      * @override
      */
     start: function () {
-        this.options.wysiwyg.odooEditor.observerUnactive();
         this.$link.addClass('oe_edited_link');
         this.$button.addClass('active');
         return this._super(...arguments);
@@ -64,7 +63,6 @@ const LinkTools = Link.extend({
             $contents.unwrap();
         }
         this.$button.removeClass('active');
-        this.options.wysiwyg.odooEditor.observerActive();
         this.applyLinkToDom(this._getData());
         if (!this.options.wysiwyg.odooEditor.isDestroyed) {
             this.options.wysiwyg.odooEditor.historyStep();
@@ -75,9 +73,7 @@ const LinkTools = Link.extend({
 
     applyLinkToDom() {
         this._observer.disconnect();
-        this.options.wysiwyg.odooEditor.observerActive();
         this._super(...arguments);
-        this.options.wysiwyg.odooEditor.observerUnactive();
         this._observer.observe(this._link, {subtree: true, childList: true, characterData: true});
     },
 

--- a/addons/website/static/tests/tours/website_form_editor.js
+++ b/addons/website/static/tests/tours/website_form_editor.js
@@ -136,10 +136,6 @@ odoo.define('website.tour.form_editor', function (require) {
         {
             content: "Form has a model name",
             trigger: 'section.s_website_form form[data-model_name="mail.mail"]',
-        }, {
-            content: "Complete Recipient E-mail",
-            trigger: '[data-field-name="email_to"] input',
-            run: 'text_blur test@test.test',
         },
         ...addExistingField('email_cc', 'text', 'Test conditional visibility', false, {visibility: CONDITIONALVISIBILITY, condition: 'odoo'}),
 
@@ -314,7 +310,34 @@ odoo.define('website.tour.form_editor', function (require) {
         {
             content:  "Wait reloading...",
             trigger:  "html:not(:has(#completlyloaded)) div",
-        }
+        },
+        {
+            content: 'Enter in edit mode again',
+            trigger: 'a[data-action="edit"]',
+            run: 'click',
+        },
+        {
+            content: 'Click on the submit button',
+            trigger: '.s_website_form_send',
+            extra_trigger: 'button[data-action="save"]',
+            run: 'click',
+        },
+        {
+            content: 'Change the Recipient Email',
+            trigger: '[data-field-name="email_to"] input',
+            run: 'text test@test.test',
+        },
+        {
+            content: 'Save the page',
+            trigger: 'button[data-action=save]',
+            run: 'click',
+        },
+        {
+            content: 'Verify that the recipient email has been saved',
+            trigger: 'body:not(.editor_enable)',
+            // We have to this that way because the input type = hidden.
+            extra_trigger: 'form:has(input[name="email_to"][value="test@test.test"])',
+        },
     ]);
 
     tour.register("website_form_editor_tour_submit", {


### PR DESCRIPTION
Before this commit, the modifications of the form were not saved if the user had only clicked on the submit button of the form. Only elements with the class o_dirty are saved, but since this commit [1], the observer that adds this class was disabled. This commit fixes this bug and adds a test to make sure that this bug does not happen again.

Here are the steps to see the bug:
- Go to /contactus page
- Click on edit
- Click on the Submit button
- Change a Form option (eg: Recipient Email, Labels Width, URL, ...)
- Save

Edit again the see that the changes are not saved

[1]: https://github.com/odoo/odoo/commit/c29fe9fa8fc8ff4a5e6f042607ef9b3070d1d339

task-2812722
--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
