### PR TITLE
[FIX] sale: log notes in salesman/company language

### DIFF
--- a/addons/sale/controllers/portal.py
+++ b/addons/sale/controllers/portal.py
@@ -127,10 +127,15 @@ class CustomerPortal(portal.CustomerPortal):
             if session_obj_date != today:
                 # store the date as a string in the session to allow serialization
                 request.session['view_quote_%s' % order_sudo.id] = today
+                # The "Quotation viewed by customer" log note is an information
+                # dedicated to the salesman and shouldn't be translated in the customer/website lgg
+                context = {'lang': order_sudo.user_id.partner_id.lang or order_sudo.company_id.partner_id.lang}
+                msg = _('Quotation viewed by customer %s', order_sudo.partner_id.name)
+                del context
                 _message_post_helper(
                     "sale.order",
                     order_sudo.id,
-                    message=_('Quotation viewed by customer %s', order_sudo.partner_id.name),
+                    message=msg,
                     token=order_sudo.access_token,
                     message_type="notification",
                     subtype_xmlid="mail.mt_note",


### PR DESCRIPTION
The note "Quotation viewed by customer" posted when a public user
accesses an order on the portal (with a token) was translated in
the "automatic" language, i.e. the website or user (or browser language).

This doesn't make much sense since log notes are not meant to be shown to
the user, only to the internal user(s) (/salesman).

This commit makes sure that the message is not translated in the website/customer lang,
but in the salesman or company language instead.

Task - 2836421


--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
