### PR TITLE
[IMP] hr_holidays: set time off default employee when created from al…

### DIFF
--- a/addons/hr_holidays/models/hr_leave_type.py
+++ b/addons/hr_holidays/models/hr_leave_type.py
@@ -397,7 +397,8 @@ class HolidaysType(models.Model):
     @api.depends('employee_requests')
     def _compute_allocation_validation_type(self):
         for leave_type in self:
-            leave_type.allocation_validation_type = 'no' if leave_type.employee_requests == 'no' else 'officer'
+            if leave_type.employee_requests == 'no':
+                leave_type.allocation_validation_type = 'officer'
 
     def requested_name_get(self):
         return self._context.get('holiday_status_name_get', True) and self._context.get('employee_id')


### PR DESCRIPTION
…location smart button

In hr_holidays, each allocation granted to an employee has a smart button to see the linked
time off for this employee.
The create button on the tree view that shows these time off opens the form
with self.env.user.employee_id as default employee.

This commit changes the default employee of the time off to be the one of the original allocation

task-2844554

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
