### PR TITLE
[FIX] web_editor: not fail when clicking on a technical SVG

### DIFF
--- a/addons/web_editor/static/lib/odoo-editor/src/OdooEditor.js
+++ b/addons/web_editor/static/lib/odoo-editor/src/OdooEditor.js
@@ -1871,7 +1871,7 @@ export class OdooEditor extends EventTarget {
                 description: 'Insert a rating over 3 stars.',
                 fontawesome: 'fa-star-o',
                 callback: () => {
-                    let html = '<span contenteditable="false" class="o_stars o_three_stars">';
+                    let html = '\u200B<span contenteditable="false" class="o_stars o_three_stars">';
                     html += Array(3).fill().map(() => '<i class="fa fa-star-o"></i>').join('');
                     html += '</span>';
                     this.execCommand('insertHTML', html);
@@ -1883,7 +1883,7 @@ export class OdooEditor extends EventTarget {
                 description: 'Insert a rating over 5 stars.',
                 fontawesome: 'fa-star',
                 callback: () => {
-                    let html = '<span contenteditable="false" class="o_stars o_five_stars">';
+                    let html = '\u200B<span contenteditable="false" class="o_stars o_five_stars">';
                     html += Array(5).fill().map(() => '<i class="fa fa-star-o"></i>').join('');
                     html += '</span>';
                     this.execCommand('insertHTML', html);

--- a/addons/web_editor/static/lib/odoo-editor/src/OdooEditor.js
+++ b/addons/web_editor/static/lib/odoo-editor/src/OdooEditor.js
@@ -2958,14 +2958,13 @@ export class OdooEditor extends EventTarget {
         }
 
         // handle stars
-        if (node.nodeType === Node.ELEMENT_NODE && node.className.includes('fa-star') &&
+        const isStar = el => el.nodeType === Node.ELEMENT_NODE && (
+            el.classList.contains('fa-star') || el.classList.contains('fa-star-o')
+        );
+        if (isStar(node) &&
             node.parentElement && node.parentElement.className.includes('o_stars')) {
-            const previousStars = getAdjacentPreviousSiblings(node, sib => (
-                sib.nodeType === Node.ELEMENT_NODE && sib.className.includes('fa-star')
-            ));
-            const nextStars = getAdjacentNextSiblings(node, sib => (
-                sib.nodeType === Node.ELEMENT_NODE && sib.className.includes('fa-star')
-            ));
+            const previousStars = getAdjacentPreviousSiblings(node, isStar);
+            const nextStars = getAdjacentNextSiblings(node, isStar);
             if (nextStars.length || previousStars.length) {
                 const shouldToggleOff = node.classList.contains('fa-star') &&
                     (!nextStars[0] || !nextStars[0].classList.contains('fa-star'));

--- a/addons/web_editor/static/src/js/backend/convert_inline.js
+++ b/addons/web_editor/static/src/js/backend/convert_inline.js
@@ -530,7 +530,10 @@ function fontToImg($editable) {
             wrapper.style.setProperty('height', height + 'px');
             wrapper.style.setProperty('vertical-align', 'middle');
             wrapper.style.setProperty('background-color', image.style.backgroundColor);
-            wrapper.setAttribute('class', font.getAttribute('class').replace(new RegExp('(^|\\s+)' + icon + '(-[^\\s]+)?', 'gi'), '')); // remove inline font-awsome style);
+            wrapper.setAttribute('class',
+                'oe_unbreakable ' + // prevent sanitize from grouping image wrappers
+                font.getAttribute('class').replace(new RegExp('(^|\\s+)' + icon + '(-[^\\s]+)?', 'gi'), '') // remove inline font-awsome style
+            );
         } else {
             font.remove();
         }


### PR DESCRIPTION
Since [1] when the stars were made available in the power box, an
exception is raised when clicking on a technical SVG.
This happens because SVGs have their `nodeType === Node.ELEMENT_NODE`,
they have `className` and `classList` properties, but their `className`
is not a string: it is an `SVGAnimatedString`. Because of this, the
`includes` method is not available on `className`.

This commit makes prevents that the non-existing `includes` get called.

Steps to reproduce:
- Drop a "Steps" block into the page.
- Click on the column before the first step, at the same height as the
steps icons. (There is an hidden SVG there containing the definition of
the arrows head.)
=> Did raise an exception.

This PR also makes it possible to continue to use the "3|5 Stars" blocks after they have been saved in a page, and to be able to include it inside "style-inline" HTML field (e.g. profile signature).

[1]: https://github.com/odoo/odoo/commit/8266b978e1bfa5bedfaf1c4fcceadd26400fc85c

task-2845963

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
