### PR TITLE
[FIX] l10n_de: will allow DE PDF to be DIN5008 compliant (address block)

### DIFF
--- a/addons/l10n_de/report/din5008_report.xml
+++ b/addons/l10n_de/report/din5008_report.xml
@@ -54,24 +54,26 @@
                         <tr>
                             <td>
                                 <div class="address">
-                                    <t t-if="company.name">
-                                        <span t-field="company.name"/>
-                                    </t>
-                                    <t t-if="company.street">
-                                        <span>|</span> <span t-field="company.street"/>
-                                    </t>
-                                    <t t-if="company.street2">
-                                        <span>|</span> <span t-field="company.street2"/>
-                                    </t>
-                                    <t t-if="company.zip">
-                                        <span>|</span> <span t-field="company.zip"/>
-                                    </t>
-                                    <t t-if="company.city">
-                                        <span t-if="not company.zip">|</span> <span t-field="company.city"/>
-                                    </t>
-                                    <t t-if="company.country_id">
-                                        <span>|</span> <span t-field="company.country_id.name"/>
-                                    </t>
+                                    <div id="company_address">
+                                        <t t-if="company.name">
+                                            <span t-field="company.name"/>
+                                        </t>
+                                        <t t-if="company.street">
+                                            <span>|</span> <span t-field="company.street"/>
+                                        </t>
+                                        <t t-if="company.street2">
+                                            <span>|</span> <span t-field="company.street2"/>
+                                        </t>
+                                        <t t-if="company.zip">
+                                            <span>|</span> <span t-field="company.zip"/>
+                                        </t>
+                                        <t t-if="company.city">
+                                            <span t-if="not company.zip">|</span> <span t-field="company.city"/>
+                                        </t>
+                                        <t t-if="company.country_id">
+                                            <span>|</span> <span t-field="company.country_id.name"/>
+                                        </t>
+                                    </div>
                                     <hr class="company_invoice_line" />
                                     <div t-if="address">
                                         <t t-raw="address"/>
@@ -196,6 +198,22 @@
                         }
                     }
                 </t>
+            </xpath>
+        </template>
+
+        <template id="minimal_layout" inherit_id="web.minimal_layout">
+            <xpath expr="//meta" position="after">
+                <script t-if="env.company.external_report_layout_id.xml_id == 'l10n_de.external_layout_din5008'">
+                    window.addEventListener('onload', function (evt) {
+                        var companyAddress = document.getElementById('company_address');
+                        if (companyAddress) {
+                            var initialFont = 9;
+                            for (var fontSize = initialFont; companyAddress.scrollWidth > companyAddress.offsetWidth; fontSize-=0.1) {
+                                companyAddress.style.fontSize = fontSize + "pt";
+                            }
+                        }
+                    });
+                </script>
             </xpath>
         </template>
     </data>

--- a/addons/l10n_de/static/src/scss/report_din5008.scss
+++ b/addons/l10n_de/static/src/scss/report_din5008.scss
@@ -45,6 +45,9 @@
                     color: $o-default-report-secondary-color;
                 }
             }
+            #company_address {
+                white-space: nowrap;
+            }
             .information_block, .invoice_address {
                 width: 75mm;
                 min-height: 40mm;


### PR DESCRIPTION
In an invoice, the company field is supposed to have the maximum height of 5mm
and max width of 85mm (to be DIN5008 compliant). The width and height are
correct. However, when a company's address is long, it goes to the next line
which doubles the height. Therefore, it is not following the German DIN5008
standards.

Step to reproduce the issue:
1. Install Sale and Accounting module
2. Create a German Company with a pretty long Address
3. Install the DE package in Accounting
4. Create an invoice and generate its PDF in the Accounting module
You will see that the address on the top left is taking too line and thus
not being compliant with German DIN5008 official format.

Solution: To cope with this, the only solution was to adapt the size of the
font of the address to fit into the required space. To create this behavior,
a Javascript script was done to dynamically resize the font of the Address to
match the required space. This script is executed using the `onload` listener.
However, as we can only have one `onload` listener, we still had to call the
`subst()` function if necessary (inside our new `onload` listener as it
overrides the original one).

opw-2819504
