### PR TITLE
[FIX] point_of_sale: avoid having "discount" on invoices without reason

### DIFF
--- a/addons/point_of_sale/static/src/xml/Screens/ProductScreen/Orderline.xml
+++ b/addons/point_of_sale/static/src/xml/Screens/ProductScreen/Orderline.xml
@@ -37,7 +37,7 @@
                         <span> </span><t t-esc="props.line.get_unit().name" />
                         at
                         <t t-if="props.line.display_discount_policy() == 'without_discount' and
-                            props.line.get_unit_display_price() &lt; props.line.get_lst_price()">
+                            env.pos.round_decimals_currency(props.line.get_unit_display_price()) &lt; env.pos.round_decimals_currency(props.line.get_lst_price())">
                             <s>
                                 <t t-esc="env.pos.format_currency(props.line.get_fixed_lst_price(),'Product Price')" />
                             </s>


### PR DESCRIPTION
When selecting products with a certain price in POS (e.g.: 24.99, 5.1), the
POS displays as if there were a discount while they aren't any (e.g.:
~~$24.99~~ $24.99 instead of just $24.99).

Step to reproduce the issue:
1. Install POS and Sales
2. In Sales settings activate "Discounts" and "Pricelists" with advanced price
rules
3. In the pricelist activate the discount policy
"Show public price & discount to the customer"
4. Create a product with a price of 24.99 without tax (or with tax but in the
end the total must be 24.99)
5. In POS select the product. It will show that the price of the product went
from 24.99 to 24.99, while we should simply see 24.99.

Solution: The issue comes from the backend that sends to the POS (upon loading)
some prices with invalid precision (giving, 24.990000000002 or 5.1000000005).
Consequently, following the logic of the POS, he think that the `price` and
`lst_price` are different because the `price` is rounded after applying any
discount (in this case, none). As I was not able to understand why we have such
a rounding in the backend, a workaround was to also round the `lst_price`.

opw-2780083