### PR TITLE
[FIX] account_check_printing: allow multiple payments

### DIFF
--- a/addons/account_check_printing/models/account_journal.py
+++ b/addons/account_check_printing/models/account_journal.py
@@ -36,7 +36,7 @@ class AccountJournal(models.Model):
         for journal in self:
             sequence = journal.check_sequence_id
             if sequence:
-                journal.check_next_number = sequence.get_next_char(sequence.number_next_actual)
+                journal.check_next_number = sequence.next_by_id()
             else:
                 journal.check_next_number = 1
 

--- a/addons/account_check_printing/models/account_payment.py
+++ b/addons/account_check_printing/models/account_payment.py
@@ -85,14 +85,12 @@ class AccountPayment(models.Model):
             else:
                 pay.check_amount_in_words = False
 
-    @api.depends('journal_id', 'payment_method_code')
+    @api.depends('journal_id', 'payment_method_code', 'state')
     def _compute_check_number(self):
-        for pay in self:
-            if pay.journal_id.check_manual_sequencing and pay.payment_method_code == 'check_printing':
+        for pay in self.filtered(lambda p: p.state == 'posted'):
+            if pay.journal_id.check_manual_sequencing and pay.payment_method_code == 'check_printing' and not pay.check_number:
                 sequence = pay.journal_id.check_sequence_id
-                pay.check_number = sequence.get_next_char(sequence.number_next_actual)
-            else:
-                pay.check_number = False
+                pay.check_number = sequence.next_by_id()
 
     def _inverse_check_number(self):
         for payment in self:
@@ -107,14 +105,6 @@ class AccountPayment(models.Model):
             preferred = record.partner_id.with_company(record.company_id).property_payment_method_id
             if record.payment_type == 'outbound' and preferred in record.journal_id.outbound_payment_method_ids:
                 record.payment_method_id = preferred
-
-    def action_post(self):
-        res = super(AccountPayment, self).action_post()
-        payment_method_check = self.env.ref('account_check_printing.account_payment_method_check')
-        for payment in self.filtered(lambda p: p.payment_method_id == payment_method_check and p.check_manual_sequencing):
-            sequence = payment.journal_id.check_sequence_id
-            payment.check_number = sequence.next_by_id()
-        return res
 
     def print_checks(self):
         """ Check that the recordset is valid, set the payments state to sent and call print_checks() """

--- a/addons/account_check_printing/tests/test_print_check.py
+++ b/addons/account_check_printing/tests/test_print_check.py
@@ -133,3 +133,30 @@ class TestPrintCheck(AccountTestInvoicingCommon):
             'amount_paid': '150.000 ☺',
             'currency': invoice.currency_id,
         }]])
+
+    def test_in_invoice_check_manual_sequencing_with_multiple_payments(self):
+        """
+           Test the check generation for vendor bills with multiple payments.
+        """
+        nb_invoices_to_test = INV_LINES_PER_STUB + 1
+
+        self.company_data['default_journal_bank'].write({
+            'check_manual_sequencing': True,
+            'check_next_number': '11111',
+        })
+
+        in_invoices = self.env['account.move'].create([{
+            'move_type': 'in_invoice',
+            'partner_id': self.partner_a.id,
+            'date': '2017-01-01',
+            'invoice_date': '2017-01-01',
+            'invoice_line_ids': [(0, 0, {'product_id': self.product_a.id, 'price_unit': 100.0})]
+        } for i in range(nb_invoices_to_test)])
+        in_invoices.action_post()
+
+        payments = self.env['account.payment.register'].with_context(active_model='account.move', active_ids=in_invoices.ids).create({
+            'group_payment': False,
+            'payment_method_id': self.payment_method_check.id,
+        })._create_payments()
+
+        self.assertEqual(set(payments.mapped('check_number')), {str(x) for x in range(11111, 11121)})


### PR DESCRIPTION
Apply next sequence check number with multiple payments

Steps to reproduce:

- With manual check numbering
- Create +=3 vendor bills
- In bills list view, select all bills and register payment
- Select Checks as payment methos, and validate
-> Validation Error: The following numbers are already used ...

opw-2830586

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
