### PR TITLE
[FIX] mail: fix default value of date in clock model

### DIFF
--- a/addons/mail/static/src/models/activity_view.js
+++ b/addons/mail/static/src/models/activity_view.js
@@ -74,6 +74,9 @@ registerModel({
             if (!this.activity.dateDeadline) {
                 return clear();
             }
+            if (!this.clockWatcher.clock.date) {
+                return clear();
+            }
             const today = moment(this.clockWatcher.clock.date.getTime()).startOf('day');
             const momentDeadlineDate = moment(auto_str_to_date(this.activity.dateDeadline));
             // true means no rounding

--- a/addons/mail/static/src/models/clock.js
+++ b/addons/mail/static/src/models/clock.js
@@ -17,6 +17,17 @@ registerModel({
     },
     recordMethods: {
         /**
+         * The date is set by a compute rather than using a default value. Thus,
+         * the date set at first is the time of the record creation, and not the
+         * time of the model initialization.
+         *
+         * @private
+         * @returns {Date}
+         */
+        _computeDate() {
+            return new Date();
+        },
+        /**
          * @private
          * @returns {integer}
          */
@@ -40,10 +51,11 @@ registerModel({
     },
     fields: {
         /**
-         * A Date object set at the current date, updated at every tick.
+         * A Date object set to the current date at the time the record is
+         * created, then updated at every tick.
          */
         date: attr({
-            default: new Date(),
+            compute: '_computeDate',
         }),
         /**
          * An integer representing the frequency in milliseconds at which `date`

--- a/addons/mail/static/tests/qunit_suite_tests/models/clock_tests.js
+++ b/addons/mail/static/tests/qunit_suite_tests/models/clock_tests.js
@@ -3,6 +3,8 @@
 import { insertAndReplace } from '@mail/model/model_field_command';
 import { start } from '@mail/../tests/helpers/test_utils';
 
+import { patchDate } from '@web/../tests/helpers/utils';
+
 QUnit.module('mail', {}, function () {
 QUnit.module('models', {}, function () {
 QUnit.module('clock_tests.js');
@@ -21,6 +23,26 @@ QUnit.test('Deleting all the watchers of a clock should result in the deletion o
     assert.notOk(
         clock.exists(),
         "deleting all the watchers of a clock should result in the deletion of the clock itself."
+    );
+});
+
+QUnit.test('Before ticking for the first time, the clock should indicate the date of creation of the record.', async function (assert) {
+    assert.expect(1);
+
+    const { messaging } = await start();
+    // The date is patched AFTER startup, so if the date field in Clock was set
+    // at initialization (which we don't want), it will now look completely
+    // different from the patched date.
+    patchDate(2016, 8, 8, 14, 55, 15, 352);
+
+    const { clock } = messaging.models['ClockWatcher'].insert({
+        clock: insertAndReplace({ frequency: 3600 * 1000 }),
+        qunitTestOwner: insertAndReplace(),
+    });
+    assert.strictEqual(
+        clock.date.getFullYear(), // no need to be more precise than the year
+        2016,
+        "before ticking for the first time, the clock should indicate the date of creation of the record."
     );
 });
 


### PR DESCRIPTION
The first date should be the date of the record creation instead of the time the model was initialized.