### PR TITLE
[FIX] pos_loyalty: free product reward as orderline with zero price

### DIFF
--- a/addons/point_of_sale/static/src/js/PosComponent.js
+++ b/addons/point_of_sale/static/src/js/PosComponent.js
@@ -8,11 +8,11 @@ odoo.define('point_of_sale.PosComponent', function (require) {
 
     class PosComponent extends LegacyComponent {
         setup() {
-            onRendered(() => {
-                if (this.env.isDebug()) {
-                    console.log('Rendered:', this.constructor.name);
-                }
-            });
+            // onRendered(() => {
+            //     if (this.env.isDebug()) {
+            //         console.log('Rendered:', this.constructor.name);
+            //     }
+            // });
         }
         /**
          * This function is available to all Components that inherit this class.

--- a/addons/point_of_sale/static/src/js/PosComponent.js
+++ b/addons/point_of_sale/static/src/js/PosComponent.js
@@ -8,11 +8,11 @@ odoo.define('point_of_sale.PosComponent', function (require) {
 
     class PosComponent extends LegacyComponent {
         setup() {
-            // onRendered(() => {
-            //     if (this.env.isDebug()) {
-            //         console.log('Rendered:', this.constructor.name);
-            //     }
-            // });
+            onRendered(() => {
+                if (this.env.isDebug()) {
+                    console.log('Rendered:', this.constructor.name);
+                }
+            });
         }
         /**
          * This function is available to all Components that inherit this class.

--- a/addons/point_of_sale/static/src/js/Screens/ProductScreen/ProductScreen.js
+++ b/addons/point_of_sale/static/src/js/Screens/ProductScreen/ProductScreen.js
@@ -149,7 +149,7 @@ odoo.define('point_of_sale.ProductScreen', function(require) {
             // Do not add product if options is undefined.
             if (!options) return;
             // Add the product after having the extra information.
-            this.currentOrder.add_product(product, options);
+            this._addProduct(product, options);
             NumberBuffer.reset();
         }
         _setNumpadMode(event) {
@@ -258,6 +258,9 @@ odoo.define('point_of_sale.ProductScreen', function(require) {
                     merge: false,
                 });
             }
+            this._addProduct(product, options);
+        }
+        _addProduct(product, options) {
             this.currentOrder.add_product(product,  options)
         }
         _barcodePartnerAction(code) {

--- a/addons/pos_loyalty/static/src/js/ControlButtons/RewardButton.js
+++ b/addons/pos_loyalty/static/src/js/ControlButtons/RewardButton.js
@@ -26,14 +26,14 @@ export class RewardButton extends PosComponent {
      */
     async _applyReward(reward, coupon_id) {
         const order = this.env.pos.get_order();
+
+        // Enable reward if disabled.
+        const indexDisabled = order.disabledRewards.findIndex(rewardId => rewardId === reward.id);
+        if (indexDisabled > -1) {
+            order.disabledRewards.splice(indexDisabled, 1);
+        }
+
         if (reward.reward_type === 'product') {
-
-            // Enable reward if disabled.
-            const indexDisabled = order.disabledRewards.findIndex(rewardId => rewardId === reward.id);
-            if (indexDisabled > -1) {
-                order.disabledRewards.splice(indexDisabled, 1);
-            }
-
             let selectedProduct;
             if (reward.multi_product) {
                 const productsList = reward.reward_product_ids.map((product_id) => {

--- a/addons/pos_loyalty/static/src/js/ControlButtons/RewardButton.js
+++ b/addons/pos_loyalty/static/src/js/ControlButtons/RewardButton.js
@@ -55,7 +55,7 @@ export class RewardButton extends PosComponent {
             } else {
                 selectedProduct = this.env.pos.db.get_product_by_id(reward.reward_product_ids[0]);
             }
-            this.env.pos.get_order().add_product(selectedProduct, { quantity: 1 });
+            this.env.pos.get_order().add_product(selectedProduct, { quantity: reward.reward_product_qty });
         } else {
             this.env.pos.get_order()._updateRewards();
         }

--- a/addons/pos_loyalty/static/src/js/ControlButtons/RewardButton.js
+++ b/addons/pos_loyalty/static/src/js/ControlButtons/RewardButton.js
@@ -21,8 +21,9 @@ export class RewardButton extends PosComponent {
      * Applies the reward on the current order, if multiple products can be claimed opens a popup asking for which one.
      *
      * @param {Object} reward
+     * @param {number} coupon_id
      */
-    async _applyReward(reward) {
+    async _applyReward(reward, coupon_id) {
         const order = this.env.pos.get_order();
 
         // Enable reward if disabled.
@@ -55,6 +56,7 @@ export class RewardButton extends PosComponent {
             }
             this.env.pos.get_order().add_product(selectedProduct, { quantity: reward.reward_product_qty });
         } else {
+            this.env.pos.get_order()._applyNonProductReward(reward, coupon_id, {});
             this.env.pos.get_order()._updateRewards();
         }
     }
@@ -69,7 +71,7 @@ export class RewardButton extends PosComponent {
             });
             return false;
         } else if (rewards.length === 1) {
-            return this._applyReward(rewards[0].reward);
+            return this._applyReward(rewards[0].reward, rewards[0].coupon_id);
         } else {
             const rewardsList = rewards.map((reward) => ({
                 id: reward.reward.id,
@@ -81,7 +83,7 @@ export class RewardButton extends PosComponent {
                 list: rewardsList,
             });
             if (confirmed) {
-                return this._applyReward(selectedReward.reward);
+                return this._applyReward(selectedReward.reward, selectedReward.coupon_id);
             }
         }
         return false;

--- a/addons/pos_loyalty/static/src/js/ControlButtons/RewardButton.js
+++ b/addons/pos_loyalty/static/src/js/ControlButtons/RewardButton.js
@@ -25,9 +25,16 @@ export class RewardButton extends PosComponent {
      * @param {Integer} coupon_id 
      */
     async _applyReward(reward, coupon_id) {
+        const order = this.env.pos.get_order();
         if (reward.reward_type === 'product') {
-            let selectedProduct;
 
+            // Enable reward if disabled.
+            const indexDisabled = order.disabledRewards.findIndex(rewardId => rewardId === reward.id);
+            if (indexDisabled > -1) {
+                order.disabledRewards.splice(indexDisabled, 1);
+            }
+
+            let selectedProduct;
             if (reward.multi_product) {
                 const productsList = reward.reward_product_ids.map((product_id) => {
                     const product = this.env.pos.db.get_product_by_id(product_id);

--- a/addons/pos_loyalty/static/src/js/ControlButtons/RewardButton.js
+++ b/addons/pos_loyalty/static/src/js/ControlButtons/RewardButton.js
@@ -1,6 +1,5 @@
 /** @odoo-module **/
 
-import { Gui } from 'point_of_sale.Gui';
 import PosComponent from 'point_of_sale.PosComponent';
 import ProductScreen from 'point_of_sale.ProductScreen';
 import Registries from 'point_of_sale.Registries';
@@ -21,10 +20,9 @@ export class RewardButton extends PosComponent {
     /**
      * Applies the reward on the current order, if multiple products can be claimed opens a popup asking for which one.
      *
-     * @param {Object} reward 
-     * @param {Integer} coupon_id 
+     * @param {Object} reward
      */
-    async _applyReward(reward, coupon_id) {
+    async _applyReward(reward) {
         const order = this.env.pos.get_order();
 
         // Enable reward if disabled.
@@ -71,7 +69,7 @@ export class RewardButton extends PosComponent {
             });
             return false;
         } else if (rewards.length === 1) {
-            return this._applyReward(rewards[0].reward, rewards[0].coupon_id);
+            return this._applyReward(rewards[0].reward);
         } else {
             const rewardsList = rewards.map((reward) => ({
                 id: reward.reward.id,
@@ -83,7 +81,7 @@ export class RewardButton extends PosComponent {
                 list: rewardsList,
             });
             if (confirmed) {
-                return this._applyReward(selectedReward.reward, selectedReward.coupon_id);
+                return this._applyReward(selectedReward.reward);
             }
         }
         return false;

--- a/addons/pos_loyalty/static/src/js/ControlButtons/RewardButton.js
+++ b/addons/pos_loyalty/static/src/js/ControlButtons/RewardButton.js
@@ -32,9 +32,10 @@ export class RewardButton extends PosComponent {
             order.disabledRewards.splice(indexDisabled, 1);
         }
 
+        let selectedProduct;
         if (reward.reward_type === 'product') {
-            let selectedProduct;
             if (reward.multi_product) {
+                // multi_product is always true for number of reward_product_ids more than 1.
                 const productsList = reward.reward_product_ids.map((product_id) => {
                     const product = this.env.pos.db.get_product_by_id(product_id);
                     return {
@@ -54,11 +55,9 @@ export class RewardButton extends PosComponent {
             } else {
                 selectedProduct = this.env.pos.db.get_product_by_id(reward.reward_product_ids[0]);
             }
-            this.env.pos.get_order().add_product(selectedProduct, { quantity: reward.reward_product_qty });
-        } else {
-            this.env.pos.get_order()._applyNonProductReward(reward, coupon_id, {});
-            this.env.pos.get_order()._updateRewards();
         }
+        this.env.pos.get_order().applyReward(reward, coupon_id, { product: selectedProduct });
+        this.env.pos.get_order().updateRewards();
     }
 
     async onClick() {

--- a/addons/pos_loyalty/static/src/js/Loyalty.js
+++ b/addons/pos_loyalty/static/src/js/Loyalty.js
@@ -895,6 +895,9 @@ const PosLoyaltyOrder = (Order) => class PosLoyaltyOrder extends Order {
      * @returns {Array} List of {Object} containing the coupon_id and reward keys
      */
     getClaimableRewards(coupon_id=false, program_id=false, auto=false) {
+        // Loyalty programs can only have claimable rewards when the number of items
+        // of regular lines in the order is more than zero.
+        const numberOfItems = this._get_regular_order_lines().reduce((n, l) => n + l.get_quantity(), 0);
         const allCouponPrograms = Object.values(this.couponPointChanges).map((pe) => {
             return {
                 program_id: pe.program_id,
@@ -905,7 +908,7 @@ const PosLoyaltyOrder = (Order) => class PosLoyaltyOrder extends Order {
                 program_id: coupon.program_id,
                 coupon_id: coupon.id,
             };
-        }));
+        })).filter((p) => (this.pos.program_by_id[p.program_id].program_type == 'loyalty' ? numberOfItems > 0 : true));
         const result = [];
         const totalIsZero = this.get_total_with_tax() === 0;
         const globalDiscountLines = this._getGlobalDiscountLines();

--- a/addons/pos_loyalty/static/src/js/Loyalty.js
+++ b/addons/pos_loyalty/static/src/js/Loyalty.js
@@ -717,6 +717,11 @@ const PosLoyaltyOrder = (Order) => class PosLoyaltyOrder extends Order {
                 const qtyPerProduct = {};
                 let orderedProductPaid = 0;
                 for (const line of orderLines) {
+                    if (line.is_reward_line) {
+                        // TODO-JCB: Really?
+                        // skip reward lines.
+                        continue;
+                    }
 
                     if ((!line.reward_product_id && (rule.any_product || rule.valid_product_ids.has(line.get_product().id))) ||
                         (line.reward_product_id && (rule.any_product || rule.valid_product_ids.has(line.reward_product_id)))) {

--- a/addons/pos_loyalty/static/src/js/Loyalty.js
+++ b/addons/pos_loyalty/static/src/js/Loyalty.js
@@ -201,7 +201,7 @@ const PosLoyaltyOrderline = (Orderline) => class PosLoyaltyOrderline extends Ord
     can_be_merged_with(otherLine) {
         if (this.is_reward_line && otherLine.is_reward_line) {
             if (otherLine.reward_id == this.reward_id) {
-                const reward = this.order.pos.reward_by_id[this.reward_id];
+                const reward = this.pos.reward_by_id[this.reward_id];
                 if (reward && reward.reward_type == 'product') {
                     return otherLine.product.id == this.product.id;
                 }
@@ -222,14 +222,14 @@ const PosLoyaltyOrderline = (Orderline) => class PosLoyaltyOrderline extends Ord
             // force_points_cost can be zero. As long as it's a number, we return it.
             return this.force_points_cost;
         } else {
-            const reward = this.order.pos.reward_by_id[this.reward_id];
+            const reward = this.pos.reward_by_id[this.reward_id];
             const rewardUnitCost = reward.required_points / reward.reward_product_qty;
             return rewardUnitCost * this.get_quantity();
         }
     }
     get_full_product_name() {
         if (this.is_reward_line) {
-            const reward = this.order.pos.reward_by_id[this.reward_id];
+            const reward = this.pos.reward_by_id[this.reward_id];
             if (reward.reward_type == "product") {
                 return super.get_full_product_name() + _t(' (free)');
             }
@@ -560,11 +560,11 @@ const PosLoyaltyOrder = (Order) => class PosLoyaltyOrder extends Order {
      * @return {number} The maximum possible quantity for the given reward line when the remaining points of the coupon is negative.
      */
     _getNewRewardQuantity(rewardLine) {
-        const remainingPoints = rewardLine.order._getRealCouponPoints(rewardLine.coupon_id, true);
+        const remainingPoints = this._getRealCouponPoints(rewardLine.coupon_id, true);
         let correction = 0;
         if (remainingPoints < 0) {
             // We correct the quantity of this line if the remaining points is negative.
-            const reward = rewardLine.order.pos.reward_by_id[rewardLine.reward_id];
+            const reward = rewardLine.pos.reward_by_id[rewardLine.reward_id];
             // NOTE that value of correction is negative.
             correction = this._getClaimableQty(reward, remainingPoints);
         }

--- a/addons/pos_loyalty/static/src/js/Loyalty.js
+++ b/addons/pos_loyalty/static/src/js/Loyalty.js
@@ -366,7 +366,7 @@ const PosLoyaltyOrder = (Order) => class PosLoyaltyOrder extends Order {
 
     _getPotentialReward(product) {
         const claimable = this.getClaimableRewards().find(item => item.reward.reward_product_ids.includes(product.id));
-        if (claimable) {
+        if (claimable && !this.disabledRewards.includes(claimable.reward.id)) {
             return [claimable.reward, claimable.coupon_id, claimable.reward.required_points]
         } else {
             return [false];

--- a/addons/pos_loyalty/static/src/js/Loyalty.js
+++ b/addons/pos_loyalty/static/src/js/Loyalty.js
@@ -423,7 +423,7 @@ const PosLoyaltyOrder = (Order) => class PosLoyaltyOrder extends Order {
      * @returns {{ reward: Reward, coupon_id: number } | undefined}
      */
     _isClaimable(product) {
-        const claimable = this.getClaimableRewards().find(item => item.reward.reward_product_ids.includes(product.id));
+        const claimable = this.getClaimableRewards().find(item => item.reward.reward_type === 'product' && item.reward.reward_product_ids.includes(product.id));
         if (claimable && !this.disabledRewards.includes(claimable.reward.id)) {
             return claimable;
         }
@@ -502,7 +502,7 @@ const PosLoyaltyOrder = (Order) => class PosLoyaltyOrder extends Order {
     }
     async _updateLoyaltyPrograms() {
         if (this.partner && !(this.partner.loyalty_card_id in this.pos.couponCache)) {
-            await this.pos.fetchCoupons([['id', 'in', [this.partner.loyalty_card_id]]], 1);
+            this.pos.couponCache[this.partner.loyalty_card_id] = new PosLoyaltyCard(null, this.partner.loyalty_card_id, this.pos.config.loyalty_program_id[0], this.partner.id, this.partner.loyalty_points);
         }
         await this._checkMissingCoupons();
         await this._updatePrograms();

--- a/addons/pos_loyalty/static/src/js/Loyalty.js
+++ b/addons/pos_loyalty/static/src/js/Loyalty.js
@@ -190,7 +190,7 @@ const PosLoyaltyOrderline = (Orderline) => class PosLoyaltyOrderline extends Ord
                 }
             });
             for (const line of linesToRemove) {
-                this.order.orderlines.remove(line);
+                this.order.remove_orderline(line);
             }
         }
         return super.set_quantity(...arguments);
@@ -466,7 +466,9 @@ const PosLoyaltyOrder = (Order) => class PosLoyaltyOrder extends Order {
         this.codeActivatedProgramRules = [];
         this.codeActivatedCoupons = [];
         this.couponPointChanges = {};
-        this.orderlines.remove(this._get_reward_lines());
+        for (const line of this._get_reward_lines()) {
+            this.remove_orderline(line);
+        }
         this._updateRewards();
     }
     _updateRewards() {
@@ -595,7 +597,7 @@ const PosLoyaltyOrder = (Order) => class PosLoyaltyOrder extends Order {
             } else {
                 claimedRewards.push(claimedReward);
             }
-            this.orderlines.remove(line);
+            this.remove_orderline(line);
         }
         claimedRewards.push(...paymentRewards);
         for (const claimedReward of claimedRewards) {
@@ -992,7 +994,7 @@ const PosLoyaltyOrder = (Order) => class PosLoyaltyOrder extends Order {
                     return _t("A better global discount is already applied.");
                 } else if (rewardId != rewardId.id) {
                     for (const line of globalDiscountLines) {
-                        this.orderlines.remove(line);
+                        this.remove_orderline(line);
                     }
                 }
             }

--- a/addons/pos_loyalty/static/src/js/Loyalty.js
+++ b/addons/pos_loyalty/static/src/js/Loyalty.js
@@ -681,7 +681,7 @@ const PosLoyaltyOrder = (Order) => class PosLoyaltyOrder extends Order {
                         // We only count reward products from the same program to avoid unwanted feedback loops
                         if (line.reward_product_id) {
                             const reward = this.pos.reward_by_id[line.reward_id];
-                            if (program.id !== reward.program_id) {
+                            if (program.id !== reward.program_id.id) {
                                 continue;
                             }
                         }

--- a/addons/pos_loyalty/static/src/js/Loyalty.js
+++ b/addons/pos_loyalty/static/src/js/Loyalty.js
@@ -980,7 +980,7 @@ const PosLoyaltyOrder = (Order) => class PosLoyaltyOrder extends Order {
                 if (reward.reward_type === 'discount' && totalIsZero) {
                     continue;
                 }
-                if (reward.reward_type === 'product' && !reward.multi_product) {
+                if (reward.reward_type === 'product') {
                     const availableQty = this._getClaimableQty(reward, points);
                     if (availableQty <= 0) {
                         continue;

--- a/addons/pos_loyalty/static/src/js/Loyalty.js
+++ b/addons/pos_loyalty/static/src/js/Loyalty.js
@@ -674,7 +674,7 @@ const PosLoyaltyOrder = (Order) => class PosLoyaltyOrder extends Order {
         // Also remove coupons from codeActivatedCoupons if their program applies_on current orders and the program does not give any points
         this.codeActivatedCoupons = this.codeActivatedCoupons.filter((coupon) => {
             const program = this.pos.program_by_id[coupon.program_id];
-            if (program.applies_on === 'current' && pointsAddedPerProgram[program.id].length === 0) {
+            if (program.applies_on === 'current' && pointsAddedPerProgram[program.id].length === 0 && program.rules.length > 0) {
                 return false;
             }
             return true;
@@ -739,13 +739,13 @@ const PosLoyaltyOrder = (Order) => class PosLoyaltyOrder extends Order {
      */
     _getRealCouponPoints(coupon_id, dontClear=false) {
         let points = 0;
+        // Take into account the coupon's balance.
+        const dbCoupon = this.pos.couponCache[coupon_id];
+        if (dbCoupon) {
+            points += dbCoupon.balance;
+        }
         Object.values(this.couponPointChanges).some((pe) => {
             if (pe.coupon_id === coupon_id) {
-                // Take into account the coupon's balance.
-                const dbCoupon = this.pos.couponCache[coupon_id];
-                if (dbCoupon) {
-                    points += dbCoupon.balance;
-                }
                 if (this.pos.program_by_id[pe.program_id].applies_on !== 'future') {
                     points += pe.points;
                 }

--- a/addons/pos_loyalty/static/src/js/Loyalty.js
+++ b/addons/pos_loyalty/static/src/js/Loyalty.js
@@ -201,6 +201,12 @@ const PosLoyaltyOrderline = (Orderline) => class PosLoyaltyOrderline extends Ord
             return this.is_reward_line == otherLine.is_reward_line && super.can_be_merged_with(otherLine);
         }
     }
+    merge(orderline){
+        super.merge(orderline);
+        if (this.points_cost) {
+            this.points_cost += orderline.points_cost || 0;
+        }
+    }
 }
 Registries.Model.extend(Orderline, PosLoyaltyOrderline);
 

--- a/addons/pos_loyalty/static/src/js/Loyalty.js
+++ b/addons/pos_loyalty/static/src/js/Loyalty.js
@@ -739,13 +739,22 @@ const PosLoyaltyOrder = (Order) => class PosLoyaltyOrder extends Order {
      */
     _getRealCouponPoints(coupon_id, dontClear=false) {
         let points = 0;
-        // Take into account the coupon's balance.
+        // Immediately take into account the coupon's balance.
+        // But only if the program is not loyalty. Loyalty programs are
+        // taken into account in couponPointChanges.
         const dbCoupon = this.pos.couponCache[coupon_id];
         if (dbCoupon) {
-            points += dbCoupon.balance;
+            const program = this.pos.program_by_id[dbCoupon.program_id];
+            if (program.program_type != 'loyalty') {
+                points += dbCoupon.balance;
+            }
         }
         Object.values(this.couponPointChanges).some((pe) => {
             if (pe.coupon_id === coupon_id) {
+                const program = this.pos.program_by_id[pe.program_id];
+                if (dbCoupon && program.program_type == 'loyalty') {
+                    points += dbCoupon.balance;
+                }
                 if (this.pos.program_by_id[pe.program_id].applies_on !== 'future') {
                     points += pe.points;
                 }

--- a/addons/pos_loyalty/static/src/js/Loyalty.js
+++ b/addons/pos_loyalty/static/src/js/Loyalty.js
@@ -620,12 +620,12 @@ const PosLoyaltyOrder = (Order) => class PosLoyaltyOrder extends Order {
      * Update our couponPointChanges, meaning the points/coupons each program give etc.
      */
     async _updatePrograms() {
-        const nItems = this._get_regular_order_lines().reduce((n, l) => n + l.get_quantity(), 0);
+        const hasItems = this._get_regular_order_lines().reduce((n, l) => n + l.get_quantity(), 0) > 0;
         const changesPerProgram = {};
         const programsToCheck = new Set();
         // By default include all programs that are considered 'applicable'
         for (const program of this.pos.programs) {
-            if (this._programIsApplicable(program, nItems)) {
+            if (this._programIsApplicable(program, hasItems)) {
                 programsToCheck.add(program.id);
             }
         }
@@ -643,10 +643,10 @@ const PosLoyaltyOrder = (Order) => class PosLoyaltyOrder extends Order {
         const pointsAddedPerProgram = this.pointsForPrograms(programs);
         for (const program of this.pos.programs) {
             // Future programs may split their points per unit paid (gift cards for example), consider a non applicable program to give no points
-            const pointsAdded = this._programIsApplicable(program, nItems) ? pointsAddedPerProgram[program.id] : [];
+            const pointsAdded = this._programIsApplicable(program, hasItems) ? pointsAddedPerProgram[program.id] : [];
             // For programs that apply to both (loyalty) we always add a change of 0 points, if there is none, since it makes it easier to
             //  track for claimable rewards, and makes sure to load the partner's loyalty card.
-            if (program.is_nominative && !pointsAdded.length && this.get_partner() && nItems > 0) {
+            if (program.is_nominative && !pointsAdded.length && this.get_partner() && hasItems) {
                 pointsAdded.push({points: 0});
             }
             const oldChanges = changesPerProgram[program.id] || [];
@@ -790,8 +790,13 @@ const PosLoyaltyOrder = (Order) => class PosLoyaltyOrder extends Order {
         // This type of coupons don't need to really exist up until validating the order, so no need to cache
         return new PosLoyaltyCard(null, null, program.id, (this.get_partner() || {id: -1}).id, 0);
     }
-    _programIsApplicable(program, nItems) {
-        if (program.program_type == 'loyalty' && !(nItems > 0)) {
+    /**
+     * @param {Program} program
+     * @param {boolean} hasItems - whether the order has more than 0 quantity for the regular items
+     * @returns {boolean}
+     */
+    _programIsApplicable(program, hasItems) {
+        if (program.program_type == 'loyalty' && !hasItems) {
             return false;
         }
         if (program.trigger === 'auto' && !program.rules.find((rule) => rule.mode === 'auto' || this.codeActivatedProgramRules.includes(rule.id))) {

--- a/addons/pos_loyalty/static/src/js/Loyalty.js
+++ b/addons/pos_loyalty/static/src/js/Loyalty.js
@@ -224,6 +224,15 @@ const PosLoyaltyOrderline = (Orderline) => class PosLoyaltyOrderline extends Ord
             return rewardUnitCost * this.get_quantity();
         }
     }
+    get_full_product_name() {
+        if (this.is_reward_line) {
+            const reward = this.order.pos.reward_by_id[this.reward_id];
+            if (reward.reward_type == "product") {
+                return super.get_full_product_name() + _t(' (free)');
+            }
+        }
+        return super.get_full_product_name();
+    }
 }
 Registries.Model.extend(Orderline, PosLoyaltyOrderline);
 

--- a/addons/pos_loyalty/static/src/js/Loyalty.js
+++ b/addons/pos_loyalty/static/src/js/Loyalty.js
@@ -154,7 +154,7 @@ const PosLoyaltyOrderline = (Orderline) => class PosLoyaltyOrderline extends Ord
         result.reward_product_id = this.reward_product_id;
         result.coupon_id = this.coupon_id;
         result.reward_identifier_code = this.reward_identifier_code;
-        result.points_cost = this.points_cost;
+        result.points_cost = this.getPointsCost();
         result.force_points_cost = this.force_points_cost;
         result.giftBarcode = this.giftBarcode;
         return result;
@@ -169,7 +169,7 @@ const PosLoyaltyOrderline = (Orderline) => class PosLoyaltyOrderline extends Ord
             this.coupon_id = this.order.oldCouponMapping[json.coupon_id] || json.coupon_id;
             this.reward_identifier_code = json.reward_identifier_code;
             // IMPORTANT: We introduce this field to allow forcing the
-            // value for points_cost, instead of being computed based on
+            // value for `getPointsCost()`, instead of being computed based on
             // the reward object. This is used for discount rewards which
             // needed multiple lines when claiming.
             this.force_points_cost = json.force_points_cost;
@@ -215,7 +215,7 @@ const PosLoyaltyOrderline = (Orderline) => class PosLoyaltyOrderline extends Ord
      * - Otherwise, we compute based on the reward object
      *   and quantity of this orderline.
      */
-    get points_cost() {
+    getPointsCost() {
         if (!this.is_reward_line) {
             return 0;
         } else if (this.is_reward_line && typeof this.force_points_cost == 'number') {
@@ -337,7 +337,7 @@ const PosLoyaltyOrder = (Order) => class PosLoyaltyOrder extends Order {
                     if (reward.program_id.id !== loyaltyProgramId) {
                         continue;
                     }
-                    partner.loyalty_points -= line.points_cost;
+                    partner.loyalty_points -= line.getPointsCost();
                 }
             }
         }
@@ -476,7 +476,7 @@ const PosLoyaltyOrder = (Order) => class PosLoyaltyOrder extends Order {
     /**
      * 1. Apply/update claimable rewards that are not free products.
      * 2. When claimable quantity of the existing free product reward is reduced,
-     *    update it's quantity. Remove it if the claimable quantity becomes zero.
+     *    update its quantity. Remove it if the claimable quantity becomes zero.
      */
     _updateRewards() {
         // Calls are not expected to take some time besides on the first load + when loyalty programs are made applicable
@@ -703,7 +703,7 @@ const PosLoyaltyOrder = (Order) => class PosLoyaltyOrder extends Order {
             if (couponId !== 0) {
                 for (const line of this._get_reward_lines()) {
                     if (line.coupon_id === couponId) {
-                        spent += line.points_cost;
+                        spent += line.getPointsCost();
                     }
                 }
             }
@@ -771,7 +771,7 @@ const PosLoyaltyOrder = (Order) => class PosLoyaltyOrder extends Order {
                     // once we see a reward orderline that is "clear_wallet".
                     return 0;
                 } else {
-                    points -= line.points_cost;
+                    points -= line.getPointsCost();
                 }
             }
         }

--- a/addons/pos_loyalty/static/src/js/PaymentScreen.js
+++ b/addons/pos_loyalty/static/src/js/PaymentScreen.js
@@ -26,9 +26,9 @@ export const PosLoyaltyPaymentScreen = (PaymentScreen) =>
                     continue;
                 }
                 if (!pointChanges[line.coupon_id]) {
-                    pointChanges[line.coupon_id] = -line.points_cost;
+                    pointChanges[line.coupon_id] = -line.getPointsCost();
                 } else {
-                    pointChanges[line.coupon_id] -= line.points_cost;
+                    pointChanges[line.coupon_id] -= line.getPointsCost();
                 }
             }
             // No need to do an rpc if no existing coupon is being used.
@@ -109,7 +109,7 @@ export const PosLoyaltyPaymentScreen = (PaymentScreen) =>
                 if (!couponData[line.coupon_id].line_codes.includes(line.reward_identifier_code)) {
                     !couponData[line.coupon_id].line_codes.push(line.reward_identifier_code);
                 }
-                couponData[line.coupon_id].points -= line.points_cost;
+                couponData[line.coupon_id].points -= line.getPointsCost();
             }
             // We actually do not care about coupons for 'current' programs that did not claim any reward, they will be lost if not validated
             couponData = Object.fromEntries(Object.entries(couponData).filter(([key, value]) => {

--- a/addons/pos_loyalty/static/src/js/ProductScreen.js
+++ b/addons/pos_loyalty/static/src/js/ProductScreen.js
@@ -64,13 +64,16 @@ export const PosLoyaltyProductScreen = (ProductScreen) =>
             }
             if (!selectedLine) return;
             if (selectedLine.is_reward_line && val === 'remove') {
-                this.currentOrder.disabledRewards.push(selectedLine.reward_id);
                 const coupon = this.env.pos.couponCache[selectedLine.coupon_id];
                 if (coupon && coupon.id > 0 && this.currentOrder.codeActivatedCoupons.find((c) => c.code === coupon.code)) {
                     delete this.env.pos.couponCache[selectedLine.coupon_id];
                     this.currentOrder.codeActivatedCoupons.splice(this.currentOrder.codeActivatedCoupons.findIndex((coupon) => {
                         return coupon.id === selectedLine.coupon_id;
                     }), 1);
+                } else {
+                    // Only add to disabledRewards when not from coupon.
+                    // This is because deleting coupon rewards fully deactivates the program.
+                    this.currentOrder.disabledRewards.push(selectedLine.reward_id);
                 }
             }
             if (!selectedLine.is_reward_line || (selectedLine.is_reward_line && val === 'remove')) {

--- a/addons/pos_loyalty/static/src/js/tours/PosLoyaltyFreeProductTour.js
+++ b/addons/pos_loyalty/static/src/js/tours/PosLoyaltyFreeProductTour.js
@@ -1,0 +1,94 @@
+/** @odoo-module **/
+
+import { PosLoyalty } from 'pos_loyalty.tour.PosCouponTourMethods';
+import { ProductScreen } from 'point_of_sale.tour.ProductScreenTourMethods';
+import { getSteps, startSteps } from 'point_of_sale.tour.utils';
+import Tour from 'web_tour.tour';
+
+startSteps();
+
+ProductScreen.do.confirmOpeningPopup();
+ProductScreen.do.clickHomeCategory();
+
+ProductScreen.exec.addOrderline('Desk Organizer', '2');
+
+// At this point, the free_product program is triggered.
+// The reward button should be highlighted.
+PosLoyalty.check.isRewardButtonHighlighted(true);
+// Since the reward button is highlighted, clicking the reward product should be added as reward.
+ProductScreen.do.clickDisplayedProduct('Desk Organizer');
+PosLoyalty.check.hasRewardLine('Desk Organizer (free)', '0.00', '1.00');
+
+// In the succeeding 2 clicks on the product, it is considered as a regular product.
+// In the third click, the product will be added as reward.
+ProductScreen.do.clickDisplayedProduct('Desk Organizer');
+ProductScreen.do.clickDisplayedProduct('Desk Organizer');
+PosLoyalty.check.isRewardButtonHighlighted(true);
+ProductScreen.do.clickDisplayedProduct('Desk Organizer');
+PosLoyalty.check.hasRewardLine('Desk Organizer (free)', '0.00', '2.00');
+
+
+ProductScreen.do.clickDisplayedProduct('Desk Organizer');
+PosLoyalty.check.isRewardButtonHighlighted(false);
+PosLoyalty.check.orderTotalIs('25.50');
+// Finalize order that consumed a reward.
+PosLoyalty.exec.finalizeOrder('Cash', '30');
+
+ProductScreen.do.clickDisplayedProduct('Desk Organizer');
+ProductScreen.check.selectedOrderlineHas('Desk Organizer', '1.00');
+ProductScreen.do.clickDisplayedProduct('Desk Organizer');
+ProductScreen.check.selectedOrderlineHas('Desk Organizer', '2.00');
+ProductScreen.do.clickDisplayedProduct('Desk Organizer');
+PosLoyalty.check.hasRewardLine('Desk Organizer (free)', '0.00', '1.00');
+ProductScreen.do.pressNumpad('Backspace');
+ProductScreen.check.selectedOrderlineHas('Desk Organizer', '0.00');
+ProductScreen.do.clickDisplayedProduct('Desk Organizer');
+ProductScreen.check.selectedOrderlineHas('Desk Organizer', '1.00');
+ProductScreen.do.clickDisplayedProduct('Desk Organizer');
+ProductScreen.check.selectedOrderlineHas('Desk Organizer', '2.00');
+PosLoyalty.check.isRewardButtonHighlighted(true);
+// Finalize order but without the reward.
+// This step is important. When syncing the order, no reward should be synced.
+PosLoyalty.check.orderTotalIs('10.20');
+PosLoyalty.exec.finalizeOrder('Cash', '20');
+
+
+ProductScreen.exec.addOrderline('Magnetic Board', '2');
+PosLoyalty.check.isRewardButtonHighlighted(false);
+ProductScreen.do.clickDisplayedProduct('Magnetic Board');
+PosLoyalty.check.isRewardButtonHighlighted(true);
+ProductScreen.do.clickDisplayedProduct('Whiteboard Pen');
+PosLoyalty.check.isRewardButtonHighlighted(false);
+PosLoyalty.check.hasRewardLine('Whiteboard Pen (free)', '0.00', '1.00');
+
+ProductScreen.do.pressNumpad('6');
+PosLoyalty.check.isRewardButtonHighlighted(true);
+PosLoyalty.do.claimSingleReward();
+PosLoyalty.check.isRewardButtonHighlighted(false);
+PosLoyalty.check.hasRewardLine('Whiteboard Pen (free)', '0.00', '2.00');
+// Finalize order that consumed a reward.
+PosLoyalty.check.orderTotalIs('11.88');
+PosLoyalty.exec.finalizeOrder('Cash', '20');
+
+ProductScreen.exec.addOrderline('Magnetic Board', '6');
+ProductScreen.do.clickDisplayedProduct('Whiteboard Pen');
+PosLoyalty.check.hasRewardLine('Whiteboard Pen (free)', '0.00', '1.00');
+PosLoyalty.check.isRewardButtonHighlighted(true);
+
+ProductScreen.do.clickOrderline('Magnetic Board', '6.00');
+ProductScreen.do.pressNumpad('Backspace');
+// At this point, the reward should have been removed.
+PosLoyalty.check.isRewardButtonHighlighted(false);
+ProductScreen.check.selectedOrderlineHas('Magnetic Board', '0.00');
+ProductScreen.do.clickDisplayedProduct('Magnetic Board');
+ProductScreen.check.selectedOrderlineHas('Magnetic Board', '1.00');
+ProductScreen.do.clickDisplayedProduct('Magnetic Board');
+ProductScreen.check.selectedOrderlineHas('Magnetic Board', '2.00');
+ProductScreen.do.clickDisplayedProduct('Magnetic Board');
+ProductScreen.check.selectedOrderlineHas('Magnetic Board', '3.00');
+PosLoyalty.check.isRewardButtonHighlighted(true);
+
+PosLoyalty.check.orderTotalIs('5.94');
+PosLoyalty.exec.finalizeOrder('Cash', '10');
+
+Tour.register('PosLoyaltyFreeProductTour', { test: true, url: '/pos/web' }, getSteps());

--- a/addons/pos_loyalty/static/src/js/tours/PosLoyaltyFreeProductTour.js
+++ b/addons/pos_loyalty/static/src/js/tours/PosLoyaltyFreeProductTour.js
@@ -2,6 +2,7 @@
 
 import { PosLoyalty } from 'pos_loyalty.tour.PosCouponTourMethods';
 import { ProductScreen } from 'point_of_sale.tour.ProductScreenTourMethods';
+import { SelectionPopup } from 'point_of_sale.tour.SelectionPopupTourMethods';
 import { getSteps, startSteps } from 'point_of_sale.tour.utils';
 import Tour from 'web_tour.tour';
 
@@ -63,7 +64,7 @@ PosLoyalty.check.hasRewardLine('Whiteboard Pen (free)', '0.00', '1.00');
 
 ProductScreen.do.pressNumpad('6');
 PosLoyalty.check.isRewardButtonHighlighted(true);
-PosLoyalty.do.claimSingleReward();
+PosLoyalty.do.clickRewardButton();
 PosLoyalty.check.isRewardButtonHighlighted(false);
 PosLoyalty.check.hasRewardLine('Whiteboard Pen (free)', '0.00', '2.00');
 // Finalize order that consumed a reward.
@@ -89,6 +90,34 @@ ProductScreen.check.selectedOrderlineHas('Magnetic Board', '3.00');
 PosLoyalty.check.isRewardButtonHighlighted(true);
 
 PosLoyalty.check.orderTotalIs('5.94');
+PosLoyalty.exec.finalizeOrder('Cash', '10');
+
+// Promotion: 2 items of shelves, get desk_pad/monitor_stand free
+// This is the 5th order.
+ProductScreen.exec.addOrderline('Wall Shelf Unit', '1');
+PosLoyalty.check.isRewardButtonHighlighted(false);
+ProductScreen.exec.addOrderline('Small Shelf', '1');
+PosLoyalty.check.isRewardButtonHighlighted(true);
+// Click reward product. Should be automatically added as reward.
+ProductScreen.do.clickDisplayedProduct('Desk Pad');
+PosLoyalty.check.isRewardButtonHighlighted(false);
+PosLoyalty.check.hasRewardLine('Desk Pad (free)', '0.00', '1.00');
+// Remove the reward line. The next steps will check if cashier
+// can select from the different reward products.
+PosLoyalty.exec.removeRewardLine('Desk Pad (free)');
+PosLoyalty.check.isRewardButtonHighlighted(true);
+PosLoyalty.do.clickRewardButton();
+SelectionPopup.check.hasSelectionItem('Monitor Stand');
+SelectionPopup.check.hasSelectionItem('Desk Pad');
+SelectionPopup.do.clickItem('Desk Pad');
+PosLoyalty.check.isRewardButtonHighlighted(false);
+PosLoyalty.check.hasRewardLine('Desk Pad (free)', '0.00', '1.00');
+PosLoyalty.exec.removeRewardLine('Desk Pad (free)');
+PosLoyalty.check.isRewardButtonHighlighted(true);
+PosLoyalty.do.claimReward('Monitor Stand');
+PosLoyalty.check.isRewardButtonHighlighted(false);
+PosLoyalty.check.hasRewardLine('Monitor Stand (free)', '0.00', '1.00');
+PosLoyalty.check.orderTotalIs('4.81');
 PosLoyalty.exec.finalizeOrder('Cash', '10');
 
 Tour.register('PosLoyaltyFreeProductTour', { test: true, url: '/pos/web' }, getSteps());

--- a/addons/pos_loyalty/static/src/js/tours/PosLoyaltyLoyaltyProgram.js
+++ b/addons/pos_loyalty/static/src/js/tours/PosLoyaltyLoyaltyProgram.js
@@ -1,0 +1,146 @@
+/** @odoo-module **/
+
+import { PosLoyalty } from 'pos_loyalty.tour.PosCouponTourMethods';
+import { ProductScreen } from 'point_of_sale.tour.ProductScreenTourMethods';
+import { getSteps, startSteps } from 'point_of_sale.tour.utils';
+import Tour from 'web_tour.tour';
+
+startSteps();
+
+ProductScreen.do.confirmOpeningPopup();
+ProductScreen.do.clickHomeCategory();
+
+// Order1: Generates 2 points.
+ProductScreen.exec.addOrderline('Whiteboard Pen', '2');
+ProductScreen.do.clickPartnerButton();
+ProductScreen.do.clickCustomer('Test Partner AAA');
+ProductScreen.do.clickSetCustomer();
+PosLoyalty.check.orderTotalIs('6.40');
+PosLoyalty.exec.finalizeOrder('Cash', '10');
+
+// Order2: Consumes points to get free product.
+ProductScreen.do.clickPartnerButton();
+ProductScreen.do.clickCustomer('Test Partner AAA');
+ProductScreen.do.clickSetCustomer();
+ProductScreen.do.clickDisplayedProduct('Whiteboard Pen');
+ProductScreen.check.selectedOrderlineHas('Whiteboard Pen', '1.00');
+ProductScreen.do.clickDisplayedProduct('Whiteboard Pen');
+ProductScreen.check.selectedOrderlineHas('Whiteboard Pen', '2.00');
+// At this point, Test Partner AAA has 4 points.
+PosLoyalty.check.isRewardButtonHighlighted(true);
+ProductScreen.do.clickDisplayedProduct('Whiteboard Pen');
+PosLoyalty.check.hasRewardLine('Whiteboard Pen (free)', '0.00', '1.00');
+PosLoyalty.check.isRewardButtonHighlighted(false);
+PosLoyalty.check.orderTotalIs('6.40');
+PosLoyalty.exec.finalizeOrder('Cash', '10');
+
+// Order3: Generate 4 points.
+// - Initially gets free product, but was removed automatically by changing the
+//   number of items to zero.
+// - It's impossible to checked here if the free product reward is really removed
+//   so we check in the backend the number of orders that consumed the reward.
+ProductScreen.exec.addOrderline('Whiteboard Pen', '4');
+PosLoyalty.check.orderTotalIs('12.80');
+ProductScreen.do.clickPartnerButton();
+ProductScreen.do.clickCustomer('Test Partner AAA');
+ProductScreen.do.clickSetCustomer();
+PosLoyalty.check.isRewardButtonHighlighted(true);
+ProductScreen.do.clickDisplayedProduct('Whiteboard Pen');
+PosLoyalty.check.hasRewardLine('Whiteboard Pen (free)', '0.00', '1.00');
+PosLoyalty.check.isRewardButtonHighlighted(false);
+ProductScreen.do.pressNumpad('Backspace');
+// At this point, the reward line should have been automatically removed
+// because there is not enough points to purchase it. Unfortunately, we
+// can't check that here.
+PosLoyalty.check.orderTotalIs('0.00');
+ProductScreen.do.clickDisplayedProduct('Whiteboard Pen');
+ProductScreen.check.selectedOrderlineHas('Whiteboard Pen', '1.00');
+ProductScreen.do.clickDisplayedProduct('Whiteboard Pen');
+ProductScreen.check.selectedOrderlineHas('Whiteboard Pen', '2.00');
+ProductScreen.do.clickDisplayedProduct('Whiteboard Pen');
+ProductScreen.check.selectedOrderlineHas('Whiteboard Pen', '3.00');
+ProductScreen.do.clickDisplayedProduct('Whiteboard Pen');
+ProductScreen.check.selectedOrderlineHas('Whiteboard Pen', '4.00');
+PosLoyalty.check.orderTotalIs('12.80');
+PosLoyalty.exec.finalizeOrder('Cash', '20');
+
+Tour.register('PosLoyaltyLoyaltyProgram1', { test: true, url: '/pos/web' }, getSteps());
+
+startSteps();
+
+ProductScreen.do.clickHomeCategory();
+
+// Order1: Immediately set the customer to Test Partner AAA which has 4 points.
+// - He has enough points to purchase a free product but since there is still
+//   no product in the order, reward button should not yet be highlighted.
+// - Furthermore, clicking the reward product should not add it as reward product.
+ProductScreen.do.clickPartnerButton();
+ProductScreen.do.clickCustomer('Test Partner AAA');
+ProductScreen.do.clickSetCustomer();
+PosLoyalty.check.isRewardButtonHighlighted(false);
+ProductScreen.do.clickDisplayedProduct('Whiteboard Pen');
+PosLoyalty.check.isRewardButtonHighlighted(true);
+ProductScreen.do.clickDisplayedProduct('Whiteboard Pen');
+PosLoyalty.check.hasRewardLine('Whiteboard Pen (free)', '0.00', '1.00');
+PosLoyalty.check.isRewardButtonHighlighted(false);
+PosLoyalty.check.orderTotalIs('3.20');
+PosLoyalty.exec.finalizeOrder('Cash', '10');
+
+// Order2: Generate 4 points for Test Partner CCC.
+// - Reference: Order2_CCC
+// - But set Test Partner BBB first as the customer.
+ProductScreen.do.clickPartnerButton();
+ProductScreen.do.clickCustomer('Test Partner BBB');
+ProductScreen.do.clickSetCustomer();
+PosLoyalty.check.isRewardButtonHighlighted(false);
+ProductScreen.do.clickDisplayedProduct('Whiteboard Pen');
+ProductScreen.check.selectedOrderlineHas('Whiteboard Pen', '1.00');
+ProductScreen.do.clickDisplayedProduct('Whiteboard Pen');
+ProductScreen.check.selectedOrderlineHas('Whiteboard Pen', '2.00');
+ProductScreen.do.clickDisplayedProduct('Whiteboard Pen');
+ProductScreen.check.selectedOrderlineHas('Whiteboard Pen', '3.00');
+PosLoyalty.check.isRewardButtonHighlighted(false);
+ProductScreen.do.clickDisplayedProduct('Whiteboard Pen');
+ProductScreen.check.selectedOrderlineHas('Whiteboard Pen', '4.00');
+PosLoyalty.check.isRewardButtonHighlighted(true);
+ProductScreen.do.clickPartnerButton();
+ProductScreen.do.clickCustomer('Test Partner CCC');
+ProductScreen.do.clickSetCustomer();
+PosLoyalty.check.customerIs('Test Partner CCC');
+PosLoyalty.check.orderTotalIs('12.80');
+PosLoyalty.exec.finalizeOrder('Cash', '20');
+
+// Order3: Generate 3 points for Test Partner BBB.
+// - Reference: Order3_BBB
+// - But set Test Partner CCC first as the customer.
+ProductScreen.do.clickPartnerButton();
+ProductScreen.do.clickCustomer('Test Partner CCC');
+ProductScreen.do.clickSetCustomer();
+PosLoyalty.check.isRewardButtonHighlighted(false);
+ProductScreen.exec.addOrderline('Whiteboard Pen', '3');
+ProductScreen.do.clickPartnerButton();
+ProductScreen.do.clickCustomer('Test Partner BBB');
+ProductScreen.do.clickSetCustomer();
+PosLoyalty.check.customerIs('Test Partner BBB');
+PosLoyalty.check.orderTotalIs('9.60');
+PosLoyalty.exec.finalizeOrder('Cash', '10');
+
+// Order4: Should not have reward because the customer will be removed.
+// - Reference: Order4_no_reward
+ProductScreen.do.clickDisplayedProduct('Whiteboard Pen');
+ProductScreen.check.selectedOrderlineHas('Whiteboard Pen', '1.00');
+PosLoyalty.check.isRewardButtonHighlighted(false);
+ProductScreen.do.clickPartnerButton();
+ProductScreen.do.clickCustomer('Test Partner CCC');
+ProductScreen.do.clickSetCustomer();
+PosLoyalty.check.isRewardButtonHighlighted(true);
+PosLoyalty.do.claimSingleReward();
+PosLoyalty.check.hasRewardLine('Whiteboard Pen (free)', '0.00', '1.00');
+ProductScreen.do.clickPartnerButton();
+// This deselects the customer.
+ProductScreen.do.clickSetCustomer();
+PosLoyalty.check.customerIs('Customer');
+PosLoyalty.check.orderTotalIs('3.20');
+PosLoyalty.exec.finalizeOrder('Cash', '10');
+
+Tour.register('PosLoyaltyLoyaltyProgram2', { test: true, url: '/pos/web' }, getSteps());

--- a/addons/pos_loyalty/static/src/js/tours/PosLoyaltyLoyaltyProgram.js
+++ b/addons/pos_loyalty/static/src/js/tours/PosLoyaltyLoyaltyProgram.js
@@ -134,7 +134,7 @@ ProductScreen.do.clickPartnerButton();
 ProductScreen.do.clickCustomer('Test Partner CCC');
 ProductScreen.do.clickSetCustomer();
 PosLoyalty.check.isRewardButtonHighlighted(true);
-PosLoyalty.do.claimSingleReward();
+PosLoyalty.do.clickRewardButton();
 PosLoyalty.check.hasRewardLine('Whiteboard Pen (free)', '0.00', '1.00');
 ProductScreen.do.clickPartnerButton();
 // This deselects the customer.

--- a/addons/pos_loyalty/static/src/js/tours/PosLoyaltyTour.js
+++ b/addons/pos_loyalty/static/src/js/tours/PosLoyaltyTour.js
@@ -40,7 +40,8 @@ PosLoyalty.exec.removeRewardLine('90% on the cheapest product');
 PosLoyalty.check.orderTotalIs('45.90');
 PosLoyalty.do.enterCode('invalid_code', false);
 PosLoyalty.do.enterCode('1234');
-PosLoyalty.check.hasRewardLine('Free Product - Desk Organizer', '-15.30');
+PosLoyalty.do.claimReward('Desk Organizer');
+PosLoyalty.check.hasRewardLine('Desk Organizer (free)', '0.00');
 PosLoyalty.exec.finalizeOrder('Cash', '50');
 
 // Use coupon but eventually remove the reward
@@ -51,10 +52,15 @@ ProductScreen.exec.addOrderline('Desk Organizer', '9');
 PosLoyalty.check.hasRewardLine('90% on the cheapest product', '-4.75');
 PosLoyalty.check.orderTotalIs('62.27');
 PosLoyalty.do.enterCode('5678');
-PosLoyalty.check.hasRewardLine('Free Product - Desk Organizer', '-15.30');
-PosLoyalty.check.orderTotalIs('46.97');
-PosLoyalty.exec.removeRewardLine('Free Product');
-PosLoyalty.check.orderTotalIs('62.27');
+// Clicked product becomes a reward line since it's a claimable reward.
+ProductScreen.do.clickDisplayedProduct('Desk Organizer');
+PosLoyalty.check.hasRewardLine('Desk Organizer (free)', '0.00');
+ProductScreen.do.clickDisplayedProduct('Desk Organizer');
+PosLoyalty.check.hasRewardLine('Desk Organizer (free)', '0.00', '2.00');
+PosLoyalty.exec.removeRewardLine('Desk Organizer (free)');
+// Add new product to change the order total. Important to avoid random runbot error.
+ProductScreen.do.clickDisplayedProduct('Whiteboard Pen');
+PosLoyalty.check.orderTotalIs('67.34');
 PosLoyalty.exec.finalizeOrder('Cash', '90');
 
 // specific product discount
@@ -110,17 +116,24 @@ PosLoyalty.check.hasRewardLine('10% on your order', '-5.15');
 // the discount should change after having free products
 // it should go back to cheapest discount as it is higher
 PosLoyalty.do.enterCode('5678');
-PosLoyalty.check.hasRewardLine('Free Product - Desk Organizer', '-20.40');
+ProductScreen.do.clickDisplayedProduct('Desk Organizer');
+PosLoyalty.check.hasRewardLine('Desk Organizer (free)', '0.00', '1.00');
+ProductScreen.do.clickDisplayedProduct('Desk Organizer');
+PosLoyalty.check.hasRewardLine('Desk Organizer (free)', '0.00', '2.00');
+ProductScreen.do.clickDisplayedProduct('Desk Organizer');
+PosLoyalty.check.hasRewardLine('Desk Organizer (free)', '0.00', '3.00');
+ProductScreen.do.clickDisplayedProduct('Desk Organizer');
+PosLoyalty.check.hasRewardLine('Desk Organizer (free)', '0.00', '4.00');
+ProductScreen.do.clickDisplayedProduct('Desk Organizer');
 PosLoyalty.check.hasRewardLine('90% on the cheapest product', '-4.59');
 // set quantity to 18
 // free qty stays the same since the amount of points on the card only allows for 4 free products
-ProductScreen.do.pressNumpad('Backspace 8')
-PosLoyalty.check.hasRewardLine('10% on your order', '-6.68');
-PosLoyalty.check.hasRewardLine('Free Product - Desk Organizer', '-20.40');
-// scan the code again and check notification
-PosLoyalty.do.enterCode('5678');
-PosLoyalty.check.orderTotalIs('60.13');
-PosLoyalty.exec.finalizeOrder('Cash', '65');
+ProductScreen.do.pressNumpad('1 8')
+// At this point, the number of free products didn't change.
+// TODO: Should the coupon reward (free product) be removed after changing the quantity?
+PosLoyalty.check.hasRewardLine('10% on your order', '-8.72');
+PosLoyalty.check.orderTotalIs('78.49');
+PosLoyalty.exec.finalizeOrder('Cash', '80');
 
 // Specific products discount (with promocode) and free product (1357)
 // Applied programs:
@@ -132,9 +145,12 @@ PosLoyalty.exec.removeRewardLine('90% on the cheapest product');
 PosLoyalty.do.enterCode('promocode', false);
 PosLoyalty.check.hasRewardLine('50% on specific products', '-15.30');
 PosLoyalty.do.enterCode('1357');
-PosLoyalty.check.hasRewardLine('Free Product - Desk Organizer', '-10.20');
-PosLoyalty.check.hasRewardLine('50% on specific products', '-10.20');
-PosLoyalty.check.orderTotalIs('10.20');
+ProductScreen.do.clickDisplayedProduct('Desk Organizer');
+PosLoyalty.check.hasRewardLine('Desk Organizer (free)', '0.00', '1.00');
+ProductScreen.do.clickDisplayedProduct('Desk Organizer');
+PosLoyalty.check.hasRewardLine('Desk Organizer (free)', '0.00', '2.00');
+PosLoyalty.check.hasRewardLine('50% on specific products', '-15.30');
+PosLoyalty.check.orderTotalIs('15.30');
 PosLoyalty.exec.finalizeOrder('Cash', '20');
 
 // Check reset program

--- a/addons/pos_loyalty/static/src/js/tours/PosLoyaltyTourMethods.js
+++ b/addons/pos_loyalty/static/src/js/tours/PosLoyaltyTourMethods.js
@@ -82,8 +82,8 @@ odoo.define('pos_loyalty.tour.PosCouponTourMethods', function (require) {
     }
 
     class Check {
-        hasRewardLine(rewardName, amount) {
-            return [
+        hasRewardLine(rewardName, amount, qty) {
+            const steps = [
                 {
                     content: 'check if reward line is there',
                     trigger: `.orderline.program-reward span.product-name:contains("${rewardName}")`,
@@ -95,6 +95,14 @@ odoo.define('pos_loyalty.tour.PosCouponTourMethods', function (require) {
                     run: function () {},
                 },
             ];
+            if (qty) {
+                steps.push({
+                    content: 'check if the reward qty is correct',
+                    trigger: `.order .orderline.program-reward .product-name:contains("${rewardName}") ~ .info-list em:contains("${qty}")`,
+                    run: function () {},
+                })
+            }
+            return steps;
         }
         orderTotalIs(total_str) {
             return [

--- a/addons/pos_loyalty/static/src/js/tours/PosLoyaltyTourMethods.js
+++ b/addons/pos_loyalty/static/src/js/tours/PosLoyaltyTourMethods.js
@@ -132,6 +132,14 @@ odoo.define('pos_loyalty.tour.PosCouponTourMethods', function (require) {
                 },
             ];
         }
+        customerIs(name) {
+            return [
+                {
+                    trigger: `.actionpad button.set-partner:contains("${name}")`,
+                    run: function () {},
+                }
+            ]
+        }
     }
 
     class Execute {

--- a/addons/pos_loyalty/static/src/js/tours/PosLoyaltyTourMethods.js
+++ b/addons/pos_loyalty/static/src/js/tours/PosLoyaltyTourMethods.js
@@ -59,7 +59,7 @@ odoo.define('pos_loyalty.tour.PosCouponTourMethods', function (require) {
                 },
             ];
         }
-        claimSingleReward() {
+        clickRewardButton() {
             return [
                 {
                     content: 'open reward dialog',

--- a/addons/pos_loyalty/static/src/js/tours/PosLoyaltyTourMethods.js
+++ b/addons/pos_loyalty/static/src/js/tours/PosLoyaltyTourMethods.js
@@ -122,6 +122,16 @@ odoo.define('pos_loyalty.tour.PosCouponTourMethods', function (require) {
                 }
             ]
         }
+        isRewardButtonHighlighted(isHighlighted) {
+            return [
+                {
+                    trigger: isHighlighted
+                        ? '.control-button.highlight:contains("Reward")'
+                        : '.control-button:contains("Reward"):not(:has(.highlight))',
+                    run: function () {}, // it's a check
+                },
+            ];
+        }
     }
 
     class Execute {

--- a/addons/pos_loyalty/tests/test_frontend.py
+++ b/addons/pos_loyalty/tests/test_frontend.py
@@ -135,7 +135,7 @@ class TestUi(TestPointOfSaleHttpCommon):
         )
 
         # check coupon usage
-        self.assertEqual(self.coupon1.points, 0, 'The coupon should have consumed its points.')
+        self.assertEqual(self.coupon1.points, 3.0, 'The coupon should have consumed 1.5 points.')
         self.assertEqual(self.coupon2.points, 4.5, 'The coupon was used but never validated.')
         # check pos_order_count in each program
         self.assertEqual(self.auto_promo_program_current.pos_order_count, 3)


### PR DESCRIPTION
This commit introduces a significant change in the application of free product.

**Before:** Free product reward is represented by an orderline using a dummy product with
negative price that is equivalent to the free product's price.

**After:** Free product reward is now represented by an orderline using the free product itself
with 0 price.

On top of the above change, we also introduce the following fixes/improvements:

- When clicking/scanning product, if it can be a reward, automatically add
  it as reward.
- When reward button is clicked, it should add reward in bulk (qty = `reward_product_qty`).
- Automatically update the free product rewards when decreasing the quantity.
- For loyalty program, we should not allow applying the reward if no item in
  the order.
- Fix loyalty points calculation. Also, properly set the loyalty card when changing partner.
- Suffix "(free)" to free product reward lines.

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
