### PR TITLE
[FIX] sale_loyalty: fix invalid override to `action_cancel`

### DIFF
--- a/addons/sale_loyalty/models/sale_order.py
+++ b/addons/sale_loyalty/models/sale_order.py
@@ -74,9 +74,9 @@ class SaleOrder(models.Model):
         self._send_reward_coupon_mail()
         return super(SaleOrder, self).action_confirm()
 
-    def action_cancel(self):
+    def _action_cancel(self):
         previously_confirmed = self.filtered(lambda s: s.state in ('sale', 'done'))
-        res = super(SaleOrder, self).action_cancel()
+        res = super(SaleOrder, self)._action_cancel()
         # Add/remove the points to our coupons
         for coupon, changes in previously_confirmed.filtered(lambda s: s.state not in ('sale', 'done'))._get_point_changes().items():
             coupon.points -= changes


### PR DESCRIPTION
`action_cancel` is used to conditionally display a wizard while
`_action_cancel` is the actual code that is executed when the order is
cancelled.
This commit fixes the override in sale_loyalty.
