### PR TITLE
[IMP] mail, *: add rpc to messaging

### DIFF
--- a/addons/calendar/static/src/models/activity.js
+++ b/addons/calendar/static/src/models/activity.js
@@ -30,7 +30,7 @@ patchRecordMethods('Activity', {
         if (!this.calendar_event_id){
             await this._super();
         } else {
-            await this.async(() => this.env.services.rpc({
+            await this.async(() => this.messaging.rpc({
                 model: 'mail.activity',
                 method: 'unlink_w_meeting',
                 args: [[this.id]],
@@ -47,7 +47,7 @@ patchRecordMethods('Activity', {
         if (!this.calendar_event_id){
             this._super();
         } else {
-            const action = await this.async(() => this.env.services.rpc({
+            const action = await this.async(() => this.messaging.rpc({
                 model: 'mail.activity',
                 method: 'action_create_calendar_event',
                 args: [[this.id]],

--- a/addons/hr/static/src/models/employee.js
+++ b/addons/hr/static/src/models/employee.js
@@ -47,7 +47,7 @@ registerModel({
          * @param {integer[]} param0.ids
          */
         async performRpcRead({ context, fields, ids }) {
-            const employeesData = await this.env.services.rpc({
+            const employeesData = await this.messaging.rpc({
                 model: 'hr.employee.public',
                 method: 'read',
                 args: [ids],
@@ -69,7 +69,7 @@ registerModel({
          * @param {string[]} param0.fields
          */
         async performRpcSearchRead({ context, domain, fields }) {
-            const employeesData = await this.env.services.rpc({
+            const employeesData = await this.messaging.rpc({
                 model: 'hr.employee.public',
                 method: 'search_read',
                 kwargs: {

--- a/addons/im_livechat/static/tests/qunit_suite_tests/components/chat_window_manager_tests.js
+++ b/addons/im_livechat/static/tests/qunit_suite_tests/components/chat_window_manager_tests.js
@@ -30,13 +30,13 @@ QUnit.test('closing a chat window with no message from admin side unpins it', as
             uuid: 'channel-10-uuid',
         },
     );
-    const { createMessagingMenuComponent, env } = await start({ hasChatWindow: true });
+    const { createMessagingMenuComponent, messaging } = await start({ hasChatWindow: true });
     await createMessagingMenuComponent();
 
     await afterNextRender(() => document.querySelector(`.o_MessagingMenu_toggler`).click());
     await afterNextRender(() => document.querySelector(`.o_NotificationList_preview`).click());
     await afterNextRender(() => document.querySelector(`.o_ChatWindowHeader_commandClose`).click());
-    const channels = await env.services.rpc({
+    const channels = await messaging.rpc({
         model: 'mail.channel',
         method: 'channel_info',
         args: [mailChannelId1],

--- a/addons/im_livechat/static/tests/qunit_suite_tests/components/discuss_sidebar_category_tests.js
+++ b/addons/im_livechat/static/tests/qunit_suite_tests/components/discuss_sidebar_category_tests.js
@@ -233,9 +233,9 @@ QUnit.test('livechat - states: close should update the value on the server', asy
         is_discuss_sidebar_category_livechat_open: true,
     });
     const currentUserId = pyEnv.currentUserId;
-    const { env, messaging } = await this.start();
+    const { messaging } = await this.start();
 
-    const initalSettings = await env.services.rpc({
+    const initalSettings = await messaging.rpc({
         model: 'res.users.settings',
         method: '_find_or_create_for_user',
         args: [[currentUserId]],
@@ -252,7 +252,7 @@ QUnit.test('livechat - states: close should update the value on the server', asy
             .o_DiscussSidebarCategory_title
         `).click()
     );
-    const newSettings = await env.services.rpc({
+    const newSettings = await messaging.rpc({
         model: 'res.users.settings',
         method: '_find_or_create_for_user',
         args: [[currentUserId]],
@@ -282,9 +282,9 @@ QUnit.test('livechat - states: open should update the value on the server', asyn
         is_discuss_sidebar_category_livechat_open: false,
     });
     const currentUserId = pyEnv.currentUserId;
-    const { env, messaging } = await this.start();
+    const { messaging } = await this.start();
 
-    const initalSettings = await env.services.rpc({
+    const initalSettings = await messaging.rpc({
         model: 'res.users.settings',
         method: '_find_or_create_for_user',
         args: [[currentUserId]],
@@ -301,7 +301,7 @@ QUnit.test('livechat - states: open should update the value on the server', asyn
             .o_DiscussSidebarCategory_title
         `).click()
     );
-    const newSettings = await env.services.rpc({
+    const newSettings = await messaging.rpc({
         model: 'res.users.settings',
         method: '_find_or_create_for_user',
         args: [[currentUserId]],

--- a/addons/im_livechat/static/tests/qunit_suite_tests/components/discuss_tests.js
+++ b/addons/im_livechat/static/tests/qunit_suite_tests/components/discuss_tests.js
@@ -111,7 +111,7 @@ QUnit.test('do not add livechat in the sidebar on visitor opening his chat', asy
     const imLivechatChannelId1 = pyEnv['im_livechat.channel'].create({
         user_ids: [pyEnv.currentUserId],
     });
-    const { env } = await start({
+    const { messaging } = await start({
         autoOpenDiscuss: true,
         hasDiscuss: true,
     });
@@ -122,7 +122,7 @@ QUnit.test('do not add livechat in the sidebar on visitor opening his chat', asy
     );
 
     // simulate livechat visitor opening his chat
-    await env.services.rpc({
+    await messaging.rpc({
         route: '/im_livechat/get_session',
         params: {
             context: {
@@ -159,7 +159,7 @@ QUnit.test('do not add livechat in the sidebar on visitor typing', async functio
         livechat_channel_id: imLivechatChannelId1,
         livechat_operator_id: pyEnv.currentPartnerId,
     });
-    const { env } = await start({
+    const { messaging } = await start({
         autoOpenDiscuss: true,
         hasDiscuss: true,
     });
@@ -171,7 +171,7 @@ QUnit.test('do not add livechat in the sidebar on visitor typing', async functio
 
     // simulate livechat visitor typing
     const channel = pyEnv['mail.channel'].searchRead([['id', '=', mailChannelId1]])[0];
-    await env.services.rpc({
+    await messaging.rpc({
         route: '/im_livechat/notify_typing',
         params: {
             context: {
@@ -215,7 +215,7 @@ QUnit.test('add livechat in the sidebar on visitor sending first message', async
         livechat_channel_id: imLivechatChannelId1,
         livechat_operator_id: pyEnv.currentPartnerId,
     });
-    const { env } = await start({
+    const { messaging } = await start({
         autoOpenDiscuss: true,
         hasDiscuss: true,
     });
@@ -227,7 +227,7 @@ QUnit.test('add livechat in the sidebar on visitor sending first message', async
 
     // simulate livechat visitor sending a message
     const channel = pyEnv['mail.channel'].searchRead([['id', '=', mailChannelId1]])[0];
-    await afterNextRender(async () => env.services.rpc({
+    await afterNextRender(async () => messaging.rpc({
         route: '/mail/chat_post',
         params: {
             context: {

--- a/addons/mail/static/src/models/activity.js
+++ b/addons/mail/static/src/models/activity.js
@@ -106,7 +106,7 @@ registerModel({
          * Delete the record from database and locally.
          */
         async deleteServerRecord() {
-            await this.async(() => this.env.services.rpc({
+            await this.async(() => this.messaging.rpc({
                 model: 'mail.activity',
                 method: 'unlink',
                 args: [[this.id]],
@@ -137,7 +137,7 @@ registerModel({
             });
         },
         async fetchAndUpdate() {
-            const [data] = await this.env.services.rpc({
+            const [data] = await this.messaging.rpc({
                 model: 'mail.activity',
                 method: 'activity_format',
                 args: [this.id],
@@ -167,7 +167,7 @@ registerModel({
          */
         async markAsDone({ attachments = [], feedback = false }) {
             const attachmentIds = attachments.map(attachment => attachment.id);
-            await this.async(() => this.env.services.rpc({
+            await this.async(() => this.messaging.rpc({
                 model: 'mail.activity',
                 method: 'action_feedback',
                 args: [[this.id]],
@@ -185,7 +185,7 @@ registerModel({
          * @returns {Object}
          */
         async markAsDoneAndScheduleNext({ feedback }) {
-            const action = await this.async(() => this.env.services.rpc({
+            const action = await this.async(() => this.messaging.rpc({
                 model: 'mail.activity',
                 method: 'action_feedback_schedule_next',
                 args: [[this.id]],
@@ -232,7 +232,7 @@ registerModel({
         },
         /**
          * @private
-         * @returns {Markup} 
+         * @returns {Markup}
          */
         _computeNoteAsMarkup() {
             return markup(this.note);

--- a/addons/mail/static/src/models/attachment.js
+++ b/addons/mail/static/src/models/attachment.js
@@ -77,7 +77,7 @@ registerModel({
             if (!this.isUploading) {
                 this.update({ isUnlinkPending: true });
                 try {
-                    await this.async(() => this.env.services.rpc({
+                    await this.async(() => this.messaging.rpc({
                         route: `/mail/attachment/delete`,
                         params: {
                             access_token: this.accessToken,

--- a/addons/mail/static/src/models/channel_command.js
+++ b/addons/mail/static/src/models/channel_command.js
@@ -94,7 +94,7 @@ registerModel({
          * @param {Object} [param0.body='']
          */
         async execute({ channel, body = '' }) {
-            return this.env.services.rpc({
+            return this.messaging.rpc({
                 model: 'mail.channel',
                 method: this.methodName,
                 args: [[channel.id]],

--- a/addons/mail/static/src/models/channel_invitation_form.js
+++ b/addons/mail/static/src/models/channel_invitation_form.js
@@ -47,7 +47,7 @@ registerModel({
                 }
                 channel.open();
             } else {
-                await this.env.services.rpc(({
+                await this.messaging.rpc(({
                     model: 'mail.channel',
                     method: 'add_members',
                     args: [[this.thread.id]],
@@ -127,7 +127,7 @@ registerModel({
             });
             try {
                 const channelId = (this.thread && this.thread.model === 'mail.channel') ? this.thread.id : undefined;
-                const { count, partners: partnersData } = await this.env.services.rpc(
+                const { count, partners: partnersData } = await this.messaging.rpc(
                     {
                         model: 'res.partner',
                         method: 'search_for_channel_invite',

--- a/addons/mail/static/src/models/composer_view.js
+++ b/addons/mail/static/src/models/composer_view.js
@@ -608,7 +608,7 @@ registerModel({
                 const { threadView = {} } = this;
                 const { thread: chatterThread } = this.chatter || {};
                 const { thread: threadViewThread } = threadView;
-                const messageData = await this.env.services.rpc({ route: `/mail/message/post`, params });
+                const messageData = await this.messaging.rpc({ route: `/mail/message/post`, params });
                 if (!this.messaging) {
                     return;
                 }

--- a/addons/mail/static/src/models/discuss_sidebar_category.js
+++ b/addons/mail/static/src/models/discuss_sidebar_category.js
@@ -17,7 +17,7 @@ registerModel({
          * @param {boolean} [resUsersSettings.is_category_chat_open]
          */
         async performRpcSetResUsersSettings(resUsersSettings) {
-            return this.env.services.rpc(
+            return this.messaging.rpc(
                 {
                     model: 'res.users.settings',
                     method: 'set_res_users_settings',

--- a/addons/mail/static/src/models/follower.js
+++ b/addons/mail/static/src/models/follower.js
@@ -79,7 +79,7 @@ registerModel({
         async remove() {
             const partner_ids = [];
             partner_ids.push(this.partner.id);
-            await this.async(() => this.env.services.rpc({
+            await this.async(() => this.messaging.rpc({
                 model: this.followedThread.model,
                 method: 'message_unsubscribe',
                 args: [[this.followedThread.id], partner_ids]
@@ -100,7 +100,7 @@ registerModel({
          * Show (editable) list of subtypes of this follower.
          */
         async showSubtypes() {
-            const subtypesData = await this.async(() => this.env.services.rpc({
+            const subtypesData = await this.async(() => this.messaging.rpc({
                 route: '/mail/read_subscription_data',
                 params: { follower_id: this.id },
             }));
@@ -139,7 +139,7 @@ registerModel({
                 if (this.partner) {
                     kwargs.partner_ids = [this.partner.id];
                 }
-                await this.async(() => this.env.services.rpc({
+                await this.async(() => this.messaging.rpc({
                     model: this.followedThread.model,
                     method: 'message_subscribe',
                     args: [[this.followedThread.id]],

--- a/addons/mail/static/src/models/guest.js
+++ b/addons/mail/static/src/models/guest.js
@@ -13,7 +13,7 @@ registerModel({
          * @param {string} param0.name The new name to use to rename the guest.
          */
         async performRpcGuestUpdateName({ id, name }) {
-            await this.env.services.rpc({
+            await this.messaging.rpc({
                 route: '/mail/guest/update_name',
                 params: {
                     guest_id: id,

--- a/addons/mail/static/src/models/mail_template.js
+++ b/addons/mail/static/src/models/mail_template.js
@@ -38,7 +38,7 @@ registerModel({
          * @param {Activity} activity
          */
         async send(activity) {
-            await this.async(() => this.env.services.rpc({
+            await this.async(() => this.messaging.rpc({
                 model: activity.thread.model,
                 method: 'activity_send_mail',
                 args: [[activity.thread.id], this.id],

--- a/addons/mail/static/src/models/message.js
+++ b/addons/mail/static/src/models/message.js
@@ -137,7 +137,7 @@ registerModel({
          * @param {Array[]} domain
          */
         async markAllAsRead(domain) {
-            await this.env.services.rpc({
+            await this.messaging.rpc({
                 model: 'mail.message',
                 method: 'mark_all_as_read',
                 kwargs: { domain },
@@ -155,7 +155,7 @@ registerModel({
          * @param {Message[]} messages
          */
         async markAsRead(messages) {
-            await this.env.services.rpc({
+            await this.messaging.rpc({
                 model: 'mail.message',
                 method: 'set_message_done',
                 args: [messages.map(message => message.id)]
@@ -169,7 +169,7 @@ registerModel({
          * @returns {Message[]}
          */
         async performRpcMessageFetch(route, params) {
-            const messagesData = await this.env.services.rpc({ route, params }, { shadow: true });
+            const messagesData = await this.messaging.rpc({ route, params }, { shadow: true });
             if (!this.messaging) {
                 return;
             }
@@ -196,7 +196,7 @@ registerModel({
          * Unstar all starred messages of current user.
          */
         async unstarAll() {
-            await this.env.services.rpc({
+            await this.messaging.rpc({
                 model: 'mail.message',
                 method: 'unstar_all',
             });
@@ -209,7 +209,7 @@ registerModel({
          * @param {string} content
          */
         async addReaction(content) {
-            const messageData = await this.env.services.rpc({
+            const messageData = await this.messaging.rpc({
                 route: '/mail/message/add_reaction',
                 params: { content, message_id: this.id },
             });
@@ -223,7 +223,7 @@ registerModel({
          * partner Inbox.
          */
         async markAsRead() {
-            await this.async(() => this.env.services.rpc({
+            await this.async(() => this.messaging.rpc({
                 model: 'mail.message',
                 method: 'set_message_done',
                 args: [[this.id]]
@@ -254,7 +254,7 @@ registerModel({
          * @param {string} content
          */
         async removeReaction(content) {
-            const messageData = await this.env.services.rpc({
+            const messageData = await this.messaging.rpc({
                 route: '/mail/message/remove_reaction',
                 params: { content, message_id: this.id },
             });
@@ -267,7 +267,7 @@ registerModel({
          * Toggle the starred status of the provided message.
          */
         async toggleStar() {
-            await this.async(() => this.env.services.rpc({
+            await this.async(() => this.messaging.rpc({
                 model: 'mail.message',
                 method: 'toggle_message_starred',
                 args: [[this.id]]
@@ -280,7 +280,7 @@ registerModel({
          * @param {string} param0.body the new body of the message
          */
         async updateContent({ body, attachment_ids }) {
-            const messageData = await this.env.services.rpc({
+            const messageData = await this.messaging.rpc({
                 route: '/mail/message/update_content',
                 params: {
                     body,

--- a/addons/mail/static/src/models/messaging.js
+++ b/addons/mail/static/src/models/messaging.js
@@ -129,6 +129,15 @@ registerModel({
             return this.messaging.openDocument({ id, model });
         },
         /**
+         * Perform a rpc call and return a promise resolving to the result.
+         *
+         * @param {Object} params
+         * @return {any}
+         */
+        async rpc(params, options) {
+            return this.env.services.rpc(params, options);
+        },
+        /**
          * Refreshes the value of `isNotificationPermissionDefault`.
          *
          * Must be called in flux-specific way because the browser does not

--- a/addons/mail/static/src/models/messaging_initializer.js
+++ b/addons/mail/static/src/models/messaging_initializer.js
@@ -35,7 +35,7 @@ registerModel({
             });
             this.messaging.device.start();
             const discuss = this.messaging.discuss;
-            const data = await this.async(() => this.env.services.rpc({
+            const data = await this.async(() => this.messaging.rpc({
                 route: '/mail/init_messaging',
             }, { shadow: true }));
             await this.async(() => this._init(data));
@@ -300,7 +300,7 @@ registerModel({
          * @private
          */
         async _loadMessageFailures() {
-            const data = await this.env.services.rpc({
+            const data = await this.messaging.rpc({
                 route: '/mail/load_message_failures',
             }, { shadow: true });
             this._initMailFailures(data);

--- a/addons/mail/static/src/models/notification_group.js
+++ b/addons/mail/static/src/models/notification_group.js
@@ -13,7 +13,7 @@ registerModel({
          * Cancel notifications of the group.
          */
         notifyCancel() {
-            this.env.services.rpc({
+            this.messaging.rpc({
                 model: this.res_model,
                 method: 'notify_cancel_by_type',
                 kwargs: { notification_type: this.notification_type },

--- a/addons/mail/static/src/models/partner.js
+++ b/addons/mail/static/src/models/partner.js
@@ -82,7 +82,7 @@ registerModel({
             if (isNonPublicChannel) {
                 kwargs.channel_id = thread.id;
             }
-            const suggestedPartners = await this.env.services.rpc(
+            const suggestedPartners = await this.messaging.rpc(
                 {
                     model: 'res.partner',
                     method: 'get_mention_suggestions',
@@ -195,7 +195,7 @@ registerModel({
                 }
             }
             if (!partners.length) {
-                const partnersData = await this.env.services.rpc(
+                const partnersData = await this.messaging.rpc(
                     {
                         model: 'res.partner',
                         method: 'im_search',
@@ -275,7 +275,7 @@ registerModel({
             if (partnerIds.length === 0) {
                 return;
             }
-            const dataList = await this.env.services.rpc({
+            const dataList = await this.messaging.rpc({
                 route: '/longpolling/im_status',
                 params: {
                     partner_ids: partnerIds,
@@ -299,7 +299,7 @@ registerModel({
          * applicable.
          */
         async checkIsUser() {
-            const userIds = await this.async(() => this.env.services.rpc({
+            const userIds = await this.async(() => this.messaging.rpc({
                 model: 'res.users',
                 method: 'search',
                 args: [[['partner_id', '=', this.id]]],

--- a/addons/mail/static/src/models/rtc.js
+++ b/addons/mail/static/src/models/rtc.js
@@ -691,7 +691,7 @@ registerModel({
          */
         async _pingServer() {
             const channel = this.channel;
-            const { rtcSessions } = await this.env.services.rpc({
+            const { rtcSessions } = await this.messaging.rpc({
                 route: '/mail/channel/ping',
                 params: {
                     'channel_id': channel.id,
@@ -787,7 +787,7 @@ registerModel({
             await new Promise(resolve => setTimeout(resolve, this.peerNotificationWaitDelay));
             const peerNotifications = this.peerNotificationsToSend;
             try {
-                await this.env.services.rpc({
+                await this.messaging.rpc({
                     route: '/mail/rtc/session/notify_call_members',
                     params: {
                         'peer_notifications': peerNotifications.map(peerNotification =>
@@ -1202,7 +1202,7 @@ registerModel({
         },
         /**
          * @private
-         * @param {boolean} isAboveThreshold 
+         * @param {boolean} isAboveThreshold
          */
         _onThresholdAudioMonitor(isAboveThreshold) {
             this._setSoundBroadcast(isAboveThreshold);

--- a/addons/mail/static/src/models/rtc_call_participant_card.js
+++ b/addons/mail/static/src/models/rtc_call_participant_card.js
@@ -30,7 +30,7 @@ registerModel({
                 return;
             }
             const channel = this.channel;
-            const channelData = await this.env.services.rpc(({
+            const channelData = await this.messaging.rpc(({
                 route: '/mail/rtc/channel/cancel_call_invitation',
                 params: {
                     channel_id: this.channel.id,

--- a/addons/mail/static/src/models/rtc_session.js
+++ b/addons/mail/static/src/models/rtc_session.js
@@ -283,7 +283,7 @@ registerModel({
                 return;
             }
             this.update({ broadcastTimeout: clear() });
-            this.env.services.rpc(
+            this.messaging.rpc(
                 {
                     route: '/mail/rtc/session/update_and_broadcast',
                     params: {

--- a/addons/mail/static/src/models/thread.js
+++ b/addons/mail/static/src/models/thread.js
@@ -277,7 +277,7 @@ registerModel({
          * @returns {Thread} The newly created group chat.
          */
         async createGroupChat({ default_display_mode, partners_to }) {
-            const channelData = await this.env.services.rpc({
+            const channelData = await this.messaging.rpc({
                 model: 'mail.channel',
                 method: 'create_group',
                 kwargs: {
@@ -300,7 +300,7 @@ registerModel({
          *  result in the context of given thread
          */
         async fetchSuggestions(searchTerm, { thread } = {}) {
-            const channelsData = await this.env.services.rpc(
+            const channelsData = await this.messaging.rpc(
                 {
                     model: 'mail.channel',
                     method: 'get_mention_suggestions',
@@ -377,7 +377,7 @@ registerModel({
             if (channelIds.length === 0) {
                 return;
             }
-            const channelPreviews = await this.env.services.rpc({
+            const channelPreviews = await this.messaging.rpc({
                 model: 'mail.channel',
                 method: 'channel_fetch_preview',
                 args: [channelIds],
@@ -393,7 +393,7 @@ registerModel({
          * @param {string} state
          */
         async performRpcChannelFold(channelId, state) {
-            return this.env.services.rpc({
+            return this.messaging.rpc({
                 model: 'mail.channel',
                 method: 'channel_fold',
                 args: [[channelId]],
@@ -410,7 +410,7 @@ registerModel({
          * @returns {Thread[]}
          */
         async performRpcChannelInfo({ ids }) {
-            const channelInfos = await this.env.services.rpc({
+            const channelInfos = await this.messaging.rpc({
                 model: 'mail.channel',
                 method: 'channel_info',
                 args: [ids],
@@ -428,7 +428,7 @@ registerModel({
          * @param {integer[]} param0.lastMessageId
          */
         async performRpcChannelSeen({ id, lastMessageId }) {
-            return this.env.services.rpc({
+            return this.messaging.rpc({
                 route: `/mail/channel/set_last_seen_message`,
                 params: {
                     channel_id: id,
@@ -444,7 +444,7 @@ registerModel({
          * @param {boolean} [param0.pinned=false]
          */
         async performRpcChannelPin({ channelId, pinned = false }) {
-            return this.env.services.rpc({
+            return this.messaging.rpc({
                 model: 'mail.channel',
                 method: 'channel_pin',
                 args: [[channelId]],
@@ -462,7 +462,7 @@ registerModel({
          * @returns {Thread} the created channel
          */
         async performRpcCreateChannel({ name, privacy }) {
-            const data = await this.env.services.rpc({
+            const data = await this.messaging.rpc({
                 model: 'mail.channel',
                 method: 'channel_create',
                 args: [name, privacy],
@@ -484,7 +484,7 @@ registerModel({
          */
         async performRpcCreateChat({ partnerIds, pinForCurrentPartner }) {
             // TODO FIX: potential duplicate chat task-2276490
-            const data = await this.env.services.rpc({
+            const data = await this.messaging.rpc({
                 model: 'mail.channel',
                 method: 'channel_get',
                 kwargs: {
@@ -512,7 +512,7 @@ registerModel({
                 ['name', 'ilike', searchTerm],
             ];
             const fields = ['channel_type', 'name'];
-            const channelsData = await this.env.services.rpc({
+            const channelsData = await this.messaging.rpc({
                 model: "mail.channel",
                 method: "search_read",
                 kwargs: {
@@ -568,7 +568,7 @@ registerModel({
          */
         async changeDescription(description) {
             this.update({ description });
-            return this.env.services.rpc({
+            return this.messaging.rpc({
                 model: 'mail.channel',
                 method: 'channel_change_description',
                 args: [[this.id]],
@@ -613,7 +613,7 @@ registerModel({
                 followers: followersData,
                 hasWriteAccess,
                 suggestedRecipients: suggestedRecipientsData,
-            } = await this.env.services.rpc({
+            } = await this.messaging.rpc({
                 route: '/mail/thread/data',
                 params: {
                     request_list: [...requestSet],
@@ -669,7 +669,7 @@ registerModel({
          * Add current user to provided thread's followers.
          */
         async follow() {
-            await this.async(() => this.env.services.rpc({
+            await this.async(() => this.messaging.rpc({
                 model: this.model,
                 method: 'message_subscribe',
                 args: [[this.id]],
@@ -683,7 +683,7 @@ registerModel({
          * Performs the rpc to leave the rtc call of the channel.
          */
         async performRpcLeaveCall() {
-            await this.async(() => this.env.services.rpc({
+            await this.async(() => this.messaging.rpc({
                 route: '/mail/rtc/channel/leave_call',
                 params: { channel_id: this.id },
             }, { shadow: true }));
@@ -723,7 +723,7 @@ registerModel({
                 });
                 return;
             }
-            const { rtcSessions, iceServers, sessionId, invitedPartners, invitedGuests } = await this.async(() => this.env.services.rpc({
+            const { rtcSessions, iceServers, sessionId, invitedPartners, invitedGuests } = await this.async(() => this.messaging.rpc({
                 route: '/mail/rtc/channel/join_call',
                 params: {
                     channel_id: this.id,
@@ -789,7 +789,7 @@ registerModel({
          * Joins this thread. Only makes sense on channels of type channel.
          */
         async join() {
-            await this.env.services.rpc({
+            await this.messaging.rpc({
                 model: 'mail.channel',
                 method: 'add_members',
                 args: [[this.id]],
@@ -800,7 +800,7 @@ registerModel({
          * Leaves this thread. Only makes sense on channels of type channel.
          */
         async leave() {
-            await this.env.services.rpc({
+            await this.messaging.rpc({
                 model: 'mail.channel',
                 method: 'action_unfollow',
                 args: [[this.id]],
@@ -810,7 +810,7 @@ registerModel({
          * Mark the specified conversation as fetched.
          */
         async markAsFetched() {
-            await this.async(() => this.env.services.rpc({
+            await this.async(() => this.messaging.rpc({
                 model: 'mail.channel',
                 method: 'channel_fetched',
                 args: [[this.id]],
@@ -1028,7 +1028,7 @@ registerModel({
          */
         async rename(name) {
             this.update({ name });
-            return this.env.services.rpc({
+            return this.messaging.rpc({
                 model: 'mail.channel',
                 method: 'channel_rename',
                 args: [[this.id]],
@@ -1043,7 +1043,7 @@ registerModel({
          * @param {string} newName
          */
         async setCustomName(newName) {
-            return this.env.services.rpc({
+            return this.messaging.rpc({
                 model: 'mail.channel',
                 method: 'channel_set_custom_name',
                 args: [this.id],
@@ -1694,7 +1694,7 @@ registerModel({
                 isTyping !== this._currentPartnerLastNotifiedIsTyping
             ) {
                 if (this.model === 'mail.channel') {
-                    await this.async(() => this.env.services.rpc({
+                    await this.async(() => this.messaging.rpc({
                         model: 'mail.channel',
                         method: 'notify_typing',
                         args: [this.id],
@@ -1827,7 +1827,7 @@ registerModel({
          * Handles click on the "load more members" button.
          */
         async onClickLoadMoreMembers() {
-            const members = await this.env.services.rpc({
+            const members = await this.messaging.rpc({
                 model: 'mail.channel',
                 method: 'load_more_members',
                 args: [[this.id]],

--- a/addons/mail/static/src/models/user.js
+++ b/addons/mail/static/src/models/user.js
@@ -40,7 +40,7 @@ registerModel({
          * @param {integer[]} param0.ids
          */
         async performRpcRead({ context, fields, ids }) {
-            const usersData = await this.env.services.rpc({
+            const usersData = await this.messaging.rpc({
                 model: 'res.users',
                 method: 'read',
                 args: [ids],

--- a/addons/mail/static/src/models/user_setting.js
+++ b/addons/mail/static/src/models/user_setting.js
@@ -202,7 +202,7 @@ registerModel({
                 return;
             }
             this.update({ globalSettingsTimeout: clear() });
-            await this.env.services.rpc(
+            await this.messaging.rpc(
                 {
                     model: 'res.users.settings',
                     method: 'set_res_users_settings',
@@ -228,7 +228,7 @@ registerModel({
             const newVolumeSettingsTimeouts = { ...this.volumeSettingsTimeouts };
             delete newVolumeSettingsTimeouts[partnerId];
             this.update({ volumeSettingsTimeouts: newVolumeSettingsTimeouts });
-            await this.env.services.rpc(
+            await this.messaging.rpc(
                 {
                     model: 'res.users.settings',
                     method: 'set_volume_setting',

--- a/addons/mail/static/src/models/welcome_view.js
+++ b/addons/mail/static/src/models/welcome_view.js
@@ -60,7 +60,7 @@ registerModel({
          * welcome view.
          */
         async performRpcAddGuestAsMember() {
-            await this.env.services.rpc({
+            await this.messaging.rpc({
                 route: '/mail/channel/add_guest_as_member',
                 params: {
                     channel_id: this.channel.id,

--- a/addons/mail/static/tests/qunit_suite_tests/components/chat_window_manager_tests.js
+++ b/addons/mail/static/tests/qunit_suite_tests/components/chat_window_manager_tests.js
@@ -719,7 +719,7 @@ QUnit.test("Mobile: chat window shouldn't open automatically after receiving a n
             uuid: 'channel-10-uuid',
         },
     ];
-    const { env } = await this.start({
+    const { messaging } = await this.start({
         env: {
             device: {
                 isMobile: true,
@@ -728,7 +728,7 @@ QUnit.test("Mobile: chat window shouldn't open automatically after receiving a n
     });
 
     // simulate receiving a message
-    env.services.rpc({
+    messaging.rpc({
         route: '/mail/chat_post',
         params: {
             context: {
@@ -2172,10 +2172,10 @@ QUnit.test('new message separator is shown in a chat window of a chat on receivi
         model: 'mail.channel',
         res_id: mailChannelId1,
     });
-    const { env } = await this.start();
+    const { messaging } = await this.start();
 
     // simulate receiving a message
-    await afterNextRender(async () => env.services.rpc({
+    await afterNextRender(async () => messaging.rpc({
         route: '/mail/chat_post',
         params: {
             context: {
@@ -2217,10 +2217,10 @@ QUnit.test('new message separator is not shown in a chat window of a chat on rec
         channel_type: "chat",
         uuid: 'channel-10-uuid',
     });
-    const { env } = await this.start();
+    const { messaging } = await this.start();
 
     // simulate receiving a message
-    await afterNextRender(async () => env.services.rpc({
+    await afterNextRender(async () => messaging.rpc({
         route: '/mail/chat_post',
         params: {
             context: {
@@ -2260,10 +2260,10 @@ QUnit.test('focusing a chat window of a chat should make new message separator d
         model: 'mail.channel',
         res_id: mailChannelId1,
     });
-    const { afterEvent, env } = await this.start();
+    const { afterEvent, messaging } = await this.start();
 
     // simulate receiving a message
-    await afterNextRender(() => env.services.rpc({
+    await afterNextRender(() => messaging.rpc({
         route: '/mail/chat_post',
         params: {
             context: {
@@ -2402,10 +2402,10 @@ QUnit.test('chat window should open when receiving a new DM', async function (as
         channel_type: 'chat',
         uuid: 'channel11uuid',
     });
-    const { env } = await this.start();
+    const { messaging } = await this.start();
 
     // simulate receiving the first message on channel 11
-    await afterNextRender(() => env.services.rpc({
+    await afterNextRender(() => messaging.rpc({
         route: '/mail/chat_post',
         params: {
             context: {
@@ -2444,9 +2444,9 @@ QUnit.test('chat window should remain folded when new message is received', asyn
         uuid: 'channel-10-uuid',
     });
 
-    const { env } = await this.start();
+    const { messaging } = await this.start();
     // simulate receiving a new message
-    await afterNextRender(async () => env.services.rpc({
+    await afterNextRender(async () => messaging.rpc({
         route: '/mail/chat_post',
         params: {
             context: {

--- a/addons/mail/static/tests/qunit_suite_tests/components/discuss_sidebar_category_item_tests.js
+++ b/addons/mail/static/tests/qunit_suite_tests/components/discuss_sidebar_category_item_tests.js
@@ -50,7 +50,7 @@ QUnit.test('channel - avatar: should update avatar url from bus', async function
     const pyEnv = await startServer();
     const mailChannelId1 = pyEnv['mail.channel'].create({ avatarCacheKey: '101010' });
 
-    const { env, messaging } = await start({
+    const { messaging } = await start({
         autoOpenDiscuss: true,
         hasDiscuss: true,
     });
@@ -70,7 +70,7 @@ QUnit.test('channel - avatar: should update avatar url from bus', async function
     );
 
     await afterNextRender(() => {
-        env.services.rpc({
+        messaging.rpc({
             model: 'mail.channel',
             method: 'write',
             args: [[mailChannelId1], { image_128: 'This field does not matter' }],

--- a/addons/mail/static/tests/qunit_suite_tests/components/discuss_sidebar_category_tests.js
+++ b/addons/mail/static/tests/qunit_suite_tests/components/discuss_sidebar_category_tests.js
@@ -248,9 +248,9 @@ QUnit.test('channel - states: close should update the value on the server', asyn
         is_discuss_sidebar_category_channel_open: true,
     });
     const currentUserId = pyEnv.currentUserId;
-    const { click, env } = await this.start();
+    const { click, messaging } = await this.start();
 
-    const initalSettings = await env.services.rpc({
+    const initalSettings = await messaging.rpc({
         model: 'res.users.settings',
         method: '_find_or_create_for_user',
         args: [[currentUserId]],
@@ -262,7 +262,7 @@ QUnit.test('channel - states: close should update the value on the server', asyn
     );
 
     await click(`.o_DiscussSidebar_categoryChannel .o_DiscussSidebarCategory_title`);
-    const newSettings = await env.services.rpc({
+    const newSettings = await messaging.rpc({
         model: 'res.users.settings',
         method: '_find_or_create_for_user',
         args: [[currentUserId]],
@@ -284,9 +284,9 @@ QUnit.test('channel - states: open should update the value on the server', async
         is_discuss_sidebar_category_channel_open: false,
     });
     const currentUserId = pyEnv.currentUserId;
-    const { click, env } = await this.start();
+    const { click, messaging } = await this.start();
 
-    const initalSettings = await env.services.rpc({
+    const initalSettings = await messaging.rpc({
         model: 'res.users.settings',
         method: '_find_or_create_for_user',
         args: [[currentUserId]],
@@ -298,7 +298,7 @@ QUnit.test('channel - states: open should update the value on the server', async
     );
 
     await click(`.o_DiscussSidebar_categoryChannel .o_DiscussSidebarCategory_title`);
-    const newSettings = await env.services.rpc({
+    const newSettings = await messaging.rpc({
         model: 'res.users.settings',
         method: '_find_or_create_for_user',
         args: [[currentUserId]],
@@ -620,9 +620,9 @@ QUnit.test('chat - states: close should call update server data', async function
         is_discuss_sidebar_category_chat_open: true,
     });
     const currentUserId = pyEnv.currentUserId;
-    const { click, env } = await this.start();
+    const { click, messaging } = await this.start();
 
-    const initalSettings = await env.services.rpc({
+    const initalSettings = await messaging.rpc({
         model: 'res.users.settings',
         method: '_find_or_create_for_user',
         args: [[currentUserId]],
@@ -634,7 +634,7 @@ QUnit.test('chat - states: close should call update server data', async function
     );
 
     await click(`.o_DiscussSidebar_categoryChat .o_DiscussSidebarCategory_title`);
-    const newSettings = await env.services.rpc({
+    const newSettings = await messaging.rpc({
         model: 'res.users.settings',
         method: '_find_or_create_for_user',
         args: [[currentUserId]],
@@ -655,9 +655,9 @@ QUnit.test('chat - states: open should call update server data', async function 
         user_id: pyEnv.currentUserId,
         is_discuss_sidebar_category_chat_open: false,
     });
-    const { click, env } = await this.start();
+    const { click, messaging } = await this.start();
 
-    const initalSettings = await env.services.rpc({
+    const initalSettings = await messaging.rpc({
         model: 'res.users.settings',
         method: '_find_or_create_for_user',
         args: [[pyEnv.currentUserId]],
@@ -669,7 +669,7 @@ QUnit.test('chat - states: open should call update server data', async function 
     );
 
     await click(`.o_DiscussSidebar_categoryChat .o_DiscussSidebarCategory_title`);
-    const newSettings = await env.services.rpc({
+    const newSettings = await messaging.rpc({
         model: 'res.users.settings',
         method: '_find_or_create_for_user',
         args: [[pyEnv.currentUserId]],

--- a/addons/mail/static/tests/qunit_suite_tests/components/discuss_tests.js
+++ b/addons/mail/static/tests/qunit_suite_tests/components/discuss_tests.js
@@ -1753,7 +1753,7 @@ QUnit.test('new messages separator [REQUIRE FOCUS]', async function (assert) {
     }
     const [mailChannelPartnerId] = pyEnv['mail.channel.partner'].search([['channel_id', '=', mailChannelId1], ['partner_id', '=', pyEnv.currentPartnerId]]);
     pyEnv['mail.channel.partner'].write([mailChannelPartnerId], { seen_message_id: lastMessage.id });
-    const { afterEvent, env } = await this.start({
+    const { afterEvent, messaging } = await this.start({
         discuss: {
             params: {
                 default_active_id: `mail.channel_${mailChannelId1}`,
@@ -1803,7 +1803,7 @@ QUnit.test('new messages separator [REQUIRE FOCUS]', async function (assert) {
     // composer is focused by default, we remove that focus
     document.querySelector('.o_ComposerTextInput_textarea').blur();
     // simulate receiving a message
-    await afterNextRender(async () => env.services.rpc({
+    await afterNextRender(async () => messaging.rpc({
         route: '/mail/chat_post',
         params: {
             context: {

--- a/addons/mail/static/tests/qunit_suite_tests/components/thread_view_tests.js
+++ b/addons/mail/static/tests/qunit_suite_tests/components/thread_view_tests.js
@@ -229,7 +229,7 @@ QUnit.test('mark channel as fetched when a new message is loaded and as seen whe
         ],
         channel_type: 'chat',
     });
-    const { afterEvent, createThreadViewComponent, env, messaging } = await start({
+    const { afterEvent, createThreadViewComponent, messaging } = await start({
         mockRPC(route, args) {
             if (args.method === 'channel_fetched') {
                 assert.strictEqual(
@@ -264,7 +264,7 @@ QUnit.test('mark channel as fetched when a new message is loaded and as seen whe
         thread: link(thread),
     });
     await createThreadViewComponent(threadViewer.threadView);
-    await afterNextRender(async () => env.services.rpc({
+    await afterNextRender(async () => messaging.rpc({
         route: '/mail/chat_post',
         params: {
             context: {
@@ -305,7 +305,7 @@ QUnit.test('mark channel as fetched and seen when a new message is loaded if com
         partner_id: resPartnerId1,
     });
     const mailChannelId1 = pyEnv['mail.channel'].create({});
-    const { afterEvent, createThreadViewComponent, env, messaging } = await start({
+    const { afterEvent, createThreadViewComponent, messaging } = await start({
         data: this.data,
         mockRPC(route, args) {
             if (args.method === 'channel_fetched' && args.args[0] === mailChannelId1) {
@@ -335,7 +335,7 @@ QUnit.test('mark channel as fetched and seen when a new message is loaded if com
     // simulate receiving a message
     await afterEvent({
         eventName: 'o-thread-last-seen-by-current-partner-message-id-changed',
-        func: () => env.services.rpc({
+        func: () => messaging.rpc({
             route: '/mail/chat_post',
             params: {
                 context: {
@@ -532,7 +532,7 @@ QUnit.test('new messages separator on receiving new message [REQUIRE FOCUS]', as
     });
     const [mailChannelPartnerId] = pyEnv['mail.channel.partner'].search([['channel_id', '=', mailChannelId1], ['partner_id', '=', pyEnv.currentPartnerId]]);
     pyEnv['mail.channel.partner'].write([mailChannelPartnerId], { seen_message_id: mailMessageId1 });
-    const { afterEvent, createThreadViewComponent, env, messaging } = await start();
+    const { afterEvent, createThreadViewComponent, messaging } = await start();
     const thread = messaging.models['Thread'].findFromIdentifyingData({
         id: mailChannelId1,
         model: 'mail.channel'
@@ -559,7 +559,7 @@ QUnit.test('new messages separator on receiving new message [REQUIRE FOCUS]', as
     // simulate receiving a message
     await afterEvent({
         eventName: 'o-thread-view-hint-processed',
-        func: () => env.services.rpc({
+        func: () => messaging.rpc({
             route: '/mail/chat_post',
             params: {
                 context: {
@@ -775,7 +775,7 @@ QUnit.test('should scroll to bottom on receiving new message if the list is init
             res_id: mailChannelId1,
         });
     }
-    const { afterEvent, createThreadViewComponent, env, messaging } = await start();
+    const { afterEvent, createThreadViewComponent, messaging } = await start();
     const thread = messaging.models['Thread'].findFromIdentifyingData({
         id: mailChannelId1,
         model: 'mail.channel'
@@ -806,7 +806,7 @@ QUnit.test('should scroll to bottom on receiving new message if the list is init
     await afterEvent({
         eventName: 'o-component-message-list-scrolled',
         func: () =>
-            env.services.rpc({
+            messaging.rpc({
                 route: '/mail/chat_post',
                 params: {
                     context: {
@@ -847,7 +847,7 @@ QUnit.test('should not scroll on receiving new message if the list is initially 
             res_id: mailChannelId1,
         });
     }
-    const { afterEvent, createThreadViewComponent, env, messaging } = await start();
+    const { afterEvent, createThreadViewComponent, messaging } = await start();
     const thread = messaging.models['Thread'].findFromIdentifyingData({
         id: mailChannelId1,
         model: 'mail.channel'
@@ -890,7 +890,7 @@ QUnit.test('should not scroll on receiving new message if the list is initially 
     await afterEvent({
         eventName: 'o-thread-view-hint-processed',
         func: () =>
-            env.services.rpc({
+            messaging.rpc({
                 route: '/mail/chat_post',
                 params: {
                     context: {
@@ -1515,7 +1515,7 @@ QUnit.test('first unseen message should be directly preceded by the new message 
         name: "General",
         uuid: 'channel20uuid',
     });
-    const { click, createThreadViewComponent, env, messaging } = await start();
+    const { click, createThreadViewComponent, messaging } = await start();
     const thread = messaging.models['Thread'].findFromIdentifyingData({
         id: mailChannelId1,
         model: 'mail.channel'
@@ -1534,7 +1534,7 @@ QUnit.test('first unseen message should be directly preceded by the new message 
     // composer is focused by default, we remove that focus
     document.querySelector('.o_ComposerTextInput_textarea').blur();
     // simulate receiving a message
-    await afterNextRender(() => env.services.rpc({
+    await afterNextRender(() => messaging.rpc({
         route: '/mail/chat_post',
         params: {
             context: {

--- a/addons/mail_bot/static/src/models/messaging_initializer.js
+++ b/addons/mail_bot/static/src/models/messaging_initializer.js
@@ -9,7 +9,7 @@ addRecordMethods('MessagingInitializer', {
      * @private
      */
     async _initializeOdooBot() {
-        const data = await this.async(() => this.env.services.rpc({
+        const data = await this.async(() => this.messaging.rpc({
             model: 'mail.channel',
             method: 'init_odoobot',
         }));

--- a/addons/snailmail/static/src/models/message.js
+++ b/addons/snailmail/static/src/models/message.js
@@ -12,7 +12,7 @@ addRecordMethods('Message', {
      */
     async cancelLetter() {
         // the result will come from longpolling: message_notification_update
-        await this.async(() => this.env.services.rpc({
+        await this.async(() => this.messaging.rpc({
             model: 'mail.message',
             method: 'cancel_letter',
             args: [[this.id]],
@@ -35,7 +35,7 @@ addRecordMethods('Message', {
      * Opens the action about 'snailmail.letter' missing fields.
      */
     async openMissingFieldsLetterAction() {
-        const letterIds = await this.async(() => this.env.services.rpc({
+        const letterIds = await this.async(() => this.messaging.rpc({
             model: 'snailmail.letter',
             method: 'search',
             args: [[['message_id', '=', this.id]]],
@@ -54,7 +54,7 @@ addRecordMethods('Message', {
      */
     async resendLetter() {
         // the result will come from longpolling: message_notification_update
-        await this.async(() => this.env.services.rpc({
+        await this.async(() => this.messaging.rpc({
             model: 'mail.message',
             method: 'send_letter',
             args: [[this.id]],

--- a/addons/snailmail/static/src/models/messaging.js
+++ b/addons/snailmail/static/src/models/messaging.js
@@ -7,7 +7,7 @@ import '@mail/models/messaging';
 
 addRecordMethods('Messaging', {
     async fetchSnailmailCreditsUrl() {
-        const snailmail_credits_url = await this.async(() => this.env.services.rpc({
+        const snailmail_credits_url = await this.async(() => this.messaging.rpc({
             model: 'iap.account',
             method: 'get_credits_url',
             args: ['snailmail'],
@@ -17,7 +17,7 @@ addRecordMethods('Messaging', {
         });
     },
     async fetchSnailmailCreditsUrlTrial() {
-        const snailmail_credits_url_trial = await this.async(() => this.env.services.rpc({
+        const snailmail_credits_url_trial = await this.async(() => this.messaging.rpc({
             model: 'iap.account',
             method: 'get_credits_url',
             args: ['snailmail', '', 0, true],

--- a/addons/website_slides/static/src/models/activity_view.js
+++ b/addons/website_slides/static/src/models/activity_view.js
@@ -10,7 +10,7 @@ addRecordMethods('ActivityView', {
      */
     async onGrantAccess(ev) {
         const { chatter } = this.activityBoxView; // save value before deleting activity
-        await this.env.services.rpc({
+        await this.messaging.rpc({
             model: 'slide.channel',
             method: 'action_grant_access',
             args: [[this.activity.thread.id]],
@@ -26,7 +26,7 @@ addRecordMethods('ActivityView', {
      */
     async onRefuseAccess(ev) {
         const { chatter } = this.activityBoxView; // save value before deleting activity
-        await this.env.services.rpc({
+        await this.messaging.rpc({
             model: 'slide.channel',
             method: 'action_refuse_access',
             args: [[this.activity.thread.id]],


### PR DESCRIPTION
*: board, calendar, google_spreadsheet, hr, im_livechat, lunch, mail_bot,
snailmail, website_slides.

This PR prepares the ground for the one introducing the new env in discuss.
The signature of the rpc function has changed a lot from the one in the old env.
In order to ease the transition and reduce the noise, the discuss models now
rely on the messaging's rpc function.

task-2582313

enterprise: https://github.com/odoo/enterprise/pull/26676