### PR TITLE
[IMP] *: remove useless keys from manifests

### DIFF
--- a/addons/account/__manifest__.py
+++ b/addons/account/__manifest__.py
@@ -84,7 +84,6 @@ You could use this simplified accounting in case you work with an (external) acc
     ],
     'installable': True,
     'application': True,
-    'auto_install': False,
     'post_init_hook': '_account_post_init',
     'assets': {
         'web._assets_primary_variables': [

--- a/addons/account_check_printing/__manifest__.py
+++ b/addons/account_check_printing/__manifest__.py
@@ -23,7 +23,6 @@ The check settings are located in the accounting journals configuration page.
         'wizard/print_prenumbered_checks_views.xml'
     ],
     'installable': True,
-    'auto_install': False,
     'post_init_hook': 'create_check_sequence_on_bank_journals',
     'license': 'LGPL-3',
 }

--- a/addons/account_debit_note/__manifest__.py
+++ b/addons/account_debit_note/__manifest__.py
@@ -19,6 +19,5 @@ The wizard used is similar as the one for the credit note.
         'security/ir.model.access.csv',
     ],
     'installable': True,
-    'auto_install': False,
     'license': 'LGPL-3',
 }

--- a/addons/account_edi/__manifest__.py
+++ b/addons/account_edi/__manifest__.py
@@ -22,7 +22,6 @@ governements, etc.)
         'data/cron.xml'
     ],
     'installable': True,
-    'application': False,
     'auto_install': True,
     'license': 'LGPL-3',
 }

--- a/addons/account_edi_facturx/__manifest__.py
+++ b/addons/account_edi_facturx/__manifest__.py
@@ -12,7 +12,6 @@
         'data/facturx_templates.xml',
     ],
     'installable': True,
-    'application': False,
     'auto_install': True,
     'license': 'LGPL-3',
 }

--- a/addons/account_edi_proxy_client/__manifest__.py
+++ b/addons/account_edi_proxy_client/__manifest__.py
@@ -19,7 +19,6 @@ Odoo database.
         'security/ir.model.access.csv',
     ],
     'installable': True,
-    'application': False,
     'license': 'LGPL-3',
     'post_init_hook': '_create_demo_config_param',
 }

--- a/addons/account_edi_ubl/__manifest__.py
+++ b/addons/account_edi_ubl/__manifest__.py
@@ -12,6 +12,5 @@
         'data/account_edi_data.xml',
     ],
     'installable': True,
-    'application': False,
     'license': 'LGPL-3',
 }

--- a/addons/account_edi_ubl_bis3/__manifest__.py
+++ b/addons/account_edi_ubl_bis3/__manifest__.py
@@ -11,6 +11,5 @@
         'data/bis3_templates.xml',
     ],
     'installable': True,
-    'application': False,
     'license': 'LGPL-3',
 }

--- a/addons/account_fleet/__manifest__.py
+++ b/addons/account_fleet/__manifest__.py
@@ -4,7 +4,6 @@
     'name': 'Accounting/Fleet bridge',
     'category': 'Accounting/Accounting',
     'summary': 'Manage accounting with fleets',
-    'description': "",
     'version': '1.0',
     'depends': ['fleet', 'account'],
     'data': [
@@ -14,6 +13,5 @@
     ],
     'installable': True,
     'auto_install': True,
-    'application': False,
     'license': 'LGPL-3',
 }

--- a/addons/account_lock/__manifest__.py
+++ b/addons/account_lock/__manifest__.py
@@ -12,6 +12,5 @@
     * Any new All Users Lock Date must be posterior (or equal) to the previous one.
     """,
     'depends': ['account'],
-    'data': [],
     'license': 'LGPL-3',
 }

--- a/addons/account_payment/__manifest__.py
+++ b/addons/account_payment/__manifest__.py
@@ -17,6 +17,5 @@ enable payment.
         'views/account_portal_templates.xml',
     ],
     'installable': True,
-    'auto_install': False,
     'license': 'LGPL-3',
 }

--- a/addons/account_qr_code_sepa/__manifest__.py
+++ b/addons/account_qr_code_sepa/__manifest__.py
@@ -12,9 +12,6 @@
     # any module necessary for this one to work correctly
     'depends': ['account', 'base_iban'],
 
-    'data': [
-    ],
-
     'auto_install': True,
     'license': 'LGPL-3',
 }

--- a/addons/analytic/__manifest__.py
+++ b/addons/analytic/__manifest__.py
@@ -24,6 +24,5 @@ that have no counterpart in the general financial accounts.
         'data/analytic_account_demo.xml',
     ],
     'installable': True,
-    'auto_install': False,
     'license': 'LGPL-3',
 }

--- a/addons/association/__manifest__.py
+++ b/addons/association/__manifest__.py
@@ -15,8 +15,6 @@ membership products (schemes).
     """,
     'depends': ['base_setup', 'membership', 'event'],
     'data': ['views/association_views.xml'],
-    'demo': [],
     'installable': True,
-    'auto_install': False,
     'license': 'LGPL-3',
 }

--- a/addons/barcodes/__manifest__.py
+++ b/addons/barcodes/__manifest__.py
@@ -10,7 +10,6 @@
         'security/ir.model.access.csv',
         ],
     'installable': True,
-    'auto_install': False,
     'post_init_hook': '_assign_default_nomeclature_id',
     'assets': {
         'web.assets_backend': [

--- a/addons/barcodes_gs1_nomenclature/__manifest__.py
+++ b/addons/barcodes_gs1_nomenclature/__manifest__.py
@@ -11,7 +11,6 @@
         'views/barcodes_view.xml',
     ],
     'installable': True,
-    'auto_install': False,
     'assets': {
         'web.assets_backend': [
             'barcodes_gs1_nomenclature/static/src/js/barcode_parser.js',

--- a/addons/base_import_module/__manifest__.py
+++ b/addons/base_import_module/__manifest__.py
@@ -12,7 +12,6 @@ for customization purpose.
     'category': 'Hidden/Tools',
     'depends': ['web'],
     'installable': True,
-    'auto_install': False,
     'data': [
         'security/ir.model.access.csv',
         'views/base_import_module_view.xml'

--- a/addons/base_setup/__manifest__.py
+++ b/addons/base_setup/__manifest__.py
@@ -17,9 +17,7 @@ Shows you a list of applications features to install from.
         'views/res_config_settings_views.xml',
         'views/res_partner_views.xml',
         ],
-    'demo': [],
     'installable': True,
-    'auto_install': False,
 
     'assets': {
         'web.assets_backend': [

--- a/addons/calendar/__manifest__.py
+++ b/addons/calendar/__manifest__.py
@@ -36,7 +36,6 @@ If you need to manage your meetings, you should install the CRM module.
     ],
     'installable': True,
     'application': True,
-    'auto_install': False,
     'assets': {
         'web.assets_backend': [
             'calendar/static/src/models/*.js',

--- a/addons/calendar_sms/__manifest__.py
+++ b/addons/calendar_sms/__manifest__.py
@@ -12,7 +12,6 @@
         'data/sms_data.xml',
         'views/calendar_views.xml',
     ],
-    'application': False,
     'auto_install': True,
     'license': 'LGPL-3',
 }

--- a/addons/crm/__manifest__.py
+++ b/addons/crm/__manifest__.py
@@ -8,7 +8,6 @@
     'category': 'Sales/CRM',
     'sequence': 15,
     'summary': 'Track leads and close opportunities',
-    'description': "",
     'website': 'https://www.odoo.com/app/crm',
     'depends': [
         'base_setup',
@@ -71,7 +70,6 @@
     ],
     'installable': True,
     'application': True,
-    'auto_install': False,
     'assets': {
         'web.assets_qweb': [
             'crm/static/src/xml/forecast_kanban.xml',

--- a/addons/crm_mail_plugin/__manifest__.py
+++ b/addons/crm_mail_plugin/__manifest__.py
@@ -18,7 +18,6 @@
         'views/crm_lead_views.xml'
     ],
     'installable': True,
-    'application': False,
     'auto_install': True,
     'license': 'LGPL-3',
 }

--- a/addons/crm_sms/__manifest__.py
+++ b/addons/crm_sms/__manifest__.py
@@ -6,7 +6,6 @@
     'version': '1.1',
     'category': 'Sales/CRM',
     'summary': 'Add SMS capabilities to CRM',
-    'description': "",
     'depends': ['crm', 'sms'],
     'data': [
         'views/crm_lead_views.xml',
@@ -14,7 +13,6 @@
         'security/sms_security.xml',
     ],
     'installable': True,
-    'application': False,
     'auto_install': True,
     'license': 'LGPL-3',
 }

--- a/addons/event/__manifest__.py
+++ b/addons/event/__manifest__.py
@@ -46,7 +46,6 @@ Key Features
         'data/event_registration_demo.xml',
     ],
     'installable': True,
-    'auto_install': False,
     'assets': {
         'web.assets_backend': [
             'event/static/src/scss/event.scss',

--- a/addons/event_sms/__manifest__.py
+++ b/addons/event_sms/__manifest__.py
@@ -12,8 +12,6 @@
         'security/ir.model.access.csv',
         'security/sms_security.xml',
     ],
-    'demo': [
-    ],
     'installable': True,
     'auto_install': True,
     'license': 'LGPL-3',

--- a/addons/fetchmail/__manifest__.py
+++ b/addons/fetchmail/__manifest__.py
@@ -41,7 +41,6 @@ For more specific needs, you may also assign custom-defined actions
         'views/mail_mail_views.xml',
         'views/res_config_settings_views.xml',
     ],
-    'demo': [],
     'installable': True,
     'auto_install': True,
     'license': 'LGPL-3',

--- a/addons/google_calendar/__manifest__.py
+++ b/addons/google_calendar/__manifest__.py
@@ -5,7 +5,6 @@
     'name': 'Google Calendar',
     'version': '1.0',
     'category': 'Productivity',
-    'description': "",
     'depends': ['google_account', 'calendar'],
     'data': [
         'data/google_calendar_data.xml',
@@ -15,9 +14,7 @@
         'views/res_users_views.xml',
         'views/google_calendar_views.xml',
         ],
-    'demo': [],
     'installable': True,
-    'auto_install': False,
     'assets': {
         'web.assets_backend': [
             'google_calendar/static/src/js/google_calendar_popover.js',

--- a/addons/google_drive/__manifest__.py
+++ b/addons/google_drive/__manifest__.py
@@ -6,7 +6,6 @@
     'version': '0.2',
     'category': 'Productivity',
     'installable': True,
-    'auto_install': False,
     'data': [
         'security/ir.model.access.csv',
         'data/google_drive_data.xml',

--- a/addons/google_recaptcha/__manifest__.py
+++ b/addons/google_recaptcha/__manifest__.py
@@ -12,7 +12,6 @@
     'data': [
         'views/res_config_settings_view.xml',
     ],
-    'auto_install': False,
     'assets': {
         'web.assets_frontend': [
             'google_recaptcha/static/src/scss/recaptcha.scss',

--- a/addons/google_spreadsheet/__manifest__.py
+++ b/addons/google_spreadsheet/__manifest__.py
@@ -15,9 +15,7 @@ The module adds the possibility to display data from Odoo in Google Spreadsheets
         'views/google_spreadsheet_views.xml',
         'views/res_config_settings_views.xml',
     ],
-    'demo': [],
     'installable': True,
-    'auto_install': False,
     'assets': {
         'web.assets_backend': [
             'google_spreadsheet/static/src/**/*.js',

--- a/addons/hr/__manifest__.py
+++ b/addons/hr/__manifest__.py
@@ -7,7 +7,6 @@
     'category': 'Human Resources/Employees',
     'sequence': 95,
     'summary': 'Centralize employee information',
-    'description': "",
     'website': 'https://www.odoo.com/app/employees',
     'images': [
         'images/hr_department.jpeg',
@@ -47,7 +46,6 @@
     ],
     'installable': True,
     'application': True,
-    'auto_install': False,
     'assets': {
         'mail.assets_discuss_public': [
             'hr/static/src/models/*.js',

--- a/addons/hr_attendance/__manifest__.py
+++ b/addons/hr_attendance/__manifest__.py
@@ -31,7 +31,6 @@ actions(Check in/Check out) performed by them.
         'data/hr_attendance_demo.xml'
     ],
     'installable': True,
-    'auto_install': False,
     'application': True,
     'assets': {
         'web.assets_backend': [

--- a/addons/hr_contract/__manifest__.py
+++ b/addons/hr_contract/__manifest__.py
@@ -32,7 +32,6 @@ You can assign several contracts per employee.
     ],
     'demo': ['data/hr_contract_demo.xml'],
     'installable': True,
-    'auto_install': False,
     'application': True,
     'assets': {
         'web.assets_backend': [

--- a/addons/hr_fleet/__manifest__.py
+++ b/addons/hr_fleet/__manifest__.py
@@ -5,7 +5,6 @@
     'version': '1.0',
     'category': 'Human Resources',
     'summary': 'Get history of driven cars by employees',
-    'description': "",
     'depends': ['hr', 'fleet'],
     'data': [
         'security/ir.model.access.csv',

--- a/addons/hr_holidays/__manifest__.py
+++ b/addons/hr_holidays/__manifest__.py
@@ -60,7 +60,6 @@ A synchronization with an internal agenda (Meetings of the CRM module) is also p
     ],
     'installable': True,
     'application': True,
-    'auto_install': False,
     'assets': {
         'mail.assets_discuss_public': [
             'hr_holidays/static/src/components/*/*',

--- a/addons/hr_maintenance/__manifest__.py
+++ b/addons/hr_maintenance/__manifest__.py
@@ -14,7 +14,6 @@
         'views/maintenance_views.xml',
         'views/hr_views.xml',
     ],
-    'demo': [],
     'installable': True,
     'auto_install': True,
     'license': 'LGPL-3',

--- a/addons/hr_presence/__manifest__.py
+++ b/addons/hr_presence/__manifest__.py
@@ -26,9 +26,7 @@ Allows to contact directly the employee in case of unjustified absence.
         'data/sms_data.xml',
         'data/ir_cron.xml',
     ],
-    'demo': [],
     'installable': True,
-    'auto_install': False,
     'post_init_hook': 'post_init_hook',
     'license': 'LGPL-3',
 }

--- a/addons/hr_recruitment/__manifest__.py
+++ b/addons/hr_recruitment/__manifest__.py
@@ -7,7 +7,6 @@
     'category': 'Human Resources/Recruitment',
     'sequence': 90,
     'summary': 'Track your recruitment pipeline',
-    'description': "",
     'website': 'https://www.odoo.com/app/recruitment',
     'depends': [
         'hr',
@@ -39,7 +38,6 @@
         'data/hr_recruitment_demo.xml',
     ],
     'installable': True,
-    'auto_install': False,
     'application': True,
     'assets': {
         'web.assets_backend': [

--- a/addons/hr_recruitment_survey/__manifest__.py
+++ b/addons/hr_recruitment_survey/__manifest__.py
@@ -20,6 +20,5 @@
         'data/survey_demo.xml',
         'data/hr_job_demo.xml',
     ],
-    'auto_install': False,
     'license': 'LGPL-3',
 }

--- a/addons/hr_timesheet/__manifest__.py
+++ b/addons/hr_timesheet/__manifest__.py
@@ -42,8 +42,6 @@ up a management by affair.
         'data/hr_timesheet_demo.xml',
     ],
     'installable': True,
-    'application': False,
-    'auto_install': False,
     'post_init_hook': 'create_internal_project',
     'uninstall_hook': '_uninstall_hook',
     'assets': {

--- a/addons/hr_work_entry/__manifest__.py
+++ b/addons/hr_work_entry/__manifest__.py
@@ -6,7 +6,6 @@
     'category': 'Human Resources/Employees',
     'sequence': 39,
     'summary': 'Manage work entries',
-    'description': "",
     'installable': True,
     'depends': [
         'hr',

--- a/addons/hr_work_entry_contract/__manifest__.py
+++ b/addons/hr_work_entry_contract/__manifest__.py
@@ -6,7 +6,6 @@
     'category': 'Human Resources/Employees',
     'sequence': 39,
     'summary': 'Manage work entries',
-    'description': "",
     'installable': True,
     'depends': [
         'hr_work_entry',

--- a/addons/hr_work_entry_holidays/__manifest__.py
+++ b/addons/hr_work_entry_holidays/__manifest__.py
@@ -20,7 +20,6 @@ This application allows you to integrate time off in payslips.
     ],
     'demo': ['data/hr_payroll_holidays_demo.xml'],
     'installable': True,
-    'application': False,
     'auto_install': True,
     'post_init_hook': '_validate_existing_work_entry',
     'license': 'LGPL-3',

--- a/addons/iap_crm/__manifest__.py
+++ b/addons/iap_crm/__manifest__.py
@@ -12,10 +12,7 @@
         'crm',
         'iap_mail',
     ],
-    'application': False,
     'installable': True,
     'auto_install': True,
-    'data': [
-    ],
     'license': 'LGPL-3',
 }

--- a/addons/iap_mail/__manifest__.py
+++ b/addons/iap_mail/__manifest__.py
@@ -12,7 +12,6 @@
         'iap',
         'mail',
     ],
-    'application': False,
     'installable': True,
     'auto_install': True,
     'data': [

--- a/addons/im_livechat/__manifest__.py
+++ b/addons/im_livechat/__manifest__.py
@@ -44,7 +44,6 @@ Help your customers with this chat, and analyse their feedback.
     ],
     'depends': ["mail", "rating", "digest", "utm"],
     'installable': True,
-    'auto_install': False,
     'application': True,
     'assets': {
         'mail.assets_discuss_public': [

--- a/addons/im_livechat_mail_bot/__manifest__.py
+++ b/addons/im_livechat_mail_bot/__manifest__.py
@@ -6,11 +6,9 @@
     'version': '1.0',
     'category': 'Productivity/Discuss',
     'summary': 'Add livechat support for OdooBot',
-    'description': "",
     'website': 'https://www.odoo.com/app/discuss',
     'depends': ['mail_bot', 'im_livechat'],
     'installable': True,
-    'application': False,
     'auto_install': True,
     'license': 'LGPL-3',
 }

--- a/addons/l10n_ar/__manifest__.py
+++ b/addons/l10n_ar/__manifest__.py
@@ -120,8 +120,6 @@ Master Data:
         'demo/account_supplier_refund_demo.xml',
     ],
     'installable': True,
-    'auto_install': False,
-    'application': False,
     'assets': {
         'web.assets_backend': [
             'l10n_ar/static/src/**/*',

--- a/addons/l10n_ar_website_sale/__manifest__.py
+++ b/addons/l10n_ar_website_sale/__manifest__.py
@@ -19,6 +19,5 @@
     ],
     'installable': True,
     'auto_install': True,
-    'application': False,
     'license': 'LGPL-3',
 }

--- a/addons/l10n_ec/__manifest__.py
+++ b/addons/l10n_ec/__manifest__.py
@@ -76,6 +76,4 @@ Master Data:
         "demo/demo_company.xml",
     ],
     "installable": True,
-    "auto_install": False,
-    "application": False,
 }

--- a/addons/l10n_fi_sale/__manifest__.py
+++ b/addons/l10n_fi_sale/__manifest__.py
@@ -11,7 +11,6 @@
         'sale',
     ],
     'installable': True,
-    'application': False,
     'auto_install': True,
     'license': 'LGPL-3',
 }

--- a/addons/l10n_fr_pos_cert/__manifest__.py
+++ b/addons/l10n_fr_pos_cert/__manifest__.py
@@ -25,7 +25,6 @@ The module adds following features:
     'depends': ['l10n_fr', 'point_of_sale'],
     'installable': True,
     'auto_install': True,
-    'application': False,
     'data': [
         'views/account_views.xml',
         'views/pos_views.xml',

--- a/addons/l10n_gcc_pos/__manifest__.py
+++ b/addons/l10n_gcc_pos/__manifest__.py
@@ -10,8 +10,6 @@ GCC POS Localization
     """,
     'license': 'LGPL-3',
     'depends': ['point_of_sale', 'l10n_gcc_invoice'],
-    'data': [
-    ],
     'assets': {
         'web.assets_qweb': [
             'l10n_gcc_pos/static/src/xml/OrderReceipt.xml',

--- a/addons/l10n_hu/__manifest__.py
+++ b/addons/l10n_hu/__manifest__.py
@@ -8,7 +8,6 @@
     'name': 'Hungarian - Accounting',
     'version': '3.0',
     'category': 'Accounting/Localizations/Account Charts',
-    'author': 'Odoo S.A.',
     'description': """
 
 Base module for Hungarian localization

--- a/addons/l10n_id_efaktur/__manifest__.py
+++ b/addons/l10n_id_efaktur/__manifest__.py
@@ -37,7 +37,6 @@
             'views/res_config_settings_views.xml',
             'views/res_partner_views.xml',
     ],
-    'demo': [],
     'installable': True,
     'auto_install': True,
     'license': 'LGPL-3',

--- a/addons/l10n_in_edi/__manifest__.py
+++ b/addons/l10n_in_edi/__manifest__.py
@@ -34,7 +34,5 @@ For the creation of API username and password please ref this document: <https:/
     ],
     "installable": True,
     # only applicable for taxpayers turnover higher than Rs.50 crore so auto_install is False
-    "auto_install": False,
-    "application": False,
     "license": "LGPL-3",
 }

--- a/addons/l10n_in_purchase/__manifest__.py
+++ b/addons/l10n_in_purchase/__manifest__.py
@@ -16,7 +16,6 @@
         'views/purchase_order_views.xml',
     ],
     'installable': True,
-    'application': False,
     'auto_install': True,
     'license': 'LGPL-3',
 }

--- a/addons/l10n_in_sale/__manifest__.py
+++ b/addons/l10n_in_sale/__manifest__.py
@@ -20,7 +20,6 @@
         'data/product_demo.xml',
     ],
     'installable': True,
-    'application': False,
     'auto_install': True,
     'license': 'LGPL-3',
 }

--- a/addons/l10n_in_stock/__manifest__.py
+++ b/addons/l10n_in_stock/__manifest__.py
@@ -18,7 +18,6 @@
         'data/product_demo.xml',
     ],
     'installable': True,
-    'application': False,
     'auto_install': True,
     'license': 'LGPL-3',
 }

--- a/addons/l10n_latam_base/__manifest__.py
+++ b/addons/l10n_latam_base/__manifest__.py
@@ -56,8 +56,6 @@ This module is compatible with base_vat module in order to be able to validate V
         'security/ir.model.access.csv',
     ],
     'installable': True,
-    'auto_install': False,
-    'application': False,
     'post_init_hook': '_set_default_identification_type',
     'license': 'LGPL-3',
 }

--- a/addons/l10n_nl/__manifest__.py
+++ b/addons/l10n_nl/__manifest__.py
@@ -33,7 +33,6 @@
     'demo': [
         'demo/demo_company.xml',
     ],
-    'auto_install': False,
     'installable': True,
     'license': 'LGPL-3',
 }

--- a/addons/l10n_pk/__manifest__.py
+++ b/addons/l10n_pk/__manifest__.py
@@ -6,7 +6,6 @@
     'version': '1.0',
     'category': 'Accounting/Localizations/Account Charts',
     'description': """ This is the base module to manage chart of accounts and localization for the Pakistan """,
-    'author': 'Odoo S.A.',
     'depends': ['account'],
     'data': [
         'data/account_chart_template_data.xml',

--- a/addons/l10n_sa_pos/__manifest__.py
+++ b/addons/l10n_sa_pos/__manifest__.py
@@ -13,8 +13,6 @@ K.S.A. POS Localization
         'l10n_gcc_pos',
         'l10n_sa',
     ],
-    'data': [
-    ],
     'assets': {
         'web.assets_qweb': [
             'l10n_sa_pos/static/src/xml/OrderReceipt.xml',

--- a/addons/loyalty_delivery/__manifest__.py
+++ b/addons/loyalty_delivery/__manifest__.py
@@ -10,8 +10,6 @@
         'data/loyalty_delivery_data.xml',
         'views/loyalty_reward_views.xml',
     ],
-    'assets': {
-    },
     'installable': True,
     'auto_install': True,
     'license': 'LGPL-3',

--- a/addons/mail/__manifest__.py
+++ b/addons/mail/__manifest__.py
@@ -6,7 +6,6 @@
     'category': 'Productivity/Discuss',
     'sequence': 145,
     'summary': 'Chat, mail gateway and private channels',
-    'description': "",
     'website': 'https://www.odoo.com/app/discuss',
     'depends': ['base', 'base_setup', 'bus', 'web_tour'],
     'data': [

--- a/addons/mail_bot/__manifest__.py
+++ b/addons/mail_bot/__manifest__.py
@@ -6,12 +6,10 @@
     'version': '1.2',
     'category': 'Productivity/Discuss',
     'summary': 'Add OdooBot in discussions',
-    'description': "",
     'website': 'https://www.odoo.com/app/discuss',
     'depends': ['mail'],
     'auto_install': True,
     'installable': True,
-    'application': False,
     'data': [
         'views/res_users_views.xml',
         'data/mailbot_data.xml',

--- a/addons/mail_bot_hr/__manifest__.py
+++ b/addons/mail_bot_hr/__manifest__.py
@@ -7,7 +7,6 @@
     'category': 'Productivity/Discuss',
     'version': '1.0',
     'depends': ['mail_bot', 'hr'],
-    'application': False,
     'installable': True,
     'auto_install': True,
     'data': [

--- a/addons/mail_group/__manifest__.py
+++ b/addons/mail_group/__manifest__.py
@@ -12,7 +12,6 @@
         'mail',
         'portal',
     ],
-    'auto_install': False,
     'data': [
         'data/ir_cron_data.xml',
         'data/mail_templates.xml',

--- a/addons/mail_plugin/__manifest__.py
+++ b/addons/mail_plugin/__manifest__.py
@@ -19,7 +19,5 @@
         'security/ir.model.access.csv',
     ],
     'installable': True,
-    'application': False,
-    'auto_install': False,
     'license': 'LGPL-3',
 }

--- a/addons/mass_mailing/__manifest__.py
+++ b/addons/mass_mailing/__manifest__.py
@@ -4,7 +4,6 @@
 {
     'name': 'Email Marketing',
     'summary': 'Design, send and track emails',
-    'description': "",
     'version': '2.5',
     'sequence': 60,
     'website': 'https://www.odoo.com/app/email-marketing',

--- a/addons/mass_mailing_event_sms/__manifest__.py
+++ b/addons/mass_mailing_event_sms/__manifest__.py
@@ -18,8 +18,6 @@ Bridge module adding UX requirements to ease SMS marketing o, event attendees.
         'mass_mailing_sms',
         'sms',
     ],
-    'data': [
-    ],
     'auto_install': True,
     'license': 'LGPL-3',
 }

--- a/addons/mass_mailing_event_track_sms/__manifest__.py
+++ b/addons/mass_mailing_event_track_sms/__manifest__.py
@@ -19,8 +19,6 @@ speakers..
         'sms',
         'website_event_track'
     ],
-    'data': [
-    ],
     'auto_install': True,
     'license': 'LGPL-3',
 }

--- a/addons/mass_mailing_sms/__manifest__.py
+++ b/addons/mass_mailing_sms/__manifest__.py
@@ -4,7 +4,6 @@
 {
     'name': 'SMS Marketing',
     'summary': 'Design, send and track SMS',
-    'description': '',
     'version': '1.0',
     'category': 'Marketing/Email Marketing',
     'sequence': 245,

--- a/addons/microsoft_calendar/__manifest__.py
+++ b/addons/microsoft_calendar/__manifest__.py
@@ -5,7 +5,6 @@
     'name': 'Outlook Calendar',
     'version': '1.0',
     'category': 'Productivity',
-    'description': "",
     'depends': ['microsoft_account', 'calendar'],
     'data': [
         'data/microsoft_calendar_data.xml',
@@ -15,9 +14,7 @@
         'views/res_users_views.xml',
         'views/microsoft_calendar_views.xml',
         ],
-    'demo': [],
     'installable': True,
-    'auto_install': False,
     'post_init_hook': 'init_initiating_microsoft_uuid',
     'assets': {
         'web.assets_backend': [

--- a/addons/microsoft_outlook/__manifest__.py
+++ b/addons/microsoft_outlook/__manifest__.py
@@ -14,6 +14,5 @@
         "views/res_config_settings_views.xml",
         "views/templates.xml",
     ],
-    "auto_install": False,
     "license": "LGPL-3",
 }

--- a/addons/mrp/__manifest__.py
+++ b/addons/mrp/__manifest__.py
@@ -10,7 +10,6 @@
     'sequence': 55,
     'summary': 'Manufacturing Orders & BOMs',
     'depends': ['product', 'stock', 'resource'],
-    'description': "",
     'data': [
         'security/mrp_security.xml',
         'security/ir.model.access.csv',
@@ -53,7 +52,6 @@
     'demo': [
         'data/mrp_demo.xml',
     ],
-    'test': [],
     'application': True,
     'pre_init_hook': '_pre_init_mrp',
     'post_init_hook': '_create_warehouse_data',

--- a/addons/mrp_product_expiry/__manifest__.py
+++ b/addons/mrp_product_expiry/__manifest__.py
@@ -15,6 +15,5 @@ Technical module.
     ],
     'installable': True,
     'auto_install': True,
-    'application': False,
     'license': 'LGPL-3',
 }

--- a/addons/mrp_repair/__manifest__.py
+++ b/addons/mrp_repair/__manifest__.py
@@ -9,6 +9,5 @@
     'depends': ['repair', 'mrp'],
     'installable': True,
     'auto_install': True,
-    'application': False,
     'license': 'LGPL-3',
 }

--- a/addons/mrp_subcontracting/__manifest__.py
+++ b/addons/mrp_subcontracting/__manifest__.py
@@ -5,7 +5,6 @@
     'name': "mrp_subcontracting",
     'version': '0.1',
     'summary': "Subcontract Productions",
-    'description': "",
     'website': 'https://www.odoo.com/app/manufacturing',
     'category': 'Manufacturing/Manufacturing',
     'depends': ['mrp'],

--- a/addons/note/__manifest__.py
+++ b/addons/note/__manifest__.py
@@ -5,7 +5,6 @@
     'name': 'Notes',
     'version': '1.0',
     'category': 'Productivity/Notes',
-    'description': "",
     'website': 'https://www.odoo.com/app/notes',
     'summary': 'Organize your work with memos',
     'sequence': 260,
@@ -23,11 +22,8 @@
     'demo': [
         'data/note_demo.xml',
     ],
-    'test': [
-    ],
     'installable': True,
     'application': True,
-    'auto_install': False,
     'assets': {
         'web.assets_backend': [
             'note/static/src/scss/note.scss',

--- a/addons/partner_autocomplete/__manifest__.py
+++ b/addons/partner_autocomplete/__manifest__.py
@@ -9,7 +9,6 @@
     'description': """
        Auto-complete partner companies' data
     """,
-    'author': "Odoo S.A.",
     'category': 'Hidden/Tools',
     'depends': [
         'iap_mail',

--- a/addons/point_of_sale/__manifest__.py
+++ b/addons/point_of_sale/__manifest__.py
@@ -7,7 +7,6 @@
     'category': 'Sales/Point of Sale',
     'sequence': 40,
     'summary': 'User-friendly PoS interface for shops and restaurants',
-    'description': "",
     'depends': ['stock_account', 'barcodes', 'web_editor', 'digest'],
     'data': [
         'security/point_of_sale_security.xml',

--- a/addons/pos_adyen/__manifest__.py
+++ b/addons/pos_adyen/__manifest__.py
@@ -6,7 +6,6 @@
     'category': 'Sales/Point of Sale',
     'sequence': 6,
     'summary': 'Integrate your POS with an Adyen payment terminal',
-    'description': '',
     'data': [
         'views/pos_config_views.xml',
         'views/pos_payment_method_views.xml',

--- a/addons/pos_loyalty/__manifest__.py
+++ b/addons/pos_loyalty/__manifest__.py
@@ -7,7 +7,6 @@
     'category': 'Sales/Point Of Sale',
     'sequence': 6,
     'summary': 'Use Coupons, Gift Cards and Loyalty programs in Point of Sale',
-    'description': '',
     'depends': ['loyalty', 'point_of_sale'],
     'data': [
         'security/ir.model.access.csv',

--- a/addons/pos_mercury/__manifest__.py
+++ b/addons/pos_mercury/__manifest__.py
@@ -33,7 +33,6 @@ following:
         'data/pos_mercury_demo.xml',
     ],
     'installable': True,
-    'auto_install': False,
     'assets': {
         'point_of_sale.assets': [
             'pos_mercury/static/src/js/pos_mercury.js',

--- a/addons/pos_restaurant/__manifest__.py
+++ b/addons/pos_restaurant/__manifest__.py
@@ -28,7 +28,6 @@ This module adds several features to the Point of Sale that are specific to rest
         'data/pos_restaurant_demo.xml',
     ],
     'installable': True,
-    'auto_install': False,
     'assets': {
         'point_of_sale.assets': [
             'pos_restaurant/static/lib/js/jquery.ui.touch-punch.js',

--- a/addons/pos_restaurant_adyen/__manifest__.py
+++ b/addons/pos_restaurant_adyen/__manifest__.py
@@ -7,7 +7,6 @@
     'category': 'Point of Sale',
     'sequence': 6,
     'summary': 'Adds American style tipping to Adyen',
-    'description': '',
     'depends': ['pos_adyen', 'pos_restaurant', 'payment_adyen'],
     'data': [
         'views/pos_payment_method_views.xml',

--- a/addons/pos_six/__manifest__.py
+++ b/addons/pos_six/__manifest__.py
@@ -6,10 +6,9 @@
     'category': 'Sales/Point Of Sale',
     'sequence': 6,
     'summary': 'Integrate your POS with a Six payment terminal',
-    'description': '',
     'data': [
         'views/pos_payment_method_views.xml',
-        ],
+    ],
     'depends': ['point_of_sale'],
     'installable': True,
     'license': 'LGPL-3',

--- a/addons/product/__manifest__.py
+++ b/addons/product/__manifest__.py
@@ -57,7 +57,6 @@ Print product labels with barcode.
         'data/product_demo.xml',
     ],
     'installable': True,
-    'auto_install': False,
     'assets': {
         'web.assets_backend': [
             'product/static/src/js/**/*',

--- a/addons/product_expiry/__manifest__.py
+++ b/addons/product_expiry/__manifest__.py
@@ -3,7 +3,6 @@
     'name': 'Products Expiration Date',
     'category': 'Inventory/Inventory',
     'depends': ['stock'],
-    'demo': [],
     'description': """
 Track different dates on products and production lots.
 ======================================================

--- a/addons/project/__manifest__.py
+++ b/addons/project/__manifest__.py
@@ -19,7 +19,6 @@
         'web_tour',
         'digest',
     ],
-    'description': "",
     'data': [
         'security/project_security.xml',
         'security/ir.model.access.csv',
@@ -55,10 +54,7 @@
         'data/mail_template_demo.xml',
         'data/project_demo.xml',
     ],
-    'test': [
-    ],
     'installable': True,
-    'auto_install': False,
     'application': True,
     'post_init_hook': '_project_post_init',
     'assets': {

--- a/addons/project_mail_plugin/__manifest__.py
+++ b/addons/project_mail_plugin/__manifest__.py
@@ -17,7 +17,6 @@
         'mail_plugin',
     ],
     'installable': True,
-    'application': False,
     'auto_install': True,
     'license': 'LGPL-3',
 }

--- a/addons/project_mrp/__manifest__.py
+++ b/addons/project_mrp/__manifest__.py
@@ -5,7 +5,6 @@
     'name': "MRP Project",
     'version': '1.0',
     'summary': "Monitor MRP using project",
-    'description': "",
     'category': 'Services/Project',
     'depends': ['mrp_account', 'project'],
     'data': [
@@ -14,7 +13,6 @@
     'demo': [
         'data/project_mrp_demo.xml',
     ],
-    'application': False,
     'auto_install': True,
     'license': 'LGPL-3',
 }

--- a/addons/project_purchase/__manifest__.py
+++ b/addons/project_purchase/__manifest__.py
@@ -5,7 +5,6 @@
     'name': "Project Purchase",
     'version': '1.0',
     'summary': "Monitor purchase in project",
-    'description': "",
     'category': 'Services/Project',
     'depends': ['purchase', 'project'],
     'data': [
@@ -14,7 +13,6 @@
     'demo': [
         'data/project_purchase_demo.xml',
     ],
-    'application': False,
     'auto_install': True,
     'license': 'LGPL-3',
 }

--- a/addons/project_sale_expense/__manifest__.py
+++ b/addons/project_sale_expense/__manifest__.py
@@ -8,8 +8,5 @@
     'license': 'LGPL-3',
     'category': 'Hidden',
     'depends': ['sale_project', 'sale_expense', 'project_hr_expense'],
-    'data': [],
-    'demo': [],
     'auto_install': True,
-    'application': False,
 }

--- a/addons/project_sms/__manifest__.py
+++ b/addons/project_sms/__manifest__.py
@@ -14,7 +14,6 @@
         'security/ir.model.access.csv',
         'security/project_sms_security.xml',
     ],
-    'application': False,
     'auto_install': True,
     'license': 'LGPL-3',
 }

--- a/addons/project_timesheet_holidays/__manifest__.py
+++ b/addons/project_timesheet_holidays/__manifest__.py
@@ -20,7 +20,6 @@ on leaves. Project and task can be configured company-wide.
         'security/ir.model.access.csv',
 
     ],
-    'demo': [],
     'installable': True,
     'auto_install': True,
     'post_init_hook': 'post_init',

--- a/addons/purchase/__manifest__.py
+++ b/addons/purchase/__manifest__.py
@@ -7,7 +7,6 @@
     'category': 'Inventory/Purchase',
     'sequence': 35,
     'summary': 'Purchase orders, tenders and agreements',
-    'description': "",
     'website': 'https://www.odoo.com/app/purchase',
     'depends': ['account'],
     'data': [
@@ -36,7 +35,6 @@
         'data/purchase_demo.xml',
     ],
     'installable': True,
-    'auto_install': False,
     'application': True,
     'assets': {
         'web.assets_backend': [

--- a/addons/purchase_requisition_stock/__manifest__.py
+++ b/addons/purchase_requisition_stock/__manifest__.py
@@ -6,8 +6,6 @@
     'version': '1.2',
     'category': 'Inventory/Purchase',
     'sequence': 70,
-    'summary': '',
-    'description': "",
     'depends': ['purchase_requisition', 'purchase_stock'],
     'demo': [
         'data/purchase_requisition_stock_demo.xml'

--- a/addons/purchase_stock/__manifest__.py
+++ b/addons/purchase_stock/__manifest__.py
@@ -7,7 +7,6 @@
     'category': 'Inventory/Purchase',
     'sequence': 60,
     'summary': 'Purchase Orders, Receipts, Vendor Bills for Stock',
-    'description': "",
     'depends': ['stock_account', 'purchase'],
     'data': [
         'security/ir.model.access.csv',

--- a/addons/rating/__manifest__.py
+++ b/addons/rating/__manifest__.py
@@ -18,7 +18,6 @@ This module allows a customer to give rating.
         'security/ir.model.access.csv'
     ],
     'installable': True,
-    'auto_install': False,
     'assets': {
         'web.assets_backend': [
             'rating/static/src/scss/rating_rating_views.scss',

--- a/addons/repair/__manifest__.py
+++ b/addons/repair/__manifest__.py
@@ -37,9 +37,7 @@ The following topics are covered by this module:
         'data/mail_template_data.xml',
     ],
     'demo': ['data/repair_demo.xml'],
-    'test': [],
     'installable': True,
-    'auto_install': False,
     'application': True,
     'license': 'LGPL-3',
 }

--- a/addons/resource/__manifest__.py
+++ b/addons/resource/__manifest__.py
@@ -19,8 +19,6 @@ associated to every resource. It also manages the leaves of every resource.
         'security/ir.model.access.csv',
         'security/resource_security.xml',
         'views/resource_views.xml',
-        ],
-    'demo': [
     ],
     'assets': {
         'web.assets_backend': [

--- a/addons/sale/__manifest__.py
+++ b/addons/sale/__manifest__.py
@@ -56,7 +56,6 @@ This module contains all the common features of Sales Management and eCommerce.
         'data/sale_demo.xml',
     ],
     'installable': True,
-    'auto_install': False,
     'assets': {
         'web.assets_backend': [
             'sale/static/src/scss/sale_onboarding.scss',

--- a/addons/sale_expense/__manifest__.py
+++ b/addons/sale_expense/__manifest__.py
@@ -20,7 +20,6 @@ This module allow to reinvoice employee expense, by setting the SO directly on t
         'views/sale_order_views.xml',
     ],
     'demo': ['data/sale_expense_demo.xml'],
-    'test': [],
     'installable': True,
     'auto_install': True,
     'assets': {

--- a/addons/sale_loyalty_delivery/__manifest__.py
+++ b/addons/sale_loyalty_delivery/__manifest__.py
@@ -7,8 +7,6 @@
     'category': 'Sales/Sales',
     'version': '1.0',
     'depends': ['sale_loyalty', 'loyalty_delivery'],
-    'data': [
-    ],
     'auto_install': True,
     'license': 'LGPL-3',
 }

--- a/addons/sale_mrp/__manifest__.py
+++ b/addons/sale_mrp/__manifest__.py
@@ -20,7 +20,6 @@ from sales order. It adds sales name and sales Reference on production order.
         'views/sale_order_views.xml',
         'views/sale_portal_templates.xml'
     ],
-    'demo': [],
     'installable': True,
     'auto_install': True,
     'license': 'LGPL-3',

--- a/addons/sale_project_stock/__manifest__.py
+++ b/addons/sale_project_stock/__manifest__.py
@@ -12,7 +12,5 @@
     'data': [
         'views/stock_move_views.xml',
     ],
-    'demo': [],
     'auto_install': True,
-    'application': False,
 }

--- a/addons/sale_purchase/__manifest__.py
+++ b/addons/sale_purchase/__manifest__.py
@@ -21,8 +21,6 @@ by external providers and will automatically generate purchase orders directed t
         'views/sale_order_views.xml',
         'views/purchase_order_views.xml',
     ],
-    'demo': [
-    ],
     'auto_install': True,
     'license': 'LGPL-3',
 }

--- a/addons/sale_purchase_stock/__manifest__.py
+++ b/addons/sale_purchase_stock/__manifest__.py
@@ -10,8 +10,6 @@
 Add relation information between Sale Orders and Purchase Orders if Make to Order (MTO) is activated on one sold product.
 """,
     'depends': ['sale_stock', 'purchase_stock', 'sale_purchase'],
-    'data': [],
-    'demo': [],
     'installable': True,
     'auto_install': True,
     'license': 'LGPL-3',

--- a/addons/sale_sms/__manifest__.py
+++ b/addons/sale_sms/__manifest__.py
@@ -12,7 +12,6 @@
         'security/ir.model.access.csv',
         'security/security.xml',
     ],
-    'application': False,
     'auto_install': True,
     'license': 'LGPL-3',
 }

--- a/addons/sale_stock_margin/__manifest__.py
+++ b/addons/sale_stock_margin/__manifest__.py
@@ -2,7 +2,6 @@
 {
     'name': "Sale Stock Margin",
     'category': 'Sales/Sales',
-    'summary': '',
     'description': 'Once the delivery is validated, update the cost on the SO to have an exact margin computation.',
     'version': '0.1',
     'depends': ['sale_stock', 'sale_margin'],

--- a/addons/sale_timesheet_margin/__manifest__.py
+++ b/addons/sale_timesheet_margin/__manifest__.py
@@ -11,8 +11,6 @@ Allows to compute accurate margin for Service sales.
 """,
     'category': 'Hidden',
     'depends': ['sale_margin', 'sale_timesheet'],
-    'demo': [],
-    'data': [],
     'auto_install': True,
     'license': 'LGPL-3',
 }

--- a/addons/sales_team/__manifest__.py
+++ b/addons/sales_team/__manifest__.py
@@ -27,7 +27,6 @@ Using this application you can manage Sales Teams with CRM and/or Sales
         'data/crm_tag_demo.xml',
     ],
     'installable': True,
-    'auto_install': False,
     'assets': {
         'web.assets_backend': [
             'sales_team/static/**/*',

--- a/addons/social_media/__manifest__.py
+++ b/addons/social_media/__manifest__.py
@@ -8,7 +8,6 @@
 The purpose of this technical module is to provide a front for
 social media configuration for any other module that might need it.
     """,
-    'author': "Odoo S.A.",
     'category': 'Hidden',
     'version': '0.1',
     'depends': ['base'],

--- a/addons/stock/__manifest__.py
+++ b/addons/stock/__manifest__.py
@@ -5,7 +5,6 @@
     'name': 'Inventory',
     'version': '1.1',
     'summary': 'Manage your stock and logistics activities',
-    'description': "",
     'website': 'https://www.odoo.com/app/inventory',
     'depends': ['product', 'barcodes_gs1_nomenclature', 'digest'],
     'category': 'Inventory/Inventory',
@@ -90,7 +89,6 @@
     ],
     'installable': True,
     'application': True,
-    'auto_install': False,
     'pre_init_hook': 'pre_init_hook',
     'post_init_hook': '_assign_default_mail_template_picking_id',
     'assets': {

--- a/addons/stock_account/__manifest__.py
+++ b/addons/stock_account/__manifest__.py
@@ -37,8 +37,6 @@ Dashboard / Reports for Warehouse Management includes:
         'wizard/stock_valuation_layer_revaluation_views.xml',
         'report/report_stock_forecasted.xml',
     ],
-    'test': [
-    ],
     'installable': True,
     'auto_install': True,
     'post_init_hook': '_configure_journals',

--- a/addons/stock_dropshipping/__manifest__.py
+++ b/addons/stock_dropshipping/__manifest__.py
@@ -27,6 +27,5 @@ internal transfer document is needed.
         'views/purchase_order_views.xml'
     ],
     'installable': True,
-    'auto_install': False,
     'license': 'LGPL-3',
 }

--- a/addons/stock_landed_costs/__manifest__.py
+++ b/addons/stock_landed_costs/__manifest__.py
@@ -13,8 +13,6 @@ This module allows you to easily add extra costs on pickings and decide the spli
     'depends': ['stock_account', 'purchase_stock'],
     'category': 'Inventory/Inventory',
     'sequence': 16,
-    'demo': [
-    ],
     'data': [
         'security/ir.model.access.csv',
         'security/stock_landed_cost_security.xml',
@@ -26,6 +24,5 @@ This module allows you to easily add extra costs on pickings and decide the spli
         'views/res_config_settings_views.xml',
     ],
     'installable': True,
-    'auto_install': False,
     'license': 'LGPL-3',
 }

--- a/addons/stock_sms/__manifest__.py
+++ b/addons/stock_sms/__manifest__.py
@@ -15,7 +15,6 @@
         'security/ir.model.access.csv',
         'security/sms_security.xml',
     ],
-    'application': False,
     'auto_install': True,
     'post_init_hook': '_assign_default_sms_template_picking_id',
     'license': 'LGPL-3',

--- a/addons/survey/__manifest__.py
+++ b/addons/survey/__manifest__.py
@@ -56,7 +56,6 @@ sent mails with personal token for the invitation of the survey.
         'data/survey_demo_conditional.xml',
     ],
     'installable': True,
-    'auto_install': False,
     'application': True,
     'sequence': 220,
     'assets': {

--- a/addons/test_base_automation/__manifest__.py
+++ b/addons/test_base_automation/__manifest__.py
@@ -15,6 +15,5 @@ tests independently to functional aspects of other models.""",
         'security/ir.model.access.csv',
     ],
     'installable': True,
-    'application': False,
     'license': 'LGPL-3',
 }

--- a/addons/test_discuss_full/__manifest__.py
+++ b/addons/test_discuss_full/__manifest__.py
@@ -16,11 +16,6 @@
         'mail_bot',
         'website_livechat',
     ],
-    'data': [
-    ],
-    'demo': [
-    ],
     'installable': True,
-    'application': False,
     'license': 'LGPL-3',
 }

--- a/addons/test_mail/__manifest__.py
+++ b/addons/test_mail/__manifest__.py
@@ -17,8 +17,6 @@ tests independently to functional aspects of other models. """,
         'data/mail_template_data.xml',
         'data/subtype_data.xml',
     ],
-    'demo': [
-    ],
     'assets': {
         'web.qunit_suite_tests': [
             'test_mail/static/tests/*',
@@ -28,6 +26,5 @@ tests independently to functional aspects of other models. """,
         ],
     },
     'installable': True,
-    'application': False,
     'license': 'LGPL-3',
 }

--- a/addons/test_mail_full/__manifest__.py
+++ b/addons/test_mail_full/__manifest__.py
@@ -28,9 +28,6 @@ real applications. """,
         'security/ir.model.access.csv',
         'security/ir_rule_data.xml',
     ],
-    'demo': [
-    ],
     'installable': True,
-    'application': False,
     'license': 'LGPL-3',
 }

--- a/addons/test_mass_mailing/__manifest__.py
+++ b/addons/test_mass_mailing/__manifest__.py
@@ -13,9 +13,6 @@ test_mail. """,
     'data': [
         'security/ir.model.access.csv',
     ],
-    'demo': [
-    ],
     'installable': True,
-    'application': False,
     'license': 'LGPL-3',
 }

--- a/addons/test_resource/__manifest__.py
+++ b/addons/test_resource/__manifest__.py
@@ -5,12 +5,9 @@
     'name': 'Test - Resource',
     'version': '1.1',
     'category': 'Hidden',
-    'description': """""",
     'depends': ['resource'],
     'data': [
         'security/ir.model.access.csv',
     ],
-    'demo': [],
-    'assets': {},
     'license': 'LGPL-3',
 }

--- a/addons/test_sale_product_configurators/__manifest__.py
+++ b/addons/test_sale_product_configurators/__manifest__.py
@@ -16,6 +16,5 @@
             'test_sale_product_configurators/static/tests/tours/**/*',
         ],
     },
-    'application': False,
     'license': 'OEEL-1',
 }

--- a/addons/test_website/__manifest__.py
+++ b/addons/test_website/__manifest__.py
@@ -23,7 +23,6 @@ models which only purpose is to run tests.""",
         'security/ir.model.access.csv',
     ],
     'installable': True,
-    'application': False,
     'assets': {
         'web.assets_frontend': [
             'test_website/static/src/js/test_error.js',

--- a/addons/test_website_modules/__manifest__.py
+++ b/addons/test_website_modules/__manifest__.py
@@ -16,10 +16,7 @@ installed.""",
         'website_event_sale',
         'website_slides',
     ],
-    'data': [
-    ],
     'installable': True,
-    'application': False,
     'assets': {
         'web.assets_tests': [
             'test_website_modules/static/tests/**/*',

--- a/addons/test_xlsx_export/__manifest__.py
+++ b/addons/test_xlsx_export/__manifest__.py
@@ -8,6 +8,5 @@
     'depends': ['web', 'test_mail'],
     'data': ['ir.model.access.csv'],
     'installable': True,
-    'auto_install': False,
     'license': 'LGPL-3',
 }

--- a/addons/theme_default/__manifest__.py
+++ b/addons/theme_default/__manifest__.py
@@ -8,7 +8,6 @@
     'sequence': 1000,
     'version': '1.0',
     'depends': ['website'],
-    'data': [],
     'images': [
         'static/description/cover.png',
         'static/description/theme_default_screenshot.jpg',
@@ -20,7 +19,5 @@
         'pricing': ['s_comparisons'],
         'privacy_policy': ['s_faq_collapse'],
     },
-    'application': False,
-    'auto_install': False,
     'license': 'LGPL-3',
 }

--- a/addons/uom/__manifest__.py
+++ b/addons/uom/__manifest__.py
@@ -17,6 +17,5 @@ This is the base module for managing Units of measure.
         'views/uom_uom_views.xml',
     ],
     'installable': True,
-    'auto_install': False,
     'license': 'LGPL-3',
 }

--- a/addons/utm/__manifest__.py
+++ b/addons/utm/__manifest__.py
@@ -26,7 +26,6 @@ Enable management of UTM trackers: campaign, medium, source.
         'data/utm_campaign_demo.xml',
         'data/utm_stage_demo.xml',
     ],
-    'auto_install': False,
     'assets': {
         'web.assets_backend': [
             'utm/static/src/**/*',

--- a/addons/website/__manifest__.py
+++ b/addons/website/__manifest__.py
@@ -8,7 +8,6 @@
     'summary': 'Enterprise website builder',
     'website': 'https://www.odoo.com/app/website',
     'version': '1.0',
-    'description': "",
     'depends': [
         'digest',
         'web',

--- a/addons/website_blog/__manifest__.py
+++ b/addons/website_blog/__manifest__.py
@@ -8,7 +8,6 @@
     'website': 'https://www.odoo.com/app/blog',
     'summary': 'Publish blog posts, announces, news',
     'version': '1.1',
-    'description': "",
     'depends': ['website_mail', 'website_partner'],
     'data': [
         'data/mail_data.xml',
@@ -26,8 +25,6 @@
     ],
     'demo': [
         'data/website_blog_demo.xml'
-    ],
-    'test': [
     ],
     'installable': True,
     'application': True,

--- a/addons/website_crm_sms/__manifest__.py
+++ b/addons/website_crm_sms/__manifest__.py
@@ -8,7 +8,6 @@
     'version': '1.0',
     'description': """Allows to send sms to website visitor if the visitor is linked to a lead.""",
     'depends': ['website_sms', 'crm'],
-    'data': [],
     'installable': True,
     'auto_install': True,
     'license': 'LGPL-3',

--- a/addons/website_event/__manifest__.py
+++ b/addons/website_event/__manifest__.py
@@ -8,7 +8,6 @@
     'sequence': 140,
     'summary': 'Publish events, sell tickets',
     'website': 'https://www.odoo.com/app/events',
-    'description': "",
     'depends': [
         'event',
         'website',

--- a/addons/website_event_booth_sale/__manifest__.py
+++ b/addons/website_event_booth_sale/__manifest__.py
@@ -12,7 +12,6 @@ Use the e-commerce to sell your event booths.
     'data': [
         'views/event_booth_templates.xml',
     ],
-    'demo': [],
     'auto_install': True,
     'assets': {
         'web.assets_frontend': [

--- a/addons/website_event_booth_sale_exhibitor/__manifest__.py
+++ b/addons/website_event_booth_sale_exhibitor/__manifest__.py
@@ -5,10 +5,7 @@
     'category': 'Marketing/Events',
     'version': '1.0',
     'summary': 'Bridge module between website_event_booth_exhibitor and website_event_booth_sale.',
-    'description': """
-    """,
     'depends': ['website_event_exhibitor', 'website_event_booth_sale'],
-    'data': [],
     'auto_install': True,
     'assets': {
         'web.assets_tests': [

--- a/addons/website_event_crm_questions/__manifest__.py
+++ b/addons/website_event_crm_questions/__manifest__.py
@@ -11,7 +11,6 @@
         the questions and answers linked to the registrations.
     """,
     'depends': ['website_event_crm', 'website_event_questions'],
-    'data': [],
     'installable': True,
     'auto_install': True,
     'license': 'LGPL-3',

--- a/addons/website_event_exhibitor/__manifest__.py
+++ b/addons/website_event_exhibitor/__manifest__.py
@@ -8,7 +8,6 @@
     'version': '1.1',
     'summary': 'Event: manage sponsors and exhibitors',
     'website': 'https://www.odoo.com/app/events',
-    'description': "",
     'depends': [
         'website_event_jitsi',
     ],
@@ -30,7 +29,6 @@
         'data/event_demo.xml',
         'data/event_sponsor_demo.xml',
     ],
-    'application': False,
     'installable': True,
     'assets': {
         'web.assets_frontend': [

--- a/addons/website_event_jitsi/__manifest__.py
+++ b/addons/website_event_jitsi/__manifest__.py
@@ -8,16 +8,13 @@
     'version': '1.0',
     'summary': 'Event / Jitsi',
     'website': 'https://www.odoo.com/app/events',
-    'description': "",
     'depends': [
         'website_event',
         'website_jitsi',
     ],
-    'demo': [],
     'data': [
         'views/res_config_settings_views.xml',
     ],
-    'application': False,
     'auto_install': True,
     'license': 'LGPL-3',
 }

--- a/addons/website_event_meet/__manifest__.py
+++ b/addons/website_event_meet/__manifest__.py
@@ -9,7 +9,6 @@
     'version': '1.0',
     'summary': 'Event: meeting and chat rooms',
     'website': 'https://www.odoo.com/app/events',
-    'description': "",
     'depends': [
         'website_event_jitsi',
     ],
@@ -23,7 +22,6 @@
         'views/event_event_views.xml',
         'views/event_type_views.xml',
     ],
-    'application': False,
     'installable': True,
     'assets': {
         'web.assets_frontend': [

--- a/addons/website_event_meet_quiz/__manifest__.py
+++ b/addons/website_event_meet_quiz/__manifest__.py
@@ -9,7 +9,6 @@
     'version': '1.0',
     'summary': 'Quiz and Meet on community route',
     'website': 'https://www.odoo.com/app/events',
-    'description': "",
     'depends': [
         'website_event_meet',
         'website_event_track_quiz',
@@ -17,9 +16,6 @@
     'data': [
         'views/event_meet_templates.xml',
     ],
-    'demo': [
-    ],
-    'application': False,
     'auto_install': True,
     'license': 'LGPL-3',
 }

--- a/addons/website_event_track/__manifest__.py
+++ b/addons/website_event_track/__manifest__.py
@@ -6,7 +6,6 @@
     'category': 'Marketing',
     'summary': 'Sponsors, Tracks, Agenda, Event News',
     'version': '1.3',
-    'description': "",
     'depends': ['website_event'],
     'data': [
         'security/ir.model.access.csv',

--- a/addons/website_event_track_live/__manifest__.py
+++ b/addons/website_event_track_live/__manifest__.py
@@ -9,7 +9,6 @@
     'version': '1.0',
     'summary': 'Support live tracks: streaming, participation, youtube',
     'website': 'https://www.odoo.com/app/events',
-    'description': "",
     'depends': [
         'website_event_track',
     ],
@@ -21,7 +20,6 @@
     'demo': [
         'data/event_track_demo.xml'
     ],
-    'application': False,
     'installable': True,
     'assets': {
         'web.assets_frontend': [

--- a/addons/website_event_track_live_quiz/__manifest__.py
+++ b/addons/website_event_track_live_quiz/__manifest__.py
@@ -8,7 +8,6 @@
     'version': '1.0',
     'summary': 'Bridge module to support quiz features during "live" tracks. ',
     'website': 'https://www.odoo.com/app/events',
-    'description': "",
     'depends': [
         'website_event_track_live',
         'website_event_track_quiz',
@@ -16,9 +15,6 @@
     'data': [
         'views/event_track_templates_page.xml',
     ],
-    'demo': [
-    ],
-    'application': False,
     'installable': True,
     'auto_install': True,
     'assets': {

--- a/addons/website_event_track_quiz/__manifest__.py
+++ b/addons/website_event_track_quiz/__manifest__.py
@@ -9,7 +9,6 @@
     'version': '1.0',
     'summary': 'Quizzes on tracks',
     'website': 'https://www.odoo.com/app/events',
-    'description': "",
     'depends': [
         'website_profile',
         'website_event_track',
@@ -30,7 +29,6 @@
     'demo': [
         'data/quiz_demo.xml',
     ],
-    'application': False,
     'installable': True,
     'assets': {
         'web.assets_frontend': [

--- a/addons/website_jitsi/__manifest__.py
+++ b/addons/website_jitsi/__manifest__.py
@@ -17,7 +17,6 @@
         'views/chat_room_views.xml',
         'security/ir.model.access.csv',
     ],
-    'application': False,
     'assets': {
         'web.assets_frontend': [
             'website_jitsi/static/src/css/chat_room.css',

--- a/addons/website_livechat/__manifest__.py
+++ b/addons/website_livechat/__manifest__.py
@@ -9,7 +9,6 @@ Allow website visitors to chat with the collaborators. This module also brings a
     """,
     'depends': ['website', 'im_livechat'],
     'installable': True,
-    'application': False,
     'auto_install': True,
     'data': [
         'views/website_livechat.xml',

--- a/addons/website_mail_group/__manifest__.py
+++ b/addons/website_mail_group/__manifest__.py
@@ -4,7 +4,6 @@
 {
     'name': "Website Mail Group",
     'summary': "Add a website snippet for the mail groups.",
-    'description': "",
     'version': '1.0',
     'depends': ['mail_group', 'website'],
     'auto_install': True,

--- a/addons/website_partner/__manifest__.py
+++ b/addons/website_partner/__manifest__.py
@@ -17,6 +17,5 @@ This is a base module. It holds website-related stuff for Contact model (res.par
     ],
     'demo': ['data/website_partner_demo.xml'],
     'installable': True,
-    'auto_install': False,
     'license': 'LGPL-3',
 }

--- a/addons/website_payment_authorize/__manifest__.py
+++ b/addons/website_payment_authorize/__manifest__.py
@@ -7,7 +7,6 @@
     'category': 'Accounting/Payment Acquirers',
     'sequence': 365,
     'summary': 'Website - Payment Authorize',
-    'description': """""",
     'depends': ['website_payment', 'payment_authorize'],
     'data': [
         'views/res_config_settings_views.xml'

--- a/addons/website_payment_paypal/__manifest__.py
+++ b/addons/website_payment_paypal/__manifest__.py
@@ -7,7 +7,6 @@
     'category': 'Accounting/Payment Acquirers',
     'sequence': 365,
     'summary': 'Website - Payment Paypal',
-    'description': """""",
     'depends': ['website_payment', 'payment_paypal'],
     'data': [
         'views/res_config_settings_views.xml'

--- a/addons/website_profile/__manifest__.py
+++ b/addons/website_profile/__manifest__.py
@@ -17,7 +17,6 @@
         'views/website_profile.xml',
         'security/ir.model.access.csv',
     ],
-    'auto_install': False,
     'assets': {
         'web.assets_frontend': [
             'website_profile/static/src/scss/website_profile.scss',

--- a/addons/website_sale/__manifest__.py
+++ b/addons/website_sale/__manifest__.py
@@ -8,7 +8,6 @@
     'summary': 'Sell your products online',
     'website': 'https://www.odoo.com/app/ecommerce',
     'version': '1.1',
-    'description': "",
     'depends': ['website', 'sale', 'website_payment', 'website_mail', 'portal_rating', 'digest'],
     'data': [
         'security/ir.model.access.csv',

--- a/addons/website_utm/__manifest__.py
+++ b/addons/website_utm/__manifest__.py
@@ -2,8 +2,6 @@
 {
     'name': "Website UTM glue code",
     'summary': "Technical module adding utm compatibility to website.",
-    'description': "",
-    'author': "Odoo S.A.",
     'website': "https://www.odoo.com",
     'category': 'Hidden',
     'version': '1.0',

--- a/odoo/addons/base/__manifest__.py
+++ b/odoo/addons/base/__manifest__.py
@@ -10,7 +10,6 @@
 The kernel of Odoo, needed for all installation.
 ===================================================
 """,
-    'depends': [],
     'data': [
         'data/res_bank.xml',
         'data/res.lang.csv',
@@ -87,7 +86,6 @@ The kernel of Odoo, needed for all installation.
         'data/res_partner_demo.xml',
         'data/res_partner_image_demo.xml',
     ],
-    'test': [],
     'installable': True,
     'auto_install': True,
     'post_init_hook': 'post_init',

--- a/odoo/addons/test_assetsbundle/__manifest__.py
+++ b/odoo/addons/test_assetsbundle/__manifest__.py
@@ -10,7 +10,6 @@
         "data/ir_asset.xml",
         "views/views.xml",
     ],
-    'auto_install': False,
 
     'assets': {
         'test_assetsbundle.bundle2': [

--- a/odoo/addons/test_auth_custom/__manifest__.py
+++ b/odoo/addons/test_auth_custom/__manifest__.py
@@ -3,6 +3,5 @@
 {
     'name': 'Tests that custom auth works & is not impaired by CORS',
     'category': 'Hidden',
-    'data': [],
     'license': 'LGPL-3',
 }

--- a/odoo/addons/test_converter/__manifest__.py
+++ b/odoo/addons/test_converter/__manifest__.py
@@ -8,6 +8,5 @@
     'depends': ['base'],
     'data': ['ir.model.access.csv'],
     'installable': True,
-    'auto_install': False,
     'license': 'LGPL-3',
 }

--- a/odoo/addons/test_exceptions/__manifest__.py
+++ b/odoo/addons/test_exceptions/__manifest__.py
@@ -8,6 +8,5 @@
     'depends': ['base'],
     'data': ['view.xml', 'ir.model.access.csv'],
     'installable': True,
-    'auto_install': False,
     'license': 'LGPL-3',
 }

--- a/odoo/addons/test_http/__manifest__.py
+++ b/odoo/addons/test_http/__manifest__.py
@@ -6,7 +6,6 @@
     'description': """A module to test HTTP""",
     'depends': ['base', 'web', 'web_tour'],
     'installable': True,
-    'auto_install': False,
     'data': [
         'data.xml',
         'ir.model.access.csv',

--- a/odoo/addons/test_impex/__manifest__.py
+++ b/odoo/addons/test_impex/__manifest__.py
@@ -7,6 +7,5 @@
     'depends': ['base'],
     'data': ['ir.model.access.csv'],
     'installable': True,
-    'auto_install': False,
     'license': 'LGPL-3',
 }

--- a/odoo/addons/test_inherit/__manifest__.py
+++ b/odoo/addons/test_inherit/__manifest__.py
@@ -10,6 +10,5 @@
         'demo_data.xml',
     ],
     'installable': True,
-    'auto_install': False,
     'license': 'LGPL-3',
 }

--- a/odoo/addons/test_inherit_depends/__manifest__.py
+++ b/odoo/addons/test_inherit_depends/__manifest__.py
@@ -7,6 +7,5 @@
     'description': """A module to verify the inheritance using _inherit across modules.""",
     'depends': ['test_inherit', 'test_new_api'],
     'installable': True,
-    'auto_install': False,
     'license': 'LGPL-3',
 }

--- a/odoo/addons/test_inherits/__manifest__.py
+++ b/odoo/addons/test_inherits/__manifest__.py
@@ -12,6 +12,5 @@
         'demo_data.xml',
     ],
     'installable': True,
-    'auto_install': False,
     'license': 'LGPL-3',
 }

--- a/odoo/addons/test_inherits_depends/__manifest__.py
+++ b/odoo/addons/test_inherits_depends/__manifest__.py
@@ -6,8 +6,6 @@
     'category': 'Hidden/Tests',
     'description': """A module to verify the inheritance using _inherits in non-original modules.""",
     'depends': ['test_inherits'],
-    'data': [],
     'installable': True,
-    'auto_install': False,
     'license': 'LGPL-3',
 }

--- a/odoo/addons/test_limits/__manifest__.py
+++ b/odoo/addons/test_limits/__manifest__.py
@@ -8,6 +8,5 @@
     'depends': ['base'],
     'data': ['ir.model.access.csv'],
     'installable': True,
-    'auto_install': False,
     'license': 'LGPL-3',
 }

--- a/odoo/addons/test_lint/__manifest__.py
+++ b/odoo/addons/test_lint/__manifest__.py
@@ -6,6 +6,5 @@
     'description': """A module to test Odoo code with various linters.""",
     'depends': ['base'],
     'installable': True,
-    'auto_install': False,
     'license': 'LGPL-3',
 }

--- a/odoo/addons/test_new_api/__manifest__.py
+++ b/odoo/addons/test_new_api/__manifest__.py
@@ -8,14 +8,11 @@
     'description': """A module to test the API.""",
     'depends': ['base', 'web', 'web_tour'],
     'installable': True,
-    'auto_install': False,
     'data': [
         'security/ir.model.access.csv',
         'security/test_new_api_security.xml',
         'views/test_new_api_views.xml',
         'data/test_new_api_data.xml',
-    ],
-    'demo': [
     ],
     'assets': {
         'web.assets_tests': [

--- a/odoo/addons/test_populate/__manifest__.py
+++ b/odoo/addons/test_populate/__manifest__.py
@@ -9,6 +9,5 @@
         'ir.model.access.csv',
     ],
     'installable': True,
-    'auto_install': False,
     'license': 'LGPL-3',
 }

--- a/odoo/addons/test_rpc/__manifest__.py
+++ b/odoo/addons/test_rpc/__manifest__.py
@@ -6,7 +6,6 @@
     "description": """A module to test the RPC requests.""",
     "depends": ["base", "web"],
     "installable": True,
-    "auto_install": False,
     "data": ["ir.model.access.csv"],
     'license': 'LGPL-3',
 }

--- a/odoo/addons/test_translation_import/__manifest__.py
+++ b/odoo/addons/test_translation_import/__manifest__.py
@@ -10,7 +10,6 @@
         'view.xml'
     ],
     'installable': True,
-    'auto_install': False,
     'assets': {
         'web.assets_qweb': [
             'test_translation_import/static/src/xml/js_templates.xml',

--- a/odoo/addons/test_uninstall/__manifest__.py
+++ b/odoo/addons/test_uninstall/__manifest__.py
@@ -8,6 +8,5 @@
     'depends': ['base'],
     'data': ['ir.model.access.csv'],
     'installable': True,
-    'auto_install': False,
     'license': 'LGPL-3',
 }


### PR DESCRIPTION
Remove most values uselessly specified because giving the same value as 
the default one (see _DEFAULT_MANIFEST in odoo/modules/module.py)

* auto_install is Falsy by default
* author is Odoo SA by default
* summary & description are empty strings by default
* application is False by default
* test, demo, depends and data are empty lists by default

This will reduce noise/inconsistencies between manifests specifications, 
simplify analysis of manifests content, ...

Enterprise PR: https://github.com/odoo/enterprise/pull/26807

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
