### PR TITLE
[FIX] account_facturx: fix uom unece code fetch

### DIFF
--- a/addons/account_facturx/models/uom.py
+++ b/addons/account_facturx/models/uom.py
@@ -10,35 +10,30 @@ class UoM(models.Model):
         """ Returns the UNECE code used for international trading for corresponding to the UoM as per
         https://unece.org/fileadmin/DAM/cefact/recommendations/bkup_htm/add2d.htm.
         """
-        if len(self) != 1:
-            return 'C62'
-
-        xml_id = self.env['ir.model.data'].search([
-                ('model', '=', 'uom.uom'),
-                ('res_id', '=', self.id),
-        ]).name
         mapping = {
-            'product_uom_unit': 'C62',
-            'product_uom_dozen': 'DZN',
-            'product_uom_kgm': 'KGM',
-            'product_uom_gram': 'GRM',
-            'product_uom_day': 'DAY',
-            'product_uom_hour': 'HUR',
-            'product_uom_ton': 'TNE',
-            'product_uom_meter': 'MTR',
-            'product_uom_km': 'KTM',
-            'product_uom_cm': 'CMT',
-            'product_uom_litre': 'LTR',
-            'product_uom_lb': 'LBR',
-            'product_uom_oz': 'ONZ',
-            'product_uom_inch': 'INH',
-            'product_uom_foot': 'FOT',
-            'product_uom_mile': 'SMI',
-            'product_uom_floz': 'OZA',
-            'product_uom_qt': 'QT',
-            'product_uom_gal': 'GLL',
-            'product_uom_cubic_meter': 'MTQ',
-            'product_uom_cubic_inch': 'INQ',
-            'product_uom_cubic_foot': 'FTQ',
+            'uom.product_uom_unit': 'C62',
+            'uom.product_uom_dozen': 'DZN',
+            'uom.product_uom_kgm': 'KGM',
+            'uom.product_uom_gram': 'GRM',
+            'uom.product_uom_day': 'DAY',
+            'uom.product_uom_hour': 'HUR',
+            'uom.product_uom_ton': 'TNE',
+            'uom.product_uom_meter': 'MTR',
+            'uom.product_uom_km': 'KTM',
+            'uom.product_uom_cm': 'CMT',
+            'uom.product_uom_litre': 'LTR',
+            'uom.product_uom_lb': 'LBR',
+            'uom.product_uom_oz': 'ONZ',
+            'uom.product_uom_inch': 'INH',
+            'uom.product_uom_foot': 'FOT',
+            'uom.product_uom_mile': 'SMI',
+            'uom.product_uom_floz': 'OZA',
+            'uom.product_uom_qt': 'QT',
+            'uom.product_uom_gal': 'GLL',
+            'uom.product_uom_cubic_meter': 'MTQ',
+            'uom.product_uom_cubic_inch': 'INQ',
+            'uom.product_uom_cubic_foot': 'FTQ',
         }
-        return mapping.get(xml_id, 'C62')
+        xml_ids = self._get_external_ids().get(self.id, [])
+        matches = list(set(xml_ids) & set(mapping.keys()))
+        return matches and mapping[matches[0]] or 'C62'


### PR DESCRIPTION
The _get_unece_code method does not work in cases where a specific uom
has multiple xml_ids.
Change it to handle such cases and try to match every XML ids with a
unece code if possible.

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
