### PR TITLE
[FIX] stock: print traceability report

### DIFF
--- a/addons/stock/static/src/js/stock_traceability_report_widgets.js
+++ b/addons/stock/static/src/js/stock_traceability_report_widgets.js
@@ -43,7 +43,7 @@ var ReportWidget = Widget.extend({
             context: {
                 active_id : $el.data('lot_id'),
                 active_model : 'stock.production.lot',
-                url: '/stock/output_format/stock/active_id'
+                url: '/stock/output_format/stock?active_id=:active_id&active_model=:active_model',
             },
         });
     },


### PR DESCRIPTION
On a traceability report, if a user clicks on a lot and prints the new
report, an erorr will be displayed

To reproduce the issue:
(Need mrp)
1. Create two storable and tracked-by-lot products P_compo, P_finished
2. Update quantity of P_compo:
    - 1 x P_compo with lot L_compo
3. Create a bill of materials
    - Product: P_finished
    - Components
        - 1 x P_compo
4. Produce 1 x P_finished (lot L_finished)
5. Inventory > Products > Lots/Serial Numbers, open L_finished
6. Click on Traceability, unfold the line and click on L_compo
7. Print the report

Error: an Odoo Server Error is displayed (RPC_ERROR)

Since [1], the route has changed

[1] e2f59a6dd19ee966283d8baa03e2bb397b111b63

OPW-2773967