### PR TITLE
Draft: [POC][IMP] base: prevent slow query with LIMIT 1

### DIFF
--- a/odoo/models.py
+++ b/odoo/models.py
@@ -1807,8 +1807,10 @@ class BaseModel(metaclass=MetaModel):
 
         :raise AccessError: * if user tries to bypass access rules for read on the requested object.
         """
-        res = self._search(args, offset=offset, limit=limit, order=order, count=count)
-        return res if count else self.browse(res)
+        # if LIMIT 1 it can be very very slow https://twitter.com/Xof/status/1413542818673577987
+        new_limit = limit if limit == 1 and not count else 10
+        res = self._search(args, offset=offset, limit=new_limit, order=order, count=count)[:limit]
+        return res if count else self.browse(res)[:limit if limit else None]
 
     #
     # display_name, name_get, name_create, name_search


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
Hi after this issue https://github.com/odoo/enterprise/pull/27141, it is an idea to improve the speed of search with LIMIT 1


With limit search with complexe where condition the search can be very very long (hours with LIMIT 1, secondes with LIMIT 15

@odony @rco-odoo 



https://twitter.com/Xof/status/1413542818673577987



Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
