### PR TITLE
[IMP] purchase,sale: add a smart button to view source SO/PO

### DIFF
--- a/addons/purchase/views/account_move_views.xml
+++ b/addons/purchase/views/account_move_views.xml
@@ -33,6 +33,15 @@
             <xpath expr="//field[@name='line_ids']/tree/field[@name='company_id']" position="after">
                 <field name="purchase_line_id" invisible="1"/>
             </xpath>
+            <xpath expr="//div[@name='button_box']" position="inside">
+                <button class="oe_stat_button"
+                        name="action_view_source_purchase_orders"
+                        type="object"
+                        icon="fa-pencil-square-o"
+                        attrs="{'invisible': ['|', ('purchase_order_count', '=', 0), ('move_type', 'not in', ('out_invoice', 'out_refund', 'in_invoice', 'in_refund', 'out_receipt', 'in_receipt'))]}">
+                    <field string="Purchases" name="purchase_order_count" widget="statinfo"/>
+                </button>
+            </xpath>
         </field>
     </record>
 </odoo>

--- a/addons/sale/models/account_move.py
+++ b/addons/sale/models/account_move.py
@@ -23,6 +23,7 @@ class AccountMove(models.Model):
     campaign_id = fields.Many2one(ondelete='set null')
     medium_id = fields.Many2one(ondelete='set null')
     source_id = fields.Many2one(ondelete='set null')
+    sale_order_count = fields.Integer(compute="_compute_origin_so_count", string='Sale Order Count')
 
     fiscal_position_id = fields.Many2one(
         compute='_compute_fiscal_position_id', store=True)
@@ -53,6 +54,11 @@ class AccountMove(models.Model):
             move.team_id = self.env['crm.team']._get_default_team_id(
                 user_id=move.invoice_user_id.id,
                 domain=[('company_id', '=', move.company_id.id)])
+
+    @api.depends('line_ids.sale_line_ids')
+    def _compute_origin_so_count(self):
+        for move in self:
+            move.sale_order_count = len(move.line_ids.sale_line_ids.order_id)
 
     def _reverse_moves(self, default_values_list=None, cancel=False):
         # OVERRIDE
@@ -125,3 +131,16 @@ class AccountMove(models.Model):
             send_invoice_cron._trigger()
 
         return res
+
+    def action_view_source_sale_orders(self):
+        self.ensure_one()
+        source_orders = self.line_ids.sale_line_ids.order_id
+        result = self.env['ir.actions.act_window']._for_xml_id('sale.action_orders')
+        if len(source_orders) > 1:
+            result['domain'] = [('id', 'in', source_orders.ids)]
+        elif len(source_orders) == 1:
+            result['views'] = [(self.env.ref('sale.view_order_form', False).id, 'form')]
+            result['res_id'] = source_orders.id
+        else:
+            result = {'type': 'ir.actions.act_window_close'}
+        return result

--- a/addons/sale/views/account_views.xml
+++ b/addons/sale/views/account_views.xml
@@ -44,6 +44,15 @@
                     <field name="source_id"/>
                 </group>
             </xpath>
+            <xpath expr="//div[@name='button_box']" position="inside">
+                <button class="oe_stat_button"
+                        name="action_view_source_sale_orders"
+                        type="object"
+                        icon="fa-pencil-square-o"
+                        attrs="{'invisible': ['|', ('sale_order_count', '=', 0), ('move_type', 'not in', ('out_invoice', 'out_refund', 'in_invoice', 'in_refund', 'out_receipt', 'in_receipt'))]}">
+                    <field string="Sale Orders" name="sale_order_count" widget="statinfo"/>
+                </button>
+            </xpath>
         </field>
     </record>
 


### PR DESCRIPTION
Task 2833338

Add a smart button to show the origin SO/PO on invoices and vendor bills.
If there is one SO/PO, redirect to a form view.
If there are several, redirect to a tree view.


--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
