### PR TITLE
[FIX] hr_recruitment: avoid to write on empty record set

### DIFF
--- a/addons/hr_recruitment/models/res_users.py
+++ b/addons/hr_recruitment/models/res_users.py
@@ -13,6 +13,8 @@ class ResUsers(models.Model):
         recruitment_group = self.env.ref('hr_recruitment.group_hr_recruitment_user')
 
         interviewers = self - recruitment_group.users
+        if not interviewers:
+            return
         interviewers.sudo().write({
             'groups_id': [(4, interviewer_group.id)]
         })


### PR DESCRIPTION
In the method _create_recruitment_interviewers, the users that
belong to recruitment user group are remove from the record set.

This lead, in some case to write on an empty record set.

That may lead to a crash if some custom code expect to have a
non empty record set




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
