### PR TITLE
[FIX][15.0]mrp_subcontracting: stock users without mrp permission can't validate picking

### DIFF
--- a/addons/mrp_subcontracting/models/stock_picking.py
+++ b/addons/mrp_subcontracting/models/stock_picking.py
@@ -75,6 +75,8 @@ class StockPicking(models.Model):
 
         for picking in self:
             productions_to_done = picking._get_subcontract_production()._subcontracting_filter_to_done()
+            if not productions_to_done:
+                continue
             production_ids_backorder = []
             if not self.env.context.get('cancel_backorder'):
                 production_ids_backorder = productions_to_done.filtered(lambda mo: mo.state == "progress").ids


### PR DESCRIPTION
stock users without mrp permission can't be able to validate stock picking

Bug detected since commit: https://github.com/odoo/odoo/commit/5682015958d03f4a65969afe3fce9b9b05e5b505

Video:

https://user-images.githubusercontent.com/66937593/165886175-90fbe9c7-e0cc-495d-ac9f-7628410bee1a.mp4




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
