### PR TITLE
[FIX] web: allow Year calendar to display activities on correct dates

### DIFF
--- a/addons/web/static/src/legacy/js/libs/fullcalendar.js
+++ b/addons/web/static/src/legacy/js/libs/fullcalendar.js
@@ -197,8 +197,8 @@ odoo.define('/web/static/src/js/libs/fullcalendar.js', function () {
                     el.classList.remove('fc-has-event');
                 }
                 for (const event of Object.values(this.events)) {
-                    let currentDate = moment(event._instance.range.start);
-                    while (currentDate.isBefore(event._instance.range.end, 'day')) {
+                    let currentDate = moment(event.start);
+                    while (currentDate.isBefore(event.end, 'day')) {
                         const formattedDate = currentDate.format('YYYY-MM-DD');
                         const el = this.el.querySelector(`.fc-day-top[data-date="${formattedDate}"]`);
                         if (el) {


### PR DESCRIPTION
When a timezone before UTC is selected (e.g.: US/Pacific), the highlighted days
of some events are not rendered on the correct day (offseted one day before).
More technically, events wrongly displayed will be the ones where:
      event.start_date.hour < (UTC - current_tz)

Step to reproduce the issue:
1. Change the Odoo user and your computer timezone to any timezone matching the
condition above (e.g.: US/Pacific)
2. Create an event matching the condition above (e.g.: a full day event is
the easiest)
You will see that the day that is highlited is the day before the real date
of the event (e.g.: 14th July is highlited while the event is a whole day
event the 15th of July)

Solution: The issue is that the cursor (highlight of the day), doesn't take
into account the timezone of the calendar (which is the timezone of the
computer). Consequently, the highlight is sometimes done on the wrong day.
As stated in commit [1], the `FullCalendar` library contains a `start` and
`end` property that takes into account the timezone of the calendar (as
described in [2]). Consequently an aside modification was done to use this
properties instead of doing it by hand.

[1]: https://github.com/odoo/odoo/commit/94018575c6ac21fc94591c3265e017c769d87c0c
[2]: https://fullcalendar.io/docs/event-object

opw-2830697
