### PR TITLE
[15.0][FIX] sale_timesheet: fix view dependencies

### DIFF
--- a/addons/project/views/project_views.xml
+++ b/addons/project/views/project_views.xml
@@ -849,6 +849,7 @@
                             <field name="active" invisible="1"/>
                             <field name="partner_id" widget="res_partner_many2one" class="o_task_customer_field"/>
                             <field name="partner_phone" widget="phone" attrs="{'invisible': True}"/>
+                            <field name="commercial_partner_id" invisible="1" />
                             <field name="date_deadline" attrs="{'invisible': [('is_closed', '=', True)]}"/>
                             <field name="tag_ids" widget="many2many_tags" options="{'color_field': 'color', 'no_create_edit': True}"/>
                             <field name="recurring_task" attrs="{'invisible': ['|', ('allow_recurring_tasks', '=', False), ('active', '=', False)]}" />

--- a/addons/sale_project/views/project_task_views.xml
+++ b/addons/sale_project/views/project_task_views.xml
@@ -67,7 +67,6 @@
             <xpath expr="//field[@name='partner_phone']" position="after">
                 <field name="sale_order_id" attrs="{'invisible': True}" groups="sales_team.group_sale_salesman"/>
                 <field name="sale_line_id" string="Sales Order Item" attrs="{'invisible': [('partner_id', '=', False)]}" options='{"no_open": True}' readonly="1" context="{'create': False, 'edit': False, 'delete': False}"/>
-                <field name="commercial_partner_id" invisible="1" />
             </xpath>
         </field>
     </record>

--- a/addons/sale_timesheet/views/project_sharing_views.xml
+++ b/addons/sale_timesheet/views/project_sharing_views.xml
@@ -4,7 +4,7 @@
     <record id="project_sharing_inherit_project_task_view_form" model="ir.ui.view">
         <field name="name">project.task.form.inherit.timesheet</field>
         <field name="model">project.task</field>
-        <field name="inherit_id" ref="project.project_sharing_project_task_view_form"/>
+        <field name="inherit_id" ref="hr_timesheet.project_sharing_inherit_project_task_view_form"/>
         <field name="arch" type="xml">
             <xpath expr="//field[@name='timesheet_ids']/tree" position="attributes">
                 <attribute name="decoration-muted">timesheet_invoice_id != False</attribute>

--- a/addons/sale_timesheet/views/project_task_views.xml
+++ b/addons/sale_timesheet/views/project_task_views.xml
@@ -6,9 +6,6 @@
         <field name="model">project.project</field>
         <field name="inherit_id" ref="hr_timesheet.project_invoice_form"/>
         <field name="arch" type="xml">
-            <xpath expr="//button[@name='action_view_so']" position="attributes">
-                <attribute name="attrs">{'invisible': ['|', ('allow_billable', '=', False), ('sale_order_id', '=', False)]}</attribute>
-            </xpath>
             <xpath expr="//button[@name='%(project.action_project_task_burndown_chart_report)d']" position="after">
                 <button name="action_billable_time_button" type="object" class="oe_stat_button" icon="fa-clock-o" attrs="{'invisible': ['|', ('allow_timesheets', '=', False), ('analytic_account_id', '=', False)]}" groups="hr_timesheet.group_hr_timesheet_approver">
                     <div class="o_field_widget o_stat_info">
@@ -64,6 +61,17 @@
                         </div>
                     </div>
                 </div>
+            </xpath>
+        </field>
+    </record>
+
+    <record id="project_project_view_form_sale_project" model="ir.ui.view">
+        <field name="name">project.project.form.inherit.sale_project</field>
+        <field name="model">project.project</field>
+        <field name="inherit_id" ref="sale_project.view_edit_project_inherit_form"/>
+        <field name="arch" type="xml">
+            <xpath expr="//button[@name='action_view_so']" position="attributes">
+                <attribute name="attrs">{'invisible': ['|', ('allow_billable', '=', False), ('sale_order_id', '=', False)]}</attribute>
             </xpath>
         </field>
     </record>
@@ -135,7 +143,7 @@
         <record id="project_task_view_form_inherit_sale_timesheet" model="ir.ui.view">
             <field name="name">project.task.form.inherit.timesheet</field>
             <field name="model">project.task</field>
-            <field name="inherit_id" ref="project.view_task_form2"/>
+            <field name="inherit_id" ref="sale_project.view_sale_project_inherit_form"/>
             <field name="groups_id" eval="[(6,0, (ref('hr_timesheet.group_hr_timesheet_user'),))]"/>
             <field name="arch" type="xml">
                 <xpath expr="//field[@name='timesheet_ids']/tree" position="attributes">
@@ -194,7 +202,7 @@
         <record id="view_task_form2_inherit_sale_timesheet" model="ir.ui.view">
             <field name="name">view.task.form2.inherit</field>
             <field name="model">project.task</field>
-            <field name="inherit_id" ref="project.view_task_form2"/>
+            <field name="inherit_id" ref="sale_project.view_sale_project_inherit_form"/>
             <field name="arch" type="xml">
                 <xpath expr="//field[@name='sale_line_id']" position="attributes">
                     <attribute name="context">{'with_remaining_hours': True, 'with_price_unit': True}</attribute>


### PR DESCRIPTION
### Description of the issue/feature this PR addresses:

Upgrade of `sale_timesheet` addon fails because it can't find elements in the parent view.
This happens on a DB migrated from 13.0 to 15.0 with an update of `base`.

### Current behavior before PR:

Several errors are raised, here is the list:

1.
```
2022-05-04 10:19:08,969 117 INFO v15_20220429 odoo.modules.loading: loading sale_timesheet/views/project_task_views.xml 
2022-05-04 10:19:09,055 117 WARNING v15_20220429 odoo.modules.loading: Transient module states were reset 
2022-05-04 10:19:09,057 117 ERROR v15_20220429 odoo.modules.registry: Failed to load registry 
2022-05-04 10:19:09,057 117 CRITICAL v15_20220429 odoo.service.server: Failed to initialize database `v15_20220429`. 
Traceback (most recent call last):
  File "/odoo/src/odoo/service/server.py", line 1260, in preload_registries
    registry = Registry.new(dbname, update_module=update_module)
  File "/odoo/src/odoo/modules/registry.py", line 87, in new
    odoo.modules.load_modules(registry, force_demo, status, update_module)
  File "/odoo/src/odoo/modules/loading.py", line 470, in load_modules
    processed_modules += load_marked_modules(cr, graph,
  File "/odoo/src/odoo/modules/loading.py", line 363, in load_marked_modules
    loaded, processed = load_module_graph(
  File "/odoo/src/odoo/modules/loading.py", line 222, in load_module_graph
    load_data(cr, idref, mode, kind='data', package=package)
  File "/odoo/src/odoo/modules/loading.py", line 69, in load_data
    tools.convert_file(cr, package.name, filename, idref, mode, noupdate, kind)
  File "/odoo/src/odoo/tools/convert.py", line 745, in convert_file
    convert_xml_import(cr, module, fp, idref, mode, noupdate)
  File "/odoo/src/odoo/tools/convert.py", line 811, in convert_xml_import
    obj.parse(doc.getroot())
  File "/odoo/src/odoo/tools/convert.py", line 731, in parse
    self._tag_root(de)
  File "/odoo/src/odoo/tools/convert.py", line 691, in _tag_root
    raise ParseError(msg) from None  # Restart with "--log-handler odoo.tools.convert:DEBUG" for complete traceback
odoo.tools.convert.ParseError: while parsing /odoo/src/addons/sale_timesheet/views/project_task_views.xml:4
Error while validating view:

Element '<xpath expr="//button[@name=&#39;action_view_so&#39;]">' cannot be located in parent view

View error context:
{'file': '/odoo/src/addons/sale_timesheet/views/project_task_views.xml',
 'line': 2,
 'name': 'project.project.form.inherit',
 'view': ir.ui.view(9342,),
 'view.model': 'project.project',
 'view.parent': ir.ui.view(7562,),
 'xmlid': 'project_project_view_form'}
```

2.
```
2022-05-04 10:36:58,214 117 INFO v15_20220429 odoo.modules.loading: loading sale_timesheet/views/project_task_views.xml 
2022-05-04 10:36:58,415 117 WARNING v15_20220429 odoo.modules.loading: Transient module states were reset 
2022-05-04 10:36:58,417 117 ERROR v15_20220429 odoo.modules.registry: Failed to load registry 
2022-05-04 10:36:58,417 117 CRITICAL v15_20220429 odoo.service.server: Failed to initialize database `v15_20220429`. 
Traceback (most recent call last):
  File "/odoo/src/odoo/service/server.py", line 1260, in preload_registries
    registry = Registry.new(dbname, update_module=update_module)
  File "/odoo/src/odoo/modules/registry.py", line 87, in new
    odoo.modules.load_modules(registry, force_demo, status, update_module)
  File "/odoo/src/odoo/modules/loading.py", line 470, in load_modules
    processed_modules += load_marked_modules(cr, graph,
  File "/odoo/src/odoo/modules/loading.py", line 363, in load_marked_modules
    loaded, processed = load_module_graph(
  File "/odoo/src/odoo/modules/loading.py", line 222, in load_module_graph
    load_data(cr, idref, mode, kind='data', package=package)
  File "/odoo/src/odoo/modules/loading.py", line 69, in load_data
    tools.convert_file(cr, package.name, filename, idref, mode, noupdate, kind)
  File "/odoo/src/odoo/tools/convert.py", line 745, in convert_file
    convert_xml_import(cr, module, fp, idref, mode, noupdate)
  File "/odoo/src/odoo/tools/convert.py", line 811, in convert_xml_import
    obj.parse(doc.getroot())
  File "/odoo/src/odoo/tools/convert.py", line 731, in parse
    self._tag_root(de)
  File "/odoo/src/odoo/tools/convert.py", line 691, in _tag_root
    raise ParseError(msg) from None  # Restart with "--log-handler odoo.tools.convert:DEBUG" for complete traceback
odoo.tools.convert.ParseError: while parsing /odoo/src/addons/sale_timesheet/views/project_task_views.xml:131
Error while validating view:

Element '<xpath expr="//field[@name=&#39;sale_line_id&#39;]">' cannot be located in parent view

View error context:
{'file': '/odoo/src/addons/sale_timesheet/views/project_task_views.xml',
 'line': 2,
 'name': 'view.task.form2.inherit',
 'view': ir.ui.view(9345,),
 'view.model': 'project.task',
 'view.parent': ir.ui.view(7279,),
 'xmlid': 'view_sale_service_inherit_form2'}
```

3.
```
022-05-04 11:13:47,290 116 INFO v15_20220429 odoo.modules.loading: loading sale_timesheet/views/project_task_views.xml 
2022-05-04 11:13:47,588 116 WARNING v15_20220429 odoo.modules.loading: Transient module states were reset 
2022-05-04 11:13:47,590 116 ERROR v15_20220429 odoo.modules.registry: Failed to load registry 
2022-05-04 11:13:47,590 116 CRITICAL v15_20220429 odoo.service.server: Failed to initialize database `v15_20220429`. 
Traceback (most recent call last):
  File "/odoo/src/odoo/service/server.py", line 1260, in preload_registries
    registry = Registry.new(dbname, update_module=update_module)
  File "/odoo/src/odoo/modules/registry.py", line 87, in new
    odoo.modules.load_modules(registry, force_demo, status, update_module)
  File "/odoo/src/odoo/modules/loading.py", line 470, in load_modules
    processed_modules += load_marked_modules(cr, graph,
  File "/odoo/src/odoo/modules/loading.py", line 363, in load_marked_modules
    loaded, processed = load_module_graph(
  File "/odoo/src/odoo/modules/loading.py", line 222, in load_module_graph
    load_data(cr, idref, mode, kind='data', package=package)
  File "/odoo/src/odoo/modules/loading.py", line 69, in load_data
    tools.convert_file(cr, package.name, filename, idref, mode, noupdate, kind)
  File "/odoo/src/odoo/tools/convert.py", line 745, in convert_file
    convert_xml_import(cr, module, fp, idref, mode, noupdate)
  File "/odoo/src/odoo/tools/convert.py", line 811, in convert_xml_import
    obj.parse(doc.getroot())
  File "/odoo/src/odoo/tools/convert.py", line 731, in parse
    self._tag_root(de)
  File "/odoo/src/odoo/tools/convert.py", line 691, in _tag_root
    raise ParseError(msg) from None  # Restart with "--log-handler odoo.tools.convert:DEBUG" for complete traceback
odoo.tools.convert.ParseError: while parsing /odoo/src/addons/sale_timesheet/views/project_task_views.xml:131
Error while validating view near:

<form string="Task" class="o_form_project_tasks" js_class="project_form" __validate__="1">
                    <field name="allow_subtasks" invisible="1"/>
                    <field name="is_closed" invisible="1"/>

Field 'commercial_partner_id' used in domain of <field name="so_line"> ([('is_service', '=', True), ('order_partner_id', 'child_of', parent.commercial_partner_id), ('is_expense', '=', False), ('state', 'in', ['sale', 'done'])]) must be present in view but is missing.

View error context:
{'file': '/odoo/src/addons/sale_timesheet/views/project_task_views.xml',
 'line': 1,
 'name': 'sale.service.form.view.inherit',
 'view': ir.ui.view(8135,),
 'view.model': 'project.task',
 'view.parent': ir.ui.view(7279,),
 'xmlid': 'view_sale_service_inherit_form2'}
```

4.
```
2022-05-04 11:31:33,197 115 INFO v15_20220429 odoo.modules.loading: loading sale_timesheet/views/project_task_views.xml 
2022-05-04 11:31:33,453 115 WARNING v15_20220429 odoo.modules.loading: Transient module states were reset 
2022-05-04 11:31:33,455 115 ERROR v15_20220429 odoo.modules.registry: Failed to load registry 
2022-05-04 11:31:33,455 115 CRITICAL v15_20220429 odoo.service.server: Failed to initialize database `v15_20220429`. 
Traceback (most recent call last):
  File "/odoo/src/odoo/service/server.py", line 1260, in preload_registries
    registry = Registry.new(dbname, update_module=update_module)
  File "/odoo/src/odoo/modules/registry.py", line 87, in new
    odoo.modules.load_modules(registry, force_demo, status, update_module)
  File "/odoo/src/odoo/modules/loading.py", line 470, in load_modules
    processed_modules += load_marked_modules(cr, graph,
  File "/odoo/src/odoo/modules/loading.py", line 363, in load_marked_modules
    loaded, processed = load_module_graph(
  File "/odoo/src/odoo/modules/loading.py", line 222, in load_module_graph
    load_data(cr, idref, mode, kind='data', package=package)
  File "/odoo/src/odoo/modules/loading.py", line 69, in load_data
    tools.convert_file(cr, package.name, filename, idref, mode, noupdate, kind)
  File "/odoo/src/odoo/tools/convert.py", line 745, in convert_file
    convert_xml_import(cr, module, fp, idref, mode, noupdate)
  File "/odoo/src/odoo/tools/convert.py", line 811, in convert_xml_import
    obj.parse(doc.getroot())
  File "/odoo/src/odoo/tools/convert.py", line 731, in parse
    self._tag_root(de)
  File "/odoo/src/odoo/tools/convert.py", line 691, in _tag_root
    raise ParseError(msg) from None  # Restart with "--log-handler odoo.tools.convert:DEBUG" for complete traceback
odoo.tools.convert.ParseError: while parsing /odoo/src/addons/sale_timesheet/views/project_task_views.xml:131
Error while validating view near:

<form string="Task" class="o_form_project_tasks" js_class="project_form" __validate__="1">
                    <field name="allow_subtasks" invisible="1"/>
                    <field name="is_closed" invisible="1"/>

Field 'sale_line_id' used in attrs ({'invisible': ['|', '|', '|', '|', ('allow_billable', '=', False), ('sale_order_id', '=', False), ('partner_id', '=', False), ('sale_line_id', '=', False), ('remaining_hours_available', '=', False)]}) must be present in view but is missing.

View error context:
{'file': '/odoo/src/addons/sale_timesheet/views/project_task_views.xml',
 'line': 1,
 'name': 'sale.service.form.view.inherit',
 'view': ir.ui.view(8135,),
 'view.model': 'project.task',
 'view.parent': ir.ui.view(7279,),
 'xmlid': 'view_sale_service_inherit_form2'}
```

5.
```
2022-05-04 12:01:14,053 115 INFO v15_20220429 odoo.modules.loading: loading sale_timesheet/views/project_sharing_views.xml 
2022-05-04 12:01:14,135 115 WARNING v15_20220429 odoo.modules.loading: Transient module states were reset 
2022-05-04 12:01:14,136 115 ERROR v15_20220429 odoo.modules.registry: Failed to load registry 
2022-05-04 12:01:14,137 115 CRITICAL v15_20220429 odoo.service.server: Failed to initialize database `v15_20220429`. 
Traceback (most recent call last):
  File "/odoo/src/odoo/service/server.py", line 1260, in preload_registries
    registry = Registry.new(dbname, update_module=update_module)
  File "/odoo/src/odoo/modules/registry.py", line 87, in new
    odoo.modules.load_modules(registry, force_demo, status, update_module)
  File "/odoo/src/odoo/modules/loading.py", line 470, in load_modules
    processed_modules += load_marked_modules(cr, graph,
  File "/odoo/src/odoo/modules/loading.py", line 363, in load_marked_modules
    loaded, processed = load_module_graph(
  File "/odoo/src/odoo/modules/loading.py", line 222, in load_module_graph
    load_data(cr, idref, mode, kind='data', package=package)
  File "/odoo/src/odoo/modules/loading.py", line 69, in load_data
    tools.convert_file(cr, package.name, filename, idref, mode, noupdate, kind)
  File "/odoo/src/odoo/tools/convert.py", line 745, in convert_file
    convert_xml_import(cr, module, fp, idref, mode, noupdate)
  File "/odoo/src/odoo/tools/convert.py", line 811, in convert_xml_import
    obj.parse(doc.getroot())
  File "/odoo/src/odoo/tools/convert.py", line 731, in parse
    self._tag_root(de)
  File "/odoo/src/odoo/tools/convert.py", line 691, in _tag_root
    raise ParseError(msg) from None  # Restart with "--log-handler odoo.tools.convert:DEBUG" for complete traceback
odoo.tools.convert.ParseError: while parsing /odoo/src/addons/sale_timesheet/views/project_sharing_views.xml:4
Error while validating view:

Element '<xpath expr="//field[@name=&#39;timesheet_ids&#39;]/tree">' cannot be located in parent view

View error context:
{'file': '/odoo/src/addons/sale_timesheet/views/project_sharing_views.xml',
 'line': 2,
 'name': 'project.task.form.inherit.timesheet',
 'view': ir.ui.view(10016,),
 'view.model': 'project.task',
 'view.parent': ir.ui.view(9754,),
 'xmlid': 'project_sharing_inherit_project_task_view_form'}
```

### Desired behavior after PR is merged:

Upgrade without crash.


--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
