### PR TITLE
[IMP] l10n_ec: user-friendly document number

### DIFF
--- a/addons/l10n_ec/models/l10n_latam_document_type.py
+++ b/addons/l10n_ec/models/l10n_latam_document_type.py
@@ -24,13 +24,16 @@ class L10nLatamDocumentType(models.Model):
             return super()._format_document_number(document_number)
         if not document_number:
             return False
-        if (
-            not re.match(r"\d{3}-\d{3}-\d{9}$", document_number)
-            and self.l10n_ec_check_format
-            and not self.env.context.get("l10n_ec_foreign", False)
-        ):
-            raise UserError(
-                _(u"Ecuadorian Document %s must be like 001-001-123456789")
-                % (self.display_name)
-            )
+        if self.l10n_ec_check_format:
+            document_number = re.sub(r'\s+', "", document_number)  # remove any whitespace
+            num_match = re.match(r'(\d{1,3})-(\d{1,3})-(\d{1,9})', document_number)
+            if num_match:
+                # Fill each number group with zeroes (3, 3 and 9 respectively)
+                document_number = "-".join([n.zfill(3 if i < 2 else 9) for i, n in enumerate(num_match.groups())])
+            else:
+                raise UserError(
+                    _(u"Ecuadorian Document %s must be like 001-001-123456789")
+                    % (self.display_name)
+                )
+
         return document_number


### PR DESCRIPTION
Do not require user to type all digits of the document number
Instead, fill the dash-separated numbers with zeroes, as needed
Also, remove the condition on `l10n_ec_foreign` which is not an actual field of `l10n_ec`

Description of the issue/feature this PR addresses:
Filling a lot of zeroes in a field is not user-friendly
The formatting of a document number should not depend on a nonexistent field.

Current behavior before PR:
Users have to type the exact characters of the document number for it to be validated

Desired behavior after PR is merged:
Users no longer have to type leading zeroes


--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
