### PR TITLE
[FIX] website: use field_widget in anycase

### DIFF
--- a/addons/website/models/website_snippet_filter.py
+++ b/addons/website/models/website_snippet_filter.py
@@ -129,14 +129,14 @@ class WebsiteSnippetFilter(models.Model):
                 field_name, _, field_widget = field_name.partition(":")
                 field = model._fields.get(field_name)
                 field_widget = field_widget or field.type
-                if field.type == 'binary':
+                if field_widget == 'binary':
                     data['image_fields'][field_name] = self.escape_falsy_as_empty(Website.image_url(record, field_name))
                 elif field_widget == 'image':
                     data['image_fields'][field_name] = self.escape_falsy_as_empty(record[field_name])
                 elif field_widget == 'monetary':
                     FieldMonetary = self.env['ir.qweb.field.monetary']
                     model_currency = None
-                    if field.type == 'monetary':
+                    if field_widget == 'monetary':
                         model_currency = record[record[field_name].currency_field]
                     elif 'currency_id' in model._fields:
                         model_currency = record['currency_id']

--- a/doc/cla/individual/petrus-v.md
+++ b/doc/cla/individual/petrus-v.md
@@ -1,0 +1,11 @@
+France, 2021-03-22
+
+I hereby agree to the terms of the Odoo Individual Contributor License
+Agreement v1.0.
+
+I declare that I am authorized and able to make this agreement and sign this
+declaration.
+
+Signed,
+
+Pierre Verkest pierreverkest84@gmail.com https://github.com/petrus-v


### PR DESCRIPTION
## Description of the issue/feature this PR addresses:

In `website.snippet.filter` a model used by dynamic snippets
the field type can be enforce using semi column in `field_name` descriptions.

field_widget is set using this field description and fall back to the filed type if not provide.

Field description should be honour in any case to let use related field.

As today unfortunately some condition do not use this field_widget and
if we are using field provide by abstract models (likes `website.seo.metadata` or `mail.thread`,
(I wonder why) but those `model._fields` definition on those related fields returns None which can't have .type attribute 

## To reproduce

We are going to use the dynamic carousel  snippet which use `website.snippet.filter` to display blog post.

* install `website` and `website_blog`
* Create and save a custom filter from blog post list view
*  Create a `website.snippet.filter` record with following informations
  > **NOTE**: to create this record I'm  using [website_snippet_filter_views](https://github.com/OCA/website/pull/888) module to edit from the Graphical User Interface but could be done in SQL or using source code of course.
  * set filter used previous saved filter
  * choose appropriate website
  * set **fieldname** with `name,subtitle,author_name,website_meta_og_img:image`
* go to the web site and edit the home page **you must use debug mode in oder to select the dynamic carousel
* 




## Current behaviour before PR:

Got the following trace back on frontend while using dynamic snippet on model using related fields:

```log
Odoo Server Error

Traceback (most recent call last):
  File "//odoo/addons/base/models/ir_http.py", line 237, in _dispatch
    result = request.dispatch()
  File "//odoo/http.py", line 683, in dispatch
    result = self._call_function(**self.params)
  File "//odoo/http.py", line 359, in _call_function
    return checked_call(self.db, *args, **kwargs)
  File "//odoo/service/model.py", line 94, in wrapper
    return f(dbname, *args, **kwargs)
  File "//odoo/http.py", line 347, in checked_call
    result = self.endpoint(*a, **kw)
  File "//odoo/http.py", line 912, in __call__
    return self.method(*args, **kw)
  File "//odoo/http.py", line 531, in response_wrap
    response = f(*args, **kw)
  File "//addons/website/controllers/main.py", line 306, in get_dynamic_filter
    return dynamic_filter and dynamic_filter.render(template_key, limit, search_domain) or ''
  File "//addons/website/models/website_snippet_filter.py", line 60, in render
    records = self._prepare_values(limit, search_domain)
  File "//addons/website/models/website_snippet_filter.py", line 82, in _prepare_values
    return self._filter_records_to_dict_values(records)
  File "//addons/website/models/website_snippet_filter.py", line 131, in _filter_records_to_dict_values
    field_widget = field_widget or field.type
Exception

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "//odoo/http.py", line 639, in _handle_exception
    return super(JsonRequest, self)._handle_exception(exception)
  File "//odoo/http.py", line 315, in _handle_exception
    raise exception.with_traceback(None) from new_cause
AttributeError: 'NoneType' object has no attribute 'type'
```


## Desired behavior after PR is merged:

Be able to force type without getting trackback.


--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
