### PR TITLE
15.0 link tool step link nby

### DIFF
--- a/addons/web_editor/static/lib/odoo-editor/src/OdooEditor.js
+++ b/addons/web_editor/static/lib/odoo-editor/src/OdooEditor.js
@@ -204,6 +204,7 @@ export class OdooEditor extends EventTarget {
                         return closestElement(selection.anchorNode, 'P, DIV');
                     }
                 },
+                preHistoryUndo: () => {},
                 onChange: () => {},
                 isHintBlacklisted: () => false,
                 filterMutationRecords: (records) => records,
@@ -805,6 +806,7 @@ export class OdooEditor extends EventTarget {
      * "consumed": The position has been undone and is considered consumed.
      */
     historyUndo() {
+        this.options.preHistoryUndo();
         // The last step is considered an uncommited draft so always revert it.
         const lastStep = this._currentStep;
         this.historyRevert(lastStep);

--- a/addons/web_editor/static/src/js/editor/snippets.options.js
+++ b/addons/web_editor/static/src/js/editor/snippets.options.js
@@ -6817,7 +6817,9 @@ registry.ColoredLevelBackground = registry.BackgroundToggler.extend({
      * @private
      */
     _markColorLevel: function () {
+        this.options.wysiwyg.odooEditor.observerUnactive('_markColorLevel');
         this.$target.addClass('o_colored_level');
+        this.options.wysiwyg.odooEditor.observerActive('_markColorLevel');
     },
 });
 

--- a/addons/web_editor/static/src/js/wysiwyg/widgets/link.js
+++ b/addons/web_editor/static/src/js/wysiwyg/widgets/link.js
@@ -19,6 +19,7 @@ const Link = Widget.extend({
         'input': '_onAnyChange',
         'change': '_onAnyChange',
         'input input[name="url"]': '_onURLInput',
+        'change input[name="url"]': '_onURLInputChange',
     },
 
     /**
@@ -142,6 +143,7 @@ const Link = Widget.extend({
             var match = /mailto:(.+)/.exec(this.data.url);
             this.$('input[name="url"]').val(match ? match[1] : this.data.url);
             this._onURLInput();
+            this._savedURLInputOnDestroy = false;
         }
 
         this._updateOptionsUI();
@@ -151,6 +153,15 @@ const Link = Widget.extend({
         }
 
         return this._super.apply(this, arguments);
+    },
+    /**
+     * @override
+     */
+    destroy () {
+        if (this._savedURLInputOnDestroy) {
+            this._adaptPreview();
+        }
+        this._super(...arguments);
     },
 
     //--------------------------------------------------------------------------
@@ -458,18 +469,25 @@ const Link = Widget.extend({
     /**
      * @private
      */
-    _onAnyChange: function () {
-        this._adaptPreview();
+    _onAnyChange: function (e) {
+        if (!e.target.closest('input[type="text"]')) {
+            this._adaptPreview();
+        }
     },
     /**
      * @private
      */
     _onURLInput: function () {
+        this._savedURLInputOnDestroy = true;
         var $linkUrlInput = this.$('#o_link_dialog_url_input');
         let value = $linkUrlInput.val();
         let isLink = value.indexOf('@') < 0;
         this.$('input[name="is_new_window"]').closest('.form-group').toggleClass('d-none', !isLink);
         this.$('.o_strip_domain').toggleClass('d-none', value.indexOf(window.location.origin) !== 0);
+    },
+    _onURLInputChange: function () {
+        this._adaptPreview();
+        this._savedURLInputOnDestroy = false;
     },
 });
 

--- a/addons/web_editor/static/src/js/wysiwyg/widgets/link_popover_widget.js
+++ b/addons/web_editor/static/src/js/wysiwyg/widgets/link_popover_widget.js
@@ -76,13 +76,19 @@ const LinkPopoverWidget = Widget.extend({
             container: this.options.wysiwyg.odooEditor.document.body,
         })
         .on('show.bs.popover.link_popover', () => {
+            this.options.wysiwyg.odooEditor.observerUnactive('show.bs.popover');
             this._loadAsyncLinkPreview();
             popoverShown = true;
         })
+        .on('inserted.bs.popover', () => {
+            this.options.wysiwyg.odooEditor.observerActive('show.bs.popover');
+        })
         .on('hide.bs.popover.link_popover', () => {
+            this.options.wysiwyg.odooEditor.observerUnactive('hide.bs.popover');
             popoverShown = false;
         })
         .on('hidden.bs.popover.link_popover', () => {
+            this.options.wysiwyg.odooEditor.observerActive('hide.bs.popover');
             for (const tooltip of tooltips) {
                 tooltip.hide();
             }
@@ -261,7 +267,15 @@ LinkPopoverWidget.createFor = async function (parent, targetEl, options) {
         return null;
     }
     const popoverWidget = new this(parent, targetEl, options);
-    return popoverWidget.appendTo(targetEl).then(() => popoverWidget);
+    const wysiwyg = $('#wrapwrap').data('wysiwyg');
+    if (wysiwyg) {
+        wysiwyg.odooEditor.observerUnactive('LinkPopoverWidget');
+    }
+    await popoverWidget.appendTo(targetEl)
+    if (wysiwyg) {
+        wysiwyg.odooEditor.observerActive('LinkPopoverWidget');
+    }
+    return popoverWidget;
 };
 
 export default LinkPopoverWidget;

--- a/addons/web_editor/static/src/js/wysiwyg/widgets/link_tools.js
+++ b/addons/web_editor/static/src/js/wysiwyg/widgets/link_tools.js
@@ -45,7 +45,6 @@ const LinkTools = Link.extend({
      * @override
      */
     start: function () {
-        this.options.wysiwyg.odooEditor.observerUnactive();
         this.$link.addClass('oe_edited_link');
         this.$button.addClass('active');
         return this._super(...arguments);
@@ -60,7 +59,6 @@ const LinkTools = Link.extend({
             $contents.unwrap();
         }
         this.$button.removeClass('active');
-        this.options.wysiwyg.odooEditor.observerActive();
         this.applyLinkToDom(this._getData());
         if (!this.options.wysiwyg.odooEditor.isDestroyed) {
             this.options.wysiwyg.odooEditor.historyStep();
@@ -71,9 +69,7 @@ const LinkTools = Link.extend({
 
     applyLinkToDom() {
         this._observer.disconnect();
-        this.options.wysiwyg.odooEditor.observerActive();
         this._super(...arguments);
-        this.options.wysiwyg.odooEditor.observerUnactive();
         this._observer.observe(this._link, {subtree: true, childList: true, characterData: true});
     },
 

--- a/addons/web_editor/static/src/js/wysiwyg/widgets/link_tools.js
+++ b/addons/web_editor/static/src/js/wysiwyg/widgets/link_tools.js
@@ -45,31 +45,28 @@ const LinkTools = Link.extend({
      * @override
      */
     start: function () {
-        this.$link.addClass('oe_edited_link');
-        this.$button.addClass('active');
+        this._addHintClasses();
         return this._super(...arguments);
     },
     destroy: function () {
         if (!this.el) {
             return this._super(...arguments);
         }
-        $(this.options.wysiwyg.odooEditor.document).find('.oe_edited_link').removeClass('oe_edited_link');
         const $contents = this.$link.contents();
         if (!this.$link.attr('href') && !this.colorCombinationClass) {
             $contents.unwrap();
         }
-        this.$button.removeClass('active');
-        this.applyLinkToDom(this._getData());
-        if (!this.options.wysiwyg.odooEditor.isDestroyed) {
-            this.options.wysiwyg.odooEditor.historyStep();
-        }
         this._observer.disconnect();
         this._super(...arguments);
+        this._removeHintClasses();
     },
 
     applyLinkToDom() {
         this._observer.disconnect();
+        this._removeHintClasses();
         this._super(...arguments);
+        this.options.wysiwyg.odooEditor.historyStep();
+        this._addHintClasses();
         this._observer.observe(this._link, {subtree: true, childList: true, characterData: true});
     },
 
@@ -97,7 +94,6 @@ const LinkTools = Link.extend({
         if (data === null) {
             return;
         }
-        data.classes += ' oe_edited_link';
         this.applyLinkToDom(data);
     },
     /**
@@ -322,6 +318,24 @@ const LinkTools = Link.extend({
             $colorPreview.css('background-color', isColorGradient(color) ? 'rgba(0, 0, 0, 0)' : color);
             $colorPreview.css('background-image', isColorGradient(color) ? color : '');
         }
+    },
+    /**
+     * Add hint to the classes of the link and button.
+     */
+    _addHintClasses () {
+        this.options.wysiwyg.odooEditor.observerUnactive("hint_classes");
+        this.$link.addClass('oe_edited_link');
+        this.$button.addClass('active');
+        this.options.wysiwyg.odooEditor.observerActive("hint_classes");
+    },
+    /**
+     * Remove hint to the classes of the link and button.
+     */
+    _removeHintClasses () {
+        this.options.wysiwyg.odooEditor.observerUnactive("hint_classes");
+        $(this.options.wysiwyg.odooEditor.document).find('.oe_edited_link').removeClass('oe_edited_link');
+        this.$button.removeClass('active');
+        this.options.wysiwyg.odooEditor.observerActive("hint_classes");
     },
 
     //--------------------------------------------------------------------------

--- a/addons/web_editor/static/src/js/wysiwyg/wysiwyg.js
+++ b/addons/web_editor/static/src/js/wysiwyg/wysiwyg.js
@@ -164,6 +164,12 @@ const Wysiwyg = Widget.extend({
                     return !(record.target.classList && record.target.classList.contains('o_header_standard'));
                 });
             },
+            preHistoryUndo: () => {
+                if (this.linkTools) {
+                    this.linkTools.destroy();
+                    this.linkTools = undefined;
+                }
+            },
             commands: commands,
             onChange: options.onChange,
             plugins: options.editorPlugins,

--- a/addons/website/static/tests/tours/link_tools.js
+++ b/addons/website/static/tests/tours/link_tools.js
@@ -57,6 +57,18 @@ tour.register('link_tools', {
         trigger: '#toolbar button[data-original-title="Link Style"]',
     },
     {
+        trigger: 'body',
+        run: () => {
+            // When doing automated testing, the link popover takes time to
+            // hide. While hidding, the editor observer is unactive in order to
+            // prevent the popover mutation to be recorded. In a manual
+            // scenario, the popover has plenty of time to be hidden and the
+            // obsever would be re-activated in time. As this problem arise only
+            // in test, we activate the observer here for the popover.
+            $('#wrapwrap').data('wysiwyg').odooEditor.observerActive('hide.bs.popover');
+        },
+    },
+    {
         content: "Click on the secondary style button.",
         trigger: '#toolbar we-button[data-value="secondary"]',
     },

--- a/addons/website/static/tests/tours/website_form_editor.js
+++ b/addons/website/static/tests/tours/website_form_editor.js
@@ -137,10 +137,6 @@ odoo.define('website.tour.form_editor', function (require) {
             content: "Form has a model name",
             trigger: 'section.s_website_form form[data-model_name="mail.mail"]',
         }, {
-            content: "Complete Recipient E-mail",
-            trigger: '[data-field-name="email_to"] input',
-            run: 'text_blur test@test.test',
-        }, {
             content: 'Edit the Phone Number field',
             trigger: 'input[name="phone"]',
         }, {
@@ -348,7 +344,34 @@ odoo.define('website.tour.form_editor', function (require) {
         {
             content: 'Verify that the value has not been deleted',
             trigger: '.s_website_form_field:eq(0) input[value="John Smith"]',
-        }
+        },
+        {
+            content: 'Enter in edit mode again',
+            trigger: 'a[data-action="edit"]',
+            run: 'click',
+        },
+        {
+            content: 'Click on the submit button',
+            trigger: '.s_website_form_send',
+            extra_trigger: 'button[data-action="save"]',
+            run: 'click',
+        },
+        {
+            content: 'Change the Recipient Email',
+            trigger: '[data-field-name="email_to"] input',
+            run: 'text test@test.test',
+        },
+        {
+            content: 'Save the page',
+            trigger: 'button[data-action=save]',
+            run: 'click',
+        },
+        {
+            content: 'Verify that the recipient email has been saved',
+            trigger: 'body:not(.editor_enable)',
+            // We have to this that way because the input type = hidden.
+            extra_trigger: 'form:has(input[name="email_to"][value="test@test.test"])',
+        },
     ]);
 
     tour.register("website_form_editor_tour_submit", {


### PR DESCRIPTION
The linktool is disabling the editor observer until it is destroyed. This messed up with the undo/redo and the isDirty.

Change the linktool to only disable the observer when necessary.

task-2836351


--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
