### PR TITLE
[IMP] crm: change default company in crm lead

### DIFF
--- a/addons/crm/tests/test_crm_lead_multicompany.py
+++ b/addons/crm/tests/test_crm_lead_multicompany.py
@@ -90,32 +90,81 @@ class TestCRMLeadMultiCompany(TestCrmCommon):
     @users('user_sales_manager_mc')
     def test_lead_mc_company_computation_env_user_restrict(self):
         """ Check that the computed company is allowed (aka in self.env.companies).
-        User is logged in company_main even their default default company is
-        company_2. """
+        User is logged in company_main even their default company is company_2.
+        Conversely, if not company is set on team, preferentially choose env current company."""
         LeadUnsyncCids = self.env['crm.lead'].with_context(allowed_company_ids=[self.company_main.id])
         self.assertEqual(LeadUnsyncCids.env.company, self.company_main)
         self.assertEqual(LeadUnsyncCids.env.companies, self.company_main)
         self.assertEqual(LeadUnsyncCids.env.user.company_id, self.company_2)
 
         # simulate auto-creation through sudo (assignment-like)
-        lead = LeadUnsyncCids.sudo().create({
-            'name': 'My Lead MC',
+        lead_1_auto = LeadUnsyncCids.sudo().create({
+            'name': 'My Lead MC 1 Auto',
         })
-        self.assertFalse(lead.company_id,
-                         'Lead: due to MC rule, avoid setting a company when it would cause crashes')
-        self.assertEqual(lead.team_id, self.sales_team_1,
-                         'Lead: due to MC rule, took first availability in other company')
-        self.assertEqual(lead.user_id, self.user_sales_manager_mc)
+        self.assertEqual(lead_1_auto.company_id, self.company_main)
+        self.assertEqual(lead_1_auto.team_id, self.sales_team_1,
+                         'Lead: due to MC rule, took first available team')
+        self.assertEqual(lead_1_auto.user_id, self.user_sales_manager_mc)
 
         # manual creation
-        lead = LeadUnsyncCids.create({
+        lead_1_manual = LeadUnsyncCids.create({
             'name': 'My Lead MC',
         })
-        self.assertFalse(lead.company_id,
-                         'Lead: due to MC rule, avoid setting a company when it would cause crashes')
-        self.assertEqual(lead.team_id, self.sales_team_1)
-        self.assertEqual(lead.user_id, self.user_sales_manager_mc)
+        self.assertEqual(lead_1_manual.company_id, self.company_main)
+        self.assertEqual(lead_1_manual.team_id, self.sales_team_1)
+        self.assertEqual(lead_1_manual.user_id, self.user_sales_manager_mc)
 
+        # Logged on other company will use that one for the lead company with sales_team_2 as is assigned to company_2
+        LeadUnsyncCids = self.env['crm.lead'].with_context(allowed_company_ids=[self.company_main.id, self.company_2.id])
+        LeadUnsyncCids = LeadUnsyncCids.with_company(self.company_2)
+        self.assertEqual(LeadUnsyncCids.env.company, self.company_2)
+
+        # simulate auto-creation through sudo (assignment-like)
+        lead_2_auto = LeadUnsyncCids.sudo().create({
+            'name': 'My Lead MC 2 Auto',
+        })
+        self.assertEqual(lead_2_auto.company_id, self.company_2)
+        self.assertEqual(lead_2_auto.team_id, self.team_company2)
+
+        # Manual assignment
+        lead_2_manual = LeadUnsyncCids.create({
+            'name': 'My Lead MC 2 Manual',
+        })
+        self.assertEqual(lead_2_manual.company_id, self.company_2)
+        self.assertEqual(lead_2_auto.team_id, self.team_company2)
+
+        # If company_2 and other teams have no set company, current company is used, with first
+        # sales team including user.
+        self.team_company2.write({'company_id': False})
+        lead_3_auto = LeadUnsyncCids.sudo().create({
+            'name': 'My Lead MC 3 Auto',
+        })
+        self.assertEqual(lead_3_auto.company_id, self.company_2)
+        self.assertEqual(lead_3_auto.team_id, self.team_company2)
+
+        # Manual assignment
+        lead_3_manual = LeadUnsyncCids.create({
+            'name': 'My Lead MC 3 Manual',
+        })
+        self.assertEqual(lead_3_manual.company_id, self.company_2)
+        self.assertEqual(lead_3_manual.team_id, self.team_company2)
+
+        # If company_2 does not include user, then the first sales team is used again
+        self.team_company2.write({'member_ids': [(3, self.user_sales_manager_mc.id)]})
+
+        # simulate auto-creation through sudo (assignment-like)
+        lead_4_auto = LeadUnsyncCids.sudo().create({
+            'name': 'My Lead MC 4 Auto',
+        })
+        self.assertEqual(lead_4_auto.company_id, self.company_2)
+        self.assertEqual(lead_4_auto.team_id, self.sales_team_1)
+
+        # Manual assignment
+        lead_4_manual = LeadUnsyncCids.create({
+            'name': 'My Lead MC 4 Manual',
+        })
+        self.assertEqual(lead_4_manual.company_id, self.company_2)
+        self.assertEqual(lead_4_manual.team_id, self.sales_team_1)
 
     @users('user_sales_manager_mc')
     def test_lead_mc_company_computation_partner_restrict(self):

--- a/addons/test_event_full/tests/test_performance.py
+++ b/addons/test_event_full/tests/test_performance.py
@@ -225,7 +225,7 @@ class TestRegistrationPerformance(EventPerformanceCase):
         """
         event = self.env['event.event'].browse(self.test_event.ids)
 
-        with freeze_time(self.reference_now), self.assertQueryCount(event_user=734):  # tef only: 672? - com runbot 731 - ent runbot 734
+        with freeze_time(self.reference_now), self.assertQueryCount(event_user=735):  # tef only: 673? - com runbot 732 - ent runbot 735
             self.env.cr._now = self.reference_now  # force create_date to check schedulers
             registration_values = [
                 dict(reg_data,
@@ -271,7 +271,7 @@ class TestRegistrationPerformance(EventPerformanceCase):
         form like) """
         event = self.env['event.event'].browse(self.test_event.ids)
 
-        with freeze_time(self.reference_now), self.assertQueryCount(event_user=745):  # tef only: 683? - com runbot 742 - ent runbot: 745
+        with freeze_time(self.reference_now), self.assertQueryCount(event_user=746):  # tef only: 684? - com runbot 743 - ent runbot: 746
             self.env.cr._now = self.reference_now  # force create_date to check schedulers
             registration_values = [
                 dict(reg_data,
@@ -292,7 +292,7 @@ class TestRegistrationPerformance(EventPerformanceCase):
         """ Test a single registration creation using Form """
         event = self.env['event.event'].browse(self.test_event.ids)
 
-        with freeze_time(self.reference_now), self.assertQueryCount(event_user=212):  # tef only: 208? - com runbot: 200 - ent runbot: 212
+        with freeze_time(self.reference_now), self.assertQueryCount(event_user=213):  # tef only: 209? - com runbot: 201 - ent runbot: 213
             self.env.cr._now = self.reference_now  # force create_date to check schedulers
             with Form(self.env['event.registration']) as reg_form:
                 reg_form.event_id = event
@@ -308,7 +308,7 @@ class TestRegistrationPerformance(EventPerformanceCase):
         """ Test a single registration creation using Form """
         event = self.env['event.event'].browse(self.test_event.ids)
 
-        with freeze_time(self.reference_now), self.assertQueryCount(event_user=214):  # tef only: 211? - com runbot: 201 - ent runbot: 214
+        with freeze_time(self.reference_now), self.assertQueryCount(event_user=215):  # tef only: 212? - com runbot: 202 - ent runbot: 215
             self.env.cr._now = self.reference_now  # force create_date to check schedulers
             with Form(self.env['event.registration']) as reg_form:
                 reg_form.event_id = event
@@ -335,7 +335,7 @@ class TestRegistrationPerformance(EventPerformanceCase):
         event = self.env['event.event'].browse(self.test_event.ids)
 
         # simple customer data
-        with freeze_time(self.reference_now), self.assertQueryCount(event_user=138):  # tef only: 133? - com runbot: 136 - ent runbot: 138
+        with freeze_time(self.reference_now), self.assertQueryCount(event_user=139):  # tef only: 134? - com runbot: 137 - ent runbot: 139
             self.env.cr._now = self.reference_now  # force create_date to check schedulers
             registration_values = dict(
                 self.customer_data[0],
@@ -349,7 +349,7 @@ class TestRegistrationPerformance(EventPerformanceCase):
         event = self.env['event.event'].browse(self.test_event.ids)
 
         # partner-based customer
-        with freeze_time(self.reference_now), self.assertQueryCount(event_user=144):  # tef only: 141? - com runbot: 143 - ent runbot: 144
+        with freeze_time(self.reference_now), self.assertQueryCount(event_user=145):  # tef only: 141? - com runbot: 143 - ent runbot: 145
             self.env.cr._now = self.reference_now  # force create_date to check schedulers
             registration_values = {
                 'event_id': event.id,
@@ -379,7 +379,7 @@ class TestRegistrationPerformance(EventPerformanceCase):
         event = self.env['event.event'].browse(self.test_event.ids)
 
         # website customer data
-        with freeze_time(self.reference_now), self.assertQueryCount(event_user=146):  # tef only: 140? - com runbot: 142 - ent runbot: 146
+        with freeze_time(self.reference_now), self.assertQueryCount(event_user=147):  # tef only: 141? - com runbot: 143 - ent runbot: 147
             self.env.cr._now = self.reference_now  # force create_date to check schedulers
             registration_values = dict(
                 self.website_customer_data[0],


### PR DESCRIPTION
Purpose
=======
Take into account the company selected by the user in the systray when
creating a new lead.

Specifications
=============
If there is no company on the sales team and the user belong to many
companies and there is more than one possible value for the company,
we take the one in the env (if env.company in user.company_ids)

Task-2824913