### PR TITLE
[FIX] web: fix debounce utility function when used with immediate

### DIFF
--- a/addons/web/static/tests/core/utils/timing_tests.js
+++ b/addons/web/static/tests/core/utils/timing_tests.js
@@ -69,11 +69,7 @@ QUnit.module("utils", () => {
     });
 
     QUnit.test("debounce with immediate", async function (assert) {
-        patchWithCleanup(browser, {
-            setTimeout: (later) => {
-                later();
-            },
-        });
+        const execRegisteredTimeouts = mockTimeout();
         const myFunc = () => {
             assert.step("myFunc");
             return 42;
@@ -83,14 +79,27 @@ QUnit.module("utils", () => {
             assert.step("resolved " + x);
         });
         assert.verifySteps(["myFunc"]);
-        await Promise.resolve(); // wait for promise returned by myFunc
         await Promise.resolve(); // wait for promise returned by debounce
+        await Promise.resolve(); // wait for promise returned chained onto it (step resolved x)
+        assert.verifySteps(["resolved 42"]);
 
+        myDebouncedFunc().then((x) => {
+            assert.step("resolved " + x);
+        });
+        await execRegisteredTimeouts();
+        assert.verifySteps([]); // not called 3000ms did not elapse between the previous call and the first
+
+        myDebouncedFunc().then((x) => {
+            assert.step("resolved " + x);
+        });
+        assert.verifySteps(["myFunc"]);
+        await Promise.resolve(); // wait for promise returned by debounce
+        await Promise.resolve(); // wait for promise returned chained onto it (step resolved x)
         assert.verifySteps(["resolved 42"]);
     });
 
-    QUnit.test("debounced call can be canceled", async function (assert) {
-        assert.expect(1);
+    QUnit.test("debounced call can be cancelled", async function (assert) {
+        assert.expect(3);
         const execRegisteredTimeouts = mockTimeout();
         const myFunc = () => {
             assert.step("myFunc");
@@ -99,7 +108,11 @@ QUnit.module("utils", () => {
         myDebouncedFunc();
         myDebouncedFunc.cancel();
         execRegisteredTimeouts();
-        assert.verifySteps([], "Debounced call was canceled");
+        assert.verifySteps([], "Debounced call was cancelled");
+
+        myDebouncedFunc();
+        execRegisteredTimeouts();
+        assert.verifySteps(["myFunc"], "Debounced call was not cancelled");
     });
 
     QUnit.test("throttleForAnimation", async (assert) => {

--- a/addons/web/static/tests/helpers/utils.js
+++ b/addons/web/static/tests/helpers/utils.js
@@ -332,7 +332,7 @@ for (const propName of Object.keys(window.console)) {
 
 export function mockTimeout() {
     const timeouts = new Map();
-    let id = 0;
+    let id = 1;
     patchWithCleanup(browser, {
         setTimeout(fn) {
             timeouts.set(id, fn);
@@ -352,7 +352,7 @@ export function mockTimeout() {
 
 export function mockAnimationFrame() {
     const callbacks = new Map();
-    let id = 0;
+    let id = 1;
     patchWithCleanup(browser, {
         requestAnimationFrame(fn) {
             callbacks.set(id, fn);


### PR DESCRIPTION
Previously, the "debounce" util function was broken when passing
immediate=true, this was caused by the fact that the timeout was not set
to null after being executed, leading the function to always act as
though a call is already scheduled.

This commit basically rewrites the entire debounce function to fix this
problem, simplify the code, and make the API of debounce as close as
possible to underscorejs' debounce utility (with the exception that our
debounce function returns a Promise that gets resolved if and when the
call eventually goes through)
