### PR TITLE
[MOV] im_livechat: replace underscore.js methods in legacy livechat

### DIFF
--- a/addons/im_livechat/static/src/legacy/models/abstract_message.js
+++ b/addons/im_livechat/static/src/legacy/models/abstract_message.js
@@ -450,9 +450,9 @@ var AbstractMessage = Class.extend({
      * @private
      */
     _processAttachmentURL: function () {
-        _.each(this.getAttachments(), function (attachment) {
+        for (let attachment of this.getAttachments()) {
             attachment.url = '/web/content/' + attachment.id + '?download=true';
-        });
+        }
     },
 
 });

--- a/addons/im_livechat/static/src/legacy/models/website_livechat_window.js
+++ b/addons/im_livechat/static/src/legacy/models/website_livechat_window.js
@@ -9,7 +9,7 @@ var AbstractThreadWindow = require('im_livechat.legacy.mail.AbstractThreadWindow
  * @see im_livechat.legacy.mail.AbstractThreadWindow for more information
  */
 var LivechatWindow = AbstractThreadWindow.extend({
-    events: _.extend(AbstractThreadWindow.prototype.events, {
+    events: Object.assign(AbstractThreadWindow.prototype.events, {
         'input .o_composer_text_field': '_onInput',
     }),
     /**

--- a/addons/im_livechat/static/src/legacy/widgets/feedback.js
+++ b/addons/im_livechat/static/src/legacy/widgets/feedback.js
@@ -8,6 +8,7 @@ var utils = require('web.utils');
 var Widget = require('web.Widget');
 
 var { RATING_TO_EMOJI } = require('im_livechat.legacy.im_livechat.Constants');
+var { sprintf } = require('web.utils');
 
 var _t = core._t;
 /*
@@ -57,7 +58,7 @@ var Feedback = Widget.extend({
         this.dp.add(session.rpc('/im_livechat/feedback', args)).then(function (response) {
             var emoji = RATING_TO_EMOJI[self.rating] || "??";
             if (!reason) {
-                var content = utils.sprintf(_t("Rating: %s"), emoji);
+                var content = sprintf(_t("Rating: %s"), emoji);
             }
             else {
                 var content = "Rating reason: \n" + reason;

--- a/addons/im_livechat/static/src/legacy/widgets/livechat_button.js
+++ b/addons/im_livechat/static/src/legacy/widgets/livechat_button.js
@@ -101,7 +101,7 @@ var LivechatButton = Widget.extend({
      * @param {Object} [options={}]
      */
     _addMessage: function (data, options) {
-        options = _.extend({}, this.options, options, {
+        options = Object.assign({}, this.options, options, {
             serverURL: this._serverURL,
         });
         var message = new WebsiteLivechatMessage(this, data, options);
@@ -203,9 +203,9 @@ var LivechatButton = Widget.extend({
      */
     _loadQWebTemplate: function () {
         return session.rpc('/im_livechat/load_templates').then(function (templates) {
-            _.each(templates, function (template) {
+            for (let template of templates) {
                 QWeb.add_template(template);
-            });
+            }
         });
     },
     /**
@@ -397,7 +397,7 @@ var LivechatButton = Widget.extend({
     _onCloseChatWindow: function (ev) {
         ev.stopPropagation();
         var isComposerDisabled = this._chatWindow.$('.o_thread_composer input').prop('disabled');
-        var shouldAskFeedback = !isComposerDisabled && _.find(this._messages, function (message) {
+        var shouldAskFeedback = !isComposerDisabled && this._messages.find(function (message) {
             return message.getID() !== '_welcome';
         });
         if (shouldAskFeedback) {
@@ -414,9 +414,9 @@ var LivechatButton = Widget.extend({
      */
     _onNotification: function (notifications) {
         var self = this;
-        _.each(notifications, function (notification) {
+        for (let notification of notifications) {
             self._handleNotification(notification);
-        });
+        }
     },
     /**
      * @private

--- a/addons/im_livechat/static/src/legacy/widgets/thread.js
+++ b/addons/im_livechat/static/src/legacy/widgets/thread.js
@@ -130,11 +130,12 @@ var ThreadWidget = Widget.extend({
                                                     this._enabledOptions;
 
         // attachments ordered by messages order (increasing ID)
-        this.attachments = _.uniq(_.flatten(_.map(messages, function (message) {
+        // [ ...newSet() ]
+        this.attachments = [...new Set(_.flatten(messages.map(function (message) {
             return message.getAttachments();
-        })));
+        })))];
 
-        options = _.extend({}, modeOptions, options, {
+        options = Object.assign({}, modeOptions, options, {
             selectedMessageID: this._selectedMessageID,
         });
 
@@ -147,7 +148,7 @@ var ThreadWidget = Widget.extend({
         // and in the same document (users can now post message in documents
         // directly from a channel that follows it)
         var prevMessage;
-        _.each(messages, function (message) {
+        for (let message of messages) {
             if (
                 // is first message of thread
                 !prevMessage ||
@@ -175,7 +176,7 @@ var ThreadWidget = Widget.extend({
                 displayAuthorMessages[message.getID()] = !options.squashCloseMessages;
             }
             prevMessage = message;
-        });
+        }
 
         if (modeOptions.displayOrder === ORDER.DESC) {
             messages.reverse();
@@ -189,12 +190,12 @@ var ThreadWidget = Widget.extend({
             dateFormat: time.getLangDatetimeFormat(),
         }));
 
-        _.each(messages, function (message) {
+        for (let message of messages) {
             var $message = self.$('.o_thread_message[data-message-id="' + message.getID() + '"]');
             $message.find('.o_mail_timestamp').data('date', message.getDate());
 
             self._insertReadMore($message);
-        });
+        }
 
         if (shouldScrollToBottomAfterRendering) {
             this.scrollToBottom();
@@ -349,7 +350,7 @@ var ThreadWidget = Widget.extend({
                         this.nodeValue.trim();
             });
 
-        _.each($children, function (child) {
+        for (let child of $children) {
             var $child = $(child);
 
             // Hide Text nodes if "stopSpelling"
@@ -383,9 +384,9 @@ var ThreadWidget = Widget.extend({
                 readMoreNodes = undefined;
                 self._insertReadMore($child);
             }
-        });
+        }
 
-        _.each(groups, function (group) {
+        for (let group of groups) {
             // Insert link just before the first node
             var $readMore = $('<a>', {
                 class: 'o_mail_read_more',
@@ -398,13 +399,13 @@ var ThreadWidget = Widget.extend({
             $readMore.click(function (e) {
                 e.preventDefault();
                 isReadMore = !isReadMore;
-                _.each(group, function ($child) {
+                for (let $child of group) {
                     $child.hide();
                     $child.toggle(!isReadMore);
-                });
+                }
                 $readMore.text(isReadMore ? READ_MORE : READ_LESS);
             });
-        });
+        }
     },
     /**
     * @private
@@ -457,7 +458,7 @@ var ThreadWidget = Widget.extend({
             offset: '0, 1',
             content: function () {
                 var messageID = $(this).data('message-id');
-                var message = _.find(messages, function (message) {
+                var message = messages.find(function (message) {
                     return message.getID() === messageID;
                 });
                 return QWeb.render('im_livechat.legacy.mail.widget.Thread.Message.MailTooltip', {


### PR DESCRIPTION
We used underscore.js to have some utils function that native JS lacked in ES5.

But since ES6, it's best to use native: more performant, better syntax
for readability, and also underscore.js is problematic in many aspects:
(versioning, conflict in external livechat, artificial function nesting, etc.) 

Change some uses of underscore.js that are easily changeable. Like

- `_.each()` => `for of` loop;
- `_.str.sprintf` => `sprintf` (Odoo `web.utils` import)
- `_.extend` => `Object.assign()`
- `_.uniq` => `[...new Set()]`
- `_.map` => `.map()`
- `_.find` => `.find()`

Task-2825104
