### PR TITLE
[FIX] web: fix error on setting default value for res.users

### DIFF
--- a/addons/web/static/src/legacy/debug_manager.js
+++ b/addons/web/static/src/legacy/debug_manager.js
@@ -117,6 +117,7 @@ class SetDefaultDialog extends Dialog {
                     fieldInfo.type === "many2many" ||
                     fieldInfo.type === "binary" ||
                     fieldsInfo[fieldName].options.isPassword ||
+                    fieldInfo.depends === undefined ||
                     fieldInfo.depends.length !== 0
                 ) {
                     return false;


### PR DESCRIPTION
`res.users` has virtual fields which are emulation of the real fields.
It requires extra check to ignore such fields. BEFORE there was the following
error:

```
undefined is not an object (evaluating 'fieldInfo.depends.length')
```

STEPS: Go to a User record and use the Dev settings to 'Set Defaults'

---

opw-2731081

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
