### PR TITLE
[FIX] mail: reload view on fetching thread data in chatter

### DIFF
--- a/addons/mail/static/src/bugfix/bugfix.js
+++ b/addons/mail/static/src/bugfix/bugfix.js
@@ -196,3 +196,54 @@ function useShouldUpdateBasedOnProps({ compareDepth = {} } = {}) {
 return useShouldUpdateBasedOnProps;
 
 });
+
+
+odoo.define('mail/static/src/component_hooks/use_component_to_model/use_component_to_model.js', function (require) {
+'use strict';
+
+const { clear } = require('mail/static/src/model/model_field_command.js');
+
+const { Component } = owl;
+const { onWillUpdateProps } = owl.hooks;
+
+/**
+ * This hook provides support for saving the reference of the component directly
+ * into the field of a record, and appropriately updates it when necessary
+ * (props change or destroy).
+ *
+ * @param {Object} param0
+ * @param {string} param0.fieldName Name of the field on the target record.
+ * @param {string} param0.modelName Name of the model of the target record.
+ * @param {string} param0.propNameAsRecordLocalId Name of the prop of this
+ *  component containing the localId of the target record.
+ */
+function useComponentToModel({ fieldName, modelName, propNameAsRecordLocalId }) {
+    const component = Component.current;
+    const env = component.env;
+    const record = env.models[modelName].get(component.props[propNameAsRecordLocalId]);
+    if (record) {
+        record.update({ [fieldName]: component });
+    }
+    onWillUpdateProps(nextProps => {
+        const currentRecord = env.models[modelName].get(component.props[propNameAsRecordLocalId]);
+        const nextRecord = env.models[modelName].get(nextProps[propNameAsRecordLocalId]);
+        if (currentRecord && currentRecord !== nextRecord) {
+            currentRecord.update({ [fieldName]: clear() });
+        }
+        if (nextRecord) {
+            nextRecord.update({ [fieldName]: component });
+        }
+    });
+    const __destroy = component.__destroy;
+    component.__destroy = parent => {
+        const record = env.models[modelName].get(component.props[propNameAsRecordLocalId]);
+        if (record) {
+            record.update({ [fieldName]: clear() });
+        }
+        __destroy.call(component, parent);
+    };
+}
+
+return useComponentToModel;
+
+});

--- a/addons/mail/static/src/components/chatter/chatter.js
+++ b/addons/mail/static/src/components/chatter/chatter.js
@@ -8,6 +8,7 @@ const components = {
     Composer: require('mail/static/src/components/composer/composer.js'),
     ThreadView: require('mail/static/src/components/thread_view/thread_view.js'),
 };
+const useComponentToModel = require('mail/static/src/component_hooks/use_component_to_model/use_component_to_model.js');
 const useShouldUpdateBasedOnProps = require('mail/static/src/component_hooks/use_should_update_based_on_props/use_should_update_based_on_props.js');
 const useStore = require('mail/static/src/component_hooks/use_store/use_store.js');
 const useUpdate = require('mail/static/src/component_hooks/use_update/use_update.js');
@@ -43,6 +44,7 @@ class Chatter extends Component {
             },
         });
         useUpdate({ func: () => this._update() });
+        useComponentToModel({ fieldName: 'component', modelName: 'mail.chatter', propNameAsRecordLocalId: 'chatterLocalId' });
         /**
          * Reference of the composer. Useful to focus it.
          */

--- a/addons/mail/static/src/components/chatter_container/chatter_container.js
+++ b/addons/mail/static/src/components/chatter_container/chatter_container.js
@@ -87,7 +87,11 @@ class ChatterContainer extends Component {
      */
     _update() {
         if (this.chatter) {
-            this.chatter.refresh();
+            if (!this.chatter.skipRefreshOnViewReload) {
+                this.chatter.refresh();
+            } else {
+                this.chatter.update({ skipRefreshOnViewReload: clear() });
+            }
         }
     }
 

--- a/addons/mail/static/src/models/chatter/chatter.js
+++ b/addons/mail/static/src/models/chatter/chatter.js
@@ -53,6 +53,12 @@ function factory(dependencies) {
             }
         }
 
+        reloadParentView() {
+            if (this.component) {
+                this.component.trigger('reload', { keepChanges: true });
+            }
+        }
+
         showLogNote() {
             this.update({ isComposerVisible: true });
             this.thread.composer.update({ isLog: true });
@@ -179,6 +185,10 @@ function factory(dependencies) {
     }
 
     Chatter.fields = {
+        /**
+         * States the OWL Chatter component of this chatter.
+         */
+        component: attr(),
         composer: many2one('mail.composer', {
             related: 'thread.composer',
         }),
@@ -284,10 +294,15 @@ function factory(dependencies) {
                 'threadIsLoadingAttachments',
             ],
         }),
+        skipRefreshOnViewReload: attr({
+            default: false,
+        }),
         /**
          * Determines the `mail.thread` that should be displayed by `this`.
          */
-        thread: many2one('mail.thread'),
+        thread: many2one('mail.thread', {
+            inverse: 'chatters',
+        }),
         /**
          * Determines the id of the thread that will be displayed by `this`.
          */

--- a/addons/mail/static/src/models/thread/thread.js
+++ b/addons/mail/static/src/models/thread/thread.js
@@ -708,6 +708,10 @@ function factory(dependencies) {
                 });
             }
             this.update(values);
+            for (const chatter of this.chatters) {
+                chatter.update({ skipRefreshOnViewReload: true });
+                chatter.reloadParentView();
+            }
         }
 
         /**
@@ -1833,6 +1837,9 @@ function factory(dependencies) {
             isCausal: true,
         }),
         channel_type: attr(),
+        chatters: one2many('mail.chatter', {
+            inverse: 'thread',
+        }),
         /**
          * States the `mail.chat_window` related to `this`. Serves as compute
          * dependency. It is computed from the inverse relation and it should


### PR DESCRIPTION
Before this commit, many actions that change thread data did
not update view data with explicit reload.

As a result, the view data were outdated, and some following actions
were not working properly. For example:

- Marking an activity as done from the edit button made most
 actions on view raise a server-side "Missing Record" error;
- Deleting followers in follower list then editing the view
 made most actions on view raise a server-side "Missing Record"
 error

This commit fixes all these issues by ensuring that all fetching
of data in thread reload the view of the chatter, so that view
data are sync properly.

Task-2810734
Task-2842077
Task-2843016