### PR TITLE
[FIX] web_editor: save editor value during urgentSave

### DIFF
--- a/addons/web_editor/static/src/js/backend/field_html.js
+++ b/addons/web_editor/static/src/js/backend/field_html.js
@@ -98,6 +98,7 @@ var FieldHtml = basic_fields.DebouncedField.extend(TranslatableFieldMixin, {
         }
         var _super = this._super.bind(this);
         this.wysiwyg.odooEditor.clean();
+        this._setValue(this._getValue());
         return this.wysiwyg.saveModifiedImages(this.$content).then(async () => {
             await this.wysiwyg.preSavePromise;
             this._isDirty = this.wysiwyg.isDirty();


### PR DESCRIPTION
Ensure the current editor value is set in the Odoo FieldHtml during
`commitChanges` so it can be used by the `urgentSave` when needed.


--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
