### PR TITLE
[FIX] mail: prevent crash when destroying during attachment upload

### DIFF
--- a/addons/mail/static/src/models/file_uploader/file_uploader.js
+++ b/addons/mail/static/src/models/file_uploader/file_uploader.js
@@ -145,7 +145,7 @@ registerModel({
                     return;
                 }
                 try {
-                    const response = await this.messaging.browser.fetch('/mail/attachment/upload', {
+                    const response = await (composer || thread).messaging.browser.fetch('/mail/attachment/upload', {
                         method: 'POST',
                         body: this._createFormData({ composer, file, thread }),
                         signal: uploadingAttachment.uploadingAbortController.signal,


### PR DESCRIPTION
File uploader might be deleted because it is linked to views, but the process of
upload should still happen for the related thread.