### PR TITLE
[FIX] server: make sure tests are cleaned up with --test-file

### DIFF
--- a/odoo/service/server.py
+++ b/odoo/service/server.py
@@ -1169,9 +1169,9 @@ def load_test_file_py(registry, test_file):
             for mod_mod in get_test_modules(mod):
                 mod_path, _ = os.path.splitext(getattr(mod_mod, '__file__', ''))
                 if test_path == config._normalize(mod_path):
-                    suite = OdooSuite()
-                    for t in unittest.TestLoader().loadTestsFromModule(mod_mod):
-                        suite.addTest(t)
+                    loader = unittest.TestLoader()
+                    loader.suiteClass = OdooSuite
+                    suite = loader.loadTestsFromModule(mod_mod)
                     _logger.log(logging.INFO, 'running tests %s.', mod_mod.__name__)
                     result = odoo.modules.module.OdooTestRunner().run(suite)
                     success = result.wasSuccessful()


### PR DESCRIPTION
**Description of the issue/feature this PR addresses:**

When tests are started with the `--test-file` command line option, the test classes do not run their cleanup functions. This is because the `odoo.tests.common.OdooSuite` class is responsible for cleaning up the tests, but is ultimately not used where it counts. Instead, `unittest.suite.TestSuite` handles it, and it fails to address any of the "class cleanups" that Odoo tests use.

In most cases, this is harmless, as most test modules only contain 1 test class. However, in cases where there are multiple test classes in a module (such as [this recent addition to Odoo 13](https://github.com/odoo/odoo/blob/ebb3bb9176dff9b4c7f615d320025aa3449cdb1b/addons/sale/tests/test_sale_pricelist.py)), attempting to use `--test-file` with it can result in a postgres deadlock due to an unclosed cursor.

**Current behavior before PR:**

Tests are not properly cleaned up when run with `--test-file`, and postgres deadlocks can occur

**Desired behavior after PR is merged:**

Tests are successfully cleaned up when run with `--test-file`, and postgres deadlocks do not occur.



--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
