### PR TITLE
[FIX] website_slides: fix void answer tags at creation

### DIFF
--- a/addons/website_slides/views/slide_question_views.xml
+++ b/addons/website_slides/views/slide_question_views.xml
@@ -12,6 +12,7 @@
                     </h1>
                     <field name="answer_ids">
                         <tree editable="bottom" create="true" delete="true">
+                            <field name="display_name" invisible="1"/>
                             <field name="text_value"/>
                             <field name="is_correct"/>
                             <field name="comment"/>


### PR DESCRIPTION
When creating a quiz, the answers were not displayed in the
many2many_tags and void tags were displayed.
This commit ensures that the answers is always displayed even
if the record is not yet created.

task-2849896