### PR TITLE
[FIX] point_of_sale: wrong override of _shouldResetIdleTimer

### DIFF
--- a/addons/point_of_sale/static/src/js/Chrome.js
+++ b/addons/point_of_sale/static/src/js/Chrome.js
@@ -539,6 +539,9 @@ odoo.define('point_of_sale.Chrome', function(require) {
                 console.error('Unknown error. Unable to show information about this error.', errorToHandle);
             }
         }
+        _shouldResetIdleTimer() {
+            return true;
+        }
     }
     Chrome.template = 'Chrome';
 

--- a/addons/pos_restaurant/static/src/js/Chrome.js
+++ b/addons/pos_restaurant/static/src/js/Chrome.js
@@ -72,7 +72,7 @@ odoo.define('pos_restaurant.chrome', function (require) {
                 this.showScreen('FloorScreen', { floor: table ? table.floor : null });
             }
             _shouldResetIdleTimer() {
-                return this.env.pos.config.iface_floorplan && this.mainScreen.name !== 'FloorScreen';
+                return super._shouldResetIdleTimer() && this.env.pos.config.iface_floorplan && this.mainScreen.name !== 'FloorScreen';
             }
             __showScreen() {
                 super.__showScreen(...arguments);


### PR DESCRIPTION
The method "_shouldResetIdleTimer" declared in pos_restaurant is
overriden in "pos_hr" but there are no dependencies between those
modules. As ther is no bridge module between those two modules, we are
doing a function that return "true" in the parent module point of sale,
to allow correct inheritance.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
