### PR TITLE
[15.0][FIX] l10n_de, l10n_fr: company view should inherit from 'account'

### DIFF
--- a/addons/l10n_de/views/res_company_views.xml
+++ b/addons/l10n_de/views/res_company_views.xml
@@ -3,7 +3,7 @@
         <record id="res_company_form_l10n_de" model="ir.ui.view">
             <field name="name">res.company.form</field>
             <field name="model">res.company</field>
-            <field name="inherit_id" ref="base.view_company_form"/>
+            <field name="inherit_id" ref="account.view_company_form"/>
             <field name="arch" type="xml">
                 <field name="vat" position="after">
                     <field name="l10n_de_stnr" attrs="{'invisible':[('country_code', '!=', 'DE')]}"/>

--- a/addons/l10n_fr/views/l10n_fr_view.xml
+++ b/addons/l10n_fr/views/l10n_fr_view.xml
@@ -4,7 +4,7 @@
             <field name="name">res.company.form.l10n.fr</field>
             <field name="model">res.company</field>
             <field name="priority">20</field>
-            <field name="inherit_id" ref="base.view_company_form"/>
+            <field name="inherit_id" ref="account.view_company_form"/>
             <field name="arch" type="xml">
             <data>
                  <xpath expr="//field[@name='company_registry']" position="after">


### PR DESCRIPTION
### Description of the issue/feature this PR addresses:

To find the `country_code` field, `l10n_de` and `l10n_fr` addons have to inherit from `account` company form.

### Current behavior before PR:

Upgrade of `l10n_de` and `l10n_fr` are failing.

### Desired behavior after PR is merged:

Smooth upgrade.

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
