### PR TITLE
[FIX] project: Burndown Chart date_group_by selection is empty

### DIFF
--- a/addons/project/report/project_task_burndown_chart_report.py
+++ b/addons/project/report/project_task_burndown_chart_report.py
@@ -25,12 +25,12 @@ class ReportProjectTaskBurndownChart(models.Model):
     partner_id = fields.Many2one('res.partner', string='Customer', readonly=True)
     nb_tasks = fields.Integer('# of Tasks', readonly=True, group_operator="sum")
     date_group_by = fields.Selection(
-        (
+        [
             ('day', 'By Day'),
             ('month', 'By Month'),
             ('quarter', 'By quarter'),
             ('year', 'By Year')
-        ), string="Date Group By", readonly=True)
+        ], string="Date Group By", readonly=True)
 
     @api.model
     def read_group(self, domain, fields, groupby, offset=0, limit=None, orderby=False, lazy=True):


### PR DESCRIPTION
**Steps to follow**

  - Go to project
  - Click on the 3 littles dots on a card
  - Go to Burndown Chart
  - Add a custom filter on the date_group_by field
  -> this.fields[condition.field].selection[0] is undefined

**Cause of the issue**

  The date_group_by field selection should be declared as a list, not a
  tuple

opw-2819936