### PR TITLE
[IMP] web: make rpc error handling code more robust

### DIFF
--- a/addons/web/static/src/core/errors/error_handlers.js
+++ b/addons/web/static/src/core/errors/error_handlers.js
@@ -97,7 +97,7 @@ export function rpcErrorHandler(env, error, originalError) {
                 ErrorComponent = errorDialogRegistry.get(exceptionName);
             }
         }
-        if (!ErrorComponent && originalError.data.context) {
+        if (!ErrorComponent && originalError.data && originalError.data.context) {
             const exceptionClass = originalError.data.context.exception_class;
             if (errorDialogRegistry.contains(exceptionClass)) {
                 ErrorComponent = errorDialogRegistry.get(exceptionClass);

--- a/addons/web/static/src/core/network/rpc_service.js
+++ b/addons/web/static/src/core/network/rpc_service.js
@@ -64,10 +64,19 @@ export function jsonrpc(env, rpcId, url, params, settings = {}) {
                 reject(new ConnectionLostError());
                 return;
             }
-            const { error: responseError, result: responseResult } = JSON.parse(request.response);
             if (!settings.silent) {
                 bus.trigger("RPC:RESPONSE", data.id);
             }
+            let resultObj;
+            try {
+                resultObj = JSON.parse(request.response);
+            } catch (e) {
+                // error was not a json parsable string => probably a hard server crash
+                const error = new RPCError();
+                error.message = request.response;
+                return reject(error);
+            }
+            const { error: responseError, result: responseResult } = resultObj;
             if (!responseError) {
                 return resolve(responseResult);
             }

--- a/addons/web/static/tests/core/network/rpc_service_tests.js
+++ b/addons/web/static/tests/core/network/rpc_service_tests.js
@@ -242,6 +242,32 @@ QUnit.test("check trigger RPC:REQUEST and RPC:RESPONSE for a rpc with an error",
     unpatch(browser, "mock.xhr");
 });
 
+QUnit.test(
+    "check trigger RPC:REQUEST and RPC:RESPONSE for a rpc returning an error",
+    async (assert) => {
+        let MockXHR = makeMockXHR("non jsonparsable string", null, null, true);
+        patch(browser, "mock.xhr", { XMLHttpRequest: MockXHR }, { pure: true });
+
+        const env = await makeTestEnv({
+            serviceRegistry,
+        });
+        env.bus.addEventListener("RPC:REQUEST", (rpcId) => {
+            assert.step("RPC:REQUEST");
+        });
+        env.bus.addEventListener("RPC:RESPONSE", (rpcId) => {
+            assert.step("RPC:RESPONSE");
+        });
+        try {
+            await env.services.rpc("/test/");
+        } catch (e) {
+            assert.step("error");
+        }
+        assert.verifySteps(["RPC:REQUEST", "RPC:RESPONSE", "error"]);
+
+        unpatch(browser, "mock.xhr");
+    }
+);
+
 QUnit.test("check connection aborted", async (assert) => {
     const def = makeDeferred();
     let MockXHR = makeMockXHR({}, () => {}, def);

--- a/addons/web/static/tests/helpers/mock_services.js
+++ b/addons/web/static/tests/helpers/mock_services.js
@@ -66,7 +66,8 @@ export function makeFakeRPCService(mockRPC) {
     };
 }
 
-export function makeMockXHR(response, sendCb, def) {
+export function makeMockXHR(response, sendCb, def, doNotStringifyResponse) {
+    response = doNotStringifyResponse ? response : JSON.stringify(response || "");
     let MockXHR = function () {
         return {
             _loadListener: null,
@@ -108,7 +109,7 @@ export function makeMockXHR(response, sendCb, def) {
                 }
                 listener.call(this);
             },
-            response: JSON.stringify(response || ""),
+            response,
         };
     };
     return MockXHR;


### PR DESCRIPTION
This commit solves a few different small issues encountered in the rpc
and error handling code.

1. the code handling a rpc tried to JSON parse que response, but if the
server did bad stuff, such as answering a non json object (which
can (and did) happen if there are bugs in the server code), then:
    - the code would crash, without handling properly the error,
    - and without notifying the rpc service that the rpc is completed
      (which would lock the UI)
2. also, once the rpc crashes, it would always display a CORS error dialog
(even though what happens is not at all a cors error, but the error
handling code assumed that it was a cors error because there was no
line number in the error event.

This commit improves the situation by always notifying the rpc service
that the rpc is completed, by handling the case where we are unable to
json parse the response, and by protecting against crash in the error
handling code.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
