### PR TITLE
[FIX] web: accept language from html_data for translations

### DIFF
--- a/addons/web/static/src/legacy/js/core/session.js
+++ b/addons/web/static/src/legacy/js/core/session.js
@@ -197,7 +197,18 @@ var Session = core.Class.extend(mixins.EventDispatcherMixin, {
         });
     },
     load_translations: function (modules=null) {
-        return _t.database.load_translations(this, modules, this.user_context.lang, this.translationURL);
+        var lang = this.user_context.lang
+        /* We need to get the website lang at this level.
+           The only way is to get it is to take the HTML tag lang
+           Without it, we will always send undefined if there is no lang
+           in the user_context. */
+        var html = document.documentElement,
+            htmlLang = html.getAttribute('lang');
+        if (!this.user_context.lang && htmlLang) {
+            lang = htmlLang.replace('-', '_');
+        }
+
+        return _t.database.load_translations(this, modules, lang, this.translationURL);
     },
     load_js: function (files) {
         var self = this;


### PR DESCRIPTION
This reverts commit 00e6b87c9d16af1bfb3e63b9b857fbaad90e620a.

The deletion of this code portion creates another bug in the sign
app where the language is set in the html_data and the frontend
translations were hence broken. 
https://github.com/odoo/enterprise/blob/d1addb1d663937a65b46b43f200e199299a8116a/sign/views/sign_request_templates.xml#L89-L92

So even if removing these lines did not reproduce opw-2244843 the lines remain necessary.

opw-2777044