### PR TITLE
[FIX] project : average rating is wrong in tasks analysis

### DIFF
--- a/addons/project/data/project_demo.xml
+++ b/addons/project/data/project_demo.xml
@@ -1261,6 +1261,16 @@ Send it ASAP, its urgent.</field>
         <function model="project.task" name="rating_apply"
             eval="([ref('project.project_1_task_4')], 5, 'PROJECT_3', None, 'Exactly what I asked for, thank you!')"/>
 
+        <record id="rating_task_3_part2" model="rating.rating">
+            <field name="access_token">PROJECT_3_part2</field>
+            <field name="res_model_id" ref="project.model_project_task"/>
+            <field name="rated_partner_id" ref="base.partner_root"/>
+            <field name="partner_id" ref="base.partner_demo_portal"/>
+            <field name="res_id" ref="project.project_1_task_4"/>
+        </record>
+        <function model="project.task" name="rating_apply"
+            eval="([ref('project.project_1_task_4')], 4, 'PROJECT_3_part2', None, 'Exactly what I asked for, but one day late from the deadline')"/>
+
         <record id="rating_task_4" model="rating.rating">
             <field name="access_token">PROJECT_4</field>
             <field name="res_model_id" ref="project.model_project_task"/>


### PR DESCRIPTION
Before this commit:
- Join between task and rating is made on parent_res_id
- Displayed value is the sum of tasks average_rating
- No Unit test to detect this anomalie
- Each task is rated one time so average_rating and last_rating are the same

After this commit:
- Join is made on res_id which is the task_id
- Displayed value is the avg of tasks average_rating
- Unit test added to cover mesaures calculation
- New demo record added to let average_rating be different from last_rating

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
