### PR TITLE
[FIX] website,website_sale: fix unable to save in multi company settings

### DIFF
--- a/addons/website/models/res_config_settings.py
+++ b/addons/website/models/res_config_settings.py
@@ -133,7 +133,9 @@ class ResConfigSettings(models.TransientModel):
     @api.depends('website_id.auth_signup_uninvited')
     def _compute_auth_signup_uninvited(self):
         for config in self:
-            config.auth_signup_uninvited = config.website_id.auth_signup_uninvited
+            # Default to `b2b` in case no website is set to avoid not being
+            # able to save.
+            config.auth_signup_uninvited = config.website_id.auth_signup_uninvited or 'b2b'
 
     def _inverse_auth_signup_uninvited(self):
         for config in self:


### PR DESCRIPTION
This commit is a follow-up to https://github.com/odoo/odoo/pull/89707

The above PR fixed most issues with the configuration but since the
default value was not set anymore for `auth_signup_uninvited` a
configuration with no website attached would make the config not
saveable (required field not set).
