### PR TITLE
[FIX] mrp: update the “stock.move” name after the MO creation

### DIFF
--- a/addons/mrp/models/mrp_production.py
+++ b/addons/mrp/models/mrp_production.py
@@ -537,7 +537,6 @@ class MrpProduction(models.Model):
         production = super(MrpProduction, self).create(values)
         production.move_raw_ids.write({
             'group_id': production.procurement_group_id.id,
-            'reference': production.name,  # set reference when MO name is different than 'New'
         })
         # Trigger move_raw creation when importing a file
         if 'import_file' in self.env.context:

--- a/addons/mrp/models/stock_move.py
+++ b/addons/mrp/models/stock_move.py
@@ -125,6 +125,19 @@ class StockMove(models.Model):
         for move in self:
             move.is_done = (move.state in ('done', 'cancel'))
 
+    @api.depends('raw_material_production_id.name')
+    def _compute_reference(self):
+        not_prod_move = self.env['stock.move']
+        for move in self:
+            if not move.raw_material_production_id:
+                not_prod_move |= move
+                continue
+            move.write({
+                'name': move.raw_material_production_id.name,
+                'reference': move.raw_material_production_id.name,
+            })
+        super(StockMove, not_prod_move)._compute_reference()
+
     @api.model
     def default_get(self, fields_list):
         defaults = super(StockMove, self).default_get(fields_list)


### PR DESCRIPTION
**Steps to reproduce the bug:**
- Create a storable product “P1” with BOM:
    - component: 1 unit of “C1”
    - Consumption: Flexible

- Create a MO to produce one “P1”:
    - Click on “Mark as todo”
    - Click on “produce”
    - In the window that opens, add one unit of "C1" in new line
    - Confirm the MO

- Go to the product form of “C1”:
     - Click on the traceability button

**Problem:**
The `stock.move` for the additional unit component(not initially planned in the Bill of materials)
is with reference “New” instead of the  MO name

**Bug:**
The first `stock.move` will be created with the name `New` and after the MO creation,
its reference will be updated but not its name:
https://github.com/odoo/odoo/blob/13241c7a0ebb93998cd918b839e7372f332ec7b1/addons/mrp/models/mrp_production.py#L504-L508

So when an additional unit of the component will be added, the `_create_extra_move`
function will be called, therefore a copy of the first stock.move will be made:
https://github.com/odoo/odoo/blob/13.0/addons/stock/models/stock_move.py#L1371

But as its name is `new` the new `stock.move` will have the same name
and its reference will be calculated based on the name:
https://github.com/odoo/odoo/blob/0b9105cc2c02a714bf5c9a2f554cc181169838af/addons/stock/models/stock_move.py#L212-L215

opw-2839202


https://user-images.githubusercontent.com/78867936/167586872-d89ed114-b828-4b47-922a-a3b11da14b56.mp4




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
