### PR TITLE
[FIX] website: prevent btn on 404 page to be clicked before JS loaded

### DIFF
--- a/addons/website/static/src/js/post_link.js
+++ b/addons/website/static/src/js/post_link.js
@@ -9,6 +9,27 @@ publicWidget.registry.postLink = publicWidget.Widget.extend({
     events: {
         'click': '_onClickPost',
     },
+
+    /**
+     * @override
+     */
+    start() {
+        // Allows the link to be interacted with only when Javascript is loaded.
+        this.el.classList.add('o_post_link_js_loaded');
+        return this._super(...arguments);
+    },
+    /**
+     * @override
+     */
+    destroy() {
+        this._super(...arguments);
+        this.el.classList.remove('o_post_link_js_loaded');
+    },
+
+    //--------------------------------------------------------------------------
+    // Handlers
+    //--------------------------------------------------------------------------
+
     _onClickPost: function (ev) {
         ev.preventDefault();
         const url = this.el.dataset.post || this.el.href;
@@ -17,7 +38,7 @@ publicWidget.registry.postLink = publicWidget.Widget.extend({
             if (key.startsWith('post_')) {
                 data[key.slice(5)] = value;
             }
-        };
+        }
         wUtils.sendRequest(url, data);
     },
 });

--- a/addons/website/static/src/scss/website.ui.scss
+++ b/addons/website/static/src/scss/website.ui.scss
@@ -527,3 +527,8 @@ body .modal {
         max-height: 14.2rem;
     }
 }
+
+// Post Submit Links
+.post_link:not(.o_post_link_js_loaded) {
+    pointer-events: none;
+}


### PR DESCRIPTION
Before this commit, it was possible to click on the "Create page" button
before the JS was loaded, as that button is a simple link with a href.
But that link is supposed to be handled by the JS which transform the
GET href link to a fake form submit to send a POST request to the
`/website/add` controller.

If the user clicks before the JS had the chance to handle that click and
do the "transformation", the controller will reject the GET request and
a raw 405 error page will be shown.

Now, we wait for the JS to be fully loaded before allowing user to click
on this button.
The fix is made globally as it should be the case of every link related
to this behavior.

Note that the `/website/add` controller was changed from GET to POST
with commit [1]. It most likely forgot to adapt the button from the 404
page which was later done with [2] by using the `post_link` util class
introduced with [3] (for need of website_blog at the time).

[1]: https://github.com/odoo/odoo/commit/714f0aa07f25e8a88a778e8b21c79b48e9801231
[2]: https://github.com/odoo/odoo/commit/2c85c1cb6ee0f6000cd2db182d5b8cfd3d040876
[3]: https://github.com/odoo/odoo/commit/0f2cada32319b3910d6ace6d412cfa94a646c9c7

task-2847785