### PR TITLE
[FIX] sale: email template shows free shipping over an amount

### DIFF
--- a/addons/sale/data/mail_data.xml
+++ b/addons/sale/data/mail_data.xml
@@ -269,7 +269,7 @@
                 <td>
                     <strong>Shipping Method:</strong>
                     ${object.carrier_id.name}
-                    % if object.carrier_id.fixed_price == 0.0:
+                    % if object.carrier_id.fixed_price == 0.0 or object.amount_delivery == 0.0:
                         (Free)
                     % else:
                         (${format_amount(object.carrier_id.fixed_price, object.currency_id)})


### PR DESCRIPTION
Reproduction:
1. Install Sales and eCommerce, check “Delivery Methods” in Settings ->
Sales
2. Go to Sales->Configuration->Shipping Methods, create a Fixed Price
shipping method with “Free if order amount is above” checked, and set
amount 500. Make this delivery method the only published one
3. Go to the webshop, order something with a price above 500, and
checkout
4. At the backend, check the Sales->Quotations, click the order and
check the confirmation message (or click “SEND BY EMAIL ”, choose the
confirmation email)
5. The Shipping Method still shows the fixed price instead of “Free”

Reason: The confirmation email template doesn’t show the delivery price
based on the actual cost of this order

Fix: Add another condition to the “Free” case. If the amount_delivery is
0, we show the price behind the delivery method as “Free”. Added the pot
term for this fix.

opw-2834505

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
