### PR TITLE
[IMP] mail, *: add sendmany/sendone to the mock server

### DIFF
--- a/addons/im_livechat/static/tests/qunit_suite_tests/components/discuss_sidebar_category_tests.js
+++ b/addons/im_livechat/static/tests/qunit_suite_tests/components/discuss_sidebar_category_tests.js
@@ -325,7 +325,7 @@ QUnit.test('livechat - states: close from the bus', async function (assert) {
         channel_type: 'livechat',
         livechat_operator_id: pyEnv.currentPartnerId,
     });
-    const { env, messaging } = await this.start();
+    const { messaging } = await this.start();
 
     assert.containsOnce(
         document.body,
@@ -338,12 +338,9 @@ QUnit.test('livechat - states: close from the bus', async function (assert) {
     );
 
     await afterNextRender(() => {
-        env.services.bus_service.trigger('notification', [{
-            type: "res.users.settings/changed",
-            payload: {
-                is_discuss_sidebar_category_livechat_open: false,
-            },
-        }]);
+        pyEnv['bus.bus']._sendone(pyEnv.currentPartner, 'res.users.settings/changed', {
+            'is_discuss_sidebar_category_livechat_open': false,
+        });
     });
     assert.containsNone(
         document.body,
@@ -374,7 +371,7 @@ QUnit.test('livechat - states: open from the bus', async function (assert) {
         user_id: pyEnv.currentUserId,
         is_discuss_sidebar_category_livechat_open: false,
     });
-    const { env, messaging } = await this.start();
+    const { messaging } = await this.start();
 
     assert.containsNone(
         document.body,
@@ -387,12 +384,9 @@ QUnit.test('livechat - states: open from the bus', async function (assert) {
     );
 
     await afterNextRender(() => {
-        env.services.bus_service.trigger('notification', [{
-            type: "res.users.settings/changed",
-            payload: {
-                is_discuss_sidebar_category_livechat_open: true,
-            },
-        }]);
+        pyEnv['bus.bus']._sendone(pyEnv.currentPartner, "res.users.settings/changed", {
+            'is_discuss_sidebar_category_livechat_open': true,
+        });
     });
     assert.containsOnce(
         document.body,

--- a/addons/im_livechat/static/tests/qunit_suite_tests/components/thread_icon_tests.js
+++ b/addons/im_livechat/static/tests/qunit_suite_tests/components/thread_icon_tests.js
@@ -33,7 +33,7 @@ QUnit.test('livechat: public website visitor is typing', async function (assert)
         channel_type: 'livechat',
         livechat_operator_id: pyEnv.currentPartnerId,
     });
-    const { messaging, target, widget } = await start();
+    const { messaging, target } = await start();
     const thread = messaging.models['Thread'].findFromIdentifyingData({
         id: mailChannelId1,
         model: 'mail.channel',
@@ -50,17 +50,15 @@ QUnit.test('livechat: public website visitor is typing', async function (assert)
         "should have default livechat icon"
     );
 
+    const mailChannel1 = pyEnv['mail.channel'].searchRead([['id', '=', mailChannelId1]])[0];
     // simulate receive typing notification from livechat visitor "is typing"
     await afterNextRender(() => {
-        widget.call('bus_service', 'trigger', 'notification', [{
-            type: 'mail.channel.partner/typing_status',
-            payload: {
-                channel_id: mailChannelId1,
-                is_typing: true,
-                partner_id: messaging.publicPartners[0].id,
-                partner_name: messaging.publicPartners[0].name,
-            },
-        }]);
+        pyEnv['bus.bus']._sendone(mailChannel1, 'mail.channel.partner/typing_status', {
+            'channel_id': mailChannelId1,
+            'is_typing': true,
+            'partner_id': messaging.publicPartners[0].id,
+            'partner_name': messaging.publicPartners[0].name,
+        });
     });
     assert.containsOnce(
         document.body,

--- a/addons/im_livechat/static/tests/qunit_suite_tests/components/thread_textual_typing_status_tests.js
+++ b/addons/im_livechat/static/tests/qunit_suite_tests/components/thread_textual_typing_status_tests.js
@@ -33,7 +33,7 @@ QUnit.test('receive visitor typing status "is typing"', async function (assert) 
         channel_type: 'livechat',
         livechat_operator_id: pyEnv.currentPartnerId,
     });
-    const { messaging, target, widget } = await start();
+    const { messaging, target } = await start();
     const thread = messaging.models['Thread'].findFromIdentifyingData({
         id: mailChannelId1,
         model: 'mail.channel',
@@ -46,17 +46,15 @@ QUnit.test('receive visitor typing status "is typing"', async function (assert) 
         "Should display no one is currently typing"
     );
 
+    const mailChannel1 = pyEnv['mail.channel'].searchRead([['id', '=', mailChannelId1]])[0];
     // simulate receive typing notification from livechat visitor "is typing"
     await afterNextRender(() => {
-        widget.call('bus_service', 'trigger', 'notification', [{
-            type: 'mail.channel.partner/typing_status',
-            payload: {
-                channel_id: mailChannelId1,
-                is_typing: true,
-                partner_id: messaging.publicPartners[0].id,
-                partner_name: messaging.publicPartners[0].name,
-            },
-        }]);
+        pyEnv['bus.bus']._sendone(mailChannel1, 'mail.channel.partner/typing_status', {
+            'channel_id': mailChannelId1,
+            'is_typing': true,
+            'partner_id': messaging.publicPartners[0].id,
+            'partner_name': messaging.publicPartners[0].name,
+        });
     });
     assert.strictEqual(
         document.querySelector('.o_ThreadTextualTypingStatus').textContent,

--- a/addons/mail/static/src/models/composer_view.js
+++ b/addons/mail/static/src/models/composer_view.js
@@ -9,6 +9,7 @@ import { addLink, escapeAndCompactTextContent, parseAndTransform } from '@mail/j
 import { isEventHandled, markEventHandled } from '@mail/utils/utils';
 
 import { escape, sprintf } from '@web/core/utils/strings';
+import { url } from '@web/core/utils/urls';
 
 registerModel({
     name: 'ComposerView',
@@ -842,7 +843,7 @@ registerModel({
          */
         _computeCurrentPartnerAvatar() {
             if (this.messaging.currentUser) {
-                return this.env.session.url('/web/image', {
+                return url('/web/image', {
                     field: 'avatar_128',
                     id: this.messaging.currentUser.id,
                     model: 'res.users',
@@ -1208,7 +1209,7 @@ registerModel({
                 });
                 body = body.replace(text, placeholder);
             }
-            const baseHREF = this.env.session.url('/web');
+            const baseHREF = url('/web');
             for (const mention of mentions) {
                 const href = `href='${baseHREF}#model=${mention.model}&id=${mention.id}'`;
                 const attClass = `class='${mention.class}'`;

--- a/addons/mail/static/src/models/thread.js
+++ b/addons/mail/static/src/models/thread.js
@@ -10,6 +10,8 @@ import { cleanSearchTerm } from '@mail/utils/utils';
 import * as mailUtils from '@mail/js/utils';
 
 import { sprintf } from '@web/core/utils/strings';
+import { url } from '@web/core/utils/urls';
+
 import { str_to_datetime } from 'web.time';
 
 const getSuggestedRecipientInfoNextTemporaryId = (function () {
@@ -1628,7 +1630,7 @@ registerModel({
          * @returns {string}
          */
         _computeUrl() {
-            const baseHref = this.env.session.url('/web');
+            const baseHref = url('/web');
             if (this.model === 'mail.channel') {
                 return `${baseHref}#action=mail.action_discuss&active_id=${this.model}_${this.id}`;
             }

--- a/addons/mail/static/tests/helpers/test_utils.js
+++ b/addons/mail/static/tests/helpers/test_utils.js
@@ -220,7 +220,7 @@ let pyEnv;
                 if (target[name]) {
                     return target[name];
                 }
-                return {
+                const modelAPI = {
                     /**
                      * Simulate a 'create' operation on a model.
                      *
@@ -284,6 +284,11 @@ let pyEnv;
                         return target.mockServer.mockWrite(name, [ids, values]);
                     },
                 };
+                if (name === 'bus.bus') {
+                    modelAPI['_sendone'] = target.mockServer._mockBusBus__sendone.bind(target.mockServer);
+                    modelAPI['_sendmany'] = target.mockServer._mockBusBus__sendmany.bind(target.mockServer);
+                }
+                return modelAPI;
             },
             set(target, name, value) {
                 return target[name] = value;

--- a/addons/mail/static/tests/qunit_suite_tests/components/discuss_pinned_tests.js
+++ b/addons/mail/static/tests/qunit_suite_tests/components/discuss_pinned_tests.js
@@ -115,7 +115,7 @@ QUnit.test('sidebar: unpin channel from bus', async function (assert) {
 
     const pyEnv = await startServer();
     const mailChannelId1 = pyEnv['mail.channel'].create();
-    const { click, env, messaging } = await start({
+    const { click, messaging } = await start({
         autoOpenDiscuss: true,
     });
     const threadGeneral = messaging.models['Thread'].findFromIdentifyingData({
@@ -146,16 +146,13 @@ QUnit.test('sidebar: unpin channel from bus', async function (assert) {
     // Simulate receiving a leave channel notification
     // (e.g. from user interaction from another device or browser tab)
     await afterNextRender(() => {
-        env.services.bus_service.trigger('notification', [{
-            type: 'mail.channel/unpin',
-            payload: {
-                channel_type: 'channel',
-                id: mailChannelId1,
-                name: "General",
-                public: 'public',
-                state: 'open',
-            },
-        }]);
+        pyEnv['bus.bus']._sendone(pyEnv.currentPartner, 'mail.channel/unpin', {
+            'channel_type': 'channel',
+            'id': mailChannelId1,
+            'name': "General",
+            'public': 'public',
+            'state': 'open',
+        });
     });
     assert.containsOnce(
         document.body,

--- a/addons/mail/static/tests/qunit_suite_tests/components/discuss_sidebar_category_tests.js
+++ b/addons/mail/static/tests/qunit_suite_tests/components/discuss_sidebar_category_tests.js
@@ -318,15 +318,12 @@ QUnit.test('channel - states: close from the bus', async function (assert) {
         user_id: pyEnv.currentUserId,
         is_discuss_sidebar_category_channel_open: true,
     });
-    const { messaging, env } = await this.start();
+    const { messaging } = await this.start();
 
     await afterNextRender(() => {
-        env.services.bus_service.trigger('notification', [{
-            type: "res.users.settings/changed",
-            payload: {
-                is_discuss_sidebar_category_channel_open: false,
-            },
-        }]);
+        pyEnv['bus.bus']._sendone(pyEnv.currentPartner, "res.users.settings/changed", {
+            'is_discuss_sidebar_category_channel_open': false,
+        });
     });
     assert.containsNone(
         document.body,
@@ -349,15 +346,12 @@ QUnit.test('channel - states: open from the bus', async function (assert) {
         user_id: pyEnv.currentUserId,
         is_discuss_sidebar_category_channel_open: false,
     });
-    const { env, messaging } = await this.start();
+    const { messaging } = await this.start();
 
     await afterNextRender(() => {
-        env.services.bus_service.trigger('notification', [{
-            type: "res.users.settings/changed",
-            payload: {
-                is_discuss_sidebar_category_channel_open: true,
-            },
-            }]);
+        pyEnv['bus.bus']._sendone(pyEnv.currentPartner, "res.users.settings/changed", {
+            'is_discuss_sidebar_category_channel_open': true,
+        });
     });
     assert.containsOnce(
         document.body,
@@ -692,15 +686,12 @@ QUnit.test('chat - states: close from the bus', async function (assert) {
         user_id: pyEnv.currentUserId,
         is_discuss_sidebar_category_chat_open: true,
     });
-    const { env, messaging } = await this.start();
+    const { messaging } = await this.start();
 
     await afterNextRender(() => {
-        env.services.bus_service.trigger('notification', [{
-            type: "res.users.settings/changed",
-            payload: {
-                is_discuss_sidebar_category_chat_open: false,
-            },
-        }]);
+        pyEnv['bus.bus']._sendone(pyEnv.currentPartner, "res.users.settings/changed", {
+            'is_discuss_sidebar_category_chat_open': false,
+        });
     });
     assert.containsNone(
         document.body,
@@ -726,15 +717,12 @@ QUnit.test('chat - states: open from the bus', async function (assert) {
         user_id: pyEnv.currentUserId,
         is_discuss_sidebar_category_chat_open: false,
     });
-    const { env, messaging } = await this.start();
+    const { messaging } = await this.start();
 
     await afterNextRender(() => {
-        env.services.bus_service.trigger('notification', [{
-            type: "res.users.settings/changed",
-            payload: {
-                is_discuss_sidebar_category_chat_open: true,
-            },
-        }]);
+        pyEnv['bus.bus']._sendone(pyEnv.currentPartner, "res.users.settings/changed", {
+            'is_discuss_sidebar_category_chat_open': true,
+        });
     });
     assert.containsOnce(
         document.body,

--- a/addons/mail/static/tests/qunit_suite_tests/components/discuss_tests.js
+++ b/addons/mail/static/tests/qunit_suite_tests/components/discuss_tests.js
@@ -2969,7 +2969,7 @@ QUnit.test('mark channel as seen on last message visible [REQUIRE FOCUS]', async
 QUnit.test('receive new needaction messages', async function (assert) {
     assert.expect(12);
 
-    const { messaging, pyEnv, widget } = await this.start();
+    const { messaging, pyEnv } = await this.start();
     assert.ok(
         document.querySelector(`
             .o_DiscussSidebarMailbox[data-thread-local-id="${
@@ -3003,16 +3003,13 @@ QUnit.test('receive new needaction messages', async function (assert) {
 
     // simulate receiving a new needaction message
     await afterNextRender(() => {
-        widget.call('bus_service', 'trigger', 'notification', [{
-            type: 'mail.message/inbox',
-            payload: {
-                body: "not empty",
-                id: 100,
-                needaction_partner_ids: [pyEnv.currentPartnerId],
-                model: 'res.partner',
-                res_id: 20,
-            },
-        }]);
+        pyEnv['bus.bus']._sendone(pyEnv.currentPartner, 'mail.message/inbox', {
+            'body': "not empty",
+            'id': 100,
+            'needaction_partner_ids': [pyEnv.currentPartnerId],
+            'model': 'res.partner',
+            'res_id': 20,
+        });
     });
     assert.ok(
         document.querySelector(`
@@ -3046,16 +3043,13 @@ QUnit.test('receive new needaction messages', async function (assert) {
 
     // simulate receiving another new needaction message
     await afterNextRender(() => {
-        widget.call('bus_service', 'trigger', 'notification', [{
-            type: 'mail.message/inbox',
-            payload: {
-                body: "not empty",
-                id: 101,
-                needaction_partner_ids: [pyEnv.currentPartnerId],
-                model: 'res.partner',
-                res_id: 20,
-            },
-        }]);
+        pyEnv['bus.bus']._sendone(pyEnv.currentPartner, 'mail.message/inbox', {
+            'body': "not empty",
+            'id': 101,
+            'needaction_partner_ids': [pyEnv.currentPartnerId],
+            'model': 'res.partner',
+            'res_id': 20,
+        });
     });
     assert.strictEqual(
         document.querySelector(`
@@ -3545,7 +3539,7 @@ QUnit.test('receive new chat message: out of odoo focus (notification, channel)'
         assert.strictEqual(payload.part, '_chat');
         assert.strictEqual(payload.title, "1 Message");
     });
-    const { widget } = await this.start({
+    await this.start({
         env: { bus },
         services: {
             bus_service: BusService.extend({
@@ -3558,19 +3552,17 @@ QUnit.test('receive new chat message: out of odoo focus (notification, channel)'
         },
     });
 
+    const mailChannel1 = pyEnv['mail.channel'].searchRead([['id', '=', mailChannelId1]])[0];
     // simulate receiving a new message with odoo focused
     await afterNextRender(() => {
-        widget.call('bus_service', 'trigger', 'notification', [{
-            type: 'mail.channel/new_message',
-            payload: {
-                id: mailChannelId1,
-                message: {
-                    id: 126,
-                    model: 'mail.channel',
-                    res_id: mailChannelId1,
-                },
+        pyEnv['bus.bus']._sendone(mailChannel1, 'mail.channel/new_message', {
+            'id': mailChannelId1,
+            'message': {
+                id: 126,
+                model: 'mail.channel',
+                res_id: mailChannelId1,
             },
-        }]);
+        });
     });
     assert.verifySteps(['set_title_part']);
 });
@@ -3586,7 +3578,7 @@ QUnit.test('receive new chat message: out of odoo focus (notification, chat)', a
         assert.strictEqual(payload.part, '_chat');
         assert.strictEqual(payload.title, "1 Message");
     });
-    const { widget } = await this.start({
+    await this.start({
         env: { bus },
         services: {
             bus_service: BusService.extend({
@@ -3599,19 +3591,17 @@ QUnit.test('receive new chat message: out of odoo focus (notification, chat)', a
         },
     });
 
+    const mailChannel1 = pyEnv['mail.channel'].searchRead([['id', '=', mailChannelId1]])[0];
     // simulate receiving a new message with odoo focused
     await afterNextRender(() => {
-        widget.call('bus_service', 'trigger', 'notification', [{
-            type: 'mail.channel/new_message',
-            payload: {
-                id: mailChannelId1,
-                message: {
-                    id: 126,
-                    model: 'mail.channel',
-                    res_id: mailChannelId1,
-                },
+        pyEnv['bus.bus']._sendone(mailChannel1, 'mail.channel/new_message', {
+            'id': mailChannelId1,
+            'message': {
+                id: 126,
+                model: 'mail.channel',
+                res_id: mailChannelId1,
             },
-        }]);
+        });
     });
     assert.verifySteps(['set_title_part']);
 });
@@ -3640,7 +3630,7 @@ QUnit.test('receive new chat messages: out of odoo focus (tab title)', async fun
             assert.strictEqual(payload.title, "3 Messages");
         }
     });
-    const { widget } = await this.start({
+    await this.start({
         env: { bus },
         services: {
             bus_service: BusService.extend({
@@ -3653,51 +3643,44 @@ QUnit.test('receive new chat messages: out of odoo focus (tab title)', async fun
         },
     });
 
+    const mailChannel1 = pyEnv['mail.channel'].searchRead([['id', '=', mailChannelId1]])[0];
     // simulate receiving a new message in chat 1 with odoo focused
     await afterNextRender(() => {
-        widget.call('bus_service', 'trigger', 'notification', [{
-            type: 'mail.channel/new_message',
-            payload: {
-                id: mailChannelId1,
-                message: {
-                    id: 126,
-                    model: 'mail.channel',
-                    res_id: mailChannelId1,
-                },
+        pyEnv['bus.bus']._sendone(mailChannel1, 'mail.channel/new_message', {
+            'id': mailChannelId1,
+            'message': {
+                id: 126,
+                model: 'mail.channel',
+                res_id: mailChannelId1,
             },
-        }]);
+        });
     });
     assert.verifySteps(['set_title_part']);
 
+    const mailChannel2 = pyEnv['mail.channel'].searchRead([['id', '=', mailChannelId2]])[0];
     // simulate receiving a new message in chat 2 with odoo focused
     await afterNextRender(() => {
-        widget.call('bus_service', 'trigger', 'notification', [{
-            type: 'mail.channel/new_message',
-            payload: {
-                id: mailChannelId2,
-                message: {
-                    id: 127,
-                    model: 'mail.channel',
-                    res_id: mailChannelId2,
-                },
+        pyEnv['bus.bus']._sendone(mailChannel2, 'mail.channel/new_message', {
+            'id': mailChannelId2,
+            'message': {
+                id: 127,
+                model: 'mail.channel',
+                res_id: mailChannelId2,
             },
-        }]);
+        });
     });
     assert.verifySteps(['set_title_part']);
 
     // simulate receiving another new message in chat 2 with odoo focused
     await afterNextRender(() => {
-        widget.call('bus_service', 'trigger', 'notification', [{
-            type: 'mail.channel/new_message',
-            payload: {
-                id: mailChannelId2,
-                message: {
-                    id: 128,
-                    model: 'mail.channel',
-                    res_id: mailChannelId2,
-                },
+        pyEnv['bus.bus']._sendone(mailChannel2, 'mail.channel/new_message', {
+            'id': mailChannelId2,
+            'message': {
+                id: 128,
+                model: 'mail.channel',
+                res_id: mailChannelId2,
             },
-        }]);
+        });
     });
     assert.verifySteps(['set_title_part']);
 });

--- a/addons/mail/static/tests/qunit_suite_tests/components/message_tests.js
+++ b/addons/mail/static/tests/qunit_suite_tests/components/message_tests.js
@@ -256,7 +256,7 @@ QUnit.test("'channel_fetch' notification received is correctly handled", async f
         ],
         channel_type: 'chat',
     });
-    const { createThreadViewComponent, messaging, widget } = await start();
+    const { createThreadViewComponent, messaging } = await start();
     const currentPartner = messaging.models['Partner'].insert({
         id: messaging.currentPartner.id,
         display_name: "Demo User",
@@ -290,16 +290,14 @@ QUnit.test("'channel_fetch' notification received is correctly handled", async f
         "message component should not have any check (V) as message is not yet received"
     );
 
+    const mailChannel1 = pyEnv['mail.channel'].searchRead([['id', '=', mailChannelId1]])[0];
     // Simulate received channel fetched notification
     await afterNextRender(() => {
-        widget.call('bus_service', 'trigger', 'notification', [{
-            type: 'mail.channel.partner/fetched',
-            payload: {
-                channel_id: mailChannelId1,
-                last_message_id: 100,
-                partner_id: resPartnerId1,
-            },
-    }]);
+        pyEnv['bus.bus']._sendone(mailChannel1, 'mail.channel.partner/fetched', {
+            'channel_id': mailChannelId1,
+            'last_message_id': 100,
+            'partner_id': resPartnerId1,
+        });
     });
 
     assert.containsOnce(
@@ -321,7 +319,7 @@ QUnit.test("'channel_seen' notification received is correctly handled", async fu
         ],
         channel_type: 'chat',
     });
-    const { createThreadViewComponent, messaging, widget } = await start();
+    const { createThreadViewComponent, messaging } = await start();
     const currentPartner = messaging.models['Partner'].insert({
         id: messaging.currentPartner.id,
         display_name: "Demo User",
@@ -354,16 +352,14 @@ QUnit.test("'channel_seen' notification received is correctly handled", async fu
         "message component should not have any check (V) as message is not yet received"
     );
 
+    const mailChannel1 = pyEnv['mail.channel'].searchRead([['id', '=', mailChannelId1]])[0];
     // Simulate received channel seen notification
     await afterNextRender(() => {
-        widget.call('bus_service', 'trigger', 'notification', [{
-            type: 'mail.channel.partner/seen',
-            payload: {
-                channel_id: mailChannelId1,
-                last_message_id: 100,
-                partner_id: resPartnerId1,
-            },
-        }]);
+        pyEnv['bus.bus']._sendone(mailChannel1, 'mail.channel.partner/seen', {
+            'channel_id': mailChannelId1,
+            'last_message_id': 100,
+            'partner_id': resPartnerId1,
+        });
     });
     assert.containsN(
         document.body,
@@ -385,7 +381,7 @@ QUnit.test("'channel_fetch' notification then 'channel_seen' received  are corre
         ],
         channel_type: 'chat',
     });
-    const { createThreadViewComponent, messaging, widget } = await start();
+    const { createThreadViewComponent, messaging } = await start();
     const currentPartner = messaging.models['Partner'].insert({
         id: messaging.currentPartner.id,
         display_name: "Demo User",
@@ -418,16 +414,14 @@ QUnit.test("'channel_fetch' notification then 'channel_seen' received  are corre
         "message component should not have any check (V) as message is not yet received"
     );
 
+    const mailChannel1 = pyEnv['mail.channel'].searchRead([['id', '=', mailChannelId1]])[0];
     // Simulate received channel fetched notification
     await afterNextRender(() => {
-        widget.call('bus_service', 'trigger', 'notification', [{
-            type: 'mail.channel.partner/fetched',
-            payload: {
-                channel_id: mailChannelId1,
-                last_message_id: 100,
-                partner_id: resPartnerId1,
-            }
-        }]);
+        pyEnv['bus.bus']._sendone(mailChannel1, 'mail.channel.partner/fetched', {
+            'channel_id': mailChannelId1,
+            'last_message_id': 100,
+            'partner_id': resPartnerId1,
+        });
     });
     assert.containsOnce(
         document.body,
@@ -437,14 +431,11 @@ QUnit.test("'channel_fetch' notification then 'channel_seen' received  are corre
 
     // Simulate received channel seen notification
     await afterNextRender(() => {
-        widget.call('bus_service', 'trigger', 'notification', [{
-            type: 'mail.channel.partner/seen',
-            payload: {
-                channel_id: mailChannelId1,
-                last_message_id: 100,
-                partner_id: resPartnerId1,
-            },
-        }]);
+        pyEnv['bus.bus']._sendone(mailChannel1, 'mail.channel.partner/seen', {
+            'channel_id': mailChannelId1,
+            'last_message_id': 100,
+            'partner_id': resPartnerId1,
+        });
     });
     assert.containsN(
         document.body,

--- a/addons/mail/static/tests/qunit_suite_tests/components/notification_list_tests.js
+++ b/addons/mail/static/tests/qunit_suite_tests/components/notification_list_tests.js
@@ -67,7 +67,7 @@ QUnit.test('thread notifications are re-ordered on receiving a new message', asy
             res_id: mailChannelId2,
         },
     ]);
-    const { createNotificationListComponent, widget } = await start();
+    const { createNotificationListComponent } = await start();
     await createNotificationListComponent({ filter: 'all' });
     assert.containsN(
         document.body,
@@ -76,23 +76,21 @@ QUnit.test('thread notifications are re-ordered on receiving a new message', asy
         "there should be two thread previews"
     );
 
+    const mailChannel1 = pyEnv['mail.channel'].searchRead([['id', '=', mailChannelId1]])[0];
     await afterNextRender(() => {
-        widget.call('bus_service', 'trigger', 'notification', [{
-            type: 'mail.channel/new_message',
-            payload: {
-                id: mailChannelId1,
-                message: {
-                    author_id: [7, "Demo User"],
-                    body: "<p>New message !</p>",
-                    date: "2020-03-23 10:00:00",
-                    id: 44,
-                    message_type: 'comment',
-                    model: 'mail.channel',
-                    record_name: 'Channel 2019',
-                    res_id: mailChannelId1,
-                },
+        pyEnv['bus.bus']._sendone(mailChannel1, 'mail.channel/new_message', {
+            'id': mailChannelId1,
+            'message': {
+                author_id: [7, "Demo User"],
+                body: "<p>New message !</p>",
+                date: "2020-03-23 10:00:00",
+                id: 44,
+                message_type: 'comment',
+                model: 'mail.channel',
+                record_name: 'Channel 2019',
+                res_id: mailChannelId1,
             },
-        }]);
+        });
     });
     assert.containsN(
         document.body,

--- a/addons/mail/static/tests/qunit_suite_tests/components/thread_icon_tests.js
+++ b/addons/mail/static/tests/qunit_suite_tests/components/thread_icon_tests.js
@@ -35,7 +35,7 @@ QUnit.test('chat: correspondent is typing', async function (assert) {
         ],
         channel_type: 'chat',
     });
-    const { messaging, target, widget } = await start();
+    const { messaging, target } = await start();
     const thread = messaging.models['Thread'].findFromIdentifyingData({
         id: mailChannelId1,
         model: 'mail.channel',
@@ -53,17 +53,15 @@ QUnit.test('chat: correspondent is typing', async function (assert) {
         "should have thread icon with partner im status icon 'online'"
     );
 
+    const mailChannel1 = pyEnv['mail.channel'].searchRead([['id', '=', mailChannelId1]])[0];
     // simulate receive typing notification from demo "is typing"
     await afterNextRender(() => {
-        widget.call('bus_service', 'trigger', 'notification', [{
-            type: 'mail.channel.partner/typing_status',
-            payload: {
-                channel_id: mailChannelId1,
-                is_typing: true,
-                partner_id: resPartnerId1,
-                partner_name: "Demo",
-            },
-        }]);
+        pyEnv['bus.bus']._sendone(mailChannel1, 'mail.channel.partner/typing_status', {
+            'channel_id': mailChannelId1,
+            'is_typing': true,
+            'partner_id': resPartnerId1,
+            'partner_name': "Demo",
+        });
     });
     assert.containsOnce(
         document.body,
@@ -78,15 +76,12 @@ QUnit.test('chat: correspondent is typing', async function (assert) {
 
     // simulate receive typing notification from demo "no longer is typing"
     await afterNextRender(() => {
-        widget.call('bus_service', 'trigger', 'notification', [{
-            type: 'mail.channel.partner/typing_status',
-            payload: {
-                channel_id: mailChannelId1,
-                is_typing: false,
-                partner_id: resPartnerId1,
-                partner_name: "Demo",
-            },
-        }]);
+        pyEnv['bus.bus']._sendone(mailChannel1, 'mail.channel.partner/typing_status', {
+            'channel_id': mailChannelId1,
+            'is_typing': false,
+            'partner_id': resPartnerId1,
+            'partner_name': "Demo",
+        });
     });
     assert.containsOnce(
         document.body,

--- a/addons/mail/static/tests/qunit_suite_tests/components/thread_textual_typing_status_tests.js
+++ b/addons/mail/static/tests/qunit_suite_tests/components/thread_textual_typing_status_tests.js
@@ -32,7 +32,7 @@ QUnit.test('receive other member typing status "is typing"', async function (ass
             [0, 0, { partner_id: resPartnerId1 }],
         ],
     });
-    const { messaging, target, widget } = await start();
+    const { messaging, target } = await start();
     const thread = messaging.models['Thread'].findFromIdentifyingData({
         id: mailChannelId1,
         model: 'mail.channel',
@@ -45,17 +45,15 @@ QUnit.test('receive other member typing status "is typing"', async function (ass
         "Should display no one is currently typing"
     );
 
+    const mailChannel1 = pyEnv['mail.channel'].searchRead([['id', '=', mailChannelId1]])[0];
     // simulate receive typing notification from demo
     await afterNextRender(() => {
-        widget.call('bus_service', 'trigger', 'notification', [{
-            type: 'mail.channel.partner/typing_status',
-            payload: {
-                channel_id: mailChannelId1,
-                is_typing: true,
-                partner_id: resPartnerId1,
-                partner_name: "Demo",
-            },
-        }]);
+        pyEnv['bus.bus']._sendone(mailChannel1, 'mail.channel.partner/typing_status', {
+            channel_id: mailChannelId1,
+            is_typing: true,
+            partner_id: resPartnerId1,
+            partner_name: "Demo",
+        });
     });
     assert.strictEqual(
         document.querySelector('.o_ThreadTextualTypingStatus').textContent,
@@ -75,7 +73,7 @@ QUnit.test('receive other member typing status "is typing" then "no longer is ty
             [0, 0, { partner_id: resPartnerId1 }],
         ],
     });
-    const { messaging, target, widget } = await start();
+    const { messaging, target } = await start();
     const thread = messaging.models['Thread'].findFromIdentifyingData({
         id: mailChannelId1,
         model: 'mail.channel',
@@ -88,17 +86,15 @@ QUnit.test('receive other member typing status "is typing" then "no longer is ty
         "Should display no one is currently typing"
     );
 
+    const mailChannel1 = pyEnv['mail.channel'].searchRead([['id', '=', mailChannelId1]])[0];
     // simulate receive typing notification from demo "is typing"
     await afterNextRender(() => {
-        widget.call('bus_service', 'trigger', 'notification', [{
-            type: 'mail.channel.partner/typing_status',
-            payload: {
-                channel_id: mailChannelId1,
-                is_typing: true,
-                partner_id: resPartnerId1,
-                partner_name: "Demo",
-            },
-        }]);
+        pyEnv['bus.bus']._sendone(mailChannel1, 'mail.channel.partner/typing_status', {
+            'channel_id': mailChannelId1,
+            'is_typing': true,
+            'partner_id': resPartnerId1,
+            'partner_name': "Demo",
+        });
     });
     assert.strictEqual(
         document.querySelector('.o_ThreadTextualTypingStatus').textContent,
@@ -108,15 +104,12 @@ QUnit.test('receive other member typing status "is typing" then "no longer is ty
 
     // simulate receive typing notification from demo "is no longer typing"
     await afterNextRender(() => {
-        widget.call('bus_service', 'trigger', 'notification', [{
-            type: 'mail.channel.partner/typing_status',
-            payload: {
-                channel_id: mailChannelId1,
-                is_typing: false,
-                partner_id: resPartnerId1,
-                partner_name: "Demo",
-            },
-        }]);
+        pyEnv['bus.bus']._sendone(mailChannel1, 'mail.channel.partner/typing_status', {
+            'channel_id': mailChannelId1,
+            'is_typing': false,
+            'partner_id': resPartnerId1,
+            'partner_name': "Demo",
+        });
     });
     assert.strictEqual(
         document.querySelector('.o_ThreadTextualTypingStatus').textContent,
@@ -136,7 +129,7 @@ QUnit.test('assume other member typing status becomes "no longer is typing" afte
             [0, 0, { partner_id: resPartnerId1 }],
         ],
     });
-    const { advanceTime, messaging, target, widget } = await start({
+    const { advanceTime, messaging, target } = await start({
         hasTimeControl: true,
     });
     const thread = messaging.models['Thread'].findFromIdentifyingData({
@@ -151,17 +144,15 @@ QUnit.test('assume other member typing status becomes "no longer is typing" afte
         "Should display no one is currently typing"
     );
 
+    const mailChannel1 = pyEnv['mail.channel'].searchRead([['id', '=', mailChannelId1]])[0];
     // simulate receive typing notification from demo "is typing"
     await afterNextRender(() => {
-        widget.call('bus_service', 'trigger', 'notification', [{
-            type: 'mail.channel.partner/typing_status',
-            payload: {
-                channel_id: mailChannelId1,
-                is_typing: true,
-                partner_id: resPartnerId1,
-                partner_name: "Demo",
-            },
-        }]);
+        pyEnv['bus.bus']._sendone(mailChannel1, 'mail.channel.partner/typing_status', {
+            'channel_id': mailChannelId1,
+            'is_typing': true,
+            'partner_id': resPartnerId1,
+            'partner_name': "Demo",
+        });
     });
     assert.strictEqual(
         document.querySelector('.o_ThreadTextualTypingStatus').textContent,
@@ -188,7 +179,7 @@ QUnit.test ('other member typing status "is typing" refreshes 60 seconds timer o
             [0, 0, { partner_id: resPartnerId1 }],
         ],
     });
-    const { advanceTime, messaging, target, widget } = await start({
+    const { advanceTime, messaging, target } = await start({
         hasTimeControl: true,
     });
     const thread = messaging.models['Thread'].findFromIdentifyingData({
@@ -203,17 +194,15 @@ QUnit.test ('other member typing status "is typing" refreshes 60 seconds timer o
         "Should display no one is currently typing"
     );
 
+    const mailChannel1 = pyEnv['mail.channel'].searchRead([['id', '=', mailChannelId1]])[0];
     // simulate receive typing notification from demo "is typing"
     await afterNextRender(() => {
-        widget.call('bus_service', 'trigger', 'notification', [{
-            type: 'mail.channel.partner/typing_status',
-            payload: {
-                channel_id: mailChannelId1,
-                is_typing: true,
-                partner_id: resPartnerId1,
-                partner_name: "Demo",
-            },
-        }]);
+        pyEnv['bus.bus']._sendone(mailChannel1, 'mail.channel.partner/typing_status', {
+            'channel_id': mailChannelId1,
+            'is_typing': true,
+            'partner_id': resPartnerId1,
+            'partner_name': "Demo",
+        });
     });
     assert.strictEqual(
         document.querySelector('.o_ThreadTextualTypingStatus').textContent,
@@ -223,15 +212,12 @@ QUnit.test ('other member typing status "is typing" refreshes 60 seconds timer o
 
     // simulate receive typing notification from demo "is typing" again after 50s.
     await advanceTime(50 * 1000);
-    widget.call('bus_service', 'trigger', 'notification', [{
-        type: 'mail.channel.partner/typing_status',
-        payload: {
-            channel_id: mailChannelId1,
-            is_typing: true,
-            partner_id: resPartnerId1,
-            partner_name: "Demo",
-        },
-    }]);
+    pyEnv['bus.bus']._sendone(mailChannel1, 'mail.channel.partner/typing_status', {
+        'channel_id': mailChannelId1,
+        'is_typing': true,
+        'partner_id': resPartnerId1,
+        'partner_name': "Demo",
+    });
     await advanceTime(50 * 1000);
     await nextAnimationFrame();
     assert.strictEqual(
@@ -265,7 +251,7 @@ QUnit.test('receive several other members typing status "is typing"', async func
             [0, 0, { partner_id: resPartnerId3 }],
         ],
     });
-    const { messaging, target, widget } = await start();
+    const { messaging, target } = await start();
     const thread = messaging.models['Thread'].findFromIdentifyingData({
         id: mailChannelId1,
         model: 'mail.channel',
@@ -278,17 +264,15 @@ QUnit.test('receive several other members typing status "is typing"', async func
         "Should display no one is currently typing"
     );
 
+    const mailChannel1 = pyEnv['mail.channel'].searchRead([['id', '=', mailChannelId1]])[0];
     // simulate receive typing notification from other10 (is typing)
     await afterNextRender(() => {
-        widget.call('bus_service', 'trigger', 'notification', [{
-            type: 'mail.channel.partner/typing_status',
-            payload: {
-                channel_id: mailChannelId1,
-                is_typing: true,
-                partner_id: resPartnerId1,
-                partner_name: "Other10",
-            },
-        }]);
+        pyEnv['bus.bus']._sendone(mailChannel1, 'mail.channel.partner/typing_status', {
+            'channel_id': mailChannelId1,
+            'is_typing': true,
+            'partner_id': resPartnerId1,
+            'partner_name': "Other10",
+        });
     });
     assert.strictEqual(
         document.querySelector('.o_ThreadTextualTypingStatus').textContent,
@@ -298,15 +282,12 @@ QUnit.test('receive several other members typing status "is typing"', async func
 
     // simulate receive typing notification from other11 (is typing)
     await afterNextRender(() => {
-        widget.call('bus_service', 'trigger', 'notification', [{
-            type: 'mail.channel.partner/typing_status',
-            payload: {
-                channel_id: mailChannelId1,
-                is_typing: true,
-                partner_id: resPartnerId2,
-                partner_name: "Other11",
-            },
-        }]);
+        pyEnv['bus.bus']._sendone(mailChannel1, 'mail.channel.partner/typing_status', {
+            'channel_id': mailChannelId1,
+            'is_typing': true,
+            'partner_id': resPartnerId2,
+            'partner_name': "Other11",
+        });
     });
     assert.strictEqual(
         document.querySelector('.o_ThreadTextualTypingStatus').textContent,
@@ -316,15 +297,12 @@ QUnit.test('receive several other members typing status "is typing"', async func
 
     // simulate receive typing notification from other12 (is typing)
     await afterNextRender(() => {
-        widget.call('bus_service', 'trigger', 'notification', [{
-            type: 'mail.channel.partner/typing_status',
-            payload: {
-                channel_id: mailChannelId1,
-                is_typing: true,
-                partner_id: resPartnerId3,
-                partner_name: "Other12",
-            },
-        }]);
+        pyEnv['bus.bus']._sendone(mailChannel1, 'mail.channel.partner/typing_status', {
+            'channel_id': mailChannelId1,
+            'is_typing': true,
+            'partner_id': resPartnerId3,
+            'partner_name': "Other12",
+        });
     });
     assert.strictEqual(
         document.querySelector('.o_ThreadTextualTypingStatus').textContent,
@@ -334,15 +312,12 @@ QUnit.test('receive several other members typing status "is typing"', async func
 
     // simulate receive typing notification from other10 (no longer is typing)
     await afterNextRender(() => {
-        widget.call('bus_service', 'trigger', 'notification', [{
-            type: 'mail.channel.partner/typing_status',
-            payload: {
-                channel_id: mailChannelId1,
-                is_typing: false,
-                partner_id: resPartnerId1,
-                partner_name: "Other10",
-            },
-        }]);
+        pyEnv['bus.bus']._sendone(mailChannel1, 'mail.channel.partner/typing_status', {
+            'channel_id': mailChannelId1,
+            'is_typing': false,
+            'partner_id': resPartnerId1,
+            'partner_name': "Other10",
+        });
     });
     assert.strictEqual(
         document.querySelector('.o_ThreadTextualTypingStatus').textContent,
@@ -352,15 +327,12 @@ QUnit.test('receive several other members typing status "is typing"', async func
 
     // simulate receive typing notification from other10 (is typing again)
     await afterNextRender(() => {
-        widget.call('bus_service', 'trigger', 'notification', [{
-            type: 'mail.channel.partner/typing_status',
-            payload: {
-                channel_id: mailChannelId1,
-                is_typing: true,
-                partner_id: resPartnerId1,
-                partner_name: "Other10",
-            },
-        }]);
+        pyEnv['bus.bus']._sendone(mailChannel1, 'mail.channel.partner/typing_status', {
+            'channel_id': mailChannelId1,
+            'is_typing': true,
+            'partner_id': resPartnerId1,
+            'partner_name': "Other10",
+        });
     });
     assert.strictEqual(
         document.querySelector('.o_ThreadTextualTypingStatus').textContent,

--- a/addons/website_livechat/static/tests/helpers/mock_server.js
+++ b/addons/website_livechat/static/tests/helpers/mock_server.js
@@ -68,10 +68,9 @@ MockServer.include({
                 public: 'private',
             });
             // notify operator
-            this._widget.call('bus_service', 'trigger', 'notification', [{
-                type: 'website_livechat.send_chat_request',
-                payload: this._mockMailChannelChannelInfo([livechatId])[0],
-            }]);
+            this.pyEnv['bus.bus']._sendone(this.currentPartner, 'website_livechat.send_chat_request',
+                this._mockMailChannelChannelInfo([livechatId])[0]
+            );
         }
     },
 });


### PR DESCRIPTION
*: im_livechat, website_livechat.

In order to reduce the noise in the PR introducing the new environment in
the discuss app, calls to widget.call, env.bus_service.call during tests
have been replaced by a mocked implementation of _sendone/_sendmany. Moreover,
this approach will allow us to mock the longpolling during tests, resulting in
a more realistic behavior.

task-2582313