### PR TITLE
[FIX] web: allow date to be validated through the ENTER keyboard

### DIFF
--- a/addons/web/static/src/js/fields/basic_fields.js
+++ b/addons/web/static/src/js/fields/basic_fields.js
@@ -934,7 +934,7 @@ var FieldDate = InputField.extend({
             let value = this.$input.val();
             try {
                 value = this._parseValue(value);
-                if (this.field.type === "datetime") {
+                if (this.datewidget.type_of_date === "datetime") {
                     value.add(-this.getSession().getTZOffset(value), "minutes");
                 }
             } catch (err) {}

--- a/addons/web/static/tests/fields/basic_fields_tests.js
+++ b/addons/web/static/tests/fields/basic_fields_tests.js
@@ -4783,6 +4783,41 @@ QUnit.module('basic_fields', {
         form.destroy();
     });
 
+    QUnit.test('datetime field with date widget: hit enter should update value', async function (assert) {
+        assert.expect(2);
+
+        const form = await createView({
+            View: FormView,
+            model: 'partner',
+            data: this.data,
+            arch:'<form string="Partners"><field name="datetime" widget="date"/></form>',
+            res_id: 1,
+            translateParameters: {  // Avoid issues due to localization formats
+                date_format: '%m/%d/%Y',
+            },
+            viewOptions: {
+                mode: 'edit',
+            },
+            session: {
+                getTZOffset: function () {
+                    return 120;
+                },
+            },
+        });
+
+        const datetime = form.el.querySelector('input[name="datetime"]');
+
+        await testUtils.fields.editInput(datetime, '01/08/22');
+        await testUtils.fields.triggerKeydown(datetime, 'enter');
+        assert.strictEqual(datetime.value, '01/08/2022');
+
+        // Click outside the field to check that the field is not changed
+        await testUtils.dom.click(form.$el);
+        assert.strictEqual(datetime.value, '01/08/2022');
+
+        form.destroy();
+    });
+
     QUnit.module('RemainingDays');
 
     QUnit.test('remaining_days widget on a date field in list view', async function (assert) {


### PR DESCRIPTION
When creating a custom date field (not datetime) with Studio and that you
edit the field manually then validates with the ENTER keyboard, the date
is changed (one day is removed - mm/dd-1/yy).

Step to reproduce the issue:
1. Add a datetime field via studio (e.g. on the product form)
2. Put a date widget (no datetime)
3. Enter a date manually mm/dd/yy
4. Hit ENTER without clicking outside the box
You will see that the final date will be mm/dd-1/yy.

Solution: The path applied when clicking outside the box and cliking ENTER is
not the same. In the ENTER path, we don't parse the initial date to the TZ of
the client, therefore causing some unexpected behavior. The `date_picker`
already implemented a method to take this into account.

opw-2830843
