### PR TITLE
[FIX] web: allow auto_save when using the keyboard to switch records

### DIFF
--- a/addons/web/static/src/legacy/js/views/basic/basic_controller.js
+++ b/addons/web/static/src/legacy/js/views/basic/basic_controller.js
@@ -176,9 +176,12 @@ var BasicController = AbstractController.extend(FieldManagerMixin, {
      * @return {Promise}
      */
     saveChanges: async function (recordId) {
+        // waits for _applyChanges to finish
+        await this.mutex.getUnlockedDef();
+
         recordId = recordId || this.handle;
         if (this.isDirty(recordId)) {
-            await Promise.all([this.mutex.getUnlockedDef(), this.savingDef]);
+            await this.savingDef;
             await this.saveRecord(recordId, {
                 stayInEdit: true,
                 reload: false,


### PR DESCRIPTION
When using the keyboard to switch records (e.g.: Leads records), we can use
keyboard shortcuts (ALT + N / P) to travel from records to records. However,
when using these shortcuts, the changes on the current record are not applied
when switch.

Step to reproduce the issue:
1. Install CRM module and activate Lead
2. Ensure that there are multiple Lead already created
3. Go on one Lead and edit its title WITHOUT clicking outside the box
4. Press ALT+N on your keyboard to switch to the next record
5. Press ALT+P to come back to the initial record
You will see that the initial record's changes have not been saved.

Solution: The issue is a racing condition. Somehow, when we use the keyboard
shortcuts, the `mutex.exec` from the `applyChanges` function (cfr. Line [1]) is
not prioritized and the `isDirty` check from `saveChanges` is executed first (
cfr. [2]). We can check this with the debugger, we stop on the `mutex.exec`
then we execute the `isDirty` then we execute the callback of the initial
mutex. The issue is that, it is the callback of the mutex that allows to set
the `_isDirty` flag to True which in return allows the `saveChanges` to
save the record as he spot some changes.

[1]: https://github.com/odoo/odoo/blob/ef789170ce2f1553b325b379aac4452e473de1e9/addons/web/static/src/legacy/js/views/basic/basic_controller.js#L281
[2]: https://github.com/odoo/odoo/blob/ef789170ce2f1553b325b379aac4452e473de1e9/addons/web/static/src/legacy/js/views/basic/basic_controller.js#L180

opw-2824986
