### PR TITLE
[FIX] point_of_sale: prevent multiple click on print invoice

### DIFF
--- a/addons/point_of_sale/static/src/js/Screens/TicketScreen/ControlButtons/InvoiceButton.js
+++ b/addons/point_of_sale/static/src/js/Screens/TicketScreen/ControlButtons/InvoiceButton.js
@@ -117,6 +117,7 @@ odoo.define('point_of_sale.InvoiceButton', function (require) {
         }
         async _onClick() {
             try {
+                this.el.style.pointerEvents = 'none';
                 await this._invoiceOrder();
             } catch (error) {
                 if (isConnectionError(error)) {
@@ -127,6 +128,8 @@ odoo.define('point_of_sale.InvoiceButton', function (require) {
                 } else {
                     throw error;
                 }
+            } finally {
+                this.el.style.pointerEvents = 'auto';
             }
         }
     }


### PR DESCRIPTION
Current behavior:
When clicking multiple times on the print invoice button of an order
the customer rank would not update correctly

Steps to reproduce:
- Have PoS installed
- Start a PoS session, and select customer A
- Create an order, make the payment
- Go in the order tab and select the order you just made
- Click on the Print invoice button multiple times
- Customer rank isn't updated correctly

opw-2813512
--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
