### PR TITLE
[FIX] base: test_mimetype_svg working with magic


### DIFF
--- a/odoo/addons/base/tests/test_mimetypes.py
+++ b/odoo/addons/base/tests/test_mimetypes.py
@@ -1,6 +1,11 @@
 import base64
 import unittest
 
+try:
+    import magic
+except ImportError:
+    magic = None
+
 from odoo.tests.common import BaseCase
 from odoo.tools.mimetypes import guess_mimetype, get_extension
 
@@ -65,9 +70,11 @@ class test_guess_mimetype(BaseCase):
         content = base64.b64decode(SVG)
         mimetype = guess_mimetype(content, default='test')
         self.assertTrue(mimetype.startswith('image/svg'))
-        # Tests that whitespace padded SVG are not detected as SVG
-        mimetype = guess_mimetype(b"   " + content, default='test')
-        self.assertNotIn("svg", mimetype)
+        # Tests that whitespace padded SVG are not detected as SVG in odoo implementation
+        if not magic:
+            mimetype = guess_mimetype(b"   " + content, default='test')
+            self.assertNotIn("svg", mimetype)
+
 
     def test_mimetype_zip(self):
         content = base64.b64decode(ZIP)


### PR DESCRIPTION

libmagic and odoo implementation of guess_mimetype differ, and part of
the `test_mimetype_svg` would fail if python-magic is installed.

The test could be only run when python-magic is not installed, but this
commit just remove this part of the test.

opw-2746934
