### PR TITLE
[IMP] core: use read_group to compute o2m values

### DIFF
--- a/odoo/osv/query.py
+++ b/odoo/osv/query.py
@@ -76,6 +76,7 @@ class Query(object):
         self.order = None
         self.limit = None
         self.offset = None
+        self.groupby = None
 
     def add_table(self, alias, table=None):
         """ Add a table with a given alias to the from clause. """
@@ -169,6 +170,7 @@ class Query(object):
             ", ".join(args or [f'"{next(iter(self._tables))}".id']),
             from_clause,
             where_clause or "TRUE",
+            (" GROUP BY %s" % self.groupby) if self.groupby else "",
             (" ORDER BY %s" % self.order) if self.order else "",
             (" LIMIT %d" % self.limit) if self.limit else "",
             (" OFFSET %d" % self.offset) if self.offset else "",


### PR DESCRIPTION
Going from 
```
2022-04-29 13:03:16,822 480088 INFO master odoo.service.server: 371 post-tests in 208.91s, 312895 queries
2022-04-29 13:03:16,822 480088 INFO master odoo.tests.runner: 0 failed, 0 error(s) of 379 tests when loading database 'master'
```
to
```
2022-04-29 12:58:56,512 473767 INFO master odoo.service.server: 371 post-tests in 209.68s, 307742 queries
2022-04-29 12:58:56,512 473767 INFO master odoo.tests.runner: 0 failed, 0 error(s) of 379 tests when loading database 'master'
```

When running `--test-tags /account`, removing more than 1% of queries run in that case.
