### PR TITLE
[FIX] website_sale: add the terms and condition to sale order for website

### DIFF
--- a/addons/website_sale/models/website.py
+++ b/addons/website_sale/models/website.py
@@ -226,9 +226,6 @@ class Website(models.Model):
         company = self.company_id or pricelist.company_id
         if company:
             values['company_id'] = company.id
-            if self.env['ir.config_parameter'].sudo().get_param('sale.use_sale_note'):
-                values['note'] = company.sale_note or ""
-
         return values
 
     def sale_get_order(self, force_create=False, code=None, update_pricelist=False, force_pricelist=False):


### PR DESCRIPTION
Explanation:
The code used deprecated variable names for the system parameter and value of the
terms and conditions. If the system still has the old system parameter name set
 it can lead to errors. We remove this line as it seems the terms and conditions
 are added somewhere else in the code to the sale order.

opw-2846046
