### PR TITLE
[CLA][FIX] prevent to error on editing mass.mailing

### DIFF
--- a/addons/mass_mailing/models/mailing.py
+++ b/addons/mass_mailing/models/mailing.py
@@ -439,7 +439,7 @@ class MassMailing(models.Model):
         """
 
         # Apply same 'get email field' rule from mail_thread.message_get_default_recipients
-        if 'partner_id' in target._fields:
+        if 'partner_id' in target._fields and target._fields['partner_id'].store:
             mail_field = 'email'
             query = """
                 SELECT lower(substring(p.%(mail_field)s, '([^ ,;<@]+@[^> ,;]+)'))
@@ -450,21 +450,21 @@ class MassMailing(models.Model):
             """
         elif issubclass(type(target), self.pool['mail.address.mixin']):
             mail_field = 'email_normalized'
-        elif 'email_from' in target._fields:
+        elif 'email_from' in target._fields and target._fields['email_from'].store:
             mail_field = 'email_from'
-        elif 'partner_email' in target._fields:
+        elif 'partner_email' in target._fields and target._fields['partner_email'].store:
             mail_field = 'partner_email'
-        elif 'email' in target._fields:
+        elif 'email' in target._fields and target._fields['email'].store:
             mail_field = 'email'
         else:
             raise UserError(_("Unsupported mass mailing model %s") % self.mailing_model_id.name)
 
         if self.unique_ab_testing:
-            query +="""
+            query += """
                AND s.campaign_id = %%(mailing_campaign_id)s;
             """
         else:
-            query +="""
+            query += """
                AND s.mass_mailing_id = %%(mailing_id)s
                AND s.model = %%(target_model)s;
             """

--- a/addons/mass_mailing_sms/models/mailing_mailing.py
+++ b/addons/mass_mailing_sms/models/mailing_mailing.py
@@ -156,12 +156,15 @@ class Mailing(models.Model):
         if issubclass(type(target), self.pool['mail.thread.phone']):
             phone_fields = ['phone_sanitized']
         elif issubclass(type(target), self.pool['mail.thread']):
-            phone_fields = target._sms_get_number_fields()
+            phone_fields = [
+                fname for fname in target._sms_get_number_fields()
+                if fname in target._fields and target._fields[fname].store
+            ]
         else:
             phone_fields = []
-            if 'mobile' in target._fields:
+            if 'mobile' in target._fields and target._fields['mobile'].store:
                 phone_fields.append('mobile')
-            if 'phone' in target._fields:
+            if 'phone' in target._fields and target._fields['phone'].store:
                 phone_fields.append('phone')
         if not phone_fields:
             raise UserError(_("Unsupported %s for mass SMS") % self.mailing_model_id.name)

--- a/addons/test_mass_mailing/models/__init__.py
+++ b/addons/test_mass_mailing/models/__init__.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
+from . import mailing_test_models_cornercases
 from . import mass_mail_test

--- a/addons/test_mass_mailing/models/mailing_test_models_cornercases.py
+++ b/addons/test_mass_mailing/models/mailing_test_models_cornercases.py
@@ -1,0 +1,32 @@
+# -*- coding: utf-8 -*-
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from odoo import api, fields, models
+
+
+class MailingTestPartnerUnstored(models.Model):
+    """ Check mailing with unstored fields """
+    _description = 'Mailing Model without stored partner_id'
+    _name = 'mailing.test.partner.unstored'
+    _inherit = ['mail.thread.blacklist']
+    _primary_email = 'email_from'
+
+    name = fields.Char()
+    email_from = fields.Char()
+    partner_id = fields.Many2one(
+        'res.partner', 'Customer',
+        compute='_compute_partner_id',
+        store=False)
+
+    @api.depends('email_from')
+    def _compute_partner_id(self):
+        partners = self.env['res.partner'].search(
+            [('email_normalized', 'in', self.filtered('email_from').mapped('email_normalized'))]
+        )
+        self.partner_id = False
+        for record in self.filtered('email_from'):
+            record.partner_id = next(
+                (partner.id for partner in partners
+                 if partner.email_normalized == record.email_normalized),
+                False
+            )

--- a/addons/test_mass_mailing/security/ir.model.access.csv
+++ b/addons/test_mass_mailing/security/ir.model.access.csv
@@ -3,3 +3,5 @@ access_mass_mail_test_all,mass.mail.test.all,model_mass_mail_test,,0,0,0,0
 access_mass_mail_test_user,mass.mail.test.user,model_mass_mail_test,base.group_user,1,1,1,1
 access_mass_mail_test_bl_all,mass.mail.test.bl.all,model_mass_mail_test_bl,,0,0,0,0
 access_mass_mail_test_bl_user,mass.mail.test.bl.user,model_mass_mail_test_bl,base.group_user,1,1,1,1
+access_mailing_test_partner_unstored_all,access.mailing.test.partner.unstored.all,model_mailing_test_partner_unstored,,0,0,0,0
+access_mailing_test_partner_unstored_user,access.mailing.test.partner.unstored.user,model_mailing_test_partner_unstored,base.group_user,1,1,1,1

--- a/addons/test_mass_mailing/tests/test_mass_mailing.py
+++ b/addons/test_mass_mailing/tests/test_mass_mailing.py
@@ -1,6 +1,8 @@
 # -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
+import random
+
 from unittest.mock import patch
 from werkzeug import urls
 
@@ -27,6 +29,49 @@ class TestMassMail(MassMailingCase):
         })
 
         self.test_medium = self.env['utm.medium'].create({'name': 'TestMedium'})
+
+    @users('marketing')
+    def test_mailing_seen_list_unstored_partner(self):
+        """ Test seen list / blacklist when partners are not stored. """
+        test_customers = self.env['res.partner'].sudo().create([
+            {'email': f'"Mailing Partner {idx}" <email.from.{idx}@test.example.com',
+             'name': f'Mailing Partner {idx}',
+            } for idx in range(8)
+        ])
+        test_records = self.env['mailing.test.partner.unstored'].create([
+            {'email_from': f'email.from.{idx}@test.example.com',
+             'name': f'Mailing Record {idx}',
+            } for idx in range(10)
+        ])
+        self.assertEqual(test_records[:8].partner_id, test_customers)
+        self.assertFalse(test_records[9:].partner_id)
+
+        mailing = self.env['mailing.mailing'].create({
+            'body_html': '<p>Marketing stuff for ${object.name}</p>',
+            'mailing_domain': [('id', 'in', test_records.ids)],
+            'mailing_model_id': self.env['ir.model']._get_id('mailing.test.partner.unstored'),
+            'name': 'test',
+            'subject': 'Blacklisted',
+        })
+
+        # create existing traces to check the seen list
+        traces = self.env['mailing.trace'].create([{
+            'email': record.email_from,
+            'mass_mailing_id': mailing.id,
+            'message_id': '<%5f@gilbert.boitempomils>' % random.random(),
+            'model': record._name,
+            'res_id': record.id,
+            'state': 'sent',
+        } for record in test_records[:3]])
+        traces.flush()
+
+        # check remaining recipients effectively check seen list
+        mailing.action_put_in_queue()
+        res_ids = mailing._get_remaining_recipients()
+        self.assertEqual(sorted(res_ids), sorted(test_records[3:].ids))
+
+        mailing.action_send_mail(res_ids=test_records.ids)
+        self.assertEqual(len(self._mails), 7, 'Mailing: seen list should contain 3 existing traces')
 
     @users('marketing')
     @mute_logger('odoo.addons.mail.models.mail_mail', 'odoo.models.unlink')

--- a/doc/cla/individual/grzana12.md
+++ b/doc/cla/individual/grzana12.md
@@ -1,0 +1,11 @@
+Poland, 2022-05-04
+
+I hereby agree to the terms of the Odoo Individual Contributor License
+Agreement v1.0.
+
+I declare that I am authorized and able to make this agreement and sign this
+declaration.
+
+Signed,
+
+Łukasz Grzenkowicz lukasz@grzana.pl https://github.com/grzana12


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
after made customization where we need in `mailing.contact.subscription` value of `partner_id` Odoo generate internal Server Error.
Please merge it to 13.0 too

Current behavior before PR:
after added field `partner_id` to model `mailing.contact.subscription` which is not storable application generate 500 error

Desired behavior after PR is merged:
`partner_id` is not storable in result first condition is skipped what is fine



--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr