### PR TITLE
[FIX] mail: properly place dropdowns in Kanban Activity views

### DIFF
--- a/addons/mail/static/src/js/activity.js
+++ b/addons/mail/static/src/js/activity.js
@@ -713,6 +713,10 @@ var KanbanActivity = BasicActivity.extend({
      */
     _renderDropdown: function () {
         var self = this;
+        this.$el.dropdown({
+            boundary: 'viewport',
+            flip: false,
+        });
         this.$('.o_activity')
             .toggleClass('dropdown-menu-right', config.device.isMobile)
             .html(QWeb.render('mail.KanbanActivityLoading'));

--- a/addons/mail/static/src/scss/activity_view.scss
+++ b/addons/mail/static/src/scss/activity_view.scss
@@ -1,5 +1,6 @@
 .o_activity_view {
     height: 100%;
+    overflow: auto;
     > table {
         background-color: white;
         thead > tr > th:first-of-type {

--- a/addons/mail/static/src/xml/web_kanban_activity.xml
+++ b/addons/mail/static/src/xml/web_kanban_activity.xml
@@ -3,7 +3,8 @@
 
 <t t-name="mail.KanbanActivity">
     <div class="o_kanban_inline_block dropdown o_mail_activity">
-        <a class="dropdown-toggle o-no-caret o_activity_btn" data-boundary="viewport" data-flip="false" data-toggle="dropdown" role="button">
+        <!-- Dropdowns are created in JS to avoid some bugs, that's why the <a/> contains no args for the dropdown creation -->
+        <a class="dropdown-toggle o-no-caret o_activity_btn" data-toggle="dropdown" role="button">
             <!-- span classes are generated dynamically (see _render) -->
             <span t-att-title="widget.selection[widget.activityState]" role="img" t-att-aria-label="widget.selection[widget.activity_state]"/>
        </a>


### PR DESCRIPTION
For the kanban_activity view (e.g.: in the CRM module), when we have enough
entries to require the scrolling, dropdowns are not displayed at the correct
location.
Furthermore, in kanban views, when dropdowns are opening on the edge of the
parent element (e.g.: in Documents), the dropdowns are partially hidden and not
accessible by the client.

Step to reproduce the issue:
1) Install CRM and Documents module
2) Go to CRM and create multiple leads with at least one activity
3) Go to the Activity view and scroll down and click on an item. The dropdown
is not placed at the correct location -> BUG 1
4) Go to the Documents modules and check the activity (the small clock icon)
of a Document on the right most column. The dropdown is hidden by the
description of the file.

Solution: Firstly, the parent container of the Kanban Activity view did not had
the `overflow: auto` property activated. Consequently, while the children were
somehow taking all the spaces of the screen, Popper (the third party that
handles the dynamic positioning of the dropdowns) was wrongly computing the
positionning.
Secondly, dynamically creating the dropdown via Javascript (through the
JQueryInterface of the Dropdown class in Bootstrap) somehow allows to fix the
issue in Documents. Consequently, it is important to keep them into the
Javascript and not move the arguments into the XML.

opw-[2827873](https://www.odoo.com/web#id=2827873&view_type=form&model=project.task)