### PR TITLE
[FIX] web: multi lines don't work in warnings

### DIFF
--- a/addons/web/static/src/legacy/action_adapters.js
+++ b/addons/web/static/src/legacy/action_adapters.js
@@ -13,7 +13,7 @@ import { mapDoActionOptionAPI } from "./backend_utils";
 
 const { Component, tags, hooks } = owl;
 
-const warningDialogBodyTemplate = tags.xml`<t t-esc="props.message"/>`;
+const warningDialogBodyTemplate = tags.xml`<p style="white-space:pre-wrap" t-esc="props.message"/>`;
 
 class ActionAdapter extends ComponentAdapter {
     setup() {

--- a/addons/web/static/tests/webclient/actions/legacy_tests.js
+++ b/addons/web/static/tests/webclient/actions/legacy_tests.js
@@ -83,6 +83,32 @@ QUnit.module("ActionManager", (hooks) => {
         assert.strictEqual($(".modal-body").text(), "This is a warning...");
     });
 
+    QUnit.test("display multiline warning as modal", async function (assert) {
+        assert.expect(5);
+        let list;
+        patchWithCleanup(ListController.prototype, {
+            init() {
+                this._super(...arguments);
+                list = this;
+            },
+        });
+
+        const webClient = await createWebClient({ serverData });
+        await doAction(webClient, 3);
+        assert.containsOnce(webClient, ".o_list_view");
+        list.trigger_up("warning", {
+            title: "Warning!!!",
+            message: "This is a warning...\nabc",
+            type: "dialog",
+        });
+        await testUtils.nextTick();
+        await legacyExtraNextTick();
+        assert.containsOnce(webClient, ".o_list_view");
+        assert.containsOnce(document.body, ".modal");
+        assert.strictEqual($(".modal-title").text(), "Warning!!!");
+        assert.strictEqual($(".modal-body")[0].innerText, "This is a warning...\nabc");
+    });
+
     QUnit.test(
         "legacy crash manager is still properly remapped to error service",
         async function (assert) {


### PR DESCRIPTION
Steps to reproduce:

1- install sales
2- allow warnings on sale orders
3- set a warning w with multiple lines on
 sale order on customer c
4- try to add c to a sale order
5- w will be shown in one line

Bug:

the html is escaped and the proper styling is missing

Fix:
add the proper style

OPW-2847660

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
