### PR TITLE
[FIX] mass_mailing: allow duplicate in test mode

### DIFF
--- a/addons/mass_mailing/models/mailing.py
+++ b/addons/mass_mailing/models/mailing.py
@@ -477,7 +477,9 @@ class MassMailing(models.Model):
             SELECT lower(substring(t.%(mail_field)s, '([^ ,;<@]+@[^> ,;]+)'))
               FROM mailing_trace s
               JOIN %(target)s t ON (s.res_id = t.id)
+              %(join_domain)s
              WHERE substring(t.%(mail_field)s, '([^ ,;<@]+@[^> ,;]+)') IS NOT NULL
+              %(where_domain)s                               
         """
 
         # Apply same 'get email field' rule from mail_thread.message_get_default_recipients
@@ -488,7 +490,9 @@ class MassMailing(models.Model):
                   FROM mailing_trace s
                   JOIN %(target)s t ON (s.res_id = t.id)
                   JOIN res_partner p ON (t.partner_id = p.id)
+                  %(join_domain)s                  
                  WHERE substring(p.%(mail_field)s, '([^ ,;<@]+@[^> ,;]+)') IS NOT NULL
+                  %(where_domain)s 
             """
         elif issubclass(type(target), self.pool['mail.thread.blacklist']):
             mail_field = 'email_normalized'
@@ -510,13 +514,17 @@ class MassMailing(models.Model):
                AND s.mass_mailing_id = %%(mailing_id)s
                AND s.model = %%(target_model)s;
             """
-        query = query % {'target': target._table, 'mail_field': mail_field}
+        join_domain, where_domain = self._get_seen_list_extra()
+        query = query % {'target': target._table, 'mail_field': mail_field, 'join_domain': join_domain, 'where_domain': where_domain}
         params = {'mailing_id': self.id, 'mailing_campaign_id': self.campaign_id.id, 'target_model': self.mailing_model_real}
         self._cr.execute(query, params)
         seen_list = set(m[0] for m in self._cr.fetchall())
         _logger.info(
             "Mass-mailing %s has already reached %s %s emails", self, len(seen_list), target._name)
         return seen_list
+
+    def _get_seen_list_extra(self):
+        return ('', '')
 
     def _get_mass_mailing_context(self):
         """Returns extra context items with pre-filled blacklist and seen list for massmailing"""


### PR DESCRIPTION
Steps to reproduce:
- In Marketing Automation - Campaigns
- Select the demo campaign
- Click on "Launch a test"
- Select Brandon
- Send the two mails from the campaign
- Redo all the steps with a new Test but the same contact

Issue:
- The mails won't be sent

Cause:
- Since for this campaign we already sent these mails to Brandon, the mails will be considered as duplicate in:
https://github.com/odoo/odoo/blob/15.0/addons/mail/wizard/mail_compose_message.py#L499-L501

Solution:
We want to make sure that:
- when doing a test, since there is only one linked partner to it, we can send as many mails as we launch tests.
-> repeated tests make sense as we want to fine tune campaigns and maybe get feedback from actual customers
- when launching the actual campaign, there are no duplicates (normal flow) but that eventual test-customers receive the final campaign

In order to do that, we have to filter out from the seen_list
https://github.com/odoo/odoo/tree/15.0/addons/mass_mailing/models/mailing.py#L736
the test-records.

opw-2810298