### PR TITLE
[IMP] mail, *: replace link commands to replace

### DIFF
--- a/addons/hr/static/src/models/employee.js
+++ b/addons/hr/static/src/models/employee.js
@@ -2,7 +2,7 @@
 
 import { registerModel } from '@mail/model/model_core';
 import { attr, one } from '@mail/model/model_field';
-import { insert, unlink } from '@mail/model/model_field_command';
+import { clear, insert } from '@mail/model/model_field_command';
 
 registerModel({
     name: 'Employee',
@@ -20,7 +20,7 @@ registerModel({
             if ('user_id' in data) {
                 data2.hasCheckedUser = true;
                 if (!data.user_id) {
-                    data2.user = unlink();
+                    data2.user = clear();
                 } else {
                     const partnerNameGet = data['user_partner_id'];
                     const partnerData = {

--- a/addons/hr_holidays/static/tests/qunit_suite_tests/components/thread_view_tests.js
+++ b/addons/hr_holidays/static/tests/qunit_suite_tests/components/thread_view_tests.js
@@ -1,6 +1,6 @@
 /** @odoo-module **/
 
-import { insertAndReplace, link } from '@mail/model/model_field_command';
+import { insertAndReplace, replace } from '@mail/model/model_field_command';
 import {
     start,
     startServer,
@@ -36,7 +36,7 @@ QUnit.test('out of office message on direct chat with out of office partner', as
     const threadViewer = messaging.models['ThreadViewer'].create({
         hasThreadView: true,
         qunitTest: insertAndReplace(),
-        thread: link(thread),
+        thread: replace(thread),
     });
     await createThreadViewComponent(threadViewer.threadView);
     assert.containsOnce(

--- a/addons/im_livechat/static/src/models/thread.js
+++ b/addons/im_livechat/static/src/models/thread.js
@@ -65,7 +65,7 @@ patchModelMethods('Thread', {
                     )
                 );
                 data2.members.push(link(partner));
-                data2.correspondent = link(partner);
+                data2.correspondent = replace(partner);
             } else {
                 const partnerData = this.messaging.models['Partner'].convertData(data.livechat_visitor);
                 data2.members.push(insert(partnerData));

--- a/addons/mail/static/src/models/activity.js
+++ b/addons/mail/static/src/models/activity.js
@@ -2,7 +2,7 @@
 
 import { registerModel } from '@mail/model/model_core';
 import { attr, many, one } from '@mail/model/model_field';
-import { clear, insert, unlink, unlinkAll } from '@mail/model/model_field_command';
+import { clear, insert } from '@mail/model/model_field_command';
 
 const { markup } = owl;
 
@@ -50,7 +50,7 @@ registerModel({
             // relation
             if ('activity_type_id' in data) {
                 if (!data.activity_type_id) {
-                    data2.type = unlinkAll();
+                    data2.type = clear();
                 } else {
                     data2.type = insert({
                         displayName: data.activity_type_id[1],
@@ -60,7 +60,7 @@ registerModel({
             }
             if ('create_uid' in data) {
                 if (!data.create_uid) {
-                    data2.creator = unlinkAll();
+                    data2.creator = clear();
                 } else {
                     data2.creator = insert({
                         id: data.create_uid[0],
@@ -79,7 +79,7 @@ registerModel({
             }
             if ('user_id' in data) {
                 if (!data.user_id) {
-                    data2.assignee = unlinkAll();
+                    data2.assignee = clear();
                 } else {
                     data2.assignee = insert({
                         id: data.user_id[0],
@@ -89,7 +89,7 @@ registerModel({
             }
             if ('request_partner_id' in data) {
                 if (!data.request_partner_id) {
-                    data2.requestingPartner = unlink();
+                    data2.requestingPartner = clear();
                 } else {
                     data2.requestingPartner = insert({
                         id: data.request_partner_id[0],

--- a/addons/mail/static/src/models/chat_window.js
+++ b/addons/mail/static/src/models/chat_window.js
@@ -2,7 +2,7 @@
 
 import { registerModel } from '@mail/model/model_core';
 import { attr, one } from '@mail/model/model_field';
-import { clear, insertAndReplace, link, unlink } from '@mail/model/model_field_command';
+import { clear, insertAndReplace, replace } from '@mail/model/model_field_command';
 import { isEventHandled, markEventHandled } from '@mail/utils/utils';
 
 registerModel({
@@ -511,7 +511,7 @@ registerModel({
             return insertAndReplace({
                 compact: true,
                 hasThreadView: this.hasThreadView,
-                thread: this.thread ? link(this.thread) : unlink(),
+                thread: this.thread ? replace(this.thread) : clear(),
             });
         },
         /**

--- a/addons/mail/static/src/models/chat_window_manager.js
+++ b/addons/mail/static/src/models/chat_window_manager.js
@@ -2,7 +2,7 @@
 
 import { registerModel } from '@mail/model/model_core';
 import { attr, many, one } from '@mail/model/model_field';
-import { clear, insertAndReplace, link, replace, unlink } from '@mail/model/model_field_command';
+import { clear, insertAndReplace, link, replace } from '@mail/model/model_field_command';
 
 const BASE_VISUAL = {
     /**
@@ -121,8 +121,8 @@ registerModel({
             if (!chatWindow) {
                 chatWindow = this.messaging.models['ChatWindow'].create({
                     isFolded,
-                    manager: link(this),
-                    thread: link(thread),
+                    manager: replace(this),
+                    thread: replace(thread),
                 });
             } else {
                 chatWindow.update({ isFolded });
@@ -262,9 +262,9 @@ registerModel({
         _computeLastVisible() {
             const { length: l, [l - 1]: lastVisible } = this.allOrderedVisible;
             if (!lastVisible) {
-                return unlink();
+                return clear();
             }
-            return link(lastVisible);
+            return replace(lastVisible);
         },
         /**
          * @private

--- a/addons/mail/static/src/models/chatter.js
+++ b/addons/mail/static/src/models/chatter.js
@@ -2,7 +2,7 @@
 
 import { registerModel } from '@mail/model/model_core';
 import { attr, one } from '@mail/model/model_field';
-import { clear, insert, insertAndReplace, link, unlink } from '@mail/model/model_field_command';
+import { clear, insert, insertAndReplace, link, replace } from '@mail/model/model_field_command';
 import { OnChange } from '@mail/model/model_onchange';
 
 const getThreadNextTemporaryId = (function () {
@@ -193,7 +193,7 @@ registerModel({
             return insertAndReplace({
                 hasThreadView: this.hasThreadView,
                 order: 'desc',
-                thread: this.thread ? link(this.thread) : unlink(),
+                thread: this.thread ? replace(this.thread) : clear(),
             });
         },
         /**
@@ -226,7 +226,7 @@ registerModel({
             } else if (!this.thread || !this.thread.isTemporary) {
                 const currentPartner = this.messaging.currentPartner;
                 const message = this.messaging.models['Message'].create({
-                    author: link(currentPartner),
+                    author: replace(currentPartner),
                     body: this.env._t("Creating a new record..."),
                     id: getMessageNextTemporaryId(),
                     isTemporary: true,

--- a/addons/mail/static/src/models/discuss.js
+++ b/addons/mail/static/src/models/discuss.js
@@ -2,7 +2,7 @@
 
 import { registerModel } from '@mail/model/model_core';
 import { attr, many, one } from '@mail/model/model_field';
-import { clear, insertAndReplace, link, replace, unlink } from '@mail/model/model_field_command';
+import { clear, insertAndReplace, replace } from '@mail/model/model_field_command';
 import { escape, sprintf } from '@web/core/utils/strings';
 
 registerModel({
@@ -158,7 +158,7 @@ registerModel({
          */
         async openThread(thread, { focus } = {}) {
             this.update({
-                thread: link(thread),
+                thread: replace(thread),
             });
             if (focus !== undefined ? focus : !this.messaging.device.isMobileDevice) {
                 this.focus();
@@ -323,7 +323,7 @@ registerModel({
          */
         _computeThread() {
             if (!this.thread || !this.thread.isPinned) {
-                return unlink();
+                return clear();
             }
         },
         /**
@@ -335,7 +335,7 @@ registerModel({
                 hasMemberList: true,
                 hasThreadView: this.hasThreadView,
                 hasTopbar: true,
-                thread: this.thread ? link(this.thread) : unlink(),
+                thread: this.thread ? replace(this.thread) : clear(),
             });
         },
     },

--- a/addons/mail/static/src/models/discuss_public_view.js
+++ b/addons/mail/static/src/models/discuss_public_view.js
@@ -2,7 +2,7 @@
 
 import { attr, one } from '@mail/model/model_field';
 import { registerModel } from '@mail/model/model_core';
-import { clear, insertAndReplace, link } from '@mail/model/model_field_command';
+import { clear, insertAndReplace, replace } from '@mail/model/model_field_command';
 
 registerModel({
     name: 'DiscussPublicView',
@@ -18,7 +18,7 @@ registerModel({
                     hasMemberList: true,
                     hasThreadView: true,
                     hasTopbar: true,
-                    thread: link(this.channel),
+                    thread: replace(this.channel),
                 }),
                 welcomeView: clear(),
             });
@@ -38,7 +38,7 @@ registerModel({
             this.update({
                 threadViewer: clear(),
                 welcomeView: insertAndReplace({
-                    channel: link(this.channel),
+                    channel: replace(this.channel),
                     isDoFocusGuestNameInput: true,
                     originalGuestName: this.messaging.currentGuest && this.messaging.currentGuest.name,
                     pendingGuestName: this.messaging.currentGuest && this.messaging.currentGuest.name,

--- a/addons/mail/static/src/models/follower.js
+++ b/addons/mail/static/src/models/follower.js
@@ -2,7 +2,7 @@
 
 import { registerModel } from '@mail/model/model_core';
 import { attr, many, one } from '@mail/model/model_field';
-import { clear, insert, insertAndReplace, link, unlink, unlinkAll } from '@mail/model/model_field_command';
+import { clear, insert, insertAndReplace, link, unlink } from '@mail/model/model_field_command';
 
 registerModel({
     name: 'Follower',
@@ -22,7 +22,7 @@ registerModel({
             }
             if ('partner_id' in data) {
                 if (!data.partner_id) {
-                    data2.partner = unlinkAll();
+                    data2.partner = clear();
                 } else {
                     const partnerData = {
                         display_name: data.display_name,
@@ -104,7 +104,7 @@ registerModel({
                 route: '/mail/read_subscription_data',
                 params: { follower_id: this.id },
             }));
-            this.update({ subtypes: unlinkAll() });
+            this.update({ subtypes: clear() });
             for (const data of subtypesData) {
                 const subtype = this.messaging.models['FollowerSubtype'].insert(
                     this.messaging.models['FollowerSubtype'].convertData(data)

--- a/addons/mail/static/src/models/message.js
+++ b/addons/mail/static/src/models/message.js
@@ -2,7 +2,7 @@
 
 import { registerModel } from '@mail/model/model_core';
 import { attr, many, one } from '@mail/model/model_field';
-import { clear, insert, insertAndReplace, replace, unlinkAll } from '@mail/model/model_field_command';
+import { clear, insert, insertAndReplace, replace } from '@mail/model/model_field_command';
 import emojis from '@mail/js/emojis';
 import { addLink, htmlToTextContentInline, parseAndTransform, timeFromNow } from '@mail/js/utils';
 
@@ -26,7 +26,7 @@ registerModel({
             const data2 = {};
             if ('attachment_ids' in data) {
                 if (!data.attachment_ids) {
-                    data2.attachments = unlinkAll();
+                    data2.attachments = clear();
                 } else {
                     data2.attachments = insertAndReplace(data.attachment_ids.map(attachmentData =>
                         this.messaging.models['Attachment'].convertData(attachmentData)
@@ -35,7 +35,7 @@ registerModel({
             }
             if ('author_id' in data) {
                 if (!data.author_id) {
-                    data2.author = unlinkAll();
+                    data2.author = clear();
                 } else if (data.author_id[0] !== 0) {
                     // partner id 0 is a hack of message_format to refer to an
                     // author non-related to a partner. display_name equals

--- a/addons/mail/static/src/models/message_seen_indicator.js
+++ b/addons/mail/static/src/models/message_seen_indicator.js
@@ -2,7 +2,7 @@
 
 import { registerModel } from '@mail/model/model_core';
 import { attr, many, one } from '@mail/model/model_field';
-import { clear, replace, unlinkAll } from '@mail/model/model_field_command';
+import { clear, replace } from '@mail/model/model_field_command';
 import { sprintf } from '@web/core/utils/strings';
 
 registerModel({
@@ -118,7 +118,7 @@ registerModel({
          */
         _computePartnersThatHaveFetched() {
             if (!this.message || !this.thread || !this.thread.partnerSeenInfos) {
-                return unlinkAll();
+                return clear();
             }
             const otherPartnersThatHaveFetched = this.thread.partnerSeenInfos
                 .filter(partnerSeenInfo =>
@@ -134,7 +134,7 @@ registerModel({
                 )
                 .map(partnerSeenInfo => partnerSeenInfo.partner);
             if (otherPartnersThatHaveFetched.length === 0) {
-                return unlinkAll();
+                return clear();
             }
             return replace(otherPartnersThatHaveFetched);
         },
@@ -147,7 +147,7 @@ registerModel({
          */
         _computePartnersThatHaveSeen() {
             if (!this.message || !this.thread || !this.thread.partnerSeenInfos) {
-                return unlinkAll();
+                return clear();
             }
             const otherPartnersThatHaveSeen = this.thread.partnerSeenInfos
                 .filter(partnerSeenInfo =>
@@ -162,7 +162,7 @@ registerModel({
                     partnerSeenInfo.lastSeenMessage.id >= this.message.id)
                 .map(partnerSeenInfo => partnerSeenInfo.partner);
             if (otherPartnersThatHaveSeen.length === 0) {
-                return unlinkAll();
+                return clear();
             }
             return replace(otherPartnersThatHaveSeen);
         },

--- a/addons/mail/static/src/models/messaging.js
+++ b/addons/mail/static/src/models/messaging.js
@@ -3,7 +3,7 @@
 import { registerModel } from '@mail/model/model_core';
 import { attr, many, one } from '@mail/model/model_field';
 import { OnChange } from '@mail/model/model_onchange';
-import { clear, insertAndReplace, link, replace, unlink } from '@mail/model/model_field_command';
+import { clear, insertAndReplace, replace } from '@mail/model/model_field_command';
 import { makeDeferred } from '@mail/utils/deferred';
 
 const { EventBus } = owl;
@@ -146,10 +146,10 @@ registerModel({
             });
             const focusedSessionId = this.focusedRtcSession && this.focusedRtcSession.id;
             if (!sessionId || focusedSessionId === sessionId) {
-                this.update({ focusedRtcSession: unlink() });
+                this.update({ focusedRtcSession: clear() });
                 return;
             }
-            this.update({ focusedRtcSession: link(rtcSession) });
+            this.update({ focusedRtcSession: replace(rtcSession) });
             if (this.userSetting.rtcLayout !== 'tiled') {
                 return;
             }

--- a/addons/mail/static/src/models/messaging_initializer.js
+++ b/addons/mail/static/src/models/messaging_initializer.js
@@ -2,7 +2,7 @@
 
 import { registerModel } from '@mail/model/model_core';
 import { executeGracefully } from '@mail/utils/utils';
-import { link, insert, insertAndReplace } from '@mail/model/model_field_command';
+import { link, insert, insertAndReplace, replace } from '@mail/model/model_field_command';
 
 registerModel({
     name: 'MessagingInitializer',
@@ -205,7 +205,7 @@ registerModel({
                 // implicit: failures are sent by the server at initialization
                 // only if the current partner is author of the message
                 if (!message.author && this.messaging.currentPartner) {
-                    message.update({ author: link(this.messaging.currentPartner) });
+                    message.update({ author: replace(this.messaging.currentPartner) });
                 }
             }));
         },

--- a/addons/mail/static/src/models/messaging_notification_handler.js
+++ b/addons/mail/static/src/models/messaging_notification_handler.js
@@ -1,7 +1,7 @@
 /** @odoo-module **/
 
 import { registerModel } from '@mail/model/model_core';
-import { decrement, increment, insert, insertAndReplace, link, replace, unlink } from '@mail/model/model_field_command';
+import { decrement, increment, insert, insertAndReplace, replace, unlink } from '@mail/model/model_field_command';
 import { htmlToTextContentInline } from '@mail/js/utils';
 
 import { escape, sprintf } from '@web/core/utils/strings';
@@ -316,7 +316,7 @@ registerModel({
             const shouldComputeSeenIndicators = channel.channel_type !== 'channel';
             if (shouldComputeSeenIndicators) {
                 this.messaging.models['ThreadPartnerSeenInfo'].insert({
-                    lastSeenMessage: link(lastMessage),
+                    lastSeenMessage: replace(lastMessage),
                     partner: insertAndReplace({ id: partner_id }),
                     thread: replace(channel),
                 });
@@ -510,7 +510,7 @@ registerModel({
                 // implicit: failures are sent by the server as notification
                 // only if the current partner is author of the message
                 if (!message.author && this.messaging.currentPartner) {
-                    message.update({ author: link(this.messaging.currentPartner) });
+                    message.update({ author: replace(this.messaging.currentPartner) });
                 }
             }
         },
@@ -593,7 +593,7 @@ registerModel({
             );
             const partnerRoot = this.messaging.partnerRoot;
             const message = this.messaging.models['Message'].create(Object.assign(convertedData, {
-                author: link(partnerRoot),
+                author: replace(partnerRoot),
                 id: lastMessageId + 0.01,
                 isTransient: true,
             }));

--- a/addons/mail/static/src/models/notification.js
+++ b/addons/mail/static/src/models/notification.js
@@ -2,7 +2,7 @@
 
 import { registerModel } from '@mail/model/model_core';
 import { attr, one } from '@mail/model/model_field';
-import { clear, insert, insertAndReplace, unlinkAll } from '@mail/model/model_field_command';
+import { clear, insert, insertAndReplace } from '@mail/model/model_field_command';
 
 registerModel({
     name: 'Notification',
@@ -28,7 +28,7 @@ registerModel({
             }
             if ('res_partner_id' in data) {
                 if (!data.res_partner_id) {
-                    data2.partner = unlinkAll();
+                    data2.partner = clear();
                 } else {
                     data2.partner = insert({
                         display_name: data.res_partner_id[1],

--- a/addons/mail/static/src/models/notification_group.js
+++ b/addons/mail/static/src/models/notification_group.js
@@ -2,7 +2,7 @@
 
 import { registerModel } from '@mail/model/model_core';
 import { attr, many, one } from '@mail/model/model_field';
-import { clear, insert, unlink } from '@mail/model/model_field_command';
+import { clear, insert } from '@mail/model/model_field_command';
 import { OnChange } from '@mail/model/model_onchange';
 
 registerModel({
@@ -40,7 +40,7 @@ registerModel({
                   .map(notification => notification.message.originThread.id);
             const threadIds = new Set(notificationsThreadIds);
             if (threadIds.size !== 1) {
-                return unlink();
+                return clear();
             }
             return insert({
                 id: notificationsThreadIds[0],

--- a/addons/mail/static/src/models/partner.js
+++ b/addons/mail/static/src/models/partner.js
@@ -2,7 +2,7 @@
 
 import { registerModel } from '@mail/model/model_core';
 import { attr, many, one } from '@mail/model/model_field';
-import { insert, link, unlinkAll } from '@mail/model/model_field_command';
+import { clear, insert, link } from '@mail/model/model_field_command';
 import { cleanSearchTerm } from '@mail/utils/utils';
 
 registerModel({
@@ -20,7 +20,7 @@ registerModel({
             }
             if ('country' in data) {
                 if (!data.country) {
-                    data2.country = unlinkAll();
+                    data2.country = clear();
                 } else {
                     data2.country = insert({
                         id: data.country[0],
@@ -47,7 +47,7 @@ registerModel({
             // relation
             if ('user_id' in data) {
                 if (!data.user_id) {
-                    data2.user = unlinkAll();
+                    data2.user = clear();
                 } else {
                     let user = {};
                     if (Array.isArray(data.user_id)) {

--- a/addons/mail/static/src/models/rtc_call_viewer.js
+++ b/addons/mail/static/src/models/rtc_call_viewer.js
@@ -5,7 +5,7 @@ import { browser } from "@web/core/browser/browser";
 import { registerModel } from '@mail/model/model_core';
 import { attr, many, one } from '@mail/model/model_field';
 import { OnChange } from '@mail/model/model_onchange';
-import { clear, insert, insertAndReplace, link, unlink } from '@mail/model/model_field_command';
+import { clear, insert, insertAndReplace, replace } from '@mail/model/model_field_command';
 
 import { isEventHandled, markEventHandled } from '@mail/utils/utils';
 
@@ -108,7 +108,7 @@ registerModel({
                 this.update({ rtcLayoutMenu: insertAndReplace() });
                 return;
             }
-            this.update({ rtcLayoutMenu: unlink() });
+            this.update({ rtcLayoutMenu: clear() });
         },
         //----------------------------------------------------------------------
         // Private
@@ -184,16 +184,16 @@ registerModel({
          */
         _computeMainParticipantCard() {
             if (!this.messaging || !this.threadView) {
-                return unlink();
+                return clear();
             }
             if (this.messaging.focusedRtcSession && this.messaging.focusedRtcSession.channel === this.threadView.thread) {
                 return insert({
                     relationalId: `rtc_session_${this.messaging.focusedRtcSession.localId}_${this.threadView.thread.localId}`,
-                    rtcSession: link(this.messaging.focusedRtcSession),
-                    channel: link(this.threadView.thread),
+                    rtcSession: replace(this.messaging.focusedRtcSession),
+                    channel: replace(this.threadView.thread),
                 });
             }
-            return unlink();
+            return clear();
         },
         /**
          * @private
@@ -217,8 +217,8 @@ registerModel({
                 rtcSession.guest && sessionPartners.add(rtcSession.guest.id);
                 tileCards.push({
                     relationalId: `rtc_session_${rtcSession.localId}_${this.threadView.thread.localId}`,
-                    rtcSession: link(rtcSession),
-                    channel: link(this.threadView.thread),
+                    rtcSession: replace(rtcSession),
+                    channel: replace(this.threadView.thread),
                 });
             }
             for (const partner of this.threadView.thread.invitedPartners) {
@@ -227,8 +227,8 @@ registerModel({
                 }
                 tileCards.push({
                     relationalId: `invited_partner_${partner.localId}_${this.threadView.thread.localId}`,
-                    invitedPartner: link(partner),
-                    channel: link(this.threadView.thread),
+                    invitedPartner: replace(partner),
+                    channel: replace(this.threadView.thread),
                 });
             }
             for (const guest of this.threadView.thread.invitedGuests) {
@@ -237,8 +237,8 @@ registerModel({
                 }
                 tileCards.push({
                     relationalId: `invited_guest_${guest.localId}_${this.threadView.thread.localId}`,
-                    invitedGuest: link(guest),
-                    channel: link(this.threadView.thread),
+                    invitedGuest: replace(guest),
+                    channel: replace(this.threadView.thread),
                 });
             }
             return insertAndReplace(tileCards);

--- a/addons/mail/static/src/models/thread_cache.js
+++ b/addons/mail/static/src/models/thread_cache.js
@@ -2,7 +2,7 @@
 
 import { registerModel } from '@mail/model/model_core';
 import { attr, many, one } from '@mail/model/model_field';
-import { link, replace, unlink, unlinkAll } from '@mail/model/model_field_command';
+import { clear, link, replace, unlink } from '@mail/model/model_field_command';
 import { OnChange } from '@mail/model/model_onchange';
 
 registerModel({
@@ -68,7 +68,7 @@ registerModel({
          */
         _computeFetchedMessages() {
             if (!this.thread) {
-                return unlinkAll();
+                return clear();
             }
             const toUnlinkMessages = [];
             for (const message of this.fetchedMessages) {
@@ -88,9 +88,9 @@ registerModel({
                 [l - 1]: lastFetchedMessage,
             } = this.orderedFetchedMessages;
             if (!lastFetchedMessage) {
-                return unlink();
+                return clear();
             }
-            return link(lastFetchedMessage);
+            return replace(lastFetchedMessage);
         },
         /**
          * @private
@@ -102,9 +102,9 @@ registerModel({
                 [l - 1]: lastMessage,
             } = this.orderedMessages;
             if (!lastMessage) {
-                return unlink();
+                return clear();
             }
-            return link(lastMessage);
+            return replace(lastMessage);
         },
         /**
          * @private
@@ -112,7 +112,7 @@ registerModel({
          */
         _computeMessages() {
             if (!this.thread) {
-                return unlinkAll();
+                return clear();
             }
             let newerMessages;
             if (!this.lastFetchedMessage) {

--- a/addons/mail/static/src/models/thread_view.js
+++ b/addons/mail/static/src/models/thread_view.js
@@ -3,7 +3,7 @@
 import { registerModel } from '@mail/model/model_core';
 import { RecordDeletedError } from '@mail/model/model_errors';
 import { attr, many, one } from '@mail/model/model_field';
-import { clear, insertAndReplace, link, replace, unlink } from '@mail/model/model_field_command';
+import { clear, insertAndReplace, replace } from '@mail/model/model_field_command';
 import { OnChange } from '@mail/model/model_onchange';
 
 registerModel({
@@ -38,7 +38,7 @@ registerModel({
          */
         handleVisibleMessage(message) {
             if (!this.lastVisibleMessage || this.lastVisibleMessage.id < message.id) {
-                this.update({ lastVisibleMessage: link(message) });
+                this.update({ lastVisibleMessage: replace(message) });
             }
         },
         /**
@@ -266,7 +266,7 @@ registerModel({
                     isMarkAllAsReadRequested: true,
                 });
             }
-            this.update({ lastVisibleMessage: unlink() });
+            this.update({ lastVisibleMessage: clear() });
         },
         /**
          * @private

--- a/addons/mail/static/src/models/user.js
+++ b/addons/mail/static/src/models/user.js
@@ -2,7 +2,7 @@
 
 import { registerModel } from '@mail/model/model_core';
 import { attr, one } from '@mail/model/model_field';
-import { insert, unlink } from '@mail/model/model_field_command';
+import { clear, insert } from '@mail/model/model_field_command';
 
 registerModel({
     name: 'User',
@@ -19,7 +19,7 @@ registerModel({
             }
             if ('partner_id' in data) {
                 if (!data.partner_id) {
-                    data2.partner = unlink();
+                    data2.partner = clear();
                 } else {
                     const partnerNameGet = data['partner_id'];
                     const partnerData = {

--- a/addons/mail/static/tests/qunit_suite_tests/components/attachment_image_tests.js
+++ b/addons/mail/static/tests/qunit_suite_tests/components/attachment_image_tests.js
@@ -1,6 +1,6 @@
 /** @odoo-module **/
 
-import { link } from '@mail/model/model_field_command';
+import { link, replace } from '@mail/model/model_field_command';
 import { start } from '@mail/../tests/helpers/test_utils';
 
 QUnit.module('mail', {}, function () {
@@ -19,7 +19,7 @@ QUnit.test('auto layout with image', async function (assert) {
     });
     const message = messaging.models['Message'].create({
         attachments: link(attachment),
-        author: link(messaging.currentPartner),
+        author: replace(messaging.currentPartner),
         body: "<p>Test</p>",
         id: 100,
     });

--- a/addons/mail/static/tests/qunit_suite_tests/components/attachment_list_tests.js
+++ b/addons/mail/static/tests/qunit_suite_tests/components/attachment_list_tests.js
@@ -1,6 +1,6 @@
 /** @odoo-module **/
 
-import { link } from '@mail/model/model_field_command';
+import { link, replace } from '@mail/model/model_field_command';
 
 import { afterNextRender, start } from '@mail/../tests/helpers/test_utils';
 
@@ -20,7 +20,7 @@ QUnit.test('simplest layout', async function (assert) {
     });
     const message = messaging.models['Message'].create({
         attachments: link(attachment),
-        author: link(messaging.currentPartner),
+        author: replace(messaging.currentPartner),
         body: "<p>Test</p>",
         id: 100,
     });
@@ -92,7 +92,7 @@ QUnit.test('simplest layout + editable', async function (assert) {
     });
     const message = messaging.models['Message'].create({
         attachments: link(attachment),
-        author: link(messaging.currentPartner),
+        author: replace(messaging.currentPartner),
         body: "<p>Test</p>",
         id: 100,
     });
@@ -148,7 +148,7 @@ QUnit.test('layout with card details and filename and extension', async function
     });
     const message = messaging.models['Message'].create({
         attachments: link(attachment),
-        author: link(messaging.currentPartner),
+        author: replace(messaging.currentPartner),
         body: "<p>Test</p>",
         id: 100,
     });
@@ -178,7 +178,7 @@ QUnit.test('view attachment', async function (assert) {
     });
     const message = messaging.models['Message'].create({
         attachments: link(attachment),
-        author: link(messaging.currentPartner),
+        author: replace(messaging.currentPartner),
         body: "<p>Test</p>",
         id: 100,
     });
@@ -214,7 +214,7 @@ QUnit.test('close attachment viewer', async function (assert) {
     });
     const message = messaging.models['Message'].create({
         attachments: link(attachment),
-        author: link(messaging.currentPartner),
+        author: replace(messaging.currentPartner),
         body: "<p>Test</p>",
         id: 100,
     });
@@ -262,7 +262,7 @@ QUnit.test('clicking on the delete attachment button multiple times should do th
     });
     const message = messaging.models['Message'].create({
         attachments: link(attachment),
-        author: link(messaging.currentPartner),
+        author: replace(messaging.currentPartner),
         body: "<p>Test</p>",
         id: 100,
     });
@@ -302,7 +302,7 @@ QUnit.test('[technical] does not crash when the viewer is closed before image lo
     });
     const message = messaging.models['Message'].create({
         attachments: link(attachment),
-        author: link(messaging.currentPartner),
+        author: replace(messaging.currentPartner),
         body: "<p>Test</p>",
         id: 100,
     });
@@ -334,7 +334,7 @@ QUnit.test('plain text file is viewable', async function (assert) {
     });
     const message = messaging.models['Message'].create({
         attachments: link(attachment),
-        author: link(messaging.currentPartner),
+        author: replace(messaging.currentPartner),
         body: "<p>Test</p>",
         id: 100,
     });
@@ -359,7 +359,7 @@ QUnit.test('HTML file is viewable', async function (assert) {
     });
     const message = messaging.models['Message'].create({
         attachments: link(attachment),
-        author: link(messaging.currentPartner),
+        author: replace(messaging.currentPartner),
         body: "<p>Test</p>",
         id: 100,
     });
@@ -383,7 +383,7 @@ QUnit.test('ODT file is not viewable', async function (assert) {
     });
     const message = messaging.models['Message'].create({
         attachments: link(attachment),
-        author: link(messaging.currentPartner),
+        author: replace(messaging.currentPartner),
         body: "<p>Test</p>",
         id: 100,
     });
@@ -407,7 +407,7 @@ QUnit.test('DOCX file is not viewable', async function (assert) {
     });
     const message = messaging.models['Message'].create({
         attachments: link(attachment),
-        author: link(messaging.currentPartner),
+        author: replace(messaging.currentPartner),
         body: "<p>Test</p>",
         id: 100,
     });

--- a/addons/mail/static/tests/qunit_suite_tests/components/follower_list_menu_tests.js
+++ b/addons/mail/static/tests/qunit_suite_tests/components/follower_list_menu_tests.js
@@ -1,6 +1,6 @@
 /** @odoo-module **/
 
-import { insert, link } from '@mail/model/model_field_command';
+import { insert, replace } from '@mail/model/model_field_command';
 import {
     start,
     startServer,
@@ -217,7 +217,7 @@ QUnit.test('click on remove follower', async function (assert) {
         model: 'res.partner',
     });
     await messaging.models['Follower'].create({
-        followedThread: link(thread),
+        followedThread: replace(thread),
         id: 2,
         isActive: true,
         partner: insert({

--- a/addons/mail/static/tests/qunit_suite_tests/components/follower_tests.js
+++ b/addons/mail/static/tests/qunit_suite_tests/components/follower_tests.js
@@ -1,6 +1,6 @@
 /** @odoo-module **/
 
-import { insert, link } from '@mail/model/model_field_command';
+import { insert, replace } from '@mail/model/model_field_command';
 import { makeDeferred } from '@mail/utils/deferred';
 import {
     createRootMessagingComponent,
@@ -38,7 +38,7 @@ QUnit.test('base rendering not editable', async function (assert) {
             id: 1,
             name: "François Perusse",
         }),
-        followedThread: link(thread),
+        followedThread: replace(thread),
         id: 2,
         isActive: true,
     });
@@ -84,7 +84,7 @@ QUnit.test('base rendering editable', async function (assert) {
             id: 1,
             name: "François Perusse",
         }),
-        followedThread: link(thread),
+        followedThread: replace(thread),
         id: 2,
         isActive: true,
     });
@@ -153,7 +153,7 @@ QUnit.test('click on partner follower details', async function (assert) {
         model: 'res.partner',
     });
     const follower = await messaging.models['Follower'].create({
-        followedThread: link(thread),
+        followedThread: replace(thread),
         id: 2,
         isActive: true,
         partner: insert({
@@ -258,7 +258,7 @@ QUnit.test('edit follower and close subtype dialog', async function (assert) {
         model: 'res.partner',
     });
     const follower = await messaging.models['Follower'].create({
-        followedThread: link(thread),
+        followedThread: replace(thread),
         id: 2,
         isActive: true,
         partner: insert({

--- a/addons/mail/static/tests/qunit_suite_tests/components/message_tests.js
+++ b/addons/mail/static/tests/qunit_suite_tests/components/message_tests.js
@@ -1,6 +1,6 @@
 /** @odoo-module **/
 
-import { insert, insertAndReplace, link, replace } from '@mail/model/model_field_command';
+import { insert, insertAndReplace, replace } from '@mail/model/model_field_command';
 import { makeDeferred } from '@mail/utils/deferred';
 import {
     afterNextRender,
@@ -117,7 +117,7 @@ QUnit.test('Notification Sent', async function (assert) {
     const threadViewer = messaging.models['ThreadViewer'].create({
         hasThreadView: true,
         qunitTest: insertAndReplace(),
-        thread: link(thread),
+        thread: replace(thread),
     });
     await createThreadViewComponent(threadViewer.threadView);
 
@@ -212,7 +212,7 @@ QUnit.test('Notification Error', async function (assert) {
     const threadViewer = messaging.models['ThreadViewer'].create({
         hasThreadView: true,
         qunitTest: insertAndReplace(),
-        thread: link(thread),
+        thread: replace(thread),
     });
     await createThreadViewComponent(threadViewer.threadView);
 
@@ -268,13 +268,13 @@ QUnit.test("'channel_fetch' notification received is correctly handled", async f
     const threadViewer = messaging.models['ThreadViewer'].create({
         hasThreadView: true,
         qunitTest: insertAndReplace(),
-        thread: link(thread),
+        thread: replace(thread),
     });
     messaging.models['Message'].create({
-        author: link(currentPartner),
+        author: replace(currentPartner),
         body: "<p>Test</p>",
         id: 100,
-        originThread: link(thread),
+        originThread: replace(thread),
     });
 
     await createThreadViewComponent(threadViewer.threadView);
@@ -333,13 +333,13 @@ QUnit.test("'channel_seen' notification received is correctly handled", async fu
     const threadViewer = messaging.models['ThreadViewer'].create({
         hasThreadView: true,
         qunitTest: insertAndReplace(),
-        thread: link(thread),
+        thread: replace(thread),
     });
     messaging.models['Message'].create({
-        author: link(currentPartner),
+        author: replace(currentPartner),
         body: "<p>Test</p>",
         id: 100,
-        originThread: link(thread),
+        originThread: replace(thread),
     });
     await createThreadViewComponent(threadViewer.threadView);
 
@@ -397,13 +397,13 @@ QUnit.test("'channel_fetch' notification then 'channel_seen' received  are corre
     const threadViewer = messaging.models['ThreadViewer'].create({
         hasThreadView: true,
         qunitTest: insertAndReplace(),
-        thread: link(thread),
+        thread: replace(thread),
     });
     messaging.models['Message'].create({
-        author: link(currentPartner),
+        author: replace(currentPartner),
         body: "<p>Test</p>",
         id: 100,
-        originThread: link(thread),
+        originThread: replace(thread),
     });
     await createThreadViewComponent(threadViewer.threadView);
 
@@ -480,13 +480,13 @@ QUnit.test('do not show messaging seen indicator if not authored by me', async f
     const threadViewer = messaging.models['ThreadViewer'].create({
         hasThreadView: true,
         qunitTest: insertAndReplace(),
-        thread: link(thread),
+        thread: replace(thread),
     });
     messaging.models['Message'].insert({
-        author: link(author),
+        author: replace(author),
         body: "<p>Test</p>",
         id: 100,
-        originThread: link(thread),
+        originThread: replace(thread),
     });
     await createThreadViewComponent(threadViewer.threadView);
 
@@ -521,28 +521,28 @@ QUnit.test('do not show messaging seen indicator if before last seen by all mess
     const threadViewer = messaging.models['ThreadViewer'].create({
         hasThreadView: true,
         qunitTest: insertAndReplace(),
-        thread: link(thread),
+        thread: replace(thread),
     });
     const lastSeenMessage = messaging.models['Message'].create({
-        author: link(currentPartner),
+        author: replace(currentPartner),
         body: "<p>You already saw me</p>",
         id: 100,
-        originThread: link(thread),
+        originThread: replace(thread),
     });
     messaging.models['Message'].insert({
-        author: link(currentPartner),
+        author: replace(currentPartner),
         body: "<p>Test</p>",
         id: 99,
-        originThread: link(thread),
+        originThread: replace(thread),
     });
     messaging.models['ThreadPartnerSeenInfo'].insert([
         {
-            lastSeenMessage: link(lastSeenMessage),
+            lastSeenMessage: replace(lastSeenMessage),
             partner: replace(messaging.currentPartner),
             thread: replace(thread),
         },
         {
-            lastSeenMessage: link(lastSeenMessage),
+            lastSeenMessage: replace(lastSeenMessage),
             partner: insertAndReplace({ id: 100 }),
             thread: replace(thread),
         },
@@ -599,13 +599,13 @@ QUnit.test('only show messaging seen indicator if authored by me, after last see
     const threadViewer = messaging.models['ThreadViewer'].create({
         hasThreadView: true,
         qunitTest: insertAndReplace(),
-        thread: link(thread),
+        thread: replace(thread),
     });
     messaging.models['Message'].insert({
-        author: link(currentPartner),
+        author: replace(currentPartner),
         body: "<p>Test</p>",
         id: 100,
-        originThread: link(thread),
+        originThread: replace(thread),
     });
     await createThreadViewComponent(threadViewer.threadView);
 
@@ -638,7 +638,7 @@ QUnit.test('allow attachment delete on authored message', async function (assert
             name: "BLAH",
             mimetype: 'image/jpeg',
         }),
-        author: link(messaging.currentPartner),
+        author: replace(messaging.currentPartner),
         body: "<p>Test</p>",
         id: 100,
     });
@@ -896,7 +896,7 @@ QUnit.test('open chat with author on avatar click should be disabled when curren
     const threadViewer = messaging.models['ThreadViewer'].create({
         hasThreadView: true,
         qunitTest: insertAndReplace(),
-        thread: link(thread),
+        thread: replace(thread),
     });
     await createThreadViewComponent(threadViewer.threadView);
     assert.containsOnce(

--- a/addons/mail/static/tests/qunit_suite_tests/components/thread_view_tests.js
+++ b/addons/mail/static/tests/qunit_suite_tests/components/thread_view_tests.js
@@ -1,6 +1,6 @@
 /** @odoo-module **/
 
-import { insert, insertAndReplace, link } from '@mail/model/model_field_command';
+import { insert, insertAndReplace, replace } from '@mail/model/model_field_command';
 import {
     afterNextRender,
     dragenterFiles,
@@ -29,7 +29,7 @@ QUnit.test('dragover files on thread with composer', async function (assert) {
     const threadViewer = messaging.models['ThreadViewer'].create({
         hasThreadView: true,
         qunitTest: insertAndReplace(),
-        thread: link(thread),
+        thread: replace(thread),
     });
     await createThreadViewComponent(threadViewer.threadView);
     await afterNextRender(() =>
@@ -66,7 +66,7 @@ QUnit.test('message list desc order', async function (assert) {
         hasThreadView: true,
         qunitTest: insertAndReplace(),
         order: 'desc',
-        thread: link(thread),
+        thread: replace(thread),
     });
     await afterEvent({
         eventName: 'o-thread-view-hint-processed',
@@ -151,7 +151,7 @@ QUnit.test('message list asc order', async function (assert) {
     const threadViewer = messaging.models['ThreadViewer'].create({
         hasThreadView: true,
         qunitTest: insertAndReplace(),
-        thread: link(thread),
+        thread: replace(thread),
     });
     await afterEvent({
         eventName: 'o-thread-view-hint-processed',
@@ -261,7 +261,7 @@ QUnit.test('mark channel as fetched when a new message is loaded and as seen whe
     const threadViewer = messaging.models['ThreadViewer'].create({
         hasThreadView: true,
         qunitTest: insertAndReplace(),
-        thread: link(thread),
+        thread: replace(thread),
     });
     await createThreadViewComponent(threadViewer.threadView);
     await afterNextRender(async () => env.services.rpc({
@@ -328,7 +328,7 @@ QUnit.test('mark channel as fetched and seen when a new message is loaded if com
     const threadViewer = messaging.models['ThreadViewer'].create({
         hasThreadView: true,
         qunitTest: insertAndReplace(),
-        thread: link(thread),
+        thread: replace(thread),
     });
     await createThreadViewComponent(threadViewer.threadView);
     document.querySelector('.o_ComposerTextInput_textarea').focus();
@@ -382,7 +382,7 @@ QUnit.test('show message subject when subject is not the same as the thread name
     const threadViewer = messaging.models['ThreadViewer'].create({
         hasThreadView: true,
         qunitTest: insertAndReplace(),
-        thread: link(thread),
+        thread: replace(thread),
     });
     await createThreadViewComponent(threadViewer.threadView);
 
@@ -467,7 +467,7 @@ QUnit.test('[technical] new messages separator on posting message', async functi
     const threadViewer = messaging.models['ThreadViewer'].create({
         hasThreadView: true,
         qunitTest: insertAndReplace(),
-        thread: link(thread),
+        thread: replace(thread),
     });
     await createThreadViewComponent(threadViewer.threadView);
 
@@ -540,7 +540,7 @@ QUnit.test('new messages separator on receiving new message [REQUIRE FOCUS]', as
     const threadViewer = messaging.models['ThreadViewer'].create({
         hasThreadView: true,
         qunitTest: insertAndReplace(),
-        thread: link(thread),
+        thread: replace(thread),
     });
     await createThreadViewComponent(threadViewer.threadView);
 
@@ -638,7 +638,7 @@ QUnit.test('new messages separator on posting message', async function (assert) 
     const threadViewer = messaging.models['ThreadViewer'].create({
         hasThreadView: true,
         qunitTest: insertAndReplace(),
-        thread: link(thread),
+        thread: replace(thread),
     });
     await createThreadViewComponent(threadViewer.threadView);
 
@@ -783,7 +783,7 @@ QUnit.test('should scroll to bottom on receiving new message if the list is init
     const threadViewer = messaging.models['ThreadViewer'].create({
         hasThreadView: true,
         qunitTest: insertAndReplace(),
-        thread: link(thread),
+        thread: replace(thread),
     });
     await afterEvent({
         eventName: 'o-component-message-list-scrolled',
@@ -855,7 +855,7 @@ QUnit.test('should not scroll on receiving new message if the list is initially 
     const threadViewer = messaging.models['ThreadViewer'].create({
         hasThreadView: true,
         qunitTest: insertAndReplace(),
-        thread: link(thread),
+        thread: replace(thread),
     });
     await afterEvent({
         eventName: 'o-component-message-list-scrolled',
@@ -1034,7 +1034,7 @@ QUnit.test('Post a message containing an email address followed by a mention on 
     const threadViewer = messaging.models['ThreadViewer'].create({
         hasThreadView: true,
         qunitTest: insertAndReplace(),
-        thread: link(thread),
+        thread: replace(thread),
     });
     await createThreadViewComponent(threadViewer.threadView);
     await insertText('.o_ComposerTextInput_textarea', "email@odoo.com\n");
@@ -1065,7 +1065,7 @@ QUnit.test(`Mention a partner with special character (e.g. apostrophe ')`, async
     const threadViewer = messaging.models['ThreadViewer'].create({
         hasThreadView: true,
         qunitTest: insertAndReplace(),
-        thread: link(thread),
+        thread: replace(thread),
     });
     await createThreadViewComponent(threadViewer.threadView);
     await insertText('.o_ComposerTextInput_textarea', "@Pyn");
@@ -1101,7 +1101,7 @@ QUnit.test('mention 2 different partners that have the same name', async functio
     const threadViewer = messaging.models['ThreadViewer'].create({
         hasThreadView: true,
         qunitTest: insertAndReplace(),
-        thread: link(thread),
+        thread: replace(thread),
     });
     await createThreadViewComponent(threadViewer.threadView);
     await insertText('.o_ComposerTextInput_textarea', "@Te");
@@ -1137,7 +1137,7 @@ QUnit.test('mention a channel with space in the name', async function (assert) {
     const threadViewer = messaging.models['ThreadViewer'].create({
         hasThreadView: true,
         qunitTest: insertAndReplace(),
-        thread: link(thread),
+        thread: replace(thread),
     });
     await createThreadViewComponent(threadViewer.threadView);
 
@@ -1171,7 +1171,7 @@ QUnit.test('mention a channel with "&" in the name', async function (assert) {
     const threadViewer = messaging.models['ThreadViewer'].create({
         hasThreadView: true,
         qunitTest: insertAndReplace(),
-        thread: link(thread),
+        thread: replace(thread),
     });
     await createThreadViewComponent(threadViewer.threadView);
 
@@ -1205,7 +1205,7 @@ QUnit.test('mention a channel on a second line when the first line contains #', 
     const threadViewer = messaging.models['ThreadViewer'].create({
         hasThreadView: true,
         qunitTest: insertAndReplace(),
-        thread: link(thread),
+        thread: replace(thread),
     });
     await createThreadViewComponent(threadViewer.threadView);
 
@@ -1240,7 +1240,7 @@ QUnit.test('mention a channel when replacing the space after the mention by anot
     const threadViewer = messaging.models['ThreadViewer'].create({
         hasThreadView: true,
         qunitTest: insertAndReplace(),
-        thread: link(thread),
+        thread: replace(thread),
     });
     await createThreadViewComponent(threadViewer.threadView);
 
@@ -1283,7 +1283,7 @@ QUnit.test('mention 2 different channels that have the same name', async functio
     const threadViewer = messaging.models['ThreadViewer'].create({
         hasThreadView: true,
         qunitTest: insertAndReplace(),
-        thread: link(thread),
+        thread: replace(thread),
     });
     await createThreadViewComponent(threadViewer.threadView);
     document.querySelector('.o_ComposerTextInput_textarea').focus();
@@ -1523,7 +1523,7 @@ QUnit.test('first unseen message should be directly preceded by the new message 
     const threadViewer = messaging.models['ThreadViewer'].create({
         hasThreadView: true,
         qunitTest: insertAndReplace(),
-        thread: link(thread),
+        thread: replace(thread),
     });
     await createThreadViewComponent(threadViewer.threadView);
     // send a command that leads to receiving a transient message
@@ -1577,7 +1577,7 @@ QUnit.test('composer should be focused automatically after clicking on the send 
     const threadViewer = messaging.models['ThreadViewer'].create({
         hasThreadView: true,
         qunitTest: insertAndReplace(),
-        thread: link(thread),
+        thread: replace(thread),
     });
     await createThreadViewComponent(threadViewer.threadView);
     document.querySelector('.o_ComposerTextInput_textarea').focus();
@@ -1613,7 +1613,7 @@ QUnit.test('failure on loading messages should display error', async function (a
     const threadViewer = messaging.models['ThreadViewer'].create({
         hasThreadView: true,
         qunitTest: insertAndReplace(),
-        thread: link(thread),
+        thread: replace(thread),
     });
     await createThreadViewComponent(threadViewer.threadView, undefined, { waitUntilMessagesLoaded: false });
 
@@ -1647,7 +1647,7 @@ QUnit.test('failure on loading messages should prompt retry button', async funct
     const threadViewer = messaging.models['ThreadViewer'].create({
         hasThreadView: true,
         qunitTest: insertAndReplace(),
-        thread: link(thread),
+        thread: replace(thread),
     });
     await createThreadViewComponent(threadViewer.threadView, undefined, { waitUntilMessagesLoaded: false });
 
@@ -1694,7 +1694,7 @@ QUnit.test('failure on loading more messages should not alter message list displ
     const threadViewer = messaging.models['ThreadViewer'].create({
         hasThreadView: true,
         qunitTest: insertAndReplace(),
-        thread: link(thread),
+        thread: replace(thread),
     });
     await createThreadViewComponent(threadViewer.threadView, undefined, { waitUntilMessagesLoaded: false });
 
@@ -1744,7 +1744,7 @@ QUnit.test('failure on loading more messages should display error and prompt ret
     const threadViewer = messaging.models['ThreadViewer'].create({
         hasThreadView: true,
         qunitTest: insertAndReplace(),
-        thread: link(thread),
+        thread: replace(thread),
     });
     await createThreadViewComponent(threadViewer.threadView, undefined, { waitUntilMessagesLoaded: false });
 
@@ -1803,7 +1803,7 @@ QUnit.test('Retry loading more messages on failed load more messages should load
     const threadViewer = messaging.models['ThreadViewer'].create({
         hasThreadView: true,
         qunitTest: insertAndReplace(),
-        thread: link(thread),
+        thread: replace(thread),
     });
     await createThreadViewComponent(threadViewer.threadView, undefined, { waitUntilMessagesLoaded: false });
     messageFetchShouldFail = true;
@@ -1851,7 +1851,7 @@ QUnit.test("highlight the message mentioning the current user inside the channel
     const threadViewer = messaging.models['ThreadViewer'].create({
         hasThreadView: true,
         qunitTest: insertAndReplace(),
-        thread: link(thread),
+        thread: replace(thread),
     });
     await createThreadViewComponent(threadViewer.threadView);
     assert.hasClass(
@@ -1889,7 +1889,7 @@ QUnit.test("not highlighting the message if not mentioning the current user insi
     const threadViewer = messaging.models['ThreadViewer'].create({
         hasThreadView: true,
         qunitTest: insertAndReplace(),
-        thread: link(thread),
+        thread: replace(thread),
     });
     await createThreadViewComponent(threadViewer.threadView);
     assert.doesNotHaveClass(

--- a/addons/mail/static/tests/qunit_suite_tests/model_field_commands/link_tests.js
+++ b/addons/mail/static/tests/qunit_suite_tests/model_field_commands/link_tests.js
@@ -1,6 +1,6 @@
 /** @odoo-module **/
 
-import { insertAndReplace, link } from '@mail/model/model_field_command';
+import { insertAndReplace, link, replace } from '@mail/model/model_field_command';
 import { start } from '@mail/../tests/helpers/test_utils';
 
 QUnit.module('mail', {}, function () {
@@ -13,7 +13,7 @@ QUnit.test('link: should link a record to an empty x2one field', async function 
 
     const contact = messaging.models['TestContact'].create({ id: 10 });
     const address = messaging.models['TestAddress'].create({ id: 10 });
-    contact.update({ address: link(address) });
+    contact.update({ address: replace(address) });
     assert.strictEqual(
         contact.address,
         address,
@@ -36,7 +36,7 @@ QUnit.test('link: should replace a record to a non-empty x2one field', async fun
     });
     const address10 = messaging.models['TestAddress'].findFromIdentifyingData({ id: 10 });
     const address20 = messaging.models['TestAddress'].create({ id: 20 });
-    contact.update({ address: link(address20) });
+    contact.update({ address: replace(address20) });
     assert.strictEqual(
         contact.address,
         address20,

--- a/addons/mail/static/tests/qunit_suite_tests/model_field_commands/unlink_tests.js
+++ b/addons/mail/static/tests/qunit_suite_tests/model_field_commands/unlink_tests.js
@@ -1,6 +1,6 @@
 /** @odoo-module **/
 
-import { insertAndReplace, unlink } from '@mail/model/model_field_command';
+import { clear, insertAndReplace, unlink } from '@mail/model/model_field_command';
 import { start } from '@mail/../tests/helpers/test_utils';
 
 QUnit.module('mail', {}, function () {
@@ -17,7 +17,7 @@ QUnit.test('unlink: should unlink the record for x2one field', async function (a
         address: insertAndReplace({ id: 10 }),
     });
     const address = messaging.models['TestAddress'].findFromIdentifyingData({ id: 10 });
-    contact.update({ address: unlink() });
+    contact.update({ address: clear() });
     assert.strictEqual(
         contact.address,
         undefined,

--- a/addons/mail/static/tests/qunit_suite_tests/models/message_tests.js
+++ b/addons/mail/static/tests/qunit_suite_tests/models/message_tests.js
@@ -1,6 +1,6 @@
 /** @odoo-module **/
 
-import { insert, insertAndReplace, link } from '@mail/model/model_field_command';
+import { insert, insertAndReplace, replace } from '@mail/model/model_field_command';
 import { start } from '@mail/../tests/helpers/test_utils';
 
 import { str_to_datetime } from 'web.time';
@@ -39,7 +39,7 @@ QUnit.test('create', async function (assert) {
         id: 4000,
         isNeedaction: true,
         isStarred: true,
-        originThread: link(thread),
+        originThread: replace(thread),
     });
 
     assert.ok(messaging.models['Partner'].findFromIdentifyingData({ id: 5 }));

--- a/addons/website_livechat/static/src/models/thread.js
+++ b/addons/website_livechat/static/src/models/thread.js
@@ -2,7 +2,7 @@
 
 import { addFields, patchModelMethods } from '@mail/model/model_core';
 import { one } from '@mail/model/model_field';
-import { insert, unlink } from '@mail/model/model_field_command';
+import { clear, insert } from '@mail/model/model_field_command';
 // ensure that the model definition is loaded before the patch
 import '@mail/models/thread';
 
@@ -16,7 +16,7 @@ patchModelMethods('Thread', {
             if (data.visitor) {
                 data2.visitor = insert(this.messaging.models['Visitor'].convertData(data.visitor));
             } else {
-                data2.visitor = unlink();
+                data2.visitor = clear();
             }
         }
         return data2;

--- a/addons/website_livechat/static/src/models/visitor.js
+++ b/addons/website_livechat/static/src/models/visitor.js
@@ -2,7 +2,7 @@
 
 import { registerModel } from '@mail/model/model_core';
 import { attr, many, one } from '@mail/model/model_field';
-import { insert, link, unlink } from '@mail/model/model_field_command';
+import { clear, insert, replace } from '@mail/model/model_field_command';
 
 registerModel({
     name: 'Visitor',
@@ -17,7 +17,7 @@ registerModel({
                         code: data.country_code,
                     });
                 } else {
-                    data2.country = unlink();
+                    data2.country = clear();
                 }
             }
             if ('history' in data) {
@@ -39,7 +39,7 @@ registerModel({
                 if (data.partner_id) {
                     data2.partner = insert({ id: data.partner_id });
                 } else {
-                    data2.partner = unlink();
+                    data2.partner = clear();
                 }
             }
             if ('website_name' in data) {
@@ -65,12 +65,12 @@ registerModel({
          */
         _computeCountry() {
             if (this.partner && this.partner.country) {
-                return link(this.partner.country);
+                return replace(this.partner.country);
             }
             if (this.country) {
-                return link(this.country);
+                return replace(this.country);
             }
-            return unlink();
+            return clear();
         },
         /**
          * @private


### PR DESCRIPTION
*: hr, hr_holidays, im_livechat, website_livechat

This commit turns some `link`/`unlink`/`unlinkAll` to `replace`/`clear`.
The commands `replace`/`clear` are easier to understand, and also clearly tells what’s the expected resulting value of this field.

This change will help turning big and imperative code into smaller declarative code.

Task-2834598

enterprise: https://github.com/odoo/enterprise/pull/26673