### PR TITLE
[FIX] bus: Bus unavailable error in multi process mode

### DIFF
--- a/addons/bus/models/bus.py
+++ b/addons/bus/models/bus.py
@@ -203,7 +203,7 @@ class ImDispatch(object):
         self.started = True
         return self
 
-dispatch = None
-if not odoo.multi_process or odoo.evented:
-    # We only use the event dispatcher in threaded and gevent mode
-    dispatch = ImDispatch()
+# Partially undo a2ed3d3d5bdb6025a1ba14ad557a115a86413e65
+# IMDispatch has a lazy start, so we could initialize it anyway
+# And this avoids the Bus unavailable error messages
+dispatch = ImDispatch()


### PR DESCRIPTION
Starting the Odoo server with more than one worker results in repeated
"Bus unavailable" exceptions in the server log.

This seems related to the change made at
https://github.com/odoo/odoo/commit/a2ed3d3d5bdb6025a1ba14ad557a115a86413e65

 Investigation shows the the bus model file is loaded before gevented
 mode is started, and thus the wroker won't have the ImDispach
 available.
