### PR TITLE
[IMP] base: replace LXML HTML cleaner by bleach

### DIFF
--- a/addons/auth_totp/static/tests/totp_flow.js
+++ b/addons/auth_totp/static/tests/totp_flow.js
@@ -31,6 +31,15 @@ function openUserProfileAtSecurityTab() {
         content: "Switch to security tab",
         trigger: 'a[role=tab]:contains("Account Security")',
         run: 'click',
+    }, {
+        // the web editor of the signature is always dirty, switching the tab
+        // will ask to save the change even if there's no change
+        // and can make this tour fail
+        content: "Discard web editor changes",
+        trigger: '.o_form_button_cancel',
+        run: 'click',
+    }, {
+        trigger: '.o_form_status_indicator_buttons.invisible'
     }];
 }
 

--- a/addons/calendar/tests/test_calendar.py
+++ b/addons/calendar/tests/test_calendar.py
@@ -125,7 +125,7 @@ class TestCalendar(SavepointCaseWithUserDemo):
 
         # update event with a description that have a special character and a new line
         test_description3 = 'Test & <br> Description'
-        test_note3 = '<p>Test &amp; <br> Description</p>'
+        test_note3 = '<p>Test &amp; <br /> Description</p>'
         test_event.write({
             'description': test_description3,
         })

--- a/addons/crm/tests/common.py
+++ b/addons/crm/tests/common.py
@@ -480,7 +480,7 @@ class TestCrmCommon(TestSalesCommon, MailCase):
 
         def _get_description():
             values = [_find_value(lead, 'description') for lead in leads]
-            return '<br><br>'.join(value for value in values if value)
+            return '<br /><br />'.join(value for value in values if value)
 
         def _get_priority():
             values = [_find_value(lead, 'priority') for lead in leads]

--- a/addons/crm/tests/test_crm_lead_merge.py
+++ b/addons/crm/tests/test_crm_lead_merge.py
@@ -177,7 +177,7 @@ class TestLeadMerge(TestLeadMergeCommon):
         # and exclude inactive leads, but that's not written anywhere ... intended ??
         self.assertEqual(merge.opportunity_ids, self.leads - self.lead_w_partner_company - self.lead_w_email_lost)
         ordered_merge = self.lead_w_contact + self.lead_w_email + self.lead_1 + self.lead_w_partner
-        ordered_merge_description = '<br><br>'.join(l.description for l in ordered_merge)
+        ordered_merge_description = '<br /><br />'.join(l.description for l in ordered_merge)
 
         # merged opportunity: in this test, all input are leads. Confidence is based on stage
         # sequence -> lead_w_contact has a stage sequence of 3 and probability is greater

--- a/addons/event/models/event_event.py
+++ b/addons/event/models/event_event.py
@@ -114,7 +114,7 @@ class EventEvent(models.Model):
 
     name = fields.Char(string='Event', translate=True, required=True)
     note = fields.Html(string='Note', store=True, compute="_compute_note", readonly=False)
-    description = fields.Html(string='Description', translate=html_translate, sanitize_attributes=False, sanitize_form=False, default=_default_description)
+    description = fields.Html(string='Description', translate=html_translate, restricted_attributes=False, sanitize_form=False, default=_default_description)
     active = fields.Boolean(default=True)
     user_id = fields.Many2one(
         'res.users', string='Responsible', tracking=True,

--- a/addons/gamification/models/gamification_karma_rank.py
+++ b/addons/gamification/models/gamification_karma_rank.py
@@ -11,9 +11,9 @@ class KarmaRank(models.Model):
     _order = 'karma_min'
 
     name = fields.Text(string='Rank Name', translate=True, required=True)
-    description = fields.Html(string='Description', translate=html_translate, sanitize_attributes=False,)
+    description = fields.Html(string='Description', translate=html_translate, restricted_attributes=False,)
     description_motivational = fields.Html(
-        string='Motivational', translate=html_translate, sanitize_attributes=False,
+        string='Motivational', translate=html_translate, restricted_attributes=False,
         help="Motivational phrase to reach this rank on your profile page")
     karma_min = fields.Integer(
         string='Required Karma', required=True, default=1)

--- a/addons/purchase/tests/test_purchase.py
+++ b/addons/purchase/tests/test_purchase.py
@@ -169,7 +169,7 @@ class TestPurchase(AccountTestInvoicingCommon):
         self.assertEqual(po.order_line[1].date_planned, fields.Datetime.today())
         self.assertIn(
             '<p>partner_a modified receipt dates for the following products:</p>\n'
-            '<p> - product_a from 2020-06-06 to %(today)s</p>\n'
+            '<p> - product_a from 2020-06-06 to %(today)s</p>'
             '<p> - product_b from 2020-06-06 to %(today)s</p>' % {'today': fields.Date.today()},
             activity.note,
         )

--- a/addons/purchase_stock/tests/test_purchase_order.py
+++ b/addons/purchase_stock/tests/test_purchase_order.py
@@ -240,7 +240,7 @@ class TestPurchaseOrder(ValuationReconciliationTestCommon):
         self.assertTrue(activity)
         self.assertEqual(
             '<p>partner_a modified receipt dates for the following products:</p>\n'
-            '<p> - Large Desk from %s to %s</p>\n'
+            '<p> - Large Desk from %s to %s</p>'
             '<p>Those dates have been updated accordingly on the receipt %s.</p>' % (today.date(), tomorrow.date(), po.picking_ids.name),
             activity.note,
         )
@@ -256,8 +256,8 @@ class TestPurchaseOrder(ValuationReconciliationTestCommon):
         self.assertEqual(po.order_line[1].date_planned, old_date)
         self.assertEqual(
             '<p>partner_a modified receipt dates for the following products:</p>\n'
-            '<p> - Large Desk from %s to %s</p>\n'
-            '<p> - Conference Chair from %s to %s</p>\n'
+            '<p> - Large Desk from %s to %s</p>'
+            '<p> - Conference Chair from %s to %s</p>'
             '<p>Those dates couldn’t be modified accordingly on the receipt %s which had already been validated.</p>' % (
                 today.date(), tomorrow.date(), today.date(), tomorrow.date(), po.picking_ids.name),
             activity.note,

--- a/addons/sale_quotation_builder/models/product_template.py
+++ b/addons/sale_quotation_builder/models/product_template.py
@@ -11,13 +11,13 @@ class ProductTemplate(models.Model):
     quotation_only_description = fields.Html(
         string="Quotation Only Description",
         translate=html_translate,
-        sanitize_attributes=False,
+        restricted_attributes=False,
         help="The quotation description (not used on eCommerce)")
 
     quotation_description = fields.Html(
         string="Quotation Description",
         compute='_compute_quotation_description',
-        sanitize_attributes=False,
+        restricted_attributes=False,
         help="This field uses the Quotation Only Description if it is defined, "
             "otherwise it will try to read the eCommerce Description.")
 

--- a/addons/sale_quotation_builder/models/sale_order.py
+++ b/addons/sale_quotation_builder/models/sale_order.py
@@ -13,7 +13,7 @@ class SaleOrder(models.Model):
         compute='_compute_website_description',
         store=True, readonly=False, precompute=True,
         sanitize_overridable=True,
-        sanitize_attributes=False, translate=html_translate, sanitize_form=False)
+        restricted_attributes=False, translate=html_translate, sanitize_form=False)
 
     @api.depends('partner_id', 'sale_order_template_id')
     def _compute_website_description(self):

--- a/addons/sale_quotation_builder/models/sale_order_option.py
+++ b/addons/sale_quotation_builder/models/sale_order_option.py
@@ -13,7 +13,7 @@ class SaleOrderOption(models.Model):
         compute='_compute_website_description',
         store=True, readonly=False, precompute=True,
         sanitize_overridable=True,
-        sanitize_attributes=False, translate=html_translate)
+        restricted_attributes=False, translate=html_translate)
 
     @api.depends('product_id')
     def _compute_website_description(self):

--- a/addons/sale_quotation_builder/models/sale_order_template.py
+++ b/addons/sale_quotation_builder/models/sale_order_template.py
@@ -12,7 +12,7 @@ class SaleOrderTemplate(models.Model):
         string="Website Description",
         translate=html_translate,
         sanitize_overridable=True,
-        sanitize_attributes=False,
+        restricted_attributes=False,
         sanitize_form=False)
 
     def action_open_template(self):

--- a/addons/sale_quotation_builder/models/sale_order_template_option.py
+++ b/addons/sale_quotation_builder/models/sale_order_template_option.py
@@ -14,7 +14,7 @@ class SaleOrderTemplateOption(models.Model):
         store=True, readonly=False,
         translate=html_translate,
         sanitize_overridable=True,
-        sanitize_attributes=False)
+        restricted_attributes=False)
 
     @api.depends('product_id')
     def _compute_website_description(self):

--- a/addons/test_mail/tests/test_mail_gateway.py
+++ b/addons/test_mail/tests/test_mail_gateway.py
@@ -83,7 +83,7 @@ class TestEmailParsing(TestMailCommon):
 
         # message with empty body (including only void characters)
         res = self.env['mail.thread'].message_parse(self.from_string(test_mail_data.MAIL_NO_BODY))
-        self.assertEqual(res['body'], '\n \n', 'Gateway should not crash with void content')
+        self.assertEqual(res['body'], '\n\n\n\n    \n \n', 'Gateway should not crash with void content')
 
     def test_message_parse_eml(self):
         # Test that the parsing of mail with embedded emails as eml(msg) which generates empty attachments, can be processed.

--- a/addons/test_mail/tests/test_mail_gateway.py
+++ b/addons/test_mail/tests/test_mail_gateway.py
@@ -55,7 +55,7 @@ class TestEmailParsing(TestMailCommon):
             'Should create a multipart/mixed: from gmail, *bold*, with attachment', res['body'],
             'message_parse: text version should not be in body after parsing multipart/mixed')
         self.assertIn(
-            '<div dir="ltr">Should create a multipart/mixed: from gmail, <b>bold</b>, with attachment.<br clear="all"><div><br></div>', res['body'],
+            '<div dir="ltr">Should create a multipart/mixed: from gmail, <b>bold</b>, with attachment.<br clear="all"/><div><br/></div>', res['body'],
             'message_parse: html version should be in body after parsing multipart/mixed')
 
         res = self.env['mail.thread'].message_parse(self.from_string(test_mail_data.MAIL_MULTIPART_MIXED_TWO))
@@ -133,7 +133,7 @@ class TestEmailParsing(TestMailCommon):
         """ Incoming email in plaintext should be stored as html """
         mail = self.format(test_mail_data.MAIL_TEMPLATE_PLAINTEXT, email_from='"Sylvie Lelitre" <test.sylvie.lelitre@agrolait.com>', to='generic@test.com')
         res = self.env['mail.thread'].message_parse(self.from_string(mail))
-        self.assertIn('<pre>\nPlease call me as soon as possible this afternoon!\n\n--\nSylvie\n</pre>', res['body'])
+        self.assertIn('<pre>\nPlease call me as soon as possible this afternoon!\n<span data-o-mail-quote="1">\n--\nSylvie\n</span></pre>', res['body'])
 
     def test_message_parse_xhtml(self):
         # Test that the parsing of XHTML mails does not fail

--- a/addons/test_mail/tests/test_mail_message.py
+++ b/addons/test_mail/tests/test_mail_message.py
@@ -136,8 +136,8 @@ class TestMessageValues(TestMailCommon):
         self.assertEqual(len(msg.attachment_ids), 1)
         self.assertEqual(
             msg.body,
-            '<p>taratata <img src="/web/image/{attachment.id}?access_token={attachment.access_token}" alt="image0" width="2"> '
-            '<img src="/web/image/{attachment.id}?access_token={attachment.access_token}" alt="image0" width="2"></p>'.format(attachment=msg.attachment_ids[0])
+            '<p>taratata <img alt="image0" src="/web/image/{attachment.id}?access_token={attachment.access_token}" width="2" /> '
+            '<img alt="image0" src="/web/image/{attachment.id}?access_token={attachment.access_token}" width="2" /></p>'.format(attachment=msg.attachment_ids[0])
         )
 
     @mute_logger('odoo.models.unlink')

--- a/addons/test_mail/tests/test_message_post.py
+++ b/addons/test_mail/tests/test_message_post.py
@@ -1179,7 +1179,7 @@ class TestMessagePostHelpers(TestMessagePostCommon):
 
         # check notifications have been sent
         self.assertMailNotifications(new_message, [{
-            'content': f'<p>Body for: {test_record.name}<a href="">link</a></p>',
+            'content': f'<p>Body for: {test_record.name}<a>link</a></p>',
             'message_type': 'comment',
             'notif': [
                 {'partner': self.partner_1, 'type': 'email'},
@@ -1220,7 +1220,7 @@ class TestMessagePostHelpers(TestMessagePostCommon):
 
         # check notifications have been sent
         self.assertMailNotifications(new_message, [{
-            'content': f'<p>Body for: {test_record.name}<a href="">link</a></p>',
+            'content': f'<p>Body for: {test_record.name}<a>link</a></p>',
             'message_type': 'notification',
             'notif': [
                 {'partner': self.partner_1, 'type': 'email'},

--- a/addons/test_mail_sms/tests/test_sms_post.py
+++ b/addons/test_mail_sms/tests/test_sms_post.py
@@ -26,9 +26,9 @@ class TestSMSPost(TestSMSCommon, TestSMSRecipients):
     def test_message_sms_internals_body(self):
         with self.with_user('employee'), self.mockSMSGateway():
             test_record = self.env['mail.test.sms'].browse(self.test_record.id)
-            messages = test_record._message_sms('<p>Mega SMS<br/>Top moumoutte</p>', partner_ids=self.partner_1.ids)
+            messages = test_record._message_sms('<p>Mega SMS<br>Top moumoutte</p>', partner_ids=self.partner_1.ids)
 
-        self.assertEqual(messages.body, '<p>Mega SMS<br>Top moumoutte</p>')
+        self.assertEqual(messages.body, '<p>Mega SMS<br />Top moumoutte</p>')
         self.assertEqual(messages.subtype_id, self.env.ref('mail.mt_note'))
         self.assertSMSNotification([{'partner': self.partner_1}], 'Mega SMS\nTop moumoutte', messages)
 
@@ -56,7 +56,7 @@ class TestSMSPost(TestSMSCommon, TestSMSRecipients):
             test_record = self.env['mail.test.sms'].browse(self.test_record.id)
             messages = test_record._message_sms('<p>Mega SMS<br/>Top moumoutte</p>', subtype_id=self.env.ref('mail.mt_comment').id, partner_ids=self.partner_1.ids)
 
-        self.assertEqual(messages.body, '<p>Mega SMS<br>Top moumoutte</p>')
+        self.assertEqual(messages.body, '<p>Mega SMS<br />Top moumoutte</p>')
         self.assertEqual(messages.subtype_id, self.env.ref('mail.mt_comment'))
         self.assertSMSNotification([{'partner': self.partner_1}], 'Mega SMS\nTop moumoutte', messages)
 

--- a/addons/website_event_exhibitor/models/event_sponsor.py
+++ b/addons/website_event_exhibitor/models/event_sponsor.py
@@ -43,7 +43,7 @@ class Sponsor(models.Model):
     website_description = fields.Html(
         'Description', compute='_compute_website_description',
         sanitize_overridable=True,
-        sanitize_attributes=False, sanitize_form=True, translate=html_translate,
+        restricted_attributes=False, sanitize_form=True, translate=html_translate,
         readonly=False, store=True)
     # contact information
     partner_id = fields.Many2one('res.partner', 'Partner', required=True, auto_join=True)

--- a/addons/website_event_track/models/event_track.py
+++ b/addons/website_event_track/models/event_track.py
@@ -29,7 +29,7 @@ class Track(models.Model):
     user_id = fields.Many2one('res.users', 'Responsible', tracking=True, default=lambda self: self.env.user)
     company_id = fields.Many2one('res.company', related='event_id.company_id')
     tag_ids = fields.Many2many('event.track.tag', string='Tags')
-    description = fields.Html(translate=html_translate, sanitize_attributes=False, sanitize_form=False)
+    description = fields.Html(translate=html_translate, restricted_attributes=False, sanitize_form=False)
     color = fields.Integer('Color')
     priority = fields.Selection([
         ('0', 'Low'), ('1', 'Medium'),

--- a/addons/website_forum/models/forum.py
+++ b/addons/website_forum/models/forum.py
@@ -68,7 +68,7 @@ class Forum(models.Model):
                             </div>
                         </div>
                     </section>""",
-        sanitize_attributes=False,
+        restricted_attributes=False,
         sanitize_form=False)
     default_order = fields.Selection([
         ('create_date desc', 'Newest'),
@@ -830,7 +830,7 @@ class Post(models.Model):
         values = {
             'author_id': self_sudo.create_uid.partner_id.id,  # use sudo here because of access to res.users model
             'email_from': self_sudo.create_uid.email_formatted,  # use sudo here because of access to res.users model
-            'body': tools.html_sanitize(self.content, sanitize_attributes=True, strip_style=True, strip_classes=True),
+            'body': tools.html_sanitize(self.content, restricted_attributes=True, strip_style=True, strip_classes=True),
             'message_type': 'comment',
             'subtype_xmlid': 'mail.mt_comment',
             'date': self.create_date,

--- a/addons/website_hr_recruitment/models/hr_job.py
+++ b/addons/website_hr_recruitment/models/hr_job.py
@@ -19,7 +19,7 @@ class Job(models.Model):
         'Website description', translate=html_translate,
         default=_get_default_website_description, prefetch=False,
         sanitize_overridable=True,
-        sanitize_attributes=False, sanitize_form=False)
+        restricted_attributes=False, sanitize_form=False)
     job_details = fields.Html(
         'Process Details',
         translate=True,

--- a/addons/website_livechat/models/im_livechat.py
+++ b/addons/website_livechat/models/im_livechat.py
@@ -19,5 +19,5 @@ class ImLivechatChannel(models.Model):
     website_description = fields.Html(
         "Website description", default=False, translate=html_translate,
         sanitize_overridable=True,
-        sanitize_attributes=False, sanitize_form=False,
+        restricted_attributes=False, sanitize_form=False,
         help="Description of the channel displayed on the website page")

--- a/addons/website_livechat/tests/test_chatbot_ui.py
+++ b/addons/website_livechat/tests/test_chatbot_ui.py
@@ -41,26 +41,26 @@ class TestLivechatChatbotUI(tests.HttpCase, TestLivechatCommon, ChatbotCase):
         conversation_messages = livechat_mail_channel.message_ids.sorted('id')
 
         expected_messages = [
-            ("Hello! I'm a bot!", operator, False),
+            ("Hello! I&#39;m a bot!", operator, False),
             ("I help lost visitors find their way.", operator, False),
             # next message would normally have 'self.step_dispatch_buy_software' as answer
             # but it's wiped when restarting the script
             ("How can I help you?", operator, False),
             ("I want to buy the software", False, False),
             ("Can you give us your email please?", operator, False),
-            ("No, you won't get my email!", False, False),
-            ("'No, you won't get my email!' does not look like a valid email. Can you please try again?", operator, False),
+            ("No, you won&#39;t get my email!", False, False),
+            ("&#39;No, you won&#39;t get my email!&#39; does not look like a valid email. Can you please try again?", operator, False),
             ("okfine@fakeemail.com", False, False),
             ("Your email is validated, thank you!", operator, False),
             ("Would you mind providing your website address?", operator, False),
             ("https://www.fakeaddress.com", False, False),
             ("Great, do you want to leave any feedback for us to improve?", operator, False),
-            ("Yes, actually, I'm glad you asked!", False, False),
-            ("I think it's outrageous that you ask for all my personal information!", False, False),
+            ("Yes, actually, I&#39;m glad you asked!", False, False),
+            ("I think it&#39;s outrageous that you ask for all my personal information!", False, False),
             ("I will be sure to take this to your manager!", False, False),
             ("Ok bye!", operator, False),
             ("Restarting conversation...", operator, False),
-            ("Hello! I'm a bot!", operator, False),
+            ("Hello! I&#39;m a bot!", operator, False),
             ("I help lost visitors find their way.", operator, False),
             ("How can I help you?", operator, self.step_dispatch_pricing),
             ("Pricing Question", False, False),

--- a/addons/website_sale/models/product_public_category.py
+++ b/addons/website_sale/models/product_public_category.py
@@ -29,7 +29,7 @@ class ProductPublicCategory(models.Model):
     child_id = fields.One2many('product.public.category', 'parent_id', string='Children Categories')
     parents_and_self = fields.Many2many('product.public.category', compute='_compute_parents_and_self')
     sequence = fields.Integer(help="Gives the sequence order when displaying a list of product categories.", index=True, default=_default_sequence)
-    website_description = fields.Html('Category Description', sanitize_overridable=True, sanitize_attributes=False, translate=html_translate, sanitize_form=False)
+    website_description = fields.Html('Category Description', sanitize_overridable=True, restricted_attributes=False, translate=html_translate, sanitize_form=False)
     product_tmpl_ids = fields.Many2many('product.template', relation='product_public_category_product_template_rel')
 
     @api.constrains('parent_id')

--- a/addons/website_sale/models/product_template.py
+++ b/addons/website_sale/models/product_template.py
@@ -23,7 +23,7 @@ class ProductTemplate(models.Model):
     website_description = fields.Html(
         'Description for the website', translate=html_translate,
         sanitize_overridable=True,
-        sanitize_attributes=False, sanitize_form=False)
+        restricted_attributes=False, sanitize_form=False)
     alternative_product_ids = fields.Many2many(
         'product.template', 'product_alternative_rel', 'src_id', 'dest_id', check_company=True,
         string='Alternative Products', help='Suggest alternatives to your customer (upsell strategy). '

--- a/addons/website_slides/models/slide_channel.py
+++ b/addons/website_slides/models/slide_channel.py
@@ -223,9 +223,9 @@ class Channel(models.Model):
     # description
     name = fields.Char('Name', translate=True, required=True)
     active = fields.Boolean(default=True, tracking=100)
-    description = fields.Html('Description', translate=True, sanitize_attributes=False, sanitize_form=False, help="The description that is displayed on top of the course page, just below the title")
-    description_short = fields.Html('Short Description', translate=True, sanitize_attributes=False, sanitize_form=False, help="The description that is displayed on the course card")
-    description_html = fields.Html('Detailed Description', translate=tools.html_translate, sanitize_attributes=False, sanitize_form=False)
+    description = fields.Html('Description', translate=True, restricted_attributes=False, sanitize_form=False, help="The description that is displayed on top of the course page, just below the title")
+    description_short = fields.Html('Short Description', translate=True, restricted_attributes=False, sanitize_form=False, help="The description that is displayed on the course card")
+    description_html = fields.Html('Detailed Description', translate=tools.html_translate, restricted_attributes=False, sanitize_form=False)
     channel_type = fields.Selection([
         ('training', 'Training'), ('documentation', 'Documentation')],
         string="Course type", default="training", required=True)
@@ -292,7 +292,7 @@ class Channel(models.Model):
         help='Defines how people can enroll to your Course.', copy=False)
     enroll_msg = fields.Html(
         'Enroll Message', help="Message explaining the enroll process",
-        default=_get_default_enroll_msg, translate=tools.html_translate, sanitize_attributes=False)
+        default=_get_default_enroll_msg, translate=tools.html_translate, restricted_attributes=False)
     enroll_group_ids = fields.Many2many('res.groups', string='Auto Enroll Groups', help="Members of those groups are automatically added as members of the channel.")
     visibility = fields.Selection([
         ('public', 'Open To All'), ('members', 'Members Only')],

--- a/addons/website_slides/models/slide_slide.py
+++ b/addons/website_slides/models/slide_slide.py
@@ -171,7 +171,7 @@ class Slide(models.Model):
     # google
     google_drive_id = fields.Char('Google Drive ID of the external URL', compute='_compute_google_drive_id')
     # content - webpage
-    html_content = fields.Html("HTML Content", help="Custom HTML content for slides of category 'Article'.", translate=True, sanitize_attributes=False, sanitize_form=False)
+    html_content = fields.Html("HTML Content", help="Custom HTML content for slides of category 'Article'.", translate=True, restricted_attributes=False, sanitize_form=False)
     # content - images
     image_binary_content = fields.Binary('Image Content', related='binary_content', readonly=False) # Used to filter file input to images only
     image_google_url = fields.Char('Image Link', related='url', readonly=False,

--- a/odoo/addons/base/models/ir_qweb_fields.py
+++ b/odoo/addons/base/models/ir_qweb_fields.py
@@ -13,7 +13,7 @@ from lxml import etree, html
 
 from odoo import api, fields, models, _, _lt, tools
 from odoo.tools import posix_to_ldml, float_utils, format_date, format_duration, pycompat
-from odoo.tools.mail import safe_attrs
+from odoo.tools.html_sanitize import SAFE_ATTRIBUTES
 from odoo.tools.misc import get_lang, babel_locale_parse
 
 _logger = logging.getLogger(__name__)
@@ -716,7 +716,7 @@ class BarcodeConverter(models.AbstractModel):
 
         img_element = html.Element('img')
         for k, v in options.items():
-            if k.startswith('img_') and k[4:] in safe_attrs:
+            if k.startswith('img_') and k[4:] in SAFE_ATTRIBUTES:
                 img_element.set(k[4:], v)
         if not img_element.get('alt'):
             img_element.set('alt', _('Barcode %s') % value)

--- a/odoo/addons/base/tests/test_mail.py
+++ b/odoo/addons/base/tests/test_mail.py
@@ -18,6 +18,7 @@ from odoo.tools import (
     email_split, email_domain_normalize,
     misc, formataddr,
     prepend_html_content,
+    quote_email,
 )
 
 from . import test_mail_examples
@@ -155,49 +156,54 @@ class TestSanitizer(BaseCase):
             'html_sanitize removed valid img')
         self.assertNotIn('</body></html>', html, 'html_sanitize did not remove extra closing tags')
 
+    def test_quote_escape(self):
+        """Test that the email quoting do not escape some specials characters."""
+        src = 'éàè@$€£%~#'
+        self.assertIn(src, quote_email(src))
+
     def test_quote_blockquote(self):
-        html = html_sanitize(test_mail_examples.QUOTE_BLOCKQUOTE)
+        html = quote_email(test_mail_examples.QUOTE_BLOCKQUOTE)
         for ext in test_mail_examples.QUOTE_BLOCKQUOTE_IN:
             self.assertIn(ext, html)
         for ext in test_mail_examples.QUOTE_BLOCKQUOTE_OUT:
-            self.assertIn(u'<span data-o-mail-quote="1">%s' % misc.html_escape(ext), html)
+            self.assertIn('<span data-o-mail-quote="1">%s' % misc.html_escape(ext), html)
 
     def test_quote_thunderbird(self):
-        html = html_sanitize(test_mail_examples.QUOTE_THUNDERBIRD_1)
+        html = quote_email(test_mail_examples.QUOTE_THUNDERBIRD_1)
         for ext in test_mail_examples.QUOTE_THUNDERBIRD_1_IN:
             self.assertIn(ext, html)
         for ext in test_mail_examples.QUOTE_THUNDERBIRD_1_OUT:
-            self.assertIn(u'<span data-o-mail-quote="1">%s</span>' % misc.html_escape(ext), html)
+            self.assertIn('<span data-o-mail-quote="1">%s</span>' % misc.html_escape(ext), html)
 
     def test_quote_hotmail_html(self):
-        html = html_sanitize(test_mail_examples.QUOTE_HOTMAIL_HTML)
+        html = quote_email(test_mail_examples.QUOTE_HOTMAIL_HTML)
         for ext in test_mail_examples.QUOTE_HOTMAIL_HTML_IN:
             self.assertIn(ext, html)
         for ext in test_mail_examples.QUOTE_HOTMAIL_HTML_OUT:
             self.assertIn(ext, html)
 
-        html = html_sanitize(test_mail_examples.HOTMAIL_1)
+        html = quote_email(test_mail_examples.HOTMAIL_1)
         for ext in test_mail_examples.HOTMAIL_1_IN:
             self.assertIn(ext, html)
         for ext in test_mail_examples.HOTMAIL_1_OUT:
             self.assertIn(ext, html)
 
     def test_quote_outlook_html(self):
-        html = html_sanitize(test_mail_examples.QUOTE_OUTLOOK_HTML)
+        html = quote_email(test_mail_examples.QUOTE_OUTLOOK_HTML)
         for ext in test_mail_examples.QUOTE_OUTLOOK_HTML_IN:
             self.assertIn(ext, html)
         for ext in test_mail_examples.QUOTE_OUTLOOK_HTML_OUT:
             self.assertIn(ext, html)
 
     def test_quote_thunderbird_html(self):
-        html = html_sanitize(test_mail_examples.QUOTE_THUNDERBIRD_HTML)
+        html = quote_email(test_mail_examples.QUOTE_THUNDERBIRD_HTML)
         for ext in test_mail_examples.QUOTE_THUNDERBIRD_HTML_IN:
             self.assertIn(ext, html)
         for ext in test_mail_examples.QUOTE_THUNDERBIRD_HTML_OUT:
             self.assertIn(ext, html)
 
     def test_quote_yahoo_html(self):
-        html = html_sanitize(test_mail_examples.QUOTE_YAHOO_HTML)
+        html = quote_email(test_mail_examples.QUOTE_YAHOO_HTML)
         for ext in test_mail_examples.QUOTE_YAHOO_HTML_IN:
             self.assertIn(ext, html)
         for ext in test_mail_examples.QUOTE_YAHOO_HTML_OUT:
@@ -224,50 +230,50 @@ class TestSanitizer(BaseCase):
             )
         ]
         for test, in_lst, out_lst in test_data:
-            new_html = html_sanitize(test)
+            new_html = quote_email(test)
             for text in in_lst:
                 self.assertIn(text, new_html)
             for text in out_lst:
-                self.assertIn(u'<span data-o-mail-quote="1">%s</span>' % misc.html_escape(text), new_html)
+                self.assertIn('<span data-o-mail-quote="1">%s</span>' % misc.html_escape(text), new_html)
 
     def test_quote_signature(self):
         test_data = [
             (
                 """<div>Hello<pre>--<br />Administrator</pre></div>""",
-                ["<pre data-o-mail-quote=\"1\">--", "<br data-o-mail-quote=\"1\">"],
+                ["<pre data-o-mail-quote=\"1\">--", '<br data-o-mail-quote="1">'],
             )
         ]
         for test, in_lst in test_data:
-            new_html = html_sanitize(test)
+            new_html = quote_email(test)
             for text in in_lst:
                 self.assertIn(text, new_html)
 
     def test_quote_gmail(self):
-        html = html_sanitize(test_mail_examples.GMAIL_1)
+        html = quote_email(test_mail_examples.GMAIL_1)
         for ext in test_mail_examples.GMAIL_1_IN:
             self.assertIn(ext, html)
         for ext in test_mail_examples.GMAIL_1_OUT:
-            self.assertIn(u'<span data-o-mail-quote="1">%s</span>' % misc.html_escape(ext), html)
+            self.assertIn('<span data-o-mail-quote="1">%s</span>' % misc.html_escape(ext), html)
 
     def test_quote_text(self):
-        html = html_sanitize(test_mail_examples.TEXT_1)
+        html = quote_email(test_mail_examples.TEXT_1)
         for ext in test_mail_examples.TEXT_1_IN:
             self.assertIn(ext, html)
         for ext in test_mail_examples.TEXT_1_OUT:
-            self.assertIn(u'<span data-o-mail-quote="1">%s</span>' % misc.html_escape(ext), html)
+            self.assertIn('<span data-o-mail-quote="1">%s</span>' % misc.html_escape(ext), html)
 
-        html = html_sanitize(test_mail_examples.TEXT_2)
+        html = quote_email(test_mail_examples.TEXT_2)
         for ext in test_mail_examples.TEXT_2_IN:
             self.assertIn(ext, html)
         for ext in test_mail_examples.TEXT_2_OUT:
-            self.assertIn(u'<span data-o-mail-quote="1">%s</span>' % misc.html_escape(ext), html)
+            self.assertIn('<span data-o-mail-quote="1">%s</span>' % misc.html_escape(ext), html)
 
     def test_quote_bugs(self):
-        html = html_sanitize(test_mail_examples.BUG1)
+        html = quote_email(test_mail_examples.BUG1)
         for ext in test_mail_examples.BUG_1_IN:
             self.assertIn(ext, html)
         for ext in test_mail_examples.BUG_1_OUT:
-            self.assertIn(u'<span data-o-mail-quote="1">%s</span>' % misc.html_escape(ext), html)
+            self.assertIn('<span data-o-mail-quote="1">%s</span>' % misc.html_escape(ext), html)
 
     def test_misc(self):
         # False / void should not crash

--- a/odoo/addons/base/tests/test_mail_examples.py
+++ b/odoo/addons/base/tests/test_mail_examples.py
@@ -104,8 +104,7 @@ web: <a class="moz-txt-link-freetext" href="https://opener.am">https://opener.am
 </html>"""
 
 QUOTE_BLOCKQUOTE_IN = [u"""<blockquote cite="mid:CAEJSRZvWvud8c6Qp=wfNG6O1+wK3i_jb33qVrF7XyrgPNjnyUA@mail.gmail.com" type="cite" data-o-mail-quote-node="1" data-o-mail-quote="1">"""]
-QUOTE_BLOCKQUOTE_OUT = [u"""-- 
-Opener B.V. - Business solutions driven by open source collaboration
+QUOTE_BLOCKQUOTE_OUT = [u"""-- \nOpener B.V. - Business solutions driven by open source collaboration
 
 Stefan Rijnhart - Consultant/developer"""]
 
@@ -595,9 +594,25 @@ REMOVE_CLASS = u"""
 </div>
 """
 REMOVE_CLASS_IN = [
-    u'<div style="font-size:12pt; font-family:\'Times New Roman\'; color:#000000">',
-    u'An error occurred in a modal and I will send you back the html to try opening one on your end']
+    '<div style="FONT-SIZE: 12pt; FONT-FAMILY: \'Times New Roman\'; COLOR: #000000;">',
+    'An error occurred in a modal and I will send you back the html to try opening one on your end']
 REMOVE_CLASS_OUT = [
     u'<div class="modal-backdrop in">',
     u'<div class="modal-content openerp">',
     u'<div class="modal-header">']
+
+BASIC_STYLES = u"""
+<div>
+<p><span style="font-weight: bolder;">Bold</span></p>
+<p><span style="font-style: italic;">Italic</span></p>
+<p><span style="text-decoration: line-through;">Strike&nbsp;trough</span><br></p>
+<p><span style="text-decoration-line: underline;">Underlined</span></p>
+<p><font style="background-color: rgb(255, 255, 0);">Background color</font></p>
+<p><font style="background-image: linear-gradient(135deg, rgb(255, 204, 51) 0%, rgb(226, 51, 255) 100%);">Gradient</font></p>
+<p><span style="font-size: 10px;">Font size</span></p>
+</div>
+"""
+BASIC_STYLES_EXPECTED = ['font-weight: bolder;', 'font-style: italic;', 'text-decoration: line-through;',
+                        'text-decoration-line: underline;', 'background-color: rgb(255, 255, 0);',
+                        'background-image: linear-gradient(135deg, rgb(255, 204, 51) 0%, rgb(226, 51, 255) 100%);',
+                        'font-size: 10px;']

--- a/odoo/addons/base/tests/test_xmlrpc.py
+++ b/odoo/addons/base/tests/test_xmlrpc.py
@@ -53,7 +53,7 @@ class TestXMLRPC(common.HttpCase):
         )
 
     def test_xmlrpc_html_field(self):
-        sig = '<p>bork bork bork <span style="font-weight: bork">bork</span><br></p>'
+        sig = '<p>bork bork bork <span style="font-weight: bork;">bork</span><br /></p>'
         r = self.env['res.users'].create({
             'name': 'bob',
             'login': 'bob',

--- a/odoo/addons/test_new_api/models/test_new_api.py
+++ b/odoo/addons/test_new_api/models/test_new_api.py
@@ -333,10 +333,10 @@ class MixedModel(models.Model):
     reference = fields.Reference(string='Related Document',
         selection='_reference_models')
     comment1 = fields.Html(sanitize=False)
-    comment2 = fields.Html(sanitize_attributes=True, strip_classes=False)
-    comment3 = fields.Html(sanitize_attributes=True, strip_classes=True)
-    comment4 = fields.Html(sanitize_attributes=True, strip_style=True)
-    comment5 = fields.Html(sanitize_overridable=True, sanitize_attributes=False)
+    comment2 = fields.Html(restricted_attributes=True, strip_classes=False)
+    comment3 = fields.Html(restricted_attributes=True, strip_classes=True)
+    comment4 = fields.Html(restricted_attributes=True, strip_style=True)
+    comment5 = fields.Html(sanitize_overridable=True, restricted_attributes=False)
 
     currency_id = fields.Many2one('res.currency', default=lambda self: self.env.ref('base.EUR'))
     amount = fields.Monetary()

--- a/odoo/tools/__init__.py
+++ b/odoo/tools/__init__.py
@@ -9,6 +9,7 @@ from . import pycompat
 from . import win32
 from .barcode import *
 from .config import config
+from .html_sanitize import html_sanitize, html_compare
 from .date_utils import *
 from .debugger import *
 from .float_utils import *

--- a/odoo/tools/html_sanitize.py
+++ b/odoo/tools/html_sanitize.py
@@ -1,0 +1,327 @@
+# -*- coding: utf-8 -*-
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from lxml import etree, html
+import logging
+import markupsafe
+import re
+
+from bleach import html5lib_shim
+from bleach.sanitizer import BleachSanitizerFilter
+from odoo.loglevels import ustr
+
+
+_logger = logging.getLogger(__name__)
+
+SAFE_ATTRIBUTES = {
+    'aria-expanded', 'abbr', 'accept', 'accept-charset', 'accesskey', 'action', 'align',
+    'alt', 'axis', 'backdropxmlns', 'bgcolor', 'border', 'cellpadding', 'cellspacing',
+    'char', 'charoff', 'charset', 'checked', 'cite', 'class', 'clear', 'color', 'cols',
+    'colspan', 'compact', 'content', 'contentxmlns', 'coords', 'data-class',
+    'data-file-name', 'data-gl-filter', 'data-id', 'data-interval', 'data-member_id',
+    'data-mimetype', 'data-o-mail-quote', 'data-o-mail-quote-container',
+    'data-o-mail-quote-node', 'data-oe-expression', 'data-oe-field', 'data-oe-id',
+    'data-oe-model', 'data-oe-nodeid', 'data-oe-translation-id', 'data-oe-type',
+    'data-original-id', 'data-original-mimetype', 'data-original-src', 'data-publish',
+    'data-quality', 'data-res_id', 'data-resize-width', 'data-scroll-background-ratio',
+    'data-shape', 'data-shape-colors', 'data-view-id', 'data-oe-translation-initial-sha',
+    'data-oe-protected',  # editor
+    'data-behavior-props', 'data-prop-name',  # knowledge commands
+    'datetime', 'dir', 'disabled',
+    'enctype', 'equiv', 'face', 'for', 'headers', 'height', 'hidden', 'href', 'hreflang',
+    'hspace', 'http-equiv', 'id', 'ismap', 'itemprop', 'itemscope', 'itemtype', 'label',
+    'lang', 'loading', 'longdesc', 'maxlength', 'media', 'method', 'multiple', 'name',
+    'nohref', 'noshade', 'nowrap', 'prompt', 'readonly', 'rel', 'res_id', 'res_model',
+    'rev', 'role', 'rows', 'rowspan', 'rules', 'scope', 'selected', 'shape', 'size',
+    'span', 'src', 'start', 'style', 'summary', 'tabindex', 'target', 'text', 'title',
+    'token', 'type', 'usemap', 'valign', 'value', 'version', 'vspace', 'widget', 'width',
+    'xml:lang', 'xmlns',
+}
+
+SAFE_TAGS = {
+    'a', 'abbr', 'acronym', 'address', 'applet', 'area', 'article', 'aside',
+    'audio', 'b', 'basefont', 'bdi', 'bdo', 'big', 'blink', 'blockquote', 'bodyb',
+    'br', 'button', 'c', 'canvas', 'caption', 'center', 'cite', 'code', 'col',
+    'colgroup', 'command', 'd', 'datalist', 'dd', 'del', 'details', 'dfn', 'dir',
+    'div', 'dl', 'dt', 'e', 'em', 'f', 'fieldset', 'figcaption', 'figure', 'font',
+    'footer', 'form', 'frameset', 'h', 'h1', 'h2', 'h3', 'h4', 'h5', 'h6', 'header',
+    'hgroup', 'hr', 'html', 'i', 'img', 'input', 'ins', 'isindex', 'kbd', 'keygen',
+    'l', 'label', 'legend', 'li', 'm', 'main', 'map', 'mark', 'marquee', 'math',
+    'menu', 'meter', 'n', 'nav', 'o', 'ol', 'optgroup', 'option', 'output', 'p',
+    'param', 'pre', 'progress', 'q', 'role', 'rp', 'rt', 'ruby', 's', 'samp', 'section',
+    'select', 'small', 'source', 'span', 'strike', 'strong', 'sub', 'summary', 'sup',
+    'svg', 't', 'table', 'tbody', 'td', 'textarea', 'tfoot', 'th', 'thead', 'time',
+    'tr', 'track', 'tt', 'u', 'ul', 'var', 'video', 'wbr',
+}
+
+
+# Those tags are removed and their children as well
+# If sanitize_tags is False, this list is ignored
+KILL_TAGS = {
+    'base', 'embed', 'frame', 'head', 'iframe', 'link', 'meta',
+    'noscript', 'object', 'script', 'style', 'title',
+}
+
+# Those tag are remove even if sanitize_tags is False
+CLEAN_TAGS = {
+    'meta',
+}
+
+STYLE_SAFE_ATTRIBUTES = {
+    'background-color', 'color', 'display', 'float', 'font-family', 'font-size', 'font-style',
+    'font-weight', 'letter-spacing', 'line-height', 'margin', 'margin-bottom',
+    'margin-left', 'margin-right', 'margin-top', 'opacity', 'padding', 'padding-bottom',
+    'padding-left', 'padding-right', 'padding-top', 'text-align', 'text-decoration',
+    'text-transform', 'vertical-align', 'white-space'
+    # box model
+    'border', 'border-bottom', 'border-color', 'border-radius', 'border-style',
+    'border-top', 'border-width', 'height', 'max-width', 'min-height', 'min-width',
+    'width',
+    # tables
+    'border-collapse', 'border-spacing', 'caption-side',
+    'empty-cells', 'table-layout',
+    # border style
+    *{
+        f'border-{position}-{attribute}'
+        for position in ('top', 'bottom', 'left', 'right')
+        for attribute in ('style', 'color', 'width', 'left-radius', 'right-radius')
+    },
+}
+
+
+KILLED_TAG_NAME = '__<killed>__'
+re_tag_start = rf'<\s*{KILLED_TAG_NAME}[^>]*>'
+re_tag_end = rf'<\/\s*{KILLED_TAG_NAME}\s*>'
+
+re_killed_tag = re.compile(re_tag_start + '.*?' + re_tag_end, re.DOTALL)
+re_killed_empty = re.compile(re_tag_start, re.DOTALL)
+
+DATA_ATTRIBUTE_REGEX = re.compile(r'^[a-zA-Z0-9\-_]*$')
+
+
+class OdooCleaner(BleachSanitizerFilter):
+    """HTML cleaner, allow us to have more control on the bleach sanitizer.
+
+    We do not use the standard bleach Cleaner, because we are limited in the
+    customization we can make. E.G. the "data:" protocol is blocked for a good reason.
+    But it can be useful to embed image "data:image/png;base64,". With the standard
+    cleaner, there's no way to check the entire value (we can only allow the entire
+    protocol "data:" or block it).
+
+    We also need to strip some elements all their children. E.G. if we remove a
+    <style/> tags, we don't want to keep the CSS code in the HTML source.
+    """
+
+    def __init__(self, sanitize_tags=True, sanitize_form=True, sanitize_style=False, **kwargs):
+        self.sanitize_tags = sanitize_tags
+        self.sanitize_form = sanitize_form
+        self.sanitize_style = sanitize_style
+        super().__init__(**kwargs)
+
+    def sanitize_css(self, style):
+        """Disable sanitization of CSS based on self.sanitize_style."""
+        if self.sanitize_style:
+            return super().sanitize_css(style)
+
+        return style
+
+    def sanitize_token(self, token):
+        tag_name = token.get('name', '').lower().strip()
+        tag_type = token['type']
+
+        if self.sanitize_form and tag_name == 'form':
+            # Ignore sanitize_tags, always remove it
+            return self._mark_to_kill(token)
+
+        if self.sanitize_tags and tag_name in KILL_TAGS:
+            # We will strip manually those token because
+            # bleach will keep the child elements
+            return self._mark_to_kill(token)
+
+        if (not self.sanitize_tags
+           and tag_type in ('StartTag', 'EmptyTag', 'EndTag')
+           and tag_name not in CLEAN_TAGS):
+            return self.allow_token(token)
+
+        # Sanitize attributes and tags
+        return super().sanitize_token(token)
+
+    def _mark_to_kill(self, token):
+        """Kill a token, the element and all its children will be removed.
+
+        We just keep the token type (StartTag, EndTag,...) and use a custom tag name
+        to be able to remove it after the bleach sanitization. This is needed because
+        bleach only remove the element itself and not its children.
+
+        See https://github.com/mozilla/bleach/issues/67
+        See https://github.com/mozilla/bleach/issues/185
+        """
+        return {
+            'name': KILLED_TAG_NAME,
+            'type': token['type'],
+            'data': {},
+        }
+
+    def sanitize_uri_value(self, value, allowed_protocols):
+        allowed_data_protocols = (
+            'data:image/png;base64,',
+            'data:image/jpg;base64,',
+            'data:image/jpeg;base64,',
+            'data:image/bmp;base64,',
+            'data:image/gif;base64,',
+        )
+
+        if value.startswith(allowed_data_protocols):
+            return value
+
+        return super().sanitize_uri_value(value, allowed_protocols)
+
+
+def html_sanitize(
+    src,
+    silent=True,
+    sanitize_tags=True,
+    restricted_attributes=True,
+    sanitize_style=False,
+    sanitize_form=True,
+    strip_style=False,
+    strip_classes=False,
+):
+    """Sanitize an un-trusted HTML source to be safe from a XSS point of view.
+
+    Automatically close the HTML tags, can remove form, style tags, prevent
+    dangling markup, etc...
+
+    Careful if you change one default value, it might create a XSS,
+    do not change them if you don't know what you do!
+
+    :param src: HTML string to sanitize
+    :param silent: If an error occurs during the parsing, do not raise
+        If True, the HTML content is replaced by an error message
+    :param sanitize_tags: Allow only an allowed list of HTML tags
+    :param restricted_attributes: Allow only an allowed list of attributes
+        If False, all data-XXX attributes are already allowed
+    :param sanitize_style: Sanitize the style attribute, allow only an allowed list of CSS value
+    :param sanitize_form: Remove any <form/> tags
+    :param strip_style: Remove any "style" attribute, can not be used when sanitize_style is set
+    :param strip_classes: Remove any "class" attribute
+    """
+    if isinstance(src, bytes):
+        src = ustr(src)
+
+    if not src or src.isspace():
+        return src
+
+    safe_tag = SAFE_TAGS.copy()
+    safe_attributes = SAFE_ATTRIBUTES.copy()
+
+    assert not (
+        strip_style and sanitize_style
+    ), 'You can not both sanitize and remove the style attributes at the same time.'
+
+    if strip_style:
+        safe_attributes.remove('style')
+    if strip_classes:
+        safe_attributes.remove('class')
+
+    def check_attribute(tag, name, value):
+        if not restricted_attributes and name.lower().startswith('data-'):
+            return bool(DATA_ATTRIBUTE_REGEX.match(name))
+        return name.lower() in safe_attributes
+
+    parser = html5lib_shim.BleachHTMLParser(
+        tags=None,
+        strip=False,
+        consume_entities=False,
+        namespaceHTMLElements=False,
+    )
+    walker = html5lib_shim.getTreeWalker('etree')
+
+    serializer = html5lib_shim.BleachHTMLSerializer(
+        quote_attr_values='always',
+        omit_optional_tags=False,
+        escape_lt_in_attrs=True,
+        resolve_entities=False,
+        sanitize=False,
+        alphabetical_attributes=False,
+        minimize_boolean_attributes=False,
+        use_trailing_solidus=True,
+    )
+
+    try:
+        filtered = OdooCleaner(
+            source=walker(parser.parseFragment(src)),
+            allowed_elements=safe_tag,
+            attributes={'*': check_attribute},
+            allowed_protocols={
+                'http',
+                'https',
+                'mailto',
+                'tel',
+                'sms',
+                'mid',
+                'cid',
+            },
+            strip_disallowed_elements=True,
+            strip_html_comments=True,
+            allowed_css_properties=STYLE_SAFE_ATTRIBUTES,
+            # Custom arguments
+            sanitize_tags=sanitize_tags,
+            sanitize_form=sanitize_form,
+            sanitize_style=sanitize_style,
+        )
+
+        cleaned_src = serializer.render(filtered)
+
+    except Exception:
+        if not silent:
+            raise
+
+        _logger.warning('unknown error when sanitizing %r', src, exc_info=True)
+        cleaned_src = '<p>Unknown error when sanitizing</p>'
+
+    # See OdooCleaner, we need to removed the killed elements
+    cleaned_src = re_killed_tag.sub('', cleaned_src)
+    cleaned_src = re_killed_empty.sub('', cleaned_src)
+
+    return html_normalize(cleaned_src)
+
+
+def html_normalize(html_value):
+    """Normalize `html_value` for storage as an html field value.
+
+    :param html_value: the html string to normalize
+    """
+    if not html_value:
+        return html_value
+
+    if not html_value or html_value.isspace():
+        return html_value
+
+    html_value = html_value.strip()
+
+    if '<p' not in html_value and html_value[0] != '<':
+        # ensure that a simple text will be embed into a <p/>
+        html_value = f'<p>{html_value}</p>'
+
+    return markupsafe.Markup(html_value)
+
+
+def html_canonicalize(html_value):
+    """Return the canonical form of the HTML value (attributes are sorted, etc)."""
+    if not html_value:
+        return ''
+
+    # method "c14n" sort XML attributes
+    # (encoding is not compatible with canonicalisation)
+    result = etree.tostring(html.fromstring(html_value), method='c14n').decode()
+    # replace multiple space between tags with a single space
+    result = re.sub(r'(>|^)\s+(<|$)', r'\g<1> \g<2>', result)
+    return result
+
+
+def html_compare(source_1, source_2):
+    """Compare 2 HTML sources and return True if they are considered as the same."""
+    source_1 = html_canonicalize(html_normalize(source_1))
+    source_2 = html_canonicalize(html_normalize(source_2))
+    return source_1 == source_2

--- a/odoo/tools/mail.py
+++ b/odoo/tools/mail.py
@@ -105,6 +105,11 @@ class _Cleaner(clean.Cleaner):
                 del el.attrib['style']
 
 
+# ----------------------------------------------------------
+# Email Quote
+# ----------------------------------------------------------
+
+
 def tag_quote(el):
     def _create_new_node(tag, text, tail=None, attrs=None):
         new_node = etree.Element(tag)
@@ -205,11 +210,6 @@ def html_normalize(src, filter_callback=None):
             return u""
         raise
 
-    # perform quote detection before cleaning and class removal
-    if doc is not None:
-        for el in doc.iter(tag=etree.Element):
-            tag_quote(el)
-
     if filter_callback:
         doc = filter_callback(doc)
 
@@ -278,6 +278,23 @@ def html_sanitize(src, silent=True, sanitize_tags=True, sanitize_attributes=Fals
         sanitized = '<p>Unknown error when sanitizing</p>'
 
     return markupsafe.Markup(sanitized)
+
+
+def quote_email(src):
+    root = etree.HTML(src)
+    for el in root.iter(tag=etree.Element):
+        tag_quote(el)
+
+    quoted_src = etree.tostring(root, method='html').decode()
+
+    quoted_src = quoted_src.replace('&#233;', 'é')
+    quoted_src = quoted_src.replace('&#224;', 'à')
+    quoted_src = quoted_src.replace('&#232;', 'è')
+    quoted_src = quoted_src.replace('&#8364;', '€')
+    quoted_src = quoted_src.replace('&#163;', '£')
+
+    return quoted_src
+
 
 # ----------------------------------------------------------
 # HTML/Text management

--- a/odoo/tools/mail.py
+++ b/odoo/tools/mail.py
@@ -2,108 +2,26 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 import base64
-import collections
+import html
 import logging
 import random
 import re
 import socket
-import threading
 import time
 from email.utils import getaddresses
 from urllib.parse import urlparse
 
 import idna
 import markupsafe
-from lxml import etree, html
-from lxml.html import clean
+from lxml import etree
 from werkzeug import urls
 
-import odoo
 from odoo.loglevels import ustr
 from odoo.tools import misc
 
+from .html_sanitize import html_sanitize
+
 _logger = logging.getLogger(__name__)
-
-#----------------------------------------------------------
-# HTML Sanitizer
-#----------------------------------------------------------
-
-safe_attrs = clean.defs.safe_attrs | frozenset(
-    ['style',
-     'data-o-mail-quote',  # quote detection
-     'data-oe-model', 'data-oe-id', 'data-oe-field', 'data-oe-type', 'data-oe-expression', 'data-oe-translation-initial-sha', 'data-oe-nodeid',
-     'data-publish', 'data-id', 'data-res_id', 'data-interval', 'data-member_id', 'data-scroll-background-ratio', 'data-view-id',
-     'data-class', 'data-mimetype', 'data-original-src', 'data-original-id', 'data-gl-filter', 'data-quality', 'data-resize-width',
-     'data-shape', 'data-shape-colors', 'data-file-name', 'data-original-mimetype',
-     'data-oe-protected',  # editor
-     'data-behavior-props', 'data-prop-name',  # knowledge commands
-     ])
-SANITIZE_TAGS = {
-    # allow new semantic HTML5 tags
-    'allow_tags': clean.defs.tags | frozenset('article bdi section header footer hgroup nav aside figure main'.split() + [etree.Comment]),
-    'kill_tags': ['base', 'embed', 'frame', 'head', 'iframe', 'link', 'meta',
-                  'noscript', 'object', 'script', 'style', 'title'],
-    'remove_tags': ['html', 'body'],
-}
-
-
-class _Cleaner(clean.Cleaner):
-
-    _style_re = re.compile(r'''([\w-]+)\s*:\s*((?:[^;"']|"[^";]*"|'[^';]*')+)''')
-
-    _style_whitelist = [
-        'font-size', 'font-family', 'font-weight', 'font-style', 'background-color', 'color', 'text-align',
-        'line-height', 'letter-spacing', 'text-transform', 'text-decoration', 'text-decoration', 'opacity',
-        'float', 'vertical-align', 'display',
-        'padding', 'padding-top', 'padding-left', 'padding-bottom', 'padding-right',
-        'margin', 'margin-top', 'margin-left', 'margin-bottom', 'margin-right',
-        'white-space',
-        # box model
-        'border', 'border-color', 'border-radius', 'border-style', 'border-width', 'border-top', 'border-bottom',
-        'height', 'width', 'max-width', 'min-width', 'min-height',
-        # tables
-        'border-collapse', 'border-spacing', 'caption-side', 'empty-cells', 'table-layout']
-
-    _style_whitelist.extend(
-        ['border-%s-%s' % (position, attribute)
-            for position in ['top', 'bottom', 'left', 'right']
-            for attribute in ('style', 'color', 'width', 'left-radius', 'right-radius')]
-    )
-
-    strip_classes = False
-    sanitize_style = False
-
-    def __call__(self, doc):
-        super(_Cleaner, self).__call__(doc)
-
-        # if we keep attributes but still remove classes
-        if not getattr(self, 'safe_attrs_only', False) and self.strip_classes:
-            for el in doc.iter(tag=etree.Element):
-                self.strip_class(el)
-
-        # if we keep style attribute, sanitize them
-        if not self.style and self.sanitize_style:
-            for el in doc.iter(tag=etree.Element):
-                self.parse_style(el)
-
-    def strip_class(self, el):
-        if el.attrib.get('class'):
-            del el.attrib['class']
-
-    def parse_style(self, el):
-        attributes = el.attrib
-        styling = attributes.get('style')
-        if styling:
-            valid_styles = collections.OrderedDict()
-            styles = self._style_re.findall(styling)
-            for style in styles:
-                if style[0].lower() in self._style_whitelist:
-                    valid_styles[style[0].lower()] = style[1]
-            if valid_styles:
-                el.attrib['style'] = '; '.join('%s:%s' % (key, val) for (key, val) in valid_styles.items())
-            else:
-                del el.attrib['style']
-
 
 # ----------------------------------------------------------
 # Email Quote
@@ -179,107 +97,6 @@ def tag_quote(el):
         el.set('data-o-mail-quote', '1')
 
 
-def html_normalize(src, filter_callback=None):
-    """ Normalize `src` for storage as an html field value.
-
-    The string is parsed as an html tag soup, made valid, then decorated for
-    "email quote" detection, and prepared for an optional filtering.
-    The filtering step (e.g. sanitization) should be performed by the
-    `filter_callback` function (to avoid multiple parsing operations, and
-    normalize the result).
-
-    :param src: the html string to normalize
-    :param filter_callback: optional callable taking a single `etree._Element`
-        document parameter, to be called during normalization in order to
-        filter the output document
-    """
-
-    if not src:
-        return src
-
-    src = ustr(src, errors='replace')
-    # html: remove encoding attribute inside tags
-    doctype = re.compile(r'(<[^>]*\s)(encoding=(["\'][^"\']*?["\']|[^\s\n\r>]+)(\s[^>]*|/)?>)', re.IGNORECASE | re.DOTALL)
-    src = doctype.sub(u"", src)
-
-    try:
-        doc = html.fromstring(src)
-    except etree.ParserError as e:
-        # HTML comment only string, whitespace only..
-        if 'empty' in str(e):
-            return u""
-        raise
-
-    if filter_callback:
-        doc = filter_callback(doc)
-
-    src = html.tostring(doc, encoding='unicode')
-
-    # this is ugly, but lxml/etree tostring want to put everything in a
-    # 'div' that breaks the editor -> remove that
-    if src.startswith('<div>') and src.endswith('</div>'):
-        src = src[5:-6]
-
-    # html considerations so real html content match database value
-    src = src.replace(u'\xa0', u'&nbsp;')
-
-    return src
-
-
-def html_sanitize(src, silent=True, sanitize_tags=True, sanitize_attributes=False, sanitize_style=False, sanitize_form=True, strip_style=False, strip_classes=False):
-    if not src:
-        return src
-
-    logger = logging.getLogger(__name__ + '.html_sanitize')
-
-    def sanitize_handler(doc):
-        kwargs = {
-            'page_structure': True,
-            'style': strip_style,              # True = remove style tags/attrs
-            'sanitize_style': sanitize_style,  # True = sanitize styling
-            'forms': sanitize_form,            # True = remove form tags
-            'remove_unknown_tags': False,
-            'comments': False,
-            'processing_instructions': False
-        }
-        if sanitize_tags:
-            kwargs.update(SANITIZE_TAGS)
-
-        if sanitize_attributes:  # We keep all attributes in order to keep "style"
-            if strip_classes:
-                current_safe_attrs = safe_attrs - frozenset(['class'])
-            else:
-                current_safe_attrs = safe_attrs
-            kwargs.update({
-                'safe_attrs_only': True,
-                'safe_attrs': current_safe_attrs,
-            })
-        else:
-            kwargs.update({
-                'safe_attrs_only': False,  # keep oe-data attributes + style
-                'strip_classes': strip_classes,  # remove classes, even when keeping other attributes
-            })
-
-        cleaner = _Cleaner(**kwargs)
-        cleaner(doc)
-        return doc
-
-    try:
-        sanitized = html_normalize(src, filter_callback=sanitize_handler)
-    except etree.ParserError:
-        if not silent:
-            raise
-        logger.warning(u'ParserError obtained when sanitizing %r', src, exc_info=True)
-        sanitized = '<p>ParserError when sanitizing</p>'
-    except Exception:
-        if not silent:
-            raise
-        logger.warning(u'unknown error obtained when sanitizing %r', src, exc_info=True)
-        sanitized = '<p>Unknown error when sanitizing</p>'
-
-    return markupsafe.Markup(sanitized)
-
-
 def quote_email(src):
     root = etree.HTML(src)
     for el in root.iter(tag=etree.Element):
@@ -341,15 +158,16 @@ def html_keep_url(text):
     return final
 
 
-def html_to_inner_content(html):
+def html_to_inner_content(html_content):
     """Returns unformatted text after removing html tags and excessive whitespace from a
     string/Markup. Passed strings will first be sanitized.
     """
-    if is_html_empty(html):
+    if is_html_empty(html_content):
         return ''
-    if not isinstance(html, markupsafe.Markup):
-        html = html_sanitize(html)
-    processed = re.sub(HTML_NEWLINES_REGEX, ' ', html)
+    if not isinstance(html_content, markupsafe.Markup):
+        html_content = html.unescape(html_content)
+        html_content = html_sanitize(html_content)
+    processed = re.sub(HTML_NEWLINES_REGEX, ' ', html_content)
     processed = re.sub(HTML_TAGS_REGEX, '', processed)
     processed = re.sub(r' {2,}|\t', ' ', processed)
     processed = processed.strip()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 Babel==2.9.1  # min version = 2.6.0 (Focal with security backports)
+bleach==4.1.0
 chardet==3.0.4
 cryptography==3.4.8
 decorator==4.4.2


### PR DESCRIPTION
Purpose
=======
LXML has officially declared that the Cleaner is not appropriate for
untrusted inputs. Because of that we want to refactor our HTML
sanitizer.

Changes
=======
Now, empty tag are automatically closed `<br>` => `<br />`

When sanitize_attributes is set to False, we use an extended list
of safe attributes.

The single quote and double quote are escaped when they are in the
HTML element content. This is wanted as it can be used to trick the
browser parser.

The Bleach version we are using (4.1.0) automatically sorts the
attributes. This will create some additional diff during our library
change but there is nothing we can do to turn that off.
(The future version of Bleach will apparently stop doing that).

Support for XSS on old IE versions has been removed.

Technical
=========
The Bleach sanitizer has an option to strip the not allowed elements.
But it will just remove the element itself and not its children. Also,
we want to have more control on what we do. E.G. we want to allow the
"data:" protocol only for non-svg image and bleach just offer you to
block the entire protocol or not.

For those reason, we need to use directly `BleachSanitizerFilter` and
to overwrite some method to have the behavior we want. Because of those
overwrite, the sanitizer may not be forward-compatible and might be
adapted for future bleach version.

We have a list of "kill tags". When those tags are removed, we also
remove all of their children.

Performance
===========
The bleach sanitizer is slower than the LXML sanitizer, the sanitization
of the stackoverflow home page (~172 Kb) take 15ms with the LXML
sanitizer and now take 70ms with bleach.

The most of execution time is spent in the library bleach use, so
there's nothing we can do to improve it significantly.

Task-2812488