### PR TITLE
[IMP] base,{fetch}mail,l10n_it_edi,{test}mass_mailing:prevent using arch server

### DIFF
--- a/addons/l10n_it_edi/models/ir_mail_server.py
+++ b/addons/l10n_it_edi/models/ir_mail_server.py
@@ -408,6 +408,12 @@ class IrMailServer(models.Model):
     _name = "ir.mail_server"
     _inherit = "ir.mail_server"
 
+    res_company_l10n_it_mail_pec_server_ids = fields.One2many(
+        comodel_name='res.company',
+        inverse_name='l10n_it_mail_pec_server_id',
+        string='PEC-mail server active usage',
+        readonly=True)
+
     def _get_test_email_addresses(self):
         self.ensure_one()
 
@@ -422,6 +428,15 @@ class IrMailServer(models.Model):
         if not email_to:
             raise UserError(_('Please configure Government PEC-mail	in company settings'))
         return email_from, email_to
+
+    def _active_usages_compute(self):
+        usages_super = super()._active_usages_compute()
+        for record in self.filtered('res_company_l10n_it_mail_pec_server_ids'):
+            usages_super.setdefault(record.id, []).extend(
+                map(lambda c: _('%s (Company E-Invoicing PEC-mail Server)', c.display_name),
+                    record.res_company_l10n_it_mail_pec_server_ids)
+            )
+        return usages_super
 
     def build_email(self, email_from, email_to, subject, body, email_cc=None, email_bcc=None, reply_to=False,
                 attachments=None, message_id=None, references=None, object_id=False, subtype='plain', headers=None,

--- a/addons/mail/models/__init__.py
+++ b/addons/mail/models/__init__.py
@@ -48,6 +48,7 @@ from . import ir_actions_server
 from . import ir_attachment
 from . import ir_config_parameter
 from . import ir_http
+from . import ir_mail_server
 from . import ir_model
 from . import ir_model_fields
 from . import ir_translation

--- a/addons/mail/models/ir_mail_server.py
+++ b/addons/mail/models/ir_mail_server.py
@@ -1,0 +1,23 @@
+# -*- coding: utf-8 -*-
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from odoo import _, fields, models
+
+
+class IrMailServer(models.Model):
+    _name = 'ir.mail_server'
+    _inherit = ['ir.mail_server']
+
+    mail_template_ids = fields.One2many(
+        comodel_name='mail.template',
+        inverse_name='mail_server_id',
+        string='Mail template using this mail server',
+        readonly=True)
+
+    def _active_usages_compute(self):
+        usages_super = super()._active_usages_compute()
+        for record in self.filtered('mail_template_ids'):
+            usages_super.setdefault(record.id, []).extend(
+                map(lambda t: _('%s (Email Template)', t.display_name), record.mail_template_ids)
+            )
+        return usages_super

--- a/addons/mass_mailing/models/__init__.py
+++ b/addons/mass_mailing/models/__init__.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
+from . import ir_mail_server
 from . import ir_model
 from . import link_tracker
 from . import mailing_contact_subscription

--- a/addons/mass_mailing/models/ir_mail_server.py
+++ b/addons/mass_mailing/models/ir_mail_server.py
@@ -1,0 +1,36 @@
+# -*- coding: utf-8 -*-
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from odoo import _, fields, models
+from odoo.tools.misc import format_date
+
+
+class IrMailServer(models.Model):
+    _name = 'ir.mail_server'
+    _inherit = ['ir.mail_server']
+
+    active_mailing_ids = fields.One2many(
+        comodel_name='mailing.mailing',
+        inverse_name='mail_server_id',
+        string='Active mailing using this mail server',
+        readonly=True,
+        domain=[('state', '!=', 'done'), ('active', '=', True)])
+
+    def _active_usages_compute(self):
+        def format_usage(mailing_id):
+            base = _('Mass Mailing "%s"', mailing_id.display_name)
+            if not mailing_id.schedule_date:
+                return base
+            details = _('(scheduled for %s)', format_date(self.env, mailing_id.schedule_date))
+            return f'{base} {details}'
+
+        usages_super = super(IrMailServer, self)._active_usages_compute()
+        default_mail_server_id = self.env['mailing.mailing']._get_default_mail_server_id()
+        for record in self:
+            usages = []
+            if default_mail_server_id == record.id:
+                usages.append(_('Email Marketing uses it as its default mail server to send mass mailings'))
+            usages.extend(map(format_usage, record.active_mailing_ids))
+            if usages:
+                usages_super.setdefault(record.id, []).extend(usages)
+        return usages_super

--- a/addons/mass_mailing/models/mailing.py
+++ b/addons/mass_mailing/models/mailing.py
@@ -502,6 +502,8 @@ class MassMailing(models.Model):
     def copy(self, default=None):
         self.ensure_one()
         default = dict(default or {}, contact_list_ids=self.contact_list_ids.ids)
+        if self.mail_server_id and not self.mail_server_id.active:
+            default['mail_server_id'] = self._get_default_mail_server_id()
         return super(MassMailing, self).copy(default=default)
 
     def _group_expand_states(self, states, domain, order):

--- a/addons/mass_mailing/views/res_config_settings_views.xml
+++ b/addons/mass_mailing/views/res_config_settings_views.xml
@@ -28,14 +28,15 @@
                                 <div class="o_setting_right_pane">
                                     <label for="mass_mailing_outgoing_mail_server"/>
                                     <div class="text-muted">
-                                        Use a dedicated server for mailings
+                                        Pick a dedicated outgoing mail server for your mass mailings
                                     </div>
                                     <div class="content-group" attrs="{'invisible': [('mass_mailing_outgoing_mail_server', '=', False)]}">
                                         <div class="mt16">
-                                            <field name="mass_mailing_mail_server_id" options="{'no_create': True, 'no_open': True}"/>
+                                            <field name="mass_mailing_mail_server_id" options="{'no_create': True, 'no_open': True}"
+                                                   placeholder="Default Server"/>
                                         </div>
                                         <div class="mt8">
-                                            <button type="action" name="base.action_ir_mail_server_list" string="Configure Email Server" icon="fa-arrow-right" class="oe_link"/>
+                                            <button type="action" name="base.action_ir_mail_server_list" string="Configure Outgoing Mail Servers" icon="fa-arrow-right" class="oe_link"/>
                                         </div>
                                     </div>
                                 </div>

--- a/addons/test_mass_mailing/tests/test_mailing_server.py
+++ b/addons/test_mass_mailing/tests/test_mailing_server.py
@@ -2,6 +2,7 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 from odoo.addons.test_mass_mailing.tests.common import TestMassMailCommon
+from odoo.exceptions import UserError
 from odoo.tests import tagged
 from odoo.tests.common import users
 from odoo.tools import mute_logger
@@ -15,6 +16,60 @@ class TestMassMailingServer(TestMassMailCommon):
         super(TestMassMailingServer, cls).setUpClass()
         cls._init_mail_servers()
         cls.recipients = cls._create_mailing_test_records(model='mailing.test.optout', count=8)
+
+    def test_mass_mailing_server_archived_usage_protection(self):
+        """ Test the protection against using archived server:
+        - servers used cannot be archived
+        - mailing clone of a mailing with an archived server gets the default one instead
+        """
+        servers = self.env['ir.mail_server'].create([{
+            'name': 'Server 1',
+            'smtp_host': 'archive-test1.smtp.local',
+        }, {
+            'name': 'Server 2',
+            'smtp_host': 'archive-test2.smtp.local',
+        }])
+        self.env['ir.config_parameter'].set_param('mass_mailing.mail_server_id', servers[0].id)
+        mailing = self.env['mailing.mailing'].create({
+            'subject': 'Mailing',
+            'body_html': 'Body for <t t-out="object.name" />',
+            'email_from': 'specific_user@test.com',
+            'mailing_model_id': self.env['ir.model']._get('mailing.test.optout').id,
+        })
+
+        mailing_clone = mailing.copy()
+        self.assertEqual(mailing_clone.mail_server_id.id, servers[0].id,
+                         'The clone of a mailing inherits from the server of the copied mailing')
+        with self.assertRaises(UserError, msg='Servers still used as default and for 2 mailings'):
+            servers.action_archive()
+        self.assertTrue(all(server.active for server in servers), 'All servers must be active')
+        self.env['ir.config_parameter'].set_param('mass_mailing.mail_server_id', False)
+        with self.assertRaises(UserError, msg='Servers still used for 2 mailings'):
+            servers.action_archive()
+        self.assertTrue(all(server.active for server in servers), 'All servers must be active')
+        with self.mock_smtplib_connection():
+            mailing.action_send_mail()
+        with self.assertRaises(UserError, msg='Servers still used for 1 mailings'):
+            servers.action_archive()
+        self.assertTrue(all(server.active for server in servers), 'All servers must be active')
+        with self.mock_smtplib_connection():
+            mailing_clone.action_send_mail()
+        servers.action_archive()  # Servers no more used -> no error
+        self.assertFalse(servers.filtered('active'), 'All servers must be archived')
+        self.assertFalse(mailing.copy().mail_server_id,
+                         'The clone of a mailing with an archived server gets the default one (none here)')
+        servers[1].action_unarchive()
+        self.env['ir.config_parameter'].set_param('mass_mailing.mail_server_id', servers[1].id)
+        mailing_clone = mailing.copy()
+        self.assertEqual(mailing_clone.mail_server_id.id, servers[1].id,
+                         'The clone of a mailing with an archived server gets the default one')
+        mailing_clone.action_archive()
+        with self.assertRaises(UserError, msg='Servers still used as default'):
+            servers.action_archive()
+        self.assertTrue(servers[1].active)
+        self.env['ir.config_parameter'].set_param('mass_mailing.mail_server_id', False)
+        servers.action_archive()  # Servers no more used -> no error
+        self.assertFalse(servers.filtered('active'), 'All servers must be archived')
 
     @users('user_marketing')
     @mute_logger('odoo.addons.mail.models.mail_mail', 'odoo.models.unlink', 'odoo.addons.mass_mailing.models.mailing')


### PR DESCRIPTION
Prevent archiving in-use mail servers by displaying an error message that
lists where it is still used, allowing to easily identify what need to be
updated before being able to archive the mail server.

Additionally,
- prevent the use of archived server as a fall-safe
- when duplicating a mailing with an archived mail server, replace mail
server by the default one

Detailed explanation:
1. A check has been added that raise an exception when trying to connect to the
smtp server or send an email when the server is archived (_ensure_active).
With that solution,
- testing the connection of an archived server displays an error telling that
an archived server cannot be used.
- if a mail is still sent with an archived server, mail are in error :
"Connection failed (outgoing mail server problem)"
This fail-safe ensures that no mail will be sent through an archived mail server
and that the user will get some feedback about it.

The same fail-safe for the incoming mail server has been added.

Notes:
- the connection will outlive the archiving of a mail server still allowing
to send email through the archived server until the connection is closed. But
connection are not kept for long so this shouldn't be a problem.
- it cannot be tested because the connect method return immediately in test
mode.

2. When a mail server is archived, an user error is raised if it is in-use.
The implementation relies on each module to override the method
"_active_usages_compute" in "ir_mail_server" to complete the list with
user-friendly message describing the active elements that could send mail
through the mail server. This has been implemented for:
- l10n_it_edi: server used to send e-invoice
- mail: optional server configured for template
- mass_mailing:
-- default mail server
-- active server configured for mailing

Mail server are referenced in other elements but are not active anymore, it is
just for temporary or history purpose. Those references doesn’t prevent the
archiving of the mail server:
- mail_message
- wizard survey_invite and compose_message
- res_config_settings

Task-2821516

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
