### PR TITLE
[REV] web_editor: revert fix onChange event

### DIFF
--- a/addons/web_editor/static/src/js/backend/field_html.js
+++ b/addons/web_editor/static/src/js/backend/field_html.js
@@ -468,7 +468,7 @@ var FieldHtml = basic_fields.DebouncedField.extend(TranslatableFieldMixin, {
      * @param {OdooEvent} ev
      */
     _onChange: function (ev) {
-        this._doAction();
+        this._doDebouncedAction.apply(this, arguments);
 
         var $lis = this.$content.find('.note-editable ul.o_checklist > li:not(:has(> ul.o_checklist))');
         if (!$lis.length) {


### PR DESCRIPTION
This reverts commit 7dd6b8ff39b9a35cd4c159fb9bcd68b752c8475b.

It was initially meant to fix the urgentSave feature not working
properly with the html field but it triggered too many onchanges.

It had already been partially reverted by 46ef7a5d99a3ed0d3eb864dcce194ac73eb4a9f0.