### PR TITLE
[FIX] point_of_sale: use total_amount value when down payment tax is not specified

### DIFF
--- a/addons/pos_sale/static/src/js/OrderManagementScreen/SaleOrderManagementScreen.js
+++ b/addons/pos_sale/static/src/js/OrderManagementScreen/SaleOrderManagementScreen.js
@@ -202,8 +202,14 @@ odoo.define('pos_sale.SaleOrderManagementScreen', function (require) {
                         };
                     }
                     let down_payment_product = this.env.pos.db.get_product_by_id(this.env.pos.config.down_payment_product_id[0])
-                    let down_payment_tax = this.env.pos.taxes_by_id[down_payment_product.taxes_id]
-                    let down_payment = down_payment_tax.price_include ? sale_order.amount_total : sale_order.amount_untaxed;
+                    let down_payment_tax = this.env.pos.taxes_by_id[down_payment_product.taxes_id] || false ;
+                    let down_payment;
+                    if (down_payment_tax) {
+                        down_payment = down_payment_tax.price_include ? sale_order.amount_total : sale_order.amount_untaxed;
+                    }
+                    else{
+                        down_payment = sale_order.amount_total;
+                    }
 
                     const { confirmed, payload } = await this.showPopup('NumberPopup', {
                         title: sprintf(this.env._t("Percentage of %s"), this.env.pos.format_currency(sale_order.amount_total)),


### PR DESCRIPTION
Currently, when customer does not specify taxes on down payment product in pos
and tries to use down payment for quotation, they get javascript error.
With this fix we check if down payment product has tax specified and if it
does not, we give it value of 0.

fixes OPW-2843483





--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
