### PR TITLE
[FIX] mass_mailing(_sms): make 'Retry' button generate a cron trigger

### DIFF
--- a/addons/mass_mailing/models/mailing.py
+++ b/addons/mass_mailing/models/mailing.py
@@ -504,7 +504,7 @@ class MassMailing(models.Model):
         ])
         failed_mails.mapped('mailing_trace_ids').unlink()
         failed_mails.unlink()
-        self.write({'state': 'in_queue'})
+        self.action_put_in_queue()
 
     def action_view_traces_scheduled(self):
         return self._action_view_traces_filtered('scheduled')

--- a/addons/mass_mailing/tests/__init__.py
+++ b/addons/mass_mailing/tests/__init__.py
@@ -8,3 +8,4 @@ from . import test_mailing_list
 from . import test_mailing_controllers
 from . import test_mailing_mailing_schedule_date
 from . import test_mailing_ui
+from . import test_mailing_retry

--- a/addons/mass_mailing/tests/test_mailing_retry.py
+++ b/addons/mass_mailing/tests/test_mailing_retry.py
@@ -1,0 +1,41 @@
+# -*- coding: utf-8 -*-
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from odoo.addons.mass_mailing.tests.common import MassMailCommon
+from odoo.addons.base.tests.test_ir_cron import CronMixinCase
+from odoo.tests.common import users
+
+from unittest.mock import patch
+
+class TestMailingRetry(MassMailCommon, CronMixinCase):
+
+    @classmethod
+    def setUpClass(cls):
+        super(TestMailingRetry, cls).setUpClass()
+        cls._create_mailing_list()
+
+    @users('user_marketing')
+    def test_mailing_retry_immediate_trigger(self):
+        mailing = self.env['mailing.mailing'].create({
+            'name': 'TestMailing',
+            'subject': 'Test',
+            'mailing_type': 'mail',
+            'body_html': '<div>Hello</div>',
+            'mailing_model_id': self.env['ir.model']._get('res.partner').id,
+            'contact_list_ids': [(4, self.mailing_list_1.id)],
+        })
+        mailing.action_launch()
+
+        # force email sending to fail to test our retry mechanism
+        def patched_mail_mail_send(mail_records, auto_commit=False, raise_exception=False, smtp_session=None):
+            mail_records.write({'state': 'exception', 'failure_reason': 'forced_failure'})
+
+        with patch('odoo.addons.mail.models.mail_mail.MailMail._send', patched_mail_mail_send):
+            self.env.ref('mass_mailing.ir_cron_mass_mailing_queue').sudo().method_direct_trigger()
+
+        with self.capture_triggers('mass_mailing.ir_cron_mass_mailing_queue') as captured_triggers:
+            mailing.action_retry_failed()
+
+        self.assertEqual(len(captured_triggers.records), 1, "Should have created an additional trigger immediately")
+        captured_trigger = captured_triggers.records[0]
+        self.assertEqual(captured_trigger.cron_id, self.env.ref('mass_mailing.ir_cron_mass_mailing_queue'))

--- a/addons/mass_mailing_sms/models/mailing_mailing.py
+++ b/addons/mass_mailing_sms/models/mailing_mailing.py
@@ -112,7 +112,7 @@ class Mailing(models.Model):
         ])
         failed_sms.mapped('mailing_trace_ids').unlink()
         failed_sms.unlink()
-        self.write({'state': 'in_queue'})
+        self.action_put_in_queue()
 
     def action_test(self):
         if self.mailing_type == 'sms':

--- a/addons/mass_mailing_sms/tests/__init__.py
+++ b/addons/mass_mailing_sms/tests/__init__.py
@@ -3,3 +3,4 @@
 
 from . import common
 from . import test_mailing_internals
+from . import test_mailing_retry

--- a/addons/mass_mailing_sms/tests/test_mailing_retry.py
+++ b/addons/mass_mailing_sms/tests/test_mailing_retry.py
@@ -1,0 +1,41 @@
+# -*- coding: utf-8 -*-
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from odoo.addons.mass_mailing_sms.tests.common import MassSMSCommon
+from odoo.addons.base.tests.test_ir_cron import CronMixinCase
+from odoo.tests.common import users
+
+from unittest.mock import patch
+
+class TestMailingRetrySMS(MassSMSCommon, CronMixinCase):
+
+    @classmethod
+    def setUpClass(cls):
+        super(TestMailingRetrySMS, cls).setUpClass()
+        cls._create_mailing_list()
+
+    @users('user_marketing')
+    def test_sms_retry_immediate_trigger(self):
+        mailing = self.env['mailing.mailing'].create({
+            'name': 'TestMailing',
+            'subject': 'Test',
+            'mailing_type': 'sms',
+            'body_plaintext': 'Coucou hibou',
+            'mailing_model_id': self.env['ir.model']._get('res.partner').id,
+            'contact_list_ids': [(4, self.mailing_list_1.id)],
+        })
+        mailing.action_send_sms()
+
+        # force the SMS sending to fail to test our retry mechanism
+        def patched_sms_sms_send(sms_records, unlink_failed=False, unlink_sent=True, raise_exception=False):
+            sms_records.write({'state': 'error', 'failure_type':'sms_credit'})
+
+        with patch('odoo.addons.sms.models.sms_sms.SmsSms._send', patched_sms_sms_send):
+            self.env.ref('sms.ir_cron_sms_scheduler_action').sudo().method_direct_trigger()
+
+        with self.capture_triggers('mass_mailing.ir_cron_mass_mailing_queue') as captured_triggers:
+            mailing.action_retry_failed()
+
+        self.assertEqual(len(captured_triggers.records), 1, "Should have created an additional trigger immediately")
+        captured_trigger = captured_triggers.records[0]
+        self.assertEqual(captured_trigger.cron_id, self.env.ref('mass_mailing.ir_cron_mass_mailing_queue'))


### PR DESCRIPTION
When we use the "Retry" button in case of a failed SMS mailing, it puts
the mailing back to the queue, which will be processed when on the next
cron call of `Mail Marketing: Process queue`  (generally on the next
day). However, it should immediately generate a cron trigger in this
case so that SMS(s) can be sent right away.

The same goes for Email Marketing, where it should immediately generate
 a cron trigger so the mailing can be sent immediately.

With this PR, instead of simply putting the mailing back to the
queue, we utilize the method `action_put_in_queue` which immediately
generates the cron trigger in both cases.

taskID-2760101
