### PR TITLE
[ADD] web_editor: add basic image shapes for mass_mailing

### DIFF
--- a/addons/mass_mailing/static/image_shapes/basic/circle.svg
+++ b/addons/mass_mailing/static/image_shapes/basic/circle.svg
@@ -1,0 +1,12 @@
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="800" height="600">
+	<defs>
+		<clipPath id="clip-path" clipPathUnits="objectBoundingBox">
+			<use xlink:href="#filterPath" fill="none"></use>
+		</clipPath>
+		<path id="filterPath" d="M0.5,1C-0.1667,0.9795-0.1667,0.0203,0.5,0C1.1667,0.0205,1.1667,0.9797,0.5,1z"></path>
+	</defs>
+	<svg viewBox="0 0 1 1" width="800" height="600" id="preview" preserveAspectRatio="none">
+		<use xlink:href="#filterPath" fill="darkgrey"></use>
+	</svg>
+	<image xlink:href="" clip-path="url(#clip-path)"></image>
+</svg>

--- a/addons/mass_mailing/static/image_shapes/basic/slanted.svg
+++ b/addons/mass_mailing/static/image_shapes/basic/slanted.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" version="1.1" width="800" height="600">
+
+<defs><clipPath id="clip-path" clipPathUnits="objectBoundingBox"><use xlink:href="#filterPath" fill="none"></use></clipPath><path id="filterPath" d="M0.4128,0h0.5872L0.5872,1H0L0.4128,0z"></path></defs><svg viewBox="0 0 1 1" width="800" height="600" id="preview" preserveAspectRatio="none"><use xlink:href="#filterPath" fill="darkgrey"></use></svg><image xlink:href="" clip-path="url(#clip-path)"></image></svg>

--- a/addons/mass_mailing/static/image_shapes/basic/triangle.svg
+++ b/addons/mass_mailing/static/image_shapes/basic/triangle.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" version="1.1" width="800" height="600">
+
+<defs><clipPath id="clip-path" clipPathUnits="objectBoundingBox"><use xlink:href="#filterPath" fill="none"></use></clipPath><path id="filterPath" d="M1,1L0,0h1V1z"></path></defs><svg viewBox="0 0 1 1" width="800" height="600" id="preview" preserveAspectRatio="none"><use xlink:href="#filterPath" fill="darkgrey"></use></svg><image xlink:href="" clip-path="url(#clip-path)"></image></svg>

--- a/addons/mass_mailing/views/snippets_themes.xml
+++ b/addons/mass_mailing/views/snippets_themes.xml
@@ -346,10 +346,17 @@
             t-att-data-variable="radius_variable"/>
 </template>
 
+<template id="snippet_options_extra_shapes" inherit_id="web_editor.snippet_options">
+    <xpath expr="//div[hasclass('o_we_image_shape')]//we-select-page[hasclass('o_we_basic_shapes')]" position="inside">
+        <we-button data-set-img-shape="mass_mailing/basic/circle" data-select-label="Circle"/>
+        <we-button data-set-img-shape="mass_mailing/basic/triangle" data-select-label="Triangle"/>
+        <we-button data-set-img-shape="mass_mailing/basic/slanted" data-select-label="Slanted"/>
+    </xpath>
+</template>
 <!-- Snippet themes Options -->
 <template id="snippet_options">
     <t t-set="no_animations" t-value="True"/>
-    <t t-call="web_editor.snippet_options"/>
+    <t t-call="mass_mailing.snippet_options_extra_shapes"/>
     <t t-out="0"/>
 
     <!-- Border | Columns -->

--- a/addons/web_editor/views/snippets.xml
+++ b/addons/web_editor/views/snippets.xml
@@ -444,18 +444,18 @@
         <div class="o_we_image_shape">
             <we-row string="Shape" class="o_we_full_row">
                 <we-select-pager data-name="shape_img_opt" class="o_we_select_grid o_we_fake_transparent_background">
-                    <we-select-page string="Basics" t-if="not no_animations">
-                        <we-button data-set-img-shape="web_editor/basic/bsc_square_1" data-select-label="Square 1" data-animated="true"/>
-                        <we-button data-set-img-shape="web_editor/basic/bsc_square_2" data-select-label="Square 2" data-animated="true"/>
-                        <we-button data-set-img-shape="web_editor/basic/bsc_square_3" data-select-label="Square 3" data-animated="true"/>
-                        <we-button data-set-img-shape="web_editor/basic/bsc_square_4" data-select-label="Square 4" data-animated="true"/>
-                        <we-button data-set-img-shape="web_editor/basic/bsc_square_5" data-select-label="Square 5" data-animated="true"/>
-                        <we-button data-set-img-shape="web_editor/basic/bsc_square_6" data-select-label="Square 6" data-animated="true"/>
-                        <we-button data-set-img-shape="web_editor/basic/bsc_square_rounded_1" data-select-label="Square Rounded 1" data-animated="true"/>
-                        <we-button data-set-img-shape="web_editor/basic/bsc_square_rounded_2" data-select-label="Square Rounded 2" data-animated="true"/>
-                        <we-button data-set-img-shape="web_editor/basic/bsc_organic_1" data-select-label="Organic Soft" data-animated="true"/>
-                        <we-button data-set-img-shape="web_editor/basic/bsc_organic_2" data-select-label="Organic Medium" data-animated="true"/>
-                        <we-button data-set-img-shape="web_editor/basic/bsc_organic_3" data-select-label="Organic Hard" data-animated="true"/>
+                    <we-select-page class="o_we_basic_shapes" string="Basics">
+                        <we-button t-if="not no_animations" data-set-img-shape="web_editor/basic/bsc_square_1" data-select-label="Square 1" data-animated="true"/>
+                        <we-button t-if="not no_animations" data-set-img-shape="web_editor/basic/bsc_square_2" data-select-label="Square 2" data-animated="true"/>
+                        <we-button t-if="not no_animations" data-set-img-shape="web_editor/basic/bsc_square_3" data-select-label="Square 3" data-animated="true"/>
+                        <we-button t-if="not no_animations" data-set-img-shape="web_editor/basic/bsc_square_4" data-select-label="Square 4" data-animated="true"/>
+                        <we-button t-if="not no_animations" data-set-img-shape="web_editor/basic/bsc_square_5" data-select-label="Square 5" data-animated="true"/>
+                        <we-button t-if="not no_animations" data-set-img-shape="web_editor/basic/bsc_square_6" data-select-label="Square 6" data-animated="true"/>
+                        <we-button t-if="not no_animations" data-set-img-shape="web_editor/basic/bsc_square_rounded_1" data-select-label="Square Rounded 1" data-animated="true"/>
+                        <we-button t-if="not no_animations" data-set-img-shape="web_editor/basic/bsc_square_rounded_2" data-select-label="Square Rounded 2" data-animated="true"/>
+                        <we-button t-if="not no_animations" data-set-img-shape="web_editor/basic/bsc_organic_1" data-select-label="Organic Soft" data-animated="true"/>
+                        <we-button t-if="not no_animations" data-set-img-shape="web_editor/basic/bsc_organic_2" data-select-label="Organic Medium" data-animated="true"/>
+                        <we-button t-if="not no_animations" data-set-img-shape="web_editor/basic/bsc_organic_3" data-select-label="Organic Hard" data-animated="true"/>
                     </we-select-page>
                     <we-select-page string="Solids">
                         <we-button data-set-img-shape="web_editor/solid/blob_1_solid_rd" data-select-label="Blob Solid 1" />


### PR DESCRIPTION
In a goal to remove the "Style" option on images in mass_mailing — because shadows aren't well supported, the rounded rectangle can be replaced by the border's widget which also allows to modify the border-radius, the thumbnail styling on images can be done with the border and padding options already available, the only thing missing was a simple circle shape — some basic shapes have been added to the shapes already provided by the web_editor.



--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
