### PR TITLE
[IMP] base,web: add the document name in the footer

### DIFF
--- a/addons/web/views/report_templates.xml
+++ b/addons/web/views/report_templates.xml
@@ -460,6 +460,7 @@
                 </ul>
 
                 <div t-if="report_type == 'pdf'" class="text-muted">
+                    <span id="document_name"/>
                     Page: <span class="page"/> / <span class="topage"/>
                 </div>
             </div>

--- a/odoo/addons/base/models/ir_actions_report.py
+++ b/odoo/addons/base/models/ir_actions_report.py
@@ -342,12 +342,6 @@ class IrActionsReport(models.Model):
             node.getparent().remove(node)
             header_node.append(node)
 
-        # Retrieve footers
-        for node in root.xpath(match_klass.format('footer')):
-            body_parent = node.getparent()
-            node.getparent().remove(node)
-            footer_node.append(node)
-
         # Retrieve bodies
         for node in root.xpath(match_klass.format('article')):
             # set context language to body language
@@ -369,6 +363,14 @@ class IrActionsReport(models.Model):
         if not bodies:
             body = ''.join(lxml.html.tostring(c, encoding='unicode') for c in body_parent.getchildren())
             bodies.append(body)
+
+        # Retrieve footers
+        for i, node in enumerate(root.xpath(match_klass.format('footer'))):
+            record = self.env[report_model].browse(res_ids[i])
+            if 'name' in self.env[report_model]._fields:
+                node.xpath("//span[@id='document_name']")[0].text = f"{record.name} - "
+            node.getparent().remove(node)
+            footer_node.append(node)
 
         # Get paperformat arguments set in the root html tag. They are prioritized over
         # paperformat-record arguments.


### PR DESCRIPTION
This PR adds the document name in the footer. Whenever we print a document, the document name will be present on every page along with the page number.

This is a requirement for the Portuguese certification:

See https://info.portaldasfinancas.gov.pt/pt/docs/Portug_tax_system/Documents/Order_No_8632_2014_of_the_3rd_July.pdf

Task id: 2794389