### PR TITLE
[IMP] account: improve display of the journals audit report

### DIFF
--- a/addons/account/views/report_journal.xml
+++ b/addons/account/views/report_journal.xml
@@ -65,12 +65,13 @@
                                 <th t-if="data['form'].get('sort_selection') == 'move_name'">Date</th>
                                 <th t-if="data['form'].get('sort_selection') == 'date'">Date</th>
                                 <th t-if="data['form'].get('sort_selection') == 'date'">Move</th>
-                                <th>Partner</th>
-                                <th>Account</th>
-                                <th>Label</th>
-                                <th t-if="data['form']['amount_currency']" class="text-right">Currency</th>
-                                <th class="text-right">Debit</th>
-                                <th class="text-right">Credit</th>
+                                <!-- Set a minimum width for columns, otherwise the line breaks too early -->
+                                <th style="min-width: 150px">Partner</th>
+                                <th style="min-width: 250px">Account</th>
+                                <th style="min-width: 350px">Label</th>
+                                <th t-if="data['form']['amount_currency']" style="text-align: right;">Currency</th>
+                                <th style="text-align: right;">Debit</th>
+                                <th style="text-align: right;">Credit</th>
                             </tr>
                         </thead>
                         <tbody>
@@ -119,7 +120,7 @@
                                         <t t-set="last_partner" t-value=""/>
                                     </t>
                                 </t>
-                                <t t-set="partner_name" t-value="aml.sudo().partner_id and aml.sudo().partner_id.name and aml.sudo().partner_id.name[:23] or ''"/>
+                                <t t-set="partner_name" t-value="aml.sudo().partner_id and aml.sudo().partner_id.name and aml.sudo().partner_id.name or ''"/>
                                 <!-- general journals always show partners, as we can have multiple != ones in a single move -->
                                 <t t-if="last_partner == partner_name and o.type != 'general'">
                                     <td/>
@@ -128,30 +129,30 @@
                                     <td><span t-esc="partner_name"/></td>
                                     <t t-set="last_partner" t-value="partner_name"/>
                                 </t>
-                                <td><span t-field="aml.account_id.code"/></td>
+                                <td><span t-field="aml.account_id.code"/> <span t-field="aml.account_id.name"/></td>
                                 <td><span t-esc="aml.name"/></td>
                                 <td t-if="data['form']['amount_currency'] and aml.amount_currency" class="pull-right">
                                     <span class="text-monospace"
                                           t-esc="aml.amount_currency"
                                           t-options="{'widget': 'monetary', 'display_currency': aml.currency_id}"/>
                                 </td>
-                                <td>
+                                <td style="text-align: right;">
                                     <span t-if="not (company_id or res_company).currency_id.is_zero(aml.debit)"
                                           t-esc="aml.debit"
                                           t-options="{
                                               'widget': 'monetary',
                                               'display_currency': (company_id or res_company).currency_id
                                           }"
-                                          class="pull-right text-monospace"/>
+                                          class="text-monospace"/>
                                 </td>
-                                <td>
+                                <td style="text-align: right;">
                                     <span t-if="not (company_id or res_company).currency_id.is_zero(aml.credit)"
                                           t-esc="aml.credit"
                                           t-options="{
                                               'widget': 'monetary',
                                               'display_currency': (company_id or res_company).currency_id
                                           }"
-                                          class="pull-right text-monospace"/>
+                                          class="text-monospace"/>
                                 </td>
                             </tr>
                             <tr class="bg-white">
@@ -160,21 +161,21 @@
                                 <td/>
                                 <td/>
                                 <td class="text-right"><strong>Total</strong></td>
-                                <td>
+                                <td style="text-align: right;">
                                     <span t-esc="sum_debit(data, o)"
                                           t-options="{
                                             'widget': 'monetary',
                                             'display_currency': (company_id or res_company).currency_id
                                           }"
-                                          class="pull-right font-weight-bold text-monospace"/>
+                                          class="font-weight-bold text-monospace"/>
                                 </td>
-                                <td>
+                                <td style="text-align: right;">
                                     <span t-esc="sum_credit(data, o)"
                                           t-options="{
                                               'widget': 'monetary',
                                               'display_currency': (company_id or res_company).currency_id
                                           }"
-                                          class="pull-right font-weight-bold text-monospace"/>
+                                          class="font-weight-bold text-monospace"/>
 
                                 </td>
                                 <td t-if="data['form']['amount_currency']"/>
@@ -190,28 +191,28 @@
                                     <tr><th colspan="3">Taxes Applied</th></tr>
                                     <tr>
                                         <th>Name</th>
-                                        <th class="text-right">Base Amount</th>
-                                        <th class="text-right">Tax Amount</th>
+                                        <th style="text-align: right;">Base Amount</th>
+                                        <th style="text-align: right;">Tax Amount</th>
                                     </tr>
                                 </thead>
                                 <tbody>
                                     <tr t-foreach="taxes" t-as="tax">
                                         <td><span t-esc="tax.name"/></td>
-                                        <td>
+                                        <td style="text-align: right;">
                                             <span t-esc="taxes[tax]['base_amount']"
                                                   t-options="{
                                                       'widget': 'monetary',
                                                       'display_currency': (company_id or res_company).currency_id
                                                   }"
-                                                  class="pull-right text-monospace"/>
+                                                  class="text-monospace"/>
                                         </td>
-                                        <td>
+                                        <td style="text-align: right;">
                                             <span t-esc="taxes[tax]['tax_amount']"
                                                   t-options="{
                                                       'widget': 'monetary',
                                                       'display_currency': (company_id or res_company).currency_id
                                                   }"
-                                                  class="pull-right text-monospace"/>
+                                                  class="text-monospace"/>
                                         </td>
                                     </tr>
                                 </tbody>


### PR DESCRIPTION
A few points can be improved in the display of the journals audit report:
1. it only contains the account codes. This can be unclear and lead to hard to read reports, especially for manually created accounts
2. the width of the columns Partner, Account, Label can sometimes be too small which causes a line break to happen too early
3. monetary fields do not align right for right-to-left languages.

This commit addresses these issues by:
1. adding the account name right next to the account code (same column) for more clarity.
2. setting a minimum width to mentioned columns
3. modifying the html classes accordingly to ensure the text aligns right.

`style="text-align: right;"`, contrary to `class="pull-right"`, allows the fields to always be aligned right, no matter the direction of the language (l2r or r2l)

before this commit
arabic (r2l):
![before_arabic](https://user-images.githubusercontent.com/17080602/169004343-253af663-47e1-4c03-b4ff-702f8c9e2516.png)
english (l2r):
![before_en](https://user-images.githubusercontent.com/17080602/169004375-7921ac17-4e7d-441d-9523-23694c1df8aa.png)

after this commit
arabic (r2l):
![after_arabic](https://user-images.githubusercontent.com/17080602/169004141-69e0f693-e027-42b0-8e4d-9e8a3046966f.png)
english (l2r) - no change:
![after_en](https://user-images.githubusercontent.com/17080602/169004319-66eb81a2-56ef-4c65-9536-0228b4801cfb.png)



Also see https://github.com/odoo/enterprise/pull/26983 for the enterprise PR

task id=2824121