### PR TITLE
[FIX] core: use non-breaking space for currency symbol

### DIFF
--- a/addons/account_check_printing/tests/test_print_check.py
+++ b/addons/account_check_printing/tests/test_print_check.py
@@ -2,6 +2,7 @@
 from odoo.addons.account.tests.common import AccountTestInvoicingCommon
 from odoo.addons.account_check_printing.models.account_payment import INV_LINES_PER_STUB
 from odoo.tests import tagged
+from odoo.tools.misc import NON_BREAKING_SPACE
 
 import math
 
@@ -124,8 +125,8 @@ class TestPrintCheck(AccountTestInvoicingCommon):
         self.assertEqual(stub_pages, [[{
             'due_date': '01/01/2016',
             'number': invoice.name,
-            'amount_total': '$ 100.00',
-            'amount_residual': '$ 50.00',
-            'amount_paid': '150.000 ☺',
+            'amount_total': f'${NON_BREAKING_SPACE}100.00',
+            'amount_residual': f'${NON_BREAKING_SPACE}50.00',
+            'amount_paid': f'150.000{NON_BREAKING_SPACE}☺',
             'currency': invoice.currency_id,
         }]])

--- a/odoo/tools/misc.py
+++ b/odoo/tools/misc.py
@@ -60,6 +60,8 @@ SKIPPED_ELEMENT_TYPES = (etree._Comment, etree._ProcessingInstruction, etree.Com
 # Configure default global parser
 etree.set_default_parser(etree.XMLParser(resolve_entities=False))
 
+NON_BREAKING_SPACE = u'\N{NO-BREAK SPACE}'
+
 #----------------------------------------------------------
 # Subprocesses
 #----------------------------------------------------------
@@ -1265,9 +1267,9 @@ def formatLang(env, value, digits=None, grouping=True, monetary=False, dp=False,
 
     if currency_obj and currency_obj.symbol:
         if currency_obj.position == 'after':
-            res = '%s %s' % (res, currency_obj.symbol)
+            res = '%s%s%s' % (res, NON_BREAKING_SPACE, currency_obj.symbol)
         elif currency_obj and currency_obj.position == 'before':
-            res = '%s %s' % (currency_obj.symbol, res)
+            res = '%s%s%s' % (currency_obj.symbol, NON_BREAKING_SPACE, res)
     return res
 
 


### PR DESCRIPTION
In some languages and layout the currency symbol might be wrapped in a separate
line, which is not acceptable from accounting point of view. Fix it by replacing
space with a special symbol.

STEPS:
* install MX localization;
* create a Spanish speaking customer
* generate a pdf:
1) Create quotation with products
2) Add IVA 16%tax
3) print a report

BEFORE: the currency symbol is incorrectly displayed on a separate line
AFTER:  currency symbol is always with the amount

---

opw-2829138

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
