### PR TITLE
[IMP] mail, project: improves message recipients visibility

### DIFF
--- a/addons/mail/data/mail_message_subtype_data.xml
+++ b/addons/mail/data/mail_message_subtype_data.xml
@@ -5,12 +5,14 @@
     <record id="mt_comment" model="mail.message.subtype">
         <field name="name">Discussions</field>
         <field name="sequence" eval="0"/>
+        <field name="track_recipients" eval="True"/>
     </record>
     <record id="mt_note" model="mail.message.subtype">
         <field name="name">Note</field>
         <field name="default" eval="False"/>
         <field name="internal" eval="True"/>
         <field name="sequence" eval="100"/>
+        <field name="track_recipients" eval="True"/>
     </record>
     <record id="mt_activities" model="mail.message.subtype">
         <field name="name">Activities</field>

--- a/addons/mail/models/mail_message_subtype.py
+++ b/addons/mail/models/mail_message_subtype.py
@@ -40,6 +40,8 @@ class MailMessageSubtype(models.Model):
     default = fields.Boolean('Default', default=True, help="Activated by default when subscribing.")
     sequence = fields.Integer('Sequence', default=1, help="Used to order subtypes.")
     hidden = fields.Boolean('Hidden', help="Hide the subtype in the follower options")
+    track_recipients = fields.Boolean('Track Recipients',
+                                      help="Whether to display all the recipients or only the important ones.")
 
     @api.model_create_multi
     def create(self, vals_list):

--- a/addons/mail/static/tests/helpers/model_definitions_setup.js
+++ b/addons/mail/static/tests/helpers/model_definitions_setup.js
@@ -93,8 +93,11 @@ insertRecords('mail.activity.type', [
 ]);
 insertRecords('mail.message.subtype', [
     { default: false, internal: true, name: "Activities", sequence: 90, subtype_xmlid: 'mail.mt_activities' },
-    { default: false, internal: true, name: "Note", sequence: 100, subtype_xmlid: 'mail.mt_note' },
-    { name: "Discussions", sequence: 0, subtype_xmlid: 'mail.mt_comment' },
+    {
+        default: false, internal: true, name: "Note", sequence: 100, subtype_xmlid: 'mail.mt_note',
+        track_recipients: true
+    },
+    { name: "Discussions", sequence: 0, subtype_xmlid: 'mail.mt_comment', track_recipients: true },
 ]);
 insertRecords('res.company', [{ id: 1 }]);
 insertRecords('res.users', [

--- a/addons/mail/views/mail_message_subtype_views.xml
+++ b/addons/mail/views/mail_message_subtype_views.xml
@@ -31,6 +31,7 @@
                                 <field name="default"/>
                                 <field name="internal"/>
                                 <field name="hidden"/>
+                                <field name="track_recipients"/>
                             </group>
                             <group string='Auto subscription'>
                                 <field name="parent_id"/>

--- a/addons/test_mail/tests/test_performance.py
+++ b/addons/test_mail/tests/test_performance.py
@@ -360,7 +360,7 @@ class TestMailAPIPerformance(BaseMailPerformance):
                 composer_form.attachment_ids.add(attachment)
             composer = composer_form.save()
 
-        with self.assertQueryCount(__system__=43, employee=51):
+        with self.assertQueryCount(__system__=44, employee=52):
             composer._action_send_mail()
 
         # notifications
@@ -469,7 +469,7 @@ class TestMailAPIPerformance(BaseMailPerformance):
             )
             composer = composer_form.save()
 
-        with self.assertQueryCount(__system__=40, employee=46):
+        with self.assertQueryCount(__system__=41, employee=47):
             composer._action_send_mail()
 
         # notifications
@@ -501,7 +501,7 @@ class TestMailAPIPerformance(BaseMailPerformance):
             )
             composer = composer_form.save()
 
-        with self.assertQueryCount(__system__=52, employee=69):
+        with self.assertQueryCount(__system__=53, employee=70):
             composer._action_send_mail()
 
         # notifications
@@ -1153,7 +1153,7 @@ class TestMailHeavyPerformancePost(BaseMailPerformance):
             ('attach tuple 3', "attachement tupple content 3", {'cid': 'cid2'}),
         ]
         attachments = self.env['ir.attachment'].with_user(self.env.user).create(self.test_attachments_vals)
-        with self.assertQueryCount(employee=67):
+        with self.assertQueryCount(employee=68):
             self.cr.sql_log = self.warm and self.cr.sql_log_count
             record_container.with_context({}).message_post(
                 body='<p>Test body <img src="cid:cid1"> <img src="cid:cid2"></p>',

--- a/addons/test_mail_full/tests/test_mail_performance.py
+++ b/addons/test_mail_full/tests/test_mail_performance.py
@@ -81,7 +81,7 @@ class TestMailPerformance(BaseMailPerformance):
         record_ticket = self.env['mail.test.ticket.mc'].browse(self.record_ticket.ids)
         attachments = self.env['ir.attachment'].create(self.test_attachments_vals)
 
-        with self.assertQueryCount(employee=100):  # tmf: 93 / com: 98
+        with self.assertQueryCount(employee=101):  # tmf: 92 / com: 101
             new_message = record_ticket.message_post(
                 attachment_ids=attachments.ids,
                 body='<p>Test Content</p>',


### PR DESCRIPTION
All the recipients of message were not always displayed in discuss and some
users were wondering if the message has been sent to everybody concerned.
This solves the problem by allowing to specify whether to display all
recipients based on the message sub type and defining for which sub type it
must.

Task-2429708

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
