### PR TITLE
[FIX] web_editor: resolve bug when clicking on form fields in edit mode

### DIFF
--- a/addons/web_editor/static/src/js/wysiwyg/root.js
+++ b/addons/web_editor/static/src/js/wysiwyg/root.js
@@ -89,3 +89,28 @@ return {
     fontSizes: [_lt('Default'), 8, 9, 10, 11, 12, 14, 18, 24, 36, 48, 62],
 };
 });
+
+// TODO should be moved in a dedicated file in newer versions
+odoo.define('web_editor.browser_extensions', function (require) {
+'use strict';
+
+// Redefine the getRangeAt function in order to avoid an error appearing
+// sometimes when an input element is focused on Firefox.
+// The error happens because the range returned by getRangeAt is "restricted".
+// Ex: Range { commonAncestorContainer: Restricted, startContainer: Restricted,
+// startOffset: 0, endContainer: Restricted, endOffset: 0, collapsed: true }
+// The solution consists in detecting when the range is restricted and then
+// redefining it manually based on the current selection.
+const originalGetRangeAt = Selection.prototype.getRangeAt;
+Selection.prototype.getRangeAt = function () {
+    let range = originalGetRangeAt.apply(this, arguments);
+    // Check if the range is restricted
+    if (range.startContainer && !Object.getPrototypeOf(range.startContainer)) {
+        // Define the range manually based on the selection
+        range = document.createRange();
+        range.setStart(this.anchorNode, 0);
+        range.setEnd(this.focusNode, 0);
+    }
+    return range;
+};
+});


### PR DESCRIPTION
In the Firefox browser, when in edit mode, if we click on an input
element, a traceback sometimes appears for no apparent reasons.
The error comes from the fact that when calling the getRangeAt function
on the selection, it sometimes returns a "restricted" range.
Ex: Range { commonAncestorContainer: Restricted, startContainer:
Restricted, startOffset: 0, endContainer: Restricted, endOffset: 0,
collapsed: true }
And so, trying to access a container property (ex: nodetype) will
trigger a "Permission denied to access property "nodetype"" error.

This commit provides a solution to bypass the error. It consists in
redefining the getRangeAt function as the following:
- a range is created by calling the original function that was saved
beforehand,
- we check if the range is restricted (the same way as what was done in
this issue: https://github.com/tinymce/tinymce/issues/2194)
	- if it is not restricted, the range is simply returned;
	- otherwise, a new range is created manually, based on the
	selection.

The fix was made in a new file called browser_compatibility.js in the
web_editor/static/src/js/common/ folder in order to be applicable
everywhere, as this bug could happen anywhere.

Steps to reproduce the bug:
- Install website
- Drop a form snippet
- Click on the input fields
-> Sometimes a traceback appears

task-2810365