### PR TITLE
[FIX] web_editor: traceback on strikethrough with a checklist

### DIFF
--- a/addons/web_editor/static/lib/odoo-editor/src/commands/commands.js
+++ b/addons/web_editor/static/lib/odoo-editor/src/commands/commands.js
@@ -409,15 +409,17 @@ export function toggleFormat(editor, format) {
     if (isAlreadyFormatted && style.name === 'textDecorationLine') {
         const decoratedPairs = new Set(selectedTextNodes.map(n => [closestElement(n, `[style*="text-decoration-line: ${style.value}"]`), n]));
         for (const [closestDecorated, textNode] of decoratedPairs) {
-            const splitResult = splitAroundUntil(textNode, closestDecorated);
-            const decorationToRemove = splitResult[0] || splitResult[1] || closestDecorated;
-            decorationToRemove.style.removeProperty('text-decoration-line');
-            if (!decorationToRemove.style.cssText) {
-                for (const child of decorationToRemove.childNodes) {
-                    decorationToRemove.before(child);
-                    changedElements.push(child);
+            if (closestDecorated) {
+                const splitResult = splitAroundUntil(textNode, closestDecorated);
+                const decorationToRemove = splitResult[0] || splitResult[1] || closestDecorated;
+                decorationToRemove.style.removeProperty('text-decoration-line');
+                if (!decorationToRemove.style.cssText) {
+                    for (const child of decorationToRemove.childNodes) {
+                        decorationToRemove.before(child);
+                        changedElements.push(child);
+                    }
+                    decorationToRemove.remove();
                 }
-                decorationToRemove.remove();
             }
         }
         if (wasCollapsed) {


### PR DESCRIPTION
**Current behavior before PR:**

When having a checked checklist and clicking on the `strikethrough` gives
traceback.

**Desired behavior after PR is merged:**

No traceback is being generated.

Task-2833325




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
