### PR TITLE
[FIX] sale_product_configurator: fix price when already configured

### DIFF
--- a/addons/sale/static/src/js/variant_mixin.js
+++ b/addons/sale/static/src/js/variant_mixin.js
@@ -271,10 +271,16 @@ var VariantMixin = {
 
     /**
      * Will return the list of selected product.template.attribute.value ids
+     * For the modal, the "main product"'s attribute values are stored in the
+     * "unchanged_value_ids" data
+     *
      * @param {$.Element} $container the container to look into
      */
     getSelectedVariantValues: function ($container) {
         var values = [];
+        var unchangedValues = $container
+            .find('div.oe_unchanged_value_ids')
+            .data('unchanged_value_ids') || [];
 
         var variantsValuesSelectors = [
             'input.js_variant_change:checked',
@@ -284,7 +290,7 @@ var VariantMixin = {
             values.push(+$(el).val());
         });
 
-        return values;
+        return values.concat(unchangedValues);
     },
 
     /**

--- a/addons/sale_product_configurator/views/templates.xml
+++ b/addons/sale_product_configurator/views/templates.xml
@@ -114,6 +114,7 @@
                         </t>
                         <t t-else="">
                             <ul class="d-none js_add_cart_variants" t-att-data-attribute_exclusions="{'exclusions: []'}"/>
+                            <div class="d-none oe_unchanged_value_ids" t-att-data-unchanged_value_ids="variant_values" ></div>
                         </t>
                     </div>
                 </td>

--- a/addons/website_sale_product_configurator/static/tests/tours/website_sale_preconfigured_variant_price.js
+++ b/addons/website_sale_product_configurator/static/tests/tours/website_sale_preconfigured_variant_price.js
@@ -1,0 +1,19 @@
+/** @odoo-module **/
+
+import tour from 'web_tour.tour';
+
+tour.register('website_sale_product_configurator_optional_products_tour', {
+    test: true,
+}, [{
+    name: 'Click Aluminium Option',
+    trigger: 'ul.js_add_cart_variants span:contains("Aluminium")',
+    extra_trigger: 'ul.js_add_cart_variants span:contains("Aluminium") ~ span.badge:contains("50.40")',
+}, {
+    name: 'Add to cart',
+    trigger: '#add_to_cart',
+}, {
+    name: 'Check that modal was opened with the correct variant price',
+    trigger: 'main.oe_advanced_configurator_modal',
+    extra_trigger: 'main.oe_advanced_configurator_modal span:contains("800.40")',
+    run: () => {},
+}]);

--- a/addons/website_sale_product_configurator/tests/__init__.py
+++ b/addons/website_sale_product_configurator/tests/__init__.py
@@ -2,3 +2,4 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 from . import test_customize
+from . import test_website_sale_configurator

--- a/addons/website_sale_product_configurator/tests/test_website_sale_configurator.py
+++ b/addons/website_sale_product_configurator/tests/test_website_sale_configurator.py
@@ -1,0 +1,34 @@
+# -*- coding: utf-8 -*-
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from odoo.tests import tagged
+from odoo.addons.sale_product_configurator.tests.common import TestProductConfiguratorCommon
+from odoo.addons.base.tests.common import HttpCaseWithUserPortal
+
+
+@tagged('post_install', '-at_install')
+class TestWebsiteSaleProductConfigurator(TestProductConfiguratorCommon, HttpCaseWithUserPortal):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.product_product_custo_desk.write({
+            'optional_product_ids': [(4, cls.product_product_conf_chair.id)],
+            'website_published': True,
+        })
+        cls.product_product_conf_chair.website_published = True
+
+        ptav_ids = cls.product_product_custo_desk.attribute_line_ids.product_template_value_ids
+        ptav_ids.filtered(lambda ptav: ptav.name == 'Aluminium').price_extra = 50.4
+
+    def test_01_product_configurator_variant_price(self):
+        product = self.product_product_conf_chair.with_user(self.user_portal)
+        ptav_ids = self.product_product_custo_desk.attribute_line_ids.product_template_value_ids
+        parent_combination = ptav_ids.filtered(lambda ptav: ptav.name in ('Aluminium', 'White'))
+        self.assertEqual(product._is_add_to_cart_possible(parent_combination), True)
+        # This is a regression test. The product configurator menu is proposed
+        # whenever a product has optional products. However, as the end user
+        # already picked a variant, the variant configuration menu is omitted
+        # in this case. However, we still want to make sure that the correct
+        # variant attributes are taken into account when calculating the price.
+        url = self.product_product_custo_desk.website_url
+        self.start_tour(url, 'website_sale_product_configurator_optional_products_tour', login='portal')


### PR DESCRIPTION
The changes introduced by [commit 1] broke the `getSelectedVariantValues` method when using the optional products modal with a preconfigured variant. When the variant is preconfigured, the variant selection form is not rendered. As a consequence the `VariantMixin` fails to retrieve the combination used when calling `getSelectedVariantValues`.

In v14 this problem was solved by including an element in the DOM containing the attribute value ids in one of its data attributes. Restoring this element and the associated logic for retrieving it solves the problem.

[commit 1]: https://github.com/odoo/odoo/commit/2b832269f474d9b08c7c6cd827e5f78ebcfafeca

opw-2722176