### PR TITLE
[FIX] sale_purchase: change to _action_cancel

### DIFF
--- a/addons/sale_purchase/models/sale_order.py
+++ b/addons/sale_purchase/models/sale_order.py
@@ -28,8 +28,8 @@ class SaleOrder(models.Model):
             order.order_line.sudo()._purchase_service_generation()
         return result
 
-    def action_cancel(self):
-        result = super(SaleOrder, self).action_cancel()
+    def _action_cancel(self):
+        result = super()._action_cancel()
         # When a sale person cancel a SO, he might not have the rights to write
         # on PO. But we need the system to create an activity on the PO (so 'write'
         # access), hence the `sudo`.


### PR DESCRIPTION
An activity should be posted only when a SO is cancelled, this happens
after _action_cancel as action_cancel doesn't always cancel the order.

sale_purchase was forgotten in commit
7c8f15d4141d4ae130da59d58ee2eaff39e363c4

Backport of 7a146e6f0b2d17af1dc496807d0025e1c7ba0c19


--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
