### PR TITLE
[FIX] web: cp's search menu-items, highlight design

### DIFF
--- a/addons/web/static/src/legacy/xml/base.xml
+++ b/addons/web/static/src/legacy/xml/base.xml
@@ -371,7 +371,7 @@
             <li t-foreach="state.sources" t-as="src" t-key="src.id"
                 t-att-id="src.id"
                 class="o_menu_item dropdown-item"
-                t-att-class="{ o_indent: src.parent and !src.parent.selection, o_selection_focus: src_index === state.focusedItem }"
+                t-att-class="{ o_indent: src.parent and !src.parent.selection, focus: src_index === state.focusedItem}"
                 t-on-click="()=>this._selectSource(src)"
                 t-on-mousemove="()=>this._onSourceMousemove(src_index)"
                 >

--- a/addons/web/static/src/search/search_bar/search_bar.xml
+++ b/addons/web/static/src/search/search_bar/search_bar.xml
@@ -49,7 +49,7 @@
         <ul class="dropdown-menu o_searchview_autocomplete dropdown-menu show" role="menu">
             <t t-foreach="items" t-as="item" t-key="item.id">
                 <li class="o_menu_item dropdown-item"
-                    t-att-class="{ o_indent: item.isChild, o_selection_focus: item_index === state.focusedIndex}"
+                    t-att-class="{ o_indent: item.isChild, focus: item_index === state.focusedIndex}"
                     t-att-id="item.id"
                     t-on-click="() => this.selectItem(item)"
                     t-on-mousemove="() => this.onItemMousemove(item_index)"

--- a/addons/web/static/tests/legacy/control_panel/search_bar_tests.js
+++ b/addons/web/static/tests/legacy/control_panel/search_bar_tests.js
@@ -383,7 +383,7 @@ QUnit.module("Search Bar (legacy)", (hooks) => {
             await testUtils.dom.triggerEvent(searchInput, 'keydown', { key: 'ArrowRight' });
             await testUtils.dom.triggerEvent(searchInput, 'keydown', { key: 'ArrowDown' });
 
-            assert.strictEqual(target.querySelector('.o_searchview_autocomplete .o_selection_focus').innerText.trim(), "(no result)",
+            assert.strictEqual(target.querySelector('.o_searchview_autocomplete .focus').innerText.trim(), "(no result)",
                 "there should be no result for 'a' in bar");
 
             await testUtils.dom.triggerEvent(searchInput, 'keydown', { key: 'Enter' });
@@ -544,11 +544,11 @@ QUnit.module("Search Bar (legacy)", (hooks) => {
             await testUtils.controlPanel.editSearch(target, "null");
 
             assert.strictEqual(
-                target.querySelector('.o_searchview_autocomplete .o_selection_focus').innerText,
+                target.querySelector('.o_searchview_autocomplete .focus').innerText,
                 "Search Foo for: null"
             );
 
-            await testUtils.dom.click(target.querySelector('.o_searchview_autocomplete li.o_selection_focus a'));
+            await testUtils.dom.click(target.querySelector('.o_searchview_autocomplete li.focus a'));
 
             assert.verifySteps([
                 JSON.stringify([]), // initial search

--- a/addons/web/static/tests/search/search_bar_tests.js
+++ b/addons/web/static/tests/search/search_bar_tests.js
@@ -403,7 +403,7 @@ QUnit.module("Search", (hooks) => {
         await triggerEvent(searchInput, null, "keydown", { key: "ArrowDown" });
 
         assert.strictEqual(
-            target.querySelector(".o_searchview_autocomplete .o_selection_focus").innerText.trim(),
+            target.querySelector(".o_searchview_autocomplete .focus").innerText.trim(),
             "(no result)",
             "there should be no result for 'a' in bar"
         );
@@ -601,11 +601,11 @@ QUnit.module("Search", (hooks) => {
         await editSearch(target, "null");
 
         assert.strictEqual(
-            target.querySelector(".o_searchview_autocomplete .o_selection_focus").innerText,
+            target.querySelector(".o_searchview_autocomplete .focus").innerText,
             "Search Foo for: null"
         );
 
-        await click(target.querySelector(".o_searchview_autocomplete li.o_selection_focus a"));
+        await click(target.querySelector(".o_searchview_autocomplete li.focus a"));
 
         assert.deepEqual(getDomain(controlPanel), [["foo", "ilike", "null"]]);
     });
@@ -830,7 +830,7 @@ QUnit.module("Search", (hooks) => {
         );
         const searchInput = target.querySelector(".o_searchview input");
         await triggerEvent(searchInput, null, "keydown", { key: "ArrowDown" });
-        assert.containsOnce(target, ".o_selection_focus");
+        assert.containsOnce(target, ".focus");
     });
 
     QUnit.test("checks that an arrowUp always selects an item", async function (assert) {
@@ -858,6 +858,6 @@ QUnit.module("Search", (hooks) => {
         );
         const searchInput = target.querySelector(".o_searchview input");
         await triggerEvent(searchInput, null, "keydown", { key: "ArrowUp" });
-        assert.containsOnce(target, ".o_selection_focus");
+        assert.containsOnce(target, ".focus");
     });
 });


### PR DESCRIPTION
As result of [1], control panel's search menu-items were highlighted correctly on `:hover`, but not using the keyboard.
This commit assigns the default <Dropdown> 'focus' class in both circumstances.

[1] https://github.com/odoo/odoo/pull/87448

task#2852217


--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
