### PR TITLE
[FIX] mail: fix mocked attachment upload

### DIFF
--- a/addons/mail/static/tests/helpers/mock_server.js
+++ b/addons/mail/static/tests/helpers/mock_server.js
@@ -56,7 +56,7 @@ MockServer.include({
     async _performFetch(resource, init) {
         if (resource === '/mail/attachment/upload') {
             const ufile = init.body.get('ufile');
-            const is_pending = init.body.get('is_pending');
+            const is_pending = init.body.get('is_pending') === 'true';
             const model = is_pending ? 'mail.compose.message' : init.body.get('thread_model');
             const id = is_pending ? 0 : parseInt(init.body.get('thread_id'));
             const attachmentId = this._mockCreate('ir.attachment', {


### PR DESCRIPTION
The performFetch method has been rewritten in 14.5. Since then, we're relying
on the is_pending parameter given in the form data. This parameter is used as
if it was a boolean but is in fact a string representation of a boolean. This results
in incorrect  attachments since this parameter is used to determine both the
res_model and the res_id of the created attachment.