### PR TITLE
[IMP] mail: use clear to default a computed field

### DIFF
--- a/addons/mail/static/src/models/thread.js
+++ b/addons/mail/static/src/models/thread.js
@@ -1619,7 +1619,7 @@ registerModel({
          */
         _computeTypingStatusText() {
             if (this.orderedOtherTypingMembers.length === 0) {
-                return this.constructor.fields.typingStatusText.default;
+                return clear();
             }
             if (this.orderedOtherTypingMembers.length === 1) {
                 return sprintf(


### PR DESCRIPTION
Computed field that should return default value should use
command `clear()`.