### PR TITLE
[FIX] point_of_sale: recomputation of accounting data in sales report

### DIFF
--- a/addons/point_of_sale/models/pos_order.py
+++ b/addons/point_of_sale/models/pos_order.py
@@ -941,15 +941,15 @@ class ReportSaleDetails(models.AbstractModel):
                 products_sold.setdefault(key, 0.0)
                 products_sold[key] += line.qty
 
-                if line.tax_ids_after_fiscal_position:
-                    line_taxes = line.tax_ids_after_fiscal_position.compute_all(line.price_unit * (1-(line.discount or 0.0)/100.0), currency, line.qty, product=line.product_id, partner=line.order_id.partner_id or False)
-                    for tax in line_taxes['taxes']:
-                        taxes.setdefault(tax['id'], {'name': tax['name'], 'tax_amount':0.0, 'base_amount':0.0})
-                        taxes[tax['id']]['tax_amount'] += tax['amount']
-                        taxes[tax['id']]['base_amount'] += tax['base']
-                else:
+                if not line.tax_ids_after_fiscal_position:
                     taxes.setdefault(0, {'name': _('No Taxes'), 'tax_amount':0.0, 'base_amount':0.0})
                     taxes[0]['base_amount'] += line.price_subtotal_incl
+        for line in orders.session_move_id.line_ids.filtered(lambda l: l.tax_line_id):
+            for tax in line.tax_line_id:
+                taxes.setdefault(tax.id, {'name': tax.name, 'tax_amount':0.0, 'base_amount':0.0})
+                sign = -1 if (line.debit - line.credit) > 0 else 1
+                taxes[tax.id]['tax_amount'] += -line.balance
+                taxes[tax.id]['base_amount'] += sign * line.tax_base_amount
 
         payment_ids = self.env["pos.payment"].search([('pos_order_id', 'in', orders.ids)]).ids
         if payment_ids:


### PR DESCRIPTION
Have a Product with [TAX]
Make a sale in POS, close and validate session
Generate sales report for POS sale
Alter [TAX]
Generate sales report for POS sale (again)

The report will be altered, following the modification of [TAX]
This should not occur, the sales report could make use of the
accounting data instead of recomputing the amount each time a report is
requested.

opw-2825276

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
