### PR TITLE
[FIX] account_edi: enable to parse XML facturx in mail

### DIFF
--- a/addons/account_edi/models/account_edi_format.py
+++ b/addons/account_edi/models/account_edi_format.py
@@ -428,9 +428,12 @@ class AccountEdiFormat(models.Model):
         content = base64.b64decode(attachment.with_context(bin_size=False).datas)
         to_process = []
 
+        # XML attachments received by mail have a 'text/plain' mimetype.
+        # Therefore, if content start with '<?xml', it is considered as XML.
+        is_text_plain_xml = 'text/plain' in attachment.mimetype and content.startswith(b'<?xml')
         if 'pdf' in attachment.mimetype:
             to_process.extend(self._decode_pdf(attachment.name, content))
-        elif 'xml' in attachment.mimetype:
+        elif 'xml' in attachment.mimetype or is_text_plain_xml:
             to_process.extend(self._decode_xml(attachment.name, content))
         else:
             to_process.extend(self._decode_binary(attachment.name, content))


### PR DESCRIPTION
Issue:

  When receiving a mail with a facturx XML file as attachment,
  the datas in the XML files are not parsed.

Cause:

  For security reason, if a mail attachment is a XML file, it will
  be saved as plain text and therefore not be parsed.

Solution:

  If attachment mimetype is `plain/text` and content starts with
  `<?xml`, consider attachment as XML for the parsing.

opw-2655445