### PR TITLE
[FIX] mail: process first 100 mail failures only

### DIFF
--- a/addons/mail/models/res_partner.py
+++ b/addons/mail/models/res_partner.py
@@ -125,7 +125,7 @@ class Partner(models.Model):
         return partners_format
 
     def _message_fetch_failed(self):
-        """Returns all messages, sent by the current partner, that have errors, in
+        """Returns first 100 messages, sent by the current partner, that have errors, in
         the format expected by the web client."""
         self.ensure_one()
         messages = self.env['mail.message'].search([
@@ -134,7 +134,7 @@ class Partner(models.Model):
             ('res_id', '!=', 0),
             ('model', '!=', False),
             ('message_type', '!=', 'user_notification')
-        ])
+        ], limit=100)
         return messages._message_notification_format()
 
     def _get_channels_as_member(self):


### PR DESCRIPTION
Processing failed mails is quite consuming operation that leads to browser
slowness or even crash. It's especially painful, because user doesn't see the
reason for it.

Bypass the problem by processing first 100 notifications only.

---

opw-2810681
opw-2754243
task-2806549

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
