### PR TITLE
[FIX] point_of_sale: update customer screen after clicking on "New Order"

### DIFF
--- a/addons/point_of_sale/static/src/js/Screens/ReceiptScreen/ReceiptScreen.js
+++ b/addons/point_of_sale/static/src/js/Screens/ReceiptScreen/ReceiptScreen.js
@@ -89,6 +89,9 @@ odoo.define('point_of_sale.ReceiptScreen', function (require) {
                 this.currentOrder.finalize();
                 const { name, props } = this.nextScreen;
                 this.showScreen(name, props);
+                if (this.env.pos.config.iface_customer_facing_display) {
+                    this.env.pos.send_current_order_to_customer_facing_display();
+                }
             }
             async printReceipt() {
                 const isPrinted = await this._printReceipt();


### PR DESCRIPTION

When customer pays for the order and cashier validates it and creates new order, customer screen does not update.
This means that new customer can still see the previous order until cashier starts adding new products to empty order.

With this fix customer screen will update after cashier clicks on "New Order" button.

fixes OPW-2734487


--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
