### PR TITLE
[FIX] web, test_assetsbundle: make useAssets work in owl 2

### DIFF
--- a/addons/web/static/src/core/errors/error_utils.js
+++ b/addons/web/static/src/core/errors/error_utils.js
@@ -1,6 +1,6 @@
 /** @odoo-module **/
 
-import { loadAssets } from "../assets";
+import { loadJS } from "../assets";
 import { isBrowserChrome } from "../browser/feature_detection";
 
 /**
@@ -49,9 +49,7 @@ export function formatTraceback(error) {
 export async function annotateTraceback(error) {
     const traceback = formatTraceback(error);
     try {
-        await loadAssets({
-            jsLibs: ["/web/static/lib/stacktracejs/stacktrace.js"],
-        });
+        await loadJS("/web/static/lib/stacktracejs/stacktrace.js");
     } catch (_e) {
         return traceback;
     }

--- a/addons/web/static/src/legacy/js/public/public_root.js
+++ b/addons/web/static/src/legacy/js/public/public_root.js
@@ -21,7 +21,7 @@ import {
 } from "../../utils";
 import { standaloneAdapter } from "web.OwlCompatibility";
 
-import { loadBundleTemplates } from "@web/core/assets";
+import { fetchAndProcessTemplates } from "@web/core/assets";
 import { makeEnv, startServices } from "@web/env";
 import { MainComponentsContainer } from "@web/core/main_components_container";
 import { browser } from '@web/core/browser/browser';
@@ -405,7 +405,7 @@ export async function createPublicRoot(RootWidget) {
 
     const wowlEnv = makeEnv();
 
-    const templates = await loadBundleTemplates("web.assets_frontend");
+    const templates = await fetchAndProcessTemplates("web.assets_frontend");
     window.__OWL_TEMPLATES__ = templates;
     await startServices(wowlEnv);
     mapLegacyEnvToWowlEnv(legacyEnv, wowlEnv);

--- a/addons/web/static/src/start.js
+++ b/addons/web/static/src/start.js
@@ -3,7 +3,7 @@
 import { makeEnv, startServices } from "./env";
 import { legacySetupProm } from "./legacy/legacy_setup";
 import { mapLegacyEnvToWowlEnv } from "./legacy/utils";
-import { processTemplates } from "./core/assets";
+import { processTemplates, loadBundle } from "./core/assets";
 import { localization } from "@web/core/l10n/localization";
 import { session } from "@web/session";
 import { renderToString } from "./core/utils/render";
@@ -47,6 +47,7 @@ export async function startWebClient(Webclient) {
         translateFn: env._t,
     });
     renderToString.app = app;
+    loadBundle.app = app;
     const root = await app.mount(document.body);
     const classList = document.body.classList;
     if (localization.direction === "rtl") {

--- a/addons/web/static/src/views/graph/graph_renderer.js
+++ b/addons/web/static/src/views/graph/graph_renderer.js
@@ -5,10 +5,10 @@ import { BORDER_WHITE, DEFAULT_BG, getColor, hexToRGBA } from "./colors";
 import { formatFloat } from "@web/fields/formatters";
 import { SEP } from "./graph_model";
 import { sortBy } from "@web/core/utils/arrays";
-import { useAssets } from "@web/core/assets";
+import { loadJS } from "@web/core/assets";
 import { renderToString } from "@web/core/utils/render";
 
-const { Component, onWillUnmount, useEffect, useRef } = owl;
+const { Component, onWillUnmount, useEffect, useRef, onWillStart } = owl;
 
 const NO_DATA = _lt("No data");
 
@@ -50,7 +50,7 @@ export class GraphRenderer extends Component {
         this.tooltip = null;
         this.legendTooltip = null;
 
-        useAssets({ jsLibs: ["/web/static/lib/Chart/Chart.js"] });
+        onWillStart(() => loadJS(["/web/static/lib/Chart/Chart.js"]));
 
         useEffect(() => this.renderChart());
         onWillUnmount(this.onWillUnmount);

--- a/addons/web/static/tests/core/utils/assets_tests.js
+++ b/addons/web/static/tests/core/utils/assets_tests.js
@@ -1,15 +1,15 @@
 /** @odoo-module **/
 
-import { loadAssets } from "@web/core/assets";
+import { loadJS, loadCSS, fetchAndProcessTemplates } from "@web/core/assets";
 import { patchWithCleanup } from "@web/../tests/helpers/utils";
 import { browser } from "@web/core/browser/browser";
 
 QUnit.module("utils", () => {
     QUnit.module("Assets");
 
-    QUnit.test("loadAssets: load invalid JS lib", function (assert) {
+    QUnit.test("loadJS: load invalid JS lib", function (assert) {
         assert.rejects(
-            loadAssets({ jsLibs: ["/some/invalid/file.js"] }),
+            loadJS("/some/invalid/file.js"),
             new RegExp("The loading of /some/invalid/file.js failed"),
             "Trying to load an invalid file rejects the promise"
         );
@@ -19,9 +19,9 @@ QUnit.module("utils", () => {
         );
     });
 
-    QUnit.test("loadAssets: load invalid CSS lib", function (assert) {
+    QUnit.test("loadCSS: load invalid CSS lib", function (assert) {
         assert.rejects(
-            loadAssets({ cssLibs: ["/some/invalid/file.css"] }),
+            loadCSS("/some/invalid/file.css"),
             new RegExp("The loading of /some/invalid/file.css failed"),
             "Trying to load an invalid file rejects the promise"
         );
@@ -31,7 +31,7 @@ QUnit.module("utils", () => {
         );
     });
 
-    QUnit.test("loadAssets: load invalid bundle", function (assert) {
+    QUnit.test("fetchAndProcessTemplates: load invalid bundle", function (assert) {
         let lastFetchedURL;
         patchWithCleanup(browser, {
             fetch: function (url) {
@@ -40,11 +40,7 @@ QUnit.module("utils", () => {
             },
         });
         assert.rejects(
-            loadAssets({
-                bundles: {
-                    "web.some_invalid_bundle": { templates: true },
-                },
-            }),
+            fetchAndProcessTemplates("web.some_invalid_bundle"),
             "Trying to load an invalid bundle rejects the promise"
         );
         assert.ok(

--- a/odoo/addons/test_assetsbundle/__manifest__.py
+++ b/odoo/addons/test_assetsbundle/__manifest__.py
@@ -57,6 +57,12 @@
             ('include', 'test_assetsbundle.manifest4'),
         ],
         'test_assetsbundle.manifest_multi_module1': [],
+        'web.qunit_suite_tests': [
+            'test_assetsbundle/static/tests/lazyloading_test.js'
+        ],
+        'test_assetsbundle.lazy_test_component': [
+            'test_assetsbundle/static/tests/lazy_test_component/**/*',
+        ],
     },
     'license': 'LGPL-3',
 }

--- a/odoo/addons/test_assetsbundle/static/tests/lazy_test_component/lazy_test_component.js
+++ b/odoo/addons/test_assetsbundle/static/tests/lazy_test_component/lazy_test_component.js
@@ -1,0 +1,14 @@
+/** @odoo-module */
+
+import { registry } from "@web/core/registry";
+
+const { Component } = owl;
+
+export class LazyTestComponent extends Component {
+    setup() {
+        this.props.onCreated();
+    }
+}
+LazyTestComponent.template = "test_assetsbundle.LazyTestComponent";
+
+registry.category("lazy_components").add("LazyTestComponent", LazyTestComponent);

--- a/odoo/addons/test_assetsbundle/static/tests/lazy_test_component/lazy_test_component.scss
+++ b/odoo/addons/test_assetsbundle/static/tests/lazy_test_component/lazy_test_component.scss
@@ -1,0 +1,3 @@
+.o_lazy_test_component {
+    background-color: rgb(165, 94, 117);
+}

--- a/odoo/addons/test_assetsbundle/static/tests/lazy_test_component/lazy_test_component.xml
+++ b/odoo/addons/test_assetsbundle/static/tests/lazy_test_component/lazy_test_component.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<templates xml:space="preserve">
+
+<t t-name="test_assetsbundle.LazyTestComponent" owl="1">
+    <div class="o_lazy_test_component">Lazy Component!</div>
+</t>
+
+</templates>

--- a/odoo/addons/test_assetsbundle/static/tests/lazyloading_test.js
+++ b/odoo/addons/test_assetsbundle/static/tests/lazyloading_test.js
@@ -1,0 +1,47 @@
+/** @odoo-module */
+
+import { loadBundle, LazyComponent } from "@web/core/assets";
+import { registerCleanup } from "@web/../tests/helpers/cleanup";
+import { makeTestEnv } from "@web/../tests/helpers/mock_env";
+import { getFixture, patchWithCleanup } from "@web/../tests/helpers/utils";
+
+const { Component, App, xml } = owl;
+
+QUnit.module("utils", () => {
+    QUnit.module("Assets");
+
+    QUnit.test("LazyComponent loads the required bundle", async function (assert) {
+        class Test extends Component {
+            get childProps() {
+                return {
+                    onCreated: () => assert.step("Lazy test component created"),
+                };
+            }
+        }
+        Test.template = xml`
+            <LazyComponent bundle="'test_assetsbundle.lazy_test_component'" Component="'LazyTestComponent'" props="childProps"/>
+        `;
+        Test.components = { LazyComponent };
+
+        const target = getFixture();
+        const app = new App(Test, {
+            test: true,
+            env: makeTestEnv(),
+        });
+        registerCleanup(() => app.destroy());
+        patchWithCleanup(loadBundle, { app });
+
+        assert.verifySteps([]);
+        await app.mount(target);
+        assert.verifySteps(["Lazy test component created"]);
+        assert.strictEqual(
+            target.innerHTML,
+            `<div class="o_lazy_test_component">Lazy Component!</div>`
+        );
+        assert.strictEqual(
+            window.getComputedStyle(target.querySelector(".o_lazy_test_component")).backgroundColor,
+            "rgb(165, 94, 117)",
+            "scss file was loaded"
+        );
+    });
+});


### PR DESCRIPTION
Previously, the useAssets hook would load the templates from the given
bundles into the qweb instance that was in the environment. In owl 2,
qweb is no longer in the environment, and templates need to be loaded in
the app.

This commit fixes that by exporting a function to load templates in the
main app from assets.js, when the main app is created, it should be
written on the function in a similar vein to renderToString, so that all
further calls to the function will load the templates in that app.

This commit also adds an actual lazy-loading test in the
test_assetsbundle module, as we don't want to pollute the manifest of
web with bundles that only exist for one specific test.