### PR TITLE
[FIX] l10n_ch: not send QR bill with non Swiss Cie°

### DIFF
--- a/addons/l10n_ch/models/account_invoice.py
+++ b/addons/l10n_ch/models/account_invoice.py
@@ -318,7 +318,8 @@ class AccountMove(models.Model):
         # as the QR report data haven't been loaded.
         # TODO: remove this in master
         return not self.env.ref('l10n_ch.l10n_ch_swissqr_template').inherit_id \
-               and self.invoice_partner_bank_id.validate_swiss_code_arguments(self.invoice_partner_bank_id.currency_id, self.partner_id, self.invoice_payment_ref)
+               and self.invoice_partner_bank_id.validate_swiss_code_arguments(self.invoice_partner_bank_id.currency_id, self.partner_id, self.invoice_payment_ref) \
+               and self.company_id.country_id.code == 'CH'
 
     def print_ch_qr_bill(self):
         """ Triggered by the 'Print QR-bill' button.


### PR DESCRIPTION
Steps:

- Swiss company with l10n_ch, and an other
  one with ie US accounting.
- Select the US company
- Create and confirm an invoice
- Send & Print
-> The QR bill is generated and sent

Before this commit, the can_generate_qr_bill
method was returning True without taking into account
the country of the company that created the invoice.

opw-2784193

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
