### PR TITLE
[FIX] account: Fix reconcile not posted entries in register payment w…

### DIFF
--- a/addons/account/wizard/account_payment_register.py
+++ b/addons/account/wizard/account_payment_register.py
@@ -621,7 +621,11 @@ class AccountPaymentRegister(models.TransientModel):
                                             to which a payment will be created (see '_get_batches').
         :param edit_mode:   Is the wizard in edition mode.
         """
-        domain = [('account_internal_type', 'in', ('receivable', 'payable')), ('reconciled', '=', False)]
+        domain = [
+            ('parent_state', '=', 'posted'),
+            ('account_internal_type', 'in', ('receivable', 'payable')),
+            ('reconciled', '=', False),
+        ]
         for vals in to_process:
             payment_lines = vals['payment'].line_ids.filtered_domain(domain)
             lines = vals['to_reconcile']


### PR DESCRIPTION
…izard

Fix a lost condition during a refactoring introduced by:
https://github.com/odoo/odoo/pull/82025

When dealing with payment transactions, a payment could be still in draft even after the call the 'action_post'.

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
