### PR TITLE
[IMP] mail: `Composer`, adapt vertical alignment

### DIFF
--- a/addons/mail/static/src/components/composer/composer.xml
+++ b/addons/mail/static/src/components/composer/composer.xml
@@ -59,10 +59,10 @@
                 <t t-if="composerView.hasCurrentPartnerAvatar">
                     <div class="o_Composer_sidebarMain">
                         <t t-if="!messaging.currentGuest or composerView.composer.activeThread.model !== 'mail.channel'">
-                            <img class="o_Composer_currentPartnerAvatar rounded-circle o_object_fit_cover" t-att-src="composerView.currentPartnerAvatar" alt="Avatar of user"/>
+                            <img class="o_Composer_currentPartnerAvatar mt-1 rounded-circle o_object_fit_cover" t-att-src="composerView.currentPartnerAvatar" alt="Avatar of user"/>
                         </t>
                         <t t-if="messaging.currentGuest and composerView.composer.activeThread.model === 'mail.channel'">
-                            <img class="o_Composer_currentPartnerAvatar rounded-circle o_object_fit_cover" t-attf-src="/mail/channel/{{ composerView.composer.activeThread.id }}/guest/{{ messaging.currentGuest.id }}/avatar_128?unique={{ messaging.currentGuest.name }}" alt="Avatar of guest"/>
+                            <img class="o_Composer_currentPartnerAvatar mt-1 rounded-circle o_object_fit_cover" t-attf-src="/mail/channel/{{ composerView.composer.activeThread.id }}/guest/{{ messaging.currentGuest.id }}/avatar_128?unique={{ messaging.currentGuest.name }}" alt="Avatar of guest"/>
                         </t>
                     </div>
                 </t>


### PR DESCRIPTION
Prior to this commit, the height of the `ComposerTextInput` was not the
same as the avatar height, which created an alignment inconsistency.

This commit adjusts the alignment to fix this inconsistency.

task-2852255

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
