### PR TITLE
[FIX] sale_project: Expecting an ID in write for Many2One

### DIFF
--- a/addons/sale_project/models/sale_order_line.py
+++ b/addons/sale_project/models/sale_order_line.py
@@ -169,7 +169,7 @@ class SaleOrderLine(models.Model):
             # duplicating a project doesn't set the SO on sub-tasks
             project.tasks.filtered('parent_id').write({
                 'sale_line_id': self.id,
-                'sale_order_id': self.order_id,
+                'sale_order_id': self.order_id.id,
             })
         else:
             project_only_sol_count = self.env['sale.order.line'].search_count([


### PR DESCRIPTION
When we are writing on a Many2One field, we are supposed to pass the id
of the object, in this case we are passing directly the object which is
working with the ORM, but is not expected in overrides as the
documentation suppose that an int is passed.

community PR refused in stable:https://github.com/odoo/odoo/pull/88736

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
