### PR TITLE
[FIX] base: _name_search() of partner returns a query instead of ids

### DIFF
--- a/odoo/addons/base/models/res_partner.py
+++ b/odoo/addons/base/models/res_partner.py
@@ -16,7 +16,7 @@ from werkzeug import urls
 
 from odoo import api, fields, models, tools, SUPERUSER_ID, _
 from odoo.modules import get_module_resource
-from odoo.osv.expression import get_unaccent_wrapper
+from odoo.osv.expression import get_unaccent_wrapper, AND
 from odoo.exceptions import UserError, ValidationError
 
 # Global variables used for the warning fields declared on the res.partner
@@ -756,61 +756,44 @@ class Partner(models.Model):
     def _get_name_search_order_by_fields(self):
         return ''
 
+    def _get_name_search_domain(self, operator, name):
+        return ['|', '|', '|', ('display_name', operator, name),
+                ('ref', operator, name),
+                ('email', operator, name),
+                ('vat', operator, re.sub(r'[^a-zA-Z0-9\-\.]+', '', name))]
+
     @api.model
     def _name_search(self, name, args=None, operator='ilike', limit=100, name_get_uid=None):
-        self = self.with_user(name_get_uid or self.env.uid)
-        # as the implementation is in SQL, we force the recompute of fields if necessary
-        self.recompute(['display_name'])
-        self.flush()
         if args is None:
             args = []
-        order_by_rank = self.env.context.get('res_partner_search_mode') 
+        order_by_rank = self.env.context.get('res_partner_search_mode')
         if (name or order_by_rank) and operator in ('=', 'ilike', '=ilike', 'like', '=like'):
-            self.check_access_rights('read')
-            where_query = self._where_calc(args)
-            self._apply_ir_rules(where_query, 'read')
-            from_clause, where_clause, where_clause_params = where_query.get_sql()
-            from_str = from_clause if from_clause else 'res_partner'
-            where_str = where_clause and (" WHERE %s AND " % where_clause) or ' WHERE '
-
-            # search on the name of the contacts and of its company
-            search_name = name
-            if operator in ('ilike', 'like'):
-                search_name = '%%%s%%' % name
-            if operator in ('=ilike', '=like'):
-                operator = operator[1:]
+            self = self.with_user(name_get_uid) if name_get_uid else self
 
             unaccent = get_unaccent_wrapper(self.env.cr)
+            domain = AND([args, self._get_name_search_domain(operator, name)])
 
-            fields = self._get_name_search_order_by_fields()
+            # don't use _search() because it can be return list of ids
+            self.check_access_rights('read')
+            self._flush_search(domain)
+            query = self._where_calc(domain)
+            self._apply_ir_rules(query, 'read')
+            if limit is not None:
+                query.limit = int(limit)
 
-            query = """SELECT res_partner.id
-                         FROM {from_str}
-                      {where} ({email} {operator} {percent}
-                           OR {display_name} {operator} {percent}
-                           OR {reference} {operator} {percent}
-                           OR {vat} {operator} {percent})
-                           -- don't panic, trust postgres bitmap
-                     ORDER BY {fields} {display_name} {operator} {percent} desc,
-                              {display_name}
-                    """.format(from_str=from_str,
-                               fields=fields,
-                               where=where_str,
-                               operator=operator,
-                               email=unaccent('res_partner.email'),
-                               display_name=unaccent('res_partner.display_name'),
-                               reference=unaccent('res_partner.ref'),
-                               percent=unaccent('%s'),
-                               vat=unaccent('res_partner.vat'),)
-
-            where_clause_params += [search_name]*3  # for email / display_name, reference
-            where_clause_params += [re.sub('[^a-zA-Z0-9\-\.]+', '', search_name) or None]  # for vat
-            where_clause_params += [search_name]  # for order by
-            if limit:
-                query += ' limit %s'
-                where_clause_params.append(limit)
-            self.env.cr.execute(query, where_clause_params)
-            return [row[0] for row in self.env.cr.fetchall()]
+            order = [self._get_name_search_order_by_fields()]
+            if name:
+                search_name = name
+                if operator in ('ilike', 'like'):
+                    search_name = f'%%{name}%%'
+                if operator in ('=ilike', '=like'):
+                    operator = operator[1:]
+                display_name = unaccent('res_partner.display_name')
+                order_by = f'{display_name} {operator} %s desc,'
+                order.append(self.env.cr.mogrify(order_by, (search_name, )).decode(self.env.cr.connection.encoding))
+            order.append(str(unaccent('res_partner.display_name')))
+            query.order = ' '.join(item for item in order if item)
+            return query
 
         return super(Partner, self)._name_search(name, args, operator=operator, limit=limit, name_get_uid=name_get_uid)
 


### PR DESCRIPTION
**Description of the issue/feature this PR addresses:**
Before this commit _name_search() of res.partner return ['id', 'in', [...]], it can create a big query when user try to find invoice (or order) with database with lot of partner (and can crash the database).
Now _name_search return a sub query.

@rco-odoo 




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
