### PR TITLE
[FIX] stock: fix default route

### DIFF
--- a/addons/stock/models/stock_orderpoint.py
+++ b/addons/stock/models/stock_orderpoint.py
@@ -409,8 +409,9 @@ class StockWarehouseOrderpoint(models.Model):
         orderpoints = self.env['stock.warehouse.orderpoint'].with_user(SUPERUSER_ID).create(orderpoint_values_list)
         for orderpoint in orderpoints:
             orderpoint_wh = orderpoint.location_id.get_warehouse()
-            orderpoint.route_id = next((r for r in orderpoint.product_id.route_ids if not r.supplied_wh_id or r.supplied_wh_id == orderpoint_wh), None) \
-                                  or orderpoint._set_default_route_id()
+            orderpoint.route_id = next((r for r in orderpoint.product_id.route_ids if not r.supplied_wh_id or r.supplied_wh_id == orderpoint_wh), orderpoint.route_id)
+            if not orderpoint.route_id:
+                orderpoint._set_default_route_id()
         return action
 
     @api.model


### PR DESCRIPTION
Issue:
The call `_set_default_route_id` returns None. Whenever the iterator finds nothing, the route would be set to None.