### PR TITLE
[FIX] sale_purchase: ignore SOL with display type

### DIFF
--- a/addons/sale_purchase/tests/test_access_rights.py
+++ b/addons/sale_purchase/tests/test_access_rights.py
@@ -116,7 +116,7 @@ class TestAccessRights02(TestCommonSalePurchaseNoChart):
             'partner_id': self.partner_customer_usd.id,
             'user_id': self.user_salesperson.id,
         })
-        so_line = self.env['sale.order.line'].create({
+        so_line, _ = self.env['sale.order.line'].create([{
             'name': product.name,
             'product_id': product.id,
             'product_uom_qty': 1,
@@ -124,7 +124,11 @@ class TestAccessRights02(TestCommonSalePurchaseNoChart):
             'price_unit': product.list_price,
             'tax_id': False,
             'order_id': so.id,
-        })
+        }, {
+            'name': 'Super Section',
+            'display_type': 'line_section',
+            'order_id': so.id,
+        }])
 
         so.action_confirm()
 

--- a/addons/sale_stock/models/sale_order.py
+++ b/addons/sale_stock/models/sale_order.py
@@ -83,10 +83,13 @@ class SaleOrder(models.Model):
 
         res = super(SaleOrder, self).write(values)
         if values.get('order_line') and self.state == 'sale':
+            rounding = self.env['decimal.precision'].precision_get('Product Unit of Measure')
             for order in self:
                 to_log = {}
                 for order_line in order.order_line:
-                    if float_compare(order_line.product_uom_qty, pre_order_line_qty.get(order_line, 0.0), precision_rounding=order_line.product_uom.rounding) < 0:
+                    if order_line.display_type:
+                        continue
+                    if float_compare(order_line.product_uom_qty, pre_order_line_qty.get(order_line, 0.0), precision_rounding=order_line.product_uom.rounding or rounding) < 0:
                         to_log[order_line] = (order_line.product_uom_qty, pre_order_line_qty.get(order_line, 0.0))
                 if to_log:
                     documents = self.env['stock.picking']._log_activity_get_documents(to_log, 'move_ids', 'UP')


### PR DESCRIPTION
Same steps as [1], but add a section or a note on the SO.

It will raise an error: "AssertionError: precision_rounding must be
positive, got 0.0"

[1] 1351f370050c7fa189f501ef5e751fe390705e90