### PR TITLE
[MERGE][IMP] website_sale_slides: slightly improve "publish" management

### DIFF
--- a/addons/website_sale_slides/controllers/slides.py
+++ b/addons/website_sale_slides/controllers/slides.py
@@ -21,10 +21,15 @@ class WebsiteSaleSlides(WebsiteSlides):
     def _prepare_additional_channel_values(self, values, **kwargs):
         values = super(WebsiteSaleSlides, self)._prepare_additional_channel_values(values, **kwargs)
         channel = values['channel']
-        if channel.enroll == 'payment' and channel.product_id:
-            pricelist = request.website.get_current_pricelist()
-            values['product_info'] = channel.product_id.product_tmpl_id._get_combination_info(product_id=channel.product_id.id, pricelist=pricelist)
-            values['product_info']['currency_id'] = request.website.currency_id
+        if channel.enroll == 'payment':
+            # search the product to apply ACLs, notably on published status, to avoid access errors
+            product = request.env['product.product'].search([('id', '=', channel.product_id.id)]) if channel.product_id else request.env['product.product']
+            if product:
+                pricelist = request.website.get_current_pricelist()
+                values['product_info'] = channel.product_id.product_tmpl_id._get_combination_info(product_id=channel.product_id.id, pricelist=pricelist)
+                values['product_info']['currency_id'] = request.website.currency_id
+            else:
+                values['product_info'] = False
         return values
 
     def _slide_channel_prepare_values(self, **kwargs):

--- a/addons/website_sale_slides/views/website_slides_templates.xml
+++ b/addons/website_sale_slides/views/website_slides_templates.xml
@@ -84,7 +84,7 @@
 </template>
 
 <template name="Buy Course Button" id="course_buy_course_button">
-    <t t-if="channel.product_id.website_published and not channel.is_member">
+    <t t-if="product_info and channel.product_id.website_published and not channel.is_member">
         <div t-attf-class="text-center d-flex align-items-center text-center pb-1 #{'justify-content-between' if product_info['has_discounted_price'] else 'justify-content-around'}">
             <div class="css_editable_mode_hidden">
                 <!-- real price -->

--- a/addons/website_sale_slides/views/website_slides_templates.xml
+++ b/addons/website_sale_slides/views/website_slides_templates.xml
@@ -68,6 +68,18 @@
 </template>
 
 <!-- COURSE -->
+<template name="Course Main" id="course_main" inherit_id="website_slides.course_main">
+    <xpath expr="//div[@id='home']" position="before">
+        <div t-if="channel.enroll == 'payment' and not channel.product_id.is_published"
+            class="alert alert-info" role="alert" groups="website_slides.group_website_slides_officer">
+            This course cannot be bought because its linked product
+            <a t-attf-href="/web#id=#{channel.product_id.product_tmpl_id.id}&amp;view_type=form&amp;model=#{channel.product_id.product_tmpl_id._name}&amp;action=website_sale.product_template_action_website"
+                class="alert-link" t-out="channel.product_id.name"/>
+            is not published.
+        </div>
+    </xpath>
+</template>
+
 <template name="Course Sidebar (infos, CTA)" id="course_join" inherit_id="website_slides.course_join">
     <!-- Channel main template: override button to join channel -->
     <xpath expr="//div[hasclass('o_wslides_js_course_join')]" position="inside">
@@ -120,7 +132,7 @@
     </t>
     <t t-elif="not channel.is_member">
         <div class="alert my-0 bg-200 text-center">
-            Course Not Buyable
+            Course Unavailable
         </div>
     </t>
 </template>


### PR DESCRIPTION
This commit adds a couple improvement to the "publish" flow of courses:

- Improve the published synchronization between the course and its product
- Adapt wording when the course is unavailable on the frontend view

See underlying commits for details.

task-2842624