### PR TITLE
[FIX] website_sale : use smaller pictures if possible for the shop grid.

### DIFF
--- a/addons/website_sale/models/product_template.py
+++ b/addons/website_sale/models/product_template.py
@@ -298,6 +298,12 @@ class ProductTemplate(models.Model):
         # if the variant has no image anyway, spare some queries by using template
         return variant if variant.image_variant_128 else self
 
+    def _get_suitable_image_size(self, columns, x_size, y_size):
+        if x_size == 1 and y_size == 1 and columns >= 3:
+            return 'image_512'
+        return 'image_1024'
+
+
     def _get_current_company_fallback(self, **kwargs):
         """Override: if a website is set on the product or given, fallback to
         the company of the website. Otherwise use the one from parent method."""

--- a/addons/website_sale/views/templates.xml
+++ b/addons/website_sale/views/templates.xml
@@ -157,6 +157,7 @@
 
     <template id="products_item" name="Products item">
         <t t-set="product_href" t-value="keep(product.website_url, page=(pager['page']['num'] if pager['page']['num']&gt;1 else None))" />
+        <t t-set="image_type" t-value="product._get_suitable_image_size(ppr, td_product['x'], td_product['y'])"/>
 
         <form action="/shop/cart/update" method="post" class="oe_product_cart h-100 d-flex"
             t-att-data-publish="product.website_published and 'on' or 'off'"
@@ -166,7 +167,7 @@
                 <a t-att-href="product_href" class="oe_product_image_link d-block h-100 position-relative" itemprop="url" contenteditable="false">
                     <t t-set="image_holder" t-value="product._get_image_holder()"/>
                     <span t-field="image_holder.image_1920"
-                        t-options="{'widget': 'image', 'preview_image': 'image_1024', 'itemprop': 'image', 'class': 'h-100 w-100 position-absolute'}"
+                        t-options="{'widget': 'image', 'preview_image': image_type, 'itemprop': 'image', 'class': 'h-100 w-100 position-absolute'}"
                         class="oe_product_image_img_wrapper d-flex h-100 justify-content-center align-items-center position-absolute"/>
 
                     <t t-set="bg_color" t-value="td_product['ribbon']['bg_color'] or ''"/>


### PR DESCRIPTION
This should improve the page loading time.
Now, setting 2 columns per line will use the 1024px picture
	3 or more : 512px
If the picture is set bigger (2x1 or more, the 1024px version will be used)

task-id : 2823110
related : https://github.com/odoo/odoo/pull/86294

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
