### PR TITLE
[IMP] web_editor: add filter-in to m2o/m2m snippet widget

### DIFF
--- a/addons/website/views/snippets/snippets.xml
+++ b/addons/website/views/snippets/snippets.xml
@@ -637,7 +637,7 @@
         <!-- /!\ drop-in here is partly duplicated for s_popup (see dedicated options) -->
         <!-- TODO should be improved -->
 
-    <t t-set="so_content_addition_selector" t-translation="off">blockquote, .s_card:not(.s_timeline_card), .s_alert, .o_facebook_page, .s_share, .s_social_media, .s_rating, .s_hr, .s_google_map, .s_map, .s_countdown, .s_chart, .s_text_highlight, .s_progress_bar, .s_badge, .s_embed_code, .s_donation, .s_add_to_cart</t>
+    <t t-set="so_content_addition_selector" t-translation="off">blockquote, .s_card:not(.s_timeline_card), .s_alert, .o_facebook_page, .s_share, .s_social_media, .s_rating, .s_hr, .s_google_map, .s_map, .s_countdown, .s_chart, .s_text_highlight, .s_progress_bar, .s_badge, .s_embed_code, .s_donation, .s_add_to_cart, .s_online_appointment</t>
     <div id="so_content_addition"
         t-att-data-selector="so_content_addition_selector"
         t-attf-data-drop-near="p, h1, h2, h3, ul, ol, .row > div:not(.o_grid_item_image) > img, #{so_content_addition_selector}"


### PR DESCRIPTION
Adds basic support to filter possible m2x values based on another
record. This is necessary for the website_appointment snippet
introduced within this bundle (see related ENT PR).

An important need implemented here is to not store a list of valid IDs
in the DOM but fetch them based on data stored by a different widget.

Use case covered:
Model A has a Many2Many relationship with Model B via a `model_b_ids`
field.

A first widget (Wa) on a snippet's options allows to select a record of
Model A. A second widget (Wb) allows to select records of Model B.

```xml
<!--Widget A-->
<we-many2many data-model="model.a" data-m2o-field="name"
 data-fakem2m="true".../>

<!--Widget B-->
<we-many2many data-model="model.a" data-m2o-field="model_b_ids"
 data-filter-in="true" .../>
```

Before this commit, the second widget would only be able to show
all records of Model B linked to any Model A record and matching a
static domain provided as attribute, which is still supported.

This commit allows, after having selected `record_a` in the first
widget, to only populate the second widget with the records of
Model B that are in `record_a.model_b_ids`.

Implementing this is done by
 * Adding `data-filter-in` to Wb's xml attributes (as above)
 * Calling `Wb.setFilterInDomainIds()` when another record is selected
   in Wa.

Task-2574175
https://github.com/odoo/odoo/pull/90748
See https://github.com/odoo/enterprise/pull/23750