### PR TITLE
[FIX] account_analytic_default: fixing restrictions on analytic tags

### DIFF
--- a/addons/account_analytic_default/models/account_analytic_default.py
+++ b/addons/account_analytic_default/models/account_analytic_default.py
@@ -25,8 +25,9 @@ class AccountAnalyticDefault(models.Model):
     @api.constrains('analytic_id', 'analytic_tag_ids')
     def _check_account_or_tags(self):
         if any(not default.analytic_id
-               and not default.analytic_tag_ids
-               or not any(tag.analytic_distribution_ids for tag in default.analytic_tag_ids) for default in self):
+               and not any(tag.analytic_distribution_ids for tag in default.analytic_tag_ids)
+               for default in self
+               ):
             raise ValidationError(_('An analytic default requires an analytic account or an analytic tag used for analytic distribution.'))
 
     @api.model


### PR DESCRIPTION
If applied, this commit will fix the following bug by adding some
restrictions on the creation of analytic default
and the uses of tags in account.move

Steps to reproduce:
1- install account.accountant, account_analytic_default
2- Accounting --> Configuration --> Analytic Tags, analytic accounting
3-  Create an Analytic Tag, with no Analytic Distribution.
4-  Accounting --> Configuration --> Analytic Default Rules.
Create an Analytic Default Rule, using the Analytic Tag above
and select a Partner
5- Create a Vendor Bill on that partner. The Analytic Tag is added to
the invoice, as expected
6- However when selecting Accounting --> Reporting --> Analytic Report,
the report is empty and does not contain the Analytic Tag. Adding the
 Analytic Tag to the filter has no effect.
Bug/Issue:
An analytic tag is meant to be an additional dimension of analysis.
Dimension which is only worth/valid when an analytic account is
specified.

An analytic default rule should never be applied without
- either an analytic account
- or analytic tag used for distribution
Fixes:
1- changing the error condition on creating analytic default
2- changing the error message accordingly to better explain the issue
3- raise an error when the user creates an account.move with analytic
tags without (analytic tags + analytic account) or (analytic tags with
analytic distrubtion)

Please refer to the ticket for the whole discussion on this

corrects https://github.com/odoo/odoo/issues/91177

OPW-2766749
