### PR TITLE
[FIX] fleet: fix fuel types

### DIFF
--- a/addons/fleet/models/fleet_vehicle_model.py
+++ b/addons/fleet/models/fleet_vehicle_model.py
@@ -7,8 +7,7 @@ from odoo import _, api, fields, models
 FUEL_TYPES = [
     ('diesel', 'Diesel'),
     ('gasoline', 'Gasoline'),
-    ('hybrid', 'Hybrid Diesel'),
-    ('full_hybrid_gasoline', 'Hybrid Gasoline'),
+    ('full_hybrid', 'Full Hybrid'),
     ('plug_in_hybrid_diesel', 'Plug-in Hybrid Diesel'),
     ('plug_in_hybrid_gasoline', 'Plug-in Hybrid Gasoline'),
     ('cng', 'CNG'),


### PR DESCRIPTION
There shouldn't be a distinction between full hybrids.
'hybrid' and 'full_hybrid_gasoline' are replaced in this commit by a unique 'full_hybrid'.
fixes task 2629318

taskID 2753096