### PR TITLE
[FIX] account: extensible subtree views

### DIFF
--- a/addons/account/views/account_tax_views.xml
+++ b/addons/account/views/account_tax_views.xml
@@ -148,12 +148,10 @@
                         <page string="Definition" name="definition">
                             <div attrs="{'invisible': [('amount_type', '=', 'group')]}">
                                 <field name="country_code" invisible="1"/>
-                                <group string="Distribution for Invoices">
-                                    <field name="invoice_repartition_line_ids" nolabel="1" context="{'default_company_id': company_id}"/>
-                                </group>
-                                <group string="Distribution for Credit Notes">
-                                    <field name="refund_repartition_line_ids" nolabel="1" context="{'default_company_id': company_id}"/>
-                                </group>
+                                <label for="invoice_repartition_line_ids"/>
+                                <field name="invoice_repartition_line_ids" context="{'default_company_id': company_id}"/>
+                                <label for="refund_repartition_line_ids"/>
+                                <field name="refund_repartition_line_ids" context="{'default_company_id': company_id}"/>
                             </div>
                             <field name="children_tax_ids" attrs="{'invisible':['|', ('amount_type','!=','group'), ('type_tax_use','=','none')]}" domain="[('type_tax_use','in',('none',type_tax_use)), ('amount_type','!=','group')]">
                                 <tree string="Children Taxes">

--- a/addons/account/views/partner_view.xml
+++ b/addons/account/views/partner_view.xml
@@ -69,7 +69,6 @@
                     </group>
                     <notebook>
                         <page name="tax_mapping" string="Tax Mapping">
-                        <group>
                             <field name="tax_ids" widget="one2many" nolabel="1" context="{'append_type_to_tax_name': True}">
                                 <tree name="tax_map_tree" string="Tax Mapping" editable="bottom">
                                     <field name="tax_src_id"
@@ -96,10 +95,8 @@
                                     </group>
                                 </form>
                             </field>
-                        </group>
                         </page>
                         <page name="account_mapping" string="Account Mapping" groups="account.group_account_readonly">
-                        <group>
                             <field name="account_ids" widget="one2many" nolabel="1">
                                 <tree string="Account Mapping" editable="bottom">
                                     <field name="account_src_id" domain="['|', ('company_id', '=', False), ('company_id', '=', parent.company_id)]"/>
@@ -110,7 +107,6 @@
                                     <field name="account_dest_id" domain="['|', ('company_id', '=', False), ('company_id', '=', parent.company_id)]"/>
                                 </form>
                             </field>
-                        </group>
                         </page>
                     </notebook>
                     <field name="note" class="oe-bordered-editor" placeholder="Legal Notes..."/>


### PR DESCRIPTION
Both the CE and EE web clients don't support proper responsivity when a subtree view is inside a `<group>`.

By removing them (they were unnecessary anyway) we recover proper responsivity in these views.

@moduon MT-688 OPW-2843895

See (video is from v15, but the same problem exists in v14 and v13): 

https://user-images.githubusercontent.com/973709/167584174-e2405df7-8a60-4be6-ab81-b722ec82bb78.mp4




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
