### PR TITLE
[FIX] partner_autocomplete: Partner autocomplete padding fixed to avoid overlap

### DIFF
--- a/addons/partner_autocomplete/static/src/scss/partner_autocomplete.scss
+++ b/addons/partner_autocomplete/static/src/scss/partner_autocomplete.scss
@@ -26,8 +26,8 @@
             overflow: hidden;
             text-overflow: ellipsis;
             position: relative;
-            padding-right: 50px;
-            padding-left: 40px;
+            padding-right: 50px !important;
+            padding-left: 40px !important;
             max-width: 400px;
             > img {
                 position: absolute;


### PR DESCRIPTION
Description of the issue/feature this PR addresses:

Current behavior before PR:

If the company name and email (proposed by the partner autocomplete) is too long, the text goes under the logo of the company.

Desired behavior after PR is merged:

The company name (and email) is clipped to avoid overlapping with the logo.

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
