### PR TITLE
[FIX] product: speed up _prepare_sellers

### DIFF
--- a/addons/product/models/product.py
+++ b/addons/product/models/product.py
@@ -591,8 +591,10 @@ class ProductProduct(models.Model):
 
     def _prepare_sellers(self, params):
         # This search is made to avoid retrieving seller_ids from the cache.
-        return self.env['product.supplierinfo'].search([('product_tmpl_id', '=', self.product_tmpl_id.id),
-                                                        ('name.active', '=', True)]).sorted(lambda s: (s.sequence, -s.min_qty, s.price, s.id))
+        return self.env['product.supplierinfo']\
+                   .search([('product_tmpl_id', '=', self.product_tmpl_id.id)])\
+                   .filtered(lambda r: r.name.active)\
+                   .sorted(lambda s: (s.sequence, -s.min_qty, s.price, s.id))
 
     def _select_seller(self, partner_id=False, quantity=0.0, date=None, uom_id=False, params=False):
         self.ensure_one()


### PR DESCRIPTION
Using `name.active` filter directly in domain leads to loading all active
partners to use it in sql query. It's not scalable solution.
Instead, filter out inactive partners after making the query.

---

opw-2740114

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
