### PR TITLE
[FIX] l10n_lt: add right amount type for taxes data

### DIFF
--- a/addons/l10n_lt/data/account_tax_template_data.xml
+++ b/addons/l10n_lt/data/account_tax_template_data.xml
@@ -213,7 +213,7 @@
         <field name="description">21% VAT</field>
         <field name="type_tax_use">sale</field>
         <field name="amount" eval="21.0"/>
-        <field name="amount_type">group</field>
+        <field name="amount_type">percent</field>
         <field name="chart_template_id" ref="account_chart_template_lithuania"/>
         <field name="sequence" eval="10"/>
         <field name="invoice_repartition_line_ids" eval="[(5, 0, 0),
@@ -600,7 +600,7 @@
         <field name="description">21% VAT</field>
         <field name="type_tax_use">purchase</field>
         <field name="amount" eval="21.0"/>
-        <field name="amount_type">group</field>
+        <field name="amount_type">percent</field>
         <field name="chart_template_id" ref="account_chart_template_lithuania"/>
         <field name="sequence" eval="90"/>
         <field name="invoice_repartition_line_ids" eval="[(5, 0, 0),
@@ -646,7 +646,7 @@
         <field name="description">Assumed 21% VAT</field>
         <field name="type_tax_use">purchase</field>
         <field name="amount" eval="21"/>
-        <field name="amount_type">group</field>
+        <field name="amount_type">percent</field>
         <field name="chart_template_id" ref="account_chart_template_lithuania"/>
         <field name="sequence" eval="100"/>
         <field name="invoice_repartition_line_ids" eval="[(5, 0, 0),
@@ -691,7 +691,7 @@
         <field name="description">Assumed 21% VAT</field>
         <field name="type_tax_use">purchase</field>
         <field name="amount" eval="21.0"/>
-        <field name="amount_type">group</field>
+        <field name="amount_type">percent</field>
         <field name="chart_template_id" ref="account_chart_template_lithuania"/>
         <field name="sequence" eval="110"/>
         <field name="invoice_repartition_line_ids" eval="[(5, 0, 0),
@@ -736,7 +736,7 @@
         <field name="description">Assumed 21% VAT</field>
         <field name="type_tax_use">purchase</field>
         <field name="amount" eval="21.0"/>
-        <field name="amount_type">group</field>
+        <field name="amount_type">percent</field>
         <field name="chart_template_id" ref="account_chart_template_lithuania"/>
         <field name="sequence" eval="120"/>
         <field name="invoice_repartition_line_ids" eval="[(5, 0, 0),


### PR DESCRIPTION
Some taxes had the wrong type of tax set when updating from 12.0 to 13.0. The type should be Percentage of Price instead of Group of Taxes.

opw-2801421