### PR TITLE
[IMP] account: add a line type on account move lines

### DIFF
--- a/addons/account/models/account_move.py
+++ b/addons/account/models/account_move.py
@@ -327,7 +327,7 @@ class AccountMove(models.Model):
     # /!\ invoice_line_ids is just a subset of line_ids.
     invoice_line_ids = fields.One2many('account.move.line', 'move_id', string='Invoice lines',
         copy=False, readonly=True,
-        domain=[('exclude_from_invoice_tab', '=', False)],
+        domain=[('line_type', '=like', 'invoice_line%')],
         states={'draft': [('readonly', False)]})
     invoice_incoterm_id = fields.Many2one('account.incoterms', string='Incoterm',
         default=_get_default_invoice_incoterm,
@@ -602,7 +602,7 @@ class AccountMove(models.Model):
 
     @api.onchange('invoice_line_ids')
     def _onchange_invoice_line_ids(self):
-        current_invoice_lines = self.line_ids.filtered(lambda line: not line.exclude_from_invoice_tab)
+        current_invoice_lines = self.line_ids.filtered(lambda line: line.is_invoice_line())
         others_lines = self.line_ids - current_invoice_lines
         if others_lines and current_invoice_lines - self.invoice_line_ids:
             others_lines[0].recompute_tax_line = True
@@ -705,7 +705,7 @@ class AccountMove(models.Model):
                 'amount_currency': amount_currency,
                 'debit': self._get_debit_from_balance(balance, currency.id),
                 'credit': self._get_credit_from_balance(balance, currency.id),
-                'exclude_from_invoice_tab': True,
+                'line_type': False,
                 'currency_id': currency.id,
                 'group_tax_id': group_tax.id if group_tax else None,
             })
@@ -714,12 +714,12 @@ class AccountMove(models.Model):
         is_invoice = self.is_invoice(include_receipts=True)
 
         if is_invoice:
-            base_lines = self.line_ids.filtered(lambda x: not x.display_type and not x.exclude_from_invoice_tab)
+            base_lines = self.line_ids.filtered(lambda x: x.is_invoice_line(with_display_line_check=True))
             force_sign = 1
         else:
-            base_lines = self.line_ids.filtered(lambda x: not x.display_type and not x.tax_repartition_line_id)
+            base_lines = self.line_ids.filtered(lambda x: not x.is_display_line() and not x.tax_repartition_line_id)
             force_sign = self._get_tax_force_sign()
-        tax_lines = self.line_ids.filtered(lambda x: not x.display_type and x.tax_repartition_line_id)
+        tax_lines = self.line_ids.filtered(lambda x: not x.is_display_line() and x.tax_repartition_line_id)
 
         tax_results = self.env['account.tax'].with_context(force_sign=force_sign)._compute_taxes(
             [x._convert_to_tax_base_line_dict() for x in base_lines],
@@ -830,7 +830,6 @@ class AccountMove(models.Model):
                 'currency_id': self.currency_id.id,
                 'company_id': self.company_id.id,
                 'company_currency_id': self.company_id.currency_id.id,
-                'is_rounding_line': True,
                 'sequence': 9999,
             }
 
@@ -849,7 +848,7 @@ class AccountMove(models.Model):
                     'account_id': biggest_tax_line.account_id.id,
                     'tax_repartition_line_id': biggest_tax_line.tax_repartition_line_id.id,
                     'tax_tag_ids': [(6, 0, biggest_tax_line.tax_tag_ids.ids)],
-                    'exclude_from_invoice_tab': True,
+                    'line_type': 'invoice_cash_rounding',
                 })
 
             elif self.invoice_cash_rounding_id.strategy == 'add_invoice_line':
@@ -860,6 +859,7 @@ class AccountMove(models.Model):
                 rounding_line_vals.update({
                     'name': self.invoice_cash_rounding_id.name,
                     'account_id': account_id,
+                    'line_type': 'invoice_line_cash_rounding',
                 })
 
             # Create or update the cash rounding line.
@@ -877,7 +877,7 @@ class AccountMove(models.Model):
             if in_draft_mode:
                 cash_rounding_line.update(cash_rounding_line._get_fields_onchange_balance(force_computation=True))
 
-        existing_cash_rounding_line = self.line_ids.filtered(lambda line: line.is_rounding_line)
+        existing_cash_rounding_line = self.line_ids.filtered(lambda line: line.line_type in ['invoice_line_cash_rounding', 'invoice_cash_rounding'])
 
         # The cash rounding has been removed.
         if not self.invoice_cash_rounding_id:
@@ -1008,7 +1008,7 @@ class AccountMove(models.Model):
                         'currency_id': self.currency_id.id,
                         'account_id': account.id,
                         'partner_id': self.commercial_partner_id.id,
-                        'exclude_from_invoice_tab': True,
+                        'line_type': False,
                     })
                 new_terms_lines += candidate
                 if in_draft_mode:
@@ -1070,7 +1070,7 @@ class AccountMove(models.Model):
 
                 # Only synchronize one2many in onchange.
                 if invoice != invoice._origin:
-                    invoice.invoice_line_ids = invoice.line_ids.filtered(lambda line: not line.exclude_from_invoice_tab)
+                    invoice.invoice_line_ids = invoice.line_ids.filtered(lambda line: line.is_invoice_line())
 
     @api.depends('journal_id')
     def _compute_company_id(self):
@@ -1427,7 +1427,7 @@ class AccountMove(models.Model):
                 if move._payment_state_matters():
                     # === Invoices ===
 
-                    if not line.exclude_from_invoice_tab:
+                    if line.is_invoice_line():
                         # Untaxed amount.
                         total_untaxed += line.balance
                         total_untaxed_currency += line.amount_currency
@@ -1689,8 +1689,8 @@ class AccountMove(models.Model):
         """
         for move in self:
             if move.is_invoice(include_receipts=True):
-                base_lines = move.line_ids.filtered(lambda x: not x.display_type and not x.exclude_from_invoice_tab)
-                tax_lines = move.line_ids.filtered(lambda x: not x.display_type and x.tax_repartition_line_id)
+                base_lines = move.line_ids.filtered(lambda x: x.is_invoice_line(with_display_line_check=True))
+                tax_lines = move.line_ids.filtered(lambda x: not x.is_display_line() and x.tax_repartition_line_id)
 
                 tax_totals = self.env['account.tax']._prepare_tax_totals_json(
                     [x._convert_to_tax_base_line_dict() for x in base_lines],
@@ -1979,7 +1979,7 @@ class AccountMove(models.Model):
         '''
         self.ensure_one()
 
-        invoice_lines = self.line_ids.filtered(lambda x: not x.exclude_from_invoice_tab and not x.display_type and not x._origin)
+        invoice_lines = self.line_ids.filtered(lambda x: x.is_invoice_line(with_display_line_check=True) and not x._origin)
         cached_vals_list = [dict(x._cache) for x in invoice_lines]
 
         for cached_vals, line in zip(cached_vals_list, invoice_lines):
@@ -2051,7 +2051,7 @@ class AccountMove(models.Model):
             self_ctx = self.with_context(**ctx_vals)
             vals = self_ctx._add_missing_default_values(vals)
 
-            is_invoice = vals.get('move_type') in self.get_invoice_types(include_receipts=True)
+            is_invoice = default_move_type in self.get_invoice_types(include_receipts=True)
 
             if 'line_ids' in vals:
                 vals.pop('invoice_line_ids', None)
@@ -2077,7 +2077,7 @@ class AccountMove(models.Model):
         :param vals_list:   A python dict representing the values to write.
         :return:            True if the auto-completion did something, False otherwise.
         '''
-        enable_autocomplete = 'invoice_line_ids' in vals and 'line_ids' not in vals and True or False
+        enable_autocomplete = 'invoice_line_ids' in vals and 'line_ids' not in vals
 
         if not enable_autocomplete:
             return False
@@ -2089,6 +2089,7 @@ class AccountMove(models.Model):
                 default_journal_id=invoice.journal_id.id,
                 default_partner_id=invoice.partner_id.id,
                 default_currency_id=invoice.currency_id.id,
+                default_line_type='invoice_line',
             ).new(origin=invoice)
             invoice_new.update(vals)
             values = invoice_new._move_autocomplete_invoice_lines_values()
@@ -2747,7 +2748,7 @@ class AccountMove(models.Model):
                 raise UserError(_("The recipient bank account link to this invoice is archived.\nSo you cannot confirm the invoice."))
             if move.state == 'posted':
                 raise UserError(_('The entry %s (id %s) is already posted.') % (move.name, move.id))
-            if not move.line_ids.filtered(lambda line: not line.display_type):
+            if not move.line_ids.filtered(lambda line: not line.is_display_line()):
                 raise UserError(_('You need to add a line before posting.'))
             if move.auto_post and move.date > fields.Date.context_today(self):
                 date_msg = move.date.strftime(get_lang(self.env).date_format)
@@ -3072,8 +3073,8 @@ class AccountMove(models.Model):
             reversed_move = move._reverse_move_vals({}, False)
             new_invoice_line_ids = []
             for cmd, virtualid, line_vals in reversed_move['line_ids']:
-                if not line_vals['exclude_from_invoice_tab']:
-                    new_invoice_line_ids.append((0, 0,line_vals))
+                if (line_vals.get('line_type') or '').startswith('invoice_line'):
+                    new_invoice_line_ids.append((0, 0, line_vals))
             if move.amount_total < 0:
                 # Inverse all invoice_line_ids
                 for cmd, virtualid, line_vals in new_invoice_line_ids:
@@ -3083,10 +3084,10 @@ class AccountMove(models.Model):
                     })
             move.write({
                 'move_type': move.move_type.replace('invoice', 'refund'),
-                'invoice_line_ids' : [(5, 0, 0)],
+                'invoice_line_ids': [(5, 0, 0)],
                 'partner_bank_id': False,
             })
-            move.write({'invoice_line_ids' : new_invoice_line_ids})
+            move.write({'invoice_line_ids': new_invoice_line_ids})
 
     def _get_report_base_filename(self):
         return self._get_move_display_name()
@@ -3440,6 +3441,21 @@ class AccountMoveLine(models.Model):
     product_uom_id = fields.Many2one('uom.uom', string='Unit of Measure', domain="[('category_id', '=', product_uom_category_id)]", ondelete="restrict")
     product_id = fields.Many2one('product.product', string='Product', ondelete='restrict')
     product_uom_category_id = fields.Many2one('uom.category', related='product_id.uom_id.category_id')
+    line_type = fields.Selection(
+        selection=[
+            ('invoice_line', 'Invoice line'),
+            ('invoice_line_section', 'Section line'),
+            ('invoice_line_note', 'Note line'),
+            ('invoice_line_cash_rounding', 'Cash rounding line'),
+            ('invoice_cash_rounding', 'Tax cash rounding line'),
+        ],
+        help="Technical field used to define the purpose of this line when used in synchronization with models that _inherits account_move."
+             "For example, can be used to easily determine which line is liquidity/counterpart for a move linked to a payment."
+             "Selections starting with invoice_line are equivalent to lines with exclude_from_invoice_tab=False before this change.",
+        compute='_compute_line_type',
+        store=True,
+        readonly=False,
+    )
 
     # ==== Origin fields ====
     reconcile_model_id = fields.Many2one('account.reconcile.model', string="Reconciliation Model", copy=False, readonly=True, check_company=True)
@@ -3511,12 +3527,6 @@ class AccountMoveLine(models.Model):
     # ==== Onchange / display purpose fields ====
     recompute_tax_line = fields.Boolean(store=False, readonly=True,
         help="Technical field used to know on which lines the taxes must be recomputed.")
-    display_type = fields.Selection([
-        ('line_section', 'Section'),
-        ('line_note', 'Note'),
-    ], default=False, help="Technical field for UX purpose.")
-    is_rounding_line = fields.Boolean(help="Technical field used to retrieve the cash rounding line.")
-    exclude_from_invoice_tab = fields.Boolean(help="Technical field used to exclude some lines from the invoice_line_ids tab in the form view.")
 
     _sql_constraints = [
         (
@@ -3526,12 +3536,12 @@ class AccountMoveLine(models.Model):
         ),
         (
             'check_accountable_required_fields',
-             "CHECK(COALESCE(display_type IN ('line_section', 'line_note'), 'f') OR account_id IS NOT NULL)",
+             "CHECK(COALESCE(line_type, 'false') IN ('invoice_line_section', 'invoice_line_note') OR account_id IS NOT NULL)",
              "Missing required account on accountable invoice line."
         ),
         (
             'check_non_accountable_fields_null',
-             "CHECK(display_type NOT IN ('line_section', 'line_note') OR (amount_currency = 0 AND debit = 0 AND credit = 0 AND account_id IS NULL))",
+             "CHECK(COALESCE(line_type, 'false') NOT IN ('invoice_line_section', 'invoice_line_note') OR (amount_currency = 0 AND debit = 0 AND credit = 0 AND account_id IS NULL))",
              "Forbidden unit price, account and quantity on non-accountable invoice line"
         ),
         (
@@ -3665,7 +3675,7 @@ class AccountMoveLine(models.Model):
                 tax_ids = self.account_id.tax_ids
             else:
                 tax_ids = self.env['account.tax']
-            if not tax_ids and not self.exclude_from_invoice_tab:
+            if not tax_ids and self.is_invoice_line():
                 tax_ids = self.move_id.company_id.account_sale_tax_id
         elif self.move_id.is_purchase_document(include_receipts=True):
             # In invoice.
@@ -3675,7 +3685,7 @@ class AccountMoveLine(models.Model):
                 tax_ids = self.account_id.tax_ids
             else:
                 tax_ids = self.env['account.tax']
-            if not tax_ids and not self.exclude_from_invoice_tab:
+            if not tax_ids and self.is_invoice_line():
                 tax_ids = self.move_id.company_id.account_purchase_tax_id
         else:
             # Miscellaneous operation.
@@ -3712,10 +3722,19 @@ class AccountMoveLine(models.Model):
             if 'price_unit' in business_vals:
                 self.price_unit = business_vals['price_unit']
 
+    @api.depends('tax_line_id')
+    def _compute_line_type(self):
+        for line in self.filtered(lambda l: not l.line_type):
+            # All lines other than tax lines or payment term lines have a specific type, so we juste have to check for this one
+            if self._context.get('default_line_type'):
+                line.line_type = self._context['default_line_type']
+            elif line.move_id.is_invoice(include_receipts=True) and not line.tax_line_id and line.account_id.user_type_id.type not in ('receivable', 'payable'):
+                line.line_type = 'invoice_line'
+
     @api.depends('product_id', 'account_id', 'partner_id', 'date')
     def _compute_analytic_account_id(self):
         for record in self:
-            if not record.exclude_from_invoice_tab or not record.move_id.is_invoice(include_receipts=True):
+            if record.is_invoice_line() or not record.move_id.is_invoice(include_receipts=True):
                 rec = self.env['account.analytic.default'].account_get(
                     product_id=record.product_id.id,
                     partner_id=record.partner_id.commercial_partner_id.id or record.move_id.partner_id.commercial_partner_id.id,
@@ -3730,7 +3749,7 @@ class AccountMoveLine(models.Model):
     @api.depends('product_id', 'account_id', 'partner_id', 'date')
     def _compute_analytic_tag_ids(self):
         for record in self:
-            if not record.exclude_from_invoice_tab or not record.move_id.is_invoice(include_receipts=True):
+            if record.is_invoice_line() or not record.move_id.is_invoice(include_receipts=True):
                 rec = self.env['account.analytic.default'].account_get(
                     product_id=record.product_id.id,
                     partner_id=record.partner_id.commercial_partner_id.id or record.move_id.partner_id.commercial_partner_id.id,
@@ -3987,7 +4006,7 @@ class AccountMoveLine(models.Model):
     @api.onchange('product_id')
     def _onchange_product_id(self):
         for line in self:
-            if not line.product_id or line.display_type in ('line_section', 'line_note'):
+            if not line.product_id or line.is_display_line():
                 continue
 
             line.name = line._get_computed_name()
@@ -4002,7 +4021,7 @@ class AccountMoveLine(models.Model):
     @api.onchange('product_uom_id')
     def _onchange_uom_id(self):
         ''' Recompute the 'price_unit' depending of the unit of measure. '''
-        if self.display_type in ('line_section', 'line_note'):
+        if self.is_display_line():
             return
         taxes = self._get_computed_taxes()
         if taxes and self.move_id.fiscal_position_id:
@@ -4016,7 +4035,7 @@ class AccountMoveLine(models.Model):
         /!\ Don't remove existing taxes if there is no explicit taxes set on the account.
         '''
         for line in self:
-            if not line.display_type and (line.account_id.tax_ids or not line.tax_ids):
+            if not line.is_display_line() and (line.account_id.tax_ids or not line.tax_ids):
                 taxes = line._get_computed_taxes()
 
                 if taxes and line.move_id.fiscal_position_id:
@@ -4257,7 +4276,7 @@ class AccountMoveLine(models.Model):
 
     @api.constrains('account_id', 'journal_id')
     def _check_constrains_account_id_journal_id(self):
-        for line in self.filtered(lambda x: x.display_type not in ('line_section', 'line_note')):
+        for line in self.filtered(lambda x: not x.is_display_line()):
             account = line.account_id
             journal = line.move_id.journal_id
 
@@ -4654,7 +4673,7 @@ class AccountMoveLine(models.Model):
             if 'account_id' in default_fields and not values.get('account_id'):
                 if len(move.line_ids[-2:]) == 2 and  move.line_ids[-1].account_id == move.line_ids[-2].account_id != False:
                     values['account_id'] = move.line_ids[-2:].mapped('account_id').id
-        if values.get('display_type') or self.display_type:
+        if values.get('line_type') in ['invoice_line_note', 'invoice_line_section']:
             values.pop('account_id', None)
         return values
 
@@ -5444,7 +5463,7 @@ class AccountMoveLine(models.Model):
             if line.move_id.is_invoice() and line.account_id.user_type_id.type in ('receivable', 'payable'):
                 values['name'] = ''
             # Don't copy restricted fields of notes
-            if line.display_type in ('line_section', 'line_note'):
+            if line.is_display_line():
                 values['amount_currency'] = 0
                 values['debit'] = 0
                 values['credit'] = 0
@@ -5655,7 +5674,7 @@ class AccountMoveLine(models.Model):
         where_clause_params = []
         tables = ''
         if domain:
-            domain.append(('display_type', 'not in', ('line_section', 'line_note')))
+            domain.append(('line_type', 'not in', ('invoice_line_section', 'invoice_line_note')))
             domain.append(('parent_state', '!=', 'cancel'))
 
             query = self._where_calc(domain)
@@ -5706,3 +5725,14 @@ class AccountMoveLine(models.Model):
         if self.payment_id:
             domains.append([('res_model', '=', 'account.payment'), ('res_id', '=', self.payment_id.id)])
         return domains
+
+    def is_invoice_line(self, with_display_line_check=False):
+        """ Helps to determine if the line is an invoice line (displayed in the "invoice lines" tab or not """
+        self.ensure_one()
+        is_invoice_line = (self.line_type or '').startswith('invoice_line')
+        return is_invoice_line and (not with_display_line_check or not self.is_display_line())
+
+    def is_display_line(self):
+        """ Helps to determine if the line is a display line (a note or section) or not """
+        self.ensure_one()
+        return (self.line_type or '') in ('invoice_line_section', 'invoice_line_note')

--- a/addons/account/populate/account_move.py
+++ b/addons/account/populate/account_move.py
@@ -95,7 +95,7 @@ class AccountMove(models.Model):
             :param values (dict): the values already selected for the record.
             :return list: list of ORM create commands for the field line_ids
             """
-            def get_line(account, label, balance=None, balance_sign=False, exclude_from_invoice_tab=False):
+            def get_line(account, label, balance=None, balance_sign=False, line_type=False):
                 company_currency = account.company_id.currency_id
                 currency = self.env['res.currency'].browse(currency_id)
                 balance = balance or balance_sign * round(random.uniform(0, 1000))
@@ -108,7 +108,7 @@ class AccountMove(models.Model):
                     'partner_id': partner_id,
                     'currency_id': currency_id,
                     'amount_currency': amount_currency,
-                    'exclude_from_invoice_tab': exclude_from_invoice_tab,
+                    'line_type': line_type,
                 })
             move_type = values['move_type']
             date = values['date']
@@ -149,7 +149,7 @@ class AccountMove(models.Model):
                 account=random.choice(balance_account_ids),
                 balance=sum(l[2]['credit'] - l[2]['debit'] for l in lines),
                 label='balance',
-                exclude_from_invoice_tab=move_type in self.get_invoice_types(include_receipts=True),
+                line_type=False if move_type in self.get_invoice_types(include_receipts=True) else 'invoice_line',
             )]
 
             return lines

--- a/addons/account/report/account_invoice_report.py
+++ b/addons/account/report/account_invoice_report.py
@@ -130,7 +130,7 @@ class AccountInvoiceReport(models.Model):
         return '''
             WHERE move.move_type IN ('out_invoice', 'out_refund', 'in_invoice', 'in_refund', 'out_receipt', 'in_receipt')
                 AND line.account_id IS NOT NULL
-                AND NOT line.exclude_from_invoice_tab
+                AND COALESCE(line.line_type, 'false') LIKE 'invoice_line%%'
         '''
 
 

--- a/addons/account/static/tests/section_and_note_tests.js
+++ b/addons/account/static/tests/section_and_note_tests.js
@@ -23,10 +23,10 @@ QUnit.module('section_and_note', {
             },
             invoice_line: {
                 fields: {
-                    display_type: {
+                    line_type: {
                         string: 'Type',
                         type: 'selection',
-                        selection: [['line_section', "Section"], ['line_note', "Note"]]
+                        selection: [['invoice_line', 'Invoice line'], ['invoice_line_cash_rounding', 'Cash rounding line'], ['invoice_line_section', 'Section line'], ['invoice_line_note', 'Note line'], ['invoice_cash_rounding', 'Tax cash rounding line']]
                     },
                     invoice_id: {
                         string: "Invoice",
@@ -39,8 +39,8 @@ QUnit.module('section_and_note', {
                     },
                 },
                 records: [
-                    {id: 1, display_type: false, invoice_id: 1, name: 'product\n2 lines'},
-                    {id: 2, display_type: 'line_section', invoice_id: 1, name: 'section'},
+                    {id: 1, line_type: 'invoice_line', invoice_id: 1, name: 'product\n2 lines'},
+                    {id: 2, line_type: 'invoice_line_section', invoice_id: 1, name: 'section'},
                 ]
             },
         };
@@ -57,7 +57,7 @@ QUnit.module('section_and_note', {
                 '</form>',
             archs: {
                 'invoice_line,false,list': '<tree editable="bottom">' +
-                    '<field name="display_type" invisible="1"/>' +
+                    '<field name="line_type" invisible="1"/>' +
                     '<field name="name" widget="section_and_note_text"/>' +
                 '</tree>',
             },

--- a/addons/account/tests/common.py
+++ b/addons/account/tests/common.py
@@ -411,7 +411,8 @@ class AccountTestInvoicingCommon(TransactionCase):
 
     def assertInvoiceValues(self, move, expected_lines_values, expected_move_values):
         def sort_lines(lines):
-            return lines.sorted(lambda line: (line.exclude_from_invoice_tab, not bool(line.tax_line_id), line.name or '', line.balance))
+            return lines.sorted(lambda line: (not line.is_invoice_line(), not bool(line.tax_line_id), line.name or '', line.balance))
+
         self.assertRecordValues(sort_lines(move.line_ids.sorted()), expected_lines_values)
         self.assertRecordValues(sort_lines(move.invoice_line_ids.sorted()), expected_lines_values[:len(move.invoice_line_ids)])
         self.assertRecordValues(move, [expected_move_values])

--- a/addons/account/tests/test_account_move_entry.py
+++ b/addons/account/tests/test_account_move_entry.py
@@ -510,7 +510,11 @@ class TestAccountMove(AccountTestInvoicingCommon):
             'invoice_date': fields.Date.from_string('2019-01-01'),
             'currency_id': self.currency_data['currency'].id,
             'invoice_payment_term_id': self.pay_terms_a.id,
-            'invoice_line_ids': [{}]
+            'invoice_line_ids': [(0, 0, {
+                'name': 'Product',
+                'quantity': 26,
+                'price_unit': 2391.0,
+            })]
         })
 
         move.currency_id.active = False

--- a/addons/account/tests/test_account_move_in_refund.py
+++ b/addons/account/tests/test_account_move_in_refund.py
@@ -35,6 +35,7 @@ class TestAccountMoveInRefundOnchanges(AccountTestInvoicingCommon):
             'debit': 0.0,
             'credit': 800.0,
             'date_maturity': False,
+            'line_type': 'invoice_line',
         }
         cls.product_line_vals_2 = {
             'name': cls.product_b.name,
@@ -54,6 +55,7 @@ class TestAccountMoveInRefundOnchanges(AccountTestInvoicingCommon):
             'debit': 0.0,
             'credit': 160.0,
             'date_maturity': False,
+            'line_type': 'invoice_line',
         }
         cls.tax_line_vals_1 = {
             'name': cls.tax_purchase_a.name,
@@ -73,6 +75,7 @@ class TestAccountMoveInRefundOnchanges(AccountTestInvoicingCommon):
             'debit': 0.0,
             'credit': 144.0,
             'date_maturity': False,
+            'line_type': False,
         }
         cls.tax_line_vals_2 = {
             'name': cls.tax_purchase_b.name,
@@ -92,6 +95,7 @@ class TestAccountMoveInRefundOnchanges(AccountTestInvoicingCommon):
             'debit': 0.0,
             'credit': 24.0,
             'date_maturity': False,
+            'line_type': False,
         }
         cls.term_line_vals_1 = {
             'name': '',
@@ -111,6 +115,7 @@ class TestAccountMoveInRefundOnchanges(AccountTestInvoicingCommon):
             'debit': 1128.0,
             'credit': 0.0,
             'date_maturity': fields.Date.from_string('2019-01-01'),
+            'line_type': False,
         }
         cls.move_vals = {
             'partner_id': cls.partner_a.id,
@@ -478,6 +483,7 @@ class TestAccountMoveInRefundOnchanges(AccountTestInvoicingCommon):
                 'debit': 0.0,
                 'credit': 96.0,
                 'date_maturity': False,
+                'line_type': False,
             },
             {
                 'name': child_tax_1.name,
@@ -497,6 +503,7 @@ class TestAccountMoveInRefundOnchanges(AccountTestInvoicingCommon):
                 'debit': 0.0,
                 'credit': 64.0,
                 'date_maturity': False,
+                'line_type': False,
             },
             {
                 'name': child_tax_2.name,
@@ -516,6 +523,7 @@ class TestAccountMoveInRefundOnchanges(AccountTestInvoicingCommon):
                 'debit': 0.0,
                 'credit': 96.0,
                 'date_maturity': False,
+                'line_type': False,
             },
             {
                 **self.term_line_vals_1,
@@ -671,6 +679,7 @@ class TestAccountMoveInRefundOnchanges(AccountTestInvoicingCommon):
                 'debit': 0.04,
                 'credit': 0.0,
                 'date_maturity': False,
+                'line_type': 'invoice_cash_rounding',
             },
             {
                 **self.term_line_vals_1,

--- a/addons/account/tests/test_account_move_out_invoice.py
+++ b/addons/account/tests/test_account_move_out_invoice.py
@@ -3278,7 +3278,7 @@ class TestAccountMoveOutInvoiceOnchanges(AccountTestInvoicingCommon):
                     'tax_ids': [(6, 0, self.product_a.taxes_id.ids)],
                 }),
                 (0, 0, {
-                    'display_type': 'line_note',
+                    'line_type': 'invoice_line_note',
                     'name': 'This is a note',
                     'account_id': False,
                 }),

--- a/addons/account/tests/test_account_move_out_refund.py
+++ b/addons/account/tests/test_account_move_out_refund.py
@@ -34,6 +34,7 @@ class TestAccountMoveOutRefundOnchanges(AccountTestInvoicingCommon):
             'debit': 1000.0,
             'credit': 0.0,
             'date_maturity': False,
+            'line_type': 'invoice_line',
         }
         cls.product_line_vals_2 = {
             'name': cls.product_b.name,
@@ -53,6 +54,7 @@ class TestAccountMoveOutRefundOnchanges(AccountTestInvoicingCommon):
             'debit': 200.0,
             'credit': 0.0,
             'date_maturity': False,
+            'line_type': 'invoice_line',
         }
         cls.tax_line_vals_1 = {
             'name': cls.tax_sale_a.name,
@@ -72,6 +74,7 @@ class TestAccountMoveOutRefundOnchanges(AccountTestInvoicingCommon):
             'debit': 180.0,
             'credit': 0.0,
             'date_maturity': False,
+            'line_type': False,
         }
         cls.tax_line_vals_2 = {
             'name': cls.tax_sale_b.name,
@@ -91,6 +94,7 @@ class TestAccountMoveOutRefundOnchanges(AccountTestInvoicingCommon):
             'debit': 30.0,
             'credit': 0.0,
             'date_maturity': False,
+            'line_type': False,
         }
         cls.term_line_vals_1 = {
             'name': '',
@@ -110,6 +114,7 @@ class TestAccountMoveOutRefundOnchanges(AccountTestInvoicingCommon):
             'debit': 0.0,
             'credit': 1410.0,
             'date_maturity': fields.Date.from_string('2019-01-01'),
+            'line_type': False,
         }
         cls.move_vals = {
             'partner_id': cls.partner_a.id,
@@ -477,6 +482,7 @@ class TestAccountMoveOutRefundOnchanges(AccountTestInvoicingCommon):
                 'debit': 80.0,
                 'credit': 0.0,
                 'date_maturity': False,
+                'line_type': False,
             },
             {
                 'name': child_tax_1.name,
@@ -496,6 +502,7 @@ class TestAccountMoveOutRefundOnchanges(AccountTestInvoicingCommon):
                 'debit': 120.0,
                 'credit': 0.0,
                 'date_maturity': False,
+                'line_type': False,
             },
             {
                 'name': child_tax_2.name,
@@ -515,6 +522,7 @@ class TestAccountMoveOutRefundOnchanges(AccountTestInvoicingCommon):
                 'debit': 120.0,
                 'credit': 0.0,
                 'date_maturity': False,
+                'line_type': False,
             },
             {
                 **self.term_line_vals_1,
@@ -670,6 +678,7 @@ class TestAccountMoveOutRefundOnchanges(AccountTestInvoicingCommon):
                 'debit': 0.0,
                 'credit': 0.04,
                 'date_maturity': False,
+                'line_type': 'invoice_cash_rounding',
             },
             {
                 **self.term_line_vals_1,

--- a/addons/account/views/account_move_views.xml
+++ b/addons/account/views/account_move_views.xml
@@ -878,8 +878,8 @@
                                     <tree editable="bottom" string="Journal Items" default_order="sequence, date desc, move_name desc, id">
                                         <control>
                                             <create name="add_line_control" string="Add a line"/>
-                                            <create name="add_section_control" string="Add a section" context="{'default_display_type': 'line_section'}"/>
-                                            <create name="add_note_control" string="Add a note" context="{'default_display_type': 'line_note'}"/>
+                                            <create name="add_section_control" string="Add a section" context="{'default_line_type': 'invoice_line_section'}"/>
+                                            <create name="add_note_control" string="Add a note" context="{'default_line_type': 'invoice_line_note'}"/>
                                         </control>
 
                                         <!-- Displayed fields -->
@@ -897,7 +897,7 @@
                                                groups="account.group_account_readonly"
                                                options="{'no_create': True}"
                                                domain="[('deprecated', '=', False), ('user_type_id.type', 'not in', ('receivable', 'payable')), ('company_id', '=', parent.company_id), ('is_off_balance', '=', False)]"
-                                               attrs="{'required': [('display_type', '=', False)]}"/>
+                                               attrs="{'required': [('line_type', 'not in', ['invoice_line_section', 'invoice_line_note'])]}"/>
                                         <field name="analytic_account_id"
                                                domain="['|', ('company_id', '=', False), ('company_id', '=', parent.company_id)]"
                                                groups="analytic.group_analytic_accounting"
@@ -941,9 +941,7 @@
                                         <field name="company_id" invisible="1"/>
                                         <field name="company_currency_id" invisible="1"/>
                                         <field name="recompute_tax_line" invisible="1" force_save="1"/>
-                                        <field name="display_type" force_save="1" invisible="1"/>
-                                        <field name="is_rounding_line" invisible="1"/>
-                                        <field name="exclude_from_invoice_tab" invisible="1"/>
+                                        <field name="line_type" force_save="1" invisible="1"/>
                                         <field name="account_internal_type" invisible="1"/>
                                         <field name="account_internal_group" invisible="1"/>
                                     </tree>
@@ -959,8 +957,8 @@
                                         <field name="price_unit"/>
                                         <templates>
                                             <t t-name="kanban-box">
-                                                <div t-attf-class="oe_kanban_card oe_kanban_global_click pl-0 pr-0 {{ record.display_type.raw_value ? 'o_is_' + record.display_type.raw_value : '' }}">
-                                                    <t t-if="!record.display_type.raw_value">
+                                                <div t-attf-class="oe_kanban_card oe_kanban_global_click pl-0 pr-0 {{ ['invoice_line_section', 'invoice_line_note'].includes(record.line_type.raw_value) ? 'o_is_' + record.line_type.raw_value : '' }}">
+                                                    <t t-if="!['invoice_line_section', 'invoice_line_note'].includes(record.line_type.raw_value)">
                                                         <div class="row no-gutters">
                                                             <div class="col-2 pr-3">
                                                                 <img t-att-src="kanban_image('product.product', 'image_128', record.product_id.raw_value)" t-att-title="record.product_id.value" t-att-alt="record.product_id.value" style="max-width: 100%;"/>
@@ -989,7 +987,7 @@
                                                             </div>
                                                         </div>
                                                     </t>
-                                                    <t t-if="record.display_type.raw_value === 'line_section' || record.display_type.raw_value === 'line_note'">
+                                                    <t t-else="">
                                                         <div class="row">
                                                             <div class="col-12">
                                                                 <t t-esc="record.name.value"/>
@@ -1017,9 +1015,7 @@
                                         <field name="company_id" invisible="1"/>
                                         <field name="company_currency_id" invisible="1"/>
                                         <field name="recompute_tax_line" invisible="1" force_save="1"/>
-                                        <field name="display_type" force_save="1" invisible="1"/>
-                                        <field name="is_rounding_line" invisible="1"/>
-                                        <field name="exclude_from_invoice_tab" invisible="1"/>
+                                        <field name="line_type" force_save="1" invisible="1"/>
                                         <field name="account_internal_type" invisible="1"/>
                                         <field name="account_internal_group" invisible="1"/>
                                     </kanban>
@@ -1028,7 +1024,7 @@
                                     <form>
                                         <sheet>
                                             <field name="product_uom_category_id" invisible="1"/>
-                                            <field name="display_type" invisible="1"/>
+                                            <field name="line_type" invisible="1"/>
                                             <field name="parent_state" invisible="1"/>
                                             <group>
                                                 <field name="partner_id" invisible="1"/>
@@ -1048,9 +1044,9 @@
                                                 <field name="tax_ids" widget="many2many_tags"/>
                                                 <field name="analytic_account_id" groups="analytic.group_analytic_accounting"/>
                                             </group>
-                                            <label for="name" string="Description" attrs="{'invisible': [('display_type', '!=', False)]}"/>
-                                            <label for="name" string="Section" attrs="{'invisible': [('display_type', '!=', 'line_section')]}"/>
-                                            <label for="name" string="Note" attrs="{'invisible': [('display_type', '!=', 'line_note')]}"/>
+                                            <label for="name" string="Description" attrs="{'invisible': [('line_type', '!=', False)]}"/>
+                                            <label for="name" string="Section" attrs="{'invisible': [('line_type', '!=', 'invoice_line_section')]}"/>
+                                            <label for="name" string="Note" attrs="{'invisible': [('line_type', '!=', 'invoice_line_note')]}"/>
                                             <field name="name" widget="text"/>
                                             <group>
                                                 <field name="price_subtotal" string="Subtotal" groups="account.group_show_line_subtotals_tax_excluded"/>
@@ -1089,12 +1085,12 @@
                                        mode="tree,kanban"
                                        context="{'default_move_type': context.get('default_move_type'), 'line_ids': line_ids, 'journal_id': journal_id, 'default_partner_id': commercial_partner_id, 'default_currency_id': currency_id or company_currency_id}"
                                        attrs="{'invisible': [('payment_state', '=', 'invoicing_legacy'), ('move_type', '!=', 'entry')]}">
-                                    <tree editable="bottom" string="Journal Items" decoration-muted="display_type in ('line_section', 'line_note')" default_order="sequence, date desc, move_name desc, id">
+                                    <tree editable="bottom" string="Journal Items" decoration-muted="line_type in ('invoice_line_section', 'invoice_line_note')" default_order="sequence, date desc, move_name desc, id">
                                         <!-- Displayed fields -->
                                         <field name="account_id"
                                                attrs="{
-                                                    'required': [('display_type', 'not in', ('line_section', 'line_note'))],
-                                                    'invisible': [('display_type', 'in', ('line_section', 'line_note'))],
+                                                    'required': [('line_type', 'not in', ('invoice_line_section', 'invoice_line_note'))],
+                                                    'invisible': [('line_type', 'in', ('invoice_line_section', 'invoice_line_note'))],
                                                }"
                                                domain="[('deprecated', '=', False), ('company_id', '=', parent.company_id)]" />
                                         <field name="partner_id"
@@ -1105,16 +1101,16 @@
                                                optional="hide"
                                                domain="['|', ('company_id', '=', parent.company_id), ('company_id', '=', False)]"
                                                groups="analytic.group_analytic_accounting"
-                                               attrs="{'invisible': [('display_type', 'in', ('line_section', 'line_note'))]}"/>
+                                               attrs="{'invisible': [('line_type', 'in', ('invoice_line_section', 'invoice_line_note'))]}"/>
                                         <field name="analytic_tag_ids"
                                                optional="show"
                                                groups="analytic.group_analytic_tags"
                                                widget="many2many_tags"
-                                               attrs="{'invisible': [('display_type', 'in', ('line_section', 'line_note'))]}"/>
+                                               attrs="{'invisible': [('line_type', 'in', ('invoice_line_section', 'invoice_line_note'))]}"/>
                                         <field name="date_maturity"
                                                optional="hide"
                                                invisible="context.get('view_no_maturity')"
-                                               attrs="{'invisible': [('display_type', 'in', ('line_section', 'line_note'))]}"/>
+                                               attrs="{'invisible': [('line_type', 'in', ('invoice_line_section', 'invoice_line_note'))]}"/>
                                         <field name="amount_currency"
                                                groups="base.group_multi_currency"
                                                optional="hide"/>
@@ -1129,7 +1125,7 @@
                                                force_save="1"
                                                attrs="{'readonly': [
                                                     '|', '|',
-                                                    ('display_type', 'in', ('line_section', 'line_note')),
+                                                    ('line_type', 'in', ('invoice_line_section', 'invoice_line_note')),
                                                     ('tax_line_id', '!=', False),
                                                     '&amp;',
                                                     ('parent.move_type', 'in', ('out_invoice', 'out_refund', 'in_invoice', 'in_refund', 'out_receipt', 'in_receipt')),
@@ -1137,10 +1133,10 @@
                                                 ]}"/>
                                         <field name="debit"
                                                sum="Total Debit"
-                                               attrs="{'invisible': [('display_type', 'in', ('line_section', 'line_note'))]}"/>
+                                               attrs="{'invisible': [('line_type', 'in', ('invoice_line_section', 'invoice_line_note'))]}"/>
                                         <field name="credit"
                                                sum="Total Credit"
-                                               attrs="{'invisible': [('display_type', 'in', ('line_section', 'line_note'))]}"/>
+                                               attrs="{'invisible': [('line_type', 'in', ('invoice_line_section', 'invoice_line_note'))]}"/>
 
                                         <field name="tax_tag_ids"
                                                widget="many2many_tags"
@@ -1187,9 +1183,7 @@
                                         <field name="company_id" invisible="1"/>
                                         <field name="company_currency_id" invisible="1"/>
                                         <field name="recompute_tax_line" invisible="1" force_save="1"/>
-                                        <field name="display_type" force_save="1" invisible="1"/>
-                                        <field name="is_rounding_line" invisible="1"/>
-                                        <field name="exclude_from_invoice_tab" invisible="1"/>
+                                        <field name="line_type" force_save="1" invisible="1"/>
                                         <field name="account_internal_type" invisible="1"/>
                                         <field name="account_internal_group" invisible="1"/>
                                     </tree>
@@ -1403,7 +1397,7 @@
             <field name="context">{'journal_type':'general', 'search_default_group_by_move': 1, 'search_default_posted':1, 'name_groupby':1, 'create':0}</field>
             <field name="name">Journal Items</field>
             <field name="res_model">account.move.line</field>
-            <field name="domain">[('display_type', 'not in', ('line_section', 'line_note'))]</field>
+            <field name="domain">[('line_type', 'not in', ('invoice_line_note', 'invoice_line_section'))]</field>
             <field name="view_id" ref="view_move_line_tree_grouped"/>
             <field name="view_mode">tree,pivot,graph,form,kanban</field>
         </record>
@@ -1412,7 +1406,7 @@
             <field name="context">{'journal_type':'sales', 'search_default_group_by_move': 1, 'search_default_posted':1, 'search_default_sales':1, 'name_groupby':1, 'expand': 1}</field>
             <field name="name">Sales</field>
             <field name="res_model">account.move.line</field>
-            <field name="domain">[('display_type', 'not in', ('line_section', 'line_note'))]</field>
+            <field name="domain">[('line_type', 'not in', ('invoice_line_note', 'invoice_line_section'))]</field>
             <field name="view_id" ref="view_move_line_tree_grouped_sales_purchases"/>
             <field name="view_mode">tree,pivot,graph,kanban</field>
         </record>
@@ -1421,7 +1415,7 @@
             <field name="context">{'journal_type':'purchase', 'search_default_group_by_move': 1, 'search_default_posted':1, 'search_default_purchases':1, 'name_groupby':1, 'expand': 1}</field>
             <field name="name">Purchases</field>
             <field name="res_model">account.move.line</field>
-            <field name="domain">[('display_type', 'not in', ('line_section', 'line_note'))]</field>
+            <field name="domain">[('line_type', 'not in', ('invoice_line_note', 'invoice_line_section'))]</field>
             <field name="view_id" ref="view_move_line_tree_grouped_sales_purchases"/>
             <field name="view_mode">tree,pivot,graph,kanban</field>
         </record>
@@ -1430,7 +1424,7 @@
             <field name="context">{'journal_type':'bank', 'search_default_group_by_move': 1, 'search_default_posted':1, 'search_default_bank':1, 'search_default_cash':1, 'name_groupby':1, 'expand': 1}</field>
             <field name="name">Bank and Cash</field>
             <field name="res_model">account.move.line</field>
-            <field name="domain">[('display_type', 'not in', ('line_section', 'line_note'))]</field>
+            <field name="domain">[('line_type', 'not in', ('invoice_line_note', 'invoice_line_section'))]</field>
             <field name="view_id" ref="view_move_line_tree_grouped_bank_cash"/>
             <field name="view_mode">tree,pivot,graph,kanban</field>
         </record>
@@ -1439,7 +1433,7 @@
             <field name="context">{'journal_type':'general', 'search_default_group_by_move': 1, 'search_default_posted':1, 'search_default_misc_filter':1, 'name_groupby':1, 'expand': 1}</field>
             <field name="name">Miscellaneous</field>
             <field name="res_model">account.move.line</field>
-            <field name="domain">[('display_type', 'not in', ('line_section', 'line_note'))]</field>
+            <field name="domain">[('line_type', 'not in', ('invoice_line_note', 'invoice_line_section'))]</field>
             <field name="view_id" ref="view_move_line_tree_grouped_misc"/>
             <field name="view_mode">tree,pivot,graph,kanban</field>
         </record>
@@ -1448,7 +1442,7 @@
             <field name="context">{'journal_type':'general', 'search_default_group_by_account': 1, 'search_default_posted':1}</field>
             <field name="name">General Ledger</field>
             <field name="res_model">account.move.line</field>
-            <field name="domain">[('display_type', 'not in', ('line_section', 'line_note'))]</field>
+            <field name="domain">[('line_type', 'not in', ('invoice_line_note', 'invoice_line_section'))]</field>
             <field name="view_id" ref="view_move_line_tree_grouped_general"/>
             <field name="search_view_id" ref="view_account_move_line_filter_with_root_selection"/>
             <field name="view_mode">tree,pivot,graph</field>
@@ -1458,7 +1452,7 @@
             <field name="context">{'journal_type':'general', 'search_default_group_by_partner': 1, 'search_default_posted':1, 'search_default_trade_payable':1, 'search_default_trade_receivable':1, 'search_default_unreconciled':1}</field>
             <field name="name">Partner Ledger</field>
             <field name="res_model">account.move.line</field>
-            <field name="domain">[('display_type', 'not in', ('line_section', 'line_note'))]</field>
+            <field name="domain">[('line_type', 'not in', ('invoice_line_note', 'invoice_line_section'))]</field>
             <field name="view_id" ref="view_move_line_tree_grouped_partner"/>
             <field name="search_view_id" ref="view_account_move_line_filter"/>
             <field name="view_mode">tree,pivot,graph</field>
@@ -1467,7 +1461,7 @@
         <record id="action_account_moves_all_tree" model="ir.actions.act_window">
             <field name="name">Journal Items</field>
             <field name="res_model">account.move.line</field>
-            <field name="domain">[('display_type', 'not in', ('line_section', 'line_note'))]</field>
+            <field name="domain">[('line_type', 'not in', ('invoice_line_note', 'invoice_line_section'))]</field>
             <field name="context">{'search_default_partner_id': [active_id], 'default_partner_id': active_id, 'search_default_posted':1}</field>
             <field name="view_id" ref="view_move_line_tree"/>
         </record>
@@ -1476,7 +1470,7 @@
             <field name="context">{'journal_type':'general', 'search_default_posted':1}</field>
             <field name="name">Journal Items</field>
             <field name="res_model">account.move.line</field>
-            <field name="domain">[('display_type', 'not in', ('line_section', 'line_note')), ('parent_state', '!=', 'cancel')]</field>
+            <field name="domain">[('line_type', 'not in', ('invoice_line_note', 'invoice_line_section')), ('parent_state', '!=', 'cancel')]</field>
             <field name="view_id" ref="view_move_line_tree"/>
             <field name="view_mode">tree,pivot,graph,form,kanban</field>
         </record>

--- a/addons/account/views/report_invoice.xml
+++ b/addons/account/views/report_invoice.xml
@@ -77,8 +77,8 @@
                                 <t t-set="current_subtotal" t-value="current_subtotal + line.price_subtotal" groups="account.group_show_line_subtotals_tax_excluded"/>
                                 <t t-set="current_subtotal" t-value="current_subtotal + line.price_total" groups="account.group_show_line_subtotals_tax_included"/>
 
-                                <tr t-att-class="'bg-200 font-weight-bold o_line_section' if line.display_type == 'line_section' else 'font-italic o_line_note' if line.display_type == 'line_note' else ''">
-                                    <t t-if="not line.display_type" name="account_invoice_line_accountable">
+                                <tr t-att-class="'bg-200 font-weight-bold o_line_section' if line.line_type == 'invoice_line_section' else 'font-italic o_line_note' if line.line_type == 'invoice_line_note' else ''">
+                                    <t t-if="line.line_type not in ['invoice_line_note', 'invoice_line_section']" name="account_invoice_line_accountable">
                                         <td name="account_invoice_line_name"><span t-field="line.name" t-options="{'widget': 'text'}"/></td>
                                         <td class="text-right">
                                             <span t-field="line.quantity"/>
@@ -98,21 +98,21 @@
                                             <span class="text-nowrap" t-field="line.price_total" groups="account.group_show_line_subtotals_tax_included"/>
                                         </td>
                                     </t>
-                                    <t t-if="line.display_type == 'line_section'">
+                                    <t t-if="line.line_type == 'invoice_line_section'">
                                         <td colspan="99">
                                             <span t-field="line.name" t-options="{'widget': 'text'}"/>
                                         </td>
                                         <t t-set="current_section" t-value="line"/>
                                         <t t-set="current_subtotal" t-value="0"/>
                                     </t>
-                                    <t t-if="line.display_type == 'line_note'">
+                                    <t t-if="line.line_type == 'invoice_line_note'">
                                         <td colspan="99">
                                             <span t-field="line.name" t-options="{'widget': 'text'}"/>
                                         </td>
                                     </t>
                                 </tr>
 
-                                <t t-if="current_section and (line_last or lines[line_index+1].display_type == 'line_section')">
+                                <t t-if="current_section and (line_last or lines[line_index+1].line_type == 'invoice_line_section')">
                                     <tr class="is-subtotal text-right">
                                         <td colspan="99">
                                             <strong class="mr16">Subtotal</strong>

--- a/addons/account_edi/models/account_move.py
+++ b/addons/account_edi/models/account_move.py
@@ -299,7 +299,7 @@ class AccountMove(models.Model):
             return invoice_lines_tax_values_dict
 
         # Compute the taxes values for each invoice line.
-        invoice_lines = self.invoice_line_ids.filtered(lambda line: not line.display_type)
+        invoice_lines = self.invoice_line_ids.filtered(lambda line: not line.is_display_line())
         if filter_invl_to_apply:
             invoice_lines = invoice_lines.filtered(filter_invl_to_apply)
 
@@ -435,7 +435,7 @@ class AccountMove(models.Model):
         }
 
         # Invoice lines details.
-        for index, line in enumerate(self.invoice_line_ids.filtered(lambda line: not line.display_type), start=1):
+        for index, line in enumerate(self.invoice_line_ids.filtered(lambda line: not line.is_display_line()), start=1):
             line_vals = line._prepare_edi_vals_to_export()
             line_vals['index'] = index
             res['invoice_line_vals_list'].append(line_vals)

--- a/addons/hr_expense/models/hr_expense.py
+++ b/addons/hr_expense/models/hr_expense.py
@@ -655,7 +655,7 @@ Or send your receipts at <a href="mailto:%(email)s?subject=Lunch%%20with%%20cust
                 'currency_id': expense.currency_id.id,
                 'expense_id': expense.id,
                 'partner_id': partner_id,
-                'exclude_from_invoice_tab': True,
+                'line_type': False,
             }
             move_line_values.append(move_line_dst)
 

--- a/addons/l10n_ar/tests/common.py
+++ b/addons/l10n_ar/tests/common.py
@@ -656,8 +656,8 @@ class TestAr(AccountTestInvoicingCommon):
                 invoice_form.currency_id = data.get('currency')
             for line in data.get('lines', [{}]):
                 with invoice_form.invoice_line_ids.new() as invoice_line_form:
-                    if line.get('display_type'):
-                        invoice_line_form.display_type = line.get('display_type')
+                    if line.get('line_type'):
+                        invoice_line_form.line_type = line.get('line_type')
                         invoice_line_form.name = line.get('name', 'not invoice line')
                     else:
                         invoice_line_form.product_id = line.get('product', self.product_iva_21)

--- a/addons/l10n_cl/models/account_move.py
+++ b/addons/l10n_cl/models/account_move.py
@@ -135,8 +135,8 @@ class AccountMove(models.Model):
         self.ensure_one()
         include_sii = self._l10n_cl_include_sii()
 
-        base_lines = self.line_ids.filtered(lambda x: not x.display_type and not x.exclude_from_invoice_tab)
-        tax_lines = self.line_ids.filtered(lambda x: not x.display_type and x.tax_repartition_line_id)
+        base_lines = self.line_ids.filtered(lambda x: x.is_invoice_line(with_display_line_check=True))
+        tax_lines = self.line_ids.filtered(lambda x: not x.is_display_line() and x.tax_repartition_line_id)
 
         base_line_vals_list = [x._convert_to_tax_base_line_dict() for x in base_lines]
         if include_sii:

--- a/addons/l10n_es_edi_sii/models/account_edi_format.py
+++ b/addons/l10n_es_edi_sii/models/account_edi_format.py
@@ -95,7 +95,7 @@ class AccountEdiFormat(models.Model):
         # on the same invoice, this can be deduced globally.
 
         recargo_tax_details = {} # Mapping between main tax and recargo tax details
-        invoice_lines = invoice.invoice_line_ids.filtered(lambda x: not x.display_type)
+        invoice_lines = invoice.invoice_line_ids.filtered(lambda x: not x.is_display_line())
         if filter_invl_to_apply:
             invoice_lines = invoice_lines.filtered(filter_invl_to_apply)
         for line in invoice_lines:
@@ -597,7 +597,7 @@ class AccountEdiFormat(models.Model):
 
         if not move.company_id.vat:
             res.append(_("VAT number is missing on company %s", move.company_id.display_name))
-        for line in move.invoice_line_ids.filtered(lambda line: not line.display_type):
+        for line in move.invoice_line_ids.filtered(lambda line: not line.is_display_line()):
             taxes = line.tax_ids.flatten_taxes_hierarchy()
             recargo_count = taxes.mapped('l10n_es_type').count('recargo')
             retention_count = taxes.mapped('l10n_es_type').count('retencion')

--- a/addons/l10n_gcc_invoice/views/report_invoice.xml
+++ b/addons/l10n_gcc_invoice/views/report_invoice.xml
@@ -251,8 +251,8 @@
                             <t t-set="current_subtotal" t-value="current_subtotal + line.price_total"
                                groups="account.group_show_line_subtotals_tax_included"/>
 
-                            <tr t-att-class="'bg-200 font-weight-bold o_line_section' if line.display_type == 'line_section' else 'font-italic o_line_note' if line.display_type == 'line_note' else ''">
-                                <t t-if="not line.display_type" name="account_invoice_line_accountable">
+                            <tr t-att-class="'bg-200 font-weight-bold o_line_section' if line.line_type == 'invoice_line_section' else 'font-italic o_line_note' if line.line_type == 'invoice_line_note' else ''">
+                                <t t-if="line.line_type not in ('invoice_line_note', 'invoice_line_section')" name="account_invoice_line_accountable">
                                     <td name="account_invoice_line_name">
                                         <t t-set="translation_name" t-value="line.with_context(lang='ar_001').product_id.name"/>
                                         <t t-if="line.product_id">
@@ -293,21 +293,21 @@
                                         <span class="text-nowrap" t-field="line.price_total"/>
                                     </td>
                                 </t>
-                                <t t-if="line.display_type == 'line_section'">
+                                <t t-if="line.line_type == 'invoice_line_section'">
                                     <td colspan="99">
                                         <span t-field="line.name" t-options="{'widget': 'text'}"/>
                                     </td>
                                     <t t-set="current_section" t-value="line"/>
                                     <t t-set="current_subtotal" t-value="0"/>
                                 </t>
-                                <t t-if="line.display_type == 'line_note'">
+                                <t t-if="line.line_type == 'invoice_line_note'">
                                     <td colspan="99">
                                         <span t-field="line.name" t-options="{'widget': 'text'}"/>
                                     </td>
                                 </t>
                             </tr>
 
-                            <t t-if="current_section and (line_last or lines[line_index+1].display_type == 'line_section')">
+                            <t t-if="current_section and (line_last or lines[line_index+1].line_type == 'invoice_line_section')">
                                 <tr class="is-subtotal text-right">
                                     <td colspan="99">
                                         <strong class="mr16" style="display: inline-block">Subtotal/الإجمالي الفرعي</strong>

--- a/addons/l10n_id_efaktur/models/account_move.py
+++ b/addons/l10n_id_efaktur/models/account_move.py
@@ -62,11 +62,11 @@ class AccountMove(models.Model):
     def _constraint_kode_ppn(self):
         ppn_tag = self.env.ref('l10n_id.ppn_tag')
         for move in self.filtered(lambda m: m.l10n_id_kode_transaksi != '08'):
-            if any(ppn_tag.id in line.tax_tag_ids.ids for line in move.line_ids if line.exclude_from_invoice_tab is False and not line.display_type) \
-                    and any(ppn_tag.id not in line.tax_tag_ids.ids for line in move.line_ids if line.exclude_from_invoice_tab is False and not line.display_type):
+            if any(ppn_tag.id in line.tax_tag_ids.ids for line in move.line_ids if line.is_invoice_line(with_display_line_check=True)) \
+                    and any(ppn_tag.id not in line.tax_tag_ids.ids for line in move.line_ids if line.is_invoice_line(with_display_line_check=True)):
                 raise UserError(_('Cannot mix VAT subject and Non-VAT subject items in the same invoice with this kode transaksi.'))
         for move in self.filtered(lambda m: m.l10n_id_kode_transaksi == '08'):
-            if any(ppn_tag.id in line.tax_tag_ids.ids for line in move.line_ids if line.exclude_from_invoice_tab is False and not line.display_type):
+            if any(ppn_tag.id in line.tax_tag_ids.ids for line in move.line_ids if line.is_invoice_line(with_display_line_check=True)):
                 raise UserError('Kode transaksi 08 is only for non VAT subject items.')
 
     @api.constrains('l10n_id_tax_number')
@@ -178,7 +178,7 @@ class AccountMove(models.Model):
             eTax['REFERENSI'] = number_ref
             eTax['KODE_DOKUMEN_PENDUKUNG'] = '0'
 
-            lines = move.line_ids.filtered(lambda x: x.product_id.id == int(dp_product_id) and x.price_unit < 0 and not x.display_type)
+            lines = move.line_ids.filtered(lambda x: x.product_id.id == int(dp_product_id) and x.price_unit < 0 and not x.is_display_line())
             eTax['FG_UANG_MUKA'] = 0
             eTax['UANG_MUKA_DPP'] = int(abs(sum(lines.mapped(lambda l: round(l.price_subtotal, 0)))))
             eTax['UANG_MUKA_PPN'] = int(abs(sum(lines.mapped(lambda l: round(l.price_total - l.price_subtotal, 0)))))
@@ -194,7 +194,7 @@ class AccountMove(models.Model):
             # HOW TO ADD 2 line to 1 line for free product
             free, sales = [], []
 
-            for line in move.line_ids.filtered(lambda l: not l.exclude_from_invoice_tab and not l.display_type):
+            for line in move.line_ids.filtered(lambda l: l.is_invoice_line(with_display_line_check=True)):
                 # *invoice_line_unit_price is price unit use for harga_satuan's column
                 # *invoice_line_quantity is quantity use for jumlah_barang's column
                 # *invoice_line_total_price is bruto price use for harga_total's column

--- a/addons/l10n_in_edi/models/account_edi_format.py
+++ b/addons/l10n_in_edi/models/account_edi_format.py
@@ -64,7 +64,7 @@ class AccountEdiFormat(models.Model):
         error_message += self._l10n_in_validate_partner(move.company_id.partner_id, is_company=True)
         if not re.match("^.{1,16}$", move.name):
             error_message.append(_("Invoice number should not be more than 16 characters"))
-        for line in move.invoice_line_ids.filtered(lambda line: not (line.display_type or line.is_rounding_line)):
+        for line in move.invoice_line_ids.filtered(lambda line: not (line.is_display_line() or line.line_type in ['invoice_line_cash_rounding', 'invoice_cash_rounding'])):
             if line.product_id:
                 hsn_code = self._l10n_in_edi_extract_digits(line.product_id.l10n_in_hsn_code)
                 if not hsn_code:
@@ -342,7 +342,7 @@ class AccountEdiFormat(models.Model):
         sign = invoice.is_inbound() and -1 or 1
         is_intra_state = invoice.l10n_in_state_id == invoice.company_id.state_id
         is_overseas = invoice.l10n_in_gst_treatment == "overseas"
-        lines = invoice.invoice_line_ids.filtered(lambda line: not (line.display_type or line.is_rounding_line))
+        lines = invoice.invoice_line_ids.filtered(lambda line: not (line.is_display_line() or line.line_type in ['invoice_line_cash_rounding', 'invoice_cash_rounding']))
         invoice_line_tax_details = tax_details.get("invoice_line_tax_details")
         json_payload = {
             "Version": "1.1",
@@ -376,7 +376,7 @@ class AccountEdiFormat(models.Model):
                     + tax_details_by_code.get("state_cess_non_advol_amount", 0.00)) * sign,
                 ),
                 "RndOffAmt": self._l10n_in_round_value(
-                    sum(line.balance for line in invoice.invoice_line_ids if line.is_rounding_line)),
+                    sum(line.balance for line in invoice.invoice_line_ids if line.line_type in ['invoice_line_cash_rounding', 'invoice_cash_rounding'])),
                 "TotInvVal": self._l10n_in_round_value(
                     (tax_details.get("base_amount") + tax_details.get("tax_amount")) * sign),
             },
@@ -439,7 +439,7 @@ class AccountEdiFormat(models.Model):
             }
 
         def l10n_in_filter_to_apply(tax_values):
-            if tax_values["base_line_id"].is_rounding_line:
+            if tax_values["base_line_id"].line_type in ['invoice_line_cash_rounding', 'invoice_cash_rounding']:
                 return False
             return True
 

--- a/addons/l10n_it_edi/data/invoice_it_template.xml
+++ b/addons/l10n_it_edi/data/invoice_it_template.xml
@@ -158,7 +158,7 @@
                     <DatiBeniServizi>
                         <!-- Invoice lines. -->
                         <t t-set="line_counter" t-value="0"/>
-                        <t t-foreach="record.invoice_line_ids.filtered(lambda l: not l.display_type)" t-as="line">
+                        <t t-foreach="record.invoice_line_ids.filtered(lambda l: not l.is_display_line())" t-as="line">
                             <t t-set="line_counter" t-value="line_counter + 1"/>
                             <t t-call="l10n_it_edi.account_invoice_line_it_FatturaPA"/>
                         </t>

--- a/addons/l10n_it_edi/models/account_edi_format.py
+++ b/addons/l10n_it_edi/models/account_edi_format.py
@@ -114,7 +114,7 @@ class AccountEdiFormat(models.Model):
 
         # <2.2.1>
         for invoice_line in invoice.invoice_line_ids:
-            if not invoice_line.display_type and len(invoice_line.tax_ids) != 1:
+            if not invoice_line.is_display_line() and len(invoice_line.tax_ids) != 1:
                 raise UserError(_("You must select one and only one tax by line."))
 
         if any(line.quantity < 0 for line in invoice.invoice_line_ids):

--- a/addons/l10n_it_stock_ddt/models/account_invoice.py
+++ b/addons/l10n_it_stock_ddt/models/account_invoice.py
@@ -23,7 +23,7 @@ class AccountMove(models.Model):
             return {}
         line_count = 0
         invoice_line_pickings = {}
-        for line in self.invoice_line_ids.filtered(lambda l: not l.display_type):
+        for line in self.invoice_line_ids.filtered(lambda l: not l.is_display_line()):
             line_count += 1
             done_moves_related = line.sale_line_ids.mapped('move_ids').filtered(lambda m: m.state == 'done' and m.location_dest_id.usage == 'customer')
             if len(done_moves_related) <= 1:

--- a/addons/point_of_sale/models/pos_order.py
+++ b/addons/point_of_sale/models/pos_order.py
@@ -208,12 +208,12 @@ class PosOrder(models.Model):
                     'name': _('Price discount from %s -> %s',
                               float_repr(line.product_id.lst_price, self.currency_id.decimal_places),
                               float_repr(line.price_unit, self.currency_id.decimal_places)),
-                    'display_type': 'line_note',
+                    'line_type': 'invoice_line_note',
                 }))
             if line.customer_note:
                 invoice_lines.append((0, None, {
                     'name': line.customer_note,
-                    'display_type': 'line_note',
+                    'line_type': 'invoice_line_note',
                 }))
 
 
@@ -501,7 +501,7 @@ class PosOrder(models.Model):
         if self.config_id.cash_rounding:
             rounding_applied = float_round(self.amount_paid - self.amount_total,
                                            precision_rounding=new_move.currency_id.rounding)
-            rounding_line = new_move.line_ids.filtered(lambda line: line.is_rounding_line)
+            rounding_line = new_move.line_ids.filtered(lambda line: line.line_type in ['invoice_line_cash_rounding', 'invoice_cash_rounding'])
             if rounding_line and rounding_line.debit > 0:
                 rounding_line_difference = rounding_line.debit + rounding_applied
             elif rounding_line and rounding_line.credit > 0:
@@ -533,7 +533,7 @@ class PosOrder(models.Model):
                         'currency_id': new_move.currency_id if new_move.currency_id != new_move.company_id.currency_id else False,
                         'company_id': new_move.company_id.id,
                         'company_currency_id': new_move.company_id.currency_id.id,
-                        'is_rounding_line': True,
+                        'line_type': 'invoice_line_cash_rounding',
                         'sequence': 9999,
                         'name': new_move.invoice_cash_rounding_id.name,
                         'account_id': account_id,

--- a/addons/product_margin/models/product_product.py
+++ b/addons/product_margin/models/product_product.py
@@ -105,7 +105,7 @@ class ProductProduct(models.Model):
             company_id = self.env.context['force_company']
         else:
             company_id = self.env.company.id
-        self.env['account.move.line'].flush(['price_unit', 'quantity', 'balance', 'product_id', 'display_type'])
+        self.env['account.move.line'].flush(['price_unit', 'quantity', 'balance', 'product_id', 'line_type'])
         self.env['account.move'].flush(['state', 'payment_state', 'move_type', 'invoice_date', 'company_id'])
         self.env['product.template'].flush(['list_price'])
         sqlstr = """
@@ -134,8 +134,8 @@ class ProductProduct(models.Model):
                 AND i.move_type IN %s
                 AND i.invoice_date BETWEEN %s AND  %s
                 AND i.company_id = %s
-                AND l.display_type IS NULL
-                AND l.exclude_from_invoice_tab = false
+                AND COALESCE(l.line_type, 'false') LIKE 'invoice_line%%' 
+                AND COALESCE(l.line_type, 'false') NOT IN ('invoice_line_section', 'invoice_line_note')
                 GROUP BY l.product_id
                 """.format(self.env['res.currency']._select_companies_rates())
         invoice_types = ('out_invoice', 'out_refund')

--- a/addons/purchase/models/purchase.py
+++ b/addons/purchase/models/purchase.py
@@ -1326,8 +1326,8 @@ class PurchaseOrderLine(models.Model):
         self.ensure_one()
         aml_currency = move and move.currency_id or self.currency_id
         date = move and move.date or fields.Date.today()
+        display_type_map = {'line_section': 'invoice_line_section', 'line_note': 'invoice_line_note'}
         res = {
-            'display_type': self.display_type,
             'sequence': self.sequence,
             'name': '%s: %s' % (self.order_id.name, self.name),
             'product_id': self.product_id.id,
@@ -1338,6 +1338,7 @@ class PurchaseOrderLine(models.Model):
             'analytic_account_id': self.account_analytic_id.id,
             'analytic_tag_ids': [(6, 0, self.analytic_tag_ids.ids)],
             'purchase_line_id': self.id,
+            'line_type': display_type_map.get(self.display_type, 'invoice_line'),
         }
         if not move:
             return res

--- a/addons/purchase_stock/models/account_invoice.py
+++ b/addons/purchase_stock/models/account_invoice.py
@@ -139,8 +139,7 @@ class AccountMove(models.Model):
                         'account_id': debit_pdiff_account.id,
                         'analytic_account_id': line.analytic_account_id.id,
                         'analytic_tag_ids': [(6, 0, line.analytic_tag_ids.ids)],
-                        'exclude_from_invoice_tab': True,
-                        'is_anglo_saxon_line': True,
+                        'line_type': 'invoice_anglo_saxon',
                     }
                     vals.update(line._get_fields_onchange_subtotal(price_subtotal=vals['price_subtotal']))
                     lines_vals_list.append(vals)
@@ -159,8 +158,7 @@ class AccountMove(models.Model):
                         'account_id': line.account_id.id,
                         'analytic_account_id': line.analytic_account_id.id,
                         'analytic_tag_ids': [(6, 0, line.analytic_tag_ids.ids)],
-                        'exclude_from_invoice_tab': True,
-                        'is_anglo_saxon_line': True,
+                        'line_type': 'invoice_anglo_saxon',
                     }
                     vals.update(line._get_fields_onchange_subtotal(price_subtotal=vals['price_subtotal']))
                     lines_vals_list.append(vals)

--- a/addons/sale/models/sale_order.py
+++ b/addons/sale/models/sale_order.py
@@ -1288,7 +1288,7 @@ class SaleOrder(models.Model):
         :param optional_values: any parameter that should be added to the returned down payment section
         """
         down_payments_section_line = {
-            'display_type': 'line_section',
+            'line_type': 'invoice_line_section',
             'name': _('Down Payments'),
             'product_id': False,
             'product_uom_id': False,

--- a/addons/sale/models/sale_order_line.py
+++ b/addons/sale/models/sale_order_line.py
@@ -1021,8 +1021,8 @@ class SaleOrderLine(models.Model):
         :param optional_values: any parameter that should be added to the returned invoice line
         """
         self.ensure_one()
+        display_type_map = {'line_section': 'invoice_line_section', 'line_note': 'invoice_line_note'}
         res = {
-            'display_type': self.display_type,
             'sequence': self.sequence,
             'name': self.name,
             'product_id': self.product_id.id,
@@ -1033,6 +1033,7 @@ class SaleOrderLine(models.Model):
             'tax_ids': [(6, 0, self.tax_id.ids)],
             'analytic_tag_ids': [(6, 0, self.analytic_tag_ids.ids)],
             'sale_line_ids': [(4, self.id)],
+            'line_type': display_type_map.get(self.display_type, 'invoice_line'),
         }
         if self.order_id.analytic_account_id:
             res['analytic_account_id'] = self.order_id.analytic_account_id.id

--- a/addons/sale/models/utm_campaign.py
+++ b/addons/sale/models/utm_campaign.py
@@ -23,7 +23,7 @@ class UtmCampaign(models.Model):
             campaign.quotation_count = data_map.get(campaign.id, 0)
 
     def _compute_sale_invoiced_amount(self):
-        self.env['account.move.line'].flush(['balance', 'move_id', 'account_id', 'exclude_from_invoice_tab'])
+        self.env['account.move.line'].flush(['balance', 'move_id', 'account_id', 'line_type'])
         self.env['account.move'].flush(['state', 'campaign_id', 'move_type'])
         query = """SELECT move.campaign_id, -SUM(line.balance) as price_subtotal
                     FROM account_move_line line
@@ -32,7 +32,7 @@ class UtmCampaign(models.Model):
                         AND move.campaign_id IN %s
                         AND move.move_type IN ('out_invoice', 'out_refund', 'in_invoice', 'in_refund', 'out_receipt', 'in_receipt')
                         AND line.account_id IS NOT NULL
-                        AND NOT line.exclude_from_invoice_tab
+                        AND COALESCE(line.line_type, 'false') LIKE 'invoice_line%%'
                     GROUP BY move.campaign_id
                     """
 

--- a/addons/sale/tests/test_sale_order.py
+++ b/addons/sale/tests/test_sale_order.py
@@ -408,7 +408,7 @@ class TestSaleOrder(TestSaleCommon):
         invoice = self.sale_order._create_invoices()
 
         # check note from SO has been pushed in invoice
-        self.assertEqual(len(invoice.invoice_line_ids.filtered(lambda line: line.display_type == 'line_note')), 1, 'Note SO line should have been pushed to the invoice')
+        self.assertEqual(len(invoice.invoice_line_ids.filtered(lambda line: line.line_type == 'invoice_line_note')), 1, 'Note SO line should have been pushed to the invoice')
 
     def test_multi_currency_discount(self):
         """Verify the currency used for pricelist price & discount computation."""

--- a/addons/sale/tests/test_sale_refund.py
+++ b/addons/sale/tests/test_sale_refund.py
@@ -346,8 +346,8 @@ class TestSaleToInvoice(TestSaleCommon):
         payment.create_invoices()
 
         so_invoice = max(sale_order_refund.invoice_ids)
-        self.assertEqual(len(so_invoice.invoice_line_ids.filtered(lambda l: not (l.display_type == 'line_section' and l.name == "Down Payments"))), len(sale_order_refund.order_line), 'All lines should be invoiced')
-        self.assertEqual(len(so_invoice.invoice_line_ids.filtered(lambda l: l.display_type == 'line_section' and l.name == "Down Payments")), 1, 'A single section for downpayments should be present')
+        self.assertEqual(len(so_invoice.invoice_line_ids.filtered(lambda l: not (l.line_type == 'invoice_line_section' and l.name == "Down Payments"))), len(sale_order_refund.order_line), 'All lines should be invoiced')
+        self.assertEqual(len(so_invoice.invoice_line_ids.filtered(lambda l: l.line_type == 'invoice_line_section' and l.name == "Down Payments")), 1, 'A single section for downpayments should be present')
         self.assertEqual(so_invoice.amount_total, sale_order_refund.amount_total - sol_downpayment.price_unit, 'Downpayment should be applied')
         so_invoice.action_post()
 

--- a/addons/sale/tests/test_sale_to_invoice.py
+++ b/addons/sale/tests/test_sale_to_invoice.py
@@ -117,8 +117,8 @@ class TestSaleToInvoice(TestSaleCommon):
         self.assertEqual(len(self.sale_order.invoice_ids), 3, 'Invoice should be created for the SO')
 
         invoice = max(self.sale_order.invoice_ids)
-        self.assertEqual(len(invoice.invoice_line_ids.filtered(lambda l: not (l.display_type == 'line_section' and l.name == "Down Payments"))), len(self.sale_order.order_line), 'All lines should be invoiced')
-        self.assertEqual(len(invoice.invoice_line_ids.filtered(lambda l: l.display_type == 'line_section' and l.name == "Down Payments")), 1, 'A single section for downpayments should be present')
+        self.assertEqual(len(invoice.invoice_line_ids.filtered(lambda l: not (l.line_type == 'invoice_line_section' and l.name == "Down Payments"))), len(self.sale_order.order_line), 'All lines should be invoiced')
+        self.assertEqual(len(invoice.invoice_line_ids.filtered(lambda l: l.line_type == 'invoice_line_section' and l.name == "Down Payments")), 1, 'A single section for downpayments should be present')
         self.assertEqual(invoice.amount_total, self.sale_order.amount_total - sum(downpayment_line.mapped('price_unit')), 'Downpayment should be applied')
 
     def test_downpayment_percentage_tax_icl(self):
@@ -145,7 +145,7 @@ class TestSaleToInvoice(TestSaleCommon):
         self.assertEqual(downpayment_line.price_unit, self.sale_order.amount_total/2, 'downpayment should have the correct amount')
 
         invoice = self.sale_order.invoice_ids[0]
-        downpayment_aml = invoice.line_ids.filtered(lambda l: not (l.display_type == 'line_section' and l.name == "Down Payments"))[0]
+        downpayment_aml = invoice.line_ids.filtered(lambda l: not (l.line_type == 'invoice_line_section' and l.name == "Down Payments"))[0]
         self.assertEqual(downpayment_aml.price_total, self.sale_order.amount_total/2, 'downpayment should have the correct amount')
         self.assertEqual(downpayment_aml.price_unit, self.sale_order.amount_total/2, 'downpayment should have the correct amount')
         invoice.action_post()
@@ -311,7 +311,7 @@ class TestSaleToInvoice(TestSaleCommon):
 
         invoice = sale_order.invoice_ids[0]
 
-        self.assertEqual(invoice.line_ids[0].display_type, 'line_section')
+        self.assertEqual(invoice.line_ids[0].line_type, 'invoice_line_section')
 
     def test_qty_invoiced(self):
         """Verify uom rounding is correctly considered during qty_invoiced compute"""

--- a/addons/sale_mrp/tests/test_sale_mrp_flow.py
+++ b/addons/sale_mrp/tests/test_sale_mrp_flow.py
@@ -676,8 +676,8 @@ class TestSaleMrpFlow(ValuationReconciliationTestCommon):
         self.invoice = move_form.save()
         self.invoice.action_post()
         aml = self.invoice.line_ids
-        aml_expense = aml.filtered(lambda l: l.is_anglo_saxon_line and l.debit > 0)
-        aml_output = aml.filtered(lambda l: l.is_anglo_saxon_line and l.credit > 0)
+        aml_expense = aml.filtered(lambda l: l.line_type == 'invoice_anglo_saxon' and l.debit > 0)
+        aml_output = aml.filtered(lambda l: l.line_type == 'invoice_anglo_saxon' and l.credit > 0)
         # Check that the cost of Good Sold entries are equal to 2* (2 * 20 + 1 * 10) = 100
         self.assertEqual(aml_expense.debit, 100, "Cost of Good Sold entry missing or mismatching")
         self.assertEqual(aml_output.credit, 100, "Cost of Good Sold entry missing or mismatching")
@@ -1747,8 +1747,8 @@ class TestSaleMrpFlow(ValuationReconciliationTestCommon):
 
         def check_cogs_entry_values(invoice, expected_value):
             aml = invoice.line_ids
-            aml_expense = aml.filtered(lambda l: l.is_anglo_saxon_line and l.debit > 0)
-            aml_output = aml.filtered(lambda l: l.is_anglo_saxon_line and l.credit > 0)
+            aml_expense = aml.filtered(lambda l: l.line_type == 'invoice_anglo_saxon' and l.debit > 0)
+            aml_output = aml.filtered(lambda l: l.line_type == 'invoice_anglo_saxon' and l.credit > 0)
             self.assertEqual(aml_expense.debit, expected_value, "Cost of Good Sold entry missing or mismatching for variant")
             self.assertEqual(aml_output.credit, expected_value, "Cost of Good Sold entry missing or mismatching for variant")
 

--- a/addons/sale_stock/models/account_move.py
+++ b/addons/sale_stock/models/account_move.py
@@ -32,7 +32,7 @@ class AccountMove(models.Model):
         if self.state == 'draft' or not self.invoice_date or self.move_type not in ('out_invoice', 'out_refund'):
             return res
 
-        current_invoice_amls = self.invoice_line_ids.filtered(lambda aml: not aml.display_type and aml.product_id and aml.quantity)
+        current_invoice_amls = self.invoice_line_ids.filtered(lambda aml: not aml.is_display_line() and aml.product_id and aml.quantity)
         all_invoices_amls = current_invoice_amls.sale_line_ids.invoice_lines.filtered(lambda aml: aml.move_id.state == 'posted').sorted(lambda aml: (aml.date, aml.move_name, aml.id))
         index = all_invoices_amls.ids.index(current_invoice_amls[:1].id) if current_invoice_amls[:1] in all_invoices_amls else 0
         previous_amls = all_invoices_amls[:index]
@@ -92,7 +92,7 @@ class AccountMoveLine(models.Model):
 
     def _sale_can_be_reinvoice(self):
         self.ensure_one()
-        return not self.is_anglo_saxon_line and super(AccountMoveLine, self)._sale_can_be_reinvoice()
+        return not self.line_type == 'invoice_anglo_saxon' and super(AccountMoveLine, self)._sale_can_be_reinvoice()
 
     def _stock_account_get_anglo_saxon_price_unit(self):
         self.ensure_one()

--- a/addons/sale_stock/tests/test_anglosaxon_account.py
+++ b/addons/sale_stock/tests/test_anglosaxon_account.py
@@ -29,7 +29,7 @@ class TestAngloSaxonAccounting(TestValuationReconciliation):
         company_a_invoice.with_context(allowed_company_ids=companies_with_b_first.ids).action_post()
 
         # check cost used for anglo_saxon_line is from company A
-        anglo_saxon_lines = company_a_invoice.line_ids.filtered('is_anglo_saxon_line')
+        anglo_saxon_lines = company_a_invoice.line_ids.filtered(lambda l: l.line_type == 'invoice_anglo_saxon')
         self.assertRecordValues(anglo_saxon_lines, [
             {'debit': 0.0, 'credit': company_a_standard_price},
             {'debit': company_a_standard_price, 'credit': 0.0},

--- a/addons/stock_account/models/account_move.py
+++ b/addons/stock_account/models/account_move.py
@@ -15,14 +15,14 @@ class AccountMove(models.Model):
 
     def _get_lines_onchange_currency(self):
         # OVERRIDE
-        return self.line_ids.filtered(lambda l: not l.is_anglo_saxon_line)
+        return self.line_ids.filtered(lambda l: l.line_type != 'invoice_anglo_saxon')
 
     def _reverse_move_vals(self, default_values, cancel=True):
         # OVERRIDE
         # Don't keep anglo-saxon lines if not cancelling an existing invoice.
         move_vals = super(AccountMove, self)._reverse_move_vals(default_values, cancel=cancel)
         if not cancel:
-            move_vals['line_ids'] = [vals for vals in move_vals['line_ids'] if not vals[2]['is_anglo_saxon_line']]
+            move_vals['line_ids'] = [vals for vals in move_vals['line_ids'] if vals[2].get('line_type') != 'invoice_anglo_saxon']
         return move_vals
 
     def copy_data(self, default=None):
@@ -34,7 +34,7 @@ class AccountMove(models.Model):
             for copy_vals in res:
                 if 'line_ids' in copy_vals:
                     copy_vals['line_ids'] = [line_vals for line_vals in copy_vals['line_ids']
-                                             if line_vals[0] != 0 or not line_vals[2].get('is_anglo_saxon_line')]
+                                             if line_vals[0] != 0 or line_vals[2].get('type') != 'invoice_anglo_saxon']
 
         return res
 
@@ -59,7 +59,7 @@ class AccountMove(models.Model):
         res = super(AccountMove, self).button_draft()
 
         # Unlink the COGS lines generated during the 'post' method.
-        self.mapped('line_ids').filtered(lambda line: line.is_anglo_saxon_line).unlink()
+        self.mapped('line_ids').filtered(lambda line: line.line_type == 'invoice_anglo_saxon').unlink()
         return res
 
     def button_cancel(self):
@@ -69,7 +69,7 @@ class AccountMove(models.Model):
         # Unlink the COGS lines generated during the 'post' method.
         # In most cases it shouldn't be necessary since they should be unlinked with 'button_draft'.
         # However, since it can be called in RPC, better be safe.
-        self.mapped('line_ids').filtered(lambda line: line.is_anglo_saxon_line).unlink()
+        self.mapped('line_ids').filtered(lambda line: line.line_type == 'invoice_anglo_saxon').unlink()
         return res
 
     # -------------------------------------------------------------------------
@@ -142,8 +142,7 @@ class AccountMove(models.Model):
                     'debit': balance < 0.0 and -balance or 0.0,
                     'credit': balance > 0.0 and balance or 0.0,
                     'account_id': debit_interim_account.id,
-                    'exclude_from_invoice_tab': True,
-                    'is_anglo_saxon_line': True,
+                    'line_type': 'invoice_anglo_saxon',
                 })
 
                 # Add expense account line.
@@ -160,8 +159,7 @@ class AccountMove(models.Model):
                     'account_id': credit_expense_account.id,
                     'analytic_account_id': line.analytic_account_id.id,
                     'analytic_tag_ids': [(6, 0, line.analytic_tag_ids.ids)],
-                    'exclude_from_invoice_tab': True,
-                    'is_anglo_saxon_line': True,
+                    'line_type': 'invoice_anglo_saxon',
                 })
         return lines_vals_list
 
@@ -218,7 +216,7 @@ class AccountMove(models.Model):
 class AccountMoveLine(models.Model):
     _inherit = 'account.move.line'
 
-    is_anglo_saxon_line = fields.Boolean(help="Technical field used to retrieve the anglo-saxon lines.")
+    line_type = fields.Selection(selection_add=[('invoice_anglo_saxon', 'Anglo-saxon line')])
 
     def _get_computed_account(self):
         # OVERRIDE to use the stock input account by default on vendor bills when dealing
@@ -242,7 +240,7 @@ class AccountMoveLine(models.Model):
         self.ensure_one()
         if not self.product_id:
             return self.price_unit
-        original_line = self.move_id.reversed_entry_id.line_ids.filtered(lambda l: l.is_anglo_saxon_line
+        original_line = self.move_id.reversed_entry_id.line_ids.filtered(lambda l: l.line_type == 'invoice_anglo_saxon'
             and l.product_id == self.product_id and l.product_uom_id == self.product_uom_id and l.price_unit >= 0)
         original_line = original_line and original_line[0]
         return original_line.price_unit if original_line \

--- a/addons/stock_account/tests/test_account_move.py
+++ b/addons/stock_account/tests/test_account_move.py
@@ -66,7 +66,7 @@ class TestAccountMove(AccountTestInvoicingCommon):
         self.assertAlmostEqual(self.product_A.lst_price * rate, invoice.amount_total)
         self.assertAlmostEqual(self.product_A.lst_price * rate, invoice.amount_residual)
         self.assertEqual(len(invoice.mapped("line_ids")), 4)
-        self.assertEqual(len(invoice.mapped("line_ids").filtered("is_anglo_saxon_line")), 2)
+        self.assertEqual(len(invoice.mapped("line_ids").filtered(lambda l: l.line_type == 'invoice_anglo_saxon')), 2)
         self.assertEqual(len(invoice.mapped("line_ids.currency_id")), 2)
 
     def test_fifo_perpetual_01_mc_01(self):
@@ -91,7 +91,7 @@ class TestAccountMove(AccountTestInvoicingCommon):
         self.assertAlmostEqual(self.product_A.lst_price * rate, invoice.amount_total)
         self.assertAlmostEqual(self.product_A.lst_price * rate, invoice.amount_residual)
         self.assertEqual(len(invoice.mapped("line_ids")), 4)
-        self.assertEqual(len(invoice.mapped("line_ids").filtered("is_anglo_saxon_line")), 2)
+        self.assertEqual(len(invoice.mapped("line_ids").filtered(lambda l: l.line_type == 'invoice_anglo_saxon')), 2)
         self.assertEqual(len(invoice.mapped("line_ids.currency_id")), 2)
 
     def test_average_perpetual_01_mc_01(self):
@@ -116,5 +116,5 @@ class TestAccountMove(AccountTestInvoicingCommon):
         self.assertAlmostEqual(self.product_A.lst_price * rate, invoice.amount_total)
         self.assertAlmostEqual(self.product_A.lst_price * rate, invoice.amount_residual)
         self.assertEqual(len(invoice.mapped("line_ids")), 4)
-        self.assertEqual(len(invoice.mapped("line_ids").filtered("is_anglo_saxon_line")), 2)
+        self.assertEqual(len(invoice.mapped("line_ids").filtered(lambda l: l.line_type == 'invoice_anglo_saxon')), 2)
         self.assertEqual(len(invoice.mapped("line_ids.currency_id")), 2)

--- a/addons/stock_account/tests/test_anglo_saxon_valuation_reconciliation_common.py
+++ b/addons/stock_account/tests/test_anglo_saxon_valuation_reconciliation_common.py
@@ -86,7 +86,7 @@ class ValuationReconciliationTestCommon(AccountTestInvoicingCommon):
 
         valuation_line = stock_moves.mapped('account_move_ids.line_ids').filtered(lambda x: x.account_id.id == interim_account_id)
 
-        if invoice.is_purchase_document() and any(l.is_anglo_saxon_line for l in invoice_line):
+        if invoice.is_purchase_document() and any(l.line_type == 'invoice_anglo_saxon' for l in invoice_line):
             self.assertEqual(len(invoice_line), 2, "Only two line2 should have been written by invoice in stock input account")
             self.assertTrue(valuation_line.reconciled or invoice_line[0].reconciled or invoice_line[1].reconciled, "The valuation and invoice line should have been reconciled together.")
         else:

--- a/addons/stock_account/tests/test_stockvaluationlayer.py
+++ b/addons/stock_account/tests/test_stockvaluationlayer.py
@@ -1039,7 +1039,7 @@ class TestAngloSaxonAccounting(TestStockValuationCommon):
                 line.quantity = 1
         reverse_invoice.action_post()
 
-        anglo_lines = reverse_invoice.line_ids.filtered(lambda l: l.is_anglo_saxon_line)
+        anglo_lines = reverse_invoice.line_ids.filtered(lambda l: l.line_type == 'invoice_anglo_saxon')
         self.assertEqual(len(anglo_lines), 2)
         self.assertEqual(abs(anglo_lines[0].balance), 10)
         self.assertEqual(abs(anglo_lines[1].balance), 10)


### PR DESCRIPTION
There is a few use case where we need to filter aml based on some
specificities, cash rounding lines, display lines,...

This change aims to standardize this by adding a line_type field that
would allow specifying the line purpose, making it easy to filter
or to extend if needed.

Task id #2747764

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
