### PR TITLE
[FIX] web: remove the fa-lg on the fa-bug icon from the debug menu

### DIFF
--- a/addons/web/static/src/core/debug/debug_menu.xml
+++ b/addons/web/static/src/core/debug/debug_menu.xml
@@ -8,7 +8,7 @@
           togglerClass="`o-dropdown--narrow ${env.inDialog?'btn btn-link':''}`"
         >
             <t t-set-slot="toggler">
-                <i class="fa fa-lg fa-bug"/>
+                <i class="fa fa-bug"/>
             </t>
             <t t-foreach="elements" t-as="element" t-key="element_index">
                 <DropdownItem


### PR DESCRIPTION
That icon is not meant to have a `fa-lg` class. It is a leftover of a
wrong revert. It looks way too big.

Indeed, it didn't have the `fa-lg` class initially.
When the new homemade icons were merged, the new bug icon needed to be
enlarged for some reason, it was done with [1].
It was later reverted with [2] to keep the FA icons when we can,
bringing back the `fa-bug` icon, but replacing the new `oi-large` by
`fa-lg` while the old FA icon didn't need to be enlarged.

[1]: https://github.com/odoo/odoo/commit/4e53953756b26e103efd479148e831b111c093d3
[2]: https://github.com/odoo/odoo/commit/28f910f5bef256ebb17700dea72fed4552e16357


Before:
![image](https://user-images.githubusercontent.com/30048408/167667914-473c5bef-9f48-40aa-8d80-29026098a51a.png)
![image](https://user-images.githubusercontent.com/30048408/167668124-6307f9e4-1acc-4fb5-9a5b-9749b5fac592.png)

After:
![image](https://user-images.githubusercontent.com/30048408/167668277-68a6e78c-a0c9-4a3f-b72c-e4cba800ba92.png)
![image](https://user-images.githubusercontent.com/30048408/167668248-6049aef5-182f-4594-ac21-ddca2ca87a2d.png)
