### PR TITLE
[FIX] delivery: Prevent delivery product to be set as sellable

### DIFF
--- a/addons/delivery/i18n/delivery.pot
+++ b/addons/delivery/i18n/delivery.pot
@@ -1058,3 +1058,9 @@ msgstr ""
 #: model_terms:ir.ui.view,arch_db:delivery.view_delivery_carrier_form
 msgid "e.g. UPS Express"
 msgstr ""
+
+#. module: delivery
+#: code:addons/delivery/models/product_template.py:0
+#, python-format
+msgid "This product is set as delivery product for the following shipping method(s):\n%s"
+msgstr ""

--- a/addons/delivery/models/product_template.py
+++ b/addons/delivery/models/product_template.py
@@ -1,7 +1,8 @@
 # -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
-from odoo import models, fields
+from odoo import api, models, fields, _
+from odoo.exceptions import ValidationError
 
 
 class ProductTemplate(models.Model):
@@ -11,3 +12,11 @@ class ProductTemplate(models.Model):
         string="HS Code",
         help="Standardized code for international shipping and goods declaration. At the moment, only used for the FedEx shipping provider.",
     )
+
+    @api.constrains('sale_ok', 'purchase_ok')
+    def _check_is_delivery(self):
+        carriers = self.env['delivery.carrier'].sudo().search([('product_id', 'in', self.product_variant_ids.ids)])
+        for record in self:
+            if (record.sale_ok or record.purchase_ok) and carriers:
+                raise ValidationError(_('This product is set as delivery product for the following shipping method(s):\n%s',\
+                        '\n'.join(carriers.mapped('display_name'))))


### PR DESCRIPTION
Currently, if a product is one configured on a delivery method - it is
set to be 'is_delivery' = true.
This has it's limitations if they then configure this same product as
being sell-able or purchasable. Once they have done so and sell/purchase
a product, the invoice status in the process does not follow the
standard behavior.

The point of this commit is to avoid running into this issue and
preventing the product to be configured as sell-able or purchasable if
'is_delivery' is true.

Description of the issue/feature this PR addresses:
opw-2829439

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
