### PR TITLE
[IMP] account,base,l10n_pt,web: adapt the invoice content and format for Portugal

### DIFF
--- a/addons/account/views/report_invoice.xml
+++ b/addons/account/views/report_invoice.xml
@@ -93,7 +93,7 @@
                                         <td t-attf-class="text-left {{ 'd-none d-md-table-cell' if report_type == 'html' else '' }}">
                                             <span t-esc="', '.join(map(lambda x: (x.description or x.name), line.tax_ids))" id="line_tax_ids"/>
                                         </td>
-                                        <td class="text-right o_price_total">
+                                        <td name="td_subtotal" class="text-right o_price_total">
                                             <span class="text-nowrap" t-field="line.price_subtotal" groups="account.group_show_line_subtotals_tax_excluded"/>
                                             <span class="text-nowrap" t-field="line.price_total" groups="account.group_show_line_subtotals_tax_included"/>
                                         </td>
@@ -103,7 +103,7 @@
                                             <span t-field="line.name" t-options="{'widget': 'text'}"/>
                                         </td>
                                         <t t-set="current_section" t-value="line"/>
-                                        <t t-set="current_subtotal" t-value="0"/>
+                                        <t id="reset_current_subtotal" t-set="current_subtotal" t-value="0"/>
                                     </t>
                                     <t t-if="line.display_type == 'line_note'">
                                         <td colspan="99">

--- a/addons/account/views/report_invoice.xml
+++ b/addons/account/views/report_invoice.xml
@@ -18,7 +18,7 @@
                     <address t-field="o.partner_id" t-options='{"widget": "contact", "fields": ["address", "name", "vat"], "no_marker": True}' groups="!account.group_delivery_invoice_address"/>
                 </t>
                 <div class="page">
-                    <h2 class="mt-4">
+                    <h2 id="title_move_type" class="mt-4">
                         <span t-if="o.move_type == 'out_invoice' and o.state == 'posted'">Invoice</span>
                         <span t-if="o.move_type == 'out_invoice' and o.state == 'draft'">Draft Invoice</span>
                         <span t-if="o.move_type == 'out_invoice' and o.state == 'cancel'">Cancelled Invoice</span>

--- a/addons/l10n_pt/__init__.py
+++ b/addons/l10n_pt/__init__.py
@@ -3,3 +3,5 @@
 
 # Copyright (C) 2012 Thinkopen Solutions, Lda. All Rights Reserved
 # http://www.thinkopensolutions.com.
+
+from . import models

--- a/addons/l10n_pt/__manifest__.py
+++ b/addons/l10n_pt/__manifest__.py
@@ -23,6 +23,7 @@
            'data/account_tax_report.xml',
            'data/account_tax_data.xml',
            'data/account_chart_template_configure_data.xml',
+           'views/report_invoice.xml',
            ],
     'demo': [
         'demo/demo_company.xml',

--- a/addons/l10n_pt/models/__init__.py
+++ b/addons/l10n_pt/models/__init__.py
@@ -1,0 +1,2 @@
+from . import account_move
+from . import ir_actions_report

--- a/addons/l10n_pt/models/account_move.py
+++ b/addons/l10n_pt/models/account_move.py
@@ -1,0 +1,6 @@
+from odoo import models, fields
+
+
+class AccountMove(models.Model):
+    _inherit = "account.move"
+    l10n_pt_original_html_body = fields.Text("Original HTML body of the account move", translate=False)

--- a/addons/l10n_pt/models/ir_actions_report.py
+++ b/addons/l10n_pt/models/ir_actions_report.py
@@ -1,0 +1,22 @@
+from markupsafe import Markup
+from odoo import models, _
+
+
+class IrActionsReport(models.Model):
+    _inherit = "ir.actions.report"
+
+    def _prepare_html(self, html, report_model):
+        bodies, html_ids, header, footer, specific_paperformat_args = super()._prepare_html(html, report_model)
+        if report_model != "account.move" or self.env.company.account_fiscal_country_id.code != "PT":
+            return bodies, html_ids, header, footer, specific_paperformat_args
+        records = self.env[report_model].browse(html_ids)
+        new_bodies = []
+        for i, record in enumerate(records):
+            if not record.l10n_pt_original_html_body:
+                new_bodies.append(bodies[i])
+                find = Markup(f"""<span id="original_duplicate" class="text-muted">{_('Original')}</span>""")
+                replace = Markup(f"""<span id="original_duplicate" class="text-muted">{_('Duplicate')}</span>""")
+                record.l10n_pt_original_html_body = bodies[i].replace(find, replace)
+            else:
+                new_bodies.append(Markup(record.l10n_pt_original_html_body))
+        return new_bodies, html_ids, header, footer, specific_paperformat_args

--- a/addons/l10n_pt/views/report_invoice.xml
+++ b/addons/l10n_pt/views/report_invoice.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<odoo>
+    <template id="l10n_pt_report_invoice_document_inherit" inherit_id="account.report_invoice_document">
+        <xpath expr="//th[@name='th_subtotal']" position="after">
+            <th name="th_subtotal_accumulated" class="text-right">
+                <span>Accumulated amount</span>
+            </th>
+        </xpath>
+        <xpath expr="//td[@name='td_subtotal']" position="after">
+            <td name="th_subtotal_accumulated_tax" class="text-right">
+                <span class="text-nowrap"
+                      t-esc="current_subtotal"
+                      t-options='{"widget": "monetary", "display_currency": o.currency_id}'/>
+            </td>
+        </xpath>
+<!--        Disable the accumulated amount resetting happening after a line section-->
+        <xpath expr="//tr[contains(@class, 'is-subtotal')]" position="replace">
+        </xpath>
+        <xpath expr="//t[@id='reset_current_subtotal']" position="replace">
+        </xpath>
+    </template>
+</odoo>

--- a/addons/l10n_pt/views/report_invoice.xml
+++ b/addons/l10n_pt/views/report_invoice.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <odoo>
     <template id="l10n_pt_report_invoice_document_inherit" inherit_id="account.report_invoice_document">
+<!--        Add accumulated amount column-->
         <xpath expr="//th[@name='th_subtotal']" position="after">
             <th name="th_subtotal_accumulated" class="text-right">
                 <span>Accumulated amount</span>
@@ -17,6 +18,11 @@
         <xpath expr="//tr[contains(@class, 'is-subtotal')]" position="replace">
         </xpath>
         <xpath expr="//t[@id='reset_current_subtotal']" position="replace">
+        </xpath>
+
+<!--        Add whether the document is an original or a duplicate-->
+        <xpath expr="//h2[@id='title_move_type']" position="after">
+            <span id="original_duplicate" class="text-muted">Original</span>
         </xpath>
     </template>
 </odoo>

--- a/addons/web/views/report_templates.xml
+++ b/addons/web/views/report_templates.xml
@@ -460,6 +460,7 @@
                 </ul>
 
                 <div t-if="report_type == 'pdf'" class="text-muted">
+                    <span id="document_name"/>
                     Page: <span class="page"/> / <span class="topage"/>
                 </div>
             </div>

--- a/odoo/addons/base/models/ir_actions_report.py
+++ b/odoo/addons/base/models/ir_actions_report.py
@@ -342,12 +342,6 @@ class IrActionsReport(models.Model):
             node.getparent().remove(node)
             header_node.append(node)
 
-        # Retrieve footers
-        for node in root.xpath(match_klass.format('footer')):
-            body_parent = node.getparent()
-            node.getparent().remove(node)
-            footer_node.append(node)
-
         # Retrieve bodies
         for node in root.xpath(match_klass.format('article')):
             # set context language to body language
@@ -369,6 +363,14 @@ class IrActionsReport(models.Model):
         if not bodies:
             body = ''.join(lxml.html.tostring(c, encoding='unicode') for c in body_parent.getchildren())
             bodies.append(body)
+
+        # Retrieve footers
+        for i, node in enumerate(root.xpath(match_klass.format('footer'))):
+            record = self.env[report_model].browse(res_ids[i])
+            if 'name' in self.env[report_model]._fields:
+                node.xpath("//span[@id='document_name']")[0].text = f"{record.name} - "
+            node.getparent().remove(node)
+            footer_node.append(node)
 
         # Get paperformat arguments set in the root html tag. They are prioritized over
         # paperformat-record arguments.


### PR DESCRIPTION
The goal of this PR is to address the multiple requirements needed for the Portuguese location (i.e. certification).

1. If a document contains more than one page, each page must contain the document type and its corresponding number
2. If a document contains more than one page, each page must contain the accumulated amount (i.e. the sum of all amounts present on that page)
3. The printed duplicate must:
- indicate that it is not an original
- preserve the original content i.e. in case the address or name of a client is changed in the database, the reprinting of a document must respect the original address and name


See https://info.portaldasfinancas.gov.pt/pt/docs/Portug_tax_system/Documents/Order_No_8632_2014_of_the_3rd_July.pdf

Task id: 2794389