### PR TITLE
[IMP] mail: decrease space after o_Message_headerDate

### DIFF
--- a/addons/mail/static/src/components/message/message.scss
+++ b/addons/mail/static/src/components/message/message.scss
@@ -57,7 +57,7 @@
 .o_Message_headerDate {
     // Could be replaced by "me-2" after the migration to BS5
     // for the backend AND the frontend
-    margin-inline-end: map-get($spacers, 2);
+    margin-inline-end: map-get($spacers, 1);
 }
 
 .o_Message_highlightIndicator {


### PR DESCRIPTION
Decreases the space after o_Message_headerDate

Example: https://www.awesomescreenshot.com/image/24868111?key=9198ed452bfe4388ce6ba978a1aca993

Task-2793394