### PR TITLE
[REV] account: display correct price_unit with 100% taxes

### DIFF
--- a/addons/account/models/account_move.py
+++ b/addons/account/models/account_move.py
@@ -3644,9 +3644,8 @@ class AccountMoveLine(models.Model):
                 'discount': 0.0,
                 'price_unit': amount_currency / (quantity or 1.0),
             }
-        elif not discount_factor or not amount_currency:
-            # balance of line is 0, but discount == 100% or taxes (price included) == 100%,
-            # so we display the normal unit_price
+        elif not discount_factor:
+            # balance of line is 0, but discount  == 100% so we display the normal unit_price
             vals = {}
         else:
             # balance is 0, so unit price is 0 as well


### PR DESCRIPTION
This reverts commit fe7d56dc32c71e04b54de9dbd756a48942a832f4.

The original commit created an unwanted side effect that was
being solved here https://github.com/odoo/odoo/pull/89632

But while testing the new PR, it appeared that the initial bug
was no longer there, even without the original fix.

Hence this PR.

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
