### PR TITLE
[FIX] base: fix file extension when using default name

### DIFF
--- a/odoo/addons/base/models/ir_http.py
+++ b/odoo/addons/base/models/ir_http.py
@@ -379,13 +379,10 @@ class IrHttp(models.AbstractModel):
             content = record[field] or ''
 
         # filename
-        default_filename = False
         if not filename:
             if filename_field in record:
-                default_filename = (filename_field == 'name' and model != 'ir.attachment')
                 filename = record[filename_field]
             if not filename:
-                default_filename = True
                 filename = "%s-%s-%s" % (record._name, record.id, field)
 
         if not mimetype:
@@ -396,8 +393,8 @@ class IrHttp(models.AbstractModel):
             mimetype = guess_mimetype(decoded_content, default=default_mimetype)
 
         # extension
-        _, existing_extension = os.path.splitext(filename)
-        if not existing_extension or default_filename:
+        has_extension = bool(mimetypes.guess_type(filename)[0])
+        if not has_extension:
             extension = mimetypes.guess_extension(mimetype)
             if extension:
                 filename = "%s%s" % (filename, extension)


### PR DESCRIPTION
The file extension detection previously used to determine whether a
filename required an extension was not very smart and in fact only
checked for a dot in the filename.
`mimetypes.guess_type` is now used on the filename to better determine
whether the filename still needs a file extension or not.

This commit is a follow-up to: https://github.com/odoo/odoo/pull/90614
Which aimed to fix the same issue.

TaskId-2826061