### PR TITLE
[IMP] *: provide a config parameter to disable image quality optimization

### DIFF
--- a/addons/web_editor/controllers/main.py
+++ b/addons/web_editor/controllers/main.py
@@ -666,6 +666,11 @@ class Web_Editor(http.Controller):
             ('Cache-control', 'max-age=%s' % http.STATIC_CACHE_LONG),
         ])
 
+    @http.route(['/web_editor/is_image_optimization_disabled'], type='json', auth="user", website=True)
+    def is_image_optimization_disabled(self, **params):
+        config_param = request.env['ir.config_parameter'].sudo().get_param('base.no_image_quality_optimization')
+        return True if config_param else False
+
     @http.route(['/web_editor/media_library_search'], type='json', auth="user", website=True)
     def media_library_search(self, **params):
         ICP = request.env['ir.config_parameter'].sudo()

--- a/addons/web_editor/static/src/components/media_dialog/file_selector.xml
+++ b/addons/web_editor/static/src/components/media_dialog/file_selector.xml
@@ -35,6 +35,7 @@
             <button type="button" class="btn btn-primary o_upload_media_button" t-on-click="onClickUpload">
                 <t t-esc="props.uploadText"/>
             </button>
+            <i t-if="props.isImageOptimizationDisabled" class="fa fa-warning text-warning mt-3 ms-2" title="Automatic image optimization is disabled"/>
         </div>
     </div>
 </t>
@@ -58,7 +59,8 @@
             search="(needle) => this.search(needle)"
             useMediaLibrary="props.useMediaLibrary"
             validateUrl="validateUrl"
-            multiSelect="props.multiSelect"/>
+            multiSelect="props.multiSelect"
+            isImageOptimizationDisabled="isImageOptimizationDisabled"/>
         <t t-call="{{ constructor.attachmentsListTemplate }}"/>
         <div name="load_more_attachments" class="mt-4 text-center mx-auto o_we_load_more">
             <button t-if="canLoadMore" class="btn btn-primary o_load_more" type="button" t-on-click="loadMore">Load more...</button>

--- a/addons/web_editor/static/src/components/media_dialog/image_selector.js
+++ b/addons/web_editor/static/src/components/media_dialog/image_selector.js
@@ -4,7 +4,7 @@ import { useService } from '@web/core/utils/hooks';
 import { getCSSVariableValue, DEFAULT_PALETTE } from 'web_editor.utils';
 import { Attachment, FileSelector, IMAGE_MIMETYPES, IMAGE_EXTENSIONS } from './file_selector';
 
-const { useRef, useState, useEffect } = owl;
+const { useRef, useState, useEffect, onWillStart } = owl;
 
 export class AutoResizeImage extends Attachment {
     setup() {
@@ -58,6 +58,9 @@ export class ImageSelector extends FileSelector {
         this.MIN_ROW_HEIGHT = 128;
 
         this.fileMimetypes = IMAGE_MIMETYPES.join(',');
+        onWillStart(async () => {
+            this.isImageOptimizationDisabled = await this.isImageOptimizationDisabled();
+        });
     }
 
     get canLoadMore() {
@@ -105,6 +108,10 @@ export class ImageSelector extends FileSelector {
         const { isValidUrl, path } = super.validateUrl(...args);
         const isValidFileFormat = IMAGE_EXTENSIONS.some(format => path.endsWith(format));
         return { isValidFileFormat, isValidUrl };
+    }
+
+    async isImageOptimizationDisabled() {
+        return await this.rpc('/web_editor/is_image_optimization_disabled');
     }
 
     isInitialMedia(attachment) {

--- a/addons/web_editor/static/src/js/editor/snippets.options.js
+++ b/addons/web_editor/static/src/js/editor/snippets.options.js
@@ -5361,6 +5361,9 @@ const ImageHandlerOption = SnippetOptionWidget.extend({
      */
     async willStart() {
         const _super = this._super.bind(this);
+        this.optimizationDisabled = await this._rpc({
+            route: '/web_editor/is_image_optimization_disabled',
+        });
         await this._initializeImage();
         return _super(...arguments);
     },
@@ -5641,7 +5644,8 @@ const ImageHandlerOption = SnippetOptionWidget.extend({
      * @returns {Boolean}
      */
     _isImageSupportedForProcessing(img, strict = false) {
-        return isImageSupportedForProcessing(this._getImageMimetype(img), strict);
+        return isImageSupportedForProcessing(this._getImageMimetype(img), strict)
+            && !this.optimizationDisabled;
     },
     /**
      * @override

--- a/odoo/tools/image.py
+++ b/odoo/tools/image.py
@@ -3,6 +3,7 @@
 import base64
 import binascii
 import io
+import odoo
 
 from PIL import Image, ImageOps
 # We can preload Ico too because it is considered safe
@@ -117,6 +118,14 @@ class ImageProcess():
         :return: image
         :rtype: bytes or False
         """
+        dbname = odoo.tools.config['db_name']
+        registry = odoo.registry(dbname)
+        if registry.ready:
+            with registry.cursor() as cr:
+                uid = odoo.SUPERUSER_ID
+                env = odoo.api.Environment(cr, uid, {})
+                if env['ir.config_parameter'].sudo().get_param('base.no_image_quality_optimization'):
+                    return self.source
         if not self.image:
             return self.source
 


### PR DESCRIPTION
This commit allows to have a config parameter (not set by default) that
allows to disable the quality optimization of the images that are
uploaded by the user. From this commit, if there is a value for the
Ir.config.parameter  **base.no_image_quality_optimization**, the optimization
of images will be disabled. This remains a hidden function in the system
parameters.

task-2835144
--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
