### PR TITLE
[IMP] l10n_pt: add misc restrictions to fit Portugal's requirements

### DIFF
--- a/addons/l10n_pt/__init__.py
+++ b/addons/l10n_pt/__init__.py
@@ -3,3 +3,4 @@
 
 # Copyright (C) 2012 Thinkopen Solutions, Lda. All Rights Reserved
 # http://www.thinkopensolutions.com.
+from . import models

--- a/addons/l10n_pt/models/__init__.py
+++ b/addons/l10n_pt/models/__init__.py
@@ -1,0 +1,3 @@
+from . import account_move
+from . import product_template
+from . import res_partner

--- a/addons/l10n_pt/models/account_move.py
+++ b/addons/l10n_pt/models/account_move.py
@@ -1,0 +1,36 @@
+from odoo import models, _
+from odoo.exceptions import UserError
+
+
+class AccountMove(models.Model):
+    _inherit = 'account.move'
+
+    def action_reverse(self):
+        for move in self.filtered(lambda m: m.company_id.account_fiscal_country_id.code == "PT"):
+            if move.payment_state == 'reversed':
+                raise UserError(_("You cannot reverse an invoice that has already been fully reversed."))
+        return super().action_reverse()
+
+
+class AccountMoveLine(models.Model):
+    _inherit = 'account.move.line'
+
+    def _l10n_pt_check_validity(self, vals):
+        if self.env.company.account_fiscal_country_id.code != 'PT':
+            return
+        if 'discount' in vals and \
+           (vals['discount'] < 0 or vals['discount'] > 100):
+            raise UserError(_("Discounts must be between 0% and 100%."))
+        if 'debit' in vals and vals['debit'] < 0:
+            raise UserError(_("You cannot have a negative debit amount."))
+        if 'credit' in vals and vals['credit'] < 0:
+            raise UserError(_("You cannot have a negative credit amount."))
+
+    def write(self, vals):
+        self._l10n_pt_check_validity(vals)
+        return super().write(vals)
+
+    def create(self, vals_list):
+        for line in vals_list:
+            self._l10n_pt_check_validity(line)
+        return super().create(vals_list)

--- a/addons/l10n_pt/models/product_template.py
+++ b/addons/l10n_pt/models/product_template.py
@@ -1,0 +1,16 @@
+from odoo import models, _
+from odoo.exceptions import UserError
+
+
+class ProductTemplate(models.Model):
+    _inherit = 'product.template'
+
+    def write(self, vals):
+        if self.env.company.account_fiscal_country_id.code != 'PT':
+            return super().write(vals)
+        for product in self:
+            if 'name' in vals:
+                account_move_lines_count = self.env['account.move.line'].search_count([('product_id', 'in', product.product_variant_ids.ids)])
+                if account_move_lines_count:
+                    raise UserError(_("You cannot change the name of a product that is already used in invoices."))
+        return super().write(vals)

--- a/addons/l10n_pt/models/res_partner.py
+++ b/addons/l10n_pt/models/res_partner.py
@@ -1,0 +1,18 @@
+from odoo import models, _
+from odoo.exceptions import UserError
+
+
+class Partner(models.Model):
+    _inherit = 'res.partner'
+
+    def write(self, vals):
+        if self.env.company.account_fiscal_country_id.code != 'PT':
+            return super().write(vals)
+        for partner in self:
+            if 'vat' in vals and partner.vat:
+                if self.env['account.move'].search_count([('partner_id', '=', partner.id)]):
+                    raise UserError(_("You cannot change the VAT number of a partner that already has invoices."))
+            if 'name' in vals and not partner.vat:
+                if self.env['account.move'].search_count([('partner_id', '=', partner.id)]):
+                    raise UserError(_("You cannot change the name of a partner that already has invoices but no VAT number.\n To remove this restriction, you can add the VAT number of the partner."))
+        return super().write(vals)


### PR DESCRIPTION
This PR adds miscelleanous restrictions to fit Portugal's requirements:

- Do not allow negative amounts, debit, credit
- Discounts should be between 0% and 100%
- Cannot change tax number of an existing client with already issued documents. However, missing tax number can only be entered if the field is empty
- Do not allow change the name of client (if it already has issued docs) who has no tax number. Limitation ends when client has a tax number.
- Do not allow change ProductDescription if already issued docs
- Do not allow create credit note of previous cancelled/already rectified doc

See https://info.portaldasfinancas.gov.pt/pt/docs/Portug_tax_system/Documents/Order_No_8632_2014_of_the_3rd_July.pdf

Task id: 2794910