### PR TITLE
[FIX] Use currency of analytic line

### DIFF
--- a/addons/hr_timesheet/models/hr_timesheet.py
+++ b/addons/hr_timesheet/models/hr_timesheet.py
@@ -183,7 +183,7 @@ class AccountAnalyticLine(models.Model):
                 cost = timesheet.employee_id.timesheet_cost or 0.0
                 amount = -timesheet.unit_amount * cost
                 amount_converted = timesheet.employee_id.currency_id._convert(
-                    amount, timesheet.account_id.currency_id, self.env.company, timesheet.date)
+                    amount, timesheet.account_id.currency_id or timesheet.currency_id, self.env.company, timesheet.date)
                 result[timesheet.id].update({
                     'amount': amount_converted,
                 })


### PR DESCRIPTION
Description of the issue/feature this PR addresses:

As the company is not mandatory on both the employee and the analytical account, if neither is filled in, it causes the application to crash. It is more coherent to take the currency on the current analytical line which is based on that of the current company (mandatory on this model)

Current behavior before PR:

Crash on timesheet creation (https://youtu.be/Qcnb4i7pYgM) 

Desired behavior after PR is merged:

Timesheet created without crash

OPW : 2834704



--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
