### PR TITLE
[FIX] mrp: add the `stock.move` company in the context

### DIFF
--- a/addons/mrp/views/stock_move_views.xml
+++ b/addons/mrp/views/stock_move_views.xml
@@ -49,7 +49,7 @@
                             <field name="finished_lots_exist" invisible="1"/>
                         </group>
                     </group>
-                    <field name="move_line_ids" attrs="{'invisible': [('parent.state', '=', 'draft')], 'readonly': ['|', ('is_locked', '=', True), ('state', '=', 'cancel')]}" context="{'default_workorder_id': workorder_id, 'default_product_uom_id': product_uom, 'default_product_id': product_id,  'default_location_id': location_id, 'default_location_dest_id': location_dest_id, 'default_production_id': production_id or raw_material_production_id}">
+                    <field name="move_line_ids" attrs="{'invisible': [('parent.state', '=', 'draft')], 'readonly': ['|', ('is_locked', '=', True), ('state', '=', 'cancel')]}" context="{'default_workorder_id': workorder_id, 'default_product_uom_id': product_uom, 'default_product_id': product_id,  'default_location_id': location_id, 'default_location_dest_id': location_dest_id, 'default_production_id': production_id or raw_material_production_id, 'default_company_id': company_id}">
                         <tree editable="bottom" decoration-success="product_uom_qty==qty_done" decoration-danger="(product_uom_qty &gt; 0) and (qty_done&gt;product_uom_qty)">
                             <field name="lot_id" attrs="{'column_invisible': [('parent.has_tracking', '=', 'none')]}" context="{'default_product_id': parent.product_id}"/>
                             <field name="lot_produced_ids" widget="many2many_tags" options="{'no_open': True, 'no_create': True}" domain="[('id', 'in', parent.order_finished_lot_ids)]" invisible="not context.get('final_lots')"/>


### PR DESCRIPTION
Steps to reproduce the bug:
- Create the storable  product “P1”
    - tracking by a unique serial number
    - update the qty:
        - serial number: S1, qty: 1, company: Company A
        - serial number: S1, qty: 1, company: Company A

- Create the storable product “P2” with BOM:
    - Component: “P1”, qty:1

- Create a MO to produce one unit of “P2”:
    - Click on “Mark as to do”
    - Then, “Produce”
    - In the view form that opens:
        - You can choose the product "P1" with the serial number “S1” or “S2”
        - use the “S1”
    - Confirm the MO

- Unlock the “MO”
- Edit
- Click on the product “P1”
- add a new line:
    - Select the product “P1”
    - The serial number "S2" is not proposed, while it was not used

Problem:
The new stock.move.line is created without company_id,
so when comparing the serial number one (‘company A’)
with that of the line(False) it will not be similar.

Solution:
The `stock.move.line` must always have the same company as its `stock.move`

opw-2845049


https://user-images.githubusercontent.com/78867936/168017665-6fb75a46-8a76-4545-9db9-eac4d2c3666c.mp4



--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
