### PR TITLE
[FIX] account: allow select bank account in payment register

### DIFF
--- a/addons/account/views/account_payment_view.xml
+++ b/addons/account/views/account_payment_view.xml
@@ -281,10 +281,11 @@
                                             'readonly': [('state', '!=', 'draft')],
                                         }"/>
 
-                                <field name="partner_bank_id" context="{'default_partner_id': partner_id}" string="Company Bank Account" readonly="1"
+                                <field name="partner_bank_id" context="{'default_partner_id': partner_id}" string="Company Bank Account"
                                         attrs="{
                                             'invisible': ['|', '|', ('show_partner_bank_account', '=', False), ('is_internal_transfer', '=', True), ('payment_type', '=', 'outbound')],
                                             'required': [('require_partner_bank_account', '=', True), ('is_internal_transfer', '=', False)],
+                                            'readonly': [('show_partner_bank_account', '=', True), ('is_internal_transfer', '=', False), ('payment_type', '=', 'inbound')],
                                         }"/>
 
                                 <field name="destination_journal_id" context="{'default_partner_id': partner_id}"


### PR DESCRIPTION
After this commit, we can change the bank account on an
outbound payment.

Steps to reproduce:

- Create a vendor V with two bank accounts
- Create an outbound payment for vendor V
- Select the second bank account in the dropdown list
- Save the payment
-> The bank account is now the first one, instead of the second one

We display the partner_bank_id field in three different ways
depending on certain conditions, but the third one is readonly,
unconditionally. This way, the framework was taken this readonly
into account in every case, and the field was recomputed when saving
the payment.
We made the readonly attribute depend on the inverse condition of the
invisible attribute, this way the field become readonly only when
it's needed.

opw-2790359

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
