### PR TITLE
[FIX] stock_picking_batch: fix cancel in batch

### DIFF
--- a/addons/stock_picking_batch/models/stock_picking.py
+++ b/addons/stock_picking_batch/models/stock_picking.py
@@ -127,6 +127,13 @@ class StockPicking(models.Model):
 
         return res
 
+    def action_cancel(self):
+        res = super().action_cancel()
+        for picking in self:
+            if picking.batch_id and any(picking.state != 'cancel' for picking in picking.batch_id.picking_ids):
+                picking.batch_id = None
+        return res
+
     def _should_show_transfers(self):
         if len(self.batch_id) == 1 and self == self.batch_id.picking_ids:
             return False


### PR DESCRIPTION
As done with the "done" state, if a single picking in a batch is
cancelled while the other pickings aren't, this picking is removed from
the batch, as it would create inconsistencies between the states of the
pickings in a single batch.

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
