### PR TITLE
[FIX] mail: reload view on fetching thread data in chatter

### DIFF
--- a/addons/mail/static/src/components/chatter/chatter.js
+++ b/addons/mail/static/src/components/chatter/chatter.js
@@ -2,6 +2,7 @@
 
 import { registerMessagingComponent } from '@mail/utils/messaging_component';
 import { useUpdate } from '@mail/component_hooks/use_update/use_update';
+import { useComponentToModel } from '@mail/component_hooks/use_component_to_model/use_component_to_model';
 import { useRefToModel } from '@mail/component_hooks/use_ref_to_model/use_ref_to_model';
 
 const { Component } = owl;
@@ -15,6 +16,7 @@ export class Chatter extends Component {
     constructor(...args) {
         super(...args);
         useUpdate({ func: () => this._update() });
+        useComponentToModel({ fieldName: 'component', modelName: 'mail.chatter', propNameAsRecordLocalId: 'chatterLocalId' });
         useRefToModel({ fieldName: 'threadRef', modelName: 'mail.chatter', propNameAsRecordLocalId: 'chatterLocalId', refName: 'thread' });
         /**
          * Reference of the scroll Panel (Real scroll element). Useful to pass the Scroll element to

--- a/addons/mail/static/src/components/chatter_container/chatter_container.js
+++ b/addons/mail/static/src/components/chatter_container/chatter_container.js
@@ -68,7 +68,11 @@ export class ChatterContainer extends Component {
             values.threadId = clear();
         }
         this.chatter = messaging.models['mail.chatter'].insert(values);
-        this.chatter.refresh();
+        if (!this.chatter.skipRefreshOnNextViewReload) {
+            this.chatter.refresh();
+        } else {
+            this.chatter.update({ skipRefreshOnNextViewReload: clear() });
+        }
         this.render();
     }
 

--- a/addons/mail/static/src/models/chatter/chatter.js
+++ b/addons/mail/static/src/models/chatter/chatter.js
@@ -169,6 +169,12 @@ function factory(dependencies) {
             }
         }
 
+        reloadParentView() {
+            if (this.component) {
+                this.component.trigger('reload', { keepChanges: true });
+            }
+        }
+
         showLogNote() {
             this.update({ composerView: insertAndReplace() });
             this.composerView.composer.update({ isLog: true });
@@ -321,6 +327,10 @@ function factory(dependencies) {
             readonly: true,
         }),
         /**
+         * States the OWL Chatter component of this chatter.
+         */
+        component: attr(),
+        /**
          * States the OWL component of this chatter top bar.
          */
         componentChatterTopbar: attr(),
@@ -405,10 +415,15 @@ function factory(dependencies) {
         isShowingAttachmentsLoading: attr({
             default: false,
         }),
+        skipRefreshOnNextViewReload: attr({
+            default: false,
+        }),
         /**
          * Determines the `mail.thread` that should be displayed by `this`.
          */
-        thread: many2one('mail.thread'),
+        thread: many2one('mail.thread', {
+            inverse: 'chatters',
+        }),
         /**
          * Determines the id of the thread that will be displayed by `this`.
          */

--- a/addons/mail/static/src/models/thread/thread.js
+++ b/addons/mail/static/src/models/thread/thread.js
@@ -750,6 +750,10 @@ function factory(dependencies) {
                 });
             }
             this.update(values);
+            for (const chatter of this.chatters) {
+                chatter.update({ skipRefreshOnNextViewReload: true });
+                chatter.reloadParentView();
+            }
         }
 
         /**
@@ -2162,6 +2166,9 @@ function factory(dependencies) {
             required: true,
         }),
         channel_type: attr(),
+        chatters: one2many('mail.chatter', {
+            inverse: 'thread',
+        }),
         /**
          * States the chat window related to this thread (if any).
          */


### PR DESCRIPTION
Before this commit, many actions that change thread data did
not update view data with explicit reload.

As a result, the view data were outdated, and some following actions
were not working properly. For example:

- Marking an activity as done from the edit button made most
 actions on view raise a server-side "Missing Record" error;
- Deleting followers in follower list then editing the view
 made most actions on view raise a server-side "Missing Record"
 error

This commit fixes all these issues by ensuring that all fetching
of data in thread reload the view of the chatter, so that view
data are sync properly.

Task-2810734
Task-2842077
Task-2843016