### PR TITLE
[FIX] account_facturx: Ensure singleton on `_get_unece_code`

### DIFF
--- a/addons/account_facturx/models/uom.py
+++ b/addons/account_facturx/models/uom.py
@@ -16,7 +16,11 @@ class UoM(models.Model):
         xml_id = self.env['ir.model.data'].search([
                 ('model', '=', 'uom.uom'),
                 ('res_id', '=', self.id),
-        ]).name
+        ])
+
+        if len(xml_id) != 1:
+            return 'C62'
+
         mapping = {
             'product_uom_unit': 'C62',
             'product_uom_dozen': 'DZN',
@@ -41,4 +45,4 @@ class UoM(models.Model):
             'product_uom_cubic_inch': 'INQ',
             'product_uom_cubic_foot': 'FTQ',
         }
-        return mapping.get(xml_id, 'C62')
+        return mapping.get(xml_id.name, 'C62')


### PR DESCRIPTION
This fix avoids a `ValueError: Expected singleton: ir.model.data(6209, 26649)`
in case that a uom is referenced by more than one xmlid.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
