### PR TITLE
[FIX] google_spreadsheet: fix parameters in spreadsheet pivot insertion

### DIFF
--- a/addons/google_spreadsheet/__manifest__.py
+++ b/addons/google_spreadsheet/__manifest__.py
@@ -25,6 +25,9 @@ The module adds the possibility to display data from Odoo in Google Spreadsheets
         'web.assets_qweb': [
             'google_spreadsheet/static/src/**/*.xml',
         ],
+        'web.qunit_suite_tests': [
+            'google_spreadsheet/static/tests/**/*',
+        ],
     },
     'license': 'LGPL-3',
 }

--- a/addons/google_spreadsheet/static/src/add_to_google_spreadsheet/add_to_google_spreadsheet.js
+++ b/addons/google_spreadsheet/static/src/add_to_google_spreadsheet/add_to_google_spreadsheet.js
@@ -2,6 +2,7 @@
 
 import { registry } from "@web/core/registry";
 import { useService } from "@web/core/utils/hooks";
+import { Domain } from "@web/core/domain";
 
 const { Component } = owl;
 const favoriteMenuRegistry = registry.category("favoriteMenu");
@@ -25,11 +26,13 @@ export class AddToGoogleSpreadsheet extends Component {
 
     async addToGoogleSpreadsheet() {
         const { domain, groupBy, resModel, view } = this.env.searchModel;
+        const viewId = view ? view.id : false;
+        const domainAsString = (new Domain(domain)).toString();
 
         const result = await this.orm.call(
             "google.drive.config",
             "set_spreadsheet",
-            [resModel, domain, groupBy, view.id]
+            [resModel, domainAsString, groupBy, viewId]
         );
 
         if (result.url) {

--- a/addons/google_spreadsheet/static/tests/add_to_google_spreadsheet.js
+++ b/addons/google_spreadsheet/static/tests/add_to_google_spreadsheet.js
@@ -1,0 +1,83 @@
+/** @odoo-module */
+
+import ListView from "web.ListView";
+import testUtils from "web.test_utils";
+import { AddToGoogleSpreadsheet } from "../src/add_to_google_spreadsheet/add_to_google_spreadsheet";
+
+AddToGoogleSpreadsheet.shouldBeDisplayed = (env) => true;
+import { ormService } from "@web/core/orm_service";
+import * as LegacyFavoriteMenu from "web.FavoriteMenu"
+import { makeTestEnv } from "../../../web/static/tests/helpers/mock_env";
+import { makeMockServer } from "../../../web/static/tests/helpers/mock_server";
+
+const createView = testUtils.createView;
+
+import { registry } from "@web/core/registry";
+const serviceRegistry = registry.category("services");
+const legacyFavoriteMenuRegistry = LegacyFavoriteMenu.registry;
+
+
+QUnit.module(
+    "google_spreadsheet > insert_in_google_spreadsheet_from_favorite_menu",
+    {
+        beforeEach: function () {
+            legacyFavoriteMenuRegistry.add(
+                "add-to-google-spreadsheet",
+                AddToGoogleSpreadsheet,
+                1
+            );
+            this.data = {
+                foo: {
+                    fields: {
+                        foo: {string: "Foo", type: "char"},
+                    },
+                    records: [{id: 1, foo: "yop"}],
+                },
+            };
+        },
+    },
+    function () {
+        QUnit.test("Menu item is present in list view", async function (assert) {
+            assert.expect(1);
+            const list = await createView({
+                View: ListView,
+                model: "foo",
+                data: this.data,
+                services: {orm: ormService},
+                arch: '<tree><field name="foo"/></tree>',
+            });
+            await testUtils.dom.click(list.$(".o_favorite_menu button"));
+            assert.containsOnce(list, ".o_add_to_spreadsheet");
+
+            list.destroy();
+        });
+
+        QUnit.test("Parameters are correct", async function (assert) {
+            assert.expect(3);
+
+            serviceRegistry.add("orm", ormService);
+            const mockRPC = (route, args) => {
+                if(route.includes("set_spreadsheet")){
+                    assert.strictEqual(args.args.length, 4);
+                    assert.strictEqual(typeof args.args[1], 'string');
+                    assert.notEqual(typeof args.args[3], 'undefined');
+                    return Promise.reject("erreur");
+                }
+            };
+            makeMockServer(this.data, mockRPC);
+            const env = await makeTestEnv();
+
+            const list = await createView({
+                View: ListView,
+                model: "foo",
+                data: this.data,
+                services: {orm: env.services.orm},
+                arch: '<tree><field name="foo"/></tree>',
+            });
+            await testUtils.dom.click(list.$(".o_favorite_menu button"))
+            await testUtils.dom.click(list.$(".o_add_to_spreadsheet"))
+
+            list.destroy();
+        });
+    }
+);


### PR DESCRIPTION
### Observed Behaviour
When opening a pivot view (in any of Odoo module) and trying to import it in a Google Spreadsheet, we get the following error:

> UncaughtPromiseError > TypeError
> Uncaught Promise > Cannot read properties of undefined (reading 'id')
> TypeError: Cannot read properties of undefined (reading 'id')
> at AddToGoogleSpreadsheet.addToGoogleSpreadsheet (...)
> at HTMLSpanElement.eval (eval at _compile (...)
> 

### Expected Behaviour
When trying to import the pivot in a spreadsheet, everything should work fine, openning a new tab with a Google spreadsheet.

### Reproducibility
This issue can be reproduced following these steps:
1. Install the 'Google Spreadsheet" module
2. Go to 'Settings' > 'Google Drive' and set your credentials
3. Go to the Sales App
4. Select the pivot view
5. Click on 'Favorites' > 'Add To Google Spreadsheet'

### Fix Description
The original issue was coming from the fact we try to access the ID of a null view, giving us the reported error. Moreover, after fixing this issue, we got another error coming from the fact the config method was called with a domain passed as a list, while it need a string. Both errors were corrected in the way it was already done in
https://github.com/odoo/odoo/blob/2e5acb4b15422c1ee38c5630e4fdb929d7a24d3c/addons/google_spreadsheet/static/src/legacy/js/add_to_google_spreadsheet_menu.js#L25

### Related Issues/PR
- opw-2794744
- opw-2761065
- opw-2752840

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
