### PR TITLE
[FIX] website_sale_stock : Prevent using add to cart if out of stock

### DIFF
--- a/addons/sale_product_configurator/views/templates.xml
+++ b/addons/sale_product_configurator/views/templates.xml
@@ -7,7 +7,8 @@
     </template>
 
     <template id="product_quantity_config">
-        <div class="css_quantity input-group">
+        <t t-set="product_quantity_config_classes" t-value="product_quantity_config_classes or ''"/>
+        <div id="product_configurator_quantity" t-att-class="'css_quantity input-group ' + product_quantity_config_classes">
             <div class="input-group-prepend">
                 <button t-attf-href="#" class="btn btn-primary float_left js_add_cart_json d-none d-md-inline-block" aria-label="Remove one" title="Remove one">
                     <i class="fa fa-minus"></i>

--- a/addons/website_sale/static/src/js/website_sale_utils.js
+++ b/addons/website_sale/static/src/js/website_sale_utils.js
@@ -2,6 +2,8 @@ odoo.define('website_sale.utils', function (require) {
 'use strict';
 
 const wUtils = require('website.utils');
+const _t = require('web.core')._t;
+const Dialog = require('web.Dialog');
 
 const cartHandlerMixin = {
     getRedirectOption() {
@@ -34,6 +36,12 @@ const cartHandlerMixin = {
             route: "/shop/cart/update_json",
             params: params,
         }).then(async data => {
+            if (data.warning) {
+                Dialog.alert(this, data.warning, {
+                    title: _t('Warning'),
+                });
+                return
+            }
             if (data.cart_quantity && (data.cart_quantity !== parseInt($(".my_cart_quantity").text()))) {
                 await animateClone($('header .o_wsale_my_cart').first(), this.$itemImgContainer, 25, 40);
                 updateCartNavBar(data);

--- a/addons/website_sale/views/templates.xml
+++ b/addons/website_sale/views/templates.xml
@@ -673,7 +673,8 @@
                                         </t>
                                     </t>
                                     <p t-if="True" class="css_not_available_msg alert alert-warning">This combination does not exist.</p>
-                                    <div id="o_wsale_cta_wrapper" class="d-flex flex-wrap align-items-center">
+                                    <t t-set="display_add_to_cart" t-value="True"/>
+                                    <div id="o_wsale_cta_wrapper" t-attf-class="{{'d-flex' if display_add_to_cart else 'd-none'}} flex-wrap align-items-center">
                                         <t t-set="hasQuantities" t-value="false"/>
                                         <t t-set="hasBuyNow" t-value="false"/>
                                         <t t-set="ctaSizeBig" t-value="not hasQuantities or not hasBuyNow"/>

--- a/addons/website_sale_comparison/views/website_sale_comparison_template.xml
+++ b/addons/website_sale_comparison/views/website_sale_comparison_template.xml
@@ -107,7 +107,7 @@
                                 <tr>
                                     <td t-if="len(categories)" class='td-top-left border-top-0'/>
                                     <td t-foreach="products" t-as="product" class="border-top-0">
-                                        <t t-set="combination_info" t-value="product._get_combination_info_variant()"/>
+                                        <t t-set="combination_info" t-value="product.with_context(website_sale_stock_get_quantity=True)._get_combination_info_variant()"/>
                                         <div class='product_summary'>
                                             <a class="o_product_comparison_table" t-att-href="product.website_url">
                                                 <span t-esc="combination_info['display_name']"></span><br/>
@@ -126,7 +126,7 @@
                                             <input type="hidden" name="csrf_token" t-att-value="request.csrf_token()" />
                                                 <input name="product_id" t-att-value="product.id" type="hidden"
                                                        t-att-data-product-tracking-info="json.dumps(request.env['product.template'].get_google_analytics_data(combination_info))"/>
-                                                <a role="button" class="btn btn-primary btn-block a-submit" href="#"><i class="fa fa-shopping-cart mr-2"></i>Add to Cart</a>
+                                                <button t-att-disabled="combination_info['product_type'] == 'product' and combination_info['free_qty'] &lt;= 0 and not combination_info.get('allow_out_of_stock_order', False)" role="button" class="btn btn-primary btn-block a-submit" href="#"><i class="fa fa-shopping-cart mr-2"></i>Add to Cart</button>
                                             </form>
                                         </div>
                                     </td>

--- a/addons/website_sale_product_configurator/views/website_sale_product_configurator_templates.xml
+++ b/addons/website_sale_product_configurator/views/website_sale_product_configurator_templates.xml
@@ -6,10 +6,10 @@
         </xpath>
     </template>
     <template id="product_quantity_config_website" inherit_id="sale_product_configurator.product_quantity_config" priority="18">
-        <xpath expr="//div[hasclass('css_quantity')]" position="attributes">
+        <xpath expr="//div[@id='product_configurator_quantity']" position="attributes">
             <attribute name='t-if'>not request.is_frontend or (request.is_frontend and is_view_active('website_sale.product_quantity'))</attribute>
         </xpath>
-        <xpath expr="//div[hasclass('css_quantity')]" position="after">
+        <xpath expr="//div[@id='product_configurator_quantity']" position="after">
             <input t-else="" type="hidden" class="d-none js_quantity form-control quantity" name="add_qty" t-att-value="add_qty or 1"/>
         </xpath>
     </template>

--- a/addons/website_sale_stock/views/website_sale_stock_templates.xml
+++ b/addons/website_sale_stock/views/website_sale_stock_templates.xml
@@ -30,8 +30,33 @@
     </template>
 
   <template id="website_sale_stock_product" inherit_id="website_sale.product" priority="4">
-    <xpath expr="//div[@id='o_wsale_cta_wrapper']" position="after">
-      <div class="availability_messages o_not_editable"/>
+      <xpath expr="//div[@id='o_wsale_cta_wrapper']" position="after">
+      <div class="availability_messages o_not_editable">
+        <t t-if="product.type == 'product'"><!-- show out_of_stock_message whatever the show_availability - pde's spec-->
+            <div id="out_of_stock_message" t-if="free_qty &lt;= 0 and not cart_qty" t-attf-class="availability_message_#{product_template} text-danger font-weight-bold">
+                <t t-out='product.out_of_stock_message'/>
+                <t t-if="not product.allow_out_of_stock_order">Out of Stock.</t>
+            </div>
+            <div id="threshold_message" t-elif="product.show_availability and free_qty &lt;= product.available_threshold" t-attf-class="availability_message_#{product_template} text-warning font-weight-bold">
+                Only <t t-esc='int(free_qty) if free_qty.is_integer() else free_qty'/> <t t-esc="product.uom_name" /> left in stock.
+            </div>
+
+            <div t-if="not product.allow_out_of_stock_order and product.show_availability and cart_qty" t-attf-class="availability_message_#{product_template} text-warning mt8">
+                <t t-if='not free_qty'>
+                    You already added all the available product in your cart.
+                </t>
+                <t t-else=''>
+                You already added <t t-esc="cart_qty" /> <t t-esc="uom_name" /> in your cart.
+                </t>
+            </div>
+        </t>
+      </div>
+    </xpath>
+      <xpath expr="//div[@id='o_wsale_cta_wrapper']" position="before">
+          <t t-set="cart_qty" t-value="product.cart_qty if 'cart_qty' in product else product.product_variant_ids[:1].cart_qty"/>
+          <!-- FIXME : Use _get_cart_qty() in master -->
+          <t t-set="free_qty" t-value="product.with_context(warehouse=website._get_warehouse_available()).sudo().qty_available - cart_qty"/>
+          <t t-set="display_add_to_cart" t-value="display_add_to_cart and free_qty &gt;= 1"/>
     </xpath>
   </template>
 

--- a/addons/website_sale_stock_product_configurator/__manifest__.py
+++ b/addons/website_sale_stock_product_configurator/__manifest__.py
@@ -13,5 +13,10 @@
     'data': [
         'views/product_configurator_templates.xml',
     ],
+    'assets': {
+        'web.assets_frontend': [
+            'website_sale_stock_product_configurator/static/src/js/**/*',
+        ],
+    },
     'license': 'LGPL-3',
 }

--- a/addons/website_sale_stock_product_configurator/static/src/js/product_configurator_modal.js
+++ b/addons/website_sale_stock_product_configurator/static/src/js/product_configurator_modal.js
@@ -1,0 +1,79 @@
+/** @odoo-module */
+
+import OptionalProductsModal from 'sale_product_configurator.OptionalProductsModal'
+import { _t } from '@web/core/l10n/translation'
+import { sprintf } from "@web/core/utils/strings";
+
+OptionalProductsModal.include({
+
+    _computeFooterEnabled: function () {
+        const footerButtons = document.querySelectorAll('.modal-content footer button');
+        const selectedProducts = document.querySelectorAll('.js_product.in_cart');
+        for (let product of selectedProducts) {
+            if (product.querySelector('.modal-content .input-group.d-none')) {
+                for (const button of footerButtons) {
+                    button.setAttribute('disabled', true);
+                    button.classList.add('disabled');
+                }
+                return;
+            }
+        }
+        for (const button of footerButtons) {
+            button.removeAttribute('disabled');
+            button.classList.remove('disabled');
+        }
+    },
+
+    _onAddOrRemoveOption(ev){
+        this._super(...arguments);
+        this._computeFooterEnabled();
+    },
+
+    _onChangeCombination: function (ev, $parent, combination) {
+        const result = this._super(...arguments);
+
+        if (!this.isWebsite || !$parent.is('.in_cart') || !(combination.product_type === "product")) return;
+
+        // Get all html elements to modify.
+        const addQtyInput = $parent.find('.js_quantity')[0];
+        const addQtyContainer = addQtyInput.parentNode;
+
+        // Get existing message or create it.
+        let warningMessage = addQtyContainer.parentNode.querySelector('p.text-warning');
+
+        if (!warningMessage) {
+            warningMessage = document.createElement('p');
+            warningMessage.classList.add('text-warning', 'd-none', 'pt-2');
+
+            addQtyContainer.parentNode.appendChild(warningMessage);
+        }
+
+        const quantity = parseInt(addQtyInput.value);
+        const resultingValue = combination.free_qty - (quantity + combination.cart_qty);
+
+        addQtyInput.parentNode.classList.remove('d-none');
+        warningMessage.classList.add('d-none');
+
+        if (combination.show_availability && combination.free_qty <= combination.available_threshold) {
+            warningMessage.classList.remove('d-none');
+            warningMessage.innerText = sprintf(_t('Only %s %s left in stock.'), combination.free_qty, combination.uom_name);
+        }
+
+        if (resultingValue <= 0) {
+            warningMessage.classList.remove('d-none');
+            addQtyInput.value = Math.max(combination.free_qty - combination.cart_qty, 1);
+            if (combination.free_qty - combination.cart_qty <= 0) {
+                addQtyInput.parentNode.classList.add('d-none');
+            }
+            warningMessage.innerText = _t('All items selected.');
+        }
+
+        if (combination.free_qty <= 0) {
+            addQtyInput.parentNode.classList.add('d-none');
+            warningMessage.innerText = _t('Out of stock.');
+        }
+
+        this._computeFooterEnabled();
+        return result;
+    }
+});

--- a/addons/website_sale_stock_product_configurator/views/product_configurator_templates.xml
+++ b/addons/website_sale_stock_product_configurator/views/product_configurator_templates.xml
@@ -4,10 +4,37 @@
         <xpath expr="//input[@type='text'][hasclass('quantity')]" position="attributes">
           <attribute name='t-att-data-max'>max(product.sudo().free_qty - product.cart_qty, 1) if handle_stock and product.type == "product" and not product.allow_out_of_stock_order else None</attribute>
         </xpath>
-        <xpath expr="//div[hasclass('css_quantity')]" position="after">
+        <xpath expr="//div[@id='product_configurator_quantity']" position="after">
           <t t-if="handle_stock">
             <div class='availability_messages'/>
           </t>
         </xpath>
+    </template>
+
+    <template id="website_sale_stock_product_configurator_configure_optional_product" inherit_id="sale_product_configurator.configure_optional_products">
+      <xpath expr="//td[hasclass('td-qty')]/t" position="before">
+        <t t-set="error_message" t-value=""/>
+        <t t-if="request.is_frontend">
+          <t t-set="cart_qty" t-value="product.cart_qty if 'cart_qty' in product.fields_get() else product.product_variant_ids[:1].cart_qty"/>
+          <t t-set="free_qty" t-value="product.with_context(warehouse=website._get_warehouse_available()).sudo().qty_available - cart_qty"/>
+          <t t-if="product.type == 'product'">
+            <t t-if="free_qty &lt;= 0 and not cart_qty">
+              <t t-set="error_message">Out of stock.</t>
+            </t>
+            <t t-elif="(free_qty - (cart_qty + 1)) &lt;= 0">
+              <t t-set="error_message">All items selected.</t>
+            </t>
+            <t t-elif="product.show_availability and free_qty &lt;= product.available_threshold">
+              <t t-set="error_message" t-value="'Only ' + str(int(free_qty) if free_qty.is_integer() else free_qty) + ' ' + product.uom_name + ' left in stock.'"/>
+            </t>
+            <t t-if="(free_qty - cart_qty) &lt;= 0" t-set="product_quantity_config_classes" t-value="'d-none'"/>
+          </t>
+        </t>
+      </xpath>
+      <xpath expr="//td[hasclass('td-qty')]" position="inside">
+        <p t-att-class="'text-warning p-2' + (not error_message and ' d-none' or '')">
+          <t t-esc="error_message"/>
+        </p>
+      </xpath>
     </template>
 </odoo>

--- a/addons/website_sale_wishlist/views/website_sale_wishlist_template.xml
+++ b/addons/website_sale_wishlist/views/website_sale_wishlist_template.xml
@@ -163,7 +163,7 @@
                         <table class="table table-bordered table-striped table-hover text-center mt16 table-comparator " style="table-layout:auto" id="o_comparelist_table">
                             <body>
                                 <t t-foreach="wishes" t-as="wish">
-                                    <t t-set="combination_info" t-value="wish.product_id._get_combination_info_variant()"/>
+                                    <t t-set="combination_info" t-value="wish.product_id.with_context(website_sale_stock_get_quantity=True)._get_combination_info_variant()"/>
                                     <tr t-att-data-wish-id='wish.id' t-att-data-product-id='wish.product_id.id'
                                         t-att-data-product-tracking-info="json.dumps(request.env['product.template'].get_google_analytics_data(combination_info))">
                                         <td class='td-img align-middle'>
@@ -184,7 +184,7 @@
                                         </td>
                                         <td class='text-center td-wish-btn align-middle'>
                                             <input name="product_id" t-att-value="wish.product_id.id" type="hidden"/>
-                                            <button type="button" role="button" class="btn btn-secondary btn-block o_wish_add mb4" >Add <span class='d-none d-md-inline'>to Cart</span></button>
+                                            <button t-att-disabled="combination_info['product_type'] == 'product' and combination_info['free_qty'] &lt;= 0 and not combination_info.get('allow_out_of_stock_order', False) and not combination_info.get('allow_out_of_stock_order', False)" type="button" role="button" class="btn btn-secondary btn-block o_wish_add mb4" >Add <span class='d-none d-md-inline'>to Cart</span></button>
                                         </td>
                                     </tr>
                                 </t>


### PR DESCRIPTION
Requires to enable Add to Cart on the /shop page

- Adds a message if the product is out of stock when the user clicks from the /shop page
- For products with variants, shows the product configurator, and disable the add to cart button if the variant has no more stock.
  Also adds a message on the product configurator if the variant is out of stock
- Fixes flicker of out of stock message on the product page
- Prevents using the add to cart button in the wishlist if out of stock

- If the option 'show remaining quantities' is enabled, displays it on the product configurator.
> Note : As it is too performance heavy, we did not add a message directly on the product grid when loadingthe page.

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
