### PR TITLE
[FIX] stock_account: Fix valuation on forecasted report

### DIFF
--- a/addons/stock_account/report/report_stock_forecasted.py
+++ b/addons/stock_account/report/report_stock_forecasted.py
@@ -16,14 +16,20 @@ class ReplenishmentReport(models.AbstractModel):
         domain = self._product_domain(product_template_ids, product_variant_ids)
         company = self.env['stock.location'].browse(wh_location_ids).mapped('company_id')
         svl = self.env['stock.valuation.layer'].search(domain + [('company_id', '=', company.id)])
+        domain_quants = [
+            ('company_id', '=', company.id),
+            ('location_id', 'in', wh_location_ids)
+        ]
+        if product_template_ids:
+            domain_quants += [('product_id.product_tmpl_id', 'in', product_template_ids)]
+        else:
+            domain_quants += [('product_id', 'in', product_variant_ids)]
+        quants = self.env['stock.quant'].search(domain_quants)
         currency = svl.currency_id or self.env.company.currency_id
         total_quantity = sum(svl.mapped('quantity'))
         # Because we can have negative quantities, `total_quantity` may be equal to zero even if the warehouse's `quantity` is positive.
         if svl and not float_is_zero(total_quantity, precision_rounding=svl.product_id.uom_id.rounding):
-            def filter_on_locations(layer):
-                return layer.stock_move_id.location_dest_id.id in wh_location_ids or layer.stock_move_id.location_id.id in wh_location_ids
-            quantity = sum(svl.filtered(filter_on_locations).mapped('quantity'))
-            value = sum(svl.mapped('value')) * (quantity / total_quantity)
+            value = sum(svl.mapped('value')) * (sum(quants.mapped('quantity')) / total_quantity)
         else:
             value = 0
         value = float_repr(value, precision_digits=currency.decimal_places)


### PR DESCRIPTION
When using multiwarehouse, you can have moves that will be valuated on location A
and then moved to location B. In that case, the forecasted report of Location B
will have discrepancy because the move from A to B will not be valuated (internal move)
and the initial valuated stock valuation layer will still be linked to location A.
I change the way we retrieve the quantity using stock quants linked instead of
the svl.quantity linked to the selected location.

opw-2715253

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
