### PR TITLE
[FIX] stock: add some missing indexes on stock_rule.

### DIFF
--- a/addons/stock/models/stock_rule.py
+++ b/addons/stock/models/stock_rule.py
@@ -54,14 +54,14 @@ class StockRule(models.Model):
     group_id = fields.Many2one('procurement.group', 'Fixed Procurement Group')
     action = fields.Selection(
         selection=[('pull', 'Pull From'), ('push', 'Push To'), ('pull_push', 'Pull & Push')], string='Action',
-        required=True)
+        required=True, index=True)
     sequence = fields.Integer('Sequence', default=20)
     company_id = fields.Many2one('res.company', 'Company',
         default=lambda self: self.env.company,
-        domain="[('id', '=?', route_company_id)]")
-    location_id = fields.Many2one('stock.location', 'Destination Location', required=True, check_company=True)
+        domain="[('id', '=?', route_company_id)]", index=True)
+    location_id = fields.Many2one('stock.location', 'Destination Location', required=True, check_company=True, index=True)
     location_src_id = fields.Many2one('stock.location', 'Source Location', check_company=True)
-    route_id = fields.Many2one('stock.location.route', 'Route', required=True, ondelete='cascade')
+    route_id = fields.Many2one('stock.location.route', 'Route', required=True, ondelete='cascade', index=True)
     route_company_id = fields.Many2one(related='route_id.company_id', string='Route Company')
     procure_method = fields.Selection([
         ('make_to_stock', 'Take From Stock'),
@@ -85,7 +85,7 @@ class StockRule(models.Model):
     propagate_cancel = fields.Boolean(
         'Cancel Next Move', default=False,
         help="When ticked, if the move created by this rule is cancelled, the next move will be cancelled too.")
-    warehouse_id = fields.Many2one('stock.warehouse', 'Warehouse', check_company=True)
+    warehouse_id = fields.Many2one('stock.warehouse', 'Warehouse', check_company=True, index=True)
     propagate_warehouse_id = fields.Many2one(
         'stock.warehouse', 'Warehouse to Propagate',
         help="The warehouse to propagate on the created move/procurement, which can be different of the warehouse this rule is for (e.g for resupplying rules from another warehouse)")


### PR DESCRIPTION
`product._get_rules_from_location`, `orderpoint._compute_lead_days`
and `orderpoint._compute_rules` can all be performances
bottleneck. This is mostly because the rules are retrieve
one by one, i.e lots of `SELECT ... LIMIT 1` queries
are executed.

Refactoring this in stable is difficult because
there are lots of methods involved and the rules have
some type of hierarchy based on the `location_src_id` field.
So there are recursive calls that are hard to refactor.

Instead of doing that, the idea of this commit is to speed up
these individual `SELECT ... LIMIT 1` queries by adding
b-tree indexes on some of the stock.rule fields that are
used in conditions of these select queries.

#### Speed up

In a customer DB with around 8000 stock.rule, opening the Replenishment
View went from 2 minutes to 1m30s after PR. The replenishment view with 8000
stock.rules produces around 15000 `SELECT rule.id ... LIMIT 1`. Adding indexes
reduces the time taken by each query from 3ms to 1ms, in total making it 30s faster.

The time reported below is the average time per query when the cache is hot. Also,
`max_parallel_workers_per_gather set to 0` to match the PaaS/SaaS psql config.

| No index, 8k stock.rules | Single indexes, 8k stock.rules | No index, 500k stock.rules | Single Indexes, 500k stock.rules |
|:------------------------:|:------------------------------:|:---------------------------:|:--------------------------------:|
| 3ms | 1ms | 60 ms | 1ms |

Basically without indexes, psql relies on simple Seq Scan for most of the Replenishment queries while adding
indexes allows for Index Scan/Bitmap Heap Scan.

#### Multicolumn index vs Single Column Indexes

A similar speed up is achievable by adding a single multicolumn index of the form
`stock_rule (active, action, company_id, location_id, route_id, warehouse_id)`. The advantage
of a multicolumn index is that it takes up less space on disk than 5 single column indexes.
The problem is that the index is not hit if the compute methods
are called with `with_context(active_test=False)`. And removing the active column from the index
makes it useless when active_test is set to True.

#### Cold vs Hot cache 

Time for No Index vs Single Index, cold vs hot cache average over 5 queries changing
warehouse_id and location_id, 8k stock_rules. Time taken from a test DB so the results
are a bit different than the ones above coming from a customer DB.

| No Index cold cache | No Index hot cache | Single Index cold cache | Single Index hot cache |
|:---------------------:|:-------------------:|:------------------------:|:-----------------------:|
| 6ms | 4 ms | 2 ms | 0.9 ms |

The tests were done on PG10 and PG12 and the results were the same for both.


opw-2773988


--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
