### PR TITLE
[FIX] website: increase stability of ace test tour again

### DIFF
--- a/addons/website/static/tests/tours/html_editor.js
+++ b/addons/website/static/tests/tours/html_editor.js
@@ -124,6 +124,7 @@ tour.register('test_html_editor_scss', {
             content: "check that the scss modification got applied",
             trigger: 'body:has(#wrap:hidden)',
             run: function () {}, // it's a check
+            timeout: 30000, // SCSS compilation might take some time
         },
         {
             content: "reset view (after reload, html editor should have been reopened where it was)",
@@ -137,6 +138,7 @@ tour.register('test_html_editor_scss', {
             content: "check that the scss file was reset correctly, wrap content should now be visible again",
             trigger: '#wrap:visible',
             run: function () {}, // it's a check
+            timeout: 30000, // SCSS compilation might take some time
         },
         // 3. Customize again that file (will be used in second part of the test
         //    to ensure restricted user can still use the HTML Editor)
@@ -158,6 +160,7 @@ tour.register('test_html_editor_scss', {
             run: function () {
                 window.location.href = '/web/session/logout?redirect=/web/login';
             },
+            timeout: 30000, // SCSS compilation might take some time
         },
 
         // This part of the test ensures that a restricted user can still use
@@ -213,8 +216,9 @@ tour.register('test_html_editor_scss', {
         },
         {
             content: "wait for reload",
-            trigger: ":not(.o_ace_view_editor)",
+            trigger: "body:not(:has(div.o_ace_view_editor))",
             run: function () {}, // it's a check
+            timeout: 30000, // SCSS compilation might take some time
         },
         {
             content: "reset view (after reload, html editor should have been reopened where it was)",
@@ -229,6 +233,7 @@ tour.register('test_html_editor_scss', {
             extra_trigger: `body:not(:has(div.ace_line:contains("${adminCssModif}")))`,
             trigger: `body:not(:has(div.ace_line:contains("${demoCssModif}")))`,
             run: function () {}, // it's a check
+            timeout: 30000, // SCSS compilation might take some time
         },
     ]
 );

--- a/addons/website/tests/test_ui.py
+++ b/addons/website/tests/test_ui.py
@@ -104,7 +104,7 @@ class TestUiHtmlEditor(odoo.tests.HttpCase):
                 self.env.ref('website.group_website_designer').id
             ])]
         })
-        self.start_tour("/", 'test_html_editor_scss', login='admin')
+        self.start_tour("/", 'test_html_editor_scss', login='admin', timeout=120)
 
 
 @odoo.tests.tagged('-at_install', 'post_install')


### PR DESCRIPTION
This is an attempt at fixing a runbot "race" condition.
A first attempt was done in [1] but the selector introduced to make
sure the page was reloaded after the assets were changed was wrong.

This commit fixes that selector.

During the investigation of the problem, it was also discovered that the
SCSS change could take quite a long time on a busy server becasue it
triggers the SCSS compilation each time.

To reproduce that problem locally, run the `stress` command while
executing the `test_html_editor_scss` test.
E.g.:
```sh
$ stress --cpu 32 --timeout 120
```

The error that shows up in that case is misleading because it makes it
look like the confirmation popup was not clicked on.
What is actually happening is the following:
- the Reset button is clicked on
=> the confirmation popup is shown
- the confirmation is clicked
=> the popup is closed and the RPC call is made
- the RPC does not respond within the tour step's timeout
=> the last step is not shown as succesful and the screenshot shows the
non-reset state since the server response did not arrive yet

To be safe on busy servers this commit also increases the timeouts
related to steps that follow updates of SCSS files so that they can be
recompiled on time.

[1]: https://github.com/odoo/odoo/commit/b35f127c86c1d271a76dae7186a96190e8558c73

runbot-3744

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
