### PR TITLE
[FIX] website,http: make EndPoint object reusable

### DIFF
--- a/addons/website/tests/__init__.py
+++ b/addons/website/tests/__init__.py
@@ -5,6 +5,7 @@ from . import test_base_url
 from . import test_converter
 from . import test_crawl
 from . import test_get_current_website
+from . import test_http_endpoint
 from . import test_lang_url
 from . import test_menu
 from . import test_page

--- a/addons/website/tests/test_http_endpoint.py
+++ b/addons/website/tests/test_http_endpoint.py
@@ -1,0 +1,48 @@
+# -*- coding: utf-8 -*-
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+from unittest.mock import sentinel
+
+from odoo.http import EndPoint
+from odoo.tests import HttpCase
+
+
+class TestHttpEndPoint(HttpCase):
+
+    def test_http_endpoint_equality(self):
+        sentinel.method.original_func = sentinel.method_original_func
+        args = (sentinel.method, {'routing_arg': sentinel.routing_arg})
+        endpoint1 = EndPoint(*args)
+        endpoint2 = EndPoint(*args)
+
+        self.assertEqual(endpoint1, endpoint2)
+
+        testdict = {}
+        testdict[endpoint1] = 42
+        self.assertEqual(testdict[endpoint2], 42)
+        self.assertTrue(endpoint2 in testdict)
+
+    def test_can_clear_routing_map_during_render(self):
+        """
+        The routing map might be cleared while rendering a qweb view.
+        For example, if an asset bundle is regenerated the old one is unlinked,
+        which causes a cache clearing.
+        This test ensures that the rendering still works, even in this case.
+        """
+        homepage_id = self.env['ir.ui.view'].search([
+            ('website_id', '=', self.env.ref('website.default_website').id),
+            ('key', '=', 'website.homepage'),
+        ])
+        self.env['ir.ui.view'].create({
+            'name': 'Add cache clear to Home',
+            'type': 'qweb',
+            'mode': 'extension',
+            'inherit_id': homepage_id.id,
+            'arch_db': """
+                <t t-call="website.layout" position="before">
+                    <t t-esc="website.env['ir.http']._clear_routing_map()"/>
+                </t>
+            """,
+        })
+
+        r = self.url_open('/')
+        r.raise_for_status()

--- a/addons/website/tests/test_page.py
+++ b/addons/website/tests/test_page.py
@@ -1,5 +1,9 @@
 # coding: utf-8
+from lxml import html
+
 from odoo.tests import common, HttpCase, tagged
+from odoo.tests.common import HOST
+from odoo.tools import config
 
 
 @tagged('-at_install', 'post_install')
@@ -235,3 +239,20 @@ class WithContext(HttpCase):
             [{'loc': p['loc']} for p in pages],
             [{'loc': '/page_1'}]
         )
+
+    def test_homepage_not_slash_url(self):
+        website = self.env['website'].browse([1])
+        # Set another page (/page_1) as homepage
+        website.write({
+            'homepage_id': self.page.id,
+            'domain': f"http://{HOST}:{config['http_port']}",
+        })
+        assert self.page.url != '/'
+
+        r = self.url_open('/')
+        r.raise_for_status()
+        self.assertEqual(r.status_code, 200,
+                         "There should be no crash when a public user is accessing `/` which is rerouting to another page with a different URL.")
+        root_html = html.fromstring(r.content)
+        canonical_url = root_html.xpath('//link[@rel="canonical"]')[0].attrib['href']
+        self.assertEqual(canonical_url, website.domain + "/")

--- a/odoo/http.py
+++ b/odoo/http.py
@@ -904,7 +904,7 @@ class EndPoint(object):
     def __init__(self, method, routing):
         self.method = method
         self.original = getattr(method, 'original_func', method)
-        self.routing = routing
+        self.routing = frozendict(routing)
         self.arguments = {}
 
     @property
@@ -914,6 +914,29 @@ class EndPoint(object):
 
     def __call__(self, *args, **kw):
         return self.method(*args, **kw)
+
+    # werkzeug will use these EndPoint objects as keys of a dictionary
+    # (the RoutingMap._rules_by_endpoint mapping).
+    # When Odoo clears the routing map, new EndPoint objects are created,
+    # most of them with the same values.
+    # The __eq__ and __hash__ magic methods allow older EndPoint objects
+    # to be still valid keys of the RoutingMap.
+    # For example, website._get_canonical_url_localized may use
+    # such an old endpoint if the routing map was cleared.
+    def __eq__(self, other):
+        try:
+            return self._as_tuple() == other._as_tuple()
+        except AttributeError:
+            return False
+
+    def __hash__(self):
+        return hash(self._as_tuple())
+
+    def _as_tuple(self):
+        return (self.original, self.routing)
+
+    def __repr__(self):
+        return '<EndPoint method=%r routing=%r>' % (self.method, self.routing)
 
 
 def _generate_routing_rules(modules, nodb_only, converters=None):


### PR DESCRIPTION
It may happen than the routing map is cleared while rendering a qweb view. For example, if an asset bundle is regenerated, the previous one is unlinked, which causes a cache clearing.

Previously-generated `EndPoint` objects aren't found any more in the new routing map, so `request.endpoint` cannot be used any more after a cache clearing.

This commit adds hash and comparison magic methods on `http.EndPoint` so that `EndPoint` objects created by a previous routing map generation can still be used after a cache clearing.

Two tests were added: one to test the comparison and hash methods, and the other to test them in a real-case rendering.

Commit 80a04f7ebed fixed this bug too, but introduced another issue which caused many OPW, so it was quickly reverted by deb23450f18 along with its performance improvement 33167b3928c. This commit replaces 80a04f7ebed with another way to fix the issue.

[OPW-2834546](https://www.odoo.com/web#model=project.task&id=2834546)
[OPW-2834549](https://www.odoo.com/web#model=project.task&id=2834549)
[OPW-2834625](https://www.odoo.com/web#model=project.task&id=2834625)
