### PR TITLE
[FIX] stock: report.stock.forecast, `fields_view_get` is deprecated

### DIFF
--- a/addons/stock/static/src/js/report_stock_forecasted.js
+++ b/addons/stock/static/src/js/report_stock_forecasted.js
@@ -111,11 +111,13 @@ const ReplenishReport = clientAction.extend({
      */
     async _createGraphController() {
         const model = "report.stock.quantity";
-        const viewInfo = await this._rpc({
+        const viewsInfo = await this._rpc({
             model,
-            method: "fields_view_get",
-            kwargs: { view_type: "graph" }
+            method: "get_views",
+            args: [[[false, "graph"]]],
         });
+        const viewInfo = viewsInfo.views.graph;
+        viewInfo.fields = viewsInfo.models["report.stock.quantity"];
         const params = {
             domain: this._getReportDomain(),
             modelName: model,

--- a/odoo/models.py
+++ b/odoo/models.py
@@ -1805,7 +1805,7 @@ class BaseModel(metaclass=MetaModel):
         result['fields'] = self.fields_get(view_fields)
         result.pop('models', None)
         if 'id' in result:
-            view = self.env['ir.ui.view'].sudo(result.pop('id'))
+            view = self.env['ir.ui.view'].sudo().browse(result.pop('id'))
             result['name'] = view.name
             result['type'] = view.type
             result['view_id'] = view.id


### PR DESCRIPTION
Following odoo/odoo#87522,
the use of `fields_view_get` is deprecated.
All calls to it should be replaced by a call to `get_views`.

A compatibility layer was added to preserve the method
`fields_view_get` despite it's deprecated.

In this case, when loading the report, a traceback occured:
```
Traceback (most recent call last):
  File "/home/odoo/src/odoo/master/odoo/http.py", line 1381, in _serve_db
    return service_model.retrying(self._serve_ir_http, self.env)
  File "/home/odoo/src/odoo/master/odoo/service/model.py", line 136, in retrying
    result = func()
  File "/home/odoo/src/odoo/master/odoo/http.py", line 1410, in _serve_ir_http
    response = self.dispatcher.dispatch(rule.endpoint, args)
  File "/home/odoo/src/odoo/master/odoo/http.py", line 1607, in dispatch
    result = self.request.registry['ir.http']._dispatch(endpoint)
  File "/home/odoo/src/odoo/master/addons/website/models/ir_http.py", line 220, in _dispatch
    response = super()._dispatch(endpoint)
  File "/home/odoo/src/odoo/master/addons/utm/models/ir_http.py", line 27, in _dispatch
    return super()._dispatch(endpoint)
  File "/home/odoo/src/odoo/master/odoo/addons/base/models/ir_http.py", line 137, in _dispatch
    result = endpoint(**request.params)
  File "/home/odoo/src/odoo/master/odoo/http.py", line 541, in route_wrapper
    result = endpoint(self, *args, **params_ok)
  File "/home/odoo/src/odoo/master/addons/web/controllers/dataset.py", line 42, in call_kw
    return self._call_kw(model, method, args, kwargs)
  File "/home/odoo/src/odoo/master/addons/web/controllers/dataset.py", line 33, in _call_kw
    return call_kw(request.env[model], method, args, kwargs)
  File "/home/odoo/src/odoo/master/odoo/api.py", line 457, in call_kw
    result = _call_kw_model(method, model, args, kwargs)
  File "/home/odoo/src/odoo/master/odoo/api.py", line 430, in _call_kw_model
    result = method(recs, *args, **kwargs)
  File "/home/odoo/src/odoo/master/odoo/models.py", line 1808, in fields_view_get
    view = self.env['ir.ui.view'].sudo(result.pop('id'))
  File "/home/odoo/src/odoo/master/odoo/models.py", line 5381, in sudo
    assert isinstance(flag, bool)
AssertionError
```

Demonstrating a bug in the compatibility layer.
This revision changes the call from `fields_view_get` to `get_views`
to no longer call a deprecated method,
and in addition solves the issue in the compatibility layer.
