### PR TITLE
[FIX] account: edit payment's partner_bank_id

### DIFF
--- a/addons/account/views/account_payment_view.xml
+++ b/addons/account/views/account_payment_view.xml
@@ -281,10 +281,13 @@
                                             'readonly': [('state', '!=', 'draft')],
                                         }"/>
 
-                                <field name="partner_bank_id" context="{'default_partner_id': partner_id}" string="Company Bank Account" readonly="1"
+                                <!-- This field should always be readonly but using readonly="1" overrides the other partner_bank_id
+                                fields readonly condition in the framework, preventing the modification of these fields -->
+                                <field name="partner_bank_id" context="{'default_partner_id': partner_id}" string="Company Bank Account"
                                         attrs="{
                                             'invisible': ['|', '|', ('show_partner_bank_account', '=', False), ('is_internal_transfer', '=', True), ('payment_type', '=', 'outbound')],
                                             'required': [('require_partner_bank_account', '=', True), ('is_internal_transfer', '=', False)],
+                                            'readonly': [('payment_type', '!=', 'outbound')],
                                         }"/>
 
                                 <field name="destination_journal_id" context="{'default_partner_id': partner_id}"


### PR DESCRIPTION
Payment's partner_bank_id cannot be modified because the field is in
readonly

Steps to reproduce:
1. Install Invoicing
2. Go to Invoicing > Vendors > Payments and create a new payment
3. Specify a vendor, edit this vendor and add two bank accounts (in the
Invoicing tab) then save
4. The field 'Vendor Bank Account' is populated with one of the bank
accounts
5. Save the payment then edit it again
6. Change the 'Vendor Bank Account' and save
7. Refresh the page
8. The 'Vendor Bank Account' hasn't changed

Solution:
Add a condition to the readonly so that it only applies when the field
'Company Bank Account' is displayed

opw-2826507