### PR TITLE
[FIX] base_import: handle server error

### DIFF
--- a/addons/base_import/static/src/js/import_action.js
+++ b/addons/base_import/static/src/js/import_action.js
@@ -42,6 +42,10 @@ function jsonp(form, attributes, callback) {
     }
     _.extend(attributes, {
         dataType: 'script',
+        error: function(res) {
+            $(form).text(res.statusText);
+            $(form).html('<h1>' + $(form).text() + '</h1>');
+        }
     });
     $(form).ajaxSubmit(attributes);
 }


### PR DESCRIPTION
Controller `/base_import/set_file` works as jsonp, i.e. result is executed by
browser as a js-code. However, in case of server error the response may contain
html page. So, user will see the following error with some js traceback:

```
Uncaught SyntaxError: Unexpected token '<'
```

Such error message doesn't explain anything. As a quick solution, this patch
puts text "INTERNAL SERVER ERROR" in the page.

STEPS: import big file (e.g. 500 MB) to provoke Memory Error on the server.

---

opw-2837322

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
