### PR TITLE
[FIX] account: use company name or id as suffix for journal alias name

### DIFF
--- a/addons/account/tests/test_account_journal.py
+++ b/addons/account/tests/test_account_journal.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+import odoo.tools
 from odoo.addons.account.tests.common import AccountTestInvoicingCommon
 from odoo.tests import tagged
 from odoo.exceptions import UserError, ValidationError
@@ -82,3 +83,22 @@ class TestAccountJournal(AccountTestInvoicingCommon):
         # Assigning both should be allowed
         self.company_data['default_journal_misc'].account_control_ids = \
             self.company_data['default_account_revenue'] + self.company_data['default_account_expense']
+
+    @odoo.tools.mute_logger('odoo.addons.account.models.account_journal')
+    def test_account_journal_alias_name(self):
+        journal = self.company_data['default_journal_misc']
+        self.assertEqual(journal._get_alias_values(journal.type)['alias_name'], 'Miscellaneous Operations-company_1_data')
+        self.assertEqual(journal._get_alias_values(journal.type, 'ぁ')['alias_name'], 'MISC-company_1_data')
+        journal.name = 'ぁ'
+        self.assertEqual(journal._get_alias_values(journal.type)['alias_name'], 'MISC-company_1_data')
+        journal.code = 'ぁ'
+        self.assertEqual(journal._get_alias_values(journal.type)['alias_name'], 'general-company_1_data')
+
+        self.company_data_2['company'].name = 'ぁ'
+        company_2_id = str(self.company_data_2['company'].id)
+        journal_2 = self.company_data_2['default_journal_sale']
+        self.assertEqual(journal_2._get_alias_values(journal_2.type)['alias_name'], 'Customer Invoices-' + company_2_id)
+        journal_2.name = 'ぁ'
+        self.assertEqual(journal_2._get_alias_values(journal_2.type)['alias_name'], 'INV-' + company_2_id)
+        journal_2.code = 'ぁ'
+        self.assertEqual(journal_2._get_alias_values(journal_2.type)['alias_name'], 'sale-' + company_2_id)


### PR DESCRIPTION
Loading the demo data of Accounting app when only Japanese language is
installed will raise an error because there is a non-unique alias_name

Steps to reproduce:
1. - Run odoo with parameters `-d [db_name] --without-demo all
--load-language ja_JP -i l10n_jp,account_accountant` (you can also
install those apps using the UI but only Japanese should be installed
so it will be in Japanese)
   - Or create a trial database on odoo.com with Accounting installed,
using Japan as country and Japanese as language
2. Activate debug mode and go to Settings, scroll to the bottom and load
the demo data (`デモデータをロード`, last link in 'Developer Tools')
3. A validation error is thrown

Solution:
When building the alias name, if the name of the journal is not in
ascii, use the journal's code or type followed by the company's name. If
the company's name is not ascii, use the company id as suffix

Problem:
When a journal with non-ascii characters in its name is created, its
alias name fallbacks to the journal's code. In the demo data, two
journals have the same code. It will try to create the second journal
with the same alias name, violating the unicity check in
`_clean_and_check_unique`.

opw-2831638