### PR TITLE
[FIX] web: fix SCSS syntax for fixed-width odoo icons

### DIFF
--- a/addons/web/static/src/webclient/icons.scss
+++ b/addons/web/static/src/webclient/icons.scss
@@ -40,7 +40,7 @@ $oi-sizes: (
 
 .oi-fw {
     display: inline-block;
-    width: calc($oi-fw-ratio * var(--oi-font-size, #{$oi-default-size}));
+    width: calc(#{$oi-fw-ratio} * var(--oi-font-size, #{$oi-default-size}));
     text-align: center;
 }
 


### PR DESCRIPTION
Since commit odoo/odoo@9c41002b3968f95adcfcc17c7c4ae3208282d4a3, the
`.oi-fw` width value contained the `$oi-fw-ratio` variable name instead
of its value once compiled.

This commit fixes it by using SCSS interpolation, as expected.

To use SCSS variable in CSS `calc()`, the variable should use
interpolation to be properly evaluated at compile time.

Note: this apply only for LibSass, Ruby Sass and Dart Sass prior to
1.40.0.

Reference:
https://sass-lang.com/documentation/values/calculations