### PR TITLE
[I18n][14.0] web: allow translate title of dialog warning

### DIFF
--- a/addons/web/i18n/web.pot
+++ b/addons/web/i18n/web.pot
@@ -4448,6 +4448,7 @@ msgstr ""
 #. openerp-web
 #: code:addons/web/static/src/js/chrome/action_manager_report.js:0
 #: code:addons/web/static/src/js/services/crash_manager.js:0
+#: code:addons/web/static/src/js/control_panel/favorite_menu.js:0
 #: code:addons/web/static/src/js/views/basic/basic_controller.js:0
 #: code:addons/web/static/src/js/views/basic/basic_controller.js:0
 #: code:addons/web/static/src/js/views/list/list_controller.js:0

--- a/addons/web/static/src/js/control_panel/favorite_menu.js
+++ b/addons/web/static/src/js/control_panel/favorite_menu.js
@@ -36,7 +36,9 @@ odoo.define('web.FavoriteMenu', function (require) {
         get icon() {
             return FACET_ICONS.favorite;
         }
-
+        get dialogTitle() {
+            return this.env._t("Warning");
+        }
         /**
          * @override
          */

--- a/addons/web/static/src/xml/base.xml
+++ b/addons/web/static/src/xml/base.xml
@@ -184,7 +184,7 @@
     </xpath>
     <xpath expr="//div[1]" position="inside">
         <Dialog t-if="state.deletedFavorite"
-            title="'Warning'"
+            title="dialogTitle"
             size="'medium'"
             t-on-dialog-closed="state.deletedFavorite = false"
             >


### PR DESCRIPTION
Before this commit:
Title of dialog warning can't be translated.

After this commit:
Title of dialog warning can be translated.

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
