### PR TITLE
[FIX] auth_totp: prevent variability in query counters.

### DIFF
--- a/addons/auth_totp/models/res_users.py
+++ b/addons/auth_totp/models/res_users.py
@@ -20,7 +20,7 @@ compress = functools.partial(re.sub, r'\s', '')
 class Users(models.Model):
     _inherit = 'res.users'
 
-    totp_secret = fields.Char(copy=False, groups=fields.NO_ACCESS)
+    totp_secret = fields.Char(copy=False, groups=fields.NO_ACCESS, prefetch=False)
     totp_enabled = fields.Boolean(string="Two-factor authentication", compute='_compute_totp_enabled')
     totp_trusted_device_ids = fields.One2many('auth_totp.device', 'user_id', string="Trusted Devices")
 
@@ -60,9 +60,9 @@ class Users(models.Model):
         key = base64.b32decode(sudo.totp_secret)
         match = TOTP(key).match(code)
         if match is None:
-            _logger.info("2FA check: FAIL for %s %r", self, self.login)
+            _logger.info("2FA check: FAIL for %s %r", self, sudo.login)
             raise AccessDenied(_("Verification failed, please double-check the 6-digit code"))
-        _logger.info("2FA check: SUCCESS for %s %r", self, self.login)
+        _logger.info("2FA check: SUCCESS for %s %r", self, sudo.login)
 
     def _totp_try_setting(self, secret, code):
         if self.totp_enabled or self != self.env.user:

--- a/addons/auth_totp/models/res_users.py
+++ b/addons/auth_totp/models/res_users.py
@@ -20,7 +20,7 @@ compress = functools.partial(re.sub, r'\s', '')
 class Users(models.Model):
     _inherit = 'res.users'
 
-    totp_secret = fields.Char(copy=False, groups=fields.NO_ACCESS, prefetch=False)
+    totp_secret = fields.Char(copy=False, groups=fields.NO_ACCESS)
     totp_enabled = fields.Boolean(string="Two-factor authentication", compute='_compute_totp_enabled')
     totp_trusted_device_ids = fields.One2many('auth_totp.device', 'user_id', string="Trusted Devices")
 
@@ -60,9 +60,9 @@ class Users(models.Model):
         key = base64.b32decode(sudo.totp_secret)
         match = TOTP(key).match(code)
         if match is None:
-            _logger.info("2FA check: FAIL for %s %r", self, sudo.login)
+            _logger.info("2FA check: FAIL for %s %r", self, self.login)
             raise AccessDenied(_("Verification failed, please double-check the 6-digit code"))
-        _logger.info("2FA check: SUCCESS for %s %r", self, sudo.login)
+        _logger.info("2FA check: SUCCESS for %s %r", self, self.login)
 
     def _totp_try_setting(self, secret, code):
         if self.totp_enabled or self != self.env.user:


### PR DESCRIPTION
Some tests that are run before those located in `project_enterprise/tests/test_auto_shift_dates.py`
seem to indeterministically cache information on groups `.` and `base.group_system`. This impacts
the variability of the query counters in the tests, which prevents to set them properly.

The purpose of this commit and its related enterprise one is to prevent this instability during the
tests.

This commit reaches that goal by preventing the prefetch on field `totp_secret` on `res.users`. As
a consequence to this change, the call to the `login` field in `_totp_check` has to be performed in
sudo as it is no more prefetched when accessing `totp_secret` earlier in the code.

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
