### PR TITLE
[FIX] mrp_account: add an analytic account’s company verification

### DIFF
--- a/addons/mrp_account/i18n/mrp_account.pot
+++ b/addons/mrp_account/i18n/mrp_account.pot
@@ -165,6 +165,20 @@ msgid ""
 msgstr ""
 
 #. module: mrp_account
+#: code:addons/mrp_account/models/mrp_production.py:0
+#, python-format
+msgid ""
+"The selected account belongs to another company than the MO for the product:"
+" %s"
+msgstr ""
+
+#. module: mrp_account
+#: code:addons/mrp_account/models/mrp_bom.py:0
+#, python-format
+msgid "The selected account belongs to another company than the bom: %s"
+msgstr ""
+
+#. module: mrp_account
 #: model_terms:ir.ui.view,arch_db:mrp_account.mrp_production_form_view_inherited
 msgid "Valuation"
 msgstr ""

--- a/addons/mrp_account/models/mrp_bom.py
+++ b/addons/mrp_account/models/mrp_bom.py
@@ -1,10 +1,18 @@
 # -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
-from odoo import fields, models
+from odoo import fields, models, api, _
+from odoo.exceptions import ValidationError
 
 class MrpBom(models.Model):
     _inherit = 'mrp.bom'
 
     analytic_account_id = fields.Many2one('account.analytic.account', 'Analytic Account', company_dependent=True,
+        domain="[('company_id', 'in', [company_id, False])]",
         help="Analytic account in which cost and revenue entries will take place for financial management of the manufacturing order.")
+
+    @api.constrains('analytic_account_id', 'company_id')
+    def _check_analytic_account_id(self):
+        for bom in self:
+            if bom.company_id and bom.analytic_account_id.company_id and bom.company_id != bom.analytic_account_id.company_id:
+                raise ValidationError(_('The selected account belongs to another company than the bom: %s', bom.display_name))

--- a/addons/mrp_account/models/mrp_workorder.py
+++ b/addons/mrp_account/models/mrp_workorder.py
@@ -50,7 +50,7 @@ class MrpWorkorder(models.Model):
             mo_account = wo.production_id.analytic_account_id
             wc_account = wo.workcenter_id.costs_hour_account_id
             if mo_account:
-                is_zero = float_is_zero(value, precision_rounding=mo_account.currency_id.rounding)
+                is_zero = float_is_zero(value, precision_rounding=self.company_id.currency_id.rounding)
                 if wo.mo_analytic_account_line_id:
                     wo.mo_analytic_account_line_id.write({
                         'unit_amount': hours,
@@ -60,7 +60,7 @@ class MrpWorkorder(models.Model):
                     wo_to_link_mo_analytic_line += wo
                     mo_analytic_line_vals_list.append(wo._prepare_analytic_line_values(mo_account, hours, value))
             if wc_account and wc_account != mo_account:
-                is_zero = float_is_zero(value, precision_rounding=wc_account.currency_id.rounding)
+                is_zero = float_is_zero(value, precision_rounding=self.company_id.currency_id.rounding)
                 if wo.wc_analytic_account_line_id:
                     wo.wc_analytic_account_line_id.write({
                         'unit_amount': hours,


### PR DESCRIPTION
Steps to reproduce the bug:
**Bug1:/**
- Install mrp_account
- Enable "Analytic Accounting” in the accounting settings
-  Create an analytic account:
    - Name: “AC”
    - Take the company field empty

- Create a storable product “P1” with BOM:
    - add a Component: “C1”
    - add an operation: “OP1”

- Create a MO:
    - Select the product “P1”
    - miscellaneous tab:
        - Analytic account: “AC”
- Try to confirm the MO

**Problem:**
Traceback is triggered, the currency field in the analytics account is related to the selected company:
https://github.com/odoo/odoo/blob/1dbccc8215d6efe70f3e455a52d04ddb06eba1e3/addons/analytic/models/analytic.py#L67

But as we have not selected any company in the analytics account, this field will be an empty recordset,
so its rounding is 0.0 therefore an error will be triggered when we call the `float_is_zero` function with rounding at 0.0

**Solution:**
we have to use the currency of the company selected in the MO,
because the user can only use analytic accounts of the same company as the MO anyway:

https://github.com/odoo/odoo/blob/594ccdcbf46f83129a2c19bb4a508fa75eadc0ab/addons/analytic/models/analytic_account.py#L199

**Bug2:/**
- Create an analytic account in company B
- Set the component cost to 0
- Creates an MO for company A
- You can use the analytic account of the company B

**Problem:**
You can confirm and validate the MO without an error message because the cost component = 0,
so there will be no analytical account line created, therefore no verification done:
https://github.com/odoo/odoo/blob/594ccdcbf46f83129a2c19bb4a508fa75eadc0ab/addons/analytic/models/analytic_account.py#L195-L199

opw-2833816




https://user-images.githubusercontent.com/78867936/166217869-ecf7a3bc-4ace-4252-8d21-8079b1486218.mp4


--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
