### PR TITLE
[FIX] point_of_sale: global discount taxes

### DIFF
--- a/addons/pos_discount/static/src/js/DiscountButton.js
+++ b/addons/pos_discount/static/src/js/DiscountButton.js
@@ -37,31 +37,40 @@ odoo.define('pos_discount.DiscountButton', function(require) {
             }
 
             // Remove existing discounts
-            for (const line of lines) {
-                if (line.get_product() === product) {
-                    order.remove_orderline(line);
-                }
-            }
+            lines.filter(line => line.get_product() === product)
+                .forEach(line => order.remove_orderline(line));
 
-            // Add discount
-            // We add the price as manually set to avoid recomputation when changing customer.
-            var base_to_discount = order.get_total_without_tax();
-            if (product.taxes_id.length){
-                var first_tax = this.env.pos.taxes_by_id[product.taxes_id[0]];
-                if (first_tax.price_include) {
-                    base_to_discount = order.get_total_with_tax();
-                }
-            }
-            var discount = - pc / 100.0 * base_to_discount;
+            // Add one discount line per tax group
+            let linesByTax = order.get_orderlines_grouped_by_tax_ids();
+            for (let [tax_ids, lines] of Object.entries(linesByTax)) {
 
-            if( discount < 0 ){
-                order.add_product(product, {
-                    price: discount,
-                    lst_price: discount,
-                    extras: {
-                        price_manually_set: true,
-                    },
-                });
+                // Note that tax_ids_array is an Array of tax_ids that apply to these lines
+                // That is, the use case of products with more than one tax is supported.
+                let tax_ids_array = tax_ids.split(',').filter(id => id !== '').map(id => Number(id));
+
+                let baseToDiscount = order.calculate_base_amount(tax_ids_array, lines);
+
+                // We add the price as manually set to avoid recomputation when changing customer.
+                let discount = - pc / 100.0 * baseToDiscount;
+                if (discount < 0) {
+                    order.add_product(product, {
+                        price: discount,
+                        lst_price: discount,
+                        tax_ids: tax_ids_array,
+                        merge: false,
+                        description:
+                            `${pc}%, ` +
+                            (tax_ids_array.length ?
+                                _.str.sprintf(
+                                    this.env._t('Tax: %s'),
+                                    tax_ids_array.map(taxId => this.env.pos.taxes_by_id[taxId].amount + '%').join(', ')
+                                ) :
+                            this.env._t('No tax')),
+                        extras: {
+                            price_manually_set: true,
+                        },
+                    });
+                }
             }
         }
     }


### PR DESCRIPTION
In this commit we fix the tax calculation
when applying a global discount in PoS.

Before this commit, when applying a discount
tax was calculated properly only in the use
case where in one order we had:
- all products with a single tax (had to be the same for every product)

After this commit, the calculation of discount
and taxes is extended to include these additional
use cases:
- products with more than one tax applied to them
ex. Product A -> 10% + 20%
- products with different taxes in the same order
ex. Product A -> 10%
      Product B -> 20%
- products with taxes that are included in prices
ex. Product A -> 10% (included in price) + 20%

Overall, we tried to follow a general approach
that will include as many use cases as possible
and every combination between them.

task-2421429

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
