### PR TITLE
[FIX] sale(s_team): sale.report is not a sql view anymore

### DIFF
--- a/addons/sales_team/models/crm_team.py
+++ b/addons/sales_team/models/crm_team.py
@@ -273,6 +273,9 @@ class CrmTeam(models.Model):
     def _graph_date_column(self):
         return 'create_date'
 
+    def _graph_get_table(self, GraphModel):
+        return GraphModel._table
+
     def _graph_x_query(self):
         return 'EXTRACT(WEEK FROM %s)' % self._graph_date_column()
 
@@ -305,7 +308,7 @@ class CrmTeam(models.Model):
         # apply rules
         dashboard_graph_model = self._graph_get_model()
         GraphModel = self.env[dashboard_graph_model]
-        graph_table = GraphModel._table
+        graph_table = self._graph_get_table(GraphModel)
         extra_conditions = self._extra_sql_conditions()
         where_query = GraphModel._where_calc([])
         GraphModel._apply_ir_rules(where_query, 'read')


### PR DESCRIPTION
Since #83550, the sale.report model is not a stored SQL view anymore,
but a query generated depending on the context, to show the amounts in
the currency of the current company.

Therefore, the table sale_report does not exist anymore in database, which led
to a traceback when opening the crm.team view in sale (Sales/Orders/Sales Team).

This commit makes sure that the graph content correctly uses the contextual query
instead of trying to read the sale_report table.





--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
