### PR TITLE
[FIX] sale_stock: allow printing an invoice without stock right

### DIFF
--- a/addons/sale_stock/models/account_move.py
+++ b/addons/sale_stock/models/account_move.py
@@ -70,6 +70,9 @@ class AccountMove(models.Model):
             qties_per_lot[sml.lot_id] += qty_done
 
         for lot, qty in qties_per_lot.items():
+            # access the lot as a superuser in order to avoid an error
+            # when a user prints an invoice without having the stock access
+            lot = lot.sudo()
             if float_is_zero(invoiced_qties[lot.product_id], precision_rounding=lot.product_uom_id.rounding) \
                     or float_compare(qty, 0, precision_rounding=lot.product_uom_id.rounding) <= 0:
                 continue


### PR DESCRIPTION
Steps to reproduce the bug:
- Install sale_stock and invoicing
- Create a product tracked by serial number “P1”
- Create a SO:
   - Select any customer
   - Select the product “P1”
   - Confirm the SO
- Confirm the linked picking
- Go back to the SO
- Create the invoice
- Post the invoice

- Give “sales” and “accounting“ rights to Marc Demo
- Connect with Marc
- Go to the posted invoice
- Try to print the invoice

Problem:
Traceback is triggered, to print the invoice we have to access the `Lot` field
which is defined in the stock module but as the user does not have access rights
an error is triggered:
https://github.com/odoo/odoo/blob/15.0/addons/stock_account/views/report_invoice.xml#L5

opw-2832396




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
