### PR TITLE
[FIX] stock: trigger some inter-warehouses RR

### DIFF
--- a/addons/stock/models/stock_move.py
+++ b/addons/stock/models/stock_move.py
@@ -908,15 +908,16 @@ class StockMove(models.Model):
             # for each move that why moves[0] is acceptable
             picking = moves[0]._search_picking_for_assignation()
             if picking:
-                if any(picking.partner_id.id != m.partner_id.id or
-                        picking.origin != m.origin for m in moves):
-                    # If a picking is found, we'll append `move` to its move list and thus its
-                    # `partner_id` and `ref` field will refer to multiple records. In this
-                    # case, we chose to  wipe them.
-                    picking.write({
-                        'partner_id': False,
-                        'origin': False,
-                    })
+                # If a picking is found, we'll append `move` to its move list and thus its
+                # `partner_id` and `ref` field will refer to multiple records. In this
+                # case, we chose to wipe them.
+                vals = {}
+                if any(picking.partner_id.id != m.partner_id.id for m in moves):
+                    vals['partner_id'] = False
+                if any(picking.origin != m.origin for m in moves):
+                    vals['origin'] = False
+                if vals:
+                    picking.write(vals)
             else:
                 new_picking = True
                 picking = Picking.create(moves._get_new_picking_values())

--- a/addons/stock/models/stock_rule.py
+++ b/addons/stock/models/stock_rule.py
@@ -292,7 +292,7 @@ class StockRule(models.Model):
                 partners = move_dest.location_dest_id.get_warehouse().partner_id
                 if len(partners) == 1:
                     partner = partners
-                    move_dest.partner_id = partner
+                move_dest.partner_id = self.location_src_id.get_warehouse().partner_id or self.company_id.partner_id
 
         move_values = {
             'name': name[:2000],

--- a/addons/stock/tests/test_stock_flow.py
+++ b/addons/stock/tests/test_stock_flow.py
@@ -2038,3 +2038,59 @@ class TestStockFlow(TestStockCommon):
         self.assertEqual(picking.state, 'cancel')
         self.assertEqual(move.state, 'cancel')
         self.assertEqual(scrap.move_id.state, 'done')
+
+    def test_assign_sm_to_existing_picking(self):
+        """
+        Suppose:
+            - Two warehouses WH01, WH02
+            - Three products with the route 'WH02 supplied by WH01'
+        We trigger an orderpoint for each product
+        There should be two pickings (out from WH01 + in to WH02)
+        """
+        wh01_address, wh02_address = self.env['res.partner'].create([{
+            'name': 'Address %s' % i,
+            'parent_id': self.env.company.id,
+            'type': 'delivery',
+        } for i in [1, 2]])
+
+        warehouse01 = self.env['stock.warehouse'].search([('company_id', '=', self.env.company.id)], limit=1)
+        warehouse01.partner_id = wh01_address
+        warehouse02 = self.env['stock.warehouse'].create({
+            'name': 'Second Warehouse',
+            'code': 'WH02',
+            'partner_id': wh02_address.id,
+            'resupply_wh_ids': [(6, 0, warehouse01.ids)],
+        })
+
+        wh01_stock_location = warehouse01.lot_stock_id
+        wh02_stock_location = warehouse02.lot_stock_id
+        products = self.productA + self.productB + self.productC
+
+        for product in products:
+            product.route_ids = [(6, 0, warehouse02.resupply_route_ids.ids)]
+            self.env['stock.quant']._update_available_quantity(product, wh01_stock_location, 10)
+            self.env['stock.warehouse.orderpoint'].create({
+                'name': 'RR for %s' % product.name,
+                'warehouse_id': warehouse02.id,
+                'location_id': wh02_stock_location.id,
+                'product_id': product.id,
+                'product_min_qty': 1,
+                'product_max_qty': 5,
+            })
+
+        self.env['procurement.group'].run_scheduler()
+
+        out_moves = self.env['stock.move'].search([('product_id', 'in', products.ids), ('picking_id', '!=', False), ('location_id', '=', wh01_stock_location.id)])
+        in_moves = self.env['stock.move'].search([('product_id', 'in', products.ids), ('picking_id', '!=', False), ('location_dest_id', '=', wh02_stock_location.id)])
+
+        out_picking = out_moves[0].picking_id
+        self.assertEqual(len(out_moves), 3)
+        self.assertEqual(out_moves.product_id, products)
+        self.assertEqual(out_moves.picking_id, out_picking, 'All SM should be part of the same picking')
+        self.assertEqual(out_picking.partner_id, wh02_address, 'It should be an outgoing picking to %s' % wh02_address.display_name)
+
+        in_picking = in_moves[0].picking_id
+        self.assertEqual(len(in_moves), 3)
+        self.assertEqual(in_moves.product_id, products)
+        self.assertEqual(in_moves.picking_id, in_picking, 'All SM should be part of the same picking')
+        self.assertEqual(in_picking.partner_id, wh01_address, 'It should be an incoming picking from %s' % wh01_address.display_name)


### PR DESCRIPTION
When triggering an inter-warehouses reordering rule, the partner of the
receipt is incorrect. When triggering several inter-warehouses
reordering rules, it will remove the partner of both receipt and
delivery

To reproduce the issue:
(Let C be the current company)
1. In Settings, enable "Multi-Step Routes"
2. Let WH01 be the existing warehouse. Edit WH01:
    - Set a new address ADD01:
        - Type: Individual
        - Company: C
        - Address Type: Delivery Address
3. Create a new warehouse WH02:
    - Set a new address ADD02:
        - Type: Individual
        - Company: C
        - Address Type: Delivery Address
4. Edit WH02:
    - Resupply From: WH01
5. Create 2 products PA, PB:
    - Type: Storable
    - Routes:
        - WH02: Supply product from WH01
6. For product PA:
    - Update the quantity:
        - 10 in WH01/Stock
    - Add a reordering rule:
        - Location: WH02/Stock
        - Trigger: Manual
        - Min = Max = 1
7. Run the scheduler
    - It generates a delivery D and a receipt R
8. Open R
    - Error 01: the field "Receive From" is incorrect (ADD02 instead of
ADD01)
9. Repeat step 6 for PB and run the scheduler again
    - Error 02: R and D have no more partner

Error 01: see diff

Error 02: we have two SM (one for PA, one for PB) that have a different
origin (one per reordering rule). Therefore, we remove the origin of the
pickings. However, we also remove the partners while we shouldn't

OPW-2733989