### PR TITLE
[ADD] mail: quick-open related record from activity

### DIFF
--- a/addons/mail/models/mail_activity.py
+++ b/addons/mail/models/mail_activity.py
@@ -568,6 +568,17 @@ class MailActivity(models.Model):
     def action_close_dialog(self):
         return {'type': 'ir.actions.act_window_close'}
 
+    def action_open_document(self):
+        """ Opens the related record based on the model and ID """
+        self.ensure_one()
+        return {
+            'res_id': self.res_id,
+            'res_model': self.res_model,
+            'target': 'current',
+            'type': 'ir.actions.act_window',
+            'view_mode': 'form',
+        }
+
     def activity_format(self):
         activities = self.read()
         mail_template_ids = set([template_id for activity in activities for template_id in activity["mail_template_ids"]])

--- a/addons/mail/views/mail_activity_views.xml
+++ b/addons/mail/views/mail_activity_views.xml
@@ -99,6 +99,11 @@
         <field name="arch" type="xml">
             <form string="Log an Activity" create="false">
                 <sheet string="Activity">
+                    <div class="oe_button_box" name="button_box">
+                        <button name="action_open_document" string="Open Document"
+                                type="object" class="oe_link" icon="fa-file-text-o"
+                                attrs="{'invisible': ['|', ('res_model', '=', False), ('res_id', '=', 0)]}"/>
+                    </div>
                     <group invisible="1">
                         <field name="activity_category" invisible="1" />
                         <field name="res_model" invisible="1"/>


### PR DESCRIPTION
Description of the issue/feature this PR addresses:  allow quick opening a record based on the activity it's stored relation.

Current behavior before PR: You have to find the right menu/view and then take over the ID stored on the activity (through export) to find back the record. This is annoying, painful and errorprone

Desired behavior after PR is merged:
By adding a smartbutton the user can quick-navigate to the related record in a second.
This allows for quickly finding and opening records which is usually handy when debugging things or finding back related records:
![image](https://user-images.githubusercontent.com/6352350/168103186-635105d8-02a8-45dc-a848-331cdfe72e0a.png)



--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
