### PR TITLE
[IMP] [15.0] hr_contract: more info for demo data

### DIFF
--- a/addons/hr_contract/data/hr_contract_demo.xml
+++ b/addons/hr_contract/data/hr_contract_demo.xml
@@ -22,6 +22,10 @@
         <field name="name">Contract For Mitchell Admin</field>
         <field name="date_start" eval="time.strftime('%Y-%m')+'-1'"/>
         <field name="date_end" eval="time.strftime('%Y')+'-12-31'"/>
+        <field name="job_id" model="hr.job"
+            eval="obj().env.ref('hr.employee_admin').job_id.id"/>
+        <field name="department_id" model="hr.department"
+            eval="obj().env.ref('hr.employee_admin').department_id.id"/>
         <field name="structure_type_id" ref="hr_contract.structure_type_employee"/>
         <field name="employee_id" ref="hr.employee_admin"/>
         <field name="notes">This is Mitchell Admin's contract</field>


### PR DESCRIPTION
New data in 15.0, but this contract is missing some info about `job_id`, `department_id` fields compared to other demo data.

So this PR adds demo data for 2 fields: `job_id` and `department_id`

--
I confirm I have signed the CLA and read the PR guidelines at [www.odoo.com/submit-pr](http://www.odoo.com/submit-pr)