### PR TITLE
[IMP] mail: move logic from discuss widget to discuss component

### DIFF
--- a/addons/mail/static/src/components/discuss/discuss.js
+++ b/addons/mail/static/src/components/discuss/discuss.js
@@ -2,7 +2,9 @@
 
 import { useUpdate } from '@mail/component_hooks/use_update';
 import { registerMessagingComponent } from '@mail/utils/messaging_component';
+
 import { LegacyComponent } from '@web/legacy/legacy_component';
+import { useWowlService } from '@web/legacy/utils';
 
 export class Discuss extends LegacyComponent {
 
@@ -10,6 +12,9 @@ export class Discuss extends LegacyComponent {
      * @override
      */
     setup() {
+        this.routerService = useWowlService('router');
+        this.effectService = useWowlService('effect');
+        this._lastPushStateActiveThread = null;
         this._updateLocalStoreProps();
         // bind since passed as props
         this._onMobileAddItemHeaderInputSource = this._onMobileAddItemHeaderInputSource.bind(this);
@@ -22,7 +27,14 @@ export class Discuss extends LegacyComponent {
             return;
         }
         if (this.discussView.discuss.thread) {
-            this.trigger('o-push-state-action-manager');
+            if (this._lastPushStateActiveThread === this.discussView.discuss.thread) {
+                return;
+            }
+            this.routerService.pushState({
+                action: this.discussView.actionId,
+                active_id: this.discussView.discuss.activeId,
+            });
+            this._lastPushStateActiveThread = this.discussView.discuss.thread;
         }
         if (
             this.discussView.discuss.thread &&
@@ -31,7 +43,9 @@ export class Discuss extends LegacyComponent {
             this._lastThreadCache === this.discussView.discuss.threadView.threadCache.localId &&
             this._lastThreadCounter > 0 && this.discussView.discuss.thread.counter === 0
         ) {
-            this.trigger('o-show-rainbow-man');
+            this.effectService.add({
+                message: this.env._t("Congratulations, your inbox is empty!"),
+            });
         }
         this._updateLocalStoreProps();
     }

--- a/addons/mail/static/src/models/discuss_view.js
+++ b/addons/mail/static/src/models/discuss_view.js
@@ -90,6 +90,7 @@ registerModel({
         },
     },
     fields: {
+        actionId: attr(),
         mobileAddItemHeaderAutocompleteInputView: one('AutocompleteInputView', {
             compute: '_computeMobileAddItemHeaderAutocompleteInputView',
             inverse: 'discussViewOwnerAsMobileAddItemHeader',

--- a/addons/mail/static/src/widgets/discuss/discuss.js
+++ b/addons/mail/static/src/widgets/discuss/discuss.js
@@ -1,7 +1,6 @@
 /** @odoo-module **/
 
 import { DiscussContainer } from "@mail/components/discuss_container/discuss_container";
-import { insertAndReplace } from '@mail/model/model_field_command';
 
 import AbstractAction from 'web.AbstractAction';
 
@@ -19,37 +18,12 @@ export const DiscussWidget = AbstractAction.extend({
      * @param {string} [action.params.default_active_id]
      * @param {Object} [options={}]
      */
-    init(parent, action, options={}) {
+    init(parent, action) {
         this._super(...arguments);
 
-        // control panel attributes
-        this.action = action;
-        this.actionManager = parent;
-        this.discuss = undefined;
-        this.options = options;
-
         this.app = undefined;
-
-        this._lastPushStateActiveThread = null;
+        this.action = action;
         this.env = Component.env;
-        Component.env.services.messaging.modelManager.messagingCreatedPromise.then(async () => {
-            const messaging = Component.env.services.messaging.modelManager.messaging;
-            const initActiveId = this.options.active_id ||
-                (this.action.context && this.action.context.active_id) ||
-                (this.action.params && this.action.params.default_active_id) ||
-                'mail.box_inbox';
-            this.discuss = messaging.discuss;
-            this.discuss.update({ discussView: insertAndReplace(), initActiveId });
-            // Wait for messaging to be initialized to make sure the system
-            // knows of the "init thread" if it exists.
-            await messaging.initializedPromise;
-            if (!this.discuss.isInitThreadHandled) {
-                this.discuss.update({ isInitThreadHandled: true });
-                if (!this.discuss.thread) {
-                    this.discuss.openInitThread();
-                }
-            }
-        });
     },
     /**
      * @override {web.AbstractAction}
@@ -73,31 +47,14 @@ export const DiscussWidget = AbstractAction.extend({
             // prevent twice call to on_attach_callback (FIXME)
             return;
         }
-        this._pushStateActionManagerEventListener = ev => {
-            ev.stopPropagation();
-            if (this._lastPushStateActiveThread === this.discuss.thread) {
-                return;
-            }
-            this._pushStateActionManager();
-            this._lastPushStateActiveThread = this.discuss.thread;
-        };
-        this._showRainbowManEventListener = ev => {
-            ev.stopPropagation();
-            this._showRainbowMan();
-        };
-        this.el.addEventListener(
-            'o-push-state-action-manager',
-            this._pushStateActionManagerEventListener
-        );
-        this.el.addEventListener(
-            'o-show-rainbow-man',
-            this._showRainbowManEventListener
-        );
 
         this.app = new App(DiscussContainer, {
             templates: window.__OWL_TEMPLATES__,
             env: owl.Component.env,
             dev: owl.Component.env.isDebug(),
+            props: {
+                action: this.action,
+            },
             translateFn: owl.Component.env._t,
             translatableAttributes: ["data-tooltip"],
         });
@@ -112,36 +69,5 @@ export const DiscussWidget = AbstractAction.extend({
             this.app.destroy();
         }
         this.app = undefined;
-        this.el.removeEventListener(
-            'o-push-state-action-manager',
-            this._pushStateActionManagerEventListener
-        );
-        this.el.removeEventListener(
-            'o-show-rainbow-man',
-            this._showRainbowManEventListener
-        );
-    },
-
-    //--------------------------------------------------------------------------
-    // Private
-    //--------------------------------------------------------------------------
-
-    /**
-     * @private
-     */
-    _pushStateActionManager() {
-        this.actionManager.do_push_state({
-            action: this.action.id,
-            active_id: this.discuss.activeId,
-        });
-    },
-    /**
-     * @private
-     */
-    _showRainbowMan() {
-        this.trigger_up('show_effect', {
-            message: this.env._t("Congratulations, your inbox is empty!"),
-            type: 'rainbow_man',
-        });
     },
 });


### PR DESCRIPTION
This PR prepares the ground for the introduction of the new environment in the
discuss app. The discuss widget will disappear in favor of the DiscussContainer
being added in the action registry. The logic present in the discuss widget will
be moved to the Discuss/DiscussContainer component. In order to reduce the noise
in the main PR, those changes are done now.

task-2582313
