### PR TITLE
[FIX] web: url to ping the server is incorrect

### DIFF
--- a/addons/web/static/src/legacy/js/apps.js
+++ b/addons/web/static/src/legacy/js/apps.js
@@ -36,7 +36,7 @@ var Apps = AbstractAction.extend({
                 };
             });
             var ts = new Date().getTime();
-            i.src = _.str.sprintf('%s/web/static/img/sep-a.gif?%s', client.origin, ts);
+            i.src = _.str.sprintf('%s/web/static/src/img/sep-a.gif?%s', client.origin, ts);
             return def;
         };
         if (apps_client) {


### PR DESCRIPTION
If applied, this commit will fix the following bug by fixing
the url used to ping the server

Steps to reproduce:

1- open apps with debug mode
2- click on updates
3- the server is read as if it is offline

Bug:

in ecfe85db84fb5649aaeb48ba3b221386e61a57bc all links are changed
static/src/(img|fonts) => static/(img|fonts) however in this specific
 case the server is remote
(https://apps.odoo.com) and it still needs /src/

Fix:
add /src to the url

opw-2791531