### PR TITLE
[FIX] mrp: reserve components when updating MO's qty

### DIFF
--- a/addons/mrp/models/mrp_production.py
+++ b/addons/mrp/models/mrp_production.py
@@ -1017,18 +1017,23 @@ class MrpProduction(models.Model):
         self.ensure_one()
         update_info = []
         move_to_unlink = self.env['stock.move']
+        moves_to_assign = self.env['stock.move']
         for move in self.move_raw_ids.filtered(lambda m: m.state not in ('done', 'cancel')):
             old_qty = move.product_uom_qty
             new_qty = old_qty * factor
             if new_qty > 0:
                 move.write({'product_uom_qty': new_qty})
-                move._action_assign()
+                if move._should_bypass_reservation() \
+                        or move.picking_type_id.reservation_method == 'at_confirm' \
+                        or (move.reservation_date and move.reservation_date <= fields.Date.today()):
+                    moves_to_assign |= move
                 update_info.append((move, old_qty, new_qty))
             else:
                 if move.quantity_done > 0:
                     raise UserError(_('Lines need to be deleted, but can not as you still have some quantities to consume in them. '))
                 move._action_cancel()
                 move_to_unlink |= move
+        moves_to_assign._action_assign()
         move_to_unlink.unlink()
         return update_info
 

--- a/addons/mrp/tests/test_order.py
+++ b/addons/mrp/tests/test_order.py
@@ -2589,3 +2589,31 @@ class TestMrpOrder(TestMrpCommon):
         production.workorder_ids[0].button_start()
         production.workorder_ids[0].button_start()
         self.assertEqual(len(production.workorder_ids[0].time_ids.filtered(lambda t: t.date_start and not t.date_end)), 1)
+
+    def test_qty_update_and_method_reservation(self):
+        """
+        When the reservation method of Manufacturing is 'manual', updating the
+        quantity of a confirmed MO shouldn't trigger the reservation of the
+        components
+        """
+        warehouse = self.env['stock.warehouse'].search([('company_id', '=', self.env.company.id)], order='id', limit=1)
+        warehouse.manu_type_id.reservation_method = 'manual'
+
+        for product in self.product_1 + self.product_2:
+            product.type = 'product'
+            self.env['stock.quant']._update_available_quantity(product, warehouse.lot_stock_id, 10)
+
+        mo_form = Form(self.env['mrp.production'])
+        mo_form.bom_id = self.bom_1
+        mo = mo_form.save()
+        mo.action_confirm()
+
+        self.assertFalse(mo.move_raw_ids.move_line_ids)
+
+        wizard = self.env['change.production.qty'].create({
+            'mo_id': mo.id,
+            'product_qty': 5,
+        })
+        wizard.change_prod_qty()
+
+        self.assertFalse(mo.move_raw_ids.move_line_ids)


### PR DESCRIPTION
When updating the MO quantity, the reservation of the components doesn't
respect the reservation method of the operation type.

To reproduce the issue:
(Use demo data)
1. Edit the operation type "Manufacturing":
    - Reservation Method: Manually
2. Create and confirm a MO for 1 x [FURN_8855] Drawer
    - Note: the components are not reserved, as expected
3. Update the quantity to produce (2 x Drawer)

Error: The components are reserved

The new conditions are directly based on the conditions to reserve a SM
when confirming it:
https://github.com/odoo/odoo/blob/e55988fc4d8090f84157a026b7ecc7ea0dc146a7/addons/stock/models/stock_move.py#L1242-L1248

OPW-2822205