### PR TITLE
[FIX] pos_restaurant: correctly delete orders from PoS

### DIFF
--- a/addons/point_of_sale/static/src/js/db.js
+++ b/addons/point_of_sale/static/src/js/db.js
@@ -516,7 +516,7 @@ var PosDB = core.Class.extend({
         var saved = this.load('unpaid_orders',[]);
         var orders = [];
         saved.forEach(function(o) {
-            if (ids.includes(o.id) && (o.data.server_id || o.data.lines.length)){
+            if (ids.includes(o.id)){
                 orders.push(o);
             }
         });

--- a/addons/pos_restaurant/static/src/js/floors.js
+++ b/addons/pos_restaurant/static/src/js/floors.js
@@ -236,11 +236,9 @@ models.PosModel = models.PosModel.extend({
                 }
             });
             server_orders.forEach(function(server_order){
-                if (server_order.lines.length){
-                    var new_order = new models.Order({},{pos: self, json: server_order});
-                    self.get("orders").add(new_order);
-                    new_order.save_to_db();
-                }
+                var new_order = new models.Order({},{pos: self, json: server_order});
+                self.get("orders").add(new_order);
+                new_order.save_to_db();
             })
             if (!ids_to_remove.length) {
                 self.set_synch('connected');


### PR DESCRIPTION
Current behavior:
When deleting an empty order from a restaurant/bar PoS the order was
not correctly deleted in the Db. Because of that you were not able to
close the PoS.

Steps to reproduce:
- Have PoS installed and configure a restaurant PoS
- Go on table A
- Add some products
- Go back to the mainscreen
- Go back on table A and delete all the products
- Go back on the main screen
- Go back on table A, click on orders and delete the order
- Try to close the session
- You get an error "You cannot close the POS when orders
  are still in draft

opw-2838045
--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
