### PR TITLE
[IMP] mail: improve o_MessageActionList design - alternative

### DIFF
--- a/addons/mail/static/src/components/message/message.scss
+++ b/addons/mail/static/src/components/message/message.scss
@@ -6,12 +6,7 @@
 // will be done, we could use BS5 classes to handle the position values
 // (eg. position-absolute top-0 end-0 mt-n3)
 .o_Message_actionListContainer {
-    @include o-position-absolute($top: - map-get($spacers, 3), $right: 0);
     z-index: 10; // Place the element in front of the Composer when they overlap
-    
-    &.o-squashed {
-        @include o-position-absolute($top: - map-get($spacers, 4), $right: 0);
-    }
 }
 
 .o_Message_authorAvatar {

--- a/addons/mail/static/src/components/message/message.xml
+++ b/addons/mail/static/src/components/message/message.xml
@@ -25,9 +25,8 @@
                 }" t-attf-class="{{ messageView.extraClass }} {{ className }}" t-on-click="messageView.onClick" t-on-mouseenter="messageView.onMouseenter" t-on-mouseleave="messageView.onMouseleave" t-att-data-message-local-id="messageView.message.localId"
                 t-ref="root"
             >
-                <MessageInReplyToView t-if="messageView.messageInReplyToView" messageInReplyToViewLocalId="messageView.messageInReplyToView.localId"/>
-                <div t-if="messageView.isActive and messageView.messageActionList" class="o_Message_actionListContainer position-absolute pl-5 pr-3" t-att-class="{ 'o-squashed': messageView.isSquashed }">
-                    <MessageActionList localId="messageView.messageActionList.localId"/>
+                <div class="o_Message_messageInReply">
+                    <MessageInReplyToView t-if="messageView.messageInReplyToView" messageInReplyToViewLocalId="messageView.messageInReplyToView.localId"/>
                 </div>
                 <div class="d-flex flex-shrink-0">
                     <div class="o_Message_highlightIndicator h-100" t-att-class="{ 'o-active bg-primary': messageView.message.isHighlighted or messageView.isHighlighted }"/>
@@ -64,7 +63,7 @@
                     </div>
                     <div class="o_Message_core flex-grow-1 me-4">
                         <t t-if="!messageView.isSquashed">
-                            <div class="o_Message_header d-flex flex-wrap align-items-baseline ml-2">
+                            <div class="o_Message_header d-flex flex-wrap align-items-baseline mx-2">
                                 <t t-if="messageView.message.author">
                                     <strong class="o_Message_authorName o_Message_authorRedirect o_redirect o_cursor_pointer text-truncate" t-on-click="messageView.onClickAuthorName" title="Open profile">
                                         <t t-if="messageView.message.originThread">
@@ -129,6 +128,10 @@
                                         </Popover>
                                     </t>
                                 </t>
+                                <div class="o_Message_actionList_flexgrow flex-grow-1"/>
+                                <div class="o_Message_actionListContainer flex-shrink-0">
+                                    <MessageActionList localId="messageView.messageActionList.localId"/>
+                                </div>
                             </div>
                         </t>
                         <t t-if="messageView.message.subject and !messageView.message.isSubjectSimilarToOriginThreadName">
@@ -136,7 +139,17 @@
                         </t>
                         <div class="o_Message_content mx-2 text-break" t-ref="content">
                             <t t-if="!messageView.composerViewInEditing">
-                                <div class="o_Message_prettyBody" t-ref="prettyBody"/><!-- messageView.message.prettyBody is inserted here from _update() -->
+                                <div class="o_Message_actionList_Container">
+                                  <t t-if="messageView.isSquashed">
+                                      <div class="o_Message_actionList_autogrow flex-grow-1"/>
+                                      <div class="o_Message_actionListContainer flex-shrink-0">
+                                          <MessageActionList localId="messageView.messageActionList.localId"/>
+                                      </div>
+                                  </t>
+                                </div>
+                                <div class="o_Message_actionList_Container d-flex">
+                                    <div class="o_Message_prettyBody text-wrap" t-ref="prettyBody"/><!-- messageView.message.prettyBody is inserted here from _update() -->
+                                </div>
                             </t>
                             <t t-if="messageView.composerViewInEditing">
                                 <Composer

--- a/addons/mail/static/src/components/message_action_list/message_action_list.scss
+++ b/addons/mail/static/src/components/message_action_list/message_action_list.scss
@@ -1,11 +1,12 @@
-.o_MessageActionList:hover {
-    box-shadow: 0 4px .5rem -.5rem $black;
+.o_MessageActionList_action {
+  opacity: 0.2;
 }
 
 .o_MessageActionList_action:hover {
-    background-color: mix($border-color, $white);
+    opacity: 1;
 }
 
 .o_MessageActionList_actionStar.o_MessageActionList_actionStar_active {
     color: $o-main-favorite-color;
+    opacity: 1;
 }

--- a/addons/mail/static/src/components/message_action_list/message_action_list.xml
+++ b/addons/mail/static/src/components/message_action_list/message_action_list.xml
@@ -2,7 +2,7 @@
 <templates>
     <t t-name="mail.MessageActionList" owl="1">
         <t t-if="messageActionList">
-            <div class="o_MessageActionList d-flex border rounded-sm bg-white" t-attf-class="{{ className }}" t-on-click="messageActionList.onClick" t-ref="root">
+            <div class="o_MessageActionList d-flex rounded-sm" t-attf-class="{{ className }}" t-on-click="messageActionList.onClick" t-ref="root">
                 <i t-if="messageActionList.message.hasReactionIcon" class="o_MessageActionList_action o_MessageActionList_actionReaction fa fa-lg fa-smile-o p-2 o_cursor_pointer" t-att-title="messageActionList.addReactionText" t-on-click="messageActionList.onClickActionReaction" t-ref="actionReaction"/>
                 <PopoverView t-if="messageActionList.reactionPopoverView" localId="messageActionList.reactionPopoverView.localId"/>
                 <span t-if="messageActionList.message.canStarBeToggled" class="o_MessageActionList_action o_MessageActionList_actionStar p-2 o_cursor_pointer" t-att-class="{


### PR DESCRIPTION
Improves the MessageActionList design to move the action buttons in the same
space as the message.

This PR is an alternative to [that PR](https://github.com/odoo/odoo/pull/90167)

This PR does:
    - Put the actionList Container in the same line as the header of an
          un-squashed message
    - Put a blank line on top of each squashed text message
          to put the actionList Container in.

Task-2793394