### PR TITLE
[FIX] portal: email uniqueness assertion

### DIFF
--- a/addons/portal/wizard/portal_wizard.py
+++ b/addons/portal/wizard/portal_wizard.py
@@ -4,6 +4,7 @@
 import logging
 
 from odoo.tools.translate import _
+from odoo.tools.sql import escape_psql
 from odoo.tools import email_normalize
 from odoo.exceptions import UserError
 
@@ -238,7 +239,7 @@ class PortalWizardUser(models.TransientModel):
 
         user = self.env['res.users'].sudo().with_context(active_test=False).search([
             ('id', '!=', self.user_id.id),
-            ('login', '=ilike', email),
+            ('login', '=ilike', escape_psql(email)),
         ])
 
         if user:


### PR DESCRIPTION
Bug
===

Description of the issue/feature this PR addresses:
`%` and `_` are valid characters in emails. The search domain in `_assert_user_email_uniqueness` does not escape these characters.

Current behavior before PR:
When performing the search right now on the email `john_doe@example.com` it will yield `res.users` records for the (distinct) emails `john.doe@example.com`, `johndoe@example.com` and `john_doe@example.com` (Although gmail for example ignores `.` and doesn't allow '_' but that should not be for us to decide)

Desired behaviour after PR is merged:
Make a distinction between the three examples above.


--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
