### PR TITLE
[FIX] guess_mimetype of generated _avatar_generate_svg

### DIFF
--- a/odoo/addons/base/models/avatar_mixin.py
+++ b/odoo/addons/base/models/avatar_mixin.py
@@ -65,7 +65,6 @@ class AvatarMixin(models.AbstractModel):
         initial = html_escape(self[self._avatar_name_field][0].upper())
         bgcolor = get_hsl_from_seed(self[self._avatar_name_field] + str(self.create_date.timestamp() if self.create_date else ""))
         return b64encode((
-            "<?xml version='1.0' encoding='UTF-8' ?>"
             "<svg height='180' width='180' xmlns='http://www.w3.org/2000/svg' xmlns:xlink='http://www.w3.org/1999/xlink'>"
             f"<rect fill='{bgcolor}' height='180' width='180'/>"
             f"<text fill='#ffffff' font-size='96' text-anchor='middle' x='90' y='125' font-family='sans-serif'>{initial}</text>"


### PR DESCRIPTION
Description of the issue/feature this PR addresses:

The image of the user in the avatar widget is not correctly shown when python-magic is installed on the system.
This is because the guessing of the mimetype fails when python-magic is installed.

Current behavior before PR:

 - **with** "python-magic" installed
 - `<?xml version='1.0' encoding='UTF-8' ?>` **in** result of _avatar_generate_svg
```python
guess_mimetype(base64.b64decode(session.env['res.partner'].browse(3)._avatar_generate_svg()))
```
Results in **'text/xml'**


 - **without** "python-magic" installed
 - `<?xml version='1.0' encoding='UTF-8' ?>` **in** result of _avatar_generate_svg
```python
guess_mimetype(base64.b64decode(session.env['res.partner'].browse(3)._avatar_generate_svg()))
```
Results in **'image/svg+xml'**


Desired behavior after PR is merged:

 - **with** "python-magic" installed
 - `<?xml version='1.0' encoding='UTF-8' ?>` **NOT in** result of _avatar_generate_svg
```python
guess_mimetype(base64.b64decode(session.env['res.partner'].browse(3)._avatar_generate_svg()))
```
Results in **'image/svg+xml'**


 - **without** "python-magic" installed
 - `<?xml version='1.0' encoding='UTF-8' ?>` **NOT in** result of _avatar_generate_svg
```python
guess_mimetype(base64.b64decode(session.env['res.partner'].browse(3)._avatar_generate_svg()))
```
Results in **'image/svg+xml'**



--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
