### PR TITLE
[FIX] point_of_sale: prevent PoS to use validated order as start order

### DIFF
--- a/addons/point_of_sale/static/src/js/Screens/PaymentScreen/PaymentScreen.js
+++ b/addons/point_of_sale/static/src/js/Screens/PaymentScreen/PaymentScreen.js
@@ -206,6 +206,7 @@ odoo.define('point_of_sale.PaymentScreen', function (require) {
                         });
                     }
                 }
+                this.env.pos.db.remove_unpaid_order(this.currentOrder);
             } catch (error) {
                 hasError = true;
 


### PR DESCRIPTION
Current behavior:
In a PoS if you validated an order but didn't click on "new order"
button and duplicated the PoS tab in your browser. The new tab
would have the previous order as start order but it shouldn't because
this order was already validated. This would cause the order to have
the same order number (xxxxx-xxx-xxxx).

Steps to reproduce:
- Start a new PoS session and create an order with some products
- Go in the payment menu and validate the order with any payment
  method
- Click on validate but DONT click on "new order"
- Duplicate the browser tab
- The new tab still contains the previous order
- You can modify the order and validate it but it won't be saved
  because the order number is the same as the previous one.

opw-2618951
--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
