### PR TITLE
[FIX] project: fixed tooltip text on hovering the priority widget

### DIFF
--- a/addons/web/static/src/legacy/js/fields/basic_fields.js
+++ b/addons/web/static/src/legacy/js/fields/basic_fields.js
@@ -2612,7 +2612,8 @@ var PriorityWidget = AbstractField.extend({
         const isReadonly = this.record.evalModifiers(this.attrs.modifiers).readonly;
         _.each(this.field.selection.slice(1), function (choice, index) {
             const tag = isReadonly ? '<span>' : '<a href="#">';
-            self.$el.append(self._renderStar(tag, index_value >= index + 1, index + 1, `${self.string}: ${choice[1]}`, index_value));
+            const tipValue = (self.empty_value == self.value && index_value === index) ? self.field.selection[0][1] : choice[1];
+            self.$el.append(self._renderStar(tag, index_value >= index + 1, index + 1, `${self.string}: ${tipValue}`, index_value));
         });
     },
 


### PR DESCRIPTION
currently the tooltip text contains the wrong content on hovering
the priority field widget. it always displays the priority:high when hovering
on the priority field.

so this commit fixes the issue by overriding the mouseover effect of
priority widget so that the priority widget display the priority:high if the
task is important otherwise it displays the priority:low on hover

task-2823432