### PR TITLE
[FIX] sale_stock: avoid traceback when editing confirmed sale orders

### DIFF
--- a/addons/sale_stock/models/sale_order.py
+++ b/addons/sale_stock/models/sale_order.py
@@ -85,7 +85,7 @@ class SaleOrder(models.Model):
         if values.get('order_line') and self.state == 'sale':
             for order in self:
                 to_log = {}
-                for order_line in order.order_line:
+                for order_line in order.order_line.filtered(lambda l: l.display_type not in ('line_section', 'line_note')):
                     if float_compare(order_line.product_uom_qty, pre_order_line_qty.get(order_line, 0.0), precision_rounding=order_line.product_uom.rounding) < 0:
                         to_log[order_line] = (order_line.product_uom_qty, pre_order_line_qty.get(order_line, 0.0))
                 if to_log:


### PR DESCRIPTION
The `sale_stock` module checks if any ordered quantities have been decreased when editing an already confirmed sale order. Whenever the sale order contains a note or section line, a traceback occurs, because these lines don not have an associated unit of measure.

However the check isn't necessary in the first place for notes and sections, so the problem is resolved by skipping these lines.

opw-2843125