### PR TITLE
[FIX] hr_recruitment: Don't use archived email server

### DIFF
--- a/addons/hr_recruitment/wizard/applicant_refuse_reason.py
+++ b/addons/hr_recruitment/wizard/applicant_refuse_reason.py
@@ -45,7 +45,7 @@ class ApplicantGetRefuseReason(models.TransientModel):
         self.applicant_ids.write({'refuse_reason_id': self.refuse_reason_id.id, 'active': False})
         if self.send_mail:
             applicants = self.applicant_ids.filtered(lambda x: x.email_from or x.partner_id.email)
-            applicants.message_post_with_template(self.template_id.id, **{
+            applicants.with_context(active_test=True).message_post_with_template(self.template_id.id, **{
                 'auto_delete_message': True,
                 'subtype_id': self.env['ir.model.data']._xmlid_to_res_id('mail.mt_note'),
                 'email_layout_xmlid': 'mail.mail_notification_light'


### PR DESCRIPTION
Steps to reproduce:

  - Install Recruitment module
  - Set a valid outgoing mail server and archive it
  - Go to Recruitment > Applications > All Applications
  - Create a new application
  - Set a Subject and email, then save
  - Click on button 'Refuse'
  - Select any reason (ensure "send email" is checked)

Issue:

  The email is sent to the applicant through the archived email server.

Cause:

  The current action have 'active_test' set to 'False' in the context
  (useful when archiving an applicant though action menu, since it
  trigger action 'action_refuse_reason_apply' and current applicant
  will be archived at that point).
  Therefore, the archived email server will be used (in case it's the
  only one, or if it has more priority than any other one).

Solution:

  Set 'active_test' to 'True' in the context when sending mail.

opw-2845545