### PR TITLE
[IMP] website_event: consider country and city while searching events

### DIFF
--- a/addons/event/models/event_event.py
+++ b/addons/event/models/event_event.py
@@ -8,8 +8,9 @@ from datetime import timedelta
 
 from odoo import _, api, Command, fields, models
 from odoo.addons.base.models.res_partner import _tz_get
-from odoo.tools import format_datetime, is_html_empty
 from odoo.exceptions import UserError, ValidationError
+from odoo.osv import expression
+from odoo.tools import format_datetime, is_html_empty
 from odoo.tools.misc import formatLang
 from odoo.tools.translate import html_translate
 
@@ -402,17 +403,16 @@ class EventEvent(models.Model):
         if operator != 'ilike' or not isinstance(value, str):
             raise NotImplementedError(_('Operation not supported.'))
 
-        address_ids = self.env['res.partner']._search([
-            '|', '|', '|', '|', '|',
-            ('street', 'ilike', value),
-            ('street2', 'ilike', value),
-            ('city', 'ilike', value),
-            ('zip', 'ilike', value),
-            ('state_id', 'ilike', value),
-            ('country_id', 'ilike', value),
+        return expression.OR([
+            [('address_id.name', 'ilike', value)],
+            [('address_id.street', 'ilike', value)],
+            [('address_id.street2', 'ilike', value)],
+            [('address_id.city', 'ilike', value)],
+            [('address_id.zip', 'ilike', value)],
+            [('address_id.state_id', 'ilike', value)],
+            [('address_id.country_id', 'ilike', value)],
         ])
 
-        return [('address_id', 'in', address_ids)]
 
     # seats
 

--- a/addons/website/static/src/snippets/s_searchbar/000.js
+++ b/addons/website/static/src/snippets/s_searchbar/000.js
@@ -120,14 +120,7 @@ publicWidget.registry.searchBar = publicWidget.Widget.extend({
                 'options': this.options,
             },
         });
-        const fieldNames = [
-            'name',
-            'description',
-            'extra_link',
-            'detail',
-            'detail_strike',
-            'detail_extra',
-        ];
+        const fieldNames = this._getFieldsNames();
         res.results.forEach(record => {
             for (const fieldName of fieldNames) {
                 if (record[fieldName]) {
@@ -204,6 +197,16 @@ publicWidget.registry.searchBar = publicWidget.Widget.extend({
         if ($prevMenu) {
             $prevMenu.remove();
         }
+    },
+    _getFieldsNames() {
+        return [
+            'description',
+            'detail',
+            'detail_extra',
+            'detail_strike',
+            'extra_link',
+            'name',
+        ];
     },
 
     //--------------------------------------------------------------------------

--- a/addons/website_event/models/event_event.py
+++ b/addons/website_event/models/event_event.py
@@ -527,10 +527,19 @@ class Event(models.Model):
             mapping['description'] = {'name': 'subtitle', 'type': 'text', 'match': True}
         if with_date:
             mapping['detail'] = {'name': 'range', 'type': 'html'}
+
+        # Bypassing the access rigths of partner to search the address.
+        def search_in_address(env, search_term):
+            ret = env['event.event'].sudo()._search([
+               ('address_search', 'ilike', search_term),
+            ])
+            return [('id', 'in', ret)]
+
         return {
             'model': 'event.event',
             'base_domain': domain,
             'search_fields': search_fields,
+            'search_extra': search_in_address,
             'fetch_fields': fetch_fields,
             'mapping': mapping,
             'icon': 'fa-ticket',

--- a/addons/website_event/models/event_event.py
+++ b/addons/website_event/models/event_event.py
@@ -63,6 +63,7 @@ class Event(models.Model):
     location_menu_ids = fields.One2many(
         "website.event.menu", "event_id", string="Location Menus",
         domain=[("menu_type", "=", "location_menu")])
+    address_name = fields.Char(related='address_id.name')
     register_menu = fields.Boolean(
         "Register Menu", compute="_compute_website_menu_data",
         readonly=False, store=True)
@@ -516,10 +517,11 @@ class Event(models.Model):
                     current_date = date_details[1]
 
         search_fields = ['name']
-        fetch_fields = ['name', 'website_url']
+        fetch_fields = ['name', 'website_url', 'address_name']
         mapping = {
             'name': {'name': 'name', 'type': 'text', 'match': True},
             'website_url': {'name': 'website_url', 'type': 'text', 'truncate': False},
+            'address_name': {'name': 'address_name', 'type': 'text', 'match': True},
         }
         if with_description:
             search_fields.append('subtitle')

--- a/addons/website_event/static/src/snippets/s_searchbar/000.js
+++ b/addons/website_event/static/src/snippets/s_searchbar/000.js
@@ -1,0 +1,13 @@
+/** @odoo-module **/
+
+import publicWidget from 'web.public.widget';
+
+publicWidget.registry.searchBar.include({
+    /**
+     *
+     * @override
+     */
+    _getFieldsNames() {
+        return [...this._super(), 'address_name'];
+    }
+});

--- a/addons/website_event/static/src/snippets/s_searchbar/000.xml
+++ b/addons/website_event/static/src/snippets/s_searchbar/000.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<template xml:space="preserve">
+
+    <t t-inherit="website.s_searchbar.autocomplete" t-inherit-mode="extension">
+        <xpath expr="//div[@class='o_search_result_item_detail px-3']" position="inside">
+            <span t-if="result['address_name']" class="small">
+                <span class="fa fa-map-marker"/> <t t-out="result['address_name']"/>
+            </span>
+        </xpath>
+    </t>
+
+</templates>
+

--- a/addons/website_event/views/snippets/snippets.xml
+++ b/addons/website_event/views/snippets/snippets.xml
@@ -85,4 +85,16 @@
     </xpath>
 </template>
 
+<record id="website_event.s_searchbar_000_js" model="ir.asset">
+    <field name="name">Searchbar 000 JS</field>
+    <field name="bundle">web.assets_frontend</field>
+    <field name="path">website_event/static/src/snippets/s_searchbar/000.js</field>
+</record>
+
+<record id="website_event.s_searchbar_000_xml" model="ir.asset">
+    <field name="name">Searchbar 000 XML</field>
+    <field name="bundle">web.assets_frontend</field>
+    <field name="path">website_event/static/src/snippets/s_searchbar/000.xml</field>
+</record>
+
 </odoo>


### PR DESCRIPTION
Currently, website users/visitors are not able to search the events based on
where they happen.

This PR improves the behavior by allowing the users/visitors to type the
city/country name in the search box and returns the events that are happening
in the country or city that matches the search term. To allow this, we have
utilized the `search_extra` search option and searching the matching events with
`sudo` because public users can not access the `address_search` m2o of the event.

This PR also shows the event location name when users search for the event.
Also add the "_getFieldsNames" method to easily override this method to
add a field name from another model.

Note that searching with sudo is just to add event ids in the domain. The final
result will be returned with not sudoed environment and so the record rules are
always respected.

TaskId-2791031