### PR TITLE
[FIX] mrp: Allow multiple users to start the Work order

### DIFF
--- a/addons/mrp/i18n/mrp.pot
+++ b/addons/mrp/i18n/mrp.pot
@@ -4064,7 +4064,7 @@ msgstr ""
 #. module: mrp
 #: code:addons/mrp/models/mrp_workcenter.py:0
 #, python-format
-msgid "The Workoder (%s) cannot be started twice!"
+msgid "The Workorder (%s) cannot be started twice!"
 msgstr ""
 
 #. module: mrp

--- a/addons/mrp/models/mrp_workcenter.py
+++ b/addons/mrp/models/mrp_workcenter.py
@@ -366,8 +366,9 @@ class MrpWorkcenterProductivity(models.Model):
     @api.constrains('workorder_id')
     def _check_open_time_ids(self):
         for workorder in self.workorder_id:
-            if len(workorder.time_ids.filtered(lambda t: t.date_start and not t.date_end)) > 1:
-                raise ValidationError(_('The Workoder (%s) cannot be started twice!', workorder.display_name))
+            open_time_ids_by_user = self.env["mrp.workcenter.productivity"].read_group([("id", "in", workorder.time_ids.ids), ("date_end", "=", False)], ["user_id", "open_time_ids_count:count(id)"], ["user_id"])
+            if any(data["open_time_ids_count"] > 1 for data in open_time_ids_by_user):
+                raise ValidationError(_('The Workorder (%s) cannot be started twice!', workorder.display_name))
 
     def button_block(self):
         self.ensure_one()

--- a/addons/mrp/models/mrp_workorder.py
+++ b/addons/mrp/models/mrp_workorder.py
@@ -526,7 +526,7 @@ class MrpWorkorder(models.Model):
 
     def button_start(self):
         self.ensure_one()
-        if any(time.date_start and not time.date_end for time in self.time_ids):
+        if any(not time.date_end for time in self.time_ids.filtered(lambda t: t.user_id.id == self.env.user.id)):
             return True
         # As button_start is automatically called in the new view
         if self.state in ('done', 'cancel'):


### PR DESCRIPTION
# Description of the issue/feature this PR addresses:
Cannot Start a Workorder with multiple users.

# Current behavior before PR:
With User1, create a MO with work orders, and start one Work Order.
With User2, go to the MO, and start the same Work Order
=> Nothing happen, we currently prevent the workorders to have more than 1 open Time Tracking.

# Desired behavior after PR is merged:
Multiple Users can start the same Workorder (only 1 at a time each)

OPW-2845080

---
Issue recently introduced by this PR: https://github.com/odoo/odoo/pull/89627
From this ticket: https://www.odoo.com/web#id=2802436&cids=1&menu_id=4720&action=3531&model=project.task&view_type=form

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
