### PR TITLE
[FIX] sale_project: exclude the `Section` and `note` SOLs

### DIFF
--- a/addons/sale_project/models/project.py
+++ b/addons/sale_project/models/project.py
@@ -282,7 +282,7 @@ class Project(models.Model):
 
     def _get_sale_items_domain(self, additional_domain=None):
         sale_orders = self._get_sale_order_items().sudo().order_id
-        domain = [('order_id', 'in', sale_orders.ids), ('is_downpayment', '=', False), ('state', 'in', ['sale', 'done'])]
+        domain = [('order_id', 'in', sale_orders.ids), ('is_downpayment', '=', False), ('state', 'in', ['sale', 'done']), ('display_type', '=', False)]
         if additional_domain:
             domain = expression.AND([domain, additional_domain])
         return domain

--- a/addons/sale_project/tests/test_sale_project.py
+++ b/addons/sale_project/tests/test_sale_project.py
@@ -144,6 +144,16 @@ class TestSaleProject(TransactionCase):
             'price_unit': self.product_order_service1.list_price,
             'order_id': sale_order_2.id,
         })
+        section_sale_line_order_2 = SaleOrderLine.create({
+            'display_type': 'line_section',
+            'name': 'Test Section',
+            'order_id': sale_order_2.id,
+        })
+        note_sale_line_order_2 = SaleOrderLine.create({
+            'display_type': 'line_note',
+            'name': 'Test Note',
+            'order_id': sale_order_2.id,
+        })
         sale_order_2.action_confirm()
         task = self.env['project.task'].create({
             'name': 'Task',
@@ -154,17 +164,21 @@ class TestSaleProject(TransactionCase):
         self.assertIn(task.sale_line_id, self.project_global._get_sale_order_items())
         self.assertEqual(self.project_global._get_sale_orders(), sale_order | sale_order_2)
 
-        sale_order_lines = sale_order.order_line + sale_order_2.order_line
+        sale_order_lines = sale_order.order_line + sale_line_1_order_2  # exclude the Section and Note Sales Order Items
         sale_items_data = self.project_global._get_sale_items(with_action=False)
         self.assertEqual(sale_items_data['total'], len(sale_order_lines))
         expected_sale_line_dict = {
             sol_read['id']: sol_read
             for sol_read in sale_order_lines.read(['display_name', 'product_uom_qty', 'qty_delivered', 'qty_invoiced', 'product_uom'])
         }
+        actual_sol_ids = []
         for line in sale_items_data['data']:
             sol_id = line['id']
+            actual_sol_ids.append(sol_id)
             self.assertIn(sol_id, expected_sale_line_dict)
             self.assertDictEqual(line, expected_sale_line_dict[sol_id])
+        self.assertNotIn(section_sale_line_order_2.id, actual_sol_ids, 'The section Sales Order Item should not be takken into account in the Sales section of project.')
+        self.assertNotIn(note_sale_line_order_2.id, actual_sol_ids, 'The note Sales Order Item should not be takken into account in the Sales section of project.')
 
     def test_sol_product_type_update(self):
         partner = self.env['res.partner'].create({'name': "Mur en brique"})


### PR DESCRIPTION
Before this commit, when a SO linked to the project contained a section
or a note in its Sales Order Items, the `Sales` section displayed in the
project update view displays those Sales Order Items even if there is no
product set and so the UoM will be False for those Sales Order Items.

This commit adds a condition in the domain to exclude the `Section` and
`Note` Sales Order Items in the `Sales` section displayed in the project
update view.

task-2849122