### PR TITLE
[IMP] mass_mailing: snippets adjustments

### DIFF
--- a/addons/mass_mailing/static/src/snippets/s_alert/000.scss
+++ b/addons/mass_mailing/static/src/snippets/s_alert/000.scss
@@ -1,23 +1,29 @@
+.o_mail_snippet_general .s_mail_alert [class^="col-lg"]{
+    padding-left: 0!important;
+    padding-right: 0!important;
+}
 
 .s_mail_alert {
-    margin: $grid-gutter-width/2 0;
-    border-width: $alert-border-width;
-    border-style: solid;
-    border-radius: $alert-border-radius;
-    p, ul, ol {
-        &:last-child {
-            margin-bottom: 0;
+    .s_alert {
+        margin: auto;
+        border-width: $alert-border-width;
+        border-style: solid;
+        border-radius: $alert-border-radius;
+        p, ul, ol {
+            &:last-child {
+                margin-bottom: 0;
+            }
         }
     }
-    &.s_alert_sm {
+    .s_alert_sm {
         padding: $grid-gutter-width/3;
         font-size: $font-size-sm;
     }
-    &.s_alert_md {
+    .s_alert_md {
         padding: $grid-gutter-width/2;
         font-size: $font-size-base;
     }
-    &.s_alert_lg {
+    .s_alert_lg {
         padding: $grid-gutter-width;
         font-size: $font-size-lg;
     }

--- a/addons/mass_mailing/views/snippets/s_alert.xml
+++ b/addons/mass_mailing/views/snippets/s_alert.xml
@@ -1,20 +1,29 @@
 <?xml version="1.0" encoding="utf-8"?>
 <odoo>
 <template id="s_alert" name="Alert">
-    <div class="s_mail_alert s_alert_md alert-info w-100 clearfix o_mail_snippet_general pt16 pb16 px-3" data-snippet="s_alert">
-        <div class="s_alert_icon" valign="top">
-            <i class="fa fa-2x fa-info-circle"/>
-        </div>
-        <div class="s_alert_content">
-            <p><b>Explain the benefits you offer</b>
-            <br/>Don't write about products or services here, write about solutions.</p>
+    <div class="s_mail_alert o_mail_snippet_general pt16 pb16 mx-auto" data-snippet="s_alert">
+        <div class="container o_mail_table_styles">
+            <div class="row">
+                <div class="col-lg-12">
+                    <div class="s_alert s_alert_md s_alert_info w-100" style="background-color: rgb(209 236 241); border-width: 1px !important; border-color: rgb(190 229 235) !important;">
+                        <div class="s_alert_icon" valign="top">
+                            <i class="fa fa-2x fa-info-circle" style="color: rgb(12 84 96);"/>
+                        </div>
+                        <div class="s_alert_content">
+                            <h3><span style="color: rgb(12 84 96); font-size: 16px; font-weight: bolder;">Explain the benefits you offer</span></h3>
+                            <p><font style="color: rgb(12 84 96);">Don't write about products or services here, write about solutions.</font></p>
+                        </div>
+                    </div>
+                </div>
+            </div>
         </div>
     </div>
 </template>
 
 <template id="s_alert_options" inherit_id="mass_mailing.snippet_options">
     <xpath expr="//div[@id='so_width']" position="before">
-        <div data-selector=".s_mail_alert" data-js="Alert">
+        <!-- "Type" doesn't work, but background-color, border and color work, should we keep this? -->
+        <div data-selector=".s_mail_alert .s_alert" data-js="Alert">
             <we-select string="Type" data-apply-to=".fa.s_alert_icon" data-trigger="alert_colorpicker_opt">
                 <we-button data-select-class="fa-user-circle" data-trigger-value="primary">Primary</we-button>
                 <we-button data-select-class="fa-user-circle-o" data-trigger-value="secondary">Secondary</we-button>
@@ -27,16 +36,21 @@
     </xpath>
     <!-- Keep those options in separate xpath for options order -->
     <xpath expr="//div[@id='so_width']" position="after">
-        <div data-selector=".s_mail_alert">
+        <div data-selector=".s_mail_alert .s_alert">
             <we-select string="Size">
                 <we-button data-select-class="s_alert_sm">Small</we-button>
                 <we-button data-select-class="s_alert_md">Medium</we-button>
                 <we-button data-select-class="s_alert_lg">Large</we-button>
             </we-select>
-            <we-colorpicker string="Color" data-name="alert_colorpicker_opt"
+            <we-colorpicker string="Background Color" data-name="alert_colorpicker_opt"
                 data-select-style="true"
                 data-css-property="background-color"
                 data-color-prefix="alert-"/>
+        </div>
+        <div data-selector=".s_mail_alert .s_alert">
+            <t t-call="mass_mailing.snippet_options_border_widgets">
+                <t t-set="so_rounded_no_dependencies" t-value="True"/>
+            </t>
         </div>
     </xpath>
 </template>

--- a/addons/mass_mailing/views/snippets_themes.xml
+++ b/addons/mass_mailing/views/snippets_themes.xml
@@ -108,16 +108,16 @@
 
 <!-- Snippet Templates -->
 <template id="s_mail_block_header_social" name="Left Logo">
-    <div class="o_mail_snippet_general o_mail_block_header_social s_header_social">
+    <div class="o_mail_snippet_general o_mail_block_header_social s_header_social pt16 pb16">
         <div class="o_mail_table_styles container">
             <div class="row">
-                <div class="col-lg-8 pt16 pb16">
-                    <a t-att-href="(company_id.website) or '#'" style="text-decoration:none;float:none;">
+                <div class="col-lg-8">
+                    <a t-att-href="(company_id.website) or '#'" style="text-decoration:none;"  target="_blank">
                          <img border="0" src="/mass_mailing/static/src/img/theme_basic/s_default_image_logo.png" style="height:auto;max-width:400px;" alt="Your Logo" />
                     </a>
                 </div>
-                <div class="col-lg-4 text-right o_mail_no_resize">
-                    <div class="o_mail_header_social">
+                <div class="col-lg-4">
+                    <div class="o_mail_header_social" style="text-align: right;">
                         <t t-call="mass_mailing.social_links"/>
                     </div>
                 </div>
@@ -127,17 +127,17 @@
 </template>
 
 <template id="s_mail_block_header_text_social" name="Left Text">
-    <div class="o_mail_snippet_general o_mail_block_header_text_social s_header_text_social">
+    <div class="o_mail_snippet_general o_mail_block_header_text_social s_header_text_social pt16 pb16">
         <div class="o_mail_table_styles container">
             <div class="row">
-                <div class="col-lg-8 pt16 pb16">
-                    <h3>
-                        <a t-att-href="(company_id.website) or '#'">
+                <div class="col-lg-8">
+                    <h1>
+                        <a t-att-href="(company_id.website) or '#'" target="_blank">
                             My Company
                         </a>
-                    </h3>
+                    </h1>
                 </div>
-                <div class="col-lg-4 text-right o_mail_no_resize">
+                <div class="col-lg-4" style="text-align: right;">
                     <div class="o_mail_header_social">
                         <t t-call="mass_mailing.social_links"/>
                     </div>
@@ -148,23 +148,23 @@
 </template>
 
 <template id="s_mail_block_header_logo" name="Centered Logo">
-    <div class="o_mail_snippet_general o_mail_block_header_logo s_header_logo">
+    <div class="o_mail_snippet_general o_mail_block_header_logo s_header_logo pt16 pb16">
         <div class="container o_mail_table_styles">
             <div class="row">
                 <div class="col-lg-4"/>
-                <div class="col-lg-4 text-center pt16 pb16">
-                    <a t-att-href="(company_id.website) or '#'" style="text-decoration:none;">
+                <div class="col-lg-4" style="text-align: center;">
+                    <a t-att-href="(company_id.website) or '#'" style="text-decoration:none;" target="_blank">
                         <img border="0" src="/mass_mailing/static/src/img/theme_basic/s_default_image_logo.png" style="height:auto;max-width:400px;width:auto"/>
                     </a>
                 </div>
-                <div class="col-lg-4 text-right"/>
+                <div class="col-lg-4" style="text-align: right;"/>
             </div>
         </div>
     </div>
 </template>
 
 <template id="s_mail_block_header_view" name="View Online">
-    <div class="o_mail_snippet_general o_snippet_view_in_browser pt16 pb16 px-3 text-center">
+    <div class="o_mail_snippet_general o_snippet_view_in_browser pt16 pb16 px-3" style="text-align: center;">
         <a href="/view">
             View Online
         </a>

--- a/addons/mass_mailing/views/snippets_themes.xml
+++ b/addons/mass_mailing/views/snippets_themes.xml
@@ -201,16 +201,18 @@
 </template>
 
 <template id="s_mail_block_discount1" name="Discount Offer">
-    <div class="o_mail_snippet_general o_mail_block_discount1 s_discount1">
+    <div class="o_mail_snippet_general o_mail_block_discount1 s_discount1 pt16 pb16 ">
         <div class="container o_mail_table_styles">
             <div class="row">
-                <div class="col-lg pt16 pb16 text-center">
-                    <h4 class="text-o-color-2 text-center mt0 mb16" style="font-weight:800;">-20%</h4>
-                    <p class="text-center">ON YOUR NEXT ORDER!</p>
-                    <a role="button" href="#" class="btn btn-primary">Redeem Discount!</a>
+                <div class="col-lg-6">
+                    <h3 style="text-align: center;"><font class="text-o-color-2"><span style="font-weight:bolder;">-20%</span></font></h3>
+                    <p style="text-align: center;">ON YOUR NEXT ORDER!</p>
+                    <div style="text-align: center;">
+                        <a role="button" href="#" class="btn btn-primary">Redeem Discount!</a>
+                    </div>
                 </div>
-                <div class="col-lg pt16 pb16">
-                    <p class="o_mail_no_margin">We are continuing to grow and we miss seeing you be a part of it! We've increased store hours and have lot's of new brands available. To welcome you back please accept this 20% discount on you next purchase by clicking the button.</p>
+                <div class="col-lg-6">
+                    <p>We are continuing to grow and we miss seeing you be a part of it! We've increased store hours and have lot's of new brands available. To welcome you back please accept this 20% discount on you next purchase by clicking the button.</p>
                 </div>
             </div>
         </div>

--- a/addons/mass_mailing/views/snippets_themes.xml
+++ b/addons/mass_mailing/views/snippets_themes.xml
@@ -396,7 +396,7 @@
         </we-button-group>
     </div>
 
-    <div id="so_width" data-selector=".s_mail_alert, .s_mail_blockquote, .s_mail_text_highlight">
+    <div id="so_width" data-selector=".s_mail_alert .s_alert, .s_mail_blockquote, .s_mail_text_highlight">
         <we-select string="Width">
             <we-button data-select-class="w-25">25%</we-button>
             <we-button data-select-class="w-50">50%</we-button>
@@ -405,7 +405,7 @@
         </we-select>
     </div>
 
-    <div id="so_block_align" data-selector=".s_mail_alert, .s_mail_blockquote, .s_mail_text_highlight">
+    <div id="so_block_align" data-selector=".s_mail_alert .s_alert, .s_mail_blockquote, .s_mail_text_highlight">
         <we-button-group string="Alignment" data-dependencies="!so_width_100">
             <we-button class="fa fa-fw fa-align-left" title="Left" data-select-class="mr-auto"/>
             <we-button class="fa fa-fw fa-align-center" title="Center" data-select-class="mx-auto"/>

--- a/addons/mass_mailing/views/snippets_themes.xml
+++ b/addons/mass_mailing/views/snippets_themes.xml
@@ -248,18 +248,18 @@
     <div class="s_footer_social o_mail_block_footer_social o_mail_footer_social_center o_mail_snippet_general">
         <div class="container o_mail_table_styles">
             <div class="row">
-                <div class="col-lg o_mail_footer_social">
+                <div class="col-lg-12 o_mail_footer_social">
                     <t t-call="mass_mailing.social_links"/>
                 </div>
             </div>
             <div class="row">
-                <div class="col-lg o_mail_footer_links">
+                <div class="col-lg-12 o_mail_footer_links">
                     <a role="button" href="/unsubscribe_from_list" class="btn btn-link">Unsubscribe</a>
                 </div>
             </div>
             <div class="row">
-                <div class="col-lg">
-                    <p class="o_mail_no_margin o_mail_footer_copy">
+                <div class="col-lg-12">
+                    <p class="o_mail_footer_copy">
                         © <t t-esc="datetime.datetime.now().year"/> All Rights Reserved
                     </p>
                 </div>
@@ -272,17 +272,17 @@
     <div class="s_footer_social o_mail_block_footer_social o_mail_footer_social_left o_mail_snippet_general">
         <div class="container o_mail_table_styles">
             <div class="row">
-                <div class="col-lg o_mail_footer_description">
-                    <p t-if="res_company" class="o_mail_no_margin">
+                <div class="col-lg-6 o_mail_footer_description">
+                    <p t-if="res_company">
                         <strong><t t-esc="res_company.partner_id.name"/></strong>
                     </p>
                     <div class="o_mail_footer_links">
                         <a role="button" href="/unsubscribe_from_list" class="btn btn-link">Unsubscribe</a>
                     </div>
                 </div>
-                <div class="col-lg" align="right">
-                    <div class="o_mail_footer_social pb16"><t t-call="mass_mailing.social_links"/></div>
-                    <p class="o_mail_footer_copy">© <t t-esc="datetime.datetime.now().year"/> All Rights Reserved</p>
+                <div class="col-lg-6">
+                    <div class="o_mail_footer_social pb16" style="text-align: right"><t t-call="mass_mailing.social_links"/></div>
+                    <p class="o_mail_footer_copy" style="text-align: right">© <t t-esc="datetime.datetime.now().year"/> All Rights Reserved</p>
                 </div>
             </div>
         </div>


### PR DESCRIPTION
In order for all snippets to be better supported by the builder and its new design-tab, some changes were needed.
A lot of snippets used bootstrap classes (ex: text alignment), these have been replaced by inline styles so they can be overridden by the editor.

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
