### PR TITLE
[IMP] core: fake NotFound errors for any exception

### DIFF
--- a/odoo/addons/test_http/controllers.py
+++ b/odoo/addons/test_http/controllers.py
@@ -3,7 +3,7 @@ import json
 import logging
 import werkzeug
 from odoo import http
-from odoo.exceptions import UserError
+from odoo.exceptions import AccessError, UserError
 from odoo.http import request
 
 from odoo.addons.web.controllers.utils import ensure_db
@@ -141,3 +141,22 @@ class TestHttp(http.Controller):
     def touch(self):
         request.session.touch()
         return ''
+
+    # =====================================================
+    # Error
+    # =====================================================
+    @http.route('/test_http/hide_errors/decorator', type='http', auth='none')
+    @http.exceptions_as_404(AccessError)
+    def hide_errors_deco(self, error):
+        if error == 'AccessError':
+            raise AccessError("Wrong iris code")
+        if error == 'UserError':
+            raise UserError("Walter is AFK")
+
+    @http.route('/test_http/hide_errors/context-manager', type='http', auth='none')
+    def hide_errors_cm(self, error):
+        with http.exceptions_as_404(AccessError):
+            if error == 'AccessError':
+                raise AccessError("Wrong iris code")
+            if error == 'UserError':
+                raise UserError("Walter is AFK")

--- a/odoo/addons/test_http/tests/test_http.py
+++ b/odoo/addons/test_http/tests/test_http.py
@@ -417,6 +417,28 @@ class TestHttpMisc(TestHttpBase):
             self.assertEqual(res.json()['REMOTE_ADDR'], client_ip)
             self.assertEqual(res.json()['HTTP_HOST'], host)
 
+    @mute_logger('odoo.http')  # UserError("Walter is AFK")
+    def test_misc2_exceptions_as_404(self):
+        with self.subTest('Decorator/AccessError'):
+            res = self.nodb_url_open('/test_http/hide_errors/decorator?error=AccessError')
+            self.assertEqual(res.status_code, 404, "AccessError are configured to be hidden, they should be re-thrown as NotFound")
+            self.assertNotIn("Wrong iris code", res.text, "The real AccessError message should be hidden.")
+
+        with self.subTest('Decorator/UserError'):
+            res = self.nodb_url_open('/test_http/hide_errors/decorator?error=UserError')
+            self.assertEqual(res.status_code, 400, "UserError are not configured to be hidden, they should be kept as-is.")
+            self.assertIn("Walter is AFK", res.text, "The real UserError message should be kept")
+
+        with self.subTest('Context-Manager/AccessError'):
+            res = self.nodb_url_open('/test_http/hide_errors/context-manager?error=AccessError')
+            self.assertEqual(res.status_code, 404, "AccessError are configured to be hidden, they should be re-thrown as NotFound")
+            self.assertNotIn("Wrong iris code", res.text, "The real AccessError message should be hidden.")
+
+        with self.subTest('Context-Manager/UserError'):
+            res = self.nodb_url_open('/test_http/hide_errors/context-manager?error=UserError')
+            self.assertEqual(res.status_code, 400, "UserError are not configured to be hidden, they should be kept as-is.")
+            self.assertIn("Walter is AFK", res.text, "The real UserError message should be kept")
+
 
 @tagged('post_install', '-at_install')
 class TestHttpCors(TestHttpBase):


### PR DESCRIPTION
We introduce a new decorator/context-manager to catch some exceptions
and re-raise them as fake HTTP 404 - Page not Found errors. This new
utility is at `odoo.http.exceptions_as_404`.

Its usage is as follow:

    @route('/some/route', auth='public')
    @exceptions_as_404(AccessError, AccessDenied)
    def some_route(self):
        if not request.session.uid:
            raise AccessError("Must be connected to see this route")
        ...

Or as a context-manager if you don't want to except an entire function:

    @route('/some/route', auth='public')
    def some_route(self):
        with exceptions_as_404(AccessError, AccessDenied):
            if not request.session.uid:
                raise AccessError("Must be connected to see this route")
        ...

Task: 2800772

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
