### PR TITLE
[FIX] web: close dropdown on capture outside click

### DIFF
--- a/addons/web/static/src/core/dropdown/dropdown.js
+++ b/addons/web/static/src/core/dropdown/dropdown.js
@@ -58,7 +58,7 @@ export class Dropdown extends Component {
         // Set up dynamic open/close behaviours --------------------------------
         if (!this.props.manualOnly) {
             // Close on outside click listener
-            useExternalListener(window, "click", this.onWindowClicked);
+            useExternalListener(window, "click", this.onWindowClicked, { capture: true });
             // Listen to all dropdowns state changes
             useBus(Dropdown.bus, "state-changed", ({ detail }) =>
                 this.onDropdownStateChanged(detail)

--- a/addons/web/static/tests/core/dropdown_tests.js
+++ b/addons/web/static/tests/core/dropdown_tests.js
@@ -173,10 +173,23 @@ QUnit.module("Components", ({ beforeEach }) => {
     });
 
     QUnit.test("close on outside click", async (assert) => {
-        class Parent extends Component {}
+        patchWithCleanup(Dropdown.prototype, {
+            close() {
+                assert.step("dropdown will close");
+                this._super();
+            }
+        });
+        class Parent extends Component {
+            clicked() {
+                assert.verifySteps(
+                    ["dropdown will close"],
+                    "the dropdown already knows it should close"
+                );
+            }
+        }
         Parent.template = xml`
         <div>
-          <div class="outside">outside</div>
+          <div class="outside" t-on-click.stop="clicked">outside</div>
           <Dropdown/>
         </div>
       `;

--- a/addons/web/static/tests/helpers/legacy_env_utils.js
+++ b/addons/web/static/tests/helpers/legacy_env_utils.js
@@ -30,6 +30,8 @@ export async function makeLegacyDialogMappingTestEnv() {
     serviceRegistry.add("legacy_dialog_mapping", makeLegacyDialogMappingService(legacyEnv));
 
     const env = await makeTestEnv();
+    legacyEnv.services.hotkey = env.services.hotkey;
+    legacyEnv.services.ui = env.services.ui;
 
     registerCleanup(() => {
         for (const listener of coreBusListeners) {

--- a/addons/web/static/tests/legacy/control_panel/favorite_menu_tests.js
+++ b/addons/web/static/tests/legacy/control_panel/favorite_menu_tests.js
@@ -8,6 +8,7 @@ odoo.define('web.favorite_menu_tests', function (require) {
     const testUtils = require('web.test_utils');
 
     const cpHelpers = require('@web/../tests/search/helpers');
+    const { makeLegacyDialogMappingTestEnv } = require('@web/../tests/helpers/legacy_env_utils');
     const { createControlPanel, createView, mock } = testUtils;
     const { patchDate } = mock;
 
@@ -255,6 +256,7 @@ odoo.define('web.favorite_menu_tests', function (require) {
                 sort: "[]",
                 user_id: [2, "Mitchell Admin"],
             }];
+            const { legacyEnv } = await makeLegacyDialogMappingTestEnv();
             const params = {
                 cpModelConfig: { favoriteFilters, searchMenuTypes },
                 cpProps: { searchMenuTypes, action: {} },
@@ -263,6 +265,7 @@ odoo.define('web.favorite_menu_tests', function (require) {
                     assert.deepEqual(domain, []);
                 },
                 env: {
+                    ...legacyEnv,
                     dataManager: {
                         delete_filter: function () {
                             return Promise.resolve();


### PR DESCRIPTION
Before this commit
An open dropdown stays opened if any other element stop a click event

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
