### PR TITLE
[FIX] mail: no RecordDeletedError while mentioning

### DIFF
--- a/addons/mail/static/src/models/composer_view/composer_view.js
+++ b/addons/mail/static/src/models/composer_view/composer_view.js
@@ -813,7 +813,7 @@ function factory(dependencies) {
                 }
                 const Model = this.messaging.models[this.suggestionModelName];
                 const searchTerm = this.suggestionSearchTerm;
-                await this.async(() => Model.fetchSuggestions(searchTerm, { thread: this.composer.activeThread }));
+                await Model.fetchSuggestions(searchTerm, { thread: this.composer.activeThread });
                 if (!this.exists()) {
                     return;
                 }


### PR DESCRIPTION
Before this commit, when mentioning a user in the composer text input,
it could crash with "RecordDeletedError".

This happens very rarely, and usually when mentioning a user and
then very quickly post the message with this mention.

`this.async()` generate the "RecordDeletedError" when a record
becomes deleted during a (long) async process in one of its method.

We should no longer use `this.async()` and instead always guard
`this.exists()` after the async code.

Task-2799627