### PR TITLE
[FIX] mass_mailing_sms: fix short links replacement

### DIFF
--- a/addons/mass_mailing_sms/models/sms_sms.py
+++ b/addons/mass_mailing_sms/models/sms_sms.py
@@ -24,7 +24,7 @@ class SmsSms(models.Model):
             body = sms.body
             for url in set(re.findall(tools.TEXT_URL_REGEX, body)):
                 if url.startswith(sms.get_base_url() + '/r/'):
-                    body = re.sub(url + r'(?![\w@:%.+&~#=/-])', url + f'/s/{sms.id}', body)
+                    body = re.sub(re.escape(url) + r'(?![\w@:%.+&~#=/-])', url + f'/s/{sms.id}', body)
             res[sms.id] = body
         return res
 


### PR DESCRIPTION
The regex replacement of urls introduced in 3fa91fa was incorrect.

NB: v.15.0 only.

Task-2783844
See odoo/odoo#86003