### PR TITLE
[REF] mail, *: prepare do-action for new env

### DIFF
--- a/addons/mail/static/tests/qunit_suite_tests/components/activity_mark_done_popover_tests.js
+++ b/addons/mail/static/tests/qunit_suite_tests/components/activity_mark_done_popover_tests.js
@@ -199,9 +199,9 @@ QUnit.test('activity mark done popover mark done and schedule next', async funct
     assert.expect(6);
 
     const bus = new Bus();
-    bus.on('do-action', null, payload => {
-        assert.step('activity_action');
-        throw new Error("The do-action event should not be triggered when the route doesn't return an action");
+    bus.on('do-action', null, () => {
+            assert.step('activity_action');
+            throw new Error("The do-action event should not be triggered when the route doesn't return an action");
     });
     const pyEnv = await startServer();
     const resPartnerId1 = pyEnv['res.partner'].create();
@@ -249,13 +249,13 @@ QUnit.test('[technical] activity mark done & schedule next with new action', asy
     assert.expect(3);
 
     const bus = new Bus();
-    bus.on('do-action', null, payload => {
-        assert.step('activity_action');
-        assert.deepEqual(
-            payload.action,
-            { type: 'ir.actions.act_window' },
-            "The content of the action should be correct"
-        );
+    bus.on('do-action', null, ({ action }) => {
+            assert.step('activity_action');
+            assert.deepEqual(
+                action,
+                { type: 'ir.actions.act_window' },
+                "The content of the action should be correct"
+            );
     });
     const pyEnv = await startServer();
     const resPartnerId1 = pyEnv['res.partner'].create();

--- a/addons/mail/static/tests/qunit_suite_tests/components/activity_tests.js
+++ b/addons/mail/static/tests/qunit_suite_tests/components/activity_tests.js
@@ -603,37 +603,37 @@ QUnit.test('activity with mail template: preview mail', async function (assert) 
         res_model: 'res.partner',
     });
     const bus = new Bus();
-    bus.on('do-action', null, payload => {
-        assert.step('do_action');
-        assert.strictEqual(
-            payload.action.context.default_res_id,
-            resPartnerId1,
-            'Action should have the activity res id as default res id in context'
-        );
-        assert.strictEqual(
-            payload.action.context.default_model,
-            'res.partner',
-            'Action should have the activity res model as default model in context'
-        );
-        assert.ok(
-            payload.action.context.default_use_template,
-            'Action should have true as default use_template in context'
-        );
-        assert.strictEqual(
-            payload.action.context.default_template_id,
-            mailTemplateId1,
-            'Action should have the selected mail template id as default template id in context'
-        );
-        assert.strictEqual(
-            payload.action.type,
-            "ir.actions.act_window",
-            'Action should be of type "ir.actions.act_window"'
-        );
-        assert.strictEqual(
-            payload.action.res_model,
-            "mail.compose.message",
-            'Action should have "mail.compose.message" as res_model'
-        );
+    bus.on('do-action', null, ({ action }) => {
+            assert.step('do_action');
+            assert.strictEqual(
+                action.context.default_res_id,
+                resPartnerId1,
+                'Action should have the activity res id as default res id in context'
+            );
+            assert.strictEqual(
+                action.context.default_model,
+                'res.partner',
+                'Action should have the activity res model as default model in context'
+            );
+            assert.ok(
+                action.context.default_use_template,
+                'Action should have true as default use_template in context'
+            );
+            assert.strictEqual(
+                action.context.default_template_id,
+                mailTemplateId1,
+                'Action should have the selected mail template id as default template id in context'
+            );
+            assert.strictEqual(
+                action.type,
+                "ir.actions.act_window",
+                'Action should be of type "ir.actions.act_window"'
+            );
+            assert.strictEqual(
+                action.res_model,
+                "mail.compose.message",
+                'Action should have "mail.compose.message" as res_model'
+            );
     });
     const { createChatterContainerComponent } = await start({ env: { bus } });
     await createChatterContainerComponent({
@@ -836,33 +836,33 @@ QUnit.test('activity click on edit', async function (assert) {
         res_model: 'res.partner',
     });
     const bus = new Bus();
-    bus.on('do-action', null, payload => {
-        assert.step('do_action');
-        assert.strictEqual(
-            payload.action.context.default_res_id,
-            resPartnerId1,
-            'Action should have the activity res id as default res id in context'
-        );
-        assert.strictEqual(
-            payload.action.context.default_res_model,
-            'res.partner',
-            'Action should have the activity res model as default res model in context'
-        );
-        assert.strictEqual(
-            payload.action.type,
-            "ir.actions.act_window",
-            'Action should be of type "ir.actions.act_window"'
-        );
-        assert.strictEqual(
-            payload.action.res_model,
-            "mail.activity",
-            'Action should have "mail.activity" as res_model'
-        );
-        assert.strictEqual(
-            payload.action.res_id,
-            mailActivityId1,
-            'Action should have activity id as res_id'
-        );
+    bus.on('do-action', null, ({ action }) => {
+            assert.step('do_action');
+            assert.strictEqual(
+                action.context.default_res_id,
+                resPartnerId1,
+                'Action should have the activity res id as default res id in context'
+            );
+            assert.strictEqual(
+                action.context.default_res_model,
+                'res.partner',
+                'Action should have the activity res model as default res model in context'
+            );
+            assert.strictEqual(
+                action.type,
+                "ir.actions.act_window",
+                'Action should be of type "ir.actions.act_window"'
+            );
+            assert.strictEqual(
+                action.res_model,
+                "mail.activity",
+                'Action should have "mail.activity" as res_model'
+            );
+            assert.strictEqual(
+                action.res_id,
+                mailActivityId1,
+                'Action should have activity id as res_id'
+            );
     });
     const { createChatterContainerComponent } = await start({ env: { bus } });
     await createChatterContainerComponent({
@@ -899,35 +899,35 @@ QUnit.test('activity edition', async function (assert) {
         res_model: 'res.partner',
     });
     const bus = new Bus();
-    bus.on('do-action', null, payload => {
-        assert.step('do_action');
-        assert.strictEqual(
-            payload.action.context.default_res_id,
-            resPartnerId1,
-            'Action should have the activity res id as default res id in context'
-        );
-        assert.strictEqual(
-            payload.action.context.default_res_model,
-            'res.partner',
-            'Action should have the activity res model as default res model in context'
-        );
-        assert.strictEqual(
-            payload.action.type,
-            'ir.actions.act_window',
-            'Action should be of type "ir.actions.act_window"'
-        );
-        assert.strictEqual(
-            payload.action.res_model,
-            'mail.activity',
-            'Action should have "mail.activity" as res_model'
-        );
-        assert.strictEqual(
-            payload.action.res_id,
-            mailActivityId1,
-            'Action should have activity id as res_id'
-        );
-        pyEnv['mail.activity'].write([mailActivityId1], { icon: 'fa-check' });
-        payload.options.on_close();
+    bus.on('do-action', null, ({ action, options }) => {
+            assert.step('do_action');
+            assert.strictEqual(
+                action.context.default_res_id,
+                resPartnerId1,
+                'Action should have the activity res id as default res id in context'
+            );
+            assert.strictEqual(
+                action.context.default_res_model,
+                'res.partner',
+                'Action should have the activity res model as default res model in context'
+            );
+            assert.strictEqual(
+                action.type,
+                'ir.actions.act_window',
+                'Action should be of type "ir.actions.act_window"'
+            );
+            assert.strictEqual(
+                action.res_model,
+                'mail.activity',
+                'Action should have "mail.activity" as res_model'
+            );
+            assert.strictEqual(
+                action.res_id,
+                mailActivityId1,
+                'Action should have activity id as res_id'
+            );
+            pyEnv['mail.activity'].write([mailActivityId1], { icon: 'fa-check' });
+            options.on_close();
     });
     const { click, createChatterContainerComponent } = await start({ env: { bus } });
     await createChatterContainerComponent({
@@ -1110,23 +1110,23 @@ QUnit.test('data-oe-id & data-oe-model link redirection on click', async functio
     assert.expect(7);
 
     const bus = new Bus();
-    bus.on('do-action', null, payload => {
-        assert.strictEqual(
-            payload.action.type,
-            'ir.actions.act_window',
-            "action should open view"
-        );
-        assert.strictEqual(
-            payload.action.res_model,
-            'some.model',
-            "action should open view on 'some.model' model"
-        );
-        assert.strictEqual(
-            payload.action.res_id,
-            250,
-            "action should open view on 250"
-        );
-        assert.step('do-action:openFormView_some.model_250');
+    bus.on('do-action', null, ({ action }) => {
+            assert.strictEqual(
+                action.type,
+                'ir.actions.act_window',
+                "action should open view"
+            );
+            assert.strictEqual(
+                action.res_model,
+                'some.model',
+                "action should open view on 'some.model' model"
+            );
+            assert.strictEqual(
+                action.res_id,
+                250,
+                "action should open view on 250"
+            );
+            assert.step('do-action:openFormView_some.model_250');
     });
     const pyEnv = await startServer();
     const resPartnerId1 = pyEnv['res.partner'].create();

--- a/addons/mail/static/tests/qunit_suite_tests/components/discuss_inbox_tests.js
+++ b/addons/mail/static/tests/qunit_suite_tests/components/discuss_inbox_tests.js
@@ -602,31 +602,31 @@ QUnit.test('click on (non-channel/non-partner) origin thread link should redirec
         res_partner_id: pyEnv.currentPartnerId,
     });
     const bus = new Bus();
-    bus.on('do-action', null, payload => {
-        // Callback of doing an action (action manager).
-        // Expected to be called on click on origin thread link,
-        // which redirects to form view of record related to origin thread
-        assert.step('do-action');
-        assert.strictEqual(
-            payload.action.type,
-            'ir.actions.act_window',
-            "action should open a view"
-        );
-        assert.deepEqual(
-            payload.action.views,
-            [[false, 'form']],
-            "action should open form view"
-        );
-        assert.strictEqual(
-            payload.action.res_model,
-            'res.fake',
-            "action should open view with model 'res.fake' (model of message origin thread)"
-        );
-        assert.strictEqual(
-            payload.action.res_id,
-            resFakeId1,
-            "action should open view with id of resFake1 (id of message origin thread)"
-        );
+    bus.on('do-action', null, ({ action }) => {
+            // Callback of doing an action (action manager).
+            // Expected to be called on click on origin thread link,
+            // which redirects to form view of record related to origin thread
+            assert.step('do-action');
+            assert.strictEqual(
+                action.type,
+                'ir.actions.act_window',
+                "action should open a view"
+            );
+            assert.deepEqual(
+                action.views,
+                [[false, 'form']],
+                "action should open form view"
+            );
+            assert.strictEqual(
+                action.res_model,
+                'res.fake',
+                "action should open view with model 'res.fake' (model of message origin thread)"
+            );
+            assert.strictEqual(
+                action.res_id,
+                resFakeId1,
+                "action should open view with id of resFake1 (id of message origin thread)"
+            );
     });
     await this.start({
         env: {

--- a/addons/mail/static/tests/qunit_suite_tests/components/follower_list_menu_tests.js
+++ b/addons/mail/static/tests/qunit_suite_tests/components/follower_list_menu_tests.js
@@ -105,30 +105,30 @@ QUnit.test('click on "add followers" button', async function (assert) {
         res_model: 'res.partner',
     });
     const bus = new Bus();
-    bus.on('do-action', null, payload => {
-        assert.step('action:open_view');
-        assert.strictEqual(
-            payload.action.context.default_res_model,
-            'res.partner',
-            "'The 'add followers' action should contain thread model in context'"
-        );
-        assert.strictEqual(
-            payload.action.context.default_res_id,
-            resPartnerId1,
-            "The 'add followers' action should contain thread id in context"
-        );
-        assert.strictEqual(
-            payload.action.res_model,
-            'mail.wizard.invite',
-            "The 'add followers' action should be a wizard invite of mail module"
-        );
-        assert.strictEqual(
-            payload.action.type,
-            "ir.actions.act_window",
-            "The 'add followers' action should be of type 'ir.actions.act_window'"
-        );
-        pyEnv['res.partner'].write([payload.action.context.default_res_id], { message_follower_ids: [mailFollowerId1] });
-        payload.options.on_close();
+    bus.on('do-action', null, ({ action, options }) => {
+            assert.step('action:open_view');
+            assert.strictEqual(
+                action.context.default_res_model,
+                'res.partner',
+                "'The 'add followers' action should contain thread model in context'"
+            );
+            assert.strictEqual(
+                action.context.default_res_id,
+                resPartnerId1,
+                "The 'add followers' action should contain thread id in context"
+            );
+            assert.strictEqual(
+                action.res_model,
+                'mail.wizard.invite',
+                "The 'add followers' action should be a wizard invite of mail module"
+            );
+            assert.strictEqual(
+                action.type,
+                "ir.actions.act_window",
+                "The 'add followers' action should be of type 'ir.actions.act_window'"
+            );
+            pyEnv['res.partner'].write([action.context.default_res_id], { message_follower_ids: [mailFollowerId1] });
+            options.on_close();
     });
     const { click, createFollowerListMenuComponent, messaging, widget } = await start({ env: { bus } });
     const thread = messaging.models['Thread'].create({

--- a/addons/mail/static/tests/qunit_suite_tests/components/follower_tests.js
+++ b/addons/mail/static/tests/qunit_suite_tests/components/follower_tests.js
@@ -126,24 +126,24 @@ QUnit.test('click on partner follower details', async function (assert) {
 
     const openFormDef = makeDeferred();
     const bus = new Bus();
-    bus.on('do-action', null, payload => {
-        assert.step('do_action');
-        assert.strictEqual(
-            payload.action.res_id,
-            3,
-            "The redirect action should redirect to the right res id (3)"
-        );
-        assert.strictEqual(
-            payload.action.res_model,
-            'res.partner',
-            "The redirect action should redirect to the right res model (res.partner)"
-        );
-        assert.strictEqual(
-            payload.action.type,
-            "ir.actions.act_window",
-            "The redirect action should be of type 'ir.actions.act_window'"
-        );
-        openFormDef.resolve();
+    bus.on('do-action', null, ({ action }) => {
+            assert.step('do_action');
+            assert.strictEqual(
+                action.res_id,
+                3,
+                "The redirect action should redirect to the right res id (3)"
+            );
+            assert.strictEqual(
+                action.res_model,
+                'res.partner',
+                "The redirect action should redirect to the right res model (res.partner)"
+            );
+            assert.strictEqual(
+                action.type,
+                "ir.actions.act_window",
+                "The redirect action should be of type 'ir.actions.act_window'"
+            );
+            openFormDef.resolve();
     });
     const pyEnv = await startServer();
     const resPartnerId1 = pyEnv['res.partner'].create();

--- a/addons/mail/static/tests/qunit_suite_tests/components/message_tests.js
+++ b/addons/mail/static/tests/qunit_suite_tests/components/message_tests.js
@@ -190,19 +190,19 @@ QUnit.test('Notification Error', async function (assert) {
     });
     const openResendActionDef = makeDeferred();
     const bus = new Bus();
-    bus.on('do-action', null, payload => {
-        assert.step('do_action');
-        assert.strictEqual(
-            payload.action,
-            'mail.mail_resend_message_action',
-            "action should be the one to resend email"
-        );
-        assert.strictEqual(
-            payload.options.additional_context.mail_message_to_resend,
-            mailMessageId1,
-            "action should have correct message id"
-        );
-        openResendActionDef.resolve();
+    bus.on('do-action', null, ({ action, options }) => {
+            assert.step('do_action');
+            assert.strictEqual(
+                action,
+                'mail.mail_resend_message_action',
+                "action should be the one to resend email"
+            );
+            assert.strictEqual(
+                options.additional_context.mail_message_to_resend,
+                mailMessageId1,
+                "action should have correct message id"
+            );
+            openResendActionDef.resolve();
     });
     const { createThreadViewComponent, messaging } = await start({ env: { bus } });
     const thread = messaging.models['Thread'].findFromIdentifyingData({
@@ -756,23 +756,23 @@ QUnit.test('data-oe-id & data-oe-model link redirection on click', async functio
     assert.expect(7);
 
     const bus = new Bus();
-    bus.on('do-action', null, payload => {
-        assert.strictEqual(
-            payload.action.type,
-            'ir.actions.act_window',
-            "action should open view"
-        );
-        assert.strictEqual(
-            payload.action.res_model,
-            'some.model',
-            "action should open view on 'some.model' model"
-        );
-        assert.strictEqual(
-            payload.action.res_id,
-            250,
-            "action should open view on 250"
-        );
-        assert.step('do-action:openFormView_some.model_250');
+    bus.on('do-action', null, ({ action }) => {
+            assert.strictEqual(
+                action.type,
+                'ir.actions.act_window',
+                "action should open view"
+            );
+            assert.strictEqual(
+                action.res_model,
+                'some.model',
+                "action should open view on 'some.model' model"
+            );
+            assert.strictEqual(
+                action.res_id,
+                250,
+                "action should open view on 250"
+            );
+            assert.step('do-action:openFormView_some.model_250');
     });
     const { createMessageComponent, messaging } = await start({ env: { bus } });
     const message = messaging.models['Message'].create({

--- a/addons/mail/static/tests/qunit_suite_tests/components/notification_list_notification_group_tests.js
+++ b/addons/mail/static/tests/qunit_suite_tests/components/notification_list_notification_group_tests.js
@@ -226,43 +226,43 @@ QUnit.test('grouped notifications by document model', async function (assert) {
         },
     ]);
     const bus = new Bus();
-    bus.on('do-action', null, payload => {
-        assert.step('do_action');
-        assert.strictEqual(
-            payload.action.name,
-            "Mail Failures",
-            "action should have 'Mail Failures' as name",
-        );
-        assert.strictEqual(
-            payload.action.type,
-            'ir.actions.act_window',
-            "action should have the type act_window"
-        );
-        assert.strictEqual(
-            payload.action.view_mode,
-            'kanban,list,form',
-            "action should have 'kanban,list,form' as view_mode"
-        );
-        assert.strictEqual(
-            JSON.stringify(payload.action.views),
-            JSON.stringify([[false, 'kanban'], [false, 'list'], [false, 'form']]),
-            "action should have correct views"
-        );
-        assert.strictEqual(
-            payload.action.target,
-            'current',
-            "action should have 'current' as target"
-        );
-        assert.strictEqual(
-            payload.action.res_model,
-            'res.partner',
-            "action should have the group model as res_model"
-        );
-        assert.strictEqual(
-            JSON.stringify(payload.action.domain),
-            JSON.stringify([['message_has_error', '=', true]]),
-            "action should have 'message_has_error' as domain"
-        );
+    bus.on('do-action', null, ({ action }) => {
+            assert.step('do_action');
+            assert.strictEqual(
+                action.name,
+                "Mail Failures",
+                "action should have 'Mail Failures' as name",
+            );
+            assert.strictEqual(
+                action.type,
+                'ir.actions.act_window',
+                "action should have the type act_window"
+            );
+            assert.strictEqual(
+                action.view_mode,
+                'kanban,list,form',
+                "action should have 'kanban,list,form' as view_mode"
+            );
+            assert.strictEqual(
+                JSON.stringify(action.views),
+                JSON.stringify([[false, 'kanban'], [false, 'list'], [false, 'form']]),
+                "action should have correct views"
+            );
+            assert.strictEqual(
+                action.target,
+                'current',
+                "action should have 'current' as target"
+            );
+            assert.strictEqual(
+                action.res_model,
+                'res.partner',
+                "action should have the group model as res_model"
+            );
+            assert.strictEqual(
+                JSON.stringify(action.domain),
+                JSON.stringify([['message_has_error', '=', true]]),
+                "action should have 'message_has_error' as domain"
+            );
     });
 
     const { createNotificationListComponent } = await start({ env: { bus } });

--- a/addons/mail/static/tests/qunit_suite_tests/components/thread_needaction_preview_tests.js
+++ b/addons/mail/static/tests/qunit_suite_tests/components/thread_needaction_preview_tests.js
@@ -151,18 +151,18 @@ QUnit.test('click on expand from chat window should close the chat window and op
         res_partner_id: pyEnv.currentPartnerId,
     });
     const bus = new Bus();
-    bus.on('do-action', null, payload => {
-        assert.step('do_action');
-        assert.strictEqual(
-            payload.action.res_id,
-            resPartnerId1,
-            "should redirect to the id of the thread"
-        );
-        assert.strictEqual(
-            payload.action.res_model,
-            'res.partner',
-            "should redirect to the model of the thread"
-        );
+    bus.on('do-action', null, ({ action }) => {
+            assert.step('do_action');
+            assert.strictEqual(
+                action.res_id,
+                resPartnerId1,
+                "should redirect to the id of the thread"
+            );
+            assert.strictEqual(
+                action.res_model,
+                'res.partner',
+                "should redirect to the model of the thread"
+            );
     });
     const { afterEvent, click, createMessagingMenuComponent } = await start({
         env: { bus },

--- a/addons/sms/static/tests/qunit_suite_tests/components/message_tests.js
+++ b/addons/sms/static/tests/qunit_suite_tests/components/message_tests.js
@@ -114,19 +114,19 @@ QUnit.test('Notification Error', async function (assert) {
         res_partner_id: resPartnerId1,
     });
     const bus = new Bus();
-    bus.on('do-action', null, payload => {
-        assert.step('do_action');
-        assert.strictEqual(
-            payload.action,
-            'sms.sms_resend_action',
-            "action should be the one to resend sms"
-        );
-        assert.strictEqual(
-            payload.options.additional_context.default_mail_message_id,
-            mailMessageId1,
-            "action should have correct message id"
-        );
-        openResendActionDef.resolve();
+    bus.on('do-action', null, ({ action, options }) => {
+            assert.step('do_action');
+            assert.strictEqual(
+                action,
+                'sms.sms_resend_action',
+                "action should be the one to resend sms"
+            );
+            assert.strictEqual(
+                options.additional_context.default_mail_message_id,
+                mailMessageId1,
+                "action should have correct message id"
+            );
+            openResendActionDef.resolve();
     });
     const { createThreadViewComponent, messaging } = await start({ env: { bus } });
     const threadViewer = messaging.models['ThreadViewer'].create({

--- a/addons/sms/static/tests/qunit_suite_tests/components/notification_list_notification_group_tests.js
+++ b/addons/sms/static/tests/qunit_suite_tests/components/notification_list_notification_group_tests.js
@@ -190,43 +190,43 @@ QUnit.test('grouped notifications by document model', async function (assert) {
         },
     ]);
     const bus = new Bus();
-    bus.on('do-action', null, payload => {
-        assert.step('do_action');
-        assert.strictEqual(
-            payload.action.name,
-            "SMS Failures",
-            "action should have 'SMS Failures' as name",
-        );
-        assert.strictEqual(
-            payload.action.type,
-            'ir.actions.act_window',
-            "action should have the type act_window"
-        );
-        assert.strictEqual(
-            payload.action.view_mode,
-            'kanban,list,form',
-            "action should have 'kanban,list,form' as view_mode"
-        );
-        assert.strictEqual(
-            JSON.stringify(payload.action.views),
-            JSON.stringify([[false, 'kanban'], [false, 'list'], [false, 'form']]),
-            "action should have correct views"
-        );
-        assert.strictEqual(
-            payload.action.target,
-            'current',
-            "action should have 'current' as target"
-        );
-        assert.strictEqual(
-            payload.action.res_model,
-            'res.partner',
-            "action should have the group model as res_model"
-        );
-        assert.strictEqual(
-            JSON.stringify(payload.action.domain),
-            JSON.stringify([['message_has_sms_error', '=', true]]),
-            "action should have 'message_has_sms_error' as domain"
-        );
+    bus.on('do-action', null, ({ action }) => {
+            assert.step('do_action');
+            assert.strictEqual(
+                action.name,
+                "SMS Failures",
+                "action should have 'SMS Failures' as name",
+            );
+            assert.strictEqual(
+                action.type,
+                'ir.actions.act_window',
+                "action should have the type act_window"
+            );
+            assert.strictEqual(
+                action.view_mode,
+                'kanban,list,form',
+                "action should have 'kanban,list,form' as view_mode"
+            );
+            assert.strictEqual(
+                JSON.stringify(action.views),
+                JSON.stringify([[false, 'kanban'], [false, 'list'], [false, 'form']]),
+                "action should have correct views"
+            );
+            assert.strictEqual(
+                action.target,
+                'current',
+                "action should have 'current' as target"
+            );
+            assert.strictEqual(
+                action.res_model,
+                'res.partner',
+                "action should have the group model as res_model"
+            );
+            assert.strictEqual(
+                JSON.stringify(action.domain),
+                JSON.stringify([['message_has_sms_error', '=', true]]),
+                "action should have 'message_has_sms_error' as domain"
+            );
     });
 
     const { createNotificationListComponent } = await start({ env: { bus } });

--- a/addons/snailmail/static/tests/qunit_suite_tests/components/message_tests.js
+++ b/addons/snailmail/static/tests/qunit_suite_tests/components/message_tests.js
@@ -562,18 +562,18 @@ QUnit.test('Format Error', async function (assert) {
         res_partner_id: resPartnerId1,
     });
     const bus = new Bus();
-    bus.on('do-action', null, payload => {
-        assert.step('do_action');
-        assert.strictEqual(
-            payload.action,
-            'snailmail.snailmail_letter_format_error_action',
-            "action should be the one for format error"
-        );
-        assert.strictEqual(
-            payload.options.additional_context.message_id,
-            mailMessageId1,
-            "action should have correct message id"
-        );
+    bus.on('do-action', null, ({ action, options }) => {
+            assert.step('do_action');
+            assert.strictEqual(
+                action,
+                'snailmail.snailmail_letter_format_error_action',
+                "action should be the one for format error"
+            );
+            assert.strictEqual(
+                options.additional_context.message_id,
+                mailMessageId1,
+                "action should have correct message id"
+            );
     });
     const { createThreadViewComponent, messaging } = await start({ env: { bus } });
     const threadViewer = messaging.models['ThreadViewer'].create({
@@ -637,18 +637,18 @@ QUnit.test('Missing Required Fields', async function (assert) {
         message_id: mailMessageId1,
     });
     const bus = new Bus();
-    bus.on('do-action', null, payload => {
-        assert.step('do_action');
-        assert.strictEqual(
-            payload.action,
-            'snailmail.snailmail_letter_missing_required_fields_action',
-            "action should be the one for missing fields"
-        );
-        assert.strictEqual(
-            payload.options.additional_context.default_letter_id,
-            snailMailLetterId1,
-            "action should have correct letter id"
-        );
+    bus.on('do-action', null, ({ action, options }) => {
+            assert.step('do_action');
+            assert.strictEqual(
+                action,
+                'snailmail.snailmail_letter_missing_required_fields_action',
+                "action should be the one for missing fields"
+            );
+            assert.strictEqual(
+                options.additional_context.default_letter_id,
+                snailMailLetterId1,
+                "action should have correct letter id"
+            );
     });
 
     const { createThreadViewComponent, messaging } = await start({

--- a/addons/snailmail/static/tests/qunit_suite_tests/components/notification_list_notification_group_tests.js
+++ b/addons/snailmail/static/tests/qunit_suite_tests/components/notification_list_notification_group_tests.js
@@ -190,43 +190,43 @@ QUnit.test('grouped notifications by document model', async function (assert) {
         },
     ]);
     const bus = new Bus();
-    bus.on('do-action', null, payload => {
-        assert.step('do_action');
-        assert.strictEqual(
-            payload.action.name,
-            "Snailmail Failures",
-            "action should have 'Snailmail Failures' as name",
-        );
-        assert.strictEqual(
-            payload.action.type,
-            'ir.actions.act_window',
-            "action should have the type act_window"
-        );
-        assert.strictEqual(
-            payload.action.view_mode,
-            'kanban,list,form',
-            "action should have 'kanban,list,form' as view_mode"
-        );
-        assert.strictEqual(
-            JSON.stringify(payload.action.views),
-            JSON.stringify([[false, 'kanban'], [false, 'list'], [false, 'form']]),
-            "action should have correct views"
-        );
-        assert.strictEqual(
-            payload.action.target,
-            'current',
-            "action should have 'current' as target"
-        );
-        assert.strictEqual(
-            payload.action.res_model,
-            'res.partner',
-            "action should have the group model as res_model"
-        );
-        assert.strictEqual(
-            JSON.stringify(payload.action.domain),
-            JSON.stringify([['message_ids.snailmail_error', '=', true]]),
-            "action should have 'message_has_sms_error' as domain"
-        );
+    bus.on('do-action', null, ({ action }) => {
+            assert.step('do_action');
+            assert.strictEqual(
+                action.name,
+                "Snailmail Failures",
+                "action should have 'Snailmail Failures' as name",
+            );
+            assert.strictEqual(
+                action.type,
+                'ir.actions.act_window',
+                "action should have the type act_window"
+            );
+            assert.strictEqual(
+                action.view_mode,
+                'kanban,list,form',
+                "action should have 'kanban,list,form' as view_mode"
+            );
+            assert.strictEqual(
+                JSON.stringify(action.views),
+                JSON.stringify([[false, 'kanban'], [false, 'list'], [false, 'form']]),
+                "action should have correct views"
+            );
+            assert.strictEqual(
+                action.target,
+                'current',
+                "action should have 'current' as target"
+            );
+            assert.strictEqual(
+                action.res_model,
+                'res.partner',
+                "action should have the group model as res_model"
+            );
+            assert.strictEqual(
+                JSON.stringify(action.domain),
+                JSON.stringify([['message_ids.snailmail_error', '=', true]]),
+                "action should have 'message_has_sms_error' as domain"
+            );
     });
 
     const { createNotificationListComponent } = await start({ env: { bus } });


### PR DESCRIPTION
*: sms, snailmail, test_mail.

This PR helps reducing the noise in the one introducing the new environment in
the discuss app. Indeed, we won't rely on the bus anymore to listen to do actions,
we will instead use the action service. The diff is awfull because the indentation
has changed as well as the parameter names. Changing the indentation and the parameters
now will ease the review of the main task.

task-2582313

enterprise: https://github.com/odoo/enterprise/pull/26970