### PR TITLE
[IMP] fleet: count archived services on vehicle

### DIFF
--- a/addons/fleet/models/fleet_vehicle.py
+++ b/addons/fleet/models/fleet_vehicle.py
@@ -152,32 +152,32 @@ class FleetVehicle(models.Model):
 
     def _compute_count_all(self):
         Odometer = self.env['fleet.vehicle.odometer']
-        LogService = self.env['fleet.vehicle.log.services']
-        LogContract = self.env['fleet.vehicle.log.contract']
+        LogService = self.env['fleet.vehicle.log.services'].with_context(active_test=False)
+        LogContract = self.env['fleet.vehicle.log.contract'].with_context(active_test=False)
         History = self.env['fleet.vehicle.assignation.log']
         odometers_data = Odometer.read_group([('vehicle_id', 'in', self.ids)], ['vehicle_id'], ['vehicle_id'])
-        services_data = LogService.read_group([('vehicle_id', 'in', self.ids)], ['vehicle_id'], ['vehicle_id'])
-        logs_data = LogContract.read_group([('vehicle_id', 'in', self.ids), ('state', '!=', 'closed')], ['vehicle_id'], ['vehicle_id'])
+        services_data = LogService.read_group([('vehicle_id', 'in', self.ids)], ['vehicle_id', 'active'], ['vehicle_id', 'active'], lazy=False)
+        logs_data = LogContract.read_group([('vehicle_id', 'in', self.ids), ('state', '!=', 'closed')], ['vehicle_id', 'active'], ['vehicle_id', 'active'], lazy=False)
         histories_data = History.read_group([('vehicle_id', 'in', self.ids)], ['vehicle_id'], ['vehicle_id'])
 
         mapped_odometer_data = defaultdict(lambda: 0)
-        mapped_service_data = defaultdict(lambda: 0)
-        mapped_log_data = defaultdict(lambda: 0)
+        mapped_service_data = defaultdict(lambda: defaultdict(lambda: 0))
+        mapped_log_data = defaultdict(lambda: defaultdict(lambda: 0))
         mapped_history_data = defaultdict(lambda: 0)
 
         for odometer_data in odometers_data:
             mapped_odometer_data[odometer_data['vehicle_id'][0]] = odometer_data['vehicle_id_count']
         for service_data in services_data:
-            mapped_service_data[service_data['vehicle_id'][0]] = service_data['vehicle_id_count']
+            mapped_service_data[service_data['vehicle_id'][0]][service_data['active']] = service_data['__count']
         for log_data in logs_data:
-            mapped_log_data[log_data['vehicle_id'][0]] = log_data['vehicle_id_count']
+            mapped_log_data[log_data['vehicle_id'][0]][log_data['active']] = log_data['__count']
         for history_data in histories_data:
             mapped_history_data[history_data['vehicle_id'][0]] = history_data['vehicle_id_count']
 
         for vehicle in self:
             vehicle.odometer_count = mapped_odometer_data[vehicle.id]
-            vehicle.service_count = mapped_service_data[vehicle.id]
-            vehicle.contract_count = mapped_log_data[vehicle.id]
+            vehicle.service_count = mapped_service_data[vehicle.id][vehicle.active]
+            vehicle.contract_count = mapped_log_data[vehicle.id][vehicle.active]
             vehicle.history_count = mapped_history_data[vehicle.id]
 
     @api.depends('log_contracts')


### PR DESCRIPTION
When a vehicle is archived, its corresponding services/contracts are archived
as well. However, the corresponding records were no longer counted for
the stat buttons.

TaskID: 2841384

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
