### PR TITLE
[FIX] base: fix file extension when using default name

### DIFF
--- a/odoo/addons/base/models/ir_http.py
+++ b/odoo/addons/base/models/ir_http.py
@@ -382,6 +382,7 @@ class IrHttp(models.AbstractModel):
         default_filename = False
         if not filename:
             if filename_field in record:
+                default_filename = (filename_field == 'name' and model != 'ir.attachment')
                 filename = record[filename_field]
             if not filename:
                 default_filename = True

--- a/odoo/addons/base/tests/test_ir_http.py
+++ b/odoo/addons/base/tests/test_ir_http.py
@@ -129,3 +129,23 @@ class test_ir_http_mimetype(common.TransactionCase):
         status = test_access(access_token=u'Secret')
         self.assertEqual(status, 404,
             "no access with access token for deleted attachment")
+
+    def test_ir_http_default_filename_extension(self):
+        """ Test attachment extension when the record has a dot in its name """
+        self.env.user.name = "Mr. John"
+        self.env.user.image_128 = GIF
+        _, _, filename, _, _ = self.env['ir.http']._binary_record_content(
+            self.env.user, 'image_128',
+        )
+        self.assertEqual(filename, "Mr. John.gif")
+
+        # For attachment, the name is considered to have the extension in the name
+        # and thus the extension should not be added again.
+        attachment = self.env['ir.attachment'].create({
+            'datas': GIF,
+            'name': 'image.gif'
+        })
+        _, _, filename, _, _ = self.env['ir.http']._binary_record_content(
+            attachment,
+        )
+        self.assertEqual(filename, 'image.gif')


### PR DESCRIPTION
This commit aims to fix an issue when downloading attachments and using
'name' as the field for the file's name.
When 'name' contains a dot, the file is considered to already have a
file extension, and thus the right extension is not added to the name.
After this commit, using 'name' as a filename field will also consider
the name to be a 'default' for any other model than `ir.attachment`.

TaskId-2826061
