### PR TITLE
[FIX] web: list view optional columns icon position

### DIFF
--- a/addons/web/static/src/legacy/js/views/list/list_renderer.js
+++ b/addons/web/static/src/legacy/js/views/list/list_renderer.js
@@ -1132,7 +1132,7 @@ var ListRenderer = BasicRenderer.extend({
             if (this._shouldRenderOptionalColumnsDropdown()) {
                 this.el.classList.add('o_list_optional_columns');
                 this.$('table').append(
-                    $('<i class="o_optional_columns_dropdown_toggle oi oi-settings-adjust"/>')
+                    $('<i class="o_optional_columns_dropdown_toggle oi oi-fw oi-settings-adjust lh-base"/>')
                 );
                 this.$el.append(this._renderOptionalColumnsDropdown());
             }

--- a/addons/web/static/src/legacy/scss/list_view.scss
+++ b/addons/web/static/src/legacy/scss/list_view.scss
@@ -337,7 +337,7 @@
     // Optional fields
     &.o_list_optional_columns {
         th:last-child {
-            padding-right: 15px;
+            padding-right: calc(#{$oi-fw-ratio} * var(--oi-font-size, #{$oi-default-size})); // matches the .oi-fw width calculation
         }
     }
 
@@ -347,9 +347,8 @@
 
     .o_optional_columns_dropdown_toggle {
         cursor: pointer;
-        padding: 0 5px;
-        text-align: center;
-        line-height: 30px;
+        padding-top: calc(#{$table-cell-padding-sm} + #{$table-border-width}); // matches the .table header-cell top box-size
+        padding-bottom: calc(#{$table-cell-padding-sm} + #{2 * $table-border-width}); // matches the .table header-cell bottom box-size
         z-index: 1; // must be over the resize handle
     }
 

--- a/addons/web/static/src/libs/bs5_utility_classes.scss
+++ b/addons/web/static/src/libs/bs5_utility_classes.scss
@@ -93,3 +93,21 @@ $position-properties: (
 .fst-normal {
   font-style: normal !important;
 }
+
+// == Line Height
+//------------------------------------------------------------------------------
+// "Bootstrap v5 ready" utility-class to handle line-height.
+// These class definition can be safely removed after migrating to BTS v5.
+
+$line-height-values: (
+  1: 1,
+  sm: $line-height-sm,
+  base: $line-height-base,
+  lg: $line-height-lg,
+);
+
+@each $-value-key, $-value in $line-height-values {
+  .lh-#{$-value-key} {
+    line-height: #{$-value};
+  }
+}


### PR DESCRIPTION
Before this commit, the column customization icon sometimes covers the
last column header in list views (or the 'ordering carret' icon).

Steps to reproduce:
- open Survey in list view
=> Avg Score column header overlaps with the icon

This commit adapts the headers last column's padding and the
customization icon's width to match each other and avoid overlapping.

It also adapts the vertical positionning of the icon and backport BS5 utility classes for `line-height`.

task-2816987

Related PR https://github.com/odoo/enterprise/pull/26974