### PR TITLE
[IMP] account: Add index on tax_cash_basis_rec_id

### DIFF
--- a/addons/account/models/account_move.py
+++ b/addons/account/models/account_move.py
@@ -244,6 +244,7 @@ class AccountMove(models.Model):
     tax_cash_basis_rec_id = fields.Many2one(
         'account.partial.reconcile',
         string='Tax Cash Basis Entry of',
+        index=True,
         help="Technical field used to keep track of the tax cash basis reconciliation. "
              "This is needed when cancelling the source: it will post the inverse journal entry to cancel that part too.")
     tax_cash_basis_move_id = fields.Many2one(


### PR DESCRIPTION
Description of the issue/feature this PR addresses:

Increase performances when unreconcile entries.

Current behavior before PR:

When unreconciling a great statement (e.g.: Electronic payment statement entries), the Unreconcile wizard fail and never ends (process is killed).

Desired behavior after PR is merged:

Unreconciliation is done.



As for https://github.com/odoo/odoo/pull/83472, this is unacceptable for Odoo. I do it for records. @Levizar 


--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
