### PR TITLE
Draft: [POC][IMP] core: use RECURSIVE sub query for child_of

### DIFF
--- a/odoo/addons/base/models/res_partner.py
+++ b/odoo/addons/base/models/res_partner.py
@@ -16,7 +16,7 @@ from werkzeug import urls
 
 from odoo import api, fields, models, tools, SUPERUSER_ID, _
 from odoo.modules import get_module_resource
-from odoo.osv.expression import get_unaccent_wrapper
+from odoo.osv.expression import get_unaccent_wrapper, AND
 from odoo.exceptions import UserError, ValidationError
 
 # Global variables used for the warning fields declared on the res.partner
@@ -756,61 +756,45 @@ class Partner(models.Model):
     def _get_name_search_order_by_fields(self):
         return ''
 
+    def _get_name_search_domain(self, operator, name):
+        return ['|', '|', '|', ('display_name', operator, name),
+                ('ref', operator, name),
+                ('email', operator, name),
+                ('vat', operator, re.sub(r'[^a-zA-Z0-9\-\.]+', '', name))]
+
     @api.model
     def _name_search(self, name, args=None, operator='ilike', limit=100, name_get_uid=None):
-        self = self.with_user(name_get_uid or self.env.uid)
-        # as the implementation is in SQL, we force the recompute of fields if necessary
-        self.recompute(['display_name'])
-        self.flush()
         if args is None:
             args = []
-        order_by_rank = self.env.context.get('res_partner_search_mode') 
+        order_by_rank = self.env.context.get('res_partner_search_mode')
         if (name or order_by_rank) and operator in ('=', 'ilike', '=ilike', 'like', '=like'):
-            self.check_access_rights('read')
-            where_query = self._where_calc(args)
-            self._apply_ir_rules(where_query, 'read')
-            from_clause, where_clause, where_clause_params = where_query.get_sql()
-            from_str = from_clause if from_clause else 'res_partner'
-            where_str = where_clause and (" WHERE %s AND " % where_clause) or ' WHERE '
-
-            # search on the name of the contacts and of its company
-            search_name = name
-            if operator in ('ilike', 'like'):
-                search_name = '%%%s%%' % name
-            if operator in ('=ilike', '=like'):
-                operator = operator[1:]
-
             unaccent = get_unaccent_wrapper(self.env.cr)
+            domain = AND([args, self._get_name_search_domain(operator, name)])
 
-            fields = self._get_name_search_order_by_fields()
+            # don't use _search() because it can be return list of ids
+            model = self.with_user(name_get_uid) if name_get_uid else self
+            model.check_access_rights('read')
+            self._flush_search(domain)
+            query = self._where_calc(domain)
+            self._apply_ir_rules(query, 'read')
+            if limit is not None:
+                query.limit = int(limit)
 
-            query = """SELECT res_partner.id
-                         FROM {from_str}
-                      {where} ({email} {operator} {percent}
-                           OR {display_name} {operator} {percent}
-                           OR {reference} {operator} {percent}
-                           OR {vat} {operator} {percent})
-                           -- don't panic, trust postgres bitmap
-                     ORDER BY {fields} {display_name} {operator} {percent} desc,
-                              {display_name}
-                    """.format(from_str=from_str,
-                               fields=fields,
-                               where=where_str,
-                               operator=operator,
-                               email=unaccent('res_partner.email'),
-                               display_name=unaccent('res_partner.display_name'),
-                               reference=unaccent('res_partner.ref'),
-                               percent=unaccent('%s'),
-                               vat=unaccent('res_partner.vat'),)
-
-            where_clause_params += [search_name]*3  # for email / display_name, reference
-            where_clause_params += [re.sub('[^a-zA-Z0-9\-\.]+', '', search_name) or None]  # for vat
-            where_clause_params += [search_name]  # for order by
-            if limit:
-                query += ' limit %s'
-                where_clause_params.append(limit)
-            self.env.cr.execute(query, where_clause_params)
-            return [row[0] for row in self.env.cr.fetchall()]
+            order = [self._get_name_search_order_by_fields()]
+            if name and limit is not None:
+                search_name = name
+                if operator in ('ilike', 'like'):
+                    search_name = '%%%s%%' % name
+                if operator in ('=ilike', '=like'):
+                    operator = operator[1:]
+                order.append('{display_name} {operator} %s desc,'.format(
+                    display_name=unaccent('res_partner.display_name'),
+                    operator=operator,
+                ))
+                query._where_params += [search_name]
+            order.append(str(unaccent('res_partner.display_name')))
+            query.order = ' '.join(item for item in order if item)
+            return query
 
         return super(Partner, self)._name_search(name, args, operator=operator, limit=limit, name_get_uid=name_get_uid)
 


### PR DESCRIPTION
**Description of the issue/feature this PR addresses:**

It is a POC to improve the search with child_of. Today child_of is not made directly by SQL, it is prepare by ORM (https://github.com/odoo/odoo/blob/14.0/odoo/osv/expression.py#L526), but it can generate some horrible query.

This PR use the WITH RECURCIVE of postgres to do the same things.

Note : This PR include https://github.com/odoo/odoo/pull/89962 (to make the test)
Note 2: This PR is a quick POC

@rco-odoo @odony 

Exemple of ORM query (with 0,5 M of res.partner)
```python
self.env['account.move'].search(['&', ['move_type', '=', 'in_invoice'], '|', '|', '|', '|', ['name', 'ilike', 'a'], ['invoice_origin', 'ilike', 'a'], ['ref', 'ilike', 'a'], ['payment_reference', 'ilike', 'a'], ['partner_id', 'child_of', 'a']])
```

**Before :**
4 sql query with `['in', [lot of values]]`
```SQL
SELECT "res_partner".id FROM "res_partner" 
WHERE ("res_partner"."parent_id" in (29244,680426,672283,29281,29060,29162, ... 271696,47935,47937,47936,608349,608350,608351)) ORDER BY  "res_partner"."id"   
```

```SQL
SELECT "res_partner".id FROM "res_partner" 
WHERE ("res_partner"."parent_id" in (18,127,129,130,131,25024,26420,26421, ... ,684351,684353,684354)) ORDER BY  "res_partner"."id"   
```

```SQL
SELECT "res_partner".id FROM "res_partner" 
WHERE ("res_partner"."parent_id" in (27211,27212,30500,30501,30504,36658,75883, ....85689,115514,117246,119301,119336,129680,130251,204842,334772,481456,501000,609558,625311)) ORDER BY  "res_partner"."id"   
```

```SQL
SELECT "account_move".id FROM "account_move" 
WHERE (("account_move"."move_type" = 'in_invoice') AND (((((unaccent("account_move"."name"::text) ilike unaccent('%a%')) OR (unaccent("account_move"."invoice_origin"::text) ilike unaccent('%a%'))) OR (unaccent("account_move"."ref"::text) ilike unaccent('%a%'))) OR (unaccent("account_move"."payment_reference"::text) ilike unaccent('%a%'))) 
OR ("account_move"."partner_id" in (SELECT "res_partner".id FROM "res_partner" WHERE (("res_partner"."active" = true) 
AND ("res_partner"."id" in (1,7,10,11,16,17,18,103,126,127,129,130, ... 684352,684353,684354,684355))) AND ((("res_partner"."partner_share" IS NULL or "res_partner"."partner_share" = false ) OR ("res_partner"."company_id" in (1))) OR "res_partner"."company_id" IS NULL ))))) AND ("account_move"."company_id" IS NULL  OR ("account_move"."company_id" in (1))) 
ORDER BY  "account_move"."date" DESC,"account_move"."name" DESC,"account_move"."id" DESC  LIMIT 80 
```

Time to execute : 3.68 s
Time to execute search_count: 13.06 s

**After :**
1 sql query

```SQL
SELECT "account_move".id FROM "account_move" WHERE (("account_move"."move_type" = 'in_invoice') AND (((((unaccent("account_move"."name"::text) ilike unaccent('%a%')) OR (unaccent("account_move"."invoice_origin"::text) ilike unaccent('%a%'))) OR (unaccent("account_move"."ref"::text) ilike unaccent('%a%'))) OR (unaccent("account_move"."payment_reference"::text) ilike unaccent('%a%'))) OR ("account_move"."partner_id" in (
            WITH RECURSIVE subordinates AS (
            SELECT "res_partner".id FROM "res_partner" WHERE (("res_partner"."active" = true) AND ((((unaccent("res_partner"."display_name"::text) ilike unaccent('%a%')) OR (unaccent("res_partner"."ref"::text) ilike unaccent('%a%'))) OR (unaccent("res_partner"."email"::text) ilike unaccent('%a%'))) OR (unaccent("res_partner"."vat"::text) ilike unaccent('%a%')))) AND ((("res_partner"."partner_share" IS NULL or "res_partner"."partner_share" = false ) OR ("res_partner"."company_id" in (1))) OR "res_partner"."company_id" IS NULL )
            UNION
            SELECT alias_sub.id FROM "res_partner" alias_sub
            INNER JOIN subordinates s ON s.id = alias_sub.parent_id
            ) SELECT * FROM subordinates)))) AND ("account_move"."company_id" IS NULL  OR ("account_move"."company_id" in (1))) ORDER BY  "account_move"."date" DESC,"account_move"."name" DESC,"account_move"."id" DESC  LIMIT 80 

```

Time to execute : 0,96 s
Time to execute search_count : 10,8 s (Idea : the total of record is show in the tree view, it could be nice to compte in async to prevent a long freeze, because on large database the query with LIMI 80 is more faster than the query to count).


What do you think ?

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
