### PR TITLE
[IMP] mail: introduce view models (step 8)

### DIFF
--- a/addons/mail/static/src/components/autocomplete_input/autocomplete_input.js
+++ b/addons/mail/static/src/components/autocomplete_input/autocomplete_input.js
@@ -1,5 +1,6 @@
 /** @odoo-module **/
 
+import { useComponentToModel } from '@mail/component_hooks/use_component_to_model';
 import { registerMessagingComponent } from '@mail/utils/messaging_component';
 
 const { Component, onMounted, onWillUnmount, useEffect } = owl;
@@ -11,6 +12,7 @@ export class AutocompleteInput extends Component {
      */
     setup() {
         super.setup();
+        useComponentToModel({ fieldName: 'component' });
         onMounted(() => this._mounted());
         onWillUnmount(() => this._willUnmount());
         useEffect(() => {

--- a/addons/mail/static/src/components/channel_invitation_form/channel_invitation_form.xml
+++ b/addons/mail/static/src/components/channel_invitation_form/channel_invitation_form.xml
@@ -10,8 +10,8 @@
                         <input class="o_ChannelInvitationForm_searchInput" type="text" t-att-value="channelInvitationForm.searchTerm" placeholder="Type the name of a person" t-on-input="channelInvitationForm.onInputSearch" t-ref="searchInput"/>
                     </div>
                     <div class="d-flex flex-column flex-grow-1 mx-0 py-2 overflow-auto">
-                        <t t-foreach="channelInvitationForm.selectablePartners" t-as="selectablePartner" t-key="selectablePartner.localId">
-                            <ChannelInvitationFormSelectablePartner channelInvitationForm="channelInvitationForm" selectablePartner="selectablePartner"/>
+                        <t t-foreach="channelInvitationForm.selectablePartnerViews" t-as="selectablePartnerView" t-key="selectablePartnerView.localId">
+                            <ChannelInvitationFormSelectablePartner record="selectablePartnerView"/>
                         </t>
                         <t t-if="channelInvitationForm.selectablePartners.length === 0">
                             <div class="mx-3">No user found that is not already a member of this channel.</div>
@@ -26,8 +26,8 @@
                         <div class="mx-3 mt-3">
                             <h4>Selected users:</h4>
                             <div class="o_ChannelInvitationForm_selectedPartners overflow-auto">
-                                <t t-foreach="channelInvitationForm.selectedPartners" t-as="selectedPartner" t-key="selectedPartner.localId">
-                                    <ChannelInvitationFormSelectedPartner channelInvitationForm="channelInvitationForm" selectedPartner="selectedPartner"/>
+                                <t t-foreach="channelInvitationForm.selectedPartnerViews" t-as="selectedPartnerView" t-key="selectedPartnerView.localId">
+                                    <ChannelInvitationFormSelectedPartner record="selectedPartnerView"/>
                                 </t>
                             </div>
                         </div>

--- a/addons/mail/static/src/components/channel_invitation_form_selectable_partner/channel_invitation_form_selectable_partner.js
+++ b/addons/mail/static/src/components/channel_invitation_form_selectable_partner/channel_invitation_form_selectable_partner.js
@@ -7,26 +7,16 @@ const { Component } = owl;
 export class ChannelInvitationFormSelectablePartner extends Component {
 
     /**
-     * @returns {ChannelInvitationForm}
+     * @returns {ChannelInvitationFormSelectablePartnerView}
      */
-    get channelInvitationForm() {
-        return this.props.channelInvitationForm;
-    }
-
-    /**
-     * @returns {Partner}
-     */
-    get selectablePartner() {
-        return this.props.selectablePartner;
+    get channelInvitationFormSelectablePartnerView() {
+        return this.props.record;
     }
 
 }
 
 Object.assign(ChannelInvitationFormSelectablePartner, {
-    props: {
-        channelInvitationForm: Object,
-        selectablePartner: Object,
-    },
+    props: { record: Object },
     template: 'mail.ChannelInvitationFormSelectablePartner',
 });
 

--- a/addons/mail/static/src/components/channel_invitation_form_selectable_partner/channel_invitation_form_selectable_partner.xml
+++ b/addons/mail/static/src/components/channel_invitation_form_selectable_partner/channel_invitation_form_selectable_partner.xml
@@ -2,24 +2,24 @@
 <templates xml:space="preserve">
 
     <t t-name="mail.ChannelInvitationFormSelectablePartner" owl="1">
-        <div class="o_ChannelInvitationFormSelectablePartner d-flex align-items-center px-3 py-1 btn-light" t-on-click="() => channelInvitationForm.onClickSelectablePartner(selectablePartner)" t-att-data-partner-id="selectablePartner.id" t-attf-class="{{ className }}" t-ref="root">
+        <div class="o_ChannelInvitationFormSelectablePartner d-flex align-items-center px-3 py-1 btn-light" t-on-click="() => channelInvitationFormSelectablePartnerView.channelInvitationFormOwner.onClickSelectablePartner(channelInvitationFormSelectablePartnerView.partner)" t-att-data-partner-id="channelInvitationFormSelectablePartnerView.partner.id" t-attf-class="{{ className }}" t-ref="root">
             <div class="o_ChannelInvitationFormSelectablePartner_avatarContainer position-relative flex-shrink-0">
-                <img class="o_ChannelInvitationFormSelectablePartner_avatar w-100 h-100 rounded-circle" t-att-src="selectablePartner.avatarUrl" alt="Avatar"/>
-                <t t-if="selectablePartner.im_status and selectablePartner.im_status !== 'im_partner'">
+                <img class="o_ChannelInvitationFormSelectablePartner_avatar w-100 h-100 rounded-circle" t-att-src="channelInvitationFormSelectablePartnerView.partner.avatarUrl" alt="Avatar"/>
+                <t t-if="channelInvitationFormSelectablePartnerView.partner.im_status and channelInvitationFormSelectablePartnerView.partner.im_status !== 'im_partner'">
                     <PartnerImStatusIcon
                         className="'o_ChannelInvitationFormSelectablePartner_imStatusIcon position-absolute bottom-0 end-0 d-flex align-items-center justify-content-center text-white'"
                         classNameObj="{
                             'o_ChannelInvitationFormSelectablePartner_imStatusIcon-mobile': messaging.device.isSmall,
                             'small' : !messaging.device.isSmall,
                         }"
-                        partner="selectablePartner"
+                        partner="channelInvitationFormSelectablePartnerView.partner"
                     />
                 </t>
             </div>
             <span class="o_ChannelInvitationFormSelectablePartner_name flex-grow-1 mx-2 text-truncate">
-                <t t-esc="selectablePartner.nameOrDisplayName"/>
+                <t t-esc="channelInvitationFormSelectablePartnerView.partner.nameOrDisplayName"/>
             </span>
-            <input class="o_ChannelInvitationFormSelectablePartner_checkbox flex-shrink-0" type="checkbox" t-att-checked="channelInvitationForm.selectedPartners.includes(selectablePartner) ? 'checked' : undefined" t-on-input="ev => channelInvitationForm.onInputPartnerCheckbox(selectablePartner, ev)" t-ref="selection-status"/>
+            <input class="o_ChannelInvitationFormSelectablePartner_checkbox flex-shrink-0" type="checkbox" t-att-checked="channelInvitationFormSelectablePartnerView.channelInvitationFormOwner.selectedPartners.includes(channelInvitationFormSelectablePartnerView.partner) ? 'checked' : undefined" t-on-input="ev => channelInvitationFormSelectablePartnerView.channelInvitationFormOwner.onInputPartnerCheckbox(channelInvitationFormSelectablePartnerView.partner, ev)" t-ref="selection-status"/>
         </div>
     </t>
 

--- a/addons/mail/static/src/components/channel_invitation_form_selected_partner/channel_invitation_form_selected_partner.js
+++ b/addons/mail/static/src/components/channel_invitation_form_selected_partner/channel_invitation_form_selected_partner.js
@@ -7,26 +7,16 @@ const { Component } = owl;
 export class ChannelInvitationFormSelectedPartner extends Component {
 
     /**
-     * @returns {ChannelInvitationForm}
+     * @returns {ChannelInvitationFormSelectedPartnerView}
      */
-    get channelInvitationForm() {
-        return this.props.channelInvitationForm;
-    }
-
-    /**
-     * @returns {Partner}
-     */
-    get selectedPartner() {
-        return this.props.selectedPartner;
+    get channelInvitationFormSelectedPartnerView() {
+        return this.props.record;
     }
 
 }
 
 Object.assign(ChannelInvitationFormSelectedPartner, {
-    props: {
-        channelInvitationForm: Object,
-        selectedPartner: Object,
-    },
+    props: { record: Object },
     template: 'mail.ChannelInvitationFormSelectedPartner',
 });
 

--- a/addons/mail/static/src/components/channel_invitation_form_selected_partner/channel_invitation_form_selected_partner.xml
+++ b/addons/mail/static/src/components/channel_invitation_form_selected_partner/channel_invitation_form_selected_partner.xml
@@ -2,8 +2,8 @@
 <templates xml:space="preserve">
 
     <t t-name="mail.ChannelInvitationFormSelectedPartner" owl="1">
-        <button class="btn btn-secondary" t-on-click="() => channelInvitationForm.onClickSelectedPartner(selectedPartner)">
-            <t t-esc="selectedPartner.nameOrDisplayName"/> <i class="fa fa-times"/>
+        <button class="btn btn-secondary" t-on-click="() => channelInvitationFormSelectedPartnerView.channelInvitationFormOwner.onClickSelectedPartner(channelInvitationFormSelectedPartnerView.partner)">
+            <t t-esc="channelInvitationFormSelectedPartnerView.partner.nameOrDisplayName"/> <i class="fa fa-times"/>
         </button>
     </t>
 

--- a/addons/mail/static/src/components/channel_member_list/channel_member_list.xml
+++ b/addons/mail/static/src/components/channel_member_list/channel_member_list.xml
@@ -5,16 +5,10 @@
         <t t-if="channelMemberListView">
             <div class="o_ChannelMemberList d-flex flex-column overflow-auto bg-light" t-attf-class="{{ className }}" t-ref="root">
                 <t t-if="channelMemberListView.channel.orderedOnlineMembers.length > 0">
-                    <t t-call="mail.ChannelMemberList_memberList">
-                        <t t-set="members" t-value="channelMemberListView.channel.orderedOnlineMembers"/>
-                        <t t-set="title">Online</t>
-                    </t>
+                    <ChannelMemberListCategory category="'online'" channelMemberListView="channelMemberListView"/>
                 </t>
                 <t t-if="channelMemberListView.channel.orderedOfflineMembers.length > 0">
-                    <t t-call="mail.ChannelMemberList_memberList">
-                        <t t-set="members" t-value="channelMemberListView.channel.orderedOfflineMembers"/>
-                        <t t-set="title">Offline</t>
-                    </t>
+                    <ChannelMemberListCategory category="'offline'" channelMemberListView="channelMemberListView"/>
                 </t>
                 <t t-if="channelMemberListView.channel.unknownMemberCount === 1">
                     <span class="mx-2 mt-2">And 1 other member.</span>
@@ -28,13 +22,6 @@
                     </div>
                 </t>
             </div>
-        </t>
-    </t>
-
-    <t t-name="mail.ChannelMemberList_memberList" owl="1">
-        <h6 class="m-2"><t t-esc="title"/> - <t t-esc="members.length"/></h6>
-        <t t-foreach="members" t-as="member" t-key="member.localId">
-            <ChannelMember channel="channelMemberListView.channel" member="member"/>
         </t>
     </t>
 

--- a/addons/mail/static/src/components/channel_member_list_category/channel_member_list_category.js
+++ b/addons/mail/static/src/components/channel_member_list_category/channel_member_list_category.js
@@ -1,0 +1,64 @@
+/** @odoo-module **/
+
+import { registerMessagingComponent } from '@mail/utils/messaging_component';
+
+import { sprintf } from '@web/core/utils/strings';
+
+const { Component } = owl;
+
+export class ChannelMemberListCategory extends Component {
+
+    /**
+     * @returns {ChannelMemberListView}
+     */
+    get channelMemberListView() {
+        return this.props.channelMemberListView;
+    }
+
+    /**
+     * @returns {Partner[]}
+     */
+    get members() {
+        if (!this.channelMemberListView.exists()) {
+            return [];
+        }
+        if (this.props.category === 'online') {
+            return this.channelMemberListView.channel.orderedOnlineMembers;
+        }
+        if (this.props.category === 'offline') {
+            return this.channelMemberListView.channel.orderedOfflineMembers;
+        }
+        return [];
+    }
+
+    /**
+     * @returns {string}
+     */
+    get title() {
+        let categoryText = "";
+        if (this.props.category === 'online') {
+            categoryText = this.env._t("Online");
+        }
+        if (this.props.category === 'offline') {
+            categoryText = this.env._t("Offline");
+        }
+        return sprintf(
+            this.env._t("%(categoryText)s - %(memberCount)s"),
+            {
+                categoryText,
+                memberCount: this.members.length,
+            }
+        );
+    }
+
+}
+
+Object.assign(ChannelMemberListCategory, {
+    props: {
+        category: String,
+        channelMemberListView: Object,
+    },
+    template: 'mail.ChannelMemberListCategory',
+});
+
+registerMessagingComponent(ChannelMemberListCategory);

--- a/addons/mail/static/src/components/channel_member_list_category/channel_member_list_category.xml
+++ b/addons/mail/static/src/components/channel_member_list_category/channel_member_list_category.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<templates xml:space="preserve">
+
+    <t t-name="mail.ChannelMemberListCategory" owl="1">
+        <h6 class="m-2" t-esc="title"/>
+        <t t-foreach="members" t-as="member" t-key="member.localId">
+            <ChannelMember channel="channelMemberListView.channel" member="member"/>
+        </t>
+    </t>
+
+</templates>

--- a/addons/mail/static/src/components/chatter/chatter.xml
+++ b/addons/mail/static/src/components/chatter/chatter.xml
@@ -7,7 +7,7 @@
                 <div class="o_Chatter_fixedPanel">
                     <ChatterTopbar
                         className="'o_Chatter_topbar'"
-                        record="chatter"
+                        record="chatter.topbar"
                     />
                     <t t-if="chatter.composerView">
                         <Composer

--- a/addons/mail/static/src/components/chatter_topbar/chatter_topbar.js
+++ b/addons/mail/static/src/components/chatter_topbar/chatter_topbar.js
@@ -7,9 +7,9 @@ const { Component } = owl;
 export class ChatterTopbar extends Component {
 
     /**
-     * @returns {Chatter}
+     * @returns {ChatterTopbar}
      */
-    get chatter() {
+    get chatterTopbar() {
         return this.props.record;
     }
 

--- a/addons/mail/static/src/components/chatter_topbar/chatter_topbar.xml
+++ b/addons/mail/static/src/components/chatter_topbar/chatter_topbar.xml
@@ -2,75 +2,75 @@
 <templates xml:space="preserve">
 
     <t t-name="mail.ChatterTopbar" owl="1">
-        <t t-if="chatter">
+        <t t-if="chatterTopbar">
             <div class="o_ChatterTopbar justify-content-between d-flex" t-attf-class="{{ className }}" t-ref="root">
-                <div class="o_ChatterTopbar_actions flex-wrap-reverse flex-fill d-flex border-bottom" t-attf-class="{{ chatter.composerView ? 'o-has-active-button' : 'border-white' }}">
-                    <t t-if="chatter.threadView">
+                <div class="o_ChatterTopbar_actions flex-wrap-reverse flex-fill d-flex border-bottom" t-attf-class="{{ chatterTopbar.chatter.composerView ? 'o-has-active-button' : 'border-white' }}">
+                    <t t-if="chatterTopbar.chatter.threadView">
                         <button class="o_ChatterTopbar_button o_ChatterTopbar_buttonSendMessage btn btn-link"
                             type="button"
                             t-att-class="{
-                                'o-active border-right': chatter.composerView and !chatter.composerView.composer.isLog,
-                                'o-bordered': chatter.hasExternalBorder,
-                                'border-top border-left': chatter.composerView and !chatter.composerView.composer.isLog and chatter.hasExternalBorder,
+                                'o-active border-right': chatterTopbar.chatter.composerView and !chatterTopbar.chatter.composerView.composer.isLog,
+                                'o-bordered': chatterTopbar.chatter.hasExternalBorder,
+                                'border-top border-left': chatterTopbar.chatter.composerView and !chatterTopbar.chatter.composerView.composer.isLog and chatterTopbar.chatter.hasExternalBorder,
                             }"
-                            t-att-disabled="chatter.isDisabled"
+                            t-att-disabled="chatterTopbar.chatter.isDisabled"
                             title="Send a message"
                             data-hotkey="m"
-                            t-on-click="chatter.onClickSendMessage"
+                            t-on-click="chatterTopbar.chatter.onClickSendMessage"
                         >
                             Send message
                         </button>
                         <button class="o_ChatterTopbar_button o_ChatterTopbar_buttonLogNote btn btn-link"
                             type="button"
                             t-att-class="{
-                                'o-active border-right border-left': chatter.composerView and chatter.composerView.composer.isLog,
-                                'o-bordered': chatter.hasExternalBorder,
-                                'border-top': chatter.composerView and chatter.composerView.composer.isLog and chatter.hasExternalBorder,
+                                'o-active border-right border-left': chatterTopbar.chatter.composerView and chatterTopbar.chatter.composerView.composer.isLog,
+                                'o-bordered': chatterTopbar.chatter.hasExternalBorder,
+                                'border-top': chatterTopbar.chatter.composerView and chatterTopbar.chatter.composerView.composer.isLog and chatterTopbar.chatter.hasExternalBorder,
                             }"
-                            t-att-disabled="chatter.isDisabled"
-                            t-on-click="chatter.onClickLogNote"
+                            t-att-disabled="chatterTopbar.chatter.isDisabled"
+                            t-on-click="chatterTopbar.chatter.onClickLogNote"
                             title="Log a note"
                             data-hotkey="shift+m"
                         >
                             Log note
                         </button>
                     </t>
-                    <t t-if="chatter.hasActivities">
-                        <button class="o_ChatterTopbar_button o_ChatterTopbar_buttonScheduleActivity btn btn-link" type="button" t-att-disabled="chatter.isDisabled" t-on-click="chatter.onClickScheduleActivity" title="Schedule an activity" data-hotkey="shift+a">
+                    <t t-if="chatterTopbar.chatter.hasActivities">
+                        <button class="o_ChatterTopbar_button o_ChatterTopbar_buttonScheduleActivity btn btn-link" type="button" t-att-disabled="chatterTopbar.chatter.isDisabled" t-on-click="chatterTopbar.chatter.onClickScheduleActivity" title="Schedule an activity" data-hotkey="shift+a">
                             <i class="fa fa-clock-o"/>
                             Schedule activity
                         </button>
                     </t>
                     <div class="o-autogrow"/>
                         <div class="o_ChatterTopbar_rightSection flex-grow-1 flex-shrink-0 justify-content-end d-flex">
-                            <button class="o_ChatterTopbar_button o_ChatterTopbar_buttonAttachments btn btn-link" type="button" t-att-disabled="chatter.isDisabled" t-on-click="chatter.onClickButtonAttachments">
+                            <button class="o_ChatterTopbar_button o_ChatterTopbar_buttonAttachments btn btn-link" type="button" t-att-disabled="chatterTopbar.chatter.isDisabled" t-on-click="chatterTopbar.chatter.onClickButtonAttachments">
                                 <i class="fa fa-paperclip"/>
-                                <t t-if="!chatter.isShowingAttachmentsLoading">
-                                    <span class="o_ChatterTopbar_buttonCount o_ChatterTopbar_buttonAttachmentsCount pl-1" t-esc="chatter.thread ? chatter.thread.allAttachments.length : 0"/>
+                                <t t-if="!chatterTopbar.chatter.isShowingAttachmentsLoading">
+                                    <span class="o_ChatterTopbar_buttonCount o_ChatterTopbar_buttonAttachmentsCount pl-1" t-esc="chatterTopbar.chatter.thread ? chatterTopbar.chatter.thread.allAttachments.length : 0"/>
                                 </t>
-                                <t t-if="chatter.isShowingAttachmentsLoading">
+                                <t t-if="chatterTopbar.chatter.isShowingAttachmentsLoading">
                                     <i class="o_ChatterTopbar_buttonAttachmentsCountLoader fa fa-circle-o-notch fa-spin ms-1" aria-label="Attachment counter loading..."/>
                                 </t>
                             </button>
-                            <t t-if="chatter.hasFollowers and chatter.thread">
-                                <t t-if="chatter.followButtonView">
+                            <t t-if="chatterTopbar.chatter.hasFollowers and chatterTopbar.chatter.thread">
+                                <t t-if="chatterTopbar.chatter.followButtonView">
                                     <FollowButton
                                         className="'o_ChatterTopbar_followButton'"
-                                        record="chatter.followButtonView"
+                                        record="chatterTopbar.chatter.followButtonView"
                                     />
                                 </t>
                                 <FollowerListMenu
                                     className="'o_ChatterTopbar_followerListMenu'"
-                                    isDisabled="chatter.isDisabled"
-                                    record="chatter.followerListMenuView"
-                                    thread="chatter.thread"
+                                    isDisabled="chatterTopbar.chatter.isDisabled"
+                                    record="chatterTopbar.chatter.followerListMenuView"
+                                    thread="chatterTopbar.chatter.thread"
                                     isChatterButton="true"
                                 />
                             </t>
                         </div>
                 </div>
-                <t t-if="chatter.hasTopbarCloseButton">
-                    <button class="o_ChatterTopbar_buttonClose btn btn-dark flex-shrink-0 rounded-lg-bottom" title="Close" t-on-click="chatter.onClickChatterTopbarClose">
+                <t t-if="chatterTopbar.chatter.hasTopbarCloseButton">
+                    <button class="o_ChatterTopbar_buttonClose btn btn-dark flex-shrink-0 rounded-lg-bottom" title="Close" t-on-click="chatterTopbar.chatter.onClickChatterTopbarClose">
                         <i class="oi oi-large oi-close"/>
                     </button>
                 </t>

--- a/addons/mail/static/src/components/composer_suggested_recipient/composer_suggested_recipient.js
+++ b/addons/mail/static/src/components/composer_suggested_recipient/composer_suggested_recipient.js
@@ -69,9 +69,9 @@ export class ComposerSuggestedRecipient extends Component {
     //--------------------------------------------------------------------------
 
     /**
-     * @returns {SuggestedRecipientInfo}
+     * @returns {ComposerSuggestedRecipientView}
      */
-    get suggestedRecipientInfo() {
+    get composerSuggestedRecipientView() {
         return this.props.record;
     }
 
@@ -83,8 +83,8 @@ export class ComposerSuggestedRecipient extends Component {
      * @private
      */
     _update() {
-        if (this._checkboxRef.el) {
-            this._checkboxRef.el.checked = this.suggestedRecipientInfo.isSelected;
+        if (this._checkboxRef.el && this.composerSuggestedRecipientView.suggestedRecipientInfo) {
+            this._checkboxRef.el.checked = this.composerSuggestedRecipientView.suggestedRecipientInfo.isSelected;
         }
     }
 
@@ -96,9 +96,12 @@ export class ComposerSuggestedRecipient extends Component {
      * @private
      */
     _onChangeCheckbox() {
+        if (!this.composerSuggestedRecipientView.exists()) {
+            return;
+        }
         const isChecked = this._checkboxRef.el.checked;
-        this.suggestedRecipientInfo.update({ isSelected: isChecked });
-        if (!this.suggestedRecipientInfo.partner) {
+        this.composerSuggestedRecipientView.suggestedRecipientInfo.update({ isSelected: isChecked });
+        if (!this.composerSuggestedRecipientView.suggestedRecipientInfo.partner) {
             // Recipients must always be partners. On selecting a suggested
             // recipient that does not have a partner, the partner creation form
             // should be opened.
@@ -116,7 +119,13 @@ export class ComposerSuggestedRecipient extends Component {
      * @private
      */
     _onDialogSaved() {
-        const thread = this.suggestedRecipientInfo.exists() && this.suggestedRecipientInfo.thread;
+        if (!this.composerSuggestedRecipientView.exists()) {
+            return;
+        }
+        const thread = (
+            this.composerSuggestedRecipientView.suggestedRecipientInfo &&
+            this.composerSuggestedRecipientView.suggestedRecipientInfo.thread
+        );
         if (!thread) {
             return;
         }

--- a/addons/mail/static/src/components/composer_suggested_recipient/composer_suggested_recipient.xml
+++ b/addons/mail/static/src/components/composer_suggested_recipient/composer_suggested_recipient.xml
@@ -1,30 +1,30 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <templates xml:space="preserve">
     <t t-name="mail.ComposerSuggestedRecipient" owl="1">
-        <t t-if="suggestedRecipientInfo">
-            <div class="o_ComposerSuggestedRecipient" t-attf-class="{{ className }}" t-att-data-partner-id="suggestedRecipientInfo.partner and suggestedRecipientInfo.partner.id ? suggestedRecipientInfo.partner.id : false" t-att-title="suggestedRecipientInfo.titleText" t-ref="root">
+        <t t-if="composerSuggestedRecipientView">
+            <div class="o_ComposerSuggestedRecipient" t-attf-class="{{ className }}" t-att-data-partner-id="composerSuggestedRecipientView.suggestedRecipientInfo.partner and composerSuggestedRecipientView.suggestedRecipientInfo.partner.id ? composerSuggestedRecipientView.suggestedRecipientInfo.partner.id : false" t-att-title="composerSuggestedRecipientView.suggestedRecipientInfo.titleText" t-ref="root">
                 <div class="custom-control custom-checkbox">
-                    <input t-attf-id="{{ id }}_checkbox" class="custom-control-input" type="checkbox" t-att-checked="suggestedRecipientInfo.isSelected ? 'checked' : undefined" t-on-change="_onChangeCheckbox" t-ref="checkbox" />
+                    <input t-attf-id="{{ id }}_checkbox" class="custom-control-input" type="checkbox" t-att-checked="composerSuggestedRecipientView.suggestedRecipientInfo.isSelected ? 'checked' : undefined" t-on-change="_onChangeCheckbox" t-ref="checkbox" />
                     <label class="custom-control-label" t-attf-for="{{ id }}_checkbox">
-                        <t t-if="suggestedRecipientInfo.name">
-                            <t t-esc="suggestedRecipientInfo.name"/>
+                        <t t-if="composerSuggestedRecipientView.suggestedRecipientInfo.name">
+                            <t t-esc="composerSuggestedRecipientView.suggestedRecipientInfo.name"/>
                         </t>
-                        <t t-if="suggestedRecipientInfo.email">
-                            (<t t-esc="suggestedRecipientInfo.email"/>)
+                        <t t-if="composerSuggestedRecipientView.suggestedRecipientInfo.email">
+                            (<t t-esc="composerSuggestedRecipientView.suggestedRecipientInfo.email"/>)
                         </t>
                     </label>
                 </div>
-                <t t-if="!suggestedRecipientInfo.partner">
+                <t t-if="!composerSuggestedRecipientView.suggestedRecipientInfo.partner">
                     <FormViewDialogComponentAdapter
                         Component="FormViewDialog"
                         setFormViewDialogWidget="setFormViewDialogWidget"
                         params="{
                             context: {
-                                active_id: suggestedRecipientInfo.thread.id,
+                                active_id: composerSuggestedRecipientView.suggestedRecipientInfo.thread.id,
                                 active_model: 'mail.compose.message',
-                                default_email: suggestedRecipientInfo.email,
-                                default_name: suggestedRecipientInfo.name,
-                                default_lang: suggestedRecipientInfo.lang,
+                                default_email: composerSuggestedRecipientView.suggestedRecipientInfo.email,
+                                default_name: composerSuggestedRecipientView.suggestedRecipientInfo.name,
+                                default_lang: composerSuggestedRecipientView.suggestedRecipientInfo.lang,
                                 force_email: true,
                                 ref: 'compound_context',
                             },
@@ -32,7 +32,7 @@
                             on_saved: _onDialogSaved,
                             res_id: false,
                             res_model: 'res.partner',
-                            title: suggestedRecipientInfo.dialogText,
+                            title: composerSuggestedRecipientView.suggestedRecipientInfo.dialogText,
                         }"
                     />
                 </t>

--- a/addons/mail/static/src/components/composer_suggested_recipient_list/composer_suggested_recipient_list.xml
+++ b/addons/mail/static/src/components/composer_suggested_recipient_list/composer_suggested_recipient_list.xml
@@ -3,8 +3,8 @@
     <t t-name="mail.ComposerSuggestedRecipientList" owl="1">
         <t t-if="composerSuggestedRecipientListView">
             <div class="o_ComposerSuggestedRecipientList mb-2" t-attf-class="{{ className }}" t-ref="root">
-                <t t-foreach="composerSuggestedRecipientListView.hasShowMoreButton ? composerSuggestedRecipientListView.thread.suggestedRecipientInfoList : composerSuggestedRecipientListView.thread.suggestedRecipientInfoList.slice(0,3)" t-as="recipientInfo" t-key="recipientInfo.localId">
-                    <ComposerSuggestedRecipient record="recipientInfo"/>
+                <t t-foreach="composerSuggestedRecipientListView.composerSuggestedRecipientViews" t-as="composerSuggestedRecipientView" t-key="composerSuggestedRecipientView.localId">
+                    <ComposerSuggestedRecipient record="composerSuggestedRecipientView"/>
                 </t>
                 <t t-if="composerSuggestedRecipientListView.thread.suggestedRecipientInfoList.length > 3">
                     <t t-if="!composerSuggestedRecipientListView.hasShowMoreButton" >

--- a/addons/mail/static/src/components/composer_text_input/composer_text_input.js
+++ b/addons/mail/static/src/components/composer_text_input/composer_text_input.js
@@ -74,36 +74,7 @@ export class ComposerTextInput extends Component {
             }
             this.composerView.update({ hasToRestoreContent: false });
         }
-        this._updateHeight();
-    }
-
-    /**
-     * Updates the textarea height.
-     *
-     * @private
-     */
-    _updateHeight() {
-        this.composerView.mirroredTextareaRef.el.value = this.composerView.composer.textInputContent;
-        this.composerView.textareaRef.el.style.height = this.composerView.mirroredTextareaRef.el.scrollHeight + 'px';
-    }
-
-    //--------------------------------------------------------------------------
-    // Handlers
-    //--------------------------------------------------------------------------
-
-    /**
-     * @private
-     */
-    _onInputTextarea() {
-        if (!this.composerView.exists()) {
-            return;
-        }
-        this.composerView.saveStateInStore();
-        if (this.composerView.textareaLastInputValue !== this.composerView.textareaRef.el.value) {
-            this.composerView.handleCurrentPartnerIsTyping();
-        }
-        this.composerView.update({ textareaLastInputValue: this.composerView.textareaRef.el.value });
-        this._updateHeight();
+        this.composerView.updateTextInputHeight();
     }
 
 }

--- a/addons/mail/static/src/components/composer_text_input/composer_text_input.xml
+++ b/addons/mail/static/src/components/composer_text_input/composer_text_input.xml
@@ -7,7 +7,7 @@
                 <t t-if="composerView.composerSuggestionListView">
                     <ComposerSuggestionList record="composerView.composerSuggestionListView"/>
                 </t>
-                <textarea class="o_ComposerTextInput_textarea o_ComposerTextInput_textareaStyle" t-att-class="{ 'o-composer-is-compact': composerView.isCompact }" t-esc="composerView.composer.textInputContent" t-att-placeholder="composerView.composer.placeholder" t-on-click="composerView.onClickTextarea" t-on-focusin="composerView.onFocusinTextarea" t-on-focusout="composerView.onFocusoutTextarea" t-on-keydown="composerView.onKeydownTextarea" t-on-keyup="composerView.onKeyupTextarea" t-on-input="_onInputTextarea" t-ref="textarea"/>
+                <textarea class="o_ComposerTextInput_textarea o_ComposerTextInput_textareaStyle" t-att-class="{ 'o-composer-is-compact': composerView.isCompact }" t-esc="composerView.composer.textInputContent" t-att-placeholder="composerView.composer.placeholder" t-on-click="composerView.onClickTextarea" t-on-focusin="composerView.onFocusinTextarea" t-on-focusout="composerView.onFocusoutTextarea" t-on-keydown="composerView.onKeydownTextarea" t-on-keyup="composerView.onKeyupTextarea" t-on-input="composerView.onInputTextarea" t-ref="textarea"/>
                 <!--
                      This is an invisible textarea used to compute the composer
                      height based on the text content. We need it to downsize

--- a/addons/mail/static/src/components/notification_request/notification_request.js
+++ b/addons/mail/static/src/components/notification_request/notification_request.js
@@ -1,7 +1,6 @@
 /** @odoo-module **/
 
 import { registerMessagingComponent } from '@mail/utils/messaging_component';
-import { sprintf } from '@web/core/utils/strings';
 
 const { Component } = owl;
 
@@ -10,16 +9,6 @@ export class NotificationRequest extends Component {
     //--------------------------------------------------------------------------
     // Public
     //--------------------------------------------------------------------------
-
-    /**
-     * @returns {string}
-     */
-    getHeaderText() {
-        return sprintf(
-            this.env._t("%s has a request"),
-            this.messaging.partnerRoot.nameOrDisplayName
-        );
-    }
 
     /**
      * @returns {NotificationRequestView}

--- a/addons/mail/static/src/components/notification_request/notification_request.xml
+++ b/addons/mail/static/src/components/notification_request/notification_request.xml
@@ -17,7 +17,7 @@
                 <div class="o_NotificationRequest_content">
                     <div class="o_NotificationRequest_header">
                         <span class="o_NotificationRequest_name text-truncate" t-att-class="{ 'o-isDeviceSmall': messaging.device.isSmall }">
-                            <t t-esc="getHeaderText()"/>
+                            <t t-esc="notificationRequestView.headerText"/>
                         </span>
                     </div>
                     <div class="o_NotificationRequest_core">

--- a/addons/mail/static/src/models/autocomplete_input_view.js
+++ b/addons/mail/static/src/models/autocomplete_input_view.js
@@ -95,6 +95,7 @@ registerModel({
             inverse: 'newMessageAutocompleteInputView',
             readonly: true,
         }),
+        component: attr(),
         customClass: attr({
             compute: '_computeCustomClass',
             default: '',

--- a/addons/mail/static/src/models/channel_invitation_form.js
+++ b/addons/mail/static/src/models/channel_invitation_form.js
@@ -176,6 +176,26 @@ registerModel({
          * @private
          * @returns {FieldCommand}
          */
+        _computeSelectablePartnerViews() {
+            if (this.selectablePartners.length === 0) {
+                return clear();
+            }
+            return insertAndReplace(this.selectablePartners.map(partner => ({ partner: replace(partner) })));
+        },
+        /**
+         * @private
+         * @returns {FieldCommand}
+         */
+        _computeSelectedPartnerViews() {
+            if (this.selectedPartners.length === 0) {
+                return clear();
+            }
+            return insertAndReplace(this.selectedPartners.map(partner => ({ partner: replace(partner) })));
+        },
+        /**
+         * @private
+         * @returns {FieldCommand}
+         */
         _computeThread() {
             if (
                 this.popoverViewOwner &&
@@ -253,10 +273,20 @@ registerModel({
          * search term.
          */
         selectablePartners: many('Partner'),
+        selectablePartnerViews: many('ChannelInvitationFormSelectablePartnerView', {
+            compute: '_computeSelectablePartnerViews',
+            inverse: 'channelInvitationFormOwner',
+            isCausal: true,
+        }),
         /**
          * Determines all partners that are currently selected.
          */
         selectedPartners: many('Partner'),
+        selectedPartnerViews: many('ChannelInvitationFormSelectedPartnerView', {
+            compute: '_computeSelectedPartnerViews',
+            inverse: 'channelInvitationFormOwner',
+            isCausal: true,
+        }),
         /**
          * States the thread on which this list operates (if any).
          */

--- a/addons/mail/static/src/models/channel_invitation_form_selectable_partner_view.js
+++ b/addons/mail/static/src/models/channel_invitation_form_selectable_partner_view.js
@@ -1,0 +1,21 @@
+/** @odoo-module **/
+
+import { registerModel } from '@mail/model/model_core';
+import { one } from '@mail/model/model_field';
+
+registerModel({
+    name: 'ChannelInvitationFormSelectablePartnerView',
+    identifyingFields: ['channelInvitationFormOwner', 'partner'],
+    fields: {
+        channelInvitationFormOwner: one('ChannelInvitationForm', {
+            inverse: 'selectablePartnerViews',
+            readonly: true,
+            required: true,
+        }),
+        partner: one('Partner', {
+            inverse: 'channelInvitationFormSelectablePartnerViews',
+            readonly: true,
+            required: true,
+        }),
+    },
+});

--- a/addons/mail/static/src/models/channel_invitation_form_selected_partner_view.js
+++ b/addons/mail/static/src/models/channel_invitation_form_selected_partner_view.js
@@ -1,0 +1,21 @@
+/** @odoo-module **/
+
+import { registerModel } from '@mail/model/model_core';
+import { one } from '@mail/model/model_field';
+
+registerModel({
+    name: 'ChannelInvitationFormSelectedPartnerView',
+    identifyingFields: ['channelInvitationFormOwner', 'partner'],
+    fields: {
+        channelInvitationFormOwner: one('ChannelInvitationForm', {
+            inverse: 'selectedPartnerViews',
+            readonly: true,
+            required: true,
+        }),
+        partner: one('Partner', {
+            inverse: 'channelInvitationFormSelectedPartnerViews',
+            readonly: true,
+            required: true,
+        }),
+    },
+});

--- a/addons/mail/static/src/models/chatter.js
+++ b/addons/mail/static/src/models/chatter.js
@@ -410,6 +410,11 @@ registerModel({
             readonly: true,
             required: true,
         }),
+        topbar: one('ChatterTopbar', {
+            default: insertAndReplace(),
+            inverse: 'chatter',
+            isCausal: true,
+        }),
     },
     onChanges: [
         new OnChange({

--- a/addons/mail/static/src/models/chatter_topbar.js
+++ b/addons/mail/static/src/models/chatter_topbar.js
@@ -1,0 +1,16 @@
+/** @odoo-module **/
+
+import { registerModel } from '@mail/model/model_core';
+import { one } from '@mail/model/model_field';
+
+registerModel({
+    name: 'ChatterTopbar',
+    identifyingFields: ['chatter'],
+    fields: {
+        chatter: one('Chatter', {
+            inverse: 'topbar',
+            readonly: true,
+            required: true,
+        }),
+    },
+});

--- a/addons/mail/static/src/models/composer_suggested_recipient_list_view.js
+++ b/addons/mail/static/src/models/composer_suggested_recipient_list_view.js
@@ -1,8 +1,8 @@
 /** @odoo-module **/
 
 import { registerModel } from '@mail/model/model_core';
-import { attr, one } from '@mail/model/model_field';
-import { replace } from '@mail/model/model_field_command';
+import { attr, many, one } from '@mail/model/model_field';
+import { clear, insertAndReplace, replace } from '@mail/model/model_field_command';
 
 registerModel({
     name: 'ComposerSuggestedRecipientListView',
@@ -30,11 +30,38 @@ registerModel({
          * @private
          * @returns {FieldCommand}
          */
+        _computeComposerSuggestedRecipientViews() {
+            if (!this.thread) {
+                return clear();
+            }
+            if (this.hasShowMoreButton) {
+                return insertAndReplace(
+                    this.thread.suggestedRecipientInfoList.map(
+                        suggestedRecipientInfo => ({ suggestedRecipientInfo: replace(suggestedRecipientInfo) })
+                    ),
+                );
+            } else {
+                return insertAndReplace(
+                    this.thread.suggestedRecipientInfoList.slice(0, 3).map(
+                        suggestedRecipientInfo => ({ suggestedRecipientInfo: replace(suggestedRecipientInfo) })
+                    ),
+                );
+            }
+        },
+        /**
+         * @private
+         * @returns {FieldCommand}
+         */
         _computeThread() {
             return replace(this.composerViewOwner.composer.activeThread);
         },
     },
     fields: {
+        composerSuggestedRecipientViews: many('ComposerSuggestedRecipientView', {
+            compute: '_computeComposerSuggestedRecipientViews',
+            inverse: 'composerSuggestedRecipientListViewOwner',
+            isCausal: true,
+        }),
         composerViewOwner: one('ComposerView', {
             inverse: 'composerSuggestedRecipientListView',
             readonly: true,

--- a/addons/mail/static/src/models/composer_suggested_recipient_view.js
+++ b/addons/mail/static/src/models/composer_suggested_recipient_view.js
@@ -1,0 +1,21 @@
+/** @odoo-module **/
+
+import { registerModel } from '@mail/model/model_core';
+import { one } from '@mail/model/model_field';
+
+registerModel({
+    name: 'ComposerSuggestedRecipientView',
+    identifyingFields: ['composerSuggestedRecipientListViewOwner', 'suggestedRecipientInfo'],
+    fields: {
+        composerSuggestedRecipientListViewOwner: one('ComposerSuggestedRecipientListView', {
+            inverse: 'composerSuggestedRecipientViews',
+            readonly: true,
+            required: true,
+        }),
+        suggestedRecipientInfo: one('SuggestedRecipientInfo', {
+            inverse: 'composerSuggestedRecipientViews',
+            readonly: true,
+            required: true,
+        }),
+    },
+});

--- a/addons/mail/static/src/models/composer_view.js
+++ b/addons/mail/static/src/models/composer_view.js
@@ -293,6 +293,17 @@ registerModel({
             this.saveStateInStore();
             this.update({ isFocused: false });
         },
+        onInputTextarea() {
+            if (!this.exists()) {
+                return;
+            }
+            this.saveStateInStore();
+            if (this.textareaLastInputValue !== this.textareaRef.el.value) {
+                this.handleCurrentPartnerIsTyping();
+            }
+            this.update({ textareaLastInputValue: this.textareaRef.el.value });
+            this.updateTextInputHeight();
+        },
         /**
          * @param {KeyboardEvent} ev
          */
@@ -721,6 +732,13 @@ registerModel({
             }
             const previousSuggestion = suggestions[activeElementIndex - 1];
             this.update({ activeSuggestion: replace(previousSuggestion) });
+        },
+        /**
+         * Updates the textarea height of text input.
+         */
+        updateTextInputHeight() {
+            this.mirroredTextareaRef.el.value = this.composer.textInputContent;
+            this.textareaRef.el.style.height = this.mirroredTextareaRef.el.scrollHeight + 'px';
         },
         /**
          * Update a posted message when the message is ready.

--- a/addons/mail/static/src/models/notification_request_view.js
+++ b/addons/mail/static/src/models/notification_request_view.js
@@ -1,12 +1,29 @@
 /** @odoo-module **/
 
 import { registerModel } from '@mail/model/model_core';
-import { one } from '@mail/model/model_field';
+import { attr, one } from '@mail/model/model_field';
+
+import { sprintf } from '@web/core/utils/strings';
 
 registerModel({
     name: 'NotificationRequestView',
     identifyingFields: ['notificationListViewOwner'],
+    recordMethods: {
+        /**
+         * @private
+         * @returns {string}
+         */
+        _computeHeaderText() {
+            return sprintf(
+                this.env._t("%(odoobotName)s has a request"),
+                { odoobotName: this.messaging.partnerRoot.nameOrDisplayName },
+            );
+        },
+    },
     fields: {
+        headerText: attr({
+            compute: '_computeHeaderText',
+        }),
         notificationListViewOwner: one('NotificationListView', {
             inverse: 'notificationRequestView',
             required: true,

--- a/addons/mail/static/src/models/partner.js
+++ b/addons/mail/static/src/models/partner.js
@@ -402,6 +402,14 @@ registerModel({
         avatarUrl: attr({
             compute: '_computeAvatarUrl',
         }),
+        channelInvitationFormSelectablePartnerViews: many('ChannelInvitationFormSelectablePartnerView', {
+            inverse: 'partner',
+            isCausal: true,
+        }),
+        channelInvitationFormSelectedPartnerViews: many('ChannelInvitationFormSelectedPartnerView', {
+            inverse: 'partner',
+            isCausal: true,
+        }),
         country: one('Country'),
         /**
          * Deprecated.

--- a/addons/mail/static/src/models/suggested_recipient_info.js
+++ b/addons/mail/static/src/models/suggested_recipient_info.js
@@ -1,7 +1,7 @@
 /** @odoo-module **/
 
 import { registerModel } from '@mail/model/model_core';
-import { attr, one } from '@mail/model/model_field';
+import { attr, many, one } from '@mail/model/model_field';
 
 import { sprintf } from '@web/core/utils/strings';
 
@@ -44,6 +44,10 @@ registerModel({
         },
     },
     fields: {
+        composerSuggestedRecipientViews: many('ComposerSuggestedRecipientView', {
+            inverse: 'suggestedRecipientInfo',
+            isCausal: true,
+        }),
         dialogText: attr({
             compute: '_computeDialogText',
         }),


### PR DESCRIPTION
This commit introduces models that define records being 1:1 map with components,
as a step to move further to having essentially all business code in models.

Having code in models is desirable to have very maintainable code, thanks to
robust and declarative code with an ORM-like architecture.

Task-2831082