### PR TITLE
[FIX] snailmail: fix the font-size of the address in the report

### DIFF
--- a/addons/snailmail/static/src/js/snailmail_external_layout.js
+++ b/addons/snailmail/static/src/js/snailmail_external_layout.js
@@ -1,6 +1,6 @@
 // Change address font-size if needed
 document.addEventListener('DOMContentLoaded', function (evt) {
-    var recipientAddress = document.querySelector(".address.row > div[name='address'] > div")
+    var recipientAddress = document.querySelector(".address.row > div[name='address'] > address");
     var style = window.getComputedStyle(recipientAddress, null); 
     var height = parseFloat(style.getPropertyValue('height'));
     var fontSize = parseFloat(style.getPropertyValue('font-size'));

--- a/addons/snailmail/static/src/scss/snailmail_external_layout_asset.scss
+++ b/addons/snailmail/static/src/scss/snailmail_external_layout_asset.scss
@@ -25,7 +25,7 @@
 .pt-5 {
     padding-top: 48px !important;
 }
-.article > div > .address.row > div[name="address"] {
+.article > .address.row > div[name="address"] {
     height: 65mm;
     background-color: #ffffff;
     padding-top: 11mm;


### PR DESCRIPTION
When generating the PDF for the SnailMail report, a script is executed to
adapt the size of the address to match Pingen requirements (as per [1]).

Step to reproduce the issue:
1) Have a contact created that has VAT configure
2) Create an invoice and 'Send and Print'
3) Select the POST button to send via POST
4) In dev mode, go to Techincal > Snailmail Letters
5) Download the PDF of the newly created invoice
You should see that the font becomes extremely tiny.

Solution: The script used to resize the font of the address is executed before
the CSS is loaded. Consequently, it is not taking into account the correct
size. Thus, resizing wrongly. Furthermore, the query selector that was changed
in [1] is incorrect, it is selecting the VAT number instead of the address.

[1]: https://github.com/odoo/odoo/commit/c50f5da4160c63dcc79900dc882cd36c9ad96b2e

opw-2819823

Enterprise PR: https://github.com/odoo/enterprise/pull/27712