### PR TITLE
[IMP] l10n_pt: Add accumulated amount column for PT invoices

### DIFF
--- a/addons/account/views/report_invoice.xml
+++ b/addons/account/views/report_invoice.xml
@@ -93,7 +93,7 @@
                                         <td t-attf-class="text-left {{ 'd-none d-md-table-cell' if report_type == 'html' else '' }}">
                                             <span t-esc="', '.join(map(lambda x: (x.description or x.name), line.tax_ids))" id="line_tax_ids"/>
                                         </td>
-                                        <td class="text-right o_price_total">
+                                        <td name="td_subtotal" class="text-right o_price_total">
                                             <span class="text-nowrap" t-field="line.price_subtotal" groups="account.group_show_line_subtotals_tax_excluded"/>
                                             <span class="text-nowrap" t-field="line.price_total" groups="account.group_show_line_subtotals_tax_included"/>
                                         </td>
@@ -103,7 +103,7 @@
                                             <span t-field="line.name" t-options="{'widget': 'text'}"/>
                                         </td>
                                         <t t-set="current_section" t-value="line"/>
-                                        <t t-set="current_subtotal" t-value="0"/>
+                                        <t id="reset_current_subtotal" t-set="current_subtotal" t-value="0"/>
                                     </t>
                                     <t t-if="line.display_type == 'line_note'">
                                         <td colspan="99">

--- a/addons/l10n_pt/__init__.py
+++ b/addons/l10n_pt/__init__.py
@@ -1,5 +1,4 @@
 # -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
-# Copyright (C) 2012 Thinkopen Solutions, Lda. All Rights Reserved
-# http://www.thinkopensolutions.com.
+from . import demo

--- a/addons/l10n_pt/__manifest__.py
+++ b/addons/l10n_pt/__manifest__.py
@@ -23,6 +23,7 @@
            'data/account_tax_report.xml',
            'data/account_tax_data.xml',
            'data/account_chart_template_configure_data.xml',
+           'views/report_invoice.xml',
            ],
     'demo': [
         'demo/demo_company.xml',

--- a/addons/l10n_pt/demo/__init__.py
+++ b/addons/l10n_pt/demo/__init__.py
@@ -1,0 +1,1 @@
+from . import l10n_pt_account_demo

--- a/addons/l10n_pt/demo/l10n_pt_account_demo.py
+++ b/addons/l10n_pt/demo/l10n_pt_account_demo.py
@@ -1,0 +1,39 @@
+# -*- coding: utf-8 -*-
+from odoo import api, models, Command
+import time
+from random import randint
+
+
+class AccountChartTemplate(models.Model):
+    _inherit = "account.chart.template"
+
+    @api.model
+    def _get_demo_data_move(self):
+        demo_data_move = super()._get_demo_data_move()
+        if self.env.company.country_id.code != 'PT':
+            return demo_data_move
+        cid = self.env.company.id
+        ref = self.env.ref
+        moves = demo_data_move[1]
+        # Create new invoices with loooots of lines to test the multi-page carry-over
+        nb_moves = len(moves)
+        for currency_id in (1, 2, 3):
+            self.env["res.currency"].browse(currency_id).active = True
+        for i, nb_lines in enumerate([5, 10, 20, 30, 40, 60]):
+            invoice_line_ids = []
+            for _ in range(nb_lines):
+                invoice_line_ids.append(
+                    Command.create({
+                        'product_id': ref(f'product.consu_delivery_0{randint(1, 3)}').id,
+                        'quantity': randint(1, 10)
+                    })
+                )
+            moves[f'{cid}_demo_invoice_{nb_moves+i+1}'] = {
+                'move_type': 'out_invoice',
+                'partner_id': ref('base.res_partner_12').id,
+                'invoice_user_id': ref('base.user_demo').id,
+                'invoice_date': time.strftime('%Y-%m-%d'),
+                'invoice_line_ids': invoice_line_ids,
+                'currency_id': randint(1, 3),
+            }
+        return 'account.move', moves

--- a/addons/l10n_pt/views/report_invoice.xml
+++ b/addons/l10n_pt/views/report_invoice.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<odoo>
+    <template id="l10n_pt_report_invoice_document_inherit" inherit_id="account.report_invoice_document">
+        <xpath expr="//th[@name='th_subtotal']" position="after">
+            <th name="th_subtotal_accumulated" class="text-right">
+                <span>Accumulated amount</span>
+            </th>
+        </xpath>
+        <xpath expr="//td[@name='td_subtotal']" position="after">
+            <td name="th_subtotal_accumulated_tax" class="text-right">
+                <span class="text-nowrap"
+                      t-esc="current_subtotal"
+                      t-options='{"widget": "monetary", "display_currency": o.currency_id}'/>
+            </td>
+        </xpath>
+<!--        Disable the accumulated amount resetting happening after a line section-->
+        <xpath expr="//tr[contains(@class, 'is-subtotal')]" position="replace">
+        </xpath>
+        <xpath expr="//t[@id='reset_current_subtotal']" position="replace">
+        </xpath>
+    </template>
+</odoo>


### PR DESCRIPTION
This PR adds a column containing the accumulated amount for each row in the invoice.

This is a requirement for the Portuguese certification:
> The documents referred to under point 1, if when printed results more than one page, must present on each page [...] the accumulated amounts

See https://info.portaldasfinancas.gov.pt/pt/docs/Portug_tax_system/Documents/Order_No_8632_2014_of_the_3rd_July.pdf

Task id: 2794389