### PR TITLE
[IMP] mail, *: always mount discuss/chatWindow/dialog during tests 

### DIFF
--- a/addons/hr/static/tests/m2x_avatar_employee_tests.js
+++ b/addons/hr/static/tests/m2x_avatar_employee_tests.js
@@ -41,7 +41,6 @@ QUnit.module('hr', {}, function () {
             { employee_id: hrEmployeePublicId1 },
         ]);
         const { widget: list } = await start({
-            hasChatWindow: true,
             hasView: true,
             View: ListView,
             model: 'm2x.avatar.employee',
@@ -213,7 +212,6 @@ QUnit.module('hr', {}, function () {
             { employee_ids: [hrEmployeePublicId1, hrEmployeePublicId2] },
         );
         const { widget: form } = await start({
-            hasChatWindow: true,
             hasView: true,
             View: FormView,
             model: 'm2x.avatar.employee',
@@ -271,7 +269,6 @@ QUnit.module('hr', {}, function () {
             { employee_ids: [hrEmployeePublicId1, hrEmployeePublicId2] },
         );
         const { widget: list } = await start({
-            hasChatWindow: true,
             hasView: true,
             View: ListView,
             model: 'm2x.avatar.employee',
@@ -405,7 +402,6 @@ QUnit.module('hr', {}, function () {
             { employee_ids: [hrEmployeePublicId1, hrEmployeePublicId2] },
         );
         const { widget: form } = await start({
-            hasChatWindow: true,
             hasView: true,
             View: FormView,
             model: 'm2x.avatar.employee',

--- a/addons/im_livechat/static/tests/qunit_suite_tests/components/chat_window_manager_tests.js
+++ b/addons/im_livechat/static/tests/qunit_suite_tests/components/chat_window_manager_tests.js
@@ -30,7 +30,7 @@ QUnit.test('closing a chat window with no message from admin side unpins it', as
             uuid: 'channel-10-uuid',
         },
     );
-    const { createMessagingMenuComponent, messaging } = await start({ hasChatWindow: true });
+    const { createMessagingMenuComponent, messaging } = await start();
     await createMessagingMenuComponent();
 
     await afterNextRender(() => document.querySelector(`.o_MessagingMenu_toggler`).click());

--- a/addons/im_livechat/static/tests/qunit_suite_tests/components/discuss_sidebar_category_item_tests.js
+++ b/addons/im_livechat/static/tests/qunit_suite_tests/components/discuss_sidebar_category_item_tests.js
@@ -12,7 +12,6 @@ QUnit.module('discuss_sidebar_category_item_tests.js', {
         this.start = async params => {
             return start(Object.assign({}, params, {
                 autoOpenDiscuss: true,
-                hasDiscuss: true,
             }));
         };
     },

--- a/addons/im_livechat/static/tests/qunit_suite_tests/components/discuss_sidebar_category_tests.js
+++ b/addons/im_livechat/static/tests/qunit_suite_tests/components/discuss_sidebar_category_tests.js
@@ -13,7 +13,6 @@ QUnit.module('discuss_sidebar_category_tests.js', {
         this.start = async params => {
             return start(Object.assign({}, params, {
                 autoOpenDiscuss: true,
-                hasDiscuss: true,
             }));
         };
     },

--- a/addons/im_livechat/static/tests/qunit_suite_tests/components/discuss_tests.js
+++ b/addons/im_livechat/static/tests/qunit_suite_tests/components/discuss_tests.js
@@ -28,7 +28,6 @@ QUnit.test('livechat in the sidebar: basic rendering', async function (assert) {
     });
     const { messaging } = await start({
         autoOpenDiscuss: true,
-        hasDiscuss: true,
     });
     assert.containsOnce(document.body, '.o_Discuss_sidebar',
         "should have a sidebar section"
@@ -84,7 +83,6 @@ QUnit.test('livechat in the sidebar: existing user with country', async function
     });
     await start({
         autoOpenDiscuss: true,
-        hasDiscuss: true,
     });
     assert.containsOnce(
         document.body,
@@ -113,7 +111,6 @@ QUnit.test('do not add livechat in the sidebar on visitor opening his chat', asy
     });
     const { messaging } = await start({
         autoOpenDiscuss: true,
-        hasDiscuss: true,
     });
     assert.containsNone(
         document.body,
@@ -161,7 +158,6 @@ QUnit.test('do not add livechat in the sidebar on visitor typing', async functio
     });
     const { messaging } = await start({
         autoOpenDiscuss: true,
-        hasDiscuss: true,
     });
     assert.containsNone(
         document.body,
@@ -217,7 +213,6 @@ QUnit.test('add livechat in the sidebar on visitor sending first message', async
     });
     const { messaging } = await start({
         autoOpenDiscuss: true,
-        hasDiscuss: true,
     });
     assert.containsNone(
         document.body,
@@ -286,7 +281,6 @@ QUnit.test('livechats are sorted by last activity time in the sidebar: most rece
     ]);
     const { messaging } = await start({
         autoOpenDiscuss: true,
-        hasDiscuss: true,
     });
     const livechat11 = messaging.models['Thread'].findFromIdentifyingData({
         id: mailChannelId1,
@@ -358,7 +352,6 @@ QUnit.test('invite button should be present on livechat', async function (assert
                 default_active_id: `mail.channel_${mailChannelId1}`,
             },
         },
-        hasDiscuss: true,
     });
     assert.containsOnce(
         document.body,
@@ -389,7 +382,6 @@ QUnit.test('call buttons should not be present on livechat', async function (ass
                 default_active_id: `mail.channel_${mailChannelId1}`,
             },
         },
-        hasDiscuss: true,
     });
     assert.containsNone(
         document.body,

--- a/addons/mail/static/tests/qunit_mobile_suite_tests/components/discuss_mobile_mailbox_selection_tests.js
+++ b/addons/mail/static/tests/qunit_mobile_suite_tests/components/discuss_mobile_mailbox_selection_tests.js
@@ -24,7 +24,6 @@ QUnit.test('select another mailbox', async function (assert) {
                 isMobile: true,
             },
         },
-        hasDiscuss: true,
     });
     assert.containsOnce(
         document.body,
@@ -91,7 +90,6 @@ QUnit.test('auto-select "Inbox" when discuss had channel as active thread', asyn
                 isMobile: true,
             },
         },
-        hasDiscuss: true,
     });
     assert.hasClass(
         document.querySelector('.o_MobileMessagingNavbar_tab[data-tab-id="channel"]'),

--- a/addons/mail/static/tests/qunit_suite_tests/components/attachment_box_tests.js
+++ b/addons/mail/static/tests/qunit_suite_tests/components/attachment_box_tests.js
@@ -189,7 +189,7 @@ QUnit.test('view attachments', async function (assert) {
             res_model: 'res.partner',
         },
     ]);
-    const { click, createChatterContainerComponent, messaging } = await start({ hasDialog: true });
+    const { click, createChatterContainerComponent, messaging } = await start();
     await createChatterContainerComponent({
         isAttachmentBoxVisibleInitially: true,
         threadId: resPartnerId1,
@@ -253,7 +253,7 @@ QUnit.test('remove attachment should ask for confirmation', async function (asse
         res_id: resPartnerId1,
         res_model: 'res.partner',
     });
-    const { click, createChatterContainerComponent } = await start({ hasDialog: true });
+    const { click, createChatterContainerComponent } = await start();
     await createChatterContainerComponent({
         isAttachmentBoxVisibleInitially: true,
         threadId: resPartnerId1,

--- a/addons/mail/static/tests/qunit_suite_tests/components/attachment_list_tests.js
+++ b/addons/mail/static/tests/qunit_suite_tests/components/attachment_list_tests.js
@@ -169,7 +169,7 @@ QUnit.test('layout with card details and filename and extension', async function
 QUnit.test('view attachment', async function (assert) {
     assert.expect(3);
 
-    const { click, createMessageComponent, messaging } = await start({ hasDialog: true });
+    const { click, createMessageComponent, messaging } = await start();
     const attachment = messaging.models['Attachment'].create({
         filename: "test.png",
         id: 750,
@@ -205,7 +205,7 @@ QUnit.test('view attachment', async function (assert) {
 QUnit.test('close attachment viewer', async function (assert) {
     assert.expect(3);
 
-    const { click, createMessageComponent, messaging } = await start({ hasDialog: true });
+    const { click, createMessageComponent, messaging } = await start();
     const attachment = messaging.models['Attachment'].create({
         filename: "test.png",
         id: 750,
@@ -245,7 +245,6 @@ QUnit.test('clicking on the delete attachment button multiple times should do th
     assert.expect(2);
 
     const { click, createMessageComponent, messaging } = await start({
-        hasDialog: true,
         async mockRPC(route, args) {
             if (route === '/mail/attachment/delete') {
                 assert.step('attachment_unlink');
@@ -293,7 +292,7 @@ QUnit.test('[technical] does not crash when the viewer is closed before image lo
      */
     assert.expect(1);
 
-    const { click, createMessageComponent, messaging } = await start({ hasDialog: true });
+    const { click, createMessageComponent, messaging } = await start();
     const attachment = messaging.models['Attachment'].create({
         filename: "test.png",
         id: 750,

--- a/addons/mail/static/tests/qunit_suite_tests/components/channel_invitation_form_tests.js
+++ b/addons/mail/static/tests/qunit_suite_tests/components/channel_invitation_form_tests.js
@@ -33,7 +33,6 @@ QUnit.test('should display the channel invitation form after clicking on the inv
                 active_id: mailChannelId1,
             },
         },
-        hasDiscuss: true,
     });
     await click(`.o_ThreadViewTopbar_inviteButton`);
     assert.containsOnce(
@@ -72,7 +71,6 @@ QUnit.test('should be able to search for a new user to invite from an existing c
                 active_id: mailChannelId1,
             },
         },
-        hasDiscuss: true,
     });
     await click(`.o_ThreadViewTopbar_inviteButton`);
     await insertText('.o_ChannelInvitationForm_searchInput', "TestPartner2");
@@ -112,7 +110,6 @@ QUnit.test('should be able to create a new group chat from an existing chat', as
                 active_id: mailChannelId1,
             },
         },
-        hasDiscuss: true,
     });
 
     await click(`.o_ThreadViewTopbar_inviteButton`);

--- a/addons/mail/static/tests/qunit_suite_tests/components/chat_window_manager_tests.js
+++ b/addons/mail/static/tests/qunit_suite_tests/components/chat_window_manager_tests.js
@@ -14,16 +14,7 @@ const { triggerEvent } = dom;
 
 QUnit.module('mail', {}, function () {
 QUnit.module('components', {}, function () {
-QUnit.module('chat_window_manager_tests.js', {
-    beforeEach() {
-        this.start = async params => {
-            return start(Object.assign(
-                { hasChatWindow: true },
-                params,
-            ));
-        };
-    },
-});
+QUnit.module('chat_window_manager_tests.js');
 
 QUnit.test('[technical] messaging not created', async function (assert) {
     /**
@@ -37,7 +28,7 @@ QUnit.test('[technical] messaging not created', async function (assert) {
     assert.expect(2);
 
     const messagingBeforeCreationDeferred = makeDeferred();
-    await this.start({
+    await start({
         messagingBeforeCreationDeferred,
         waitUntilMessagingCondition: 'none',
     });
@@ -61,7 +52,7 @@ QUnit.test('[technical] messaging not created', async function (assert) {
 QUnit.test('initial mount', async function (assert) {
     assert.expect(1);
 
-    await this.start();
+    await start();
     assert.containsOnce(
         document.body,
         '.o_ChatWindowManager',
@@ -72,7 +63,7 @@ QUnit.test('initial mount', async function (assert) {
 QUnit.test('chat window new message: basic rendering', async function (assert) {
     assert.expect(10);
 
-    const { click, createMessagingMenuComponent } = await this.start();
+    const { click, createMessagingMenuComponent } = await start();
     await createMessagingMenuComponent();
     await click(`.o_MessagingMenu_toggler`);
     await click(`.o_MessagingMenu_newMessageButton`);
@@ -131,7 +122,7 @@ QUnit.test('chat window new message: basic rendering', async function (assert) {
 QUnit.test('chat window new message: focused on open [REQUIRE FOCUS]', async function (assert) {
     assert.expect(2);
 
-    const { click, createMessagingMenuComponent } = await this.start();
+    const { click, createMessagingMenuComponent } = await start();
     await createMessagingMenuComponent();
     await click(`.o_MessagingMenu_toggler`);
     await click(`.o_MessagingMenu_newMessageButton`);
@@ -149,7 +140,7 @@ QUnit.test('chat window new message: focused on open [REQUIRE FOCUS]', async fun
 QUnit.test('chat window new message: close', async function (assert) {
     assert.expect(1);
 
-    const { click, createMessagingMenuComponent } = await this.start();
+    const { click, createMessagingMenuComponent } = await start();
     await createMessagingMenuComponent();
     await click(`.o_MessagingMenu_toggler`);
     await click(`.o_MessagingMenu_newMessageButton`);
@@ -164,7 +155,7 @@ QUnit.test('chat window new message: close', async function (assert) {
 QUnit.test('chat window new message: fold', async function (assert) {
     assert.expect(6);
 
-    const { click, createMessagingMenuComponent } = await this.start();
+    const { click, createMessagingMenuComponent } = await start();
     await createMessagingMenuComponent();
     await click(`.o_MessagingMenu_toggler`);
     await click(`.o_MessagingMenu_newMessageButton`);
@@ -242,7 +233,7 @@ QUnit.test('open chat from "new message" chat window should open chat in place o
         },
     ]);
     const imSearchDef = makeDeferred();
-    const { click, createMessagingMenuComponent } = await this.start({
+    const { click, createMessagingMenuComponent } = await start({
         env: {
             browser: {
                 innerWidth: 1920,
@@ -355,7 +346,7 @@ QUnit.test('new message chat window should close on selecting the user if chat w
         name: "Partner 131",
         public: 'private',
     });
-    const { afterEvent, click, createMessagingMenuComponent } = await this.start();
+    const { afterEvent, click, createMessagingMenuComponent } = await start();
     await createMessagingMenuComponent();
 
     // open "new message" chat window
@@ -397,7 +388,7 @@ QUnit.test('new message autocomplete should automatically select first result', 
     const resPartnerId1 = pyEnv['res.partner'].create({ name: "Partner 131" });
     pyEnv['res.users'].create({ partner_id: resPartnerId1 });
     const imSearchDef = makeDeferred();
-    const { click, createMessagingMenuComponent } = await this.start({
+    const { click, createMessagingMenuComponent } = await start({
         async mockRPC(route, args) {
             const res = await this._super(...arguments);
             if (args.method === 'im_search') {
@@ -435,7 +426,7 @@ QUnit.test('chat window: basic rendering', async function (assert) {
 
     const pyEnv = await startServer();
     const mailChannelId1 = pyEnv['mail.channel'].create({ name: "General" });
-    const { click, createMessagingMenuComponent, messaging } = await this.start();
+    const { click, createMessagingMenuComponent, messaging } = await start();
     await createMessagingMenuComponent();
 
     await click(`.o_MessagingMenu_toggler`);
@@ -521,7 +512,7 @@ QUnit.test('chat window: fold', async function (assert) {
 
     const pyEnv = await startServer();
     pyEnv['mail.channel'].create({});
-    const { click, createMessagingMenuComponent } = await this.start({
+    const { click, createMessagingMenuComponent } = await start({
         mockRPC(route, args) {
             if (args.method === 'channel_fold') {
                 assert.step(`rpc:${args.method}/${args.kwargs.state}`);
@@ -573,7 +564,7 @@ QUnit.test('chat window: open / close', async function (assert) {
 
     const pyEnv = await startServer();
     pyEnv['mail.channel'].create({});
-    const { click, createMessagingMenuComponent } = await this.start({
+    const { click, createMessagingMenuComponent } = await start({
         mockRPC(route, args) {
             if (args.method === 'channel_fold') {
                 assert.step(`rpc:channel_fold/${args.kwargs.state}`);
@@ -637,7 +628,7 @@ QUnit.test('Mobile: opening a chat window should not update channel state on the
             }],
         ],
     });
-    const { click, createMessagingMenuComponent } = await this.start({
+    const { click, createMessagingMenuComponent } = await start({
         env: {
             device: {
                 isMobile: true,
@@ -672,7 +663,7 @@ QUnit.test('Mobile: closing a chat window should not update channel state on the
             }],
         ],
     });
-    const { click, createMessagingMenuComponent } = await this.start({
+    const { click, createMessagingMenuComponent } = await start({
         env: {
             device: {
                 isMobile: true,
@@ -719,7 +710,7 @@ QUnit.test("Mobile: chat window shouldn't open automatically after receiving a n
             uuid: 'channel-10-uuid',
         },
     ];
-    const { messaging } = await this.start({
+    const { messaging } = await start({
         env: {
             device: {
                 isMobile: true,
@@ -759,7 +750,7 @@ QUnit.test('chat window: close on ESCAPE', async function (assert) {
             }],
         ],
     });
-    const { click, insertText } = await this.start({
+    const { click, insertText } = await start({
         mockRPC(route, args) {
             if (args.method === 'channel_fold') {
                 assert.step(`rpc:channel_fold/${args.kwargs.state}`);
@@ -866,7 +857,7 @@ QUnit.test('focus next visible chat window when closing current chat window with
             ],
         },
     ]);
-    await this.start({
+    await start({
         env: {
             browser: {
                 innerWidth: 1920,
@@ -906,7 +897,7 @@ QUnit.test('chat window: composer state conservation on toggle discuss', async f
 
     const pyEnv = await startServer();
     pyEnv['mail.channel'].create();
-    const { click, createMessagingMenuComponent, insertText, messaging } = await this.start();
+    const { click, createMessagingMenuComponent, insertText, messaging } = await start();
     const messagingMenuComponent = await createMessagingMenuComponent();
     await click(`.o_MessagingMenu_toggler`);
     await click(`.o_MessagingMenu_dropdownMenu .o_NotificationList_preview`);
@@ -977,7 +968,7 @@ QUnit.test('chat window: scroll conservation on toggle discuss', async function 
             res_id: mailChannelId1,
         });
     }
-    const { afterEvent, click, createMessagingMenuComponent, messaging } = await this.start();
+    const { afterEvent, click, createMessagingMenuComponent, messaging } = await start();
     await createMessagingMenuComponent();
     await click(`.o_MessagingMenu_toggler`);
     await afterEvent({
@@ -1052,7 +1043,7 @@ QUnit.test('open 2 different chat windows: enough screen width [REQUIRE FOCUS]',
 
     const pyEnv = await startServer();
     const [mailChannelId1, mailChannelId2] = pyEnv['mail.channel'].create([{ name: 'mailChannel1' }, { name: 'mailChannel2' }]);
-    const { click, createMessagingMenuComponent, messaging } = await this.start({
+    const { click, createMessagingMenuComponent, messaging } = await start({
         env: {
             browser: {
                 innerWidth: 1920, // enough to fit at least 2 chat windows
@@ -1167,7 +1158,7 @@ QUnit.test('open 2 chat windows: check shift operations are available', async fu
 
     const pyEnv = await startServer();
     pyEnv['mail.channel'].create([{ name: 'mailChannel1' }, { name: 'mailChannel2' }]);
-    const { click, createMessagingMenuComponent } = await this.start();
+    const { click, createMessagingMenuComponent } = await start();
     await createMessagingMenuComponent();
 
     await click('.o_MessagingMenu_toggler');
@@ -1281,7 +1272,7 @@ QUnit.test('open 2 folded chat windows: check shift operations are available', a
         channel_type: "chat",
     };
     pyEnv['mail.channel'].create([channel, chat]);
-    const { click } = await this.start({
+    const { click } = await start({
         env: {
             browser: {
                 innerWidth: 900,
@@ -1394,7 +1385,7 @@ QUnit.test('open 3 different chat windows: not enough screen width', async funct
         { name: 'mailChannel2' },
         { name: 'mailChannel3' },
     ]);
-    const { click, createMessagingMenuComponent, messaging } = await this.start({
+    const { click, createMessagingMenuComponent, messaging } = await start({
         env: {
             browser: {
                 innerWidth: 900, // enough to fit 2 chat windows but not 3
@@ -1523,7 +1514,7 @@ QUnit.test('chat window: switch on TAB', async function (assert) {
 
     const pyEnv = await startServer();
     const [mailChannelId1, mailChannelId2] = pyEnv['mail.channel'].create([{ name: 'channel1' }, { name: 'channel2' }]);
-    const { click, createMessagingMenuComponent, messaging } = await this.start();
+    const { click, createMessagingMenuComponent, messaging } = await start();
     await createMessagingMenuComponent();
 
     await click(`.o_MessagingMenu_toggler`);
@@ -1653,7 +1644,7 @@ QUnit.test('chat window: TAB cycle with 3 open chat windows [REQUIRE FOCUS]', as
             ],
         },
     ]);
-    await this.start({
+    await start({
         env: {
             browser: {
                 innerWidth: 1920,
@@ -1733,7 +1724,7 @@ QUnit.test('chat window with a thread: keep scroll position in message list on f
             res_id: mailChannelId1,
         });
     }
-    const { afterEvent, click, createMessagingMenuComponent } = await this.start();
+    const { afterEvent, click, createMessagingMenuComponent } = await start();
     await createMessagingMenuComponent();
     await click(`.o_MessagingMenu_toggler`);
     await afterEvent({
@@ -1821,7 +1812,7 @@ QUnit.test('chat window should scroll to the newly posted message just after pos
             res_id: mailChannelId1,
         });
     }
-    const { insertText } = await this.start();
+    const { insertText } = await start();
 
     // Set content of the composer of the chat window
     await insertText('.o_ComposerTextInput_textarea', 'WOLOLO');
@@ -1853,7 +1844,7 @@ QUnit.test('chat window: post message on non-mailing channel with "CTRL-Enter" k
             }],
         ],
     });
-    const { click, createMessagingMenuComponent, insertText } = await this.start({
+    const { click, createMessagingMenuComponent, insertText } = await start({
         env: {
             device: {
                 isMobile: true, // here isMobile is used for the small screen size, not actually for the mobile devices
@@ -1889,7 +1880,7 @@ QUnit.test('chat window with a thread: keep scroll position in message list on t
             res_id: mailChannelId1,
         });
     }
-    const { afterEvent, click, createMessagingMenuComponent, messaging } = await this.start();
+    const { afterEvent, click, createMessagingMenuComponent, messaging } = await start();
     await createMessagingMenuComponent();
     await click(`.o_MessagingMenu_toggler`);
     await afterEvent({
@@ -1959,7 +1950,7 @@ QUnit.test('chat window with a thread: keep scroll position in message list on t
             res_id: mailChannelId1,
         });
     }
-    const { afterEvent, click, createMessagingMenuComponent, messaging } = await this.start();
+    const { afterEvent, click, createMessagingMenuComponent, messaging } = await start();
     await createMessagingMenuComponent();
     await click(`.o_MessagingMenu_toggler`);
     await afterEvent({
@@ -2069,7 +2060,7 @@ QUnit.test('chat window does not fetch messages if hidden', async function (asse
             name: "Channel #12",
         },
     ]);
-    const { click, messaging } = await this.start({
+    const { click, messaging } = await start({
         env: {
             browser: {
                 innerWidth: 900,
@@ -2163,7 +2154,7 @@ QUnit.test('new message separator is shown in a chat window of a chat on receivi
         model: 'mail.channel',
         res_id: mailChannelId1,
     });
-    const { messaging } = await this.start();
+    const { messaging } = await start();
 
     // simulate receiving a message
     await afterNextRender(async () => messaging.rpc({
@@ -2208,7 +2199,7 @@ QUnit.test('new message separator is not shown in a chat window of a chat on rec
         channel_type: "chat",
         uuid: 'channel-10-uuid',
     });
-    const { messaging } = await this.start();
+    const { messaging } = await start();
 
     // simulate receiving a message
     await afterNextRender(async () => messaging.rpc({
@@ -2251,7 +2242,7 @@ QUnit.test('focusing a chat window of a chat should make new message separator d
         model: 'mail.channel',
         res_id: mailChannelId1,
     });
-    const { afterEvent, messaging } = await this.start();
+    const { afterEvent, messaging } = await start();
 
     // simulate receiving a message
     await afterNextRender(() => messaging.rpc({
@@ -2310,7 +2301,7 @@ QUnit.test('Textual representations of shift previous/next operations are correc
             ],
         },
     ]);
-    await this.start();
+    await start();
 
     assert.strictEqual(
         document.querySelector('.o_ChatWindowHeader_commandShiftPrev').title,
@@ -2346,7 +2337,7 @@ QUnit.test('Textual representations of shift previous/next operations are correc
             ],
         },
     ]);
-    await this.start({
+    await start({
         env: {
             _t: Object.assign((s => s), {
                 database: {
@@ -2393,7 +2384,7 @@ QUnit.test('chat window should open when receiving a new DM', async function (as
         channel_type: 'chat',
         uuid: 'channel11uuid',
     });
-    const { messaging } = await this.start();
+    const { messaging } = await start();
 
     // simulate receiving the first message on channel 11
     await afterNextRender(() => messaging.rpc({
@@ -2435,7 +2426,7 @@ QUnit.test('chat window should remain folded when new message is received', asyn
         uuid: 'channel-10-uuid',
     });
 
-    const { messaging } = await this.start();
+    const { messaging } = await start();
     // simulate receiving a new message
     await afterNextRender(async () => messaging.rpc({
         route: '/mail/chat_post',
@@ -2474,7 +2465,7 @@ QUnit.test('should not have chat window hidden menu in mobile (transition from 2
 
     const pyEnv = await startServer();
     const [mailChannelId1, mailChannelId2] = pyEnv['mail.channel'].create([{ name: 'mailChannel1' }, { name: 'mailChannel1' }]);
-    const { click, createMessagingMenuComponent, messaging } = await this.start({
+    const { click, createMessagingMenuComponent, messaging } = await start({
         env: {
             browser: {
                 innerWidth: 600, // enough to fit 1 chat window + hidden menu
@@ -2563,7 +2554,7 @@ QUnit.skip('chat window scroll position should remain the same after switching p
             res_id: mailChannelId2,
         });
     }
-    const { afterEvent, createMessagingMenuComponent, messaging } = await this.start();
+    const { afterEvent, createMessagingMenuComponent, messaging } = await start();
     await createMessagingMenuComponent();
 
     const thread1LocalId = messaging.models['Thread'].findFromIdentifyingData({
@@ -2640,7 +2631,7 @@ QUnit.skip('chat window scroll position should remain the same after switching n
             res_id: mailChannelId2,
         });
     }
-    const { afterEvent, createMessagingMenuComponent, messaging } = await this.start();
+    const { afterEvent, createMessagingMenuComponent, messaging } = await start();
     await createMessagingMenuComponent();
 
     const thread1LocalId = messaging.models['Thread'].findFromIdentifyingData({

--- a/addons/mail/static/tests/qunit_suite_tests/components/composer_suggestion_canned_response_tests.js
+++ b/addons/mail/static/tests/qunit_suite_tests/components/composer_suggestion_canned_response_tests.js
@@ -21,7 +21,6 @@ QUnit.test('canned response suggestion displayed', async function (assert) {
                 default_active_id: mailChannelId1,
             },
         },
-        hasDiscuss: true,
     });
     await openDiscuss();
     await insertText('.o_ComposerTextInput_textarea', ":hello");
@@ -47,7 +46,6 @@ QUnit.test('canned response suggestion correct data', async function (assert) {
                 default_active_id: mailChannelId1,
             },
         },
-        hasDiscuss: true,
     });
     await openDiscuss();
     await insertText('.o_ComposerTextInput_textarea', ":hello");
@@ -88,7 +86,6 @@ QUnit.test('canned response suggestion active', async function (assert) {
                 default_active_id: mailChannelId1,
             },
         },
-        hasDiscuss: true,
     });
     await openDiscuss();
     await insertText('.o_ComposerTextInput_textarea', ":hello");

--- a/addons/mail/static/tests/qunit_suite_tests/components/composer_suggestion_channel_tests.js
+++ b/addons/mail/static/tests/qunit_suite_tests/components/composer_suggestion_channel_tests.js
@@ -17,7 +17,6 @@ QUnit.test('channel mention suggestion displayed', async function (assert) {
                 default_active_id: mailChannelId1,
             },
         },
-        hasDiscuss: true,
     });
     await openDiscuss();
     await insertText('.o_ComposerTextInput_textarea', "#my-channel");
@@ -39,7 +38,6 @@ QUnit.test('channel mention suggestion correct data', async function (assert) {
                 default_active_id: mailChannelId1,
             },
         },
-        hasDiscuss: true,
     });
     await openDiscuss();
     await insertText('.o_ComposerTextInput_textarea', "#General");
@@ -66,7 +64,6 @@ QUnit.test('channel mention suggestion active', async function (assert) {
                 default_active_id: mailChannelId1,
             },
         },
-        hasDiscuss: true,
     });
     await openDiscuss();
     await insertText('.o_ComposerTextInput_textarea', "#my-channel");

--- a/addons/mail/static/tests/qunit_suite_tests/components/composer_suggestion_command_tests.js
+++ b/addons/mail/static/tests/qunit_suite_tests/components/composer_suggestion_command_tests.js
@@ -17,7 +17,6 @@ QUnit.test('command suggestion displayed', async function (assert) {
                 default_active_id: mailChannelId1,
             },
         },
-        hasDiscuss: true,
     });
     await openDiscuss();
     await insertText('.o_ComposerTextInput_textarea', "/who");
@@ -39,7 +38,6 @@ QUnit.test('command suggestion correct data', async function (assert) {
                 default_active_id: mailChannelId1,
             },
         },
-        hasDiscuss: true,
     });
     await openDiscuss();
     await insertText('.o_ComposerTextInput_textarea', "/who");
@@ -76,7 +74,6 @@ QUnit.test('command suggestion active', async function (assert) {
                 default_active_id: mailChannelId1,
             },
         },
-        hasDiscuss: true,
     });
     await openDiscuss();
     await insertText('.o_ComposerTextInput_textarea', "/who");

--- a/addons/mail/static/tests/qunit_suite_tests/components/composer_suggestion_partner_tests.js
+++ b/addons/mail/static/tests/qunit_suite_tests/components/composer_suggestion_partner_tests.js
@@ -22,7 +22,6 @@ QUnit.test('partner mention suggestion displayed', async function (assert) {
                 default_active_id: mailChannelId1,
             },
         },
-        hasDiscuss: true,
     });
     await openDiscuss();
     await insertText('.o_ComposerTextInput_textarea', "@demo");
@@ -49,7 +48,6 @@ QUnit.test('partner mention suggestion correct data', async function (assert) {
                 default_active_id: mailChannelId1,
             },
         },
-        hasDiscuss: true,
     });
     await openDiscuss();
     await insertText('.o_ComposerTextInput_textarea', "@demo");
@@ -96,7 +94,6 @@ QUnit.test('partner mention suggestion active', async function (assert) {
                 default_active_id: mailChannelId1,
             },
         },
-        hasDiscuss: true,
     });
     await openDiscuss();
     await insertText('.o_ComposerTextInput_textarea', "@demo");

--- a/addons/mail/static/tests/qunit_suite_tests/components/composer_tests.js
+++ b/addons/mail/static/tests/qunit_suite_tests/components/composer_tests.js
@@ -609,7 +609,6 @@ QUnit.test('do not send typing notification on typing "/" command', async functi
                 default_active_id: `mail.channel_${mailChannelId1}`,
             },
         },
-        hasDiscuss: true,
         async mockRPC(route, args) {
             if (args.method === 'notify_typing') {
                 assert.step(`notify_typing:${args.kwargs.is_typing}`);
@@ -634,7 +633,6 @@ QUnit.test('do not send typing notification on typing after selecting suggestion
                 default_active_id: `mail.channel_${mailChannelId1}`,
             },
         },
-        hasDiscuss: true,
         async mockRPC(route, args) {
             if (args.method === 'notify_typing') {
                 assert.step(`notify_typing:${args.kwargs.is_typing}`);
@@ -1092,7 +1090,6 @@ QUnit.test('composer with thread typing notification status', async function (as
                 default_active_id: `mail.channel_${mailChannelId1}`,
             },
         },
-        hasDiscuss: true,
     });
 
     assert.containsOnce(
@@ -1121,7 +1118,6 @@ QUnit.test('current partner notify is typing to other thread members', async fun
                 default_active_id: `mail.channel_${mailChannelId1}`,
             },
         },
-        hasDiscuss: true,
         async mockRPC(route, args) {
             if (args.method === 'notify_typing') {
                 assert.step(`notify_typing:${args.kwargs.is_typing}`);
@@ -1151,7 +1147,6 @@ QUnit.test('current partner is typing should not translate on textual typing sta
                 default_active_id: `mail.channel_${mailChannelId1}`,
             },
         },
-        hasDiscuss: true,
         hasTimeControl: true,
         async mockRPC(route, args) {
             if (args.method === 'notify_typing') {
@@ -1190,7 +1185,6 @@ QUnit.test('current partner notify no longer is typing to thread members after 5
                 default_active_id: `mail.channel_${mailChannelId1}`,
             },
         },
-        hasDiscuss: true,
         hasTimeControl: true,
         async mockRPC(route, args) {
             if (args.method === 'notify_typing') {
@@ -1228,7 +1222,6 @@ QUnit.test('current partner notify is typing again to other members every 50s of
                 default_active_id: `mail.channel_${mailChannelId1}`,
             },
         },
-        hasDiscuss: true,
         hasTimeControl: true,
         async mockRPC(route, args) {
             if (args.method === 'notify_typing') {

--- a/addons/mail/static/tests/qunit_suite_tests/components/dialog_manager_tests.js
+++ b/addons/mail/static/tests/qunit_suite_tests/components/dialog_manager_tests.js
@@ -23,7 +23,6 @@ QUnit.test('[technical] messaging not created', async function (assert) {
 
     const messagingBeforeCreationDeferred = makeDeferred();
     await start({
-        hasDialog: true,
         messagingBeforeCreationDeferred,
         waitUntilMessagingCondition: 'none',
     });
@@ -47,7 +46,7 @@ QUnit.test('[technical] messaging not created', async function (assert) {
 QUnit.test('initial mount', async function (assert) {
     assert.expect(1);
 
-    await start({ hasDialog: true });
+    await start();
     assert.containsOnce(
         document.body,
         '.o_DialogManager',

--- a/addons/mail/static/tests/qunit_suite_tests/components/discuss_inbox_tests.js
+++ b/addons/mail/static/tests/qunit_suite_tests/components/discuss_inbox_tests.js
@@ -16,7 +16,6 @@ QUnit.module('discuss_inbox_tests.js', {
         this.start = async params => {
             return start(Object.assign({}, params, {
                 autoOpenDiscuss: true,
-                hasDiscuss: true,
             }));
         };
     },

--- a/addons/mail/static/tests/qunit_suite_tests/components/discuss_message_edit_tests.js
+++ b/addons/mail/static/tests/qunit_suite_tests/components/discuss_message_edit_tests.js
@@ -23,7 +23,6 @@ QUnit.test('click on message edit button should open edit composer', async funct
                 default_active_id: `mail.channel_${mailChannelId1}`,
             },
         },
-        hasDiscuss: true,
     });
     await openDiscuss();
     await click('.o_Message');

--- a/addons/mail/static/tests/qunit_suite_tests/components/discuss_pinned_tests.js
+++ b/addons/mail/static/tests/qunit_suite_tests/components/discuss_pinned_tests.js
@@ -17,7 +17,6 @@ QUnit.test('sidebar: pinned channel 1: init with one pinned channel', async func
     const mailChannelId1 = pyEnv['mail.channel'].create();
     const { messaging } = await start({
         autoOpenDiscuss: true,
-        hasDiscuss: true,
     });
     assert.containsOnce(
         document.body,
@@ -43,7 +42,6 @@ QUnit.test('sidebar: pinned channel 2: open pinned channel', async function (ass
     const mailChannelId1 = pyEnv['mail.channel'].create();
     const { click, messaging } = await start({
         autoOpenDiscuss: true,
-        hasDiscuss: true,
     });
 
     const threadGeneral = messaging.models['Thread'].findFromIdentifyingData({
@@ -73,7 +71,6 @@ QUnit.test('sidebar: pinned channel 3: open channel and leave it', async functio
     });
     const { click, messaging } = await start({
         autoOpenDiscuss: true,
-        hasDiscuss: true,
         async mockRPC(route, args) {
             if (args.method === 'action_unfollow') {
                 assert.step('action_unfollow');
@@ -120,7 +117,6 @@ QUnit.test('sidebar: unpin channel from bus', async function (assert) {
     const mailChannelId1 = pyEnv['mail.channel'].create();
     const { click, env, messaging } = await start({
         autoOpenDiscuss: true,
-        hasDiscuss: true,
     });
     const threadGeneral = messaging.models['Thread'].findFromIdentifyingData({
         id: mailChannelId1,
@@ -191,7 +187,6 @@ QUnit.test('[technical] sidebar: channel group_based_subscription: mandatorily p
     });
     const { messaging } = await start({
         autoOpenDiscuss: true,
-        hasDiscuss: true,
     });
     const threadGeneral = messaging.models['Thread'].findFromIdentifyingData({
         id: mailChannelId1,

--- a/addons/mail/static/tests/qunit_suite_tests/components/discuss_sidebar_category_item_tests.js
+++ b/addons/mail/static/tests/qunit_suite_tests/components/discuss_sidebar_category_item_tests.js
@@ -20,7 +20,6 @@ QUnit.test('channel - avatar: should have correct avatar', async function (asser
 
     const { messaging } = await start({
         autoOpenDiscuss: true,
-        hasDiscuss: true,
     });
 
     const channelItem = document.querySelector(`
@@ -52,7 +51,6 @@ QUnit.test('channel - avatar: should update avatar url from bus', async function
 
     const { messaging } = await start({
         autoOpenDiscuss: true,
-        hasDiscuss: true,
     });
 
     const channelItemAvatar = document.querySelector(`
@@ -100,7 +98,6 @@ QUnit.test('chat - avatar: should have correct avatar', async function (assert) 
     });
     const { messaging } = await start({
         autoOpenDiscuss: true,
-        hasDiscuss: true,
     });
 
     const chatItem = document.querySelector(`
@@ -148,7 +145,6 @@ QUnit.test('chat - sorting: should be sorted by last activity time', async funct
     ]);
     const { click, messaging } = await start({
         autoOpenDiscuss: true,
-        hasDiscuss: true,
     });
 
     const chat1 = messaging.models['Thread'].findFromIdentifyingData({

--- a/addons/mail/static/tests/qunit_suite_tests/components/discuss_sidebar_category_tests.js
+++ b/addons/mail/static/tests/qunit_suite_tests/components/discuss_sidebar_category_tests.js
@@ -13,7 +13,6 @@ QUnit.module('discuss_sidebar_category_tests.js', {
         this.start = async params => {
             return start(Object.assign({}, params, {
                 autoOpenDiscuss: true,
-                hasDiscuss: true,
             }));
         };
     },

--- a/addons/mail/static/tests/qunit_suite_tests/components/discuss_sidebar_tests.js
+++ b/addons/mail/static/tests/qunit_suite_tests/components/discuss_sidebar_tests.js
@@ -24,7 +24,6 @@ QUnit.test('sidebar find shows channels matching search term', async function (a
     const searchReadDef = makeDeferred();
     const { click } = await start({
         autoOpenDiscuss: true,
-        hasDiscuss: true,
         async mockRPC(route, args) {
             const res = await this._super(...arguments);
             if (args.method === 'search_read') {
@@ -78,7 +77,6 @@ QUnit.test('sidebar find shows channels matching search term even when user is m
     const searchReadDef = makeDeferred();
     const { click } = await start({
         autoOpenDiscuss: true,
-        hasDiscuss: true,
         async mockRPC(route, args) {
             const res = await this._super(...arguments);
             if (args.method === 'search_read') {
@@ -129,7 +127,6 @@ QUnit.test('sidebar channels should be ordered case insensitive alphabetically',
     ]);
     await start({
         autoOpenDiscuss: true,
-        hasDiscuss: true,
     });
     const results = document.querySelectorAll('.o_DiscussSidebar_categoryChannel .o_DiscussSidebarCategoryItem_name');
     assert.deepEqual(

--- a/addons/mail/static/tests/qunit_suite_tests/components/discuss_tests.js
+++ b/addons/mail/static/tests/qunit_suite_tests/components/discuss_tests.js
@@ -21,7 +21,6 @@ QUnit.module('discuss_tests.js', {
         this.start = async params => {
             return start(Object.assign({}, params, {
                 autoOpenDiscuss: true,
-                hasDiscuss: true,
             }));
         };
     },

--- a/addons/mail/static/tests/qunit_suite_tests/components/follow_button_tests.js
+++ b/addons/mail/static/tests/qunit_suite_tests/components/follow_button_tests.js
@@ -43,7 +43,6 @@ QUnit.test('base rendering not editable', async function (assert) {
 
     const pyEnv = await startServer();
     await this.createView({
-        hasDialog: true,
         hasView: true,
         // View params
         View: FormView,
@@ -88,7 +87,6 @@ QUnit.test('hover following button', async function (assert) {
         message_follower_ids: [followerId],
     });
     await this.createView({
-        hasDialog: true,
         hasView: true,
         // View params
         View: FormView,
@@ -160,7 +158,6 @@ QUnit.test('click on "follow" button', async function (assert) {
 
     const pyEnv = await startServer();
     const { click } = await this.createView({
-        hasDialog: true,
         hasView: true,
         // View params
         View: FormView,
@@ -226,7 +223,6 @@ QUnit.test('click on "unfollow" button', async function (assert) {
         message_follower_ids: [followerId],
     });
     const { click } = await this.createView({
-        hasDialog: true,
         hasView: true,
         // View params
         View: FormView,

--- a/addons/mail/static/tests/qunit_suite_tests/components/follower_subtype_tests.js
+++ b/addons/mail/static/tests/qunit_suite_tests/components/follower_subtype_tests.js
@@ -69,7 +69,6 @@ QUnit.test('simplest layout of a followed subtype', async function (assert) {
         message_follower_ids: [followerId],
     });
     const { click } = await this.createView({
-        hasDialog: true,
         hasView: true,
         // View params
         View: FormView,
@@ -143,7 +142,6 @@ QUnit.test('simplest layout of a not followed subtype', async function (assert) 
         message_follower_ids: [followerId],
     });
     const { click } = await this.createView({
-        hasDialog: true,
         hasView: true,
         // View params
         View: FormView,
@@ -197,7 +195,6 @@ QUnit.test('toggle follower subtype checkbox', async function (assert) {
         message_follower_ids: [followerId],
     });
     const { click, messaging } = await this.createView({
-        hasDialog: true,
         hasView: true,
         // View params
         View: FormView,

--- a/addons/mail/static/tests/qunit_suite_tests/components/follower_tests.js
+++ b/addons/mail/static/tests/qunit_suite_tests/components/follower_tests.js
@@ -194,7 +194,6 @@ QUnit.test('click on edit follower', async function (assert) {
         res_model: 'res.partner',
     });
     const { click, messaging, widget } = await start({
-        hasDialog: true,
         async mockRPC(route, args) {
             if (route.includes('/mail/read_subscription_data')) {
                 assert.step('fetch_subtypes');
@@ -237,7 +236,6 @@ QUnit.test('edit follower and close subtype dialog', async function (assert) {
     const pyEnv = await startServer();
     const resPartnerId1 = pyEnv['res.partner'].create();
     const { click, messaging, widget } = await start({
-        hasDialog: true,
         async mockRPC(route, args) {
             if (route.includes('/mail/read_subscription_data')) {
                 assert.step('fetch_subtypes');

--- a/addons/mail/static/tests/qunit_suite_tests/components/message_seen_indicator_tests.js
+++ b/addons/mail/static/tests/qunit_suite_tests/components/message_seen_indicator_tests.js
@@ -55,7 +55,6 @@ QUnit.test('rendering when just one has received the message', async function (a
                 default_active_id: `mail.channel_${mailChannelId}`,
             },
         },
-        hasDiscuss: true,
     });
     await openDiscuss();
     assert.containsOnce(
@@ -106,7 +105,6 @@ QUnit.test('rendering when everyone have received the message', async function (
                 default_active_id: `mail.channel_${mailChannelId}`,
             },
         },
-        hasDiscuss: true,
     });
     await openDiscuss();
     assert.containsOnce(
@@ -161,7 +159,6 @@ QUnit.test('rendering when just one has seen the message', async function (asser
                 default_active_id: `mail.channel_${mailChannelId}`,
             },
         },
-        hasDiscuss: true,
     });
     await openDiscuss();
     assert.containsOnce(
@@ -213,7 +210,6 @@ QUnit.test('rendering when just one has seen & received the message', async func
                 default_active_id: `mail.channel_${mailChannelId}`,
             },
         },
-        hasDiscuss: true,
     });
     await openDiscuss();
     assert.containsOnce(
@@ -265,7 +261,6 @@ QUnit.test('rendering when just everyone has seen the message', async function (
                 default_active_id: `mail.channel_${mailChannelId}`,
             },
         },
-        hasDiscuss: true,
     });
     await openDiscuss();
     assert.containsOnce(

--- a/addons/mail/static/tests/qunit_suite_tests/components/message_tests.js
+++ b/addons/mail/static/tests/qunit_suite_tests/components/message_tests.js
@@ -630,7 +630,7 @@ QUnit.test('only show messaging seen indicator if authored by me, after last see
 QUnit.test('allow attachment delete on authored message', async function (assert) {
     assert.expect(5);
 
-    const { click, createMessageComponent, messaging } = await start({ hasDialog: true });
+    const { click, createMessageComponent, messaging } = await start();
     const message = messaging.models['Message'].create({
         attachments: insertAndReplace({
             filename: "BLAH.jpg",
@@ -804,7 +804,7 @@ QUnit.test('chat with author should be opened after clicking on his avatar', asy
     const pyEnv = await startServer();
     const resPartnerId1 = pyEnv['res.partner'].create();
     pyEnv['res.users'].create({ partner_id: resPartnerId1 });
-    const { click, createMessageComponent, messaging } = await start({ hasChatWindow: true });
+    const { click, createMessageComponent, messaging } = await start();
     const message = messaging.models['Message'].create({
         author: insert({ id: resPartnerId1 }),
         id: 10,
@@ -840,7 +840,7 @@ QUnit.test('chat with author should be opened after clicking on his im status ic
     const pyEnv = await startServer();
     const resPartnerId1 = pyEnv['res.partner'].create();
     pyEnv['res.users'].create({ partner_id: resPartnerId1 });
-    const { click, createMessageComponent, messaging } = await start({ hasChatWindow: true });
+    const { click, createMessageComponent, messaging } = await start();
     const message = messaging.models['Message'].create({
         author: insert({ id: resPartnerId1, im_status: 'online' }),
         id: 10,
@@ -890,7 +890,7 @@ QUnit.test('open chat with author on avatar click should be disabled when curren
         model: 'mail.channel',
         res_id: mailChannelId1,
     });
-    const { createThreadViewComponent, messaging } = await start({ hasChatWindow: true });
+    const { createThreadViewComponent, messaging } = await start();
     const correspondent = messaging.models['Partner'].insert({ id: resPartnerId1 });
     const thread = await correspondent.getChat();
     const threadViewer = messaging.models['ThreadViewer'].create({

--- a/addons/mail/static/tests/qunit_suite_tests/components/messaging_menu_tests.js
+++ b/addons/mail/static/tests/qunit_suite_tests/components/messaging_menu_tests.js
@@ -365,7 +365,7 @@ QUnit.test('switch tab', async function (assert) {
 QUnit.test('new message', async function (assert) {
     assert.expect(3);
 
-    const { click, createMessagingMenuComponent } = await start({ hasChatWindow: true });
+    const { click, createMessagingMenuComponent } = await start();
     await createMessagingMenuComponent();
     await click(`.o_MessagingMenu_toggler`);
     await click(`.o_MessagingMenu_newMessageButton`);
@@ -390,7 +390,6 @@ QUnit.test('no new message when discuss is open', async function (assert) {
 
     const { click, discussWidget, createMessagingMenuComponent } = await start({
         autoOpenDiscuss: true,
-        hasDiscuss: true,
     });
     await createMessagingMenuComponent();
 
@@ -672,7 +671,7 @@ QUnit.test('open chat window from preview', async function (assert) {
 
     const pyEnv = await startServer();
     pyEnv['mail.channel'].create();
-    const { click, createMessagingMenuComponent } = await start({ hasChatWindow: true });
+    const { click, createMessagingMenuComponent } = await start();
     await createMessagingMenuComponent();
 
     await click(`.o_MessagingMenu_toggler`);

--- a/addons/mail/static/tests/qunit_suite_tests/components/notification_list_notification_group_tests.js
+++ b/addons/mail/static/tests/qunit_suite_tests/components/notification_list_notification_group_tests.js
@@ -156,7 +156,7 @@ QUnit.test('grouped notifications by document', async function (assert) {
             notification_type: 'email', // expected failure type for email message
         }
     ]);
-    const { click, createNotificationListComponent } = await start({ hasChatWindow: true });
+    const { click, createNotificationListComponent } = await start();
     await createNotificationListComponent();
 
     assert.containsOnce(
@@ -336,10 +336,7 @@ QUnit.test('different mail.channel are not grouped', async function (assert) {
             notification_type: 'email',
         },
     ]);
-    const { createNotificationListComponent } = await start({
-        // needed to assert thread.open
-        hasChatWindow: true,
-    });
+    const { createNotificationListComponent } = await start();
     await createNotificationListComponent();
     assert.containsN(
         document.body,

--- a/addons/mail/static/tests/qunit_suite_tests/components/thread_needaction_preview_tests.js
+++ b/addons/mail/static/tests/qunit_suite_tests/components/thread_needaction_preview_tests.js
@@ -26,7 +26,6 @@ QUnit.test('mark as read', async function (assert) {
         res_partner_id: pyEnv.currentPartnerId,
     });
     const { afterEvent, click, createMessagingMenuComponent } = await start({
-        hasChatWindow: true,
         async mockRPC(route, args) {
             if (route.includes('mark_all_as_read')) {
                 assert.step('mark_all_as_read');
@@ -87,7 +86,6 @@ QUnit.test('click on preview should mark as read and open the thread', async fun
         res_partner_id: pyEnv.currentPartnerId,
     });
     const { afterEvent, click, createMessagingMenuComponent } = await start({
-        hasChatWindow: true,
         async mockRPC(route, args) {
             if (route.includes('mark_all_as_read')) {
                 assert.step('mark_all_as_read');
@@ -168,7 +166,6 @@ QUnit.test('click on expand from chat window should close the chat window and op
     });
     const { afterEvent, click, createMessagingMenuComponent } = await start({
         env: { bus },
-        hasChatWindow: true,
     });
     await createMessagingMenuComponent();
     await afterNextRender(() => afterEvent({
@@ -229,7 +226,6 @@ QUnit.test('[technical] opening a non-channel chat window should not call channe
         res_partner_id: pyEnv.currentPartnerId,
     });
     const { afterEvent, click, createMessagingMenuComponent } = await start({
-        hasChatWindow: true,
         async mockRPC(route, args) {
             if (route.includes('channel_fold')) {
                 const message = "should not call channel_fold when opening a non-channel chat window";
@@ -295,7 +291,7 @@ QUnit.test('preview should display last needaction message preview even if there
         notification_type: 'inbox',
         res_partner_id: pyEnv.currentPartnerId,
     });
-    const { afterEvent, createMessagingMenuComponent } = await start({ hasChatWindow: true });
+    const { afterEvent, createMessagingMenuComponent } = await start();
     await createMessagingMenuComponent();
     await afterNextRender(() => afterEvent({
         eventName: 'o-thread-cache-loaded-messages',
@@ -336,7 +332,7 @@ QUnit.test('chat window header should not have unread counter for non-channel th
         notification_type: 'inbox',
         res_partner_id: pyEnv.currentPartnerId,
     });
-    const { afterEvent, click, createMessagingMenuComponent } = await start({ hasChatWindow: true });
+    const { afterEvent, click, createMessagingMenuComponent } = await start();
     await createMessagingMenuComponent();
     await afterNextRender(() => afterEvent({
         eventName: 'o-thread-cache-loaded-messages',

--- a/addons/mail/static/tests/qunit_suite_tests/components/thread_preview_tests.js
+++ b/addons/mail/static/tests/qunit_suite_tests/components/thread_preview_tests.js
@@ -30,7 +30,6 @@ QUnit.test('mark as read', async function (assert) {
     pyEnv['mail.channel.partner'].write([mailChannelPartnerId], { seen_message_id: mailMessageId1 });
 
     const { click, createMessagingMenuComponent } = await start({
-        hasChatWindow: true,
         async mockRPC(route, args) {
             if (route.includes('set_last_seen_message')) {
                 assert.step('set_last_seen_message');

--- a/addons/mail/static/tests/qunit_suite_tests/components/thread_view_tests.js
+++ b/addons/mail/static/tests/qunit_suite_tests/components/thread_view_tests.js
@@ -924,7 +924,7 @@ QUnit.test("delete all attachments of message without content should no longer d
             res_id: mailChannelId1,
         }
     );
-    const { afterEvent, click, createThreadViewComponent, messaging } = await start({ hasDialog: true });
+    const { afterEvent, click, createThreadViewComponent, messaging } = await start();
     const threadViewer = messaging.models['ThreadViewer'].create({
         hasThreadView: true,
         qunitTest: insertAndReplace(),
@@ -977,7 +977,7 @@ QUnit.test('delete all attachments of a message with some text content should st
         model: "mail.channel",
         res_id: mailChannelId1,
     });
-    const { afterEvent, click, createThreadViewComponent, messaging } = await start({ hasDialog: true });
+    const { afterEvent, click, createThreadViewComponent, messaging } = await start();
     const threadViewer = messaging.models['ThreadViewer'].create({
         hasThreadView: true,
         qunitTest: insertAndReplace(),

--- a/addons/mail/static/tests/qunit_suite_tests/m2x_avatar_user_tests.js
+++ b/addons/mail/static/tests/qunit_suite_tests/m2x_avatar_user_tests.js
@@ -33,7 +33,6 @@ QUnit.module('mail', {}, function () {
         const resUsersId1 = pyEnv['res.users'].create({ name: "Mario", partner_id: resPartnerId1 });
         pyEnv['m2x.avatar.user'].create({ user_id: resUsersId1 });
         const { widget: list } = await start({
-            hasChatWindow: true,
             hasView: true,
             View: ListView,
             model: 'm2x.avatar.user',
@@ -59,7 +58,6 @@ QUnit.module('mail', {}, function () {
         const resUsersId1 = pyEnv['res.users'].create({ name: "Mario", partner_id: resPartnerId1 });
         const m2xAvatarUserId1 = pyEnv['m2x.avatar.user'].create({ user_ids: [resUsersId1] });
         const { widget: form } = await start({
-            hasChatWindow: true,
             hasView: true,
             View: FormView,
             model: 'm2x.avatar.user',

--- a/addons/mail/static/tests/qunit_suite_tests/webclient/commands/mail_providers_tests.js
+++ b/addons/mail/static/tests/qunit_suite_tests/webclient/commands/mail_providers_tests.js
@@ -40,7 +40,6 @@ QUnit.module('mail', {}, function () {
 
         const target = getFixture();
         await start({
-            hasChatWindow: true,
             hasWebClient: true,
             target,
         });
@@ -75,7 +74,6 @@ QUnit.module('mail', {}, function () {
         });
         const target = getFixture();
         await start({
-            hasChatWindow: true,
             hasWebClient: true,
             target,
         });

--- a/addons/snailmail/static/tests/qunit_suite_tests/components/message_tests.js
+++ b/addons/snailmail/static/tests/qunit_suite_tests/components/message_tests.js
@@ -270,7 +270,6 @@ QUnit.test('No Price Available', async function (assert) {
         res_partner_id: resPartnerId1,
     });
     const { createThreadViewComponent, messaging } = await start({
-        hasDialog: true,
         async mockRPC(route, args) {
             if (args.method === 'cancel_letter' && args.model === 'mail.message' && args.args[0][0] === mailMessageId1) {
                 assert.step(args.method);
@@ -365,7 +364,6 @@ QUnit.test('Credit Error', async function (assert) {
         res_partner_id: resPartnerId1,
     });
     const { createThreadViewComponent, messaging } = await start({
-        hasDialog: true,
         async mockRPC(route, args) {
             if (args.method === 'send_letter' && args.model === 'mail.message' && args.args[0][0] === mailMessageId1) {
                 assert.step(args.method);
@@ -465,7 +463,6 @@ QUnit.test('Trial Error', async function (assert) {
         res_partner_id: resPartnerId1,
     });
     const { createThreadViewComponent, messaging } = await start({
-        hasDialog: true,
         async mockRPC(route, args) {
             if (args.method === 'send_letter' && args.model === 'mail.message' && args.args[0][0] === mailMessageId1) {
                 assert.step(args.method);

--- a/addons/website_livechat/static/tests/qunit_suite_tests/components/discuss_tests.js
+++ b/addons/website_livechat/static/tests/qunit_suite_tests/components/discuss_tests.js
@@ -40,7 +40,6 @@ QUnit.test('rendering of visitor banner', async function (assert) {
                 active_id: `mail.channel_${mailChannelId1}`,
             },
         },
-        hasDiscuss: true,
     });
     assert.containsOnce(
         document.body,
@@ -140,7 +139,6 @@ QUnit.test('livechat with non-logged visitor should show visitor banner', async 
                 active_id: `mail.channel_${mailChannelId1}`,
             },
         },
-        hasDiscuss: true,
     });
     assert.containsOnce(
         document.body,
@@ -184,7 +182,6 @@ QUnit.test('livechat with logged visitor should show visitor banner', async func
                 active_id: `mail.channel_${mailChannelId1}`,
             },
         },
-        hasDiscuss: true,
     });
     assert.containsOnce(
         document.body,
@@ -218,7 +215,6 @@ QUnit.test('livechat without visitor should not show visitor banner', async func
                 active_id: `mail.channel_${mailChannelId1}`,
             },
         },
-        hasDiscuss: true,
     });
     assert.containsOnce(
         document.body,
@@ -244,7 +240,6 @@ QUnit.test('non-livechat channel should not show visitor banner', async function
                 active_id: `mail.channel_${mailChannelId1}`,
             },
         },
-        hasDiscuss: true,
     });
     assert.containsOnce(
         document.body,

--- a/addons/website_livechat/static/tests/qunit_suite_tests/messaging_notification_handler_tests.js
+++ b/addons/website_livechat/static/tests/qunit_suite_tests/messaging_notification_handler_tests.js
@@ -20,7 +20,6 @@ QUnit.test('should open chat window on send chat request to website visitor', as
         display_name: "Visitor #11",
     });
     const { env, widget } = await start({
-        hasChatWindow: true,
         hasView: true,
         // View params
         View: FormView,


### PR DESCRIPTION
*: hr, im_livechat, snailmail, website_livechat.

This PR prepares the ground for  the one introducing the new environment in the
discuss app. Indeed, tests will now use the mainComponentRegistry in order to mount
those components. Doing so, the parameters has{Discuss/Dialog/ChatWindow} will become
obsolete. Removing those parameters now helps reducing the noise in the main PR.

task-2582313

enterprise: https://github.com/odoo/enterprise/pull/26759