### PR TITLE
[FIX] website_blog: fix blog top banner

### DIFF
--- a/addons/website_blog/views/website_blog_templates.xml
+++ b/addons/website_blog/views/website_blog_templates.xml
@@ -93,7 +93,7 @@ list of filtered posts (by date or tag).
     Replace top-banner content with the latest published post
 -->
 <template id="opt_blog_cover_post" name="Top banner - Name / Latest Post" inherit_id="website_blog.blog_post_short" active="True" customize_show="True">
-    <xpath expr="//div[@id='o_wblog_blog_top_droppable']" position="replace">
+    <xpath expr="//div[@id='o_wblog_blog_top']" position="inside">
         <div t-if="first_post or blog" class="container">
             <div class="row py-4">
                 <div t-attf-class="mb-3 mb-md-0 #{'col-md-5' if (not opt_blog_list_view and not opt_blog_sidebar_show) else 'col-md-6'}">


### PR DESCRIPTION
Before this commit an error appeared if a block had been set at the top
of the /blog page and the user wanted to re-enable the
"top banner - Name / Latest Post" option. This commit solves the problem
and improves the behavior by not trying to replace the block that the
user had set at the top of the page. The option adds a top banner but
does not remove the blocks present.

Steps to reproduce the fixed bug:

1. go on /blog page
2. disable the customize option "Top banner - Name / Latest Post"
3. go in edit mode
4. drop a snippet in this new oe_structure
5. save the page
6. enable the customize option "Top banner - Name / Latest Post"

=>traceback

task-2774944
--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
