### PR TITLE
[IMP] mass_mailing: ignore past date when scheduling

### DIFF
--- a/addons/mass_mailing/models/mailing.py
+++ b/addons/mass_mailing/models/mailing.py
@@ -538,7 +538,7 @@ class MassMailing(models.Model):
 
     def action_schedule(self):
         self.ensure_one()
-        if self.schedule_date:
+        if self.schedule_date and self.schedule_date > fields.Datetime.now():
             return self.action_put_in_queue()
         else:
             action = self.env["ir.actions.actions"]._for_xml_id("mass_mailing.mailing_mailing_schedule_date_action")


### PR DESCRIPTION
PURPOSE

With this commit, when trying to schedule a mailing with a
past schedule_date one will be asked a new date.

LINKS

Task-2833321



--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
