### PR TITLE
[FIX] calendar:tests: fix systray activity test race condition

### DIFF
--- a/addons/calendar/static/tests/helpers/mock_server.js
+++ b/addons/calendar/static/tests/helpers/mock_server.js
@@ -17,6 +17,7 @@ MockServer.include({
      */
     _mockResUsers_SystrayGetCalendarEventDomain() {
         const startDate = new Date();
+        startDate.setUTCHours(0, 0, 0, 0);
         const endDate = new Date();
         endDate.setUTCHours(23, 59, 59, 999);
         const currentPartnerAttendeeIds = this._mockSearch('calendar.attendee', [[['partner_id', '=', this.currentPartnerId]]], {});

--- a/addons/calendar/static/tests/systray_activity_menu_tests.js
+++ b/addons/calendar/static/tests/systray_activity_menu_tests.js
@@ -4,6 +4,7 @@ import { start, startServer } from '@mail/../tests/helpers/test_utils';
 import ActivityMenu from '@mail/js/systray/systray_activity_menu';
 
 import testUtils from 'web.test_utils';
+import { patchDate } from "@web/../tests/helpers/utils";
 
 QUnit.module('calendar', {}, function () {
 QUnit.module('ActivityMenu');
@@ -11,6 +12,7 @@ QUnit.module('ActivityMenu');
 QUnit.test('activity menu widget:today meetings', async function (assert) {
     assert.expect(6);
 
+    patchDate(2018, 3, 20, 6, 0, 0);
     const pyEnv = await startServer();
     const calendarAttendeeId1 = pyEnv['calendar.attendee'].create({ partner_id: pyEnv.currentPartnerId });
     pyEnv['calendar.event'].create([


### PR DESCRIPTION
Before these commits, the qunit test on systray activity in calendar module could fail non-deterministically.
https://runbot.odoo.com/runbot/build/15116338

This was caused by 2 issues:
- `_systray_get_calendar_event_domain` was not properly considering the whole day for the start date time
- the test was relying on current datetime of execution, which was prone to failure at midnight

These commits should fix the non-deterministic crash in this test.