### PR TITLE
[REF] *: `user-select-none` refactoring

### DIFF
--- a/addons/calendar/static/src/xml/base_calendar.xml
+++ b/addons/calendar/static/src/xml/base_calendar.xml
@@ -50,7 +50,7 @@
     <t t-name="Calendar.attendee.status.popover" t-extend="CalendarView.event.popover">
         <t t-jquery=".o_cw_popover_delete" t-operation="after">
             <div t-if="widget.displayAttendeeAnswerChoice()" class="btn-group o-calendar-attendee-status ms-2">
-                <a href="#" class="btn btn-secondary dropdown-toggle" data-bs-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+                <a href="#" class="btn btn-secondary dropdown-toggle user-select-none" data-bs-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
                     <i t-attf-class="fa fa-circle o-calendar-attendee-status-icon #{widget.selectedStatusInfo.color}"/> <span class="o-calendar-attendee-status-text" t-esc="widget.selectedStatusInfo.text"></span>
                 </a>
                 <div class="dropdown-menu overflow-hidden">

--- a/addons/crm/views/crm_lead_views.xml
+++ b/addons/crm/views/crm_lead_views.xml
@@ -556,7 +556,7 @@
                                 </div>
 
                                 <div class="o_dropdown_kanban dropdown">
-                                    <a class="dropdown-toggle o-no-caret btn" role="button" data-bs-toggle="dropdown" data-bs-display="static" href="#" aria-label="Dropdown menu" title="Dropdown menu">
+                                    <a class="dropdown-toggle o-no-caret btn user-select-none" role="button" data-bs-toggle="dropdown" data-bs-display="static" href="#" aria-label="Dropdown menu" title="Dropdown menu">
                                         <span class="fa fa-ellipsis-v"/>
                                     </a>
                                     <div class="dropdown-menu" role="menu">

--- a/addons/event/views/event_registration_views.xml
+++ b/addons/event/views/event_registration_views.xml
@@ -152,7 +152,7 @@
                                             <span class="o_text_overflow" attrs="{'invisible': [('partner_id', '=', False)]}">Booked by <field name="partner_id" /></span>
                                             <div id="event_ticket_id" class="o_field_many2manytags o_field_widget d-flex mt-auto">
                                                 <t t-if="record.event_ticket_id.raw_value">
-                                                    <div t-attf-class="badge rounded-pill o_tag_color_#{(record.event_ticket_id.raw_value % 11) + 1}" >
+                                                    <div t-attf-class="badge rounded-pill user-select-none o_tag_color_#{(record.event_ticket_id.raw_value % 11) + 1}" >
                                                         <b><span class="o_badge_text o_text_overflow"><t t-out="record.event_ticket_id.value"/></span></b>
                                                     </div>
                                                 </t>

--- a/addons/fleet/views/fleet_vehicle_model_views.xml
+++ b/addons/fleet/views/fleet_vehicle_model_views.xml
@@ -206,7 +206,7 @@
                     <t t-name="kanban-box">
                         <div class="oe_kanban_vignette oe_semantic_html_override oe_kanban_global_click">
                             <div class="o_dropdown_kanban dropdown">
-                                <a class="dropdown-toggle o-no-caret btn" role="button" data-bs-toggle="dropdown" href="#" aria-label="Dropdown menu" title="Dropdown menu">
+                                <a class="dropdown-toggle o-no-caret btn user-select-none" role="button" data-bs-toggle="dropdown" href="#" aria-label="Dropdown menu" title="Dropdown menu">
                                     <span class="fa fa-ellipsis-v"/>
                                 </a>
                                 <div class="dropdown-menu" role="menu">

--- a/addons/hr_contract/views/hr_contract_views.xml
+++ b/addons/hr_contract/views/hr_contract_views.xml
@@ -272,7 +272,7 @@
                     <t t-name="kanban-box">
                         <div class="oe_kanban_card oe_kanban_global_click">
                             <div class="o_dropdown_kanban dropdown" t-if="!selection_mode" groups="hr_contract.group_hr_contract_manager">
-                                <a class="dropdown-toggle o-no-caret btn" role="button" data-bs-toggle="dropdown" data-bs-display="static" href="#" aria-label="Dropdown menu" title="Dropdown menu">
+                                <a class="dropdown-toggle o-no-caret btn user-select-none" role="button" data-bs-toggle="dropdown" data-bs-display="static" href="#" aria-label="Dropdown menu" title="Dropdown menu">
                                     <span class="fa fa-ellipsis-v"/>
                                 </a>
                                 <div class="dropdown-menu" role="menu">

--- a/addons/hr_holidays/views/hr_leave_allocation_views.xml
+++ b/addons/hr_holidays/views/hr_leave_allocation_views.xml
@@ -369,7 +369,7 @@
                                         <t t-esc="record.holiday_status_id.value"/>
                                     </div>
                                     <div class="o_dropdown_kanban dropdown" groups="base.group_user">
-                                        <a role="button" class="dropdown-toggle o-no-caret btn" data-bs-toggle="dropdown" href="#" aria-label="Dropdown menu" title="Dropdown menu">
+                                        <a role="button" class="dropdown-toggle o-no-caret btn user-select-none" data-bs-toggle="dropdown" href="#" aria-label="Dropdown menu" title="Dropdown menu">
                                             <span class="fa fa-ellipsis-v"/>
                                         </a>
                                         <div class="dropdown-menu" role="menu">

--- a/addons/hr_holidays/views/hr_leave_views.xml
+++ b/addons/hr_holidays/views/hr_leave_views.xml
@@ -117,7 +117,7 @@
                                         <t t-esc="record.holiday_status_id.value"/>
                                     </div>
                                     <div class="o_dropdown_kanban dropdown" groups="base.group_user">
-                                        <a role="button" class="dropdown-toggle o-no-caret btn" data-bs-toggle="dropdown" href="#" aria-label="Dropdown menu" title="Dropdown menu">
+                                        <a role="button" class="dropdown-toggle o-no-caret btn user-select-none" data-bs-toggle="dropdown" href="#" aria-label="Dropdown menu" title="Dropdown menu">
                                             <span class="fa fa-ellipsis-v"/>
                                         </a>
                                         <div class="dropdown-menu" role="menu">

--- a/addons/hr_recruitment/views/hr_recruitment_views.xml
+++ b/addons/hr_recruitment/views/hr_recruitment_views.xml
@@ -346,7 +346,7 @@
                             </div>
                             <span class="badge rounded-pill text-bg-danger float-end me-4" attrs="{'invisible': ['|', ('active', '=', True), ('refuse_reason_id', '=', False)]}">Refused</span>
                             <div class="o_dropdown_kanban dropdown">
-                                <a class="dropdown-toggle o-no-caret btn" role="button" data-bs-toggle="dropdown" href="#" aria-label="Dropdown menu" title="Dropdown menu" data-bs-display="static">
+                                <a class="dropdown-toggle o-no-caret btn user-select-none" role="button" data-bs-toggle="dropdown" href="#" aria-label="Dropdown menu" title="Dropdown menu" data-bs-display="static">
                                     <span class="fa fa-ellipsis-v"/>
                                 </a>
                                 <div class="dropdown-menu" role="menu">

--- a/addons/hr_work_entry/views/hr_work_entry_views.xml
+++ b/addons/hr_work_entry/views/hr_work_entry_views.xml
@@ -193,7 +193,7 @@
                     <t t-name="kanban-box">
                         <div t-attf-class="#{!selection_mode ? kanban_color(record.color.raw_value) : ''} oe_kanban_global_click">
                             <div class="o_dropdown_kanban dropdown" t-if="!selection_mode">
-                                <a class="dropdown-toggle o-no-caret btn" role="button" data-bs-toggle="dropdown" href="#" aria-label="Dropdown menu" title="Dropdown menu">
+                                <a class="dropdown-toggle o-no-caret btn user-select-none" role="button" data-bs-toggle="dropdown" href="#" aria-label="Dropdown menu" title="Dropdown menu">
                                     <span class="fa fa-ellipsis-v"/>
                                 </a>
                                 <div class="dropdown-menu" role="menu">

--- a/addons/mail/static/src/components/call_invite_request_popup/call_invite_request_popup.scss
+++ b/addons/mail/static/src/components/call_invite_request_popup/call_invite_request_popup.scss
@@ -15,10 +15,6 @@
 // Style
 // ------------------------------------------------------------------
 
-.o_CallInviteRequestPopup_buttonListButton {
-    user-select: none;
-}
-
 .o_CallInviteRequestPopup_partnerInfoImage {
     border: 3px solid gray;
 }

--- a/addons/mail/static/src/components/call_invite_request_popup/call_invite_request_popup.xml
+++ b/addons/mail/static/src/components/call_invite_request_popup/call_invite_request_popup.xml
@@ -15,13 +15,13 @@
                     </div>
                 </t>
                 <div class="o_CallInviteRequestPopup_buttonList d-flex justify-content-around align-items-center w-100 mt-4">
-                    <button class="o_CallInviteRequestPopup_buttonListButton o_CallInviteRequestPopup_buttonListRefuse p-2 rounded-circle border-0 bg-danger"
+                    <button class="o_CallInviteRequestPopup_buttonListButton o_CallInviteRequestPopup_buttonListRefuse p-2 rounded-circle border-0 bg-danger user-select-none"
                         aria-label="Refuse"
                         title="Refuse"
                         t-on-click="callInviteRequestPopup.onClickRefuse">
                         <i class="o_CallInviteRequestPopup_buttonListButtonIcon fa fa-lg fa-times m-3"/>
                     </button>
-                    <button class="o_CallInviteRequestPopup_buttonListButton o_CallInviteRequestPopup_buttonListAccept p-2 rounded-circle border-0 bg-success"
+                    <button class="o_CallInviteRequestPopup_buttonListButton o_CallInviteRequestPopup_buttonListAccept p-2 rounded-circle border-0 bg-success user-select-none"
                         aria-label="Accept"
                         title="Accept"
                         t-on-click="callInviteRequestPopup.onClickAccept">

--- a/addons/mail/static/src/components/call_participant_card/call_participant_card.scss
+++ b/addons/mail/static/src/components/call_participant_card/call_participant_card.scss
@@ -52,7 +52,3 @@
         box-shadow: inset 0 0 0 map-get($spacers, 1) darken($o-enterprise-primary-color, 5%);
     }
 }
-
-.o_CallParticipantCard_liveIndicator {
-    user-select: none;
-}

--- a/addons/mail/static/src/components/call_participant_card/call_participant_card.xml
+++ b/addons/mail/static/src/components/call_participant_card/call_participant_card.xml
@@ -20,7 +20,7 @@
                     <CallParticipantVideo record="callParticipantCard.callParticipantVideoView"/>
                 </t>
                 <t t-else="">
-                    <div class="o_CallParticipantCard_avatarFrame d-flex align-items-center justify-content-center h-100 w-100 rounded-1" t-att-class="{ 'o-isMinimized': callParticipantCard.isMinimized, 'bg-secondary': !callParticipantCard.isMinimized}" draggable="false">
+                    <div class="o_CallParticipantCard_avatarFrame d-flex align-items-center justify-content-center h-100 w-100 rounded-1 user-select-none" t-att-class="{ 'o-isMinimized': callParticipantCard.isMinimized, 'bg-secondary': !callParticipantCard.isMinimized}" draggable="false">
                         <img alt="Avatar"
                              t-att-class="{
                                 'o-isTalking': callParticipantCard.isTalking,
@@ -40,7 +40,7 @@
                             <span class="o_CallParticipantCard_name p-1 rounded-1 bg-black-75 text-white text-truncate" t-esc="callParticipantCard.name"/>
                         </t>
                         <t t-if="callParticipantCard.rtcSession.isScreenSharingOn and callParticipantCard.isMinimized and !callParticipantCard.rtcSession.channel.rtc">
-                            <small class="o_CallParticipantCard_liveIndicator o-isMinimized rounded-pill text-bg-danger d-flex align-items-center fw-bolder" title="live" aria-label="live">
+                            <small class="o_CallParticipantCard_liveIndicator o-isMinimized rounded-pill text-bg-danger d-flex align-items-center fw-bolder user-select-none" title="live" aria-label="live">
                                 LIVE
                             </small>
                         </t>
@@ -67,7 +67,7 @@
                             </span>
                         </t>
                         <t t-if="callParticipantCard.rtcSession.isScreenSharingOn and !callParticipantCard.isMinimized and !callParticipantCard.rtcSession.channel.rtc">
-                            <span class="o_CallParticipantCard_liveIndicator rounded-pill text-bg-danger d-flex align-items-center me-1 fw-bolder" title="live" aria-label="live">
+                            <span class="o_CallParticipantCard_liveIndicator rounded-pill text-bg-danger d-flex align-items-center me-1 fw-bolder user-select-none" title="live" aria-label="live">
                                 LIVE
                             </span>
                         </t>

--- a/addons/mail/static/src/components/call_settings_menu/call_settings_menu.scss
+++ b/addons/mail/static/src/components/call_settings_menu/call_settings_menu.scss
@@ -2,11 +2,6 @@
 // Layout
 // ------------------------------------------------------------------
 
-.o_CallSettingsMenu {
-    -webkit-user-select: none;
-    user-select: none;
-}
-
 .o_CallSettingsMenu_option {
     min-height: 40px;
 }

--- a/addons/mail/static/src/components/call_settings_menu/call_settings_menu.xml
+++ b/addons/mail/static/src/components/call_settings_menu/call_settings_menu.xml
@@ -2,7 +2,7 @@
 <templates xml:space="preserve">
 
     <t t-name="mail.CallSettingsMenu" owl="1">
-        <div class="o_CallSettingsMenu d-flex flex-column ms-2 overflow-auto" t-attf-class="{{ className }}" t-ref="root">
+        <div class="o_CallSettingsMenu d-flex flex-column ms-2 overflow-auto user-select-none" t-attf-class="{{ className }}" t-ref="root">
             <div class="o_CallSettingsMenu_option d-flex align-items-center flex-wrap m-2 p-1">
                 <label class="o_CallSettingsMenu_optionLabel d-flex align-items-center flex-wrap mw-100 o_cursor_pointer" title="Input device" aria-label="Input device">
                     <span class="o_CallSettingsMenuoptionName me-2 text-truncate fw-bolder">Input device</span>

--- a/addons/mail/static/src/components/chat_window_header/chat_window_header.scss
+++ b/addons/mail/static/src/components/chat_window_header/chat_window_header.scss
@@ -27,7 +27,3 @@
 .o_ChatWindowHeader_command.o-isDeviceSmall {
     font-size: 1.3rem;
 }
-
-.o_ChatWindowHeader_name {
-    user-select: none;
-}

--- a/addons/mail/static/src/components/chat_window_header/chat_window_header.xml
+++ b/addons/mail/static/src/components/chat_window_header/chat_window_header.xml
@@ -15,7 +15,7 @@
                         thread="chatWindow.thread"
                     />
                 </t>
-                <div class="o_ChatWindowHeader_item o_ChatWindowHeader_name mh-100 mx-1 my-0 text-truncate" t-att-class="{'ms-3':!chatWindow.thread or chatWindow.thread.model !== 'mail.channel'}" t-att-title="chatWindow.name">
+                <div class="o_ChatWindowHeader_item o_ChatWindowHeader_name mh-100 mx-1 my-0 text-truncate user-select-none" t-att-class="{'ms-3':!chatWindow.thread or chatWindow.thread.model !== 'mail.channel'}" t-att-title="chatWindow.name">
                     <t t-esc="chatWindow.name"/>
                 </div>
                 <t t-if="chatWindow.thread and chatWindow.thread.localMessageUnreadCounter > 0">

--- a/addons/mail/static/src/components/chat_window_hidden_menu/chat_window_hidden_menu.scss
+++ b/addons/mail/static/src/components/chat_window_hidden_menu/chat_window_hidden_menu.scss
@@ -10,11 +10,3 @@
     transform: translate(50%, -50%);
     z-index: $zindex-tooltip; // on top of bootstrap dropup menu
 }
-
-// ------------------------------------------------------------------
-// Style
-// ------------------------------------------------------------------
-
-.o_ChatWindowHiddenMenu_windowCounter {
-    user-select: none;
-}

--- a/addons/mail/static/src/components/chat_window_hidden_menu/chat_window_hidden_menu.xml
+++ b/addons/mail/static/src/components/chat_window_hidden_menu/chat_window_hidden_menu.xml
@@ -3,9 +3,9 @@
 
     <t t-name="mail.ChatWindowHiddenMenu" owl="1">
         <div class="o_ChatWindowHiddenMenu dropup position-fixed bottom-0 align-items-stretch d-flex px-2 py-1 rounded-top-3 bg-900 o_cursor_pointer" t-attf-class="{{ className }}" t-ref="root">
-            <div class="o_ChatWindowHiddenMenu_dropdownToggle dropdown-toggle justify-content-center align-items-center flex-grow-1 d-flex mw-100" t-att-class="{ 'show opacity-50': messaging.chatWindowManager.isHiddenMenuOpen }" t-on-click="messaging.chatWindowManager.onClickHiddenMenuToggler">
+            <div class="o_ChatWindowHiddenMenu_dropdownToggle dropdown-toggle justify-content-center align-items-center flex-grow-1 d-flex mw-100 user-select-none" t-att-class="{ 'show opacity-50': messaging.chatWindowManager.isHiddenMenuOpen }" t-on-click="messaging.chatWindowManager.onClickHiddenMenuToggler">
                 <div class="o_ChatWindowHiddenMenu_dropdownToggleIcon o_ChatWindowHiddenMenu_dropdownToggleItem me-1 fa fa-comments-o"/>
-                <div class="o_ChatWindowHiddenMenu_dropdownToggleItem o_ChatWindowHiddenMenu_windowCounter mx-1 text-truncate">
+                <div class="o_ChatWindowHiddenMenu_dropdownToggleItem o_ChatWindowHiddenMenu_windowCounter mx-1 text-truncate user-select-none">
                     <t t-esc="messaging.chatWindowManager.allOrderedHidden.length"/>
                 </div>
             </div>

--- a/addons/mail/static/src/components/discuss_sidebar_category/discuss_sidebar_category.scss
+++ b/addons/mail/static/src/components/discuss_sidebar_category/discuss_sidebar_category.scss
@@ -2,8 +2,3 @@
     width: $o-mail-discuss-sidebar-category-title-icon-size;
     height: $o-mail-discuss-sidebar-category-title-icon-size;
 }
-
-.o_DiscussSidebarCategory_headerItem {
-    user-select: none;
-    -webkit-user-select: none;
-}

--- a/addons/mail/static/src/components/discuss_sidebar_category/discuss_sidebar_category.xml
+++ b/addons/mail/static/src/components/discuss_sidebar_category/discuss_sidebar_category.xml
@@ -6,12 +6,12 @@
             <t t-set="o_DiscussSidebarCategory_hoverItem" t-value="'btn p-0 text-start text-700 opacity-100-hover opacity-75'"/>
             <div class="o_DiscussSidebarCategory" t-attf-class="{{ className }}" t-att-data-category-local-id="category.localId" t-ref="root">
                 <div class="o_DiscussSidebarCategory_header d-flex align-items-center my-1">
-                    <div t-attf-class="o_DiscussSidebarCategory_title o_DiscussSidebarCategory_headerItem d-flex align-items-baseline mx-1 {{ o_DiscussSidebarCategory_hoverItem }}" t-on-click="category.onClick">
+                    <div t-attf-class="o_DiscussSidebarCategory_title o_DiscussSidebarCategory_headerItem d-flex align-items-baseline mx-1 user-select-none {{ o_DiscussSidebarCategory_hoverItem }}" t-on-click="category.onClick">
                         <i class="o_DiscussSidebarCategory_titleIcon small" t-att-class="category.isOpen ? 'fa fa-chevron-down' : 'fa fa-chevron-right'"/>
                         <span class="o_DiscussSidebarCategory_titleText btn-sm p-0 text-uppercase fw-bolder"><t t-esc="category.name"/></span>
                     </div>
-                    <div class="o_DiscussSidebarCategory_headerItem flex-grow-1"/>
-                    <div class="o_DiscussSidebarCategory_commands o_DiscussSidebarCategory_headerItem d-flex me-3">
+                    <div class="o_DiscussSidebarCategory_headerItem flex-grow-1 user-select-none"/>
+                    <div class="o_DiscussSidebarCategory_commands o_DiscussSidebarCategory_headerItem d-flex me-3 user-select-none">
                         <t t-if="category.hasViewCommand">
                             <i t-attf-class="o_DiscussSidebarCategory_command o_DiscussSidebarCategory_commandView fa fa-cog {{ o_DiscussSidebarCategory_hoverItem }}" title="View or join channels" t-on-click="category.onClickCommandView" role="img"/>
                         </t>
@@ -20,7 +20,7 @@
                         </t>
                     </div>
                     <t t-if="!category.isOpen and category.counter > 0">
-                        <div class="o_DiscussSidebarCategory_counter o_DiscussSidebarCategory_headerItem badge rounded-pill text-bg-primary me-3">
+                        <div class="o_DiscussSidebarCategory_counter o_DiscussSidebarCategory_headerItem badge rounded-pill text-bg-primary me-3 user-select-none">
                             <t t-esc="category.counter"/>
                         </div>
                     </t>

--- a/addons/mail/static/src/components/messaging_menu/messaging_menu.xml
+++ b/addons/mail/static/src/components/messaging_menu/messaging_menu.xml
@@ -4,7 +4,7 @@
     <t t-name="mail.MessagingMenu" owl="1">
         <t t-if="messagingMenu">
             <div class="o_MessagingMenu dropdown" t-att-class="{ 'show bg-black-15': messagingMenu.isOpen, 'o-isDeviceSmall': messaging.device.isSmall }" t-attf-class="{{ className }}" t-ref="root">
-                <a class="o_MessagingMenu_toggler dropdown-toggle o-no-caret o-dropdown--narrow" t-att-class="{ 'o-no-notification': !messagingMenu.counter }" href="#" title="Conversations" role="button" t-att-aria-expanded="messagingMenu.isOpen ? 'true' : 'false'" aria-haspopup="true" t-on-click="messagingMenu.onClickToggler">
+                <a class="o_MessagingMenu_toggler dropdown-toggle user-select-none o-no-caret o-dropdown--narrow" t-att-class="{ 'o-no-notification': !messagingMenu.counter }" href="#" title="Conversations" role="button" t-att-aria-expanded="messagingMenu.isOpen ? 'true' : 'false'" aria-haspopup="true" t-on-click="messagingMenu.onClickToggler">
                     <i class="o_MessagingMenu_icon fa fa-lg fa-comments" role="img" aria-label="Messages"/>
                     <t t-if="!messaging.isInitialized">
                         <i class="o_MessagingMenu_loading fa fa-circle-o-notch fa-spin position-absolute bottom-50 end-0 small"/>

--- a/addons/mail/static/src/components/notification_group/notification_group.xml
+++ b/addons/mail/static/src/components/notification_group/notification_group.xml
@@ -3,7 +3,7 @@
 
     <t t-name="mail.NotificationGroup" owl="1">
         <t t-if="notificationGroupView">
-            <div class="o_NotificationListItem o_NotificationGroup d-flex flex-shrink-0 align-items-center p-1 o_cursor_pointer" t-attf-class="{{ className }}" t-on-click="notificationGroupView.onClick" t-ref="root">
+            <div class="o_NotificationListItem o_NotificationGroup d-flex flex-shrink-0 align-items-center p-1 user-select-none o_cursor_pointer" t-attf-class="{{ className }}" t-on-click="notificationGroupView.onClick" t-ref="root">
                 <div class="o_NotificationListItem_sidebar o_NotificationGroup_sidebar m-1">
                     <div class="o_NotificationListItem_imageContainer o_NotificationGroup_imageContainer o_NotificationGroup_sidebarItem position-relative">
                         <img class="o_NotificationListItem_image o_NotificationGroup_image w-100 h-100 rounded-circle" t-att-src="notificationGroupView.imageSrc" alt="Message delivery failure image"/>

--- a/addons/mail/static/src/components/notification_list/notification_list_item.scss
+++ b/addons/mail/static/src/components/notification_list/notification_list_item.scss
@@ -7,8 +7,6 @@ $o-mail-notification-list-item-muted-hover-background-color:
     darken($o-mail-notification-list-item-muted-background-color, 7%) !default;
 
 .o_NotificationListItem {
-    -webkit-user-select: none;
-    user-select: none;
     background-color: $o-mail-notification-list-item-background-color;
 
     &:hover {

--- a/addons/mail/static/src/components/notification_request/notification_request.xml
+++ b/addons/mail/static/src/components/notification_request/notification_request.xml
@@ -3,7 +3,7 @@
 
     <t t-name="mail.NotificationRequest" owl="1">
         <t t-if="notificationRequestView">
-            <div class="o_NotificationListItem o_NotificationRequest d-flex flex-shrink-0 align-items-center p-1 o_cursor_pointer" t-attf-class="{{ className }}" t-on-click="_onClick" t-ref="root">
+            <div class="o_NotificationListItem o_NotificationRequest d-flex flex-shrink-0 align-items-center p-1 user-select-none o_cursor_pointer" t-attf-class="{{ className }}" t-on-click="_onClick" t-ref="root">
                 <div class="o_NotificationListItem_sidebar o_NotificationRequest_sidebar m-1">
                     <div class="o_NotificationListItem_imageContainer o_NotificationRequest_imageContainer o_NotificationRequest_sidebarItem position-relative">
                         <img class="o_NotificationListItem_image o_NotificationRequest_image w-100 h-100 rounded-circle" t-att-src="messaging.partnerRoot.avatarUrl" alt="Avatar of OdooBot"/>

--- a/addons/mail/static/src/components/thread_needaction_preview/thread_needaction_preview.xml
+++ b/addons/mail/static/src/components/thread_needaction_preview/thread_needaction_preview.xml
@@ -7,7 +7,7 @@
                 The preview template is used by the discuss in mobile, and by the systray
                 menu in order to show preview of threads.
             -->
-            <div class="o_NotificationListItem o_ThreadNeedactionPreview d-flex flex-shrink-0 align-items-center p-1 o_cursor_pointer" t-attf-class="{{ className }}" t-on-click="threadNeedactionPreviewView.onClick" t-att-data-thread-local-id="threadNeedactionPreviewView.thread.localId" t-ref="root">
+            <div class="o_NotificationListItem o_ThreadNeedactionPreview d-flex flex-shrink-0 align-items-center p-1 user-select-none o_cursor_pointer" t-attf-class="{{ className }}" t-on-click="threadNeedactionPreviewView.onClick" t-att-data-thread-local-id="threadNeedactionPreviewView.thread.localId" t-ref="root">
                 <div class="o_NotificationListItem_sidebar o_ThreadNeedactionPreview_sidebar m-1">
                     <div class="o_NotificationListItem_imageContainer o_ThreadNeedactionPreview_imageContainer o_ThreadNeedactionPreview_sidebarItem position-relative">
                         <img class="o_NotificationListItem_image o_ThreadNeedactionPreview_image w-100 h-100" t-att-src="image()" alt="Thread Image"/>

--- a/addons/mail/static/src/components/thread_preview/thread_preview.xml
+++ b/addons/mail/static/src/components/thread_preview/thread_preview.xml
@@ -7,7 +7,7 @@
                 The preview template is used by the discuss in mobile, and by the systray
                 menu in order to show preview of threads.
             -->
-            <div class="o_NotificationListItem o_ThreadPreview d-flex flex-shrink-0 align-items-center p-1 o_cursor_pointer" t-att-class="{ 'o-muted': threadPreviewView.thread.localMessageUnreadCounter === 0 }" t-attf-class="{{ className }}" t-on-click="threadPreviewView.onClick" t-att-data-thread-local-id="threadPreviewView.thread.localId" t-ref="root">
+            <div class="o_NotificationListItem o_ThreadPreview d-flex flex-shrink-0 align-items-center p-1 user-select-none o_cursor_pointer" t-att-class="{ 'o-muted': threadPreviewView.thread.localMessageUnreadCounter === 0 }" t-attf-class="{{ className }}" t-on-click="threadPreviewView.onClick" t-att-data-thread-local-id="threadPreviewView.thread.localId" t-ref="root">
                 <div class="o_NotificationListItem_sidebar o_ThreadPreview_sidebar m-1">
                     <div class="o_NotificationListItem_imageContainer o_ThreadPreview_imageContainer o_ThreadPreview_sidebarItem position-relative">
                         <img class="o_NotificationListItem_image o_ThreadPreview_image w-100 h-100 rounded-circle" t-att-src="image()" alt="Thread Image"/>

--- a/addons/mail/static/src/xml/systray.xml
+++ b/addons/mail/static/src/xml/systray.xml
@@ -50,7 +50,7 @@
 
     <t t-name="mail.systray.ActivityMenu">
         <div class="o_mail_systray_item dropdown">
-            <a class="dropdown-toggle o-no-caret o-dropdown--narrow" data-bs-toggle="dropdown" data-bs-offset="0,0" aria-expanded="false" title="Activities" href="#" role="button">
+            <a class="dropdown-toggle user-select-none o-no-caret o-dropdown--narrow" data-bs-toggle="dropdown" data-bs-offset="0,0" aria-expanded="false" title="Activities" href="#" role="button">
                 <i class="fa fa-lg fa-clock-o" role="img" aria-label="Activities"/> <span class="o_notification_counter badge"/>
             </a>
             <div class="o_mail_systray_dropdown dropdown-menu dropdown-menu-end" role="menu">

--- a/addons/mail/static/src/xml/text_emojis.xml
+++ b/addons/mail/static/src/xml/text_emojis.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <templates xml:space="preserve">
     <div t-name="mail.EmojisDropdown" class="o_mail_emojis_dropdown o_mail_add_emoji dropdown position-relative">
-        <button class="btn btn-block dropdown-toggle px-3 py-1"
+        <button class="btn btn-block dropdown-toggle px-3 py-1 user-select-none"
             type="button"
             data-bs-toggle="dropdown"
             aria-haspopup="true"

--- a/addons/mail/static/src/xml/web_kanban_activity.xml
+++ b/addons/mail/static/src/xml/web_kanban_activity.xml
@@ -4,7 +4,7 @@
 <t t-name="mail.KanbanActivity">
     <div class="o_kanban_inline_block dropdown o_mail_activity">
         <!-- Dropdowns are created in JS to avoid some bugs, that's why the <a/> contains no args for the dropdown creation -->
-        <a class="dropdown-toggle o-no-caret o_activity_btn" data-boundary="viewport" data-flip="false" data-bs-toggle="dropdown" role="button">
+        <a class="dropdown-toggle user-select-none o-no-caret o_activity_btn" data-boundary="viewport" data-flip="false" data-bs-toggle="dropdown" role="button">
             <!-- span classes are generated dynamically (see _render) -->
             <span t-att-title="widget.selection[widget.activityState]" role="img" t-att-aria-label="widget.selection[widget.activity_state]"/>
        </a>

--- a/addons/mail/views/mail_message_views.xml
+++ b/addons/mail/views/mail_message_views.xml
@@ -145,7 +145,7 @@
                                 <div class="row">
                                     <div class="offset-10">
                                         <div class="o_dropdown_kanban dropdown" groups="base.group_user">
-                                            <a role="button" class="dropdown-toggle o-no-caret btn" data-bs-toggle="dropdown" href="#" aria-label="Dropdown menu" title="Dropdown menu">
+                                            <a role="button" class="dropdown-toggle user-select-none o-no-caret btn" data-bs-toggle="dropdown" href="#" aria-label="Dropdown menu" title="Dropdown menu">
                                                 <span class="fa fa-ellipsis-v"/>
                                             </a>
                                             <div class="dropdown-menu" role="menu">

--- a/addons/maintenance/views/maintenance_views.xml
+++ b/addons/maintenance/views/maintenance_views.xml
@@ -139,7 +139,7 @@
                         <div t-attf-class="{{!selection_mode ? 'oe_kanban_color_' + kanban_getcolor(record.color.raw_value) : ''}} oe_kanban_card oe_kanban_global_click oe_semantic_html_override">
                             <div class="o_dropdown_kanban dropdown">
 
-                                <a role="button" class="dropdown-toggle o-no-caret btn" data-bs-toggle="dropdown" data-bs-display="static" href="#" aria-label="Dropdown menu" title="Dropdown menu">
+                                <a role="button" class="dropdown-toggle o-no-caret btn user-select-none" data-bs-toggle="dropdown" data-bs-display="static" href="#" aria-label="Dropdown menu" title="Dropdown menu">
                                     <span class="fa fa-ellipsis-v"/>
                                 </a>
                                 <div class="dropdown-menu" role="menu">
@@ -438,7 +438,7 @@
                         <div t-attf-class="{{!selection_mode ? 'oe_kanban_color_' + kanban_getcolor(record.color.raw_value) : ''}} oe_kanban_card oe_kanban_global_click">
                             <div class="o_dropdown_kanban dropdown" t-if="!selection_mode">
 
-                                <a role="button" class="dropdown-toggle o-no-caret btn" data-bs-toggle="dropdown" data-bs-display="static" href="#" aria-label="Dropdown menu" title="Dropdown menu">
+                                <a role="button" class="dropdown-toggle o-no-caret btn user-select-none" data-bs-toggle="dropdown" data-bs-display="static" href="#" aria-label="Dropdown menu" title="Dropdown menu">
                                     <span class="fa fa-ellipsis-v"/>
                                 </a>
                                 <div class="dropdown-menu" role="menu">

--- a/addons/mass_mailing/views/mailing_mailing_views.xml
+++ b/addons/mass_mailing/views/mailing_mailing_views.xml
@@ -506,7 +506,7 @@
                         <t t-name="kanban-box">
                             <div t-attf-class="{{!selection_mode ? 'oe_kanban_color_' + kanban_getcolor(record.color.raw_value) : ''}} oe_kanban_card oe_kanban_global_click oe_kanban_mass_mailing">
                                 <div class="o_dropdown_kanban dropdown" t-if="!selection_mode">
-                                    <a role="button" class="dropdown-toggle o-no-caret btn" data-bs-toggle="dropdown" href="#" data-bs-display="static" aria-label="Dropdown menu" title="Dropdown menu">
+                                    <a role="button" class="dropdown-toggle user-select-none o-no-caret btn" data-bs-toggle="dropdown" href="#" data-bs-display="static" aria-label="Dropdown menu" title="Dropdown menu">
                                         <span class="fa fa-ellipsis-v"/>
                                     </a>
                                     <div class="dropdown-menu" role="menu">

--- a/addons/mrp/views/ir_attachment_view.xml
+++ b/addons/mrp/views/ir_attachment_view.xml
@@ -42,7 +42,7 @@
                                         </div>
                                     </div>
                                     <div class="o_dropdown_kanban dropdown" tabindex="-1">
-                                        <a class="dropdown-toggle o-no-caret btn" data-bs-toggle="dropdown" href="#" role="button" aria-label="Dropdown menu" title="Dropdown menu">
+                                        <a class="dropdown-toggle user-select-none o-no-caret btn" data-bs-toggle="dropdown" href="#" role="button" aria-label="Dropdown menu" title="Dropdown menu">
                                             <span class="fa fa-ellipsis-v"/>
                                         </a>
                                         <div class="dropdown-menu" role="menu" aria-labelledby="dLabel">

--- a/addons/note/views/note_views.xml
+++ b/addons/note/views/note_views.xml
@@ -98,7 +98,7 @@
                 <field name="tag_ids" widget="many2many_tags" options="{'color_field': 'color'}"/>
 
                 <div class="o_dropdown_kanban dropdown">
-                    <a role="button" class="dropdown-toggle o-no-caret btn" data-bs-toggle="dropdown" data-bs-display="static" href="#" aria-label="Dropdown menu" title="Dropdown menu">
+                    <a role="button" class="dropdown-toggle user-select-none o-no-caret btn" data-bs-toggle="dropdown" data-bs-display="static" href="#" aria-label="Dropdown menu" title="Dropdown menu">
                         <span class="fa fa-ellipsis-v"/>
                     </a>
                     <div class="dropdown-menu" role="menu">

--- a/addons/portal/views/portal_templates.xml
+++ b/addons/portal/views/portal_templates.xml
@@ -55,7 +55,7 @@
             <t t-set="active_lang" t-value="list(filter(lambda lg : lg[0] == lang, languages))[0]"/>
             <t t-set="language_selector_visible" t-value="len(languages) &gt; 1"/>
             <div t-attf-class="js_language_selector #{_div_classes} d-print-none" t-if="language_selector_visible">
-                <button t-attf-class="btn btn-sm btn-outline-secondary border-0 dropdown-toggle #{_btn_class}" type="button" data-bs-toggle="dropdown" aria-haspopup="true" aria-expanded="true">
+                <button t-attf-class="btn btn-sm btn-outline-secondary border-0 dropdown-toggle user-select-none #{_btn_class}" type="button" data-bs-toggle="dropdown" aria-haspopup="true" aria-expanded="true">
                     <span t-if="not no_text"
                             class="align-middle"
                             t-esc="active_lang[2].split('/').pop()"/>
@@ -84,7 +84,7 @@
            t-nocache-_dropdown_menu_class="_dropdown_menu_class">
             <t t-set="is_connected" t-value="not user_id._is_public()"/>
             <li t-if="is_connected" t-attf-class="#{_item_class} o_no_autohide_item">
-                <a href="#" role="button" data-bs-toggle="dropdown" t-attf-class="dropdown-toggle #{_link_class}">
+                <a href="#" role="button" data-bs-toggle="dropdown" t-attf-class="dropdown-toggle user-select-none #{_link_class}">
                     <t t-if="_avatar">
                         <t t-set="avatar_source" t-value="image_data_uri(user_id.avatar_256)"/>
                         <img t-att-src="avatar_source" t-attf-class="rounded-circle o_object_fit_cover #{_avatar_class}" width="24" height="24" alt="" loading="eager"/>
@@ -272,7 +272,7 @@
                     <div t-if="searchbar_sortings" class="form-inline">
                         <span class="small me-1 navbar-text">Sort By:</span>
                         <div class="btn-group">
-                            <button id="portal_searchbar_sortby" data-bs-toggle="dropdown" class="btn btn-secondary btn-sm dropdown-toggle">
+                            <button id="portal_searchbar_sortby" data-bs-toggle="dropdown" class="btn btn-secondary btn-sm dropdown-toggle user-select-none">
                                 <t t-esc="searchbar_sortings[sortby].get('label', 'Newest')"/>
                             </button>
                             <div class="dropdown-menu" aria-labelledby="portal_searchbar_sortby">
@@ -288,7 +288,7 @@
                     <div t-if="searchbar_filters" class="form-inline ms-lg-2">
                         <span class="small me-1 navbar-text">Filter By:</span>
                         <div class="btn-group">
-                            <button id="portal_searchbar_filters" data-bs-toggle="dropdown" class="btn btn-secondary btn-sm dropdown-toggle">
+                            <button id="portal_searchbar_filters" data-bs-toggle="dropdown" class="btn btn-secondary btn-sm dropdown-toggle user-select-none">
                                 <t t-esc="searchbar_filters.get(filterby,searchbar_filters.get('all')).get('label', 'All')"/>
                             </button>
                             <div class="dropdown-menu" aria-labelledby="portal_searchbar_filters">
@@ -304,7 +304,7 @@
                     <div t-if="searchbar_groupby" class="form-inline ms-lg-2">
                         <span class="small me-1 navbar-text">Group By:</span>
                         <div class="btn-group">
-                            <button id="portal_searchbar_groupby" data-bs-toggle="dropdown" class="btn btn-secondary btn-sm dropdown-toggle">
+                            <button id="portal_searchbar_groupby" data-bs-toggle="dropdown" class="btn btn-secondary btn-sm dropdown-toggle user-select-none">
                                 <t t-esc="searchbar_groupby[groupby].get('label', 'None')"/>
                             </button>
                             <div class="dropdown-menu" aria-labelledby="portal_searchbar_groupby">
@@ -321,7 +321,7 @@
                 </div>
                 <form t-if="searchbar_inputs" class="form-inline o_portal_search_panel ms-lg-4 col-xl-4 col-md-5">
                     <div class="input-group input-group-sm w-100">
-                        <button type="button" class="btn btn-secondary dropdown-toggle" data-bs-toggle="dropdown"/>
+                        <button type="button" class="btn btn-secondary dropdown-toggle user-select-none" data-bs-toggle="dropdown"/>
                         <div class="dropdown-menu" role="menu">
                             <t t-foreach='searchbar_inputs' t-as='input'>
                                 <a t-att-href="'#' + input_value['input']"

--- a/addons/project/views/project_sharing_views.xml
+++ b/addons/project/views/project_sharing_views.xml
@@ -74,7 +74,7 @@
                                     <t t-else="record.email_from.raw_value"><span><field name="email_from"/></span></t>
                                 </div>
                                 <div class="o_dropdown_kanban dropdown" t-if="!selection_mode">
-                                    <a role="button" class="dropdown-toggle o-no-caret btn" data-bs-toggle="dropdown" data-bs-display="static" href="#" aria-label="Dropdown menu" title="Dropdown menu">
+                                    <a role="button" class="dropdown-toggle user-select-none o-no-caret btn" data-bs-toggle="dropdown" data-bs-display="static" href="#" aria-label="Dropdown menu" title="Dropdown menu">
                                         <span class="fa fa-ellipsis-v"/>
                                     </a>
                                     <div class="dropdown-menu" role="menu">

--- a/addons/project/views/project_views.xml
+++ b/addons/project/views/project_views.xml
@@ -1428,7 +1428,7 @@
                                         <t t-else="record.email_from.raw_value"><span><field name="email_from"/></span></t>
                                     </div>
                                     <div class="o_dropdown_kanban dropdown" t-if="!selection_mode" groups="base.group_user">
-                                        <a role="button" class="dropdown-toggle o-no-caret btn" data-bs-toggle="dropdown" data-bs-display="static" href="#" aria-label="Dropdown menu" title="Dropdown menu">
+                                        <a role="button" class="dropdown-toggle o-no-caret btn user-select-none" data-bs-toggle="dropdown" data-bs-display="static" href="#" aria-label="Dropdown menu" title="Dropdown menu">
                                             <span class="fa fa-ellipsis-v"/>
                                         </a>
                                         <div class="dropdown-menu" role="menu">

--- a/addons/stock/static/src/xml/report_stock_forecasted.xml
+++ b/addons/stock/static/src/xml/report_stock_forecasted.xml
@@ -10,7 +10,7 @@
 <t t-name="warehouseFilter">
     <div id="warehouse_filter" class="btn-group dropdown o_stock_report_warehouse_filter"
         t-if="displayWarehouseFilter">
-        <button type="button" class="dropdown-toggle btn btn-secondary dropdown-toggle"
+        <button type="button" class="dropdown-toggle btn btn-secondary dropdown-toggle user-select-none"
             data-bs-toggle="dropdown">
             <span class="fa fa-home"/> Warehouse: <t t-esc="active_warehouse['name']"/>
         </button>

--- a/addons/survey/views/survey_survey_views.xml
+++ b/addons/survey/views/survey_survey_views.xml
@@ -314,7 +314,7 @@
                                 attrs="{'invisible': [('active', '=', True)]}"/>
                             <div class="o_dropdown_kanban dropdown" t-if="widget.editable">
                                 <a href="#" role="button"
-                                    class="dropdown-toggle o-no-caret btn"
+                                    class="dropdown-toggle user-select-none o-no-caret btn"
                                     data-bs-toggle="dropdown" data-bs-display="static"
                                     aria-label="Dropdown menu" title="Dropdown menu">
                                     <span class="fa fa-ellipsis-v"/>

--- a/addons/survey/views/survey_templates_statistics.xml
+++ b/addons/survey/views/survey_templates_statistics.xml
@@ -129,7 +129,7 @@
                         <t t-set="dropdown_item_classes">dropdown-item d-flex align-items-center justify-content-between</t>
                         <li class="nav-item dropdown me-2 my-1">
                             <a href="#" role="button" data-bs-toggle="dropdown"
-                               t-attf-class="btn btn-outline-primary dropdown-toggle #{'active' if search_finished else ''}">
+                               t-attf-class="btn btn-outline-primary dropdown-toggle user-select-none #{'active' if search_finished else ''}">
                                 <span t-if="search_finished">Completed surveys</span>
                                 <span t-else="">All surveys</span>
                             </a>
@@ -146,7 +146,7 @@
                         </li>
                         <li t-if="survey.scoring_type != 'no_scoring'" class="nav-item dropdown me-2 my-1">
                             <a href="#" role="button" data-bs-toggle="dropdown"
-                               t-attf-class="btn btn-outline-primary dropdown-toggle #{'active' if search_passed_or_failed else ''}">
+                               t-attf-class="btn btn-outline-primary dropdown-toggle user-select-none #{'active' if search_passed_or_failed else ''}">
                                 <span t-if="search_failed">Failed only</span>
                                 <span t-elif="search_passed">Passed only</span>
                                 <span t-else="">Passed and Failed</span>

--- a/addons/utm/views/utm_campaign_views.xml
+++ b/addons/utm/views/utm_campaign_views.xml
@@ -85,7 +85,7 @@
                     <t t-name="kanban-box">
                         <div t-attf-class="oe_kanban_color_#{kanban_getcolor(record.color.raw_value)} oe_kanban_card oe_kanban_global_click">
                             <div class="o_dropdown_kanban dropdown">
-                                <a role="button" class="dropdown-toggle o-no-caret btn" data-bs-toggle="dropdown" href="#" aria-label="Dropdown menu" title="Dropdown menu">
+                                <a role="button" class="dropdown-toggle user-select-none o-no-caret btn" data-bs-toggle="dropdown" href="#" aria-label="Dropdown menu" title="Dropdown menu">
                                     <span class="fa fa-ellipsis-v"/>
                                 </a>
                                 <div class="dropdown-menu" role="menu">

--- a/addons/web/static/src/core/debug/profiling/profiling_qweb.xml
+++ b/addons/web/static/src/core/debug/profiling/profiling_qweb.xml
@@ -2,9 +2,9 @@
 <templates xml:space="preserve">
 
 <t t-name="web.ProfilingQwebView">
-    <div class="oe_form_field o_ace_view_editor oe_ace_open o_profiling_qweb_view">
+    <div class="oe_form_field o_ace_view_editor oe_ace_open o_profiling_qweb_view user-select-none">
         <div class="o_select_view_profiling">
-            <a role="button" class="dropdown-toggle" data-bs-toggle="dropdown" aria-expanded="false" href="#"></a>
+            <a role="button" class="dropdown-toggle user-select-none" data-bs-toggle="dropdown" aria-expanded="false" href="#"></a>
             <div class="dropdown-menu" role="menu">
                 <t t-foreach="widget.views" t-as="view">
                     <a role="menuitem" href="#" t-att-data-id="view.id">

--- a/addons/web/static/src/core/dropdown/dropdown.xml
+++ b/addons/web/static/src/core/dropdown/dropdown.xml
@@ -14,7 +14,7 @@
     >
       <button
         t-if="props.toggler !== 'parent'"
-        class="dropdown-toggle"
+        class="dropdown-toggle user-select-none"
         t-attf-class="
           {{props.togglerClass || ''}}
           {{parentDropdown ? 'dropdown-item' : ''}}

--- a/addons/web/static/src/core/pager/pager.xml
+++ b/addons/web/static/src/core/pager/pager.xml
@@ -2,7 +2,7 @@
 <templates xml:space="preserve">
 
     <t t-name="web.Pager" owl="1">
-        <nav class="o_pager align-items-center d-flex gap-2" aria-label="Pager">
+        <nav class="o_pager align-items-center d-flex gap-2 user-select-none" aria-label="Pager">
             <span class="o_pager_counter" t-on-click.stop="">
                 <t t-if="state.isEditing">
                     <input type="text" class="o_pager_value o_input d-inline-block w-auto text-end" size="7" t-ref="autofocus" t-att-value="value" t-on-blur="onInputBlur" t-on-change="onInputChange" t-on-keydown.stop="onInputKeydown" />

--- a/addons/web/static/src/legacy/js/core/menu.js
+++ b/addons/web/static/src/legacy/js/core/menu.js
@@ -180,7 +180,7 @@ export async function initAutoMoreMenu(el, options) {
         Object.entries({
             role: 'button',
             href: '#',
-            class: 'nav-link dropdown-toggle o-no-caret',
+            class: 'nav-link dropdown-toggle user-select-none o-no-caret',
             'data-bs-toggle': 'dropdown',
             'aria-expanded': false,
         }).forEach(([key, value]) => {

--- a/addons/web/static/src/legacy/js/views/form/form_renderer.js
+++ b/addons/web/static/src/legacy/js/views/form/form_renderer.js
@@ -567,7 +567,7 @@ var FormRenderer = BasicRenderer.extend({
             if (folded_buttons.length) {
                 $result.append(dom.renderButton({
                     attrs: {
-                        'class': 'oe_stat_button o_button_more dropdown-toggle',
+                        'class': 'oe_stat_button o_button_more dropdown-toggle user-select-none',
                         'data-bs-toggle': 'dropdown',
                     },
                     text: _t("More"),

--- a/addons/web/static/src/legacy/js/views/list/list_renderer.js
+++ b/addons/web/static/src/legacy/js/views/list/list_renderer.js
@@ -939,7 +939,7 @@ var ListRenderer = BasicRenderer.extend({
             .attr('tabindex', -1)
             .toggleClass('o-sort-down', isNodeSorted ? !order[0].asc : false)
             .toggleClass('o-sort-up', isNodeSorted ? order[0].asc : false)
-            .addClass((field.sortable || this.state.fieldsInfo.list[name].options.allow_order || false) && 'o_column_sortable');
+            .addClass((field.sortable || this.state.fieldsInfo.list[name].options.allow_order || false) && 'o_column_sortable user-select-none');
 
         if (isNodeSorted) {
             $th.attr('aria-sort', order[0].asc ? 'ascending' : 'descending');
@@ -1010,7 +1010,7 @@ var ListRenderer = BasicRenderer.extend({
             class: 'o_optional_columns text-center dropdown',
         });
         var $a = $("<a>", {
-            'class': "dropdown-toggle text-dark o-no-caret",
+            'class': "dropdown-toggle text-dark o-no-caret user-select-none",
             'href': "#",
             'role': "button",
             'data-bs-toggle': "dropdown",
@@ -1027,7 +1027,7 @@ var ListRenderer = BasicRenderer.extend({
         var direction = _t.database.parameters.direction;
         var dropdownMenuClass = direction === 'rtl' ? 'dropdown-menu-start' : 'dropdown-menu-end';
         var $dropdown = $("<div>", {
-            class: 'dropdown-menu o_optional_columns_dropdown ' + dropdownMenuClass,
+            class: 'dropdown-menu o_optional_columns_dropdown user-select-none ' + dropdownMenuClass,
             role: 'menu',
         });
         this.optionalColumns.forEach(function (col) {

--- a/addons/web/static/src/legacy/scss/fields.scss
+++ b/addons/web/static/src/legacy/scss/fields.scss
@@ -179,7 +179,6 @@
             margin: 1px 2px 1px 0;
             border: 0;
             font-size: 12px;
-            user-select: none;
             display: flex;
             max-width: 100%;
 

--- a/addons/web/static/src/legacy/scss/list_view.scss
+++ b/addons/web/static/src/legacy/scss/list_view.scss
@@ -82,7 +82,6 @@
 
         .o_column_sortable:not(.o_handle_cell) {
             position: relative;
-            user-select: none;  // Prevent unwanted selection while sorting
 
             &::after {
                 font-family: FontAwesome;
@@ -158,7 +157,6 @@
             }
             .o_pager {
                 cursor: text;
-                user-select: none;
                 text-align: right;
                 padding-top: 0 !important;
                 padding-bottom: 0 !important;
@@ -356,7 +354,6 @@
 
     .o_optional_columns {
         .o_optional_columns_dropdown {
-            user-select: none;
             .dropdown-item {
                 label {
                     padding-left: 10px;

--- a/addons/web/static/src/legacy/scss/pivot_view.scss
+++ b/addons/web/static/src/legacy/scss/pivot_view.scss
@@ -42,7 +42,6 @@
             background-color: lighten($o-brand-secondary, 40%);
             cursor: pointer;
             white-space: nowrap;
-            user-select: none;
             &:hover {
                 background-color: lighten($o-brand-secondary, 30%);
             }
@@ -54,7 +53,6 @@
 
         .o_pivot_header_cell {
             white-space: nowrap;
-            user-select: none;
         }
 
         .o_pivot_header_cell_closed {

--- a/addons/web/static/src/legacy/scss/profiling_qweb_view.scss
+++ b/addons/web/static/src/legacy/scss/profiling_qweb_view.scss
@@ -3,7 +3,6 @@
 }
 
 .o_profiling_qweb_view {
-    user-select: none;
     .o_select_view_profiling {
         margin-bottom: 10px;
         .dropdown-menu {

--- a/addons/web/static/src/legacy/scss/ribbon.scss
+++ b/addons/web/static/src/legacy/scss/ribbon.scss
@@ -27,7 +27,6 @@
         text-transform: uppercase;
         text-align: center;
         overflow: hidden;
-        user-select: none;
         &.o_small {
             font-size: 12px;
         }

--- a/addons/web/static/src/legacy/scss/views.scss
+++ b/addons/web/static/src/legacy/scss/views.scss
@@ -105,6 +105,5 @@
     .o_sample_data_disabled {
         opacity: 0.33;
         pointer-events: none;
-        user-select: none;
     }
 }

--- a/addons/web/static/src/legacy/xml/base.xml
+++ b/addons/web/static/src/legacy/xml/base.xml
@@ -151,7 +151,7 @@
 <t t-name="web.DropdownMenu" owl="1">
     <div class="btn-group dropdown" t-att-class="{ show: state.open }">
         <button type="button"
-            class="dropdown-toggle btn btn-secondary o-no-caret"
+            class="dropdown-toggle btn btn-secondary user-select-none o-no-caret"
             t-attf-class="{{ icon || displayCaret || displayChevron ? 'd-flex align-items-center ' : ''}} {{ displayCaret || displayChevron ? 'pe-1 ' : ''}}"
             t-att-aria-expanded="state.open ? 'true' : 'false'"
             tabindex="-1"
@@ -290,7 +290,7 @@
 </t>
 
 <t t-name="web.legacy.Pager" owl="1">
-    <nav class="o_pager align-items-center d-flex gap-2" aria-label="Pager">
+    <nav class="o_pager align-items-center d-flex gap-2 user-select-none" aria-label="Pager">
         <span class="o_pager_counter" t-on-click.stop="">
             <input t-if="state.editing" type="text"
                 class="o_pager_value o_input d-inline-block w-auto text-end"
@@ -755,7 +755,7 @@
 
 <t t-name="PivotView.buttons">
     <div class="btn-group" role="toolbar" aria-label="Main actions">
-        <button class="btn btn-primary dropdown-toggle o-no-caret" data-bs-toggle="dropdown" aria-expanded="false">
+        <button class="btn btn-primary dropdown-toggle user-select-none o-no-caret" data-bs-toggle="dropdown" aria-expanded="false">
             Measures <i class="fa fa-caret-down ms-1"/>
         </button>
         <div class="dropdown-menu o_pivot_measures_list" role="menu">
@@ -1064,12 +1064,12 @@
     <t t-foreach="elements" t-as="el" t-key="el_index">
         <t t-set="color" t-value="el[colorField] || 0"/>
         <t t-set="colornames" t-value="['No color', 'Red', 'Orange', 'Yellow', 'Light blue', 'Dark purple', 'Salmon pink', 'Medium blue', 'Dark blue', 'Fushia', 'Green', 'Purple']"/>
-        <div t-attf-class="badge rounded-pill #{hasDropdown ? 'dropdown' : ''} o_tag_color_#{color}" t-att-data-color="color" t-att-data-index="el_index" t-att-data-id="el.id" t-attf-title="Tag color: #{colornames[color]}">
+        <div t-attf-class="badge rounded-pill user-select-none #{hasDropdown ? 'dropdown' : ''} o_tag_color_#{color}" t-att-data-color="color" t-att-data-index="el_index" t-att-data-id="el.id" t-attf-title="Tag color: #{colornames[color]}">
             <t t-set="_badge_text">
                 <span class="o_badge_text" t-att-title="el.display_name"><span role="img" t-attf-aria-label="Tag color: #{colornames[color]}"/><span class="o_tag_badge_text" t-esc="el.display_name"/></span>
             </t>
             <t t-if="hasDropdown">
-                <a role="button" href="#" class="dropdown-toggle o-no-caret" aria-expanded="false">
+                <a role="button" href="#" class="dropdown-toggle user-select-none o-no-caret" aria-expanded="false">
                     <t t-out="_badge_text"/>
                 </a>
             </t>

--- a/addons/web/static/src/legacy/xml/fields.xml
+++ b/addons/web/static/src/legacy/xml/fields.xml
@@ -7,7 +7,7 @@
     </t>
 
     <t t-name="web.FieldBadge" owl="1">
-        <span class="badge rounded-pill o_field_badge" t-esc="_formatValue(value)"/>
+        <span class="badge rounded-pill user-select-none o_field_badge" t-esc="_formatValue(value)"/>
     </t>
 
 </templates>

--- a/addons/web/static/src/legacy/xml/kanban.xml
+++ b/addons/web/static/src/legacy/xml/kanban.xml
@@ -16,7 +16,7 @@
                 <span t-attf-id="#kanban_header_#{widget.id or widget.db_id}" class="o_column_title"><t t-esc="widget.title"/></span>
                 <span class="o_column_unfold"><i class="fa fa-arrows-h" role="img" aria-label="Unfold" title="Unfold"/></span>
                 <span class="o_kanban_config dropdown">
-                    <a class="dropdown-toggle o-no-caret" data-bs-toggle="dropdown" href="#"><i class="fa fa-gear" role="img" aria-label="Settings" title="Settings"/></a>
+                    <a class="dropdown-toggle user-select-none o-no-caret" data-bs-toggle="dropdown" href="#"><i class="fa fa-gear" role="img" aria-label="Settings" title="Settings"/></a>
                     <div class="dropdown-menu o_cursor_default" role="menu">
                         <a t-if="!widget.isMobile" role="menuitem" class="dropdown-item o_kanban_toggle_fold" href="#">Fold</a>
                         <t t-if="widget.grouped_by_m2o">

--- a/addons/web/static/src/legacy/xml/pivot.xml
+++ b/addons/web/static/src/legacy/xml/pivot.xml
@@ -56,8 +56,8 @@
 
     <t t-name="web.legacy.PivotHeader" owl="1">
         <th t-att-colspan="isXAxis ? cell.width : undefined" t-att-rowspan="isXAxis ? cell.height : undefined" t-att-class="{
-                o_pivot_header_cell_closed: cell.isLeaf,
-                o_pivot_header_cell_opened: !cell.isLeaf,
+                'o_pivot_header_cell_closed user-select-none': cell.isLeaf,
+                'o_pivot_header_cell_opened user-select-none': !cell.isLeaf,
             }" t-attf-style="{{ isXAxis ? undefined : 'padding-left: ' + _getPadding(cell) + 'px;' }}" t-att-title="cell.label" t-on-click.self.prevent="() => this._onHeaderClick(cell, isXAxis ? 'col' : 'row')">
             <span t-on-click.self.prevent="() => this._onHeaderClick(cell, isXAxis ? 'col' : 'row')" t-esc="cell.title"/>
             <t t-if="cell.isLeaf and !cell.isFolded" t-call="web.legacy.PivotGroupBySelection"/>
@@ -67,7 +67,7 @@
     <t t-name="web.legacy.PivotMeasure" owl="1">
         <th class="text-muted" t-att-colspan="cell.width" t-att-rowspan="cell.height" t-att-class="{
                 o_pivot_origin_row: cell.originIndexes,
-                o_pivot_measure_row: !cell.originIndexes,
+                'o_pivot_measure_row user-select-none': !cell.originIndexes,
                 o_pivot_sort_order_asc: cell.order === 'asc',
                 o_pivot_sort_order_desc: cell.order === 'desc',
             }" t-on-click.prevent="() => this.trigger('sort_rows',cell)" t-on-mouseover="_onMouseEnter" t-on-mouseout="_onMouseLeave">

--- a/addons/web/static/src/legacy/xml/ribbon.xml
+++ b/addons/web/static/src/legacy/xml/ribbon.xml
@@ -3,7 +3,7 @@
 
     <t t-name="web.ribbon">
         <div class="ribbon ribbon-top-right">
-            <span t-att-class="widget.className" t-att-title="widget.tooltip">
+            <span t-att-class="widget.className + ' user-select-none'" t-att-title="widget.tooltip">
                 <t t-esc="widget.text"/>
             </span>
         </div>

--- a/addons/web/static/src/search/control_panel/control_panel.scss
+++ b/addons/web/static/src/search/control_panel/control_panel.scss
@@ -77,7 +77,6 @@
             margin: auto 0 auto auto;
             padding-left: 5px;
             text-align: center;
-            user-select: none;
         }
 
         > .o_cp_switch_buttons {

--- a/addons/web/static/src/search/control_panel/control_panel.xml
+++ b/addons/web/static/src/search/control_panel/control_panel.xml
@@ -30,7 +30,7 @@
                             </div>
                         </t>
 
-                        <div class="o_cp_pager" role="search">
+                        <div class="o_cp_pager user-select-none" role="search">
                                 <Pager t-if="pagerProps and pagerProps.total > 0" t-props="pagerProps"/>
                         </div>
 

--- a/addons/web/static/src/search/search_panel/search_panel.scss
+++ b/addons/web/static/src/search/search_panel/search_panel.scss
@@ -47,7 +47,6 @@ $o-searchpanel-filter-default-color: #D59244;
         cursor: pointer;
         display: flex;
         justify-content: space-between;
-        user-select: none;
         width: 100%;
     }
 

--- a/addons/web/static/src/search/search_panel/search_panel.xml
+++ b/addons/web/static/src/search/search_panel/search_panel.xml
@@ -37,7 +37,7 @@
                                     t-on-click="() => this.toggleFilterGroup(section.id, group)"
                                 />
                                 <label t-attf-for="{{ section.id }}_input_{{ groupId }})"
-                                    class="o_search_panel_label form-check-label"
+                                    class="o_search_panel_label user-select-none form-check-label"
                                     t-att-class="{ o_with_counters: group.enableCounters }"
                                     t-att-title="group.tooltip or false"
                                     >
@@ -81,7 +81,7 @@
                 t-att-class="{ active: state.active[section.id] === valueId }"
                 t-on-click="() => this.toggleCategory(section, value)"
                 >
-                <label class="o_search_panel_label mb0" t-att-class="{ o_with_counters: section.enableCounters }">
+                <label class="o_search_panel_label mb0 user-select-none" t-att-class="{ o_with_counters: section.enableCounters }">
                     <div class="o_toggle_fold">
                         <i t-if="value.childrenIds.length"
                             t-attf-class="fa fa-caret-{{ state.expanded[section.id][valueId] ? 'down' : 'right' }}"
@@ -116,7 +116,7 @@
                 class="form-check-input"
                 t-on-click="ev => this.toggleFilterValue(section.id, valueId, ev)"
             />
-            <label class="o_search_panel_label form-check-label"
+            <label class="o_search_panel_label user-select-none form-check-label"
                 t-attf-for="{{ section.id }}_input_{{ valueId }}"
                 t-att-title="(group and group.tooltip) or false">
                 <span class="o_search_panel_label_title" t-esc="value.display_name"/>

--- a/addons/web/static/src/views/fields/badge/badge_field.scss
+++ b/addons/web/static/src/views/fields/badge/badge_field.scss
@@ -2,7 +2,6 @@
 .o_field_badge span, span.o_field_badge {
     border: 0;
     font-size: 12px;
-    user-select: none;
     background-color: rgba(lightgray, 0.5);
     font-weight: 500;
     @include o-text-overflow;

--- a/addons/web/static/src/views/fields/badge/badge_field.xml
+++ b/addons/web/static/src/views/fields/badge/badge_field.xml
@@ -2,7 +2,7 @@
 <templates id="template" xml:space="preserve">
 
     <t t-name="web.BadgeField" owl="1">
-        <span t-if="props.value" class="badge rounded-pill" t-att-class="classFromDecoration" t-esc="formattedValue" />
+        <span t-if="props.value" class="badge rounded-pill user-select-none" t-att-class="classFromDecoration" t-esc="formattedValue" />
     </t>
 
 </templates>

--- a/addons/web/static/src/views/fields/many2many_tags/tags_list.scss
+++ b/addons/web/static/src/views/fields/many2many_tags/tags_list.scss
@@ -2,8 +2,6 @@
     gap: 2px;
 
     .o_tag {
-        user-select: none;
-    
         .o_badge_text, a {
             color: inherit;
         }

--- a/addons/web/static/src/views/fields/many2many_tags/tags_list.xml
+++ b/addons/web/static/src/views/fields/many2many_tags/tags_list.xml
@@ -4,7 +4,7 @@
     <t t-name="web.TagsList" owl="1">
         <span t-if="visibleTags.length" t-attf-class="o_tags_list {{props.className}} d-inline-flex flex-wrap" t-att-name="props.name">
             <t t-if="props.tags" t-foreach="visibleTags" t-as="tag" t-key="tag.id or tag_index">
-                <span t-attf-class="{{`o_tag_color_${ tag.colorIndex or 0 } ${props.displayBadge ? 'badge rounded-pill' : ''}`}} o_tag d-inline-flex align-items-center h-100" tabindex="-1" t-att-data-color="tag.colorIndex" t-att-title="tag.text" t-on-click="(ev) => tag.onClick and tag.onClick(ev)">
+                <span t-attf-class="{{`o_tag_color_${ tag.colorIndex or 0 } ${props.displayBadge ? 'badge rounded-pill' : ''}`}} o_tag d-inline-flex align-items-center h-100 user-select-none" tabindex="-1" t-att-data-color="tag.colorIndex" t-att-title="tag.text" t-on-click="(ev) => tag.onClick and tag.onClick(ev)">
                     <img t-if="tag.img" t-att-src="tag.img" class="o_m2m_avatar rounded-circle"/>
                     <div t-if="props.displayBadge" class="o_tag_badge_text" t-esc="tag.text" />
                     <t t-else="">

--- a/addons/web/static/src/views/graph/graph_controller.xml
+++ b/addons/web/static/src/views/graph/graph_controller.xml
@@ -56,7 +56,7 @@
                         <t t-set="noContentHelp" t-value="props.info.noContentHelp"/>
                     </t>
                     <t t-component="props.Renderer"
-                        class="model.useSampleModel ? 'o_sample_data_disabled' : ''"
+                        class="model.useSampleModel ? 'o_sample_data_disabled user-select-none' : ''"
                         model="model"
                         onGraphClicked="(domain) => this.onGraphClicked(domain)"
                         />

--- a/addons/web/static/src/views/list/list_controller.scss
+++ b/addons/web/static/src/views/list/list_controller.scss
@@ -81,7 +81,6 @@
 
         .o_column_sortable:not(.o_handle_cell) {
             position: relative;
-            user-select: none;  // Prevent unwanted selection while sorting
 
             &::after {
                 font-family: FontAwesome;
@@ -157,7 +156,6 @@
             }
             .o_pager {
                 cursor: text;
-                user-select: none;
                 text-align: right;
                 padding-top: 0 !important;
                 padding-bottom: 0 !important;
@@ -356,7 +354,6 @@
     .o_optional_columns {
         .o_optional_columns_dropdown {
             margin-top: 30px;
-            user-select: none;
             .dropdown-item {
                 label {
                     padding-left: 10px;

--- a/addons/web/static/src/views/list/list_renderer.js
+++ b/addons/web/static/src/views/list/list_renderer.js
@@ -531,7 +531,7 @@ export class ListRenderer extends Component {
         const field = this.fields[column.name];
         const classNames = [];
         if (field.sortable && column.hasLabel) {
-            classNames.push("o_column_sortable");
+            classNames.push("o_column_sortable user-select-none");
         }
         const orderBy = this.props.list.orderBy;
         if (orderBy.length && orderBy[0].name === column.name) {

--- a/addons/web/static/src/views/list/list_renderer.xml
+++ b/addons/web/static/src/views/list/list_renderer.xml
@@ -68,7 +68,7 @@
                         <td t-if="props.activeActions and props.activeActions.onDelete"/>
                     </tr>
                 </tfoot>
-                <Dropdown t-if="getOptionalFields.length" class="'o_optional_columns_dropdown'" position="'bottom-end'">
+                <Dropdown t-if="getOptionalFields.length" class="'o_optional_columns_dropdown user-select-none'" position="'bottom-end'">
                     <t t-set-slot="toggler">
                         <i class="oi oi-settings-adjust o_optional_columns_dropdown_toggle"/>
                     </t>

--- a/addons/web/static/src/views/pivot/pivot_renderer.xml
+++ b/addons/web/static/src/views/pivot/pivot_renderer.xml
@@ -8,7 +8,7 @@
                 class="table-hover table table-sm table-bordered table-borderless bg-white"
                 t-att-class="{
                     o_enable_linking: !model.metaData.disableLinking,
-                    o_sample_data_disabled: model.useSampleModel,
+                    'o_sample_data_disabled bg-info': model.useSampleModel,
                 }"
                 t-ref="table"
             >
@@ -61,8 +61,8 @@
             t-att-colspan="isXAxis ? cell.width : undefined"
             t-att-rowspan="isXAxis ? cell.height : undefined"
             t-att-class="{
-                o_pivot_header_cell_closed: cell.isLeaf,
-                o_pivot_header_cell_opened: !cell.isLeaf,
+                'o_pivot_header_cell_closed user-select-none': cell.isLeaf,
+                'o_pivot_header_cell_opened user-select-none': !cell.isLeaf,
             }"
             t-attf-style="{{
                 isXAxis
@@ -94,8 +94,8 @@
 
     <t t-name="web.PivotMeasure" owl="1">
         <th class="text-muted text-center text-nowrap fw-normal bg-100" t-att-colspan="cell.width" t-att-rowspan="cell.height" t-att-class="{
-                'o_pivot_origin_row o_cursor_pointer': cell.originIndexes,
-                'o_pivot_measure_row o_cursor_pointer': !cell.originIndexes,
+                'o_pivot_origin_row o_cursor_pointer user-select-none': cell.originIndexes,
+                'o_pivot_measure_row o_cursor_pointer user-select-none': !cell.originIndexes,
                 o_pivot_sort_order_asc: cell.order === 'asc',
                 o_pivot_sort_order_desc: cell.order === 'desc',
             }" t-on-click.prevent="() => this.onMeasureClick(cell)" t-on-mouseover="onMouseEnter" t-on-mouseout="onMouseLeave">

--- a/addons/web/static/src/views/pivot/pivot_view.scss
+++ b/addons/web/static/src/views/pivot/pivot_view.scss
@@ -16,9 +16,6 @@
     .o_pivot_origin_row,
     .o_pivot_header_cell_closed,
     .o_pivot_header_cell_opened {
-        // "user-select-none" class doesn't exist in BS 4.3.1, the user-select property
-        // could be replaced by a class after the migration to BS5
-        user-select: none;
         @include o-hover-text-color($body-color, $headings-color);
 
         &:hover {

--- a/addons/web/static/src/views/view_dialogs/export_data_dialog.scss
+++ b/addons/web/static/src/views/view_dialogs/export_data_dialog.scss
@@ -7,7 +7,6 @@
             height: inherit;
 
             .o_left_field_panel, .o_right_field_panel {
-                user-select: none;
                 .o_export_tree_item {
                     &:hover:not(.o_expanded) {
                         background: rgba($o-brand-odoo, .3);

--- a/addons/web/static/src/views/view_dialogs/export_data_dialog.xml
+++ b/addons/web/static/src/views/view_dialogs/export_data_dialog.xml
@@ -40,7 +40,7 @@
                 </div>
                 <h4 class="mt-3">Available fields</h4>
                 <input t-ref="search" type="search" class="form-control mb-3 o_export_search_input" id="o-export-search-filter" placeholder="Search" t-on-input="onSearch" />
-                <div class="o_left_field_panel h-100 overflow-auto border">
+                <div class="o_left_field_panel h-100 overflow-auto border user-select-none">
                     <div class="o_field_tree_structure">
                         <t t-if="fieldsAvailable">
                             <t t-foreach="rootFields" t-as="field" t-key="field.name">
@@ -104,7 +104,7 @@
                         </t>
                     </div>
                 </div>
-                <div class="o_right_field_panel h-100 px-2 overflow-auto border">
+                <div class="o_right_field_panel h-100 px-2 overflow-auto border user-select-none">
                     <ul class="o_fields_list list-unstyled" t-ref="draggable">
                         <t t-foreach="state.exportList" t-as="field" t-key="field.name">
                             <li class="o_export_field" t-att-data-field_id="field.name">

--- a/addons/web/static/src/webclient/burger_menu/burger_menu.xml
+++ b/addons/web/static/src/webclient/burger_menu/burger_menu.xml
@@ -5,7 +5,7 @@
 
 <div t-name="web.BurgerMenu" owl="1">
     <a type="button"
-        class="o_mobile_menu_toggle dropdown-toggle o-no-caret d-md-none"
+        class="o_mobile_menu_toggle dropdown-toggle user-select-none o-no-caret d-md-none"
         title="Toggle menu" aria-label="Toggle menu"
         t-on-click="_openBurger">
         <i class="oi oi-panel-right"/>
@@ -15,7 +15,7 @@
         <div class="o_burger_menu d-flex flex-column flex-nowrap position-fixed" t-att-class="transition.className" t-on-touchstart.stop="_onSwipeStart" t-on-touchend.stop="_onSwipeEnd">
           <div class="o_burger_menu_topbar d-flex align-items-center justify-content-between"
               t-on-click.stop='_toggleUserMenu'>
-              <span class="dropdown-toggle small d-flex align-items-center justify-content-between o-no-caret" t-att-class="{active: isUserMenuUnfolded}">
+              <span class="dropdown-toggle small d-flex align-items-center justify-content-between user-select-none o-no-caret" t-att-class="{active: isUserMenuUnfolded}">
                   <img class="o_burger_menu_avatar o_image_24_cover rounded-circle" t-att-src="'/web/image?model=res.users&amp;field=avatar_128&amp;id=' + user.userId" alt="Menu"/>
                   <span class="o_burger_menu_username px-2"><t t-esc="user.name"/></span>
                   <i t-if="isUserMenuTogglable" class="fa" t-att-class="state.isUserMenuOpened ? 'fa-caret-down' : 'fa-caret-left'"/>
@@ -50,7 +50,7 @@
 
 <t t-name="web.BurgerSection" owl="1">
     <div t-if="section.childrenTree.length" t-key="section.id" class="dropdown o_burger_menu_section show">
-        <button class="dropdown-toggle" t-att-data-menu-xmlid="section.xmlid">
+        <button class="dropdown-toggle user-select-none" t-att-data-menu-xmlid="section.xmlid">
             <span t-esc="section.name"/>
         </button>
         <div class="dropdown-menu d-block">

--- a/addons/web/static/src/webclient/navbar/navbar.variables.scss
+++ b/addons/web/static/src/webclient/navbar/navbar.variables.scss
@@ -29,7 +29,6 @@ $o-navbar-badge-bg: $o-success !default;
     align-items: center;
     width: auto;
     height: var(--o-navbar-height, #{$o-navbar-height});
-    user-select: none;
     background: transparent;
     font-size: $o-navbar-entry-font-size;
 

--- a/addons/web/static/src/webclient/navbar/navbar.xml
+++ b/addons/web/static/src/webclient/navbar/navbar.xml
@@ -17,7 +17,7 @@
           t-if="currentApp"
           href="getMenuItemHref(currentApp)"
           t-esc="currentApp.name"
-          class="'o_menu_brand d-none d-md-block'"
+          class="'o_menu_brand d-none d-md-block user-select-none'"
           dataset="{ menuXmlid: currentApp.xmlid, section: currentApp.id }"
           onSelected="() => this.onNavBarDropdownItemSelection(currentApp)"
         />
@@ -78,7 +78,7 @@
         <t t-if="!section.childrenTree.length">
           <DropdownItem
             title="section.name"
-            class="'o_nav_entry'"
+            class="'o_nav_entry user-select-none'"
             href="getMenuItemHref(section)"
             hotkey="hotkey"
             t-esc="section.name"

--- a/addons/web/static/tests/core/dropdown_tests.js
+++ b/addons/web/static/tests/core/dropdown_tests.js
@@ -48,7 +48,7 @@ QUnit.module("Components", ({ beforeEach }) => {
         await mount(Parent, target, { env });
         assert.strictEqual(
             target.querySelector(".dropdown").outerHTML,
-            '<div class="o-dropdown dropdown o-dropdown--no-caret"><button class="dropdown-toggle"></button></div>'
+            '<div class="o-dropdown dropdown o-dropdown--no-caret"><button class="dropdown-toggle user-select-none"></button></div>'
         );
         assert.containsOnce(target, "button.dropdown-toggle");
         assert.containsNone(target, ".dropdown-menu");

--- a/addons/web/static/tests/legacy/views/kanban_tests.js
+++ b/addons/web/static/tests/legacy/views/kanban_tests.js
@@ -5857,7 +5857,7 @@ QUnit.module('LegacyViews', {
                         '<t t-name="kanban-box">' +
                             '<div color="color">' +
                                 '<div class="o_dropdown_kanban dropdown">' +
-                                    '<a class="dropdown-toggle o-no-caret btn" data-bs-toggle="dropdown" href="#">' +
+                                    '<a class="dropdown-toggle user-select-none o-no-caret btn" data-bs-toggle="dropdown" href="#">' +
                                             '<span class="fa fa-bars fa-lg"/>' +
                                     '</a>' +
                                     '<ul class="dropdown-menu" role="menu">' +
@@ -6304,7 +6304,7 @@ QUnit.module('LegacyViews', {
                             '<t t-name="kanban-box">' +
                                 '<div color="color">' +
                                     '<div class="o_dropdown_kanban dropdown">' +
-                                        '<a class="dropdown-toggle o-no-caret btn" data-bs-toggle="dropdown" href="#">' +
+                                        '<a class="dropdown-toggle user-select-none o-no-caret btn" data-bs-toggle="dropdown" href="#">' +
                                             '<span class="fa fa-bars fa-lg"/>' +
                                         '</a>' +
                                         '<ul class="dropdown-menu" role="menu">' +
@@ -7778,7 +7778,7 @@ QUnit.module('LegacyViews', {
                             '<div class="oe_kanban_global_click">' +
                                 '<field name="name"/>' +
                                 '<div class="o_dropdown_kanban dropdown">' +
-                                    '<a class="dropdown-toggle o-no-caret btn" data-bs-toggle="dropdown" href="#">' +
+                                    '<a class="dropdown-toggle user-select-none o-no-caret btn" data-bs-toggle="dropdown" href="#">' +
                                         '<span class="fa fa-bars fa-lg"/>' +
                                     '</a>' +
                                     '<div class="dropdown-menu" role="menu">' +

--- a/addons/web_editor/static/src/js/editor/snippets.editor.js
+++ b/addons/web_editor/static/src/js/editor/snippets.editor.js
@@ -2170,7 +2170,7 @@ var SnippetsMenu = Widget.extend({
         };
 
         this.$snippets = $scroll.find('.o_panel_body').children()
-            .addClass('oe_snippet')
+            .addClass('oe_snippet user-select-none')
             .each((i, el) => {
                 const $snippet = $(el);
                 const name = _.escape(el.getAttribute('name'));

--- a/addons/web_editor/static/src/js/wysiwyg/widgets/link_popover_widget.js
+++ b/addons/web_editor/static/src/js/wysiwyg/widgets/link_popover_widget.js
@@ -97,7 +97,7 @@ const LinkPopoverWidget = Widget.extend({
         })
         .on('inserted.bs.popover.link_popover', () => {
             const popover = Popover.getInstance(this.target);
-            popover.tip.classList.add('o_edit_menu_popover');
+            popover.tip.classList.add('o_edit_menu_popover', 'user-select-none');
         })
         .popover('show');
 

--- a/addons/web_editor/static/src/scss/wysiwyg.scss
+++ b/addons/web_editor/static/src/scss/wysiwyg.scss
@@ -661,9 +661,6 @@ img::selection {
     max-width: $popover-max-width * 1.2;
     // Prevent UI glitch after fetching page preview (size might change)
     width: $popover-max-width * 1.2;
-    // Prevent the edited link from being deselected when clicking between
-    // buttons in the popover
-    user-select: none;
 
     .o_we_preview_favicon > img {
         max-height: 16px;

--- a/addons/web_editor/static/src/scss/wysiwyg_snippets.scss
+++ b/addons/web_editor/static/src/scss/wysiwyg_snippets.scss
@@ -369,7 +369,6 @@ body.editor_enable.editor_has_snippets {
                 background-clip: padding-box;
                 border-left: $o-we-sidebar-blocks-content-snippet-spacing solid transparent;
                 margin-bottom: $o-we-sidebar-blocks-content-snippet-spacing;
-                user-select: none;
                 @include o-grab-cursor;
 
                 .oe_snippet_thumbnail_title {

--- a/addons/website/data/website_demo.xml
+++ b/addons/website/data/website_demo.xml
@@ -55,7 +55,7 @@
 
                                             <h2 class="mt-4">Dropdown</h2>
                                             <div class="dropdown">
-                                                <button type="button" class="btn btn-primary dropdown-toggle" data-bs-toggle="dropdown">Toggle</button>
+                                                <button type="button" class="btn btn-primary dropdown-toggle user-select-none" data-bs-toggle="dropdown">Toggle</button>
                                                 <div class="dropdown-menu">
                                                     <div class="dropdown-header">Header</div>
                                                     <a class="dropdown-item" href="#">Action</a>

--- a/addons/website/static/src/xml/website.editor.xml
+++ b/addons/website/static/src/xml/website.editor.xml
@@ -20,7 +20,7 @@
                     <we-title>⌙ Page Anchor</we-title>
                     <div>
                         <div class="dropdown">
-                            <button class="dropdown-toggle"
+                            <button class="dropdown-toggle user-select-none"
                                 data-bs-toggle="dropdown" title="" tabindex="-1"
                                 data-bs-original-title="Link Size" aria-expanded="false">
                                 <we-toggler>

--- a/addons/website/views/website_templates.xml
+++ b/addons/website/views/website_templates.xml
@@ -16,7 +16,7 @@
         (submenu.clean_url() and submenu.clean_url() != '/' and any(request.httprequest.path == child.url for child in submenu.child_id if child.url) or
          (submenu.clean_url() and request.httprequest.path == submenu.clean_url())) and 'active'
         } #{submenu.is_mega_menu and 'position-static'}">
-        <a t-attf-class="#{link_class or ''} dropdown-toggle #{submenu.is_mega_menu and 'o_mega_menu_toggle'}" data-bs-toggle="dropdown" href="#">
+        <a t-attf-class="#{link_class or ''} dropdown-toggle user-select-none #{submenu.is_mega_menu and 'o_mega_menu_toggle'}" data-bs-toggle="dropdown" href="#">
             <span t-field="submenu.name"/>
         </a>
         <div t-if="submenu.is_mega_menu"
@@ -2031,7 +2031,7 @@
         <div t-attf-class="btn-group #{btn_class} js_publish_management #{object.website_published and 'css_published' or 'css_unpublished'}" t-att-data-id="object.id" t-att-data-object="object._name" t-att-data-description="env['ir.model']._get(object._name).display_name" t-att-data-controller="publish_controller">
             <button class="btn btn-danger js_publish_btn">Unpublished</button>
             <button class="btn btn-success js_publish_btn">Published</button>
-            <button type="button" t-attf-class="btn btn-default dropdown-toggle dropdown-toggle-split" t-att-id="'dopprod-%s' % object.id" data-bs-toggle="dropdown"/>
+            <button type="button" t-attf-class="btn btn-default dropdown-toggle dropdown-toggle-split user-select-none" t-att-id="'dopprod-%s' % object.id" data-bs-toggle="dropdown"/>
             <div class="dropdown-menu" role="menu" t-att-aria-labelledby="'dopprod-%s' % object.id">
                 <t t-out="0"/>
                 <a role="menuitem" t-attf-href="/web#view_type=form&amp;model=#{object._name}&amp;id=#{object.id}&amp;action=#{action}&amp;menu_id=#{menu or object.env['ir.model.data']._xmlid_to_res_id('website.menu_website_configuration')}"

--- a/addons/website/views/website_views.xml
+++ b/addons/website/views/website_views.xml
@@ -359,7 +359,7 @@
                 <qweb js_class="view_hierarchy">
                     <nav class="o_tree_nav navbar justify-content-start w-100 fixed-top bg-white shadow">
                         <div class="dropdown ms-2 border border-info rounded">
-                            <a href="#" role="button" class="btn dropdown-toggle text-info" data-bs-toggle="dropdown">
+                            <a href="#" role="button" class="btn dropdown-toggle text-info user-select-none" data-bs-toggle="dropdown">
                                 All Websites
                             </a>
                             <div class="dropdown-menu o_website_filter">

--- a/addons/website_event/views/event_templates_list.xml
+++ b/addons/website_event/views/event_templates_list.xml
@@ -52,7 +52,7 @@
                 <ul class="o_wevent_index_topbar_filters nav">
                     <t t-foreach="categories" t-as="category">
                         <li t-if="category.is_published and category.tag_ids and any(tag.color for tag in category.tag_ids)" class="nav-item dropdown me-2 my-1">
-                            <a href="#" role="button" class="btn dropdown-toggle" data-bs-toggle="dropdown">
+                            <a href="#" role="button" class="btn dropdown-toggle user-select-none" data-bs-toggle="dropdown">
                                 <i class="fa fa-folder-open"/>
                                 <t t-out="category.name"/>
                             </a>
@@ -92,7 +92,7 @@
 <template id="event_time" inherit_id="website_event.index_topbar" name="Filter by Date">
     <xpath expr="//ul[hasclass('o_wevent_index_topbar_filters')]" position="inside">
         <li class="nav-item dropdown me-2 my-1">
-            <a href="#" role="button" class="btn dropdown-toggle" data-bs-toggle="dropdown">
+            <a href="#" role="button" class="btn dropdown-toggle user-select-none" data-bs-toggle="dropdown">
                 <i class="fa fa-calendar"/>
                 <t t-if="current_date" t-out="current_date"/>
                 <t t-else="">Upcoming Events</t>
@@ -115,7 +115,7 @@
 <template id="event_location" inherit_id="website_event.index_topbar" active="False" name="Filter by Country">
     <xpath expr="//ul[hasclass('o_wevent_index_topbar_filters')]" position="inside">
         <li class="nav-item dropdown me-2 my-1">
-            <a href="#" role="button" class="btn dropdown-toggle" data-bs-toggle="dropdown">
+            <a href="#" role="button" class="btn dropdown-toggle user-select-none" data-bs-toggle="dropdown">
                 <i class="fa fa-map-marker"/>
                 <t t-if="current_country" t-out="current_country.name"/>
                 <t t-else="">All countries</t>

--- a/addons/website_event_exhibitor/views/event_exhibitor_templates_list.xml
+++ b/addons/website_event_exhibitor/views/event_exhibitor_templates_list.xml
@@ -56,7 +56,7 @@
     active="True">
     <xpath expr="//ul[hasclass('o_wesponsor_topbar_filters')]" position="inside">
         <li class="nav-item dropdown me-2 my-1">
-            <a href="#" role="button" class="btn dropdown-toggle" data-bs-toggle="dropdown">
+            <a href="#" role="button" class="btn dropdown-toggle user-select-none" data-bs-toggle="dropdown">
                 <i class="fa fa-folder-open"/>
                 By Country
             </a>
@@ -84,7 +84,7 @@
     active="True">
     <xpath expr="//ul[hasclass('o_wesponsor_topbar_filters')]" position="inside">
         <li class="nav-item dropdown me-2 my-1">
-            <a href="#" role="button" class="btn dropdown-toggle" data-bs-toggle="dropdown">
+            <a href="#" role="button" class="btn dropdown-toggle user-select-none" data-bs-toggle="dropdown">
                 <i class="fa fa-folder-open"/>
                 By Level
             </a>

--- a/addons/website_event_meet/views/event_meet_templates_list.xml
+++ b/addons/website_event_meet/views/event_meet_templates_list.xml
@@ -29,7 +29,7 @@
         <h2 class="d-flex flex-row justify-content-between">
             <span>Join a room</span>
             <div class="dropdown">
-                <a class="dropdown-toggle o-no-caret btn p-0" title="Languages Menu"
+                <a class="dropdown-toggle o-no-caret btn p-0 user-select-none" title="Languages Menu"
                     aria-label="Dropdown menu" data-bs-display="static" data-bs-toggle="dropdown" href="#" role="button">
                     <span t-out="current_lang.name if current_lang else 'All Languages'"/> ▼</a>
                 <div class="dropdown-menu" role="menu">

--- a/addons/website_event_track/views/event_track_templates_list.xml
+++ b/addons/website_event_track/views/event_track_templates_list.xml
@@ -37,7 +37,7 @@
                 <ul class="o_wesession_topbar_filters o_wevent_index_topbar_filters nav">
                     <!-- Optional wishlist filter -->
                     <li t-if="option_track_wishlist" class="nav-item dropdown me-2 my-1">
-                        <a href="#" role="button" class="btn dropdown-toggle" data-bs-toggle="dropdown">
+                        <a href="#" role="button" class="btn dropdown-toggle user-select-none" data-bs-toggle="dropdown">
                             <i class="fa fa-folder-open"/> Favorites
                         </a>
                         <div class="dropdown-menu">
@@ -78,7 +78,7 @@
     <xpath expr="//ul[hasclass('o_wesession_topbar_filters')]" position="inside">
         <t t-foreach="tag_categories" t-as="tag_category">
             <li t-if="tag_category.tag_ids and any(tag.color for tag in tag_category.tag_ids)" class="nav-item dropdown me-2 my-1">
-                <a href="#" role="button" class="btn dropdown-toggle" data-bs-toggle="dropdown">
+                <a href="#" role="button" class="btn dropdown-toggle user-select-none" data-bs-toggle="dropdown">
                     <i class="fa fa-folder-open"/>
                     <t t-out="tag_category.name"/>
                 </a>

--- a/addons/website_event_track/views/event_track_views.xml
+++ b/addons/website_event_track/views/event_track_views.xml
@@ -47,7 +47,7 @@
                         <div t-attf-class="{{!selection_mode ? 'oe_kanban_color_' + kanban_getcolor(record.color.raw_value) : ''}} oe_kanban_card oe_kanban_global_click">
                             <div class="o_dropdown_kanban dropdown" groups="base.group_user">
 
-                                <a role="button" class="dropdown-toggle o-no-caret btn" data-bs-toggle="dropdown" href="#" aria-label="Dropdown menu" title="Dropdown menu">
+                                <a role="button" class="dropdown-toggle user-select-none o-no-caret btn" data-bs-toggle="dropdown" href="#" aria-label="Dropdown menu" title="Dropdown menu">
                                     <span class="fa fa-ellipsis-v"/>
                                 </a>
                                 <div class="dropdown-menu" role="menu">

--- a/addons/website_event_track_quiz/views/event_leaderboard_templates.xml
+++ b/addons/website_event_track_quiz/views/event_leaderboard_templates.xml
@@ -111,7 +111,7 @@
                 <div class="btn-group w-100 position-relative" role="group" aria-label="Mobile sub-nav">
 
                     <div class="btn-group ms-1 position-static me-2">
-                        <a class="btn bg-black-25 text-white dropdown-toggle" href="#" role="button" data-bs-toggle="dropdown" aria-haspopup="true" aria-expanded="false"><i class="fa fa-search"></i></a>
+                        <a class="btn bg-black-25 text-white dropdown-toggle user-select-none" href="#" role="button" data-bs-toggle="dropdown" aria-haspopup="true" aria-expanded="false"><i class="fa fa-search"></i></a>
                         <div class="dropdown-menu dropdown-menu-end w-100" style="right: 10px;">
                             <form class="px-3" t-attf-action="#{'/event/%s/community/leaderboard' % (slug(event))}" role="search" method="get">
                                 <div class="input-group">

--- a/addons/website_forum/views/website_forum.xml
+++ b/addons/website_forum/views/website_forum.xml
@@ -159,7 +159,7 @@
             <ul class="navbar-nav d-lg-none flex-row flex-grow-1 justify-content-between">
                 <span class="navbar-text me-1">Go to:</span>
                 <li class="nav-item dropdown me-auto">
-                    <a class="nav-link active dropdown-toggle" type="button" data-bs-toggle="dropdown">
+                    <a class="nav-link active dropdown-toggle user-select-none" type="button" data-bs-toggle="dropdown">
                         <t t-if="searches.get('users')">People</t>
                         <t t-elif="searches.get('tags')">Tags</t>
                         <t t-elif="searches.get('badges')">Badges</t>
@@ -663,7 +663,7 @@
                 <!-- Filter post by type (mobile only) -->
                 <div class="col-6 col-md-auto d-lg-none d-flex align-items-center">
                     <div class="dropdown"> Show
-                        <a href="#" class="dropdown-toggle" data-bs-toggle="dropdown">
+                        <a href="#" class="dropdown-toggle user-select-none" data-bs-toggle="dropdown">
                             <t t-if="no_filters"> All</t>
                             <t t-elif="filters == 'solved'"> Solved</t>
                             <t t-elif="filters == 'unsolved'"> Unsolved</t>
@@ -721,7 +721,7 @@
                 <span class="mx-3  mx-lg-2 text-400 d-none d-md-inline">|</span>
                 <span class="dropdown">
                     Order by
-                    <a href="#" class="dropdown-toggle" data-bs-toggle="dropdown">
+                    <a href="#" class="dropdown-toggle user-select-none" data-bs-toggle="dropdown">
                         <t t-if="sorting == 'relevancy desc'"> trending</t>
                         <t t-elif="sorting == 'create_date desc'"> newest</t>
                         <t t-elif="sorting == 'write_date desc'"> activity date</t>
@@ -1356,7 +1356,7 @@
                             </a>
                         </div>
                         <div t-if="answer.can_comment" class="btn-group btn-group-sm ms-1 ms-md-2">
-                            <a class="btn border dropdown-toggle" type="button" id="dropdownMenuButton" data-bs-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+                            <a class="btn border dropdown-toggle user-select-none" type="button" id="dropdownMenuButton" data-bs-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
                                 More
                             </a>
                             <div class="dropdown-menu shadow">

--- a/addons/website_profile/views/website_profile.xml
+++ b/addons/website_profile/views/website_profile.xml
@@ -33,7 +33,7 @@
                     <div class="col d-md-none py-1 o_wprofile_user_profile_sub_nav_mobile_col">
                         <div class="btn-group w-100 position-relative" role="group" aria-label="Mobile sub-nav">
                             <div class="btn-group w-100 ms-2">
-                                <a class="btn bg-black-25 text-white dropdown-toggle" href="#" role="button" data-bs-toggle="dropdown" aria-haspopup="true" aria-expanded="false">Nav</a>
+                                <a class="btn bg-black-25 text-white dropdown-toggle user-select-none" href="#" role="button" data-bs-toggle="dropdown" aria-haspopup="true" aria-expanded="false">Nav</a>
 
                                 <ul class="dropdown-menu">
                                     <a class="dropdown-item" t-att-href="home_url or '/'">Home</a>
@@ -43,7 +43,7 @@
                             </div>
 
                             <div class="btn-group ms-1 position-static me-2">
-                                <a class="btn bg-black-25 text-white dropdown-toggle" href="#" role="button" data-bs-toggle="dropdown" aria-haspopup="true" aria-expanded="false"><i class="fa fa-search"></i></a>
+                                <a class="btn bg-black-25 text-white dropdown-toggle user-select-none" href="#" role="button" data-bs-toggle="dropdown" aria-haspopup="true" aria-expanded="false"><i class="fa fa-search"></i></a>
                                 <div class="dropdown-menu dropdown-menu-end w-100" style="right: 10px;">
                                     <form class="px-3" t-attf-action="/profile/users" role="search" method="get">
                                         <div class="input-group">

--- a/addons/website_sale/static/src/xml/website_sale_dashboard.xml
+++ b/addons/website_sale/static/src/xml/website_sale_dashboard.xml
@@ -150,7 +150,7 @@
 
     <t t-name="website_sale.LinkTrackersDropDown">
         <div class="dropdown">
-            <button class="btn btn-secondary dropdown-toggle utm_dropdown ml4" type="button" data-bs-toggle="dropdown" aria-haspopup="true" aria-expanded="true"><span class="utm_button_name">Campaigns</span>
+            <button class="btn btn-secondary dropdown-toggle utm_dropdown ml4 user-select-none" type="button" data-bs-toggle="dropdown" aria-haspopup="true" aria-expanded="true"><span class="utm_button_name">Campaigns</span>
             </button>
             <div class="dropdown-menu" role="menu" aria-labelledby="utm_dropdown">
                 <a name="campaign_id" class="dropdown-item js_utm_selector" role="menuitem">Campaigns</a>

--- a/addons/website_sale/views/templates.xml
+++ b/addons/website_sale/views/templates.xml
@@ -228,7 +228,7 @@
         <t t-set="website_sale_pricelists" t-value="website.get_pricelist_available(show_visible=True)" />
         <div t-attf-class="o_pricelist_dropdown dropdown#{'' if website_sale_pricelists and len(website_sale_pricelists)&gt;1 else ' d-none'} #{_classes}">
             <t t-set="curr_pl" t-value="website.pricelist_id" />
-            <a role="button" href="#" class="dropdown-toggle btn btn-light border-0 px-0 text-muted align-baseline" data-bs-toggle="dropdown">
+            <a role="button" href="#" class="dropdown-toggle btn btn-light border-0 px-0 text-muted align-baseline user-select-none" data-bs-toggle="dropdown">
                 <t t-esc="curr_pl and curr_pl.name or ' - '" />
             </a>
             <div class="dropdown-menu" role="menu">
@@ -389,7 +389,7 @@
             <t t-set="website_sale_sortable_current" t-value="[sort for sort in website_sale_sortable if sort[0]==request.params.get('order', '')]"/>
             <div class="o_sortby_dropdown dropdown dropdown_sorty_by ms-3 pb-2">
                 <span class="d-none d-lg-inline fw-bold text-muted">Sort By:</span>
-                <a role="button" href="#" class="dropdown-toggle btn btn-light border-0 px-0 text-muted align-baseline" data-bs-toggle="dropdown">
+                <a role="button" href="#" class="dropdown-toggle btn btn-light border-0 px-0 text-muted align-baseline user-select-none" data-bs-toggle="dropdown">
                     <span class="d-none d-lg-inline">
                         <t t-if='website_sale_sortable_current'>
                             <t t-esc="website_sale_sortable_current[0][1]"/>

--- a/addons/website_sale_digital/views/website_sale_digital.xml
+++ b/addons/website_sale_digital/views/website_sale_digital.xml
@@ -5,7 +5,7 @@
             <t t-if="digital_attachments" t-set="attachments" t-value="digital_attachments.get(line.product_id.id)"/>
             <t t-if="attachments">
                 <span class="dropdown">
-                    <button class="btn btn-sm btn-secondary dropdown-toggle" type="button" id="dropdownMenu1" data-bs-toggle="dropdown">
+                    <button class="btn btn-sm btn-secondary dropdown-toggle user-select-none" type="button" id="dropdownMenu1" data-bs-toggle="dropdown">
                         Downloads
                     </button>
                     <div class="dropdown-menu" role="menu" aria-labelledby="dropdownMenu1">

--- a/addons/website_slides/views/slide_channel_views.xml
+++ b/addons/website_slides/views/slide_channel_views.xml
@@ -245,7 +245,7 @@
                         <t t-name="kanban-box">
                             <div t-attf-class="oe_kanban_color_#{kanban_getcolor(record.color.raw_value)} oe_kanban_card oe_kanban_global_click">
                                 <div class="o_dropdown_kanban dropdown">
-                                    <a role="button" class="dropdown-toggle o-no-caret btn" data-bs-toggle="dropdown" href="#" aria-label="Dropdown menu" title="Dropdown menu">
+                                    <a role="button" class="dropdown-toggle user-select-none o-no-caret btn" data-bs-toggle="dropdown" href="#" aria-label="Dropdown menu" title="Dropdown menu">
                                         <span class="fa fa-ellipsis-v" aria-hidden="false"/>
                                     </a>
                                     <div class="o_kanban_card_manage_pane dropdown-menu" role="menu">

--- a/addons/website_slides/views/website_slides_templates_course.xml
+++ b/addons/website_slides/views/website_slides_templates_course.xml
@@ -53,7 +53,7 @@
                 <div class="col d-md-none py-1">
                     <div class="btn-group w-100 position-relative" role="group" aria-label="Mobile sub-nav">
                         <div class="btn-group w-100">
-                            <a class="btn bg-black-25 text-white dropdown-toggle" href="#" role="button" data-bs-toggle="dropdown" aria-haspopup="true" aria-expanded="false">Nav</a>
+                            <a class="btn bg-black-25 text-white dropdown-toggle user-select-none" href="#" role="button" data-bs-toggle="dropdown" aria-haspopup="true" aria-expanded="false">Nav</a>
 
                             <div class="dropdown-menu">
                                 <a class="dropdown-item" href="/slides">Home</a>
@@ -80,7 +80,7 @@
                         </div>
 
                         <div class="btn-group ms-1 position-static">
-                            <a class="btn bg-black-25 text-white dropdown-toggle" href="#" role="button" data-bs-toggle="dropdown" aria-haspopup="true" aria-expanded="false"><i class="fa fa-search"></i></a>
+                            <a class="btn bg-black-25 text-white dropdown-toggle user-select-none" href="#" role="button" data-bs-toggle="dropdown" aria-haspopup="true" aria-expanded="false"><i class="fa fa-search"></i></a>
                             <div class="dropdown-menu dropdown-menu-end w-100" style="right: 10px;">
                                 <t t-call="website.website_search_box_input">
                                     <t t-set="_classes" t-valuef="px-3"/>
@@ -633,7 +633,7 @@
                         <div class="col-12 d-flex align-items-start">
                             <ul class="navbar-nav me-auto">
                                 <li class="nav-item dropdown ms-lg-auto">
-                                    <a class="nav-link dropdown-toggle dropdown-toggle align-items-center d-flex" type="button" id="slidesChannelDropdownSort"
+                                    <a class="nav-link dropdown-toggle dropdown-toggle align-items-center d-flex user-select-none" type="button" id="slidesChannelDropdownSort"
                                        data-bs-toggle="dropdown" aria-haspopup="true" aria-expanded="false" href="#">
                                         <b>Order by</b>
                                         <span class="d-none d-xl-inline">:

--- a/addons/website_slides/views/website_slides_templates_homepage.xml
+++ b/addons/website_slides/views/website_slides_templates_homepage.xml
@@ -226,7 +226,7 @@
                             <t t-foreach="tag_groups" t-as="tag_group">
                                 <t t-set="group_frontend_tags" t-value="tag_group.tag_ids.filtered(lambda tag: tag.color)"/>
                                 <li class="nav-item dropdown ml16" t-if="group_frontend_tags">
-                                    <a t-att-class="'nav-link dropdown-toggle %s' % ('active' if tag_group in search_tag_groups else '')"
+                                    <a t-att-class="'nav-link dropdown-toggle user-select-none %s' % ('active' if tag_group in search_tag_groups else '')"
                                         href="/slides/all"
                                         t-att-data-bs-target="'#navToogleTagGroup%s' % tag_group.id"
                                         role="button" data-bs-toggle="dropdown"

--- a/odoo/addons/base/views/ir_module_views.xml
+++ b/odoo/addons/base/views/ir_module_views.xml
@@ -177,7 +177,7 @@
                       <div class="oe_module_vignette">
                         <t t-set="installed" t-value="record.state.raw_value == 'installed'"/>
                         <div class="o_dropdown_kanban dropdown" tabindex="-1">
-                            <a class="dropdown-toggle o-no-caret btn" data-bs-toggle="dropdown" data-bs-offset="0,-2" href="#" role="button" aria-label="Dropdown menu" title="Dropdown menu">
+                            <a class="dropdown-toggle user-select-none o-no-caret btn" data-bs-toggle="dropdown" data-bs-offset="0,-2" href="#" role="button" aria-label="Dropdown menu" title="Dropdown menu">
                                 <span class="fa fa-ellipsis-v"/>
                             </a>
                             <div class="dropdown-menu dropdown-menu-end" role="menu" aria-labelledby="dLabel">


### PR DESCRIPTION
[REF] *: `user-select-none` refactoring

*{
	base,
	calendar,
	crm,
	event,
	fleet,
	hr_contract,
	hr_holiday,
	hr_recruitment,
	hr_work_entry,
	mail,
	maintenance,
	mass_mailing,
	mrp,
	note,
	portal,
	project,
	stock,
	survey,
	utm,
	web,
	web_editor,
	website,
	website_event,
	website_event_exhibitor,
	website_event_meet,
	website_event_track,
	website_event_track_quiz,
	website_forum,
	website_profile,
	website_sale,
	website_slides
}

This PR deletes every CSS assignation in Odoo of `user-select: none`
and replaces it by a newly added BS5 `user-select-none` class either in
its template, JS component, controller or renderer.

Enterprise:
  - https://github.com/odoo/enterprise/pull/27160

task-2848355

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
