### PR TITLE
[FIX] product: fix wrong value for product type in test

### DIFF
--- a/addons/product/tests/test_product_attribute_value_config.py
+++ b/addons/product/tests/test_product_attribute_value_config.py
@@ -680,7 +680,7 @@ class TestProductAttributeValueConfig(TestProductAttributeValueSetup):
         })
         product = self.env['product.template'].create({
             'name': 'P1',
-            'type': 'product',
+            'type': 'consu',
             'attribute_line_ids': [(0, 0, {
                 'attribute_id': product_attribut.id,
                 'value_ids': [(6, 0, [a1.id])],


### PR DESCRIPTION
The test 'test_inactive_related_product_update' raises a ValueError
"Wrong value for product.template.detailed_type: 'product'".
(which causes the L10n nightly build many fails)

See for instance: https://runbot.odoo.com/runbot/batch/760686/build/15077343
