### PR TITLE
[FIX] account: tax details mapping with misc entry

### DIFF
--- a/addons/account/models/account_move_line_tax_details.py
+++ b/addons/account/models/account_move_line_tax_details.py
@@ -163,10 +163,17 @@ class AccountMoveLine(models.Model):
                     comp_curr.id = account_move_line.company_currency_id
                 JOIN account_move_line_account_tax_rel tax_rel ON
                     tax_rel.account_tax_id = COALESCE(account_move_line.group_tax_id, account_move_line.tax_line_id)
+                JOIN account_move move ON
+                    move.id = account_move_line.move_id
                 JOIN account_move_line base_line ON
                     base_line.id = tax_rel.account_move_line_id
                     AND base_line.tax_repartition_line_id IS NULL
                     AND base_line.move_id = account_move_line.move_id
+                    AND (
+                        move.move_type != 'entry'
+                        OR
+                        sign(account_move_line.balance) = sign(base_line.balance * tax.amount * tax_rep.factor_percent)
+                    )
                     AND COALESCE(base_line.partner_id, 0) = COALESCE(account_move_line.partner_id, 0)
                     AND base_line.currency_id = account_move_line.currency_id
                     AND (


### PR DESCRIPTION
## Goal:
Fix the tax details results when interacting with misc entry containing 2
opposite lines with the same tax.

## The bug:
Wrong mapping in tax details query results in wrong amount in the global tax
report.

### reproduction step pre-requisite:
- a simple sale tax A
- miscellaneous contains 2 lines,
	- amount X debit with sale tax A
	- amount Y credit with purchase tax A
- 2 tax lines gets automatically created

### Before this commit:
The global tax report will display a base amount of 2*(X-Y)
which is wrong.

### After this commit:
The global tax report will display a base amount of (X-Y)
which is correct.

### Context:
When the tax details was made, it wasn't taken into account that there
could be 2 tax line (account_move_line) for the same tax in the same
account_move if the move is a miscellaneous entry (move_type = 'entry').
As a misc can contain both refund and invoice line at the same time (Due to a
PoS order for example), there could be tax_line created by the
invoice_repartition_line and another one created by the refund_repartition_line.
This results in a mapping in which there are some wrong results that should have
been filtered out.
The wrong results are the following match:
invoice_base_line -> refund_tax_line
refund_base_line -> invoice_tax_line

### Solution:

1) To avoid the confusion we just need to filter out the wrong results.
2) In a misc entry, what makes a tax considering the base line as an invoice or
a refund is its balance.
3) In a misc entry, the sign of the tax line balance is the result of a
transformation of the base line sign.

This transformation is just a multiplication by the sign of the tax rate and
the sign of the factor_percent of the tax line repartition line.
This means that we can re apply this transformation to the base_line or the
inverse of it to the tax_line and check if it matches.
If it doesn't, we can confidently discard the match because the tax_line balance
can't be the result of a transformation applied to this base_line balance.

This is only valid for misc entry. In misc entry, negative base_line and
positive base_line are segragated for their tax line creation.

### Additional notes:
A test is added to the enterprise repository to check the global tax report
result.

Ticket: 2832745

Community-PR: https://github.com/odoo/odoo/pull/90399
Enterprise-PR: https://github.com/odoo/enterprise/pull/26827