### PR TITLE
[FIX] web: mail.MessagingMenu isn't always added in the systray 

### DIFF
--- a/addons/web/static/src/webclient/navbar/navbar.js
+++ b/addons/web/static/src/webclient/navbar/navbar.js
@@ -8,7 +8,7 @@ import { debounce } from "@web/core/utils/timing";
 import { ErrorHandler, NotUpdatable } from "@web/core/utils/components";
 
 const { Component, hooks } = owl;
-const { useExternalListener, useRef } = hooks;
+const { useExternalListener, useRef, onWillUnmount } = hooks;
 const systrayRegistry = registry.category("systray");
 
 const getBoundingClientRect = Element.prototype.getBoundingClientRect;
@@ -64,8 +64,14 @@ export class NavBar extends Component {
             this.render();
         };
 
-        useBus(systrayRegistry, "UPDATE", renderAndAdapt);
-        useBus(this.env.bus, "MENUS:APP-CHANGED", renderAndAdapt);
+        systrayRegistry.on("UPDATE", this, renderAndAdapt);
+        this.env.bus.on("MENUS:APP-CHANGED", this, renderAndAdapt);
+
+        onWillUnmount(() => {
+            systrayRegistry.off("UPDATE", this);
+            this.env.bus.off("MENUS:APP-CHANGED", this);
+        });
+
         // We don't want to adapt every time we are patched
         // rather, we adapt only when menus or systrays have changed.
         useEffect(() => {this.adapt();}, () => [adaptCounter]);

--- a/addons/web/static/tests/webclient/navbar_tests.js
+++ b/addons/web/static/tests/webclient/navbar_tests.js
@@ -180,6 +180,32 @@ QUnit.test("navbar can display systray items ordered based on their sequence", a
     navbar.destroy();
 });
 
+QUnit.test("navbar updates after adding a systray item", async (assert) => {
+    class MyItem1 extends Component {}
+    MyItem1.template = xml`<li class="my-item-1">my item 1</li>`;
+
+    clearRegistryWithCleanup(systrayRegistry);
+    systrayRegistry.add('addon.myitem1', { Component: MyItem1 });
+
+    const env = await makeTestEnv(baseConfig);
+    const target = getFixture();
+
+    patchWithCleanup(NavBar.prototype, {
+         mounted() {
+            class MyItem2 extends Component {}
+            MyItem2.template = xml`<li class="my-item-2">my item 2</li>`;
+            systrayRegistry.add('addon.myitem2', {Component: MyItem2});
+            this._super();
+        }
+    });
+
+    const navbar = await mount(NavBar, { env, target });
+    await nextTick();
+    const menuSystray = navbar.el.getElementsByClassName("o_menu_systray")[0];
+    assert.containsN(menuSystray, "li", 2, "2 systray items should be displayed");
+    navbar.destroy();
+});
+
 QUnit.test("can adapt with 'more' menu sections behavior", async (assert) => {
     class MyNavbar extends NavBar {
         async adapt() {


### PR DESCRIPTION
**Steps to follow**

  - Use chrome
  - Connect to a runbot with the demo account
  - After a couple refreshes, the mail.MessagingMenu isn't displayed

**Cause of the issue**

  The navbar should be updated when there is a new item added to the systray registry.
  For that, the navbar listen to the update event with the `useBus` function.
  `useBus` itself uses `useEffect` which only starts listening after a component has been mounted/patched.
  -> The update callback is never called in this case because new items are added before the callback is registered.

opw-2801467