### PR TITLE
[FIX] web_editor: remove temporary color gradient element

### DIFF
--- a/addons/web_editor/static/src/js/common/utils.js
+++ b/addons/web_editor/static/src/js/common/utils.js
@@ -179,6 +179,7 @@ function _areCssValuesEqual(value1, value2, cssProp, $target) {
         temp2El.style.backgroundImage = value2;
         document.body.appendChild(temp2El);
         value2 = getComputedStyle(temp2El).backgroundImage;
+        document.body.removeChild(temp2El);
 
         return value1 === value2;
     }


### PR DESCRIPTION
[FIX] web_editor: remove temporary color gradient element

Commit [1] introduced a way to use pre-configured gradient that included
a change to the util method _areCSSValuesEqual.
Commit [2] added lines of code to compare shadows but unfortunately
broke commit [1].

The changes of commit 2 left a lots of elements in the body of the
document.

Steps to reproduce:
- Install base database
- Find HTML field (e.g. Login as admin => preference => Email signature)
- Select text and click on Text Color
- Click on gradient then custom gradients
- Move the slider around
- Inspect the body element
- Lots of divs are there

[1]: https://github.com/odoo/odoo/commit/a48a30f954afcb6ff3a59c4f32b05fd0c2cfcd2b
[2]: https://github.com/odoo/odoo/commit/212d8ec10bb48e8fd7de3d3ff7660447b968c62a
