### PR TITLE
[FIX] crm: no date_closed update between 2 won stages

### DIFF
--- a/addons/crm/models/crm_lead.py
+++ b/addons/crm/models/crm_lead.py
@@ -579,13 +579,13 @@ class Lead(models.Model):
     def write(self, vals):
         if vals.get('website'):
             vals['website'] = self.env['res.partner']._clean_website(vals['website'])
-
+        stage_is_won = False
         # stage change: update date_last_stage_update
         if 'stage_id' in vals:
             stage_id = self.env['crm.stage'].browse(vals['stage_id'])
             if stage_id.is_won:
                 vals.update({'probability': 100, 'automated_probability': 100})
-
+                stage_is_won = True
         # stage change with new stage: update probability and date_closed
         if vals.get('probability', 0) >= 100 or not vals.get('active', True):
             vals['date_closed'] = fields.Datetime.now()
@@ -594,10 +594,18 @@ class Lead(models.Model):
 
         if any(field in ['active', 'stage_id'] for field in vals):
             self._handle_won_lost(vals)
+        if not stage_is_won:
+            return super(Lead, self).write(vals)
 
-        write_result = super(Lead, self).write(vals)
-
-        return write_result
+        # stage change between two won stages: does not change the date_closed
+        leads_already_won = self.filtered(lambda r: r.stage_id.is_won)
+        remaining = self - leads_already_won
+        if remaining:
+            result = super(Lead, remaining).write(vals)
+        if leads_already_won:
+            vals.pop('date_closed', False)
+            result = super(Lead, leads_already_won).write(vals)
+        return result
 
     @api.model
     def search(self, args, offset=0, limit=None, order=None, count=False):

--- a/addons/crm/tests/test_crm_lead.py
+++ b/addons/crm/tests/test_crm_lead.py
@@ -496,3 +496,26 @@ class TestCRMLead(TestCrmCommon):
         self.assertEqual(lead_1, self.env['crm.lead'].search([
             ('phone_mobile_search', 'like', '+32485001122')
         ]))
+
+    def test_no_date_closed_update_between_won_stages(self):
+        # Test for one won lead
+        stage_team1_won2 = self.env['crm.stage'].create({
+            'name': 'Won2',
+            'sequence': 75,
+            'team_id': self.sales_team_1.id,
+            'is_won': True,
+        })
+        won_lead = self.lead_team_1_won
+        date_closed = datetime.strptime('2020-02-02 15:00', '%Y-%m-%d %H:%M')
+        won_lead.date_closed = date_closed
+        with freeze_time('2020-02-02 18:00'):
+            won_lead.stage_id = stage_team1_won2
+        self.assertEqual(won_lead.date_closed, date_closed)
+
+        # Test for one won and one unwon lead
+        leads = won_lead + self.lead_1
+        self.assertFalse(self.lead_1.date_closed)
+        with freeze_time('2020-02-02 18:00'):
+            leads.stage_id = self.stage_team1_won
+        self.assertEqual(won_lead.date_closed, date_closed)
+        self.assertEqual(self.lead_1.date_closed, datetime.strptime('2020-02-02 18:00', '%Y-%m-%d %H:%M'))


### PR DESCRIPTION
Steps to reproduce:
	install crm and change a lead between two won stages

Expected behavior:
The date_closed does not change

Current behavior:
The date_closed changes

opw-2839298