### PR TITLE
[FIX] google_gmail: do not make settings required

### DIFF
--- a/addons/google_gmail/views/res_config_settings_views.xml
+++ b/addons/google_gmail/views/res_config_settings_views.xml
@@ -9,11 +9,11 @@
                 <div id="msg_module_google_gmail" position="replace">
                     <div class="row mt16" id="gmail_client_identifier">
                         <label string="Client ID" for="google_gmail_client_identifier" class="col-lg-3 o_light_label"/>
-                        <field name="google_gmail_client_identifier" class="ml-2" attrs="{'required': [('module_google_gmail', '=', True), ('external_email_server_default', '=', True)]}"/>
+                        <field name="google_gmail_client_identifier" class="ml-2"/>
                     </div>
                     <div class="row mt16" id="gmail_client_secret">
                         <label string="Client Secret" for="google_gmail_client_secret" class="col-lg-3 o_light_label"/>
-                        <field name="google_gmail_client_secret" class="ml-2" attrs="{'required': [('module_google_gmail', '=', True), ('external_email_server_default', '=', True)]}"/>
+                        <field name="google_gmail_client_secret" class="ml-2"/>
                     </div>
                 </div>
             </field>


### PR DESCRIPTION
Bug
===
If you install the module "Google Gmail", you won't be able to save
the settings without filling the API credentials which is annoying.

Task-2837340