### PR TITLE
[FIX] account: product category - limit income/expense accounts

### DIFF
--- a/addons/account/views/product_view.xml
+++ b/addons/account/views/product_view.xml
@@ -44,8 +44,8 @@
                 <group name="first" position="after">
                     <group name="account_property" >
                         <group string="Account Properties" groups="account.group_account_user">
-                            <field name="property_account_income_categ_id" domain="[('internal_type','=','other'),('deprecated', '=', False)]"/>
-                            <field name="property_account_expense_categ_id" domain="[('internal_type','=','other'),('deprecated', '=', False)]"/>
+                            <field name="property_account_income_categ_id" domain="[('internal_type','=','other'),('deprecated', '=', False),('internal_group', '=', 'income')]"/>
+                            <field name="property_account_expense_categ_id" domain="[('internal_type','=','other'),('deprecated', '=', False),('internal_group', '=', 'expense')]"/>
                         </group>
                     </group>
                 </group>


### PR DESCRIPTION
For the product categories, the default income and expense accounts
should only contain the income/expense accounts.
Such that the dropdown menu in the product view only lists the possible
income or expense accounts.

task-2835541