### PR TITLE
[FIX] mail: chatter composer padding missing after resize

### DIFF
--- a/addons/mail/static/src/components/chatter/chatter.xml
+++ b/addons/mail/static/src/components/chatter/chatter.xml
@@ -11,8 +11,8 @@
                     />
                     <t t-if="chatter.composerView">
                         <Composer
-                            className="'o_Chatter_composer'"
-                            classNameObj="{ 'o-bordered': chatter.hasExternalBorder }"
+                            class="o_Chatter_composer"
+                            t-att-class="{ 'o-bordered': chatter.hasExternalBorder }"
                             composerViewLocalId="chatter.composerView.localId"
                             hasFollowers="true"
                             hasMentionSuggestionsBelowPosition="true"


### PR DESCRIPTION
**Current behavior before PR:**

Padding is missing around partner avatar in composer view, when chatter
moves from bottom to side and vise versa after resizing window.

**Desired behavior after PR is merged:**

There is proper padding around partner avatar.

Task-2817980

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
