### PR TITLE
[FIX] point_of_sale: correctly reserve quantity on tracked product

### DIFF
--- a/addons/point_of_sale/models/stock_picking.py
+++ b/addons/point_of_sale/models/stock_picking.py
@@ -216,7 +216,7 @@ class StockMove(models.Model):
                     sum_of_lots += qty
                 if abs(line.qty) != sum_of_lots:
                     difference_qty = abs(line.qty) - sum_of_lots
-                    ml_vals = self[0]._prepare_move_line_vals()
+                    ml_vals = move._prepare_move_line_vals()
                     if line.product_id.tracking == 'serial':
                         move_lines_to_create.extend([ml_vals for i in range(int(difference_qty))])
                         mls_qties.extend([1]*int(difference_qty))


### PR DESCRIPTION
Current behavior:
When selling a product in PoS that is tracked by lot number and using
the options to shop it latter and 3 steps delivery.
The move lines associted to the different pickings would have wrong
quantity reserved

Steps to reproduce:
- Activate multi-step routes and Lot/SN in inventory
- Operation types Pos Orders tracability check marked
- Activate Ship later options in PoS
- Set 3 steps delivery in the warehouse settings
- Create an item tracked by lot number and set a quantity
- Open POS session
- Select created item
- Do NOT input a lot number
- Set quantity to 1
- Proceed to payment screen
- Select "Ship Later" on the payment screen.
- Finish Sale.
- Close POS session.
- View the picking orders of the session.
- Select the picking order that is "Ready".
- The reserved quanities in the pickings are not correct

opw-2779462
--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
