### PR TITLE
[FIX] project : apply project notification preferences to task

### DIFF
--- a/addons/project/data/project_data.xml
+++ b/addons/project/data/project_data.xml
@@ -40,7 +40,7 @@
         <record id="mt_task_rating" model="mail.message.subtype">
             <field name="name">Task Rating</field>
             <field name="res_model">project.task</field>
-            <field name="default" eval="True"/>
+            <field name="default" eval="False"/>
             <field name="description">Ratings</field>
         </record>
         <!-- Project-related subtypes for messaging / Chatter -->


### PR DESCRIPTION
Steps :
Go to a Project's settings.
In your 'Following' preferences, uncheck 'Task Rating'.
Create a new Task in this Project and see your preferences.

Issue :
Task Rating is checked.

Cause :
The default value of project's task rating notification is True.
The value of its task's is supposed to be inheritted from there.
Yet, this inherittance only happen when default is False.

Fix :
Set default to False.

opw-282497

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
