### PR TITLE
[FIX] server: close psql connections on shutdown

### DIFF
--- a/odoo/service/server.py
+++ b/odoo/service/server.py
@@ -497,6 +497,8 @@ class ThreadedServer(CommonServer):
                     thread.join(0.05)
                     time.sleep(0.05)
 
+        odoo.sql_db.close_all()
+
         _logger.debug('--')
         logging.shutdown()
 


### PR DESCRIPTION
Stopping a threaded odoo server would spam the postgresql logs with
multiple:

<...> LOG:  could not receive data from client: Connection reset by peer

Let's avoid being rude and not hang up on postgresql connections
unexpectedly.