### PR TITLE
[IMP] mail: add notify to messaging

### DIFF
--- a/addons/hr/static/src/models/employee.js
+++ b/addons/hr/static/src/models/employee.js
@@ -108,7 +108,7 @@ registerModel({
             }
             // prevent chatting with non-users
             if (!this.user) {
-                this.env.services['notification'].notify({
+                this.messaging.notify({
                     message: this.env._t("You can only chat with employees that have a dedicated user."),
                     type: 'info',
                 });

--- a/addons/mail/static/src/models/channel_invitation_form.js
+++ b/addons/mail/static/src/models/channel_invitation_form.js
@@ -16,7 +16,7 @@ registerModel({
          */
         async onClickCopy(ev) {
             await navigator.clipboard.writeText(this.thread.invitationLink);
-            this.env.services.notification.notify({
+            this.messaging.notify({
                 message: this.env._t('Link copied!'),
                 type: 'success',
             });

--- a/addons/mail/static/src/models/composer_view.js
+++ b/addons/mail/static/src/models/composer_view.js
@@ -249,7 +249,7 @@ registerModel({
             ev.preventDefault();
             if (!this.composer.canPostMessage) {
                 if (this.composer.hasUploadingAttachment) {
-                    this.env.services['notification'].notify({
+                    this.messaging.notify({
                         message: this.env._t("Please wait while the file is uploading."),
                         type: 'warning',
                     });
@@ -631,13 +631,13 @@ registerModel({
                 }
                 if (threadViewThread) {
                     if (threadViewThread === this.messaging.inbox) {
-                        if (this.exists()) {
-                            this.delete();
-                        }
-                        this.env.services['notification'].notify({
+                        this.messaging.notify({
                             message: sprintf(this.env._t(`Message posted on "%s"`), message.originThread.displayName),
                             type: 'info',
                         });
+                        if (this.exists()) {
+                            this.delete();
+                        }
                     }
                     if (threadView && threadView.exists()) {
                         threadView.update({ replyingToMessageView: clear() });
@@ -672,7 +672,7 @@ registerModel({
         sendMessage() {
             if (!this.composer.canPostMessage) {
                 if (this.composer.hasUploadingAttachment) {
-                    this.env.services['notification'].notify({
+                    this.messaging.notify({
                         message: this.env._t("Please wait while the file is uploading."),
                         type: 'warning',
                     });

--- a/addons/mail/static/src/models/file_uploader.js
+++ b/addons/mail/static/src/models/file_uploader.js
@@ -99,7 +99,7 @@ registerModel({
          */
         _onAttachmentUploaded({ attachmentData, composer, thread }) {
             if (attachmentData.error || !attachmentData.id) {
-                this.env.services['notification'].notify({
+                this.messaging.notify({
                     type: 'danger',
                     message: attachmentData.error,
                 });

--- a/addons/mail/static/src/models/follower.js
+++ b/addons/mail/static/src/models/follower.js
@@ -139,7 +139,7 @@ registerModel({
                     args: [[this.followedThread.id]],
                     kwargs,
                 }));
-                this.env.services['notification'].notify({
+                this.messaging.notify({
                     type: 'success',
                     message: this.env._t("The subscription preferences were successfully applied."),
                 });

--- a/addons/mail/static/src/models/messaging.js
+++ b/addons/mail/static/src/models/messaging.js
@@ -55,6 +55,22 @@ registerModel({
             }
         },
         /**
+         * Display a notification to the user.
+         *
+         * @param {Object} params
+         * @param {string} [params.message]
+         * @param {string} [params.subtitle]
+         * @param {Object[]} [params.buttons]
+         * @param {boolean} [params.sticky]
+         * @param {string} [params.type]
+         * @param {string} [params.className]
+         * @param {function} [params.onClose]
+         * @return {number} the id of the notification.
+         */
+        notify(params) {
+            return this.env.services.notification.notify(params);
+        },
+        /**
          * Opens a chat with the provided person and returns it.
          *
          * If a chat is not appropriate, a notification is displayed instead.
@@ -118,7 +134,7 @@ registerModel({
                     ))[0];
                 }
                 if (!channel) {
-                    this.env.services['notification'].notify({
+                    this.messaging.notify({
                         message: this.env._t("You can only open the profile of existing channels."),
                         type: 'warning',
                     });

--- a/addons/mail/static/src/models/messaging_notification_handler.js
+++ b/addons/mail/static/src/models/messaging_notification_handler.js
@@ -189,7 +189,7 @@ registerModel({
             const channel = this.messaging.models['Thread'].insert(this.messaging.models['Thread'].convertData(channelData));
             if (this.messaging.currentUser && invitedByUserId !== this.messaging.currentUser.id) {
                 // Current user was invited by someone else.
-                this.env.services['notification'].notify({
+                this.messaging.notify({
                     message: sprintf(
                         this.env._t("You have been invited to #%s"),
                         channel.displayName
@@ -440,7 +440,7 @@ registerModel({
          * @param {boolean} param1.warning
          */
         _handleNotificationSimpleNotification({ message, message_is_html, sticky, title, warning }) {
-            this.env.services['notification'].notify({
+            this.messaging.notify({
                 message: message_is_html ? Markup(message) : message,
                 sticky,
                 title,
@@ -466,7 +466,7 @@ registerModel({
             const currentSession = this.messaging.rtc.currentRtcSession;
             if (currentSession && currentSession.id === sessionId) {
                 this.messaging.rtc.channel.endCall();
-                this.env.services['notification'].notify({
+                this.messaging.notify({
                     message: this.env._t("Disconnected from the RTC call by the server"),
                     type: 'warning',
                 });
@@ -613,7 +613,7 @@ registerModel({
                 return;
             }
             const message = sprintf(this.env._t("You unsubscribed from %s."), channel.displayName);
-            this.env.services['notification'].notify({ message, type: 'info' });
+            this.messaging.notify({ message, type: 'info' });
             // We assume that arriving here the server has effectively
             // unpinned the channel
             channel.update({
@@ -635,7 +635,7 @@ registerModel({
                 return;
             }
             const message = sprintf(this.env._t("You unpinned your conversation with %s."), channel.displayName);
-            this.env.services['notification'].notify({ message, type: 'info' });
+            this.messaging.notify({ message, type: 'info' });
             // We assume that arriving here the server has effectively
             // unpinned the channel
             channel.update({

--- a/addons/mail/static/src/models/partner.js
+++ b/addons/mail/static/src/models/partner.js
@@ -325,7 +325,7 @@ registerModel({
             }
             // prevent chatting with non-users
             if (!this.user) {
-                this.env.services['notification'].notify({
+                this.messaging.notify({
                     message: this.env._t("You can only chat with partners that have a dedicated user."),
                     type: 'info',
                 });

--- a/addons/mail/static/src/models/rtc.js
+++ b/addons/mail/static/src/models/rtc.js
@@ -243,7 +243,7 @@ registerModel({
                     const audioStream = await browser.navigator.mediaDevices.getUserMedia({ audio: this.messaging.userSetting.getAudioConstraints() });
                     audioTrack = audioStream.getAudioTracks()[0];
                 } catch (_e) {
-                    this.env.services.notification.notify({
+                    this.messaging.notify({
                         message: sprintf(
                             this.env._t(`"%s" requires microphone access`),
                             window.location.host,
@@ -313,7 +313,7 @@ registerModel({
                  * in that case, voice activation is not enabled
                  * and the microphone is always 'on'.
                  */
-                this.env.services.notification.notify({
+                this.messaging.notify({
                     message: this.env._t("Your browser does not support voice activation"),
                     type: 'warning',
                 });
@@ -1001,7 +1001,7 @@ registerModel({
                     this.messaging.soundEffects.screenSharing.play();
                 }
             } catch (_e) {
-                this.env.services.notification.notify({
+                this.messaging.notify({
                     message: sprintf(
                         this.env._t(`"%s" requires "%s" access`),
                         window.location.host,
@@ -1202,7 +1202,7 @@ registerModel({
         },
         /**
          * @private
-         * @param {boolean} isAboveThreshold 
+         * @param {boolean} isAboveThreshold
          */
         _onThresholdAudioMonitor(isAboveThreshold) {
             this._setSoundBroadcast(isAboveThreshold);

--- a/addons/mail/static/src/models/rtc_call_viewer.js
+++ b/addons/mail/static/src/models/rtc_call_viewer.js
@@ -82,7 +82,7 @@ registerModel({
                 if (this.exists()) {
                     this.update({ isFullScreen: false });
                 }
-                this.env.services.notification.notify({
+                this.messaging.notify({
                     message: this.env._t("The FullScreen mode was denied by the browser"),
                     type: 'warning',
                 });

--- a/addons/mail/static/src/models/thread.js
+++ b/addons/mail/static/src/models/thread.js
@@ -717,7 +717,7 @@ registerModel({
                 return;
             }
             if (!this.messaging.rtc.isClientRtcCompatible) {
-                this.env.services.notification.notify({
+                this.messaging.notify({
                     message: this.env._t("Your browser does not support webRTC."),
                     type: 'warning',
                 });

--- a/addons/mail/static/src/models/user.js
+++ b/addons/mail/static/src/models/user.js
@@ -81,7 +81,7 @@ registerModel({
                 // - Validity of id is not verified at insert.
                 // - There is no bus notification in case of user delete from
                 //   another tab or by another user.
-                this.env.services['notification'].notify({
+                this.messaging.notify({
                     message: this.env._t("You can only chat with existing users."),
                     type: 'warning',
                 });
@@ -104,7 +104,7 @@ registerModel({
                 );
             }
             if (!chat) {
-                this.env.services['notification'].notify({
+                this.messaging.notify({
                     message: this.env._t("An unexpected error occurred during the creation of the chat."),
                     type: 'warning',
                 });
@@ -144,7 +144,7 @@ registerModel({
                 // - Validity of id is not verified at insert.
                 // - There is no bus notification in case of user delete from
                 //   another tab or by another user.
-                this.env.services['notification'].notify({
+                this.messaging.notify({
                     message: this.env._t("You can only open the profile of existing users."),
                     type: 'warning',
                 });


### PR DESCRIPTION
This PR prepares the ground for the one introducing the new env in discuss.
The signature of the notify function has changed a lot from the one in the old env.
In order to ease the transition and reduce the noise, the discuss models now
rely on the messaging's notify function.

task-2582313
