### PR TITLE
[FIX] project: prevent creation of private tasks for others

### DIFF
--- a/addons/project/security/project_security.xml
+++ b/addons/project/security/project_security.xml
@@ -82,10 +82,12 @@
         <field name="name">Project/Task: employees: follow required for follower-only projects</field>
         <field name="model_id" ref="model_project_task"/>
         <field name="domain_force">[
-        '|',
-            ('project_id.privacy_visibility', '!=', 'followers'),
             '|',
-                ('project_id.message_partner_ids', 'in', [user.partner_id.id]),
+                '&amp;',
+                    ('project_id', '!=', False),
+                    '|',
+                        ('project_id.privacy_visibility', '!=', 'followers'),
+                        ('project_id.message_partner_ids', 'in', [user.partner_id.id]),
                 '|',
                     ('message_partner_ids', 'in', [user.partner_id.id]),
                     # to subscribe check access to the record, follower is not enough at creation


### PR DESCRIPTION
Before this commit, the current user can create a private task for
another user.

This commit fixes the access rights to avoid the user to create private
tasks for another user.


--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
