### PR TITLE
[FIX] mail: template `_is_dynamic` with a field having `groups=`

### DIFF
--- a/addons/mail/models/mail_render_mixin.py
+++ b/addons/mail/models/mail_render_mixin.py
@@ -242,7 +242,7 @@ class MailRenderMixin(models.AbstractModel):
     # ------------------------------------------------------------
 
     def _is_dynamic(self):
-        for template in self:
+        for template in self.sudo():
             for fname, field in template._fields.items():
                 engine = getattr(field, 'render_engine', 'inline_template')
                 if engine in ('qweb', 'qweb_view'):


### PR DESCRIPTION
Using customization, if you add a field on `mail.template`
with a `groups=` attribute with a group your regular users do not belong to,
e.g. `groups="base.group_system"`,
the users will have an access error when attempting to read the given
field when checking if the template is dynamic,
with the `_is_dynamic` method.

We could restrict the list of fields to read/check to the fields
the user has access, but that means a user could
duplicate a template with code in the fields he cannot see.

So, read the field has sudo to make sure they do not contain code
is the way to go.