### PR TITLE
14.0 fix reconcile payment in locked period poma

### DIFF
--- a/addons/account/i18n/account.pot
+++ b/addons/account/i18n/account.pot
@@ -31,6 +31,12 @@ msgid ""
 msgstr ""
 
 #. module: account
+#: code:addons/account/models/account_move.py:0
+#, python-format
+msgid " The %(lock_type)s lock date is set on %(lock_date)s."
+msgstr ""
+
+#. module: account
 #: model:ir.model.fields,field_description:account.field_account_payment__reconciled_bills_count
 msgid "# Reconciled Bills"
 msgstr ""
@@ -11579,6 +11585,14 @@ msgstr ""
 #: code:addons/account/models/account_move.py:0
 #, python-format
 msgid ""
+"The accounting date being set prior to the %(lock_type)s lock date "
+"%(lock_date)s, it will be changed to %(accounting_date)s upon posting."
+msgstr ""
+
+#. module: account
+#: code:addons/account/models/account_move.py:0
+#, python-format
+msgid ""
 "The accounting date is set prior to the tax lock date which is set on %s. "
 "Hence, the accounting date will be changed to the next available date when "
 "posting."
@@ -14093,6 +14107,12 @@ msgid "technical field for widget tax-group-custom-field"
 msgstr ""
 
 #. module: account
+#: code:addons/account/models/account_move.py:0
+#, python-format
+msgid "tax"
+msgstr ""
+
+#. module: account
 #: model:ir.model.fields,help:account.field_account_bank_statement__previous_statement_id
 msgid "technical field to compute starting balance correctly"
 msgstr ""
@@ -14117,6 +14137,12 @@ msgstr ""
 #. module: account
 #: model_terms:ir.ui.view,arch_db:account.account_journal_dashboard_kanban_view
 msgid "to check"
+msgstr ""
+
+#. module: account
+#: code:addons/account/models/account_move.py:0
+#, python-format
+msgid "user"
 msgstr ""
 
 #. module: account

--- a/addons/account/models/account_full_reconcile.py
+++ b/addons/account/models/account_full_reconcile.py
@@ -28,8 +28,10 @@ class AccountFullReconcile(models.Model):
 
         # Reverse all exchange moves at once.
         today = fields.Date.context_today(self)
+        use_original_date = self._context.get('in_unreconcile')
+
         default_values_list = [{
-            'date': today,
+            'date': move._get_accounting_date(move.date, move._affect_tax_report()) if use_original_date else today,
             'ref': _('Reversal of: %s') % move.name,
         } for move in moves_to_reverse]
         moves_to_reverse._reverse_moves(default_values_list, cancel=True)

--- a/addons/account/models/account_move.py
+++ b/addons/account/models/account_move.py
@@ -3871,7 +3871,7 @@ class AccountMoveLine(models.Model):
             if line.move_id.is_invoice(include_receipts=True):
                 line._onchange_price_subtotal()
             elif not line.move_id.reversed_entry_id:
-                balance = line.currency_id._convert(line.amount_currency, company.currency_id, company, line.move_id.date or fields.Date.context_today(line))
+                balance = line.currency_id._convert(line.amount_currency, company.currency_id, company, line.date or fields.Date.context_today(line))
                 line.debit = balance if balance > 0.0 else 0.0
                 line.credit = -balance if balance < 0.0 else 0.0
 
@@ -5038,7 +5038,7 @@ class AccountMoveLine(models.Model):
 
     def remove_move_reconcile(self):
         """ Undo a reconciliation """
-        (self.matched_debit_ids + self.matched_credit_ids).unlink()
+        (self.matched_debit_ids + self.matched_credit_ids).with_context({'in_unreconcile': True}).unlink()
 
     def _copy_data_extend_business_fields(self, values):
         ''' Hook allowing copying business fields under certain conditions.

--- a/addons/account/tests/test_account_move_out_invoice.py
+++ b/addons/account/tests/test_account_move_out_invoice.py
@@ -145,13 +145,15 @@ class TestAccountMoveOutInvoiceOnchanges(AccountTestInvoicingCommon):
     def test_out_invoice_onchange_invoice_date(self):
         for tax_date, invoice_date, accounting_date in [
             ('2019-03-31', '2019-05-12', '2019-05-12'),
-            ('2019-03-31', '2019-02-10', '2019-04-1'),
+            ('2019-03-31', '2019-02-10', '2019-04-30'),
             ('2019-05-31', '2019-06-15', '2019-06-15'),
         ]:
             self.invoice.company_id.tax_lock_date = tax_date
-            with Form(self.invoice) as move_form:
+            invoice = self.invoice.copy()
+            with Form(invoice) as move_form:
                 move_form.invoice_date = invoice_date
-            self.assertEqual(self.invoice.date, fields.Date.to_date(accounting_date))
+            invoice.action_post()
+            self.assertEqual(invoice.date, fields.Date.to_date(accounting_date))
 
     def test_out_invoice_line_onchange_product_1(self):
         move_form = Form(self.invoice)
@@ -2472,7 +2474,7 @@ class TestAccountMoveOutInvoiceOnchanges(AccountTestInvoicingCommon):
             **self.move_vals,
             'payment_reference': move.name,
             'currency_id': self.currency_data['currency'].id,
-            'date': fields.Date.from_string('2017-01-01'),
+            'date': fields.Date.from_string('2017-01-31'),
             'amount_untaxed': 1200.0,
             'amount_tax': 230.0,
             'amount_total': 1430.0,

--- a/addons/account/tests/test_reconciliation.py
+++ b/addons/account/tests/test_reconciliation.py
@@ -1192,3 +1192,67 @@ class TestReconciliationExec(TestAccountReconciliationCommon):
         self.assertEqual(move_balance_receiv.full_reconcile_id, inv1_receivable.full_reconcile_id)
 
         self.assertTrue(inv1.payment_state in ('in_payment', 'paid'), "Invoice should be paid")
+
+    # def test_reconciling_invoice_with_caba_in_lock_period(self):
+    #     tax_waiting_account = self.env['account.account'].create({
+    #         'name': 'TAX_WAIT',
+    #         'code': 'TWAIT',
+    #         'user_type_id': self.env.ref('account.data_account_type_current_liabilities').id,
+    #         'reconcile': True,
+    #         'company_id': self.company_data['company'].id,
+    #     })
+    #     tax_final_account = self.env['account.account'].create({
+    #         'name': 'TAX_TO_DEDUCT',
+    #         'code': 'TDEDUCT',
+    #         'user_type_id': self.env.ref('account.data_account_type_current_assets').id,
+    #         'company_id': self.company_data['company'].id,
+    #     })
+    #     tax_base_amount_account = self.env['account.account'].create({
+    #         'name': 'TAX_BASE',
+    #         'code': 'TBASE',
+    #         'user_type_id': self.env.ref('account.data_account_type_current_assets').id,
+    #         'company_id': self.company_data['company'].id,
+    #     })
+    #     self.env.company.account_cash_basis_base_account_id = tax_base_amount_account
+    #     tax_tags = defaultdict(dict)
+    #     for line_type, repartition_type in [(l, r) for l in ('invoice', 'refund') for r in ('base', 'tax')]:
+    #         tax_tags[line_type][repartition_type] = self.env['account.account.tag'].create({
+    #             'name': '%s %s tag' % (line_type, repartition_type),
+    #             'applicability': 'taxes',
+    #             'country_id': self.env.ref('base.us').id,
+    #         })
+    #     tax = self.env['account.tax'].create({
+    #         'name': 'cash basis 10%',
+    #         'type_tax_use': 'sale',
+    #         'amount': 10,
+    #         'tax_exigibility': 'on_payment',
+    #         'cash_basis_transition_account_id': tax_waiting_account.id,
+    #         'invoice_repartition_line_ids': [
+    #             (0, 0, {
+    #                 'factor_percent': 100,
+    #                 'repartition_type': 'base',
+    #                 'tag_ids': [(6, 0, tax_tags['invoice']['base'].ids)],
+    #             }),
+    #             (0, 0, {
+    #                 'factor_percent': 100,
+    #                 'repartition_type': 'tax',
+    #                 'account_id': tax_final_account.id,
+    #                 'tag_ids': [(6, 0, tax_tags['invoice']['tax'].ids)],
+    #             }),
+    #         ],
+    #         'refund_repartition_line_ids': [
+    #             (0, 0, {
+    #                 'factor_percent': 100,
+    #                 'repartition_type': 'base',
+    #                 'tag_ids': [(6, 0, tax_tags['refund']['base'].ids)],
+    #             }),
+    #             (0, 0, {
+    #                 'factor_percent': 100,
+    #                 'repartition_type': 'tax',
+    #                 'account_id': tax_final_account.id,
+    #                 'tag_ids': [(6, 0, tax_tags['refund']['tax'].ids)],
+    #             }),
+    #         ],
+    #     })
+    #
+    #     self.create_invoice()


### PR DESCRIPTION
[FIX] account: accounting date for moves happen in lock period should be chosen based on sequence reset period (month/year)

also fixes:
[FIX] account: caba reconciliation in lock period
[FIX] account: foreign currency reconciliation/unreconciliation in lock period raise error

The accounting date and the related warnings were in some cases not
being set properly. This change aims to improve that by displaying better
warnings in the view and updating the date on post instead of raising
user errors.

Back port of:
5883f0a84cd3cd2330cc5ff34261252dacd8c5b9
b5fe668ce3998c39d09b28318efc58b6eb2aed88

Task : [2853102](https://www.odoo.com/web#id=2853102&menu_id=3940&cids=1&action=333&active_id=967&model=project.task&view_type=form)
Task: [2793033](https://www.odoo.com/web#id=2793033&cids=1&menu_id=3940&action=4043&model=project.task&view_type=form)

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
