### PR TITLE
[FIX] account: tax details query

### DIFF
--- a/addons/account/i18n/account.pot
+++ b/addons/account/i18n/account.pot
@@ -15255,6 +15255,14 @@ msgstr ""
 #. module: account
 #: code:addons/account/models/account_move.py:0
 #, python-format
+msgid ""
+"You cannot use a sale tax and a purchase tax on the same journal item. "
+"(entry: (%s), line: (%s))"
+msgstr ""
+
+#. module: account
+#: code:addons/account/models/account_move.py:0
+#, python-format
 msgid "You cannot use taxes on lines with an Off-Balance account"
 msgstr ""
 

--- a/addons/account/models/account_move.py
+++ b/addons/account/models/account_move.py
@@ -4452,6 +4452,14 @@ class AccountMoveLine(models.Model):
             if common_tags:
                 raise ValidationError(_("Taxes exigible on payment and on invoice cannot be mixed on the same journal item if they share some tag."))
 
+    @api.constrains('tax_ids')
+    def _check_tax_usage_consistency(self):
+        for line in self:
+            if {'sale', 'purchase'}.issubset(set(line.tax_ids.mapped('type_tax_use'))):
+                raise UserError(
+                    _('You cannot use a sale tax and a purchase tax on the same journal item. (entry: (%s), line: (%s))') % (line.move_id.name, line.name)
+                )
+
     # -------------------------------------------------------------------------
     # LOW-LEVEL METHODS
     # -------------------------------------------------------------------------

--- a/addons/account/models/account_move_line_tax_details.py
+++ b/addons/account/models/account_move_line_tax_details.py
@@ -70,6 +70,7 @@ class AccountMoveLine(models.Model):
                     tax_rel.account_tax_id = COALESCE(account_move_line.group_tax_id, account_move_line.tax_line_id)
                 JOIN account_move_line base_line ON
                     base_line.id = tax_rel.account_move_line_id
+                    AND base_line.tax_tag_invert = account_move_line.tax_tag_invert
                     AND base_line.tax_repartition_line_id IS NULL
                     AND base_line.move_id = account_move_line.move_id
                     AND base_line.currency_id = account_move_line.currency_id
@@ -167,6 +168,7 @@ class AccountMoveLine(models.Model):
                     base_line.id = tax_rel.account_move_line_id
                     AND base_line.tax_repartition_line_id IS NULL
                     AND base_line.move_id = account_move_line.move_id
+                    AND base_line.tax_tag_invert = account_move_line.tax_tag_invert
                     AND COALESCE(base_line.partner_id, 0) = COALESCE(account_move_line.partner_id, 0)
                     AND base_line.currency_id = account_move_line.currency_id
                     AND (

--- a/addons/account/tests/test_account_move_in_invoice.py
+++ b/addons/account/tests/test_account_move_in_invoice.py
@@ -756,10 +756,13 @@ class TestAccountMoveInInvoiceOnchanges(AccountTestInvoicingCommon):
         })
 
     def test_in_invoice_line_onchange_taxes_1(self):
+        purchase_armagedon_tax = self.tax_armageddon.copy()
+        purchase_armagedon_tax.children_tax_ids.type_tax_use = 'purchase'
+        purchase_armagedon_tax.type_tax_use = 'purchase'
         move_form = Form(self.invoice)
         with move_form.invoice_line_ids.edit(0) as line_form:
             line_form.price_unit = 960
-            line_form.tax_ids.add(self.tax_armageddon)
+            line_form.tax_ids.add(purchase_armagedon_tax)
         move_form.save()
 
         child_tax_1 = self.tax_armageddon.children_tax_ids[0]
@@ -771,7 +774,7 @@ class TestAccountMoveInInvoiceOnchanges(AccountTestInvoicingCommon):
                 'price_unit': 960.0,
                 'price_subtotal': 800.0,
                 'price_total': 1176.0,
-                'tax_ids': (self.tax_purchase_a + self.tax_armageddon).ids,
+                'tax_ids': (self.tax_purchase_a + purchase_armagedon_tax).ids,
             },
             self.product_line_vals_2,
             self.tax_line_vals_1,

--- a/addons/account/tests/test_account_move_in_refund.py
+++ b/addons/account/tests/test_account_move_in_refund.py
@@ -440,10 +440,13 @@ class TestAccountMoveInRefundOnchanges(AccountTestInvoicingCommon):
         })
 
     def test_in_refund_line_onchange_taxes_1(self):
+        purchase_armagedon_tax = self.tax_armageddon.copy()
+        purchase_armagedon_tax.children_tax_ids.type_tax_use = 'purchase'
+        purchase_armagedon_tax.type_tax_use = 'purchase'
         move_form = Form(self.invoice)
         with move_form.invoice_line_ids.edit(0) as line_form:
             line_form.price_unit = 960
-            line_form.tax_ids.add(self.tax_armageddon)
+            line_form.tax_ids.add(purchase_armagedon_tax)
         move_form.save()
 
         child_tax_1 = self.tax_armageddon.children_tax_ids[0]
@@ -455,7 +458,7 @@ class TestAccountMoveInRefundOnchanges(AccountTestInvoicingCommon):
                 'price_unit': 960.0,
                 'price_subtotal': 800.0,
                 'price_total': 1176.0,
-                'tax_ids': (self.tax_purchase_a + self.tax_armageddon).ids,
+                'tax_ids': (self.tax_purchase_a + purchase_armagedon_tax).ids,
             },
             self.product_line_vals_2,
             self.tax_line_vals_1,


### PR DESCRIPTION
## Goal:

The aim of this commit is to correct the tax details query when
interacting with miscellaneous.

## pre-requisite:
- a simple sale tax A
- miscellaneous contains 2 lines,
	- amount X debit with sale tax A
	- amount Y credit with purchase tax A
- 2 tax lines gets automatically created

## Before this commit:
The global tax report will display a base amount of 2*(X-Y) which
is wrong.

## After this commit:
The global tax report will display a base amount of (X-Y) which
is correct.

Ticket: 2832745

Community-PR: https://github.com/odoo/odoo/pull/90066
Enterprise-PR: https://github.com/odoo/enterprise/pull/26743
