### PR TITLE
[FIX] core: docstring of new get_view method

### DIFF
--- a/odoo/models.py
+++ b/odoo/models.py
@@ -1709,11 +1709,12 @@ class BaseModel(metaclass=MetaModel):
 
         :param int view_id: id of the view or None
         :param str view_type: type of the view to return if view_id is None ('form', 'tree', ...)
-        :param dict options: bool options to return additional features:
-            - bool load_filters: returns the model's filters (for search views)
-            - bool mobile: true if the web client is currently using the responsive mobile view
+        :param dict options: boolean options to return additional features:
+
+            - load_filters: returns the model's filters (for search views)
+            - mobile: true if the web client is currently using the responsive mobile view
               (to use kanban views instead of list views for x2many fields)
-            - bool toolbar: true to include contextual actions
+            - toolbar: true to include contextual actions
         :return: composition of the requested view (including inherited views and extensions)
         :rtype: dict
         :raise AttributeError:


### PR DESCRIPTION
Fixing docstring of new get_view method (odoo/odoo#87522),
to include it in the doc (and replace reference to the deprecated
method fields_view_get).

models.py:docstring of odoo.models.BaseModel.get_view:8: WARNING: Unexpected indentation.
models.py:docstring of odoo.models.BaseModel.get_view:9: WARNING: Block quote ends without a blank line; unexpected unindent.

+ some little improvements to the docstring

DOC PR: https://github.com/odoo/documentation/pull/1908

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
