### PR TITLE
[FIX] board: make it possible to add 2 actions in dashboard

### DIFF
--- a/addons/board/controllers/main.py
+++ b/addons/board/controllers/main.py
@@ -16,8 +16,9 @@ class Board(Controller):
         if action and action['res_model'] == 'board.board' and action['views'][0][1] == 'form' and action_id:
             # Maybe should check the content instead of model board.board ?
             view_id = action['views'][0][0]
-            board_arch, _view = request.env['board.board']._get_view(view_id, 'form')
-            if board_arch:
+            board_view = request.env['board.board'].get_view(view_id, 'form')
+            if board_view and 'arch' in board_view:
+                board_arch = ElementTree.fromstring(board_view['arch'])
                 column = board_arch.find('./board/column')
                 if column is not None:
                     new_action = ElementTree.Element('action', {


### PR DESCRIPTION
Before this commit, the code of the `add_to_dashboard` method did not go
through the get_view override of the board model. Because of that, it
did not get the arch of the current board, which means that each
add_to_dashboard call was actually a complete reset: it was not possible
to add an action without removing the current board state.

For reference, this was caused recently by a change in commit b03c227e885efa.
The fix is basically a localized revert of that commit.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
