### PR TITLE
[FIX] mail: reload view on fetching thread data in chatter

### DIFF
--- a/addons/mail/static/src/components/chatter_container/chatter_container.js
+++ b/addons/mail/static/src/components/chatter_container/chatter_container.js
@@ -65,22 +65,26 @@ export class ChatterContainer extends Component {
             values.threadId = clear();
         }
         this.chatter = messaging.models['Chatter'].insert(values);
-        /**
-         * Refresh the chatter when the parent view is (re)loaded.
-         * This serves mainly at loading initial data, but also on reload there
-         * might be new message, new attachment, ...
-         *
-         * For example in approvals this is currently necessary to fetch the
-         * newly added attachment when using the "Attach Document" button. And
-         * in sales it is necessary to see the email when using the "Send email"
-         * button.
-         *
-         * NOTE: this assumes props are actually changed when a reload of parent
-         * happens which is true so far because of the OWL compatibility layer
-         * calling the props change method but it is in general not a good
-         * assumption to make.
-         */
-        this.chatter.refresh();
+        if (!this.chatter.skipRefreshOnViewReload) {
+            /**
+             * Refresh the chatter when the parent view is (re)loaded.
+             * This serves mainly at loading initial data, but also on reload there
+             * might be new message, new attachment, ...
+             *
+             * For example in approvals this is currently necessary to fetch the
+             * newly added attachment when using the "Attach Document" button. And
+             * in sales it is necessary to see the email when using the "Send email"
+             * button.
+             *
+             * NOTE: this assumes props are actually changed when a reload of parent
+             * happens which is true so far because of the OWL compatibility layer
+             * calling the props change method but it is in general not a good
+             * assumption to make.
+             */
+            this.chatter.refresh();
+        } else {
+            this.chatter.update({ skipRefreshOnViewReload: clear() });
+        }
         this.render();
     }
 

--- a/addons/mail/static/src/models/chatter.js
+++ b/addons/mail/static/src/models/chatter.js
@@ -382,10 +382,15 @@ registerModel({
             default: false,
         }),
         scrollPanelRef: attr(),
+        skipRefreshOnViewReload: attr({
+            default: false,
+        }),
         /**
          * Determines the `Thread` that should be displayed by `this`.
          */
-        thread: one('Thread'),
+        thread: one('Thread', {
+            inverse: 'chatters',
+        }),
         /**
          * Determines the id of the thread that will be displayed by `this`.
          */

--- a/addons/mail/static/src/models/thread.js
+++ b/addons/mail/static/src/models/thread.js
@@ -664,6 +664,10 @@ registerModel({
                 });
             }
             this.update(values);
+            for (const chatter of this.chatters) {
+                chatter.update({ skipRefreshOnViewReload: true });
+                chatter.reloadParentView();
+            }
         },
         /**
          * Add current user to provided thread's followers.
@@ -1898,6 +1902,9 @@ registerModel({
             required: true,
         }),
         channel_type: attr(),
+        chatters: many('Chatter', {
+            inverse: 'thread',
+        }),
         /**
          * States the chat window related to this thread (if any).
          */


### PR DESCRIPTION
Before this commit, many actions that change thread data did
not update view data with explicit reload.

As a result, the view data were outdated, and some following actions
were not working properly. For example:

- Marking an activity as done from the edit button made most
 actions on view raise a server-side "Missing Record" error;
- Deleting followers in follower list then editing the view
 made most actions on view raise a server-side "Missing Record"
 error

This commit fixes all these issues by ensuring that all fetching
of data in thread reload the view of the chatter, so that view
data are sync properly.

Task-2810734
Task-2842077
Task-2843016
