### PR TITLE
[FIX] website_event_track: fixes the condition of event start warning

### DIFF
--- a/addons/website_event_track/views/event_track_templates_page.xml
+++ b/addons/website_event_track/views/event_track_templates_page.xml
@@ -30,7 +30,7 @@
     <div name="o_wesession_track_main"
          t-att-class="'col-12 o_wevent_online_page_main o_wesession_track_main bg-white p-0 %s' % ('col-md-9 col-lg-10' if option_widescreen else 'col-md-8 col-lg-9')">
         <!-- LIVE INFORMATIONS -->
-        <div t-if="not track.event_id.is_ongoing" class="pt-3">
+        <div t-if="not track.event_id.is_ongoing and track.event_id.start_remaining" class="pt-3">
             <div class="mx-3 alert alert-warning">
                 Event <span t-esc="track.event_id.name" class="font-weight-bold"/>
                 <span t-if="track.event_id.start_today">


### PR DESCRIPTION
The condition to display the start event warning in the track view was that
the event was not ongoing. This fix adds the condition that the event is
upcoming, preventing the warning to be displayed after the event date.

Task-2692907

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
