### PR TITLE
Prevent wkhtmltopdf javascript crash without header/footer

### DIFF
--- a/addons/web/views/report_templates.xml
+++ b/addons/web/views/report_templates.xml
@@ -268,16 +268,20 @@
 
                         var index = vars['webpage'].split('.', 4)[3];
                         var header = document.getElementById('minimal_layout_report_headers');
-                        if(header){
+                        if(header &amp;&amp; index in header.children){
                             var companyHeader = header.children[index];
                             header.textContent = '';
                             header.appendChild(companyHeader);
+                        } else if (header) {
+                            header.textContent = '';
                         }
                         var footer = document.getElementById('minimal_layout_report_footers');
-                        if(footer){
+                        if(footer &amp;&amp; index in footer.children){
                             var companyFooter = footer.children[index];
                             footer.textContent = '';
                             footer.appendChild(companyFooter);
+                        } else if (footer) {
+                            footer.textContent = '';
                         }
                     }
                 </script>

--- a/doc/cla/individual/fabienr.md
+++ b/doc/cla/individual/fabienr.md
@@ -1,0 +1,11 @@
+South Africa, 30/4/2022
+
+I hereby agree to the terms of the Odoo Individual Contributor License
+Agreement v1.0.
+
+I declare that I am authorized and able to make this agreement and sign this
+declaration.
+
+Signed,
+
+ROMANO Fabien fabienromano@gmail.com https://github.com/fabienr


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
On OpenBSD 7.1 with odoo-13.0.20220110, both wkhtmltopdf-0.12.5 and wkhtmltopdf-0.12.6 crash when you want to render PDF. Note I did not test the master version but looks like wkhtmltopdf is still required.

Current behavior before PR:
wkhtmltopdf crash : Program terminated with signal SIGSEGV, Segmentation fault.
#0  0x000002a8c1112cea in JSC::Interpreter::unwindCallFrame(JSC::ExecState*&, JSC::JSValue, unsigned int&, JSC::CodeBlock*&) ()

Desired behavior after PR is merged:
PDF rendered and download start.

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
