### PR TITLE
[FIX] sale,sale_product_configurator: company access in price_compute

### DIFF
--- a/addons/sale/static/src/js/variant_mixin.js
+++ b/addons/sale/static/src/js/variant_mixin.js
@@ -55,6 +55,7 @@ var VariantMixin = {
 
         const $parent = $(ev.target).closest('.js_product');
         const combination = this.getSelectedVariantValues($parent);
+        const context = this.context ? this.context : this.getSession() ? this.getSession().user_context : {};
         let parentCombination;
 
         if ($parent.hasClass('main_product')) {
@@ -72,6 +73,7 @@ var VariantMixin = {
                     'add_qty': parseInt($currentOptionalProduct.find('input[name="add_qty"]').val()),
                     'pricelist_id': this.pricelistId || false,
                     'parent_combination': combination,
+                    'context': context,
                 }).then((combinationData) => {
                     this._onChangeCombination(ev, $currentOptionalProduct, combinationData);
                     this._checkExclusions($currentOptionalProduct, childCombination, combinationData.parent_exclusions);
@@ -90,6 +92,7 @@ var VariantMixin = {
             'add_qty': parseInt($parent.find('input[name="add_qty"]').val()),
             'pricelist_id': this.pricelistId || false,
             'parent_combination': parentCombination,
+            'context': context,
         }).then((combinationData) => {
             this._onChangeCombination(ev, $parent, combinationData);
             this._checkExclusions($parent, combination, combinationData.parent_exclusions);

--- a/addons/sale_product_configurator/static/src/js/product_configurator_controller.js
+++ b/addons/sale_product_configurator/static/src/js/product_configurator_controller.js
@@ -129,7 +129,8 @@ var ProductConfiguratorFormController = FormController.extend({
                 ),
                 product_no_variant_attribute_value_ids: changed ? [] : this._getAttributeValueIds(
                     data.product_no_variant_attribute_value_ids
-                )
+                ),
+                context: this.getSession().user_context,
             }
         }).then(function (configurator) {
             self.renderer.configuratorHtml = configurator;

--- a/addons/sale_product_configurator/static/src/js/product_configurator_modal.js
+++ b/addons/sale_product_configurator/static/src/js/product_configurator_modal.js
@@ -79,11 +79,7 @@ var OptionalProductsModal = Dialog.extend(ServicesMixin, VariantMixin, {
             variant_values: self.rootProduct.variant_values,
             pricelist_id: self.pricelistId || false,
             add_qty: self.rootProduct.quantity,
-            kwargs: {
-                context: _.extend({
-                    'quantity': self.rootProduct.quantity
-                }, this.context),
-            }
+            context: _.extend({'quantity': self.rootProduct.quantity}, this.context),
         })
         .then(function (modalContent) {
             if (modalContent) {


### PR DESCRIPTION
There is an access error when using the product configurator in a mutli-
company environment

Steps to reproduce:
1. Install Sales
2. Go to Settings > General Settings > Companies and create a new
company
3. Go to Settings > Sales > Product Catalog and enable Product
Configurator
4. Switch to the new company
5. Go to Sales > Products > Products and create a new product
6. Set the product's company to the new company
7. Add the 'Color' variant on the product with at least two values
8. Go to Sales > Orders > Quotations and create a new quotation
9. Add the new product to the quotation, the product configurator shows
up
10. Increasing the number of product in the configurator will put the
total to 0 and the http request `/sale/get_combination_info` raises an
access error

Solution:
Pass the company in the context of the rpc call

Problem:
If we are in a secondary company, we try to acces the product of this
company from the default company in `price_compute`, which raises the
error

opw-2826227