### PR TITLE
[MOV] im_livechat: use arrow functions in legacy livechat files...

### DIFF
--- a/addons/im_livechat/static/src/legacy/widgets/abstract_thread_window.js
+++ b/addons/im_livechat/static/src/legacy/widgets/abstract_thread_window.js
@@ -66,7 +66,6 @@ var AbstractThreadWindow = Widget.extend({
         }
     },
     start: function () {
-        var self = this;
         this.$input = this.$('.o_composer_text_field');
         this.$header = this.$('.o_thread_window_header');
         var options = {
@@ -89,8 +88,8 @@ var AbstractThreadWindow = Widget.extend({
             var margin_dir = _t.database.parameters.direction === "rtl" ? "margin-left" : "margin-right";
             this.$el.css(margin_dir, $.position.scrollbarWidth());
         }
-        var def = this._threadWidget.replace(this.$('.o_thread_window_content')).then(function () {
-            self._threadWidget.$el.on('scroll', self, self._debouncedOnScroll);
+        var def = this._threadWidget.replace(this.$('.o_thread_window_content')).then(() => {
+            this._threadWidget.$el.on('scroll', this, this._debouncedOnScroll);
         });
         return Promise.all([this._super(), def]);
     },
@@ -366,13 +365,12 @@ var AbstractThreadWindow = Widget.extend({
      * @param {Object} messageData
      */
     _postMessage: function (messageData) {
-        var self = this;
         if (!this.hasThread()) {
             return;
         }
         this._thread.postMessage(messageData)
-            .then(function () {
-                self._threadWidget.scrollToBottom();
+            .then(() => {
+                this._threadWidget.scrollToBottom();
             });
     },
     /**

--- a/addons/im_livechat/static/src/legacy/widgets/feedback.js
+++ b/addons/im_livechat/static/src/legacy/widgets/feedback.js
@@ -48,21 +48,20 @@ var Feedback = Widget.extend({
      * @param {Object} options
      */
     _sendFeedback: function (reason) {
-        var self = this;
         var args = {
             uuid: this._livechat.getUUID(),
             rate: this.rating,
             reason: reason,
         };
-        this.dp.add(session.rpc('/im_livechat/feedback', args)).then(function (response) {
-            var emoji = RATING_TO_EMOJI[self.rating] || "??";
+        this.dp.add(session.rpc('/im_livechat/feedback', args)).then((response) => {
+            var emoji = RATING_TO_EMOJI[this.rating] || "??";
             if (!reason) {
                 var content = utils.sprintf(_t("Rating: %s"), emoji);
             }
             else {
                 var content = "Rating reason: \n" + reason;
             }
-            self.trigger('send_message', { content: content, isFeedback: true });
+            this.trigger('send_message', { content: content, isFeedback: true });
         });
     },
     /**
@@ -118,7 +117,6 @@ var Feedback = Widget.extend({
     * @private
     */
     _onEmailChat: function () {
-        var self = this;
         var $email = this.$('#o_email');
 
         if (utils.is_email($email.val())) {
@@ -130,11 +128,11 @@ var Feedback = Widget.extend({
                     uuid: this._livechat.getUUID(),
                     email: $email.val(),
                 }
-            }).then(function () {
-                self.$('.o_livechat_email').html($('<strong />', { text: _t('Conversation Sent') }));
-            }).guardedCatch(function () {
-                self.$('.o_livechat_email').hide();
-                self.$('.o_livechat_email_error').show();
+            }).then(() => {
+                this.$('.o_livechat_email').html($('<strong />', { text: _t('Conversation Sent') }));
+            }).guardedCatch(() => {
+                this.$('.o_livechat_email').hide();
+                this.$('.o_livechat_email_error').show();
             });
         } else {
             $email.addClass('is-invalid').prop('title', _t('Invalid email address'));

--- a/addons/im_livechat/static/src/legacy/widgets/livechat_button.js
+++ b/addons/im_livechat/static/src/legacy/widgets/livechat_button.js
@@ -215,7 +215,6 @@ var LivechatButton = Widget.extend({
         if (this._openingChat) {
             return;
         }
-        var self = this;
         var cookie = utils.get_cookie('im_livechat_session');
         var def;
         this._openingChat = true;
@@ -230,10 +229,10 @@ var LivechatButton = Widget.extend({
                 { shadow: true },
             );
         }
-        def.then(function (livechatData) {
+        def.then((livechatData) => {
             if (!livechatData || !livechatData.operator_pid) {
                 try {
-                    self.displayNotification({
+                    this.displayNotification({
                         message: _t("No available collaborator, please try again later."),
                         sticky: true,
                     });
@@ -248,19 +247,19 @@ var LivechatButton = Widget.extend({
                     console.warn(_t("No available collaborator, please try again later."));
                 }
             } else {
-                self._livechat = new WebsiteLivechat({
-                    parent: self,
+                this._livechat = new WebsiteLivechat({
+                    parent: this,
                     data: livechatData
                 });
-                return self._openChatWindow().then(function () {
-                    if (!self._history) {
-                        self._sendWelcomeMessage();
+                return this._openChatWindow().then(() => {
+                    if (!this._history) {
+                        this._sendWelcomeMessage();
                     }
-                    self._renderMessages();
-                    self.call('bus_service', 'addChannel', self._livechat.getUUID());
-                    self.call('bus_service', 'startPolling');
+                    this._renderMessages();
+                    this.call('bus_service', 'addChannel', this._livechat.getUUID());
+                    this.call('bus_service', 'startPolling');
 
-                    utils.set_cookie('im_livechat_session', utils.unaccent(JSON.stringify(self._livechat.toData()), true), 60 * 60);
+                    utils.set_cookie('im_livechat_session', utils.unaccent(JSON.stringify(this._livechat.toData()), true), 60 * 60);
                     utils.set_cookie('im_livechat_auto_popup', JSON.stringify(false), 60 * 60);
                     if (livechatData.operator_pid[0]) {
                         // livechatData.operator_pid contains a tuple (id, name)
@@ -271,10 +270,10 @@ var LivechatButton = Widget.extend({
                     }
                 });
             }
-        }).then(function () {
-            self._openingChat = false;
-        }).guardedCatch(function () {
-            self._openingChat = false;
+        }).then(() => {
+            this._openingChat = false;
+        }).guardedCatch(() => {
+            this._openingChat = false;
         });
     }, 200, true),
     /**
@@ -300,7 +299,6 @@ var LivechatButton = Widget.extend({
      * @return {Promise}
      */
     _openChatWindow: function () {
-        var self = this;
         var options = {
             displayStars: false,
             headerBackgroundColor: this.options.header_background_color,
@@ -308,11 +306,11 @@ var LivechatButton = Widget.extend({
             titleColor: this.options.title_color,
         };
         this._chatWindow = new WebsiteLivechatWindow(this, this._livechat, options);
-        return this._chatWindow.appendTo($('body')).then(function () {
+        return this._chatWindow.appendTo($('body')).then(() => {
             var cssProps = { bottom: 0 };
             cssProps[_t.database.parameters.direction === 'rtl' ? 'left' : 'right'] = 0;
-            self._chatWindow.$el.css(cssProps);
-            self.$el.hide();
+            this._chatWindow.$el.css(cssProps);
+            this.$el.hide();
         });
     },
     /**
@@ -342,14 +340,13 @@ var LivechatButton = Widget.extend({
      * @return {Promise}
      */
     _sendMessage: function (message) {
-        var self = this;
         this._livechat._notifyMyselfTyping({ typing: false });
         return session
             .rpc('/mail/chat_post', { uuid: this._livechat.getUUID(), message_content: message.content })
-            .then(function (messageId) {
+            .then((messageId) => {
                 if (!messageId) {
                     try {
-                        self.displayNotification({
+                        this.displayNotification({
                             message: _t("Session expired... Please refresh and try again."),
                             sticky: true,
                         });
@@ -364,9 +361,9 @@ var LivechatButton = Widget.extend({
                          */
                         console.warn(_t("Session expired... Please refresh and try again."));
                     }
-                    self._closeChat();
+                    this._closeChat();
                 }
-                self._chatWindow.scrollToBottom();
+                this._chatWindow.scrollToBottom();
             });
     },
     /**
@@ -413,9 +410,8 @@ var LivechatButton = Widget.extend({
      * @param {Array[]} notifications
      */
     _onNotification: function (notifications) {
-        var self = this;
-        _.each(notifications, function (notification) {
-            self._handleNotification(notification);
+        _.each(notifications, (notification) => {
+            this._handleNotification(notification);
         });
     },
     /**
@@ -425,11 +421,10 @@ var LivechatButton = Widget.extend({
      */
     _onPostMessageChatWindow: function (ev) {
         ev.stopPropagation();
-        var self = this;
         var messageData = ev.data.messageData;
-        this._sendMessage(messageData).guardedCatch(function (reason) {
+        this._sendMessage(messageData).guardedCatch((reason) => {
             reason.event.preventDefault();
-            return self._sendMessage(messageData); // try again just in case
+            return this._sendMessage(messageData); // try again just in case
         });
     },
     /**

--- a/addons/im_livechat/static/src/legacy/widgets/thread.js
+++ b/addons/im_livechat/static/src/legacy/widgets/thread.js
@@ -115,7 +115,6 @@ var ThreadWidget = Widget.extend({
      * @param {boolean} [options.squashCloseMessages]
      */
     render: function (thread, options) {
-        var self = this;
 
         var shouldScrollToBottomAfterRendering = false;
         if (this._currentThreadID === thread.getID() && this.isAtBottom()) {
@@ -189,11 +188,11 @@ var ThreadWidget = Widget.extend({
             dateFormat: time.getLangDatetimeFormat(),
         }));
 
-        _.each(messages, function (message) {
-            var $message = self.$('.o_thread_message[data-message-id="' + message.getID() + '"]');
+        _.each(messages, (message) => {
+            var $message = this.$('.o_thread_message[data-message-id="' + message.getID() + '"]');
             $message.find('.o_mail_timestamp').data('date', message.getDate());
 
-            self._insertReadMore($message);
+            this._insertReadMore($message);
         });
 
         if (shouldScrollToBottomAfterRendering) {
@@ -201,8 +200,8 @@ var ThreadWidget = Widget.extend({
         }
 
         if (!this._updateTimestampsInterval) {
-            this.updateTimestampsInterval = setInterval(function () {
-                self._updateTimestamps();
+            this.updateTimestampsInterval = setInterval(() => {
+                this._updateTimestamps();
             }, 1000 * 60);
         }
 
@@ -247,14 +246,13 @@ var ThreadWidget = Widget.extend({
      * @param {Object} [options] options for the thread rendering
      */
     removeMessageAndRender: function (messageID, thread, options) {
-        var self = this;
         this._currentThreadID = thread.getID();
-        return new Promise(function (resolve, reject) {
-            self.$('.o_thread_message[data-message-id="' + messageID + '"]')
+        return new Promise((resolve, reject) => {
+            this.$('.o_thread_message[data-message-id="' + messageID + '"]')
             .fadeOut({
-                done: function () {
-                    if (self._currentThreadID === thread.getID()) {
-                        self.render(thread, options);
+                done: () => {
+                    if (this._currentThreadID === thread.getID()) {
+                        this.render(thread, options);
                     }
                     resolve();
                 },
@@ -335,7 +333,6 @@ var ThreadWidget = Widget.extend({
      * @param {jQuery} $element
      */
     _insertReadMore: function ($element) {
-        var self = this;
 
         var groups = [];
         var readMoreNodes;
@@ -349,7 +346,7 @@ var ThreadWidget = Widget.extend({
                         this.nodeValue.trim();
             });
 
-        _.each($children, function (child) {
+        _.each($children, (child) => {
             var $child = $(child);
 
             // Hide Text nodes if "stopSpelling"
@@ -381,7 +378,7 @@ var ThreadWidget = Widget.extend({
                 readMoreNodes.push($child);
             } else {
                 readMoreNodes = undefined;
-                self._insertReadMore($child);
+                this._insertReadMore($child);
             }
         });
 


### PR DESCRIPTION
`this` is annoying in JS, and function are not bound to proper `this`
in general.
You can use arrow functions `() => {}` to keep `this` in the scope of
where the arrow function is written.
This would avoid shell game with `var self = this` and use `self` in
inner function.

Example:
    `var self = this;`
    `function () { self.x }`

Just becomes:
    `() => { this.x }`

task-2825104