### PR TITLE
[IMP] website: make configurator industry search case-insensitive

### DIFF
--- a/addons/website/static/src/components/configurator/configurator.js
+++ b/addons/website/static/src/components/configurator/configurator.js
@@ -198,7 +198,7 @@ class DescriptionScreen extends Component {
             // To match, every term should be contained in either the label or a
             // synonym
             for (const candidate of [val.label, ...(val.synonyms || '').split(/[|,\n]+/)]) {
-                if (terms.every(term => candidate.includes(term))) {
+                if (terms.every(term => candidate.toLowerCase().includes(term))) {
                     return true;
                 }
             }


### PR DESCRIPTION
Since [1] synonyms entered on IAP had to be lower-case to be matched by
the industry auto-complete.

After this commit the client-side of the configurator makes sure labels
and synonyms are matched without case sensitivity.

Steps to reproduce:
- Add an upper-case synonym on IAP
- Create a new website
- Search for added synonym
=> Industry associated with synonym did not show up.

[1]: https://github.com/odoo/odoo/commit/5d5d5d75d52a2a9e0d12bdb6442e006327ba9b0c

task-2835608

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
