### PR TITLE
[13.0] l10n_ch: Fix error correction level on QR code invoice

### DIFF
--- a/addons/l10n_ch/models/res_bank.py
+++ b/addons/l10n_ch/models/res_bank.py
@@ -249,7 +249,7 @@ class ResPartnerBank(models.Model):
     def build_swiss_code_url(self, amount, currency_name, not_used_anymore_1, debtor_partner, not_used_anymore_2, structured_communication, free_communication):
         qr_code_vals = self._build_swiss_code_vals(amount, currency_name, debtor_partner, structured_communication, free_communication)
         # use quiet to remove blank around the QR and make it easier to place it
-        return '/report/barcode/?type=%s&value=%s&width=%s&height=%s&quiet=1' % ('QR', werkzeug.urls.url_quote_plus('\n'.join(qr_code_vals)), 256, 256)
+        return '/report/barcode/?type=%s&value=%s&width=%s&height=%s&quiet=1&barlevel=M' % ('QR', werkzeug.urls.url_quote_plus('\n'.join(qr_code_vals)), 256, 256)
 
     @api.model
     def build_swiss_code_base64(self, amount, currency_name, not_used_anymore_1, debtor_partner, not_used_anymore_2, structured_communication, free_communication):

--- a/addons/web/controllers/main.py
+++ b/addons/web/controllers/main.py
@@ -1998,7 +1998,7 @@ class ReportController(http.Controller):
     # Misc. route utils
     #------------------------------------------------------
     @http.route(['/report/barcode', '/report/barcode/<type>/<path:value>'], type='http', auth="public")
-    def report_barcode(self, type, value, width=600, height=100, humanreadable=0, quiet=1):
+    def report_barcode(self, type, value, width=600, height=100, humanreadable=0, quiet=1, barlevel='L'):
         """Contoller able to render barcode images thanks to reportlab.
         Samples:
             <img t-att-src="'/report/barcode/QR/%s' % o.name"/>
@@ -2015,7 +2015,7 @@ class ReportController(http.Controller):
         """
         try:
             barcode = request.env['ir.actions.report'].barcode(type, value, width=width,
-                height=height, humanreadable=humanreadable, quiet=quiet)
+                height=height, humanreadable=humanreadable, quiet=quiet, barlevel=barlevel)
         except (ValueError, AttributeError):
             raise werkzeug.exceptions.HTTPException(description='Cannot convert into barcode.')
 

--- a/odoo/addons/base/models/ir_actions_report.py
+++ b/odoo/addons/base/models/ir_actions_report.py
@@ -496,7 +496,7 @@ class IrActionsReport(models.Model):
         return report_obj.with_context(context).search(conditions, limit=1)
 
     @api.model
-    def barcode(self, barcode_type, value, width=600, height=100, humanreadable=0, quiet=1):
+    def barcode(self, barcode_type, value, width=600, height=100, humanreadable=0, quiet=1, barlevel='L'):
         if barcode_type == 'UPCA' and len(value) in (11, 12, 13):
             barcode_type = 'EAN13'
             if len(value) in (11, 12):
@@ -514,7 +514,7 @@ class IrActionsReport(models.Model):
 
             barcode = createBarcodeDrawing(
                 barcode_type, value=value, format='png', width=width, height=height,
-                humanReadable=humanreadable, quiet=quiet, barBorder=bar_border
+                humanReadable=humanreadable, quiet=quiet, barBorder=bar_border, barLevel=barlevel
             )
             return barcode.asString('png')
         except (ValueError, AttributeError):


### PR DESCRIPTION
Correction level on the swiss QR code must use error correction level "M"
as stated in "Swiss Implementation Guidelines for the QR-bill"
(https://www.paymentstandards.ch/dam/downloads/ig-qr-bill-en.pdf)
at section 5.1:

"The code generation must take place with error correction level “M”,
which means a redundancy or assurance of around 15%."

OPW-2850995

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
