### PR TITLE
[FIX] web_editor: fix toolbar visibility check

### DIFF
--- a/addons/web_editor/static/src/js/editor/snippets.editor.js
+++ b/addons/web_editor/static/src/js/editor/snippets.editor.js
@@ -3314,7 +3314,8 @@ var SnippetsMenu = Widget.extend({
         const range = selection && selection.rangeCount && selection.getRangeAt(0);
         if (!range ||
             !$(range.commonAncestorContainer).parents('#wrapwrap, .iframe-editor-wrapper .o_editable').length ||
-            $(range.commonAncestorContainer).parent('[data-oe-model]:not([data-oe-type="html"]):not([data-oe-field="arch"])').length ||
+            $(selection.anchorNode).parent('[data-oe-model]:not([data-oe-type="html"]):not([data-oe-field="arch"])').length ||
+            $(selection.focusNode).parent('[data-oe-model]:not([data-oe-type="html"]):not([data-oe-field="arch"])').length ||
             (e && $(e.target).closest('.fa, img').length ||
             this.options.wysiwyg.lastMediaClicked && $(this.options.wysiwyg.lastMediaClicked).is('.fa, img')) ||
             (this.options.wysiwyg.lastElement && !this.options.wysiwyg.lastElement.isContentEditable)


### PR DESCRIPTION
When the selection span across two element linked
to odoo field that cannot be styled.
The toolbar should not be visible.

The visibility check was performing a verification
based on the `range.commonAncestorContainer`,
therefore when the selection spanned across multiple element
the common ancestor was higher in the DOM than we wanted, and
the check was not working.

We changed the check to use `selection.anchorNode`
and `selection.focusNode` to ensure the verification works any time.

task-2845346



--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
