### PR TITLE
[IMP] web: move mock relational field tests

### DIFF
--- a/addons/web/__manifest__.py
+++ b/addons/web/__manifest__.py
@@ -490,7 +490,6 @@ This module provides the core of the Odoo Web Client.
             'web/static/tests/webclient/**/helpers.js',
             'web/static/tests/qunit.js',
             'web/static/tests/main.js',
-            'web/static/tests/mock_relational_fields_tests.js',
             'web/static/tests/mock_server_tests.js',
             'web/static/tests/setup.js',
 

--- a/addons/web/static/tests/legacy/mock_relational_fields_tests.js
+++ b/addons/web/static/tests/legacy/mock_relational_fields_tests.js
@@ -3,6 +3,7 @@
 import MockServer from 'web.MockServer';
 
 QUnit.module('web', {}, function () {
+QUnit.module('legacy', {}, function () {
 QUnit.module('mock_relational_fields_tests.js', {
     beforeEach() {
         this.data = {
@@ -132,4 +133,5 @@ QUnit.test('many2one_ref update should update inverse field', async function (as
     assert.deepEqual([], mockServer.data['bar'].records[0].one2many_field);
 });
 
+});
 });


### PR DESCRIPTION
Since those tests are related to the legacy mockServer, they have been
moved to the legacy folder.

task-2582313
