### PR TITLE
[FIX] base: res.users, include self readable/writable fields in fields_get

### DIFF
--- a/odoo/addons/base/models/res_users.py
+++ b/odoo/addons/base/models/res_users.py
@@ -1578,6 +1578,15 @@ class UsersView(models.Model):
                         'exportable': False,
                         'selectable': False,
                     }
+        # add self readable/writable fields
+        missing = set(self.SELF_WRITEABLE_FIELDS).union(self.SELF_READABLE_FIELDS).difference(res.keys())
+        if allfields:
+            missing = missing.intersection(allfields)
+        if missing:
+            res.update({
+                key: dict(values, readonly=key not in self.SELF_WRITEABLE_FIELDS, searchable=False)
+                for key, values in super(UsersView, self.sudo()).fields_get(missing, attributes).items()
+            })
         return res
 
 class CheckIdentity(models.TransientModel):


### PR DESCRIPTION
The user profile view is loaded using sudo
https://github.com/odoo/odoo/blob/183b021b2f01595caee7fa672cc5f212a9e63075/addons/hr/models/res_users.py#L172-L185
Therefore, there are in the view field nodes which are restricted to some groups,
the user might not belong to.
These fields need to be in the result of the `fields_get` in order for
the web client to be aware of them.

```
/web/static/src/legacy/legacy_load_views.js:75
Uncaught Promise > models[resModel][fieldName] is undefined
```

This issue happens since odoo/odoo#87522
with which the fields are no longer returned in `fields_view_get`,
renamed `get_view`.

The behavior before this revision was weird:
When calling `load_views` on `res.users` to get the profile form view,
you had fields added in the `fields` key of the `form` view
which were not present in the `fields` list key of the main result dict,
which is supposed to have all the fields of the model.
e.g.:
```
{
    'fields': {
    	...
        # address_home_id not there
    },
    'views_fields': {
        'form': {
            'arch': ...,
            'fields': {
		...
                'address_home_id': ....
                ...
            }
        }
    },
}
```
