### PR TITLE
[IMP] mass_mailing(_sms): set mailing contact list view multi editable

### DIFF
--- a/addons/mass_mailing/views/mailing_contact_views.xml
+++ b/addons/mass_mailing/views/mailing_contact_views.xml
@@ -93,17 +93,19 @@
         <field name="model">mailing.contact</field>
         <field name="priority">10</field>
         <field name="arch" type="xml">
-            <tree string="Mailing List Contacts" sample="1" js_class="mailing_contact_list">
+            <tree string="Mailing List Contacts" sample="1" multi_edit="1" js_class="mailing_contact_list">
                 <header>
                     <button name="action_add_to_mailing_list" string="Add to List" type="object"/>
                 </header>
-                <field name="create_date"/>
-                <field name="name"/>
+                <field name="create_date" optional="show"/>
+                <field name="title_id" optional="hide"/>
+                <field name="name" readonly="1"/>
                 <field name="company_name"/>
-                <field name="email"/>
+                <field name="email" readonly="1"/>
                 <field name="is_blacklisted" string="Email Blacklisted"/>
-                <field name="message_bounce" sum="Total Bounces"/>
-                <field name="opt_out" invisible="'default_list_ids' not in context"/>
+                <field name="country_id" optional="hide"/>
+                <field name="message_bounce" sum="Total Bounces" readonly="1"/>
+                <field name="opt_out" invisible="'default_list_ids' not in context" readonly="1"/>
                 <field name="list_ids" widget="many2many_tags" optional="hide"/>
             </tree>
         </field>

--- a/addons/mass_mailing_sms/views/mailing_contact_views.xml
+++ b/addons/mass_mailing_sms/views/mailing_contact_views.xml
@@ -34,8 +34,8 @@
         <field name="inherit_id" ref="mass_mailing.mailing_contact_view_tree"/>
         <field name="priority">20</field>
         <field name="arch" type="xml">
-            <xpath expr="//field[@name='is_blacklisted']" position="after">
-                <field name="mobile" class="o_force_ltr"/>
+            <xpath expr="//field[@name='country_id']" position="after">
+                <field name="mobile" class="o_force_ltr" readonly="1"/>
                 <field name="phone_sanitized" invisible="1"/>
                 <field name="phone_sanitized_blacklisted"/>
             </xpath>


### PR DESCRIPTION
PURPOSE

Set the mailing contact list view multi editable. The editable fields
are 'title', 'country' and 'company name'. Along with that we add the
optional fields 'title_id' and 'country_id' to the view.

LINKS

Task-2832509



--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
