### PR TITLE
[IMP] account,l10n_pt: distinguish between original and duplicate invoices

### DIFF
--- a/addons/account/views/report_invoice.xml
+++ b/addons/account/views/report_invoice.xml
@@ -18,7 +18,7 @@
                     <address t-field="o.partner_id" t-options='{"widget": "contact", "fields": ["address", "name", "vat"], "no_marker": True}' groups="!account.group_delivery_invoice_address"/>
                 </t>
                 <div class="page">
-                    <h2 class="mt-4">
+                    <h2 id="title_move_type" class="mt-4">
                         <span t-if="o.move_type == 'out_invoice' and o.state == 'posted'">Invoice</span>
                         <span t-if="o.move_type == 'out_invoice' and o.state == 'draft'">Draft Invoice</span>
                         <span t-if="o.move_type == 'out_invoice' and o.state == 'cancel'">Cancelled Invoice</span>

--- a/addons/l10n_pt/__init__.py
+++ b/addons/l10n_pt/__init__.py
@@ -3,3 +3,5 @@
 
 # Copyright (C) 2012 Thinkopen Solutions, Lda. All Rights Reserved
 # http://www.thinkopensolutions.com.
+
+from . import models

--- a/addons/l10n_pt/__manifest__.py
+++ b/addons/l10n_pt/__manifest__.py
@@ -23,6 +23,7 @@
            'data/account_tax_report.xml',
            'data/account_tax_data.xml',
            'data/account_chart_template_configure_data.xml',
+           'views/report_invoice.xml',
            ],
     'demo': [
         'demo/demo_company.xml',

--- a/addons/l10n_pt/models/__init__.py
+++ b/addons/l10n_pt/models/__init__.py
@@ -1,0 +1,2 @@
+from . import account_move
+from . import ir_actions_report

--- a/addons/l10n_pt/models/account_move.py
+++ b/addons/l10n_pt/models/account_move.py
@@ -1,0 +1,7 @@
+from odoo import models, fields
+
+
+class AccountMove(models.Model):
+    _inherit = "account.move"
+    l10n_pt_original_pdf = fields.Binary("Original PDF", attachment=False)
+    l10n_pt_duplicate_pdf = fields.Binary("Duplicate PDF", attachment=False)

--- a/addons/l10n_pt/models/ir_actions_report.py
+++ b/addons/l10n_pt/models/ir_actions_report.py
@@ -1,0 +1,23 @@
+from odoo import models
+
+
+class IrActionsReport(models.Model):
+    _inherit = "ir.actions.report"
+
+    def _render_qweb_pdf(self, res_ids=None, data=None):
+        self_sudo = self.sudo()
+        model = self_sudo.model
+        if model != "account.move":
+            return super()._render_qweb_pdf(res_ids, data)
+        record = self.env[model].browse(res_ids)
+        if record.company_id.account_fiscal_country_id.code != "PT":
+            return super()._render_qweb_pdf(res_ids, data)
+        if not record.l10n_pt_duplicate_pdf:
+            # Create original and duplicate PDFs but return original one
+            original = super()._render_qweb_pdf(record.ids)[0]
+            record.l10n_pt_duplicate_pdf = original  # Set to something other than False to let XML report know it should show "Duplicate" instead of "Original"
+            record.l10n_pt_duplicate_pdf = super()._render_qweb_pdf(record.ids)[0]
+            return original, 'pdf'
+        return record.l10n_pt_duplicate_pdf, 'pdf'
+
+    # TODO: test with multiple invoices

--- a/addons/l10n_pt/views/report_invoice.xml
+++ b/addons/l10n_pt/views/report_invoice.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<odoo>
+    <template id="report_invoice_pt" inherit_id="account.report_invoice_document">
+        <xpath expr="//h2[@id='title_move_type']" position="after">
+            <t t-if="o.l10n_pt_duplicate_pdf">
+                <span class="text-right">Duplicate</span>
+            </t>
+            <t t-else="">
+                <span class="text-right">Original</span>
+            </t>
+        </xpath>
+    </template>
+</odoo>


### PR DESCRIPTION
This PR manages the difference between the original invoice and a duplicate when printing a PDF. 
Furthermore, the duplicates must preserve the original content, i.e. in case the address or name of a client is changed in the database, the reprinting of a document must respect the original address and name.

This is a requirement for the Portuguese certification:

See https://info.portaldasfinancas.gov.pt/pt/docs/Portug_tax_system/Documents/Order_No_8632_2014_of_the_3rd_July.pdf

Task id: 2794389