### PR TITLE
[FIX] point_of_sale: use correct tax when fixed amount discount

### DIFF
--- a/addons/pos_coupon/static/src/js/coupon.js
+++ b/addons/pos_coupon/static/src/js/coupon.js
@@ -910,7 +910,6 @@ odoo.define('pos_coupon.pos', function (require) {
                         unit_price: -discountAmount,
                         quantity: 1,
                         program: program,
-                        tax_ids: [],
                         coupon_id: coupon_id,
                     }),
                 ],


### PR DESCRIPTION
When you have a discount in a promotion propgram with a fixed amount, no
taxed are applied, so we now are applying the tax of the product to be
consistent.

OPW-2800670

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
