### PR TITLE
[IMP] base,account: Display Vat Label from the country of partner

### DIFF
--- a/odoo/addons/base/models/res_company.py
+++ b/odoo/addons/base/models/res_company.py
@@ -84,6 +84,7 @@ class Company(models.Model):
     phone = fields.Char(related='partner_id.phone', store=True, readonly=False)
     mobile = fields.Char(related='partner_id.mobile', store=True, readonly=False)
     website = fields.Char(related='partner_id.website', readonly=False)
+    vat_label = fields.Char(related='partner_id.vat_label')
     vat = fields.Char(related='partner_id.vat', string="Tax ID", readonly=False)
     company_registry = fields.Char(compute='_compute_company_registry', store=True, readonly=False)
     paperformat_id = fields.Many2one('report.paperformat', 'Paper format', default=lambda self: self.env.ref('base.paperformat_euro', raise_if_not_found=False))
@@ -122,7 +123,7 @@ class Company(models.Model):
         # exists to allow overrides
         for company in self:
             company.company_registry = company.company_registry
-    
+
     # TODO @api.depends(): currently now way to formulate the dependency on the
     # partner's contact address
     def _compute_address(self):

--- a/odoo/addons/base/models/res_partner.py
+++ b/odoo/addons/base/models/res_partner.py
@@ -167,6 +167,7 @@ class Partner(models.Model):
     user_id = fields.Many2one('res.users', string='Salesperson',
       help='The internal user in charge of this contact.')
     vat = fields.Char(string='Tax ID', index=True, help="The Tax Identification Number. Complete it if the contact is subjected to government taxes. Used in some legal statements.")
+    vat_label = fields.Char(compute='_compute_vat_label')
     same_vat_partner_id = fields.Many2one('res.partner', string='Partner with same Tax ID', compute='_compute_same_vat_partner_id', store=False)
     bank_ids = fields.One2many('res.partner.bank', 'partner_id', string='Banks')
     website = fields.Char('Website Link')
@@ -281,6 +282,12 @@ class Partner(models.Model):
         names = dict(self.with_context({}).name_get())
         for partner in self:
             partner.display_name = names.get(partner.id)
+
+    @api.depends('country_id.vat_label')
+    @api.depends_context('company_id')
+    def _compute_vat_label(self):
+        for partner in self:
+            partner.vat_label = partner.country_id.vat_label or _('Tax ID')
 
     @api.depends('lang')
     def _compute_active_lang_count(self):

--- a/odoo/addons/base/views/res_company_views.xml
+++ b/odoo/addons/base/views/res_company_views.xml
@@ -28,7 +28,8 @@
                                         <field name="zip" placeholder="ZIP" class="o_address_zip"/>
                                         <field name="country_id" placeholder="Country" class="o_address_country" options='{"no_open": True, "no_create": True}'/>
                                     </div>
-                                    <field name="vat"/>
+                                    <b><field name="vat_label" class="o_form_label o_td_label" nolabel="1"/></b>
+                                    <field name="vat" nolabel="1"/>
                                     <field name="company_registry"/>
                                     <field name="currency_id" options="{'no_create': True, 'no_open': True}" id="company_currency" context="{'active_test': False}"/>
                                 </group>

--- a/odoo/addons/base/views/res_partner_views.xml
+++ b/odoo/addons/base/views/res_partner_views.xml
@@ -204,7 +204,8 @@
                                 <field name="country_id" placeholder="Country" class="o_address_country" options='{"no_open": True, "no_create": True}'
                                     attrs="{'readonly': [('type', '=', 'contact'),('parent_id', '!=', False)]}"/>
                             </div>
-                            <field name="vat" placeholder="e.g. BE0477472701" attrs="{'readonly': [('parent_id','!=',False)]}"/>
+                            <b><field name="vat_label" class="o_form_label o_td_label" nolabel="1"/></b>
+                            <field name="vat" placeholder="e.g. BE0477472701" attrs="{'readonly': [('parent_id','!=',False)]}" nolabel="1"/>
                         </group>
                         <group>
                             <field name="function" placeholder="e.g. Sales Director"


### PR DESCRIPTION
Before this the standard VAT label was using in form view unless overridden by the localisation modules
in country address_view_id. Now it actively reflects the label of selected country.

Also in Tax units, the label reflects the country of the unit.

task ID:[2843602](https://www.odoo.com/web#id=2843602&menu_id=3940&cids=1&action=4043&model=project.task&view_type=form)

related enterprise PR: odoo/enterprise#27104

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
