### PR TITLE
[FIX] web: let clickbot properly find modal dialogs

### DIFF
--- a/addons/web/static/src/webclient/clickbot/clickbot.js
+++ b/addons/web/static/src/webclient/clickbot/clickbot.js
@@ -346,7 +346,7 @@
         let isModal = false;
         return waitForCondition(function () {
             // sometimes, the app is just a modal that needs to be closed
-            const $modal = $('.modal[role="dialog"][open="open"]');
+            const $modal = $('.modal[role="dialog"]');
             if ($modal.length > 0) {
                 const closeButton = document.querySelector("header > button.close");
                 if (closeButton) {


### PR DESCRIPTION
When clickbot opens a modal dialog, it should be detected and closed
properly. The `open` attribute was removed from the modal dialogues but
the clickbot tests were successful by accident. Even though the modal was
not found, the script was still able to continue by clicking on other
elements.

By disabling the ability to click on other elements while a dialog is
open , this 590fa18cafe2c commit revealed the truth.

