### PR TITLE
[FIX] sale: do not suggest unsaleable optional products

### DIFF
--- a/addons/sale/models/product_template.py
+++ b/addons/sale/models/product_template.py
@@ -289,7 +289,7 @@ class ProductTemplate(models.Model):
         :rtype: bool
         """
         self.ensure_one()
-        if not self.active:
+        if not self.active or not self.sale_ok:
             # for performance: avoid calling `_get_possible_combinations`
             return False
         return next(self._get_possible_combinations(parent_combination), False) is not False


### PR DESCRIPTION
If we had a product as an option to multiple products and we want to stop selling it we'll set sale_ok to `False`. We won't be able to add it to the sale lines but it will keep showing up in the products options popup and we'll be able to add it to the order that way. It must be prevented to keep a coherent behavior.

Description of the issue/feature this PR addresses:

- Add a product as optional product A to several products (B, C, D).
- Set that product to `sale_ok` = False
- Create a sale order

Current behavior before PR:

- Product A can't be selected from the order lines (:+1: )
- Add either product B, C or D and the optional products popup shows up allowing us to add Product A to the sale lines.

Desired behavior after PR is merged:

When a product is discarded from sale, we should not be able to add it as an option. Removing it as option in the affected product is not a proper workflow, as the product could be simply temporarily out of sale due to multiple commercial reasons.

cc @Tecnativa TT36178

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
