### PR TITLE
[IMP] test_mail: prepare tracking tests to new env

### DIFF
--- a/addons/test_mail/static/tests/tracking_value_tests.js
+++ b/addons/test_mail/static/tests/tracking_value_tests.js
@@ -46,10 +46,10 @@ QUnit.test('basic rendering of tracking value (float type)', async function (ass
 
     const pyEnv = await startServer();
     const mailTestTrackAllId1 = pyEnv['mail.test.track.all'].create({ float_field: 12.30 });
-    const { afterNextRender, widget: form } = await this.start({ res_id: mailTestTrackAllId1 });
+    const { click, widget: form } = await this.start({ res_id: mailTestTrackAllId1 });
 
     await testUtils.fields.editInput(form.$('input[name=float_field]'), 45.67);
-    await afterNextRender(() => testUtils.form.clickSave(form));
+    await click('.o_form_button_save');
     assert.containsOnce(
         document.body,
         '.o_Message_trackingValue',
@@ -90,8 +90,6 @@ QUnit.test('basic rendering of tracking value (float type)', async function (ass
         "45.67",
         "should display the correct new value (45.67)",
     );
-
-    form.destroy();
 });
 
 QUnit.test('rendering of tracked field of type float: from non-0 to 0', async function (assert) {
@@ -99,17 +97,15 @@ QUnit.test('rendering of tracked field of type float: from non-0 to 0', async fu
 
     const pyEnv = await startServer();
     const mailTestTrackAllId1 = pyEnv['mail.test.track.all'].create({ float_field: 1 });
-    const { afterNextRender, widget: form } = await this.start({ res_id: mailTestTrackAllId1 });
+    const { click, widget: form } = await this.start({ res_id: mailTestTrackAllId1 });
 
     await testUtils.fields.editInput(form.$('input[name=float_field]'), 0);
-    await afterNextRender(() => testUtils.form.clickSave(form));
+    await click('.o_form_button_save');
     assert.strictEqual(
         document.querySelector('.o_Message_trackingValue').textContent,
         "Float:1.000.00",
         "should display the correct content of tracked field of type float: from non-0 to 0 (Float: 1.00 -> 0.00)"
     );
-
-    form.destroy();
 });
 
 QUnit.test('rendering of tracked field of type float: from 0 to non-0', async function (assert) {
@@ -117,17 +113,15 @@ QUnit.test('rendering of tracked field of type float: from 0 to non-0', async fu
 
     const pyEnv = await startServer();
     const mailTestTrackAllId1 = pyEnv['mail.test.track.all'].create({ float_field: 0 });
-    const { afterNextRender, widget: form } = await this.start({ res_id: mailTestTrackAllId1 });
+    const { click, widget: form } = await this.start({ res_id: mailTestTrackAllId1 });
 
     await testUtils.fields.editInput(form.$('input[name=float_field]'), 1);
-    await afterNextRender(() => testUtils.form.clickSave(form));
+    await click('.o_form_button_save');
     assert.strictEqual(
         document.querySelector('.o_Message_trackingValue').textContent,
         "Float:0.001.00",
         "should display the correct content of tracked field of type float: from 0 to non-0 (Float: 0.00 -> 1.00)"
     );
-
-    form.destroy();
 });
 
 QUnit.test('rendering of tracked field of type integer: from non-0 to 0', async function (assert) {
@@ -135,17 +129,15 @@ QUnit.test('rendering of tracked field of type integer: from non-0 to 0', async 
 
     const pyEnv = await startServer();
     const mailTestTrackAllId1 = pyEnv['mail.test.track.all'].create({ integer_field: 1 });
-    const { afterNextRender, widget: form } = await this.start({ res_id: mailTestTrackAllId1 });
+    const { click, widget: form } = await this.start({ res_id: mailTestTrackAllId1 });
 
     await testUtils.fields.editInput(form.$('input[name=integer_field]'), 0);
-    await afterNextRender(() => testUtils.form.clickSave(form));
+    await click('.o_form_button_save');
     assert.strictEqual(
         document.querySelector('.o_Message_trackingValue').textContent,
         "Integer:10",
         "should display the correct content of tracked field of type integer: from non-0 to 0 (Integer: 1 -> 0)"
     );
-
-    form.destroy();
 });
 
 QUnit.test('rendering of tracked field of type integer: from 0 to non-0', async function (assert) {
@@ -153,17 +145,15 @@ QUnit.test('rendering of tracked field of type integer: from 0 to non-0', async 
 
     const pyEnv = await startServer();
     const mailTestTrackAllId1 = pyEnv['mail.test.track.all'].create({ integer_field: 0 });
-    const { afterNextRender, widget: form } = await this.start({ res_id: mailTestTrackAllId1 });
+    const { click, widget: form } = await this.start({ res_id: mailTestTrackAllId1 });
 
     await testUtils.fields.editInput(form.$('input[name=integer_field]'), 1);
-    await afterNextRender(() => testUtils.form.clickSave(form));
+    await click('.o_form_button_save');
     assert.strictEqual(
         document.querySelector('.o_Message_trackingValue').textContent,
         "Integer:01",
         "should display the correct content of tracked field of type integer: from 0 to non-0 (Integer: 0 -> 1)"
     );
-
-    form.destroy();
 });
 
 QUnit.test('rendering of tracked field of type monetary: from non-0 to 0', async function (assert) {
@@ -171,17 +161,15 @@ QUnit.test('rendering of tracked field of type monetary: from non-0 to 0', async
 
     const pyEnv = await startServer();
     const mailTestTrackAllId1 = pyEnv['mail.test.track.all'].create({ monetary_field: 1 });
-    const { afterNextRender, widget: form } = await this.start({ res_id: mailTestTrackAllId1 });
+    const { click, widget: form } = await this.start({ res_id: mailTestTrackAllId1 });
 
     await testUtils.fields.editSelect(form.$('div[name=monetary_field] > input'), 0);
-    await afterNextRender(() => testUtils.form.clickSave(form));
+    await click('.o_form_button_save');
     assert.strictEqual(
         document.querySelector('.o_Message_trackingValue').textContent,
         "Monetary:1.000.00",
         "should display the correct content of tracked field of type monetary: from non-0 to 0 (Monetary: 1.00 -> 0.00)"
     );
-
-    form.destroy();
 });
 
 QUnit.test('rendering of tracked field of type monetary: from 0 to non-0', async function (assert) {
@@ -189,17 +177,15 @@ QUnit.test('rendering of tracked field of type monetary: from 0 to non-0', async
 
     const pyEnv = await startServer();
     const mailTestTrackAllId1 = pyEnv['mail.test.track.all'].create({ monetary_field: 0 });
-    const { afterNextRender, widget: form } = await this.start({ res_id: mailTestTrackAllId1 });
+    const { click, widget: form } = await this.start({ res_id: mailTestTrackAllId1 });
 
     await testUtils.fields.editSelect(form.$('div[name=monetary_field] > input'), 1);
-    await afterNextRender(() => testUtils.form.clickSave(form));
+    await click('.o_form_button_save');
     assert.strictEqual(
         document.querySelector('.o_Message_trackingValue').textContent,
         "Monetary:0.001.00",
         "should display the correct content of tracked field of type monetary: from 0 to non-0 (Monetary: 0.00 -> 1.00)"
     );
-
-    form.destroy();
 });
 
 QUnit.test('rendering of tracked field of type boolean: from true to false', async function (assert) {
@@ -207,17 +193,15 @@ QUnit.test('rendering of tracked field of type boolean: from true to false', asy
 
     const pyEnv = await startServer();
     const mailTestTrackAllId1 = pyEnv['mail.test.track.all'].create({ boolean_field: true });
-    const { afterNextRender, widget: form } = await this.start({ res_id: mailTestTrackAllId1 });
+    const { click, widget: form } = await this.start({ res_id: mailTestTrackAllId1 });
 
     form.$('.custom-checkbox input').click();
-    await afterNextRender(() => testUtils.form.clickSave(form));
+    await click('.o_form_button_save');
     assert.strictEqual(
         document.querySelector('.o_Message_trackingValue').textContent,
         "Boolean:YesNo",
         "should display the correct content of tracked field of type boolean: from true to false (Boolean: True -> False)"
     );
-
-    form.destroy();
 });
 
 QUnit.test('rendering of tracked field of type boolean: from false to true', async function (assert) {
@@ -225,17 +209,15 @@ QUnit.test('rendering of tracked field of type boolean: from false to true', asy
 
     const pyEnv = await startServer();
     const mailTestTrackAllId1 = pyEnv['mail.test.track.all'].create({});
-    const { afterNextRender, widget: form } = await this.start({ res_id: mailTestTrackAllId1 });
+    const { click, widget: form } = await this.start({ res_id: mailTestTrackAllId1 });
 
     form.$('.custom-checkbox input').click();
-    await afterNextRender(() => testUtils.form.clickSave(form));
+    await click('.o_form_button_save');
     assert.strictEqual(
         document.querySelector('.o_Message_trackingValue').textContent,
         "Boolean:NoYes",
         "should display the correct content of tracked field of type boolean: from false to true (Boolean: False -> True)"
     );
-
-    form.destroy();
 });
 
 QUnit.test('rendering of tracked field of type char: from a string to empty string', async function (assert) {
@@ -243,17 +225,15 @@ QUnit.test('rendering of tracked field of type char: from a string to empty stri
 
     const pyEnv = await startServer();
     const mailTestTrackAllId1 = pyEnv['mail.test.track.all'].create({ char_field: 'Marc' });
-    const { afterNextRender, widget: form } = await this.start({ res_id: mailTestTrackAllId1 });
+    const { click, widget: form } = await this.start({ res_id: mailTestTrackAllId1 });
 
     await testUtils.fields.editInput(form.$('input[name=char_field]'), '');
-    await afterNextRender(() => testUtils.form.clickSave(form));
+    await click('.o_form_button_save');
     assert.strictEqual(
         document.querySelector('.o_Message_trackingValue').textContent,
         "Char:MarcNone",
         "should display the correct content of tracked field of type char: from a string to empty string (Char: Marc -> None)"
     );
-
-    form.destroy();
 });
 
 QUnit.test('rendering of tracked field of type char: from empty string to a string', async function (assert) {
@@ -261,17 +241,15 @@ QUnit.test('rendering of tracked field of type char: from empty string to a stri
 
     const pyEnv = await startServer();
     const mailTestTrackAllId1 = pyEnv['mail.test.track.all'].create({ char_field: '' });
-    const { afterNextRender, widget: form } = await this.start({ res_id: mailTestTrackAllId1 });
+    const { click, widget: form } = await this.start({ res_id: mailTestTrackAllId1 });
 
     await testUtils.fields.editInput(form.$('input[name=char_field]'), 'Marc');
-    await afterNextRender(() => testUtils.form.clickSave(form));
+    await click('.o_form_button_save');
     assert.strictEqual(
         document.querySelector('.o_Message_trackingValue').textContent,
         "Char:NoneMarc",
         "should display the correct content of tracked field of type char: from empty string to a string (Char: None -> Marc)"
     );
-
-    form.destroy();
 });
 
 QUnit.test('rendering of tracked field of type date: from no date to a set date', async function (assert) {
@@ -279,17 +257,15 @@ QUnit.test('rendering of tracked field of type date: from no date to a set date'
 
     const pyEnv = await startServer();
     const mailTestTrackAllId1 = pyEnv['mail.test.track.all'].create({ date_field: false });
-    const { afterNextRender, widget: form } = await this.start({ res_id: mailTestTrackAllId1 });
+    const { click, widget: form } = await this.start({ res_id: mailTestTrackAllId1 });
 
     await testUtils.fields.editAndTrigger(form.$('.o_datepicker[name=date_field] .o_datepicker_input'), '12/14/2018', ['change']);
-    await afterNextRender(() => testUtils.form.clickSave(form));
+    await click('.o_form_button_save');
     assert.strictEqual(
         document.querySelector('.o_Message_trackingValue').textContent,
         "Date:None12/14/2018",
         "should display the correct content of tracked field of type date: from no date to a set date (Date: None -> 12/14/2018)"
     );
-
-    form.destroy();
 });
 
 QUnit.test('rendering of tracked field of type date: from a set date to no date', async function (assert) {
@@ -297,17 +273,15 @@ QUnit.test('rendering of tracked field of type date: from a set date to no date'
 
     const pyEnv = await startServer();
     const mailTestTrackAllId1 = pyEnv['mail.test.track.all'].create({ date_field: '2018-12-14' });
-    const { afterNextRender, widget: form } = await this.start({ res_id: mailTestTrackAllId1 });
+    const { click, widget: form } = await this.start({ res_id: mailTestTrackAllId1 });
 
     await testUtils.fields.editAndTrigger(form.$('.o_datepicker[name=date_field] .o_datepicker_input'), '', ['change']);
-    await afterNextRender(() => testUtils.form.clickSave(form));
+    await click('.o_form_button_save');
     assert.strictEqual(
         document.querySelector('.o_Message_trackingValue').textContent,
         "Date:12/14/2018None",
         "should display the correct content of tracked field of type date: from a set date to no date (Date: 12/14/2018 -> None)"
     );
-
-    form.destroy();
 });
 
 QUnit.test('rendering of tracked field of type datetime: from no date and time to a set date and time', async function (assert) {
@@ -315,17 +289,15 @@ QUnit.test('rendering of tracked field of type datetime: from no date and time t
 
     const pyEnv = await startServer();
     const mailTestTrackAllId1 = pyEnv['mail.test.track.all'].create({ datetime_field: false });
-    const { afterNextRender, widget: form } = await this.start({ res_id: mailTestTrackAllId1 });
+    const { click, widget: form } = await this.start({ res_id: mailTestTrackAllId1 });
 
     await testUtils.fields.editAndTrigger(form.$('.o_datepicker[name=datetime_field] .o_datepicker_input'), '12/14/2018 13:42:28', ['change']);
-    await afterNextRender(() => testUtils.form.clickSave(form));
+    await click('.o_form_button_save');
     assert.strictEqual(
         document.querySelector('.o_Message_trackingValue').textContent,
         "Datetime:None12/14/2018 13:42:28",
         "should display the correct content of tracked field of type datetime: from no date and time to a set date and time (Datetime: None -> 12/14/2018 13:42:28)"
     );
-
-    form.destroy();
 });
 
 QUnit.test('rendering of tracked field of type datetime: from a set date and time to no date and time', async function (assert) {
@@ -333,17 +305,15 @@ QUnit.test('rendering of tracked field of type datetime: from a set date and tim
 
     const pyEnv = await startServer();
     const mailTestTrackAllId1 = pyEnv['mail.test.track.all'].create({ datetime_field: '2018-12-14 13:42:28 ' });
-    const { afterNextRender, widget: form } = await this.start({ res_id: mailTestTrackAllId1 });
+    const { click, widget: form } = await this.start({ res_id: mailTestTrackAllId1 });
 
     await testUtils.fields.editAndTrigger(form.$('.o_datepicker[name=datetime_field] .o_datepicker_input'), '', ['change']);
-    await afterNextRender(() => testUtils.form.clickSave(form));
+    await click('.o_form_button_save');
     assert.strictEqual(
         document.querySelector('.o_Message_trackingValue').textContent,
         "Datetime:12/14/2018 13:42:28None",
         "should display the correct content of tracked field of type datetime: from a set date and time to no date and time (Datetime: 12/14/2018 13:42:28 -> None)"
     );
-
-    form.destroy();
 });
 
 QUnit.test('rendering of tracked field of type text: from some text to empty', async function (assert) {
@@ -351,17 +321,15 @@ QUnit.test('rendering of tracked field of type text: from some text to empty', a
 
     const pyEnv = await startServer();
     const mailTestTrackAllId1 = pyEnv['mail.test.track.all'].create({ text_field: 'Marc' });
-    const { afterNextRender, widget: form } = await this.start({ res_id: mailTestTrackAllId1 });
+    const { click, widget: form } = await this.start({ res_id: mailTestTrackAllId1 });
 
     await testUtils.fields.editInput(form.$('textarea[name=text_field]'), '');
-    await afterNextRender(() => testUtils.form.clickSave(form));
+    await click('.o_form_button_save');
     assert.strictEqual(
         document.querySelector('.o_Message_trackingValue').textContent,
         "Text:MarcNone",
         "should display the correct content of tracked field of type text: from some text to empty (Text: Marc -> None)"
     );
-
-    form.destroy();
 });
 
 QUnit.test('rendering of tracked field of type text: from empty to some text', async function (assert) {
@@ -369,17 +337,15 @@ QUnit.test('rendering of tracked field of type text: from empty to some text', a
 
     const pyEnv = await startServer();
     const mailTestTrackAllId1 = pyEnv['mail.test.track.all'].create({ text_field: '' });
-    const { afterNextRender, widget: form } = await this.start({ res_id: mailTestTrackAllId1 });
+    const { click, widget: form } = await this.start({ res_id: mailTestTrackAllId1 });
 
     await testUtils.fields.editInput(form.$('textarea[name=text_field]'), 'Marc');
-    await afterNextRender(() => testUtils.form.clickSave(form));
+    await click('.o_form_button_save');
     assert.strictEqual(
         document.querySelector('.o_Message_trackingValue').textContent,
         "Text:NoneMarc",
         "should display the correct content of tracked field of type text: from empty to some text (Text: None -> Marc)"
     );
-
-    form.destroy();
 });
 
 QUnit.test('rendering of tracked field of type selection: from a selection to no selection', async function (assert) {
@@ -387,17 +353,15 @@ QUnit.test('rendering of tracked field of type selection: from a selection to no
 
     const pyEnv = await startServer();
     const mailTestTrackAllId1 = pyEnv['mail.test.track.all'].create({ selection_field: 'first' });
-    const { afterNextRender, widget: form } = await this.start({ res_id: mailTestTrackAllId1 });
+    const { click, widget: form } = await this.start({ res_id: mailTestTrackAllId1 });
 
     await testUtils.fields.editSelect(form.$('select[name=selection_field]'), '');
-    await afterNextRender(() => testUtils.form.clickSave(form));
+    await click('.o_form_button_save');
     assert.strictEqual(
         document.querySelector('.o_Message_trackingValue').textContent,
         "Selection:firstNone",
         "should display the correct content of tracked field of type selection: from a selection to no selection (Selection: first -> None)"
     );
-
-    form.destroy();
 });
 
 QUnit.test('rendering of tracked field of type selection: from no selection to a selection', async function (assert) {
@@ -405,17 +369,15 @@ QUnit.test('rendering of tracked field of type selection: from no selection to a
 
     const pyEnv = await startServer();
     const mailTestTrackAllId1 = pyEnv['mail.test.track.all'].create({});
-    const { afterNextRender, widget: form } = await this.start({ res_id: mailTestTrackAllId1 });
+    const { click, widget: form } = await this.start({ res_id: mailTestTrackAllId1 });
 
     await testUtils.fields.editSelect(form.$('select[name=selection_field]'), '"first"');
-    await afterNextRender(() => testUtils.form.clickSave(form));
+    await click('.o_form_button_save');
     assert.strictEqual(
         document.querySelector('.o_Message_trackingValue').textContent,
         "Selection:Nonefirst",
         "should display the correct content of tracked field of type selection: from no selection to a selection (Selection: None -> first)"
     );
-
-    form.destroy();
 });
 
 QUnit.test('rendering of tracked field of type many2one: from having a related record to no related record', async function (assert) {
@@ -424,17 +386,15 @@ QUnit.test('rendering of tracked field of type many2one: from having a related r
     const pyEnv = await startServer();
     const resPartnerId1 = pyEnv['res.partner'].create({ display_name: 'Marc' });
     const mailTestTrackAllId1 = pyEnv['mail.test.track.all'].create({ many2one_field_id: resPartnerId1 });
-    const { afterNextRender, widget: form } = await this.start({ res_id: mailTestTrackAllId1 });
+    const { click, widget: form } = await this.start({ res_id: mailTestTrackAllId1 });
 
     await testUtils.fields.editAndTrigger(form.$('.o_field_many2one_selection input'), '', ['keyup']);
-    await afterNextRender(() => testUtils.form.clickSave(form));
+    await click('.o_form_button_save');
     assert.strictEqual(
         document.querySelector('.o_Message_trackingValue').textContent,
         "Many2one:MarcNone",
         "should display the correct content of tracked field of type many2one: from having a related record to no related record (Many2one: Marc -> None)"
     );
-
-    form.destroy();
 });
 
 QUnit.test('rendering of tracked field of type many2one: from no related record to having a related record', async function (assert) {
@@ -443,17 +403,15 @@ QUnit.test('rendering of tracked field of type many2one: from no related record 
     const pyEnv = await startServer();
     pyEnv['res.partner'].create({ display_name: 'Marc' });
     const mailTestTrackAllId1 = pyEnv['mail.test.track.all'].create({});
-    const { afterNextRender, widget: form } = await this.start({ res_id: mailTestTrackAllId1 });
+    const { click } = await this.start({ res_id: mailTestTrackAllId1 });
 
     await testUtils.fields.many2one.clickOpenDropdown('many2one_field_id');
     await testUtils.fields.many2one.clickItem('many2one_field_id', 'Marc');
-    await afterNextRender(() => testUtils.form.clickSave(form));
+    await click('.o_form_button_save');
     assert.strictEqual(
         document.querySelector('.o_Message_trackingValue').textContent,
         "Many2one:NoneMarc",
         "should display the correct content of tracked field of type many2one: from no related record to having a related record (Many2one: None -> Marc)"
     );
-
-    form.destroy();
 });
 });


### PR DESCRIPTION
This PR helps reducing the noise in the one introducing the new environment
in discuss. Moreover, since the clean up of the widget is now handled by the
start method, the calls to widget.destroy in those test was not required.

task-2582313
