### PR TITLE
[FIX] requirements.txt: pin the last version of cryptography

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
 Babel==2.9.1  # min version = 2.6.0 (Focal with security backports)
 chardet==3.0.4
+cryptography==36.0.2 # last version working with pyopenssl==19.0.0
 decorator==4.4.2
 docutils==0.16
 ebaysdk==2.1.5


### PR DESCRIPTION
version 37.0.0 of cryptography is no longer working with pyopenssl==19.0.0

Description of the issue/feature this PR addresses:
When running odoo 15.0 (with dependencies installed from requirements.txt) we get the following error:
```
2022-04-27 05:59:27,091 19 CRITICAL ? odoo.modules.module: Couldn't load module web 
2022-04-27 05:59:27,091 19 CRITICAL ? odoo.modules.module: module 'lib' has no attribute 'X509_V_FLAG_CB_ISSUER_CHECK' 
2022-04-27 05:59:27,091 19 ERROR ? odoo.service.server: Failed to load server-wide module `web`.
The `web` module is provided by the addons found in the `openerp-web` project.
Maybe you forgot to add those addons in your addons_path configuration. 
Traceback (most recent call last):
  File "/opt/odoo/custom/src/odoo/odoo/service/server.py", line 1208, in load_server_wide_modules
    odoo.modules.module.load_openerp_module(m)
  File "/opt/odoo/custom/src/odoo/odoo/modules/module.py", line 396, in load_openerp_module
    __import__('odoo.addons.' + module_name)
  File "/opt/odoo/auto/addons/web/__init__.py", line 4, in <module>
    from . import controllers
  File "/opt/odoo/auto/addons/web/controllers/__init__.py", line 4, in <module>
    from . import main
  File "/opt/odoo/auto/addons/web/controllers/main.py", line 34, in <module>
    from odoo.addons.base.models.ir_qweb import render as qweb_render
  File "/opt/odoo/custom/src/odoo/odoo/addons/base/__init__.py", line 5, in <module>
    from . import models
  File "/opt/odoo/custom/src/odoo/odoo/addons/base/models/__init__.py", line 23, in <module>
    from . import ir_mail_server
  File "/opt/odoo/custom/src/odoo/odoo/addons/base/models/ir_mail_server.py", line 19, in <module>
    from OpenSSL import crypto as SSLCrypto
  File "/usr/local/lib/python3.8/site-packages/OpenSSL/__init__.py", line 8, in <module>
    from OpenSSL import crypto, SSL
  File "/usr/local/lib/python3.8/site-packages/OpenSSL/crypto.py", line 1553, in <module>
    class X509StoreFlags(object):
  File "/usr/local/lib/python3.8/site-packages/OpenSSL/crypto.py", line 1573, in X509StoreFlags
    CB_ISSUER_CHECK = _lib.X509_V_FLAG_CB_ISSUER_CHECK
AttributeError: module 'lib' has no attribute 'X509_V_FLAG_CB_ISSUER_CHECK'
2022-04-27 05:59:27,107 19 CRITICAL ? odoo.modules.module: Couldn't load module base 
2022-04-27 05:59:27,107 19 CRITICAL ? odoo.modules.module: module 'lib' has no attribute 'X509_V_FLAG_CB_ISSUER_CHECK' 
2022-04-27 05:59:27,107 19 ERROR ? odoo.service.server: Failed to load server-wide module `base`. 
Traceback (most recent call last):
  File "/opt/odoo/custom/src/odoo/odoo/service/server.py", line 1208, in load_server_wide_modules
    odoo.modules.module.load_openerp_module(m)
  File "/opt/odoo/custom/src/odoo/odoo/modules/module.py", line 396, in load_openerp_module
    __import__('odoo.addons.' + module_name)
  File "/opt/odoo/custom/src/odoo/odoo/addons/base/__init__.py", line 5, in <module>
    from . import models
  File "/opt/odoo/custom/src/odoo/odoo/addons/base/models/__init__.py", line 23, in <module>
    from . import ir_mail_server
  File "/opt/odoo/custom/src/odoo/odoo/addons/base/models/ir_mail_server.py", line 19, in <module>
    from OpenSSL import crypto as SSLCrypto
  File "/usr/local/lib/python3.8/site-packages/OpenSSL/__init__.py", line 8, in <module>
    from OpenSSL import crypto, SSL
  File "/usr/local/lib/python3.8/site-packages/OpenSSL/crypto.py", line 1553, in <module>
    class X509StoreFlags(object):
  File "/usr/local/lib/python3.8/site-packages/OpenSSL/crypto.py", line 1573, in X509StoreFlags
    CB_ISSUER_CHECK = _lib.X509_V_FLAG_CB_ISSUER_CHECK
AttributeError: module 'lib' has no attribute 'X509_V_FLAG_CB_ISSUER_CHECK'
```

Current behavior before PR:
when installing requirements the installed versions of pyOpenSSL(==19.0.0) and cryptography(==37.0.0) are not compatible with each other

Desired behavior after PR is merged:
when installing requirements the installed versions of pyOpenSSL(==19.0.0) and cryptography(==36.0.2) are compatible with each other

Info @wt-io-it

Thanks to @moylop260 for tweeting about the issue, so i could fix it faster (for us):
[https://twitter.com/moylop260/status/1519123563760033794](https://twitter.com/moylop260/status/1519123563760033794)

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
