### PR TITLE
[IMP] account: add a default currency on bank/cash journals

### DIFF
--- a/addons/account/models/account_bank_statement.py
+++ b/addons/account/models/account_bank_statement.py
@@ -289,7 +289,7 @@ class AccountBankStatement(models.Model):
     def onchange_journal_id(self):
         for st_line in self.line_ids:
             st_line.journal_id = self.journal_id
-            st_line.currency_id = self.journal_id.currency_id or self.company_id.currency_id
+            st_line.currency_id = self.journal_id.currency_id
 
     def _check_balance_end_real_same_as_computed(self):
         ''' Check the balance_end_real (encoded manually by the user) is equals to the balance_end (computed by odoo).
@@ -586,7 +586,7 @@ class AccountBankStatementLine(models.Model):
         statement = self.statement_id
         journal = statement.journal_id
         company_currency = journal.company_id.currency_id
-        journal_currency = journal.currency_id or company_currency
+        journal_currency = journal.currency_id
 
         if self.foreign_currency_id and journal_currency:
             currency_id = journal_currency.id
@@ -652,8 +652,8 @@ class AccountBankStatementLine(models.Model):
         statement = self.statement_id
         journal = statement.journal_id
         company_currency = journal.company_id.currency_id
-        journal_currency = journal.currency_id or company_currency
-        foreign_currency = self.foreign_currency_id or journal_currency or company_currency
+        journal_currency = journal.currency_id
+        foreign_currency = self.foreign_currency_id or journal_currency
         statement_line_rate = (self.amount_currency / self.amount) if self.amount else 0.0
 
         balance_to_reconcile = counterpart_vals.pop('balance', None)
@@ -851,7 +851,7 @@ class AccountBankStatementLine(models.Model):
             journal = statement.journal_id
             # Ensure the journal is the same as the statement one.
             vals['journal_id'] = journal.id
-            vals['currency_id'] = (journal.currency_id or journal.company_id.currency_id).id
+            vals['currency_id'] = journal.currency_id.id
             if 'date' not in vals:
                 vals['date'] = statement.date
 

--- a/addons/account/models/account_journal.py
+++ b/addons/account/models/account_journal.py
@@ -104,8 +104,16 @@ class AccountJournal(models.Model):
     invoice_reference_model = fields.Selection(string='Communication Standard', required=True, selection=[('odoo', 'Odoo'), ('euro', 'European')], default=_default_invoice_reference_model, help="You can choose different models for each type of reference. The default one is the Odoo reference.")
 
     #groups_id = fields.Many2many('res.groups', 'account_journal_group_rel', 'journal_id', 'group_id', string='Groups')
-    currency_id = fields.Many2one('res.currency', help="- Currency used to enter Bank or Cash statements.\n"
-                                  "- Default currency of each new move on all other journal types", string="Currency", compute='_compute_journal_currency', store=True, readonly=False, required=True, precompute=True)
+    currency_id = fields.Many2one(
+        comodel_name='res.currency',
+        string="Currency",
+        compute='_compute_journal_currency',
+        store=True,
+        readonly=False,
+        required=True,
+        precompute=True,
+        help="The default currency suggested on journal entries or the currency for bank transactions",
+    )
     company_id = fields.Many2one('res.company', string='Company', required=True, readonly=True, index=True, default=lambda self: self.env.company,
         help="Company related to this journal")
     country_code = fields.Char(related='company_id.account_fiscal_country_id.code', readonly=True)
@@ -386,8 +394,7 @@ class AccountJournal(models.Model):
     @api.depends('company_id')
     def _compute_journal_currency(self):
         for journal in self:
-            if not journal.currency_id:
-                journal.currency_id = journal.company_id.currency_id
+            journal.currency_id = journal.company_id.currency_id
 
     @api.constrains('type_control_ids')
     def _constrains_type_control_ids(self):

--- a/addons/account/models/account_move.py
+++ b/addons/account/models/account_move.py
@@ -502,11 +502,10 @@ class AccountMove(models.Model):
 
     @api.onchange('journal_id')
     def _onchange_journal(self):
-        if self.journal_id:
-            new_currency = self.journal_id.currency_id
-            if new_currency != self.currency_id:
-                self.currency_id = new_currency
-                self._onchange_currency()
+        new_currency = self.journal_id.currency_id
+        if new_currency and new_currency != self.currency_id:
+            self.currency_id = new_currency
+            self._onchange_currency()
         if self.state == 'draft' and self._get_last_sequence() and self.name and self.name != '/':
             self.name = '/'
 

--- a/addons/account/models/account_move.py
+++ b/addons/account/models/account_move.py
@@ -132,8 +132,7 @@ class AccountMove(models.Model):
     @api.model
     def _get_default_currency(self):
         ''' Get the default currency from either the journal, either the default journal's company. '''
-        journal = self._get_default_journal()
-        return journal.currency_id or journal.company_id.currency_id
+        return self._get_default_journal().currency_id
 
     @api.model
     def _get_default_invoice_incoterm(self):
@@ -503,7 +502,7 @@ class AccountMove(models.Model):
 
     @api.onchange('journal_id')
     def _onchange_journal(self):
-        if self.journal_id and self.journal_id.currency_id:
+        if self.journal_id:
             new_currency = self.journal_id.currency_id
             if new_currency != self.currency_id:
                 self.currency_id = new_currency

--- a/addons/account/models/chart_template.py
+++ b/addons/account/models/chart_template.py
@@ -386,7 +386,7 @@ class AccountChartTemplate(models.Model):
                 'name': acc['acc_name'],
                 'type': acc['account_type'],
                 'company_id': company.id,
-                'currency_id': acc.get('currency_id', self.env['res.currency']).id,
+                'currency_id': acc.get('currency_id', self.env['res.currency']).id or company.currency_id.id,
                 'sequence': 10,
             })
 

--- a/addons/account/models/chart_template.py
+++ b/addons/account/models/chart_template.py
@@ -382,13 +382,16 @@ class AccountChartTemplate(models.Model):
         bank_journals = self.env['account.journal']
         # Create the journals that will trigger the account.account creation
         for acc in self._get_default_bank_journals_data():
-            bank_journals += self.env['account.journal'].create({
+            journal_vals = {
                 'name': acc['acc_name'],
                 'type': acc['account_type'],
                 'company_id': company.id,
-                'currency_id': acc.get('currency_id', self.env['res.currency']).id or company.currency_id.id,
                 'sequence': 10,
-            })
+            }
+            if acc.get('currency_id'):
+                journal_vals['currency_id'] = acc['currency_id']
+
+            bank_journals += self.env['account.journal'].create(journal_vals)
 
         return bank_journals
 

--- a/addons/account/populate/account_journal.py
+++ b/addons/account/populate/account_journal.py
@@ -27,9 +27,6 @@ class AccountJournal(models.Model):
         return [
             ('company_id', populate.cartesian(company_ids.ids)),
             ('type', populate.cartesian(['sale', 'purchase', 'cash', 'bank', 'general'])),
-            ('currency_id', populate.randomize(self.env['res.currency'].search([
-                ('active', '=', True),
-            ]).ids + [False])),
             ('name', populate.constant("Journal {values[type]} {counter}")),
             ('code', populate.constant("{values[type]:.2}{counter}")),
         ]

--- a/addons/account/tests/test_account_payment_register.py
+++ b/addons/account/tests/test_account_payment_register.py
@@ -193,6 +193,7 @@ class TestAccountPaymentRegister(AccountTestInvoicingCommon):
             'writeoff_account_id': self.company_data['default_account_revenue'].id,
             'writeoff_label': 'writeoff',
             'payment_method_line_id': self.inbound_payment_method_line.id,
+            'currency_id': self.currency_data['currency'].id,
         })._create_payments()
 
         self.assertRecordValues(payments, [{
@@ -236,6 +237,7 @@ class TestAccountPaymentRegister(AccountTestInvoicingCommon):
             'writeoff_account_id': self.company_data['default_account_revenue'].id,
             'writeoff_label': 'writeoff',
             'payment_method_line_id': self.inbound_payment_method_line.id,
+            'currency_id': self.currency_data['currency'].id,
         })._create_payments()
 
         self.assertRecordValues(payments, [{
@@ -362,7 +364,8 @@ class TestAccountPaymentRegister(AccountTestInvoicingCommon):
             .with_context(active_model='account.move', active_ids=active_ids)\
             .create({
                 'group_payment': False,
-                'amount': 1200.0
+                'amount': 1200.0,
+                'currency_id': self.currency_data['currency'].id,
             })
         self.assertRecordValues(payment_register, [{'payment_difference': 1800.0}])
         payments = payment_register._create_payments()

--- a/addons/account/wizard/account_payment_register.py
+++ b/addons/account/wizard/account_payment_register.py
@@ -332,7 +332,7 @@ class AccountPaymentRegister(models.TransientModel):
     @api.depends('journal_id')
     def _compute_currency_id(self):
         for wizard in self:
-            wizard.currency_id = wizard.journal_id.currency_id or wizard.source_currency_id or wizard.company_id.currency_id
+            wizard.currency_id = wizard.journal_id.currency_id
 
     @api.depends('payment_type', 'company_id', 'can_edit_wizard')
     def _compute_available_journal_ids(self):

--- a/addons/point_of_sale/tests/test_point_of_sale_flow.py
+++ b/addons/point_of_sale/tests/test_point_of_sale_flow.py
@@ -773,6 +773,7 @@ class TestPointOfSaleFlow(TestPointOfSaleCommon):
             'name': 'Shop EUR Test',
             'module_account': False,
             'journal_id': sale_journal.id,
+            'invoice_journal_id': sale_journal.id, # using the same journal because the invoice journal currency should be also EUR for this config
             'use_pricelist': True,
             'available_pricelist_ids': [(6, 0, eur_pricelist.ids)],
             'pricelist_id': eur_pricelist.id,


### PR DESCRIPTION
Setting company's currency on bank/cash journals, if they are not set
by the user, helps avoid issues described in Task 2834678.


--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
