### PR TITLE
[ADD] mail: quick-open related record from email

### DIFF
--- a/addons/mail/models/mail_mail.py
+++ b/addons/mail/models/mail_mail.py
@@ -158,6 +158,17 @@ class MailMail(models.Model):
     def action_retry(self):
         self.filtered(lambda mail: mail.state == 'exception').mark_outgoing()
 
+    def action_open_document(self):
+        """ Opens the related record based on the model and ID """
+        self.ensure_one()
+        return {
+            'res_id': self.res_id,
+            'res_model': self.model,
+            'target': 'current',
+            'type': 'ir.actions.act_window',
+            'view_mode': 'form',
+        }
+
     def mark_outgoing(self):
         return self.write({'state': 'outgoing'})
 

--- a/addons/mail/views/mail_mail_views.xml
+++ b/addons/mail/views/mail_mail_views.xml
@@ -13,6 +13,11 @@
                         <field name="state" widget="statusbar" statusbar_visible="outgoing,sent,received,exception,cancel"/>
                     </header>
                     <sheet>
+                        <div class="oe_button_box" name="button_box">
+                            <button name="action_open_document" string="Open Document"
+                                    type="object" class="oe_link" icon="fa-file-text-o"
+                                    attrs="{'invisible': ['|', ('model', '=', False), ('res_id', '=', 0)]}"/>
+                        </div>
                         <field name="mail_message_id_int" required="0" invisible="1"/>
                         <label for="subject" class="oe_edit_only"/>
                         <h2><field name="subject"/></h2>


### PR DESCRIPTION
Description of the issue/feature this PR addresses:  allow quick opening a record based on the email it's stored relation.

Current behavior before PR: You have to find the right menu/view and then take over the ID stored on the email to find back the record. This is annoying, painful and errorprone

Desired behavior after PR is merged:
By adding a smartbutton the user can quick-navigate to the related record in a second.
This allows for quickly finding and opening records which is usually handy when debugging things:
![image](https://user-images.githubusercontent.com/6352350/168099854-7ce9ba95-0fce-4753-8999-695b3f34d5ea.png)



--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
