### PR TITLE
[FIX] mrp: date_deadline lost on mrp backorders

### DIFF
--- a/addons/mrp/models/stock_move.py
+++ b/addons/mrp/models/stock_move.py
@@ -414,6 +414,7 @@ class StockMove(models.Model):
         return {
             'state': 'confirmed',
             'reservation_date': self.reservation_date,
+            'date_deadline': self.date_deadline,
             'manual_consumption': self.bom_line_id.manual_consumption or self.product_id.tracking != 'none',
             'move_orig_ids': [Command.link(m.id) for m in self.mapped('move_orig_ids')],
             'move_dest_ids': [Command.link(m.id) for m in self.mapped('move_dest_ids')],

--- a/addons/sale_stock/models/sale_order.py
+++ b/addons/sale_stock/models/sale_order.py
@@ -256,10 +256,3 @@ class SaleOrder(models.Model):
             return self.env['ir.qweb']._render('sale_stock.exception_on_so', values)
 
         self.env['stock.picking']._log_activity(_render_note_exception_quantity_so, documents)
-
-    def _show_cancel_wizard(self):
-        res = super(SaleOrder, self)._show_cancel_wizard()
-        for order in self:
-            if any(picking.state == 'done' for picking in order.picking_ids) and not order._context.get('disable_cancel_warning'):
-                return True
-        return res

--- a/addons/sale_stock/wizard/sale_order_cancel.py
+++ b/addons/sale_stock/wizard/sale_order_cancel.py
@@ -12,4 +12,5 @@ class SaleOrderCancel(models.TransientModel):
     @api.depends('order_id')
     def _compute_display_delivery_alert(self):
         for wizard in self:
-            wizard.display_delivery_alert = bool(any(picking.state == 'done' for picking in wizard.order_id.picking_ids))
+            out_pickings = wizard.order_id.picking_ids.filtered(lambda p: p.picking_type_code == 'outgoing')
+            wizard.display_delivery_alert = bool(any(picking.state == 'done' for picking in out_pickings))


### PR DESCRIPTION
When creating a backorder for a manufacturing order, date_deadline for
its raw_moves are lost in the process, as the field is set to copy
False. But the split of a manufacturing order is not a usual copy paste.

In this specific case, we need to keep the date_deadline as well, or
resulting moves wouldn't be able to be merged with moves in
pre/post-production pickings from the original manufacturing order.

Part of Task-2797359

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
