### PR TITLE
[FIX] mail: ensures getMessagingComponent is called after registration

### DIFF
--- a/addons/mail/static/src/public/discuss_public_boot.js
+++ b/addons/mail/static/src/public/discuss_public_boot.js
@@ -2,6 +2,9 @@
 
 import { data } from 'mail.discuss_public_channel_template';
 
+// ensure components are registered beforehand.
+import '@mail/components/dialog_manager/dialog_manager';
+import '@mail/components/discuss_public_view/discuss_public_view';
 import { MessagingService } from '@mail/services/messaging/messaging';
 import { getMessagingComponent } from '@mail/utils/messaging_component';
 

--- a/addons/mail/static/src/services/chat_window_service/chat_window_service.js
+++ b/addons/mail/static/src/services/chat_window_service/chat_window_service.js
@@ -1,5 +1,7 @@
 /** @odoo-module **/
 
+// ensure component is registered beforehand.
+import '@mail/components/chat_window_manager/chat_window_manager';
 import { getMessagingComponent } from "@mail/utils/messaging_component";
 
 import AbstractService from 'web.AbstractService';

--- a/addons/mail/static/src/services/dialog_service/dialog_service.js
+++ b/addons/mail/static/src/services/dialog_service/dialog_service.js
@@ -1,5 +1,7 @@
 /** @odoo-module **/
 
+// ensure component is registered beforehand.
+import '@mail/components/dialog_manager/dialog_manager';
 import { getMessagingComponent } from "@mail/utils/messaging_component";
 
 import AbstractService from 'web.AbstractService';

--- a/addons/mail/static/src/services/systray_service/systray_service.js
+++ b/addons/mail/static/src/services/systray_service/systray_service.js
@@ -1,5 +1,8 @@
 /** @odoo-module **/
 
+// ensure components are registered beforehand.
+import '@mail/components/messaging_menu/messaging_menu';
+import '@mail/components/rtc_activity_notice/rtc_activity_notice';
 import { getMessagingComponent } from '@mail/utils/messaging_component';
 
 import AbstractService from 'web.AbstractService';

--- a/addons/mail/static/src/widgets/discuss/discuss.js
+++ b/addons/mail/static/src/widgets/discuss/discuss.js
@@ -1,5 +1,7 @@
 /** @odoo-module **/
 
+// ensure component is registered beforehand.
+import '@mail/components/discuss/discuss';
 import { getMessagingComponent } from "@mail/utils/messaging_component";
 
 import AbstractAction from 'web.AbstractAction';

--- a/addons/mail/static/src/widgets/form_renderer/form_renderer.js
+++ b/addons/mail/static/src/widgets/form_renderer/form_renderer.js
@@ -1,5 +1,7 @@
 /** @odoo-module **/
 
+// ensure component is registered beforehand.
+import '@mail/components/chatter_container/chatter_container';
 import { getMessagingComponent } from "@mail/utils/messaging_component";
 
 import FormRenderer from 'web.FormRenderer';

--- a/addons/mail/static/src/widgets/notification_alert/notification_alert.js
+++ b/addons/mail/static/src/widgets/notification_alert/notification_alert.js
@@ -1,5 +1,7 @@
 /** @odoo-module **/
 
+// ensure component is registered beforehand.
+import '@mail/components/notification_alert/notification_alert';
 import { getMessagingComponent } from "@mail/utils/messaging_component";
 
 import { ComponentWrapper, WidgetAdapterMixin } from 'web.OwlCompatibility';


### PR DESCRIPTION
Adds an import to wait for the required components to be added to the messaging
components registry before their parent use getMessagingComponent. Otherwise,
any slight delay could lead to missing components.

enterprise: https://github.com/odoo/enterprise/pull/27024