### PR TITLE
[FIX] purchase_requisition: hide schedule date

### DIFF
--- a/addons/purchase_requisition/views/purchase_requisition_views.xml
+++ b/addons/purchase_requisition/views/purchase_requisition_views.xml
@@ -170,7 +170,7 @@
                                 <field name="qty_ordered" optional="show"/>
                                 <field name="product_uom_category_id" invisible="1"/>
                                 <field name="product_uom_id" string="UoM" groups="uom.group_uom" optional="show" attrs="{'required': [('product_id', '!=', False)]}"/>
-                                <field name="schedule_date" groups="base.group_no_one"/>
+                                <field name="schedule_date" optional="hide"/>
                                 <field name="account_analytic_id" optional="hide" domain="['|', ('company_id', '=', False), ('company_id', '=', parent.company_id)]" groups="analytic.group_analytic_accounting"/>
                                 <field name="analytic_tag_ids" optional="hide" domain="['|', ('company_id', '=', False), ('company_id', '=', parent.company_id)]" groups="analytic.group_analytic_tags" widget="many2many_tags"/>
                                 <field name="price_unit"/>


### PR DESCRIPTION
Schedule date was hide in the view for a back to basic task in order to
simplify the view.
But it was at the time, the optional parameter did not exist, we could
readd it under the hide option

opw-2842963
