### PR TITLE
[FIX] base: auto add bot in new company

### DIFF
--- a/odoo/addons/base/models/res_company.py
+++ b/odoo/addons/base/models/res_company.py
@@ -7,7 +7,7 @@ import logging
 import os
 import re
 
-from odoo import api, fields, models, tools, _
+from odoo import api, fields, models, tools, SUPERUSER_ID, _
 from odoo.exceptions import ValidationError, UserError
 from odoo.modules.module import get_resource_path
 
@@ -220,6 +220,10 @@ class Company(models.Model):
             currency = self.env['res.currency'].browse(vals['currency_id'])
             if not currency.active:
                 currency.write({'active': True})
+
+        # Add company in OdooBot companies
+        self.env['res.users'].browse(SUPERUSER_ID).sudo().company_ids |= company
+
         return company
 
     def write(self, values):


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
After create of new company the Odoobot is attached to the new company.

It can create some errors from here https://github.com/odoo/odoo/blob/14.0/odoo/api.py#L563.



--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
