### PR TITLE
[FIX] l10n_za: tax report, fix missing line in computation

### DIFF
--- a/addons/l10n_za/data/account_tax_report_data.xml
+++ b/addons/l10n_za/data/account_tax_report_data.xml
@@ -22,10 +22,10 @@
     </record>
 
     <record id="total_input_tax" model="account.tax.report.line">
-        <field name="name">[19] Total B: TOTAL INPUT TAX (14 + 14A + 15 + 16 + 17 + 18)</field>
+        <field name="name">[19] Total B: TOTAL INPUT TAX (14 + 14A + 15 + 15A + 16 + 17 + 18)</field>
         <field name="report_id" ref="tax_report"/>
         <field name="sequence" eval="2"/>
-        <field name="formula">VAT14 + VAT14A + VAT15 + VAT16 + VAT17 + VAT18</field>
+        <field name="formula">VAT14 + VAT14A + VAT15 + VAT15A + VAT16 + VAT17 + VAT18</field>
         <field name="parent_id" ref='total_vat_payable'/>
     </record>
 


### PR DESCRIPTION
The field 19 (Total Input Tax) should be equal to:
14 + 14A + 15 + 15A + 16 + 17 + 18 as specified in:
https://www.sars.gov.za/wp-content/uploads/Ops/Guides/GEN-ELEC-04-G01-Guide-for-completing-the-Value-Added-Tax-VAT201-Declaration-External-Guide.pdf,
page 26, but 15A was missing.

opw-2832895
task-2841115