### PR TITLE
[FIX] website: change some snippets default background color

### DIFF
--- a/addons/website/views/snippets/s_searchbar.xml
+++ b/addons/website/views/snippets/s_searchbar.xml
@@ -13,7 +13,7 @@
     </t>
 </template>
 <template id="s_searchbar" name="Search">
-    <section class="s_searchbar bg-200 pt48 pb48">
+    <section class="s_searchbar o_colored_level o_cc o_cc2 pt48 pb48">
         <div class="container">
             <div class="row">
                 <div class="col-lg-8 offset-lg-2">

--- a/addons/website/views/snippets/s_text_highlight.xml
+++ b/addons/website/views/snippets/s_text_highlight.xml
@@ -2,7 +2,7 @@
 <odoo>
 
 <template name="Text Highlight" id="s_text_highlight">
-    <div class="s_text_highlight bg-secondary my-3 text-center w-100">
+    <div class="s_text_highlight o_colored_level o_cc o_cc3 my-3 text-center w-100">
         <div class="container">
             <h3>Text Highlight</h3>
             <p>Put the focus on what you have to say!</p>


### PR DESCRIPTION
Some snippets have a "hard coded" background color which doesn't change
when we want to put a preset color (theme). We have to delete the back-
ground first before being able to choose a preset color.

This commit fixes this behaviour by putting a preset color by default
on the concerned snippets (instead of a fixed color). These snippets
are searchbar and text highlight.

See [1] for the following of this fix.

[1]: https://github.com/odoo/design-themes/pull/563

task-2824393
