### PR TITLE
[FIX] website: remove the background color behind the affixed navbar

### DIFF
--- a/addons/website/static/src/scss/website.scss
+++ b/addons/website/static/src/scss/website.scss
@@ -746,7 +746,16 @@ $-transition-duration: 200ms;
     display: block;
     @include o-position-absolute(0, 0, auto, 0);
     position: fixed;
-    background: $light;
+
+    // TODO remove me in master, the $light color makes no sense as is visible
+    // if the header uses rounded corners but is impossible to edit / remove.
+    // As a stable fix, it was decided to not remove it if the header uses a
+    // transparent color, in which case mixing it with $light actually alters
+    // the whole menu color.
+    $-menu-color: o-color('menu');
+    @if $-menu-color and alpha($-menu-color) < 0.95 {
+        background: $light;
+    }
 
     &:not(.o_header_no_transition) {
         transition: transform $-transition-duration;


### PR DESCRIPTION
For some unknown reason (part of a huge refactoring during the BS3 to
BS4 migration at [1]), a background color was applied to the `<header>`
(behind the navbar) once it becomes fixed (after scroll if the related
header scroll effect has been chosen).
That $light color made no sense as is visible if the header uses rounded
corners but is impossible to edit / remove. As a stable fix, it was
decided to not remove it if the header uses a transparent color, in
which case mixing it with $light actually alters the whole menu color.

Note: this fix is done starting from 14.0 as, in 13.0, there is no
(found) standard possibility to use rounded corners or any other way to
let that $light color appear (except using a transparent menu color, in
which case we want to keep the $light color as a stable fix anyway).

[1]: https://github.com/odoo/odoo/commit/09f40036b9c14161db90c6128861369c91c8c64e

opw-2686695

Before the fix:
![image](https://user-images.githubusercontent.com/10338094/165547656-d0980f6c-932c-484c-970b-01b47216f7f0.png)

After the fix:
![image](https://user-images.githubusercontent.com/10338094/165547492-5ea5740c-e050-40f1-9d11-2cc5ca667587.png)

