### PR TITLE
[FIX] account_accountant: writeoff date should be off type date

### DIFF
--- a/addons/account/static/src/js/reconciliation/reconciliation_renderer.js
+++ b/addons/account/static/src/js/reconciliation/reconciliation_renderer.js
@@ -569,7 +569,7 @@ var LineRenderer = Widget.extend(FieldManagerMixin, {
             type: 'float',
             name: 'amount',
         }, {
-            type: 'char', //TODO is it a bug or a feature when type date exists ?
+            type: 'date',
             name: 'date',
         }, {
             type: 'boolean',


### PR DESCRIPTION
**Steps to follow**

  - Have unreconciled entries
  - Go to General Ledger
  - Filter -> Unreconciled
  - Select one, action -> Reconcile
  - Manual operations -> click on write-off date
  - Hit enter while there is calendar
  -> TypeError: value.isSame is not a function

**Cause of the issue**

  The Writeoff Date field is declared as type char
  FieldDate._onKeyDown calls _parseValue and returns a string

opw-2820370
https://www.odoo.com/web#view_type=form&model=project.task&id=2820370