### PR TITLE
[13.0] ir_module: use the correct licence

### DIFF
--- a/odoo/addons/base/models/ir_module.py
+++ b/odoo/addons/base/models/ir_module.py
@@ -287,7 +287,7 @@ class Module(models.Model):
         ('OEEL-1', 'Odoo Enterprise Edition License v1.0'),
         ('OPL-1', 'Odoo Proprietary License v1.0'),
         ('Other proprietary', 'Other Proprietary')
-    ], string='License', default='LGPL-3', readonly=True)
+    ], string='License', default='Other proprietary', readonly=True)
     menus_by_module = fields.Text(string='Menus', compute='_get_views', store=True)
     reports_by_module = fields.Text(string='Reports', compute='_get_views', store=True)
     views_by_module = fields.Text(string='Views', compute='_get_views', store=True)


### PR DESCRIPTION
When a custom module is installed and no licence is indicated,
the default licence was LGPL-3 which is an error. If there's no
licence we must assume it is proprietary.

opw-2844654 (apps)




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
