### PR TITLE
[FIX] mail: send email from CRM using a template

### DIFF
--- a/addons/mail/wizard/mail_compose_message.py
+++ b/addons/mail/wizard/mail_compose_message.py
@@ -442,6 +442,7 @@ class MailComposer(models.TransientModel):
                 'subject': record.subject or False,
                 'body_html': record.body or False,
                 'model_id': model.id or False,
+                'use_default_to': True,
             }
             template = self.env['mail.template'].create(values)
 


### PR DESCRIPTION
When sending emails from CRM, you can save the mail as a new template.
Despite having selected the desired recipients, the mails sent will not
have any recipients.

Steps to reproduce:
1. Install CRM and open the app
2. Trigger the list view of the pipeline
3. Select any opportunities, go to Action and click on 'Send email'
4. Give a subject to the email and click on 'SAVE AS NEW TEMPLATE'
5. Send the email
6. Go to emails, there are no recipients for the emails generated

Solution:
Set the `use_default_to` to true by default when using the 'SAVE AS NEW
TEMPLATE' button

opw-2827177