### PR TITLE
Update mrp_production.py

### DIFF
--- a/addons/mrp/models/mrp_production.py
+++ b/addons/mrp/models/mrp_production.py
@@ -964,7 +964,7 @@ class MrpProduction(models.Model):
                     )
                 )
 
-            if not any(order.move_raw_ids.mapped('quantity_done')):
+            if order.move_raw_ids and not any(order.move_raw_ids.mapped('quantity_done')):
                 raise UserError(_("You must indicate a non-zero amount consumed for at least one of your components"))
 
             moves_not_to_do = order.move_raw_ids.filtered(lambda x: x.state == 'done')


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
-test quantity_done only if move exist

Current behavior before PR:
- if no move the mrp raise undesired error

Desired behavior after PR is merged:
-no error more :-)



--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
