### PR TITLE
[FIX] purchase_stock: trigger RR with a defined supplied

### DIFF
--- a/addons/purchase_stock/models/stock_rule.py
+++ b/addons/purchase_stock/models/stock_rule.py
@@ -328,6 +328,6 @@ class StockRule(models.Model):
         if values.get('supplierinfo_name'):
             move_values['restrict_partner_id'] = values['supplierinfo_name'].id
         elif values.get('supplierinfo_id'):
-            partner = values['supplierinfo_id'].name
+            partner = values['supplierinfo_id'].partner_id
             move_values['restrict_partner_id'] = partner.id
         return move_values


### PR DESCRIPTION
In a 2-steps configuration, trigger a reordering rule with the vendor
defined will raise an error

To reproduce the issue:
1. In Settings, enable "Multi-Step Routes"
2. Edit the existing warehouse:
    - Incoming Shipments: 2 steps
3. Create a product P:
    - Type: Storable
    - Add a vendor V
    - Routes: Buy
4. Create a reordering rule R for P:
    - Trigger: Manual
    - Min = Max = 1
5. Open the Replenishment page and edit R:
    - Preferred Route: Buy
    - Vendor: V
6. Trigger the orderpoint

Error: An Odoo Server Error is displayed "AttributeError:
'product.supplierinfo' object has no attribute 'name'"

When triggering the orderpoint, it leads to
https://github.com/odoo/odoo/blob/c75a1a8ac9eef6c7d7c95b7bbbb22d919b952e26/addons/purchase_stock/models/stock_rule.py#L331
However, since [1], the `name` of a `product.supplierinfo` has been
renamed to `partner_id`

[1] f3fe2d50d99698eb0261c2309bd63f9f64b3d703

OPW-2780562