### PR TITLE
[FIX] web_editor: transform orphan LI into P

### DIFF
--- a/addons/web_editor/static/lib/odoo-editor/src/utils/sanitize.js
+++ b/addons/web_editor/static/lib/odoo-editor/src/utils/sanitize.js
@@ -144,6 +144,13 @@ class Sanitize {
                 return;
             }
         }
+        // Transform <li> into <p> if they are not in a <ul> / <ol>
+        if (node.nodeName === 'LI' && !node.closest('ul, ol')) {
+            const p = document.createElement("p");
+            p.replaceChildren(...node.childNodes);
+            node.replaceWith(p);
+            node = p;
+        }
 
         // Sanitize font awesome elements
         if (isFontAwesome(node)) {

--- a/addons/web_editor/static/lib/odoo-editor/test/spec/copyPaste.test.js
+++ b/addons/web_editor/static/lib/odoo-editor/test/spec/copyPaste.test.js
@@ -32,7 +32,7 @@ describe('Copy and paste', () => {
                 ];
 
                 for (const node of CLIPBOARD_WHITELISTS.nodes) {
-                    if (!['TABLE', 'THEAD', 'TH', 'TBODY', 'TR', 'TD', 'IMG', 'BR', '.fa'].includes(node)) {
+                    if (!['TABLE', 'THEAD', 'TH', 'TBODY', 'TR', 'TD', 'IMG', 'BR', 'LI', '.fa'].includes(node)) {
                         tagsToKeep.push(`a<${node.toLowerCase()}>b</${node.toLowerCase()}>c`);
                     }
                 }
@@ -63,6 +63,24 @@ describe('Copy and paste', () => {
                         await pasteHtml(editor, 'a<span>bc</span>d');
                     },
                     contentAfter: '123abcd[]',
+                });
+            });
+            it('should not keep orphan LI', async () => {
+                await testEditor(BasicEditor, {
+                    contentBefore: '123[]',
+                    stepFunction: async editor => {
+                        await pasteHtml(editor, 'a<li>bc</li>d');
+                    },
+                    contentAfter: '123a<p>bc</p>d[]',
+                });
+            });
+            it('should keep LI in UL', async () => {
+                await testEditor(BasicEditor, {
+                    contentBefore: '123[]',
+                    stepFunction: async editor => {
+                        await pasteHtml(editor, 'a<ul><li>bc</li></ul>d');
+                    },
+                    contentAfter: '123a<ul><li>bc</li></ul>d[]',
                 });
             });
             it('should keep styled span', async () => {


### PR DESCRIPTION
Avoid living `<li>` tags without a `<ul>` or `<ol>` parent
in the editable html.

task-2842638


--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
