### PR TITLE
[IMP] l10n_pe: add document type nota de debito boleta electronica

### DIFF
--- a/addons/l10n_pe/data/l10n_latam_document_type_data.xml
+++ b/addons/l10n_pe/data/l10n_latam_document_type_data.xml
@@ -45,6 +45,15 @@
         <field name='doc_code_prefix'>F</field>
         <field name='internal_type'>debit_note</field>
     </record>
+    <record model='l10n_latam.document.type' id='document_type08b'>
+        <field name='sequence'>50</field>
+        <field name='code'>08</field>
+        <field name='report_name'>Nota de débito boleta electrónica </field>
+        <field name='name'>Nota de Débito Boleta</field>
+        <field name='country_id' ref='base.pe'/>
+        <field name='doc_code_prefix'>B</field>
+        <field name='internal_type'>debit_note</field>
+    </record>
     <record model='l10n_latam.document.type' id='document_type20'>
         <field name='sequence'>60</field>
         <field name='code'>20</field>


### PR DESCRIPTION
For them, we are going to add the corresponding type of document, as was done in the credit notes

This is a fw-port, but it had to be done in community instead of enterprise
https://github.com/odoo/enterprise/pull/27180/commits

X-original-commit: 1c7f69f

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
