### PR TITLE
[FIX] stock: add translation in dynamic button contain change

### DIFF
--- a/addons/stock/i18n/stock.pot
+++ b/addons/stock/i18n/stock.pot
@@ -893,7 +893,10 @@ msgid "As soon as possible"
 msgstr ""
 
 #. module: stock
+#. openerp-web
+#: code:addons/stock/static/src/js/report_stock_reception.js:0
 #: model_terms:ir.ui.view,arch_db:stock.report_reception_body
+#, python-format
 msgid "Assign"
 msgstr ""
 
@@ -7913,7 +7916,10 @@ msgid "USPS Connector"
 msgstr ""
 
 #. module: stock
+#. openerp-web
+#: code:addons/stock/static/src/js/report_stock_reception.js:0
 #: model_terms:ir.ui.view,arch_db:stock.report_reception_body
+#, python-format
 msgid "Unassign"
 msgstr ""
 

--- a/addons/stock/static/src/js/report_stock_reception.js
+++ b/addons/stock/static/src/js/report_stock_reception.js
@@ -4,6 +4,7 @@ import clientAction from 'report.client_action';
 import core from 'web.core';
 
 const qweb = core.qweb;
+const _t = core._t;
 
 const ReceptionReport = clientAction.extend({
     /**
@@ -70,7 +71,7 @@ const ReceptionReport = clientAction.extend({
 
 
     _switchButton: function (button) {
-        button.innerText = button.innerText.includes('Unassign') ? "Assign" : "Unassign";
+        button.innerText = button.innerText.includes(_t("Unassign")) ? _t("Assign") : _t("Unassign");
         button.name = button.name === 'assign_link' ? 'unassign_link' : 'assign_link';
         button.classList.toggle("o_report_reception_assign");
         button.classList.toggle("o_report_reception_unassign");

--- a/addons/stock/static/src/scss/report_stock_reception.scss
+++ b/addons/stock/static/src/scss/report_stock_reception.scss
@@ -16,13 +16,6 @@
             &:hover:not([disabled]) {
                 background-color: darken($o-brand-primary, 10%);
             }
-            &.o_report_reception_assign,
-            &.o_report_reception_unassign {
-                width: 78px;
-            }
-            & .o_print_label_text {
-                width: 73px;
-            }
         }
     }
     & .badge {


### PR DESCRIPTION
Steps to reproduce the issue:
1)Inventory > Configuration > Settings > Activate "Reception Report"
> Activate "Show reception report"
2)Choose a non english language
3)Sales > Choose SO > Delivery > Allocation
4)Click on the Assign/Unassign equivalent in the new language

Current behavior:
The word in the Assign/Unassign button is in english

Expected behavior:
The word in the Assign/Unassign button is in the new language

Explanation:
When clicked the button starts a function in js that changes the
button text context without translating the new text. We also modify
the text in javascript and the problem is solved.

Note for the RD stock team:
I don't think this is a good practice to modify the button content of a report dynamically.
I did a fix with the fewest changes possible but I would advise fusing the two buttons into one and 
adding a condition in it for the content, it should be possible in xml/qweb.

https://github.com/odoo/odoo/blob/d3912aad67e5a519df3b355e962ce9d2e7894133/addons/stock/report/report_stock_reception.xml#L116-L135


Issue 2:
The button had fixed size specific to the english language, if a longer
translation in another language was used it was cut leading to make it
unuderstanble in some languages (e.g. german).

opw-2827247