### PR TITLE
[FIX] website: stop calling theme _post_copy() on theme update

### DIFF
--- a/addons/test_website/tests/test_views_during_module_operation.py
+++ b/addons/test_website/tests/test_views_during_module_operation.py
@@ -5,7 +5,7 @@ from odoo.addons.website.tools import MockRequest
 from odoo.tests import standalone
 
 
-@standalone('cow_views')
+@standalone('cow_views', 'website_standalone')
 def test_01_cow_views_unlink_on_module_update(env):
     """ Ensure COW views are correctly removed during module update.
     Not removing the view could lead to traceback:
@@ -84,7 +84,7 @@ def test_01_cow_views_unlink_on_module_update(env):
     ]), "Specific COW views did not get removed!"
 
 
-@standalone('theme_views')
+@standalone('theme_views', 'website_standalone')
 def test_02_copy_ids_views_unlink_on_module_update(env):
     """ Ensure copy_ids views are correctly removed during module update.
     - Having an ir.ui.view A in the codebase, eg `website.layout`

--- a/addons/website/models/ir_module_module.py
+++ b/addons/website/models/ir_module_module.py
@@ -74,6 +74,9 @@ class IrModuleModule(models.Model):
 
                     -> We want to upgrade every website using this theme.
         """
+        if request and request.context.get('apply_new_theme'):
+            self = self.with_context(apply_new_theme=True)
+
         for module in self:
             if module.name.startswith('theme_') and vals.get('state') == 'installed':
                 _logger.info('Module %s has been loaded as theme template (%s)' % (module.name, module.state))
@@ -206,7 +209,15 @@ class IrModuleModule(models.Model):
             for model_name in self._theme_model_names:
                 module._update_records(model_name, website)
 
-            self.env['theme.utils'].with_context(website_id=website.id)._post_copy(module)
+            if self._context.get('apply_new_theme'):
+                # Both the theme install and upgrade flow ends up here.
+                # The _post_copy() is supposed to be called only when the theme
+                # is installed for the first time on a website.
+                # It will basically select some header and footer template.
+                # We don't want the system to select again the theme footer or
+                # header template when that theme is updated later. It could
+                # erase the change the user made after the theme install.
+                self.env['theme.utils'].with_context(website_id=website.id)._post_copy(module)
 
     def _theme_unload(self, website):
         """
@@ -360,6 +371,10 @@ class IrModuleModule(models.Model):
         website.theme_id = self
 
         # this will install 'self' if it is not installed yet
+        if request:
+            context = dict(request.context)
+            context['apply_new_theme'] = True
+            request.context = context
         self._theme_upgrade_upstream()
 
         active_todo = self.env['ir.actions.todo'].search([('state', '=', 'open')], limit=1)

--- a/addons/website/tests/test_views_inherit_module_update.py
+++ b/addons/website/tests/test_views_inherit_module_update.py
@@ -17,7 +17,7 @@ The view receiving the `inherit_id` update is either:
 """
 
 
-@standalone('cow_views_inherit')
+@standalone('cow_views_inherit', 'website_standalone')
 def test_01_cow_views_inherit_on_module_update(env):
     #     A    B                        A    B
     #    / \                   =>           / \
@@ -49,7 +49,7 @@ def test_01_cow_views_inherit_on_module_update(env):
     assert child_cow_view.inherit_id == expected_parent_view, "COW view should also have received the `inherit_id` update."
 
 
-@standalone('cow_views_inherit')
+@standalone('cow_views_inherit', 'website_standalone')
 def test_02_cow_views_inherit_on_module_update(env):
     #     A    B    B'                  A    B   B'
     #    / \                   =>            |   |


### PR DESCRIPTION
https://github.com/odoo/design-themes/pull/562

Before this commit, both the theme install* and upgrade flow would end
up calling the theme's `_post_copy()`.
The `_post_copy()` is in charge of enabling or disabling some website
options as ripple effect, language in footer, changing header template
etc.

From there, the user could later fine-tune its website and change those
options, altering what the theme chose during the install.

We don't want a later theme update to reapply the theme pre-selected
options and erase/revert the changes the user made after the theme
install.

This commit is then removing the call to `_post_copy()` on theme update.

Note that the `_post_copy()` is encapsulating the theme python code
which is supposed to only do some visual stuff like enabling a view or a
theme option.

Also, note that calling `_post_copy()` in a theme update will not only
re-enable/disable some views but that will create a de-sync between the
activated view and the scss value.
Indeed, for instance, enabling the hamburger menu view is not enough, it
should also be coming with a scss value change.
The mismatch between the template and the scss will lead to some visual
glitches / ugly result.
Calling `_post_copy()` when applying the theme for the first time
through the UI (the only way possible) will not create that de-sync
issue as that flow is resetting the scss value:
`_reset_default_config()` will be called through `_theme_remove()`.

* `theme install` does not refer to the module install
  but the moment the theme is applied on a website, which is not the
  same as themes modules behaves in their own manner. When a theme is
  installed on the DB, it does nothing except creating fake records in
  "standalone" tables, which will then be converted to real records and
  applied on the selected website.

opw-2824045