### PR TITLE
[FIX] survey: refine the conditions in check_partner step

### DIFF
--- a/addons/survey/controllers/main.py
+++ b/addons/survey/controllers/main.py
@@ -87,7 +87,7 @@ class Survey(http.Controller):
             if request.env.user._is_public() and answer_sudo.partner_id and not answer_token:
                 # answers from public user should not have any partner_id; this indicates probably a cookie issue
                 return 'answer_wrong_user'
-            if not request.env.user._is_public() and answer_sudo.partner_id != request.env.user.partner_id:
+            if not request.env.user._is_public() and answer_sudo.partner_id and answer_sudo.partner_id != request.env.user.partner_id:
                 # partner mismatch, probably a cookie issue
                 return 'answer_wrong_user'
 


### PR DESCRIPTION
Reproduction:
1. Go to Recruitment, open a job, click on an applicant
2. Click on the “Start Interview” button
3. The page is redirected to the home page

Reason: The workflow of hr recruitment is broken in _check_validity.
When internal users click the “start interview” button for an applicant,
it returns an “answer_wrong_user” check result because the applicant
doesn’t have a partner_id, and it will never be the same with the
internal user’s partner_id.

Fix: adding a new condition to check if the answering person has a
partner_id. This fix is only needed for V14

opw-2835600

Original commit: 3c71f66bb541fcf31f31e75b60f7825d26109bc4
Check_partner adding commit: ec28022216a7de4267707cb6d098fcf211ce0ff3

I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
