### PR TITLE
[FIX] point_of_sale: stop showing "select customer" popup twice

### DIFF
--- a/addons/pos_gift_card/static/src/js/PaymentScreen.js
+++ b/addons/pos_gift_card/static/src/js/PaymentScreen.js
@@ -50,6 +50,8 @@ odoo.define('pos_gift_card.PaymentScreen', function(require) {
                     } catch (e) {
                         // do nothing with the error
                     }
+                } else {
+                    return; // do nothing if the order is not valid
                 }
             }
             await super.validateOrder(...arguments);


### PR DESCRIPTION
Current behavior:
When gift card module is activated for a certain PoS, and you use
customer account as the payment method without selecting a customer
the popup asking you to select a customer would appear 2 times.

Steps to reproduce:
- Activate gift cards for PoS A
- Start session in PoS A
- Add some products to the order
- Don't set any customer
- Go to the payment page
- Select "Customer account" as payment method
- Click on validate
- A popup will appear asking you to select a customer
- Click "Ok"
- The popup appears again

opw-2824675
--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
