### PR TITLE
[I18N][13.0] website: Update i18n of module website

### DIFF
--- a/addons/website/i18n/website.pot
+++ b/addons/website/i18n/website.pot
@@ -5258,7 +5258,7 @@ msgstr ""
 
 #. module: website
 #: model_terms:ir.ui.view,arch_db:website.website_visitor_view_form
-msgid "Visitor Informations"
+msgid "Visitor Information"
 msgstr ""
 
 #. module: website

--- a/addons/website/views/website_visitor_views.xml
+++ b/addons/website/views/website_visitor_views.xml
@@ -201,7 +201,7 @@
                         <h1><field name="display_name"/></h1>
                     </div>
                     <group id="general_info">
-                        <group string="Visitor Informations">
+                        <group string="Visitor Information">
                             <field name="is_connected" invisible="1"/>
                             <field name="partner_id" attrs="{'invisible': [('partner_id', '=', False)]}"/>
                             <field name="email"/>


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
Fix spelling error of website module in odoo13

EN: Visitor Informations => Visitor Information

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
