### PR TITLE
[FIX] product: avoid stopping product search on ref perfect match

### DIFF
--- a/addons/product/tests/__init__.py
+++ b/addons/product/tests/__init__.py
@@ -7,3 +7,4 @@ from . import test_pricelist
 from . import test_product_pricelist
 from . import test_seller
 from . import test_product_attribute_value_config
+from . import test_product_name_search

--- a/addons/product/tests/test_product_name_search.py
+++ b/addons/product/tests/test_product_name_search.py
@@ -1,0 +1,46 @@
+# -*- coding: utf-8 -*-
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from odoo.tests.common import TransactionCase
+
+
+class TestProductNameSearch(TransactionCase):
+
+    def _create_product(self, name, code, barcode=None):
+        data = {
+            'name': name,
+            'default_code': code,
+        }
+        if barcode:
+            data['barcode'] = barcode
+        self.env['product.product'].create(data)
+
+    def setUp(self):
+        super().setUp()
+        self._create_product(name='Batman', code='bruce_wayne')
+        self._create_product(name='Superman', code='superman', barcode='SUPERMAN')
+        self._create_product(name='Superman in black suit', code='superman_in_black', barcode='SUPERMAN_2.0')
+
+    def test_10_search_exact_barcode(self):
+        explanation = 'The search must return a single product if there is a perfect math on the barcode.'
+        search = self.env['product.product']._name_search('SUPERMAN', operator='ilike')
+        search = [id for id, _ in search]
+        self.assertEqual(len(search), 1, explanation)
+        self.assertEqual(self.env['product.product'].browse(search).default_code, 'superman', explanation)
+
+    def test_20_search_exact_ref_when_limit(self):
+        explanation = 'If limited, the search must at least return a product with a perfect match on the reference, if any.'
+        search = self.env['product.product']._name_search('superman', limit=1, operator='ilike')
+        search = [id for id, _ in search]
+        self.assertEqual(len(search), 1, explanation)
+        self.assertEqual(self.env['product.product'].browse(search).default_code, 'superman', explanation)
+
+    def test_30_search_not_stopping_exact_ref(self):
+        search = self.env['product.product']._name_search('superman', operator='ilike')
+        self.assertEqual(len(search), 2,
+            'The search should not be stopped if it found a perfect match on the reference.')
+
+    def test_40_search_name_and_ref(self):
+        search = self.env['product.product']._name_search('man', operator='ilike')
+        self.assertEqual(len(search), 3,
+            'The search should be done both on the reference and on the default_code.')


### PR DESCRIPTION
When doing a product search, the search is trying to first find a perfect match
to the ref of the product regardless of the operator used.

Step to reproduce the issue:
1. Install Manufacturing module
2. Create two product with a reference being a subset of one another (e.g.:
VIS.M04X012 and VIS.M04X012-02)
3. Go to Manufacturing > Bills of materials
4. Search a product using the following ref: VIS.M04x012. You will see two
two proposed products (x is in lowercase here)
5. Search a product using the following ref: VIS.M04X012. You will see only
one proposed product (X is in uppercase here)

Solution: The issue is that the `_name_search` of the product module is first
looking for an exact match of the reference (regardless of the operation). If
a match is found, the search is stopped and the exact match is returned to the
UI. Rather than that, we should continue display all the potential matches
using the operator. Furthermore, we don't want to limit search on the
reference, we still want to look at the `name`. Also, if we limit the search,
we must be sure that the exact match on the reference is at least present in
the result (as discussed in [1]).

[1]: https://github.com/odoo/odoo/commit/708660621165bd705d5a541a66bb858cddf87e0d

opw-2675253