### PR TITLE
[FIX] website_event: event ticket saleable when the event is not confirmed

### DIFF
--- a/addons/website_event/views/event_templates.xml
+++ b/addons/website_event/views/event_templates.xml
@@ -561,7 +561,9 @@
 </template>
 
 <template id="ticket" name="Ticket offer template">
-    <div class="row p-2 pl-3">
+    <t t-set="tickets_available" t-value="event.seats_available or event.seats_availability == 'unlimited'"/>
+    <t t-set="buy" t-value="tickets_available and event.state == 'confirm'"/>
+    <div t-if="buy" class="row p-2 pl-3">
         <div class="col-lg-8 d-flex flex-columns align-items-center" itemscope="itemscope" itemtype="http://schema.org/Offer">
             <h6 t-raw="name" itemprop="name" class="my-0 pr-3"/>
             <div class="border-left border-right px-3"><t t-raw="price"/></div>


### PR DESCRIPTION
Reproduction:
1. Install Event and eCommerce
2. Create an event with tickets, don’t confirm it, and publish it
3. Open an incognito tab, go to the event page
4. The tickets are shown on the page and can be booked

Reason: The event ticket template doesn’t check if we should enable
buying. The local variable “buy” in registration_template doesn’t take
into account in the ticket template

Fix: Add local variable “buy” in the ticket template. Only allow buying
tickets when the ticket is available and the event state is confirmed.

opw-2836058

Related fix: https://github.com/odoo/odoo/pull/91099

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
