### PR TITLE
[FIX] account: tax tag invert for manual reconciliation entry

### DIFF
--- a/addons/account/models/account_move.py
+++ b/addons/account/models/account_move.py
@@ -4321,7 +4321,7 @@ class AccountMoveLine(models.Model):
                     is_refund = bool(rep_line.refund_tax_id)
                 elif record.tax_ids:
                     tax_type = record.tax_ids[0].type_tax_use
-                    is_refund = (tax_type == 'sale' and record.debit) or (tax_type == 'purchase' and record.credit)
+                    is_refund = (tax_type == 'sale' and record.balance < 0) or (tax_type == 'purchase' and record.balance > 0)
 
                 record.tax_tag_invert = (tax_type == 'purchase' and is_refund) or (tax_type == 'sale' and not is_refund)
 


### PR DESCRIPTION
Setup a CH company
Create a new invoice with switzerland partner
Add a product and tax 7.7%
Confirm
Go to Accounting > Customers > Followup reports.
Remove the filters, open the invoice, then click reconcile.
In the reconciliation widget, select invoice and record the manual
operation:
- Account: 3805 Losses from bad debts
- Taxes: 7.7% Sales
- Journal: Miscellaneous operations
- Label: Loss
- Tax Included in Price: True

Click on reconcile
Open the jounrnal entry corresponding to the manual operation

Error: the tax grid on the tax account has been correctly inverted,
while the tax grid on account 3805 Losses from bad debts is not
inverted, so it account as an invoice

opw-2819575

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
