### PR TITLE
[FIX] account: create sequence index for account.move

### DIFF
--- a/addons/account/models/account_move.py
+++ b/addons/account/models/account_move.py
@@ -40,6 +40,7 @@ class AccountMove(models.Model):
     _sequence_index = "journal_id"
 
     def init(self):
+        super().init()
         self.env.cr.execute("""
             CREATE INDEX IF NOT EXISTS account_move_to_check_idx
             ON account_move(journal_id) WHERE to_check = true;


### PR DESCRIPTION
missed call of the super method leads to missed initialization of mixins.
Particually, the sequence indexes [1] were not created, which led to perofrmance
issues [2]

[1]
https://github.com/odoo/odoo/blame/8b8c94ca90c9d1faa4d735d357af316736b43562/addons/account/models/sequence_mixin.py#L38-L39
[2] opw-2825975

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
