### PR TITLE
[FIX] purchase: no reset custom description in PO  if qt change

### DIFF
--- a/addons/purchase/models/purchase.py
+++ b/addons/purchase/models/purchase.py
@@ -1193,8 +1193,15 @@ class PurchaseOrderLine(models.Model):
             price_unit = seller.product_uom._compute_price(price_unit, self.product_uom)
 
         self.price_unit = price_unit
-        product_ctx = {'seller_id': seller.id, 'lang': get_lang(self.env, self.partner_id.lang).code}
-        if seller.product_name:
+
+        default_names = []
+        vendors = self.product_id._prepare_sellers()
+        for vendor in vendors:
+            product_ctx = {'seller_id': vendor.id, 'lang': get_lang(self.env, self.partner_id.lang).code}
+            default_names.append(self._get_product_purchase_description(self.product_id.with_context(product_ctx)))
+
+        if (self.name in default_names or not self.name):
+            product_ctx = {'seller_id': seller.id, 'lang': get_lang(self.env, self.partner_id.lang).code}
             self.name = self._get_product_purchase_description(self.product_id.with_context(product_ctx))
 
     @api.onchange('product_id', 'product_qty', 'product_uom')

--- a/addons/purchase/tests/test_purchase.py
+++ b/addons/purchase/tests/test_purchase.py
@@ -248,3 +248,21 @@ class TestPurchase(AccountTestInvoicingCommon):
 
         self.assertEqual(po.order_line[0].price_unit, 200)
         self.assertEqual(po.order_line[1].price_unit, 1200)
+
+    def test_on_change_quantity_description(self):
+        """
+        When a user changes the quantity of a product in a purchase order it
+        should not change the description if the descritpion was changed by
+        the user before
+        """
+        self.env.user.write({'company_id': self.company_data['company'].id})
+
+        po = Form(self.env['purchase.order'])
+        po.partner_id = self.partner_a
+        with po.order_line.new() as pol:
+            pol.product_id = self.product_a
+            pol.product_qty = 1
+
+        pol.name = "New custom description"
+        pol.product_qty += 1
+        self.assertEqual(pol.name, "New custom description")


### PR DESCRIPTION
Step to reproduce:
	Install purchase
	Create a purchase order
	Set a vendor and a product that has this vendor in its vendor list
        Set a product name in the line of the vendor in the product purchase section 
       (you will need to add the field) 
	Change the description of the product
	Change the quantity of the product

Expected behavior:
The description stays the custom input you just set

Current behavior:
The description is reset to its default value

Explanation:
When changing the quantity the vendor from the product vendors can change.
Then its vendor product name and code can change and thus the default
description in the purchase order. To solve that we need to differentiate
a custom description from a default one and only update the description
when the quantity changes if the description is a default one (and not a
custom one)

opw-2827667