### PR TITLE
[FIX] account: Analytic account is overridden

### DIFF
--- a/addons/account/models/account_move.py
+++ b/addons/account/models/account_move.py
@@ -3849,7 +3849,7 @@ class AccountMoveLine(models.Model):
     @api.depends('product_id', 'account_id', 'partner_id', 'date')
     def _compute_analytic_account_id(self):
         for record in self:
-            if not record.exclude_from_invoice_tab or not record.move_id.is_invoice(include_receipts=True):
+            if not record.analytic_account_id and (not record.exclude_from_invoice_tab or not record.move_id.is_invoice(include_receipts=True)):
                 rec = self.env['account.analytic.default'].account_get(
                     product_id=record.product_id.id,
                     partner_id=record.partner_id.commercial_partner_id.id or record.move_id.partner_id.commercial_partner_id.id,


### PR DESCRIPTION
Steps to reproduce:

1- install sales ,accounting, project, timesheets
2- create a new service product p1 that triggers a project and a task
3- create a new sales order so with p1 and validate 1 hour in the task
4- create an invoice from so, an anayltic account is added
5- edit any field of product_id, account_id, partner_id, date
6- the analytic default rule is applied (in this case none) so the
anayltic account is removed

Bug:

the `compute_analytic_account_id` method forces the analytic default
rule even if the field is already set before the changes

Fix:
apply analytic default rule only if the analytic acount is not set.
if user wants to use analytic default rule, he needs to reset the field

OPW-2833912

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
