### PR TITLE
[FIX] hr_holidays: remove timeoff warning when unecessary

### DIFF
--- a/addons/hr_holidays/models/hr_leave.py
+++ b/addons/hr_holidays/models/hr_leave.py
@@ -78,6 +78,7 @@ class HolidaysRequest(models.Model):
 
             if lt:
                 defaults['holiday_status_id'] = lt.id
+                defaults['request_unit_custom'] = False
 
         if 'state' in fields_list and not defaults.get('state'):
             lt = self.env['hr.leave.type'].browse(defaults.get('holiday_status_id'))


### PR DESCRIPTION
Step to reproduce:
- As mitchell admin
- Change user's/employee tz to something != UTC
- Go to time off
- Click on the calendar

Current behaviour:
- Wizard Popup with a timezone warning
- If the same thing is done with the 'New Time Off' button, the
warning is not present

Behaviour after PR:
- No Warning
- `request_unit_custom` should be False if `holiday_status_id` is
set which might happen in default_values.

opw-2828936

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
