### PR TITLE
[FIX] account: do not deadlock on concurrent update

### DIFF
--- a/addons/account/models/account_move.py
+++ b/addons/account/models/account_move.py
@@ -48,6 +48,9 @@ class AccountMove(models.Model):
             ON account_move(journal_id, state, payment_state, move_type, date);
         """)
 
+    def _get_sequence_locks(self):
+        return super()._get_sequence_locks() + [self.journal_id]
+
     @property
     def _sequence_monthly_regex(self):
         return self.journal_id.sequence_override_regex or super()._sequence_monthly_regex


### PR DESCRIPTION
The behavior was previously set to do a SELECT FOR UPDATE, but it was
changed to an explicit update in [1]
However, this can deadlock if we post multiple invoices in the same
transaction, this can happen for instance when we register an invoice
and a payment right after, without commiting between the two [2]

In order to prevent a deadlock, we use FOR UPDATE NOWAIT on the document
guiding the sequence (i.e. the journal).

[1] https://github.com/odoo/odoo/commit/ba6ee0b75d66d6f22a592b1b6a7c5158461bec41
[2] https://github.com/odoo/odoo/issues/90465





--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
