### PR TITLE
[FIX] l10n_ch : generate QR-Bill only for Customer Invoice

### DIFF
--- a/addons/l10n_ch/models/mail_template.py
+++ b/addons/l10n_ch/models/mail_template.py
@@ -37,7 +37,7 @@ class MailTemplate(models.Model):
                     isr_pdf = base64.b64encode(isr_pdf)
                     new_attachments.append((isr_report_name, isr_pdf))
 
-                if record.partner_bank_id._eligible_for_qr_code('ch_qr', record.partner_id, record.currency_id):
+                if record.move_type == 'out_invoice' and record.partner_bank_id._eligible_for_qr_code('ch_qr', record.partner_id, record.currency_id):
                     # We add an attachment containing the QR-bill
                     qr_report_name = 'QR-bill-' + inv_print_name + '.pdf'
                     qr_pdf = self.env.ref('l10n_ch.l10n_ch_qr_report')._render_qweb_pdf(record.ids)[0]


### PR DESCRIPTION
To reproduce
============

- Create Swiss company with Switzerland Accounting
- Create Swiss client (with complete Address)
- Create invoice for this client
- Make payment for this invoice
- Add credit note and confirm it
- Try to "Send and Print"

a User error is raised.

Purpose
=======

When calling "send and print" action, a QR-Bill is generated, where we make some
verification and a check on QR-Reference fails which leads to the User error.

Generating a QR-Bill for a credit note has no sense, so the error comes from
the fact that QR-Bills are generated for all types of invoices.

Specification
=============

To solve the issue, we want to generate QR-Bill only for Customer Invoice,
to do that a condition on the invoice type was added.

opw-2781857