### PR TITLE
[FIX] sale_timesheet: sale_line_employee_map cost is wrong

### DIFF
--- a/addons/sale_timesheet/models/project_sale_line_employee_map.py
+++ b/addons/sale_timesheet/models/project_sale_line_employee_map.py
@@ -54,6 +54,7 @@ class ProjectProductEmployeeMap(models.Model):
 
     @api.depends('employee_id.timesheet_cost')
     def _compute_cost(self):
+        self.env.remove_to_compute(self._fields['is_cost_changed'], self)
         for map_entry in self:
             if not map_entry.is_cost_changed:
                 map_entry.cost = map_entry.employee_id.timesheet_cost or 0.0

--- a/addons/sale_timesheet/tests/test_project.py
+++ b/addons/sale_timesheet/tests/test_project.py
@@ -8,6 +8,13 @@ from odoo.tests import tagged
 
 @tagged('post_install', '-at_install')
 class TestProject(TestCommonSaleTimesheet):
+
+    def setUp(self):
+        super().setUp()
+        self.project_global.write({
+            'sale_line_id': self.so.order_line[0].id,
+        })
+
     def test_fetch_sale_order_items(self):
         """ Test _fetch_sale_order_items and _get_sale_order_items methods
 
@@ -28,10 +35,6 @@ class TestProject(TestCommonSaleTimesheet):
         self.assertFalse(self.project_non_billable._get_sale_orders())
 
         sale_item = self.so.order_line[0]
-        self.project_global.sale_line_id = sale_item
-        self.project_global.write({
-            'sale_line_id': sale_item.id,
-        })
         self.project_global.invalidate_cache()
         expected_task_sale_order_items = self.project_global.tasks.sale_line_id
         expected_sale_order_items = sale_item | expected_task_sale_order_items
@@ -93,3 +96,30 @@ class TestProject(TestCommonSaleTimesheet):
         self.project_global.allow_billable = False
         self.assertFalse(self.project_global._get_sale_order_items())
         self.assertFalse(self.project_global._get_sale_orders())
+
+    def test_compute_cost_in_employee_mappings(self):
+        self.assertFalse(self.project_global.sale_line_employee_ids)
+        employee_mapping = self.env['project.sale.line.employee.map'] \
+            .with_context(default_project_id=self.project_global.id) \
+            .create({
+                'employee_id': self.employee_manager.id,
+                'sale_line_id': self.project_global.sale_line_id.id,
+            })
+        self.assertFalse(employee_mapping.is_cost_changed)
+        self.assertEqual(employee_mapping.cost, self.employee_manager.timesheet_cost)
+
+        employee_mapping.cost = 5
+        self.assertTrue(employee_mapping.is_cost_changed)
+        self.assertEqual(employee_mapping.cost, 5)
+
+        self.employee_manager.timesheet_cost = 80
+        self.assertTrue(employee_mapping.is_cost_changed)
+        self.assertEqual(employee_mapping.cost, 5)
+
+        employee_mapping.employee_id = self.employee_user
+        self.assertTrue(employee_mapping.is_cost_changed)
+        self.assertEqual(employee_mapping.cost, 5)
+
+        employee_mapping.cost = self.employee_user.timesheet_cost
+        employee_mapping.employee_id = self.employee_company_B
+        self.assertEqual(employee_mapping.cost, self.employee_company_B.timesheet_cost)

--- a/addons/sale_timesheet/views/project_task_views.xml
+++ b/addons/sale_timesheet/views/project_task_views.xml
@@ -46,6 +46,7 @@
                             <field name="sale_line_id" attrs="{'required': True}" options="{'no_create': True}"/>
                             <field name="price_unit" widget="monetary" force_save="1" options="{'currency_field': 'currency_id'}"/>
                             <field name="cost"/>
+                            <field name="is_cost_changed" invisible="1"/>
                             <field name="currency_id" invisible="1"/>
                             <field name="cost_currency_id" invisible="1"/>
                         </tree>


### PR DESCRIPTION
[FIX] sale_timesheet: compute the cost in employee mappings
Before this commit, when the user adds an employee mapping into a
project for an Employee A, the cost does not equal to the timesheet
cost set on this employee. The reason is the `cost` field is
considered as manually edited because of the compute of
`is_cost_changed` field set the `is_cost_changed` to true when the
user changes `employee_id` field in the mapping since the cost (by
default set to 0) is different than the timesheet cost. In fact,
the compute of the cost needs value of `is_cost_changed` field
before setting a value to `cost` field since this compute should
only change the cost if it is not manually edited, that's why the
cost is never equal to the timesheet cost of the employee set on
the mapping.

This commit fixes the issue by removing the compute of
`is_cost_changed` field in the list of recompute fields when we are
in the compute of the `cost` field, because when the `cost` is
recomputed, it means the user has changed or set the employee into
the mapping and so you could avoid computing the `is_cost_changed`
fields. With this change, the compute of `is_cost_changed` will only
trigger when the user manually changes the `cost` field in the
mapping.
Also, the `is_cost_changed` field is added into the view as
invisible to avoid recomputing the field each time we need it, we
could use the cache to avoid recomputing it when it is not
necessarily.

Steps to reproduce:
------------------
1. Go to a billable project
2. Add employee mapping for an employee A

Expected Behavior:
-----------------
The cost of this mapping should be equal to the timesheet cost
set on the employee A.

Actual Behavior:
---------------
The cost of the mapping is equal to 0 because the cost is
considered as manually edited even if it is not the case.

Related PR: https://github.com/odoo/odoo/pull/70527