### PR TITLE
[IMP] website_event: lower sponsor icons on empty pages

### DIFF
--- a/addons/website_event/views/event_templates_page.xml
+++ b/addons/website_event/views/event_templates_page.xml
@@ -6,7 +6,7 @@
     <t t-call="website.layout">
         <!-- Options -->
         <t t-set="opt_events_list_categories" t-value="is_view_active('website_event.opt_events_list_categories')"/>
-        <div id="wrap" t-attf-class="o_wevent_event js_event #{'o_wevent_hide_sponsors' if hide_sponsors else ''}">
+        <div id="wrap" t-attf-class="o_wevent_event js_event d-flex flex-column #{'o_wevent_hide_sponsors' if hide_sponsors else ''}">
             <t t-if="not event.menu_id">
                 <nav class="navbar navbar-light border-top shadow-sm d-print-none">
                     <div class="container align-items-baseline justify-content-start">

--- a/addons/website_event_exhibitor/views/event_templates_sponsor.xml
+++ b/addons/website_event_exhibitor/views/event_templates_sponsor.xml
@@ -3,7 +3,7 @@
 
 <template name="Sponsors" id="event_sponsor" customize_show="True" inherit_id="website_event.layout">
     <xpath expr="//div[@id='wrap']" position="inside">
-        <section class="o_wevent_sponsor_wrapper d-none d-md-block d-print-none">
+        <section class="o_wevent_sponsor_wrapper d-none d-md-block d-print-none mt-auto">
             <div class="container pt32 pb16" t-if="event.sponsor_ids">
                 <div t-attf-class="d-flex flex-wrap mb-5 #{'' if (len(event.sponsor_ids) > 10) else 'justify-content-md-center'}">
                     <t t-foreach="event.sponsor_ids.sorted(


### PR DESCRIPTION
PURPOSE:

When a website_event with a submenu is created, some default pages
contain an empty space to lower the footer (see odoo/odoo#89602).
On these pages, the sponsor icons are now at the bottom of the page,
on top of the footer, instead of just below the page title.

Task-2850546