### PR TITLE
[FIX] mail: add missing file to mail.assets_discuss_public

### DIFF
--- a/addons/mail/__manifest__.py
+++ b/addons/mail/__manifest__.py
@@ -68,6 +68,7 @@
             'web/static/lib/bootstrap/scss/_variables.scss',
             'web/static/src/legacy/scss/import_bootstrap.scss',
             'web/static/src/legacy/scss/bootstrap_review.scss',
+            'web/static/src/libs/bs5_utility_classes.scss',
             'web/static/src/webclient/webclient.scss',
             'web/static/src/webclient/webclient_extra.scss',
             'web/static/src/core/utils/*.scss',


### PR DESCRIPTION
Add missing SCSS file to the assets bundle `mail.assets_discuss_public` fixing issue with style that wasn't applied.