### PR TITLE
[FIX] l10n_cl: adjust domain for vendor bills to exclude credit notes…

### DIFF
--- a/addons/l10n_cl/models/account_move.py
+++ b/addons/l10n_cl/models/account_move.py
@@ -31,15 +31,15 @@ class AccountMove(models.Model):
             domain = super()._get_l10n_latam_documents_domain()
             document_type_ids = self.journal_id.l10n_cl_sequence_ids.mapped('l10n_latam_document_type_id').ids
             return expression.AND([domain, [('id', 'in', document_type_ids)]])
-        domain = [
-            ('country_id.code', '=', 'CL'),
-            ('internal_type', 'in', ['invoice', 'debit_note', 'credit_note', 'invoice_in'])]
+        domain = [('country_id.code', '=', 'CL')]
+        if self.type in ['in_invoice', 'out_invoice']:
+            domain += [('internal_type', 'in', ['invoice', 'debit_note', 'invoice_in'])]
+        elif self.type in ['in_refund', 'out_refund']:
+            domain += [('internal_type', '=', 'credit_note')]
         if self.partner_id.l10n_cl_sii_taxpayer_type == '1' and self.partner_id_vat != '60805000-0':
             domain += [('code', 'not in', ['39', '70', '71', '914', '911'])]
         elif self.partner_id.l10n_cl_sii_taxpayer_type == '1' and self.partner_id_vat == '60805000-0':
             domain += [('code', 'not in', ['39', '70', '71'])]
-            if self.type == 'in_invoice':
-                domain += [('internal_type', '!=', 'credit_note')]
         elif self.partner_id.l10n_cl_sii_taxpayer_type == '2':
             domain += [('code', 'in', ['70', '71', '56', '61'])]
         elif self.partner_id.l10n_cl_sii_taxpayer_type == '3':


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
remove credit notes from domain if in_invoices (vendor bills)

Current behavior before PR:
The domain of document types for vendor bills, was failing since it included credit notes as an option

Desired behavior after PR is merged:
When entering the menu to create vendor bills, credit notes are not an option anymore.




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
