### PR TITLE
[IMP] (hr,sale)_timesheet: improve generic UX

### DIFF
--- a/addons/hr_timesheet/models/hr_timesheet.py
+++ b/addons/hr_timesheet/models/hr_timesheet.py
@@ -50,11 +50,6 @@ class AccountAnalyticLine(models.Model):
             return [('user_id', '=', self.env.user.id)]
         return []
 
-    def _domain_task_id(self):
-        if not self.user_has_groups('hr_timesheet.group_hr_timesheet_approver'):
-            return ['|', ('privacy_visibility', '!=', 'followers'), ('message_partner_ids', 'in', [self.env.user.partner_id.id])]
-        return []
-
     task_id = fields.Many2one(
         'project.task', 'Task', index='btree_not_null',
         compute='_compute_task_id', store=True, readonly=False,

--- a/addons/hr_timesheet/report/report_timesheet_templates.xml
+++ b/addons/hr_timesheet/report/report_timesheet_templates.xml
@@ -1,15 +1,17 @@
+<?xml version="1.0" encoding="utf-8"?>
 <odoo>
     <template id="hr_timesheet.timesheet_table">
-        <div class="row" style="margin-top:10px;">
-            <div class="col-lg-12">
+        <t t-set='is_uom_day' t-value='lines._is_timesheet_encode_uom_day()'/>
+        <div class="row mt8">
+            <div class="col-12">
                 <table class="table table-sm">
                     <thead>
                         <tr>
-                            <th class="align-middle"><span>Date</span></th>
-                            <th class="align-middle"><span>Employee</span></th>
-                            <th class="align-middle" t-if="show_project"><span>Project</span></th>
-                            <th class="align-middle" t-if="show_task"><span>Task</span></th>
-                            <th class="align-middle"><span>Description</span></th>
+                            <th class="text-start align-middle"><span>Date</span></th>
+                            <th class="text-start align-middle"><span>Employee</span></th>
+                            <th class="text-start align-middle" t-if="show_project"><span>Project</span></th>
+                            <th class="text-start align-middle" t-if="show_task"><span>Task</span></th>
+                            <th class="text-start align-middle"><span>Description</span></th>
                             <th class="text-end">
                                 <span t-if="is_uom_day">Days Spent</span>
                                 <span t-else="">Hours Spent</span>
@@ -17,24 +19,24 @@
                         </tr>
                    </thead>
                    <tbody>
-                        <tr t-foreach="lines" t-as="line">
-                            <td>
+                        <tr t-foreach="lines" t-as="line" t-att-style="'background-color: #F1F1F1;' if line_index % 2 == 0 else ''">
+                            <td class="align-middle">
                                <span t-field="line.date"/>
                             </td>
-                            <td>
+                            <td class="align-middle">
                                <span t-field="line.user_id.partner_id.name"/>
                                <span t-if="not line.user_id.partner_id.name" t-field="line.employee_id"/>
                             </td>
-                            <td t-if="show_project">
+                            <td t-if="show_project" class="align-middle">
                                 <span t-field="line.project_id.sudo().name"/>
                             </td>
-                            <td t-if="show_task">
-                                <t t-if="line.task_id"><span t-field="line.task_id.sudo().name"/></t>
+                            <td t-if="show_task" class="align-middle">
+                                <span t-if="line.task_id" t-field="line.task_id.sudo().name"/>
                             </td>
-                            <td >
+                            <td class="align-middle">
                                 <span t-field="line.name" t-options="{'widget': 'text'}"/>
                             </td>
-                            <td class="text-end">
+                            <td class="text-end align-middle">
                                 <span t-if="is_uom_day" t-esc="line._get_timesheet_time_day()" t-options="{'widget': 'timesheet_uom'}"/>
                                 <span t-else="" t-field="line.unit_amount" t-options="{'widget': 'duration', 'digital': True, 'unit': 'hour', 'round': 'minute'}"/>
                             </td>
@@ -60,26 +62,62 @@
         </div>
     </template>
 
+    <template id="hr_timesheet.timesheet_project_task_page">
+        <t t-set="show_record" t-value="len(docs.ids) == 1"/>
+        <t t-set="title" t-value="docs._description"/>
+        <t t-set="company" t-value="docs.company_id if len(docs) == 1 else docs.env.company"/>
+        <t t-call="web.html_container">
+            <t t-call="web.external_layout">
+                <div class="page">
+                    <t t-foreach="docs" t-as="doc">
+                        <t t-if="from_project" t-set="show_task"
+                            t-value="bool(doc.timesheet_ids.task_id)"/>
+                        <div class="oe_structure"/>
+                        <div class="row mt8">
+                            <div class="col-12">
+                                <t t-if="doc.allow_timesheets and doc.timesheet_ids">
+                                    <h1 class="my-4">
+                                        <t t-if="not show_record">
+                                            <t t-out="title"/>: <span t-field="doc.name"/>
+                                        </t>
+                                    </h1>
+                                    <h2>
+                                        <span>Timesheets
+                                            <t t-if="show_record">
+                                                for the <t t-out="doc.name"/> <t t-out="title"/>
+                                            </t>
+                                        </span>
+                                    </h2>
+                                    <t t-set='lines' t-value='doc.timesheet_ids'/>
+                                    <t t-call="hr_timesheet.timesheet_table"/>
+                                </t>
+                            </div>
+                        </div>
+                    </t>
+                </div>
+            </t>
+        </t>
+    </template>
+
     <template id="report_timesheet">
         <t t-call="web.html_container">
             <t t-call="web.external_layout">
-                <t t-set="company" t-value="docs.mapped('project_id')[0].company_id if len(docs.mapped('project_id')) == 1 else docs.env.company"/>
-                <t t-set="show_task" t-value="bool(docs.mapped('task_id'))"/>
-                <t t-set="show_project" t-value="len(docs.mapped('project_id')) > 1"/>
+                <t t-set="company" t-value="docs.project_id.company_id if len(docs.project_id) == 1 else docs.env.company"/>
+                <t t-set="show_task" t-value="bool(docs.task_id)"/>
+                <t t-set="show_project" t-value="len(docs.project_id) > 1"/>
                 <div class="page">
                     <div class="oe_structure"/>
-                    <div class="row" style="margin-top:10px;">
+                    <div class="row mt8">
                         <div class="col-lg-12">
                             <h2>
-                                <span>Timesheet Entries
-                                    <t t-if="len(docs.mapped('project_id')) == 1">
-                                        for the <t t-esc="docs.mapped('project_id')[0].name"/> Project
+                                <span>Timesheets
+                                    <t t-if="len(docs.project_id) == 1">
+                                        for the <t t-out="docs.project_id.name"/> Project
                                     </t>
                                 </span>
                             </h2>
                         </div>
                     </div>
-                    <t t-set='is_uom_day' t-value='docs._is_timesheet_encode_uom_day()'/>
                     <t t-set='lines' t-value='docs'/>
                     <t t-call="hr_timesheet.timesheet_table"/>
                     <div class="oe_structure"/>
@@ -92,24 +130,22 @@
     <template id="report_timesheet_task">
         <t t-call="web.html_container">
             <t t-call="web.external_layout">
-                <t t-set="company" t-value="docs.mapped('project_id')[0].company_id if len(docs.mapped('project_id')) == 1 else docs.env.company"/>
-                <t t-set="show_task" t-value="len(docs.mapped('task_id')) > 1"/>
+                <t t-set="company" t-value="docs.project_id.company_id if len(docs.project_id) == 1 else docs.env.company"/>
+                <t t-set="show_task" t-value="len(docs.task_id) > 1"/>
                 <t t-set="show_project" t-value="False"/>
                 <div class="page">
                     <div class="oe_structure"/>
-                    <div class="row" style="margin-top:10px;">
-                        <div class="col-lg-12">
+                    <div class="row mt8">
+                        <div class="col-12">
                             <h2>
-                                <span>Timesheet Entries
-                                    <t t-if="len(docs.mapped('task_id')) == 1">
-                                        for <t t-esc="docs.mapped('task_id')[0].name"/>
+                                <span>Timesheets
+                                    <t t-if="len(docs.task_id) == 1">
+                                        for <t t-out="docs.task_id.name"/>
                                     </t>
                                 </span>
                             </h2>
                         </div>
                     </div>
-
-                    <t t-set='is_uom_day' t-value='docs._is_timesheet_encode_uom_day()'/>
                     <t t-set='lines' t-value='docs'/>
                     <t t-call="hr_timesheet.timesheet_table"/>
                     <div class="oe_structure"/>
@@ -119,7 +155,7 @@
     </template>
 
     <record id="timesheet_report" model="ir.actions.report">
-        <field name="name">Timesheet Entries</field>
+        <field name="name">Timesheets</field>
         <field name="model">account.analytic.line</field>
         <field name="report_type">qweb-pdf</field>
         <field name="report_name">hr_timesheet.report_timesheet</field>
@@ -130,41 +166,11 @@
 
     <!-- Project Task Timesheet Report -->
     <template id="report_project_task_timesheet">
-        <t t-call="web.html_container">
-            <t t-call="web.external_layout">
-                <t t-set="show_Task" t-value="len(docs.mapped('id')) == 1"/>
-                <div class="page">
-                    <t t-foreach="docs" t-as="doc">
-                        <div class="oe_structure"/>
-                        <div class="row" style="margin-top:10px;">
-                            <div class="col-lg-12">
-                                <t t-if="doc.allow_timesheets and doc.timesheet_ids">
-                                    <h1 class="mt-4 mb-4">
-                                        <t t-if="not show_Task">
-                                            Task: <span t-field="doc.name"/>
-                                        </t>
-                                    </h1>
-                                    <h2>
-                                        <span>Timesheet Entries
-                                            <t t-if="show_Task">
-                                                for the <t t-esc="doc.name"/> Task
-                                            </t>
-                                        </span>
-                                    </h2>
-                                    <t t-set='is_uom_day' t-value='doc.encode_uom_in_days'/>
-                                    <t t-set='lines' t-value='doc.timesheet_ids'/>
-                                    <t t-call="hr_timesheet.timesheet_table"/>
-                                </t>
-                            </div>
-                        </div>
-                    </t>
-                </div>
-            </t>
-        </t>
+        <t t-call="hr_timesheet.timesheet_project_task_page"/>
     </template>
 
     <record id="timesheet_report_task" model="ir.actions.report">
-        <field name="name">Timesheet Entries</field>
+        <field name="name">Timesheets</field>
         <field name="model">project.task</field>
         <field name="report_type">qweb-pdf</field>
         <field name="report_name">hr_timesheet.report_project_task_timesheet</field>
@@ -175,36 +181,12 @@
 
     <!-- Project Timesheet Report -->
     <template id="report_timesheet_project">
-        <t t-call="web.html_container">
-            <t t-call="web.external_layout">
-                <t t-set="company" t-value="docs.company_id[0] if len(docs) == 1 else docs.env.company"/>
-                <t t-set="show_task" t-value="bool(docs.task_ids)"/>
-                <t t-set="show_project" t-value="len(docs) > 1"/>
-
-                <div class="page">
-                    <div class="oe_structure"/>
-                    <div class="row" style="margin-top:10px;">
-                        <div class="col-lg-12">
-                            <h2>
-                                <span>Timesheet Entries
-                                    <t t-if="not show_project">
-                                        for the <t t-esc="docs.name"/> Project
-                                    </t>
-                                </span>
-                            </h2>
-                        </div>
-                    </div>
-                    <t t-set="is_uom_day" t-value="docs.timesheet_ids and docs.timesheet_ids[0]._is_timesheet_encode_uom_day()"/>
-                    <t t-set="lines" t-value="docs.timesheet_ids"/>
-                    <t t-call="hr_timesheet.timesheet_table"/>
-                    <div class="oe_structure"/>
-                </div>
-            </t>
-        </t>
+        <t t-set="from_project" t-value="True"/>
+        <t t-call="hr_timesheet.timesheet_project_task_page"/>
     </template>
 
     <record id="timesheet_report_project" model="ir.actions.report">
-        <field name="name">Timesheet Entries</field>
+        <field name="name">Timesheets</field>
         <field name="model">project.project</field>
         <field name="report_type">qweb-pdf</field>
         <field name="report_name">hr_timesheet.report_timesheet_project</field>
@@ -213,7 +195,7 @@
     </record>
 
     <record id="timesheet_report_task_timesheets" model="ir.actions.report">
-        <field name="name">Timesheet Entries</field>
+        <field name="name">Timesheets</field>
         <field name="model">account.analytic.line</field>
         <field name="report_type">qweb-pdf</field>
         <field name="report_name">hr_timesheet.report_timesheet_task</field>

--- a/addons/project_timesheet_holidays/models/__init__.py
+++ b/addons/project_timesheet_holidays/models/__init__.py
@@ -4,6 +4,7 @@
 from . import res_company # has to be before hr_holidays to create needed columns on res.company
 from . import account_analytic
 from . import hr_holidays
+from . import project_task
 from . import res_config_settings
 from . import resource_calendar_leaves
 from . import hr_employee

--- a/addons/project_timesheet_holidays/models/account_analytic.py
+++ b/addons/project_timesheet_holidays/models/account_analytic.py
@@ -10,8 +10,24 @@ class AccountAnalyticLine(models.Model):
 
     holiday_id = fields.Many2one("hr.leave", string='Leave Request')
     global_leave_id = fields.Many2one("resource.calendar.leaves", string="Global Time Off", ondelete='cascade')
+    task_id = fields.Many2one(domain="[('company_id', '=', company_id), ('project_id.allow_timesheets', '=', True),"
+        "('project_id', '=?', project_id), ('is_timeoff_task', '=', False)]")
 
     @api.ondelete(at_uninstall=False)
     def _unlink_except_linked_leave(self):
         if any(line.holiday_id for line in self):
-            raise UserError(_('You cannot delete timesheets linked to time off. Please, cancel the time off instead.'))
+            raise UserError(_('You cannot delete timesheets that are linked to time off requests. Please cancel your time off request from the Time Off application instead.'))
+
+    @api.model_create_multi
+    def create(self, vals_list):
+        if not self.env.su:
+            task_ids = [vals['task_id'] for vals in vals_list if vals.get('task_id')]
+            has_timeoff_task = self.env['project.task'].search_count([('id', 'in', task_ids), ('is_timeoff_task', '=', True)], limit=1) > 0
+            if has_timeoff_task:
+                raise UserError(_('You cannot create timesheets for a task that is linked to a time off type. Please use the Time Off application to request new time off instead.'))
+        return super().create(vals_list)
+
+    def write(self, vals):
+        if not self.env.su and self.filtered('holiday_id'):
+            raise UserError(_('You cannot modify timesheets that are linked to time off requests. Please use the Time Off application to modify your time off requests instead.'))
+        return super().write(vals)

--- a/addons/project_timesheet_holidays/models/project_task.py
+++ b/addons/project_timesheet_holidays/models/project_task.py
@@ -1,0 +1,40 @@
+# -*- coding: utf-8 -*-
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from odoo import fields, models, _
+
+class Task(models.Model):
+    _inherit = 'project.task'
+
+    leave_types_count = fields.Integer(compute='_compute_leave_types_count')
+    is_timeoff_task = fields.Boolean("Is Time off Task", compute="_compute_is_timeoff_task", search="_search_is_timeoff_task")
+
+    def _compute_leave_types_count(self):
+        time_off_type_read_group = self.env['hr.leave.type']._read_group(
+            [('timesheet_task_id', 'in', self.ids)],
+            ['timesheet_task_id'],
+            ['timesheet_task_id'],
+        )
+        time_off_type_count_per_task = {res['timesheet_task_id'][0]: res['timesheet_task_id_count'] for res in time_off_type_read_group}
+        for task in self:
+            task.leave_types_count = time_off_type_count_per_task.get(task.id, 0)
+
+    def _compute_is_timeoff_task(self):
+        timeoff_tasks = self.filtered(lambda task: task.leave_types_count or task.company_id.leave_timesheet_task_id == task)
+        timeoff_tasks.is_timeoff_task = True
+        (self - timeoff_tasks).is_timeoff_task = False
+
+    def _search_is_timeoff_task(self, operator, value):
+        if operator not in ['=', '!='] or not isinstance(value, bool):
+            raise NotImplementedError(_('Operation not supported'))
+        leave_type_read_group = self.env['hr.leave.type']._read_group(
+            [('timesheet_task_id', '!=', False)],
+            ['timesheet_task_ids:array_agg(timesheet_task_id)'],
+            [],
+        )
+        timeoff_task_ids = leave_type_read_group[0]['timesheet_task_ids'] if leave_type_read_group else []
+        if self.env.company.leave_timesheet_task_id:
+            timeoff_task_ids.append(self.env.company.leave_timesheet_task_id.id)
+        if operator == '!=':
+            value = not value
+        return [('id', 'in' if value else 'not in', timeoff_task_ids)]

--- a/addons/sale_timesheet/__manifest__.py
+++ b/addons/sale_timesheet/__manifest__.py
@@ -28,6 +28,7 @@ have real delivered quantities in sales orders.
         'views/res_config_settings_views.xml',
         'views/sale_timesheet_portal_templates.xml',
         'views/project_sharing_views.xml',
+        'report/report_timesheet_templates.xml',
         'wizard/project_create_sale_order_views.xml',
         'wizard/project_create_invoice_views.xml',
         'wizard/sale_make_invoice_advance_views.xml',

--- a/addons/sale_timesheet/models/sale_order.py
+++ b/addons/sale_timesheet/models/sale_order.py
@@ -98,6 +98,14 @@ class SaleOrder(models.Model):
         action['context'] = {
             'search_default_billable_timesheet': True
         }  # erase default filters
+        if self.order_line:
+            tasks = self.order_line.task_id._filter_access_rules_python('write')
+            if tasks:
+                action['context']['default_task_id'] = tasks[0].id
+            else:
+                projects = self.order_line.project_id._filter_access_rules_python('write')
+                if projects:
+                    action['context']['default_project_id'] = projects[0].id
         if self.timesheet_count > 0:
             action['domain'] = [('so_line', 'in', self.order_line.ids)]
         else:

--- a/addons/sale_timesheet/models/sale_order.py
+++ b/addons/sale_timesheet/models/sale_order.py
@@ -129,6 +129,7 @@ class SaleOrderLine(models.Model):
     remaining_hours_available = fields.Boolean(compute='_compute_remaining_hours_available', compute_sudo=True)
     remaining_hours = fields.Float('Remaining Hours on SO', compute='_compute_remaining_hours', compute_sudo=True, store=True)
     has_displayed_warning_upsell = fields.Boolean('Has Displayed Warning Upsell')
+    timesheet_ids = fields.One2many('account.analytic.line', 'so_line', 'Timesheets')
 
     def name_get(self):
         res = super(SaleOrderLine, self).name_get()

--- a/addons/sale_timesheet/report/report_timesheet_templates.xml
+++ b/addons/sale_timesheet/report/report_timesheet_templates.xml
@@ -1,0 +1,62 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <template id="timesheet_sale_page">
+        <t t-set="show_project" t-value="true"/>
+        <t t-set="show_task" t-value="true"/>
+        <t t-call="web.html_container">
+            <t t-call="web.external_layout">
+                <div class="page">
+                    <t t-foreach="docs" t-as="doc">
+                        <t t-set="doc_name" t-value="doc.name"/>
+                        <t t-if="with_order_id" t-set="doc_name" t-value="str(doc.order_id.name) +' - '+ str(doc_name)"/>
+                        <t t-elif="doc_name == '/'" t-set="doc_name" t-value="'Draft'"/>
+                        <div class="oe_structure"/>
+                        <div class="row mt8">
+                            <div class="col-12">
+                                <t t-if="doc.timesheet_ids">
+                                    <h2>
+                                        <br/>
+                                        <span>Timesheets for the <t t-out="doc_name"/> <t t-out="record_name"/>
+                                        </span>
+                                    </h2>
+                                    <t t-set='lines' t-value='doc.timesheet_ids'/>
+                                    <t t-call="hr_timesheet.timesheet_table"/>
+                                </t>
+                            </div>
+                        </div>
+                    </t>
+                </div>
+            </t>
+        </t>
+    </template>
+
+    <!-- Sale Order Timesheet Report for given timesheets -->
+    <template id="report_timesheet_sale_order">
+        <t t-set="record_name">Sales Order Item</t>
+        <t t-set="with_order_id" t-value="true"/>
+        <t t-set="docs" t-value="docs.order_line"/>
+        <t t-call="sale_timesheet.timesheet_sale_page"/>
+    </template>
+
+    <record id="timesheet_report_sale_order" model="ir.actions.report">
+        <field name="name">Timesheets</field>
+        <field name="model">sale.order</field>
+        <field name="report_type">qweb-pdf</field>
+        <field name="report_name">sale_timesheet.report_timesheet_sale_order</field>
+        <field name="binding_model_id" ref="model_sale_order"/>
+    </record>
+
+    <!-- Invoice Timesheet Report for given timesheets -->
+    <template id="report_timesheet_account_move">
+        <t t-set="record_name">Invoice</t>
+        <t t-call="sale_timesheet.timesheet_sale_page"/>
+    </template>
+
+    <record id="timesheet_report_account_move" model="ir.actions.report">
+        <field name="name">Timesheets</field>
+        <field name="model">account.move</field>
+        <field name="report_type">qweb-pdf</field>
+        <field name="report_name">sale_timesheet.report_timesheet_account_move</field>
+        <field name="binding_model_id" ref="model_account_move"/>
+    </record>
+</odoo>


### PR DESCRIPTION
In this PR done following changes:
- adds the first project as the default project of the timesheet
  in the 'Hours Recorded' stat button's action.
- add the 'Timesheets' report in the sale order and invoice and
  rename the 'Timesheet Entries' report into 'Timesheets'.
- add context in the call of creating and writing method of the timesheet
  in which user should be able to create or update time off timesheets.

task-2826265