### PR TITLE
[FIX] website_sale_slides: fix name of products of the type 'course' …

### DIFF
--- a/addons/website_sale_slides/models/product_product.py
+++ b/addons/website_sale_slides/models/product_product.py
@@ -15,4 +15,5 @@ class Product(models.Model):
         if not payment_channels:
             return super(Product, self).get_product_multiline_description_sale()
 
-        return _('Access to:\n%s', '\n'.join(payment_channels.mapped('name')))
+        new_line = '' if len(payment_channels) == 1 else '\n'
+        return _('Access to:%s%s', new_line, '\n'.join(payment_channels.mapped('name')))


### PR DESCRIPTION
…in SOL

Currently, the name of products of the type 'course' in SOL was missing.

So this commit fixes this issue.

task: 2823432

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
