### PR TITLE
[FIX] mail_group: display Whitelist button if required

### DIFF
--- a/addons/mail_group/views/mail_group_message_views.xml
+++ b/addons/mail_group/views/mail_group_message_views.xml
@@ -52,7 +52,7 @@
                     <button name="action_moderate_allow" string="Whitelist"
                         title="Add this email address to white list of people and accept all pending messages from the same author."
                         type="object" class="btn btn-secondary"
-                        attrs="{'invisible': [('is_group_moderated', '=', False)]}"/>
+                        attrs="{'invisible': ['|', ('author_moderation', '=', 'allow'), ('is_group_moderated', '=', False)]}"/>
                     <button name="%(mail_group_message_reject_action)d"
                         string="Ban" title="Ban this email address and reject all pending messages from the same author and send an email to the author"
                         type="action" class="btn btn-secondary"


### PR DESCRIPTION
Before this commit, Button `Whitelist` was shown even if
email is already whitelisted.

With this commit, we hide button if email is whitelisted.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
