### PR TITLE
Update project_task_create_timesheet.py

### DIFF
--- a/addons/hr_timesheet/wizard/project_task_create_timesheet.py
+++ b/addons/hr_timesheet/wizard/project_task_create_timesheet.py
@@ -21,7 +21,20 @@ class ProjectTaskCreateTimesheet(models.TransientModel):
     def save_timesheet(self):
         # Deprecated the method in hr_timesheet and overridden in timesheet_grid as config has moved to timesheet_grid.
         # Move the whole wizard to timesheet_grid in master.
-        return self.env['account.analytic.line']
+        values = {
+            'task_id': self.task_id.id,
+            'project_id': self.task_id.project_id.id,
+            'date': fields.Date.context_today(self),
+            'name': self.description,
+            'user_id': self.env.uid,
+            'unit_amount': self.time_spent,
+        }
+        self.task_id.write({
+            'timesheet_timer_start': False,
+            'timesheet_timer_pause': False,
+            'timesheet_timer_last_stop': fields.datetime.now(),
+        })
+        return self.env['account.analytic.line'].create(values)
 
     def action_delete_timesheet(self):
         # Deprecated the method in hr_timesheet and overridden in timesheet_grid as timer mixin has moved to enterprise.


### PR DESCRIPTION
Description of the issue/feature this PR addresses:

Current behavior before PR:When click stop button in project test when timer is running, not created timesheet.

Desired behavior after PR is merged:When click stop button in project test when timer is running, timesheet will be created.




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
