### PR TITLE
[IMP] web: update owl to latest version

### DIFF
--- a/addons/web/static/lib/owl/owl.js
+++ b/addons/web/static/lib/owl/owl.js
@@ -1728,17 +1728,8 @@
                 return vnode.text;
             }
             const node = document.createElement(vnode.sel);
-            const elem = patch(node, vnode).elm;
-            function escapeTextNodes(node) {
-                if (node.nodeType === 3) {
-                    node.textContent = escape(node.textContent);
-                }
-                for (let n of node.childNodes) {
-                    escapeTextNodes(n);
-                }
-            }
-            escapeTextNodes(elem);
-            return elem.outerHTML;
+            const result = patch(node, vnode);
+            return result.elm.outerHTML;
         }
         /**
          * Force all widgets connected to this QWeb instance to rerender themselves.
@@ -5578,8 +5569,8 @@ See https://github.com/odoo/owl/blob/master/doc/reference/config.md#mode for mor
 
 
     __info__.version = '1.4.10';
-    __info__.date = '2021-12-07T14:32:29.551Z';
-    __info__.hash = 'bc04f72';
+    __info__.date = '2022-04-27T09:54:49.146Z';
+    __info__.hash = 'c060490';
     __info__.url = 'https://github.com/odoo/owl';
 
 


### PR DESCRIPTION
This version includes a fix pertaining to the double-escaping of text in
t-esc.
