### PR TITLE
[15.0][FIX] auth_totp_mail: user view should depend on 'auth_totp'

### DIFF
--- a/addons/auth_totp_mail/views/res_users_views.xml
+++ b/addons/auth_totp_mail/views/res_users_views.xml
@@ -3,7 +3,7 @@
     <record model="ir.ui.view" id="view_users_form">
         <field name="name">res.users.view.form.inherit.auth.totp.mail</field>
         <field name="model">res.users</field>
-        <field name="inherit_id" ref="base.view_users_form"/>
+        <field name="inherit_id" ref="auth_totp.view_totp_form"/>
         <field name="arch" type="xml">
             <xpath expr="//button[@name='action_totp_enable_wizard']" position="after">
                 <button groups="base.group_erp_manager" attrs="{'invisible': &quot;[('id', '=', uid)]&quot;}"


### PR DESCRIPTION
### Description of the issue/feature this PR addresses:

Upgrade of `auth_totp_mail` addon fails because it can't find elements in the parent view.

### Current behavior before PR:

Upgrade of `auth_totp_mail` is failing.

### Desired behavior after PR is merged:

Upgrade without crash.


--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
