### PR TITLE
[IMP] mail: make start return advanceTime function

### DIFF
--- a/addons/mail/static/tests/helpers/test_utils.js
+++ b/addons/mail/static/tests/helpers/test_utils.js
@@ -911,6 +911,9 @@ async function start(param0 = {}) {
         pyEnv,
         widget,
     };
+    if (hasTimeControl) {
+        result['advanceTime'] = env.testUtils.advanceTime;
+    }
     const { modelManager } = testEnv.services.messaging;
     registerCleanup(async() => {
         widget.destroy();

--- a/addons/mail/static/tests/qunit_suite_tests/components/chatter_topbar_tests.js
+++ b/addons/mail/static/tests/qunit_suite_tests/components/chatter_topbar_tests.js
@@ -111,7 +111,7 @@ QUnit.test('attachment loading is delayed', async function (assert) {
 
     const pyEnv = await startServer();
     const resPartnerId1 = pyEnv['res.partner'].create();
-    const { createChatterContainerComponent, env } = await start({
+    const { advanceTime, createChatterContainerComponent } = await start({
         hasTimeControl: true,
         loadingBaseDelayDuration: 100,
         async mockRPC(route) {
@@ -142,7 +142,7 @@ QUnit.test('attachment loading is delayed', async function (assert) {
         "attachments button should not have a loader yet"
     );
 
-    await afterNextRender(async () => env.testUtils.advanceTime(100));
+    await afterNextRender(async () => advanceTime(100));
     assert.strictEqual(
         document.querySelectorAll(`.o_ChatterTopbar_buttonAttachmentsCountLoader`).length,
         1,

--- a/addons/mail/static/tests/qunit_suite_tests/components/composer_tests.js
+++ b/addons/mail/static/tests/qunit_suite_tests/components/composer_tests.js
@@ -1198,7 +1198,7 @@ QUnit.test('current partner notify no longer is typing to thread members after 5
     // with a random unique id that will be referenced in the test
     const pyEnv = await startServer();
     const mailChannelId1 = pyEnv['mail.channel'].create();
-    const { env, insertText } = await start({
+    const { advanceTime, insertText } = await start({
         autoOpenDiscuss: true,
         discuss: {
             params: {
@@ -1222,7 +1222,7 @@ QUnit.test('current partner notify no longer is typing to thread members after 5
         "should have notified current partner is typing"
     );
 
-    await env.testUtils.advanceTime(5 * 1000);
+    await advanceTime(5 * 1000);
     assert.verifySteps(
         ['notify_typing:false'],
         "should have notified current partner no longer is typing (inactive for 5 seconds)"
@@ -1236,7 +1236,7 @@ QUnit.test('current partner notify is typing again to other members every 50s of
     // with a random unique id that will be referenced in the test
     const pyEnv = await startServer();
     const mailChannelId1 = pyEnv['mail.channel'].create();
-    const { env, insertText } = await start({
+    const { advanceTime, insertText } = await start({
         autoOpenDiscuss: true,
         discuss: {
             params: {
@@ -1265,7 +1265,7 @@ QUnit.test('current partner notify is typing again to other members every 50s of
     while (totalTimeElapsed < 50 * 1000) {
         await insertText('.o_ComposerTextInput_textarea', 'a');
         totalTimeElapsed += elapseTickTime;
-        await env.testUtils.advanceTime(elapseTickTime);
+        await advanceTime(elapseTickTime);
     }
 
     assert.verifySteps(

--- a/addons/mail/static/tests/qunit_suite_tests/components/thread_textual_typing_status_tests.js
+++ b/addons/mail/static/tests/qunit_suite_tests/components/thread_textual_typing_status_tests.js
@@ -136,7 +136,7 @@ QUnit.test('assume other member typing status becomes "no longer is typing" afte
             [0, 0, { partner_id: resPartnerId1 }],
         ],
     });
-    const { env, messaging, widget } = await start({
+    const { advanceTime, messaging, widget } = await start({
         hasTimeControl: true,
     });
     const thread = messaging.models['Thread'].findFromIdentifyingData({
@@ -169,7 +169,7 @@ QUnit.test('assume other member typing status becomes "no longer is typing" afte
         "Should display that demo user is typing"
     );
 
-    await afterNextRender(() => env.testUtils.advanceTime(60 * 1000));
+    await afterNextRender(() => advanceTime(60 * 1000));
     assert.strictEqual(
         document.querySelector('.o_ThreadTextualTypingStatus').textContent,
         "",
@@ -188,7 +188,7 @@ QUnit.test ('other member typing status "is typing" refreshes 60 seconds timer o
             [0, 0, { partner_id: resPartnerId1 }],
         ],
     });
-    const { env, messaging, widget } = await start({
+    const { advanceTime, messaging, widget } = await start({
         hasTimeControl: true,
     });
     const thread = messaging.models['Thread'].findFromIdentifyingData({
@@ -222,7 +222,7 @@ QUnit.test ('other member typing status "is typing" refreshes 60 seconds timer o
     );
 
     // simulate receive typing notification from demo "is typing" again after 50s.
-    await env.testUtils.advanceTime(50 * 1000);
+    await advanceTime(50 * 1000);
     widget.call('bus_service', 'trigger', 'notification', [{
         type: 'mail.channel.partner/typing_status',
         payload: {
@@ -232,7 +232,7 @@ QUnit.test ('other member typing status "is typing" refreshes 60 seconds timer o
             partner_name: "Demo",
         },
     }]);
-    await env.testUtils.advanceTime(50 * 1000);
+    await advanceTime(50 * 1000);
     await nextAnimationFrame();
     assert.strictEqual(
         document.querySelector('.o_ThreadTextualTypingStatus').textContent,
@@ -240,7 +240,7 @@ QUnit.test ('other member typing status "is typing" refreshes 60 seconds timer o
         "Should still display that demo user is typing after 100 seconds (refreshed is typing status at 50s => (100 - 50) = 50s < 60s after assuming no-longer typing)"
     );
 
-    await afterNextRender(() => env.testUtils.advanceTime(11 * 1000));
+    await afterNextRender(() => advanceTime(11 * 1000));
     assert.strictEqual(
         document.querySelector('.o_ThreadTextualTypingStatus').textContent,
         "",

--- a/addons/mail/static/tests/qunit_suite_tests/utils/throttle_tests.js
+++ b/addons/mail/static/tests/qunit_suite_tests/utils/throttle_tests.js
@@ -25,7 +25,7 @@ QUnit.module('throttle_tests.js', {
 QUnit.test('single call', async function (assert) {
     assert.expect(6);
 
-    const { env, messaging } = await start({
+    const { advanceTime, messaging } = await start({
         hasTimeControl: true,
     });
 
@@ -45,7 +45,7 @@ QUnit.test('single call', async function (assert) {
         "func should not have been invoked on immediate throttle initialization"
     );
 
-    await env.testUtils.advanceTime(0);
+    await advanceTime(0);
     assert.notOk(
         hasInvokedFunc,
         "func should not have been invoked from throttle initialization after 0ms"
@@ -73,7 +73,7 @@ QUnit.test('single call', async function (assert) {
 QUnit.test('2nd (throttled) call', async function (assert) {
     assert.expect(8);
 
-    const { env, messaging } = await start({
+    const { advanceTime, messaging } = await start({
         hasTimeControl: true,
     });
 
@@ -116,13 +116,13 @@ QUnit.test('2nd (throttled) call', async function (assert) {
         "inner function of throttle should not have been immediately invoked after 2nd call immediately after 1st call (throttled with 1s internal clock)"
     );
 
-    await env.testUtils.advanceTime(999);
+    await advanceTime(999);
     assert.verifySteps(
         [],
         "inner function of throttle should not have been invoked after 999ms of 2nd call (throttled with 1s internal clock)"
     );
 
-    await env.testUtils.advanceTime(1);
+    await advanceTime(1);
     assert.verifySteps(
         ['throttle_observed_invoke_2'],
         "inner function of throttle should not have been invoked after 1s of 2nd call (throttled with 1s internal clock)"
@@ -132,7 +132,7 @@ QUnit.test('2nd (throttled) call', async function (assert) {
 QUnit.test('throttled call reinvocation', async function (assert) {
     assert.expect(11);
 
-    const { env, messaging } = await start({
+    const { advanceTime, messaging } = await start({
         hasTimeControl: true,
     });
 
@@ -179,7 +179,7 @@ QUnit.test('throttled call reinvocation', async function (assert) {
         "inner function of throttle should not have been immediately invoked after 2nd call immediately after 1st call (throttled with 1s internal clock)"
     );
 
-    await env.testUtils.advanceTime(999);
+    await advanceTime(999);
     assert.verifySteps(
         [],
         "inner function of throttle should not have been invoked after 999ms of 2nd call (throttled with 1s internal clock)"
@@ -200,7 +200,7 @@ QUnit.test('throttled call reinvocation', async function (assert) {
         "2nd throttle call should have been canceled from 3rd throttle call (reinvoked before cooling down phase has ended)"
     );
 
-    await env.testUtils.advanceTime(1);
+    await advanceTime(1);
     assert.verifySteps(
         ['throttle_observed_invoke_2'],
         "inner function of throttle should have been invoked after 1s of 1st call (throttled with 1s internal clock, 3rd throttle call re-use timer of 2nd throttle call)"
@@ -210,7 +210,7 @@ QUnit.test('throttled call reinvocation', async function (assert) {
 QUnit.test('flush throttled call', async function (assert) {
     assert.expect(9);
 
-    const { env, messaging } = await start({
+    const { advanceTime, messaging } = await start({
         hasTimeControl: true,
     });
 
@@ -235,7 +235,7 @@ QUnit.test('flush throttled call', async function (assert) {
         "inner function of throttle should not have been immediately invoked after 2nd call immediately after 1st call (throttled with 1s internal clock)"
     );
 
-    await env.testUtils.advanceTime(10);
+    await advanceTime(10);
     assert.verifySteps(
         [],
         "inner function of throttle should not have been invoked after 10ms of 2nd call (throttled with 1s internal clock)"
@@ -250,13 +250,13 @@ QUnit.test('flush throttled call', async function (assert) {
 
     throttledFunc().then(() => assert.step('throttle_observed_invoke_3'));
     await nextTick();
-    await env.testUtils.advanceTime(999);
+    await advanceTime(999);
     assert.verifySteps(
         [],
         "inner function of throttle should not have been invoked after 999ms of 3rd call (throttled with 1s internal clock)"
     );
 
-    await env.testUtils.advanceTime(1);
+    await advanceTime(1);
     assert.verifySteps(
         ['throttle_observed_invoke_3'],
         "inner function of throttle should not have been invoked after 999ms of 3rd call (throttled with 1s internal clock)"
@@ -266,7 +266,7 @@ QUnit.test('flush throttled call', async function (assert) {
 QUnit.test('cancel throttled call', async function (assert) {
     assert.expect(10);
 
-    const { env, messaging } = await start({
+    const { advanceTime, messaging } = await start({
         hasTimeControl: true,
     });
 
@@ -302,7 +302,7 @@ QUnit.test('cancel throttled call', async function (assert) {
         "inner function of throttle should not have been immediately invoked after 2nd call immediately after 1st call (throttled with 1s internal clock)"
     );
 
-    await env.testUtils.advanceTime(500);
+    await advanceTime(500);
     assert.verifySteps(
         [],
         "inner function of throttle should not have been invoked after 500ms of 2nd call (throttled with 1s internal clock)"
@@ -322,7 +322,7 @@ QUnit.test('cancel throttled call', async function (assert) {
         "3rd throttle function call should not have invoked inner function yet (cancel reuses inner clock of throttle)"
     );
 
-    await env.testUtils.advanceTime(500);
+    await advanceTime(500);
     assert.verifySteps(
         ['throttle_observed_invoke_3'],
         "3rd throttle function call should have invoke inner function after 500ms (cancel reuses inner clock of throttle which was at 500ms in, throttle set at 1ms)"
@@ -332,7 +332,7 @@ QUnit.test('cancel throttled call', async function (assert) {
 QUnit.test('clear throttled call', async function (assert) {
     assert.expect(9);
 
-    const { env, messaging } = await start({
+    const { advanceTime, messaging } = await start({
         hasTimeControl: true,
     });
 
@@ -368,7 +368,7 @@ QUnit.test('clear throttled call', async function (assert) {
         "inner function of throttle should not have been immediately invoked after 2nd call immediately after 1st call (throttled with 1s internal clock)"
     );
 
-    await env.testUtils.advanceTime(500);
+    await advanceTime(500);
     assert.verifySteps(
         [],
         "inner function of throttle should not have been invoked after 500ms of 2nd call (throttled with 1s internal clock)"

--- a/addons/mail/static/tests/qunit_suite_tests/utils/timer_tests.js
+++ b/addons/mail/static/tests/qunit_suite_tests/utils/timer_tests.js
@@ -24,7 +24,7 @@ QUnit.module('timer_tests.js', {
 QUnit.test('timer does not timeout on initialization', async function (assert) {
     assert.expect(3);
 
-    const { env, messaging } = await start({ hasTimeControl: true });
+    const { advanceTime, messaging } = await start({ hasTimeControl: true });
 
     let hasTimedOut = false;
     this.timers.push(
@@ -40,13 +40,13 @@ QUnit.test('timer does not timeout on initialization', async function (assert) {
         "timer should not have timed out on immediate initialization"
     );
 
-    await env.testUtils.advanceTime(0);
+    await advanceTime(0);
     assert.notOk(
         hasTimedOut,
         "timer should not have timed out from initialization after 0ms"
     );
 
-    await env.testUtils.advanceTime(1000 * 1000);
+    await advanceTime(1000 * 1000);
     assert.notOk(
         hasTimedOut,
         "timer should not have timed out from initialization after 1000s"
@@ -56,7 +56,7 @@ QUnit.test('timer does not timeout on initialization', async function (assert) {
 QUnit.test('timer start (duration: 0ms)', async function (assert) {
     assert.expect(2);
 
-    const { env, messaging } = await start({ hasTimeControl: true });
+    const { advanceTime, messaging } = await start({ hasTimeControl: true });
 
     let hasTimedOut = false;
     this.timers.push(
@@ -73,7 +73,7 @@ QUnit.test('timer start (duration: 0ms)', async function (assert) {
         "timer should not have timed out immediately after start"
     );
 
-    await env.testUtils.advanceTime(0);
+    await advanceTime(0);
     assert.ok(
         hasTimedOut,
         "timer should have timed out on start after 0ms"
@@ -83,7 +83,7 @@ QUnit.test('timer start (duration: 0ms)', async function (assert) {
 QUnit.test('timer start observe termination (duration: 0ms)', async function (assert) {
     assert.expect(6);
 
-    const { env, messaging } = await start({ hasTimeControl: true });
+    const { advanceTime, messaging } = await start({ hasTimeControl: true });
 
     let hasTimedOut = false;
     this.timers.push(
@@ -116,7 +116,7 @@ QUnit.test('timer start observe termination (duration: 0ms)', async function (as
         "timer.start() should not have yet observed timeout"
     );
 
-    await env.testUtils.advanceTime(0);
+    await advanceTime(0);
     assert.ok(
         hasTimedOut,
         "timer should have timed out on start after 0ms"
@@ -130,7 +130,7 @@ QUnit.test('timer start observe termination (duration: 0ms)', async function (as
 QUnit.test('timer start (duration: 1000s)', async function (assert) {
     assert.expect(5);
 
-    const { env, messaging } = await start({ hasTimeControl: true });
+    const { advanceTime, messaging } = await start({ hasTimeControl: true });
 
     let hasTimedOut = false;
     this.timers.push(
@@ -147,25 +147,25 @@ QUnit.test('timer start (duration: 1000s)', async function (assert) {
         "timer should not have timed out immediately after start"
     );
 
-    await env.testUtils.advanceTime(0);
+    await advanceTime(0);
     assert.notOk(
         hasTimedOut,
         "timer should not have timed out on start after 0ms"
     );
 
-    await env.testUtils.advanceTime(1000);
+    await advanceTime(1000);
     assert.notOk(
         hasTimedOut,
         "timer should not have timed out on start after 1000ms"
     );
 
-    await env.testUtils.advanceTime(998 * 1000 + 999);
+    await advanceTime(998 * 1000 + 999);
     assert.notOk(
         hasTimedOut,
         "timer should not have timed out on start after 9999ms"
     );
 
-    await env.testUtils.advanceTime(1);
+    await advanceTime(1);
     assert.ok(
         hasTimedOut,
         "timer should have timed out on start after 10s"
@@ -175,7 +175,7 @@ QUnit.test('timer start (duration: 1000s)', async function (assert) {
 QUnit.test('[no cancelation intercept] timer start then immediate clear (duration: 0ms)', async function (assert) {
     assert.expect(4);
 
-    const { env, messaging } = await start({ hasTimeControl: true });
+    const { advanceTime, messaging } = await start({ hasTimeControl: true });
 
     let hasTimedOut = false;
     this.timers.push(
@@ -198,13 +198,13 @@ QUnit.test('[no cancelation intercept] timer start then immediate clear (duratio
         "timer should not have timed out immediately after start and clear"
     );
 
-    await env.testUtils.advanceTime(0);
+    await advanceTime(0);
     assert.notOk(
         hasTimedOut,
         "timer should not have timed out after 0ms of clear"
     );
 
-    await env.testUtils.advanceTime(1000);
+    await advanceTime(1000);
     assert.notOk(
         hasTimedOut,
         "timer should not have timed out after 1s of clear"
@@ -214,7 +214,7 @@ QUnit.test('[no cancelation intercept] timer start then immediate clear (duratio
 QUnit.test('[no cancelation intercept] timer start then clear before timeout (duration: 1000ms)', async function (assert) {
     assert.expect(4);
 
-    const { env, messaging } = await start({ hasTimeControl: true });
+    const { advanceTime, messaging } = await start({ hasTimeControl: true });
 
     let hasTimedOut = false;
     this.timers.push(
@@ -231,20 +231,20 @@ QUnit.test('[no cancelation intercept] timer start then clear before timeout (du
         "timer should not have timed out immediately after start"
     );
 
-    await env.testUtils.advanceTime(999);
+    await advanceTime(999);
     assert.notOk(
         hasTimedOut,
         "timer should not have timed out immediately after 999ms of start"
     );
 
     this.timers[0].clear();
-    await env.testUtils.advanceTime(1);
+    await advanceTime(1);
     assert.notOk(
         hasTimedOut,
         "timer should not have timed out after 1ms of clear that happens 999ms after start (globally 1s await)"
     );
 
-    await env.testUtils.advanceTime(1000);
+    await advanceTime(1000);
     assert.notOk(
         hasTimedOut,
         "timer should not have timed out after 1001ms after clear (timer fully cleared)"
@@ -254,7 +254,7 @@ QUnit.test('[no cancelation intercept] timer start then clear before timeout (du
 QUnit.test('[no cancelation intercept] timer start then reset before timeout (duration: 1000ms)', async function (assert) {
     assert.expect(5);
 
-    const { env, messaging } = await start({ hasTimeControl: true });
+    const { advanceTime, messaging } = await start({ hasTimeControl: true });
 
     let hasTimedOut = false;
     this.timers.push(
@@ -271,26 +271,26 @@ QUnit.test('[no cancelation intercept] timer start then reset before timeout (du
         "timer should not have timed out immediately after start"
     );
 
-    await env.testUtils.advanceTime(999);
+    await advanceTime(999);
     assert.notOk(
         hasTimedOut,
         "timer should not have timed out after 999ms of start"
     );
 
     this.timers[0].reset();
-    await env.testUtils.advanceTime(1);
+    await advanceTime(1);
     assert.notOk(
         hasTimedOut,
         "timer should not have timed out after 1ms of reset which happens 999ms after start"
     );
 
-    await env.testUtils.advanceTime(998);
+    await advanceTime(998);
     assert.notOk(
         hasTimedOut,
         "timer should not have timed out after 999ms of reset"
     );
 
-    await env.testUtils.advanceTime(1);
+    await advanceTime(1);
     assert.ok(
         hasTimedOut,
         "timer should not have timed out after 1s of reset"
@@ -341,7 +341,7 @@ QUnit.test('[with cancelation intercept] timer start then immediate clear (durat
 QUnit.test('[with cancelation intercept] timer start then immediate reset (duration: 0ms)', async function (assert) {
     assert.expect(9);
 
-    const { env, messaging } = await start({ hasTimeControl: true });
+    const { advanceTime, messaging } = await start({ hasTimeControl: true });
 
     let hasTimedOut = false;
     this.timers.push(
@@ -380,7 +380,7 @@ QUnit.test('[with cancelation intercept] timer start then immediate reset (durat
         "timer should not have timed out immediately after reset"
     );
 
-    await env.testUtils.advanceTime(0);
+    await advanceTime(0);
     assert.ok(
         hasTimedOut,
         "timer should have timed out after reset timeout"


### PR DESCRIPTION
This PR prepares the ground for the introduction of the new environment in the discuss
app. For now, the start method adds the advanceTime function to the environment. The issue
is that the new env is not extendable. This change makes a lot of noise hence the prep PR.

task-2582313
