### PR TITLE
[FIX] mail, website: fetch only relevant public users

### DIFF
--- a/addons/mail/controllers/main.py
+++ b/addons/mail/controllers/main.py
@@ -277,7 +277,7 @@ class MailController(http.Controller):
             'moderation_channel_ids': request.env.user.moderation_channel_ids.ids,
             'partner_root': request.env.ref('base.partner_root').sudo().mail_partner_format(),
             'public_partner': request.env.ref('base.public_partner').sudo().mail_partner_format(),
-            'public_partners': [partner.mail_partner_format() for partner in request.env.ref('base.group_public').sudo().with_context(active_test=False).users.partner_id],
+            'public_partners': [partner.mail_partner_format() for partner in request.env['res.users'].sudo()._get_livechat_anonymous_users().partner_id],
             'current_partner': request.env.user.partner_id.mail_partner_format(),
             'current_user_id': request.env.user.id,
         }

--- a/addons/mail/models/res_users.py
+++ b/addons/mail/models/res_users.py
@@ -102,6 +102,13 @@ GROUP BY channel_moderator.res_users_id""", [tuple(self.ids)])
         self._unsubscribe_from_channels()
         return super().unlink()
 
+    @api.model
+    def _get_livechat_anonymous_users(self):
+        """ Returns all the potential "anonymous" users that could be used as correspondents in livechat.
+            The client code needs to know them in order to differentiate them from each other on a per channel basis.
+        """
+        return self.env.ref('base.public_user')
+
     def _unsubscribe_from_channels(self):
         """ This method un-subscribes users from private mail channels. Main purpose of this
             method is to prevent sending internal communication to archived / deleted users.

--- a/addons/website/models/res_users.py
+++ b/addons/website/models/res_users.py
@@ -19,6 +19,10 @@ class ResUsers(models.Model):
         ('login_key', 'unique (login, website_id)', 'You can not have two users with the same login!'),
     ]
 
+    @api.model
+    def _get_livechat_anonymous_users(self):
+        return super()._get_livechat_anonymous_users() | self.env['website'].search([]).user_id
+
     def _has_unsplash_key_rights(self):
         self.ensure_one()
         if self.has_group('website.group_website_designer'):


### PR DESCRIPTION
Using `base.group_public` is not restrictive enough, in particular in our
production database we have thousand of irrelevant users in this group.

The only public users that have to be considered in this situation are the base
public user (when not in a website context) and the public user of each website.

This drastically reduces the size of the RPC in terms of time, bandwidth, and
subsequent JS processing.