### PR TITLE
[FIX] stock: ensure auto-reserve in multi-steps receipt

### DIFF
--- a/addons/stock/models/stock_picking.py
+++ b/addons/stock/models/stock_picking.py
@@ -860,8 +860,8 @@ class Picking(models.Model):
         todo_moves._action_done(cancel_backorder=self.env.context.get('cancel_backorder'))
         self.write({'date_done': fields.Datetime.now(), 'priority': '0'})
 
-        # if incoming moves make other confirmed/partially_available moves available, assign them
-        done_incoming_moves = self.filtered(lambda p: p.picking_type_id.code == 'incoming').move_ids.filtered(lambda m: m.state == 'done')
+        # if incoming/internal moves make other confirmed/partially_available moves available, assign them
+        done_incoming_moves = self.filtered(lambda p: p.picking_type_id.code in ('incoming', 'internal')).move_ids.filtered(lambda m: m.state == 'done')
         done_incoming_moves._trigger_assign()
 
         self._send_confirmation_email()


### PR DESCRIPTION
The auto-reserve feature does not work if the products are received in
several steps

To reproduce the issue:
1. In Settings, enable "Multi-Step Routes"
2. Edit the existing warehouse:
    - Incoming Shipments: 2 steps
3. Create a storable product P
4. Create and confirm a SO with 1 x P
    - The delivery D is created and is waiting for one available P
5. Create and validate a receipt for 1 x P
    - An internal transfer T is generated (Input -> Stock)
6. Validate T
7. Open D

Error: The delivery is still waiting for the product while this product
should be reserved. This is correctly working in 1-step receipt

In 1-step receipt, when the user marks the receipt as done, the
destination of the associated SM is WH/Stock and its operation type code
is "incoming". Therefore, the module checks if some other moves (from
WH/Stock) can reserve the newly-available quantity.
However, in [2/3]-steps receipt, the operation type code of the
in-WH/Stock move is "internal". So, the conditions are not respected and
the module doesn't check the needs of reservation.

OPW-2806423