### PR TITLE
[IMP] mail, *: remove useless widget destroy

### DIFF
--- a/addons/calendar/static/tests/systray_activity_menu_tests.js
+++ b/addons/calendar/static/tests/systray_activity_menu_tests.js
@@ -47,6 +47,5 @@ QUnit.test('activity menu widget:today meetings', async function (assert) {
     assert.containsN(activityMenu, '.o_meeting_filter', 2, 'there should be 2 meetings');
     assert.hasClass(activityMenu.$('.o_meeting_filter').eq(0), 'o_meeting_bold', 'this meeting is yet to start');
     assert.doesNotHaveClass(activityMenu.$('.o_meeting_filter').eq(1), 'o_meeting_bold', 'this meeting has been started');
-    widget.destroy();
 });
 });

--- a/addons/hr/static/tests/m2x_avatar_employee_tests.js
+++ b/addons/hr/static/tests/m2x_avatar_employee_tests.js
@@ -108,8 +108,6 @@ QUnit.module('hr', {}, function () {
             2,
             "should still have only 2 chat windows because third is the same partner as first"
         );
-
-        list.destroy();
     });
 
     QUnit.test('many2one_avatar_employee widget in kanban view', async function (assert) {
@@ -140,8 +138,6 @@ QUnit.module('hr', {}, function () {
         assert.strictEqual(kanban.$('.o_kanban_record').text().trim(), '');
         assert.containsOnce(kanban, '.o_m2o_avatar');
         assert.strictEqual(kanban.$('.o_m2o_avatar:nth(0) > img').data('src'), `/web/image/hr.employee.public/${hrEmployeePublicId1}/avatar_128`);
-
-        kanban.destroy();
     });
 
     QUnit.test('many2one_avatar_employee: click on an employee not associated with a user', async function (assert) {
@@ -194,8 +190,6 @@ QUnit.module('hr', {}, function () {
             `read m2x.avatar.employee ${m2xHrAvatarUserId1}`,
             `read hr.employee.public ${hrEmployeePublicId1}`,
         ]);
-
-        form.destroy();
     });
 
     QUnit.test('many2many_avatar_employee widget in form view', async function (assert) {
@@ -248,8 +242,6 @@ QUnit.module('hr', {}, function () {
             2,
             "should have 2 chat windows"
         );
-
-        form.destroy();
     });
 
     QUnit.test('many2many_avatar_employee widget in list view', async function (assert) {
@@ -322,8 +314,6 @@ QUnit.module('hr', {}, function () {
             "Yoshi",
             'chat window should be with clicked employee'
         );
-
-        list.destroy();
     });
 
     QUnit.test('many2many_avatar_employee widget in kanban view', async function (assert) {
@@ -384,8 +374,6 @@ QUnit.module('hr', {}, function () {
             `read hr.employee.public ${hrEmployeePublicId1}`,
             `read hr.employee.public ${hrEmployeePublicId2}`
         ]);
-
-        kanban.destroy();
     });
 
     QUnit.test('many2many_avatar_employee: click on an employee not associated with a user', async function (assert) {
@@ -454,7 +442,5 @@ QUnit.module('hr', {}, function () {
 
         assert.containsOnce(document.body, '.o_ChatWindowHeader_name',
             "should have 1 chat window");
-
-        form.destroy();
     });
 });

--- a/addons/mail/static/tests/qunit_suite_tests/chatter_tests.js
+++ b/addons/mail/static/tests/qunit_suite_tests/chatter_tests.js
@@ -31,8 +31,6 @@ QUnit.test('list activity widget with no activity', async function (assert) {
     assert.strictEqual(list.$('.o_activity_summary').text(), '');
 
     assert.verifySteps(['/web/dataset/search_read']);
-
-    list.destroy();
 });
 
 QUnit.test('list activity widget with activities', async function (assert) {
@@ -80,8 +78,6 @@ QUnit.test('list activity widget with activities', async function (assert) {
     assert.strictEqual($secondRow.find('.o_activity_summary').text(), 'Type 2');
 
     assert.verifySteps(['/web/dataset/search_read']);
-
-    list.destroy();
 });
 
 QUnit.test('list activity widget with exception', async function (assert) {
@@ -116,8 +112,6 @@ QUnit.test('list activity widget with exception', async function (assert) {
     assert.strictEqual(list.$('.o_activity_summary').text(), 'Warning');
 
     assert.verifySteps(['/web/dataset/search_read']);
-
-    list.destroy();
 });
 
 QUnit.test('list activity widget: open dropdown', async function (assert) {
@@ -204,8 +198,6 @@ QUnit.test('list activity widget: open dropdown', async function (assert) {
         'action_feedback',
         'read',
     ]);
-
-    list.destroy();
 });
 
 QUnit.test('list activity exception widget with activity', async function (assert) {
@@ -258,8 +250,6 @@ QUnit.test('list activity exception widget with activity', async function (asser
         "there is no any exception activity on record");
     assert.hasClass(list.$('.o_data_row:eq(1) .o_activity_exception_cell div'), 'fa-warning',
         "there is an exception on a record");
-
-    list.destroy();
 });
 
 QUnit.module('FieldMany2ManyTagsEmail');
@@ -313,7 +303,6 @@ QUnit.test('fieldmany2many tags email', async function (assert) {
             "tag should only show name");
         assert.hasAttrValue(firstTag.find('.o_badge_text'), 'title', "coucou@petite.perruche",
             "tag should show email address on mouse hover");
-        form.destroy();
         done();
     });
     testUtils.nextTick().then(function () {
@@ -393,8 +382,6 @@ QUnit.test('fieldmany2many tags email (edition)', async function (assert) {
     // should have read resPartnerId2 three times: when opening the dropdown, when opening the modal, and
     // after the save
     assert.verifySteps([`[${resPartnerId2}]`, `[${resPartnerId2}]`, `[${resPartnerId2}]`]);
-
-    form.destroy();
 });
 
 QUnit.test('many2many_tags_email widget can load more than 40 records', async function (assert) {
@@ -428,8 +415,6 @@ QUnit.test('many2many_tags_email widget can load more than 40 records', async fu
     await testUtils.fields.many2one.clickHighlightedItem('partner_ids');
 
     assert.strictEqual(form.$('.o_field_widget[name="partner_ids"] .badge').length, 101);
-
-    form.destroy();
 });
 
 });

--- a/addons/mail/static/tests/qunit_suite_tests/m2x_avatar_user_tests.js
+++ b/addons/mail/static/tests/qunit_suite_tests/m2x_avatar_user_tests.js
@@ -46,8 +46,6 @@ QUnit.module('mail', {}, function () {
             'Partner 1',
             'Chat window should be related to partner 1'
         );
-
-        list.destroy();
     });
 
     QUnit.test('many2many_avatar_user widget in form view', async function (assert) {
@@ -72,8 +70,6 @@ QUnit.module('mail', {}, function () {
             'Partner 1',
             'First chat window should be related to partner 1'
         );
-
-        form.destroy();
     });
 
     QUnit.test('many2many_avatar_user in kanban view', async function (assert) {
@@ -119,8 +115,6 @@ QUnit.module('mail', {}, function () {
             "should open a popover hover on o_m2m_avatar_empty");
         assert.strictEqual(kanban.$('.popover .popover-body > div').text().trim(), "LuigiTapu",
             "should have a right text in popover");
-
-        kanban.destroy();
     });
 
     QUnit.test('many2one_avatar_user widget edited by the smart action "Assign to..."', async function (assert) {
@@ -326,7 +320,6 @@ QUnit.module('mail', {}, function () {
             `/web/image/res.users/${resUsersId1}/avatar_128`,
             'Should have correct avatar image'
         );
-        list.destroy();
     });
 
     QUnit.test('avatar_user widget displays the appropriate user image in kanban view', async function (assert) {
@@ -355,7 +348,6 @@ QUnit.module('mail', {}, function () {
             `/web/image/res.users/${resUsersId1}/avatar_128`,
             'Should have correct avatar image'
         );
-        kanban.destroy();
     });
 
     QUnit.test('avatar_user widget displays the appropriate user image in form view', async function (assert) {
@@ -376,6 +368,5 @@ QUnit.module('mail', {}, function () {
             `/web/image/res.users/${resUsersId1}/avatar_128`,
             'Should have correct avatar image'
         );
-        form.destroy();
     });
 });

--- a/addons/note/static/tests/systray_activity_menu_tests.js
+++ b/addons/note/static/tests/systray_activity_menu_tests.js
@@ -62,6 +62,5 @@ QUnit.test('note activity menu widget: create note from activity menu', async fu
         'ActivityMenu add note button should be displayed');
     assert.hasClass(activityMenu.$('.o_note'), 'd-none',
         'ActivityMenu add note input should be hidden');
-    widget.destroy();
 });
 });

--- a/addons/test_mail/static/tests/activity_tests.js
+++ b/addons/test_mail/static/tests/activity_tests.js
@@ -318,8 +318,6 @@ QUnit.test('activity view: activity widget', async function (assert) {
         "action_feedback_schedule_next",
         "serverGeneratedAction"
         ]);
-
-    activity.destroy();
 });
 
 QUnit.test("activity view: no group_by_menu and no comparison_menu", async function (assert) {
@@ -427,8 +425,6 @@ QUnit.test('activity view: search more to schedule an activity for a record of a
     // select a record to schedule an activity for it (this triggers a do_action)
     testUtils.dom.click($modal.find('.o_data_row:last'));
     assert.verifySteps(['doAction']);
-
-    activity.destroy();
 });
 
 QUnit.test("Activity view: discard an activity creation dialog", async function (assert) {
@@ -551,8 +547,6 @@ QUnit.test("Activity view: on_destroy_callback doesn't crash", async function (a
         'mounted',
         'willUnmount'
     ]);
-
-    activity.destroy();
 });
 
 QUnit.test("Schedule activity dialog uses the same search view as activity view", async function (assert) {

--- a/addons/test_mail/static/tests/systray_activity_menu_tests.js
+++ b/addons/test_mail/static/tests/systray_activity_menu_tests.js
@@ -47,7 +47,6 @@ QUnit.test('activity menu widget: menu with no records', async function (assert)
     await activityMenu.appendTo($('#qunit-fixture'));
     await testUtils.nextTick();
     assert.containsOnce(activityMenu, '.o_no_activity');
-    widget.destroy();
 });
 
 QUnit.test('activity menu widget: activity menu with 2 models', async function (assert) {
@@ -99,8 +98,6 @@ QUnit.test('activity menu widget: activity menu with 2 models', async function (
     };
     await testUtils.dom.click(activityMenu.$('.dropdown-toggle'));
     await testUtils.dom.click(activityMenu.$(".o_mail_systray_dropdown_items > div[data-model_name='mail.test.activity']"));
-
-    widget.destroy();
 });
 
 QUnit.test('activity menu widget: activity view icon', async function (assert) {
@@ -153,8 +150,6 @@ QUnit.test('activity menu widget: activity view icon', async function (assert) {
         'do_action:mail.test.activity',
         'do_action:res.partner'
     ]);
-
-    widget.destroy();
 });
 
 QUnit.test('activity menu widget: close on messaging menu click', async function (assert) {
@@ -179,8 +174,6 @@ QUnit.test('activity menu widget: close on messaging menu click', async function
         'show',
         "activity menu should be hidden after click on messaging menu"
     );
-
-    widget.destroy();
 });
 
 });


### PR DESCRIPTION
*: calendar, hr, note, test_mail.

Since community#86338, widget destruction is registered in the start method. Thus,
explicit calls to widget.destroy during tests are useless. THis PR prepares the ground
for the one introducing the new environment in the discuss app. Indeed, the former PR
will use createWebClient instead of createView/Widget constructor thus, we won't be able
to call destroy on the returned value anymore. In order to reduce the noise in the main PR,
all the calls to widget.destroy have been removed.

task-2582313

enterprise: https://github.com/odoo/enterprise/pull/27192