### PR TITLE
[FIX] core: use non-breaking space for currency symbol

### DIFF
--- a/addons/account/tests/test_reconciliation_widget.py
+++ b/addons/account/tests/test_reconciliation_widget.py
@@ -3,6 +3,8 @@ import odoo.tests
 import time
 import requests
 from odoo.addons.account.tests.test_reconciliation import TestReconciliation
+from odoo.tools.misc import NON_BREAKING_SPACE
+
 
 _logger = logging.getLogger(__name__)
 
@@ -61,7 +63,7 @@ class TestReconciliationWidget(TestReconciliation):
         })
 
         result = self.env['account.reconciliation.widget'].get_bank_statement_line_data(bank_stmt_line.ids)
-        self.assertEqual(result['lines'][0]['reconciliation_proposition'][0]['amount_str'], '$ 50.00')
+        self.assertEqual(result['lines'][0]['reconciliation_proposition'][0]['amount_str'], f'${NON_BREAKING_SPACE}50.00')
 
     def test_filter_partner1(self):
         inv1 = self.create_invoice(currency_id=self.currency_euro_id)

--- a/odoo/tools/misc.py
+++ b/odoo/tools/misc.py
@@ -63,6 +63,8 @@ SKIPPED_ELEMENT_TYPES = (etree._Comment, etree._ProcessingInstruction, etree.Com
 # Configure default global parser
 etree.set_default_parser(etree.XMLParser(resolve_entities=False))
 
+NON_BREAKING_SPACE = u'\N{NO-BREAK SPACE}'
+
 #----------------------------------------------------------
 # Subprocesses
 #----------------------------------------------------------
@@ -1218,9 +1220,9 @@ def formatLang(env, value, digits=None, grouping=True, monetary=False, dp=False,
 
     if currency_obj and currency_obj.symbol:
         if currency_obj.position == 'after':
-            res = '%s %s' % (res, currency_obj.symbol)
+            res = '%s%s%s' % (res, NON_BREAKING_SPACE, currency_obj.symbol)
         elif currency_obj and currency_obj.position == 'before':
-            res = '%s %s' % (currency_obj.symbol, res)
+            res = '%s%s%s' % (currency_obj.symbol, NON_BREAKING_SPACE, res)
     return res
 
 


### PR DESCRIPTION
In some languages and layout the currency symbol might be wrapped in a separate
line, which is not acceptable from accounting point of view. Fix it by replacing
space with a special symbol.

STEPS for v15:
* install MX localization;
* create a Spanish speaking customer
* generate a pdf:
1) Create quotation with products
2) Add IVA 16%tax
3) print a report

BEFORE: the currency symbol is incorrectly displayed on a separate line
AFTER:  currency symbol is always with the amount

---

https://github.com/odoo/odoo/pull/89722
opw-2829138

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
