### PR TITLE
[IMP] web: Allow extension of DatePicker in other modules

### DIFF
--- a/addons/web/static/src/core/datepicker/datepicker.js
+++ b/addons/web/static/src/core/datepicker/datepicker.js
@@ -40,7 +40,7 @@ const luxonFormatToMomentFormat = (format) => {
  * @param {string} format
  * @returns {boolean}
  */
-const isValidStaticFormat = (format) => {
+export const isValidStaticFormat = (format) => {
     try {
         return /^[\d\s/:-]+$/.test(DateTime.local().toFormat(format));
     } catch (_err) {


### PR DESCRIPTION
Since the changes from 88aada39, we need to expose the function
`isValidStaticFormat` in order to extend `DatePicker` component in other
modules.

Odoo counterpart of https://github.com/odoo/enterprise/pull/26844

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
