### PR TITLE
[IMP] base: specify fields to `fields_get` in view postprocessing

### DIFF
--- a/odoo/addons/base/models/ir_ui_view.py
+++ b/odoo/addons/base/models/ir_ui_view.py
@@ -2196,7 +2196,7 @@ class NameManager:
 
     @lazy_property
     def field_info(self):
-        field_info = self.model.fields_get()
+        field_info = self.model.fields_get(attributes=['invisible', 'states', 'readonly', 'required'])
         has_access = functools.partial(self.model.check_access_rights, raise_exception=False)
         if not (has_access('write') or has_access('create')):
             for info in field_info.vals():


### PR DESCRIPTION
Thanks to
- odoo/odoo#87522
- odoo/odoo#87273

It's possible to speed-up the postprocessing of views
by only requesting a few attributes to `fields_get`,
therefore avoiding to load other costly attributes
(e.g. string, help, selection translations)

Before:
```
In [1]: %time for i in range(10000): env["res.partner"].get_views([(False, 'kanban'), (False, 'tree'), (False, 'form')]);env["base"].invalidate_cache()
r"CPU times: user 9min 19s, sys: 10.9 s, total: 9min 30s
Wall time: 10min 53s
```

After:
```
%time for i in range(10000): env["res.partner"].get_views([(False, 'kanban'), (False, 'tree'), (False, 'form')]);env["base"].invalidate_cache()
CPU times: user 6min 39s, sys: 11.5 s, total: 6min 50s
Wall time: 8min 14s
```
