### PR TITLE
[FIX] phone_validation: fallback if no region provided

### DIFF
--- a/addons/phone_validation/tests/__init__.py
+++ b/addons/phone_validation/tests/__init__.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
+from . import test_phonenumbers
 from . import test_phonenumbers_patch

--- a/addons/phone_validation/tests/test_phonenumbers.py
+++ b/addons/phone_validation/tests/test_phonenumbers.py
@@ -1,0 +1,22 @@
+# -*- coding: utf-8 -*-
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from odoo.addons.phone_validation.tools import phone_validation
+from odoo.tests import tagged
+from odoo.tests.common import BaseCase
+
+
+@tagged('phone_validation')
+class TestPhonenumbers(BaseCase):
+
+    def test_country_code_falsy(self):
+        print(phone_validation.phone_parse('0456998877', None))
+        print(phone_validation.phone_parse('0456998877', False))
+        self.assertEqual(
+            phone_validation.phone_format('0456998877', 'BE', '32', force_format='E164'),
+            '+32456998877'
+        )
+        self.assertEqual(
+            phone_validation.phone_format('0456998877', None, '32', force_format='E164'),
+            '+32456998877'
+        )

--- a/addons/phone_validation/tools/phone_validation.py
+++ b/addons/phone_validation/tools/phone_validation.py
@@ -15,7 +15,7 @@ try:
 
     def phone_parse(number, country_code):
         try:
-            phone_nbr = phonenumbers.parse(number, region=country_code or None, keep_raw_input=True)
+            phone_nbr = phonenumbers.parse(number, region=country_code, keep_raw_input=True)
         except phonenumbers.phonenumberutil.NumberParseException as e:
             raise UserError(_('Unable to parse %s: %s') % (number, str(e)))
 

--- a/addons/phone_validation/tools/phone_validation.py
+++ b/addons/phone_validation/tools/phone_validation.py
@@ -15,7 +15,7 @@ try:
 
     def phone_parse(number, country_code):
         try:
-            phone_nbr = phonenumbers.parse(number, region=country_code, keep_raw_input=True)
+            phone_nbr = phonenumbers.parse(number, region=country_code or None, keep_raw_input=True)
         except phonenumbers.phonenumberutil.NumberParseException as e:
             raise UserError(_('Unable to parse %s: %s') % (number, str(e)))
 


### PR DESCRIPTION
Description of the issue/feature this PR addresses: Ugly & bad traceback

Current behavior before PR: Before this commit if you would call `phone_parse` but not pass along a country code it would crash. This is reproducable by calling the `phone_parse` function and not setting a country on the contact.
In this case you would get the following traceback:
```
...
AttributeError: 'bool' object has no attribute 'upper'.
```
Desired behavior after PR is merged: By doing a fallback to `None` the phonenumbers library will natively handle this and the user in the UI does not get a traceback.




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
