### PR TITLE
[IMP] mail: remove willCreate lifecyle hook

### DIFF
--- a/addons/mail/static/src/model/model_core.js
+++ b/addons/mail/static/src/model/model_core.js
@@ -190,7 +190,7 @@ function assertIsFunction(toAssert) {
  * @throws {Error} if name is not an existing hook name.
  */
 function assertIsValidHookName(name) {
-    const validHookNames = new Set(['_created', '_willCreate', '_willDelete']);
+    const validHookNames = new Set(['_created', '_willDelete']);
     if (!validHookNames.has(name)) {
         throw new Error("invalid hook name.");
     }

--- a/addons/mail/static/src/model/model_manager.js
+++ b/addons/mail/static/src/model/model_manager.js
@@ -710,15 +710,6 @@ export class ModelManager {
             record[methodName] = record[methodName].bind(record);
         }
         /**
-         * Invoke the life-cycle hook `_willCreate.`
-         * After this step the record is in a functioning state and it is
-         * considered existing.
-         */
-        const lifecycleHooks = registry.get(model.name).get('lifecycleHooks');
-        if (lifecycleHooks.has('_willCreate')) {
-            lifecycleHooks.get('_willCreate').call(record);
-        }
-        /**
          * Register post processing operation that are to be delayed at
          * the end of the update cycle.
          */

--- a/addons/mail/static/src/models/record.js
+++ b/addons/mail/static/src/models/record.js
@@ -27,19 +27,6 @@ registerModel({
     identifyingFields: ['messaging'],
     lifecycleHooks: {
         /**
-         * This function is called during the create cycle, when the record has
-         * already been created, but its values have not yet been assigned.
-         *
-         * It is usually preferable to use @see `_created`.
-         *
-         * The main use case is to prepare the record for the assignation of its
-         * values, for example if a computed field relies on the record to have
-         * some purely technical property correctly set.
-         *
-         * @private
-         */
-        _willCreate() {},
-        /**
          * This function is called after the record has been created, more
          * precisely at the end of the update cycle (which means all implicit
          * changes such as computes have been applied too).


### PR DESCRIPTION
This lifecyle is useless. All attributes that were defined
using this hooks should become fields.

This commit remove `willCreate`, and turn attributes to fields.

Task-2837763
