### PR TITLE
[FIX] stock: correct float compare to use proper product

### DIFF
--- a/addons/stock/models/stock_move.py
+++ b/addons/stock/models/stock_move.py
@@ -1910,7 +1910,7 @@ class StockMove(models.Model):
         for move in mtso_moves:
             needed_qty = move.product_qty
             forecasted_qty = mtso_free_qties_by_loc[move.location_id][move.product_id.id]
-            if float_compare(needed_qty, forecasted_qty, precision_rounding=product_id.uom_id.rounding) <= 0:
+            if float_compare(needed_qty, forecasted_qty, precision_rounding=move.product_uom.rounding) <= 0:
                 move.procure_method = 'make_to_stock'
                 mtso_free_qties_by_loc[move.location_id][move.product_id.id] -= needed_qty
             else:


### PR DESCRIPTION
This PR will correct the precision_rounding parameter in the float_compare call to use the current move's product. Previously, this was using the product_id variable from a previous for loop.


Description of the issue/feature this PR addresses:
An issue is caused when a transfer is created from `mts_else_mto` procure methods in stock.rule records. When the '_adjust_procure_method' hits a rule with this procure method, it reaches the 'mtso_moves' for-loop. The needed quantity and forecasted quantity are compared to decide whether a stock.move record is needed to fulfill the needed amount.

Current behavior before PR:
The problem is that the 'float_compare' method is using the variable 'product_id' to set its precision_rounding method. The 'product_id' variable is only accessed in the prior for-loop and will always reference the final product iterated. As a result, any case where there are product quantities smaller than the final product's UoM, it is skipped.

Desired behavior after PR is merged:
When the needed quantity is compared to the forecasted quantity, it should use the correct precision of the move's product's UoM.


opw-2820401

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
