### PR TITLE
[FIX] web_editor: align image to the right

### DIFF
--- a/addons/web_editor/static/src/js/editor/rte.summernote.js
+++ b/addons/web_editor/static/src/js/editor/rte.summernote.js
@@ -431,9 +431,9 @@ eventHandler.modules.editor.floatMe = function ($editable, sValue) {
     var $target = $(getImgTarget($editable));
     $editable.data('NoteHistory').recordUndo();
     switch (sValue) {
-        case 'center': $target.toggleClass('d-block mx-auto').removeClass('float-right float-left'); break;
-        case 'left': $target.toggleClass('float-left').removeClass('float-right d-block mx-auto'); break;
-        case 'right': $target.toggleClass('float-right').removeClass('float-left d-block mx-auto'); break;
+        case 'center': $target.toggleClass('d-block mx-auto').removeClass('float-right float-left ml-auto'); break;
+        case 'left': $target.toggleClass('float-left').removeClass('float-right d-block mx-auto ml-auto'); break;
+        case 'right': $target.toggleClass('ml-auto float-right').removeClass('float-left d-block mx-auto'); break;
     }
 };
 eventHandler.modules.editor.imageShape = function ($editable, sValue) {

--- a/addons/web_editor/static/src/scss/web_editor.common.scss
+++ b/addons/web_editor/static/src/scss/web_editor.common.scss
@@ -199,6 +199,9 @@ img.ml-auto, img.mx-auto {
     display: block;
     text-align: center;
 }
+.fa.card-img, .fa.card-img-top, .fa.card-img-bottom {
+    width: auto;
+}
 
 div.media_iframe_video {
     margin: 0 auto;


### PR DESCRIPTION
Align images to the right by using an auto left margin.

Steps to reproduce:
- Drop a "Columns" block.
- Select an image.
- Resize image to 50%.
- Align image to the right.
=> Image did not get aligned to the right.

This PR also makes it possible for icons to be aligned.

task-2841127
