### PR TITLE
[IMP] hr_expense: allow splitting an expense

### DIFF
--- a/addons/hr_expense/__manifest__.py
+++ b/addons/hr_expense/__manifest__.py
@@ -37,6 +37,7 @@ This module also uses analytic accounting and is compatible with the invoice on 
         'data/hr_expense_data.xml',
         'wizard/hr_expense_refuse_reason_views.xml',
         'wizard/hr_expense_approve_duplicate_views.xml',
+        'wizard/hr_expense_split_wizard_views.xml',
         'views/hr_expense_views.xml',
         'views/mail_activity_views.xml',
         'security/ir_rule.xml',

--- a/addons/hr_expense/models/hr_expense.py
+++ b/addons/hr_expense/models/hr_expense.py
@@ -68,7 +68,7 @@ class HrExpense(models.Model):
         store=True, copy=True, states={'draft': [('readonly', False)], 'refused': [('readonly', False)]},
         default=_default_product_uom_id, domain="[('category_id', '=', product_uom_category_id)]")
     product_uom_category_id = fields.Many2one(related='product_id.uom_id.category_id', readonly=True, string="UoM Category")
-    unit_amount = fields.Float("Unit Price", compute='_compute_unit_amount', readonly=False, store=True, required=True, copy=True,
+    unit_amount = fields.Float("Unit Price", compute='_compute_from_product_id_company_id', readonly=False, store=True, required=True, copy=True,
         states={'done': [('readonly', True)]}, digits='Product Price')
     unit_amount_display = fields.Float("Unit Price Display", compute='_compute_unit_amount_display')
     quantity = fields.Float(required=True, states={'done': [('readonly', True)]}, digits='Product Unit of Measure', default=1)
@@ -249,16 +249,6 @@ class HrExpense(models.Model):
         for expense in self:
             expense.product_description = not is_html_empty(expense.product_id.description) and expense.product_id.description
 
-    @api.depends('product_id', 'company_id')
-    def _compute_unit_amount(self):
-        for expense in self:
-            if not expense.product_id or not expense.product_has_cost or expense.attachment_number or (not expense.attachment_number and expense.unit_amount):
-                continue
-            expense.unit_amount = expense.product_id.price_compute(
-                'standard_price',
-                uom=expense.product_uom_id,
-                currency=expense.currency_id)[expense.product_id.id]
-
     @api.depends('unit_amount', 'total_amount_company', 'product_has_cost')
     def _compute_unit_amount_display(self):
         for expense in self:
@@ -269,6 +259,9 @@ class HrExpense(models.Model):
         for expense in self:
             if not expense.product_id:
                 continue
+            # Only change unit_amount if the product has no cost defined on it
+            if not expense.attachment_number or (expense.attachment_number and not expense.unit_amount):
+                expense.unit_amount = expense.product_id.price_compute('standard_price', currency=expense.currency_id)[expense.product_id.id]
             expense = expense.with_company(expense.company_id)
             expense.name = expense.name or expense.product_id.display_name
             expense.product_uom_id = expense.product_id.uom_id

--- a/addons/hr_expense/security/ir.model.access.csv
+++ b/addons/hr_expense/security/ir.model.access.csv
@@ -16,3 +16,5 @@ access_account_analytic_line_user,account.analytic.line.user,account.model_accou
 access_mail_activity_type_expense_user,mail.activity.type.expense.user,mail.model_mail_activity_type,hr_expense.group_hr_expense_manager,1,1,1,1
 access_hr_expense_refuse_wizard,access.hr.expense.refuse.wizard,model_hr_expense_refuse_wizard,hr_expense.group_hr_expense_team_approver,1,1,1,0
 access_hr_expense_approve_duplicate,access.hr.expense.approve.duplicate,model_hr_expense_approve_duplicate,hr_expense.group_hr_expense_team_approver,1,1,1,0
+access_hr_expense_split_wizard_manager,access.hr.expense.split.wizard.manager,model_hr_expense_split_wizard,base.group_user,1,1,1,0
+access_hr_expense_split_manager,access.hr.expense.split.manager,model_hr_expense_split,base.group_user,1,1,1,1

--- a/addons/hr_expense/views/hr_expense_views.xml
+++ b/addons/hr_expense/views/hr_expense_views.xml
@@ -116,6 +116,7 @@
                   <button name="action_submit_expenses" string="Create Report" type="object" class="o_expense_submit" attrs="{'invisible': ['|', '|', ('id', '=', False), ('attachment_number', '&gt;=', 1), ('sheet_id', '!=', False)]}" data-hotkey="v"/>
                   <field name="state" widget="statusbar" statusbar_visible="draft,reported,approved,done,refused"/>
                   <button name="action_view_sheet" type="object" string="View Report" class="oe_highlight" attrs="{'invisible': [('sheet_id', '=', False)]}" data-hotkey="w"/>
+                  <button name="action_split_wizard" string="Split Expense" type="object" attrs="{'invisible': ['|', '|', ('id', '=', False), ('sheet_id', '!=', False), ('product_has_cost', '=', True)]}"/>
                 </header>
                 <sheet>
                     <div class="oe_title">

--- a/addons/hr_expense/wizard/__init__.py
+++ b/addons/hr_expense/wizard/__init__.py
@@ -3,3 +3,5 @@
 from . import hr_expense_refuse_reason
 from . import account_payment_register
 from . import hr_expense_approve_duplicate
+from . import hr_expense_split_wizard
+from . import hr_expense_split

--- a/addons/hr_expense/wizard/hr_expense_split.py
+++ b/addons/hr_expense/wizard/hr_expense_split.py
@@ -1,0 +1,83 @@
+# -*- coding: utf-8 -*-
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from odoo import fields, models, api
+from odoo.tools import float_compare
+
+
+class HrExpenseSplit(models.TransientModel):
+
+    _name = 'hr.expense.split'
+    _description = 'Expense Split'
+
+    def default_get(self, fields):
+        result = super(HrExpenseSplit, self).default_get(fields)
+        if 'expense_id' in result:
+            expense = self.env['hr.expense'].browse(result['expense_id'])
+            result['total_amount'] = 0.0
+            result['name'] = expense.name
+            result['tax_ids'] = expense.tax_ids
+            result['product_id'] = expense.product_id
+            result['company_id'] = expense.company_id
+            result['analytic_account_id'] = expense.analytic_account_id
+            result['employee_id'] = expense.employee_id
+            result['currency_id'] = expense.currency_id
+        return result
+
+    name = fields.Char('Description', required=True)
+    wizard_id = fields.Many2one('hr.expense.split.wizard')
+    expense_id = fields.Many2one('hr.expense', string='Expense')
+    product_id = fields.Many2one('product.product', string='Product', required=True)
+    tax_ids = fields.Many2many('account.tax', domain="[('company_id', '=', company_id), ('type_tax_use', '=', 'purchase'), ('price_include', '=', True)]")
+    total_amount = fields.Monetary("Total In Currency", required=True, compute='_compute_from_product_id', store=True, readonly=False)
+    amount_tax = fields.Monetary(string='Tax amount in Currency', compute='_compute_amount_tax')
+    analytic_account_id = fields.Many2one('account.analytic.account', string='Analytic Account', check_company=True)
+    employee_id = fields.Many2one('hr.employee', string="Employee", required=True)
+    company_id = fields.Many2one('res.company')
+    currency_id = fields.Many2one('res.currency')
+    product_has_tax = fields.Boolean("Whether tax is defined on a selected product", compute='_compute_product_has_tax')
+    product_has_cost = fields.Boolean("Is product with non zero cost selected", compute='_compute_from_product_id', store=True)
+
+    @api.depends('total_amount', 'tax_ids')
+    def _compute_amount_tax(self):
+        for split in self:
+            taxes = split.tax_ids.compute_all(price_unit=split.total_amount, currency=split.currency_id, quantity=1, product=split.product_id)
+            split.amount_tax = taxes['total_included'] - taxes['total_excluded']
+
+    @api.depends('product_id')
+    def _compute_from_product_id(self):
+        for split in self:
+            split.product_has_cost = split.product_id and (float_compare(split.product_id.standard_price, 0.0, precision_digits=2) != 0)
+            if split.product_has_cost:
+                split.total_amount = split.product_id.price_compute('standard_price', currency=split.currency_id)[split.product_id.id]
+
+    @api.onchange('product_id')
+    def _onchange_product_id(self):
+        """
+        In case we switch to the product without taxes defined on it, taxes should be removed.
+        Computed method won't be good for this purpose, as we don't want to recompute and reset taxes in case they are removed on purpose during splitting.
+        """
+        self.tax_ids = self.tax_ids if self.product_has_tax and self.tax_ids else self.product_id.supplier_taxes_id.filtered(lambda tax: tax.company_id == self.company_id)
+
+    @api.depends('product_id')
+    def _compute_product_has_tax(self):
+        for split in self:
+            split.product_has_tax = split.product_id and split.product_id.supplier_taxes_id.filtered(lambda tax: tax.company_id == split.company_id)
+
+    def _get_values(self):
+        self.ensure_one()
+        vals = {
+            'name': self.name,
+            'product_id': self.product_id.id,
+            'total_amount': self.total_amount,
+            'tax_ids': self.tax_ids.ids,
+            'analytic_account_id': self.analytic_account_id.id,
+            'employee_id': self.employee_id.id,
+            'product_uom_id': self.product_id.uom_id.id,
+            'unit_amount': self.product_id.price_compute('standard_price', currency=self.currency_id)[self.product_id.id]
+        }
+
+        account = self.product_id.product_tmpl_id._get_product_accounts()['expense']
+        if account:
+            vals['account_id'] = account.id
+        return vals

--- a/addons/hr_expense/wizard/hr_expense_split_wizard.py
+++ b/addons/hr_expense/wizard/hr_expense_split_wizard.py
@@ -1,0 +1,62 @@
+# -*- coding: utf-8 -*-
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from odoo import fields, models, api, _
+from odoo.tools import float_compare
+
+class HrExpenseSplitWizard(models.TransientModel):
+    _name = 'hr.expense.split.wizard'
+    _description = 'Expense Split Wizard'
+
+    expense_id = fields.Many2one('hr.expense', string='Expense', required=True)
+    expense_split_line_ids = fields.One2many('hr.expense.split', 'wizard_id')
+    total_amount = fields.Monetary('Total Amount', compute='_compute_total_amount', currency_field='currency_id')
+    total_amount_original = fields.Monetary('Total amount original', related='expense_id.total_amount', currency_field='currency_id', help='Total amount of the original Expense that we are splitting')
+    total_amount_taxes = fields.Monetary('Taxes', currency_field='currency_id', compute='_compute_total_amount_taxes')
+    split_possible = fields.Boolean(help='The sum of after split shut remain the same', compute='_compute_split_possible')
+    currency_id = fields.Many2one('res.currency', related='expense_id.currency_id')
+
+    @api.depends('expense_split_line_ids.total_amount')
+    def _compute_total_amount(self):
+        for wizard in self:
+            wizard.total_amount = sum(wizard.expense_split_line_ids.mapped('total_amount'))
+
+    @api.depends('expense_split_line_ids.amount_tax')
+    def _compute_total_amount_taxes(self):
+        for wizard in self:
+            wizard.total_amount_taxes = sum(wizard.expense_split_line_ids.mapped('amount_tax'))
+
+    @api.depends('total_amount_original', 'total_amount')
+    def _compute_split_possible(self):
+        for wizard in self:
+            wizard.split_possible = wizard.total_amount_original and (float_compare(wizard.total_amount_original, wizard.total_amount, precision_digits=2) == 0)
+
+    def action_split_expense(self):
+        self.ensure_one()
+        expense_split = self.expense_split_line_ids[0]
+        if expense_split:
+            self.expense_id.write(expense_split._get_values())
+
+            self.expense_split_line_ids -= expense_split
+            if self.expense_split_line_ids:
+                copied_expenses = self.env["hr.expense"]
+                for split in self.expense_split_line_ids:
+                    copied_expenses |= self.expense_id.copy(split._get_values())
+
+                attachment_ids = self.env['ir.attachment'].search([
+                    ('res_model', '=', 'hr.expense'),
+                    ('res_id', '=', self.expense_id.id)
+                ])
+
+                for coplied_expense in copied_expenses:
+                    for attachment in attachment_ids:
+                        attachment.copy({'res_model': 'hr.expense', 'res_id': coplied_expense.id})
+
+        return {
+            'type': 'ir.actions.act_window',
+            'res_model': 'hr.expense',
+            'name': _('Split Expenses'),
+            'view_mode': 'tree,form',
+            'target': 'current',
+            'context': {'search_default_my_expenses': 1, 'search_default_no_report': 1},
+        }

--- a/addons/hr_expense/wizard/hr_expense_split_wizard_views.xml
+++ b/addons/hr_expense/wizard/hr_expense_split_wizard_views.xml
@@ -1,0 +1,47 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <data>
+        <record id="hr_expense_split" model="ir.ui.view">
+            <field name="name">Expense split</field>
+            <field name="model">hr.expense.split.wizard</field>
+            <field name="arch" type="xml">
+                <form>
+                    <sheet>
+                        <field name="total_amount_original" invisible="1"/>
+                        <field name="expense_id" invisible="1"/>
+                        <field name="expense_split_line_ids" widget="one2many" context="{'default_expense_id': expense_id}">
+                            <tree editable="bottom">
+                                <field name="currency_id" invisible="1"/>
+                                <field name="expense_id" invisible="1"/>
+                                <field name="company_id" invisible="1"/>
+                                <field name="product_has_tax" invisible="1"/>
+                                <field name="product_has_cost" invisible="1"/>
+                                <field name="name"/>
+                                <field name="product_id"/>
+                                <field name="total_amount" force_save="1" attrs="{'readonly': [('product_has_cost', '=', True)]}"/>
+                                <field name="tax_ids" widget="many2many_tags" attrs="{'readonly': [('product_has_tax', '=', False)]}"/>
+                                <field name="amount_tax"/>
+                                <field name="analytic_account_id" domain="['|', ('company_id', '=', company_id), ('company_id', '=', False)]" groups="analytic.group_analytic_accounting"/>
+                                <field name="employee_id" widget="many2one_avatar_employee"/>
+                            </tree>
+                        </field>
+                        <field name="currency_id" invisible="1"/>
+                        <group class="oe_subtotal_footer oe_right" colspan="2" name="expense_total">
+                            <label for="total_amount" attrs="{'invisible': [('split_possible', '=', True)]}"/>
+                            <field name="total_amount" nolabel="1" class="text-danger" attrs="{'invisible': [('split_possible', '=', True)]}"/>
+                            <field name="total_amount" attrs="{'invisible': [('split_possible', '=', False)]}"/>
+                            <field name="total_amount_original" widget='monetary' string="Original Amount"/>
+                            <field name="total_amount_taxes" widget='monetary' string="Taxes"/>
+                        </group>
+                    </sheet>
+                    <field name="split_possible" invisible="1"/>
+                    <footer>
+                        <button name="action_split_expense" disabled="disabled" attrs="{'invisible': [ ('split_possible', '=', True)]}" string="Split Expense" type="object" class="oe_highlight"  data-hotkey="q"/>
+                        <button name="action_split_expense" string="Split Expense" attrs="{'invisible': [('split_possible', '=', False)]}" type="object" class="oe_highlight"  data-hotkey="q"/>
+                        <button string="Cancel" class="btn-secondary" special="cancel" data-hotkey="z"/>
+                    </footer>
+                </form>
+            </field>
+        </record>
+    </data>
+</odoo>

--- a/addons/sale_expense/models/__init__.py
+++ b/addons/sale_expense/models/__init__.py
@@ -2,6 +2,7 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 from . import hr_expense
+from . import hr_expense_split
 from . import sale_order
 from . import product_template
 from . import account_move

--- a/addons/sale_expense/models/hr_expense.py
+++ b/addons/sale_expense/models/hr_expense.py
@@ -31,6 +31,12 @@ class Expense(models.Model):
         for expense in self.filtered('sale_order_id'):
             expense.analytic_account_id = expense.sale_order_id.sudo().analytic_account_id  # `sudo` required for normal employee without sale access rights
 
+    def _get_split_values(self):
+        vals = super(Expense, self)._get_split_values()
+        for split_value in vals:
+            split_value['sale_order_id'] = self.sale_order_id.id
+        return vals
+
     def action_move_create(self):
         """ When posting expense, if the AA is given, we will track cost in that
             If a SO is set, this means we want to reinvoice the expense. But to do so, we

--- a/addons/sale_expense/models/hr_expense_split.py
+++ b/addons/sale_expense/models/hr_expense_split.py
@@ -1,0 +1,34 @@
+# -*- coding: utf-8 -*-
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from odoo import fields, models, api
+
+
+class HrExpenseSplit(models.TransientModel):
+    _inherit = "hr.expense.split"
+
+    def default_get(self, fields):
+        result = super(HrExpenseSplit, self).default_get(fields)
+        if 'expense_id' in result:
+            expense = self.env['hr.expense'].browse(result['expense_id'])
+            result['sale_order_id'] = expense.sale_order_id
+        return result
+
+    sale_order_id = fields.Many2one('sale.order', string="Customer to Reinvoice", compute='_compute_sale_order_id', readonly=False, store=True, domain="[('state', '=', 'sale'), ('company_id', '=', company_id)]")
+    can_be_reinvoiced = fields.Boolean("Can be reinvoiced", compute='_compute_can_be_reinvoiced')
+
+    def _get_values(self):
+        self.ensure_one()
+        vals = super(HrExpenseSplit, self)._get_values()
+        vals['sale_order_id'] = self.sale_order_id.id
+        return vals
+
+    @api.depends('product_id')
+    def _compute_can_be_reinvoiced(self):
+        for split in self:
+            split.can_be_reinvoiced = split.product_id.expense_policy in ['sales_price', 'cost']
+
+    @api.depends('can_be_reinvoiced')
+    def _compute_sale_order_id(self):
+        for split in self:
+            split.sale_order_id = split.sale_order_id if split.can_be_reinvoiced else False

--- a/addons/sale_expense/views/hr_expense_views.xml
+++ b/addons/sale_expense/views/hr_expense_views.xml
@@ -48,6 +48,18 @@
         <field name="groups_id" eval="[(6, 0, [ref('sales_team.group_sale_salesman')])]"/>
     </record>
 
+    <record id="hr_expense_split_view_inherit_sale_expense" model="ir.ui.view">
+        <field name="name">hr.expense.split.view.inherit.sale.expense</field>
+        <field name="model">hr.expense.split.wizard</field>
+        <field name="inherit_id" ref="hr_expense.hr_expense_split"/>
+        <field name="arch" type="xml">
+            <xpath expr="//field[@name='employee_id']" position="after">
+                <field name="can_be_reinvoiced" invisible="1"/>
+                <field name="sale_order_id" force_save="1" attrs="{'readonly': [('can_be_reinvoiced', '=', False)]}"/>
+            </xpath>
+        </field>
+    </record>
+
     <record id="hr_expense_sheet_form_view_inherit_sale_expense" model="ir.ui.view">
         <field name="name">hr.expense.sheet.form.inherit.sale.expense</field>
         <field name="model">hr.expense.sheet</field>


### PR DESCRIPTION
Purpose: Sometimes, taxes are distinct on parts of the expense
(for example alcohol and food).
Therefore the expense should be split in two.

In order to split the expense, we added an wizard.
When creating a new expense from the split, we also
copy the attachments.

task - 2831024

