### PR TITLE
[IMP] mail: improve o_MessageActionList design

### DIFF
--- a/addons/mail/static/src/components/message/message.scss
+++ b/addons/mail/static/src/components/message/message.scss
@@ -6,12 +6,7 @@
 // will be done, we could use BS5 classes to handle the position values
 // (eg. position-absolute top-0 end-0 mt-n3)
 .o_Message_actionListContainer {
-    @include o-position-absolute($top: - map-get($spacers, 3), $right: 0);
     z-index: 10; // Place the element in front of the Composer when they overlap
-    
-    &.o-squashed {
-        @include o-position-absolute($top: - map-get($spacers, 4), $right: 0);
-    }
 }
 
 .o_Message_authorAvatar {

--- a/addons/mail/static/src/components/message/message.xml
+++ b/addons/mail/static/src/components/message/message.xml
@@ -26,9 +26,6 @@
                 t-ref="root"
             >
                 <MessageInReplyToView t-if="messageView.messageInReplyToView" messageInReplyToViewLocalId="messageView.messageInReplyToView.localId"/>
-                <div t-if="messageView.isActive and messageView.messageActionList" class="o_Message_actionListContainer position-absolute pl-5 pr-3" t-att-class="{ 'o-squashed': messageView.isSquashed }">
-                    <MessageActionList localId="messageView.messageActionList.localId"/>
-                </div>
                 <div class="d-flex flex-shrink-0">
                     <div class="o_Message_highlightIndicator h-100" t-att-class="{ 'o-active bg-primary': messageView.message.isHighlighted or messageView.isHighlighted }"/>
                     <div class="o_Message_sidebar d-flex justify-content-center flex-shrink-0" t-att-class="{ 'o-message-squashed align-items-start': messageView.isSquashed }">
@@ -64,7 +61,7 @@
                     </div>
                     <div class="o_Message_core flex-grow-1 me-4">
                         <t t-if="!messageView.isSquashed">
-                            <div class="o_Message_header d-flex flex-wrap align-items-baseline ml-2">
+                            <div class="o_Message_header d-flex flex-nowrap align-items-baseline mx-2">
                                 <t t-if="messageView.message.author">
                                     <strong class="o_Message_authorName o_Message_authorRedirect o_redirect o_cursor_pointer text-truncate" t-on-click="messageView.onClickAuthorName" title="Open profile">
                                         <t t-if="messageView.message.originThread">
@@ -93,7 +90,7 @@
                                     </strong>
                                 </t>
                                 <t t-if="messageView.message.date">
-                                    <small class="o_Message_date o_Message_headerDate text-500" t-att-class="{ 'o-message-selected text-600': messageView.isSelected, 'text-500': !messageView.isSelected }" t-att-title="messageView.message.datetime">
+                                    <small class="o_Message_date o_Message_headerDate text-500 text-truncate" t-att-class="{ 'o-message-selected text-600': messageView.isSelected, 'text-500': !messageView.isSelected }" t-att-title="messageView.message.datetime">
                                         - <t t-esc="messageView.message.dateFromNow"/>
                                     </small>
                                 </t>
@@ -101,7 +98,7 @@
                                     <MessageSeenIndicator className="'o_Message_seenIndicator'" localId="messageView.messageSeenIndicatorView.localId"/>
                                 </t>
                                 <t t-if="messageView.threadView and messageView.message.originThread and messageView.message.originThread !== messageView.threadView.thread">
-                                    <small class="o_Message_originThread" t-att-class="{ 'o-message-selected text-600': messageView.isSelected, 'text-500': !messageView.isSelected }">
+                                    <small class="o_Message_originThread text-truncate" t-att-class="{ 'o-message-selected text-600': messageView.isSelected, 'text-500': !messageView.isSelected }">
                                         <t t-if="messageView.message.originThread.model === 'mail.channel'">
                                             (from <a class="o_Message_originThreadLink" t-att-href="messageView.message.originThread.url" t-on-click="messageView.onClickOriginThread"><t t-if="messageView.message.originThread.displayName">#<t t-esc="messageView.message.originThread.displayName"/></t><t t-else="">channel</t></a>)
                                         </t>
@@ -112,13 +109,13 @@
                                 </t>
                                 <t t-if="messageView.threadView and messageView.message.originThread and messageView.message.originThread === messageView.threadView.thread and messageView.message.notifications.length > 0">
                                     <t t-if="messageView.message.failureNotifications.length > 0">
-                                        <span class="o_Message_notificationIconClickable o-error o_cursor_pointer text-danger" t-on-click="messageView.onClickFailure">
+                                        <span class="o_Message_notificationIconClickable o-error o_cursor_pointer text-danger text-truncate" t-on-click="messageView.onClickFailure">
                                             <i name="failureIcon" class="o_Message_notificationIcon fa fa-envelope"/>
                                         </span>
                                     </t>
                                     <t t-else="">
                                         <Popover>
-                                            <span class="o_Message_notificationIconClickable o_cursor_pointer text-600">
+                                            <span class="o_Message_notificationIconClickable o_cursor_pointer text-600 text-truncate">
                                                 <i name="notificationIcon" class="o_Message_notificationIcon fa fa-envelope-o"/>
                                             </span>
                                             <t t-set-slot="opened">
@@ -129,6 +126,10 @@
                                         </Popover>
                                     </t>
                                 </t>
+                                <div class="o_Message_actionList_flexgrow flex-grow-1"/>
+                                <div class="o_Message_actionListContainer flex-shrink-0">
+                                    <MessageActionList localId="messageView.messageActionList.localId"/>
+                                </div>
                             </div>
                         </t>
                         <t t-if="messageView.message.subject and !messageView.message.isSubjectSimilarToOriginThreadName">
@@ -136,7 +137,15 @@
                         </t>
                         <div class="o_Message_content mx-2 text-break" t-ref="content">
                             <t t-if="!messageView.composerViewInEditing">
-                                <div class="o_Message_prettyBody" t-ref="prettyBody"/><!-- messageView.message.prettyBody is inserted here from _update() -->
+                                <div class="o_Message_actionList_Container d-flex">
+                                    <div class="o_Message_prettyBody text-wrap" t-ref="prettyBody"/><!-- messageView.message.prettyBody is inserted here from _update() -->
+                                    <t t-if="messageView.isSquashed">
+                                        <div class="o_Message_actionList_autogrow flex-grow-1"/>
+                                        <div class="o_Message_actionListContainer flex-shrink-0">
+                                            <MessageActionList localId="messageView.messageActionList.localId"/>
+                                        </div>
+                                    </t>
+                                </div>
                             </t>
                             <t t-if="messageView.composerViewInEditing">
                                 <Composer

--- a/addons/mail/static/src/components/message_action_list/message_action_list.scss
+++ b/addons/mail/static/src/components/message_action_list/message_action_list.scss
@@ -1,11 +1,12 @@
-.o_MessageActionList:hover {
-    box-shadow: 0 4px .5rem -.5rem $black;
+.o_MessageActionList_action {
+  opacity: 0.2;
 }
 
 .o_MessageActionList_action:hover {
-    background-color: mix($border-color, $white);
+    opacity: 1;
 }
 
 .o_MessageActionList_actionStar.o_MessageActionList_actionStar_active {
     color: $o-main-favorite-color;
+    opacity: 1;
 }

--- a/addons/mail/static/src/components/message_action_list/message_action_list.xml
+++ b/addons/mail/static/src/components/message_action_list/message_action_list.xml
@@ -2,7 +2,7 @@
 <templates>
     <t t-name="mail.MessageActionList" owl="1">
         <t t-if="messageActionList">
-            <div class="o_MessageActionList d-flex border rounded-sm bg-white" t-attf-class="{{ className }}" t-on-click="messageActionList.onClick" t-ref="root">
+            <div class="o_MessageActionList d-flex rounded-sm" t-attf-class="{{ className }}" t-on-click="messageActionList.onClick" t-ref="root">
                 <i t-if="messageActionList.message.hasReactionIcon" class="o_MessageActionList_action o_MessageActionList_actionReaction fa fa-lg fa-smile-o p-2 o_cursor_pointer" t-att-title="messageActionList.addReactionText" t-on-click="messageActionList.onClickActionReaction" t-ref="actionReaction"/>
                 <PopoverView t-if="messageActionList.reactionPopoverView" localId="messageActionList.reactionPopoverView.localId"/>
                 <span t-if="messageActionList.message.canStarBeToggled" class="o_MessageActionList_action o_MessageActionList_actionStar p-2 o_cursor_pointer" t-att-class="{


### PR DESCRIPTION
Improves the MessageActionList design to move the action buttons in the same
space as the message

Mockup: https://app.excalidraw.com/l/65VNwvy7c4X/AkE0bp4yO3M

It is not possible to make the text wrap around the actionList Container,
because the text is created dynamically, and there could be elements
other than text in the message.

This PR does:
    - Put the actionList Container in the same line as the header of an
          un-squashed message
    - Put a blank column on the right of each squashed text message
          to put the actionList Container in.

There is also an alternative in [that PR](https://github.com/odoo/odoo/pull/90367)

Task-2793394