### PR TITLE
POS: fix performance issues

### DIFF
--- a/addons/point_of_sale/models/pos_order.py
+++ b/addons/point_of_sale/models/pos_order.py
@@ -864,7 +864,7 @@ class PosOrderLineLot(models.Model):
     _description = "Specify product lot/serial number in pos order line"
     _rec_name = "lot_name"
 
-    pos_order_line_id = fields.Many2one('pos.order.line')
+    pos_order_line_id = fields.Many2one('pos.order.line', auto_join=True)
     order_id = fields.Many2one('pos.order', related="pos_order_line_id.order_id", readonly=False)
     lot_name = fields.Char('Lot Name')
     product_id = fields.Many2one('product.product', related='pos_order_line_id.product_id', readonly=False)


### PR DESCRIPTION
Searching on not related fields doesn't work well in Odoo v13, because it executes
subquery first. For example, even if we have zero records in
`pos.pack.operation.lot`, ORM may slowly process following query:

```
PosPackOperationLot.search([
('order_id', '=', order.id),
('product_id', '=', move.product_id.id)
])
```
( order_id and product_id are both related fields
https://github.com/odoo/odoo/blob/d80dfd30ffb6524024999f88e069a400884e605b/addons/point_of_sale/models/pos_order.py#L868-L870 )

It's because it reads `pos.order.line` twice: first for records with  specific
`order_id`, and then for records with specific `product_id`.

Fix it by adding `auto_join=True`. Such solution assumes following:

1. `pos_order_line_id` is always set (otherwise results for certain queries may
be changed, because `auto_join=True` makes INNER JOIN in v13)
2. If user has access to some `pos.pack.operation.lot`, he is supposed to have
access to linked `pos.order.line` record (with `auto_join=True` ORM doesn't
check access rights of the joined table)

---

opw-2830572