### PR TITLE
[FIX] website_sale: remove animation when out-of-stock product is added

### DIFF
--- a/addons/website_sale/static/src/js/website_sale_utils.js
+++ b/addons/website_sale/static/src/js/website_sale_utils.js
@@ -33,8 +33,10 @@ const cartHandlerMixin = {
             route: "/shop/cart/update_json",
             params: params,
         }).then(async data => {
-            await animateClone($('header .o_wsale_my_cart').first(), this.$itemImgContainer, 25, 40);
-            updateCartNavBar(data);
+            if (data.cart_quantity !== parseInt($(".my_cart_quantity").text())) {
+                await animateClone($('header .o_wsale_my_cart').first(), this.$itemImgContainer, 25, 40);
+                updateCartNavBar(data);
+            }
         });
     },
 };


### PR DESCRIPTION
Steps to reproduce:
	1) Create a product with 0 on hand qty and under Sales tab,
	"Continue Selling" if Out of Stock unchecked.
	2) Navigate to the website's shop.
	Customize -> Add Feature -> enable Add to Cart.

Current behavior:
From the Shop's screen, the button to add to cart for this product
 is clickable and the animation plays, but no item is added (because
out of stock).

Expected behavior:
There is no animation when an out-of-stock product is added to the cart

Solution:
The rpc call for /shop/cart/update_json will return a dictionary with a
cart_quantity value. If this value is different from the current cart quantity
shown in the navbar then a product was added and the animation should
be applied as usual otherwise it means no product was added and nothing
should happen.

opw-2745305