### PR TITLE
[FIX] account : fixing type of journal_id

### DIFF
--- a/addons/account/tests/test_sequence_mixin.py
+++ b/addons/account/tests/test_sequence_mixin.py
@@ -169,7 +169,7 @@ class TestSequenceMixin(AccountTestInvoicingCommon):
             for i in range(6)
         )
         (invoice + invoice2 + refund + refund2).write({
-            'journal_id': self.company_data['default_journal_sale'],
+            'journal_id': self.company_data['default_journal_sale'].id,
             'partner_id': 1,
             'invoice_date': '2016-01-01',
         })


### PR DESCRIPTION
the `write` method from `AccountMove` class and its children
expect `journal_id` in `vals` to be an `int` and not an `account.journal`.

linked PR : https://github.com/odoo/enterprise/pull/26515

opw-2794392