### PR TITLE
[FIX] account_facturx: reliable currency

### DIFF
--- a/addons/account_facturx/models/account_move.py
+++ b/addons/account_facturx/models/account_move.py
@@ -89,9 +89,9 @@ class AccountMove(models.Model):
             )
 
             if line.discount == 100.0:
-                gross_price_subtotal = line.currency_id.round(line.price_unit * line.quantity)
+                gross_price_subtotal = line.always_set_currency_id.round(line.price_unit * line.quantity)
             else:
-                gross_price_subtotal = line.currency_id.round(line.price_subtotal / (1 - (line.discount / 100.0)))
+                gross_price_subtotal = line.always_set_currency_id.round(line.price_subtotal / (1 - (line.discount / 100.0)))
             line_template_values = {
                 'line': line,
                 'index': i + 1,


### PR DESCRIPTION
Related issue: 

- [x] https://github.com/odoo/odoo/issues/89816

Fix blocking error introduced by this commit https://github.com/odoo/odoo/commit/95f4794ea8dbd415f190ad722bf3aef15f0895cd

- [x] PR: https://github.com/odoo/odoo/pull/89650

Currency isn't required at account.move.line level. Better use its account.move one.

Otherwise, we'll get a singleton error when printing an invoice which lines currency isn't set.

cc @Tecnativa TT36163


--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
