### PR TITLE
[FIX] website_hr_recruitment: allow fields in job to be auto-populated

### DIFF
--- a/addons/website_hr_recruitment/views/website_hr_recruitment_templates.xml
+++ b/addons/website_hr_recruitment/views/website_hr_recruitment_templates.xml
@@ -147,7 +147,7 @@
                                             <span class="s_website_form_mark"> *</span>
                                         </label>
                                         <div class="col-sm">
-                                            <input id="recruitment1" type="text" class="form-control s_website_form_input" name="partner_name" required=""/>
+                                            <input id="recruitment1" type="text" class="form-control s_website_form_input" name="partner_name" required="" data-fill-with="name"/>
                                         </div>
                                     </div>
                                 </div>
@@ -158,7 +158,7 @@
                                             <span class="s_website_form_mark"> *</span>
                                         </label>
                                         <div class="col-sm">
-                                            <input id="recruitment2" type="email" class="form-control s_website_form_input" name="email_from" required=""/>
+                                            <input id="recruitment2" type="email" class="form-control s_website_form_input" name="email_from" required="" data-fill-with="email"/>
                                         </div>
                                     </div>
                                 </div>
@@ -169,7 +169,7 @@
                                             <span class="s_website_form_mark"> *</span>
                                         </label>
                                         <div class="col-sm">
-                                            <input id="recruitment3" type="tel" class="form-control s_website_form_input" name="partner_phone" required=""/>
+                                            <input id="recruitment3" type="tel" class="form-control s_website_form_input" name="partner_phone" required="" data-fill-with="phone"/>
                                         </div>
                                     </div>
                                 </div>


### PR DESCRIPTION
When submitting an Application Form, the name / email / phone number are
not auto-populated.

Step to reproduce:
1. Install "Online Jobs" module
2. Go to /jobs on your website and apply to a job
The form should be auto-populated with the field mentionned before, it isn't.

Solution: From a previous commit [1], the fill-with behavior will replace
the default_values. However, the change was not completed. The
data-fill-with attribute was missing into the XML template.

[1]: https://github.com/odoo/enterprise/commit/fe5a2ffe30b6f5b5d1bd2e64a0e7f11267b34a96

opw-2803166