### PR TITLE
[FIX] mail: fix typo onMobileAddItemHeaderInputSource

### DIFF
--- a/addons/mail/static/src/models/discuss_view.js
+++ b/addons/mail/static/src/models/discuss_view.js
@@ -86,7 +86,7 @@ registerModel({
          * @param {string} req.term
          * @param {function} res
          */
-        _onMobileAddItemHeaderInputSource(req, res) {
+        onMobileAddItemHeaderInputSource(req, res) {
             if (!this.exists()) {
                 return;
             }


### PR DESCRIPTION
The method was moved in models but we forgot to remove the prefix
`_`, as it's now a public method. As a result, the feature was
not working.
