### PR TITLE
[FIX][13.0] account: duplicate email alias in journal

### DIFF
--- a/addons/account/models/account.py
+++ b/addons/account/models/account.py
@@ -912,18 +912,19 @@ class AccountJournal(models.Model):
         self.refund_sequence = self.type in ('sale', 'purchase')
 
     def _get_alias_values(self, type, alias_name=None):
+        company_name = ''
+        if self.company_id != self.env.ref('base.main_company'):
+            company_name = '-' + str(self.company_id.name)
         if not alias_name:
-            alias_name = self.name
-            if self.company_id != self.env.ref('base.main_company'):
-                alias_name += '-' + str(self.company_id.name)
+            alias_name = self.name + company_name
         try:
             remove_accents(alias_name).encode('ascii')
         except UnicodeEncodeError:
             try:
-                remove_accents(self.code).encode('ascii')
-                safe_alias_name = self.code
+                safe_alias_name = self.code + company_name
+                remove_accents(safe_alias_name).encode('ascii')
             except UnicodeEncodeError:
-                safe_alias_name = self.type
+                safe_alias_name = type
             _logger.warning("Cannot use '%s' as email alias, fallback to '%s'",
                 alias_name, safe_alias_name)
             alias_name = safe_alias_name


### PR DESCRIPTION
With 2 Vietnam company, when loading the COA Vietnam the email alias
will be duplicated

Video demo bug:



https://user-images.githubusercontent.com/26604325/166872917-c7e3a46d-8b1e-4104-bc50-e3408d34eb7c.mp4








--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
