### PR TITLE
[IMP] web_editor: cleanup channels regex

### DIFF
--- a/addons/web_editor/controllers/bus.py
+++ b/addons/web_editor/controllers/bus.py
@@ -18,8 +18,8 @@ class EditorCollaborationController(BusController):
             channels = list(channels)
             for channel in channels:
                 if isinstance(channel, str):
-                    match = re.match(r'editor_collaboration:(\w+(?:.\w+)*):(\w+):([\d]+)', channel)
-                    if (match):
+                    match = re.match(r'editor_collaboration:(\w+(?:\.\w+)*):(\w+):(\d+)', channel)
+                    if match:
                         model_name = match[1]
                         field_name = match[2]
                         res_id = int(match[3])


### PR DESCRIPTION
Model pattern was too permissive, separator is the literal `.` character, not any random thing, leading to possible incorrect matches.

Also remove unnecessary bracket expression, it's unnecessary when matching a single item.

OPW-2836106