### PR TITLE
[FIX] core: fix `!=` of filtered_domain via One2many

### DIFF
--- a/odoo/addons/base/tests/test_expression.py
+++ b/odoo/addons/base/tests/test_expression.py
@@ -498,6 +498,24 @@ class TestExpression(SavepointCaseWithUserDemo):
         partners = self._search(Partner, [('child_ids.city', '=', 'foo')])
         self.assertFalse(partners)
 
+        partners = self._search(Partner, [('child_ids.city', '!=', 'foo')])
+        self.assertTrue(partners)
+
+        # self.partners[0].child_ids[0].city = 'foo'
+        # partners = self._search(Partner, [('child_ids.city', '=', 'foo')])
+        # self.assertTrue(partners)
+
+        # partners = self._search(Partner, [('child_ids.city', '!=', 'foo')])
+        # self.assertTrue(self.partners[0] in partners)
+
+        # self.partners[0].child_ids.city = 'foo'
+        # partners = self._search(Partner, [('child_ids.city', '=', 'foo')])
+        # self.assertTrue(partners)
+
+        # partners = self._search(Partner, [('child_ids.city', '!=', 'foo')])
+        # # There are no child_ids of partners[0] where city is different 'foo'
+        # self.assertFalse(self.partners[0] in partners)
+
     def test_15_equivalent_one2many_1(self):
         Company = self.env['res.company']
         company3 = Company.create({'name': 'Acme 3'})

--- a/odoo/models.py
+++ b/odoo/models.py
@@ -5670,7 +5670,10 @@ Fields:
                     if comparator == '=':
                         ok = value in data
                     elif comparator in ('!=', '<>'):
-                        ok = value not in data
+                        # data = ['ignored','b q'], value = 'ignored'
+                        # data = [], value = False
+                        # data = ['belgium'], value = "belgium"
+                        ok = not data or any(x != value for x in data)
                     elif comparator == '=?':
                         ok = not value or (value in data)
                     elif comparator == 'in':


### PR DESCRIPTION
The filtered_domain was inconsitent with the domain `search` when
we use `!=`/`<>` with `One2many.other_field`.

task-2837562

