### PR TITLE
[FIX] mail: fix assertMailNotifications when called in batch

### DIFF
--- a/addons/mail/tests/common.py
+++ b/addons/mail/tests/common.py
@@ -418,11 +418,32 @@ class MockEmail(common.BaseCase):
         else:
             raise AssertionError('mail.mail exists for message %s / recipients %s but should not exist' % (mail_message, recipients.ids))
         finally:
-            self.assertNotSentEmail()
+            self.assertNotSentEmail(recipients)
 
-    def assertNotSentEmail(self):
-        """ Check no email was generated during gateway mock. """
-        self.assertEqual(len(self._mails), 0)
+    def assertNotSentEmail(self, recipients=None):
+        """Check no email was generated during gateway mock.
+
+        :param recipients:
+            List of partner for which we will check that no email have been sent
+            Or list of email address
+            If None, we will check that no email at all have been sent
+        """
+        if recipients is None:
+            mails = self._mails
+        else:
+            all_emails = [
+                email_to.email if isinstance(email_to, self.env['res.partner'].__class__)
+                else email_to
+                for email_to in recipients
+            ]
+
+            mails = [
+                mail
+                for mail in self._mails
+                if any(email in all_emails for email in mail['email_to'])
+            ]
+
+        self.assertEqual(len(mails), 0)
 
     def assertSentEmail(self, author, recipients, **values):
         """ Tool method to ease the check of send emails.


### PR DESCRIPTION
Bug
===
When we called assertMailNotifications in batch, with different
notification status, it might raise an error when it shouldn't.

The reason for that is we check that no mail at all are created, for
the entire batch instead of filtering on the related partner.

`assertNoMail` should only check if no mail are created for the partner
it receive in arguments.

Task-2782150