### PR TITLE
[IMP] mail: `AutocompleteInput`, add `form-control` by default

### DIFF
--- a/addons/mail/static/src/components/autocomplete_input/autocomplete_input.xml
+++ b/addons/mail/static/src/components/autocomplete_input/autocomplete_input.xml
@@ -2,7 +2,7 @@
 <templates xml:space="preserve">
 
     <t t-name="mail.AutocompleteInput" owl="1">
-        <input class="o_AutocompleteInput" t-attf-class="{{ className }}" t-on-blur="_onBlur" t-on-focusin="autocompleteInputView.onFocusin" t-on-keydown="_onKeydown" t-att-placeholder="autocompleteInputView.placeholder" t-ref="root"/>
+        <input class="o_AutocompleteInput form-control" t-attf-class="{{ className }}" t-on-blur="_onBlur" t-on-focusin="autocompleteInputView.onFocusin" t-on-keydown="_onKeydown" t-att-placeholder="autocompleteInputView.placeholder" t-ref="root"/>
     </t>
 
 </templates>


### PR DESCRIPTION
Part of the overall v16 SCSS optimization/restyle, task-2704984

This commit adds the Bootstrap `form-control` class by default to
improve the consistency of inputs in Mail.

task-2850961

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
