### PR TITLE
[FIX] hr_holidays: correct fields declaration of hr.leave.report.calendar

### DIFF
--- a/addons/hr_holidays/report/hr_leave_report_calendar.py
+++ b/addons/hr_holidays/report/hr_leave_report_calendar.py
@@ -16,7 +16,7 @@ class LeaveReportCalendar(models.Model):
     start_datetime = fields.Datetime(string='From', readonly=True)
     stop_datetime = fields.Datetime(string='To', readonly=True)
     tz = fields.Selection(_tz_get, string="Timezone", readonly=True)
-    duration = fields.Float(string='Duration', readonly=True)
+    duration = fields.Float(string='Duration', readonly=True, store=False)
     employee_id = fields.Many2one('hr.employee', readonly=True)
     company_id = fields.Many2one('res.company', readonly=True)
     state = fields.Selection([


### PR DESCRIPTION
The field `duration` was still declared but has actually been removed
from the SQL view with d2238de57630d58c4913ab44746476b83492c72f.

Avoid an error when trying to read this field.
