### PR TITLE
[FIX] web: prevent access error in calendar

### DIFF
--- a/addons/web/static/src/js/views/calendar/calendar_model.js
+++ b/addons/web/static/src/js/views/calendar/calendar_model.js
@@ -664,8 +664,8 @@ return AbstractModel.extend({
                 if (ids.length) {
                     defs.push(self._rpc({
                         model: filter.color_model,
-                        method: 'read',
-                        args: [_.uniq(ids), [filter.field_color]],
+                        method: 'search_read',
+                        args: [[['id', 'in', _.uniq(ids)]], [filter.field_color]],
                     })
                     .then(function (res) {
                         _.each(res, function (c) {


### PR DESCRIPTION
Prior to this commit:

- If the color attribute is set on a field on which the user might
  not have access to the model / record, a traceback is returned. However,
  in the case of a M2O, the name_get would be returned, so its is
  a pity that the color raise an access error.

After this commit:

- A search_read is made instead of a read, which returns nothing if
  the user does not have access to the model / record and does not raise
  a traceback.

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
