### PR TITLE
[FIX] website_event: event ticket can be sold when the event is end

### DIFF
--- a/addons/event/models/event_event.py
+++ b/addons/event/models/event_event.py
@@ -252,7 +252,7 @@ class EventEvent(models.Model):
         for event in self:
             event.seats_expected = event.seats_unconfirmed + event.seats_reserved + event.seats_used
 
-    @api.depends('date_tz', 'start_sale_date', 'date_end', 'seats_available', 'seats_limited', 'event_ticket_ids.sale_available')
+    @api.depends('stage_id', 'date_tz', 'start_sale_date', 'date_end', 'seats_available', 'seats_limited', 'event_ticket_ids.sale_available')
     def _compute_event_registrations_open(self):
         """ Compute whether people may take registrations for this event
 
@@ -269,7 +269,8 @@ class EventEvent(models.Model):
             event.event_registrations_open = (event.start_sale_date <= current_datetime.date() if event.start_sale_date else True) and \
                 (date_end_tz >= current_datetime if date_end_tz else True) and \
                 (not event.seats_limited or event.seats_available) and \
-                (not event.event_ticket_ids or any(ticket.sale_available for ticket in event.event_ticket_ids))
+                (not event.event_ticket_ids or any(ticket.sale_available for ticket in event.event_ticket_ids)) and \
+                (not event.stage_id.pipe_end)
 
     @api.depends('event_ticket_ids.start_sale_date')
     def _compute_start_sale_date(self):


### PR DESCRIPTION
Reproduction:
1. Install Event and eCommerce
2. Select one of the example events with tickets, put the event to stage
“ENDED”
3. Open an incognito tab, go to the event page
4. The tickets are shown on the page and can still be booked

Reason: The _compute_event_registrations_open doesn’t check the stage of
the event

Fix: Add dependency of stage_id to the field computation
_compute_event_registrations_open. Because in V14 we use the Kanban view
to manage the stage and new columns can be added, the fix only targets
disabling the ticket selling when the event is at End Stage (pipe_end)

opw-2836058

Related fix in V13: https://github.com/odoo/odoo/pull/91094

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
