### PR TITLE
[FIX] account: prevent draft entry for reconciled statement

### DIFF
--- a/addons/account/models/account_bank_statement.py
+++ b/addons/account/models/account_bank_statement.py
@@ -901,7 +901,7 @@ class AccountBankStatementLine(models.Model):
             st_line_vals_to_write = {}
 
             if 'state' in changed_fields:
-                if (st_line.state == 'open' and move.state != 'draft') or (st_line.state == 'posted' and move.state != 'posted'):
+                if (st_line.state == 'open' and move.state != 'draft') or (st_line.state in ('posted', 'confirm') and move.state != 'posted'):
                     raise UserError(_(
                         "You can't manually change the state of journal entry %s, as it has been created by bank "
                         "statement %s."


### PR DESCRIPTION
Journal entries of a bank statement can be reset to draft even if the
bank statement has been validated

Steps to reproduce:
1. Install Accounting
2. Go to Accounting dashboard, click on the 3 dots of Bank and go to
View > Statements
3. Create a new statement with a transaction of 100, correctly set the
ending balance, save and post
4. Click on reconcile then validate the reconciliation
5. Go back to the statement and validate it
6. Open the journal entry of the statement
7. You can reset it to draft but you shouldn't be able to

Solution:
Prevent the user from resetting a journal entry to draft if the
statement has been confirmed

opw-2827117