### PR TITLE
[IMP] website_sale: show compare_list_price for product templates on /shop

### DIFF
--- a/addons/website_sale/models/product_template.py
+++ b/addons/website_sale/models/product_template.py
@@ -168,10 +168,7 @@ class ProductTemplate(models.Model):
         sales_prices = pricelist._get_products_price(self, 1.0)
         show_discount = pricelist.discount_policy == 'without_discount'
 
-        base_sales_prices = None
-        if show_discount:
-            base_sales_prices = self.price_compute(
-                'list_price', currency=pricelist.currency_id)
+        base_sales_prices = self.price_compute('list_price', currency=pricelist.currency_id)
 
         res = {}
         for template in self:
@@ -189,14 +186,24 @@ class ProductTemplate(models.Model):
             template_price_vals = {
                 'price_reduce': price_reduce
             }
+            base_price = None
+            price_list_contains_template = price_reduce != base_sales_prices[template.id]
 
-            if show_discount:
+            if template.compare_list_price:
+                # The base_price becomes the compare list price and the price_reduce becomes the price
+                base_price = template.compare_list_price
+                if not price_list_contains_template:
+                    price_reduce = base_sales_prices[template.id]
+                    template_price_vals.update(price_reduce=price_reduce)
+            elif show_discount and price_list_contains_template:
                 base_price = base_sales_prices[template.id]
-                if base_price != price_reduce:
-                    base_price = self.env['account.tax']._fix_tax_included_price_company(
-                        base_price, product_taxes, taxes, self.env.company)
-                    base_price = taxes.compute_all(base_price, pricelist.currency_id, 1, template, partner_sudo)[tax_display]
-                    template_price_vals['base_price'] = base_price
+
+            if base_price and base_price != price_reduce:
+                base_price = self.env['account.tax']._fix_tax_included_price_company(
+                    base_price, product_taxes, taxes, self.env.company)
+                base_price = taxes.compute_all(base_price, pricelist.currency_id, 1, template, partner_sudo)[
+                    tax_display]
+                template_price_vals['base_price'] = base_price
 
             res[template.id] = template_price_vals
 

--- a/addons/website_sale/static/src/js/tours/tour_utils.js
+++ b/addons/website_sale/static/src/js/tours/tour_utils.js
@@ -1,6 +1,6 @@
 odoo.define("website_sale.tour_utils", function (require) {
     "use strict";
-    
+
     const core = require("web.core");
     const _t = core._t;
 
@@ -14,7 +14,37 @@ odoo.define("website_sale.tour_utils", function (require) {
         };
     }
 
+    /**
+     * Used to select a pricelist on the /shop view
+     */
+    function selectPriceList(pricelist) {
+        return [
+            {
+                content: "Click on pricelist dropdown",
+                trigger: "div.o_pricelist_dropdown a[data-toggle=dropdown]",
+            },
+            {
+                content: "Click on pricelist",
+                trigger: `span:contains(${pricelist})`,
+            },
+        ]
+    }
+
+    /**
+     * Used to assert if the price attribute of a given product is correct on the /shop view
+     */
+    function assertProductPrice(attribute, value, productName) {
+        return {
+            content: `The ${attribute} of the ${productName} is ${value}`,
+            trigger: `div:contains("${productName}") [data-oe-expression="template_price_vals[\'${attribute}\']"] .oe_currency_value:contains("${value}")`,
+            run: () => {
+            }
+        }
+    }
+
     return {
         goToCart,
+        selectPriceList,
+        assertProductPrice
     };
 });

--- a/addons/website_sale/static/tests/tours/website_sale_shop_compare_list_price_pricelist.js
+++ b/addons/website_sale/static/tests/tours/website_sale_shop_compare_list_price_pricelist.js
@@ -1,0 +1,38 @@
+/** @odoo-module **/
+
+import tour from 'web_tour.tour';
+import tourUtils from 'website_sale.tour_utils';
+
+tour.register('compare_list_price_price_list_display', {
+        test: true,
+        url: '/shop?search=test_product'
+    },
+    [
+        tourUtils.assertProductPrice("price_reduce", "1,000", "test_product_default"),
+        tourUtils.assertProductPrice("price_reduce", "2,000", "test_product_with_compare_list_price"),
+        tourUtils.assertProductPrice("base_price",   "2,500", "test_product_with_compare_list_price"),
+        tourUtils.assertProductPrice("price_reduce", "2,000", "test_product_with_pricelist"),
+        tourUtils.assertProductPrice("price_reduce", "4,000", "test_product_with_pricelist_and_compare_list_price"),
+        tourUtils.assertProductPrice("base_price",   "4,500", "test_product_with_pricelist_and_compare_list_price"),
+
+        ...tourUtils.selectPriceList('pricelist_with_discount'),
+
+        tourUtils.assertProductPrice("price_reduce", "1,000", "test_product_default"),
+        tourUtils.assertProductPrice("price_reduce", "2,000", "test_product_with_compare_list_price"),
+        tourUtils.assertProductPrice("base_price",   "2,500", "test_product_with_compare_list_price"),
+        tourUtils.assertProductPrice("price_reduce", "1,500", "test_product_with_pricelist"),
+        tourUtils.assertProductPrice("price_reduce", "3,500", "test_product_with_pricelist_and_compare_list_price"),
+        tourUtils.assertProductPrice("base_price",   "4,500", "test_product_with_pricelist_and_compare_list_price"),
+
+        ...tourUtils.selectPriceList('pricelist_without_discount'),
+
+        tourUtils.assertProductPrice("price_reduce", "1,000", "test_product_default"),
+        tourUtils.assertProductPrice("price_reduce", "2,000", "test_product_with_compare_list_price"),
+        tourUtils.assertProductPrice("base_price",   "2,500", "test_product_with_compare_list_price"),
+        tourUtils.assertProductPrice("price_reduce", "1,500", "test_product_with_pricelist"),
+        tourUtils.assertProductPrice("base_price",   "2,000", "test_product_with_pricelist"),
+        tourUtils.assertProductPrice("price_reduce", "3,500", "test_product_with_pricelist_and_compare_list_price"),
+        tourUtils.assertProductPrice("base_price",   "4,500", "test_product_with_pricelist_and_compare_list_price"),
+
+    ]
+);

--- a/addons/website_sale/tests/__init__.py
+++ b/addons/website_sale/tests/__init__.py
@@ -12,5 +12,6 @@ from . import test_website_sale_pricelist
 from . import test_website_sale_product_attribute_value_config
 from . import test_website_sale_image
 from . import test_website_sequence
+from . import test_website_sale_show_compare_list_price
 from . import test_website_sale_visitor
 from . import test_website_sale_product

--- a/addons/website_sale/tests/test_website_sale_show_compare_list_price.py
+++ b/addons/website_sale/tests/test_website_sale_show_compare_list_price.py
@@ -1,0 +1,93 @@
+from odoo.tests import tagged
+from odoo.tests.common import HttpCase
+
+
+@tagged('post_install', '-at_install')
+class WebsiteSaleShopPriceListCompareListPriceDispayTests(HttpCase):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        ProductTemplate = cls.env['product.template']
+        Pricelist = cls.env['product.pricelist']
+        PricelistItem = cls.env['product.pricelist.item']
+
+        cls.test_product_default = ProductTemplate.create({
+            'name': 'test_product_default',
+            'type': 'product',
+            'website_published': True,
+            'list_price': 1000
+        })
+        cls.test_product_with_compare_list_price = ProductTemplate.create({
+            'name': 'test_product_with_compare_list_price',
+            'type': 'product',
+            'website_published': True,
+            'list_price': 2000,
+            'compare_list_price': 2500
+        })
+        cls.test_product_with_pricelist = ProductTemplate.create({
+            'name': 'test_product_with_pricelist',
+            'website_published': True,
+            'type': 'product',
+            'list_price': 2000
+        })
+        cls.test_product_with_pricelist_and_compare_list_price = ProductTemplate.create({
+            'name': 'test_product_with_pricelist_and_compare_list_price',
+            'website_published': True,
+            'type': 'product',
+            'list_price': 4000,
+            'compare_list_price': 4500
+
+        })
+
+        # Two pricelists
+        website = cls.env['website'].get_current_website()
+
+        cls.pricelist_with_discount = Pricelist.create({
+            'name': 'pricelist_with_discount',
+            'website_id': website.id,
+            'selectable': True,
+            'discount_policy': 'with_discount',
+        })
+        cls.pricelist_without_discount = cls.pricelist = Pricelist.create({
+            'name': 'pricelist_without_discount',
+            'website_id': website.id,
+            'selectable': True,
+            'discount_policy': 'without_discount',
+
+        })
+
+        # Pricelist items
+        PricelistItem.create({
+            'pricelist_id': cls.pricelist_with_discount.id,
+            'applied_on': '1_product',
+            'product_tmpl_id': cls.test_product_with_pricelist.id,
+            'compute_price': 'fixed',
+            'fixed_price': 1500,
+        })
+
+        PricelistItem.create({
+            'pricelist_id': cls.pricelist_without_discount.id,
+            'applied_on': '1_product',
+            'product_tmpl_id': cls.test_product_with_pricelist.id,
+            'compute_price': 'fixed',
+            'fixed_price': 1500,
+        })
+
+        PricelistItem.create({
+            'pricelist_id': cls.pricelist_without_discount.id,
+            'applied_on': '1_product',
+            'product_tmpl_id': cls.test_product_with_pricelist_and_compare_list_price.id,
+            'compute_price': 'fixed',
+            'fixed_price': 3500,
+        })
+
+        PricelistItem.create({
+            'pricelist_id': cls.pricelist_with_discount.id,
+            'applied_on': '1_product',
+            'product_tmpl_id': cls.test_product_with_pricelist_and_compare_list_price.id,
+            'compute_price': 'fixed',
+            'fixed_price': 3500,
+        })
+
+    def test_compare_list_price_price_list_display(self):
+        self.start_tour("/", 'compare_list_price_price_list_display')


### PR DESCRIPTION
This PR adds the `compare_list_price` to `/shop`.

If there is a `compare_list_price` and a pricelist `fixed_price` for a product template, the `compare_list_price` will be striked through and the `fixed_price` will be displayed

task-2813257