### PR TITLE
[FIX] mail: stop the activity avatar to be squeezed

### DIFF
--- a/addons/mail/static/src/components/activity/activity.scss
+++ b/addons/mail/static/src/components/activity/activity.scss
@@ -18,6 +18,7 @@
 
 .o_Activity_sidebar {
     width: $o-mail-thread-avatar-size;
+    min-width: $o-mail-thread-avatar-size;
     height: $o-mail-thread-avatar-size;
 }
 


### PR DESCRIPTION
When an activity is created with a very long description, the avatar of the
user is squeezed.

Step to reproduce the issue:
1. Install the Sale module
2. Create an activity (e.g.: a To Do) with a long description (e.g.: using
the Lorem Ipsum paragraphs).
You will see that your avatar is squeezed.

Solution: In the refactoring of the SCSS of the activities (commit [1]), the
sidebar (where the avatar is shown) did not had a minimum width and as the
parent `div` is using `flex` the sidebar is squeezed. Previously, the squeeze
was prevented using `flex: 0 0 36px;` on the sidebar.

[1]: https://github.com/odoo/odoo/commit/da5d9e745fbb755745a1005ed91924ab7b79b741

opw-2799603
