### PR TITLE
[FIX] ir_sequence: Fix creating date_range_seq with range_month and range_day

### DIFF
--- a/odoo/addons/base/models/ir_sequence.py
+++ b/odoo/addons/base/models/ir_sequence.py
@@ -1,7 +1,6 @@
 # -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 from datetime import datetime
-from dateutil.relativedelta import relativedelta
 import logging
 import pytz
 from psycopg2 import sql, OperationalError, errorcodes
@@ -240,27 +239,45 @@ class IrSequence(models.Model):
 
     def _create_date_range_seq(self, date):
         date_obj = fields.Date.from_string(date)
+        sequence_range = self.env["ir.sequence.date_range"]
         prefix_suffix = "%s %s" % (self.prefix, self.suffix)
-        if '%(range_day)s' in prefix_suffix:
+        if "%(range_day)s" in prefix_suffix:
             date_from = date_obj
             date_to = date_obj
-        elif '%(range_month)s' in prefix_suffix:
-            date_from = date_obj + relativedelta(day=1)
-            date_to = date_obj + relativedelta(day=31)
+        elif "%(range_month)s" in prefix_suffix:
+            date_from = fields.Date.start_of(date_obj, "month")
+            date_to = fields.Date.end_of(date_obj, "month")
         else:
-            date_from = date_obj + relativedelta(day=1, month=1)
-            date_to = date_obj + relativedelta(day=31, month=12)
-        date_range = self.env['ir.sequence.date_range'].search([('sequence_id', '=', self.id), ('date_from', '>=', date), ('date_from', '<=', date_to)], order='date_from desc', limit=1)
+            date_from = fields.Date.start_of(date_obj, "year")
+            date_to = fields.Date.end_of(date_obj, "year")
+        date_range = sequence_range.search(
+            [
+                ("sequence_id", "=", self.id),
+                ("date_from", ">=", date),
+                ("date_from", "<=", date_to),
+            ],
+            order="date_from desc",
+            limit=1,
+        )
         if date_range:
-            date_to = date_range.date_from + relativedelta(days=-1)
-        date_range = self.env['ir.sequence.date_range'].search([('sequence_id', '=', self.id), ('date_to', '>=', date_from), ('date_to', '<=', date)], order='date_to desc', limit=1)
+            date_to = fields.Date.subtract(date_range.date_from, days=1)
+        date_range = sequence_range.search(
+            [
+                ("sequence_id", "=", self.id),
+                ("date_to", ">=", date_from),
+                ("date_to", "<=", date),
+            ],
+            order="date_to desc",
+            limit=1,
+        )
         if date_range:
-            date_from = date_range.date_to + relativedelta(days=1)
-        seq_date_range = self.env['ir.sequence.date_range'].sudo().create({
-            'date_from': date_from,
-            'date_to': date_to,
-            'sequence_id': self.id,
-        })
+            date_to = fields.Date.add(date_range.date_to, days=1)
+        sequence_range_vals = {
+            "date_from": date_from,
+            "date_to": date_to,
+            "sequence_id": self.id,
+        }
+        seq_date_range = sequence_range.sudo().create(sequence_range_vals)
         return seq_date_range
 
     def _next(self, sequence_date=None):

--- a/odoo/addons/base/tests/test_ir_sequence_date_range.py
+++ b/odoo/addons/base/tests/test_ir_sequence_date_range.py
@@ -42,6 +42,56 @@ class TestIrSequenceDateRangeStandard(SingleTransactionCase):
         seq_date_range = self.env['ir.sequence.date_range'].search(domain)
         self.assertEqual(seq_date_range.date_to, january(17))
 
+    def test_ir_sequence_date_range_2_day(self):
+        seq = self.env['ir.sequence'].search([('code', '=', 'test_sequence_date_range')])
+        self.assertTrue(seq, "seq test_sequence_date_range not found")
+        date = '2000-04-14'
+        dt_range_domain = [('sequence_id', '=', seq.id), ('date_from', '>=', '2000-01-01'), ('date_from', '<=', '2000-12-31')]
+
+        # Testing day
+        self.env['ir.sequence.date_range'].search(dt_range_domain).unlink()
+        seq.write({'prefix': '%(range_day)s/'})
+        n = seq.next_by_id(date)
+        self.assertEqual(n, '14/1')
+        date_range = self.env['ir.sequence.date_range'].search(dt_range_domain, limit=1)
+        self.assertEqual(date_range.date_from.strftime('%Y-%m-%d'), date)
+        self.assertEqual(date_range.date_to.strftime('%Y-%m-%d'), date)
+        self.env['ir.sequence.date_range'].search(dt_range_domain).unlink()
+
+    def test_ir_sequence_date_range_2_month(self):
+        seq = self.env['ir.sequence'].search([('code', '=', 'test_sequence_date_range')])
+        self.assertTrue(seq, "seq test_sequence_date_range not found")
+        date = '2000-04-14'
+        dt_range_domain = [('sequence_id', '=', seq.id), ('date_from', '>=', '2000-01-01'), ('date_from', '<=', '2000-12-31')]
+
+        # Testing month
+        self.env['ir.sequence.date_range'].search(dt_range_domain).unlink()
+        seq.write({'prefix': '%(range_month)s/'})
+        n = seq.next_by_id(date)
+        self.assertEqual(n, '04/1')
+        date_range = self.env['ir.sequence.date_range'].search(dt_range_domain, limit=1)
+        self.assertEqual(date_range.date_from.strftime('%Y-%m-%d'), '2000-04-01')
+        self.assertEqual(date_range.date_to.strftime('%Y-%m-%d'), '2000-04-30')
+
+        self.env['ir.sequence.date_range'].search(dt_range_domain).unlink()
+
+    def test_ir_sequence_date_range_2_year(self):
+        seq = self.env['ir.sequence'].search([('code', '=', 'test_sequence_date_range')])
+        self.assertTrue(seq, "seq test_sequence_date_range not found")
+        date = '2000-04-14'
+        dt_range_domain = [('sequence_id', '=', seq.id), ('date_from', '>=', '2000-01-01'), ('date_from', '<=', '2000-12-31')]
+
+        # Testing year
+        self.env['ir.sequence.date_range'].search(dt_range_domain).unlink()
+        seq.write({'prefix': '%(range_year)s/'})
+        n = seq.next_by_id(date)
+        self.assertEqual(n, '2000/1')
+        date_range = self.env['ir.sequence.date_range'].search(dt_range_domain, limit=1)
+        self.assertEqual(date_range.date_from.strftime('%Y-%m-%d'), '2000-01-01')
+        self.assertEqual(date_range.date_to.strftime('%Y-%m-%d'), '2000-12-31')
+
+        self.env['ir.sequence.date_range'].search(dt_range_domain).unlink()
+
     def test_ir_sequence_date_range_3_unlink(self):
         seq = self.env['ir.sequence'].search([('code', '=', 'test_sequence_date_range')])
         seq.unlink()


### PR DESCRIPTION
Using range_day the range of the dates for new date_range_sequence
record should be only one day

Using range_month the range of the dates for new date_range_sequence
record should be only one month

Before of this fix the date created was a range of many days or months

It fixes the range of new sequences

Add new unittests
