### PR TITLE
[FIX] account: fix terms in sitemap when it is not enabled

### DIFF
--- a/addons/account/controllers/terms.py
+++ b/addons/account/controllers/terms.py
@@ -5,9 +5,17 @@ from odoo import http, _
 from odoo.http import request
 
 
+def sitemap_terms(env, rule, qs):
+    if qs and qs.lower() not in '/terms':
+        return
+    use_invoice_terms = env['ir.config_parameter'].sudo().get_param('account.use_invoice_terms')
+    if use_invoice_terms and env.company.terms_type == 'html':
+        yield {'loc': '/terms'}
+
+
 class TermsController(http.Controller):
 
-    @http.route('/terms', type='http', auth='public', website=True, sitemap=True)
+    @http.route('/terms', type='http', auth='public', website=True, sitemap=sitemap_terms)
     def terms_conditions(self, **kwargs):
         use_invoice_terms = request.env['ir.config_parameter'].sudo().get_param('account.use_invoice_terms')
         if not (use_invoice_terms and request.env.company.terms_type == 'html'):


### PR DESCRIPTION
The /terms page may be disabled/enabled in the company settings, however
the page would always be present in the sitemap whether it is enabled or
not.
This commit adds a method that checks for this settings before adding it
to the sitemap.

TaskId-2820292
