### PR TITLE
[FIX] calendar : remove conversion to plain text

### DIFF
--- a/addons/calendar/models/mail_activity.py
+++ b/addons/calendar/models/mail_activity.py
@@ -2,7 +2,7 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 from odoo import api, models, fields, tools, _
-
+from odoo.tools import is_html_empty
 
 class MailActivityType(models.Model):
     _inherit = "mail.activity.type"
@@ -23,7 +23,7 @@ class MailActivity(models.Model):
             'default_res_id': self.env.context.get('default_res_id'),
             'default_res_model': self.env.context.get('default_res_model'),
             'default_name': self.summary or self.res_name,
-            'default_description': self.note and tools.html2plaintext(self.note).strip() or '',
+            'default_description': self.note if not is_html_empty(self.note) else '',
             'default_activity_ids': [(6, 0, self.ids)],
         }
         return action


### PR DESCRIPTION
To reproduce
============

- configure a default note on the "Meeting" type activity in html in the settings of crm
- create a meeting type activity from an opportunity: the activity created in the chat of this
opportunity is well formatted in html (the layout is preserved: bold line break, highlighting...)
- create the meeting corresponds to the activity in the calendar: the html format in the note is not kept

Purpose
=======

when creating the meeting we convert the html to plain text

Specification
=============

to solve the issue we removed the conversion to plain text.

opw-2825252