### PR TITLE
[FIX] base: include model_terms in check

### DIFF
--- a/odoo/addons/base/models/ir_translation.py
+++ b/odoo/addons/base/models/ir_translation.py
@@ -506,13 +506,13 @@ class IrTranslation(models.Model):
 
         # collect translated field records (model_ids) and other translations
         trans_ids = []
-        model_ids = defaultdict(list)
-        model_fields = defaultdict(list)
+        model_ids = defaultdict(set)
+        model_fields = defaultdict(set)
         for trans in self:
-            if trans.type == 'model':
+            if trans.type in ('model', 'model_terms'):
                 mname, fname = trans.name.split(',')
-                model_ids[mname].append(trans.res_id)
-                model_fields[mname].append(fname)
+                model_ids[mname].add(trans.res_id)
+                model_fields[mname].add(fname)
             else:
                 trans_ids.append(trans.id)
 
@@ -528,7 +528,7 @@ class IrTranslation(models.Model):
             records = self.env[mname].browse(ids).exists()
             records.check_access_rights(fmode)
             records.check_field_access_rights(fmode, model_fields[mname])
-            if mode == 'create' and set(records._ids) != set(ids):
+            if mode == 'create' and set(records._ids) != ids:
                 raise ValidationError(_("Creating translation on non existing records"))
             if not records:
                 continue

--- a/odoo/addons/base/tests/test_translate.py
+++ b/odoo/addons/base/tests/test_translate.py
@@ -620,6 +620,41 @@ class TestTranslationWrite(TransactionCase):
                 'state': 'translated',
             })
 
+    def test_write(self):
+        """ What happens with orphan translations. """
+        self.env['res.lang'].load_lang('fr_FR')
+
+        # create a user with access rights on partner categories
+        user = new_test_user(self.env, 'updater')
+        group = self.env.ref('base.group_system')
+        user.groups_id = [(4, group.id)]
+        action = user.env["ir.actions.act_window"].create({
+            "name": "Dummy Action",
+            "res_model": "res.users",
+            "help": "<p>Cheese</p>",
+        })
+
+        # create a translation, and delete the record from the database
+        translation = user.env['ir.translation'].create({
+            'type': 'model_terms',
+            'name': 'ir.actions.act_window,help',
+            'lang': 'fr_FR',
+            'res_id': action.id,
+            'src': 'Cheese',
+            'value': 'Fromage',
+            'state': 'translated',
+        })
+        translation.flush()
+        translation.invalidate_cache()
+
+        # deleting the translation should be possible, provided the user has
+        # access rights on the translation's model
+        user0 = new_test_user(self.env, 'cannot modify an action')
+        with self.assertRaises(AccessError):
+            translation.with_user(user0).unlink()
+
+        translation.with_user(user).unlink()
+
     def test_field_selection(self):
         """ Test translations of field selections. """
         field = self.env['ir.model']._fields['state']


### PR DESCRIPTION
Translations of type model_terms are similar to model and the access
rights can be checked on the referenced record instead of
ir.translation
