### PR TITLE
[REV] Revert website: use correct endpoint in get_canonical_url

### DIFF
--- a/addons/website/models/website.py
+++ b/addons/website/models/website.py
@@ -695,7 +695,7 @@ class Website(models.Model):
                 endpoint.routing['auth'] in ('none', 'public') and
                 endpoint.routing.get('website', False) and
                 all(hasattr(converter, 'generate') for converter in converters)):
-            return False
+                return False
 
         # dont't list routes without argument having no default value or converter
         spec = inspect.getargspec(endpoint.method.original_func)
@@ -862,17 +862,6 @@ class Website(models.Model):
         self.ensure_one()
         return self._get_http_domain() or super(BaseModel, self).get_base_url()
 
-    @tools.ormcache('path', 'lang')
-    def _get_canonical_url_localized_cached(self, path, args, lang):
-        router = http.root.get_db_router(request.db).bind_to_environ(request.httprequest.environ)
-        for key, val in list(args.items()):
-            if isinstance(val, models.BaseModel):
-                if val.env.context.get('lang') != lang:
-                    args[key] = val.with_context(lang=lang)
-        endpoint = router.match(path_info=path, return_rule=True)[0].endpoint
-        return router.build(endpoint, args)
-
-
     def _get_canonical_url_localized(self, lang, canonical_params):
         """Returns the canonical URL for the current request with translatable
         elements appropriately translated in `lang`.
@@ -883,11 +872,13 @@ class Website(models.Model):
         """
         self.ensure_one()
         if request.endpoint:
-            path = self._get_canonical_url_localized_cached(
-                request.httprequest.path,
-                dict(request.endpoint_arguments),
-                lang.code
-            )
+            router = http.root.get_db_router(request.db).bind('')
+            arguments = dict(request.endpoint_arguments)
+            for key, val in list(arguments.items()):
+                if isinstance(val, models.BaseModel):
+                    if val.env.context.get('lang') != lang.code:
+                        arguments[key] = val.with_context(lang=lang.code)
+            path = router.build(request.endpoint, arguments)
         else:
             # The build method returns a quoted URL so convert in this case for consistency.
             path = urls.url_quote_plus(request.httprequest.path, safe='/')

--- a/addons/website/views/website_templates.xml
+++ b/addons/website/views/website_templates.xml
@@ -243,13 +243,13 @@
             </t>
         </t>
 
-        <t t-if="request and request.is_frontend_multilang and website and website.is_public_user()">
+        <t t-if="request and request.is_frontend_multilang and website">
             <t t-set="alternate_languages" t-value="website._get_alternate_languages(canonical_params=canonical_params)"/>
             <t t-foreach="alternate_languages" t-as="lg">
                 <link rel="alternate" t-att-hreflang="lg['hreflang']" t-att-href="lg['href']"/>
             </t>
         </t>
-        <link t-if="request and website and website.is_public_user()" rel="canonical" t-att-href="website._get_canonical_url(canonical_params=canonical_params)"/>
+        <link t-if="request and website" rel="canonical" t-att-href="website._get_canonical_url(canonical_params=canonical_params)"/>
 
         <link rel="preconnect" href="https://fonts.gstatic.com/" crossorigin=""/>
     </xpath>


### PR DESCRIPTION
This commit reverts PR #88011, as it causes an unforeseen side-effect: it forces the re-matching of the current `request.httprequest.path` in order to obtain the latest Endpoint object.

Unfortunately there are cases where website re-routing (due e.g to `website.rewrite` rules) has modified the `path`, and it does not correspond to any endpoint anymore. The second matching may then be unable to match the endpoint, and the method will crash with an error.

This can happen for example when the user has configured an alternative "homepage" for their website, that is not a `route` like `/` but a simple page.

opw-2835165
opw-2835129
opw-2834776
opw-2835135
opw-2834968
opw-2834903
etc.

The symptom is an error page with this message:
```
Error to render compiling AST
NotFound: 404 Not Found: The requested URL was not found on the server. If you entered the URL manually please check your spelling and try again.
Template: web.frontend_layout
Path: /t/html/head/t[6]/t[1]
Node: <t t-set="alternate_languages" t-value="website._get_alternate_languages(canonical_params=canonical_params)"/>

The error occured while rendering the template web.frontend_layout and evaluating the following expression: <t t-set="alternate_languages" t-value="website._get_alternate_languages(canonical_params=canonical_params)"/>
```