### PR TITLE
[FIX] account: heterogeneous tax mapping

### DIFF
--- a/addons/account/models/product.py
+++ b/addons/account/models/product.py
@@ -98,7 +98,7 @@ class ProductProduct(models.Model):
             product_taxes_after_fp = fiscal_position.map_tax(product_taxes)
             flattened_taxes_after_fp = product_taxes_after_fp._origin.flatten_taxes_hierarchy()
             flattened_taxes_before_fp = product_taxes._origin.flatten_taxes_hierarchy()
-            taxes_before_included = any(tax.price_include for tax in flattened_taxes_before_fp)
+            taxes_before_included = all(tax.price_include for tax in flattened_taxes_before_fp)
 
             if set(product_taxes.ids) != set(product_taxes_after_fp.ids) and taxes_before_included:
                 taxes_res = flattened_taxes_before_fp.compute_all(


### PR DESCRIPTION
Have the taxes:
- [Ftax] any% included in price
- [TAX1] 15% not included price
- [TAX2] 15% included in price
Apply [Ftax] and [TAX1] to a product having product price [PRI]
Have a fiscal position mapping [TAX1] to [TAX2]
Make a SO with the fiscal position, add in a line the product

The unit price will not be [PRI] but will increment. This occur because
the function doing the mapping will make the computation assuming
[TAX1] is included in price

opw-2797237

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
