### PR TITLE
[IMP] project : transmit assignees and planned dates through recurrence

### DIFF
--- a/addons/project/static/src/js/project_list.js
+++ b/addons/project/static/src/js/project_list.js
@@ -111,7 +111,7 @@ const ProjectListController = ListController.extend({
         });
 
         if (allowContinue) {
-            Dialog.buttons.splice(0, 1,
+            dialog.buttons.splice(1, 0,
                 {
                     click: () => {
                         this._rpc({


### PR DESCRIPTION
Prior this, the user_ids, planned_date_begin and planned_date_end
were not set automatically upon creation of recurrent task.

Also made a fix in the dialog to delete recurrent tasks.

task-2835618

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
