### PR TITLE
[FIX] point_of_sale: misleading actions names for home action

### DIFF
--- a/addons/point_of_sale/data/point_of_sale_data.xml
+++ b/addons/point_of_sale/data/point_of_sale_data.xml
@@ -3,7 +3,7 @@
     <data noupdate="1">
         <!-- After closing the PoS, open the dashboard menu -->
         <record id="action_client_pos_menu" model="ir.actions.client">
-            <field name="name">Open POS Menu</field>
+            <field name="name">Reload POS Menu</field>
             <field name="tag">reload</field>
             <field name="params" eval="{'menu_id': ref('menu_point_root')}"/>
         </record>

--- a/addons/point_of_sale/i18n/point_of_sale.pot
+++ b/addons/point_of_sale/i18n/point_of_sale.pot
@@ -3345,11 +3345,6 @@ msgid "Open Cashbox"
 msgstr ""
 
 #. module: point_of_sale
-#: model:ir.actions.client,name:point_of_sale.action_client_pos_menu
-msgid "Open POS Menu"
-msgstr ""
-
-#. module: point_of_sale
 #: model:ir.model.fields,help:point_of_sale.field_pos_payment_method__open_session_ids
 msgid "Open PoS sessions that are using this payment method."
 msgstr ""
@@ -4651,6 +4646,11 @@ msgstr ""
 #. module: point_of_sale
 #: model_terms:ir.ui.view,arch_db:point_of_sale.view_pos_pos_form
 msgid "Refunds"
+msgstr ""
+
+#. module: point_of_sale
+#: model:ir.actions.client,name:point_of_sale.action_client_pos_menu
+msgid "Reload POS Menu"
 msgstr ""
 
 #. module: point_of_sale


### PR DESCRIPTION
Some users use home action to have internal users directly login on
the pos menu but trying to do so is difficult because of the current
misleading names:
"Open POS Menu" is a client action used in the code to reload the page
so a better fit would be "Reload POS Menu"
~~There are two "Point of Sale" actions thus changing them to "Point of
Sale Configuration" and "Point of Sale Menu" is relevant.~~

opw-2830883