### PR TITLE
[IMP] membership.membership_line : date_to used in state computation

### DIFF
--- a/addons/membership/tests/test_membership.py
+++ b/addons/membership/tests/test_membership.py
@@ -82,7 +82,10 @@ class TestMembership(TestMembershipCommon):
         self.assertEqual(
             self.partner_1.membership_state, 'old',
             'membership: after paying the invoice, customer should be in old status')
-
+        for line in self.partner_1.member_lines:
+            self.assertEqual(
+                line.state,'old', 
+                'membership.membership_line : as the date_to is in the past, state should be old')
         # check second partner then associate them
         self.assertEqual(
             self.partner_2.membership_state, 'free',


### PR DESCRIPTION
only the move state was taken into account for the membership_line
if we look at membership(res.partner) level, if the date_to is in the past -> membership_state = old
i did the same thing on line level

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
