### PR TITLE
[FIX] web_editor, website: increase stability of ace test tour

### DIFF
--- a/addons/web_editor/static/src/xml/ace.xml
+++ b/addons/web_editor/static/src/xml/ace.xml
@@ -45,7 +45,7 @@
         </div>
         <div id="ace-view-id">
             <div class="float-right mb-2">
-                <button data-action="reset" type="button" class="btn btn-sm btn-danger"><i class="fa fa-undo"/> Reset</button>
+                <button data-action="reset" type="button" class="btn btn-sm btn-danger d-none"><i class="fa fa-undo"/> Reset</button>
                 <button data-action="format" type="button" class="btn btn-sm btn-link">Format</button>
             </div>
             <span class="o_ace_editor_resource_info"/>

--- a/addons/website/static/tests/tours/html_editor.js
+++ b/addons/website/static/tests/tours/html_editor.js
@@ -212,6 +212,11 @@ tour.register('test_html_editor_scss', {
             trigger: ".o_ace_view_editor button[data-action=save]",
         },
         {
+            content: "wait for reload",
+            trigger: ":not(.o_ace_view_editor)",
+            run: function () {}, // it's a check
+        },
+        {
             content: "reset view (after reload, html editor should have been reopened where it was)",
             trigger: '#ace-view-id button[data-action="reset"]',
         },


### PR DESCRIPTION
 Since [1] the reset button could be clicked before the HTML editor was
reloaded.
The `MutationObserver` in `tour_service.js` is debounced. Because of
this the states used to detect tour steps triggers might differ between
executions.
With the Reset button of the HTML editor not being hidden in the
rendered template, it might be detected before it gets hidden during
the `start` of `ace.js`.

This commit makes sure the the editor is both closed then reopened with
the Reset button visible before clicking on it, and also makes sure the
Reset button is not visible by default upon rendering.

[1]: https://github.com/odoo/odoo/commit/d20468c3463927a54c34688769a22b3949c5c465

runbot-3674

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
