### PR TITLE
[IMP] mail, *: replace widget el by target

### DIFF
--- a/addons/mail/static/tests/qunit_suite_tests/chatter_tests.js
+++ b/addons/mail/static/tests/qunit_suite_tests/chatter_tests.js
@@ -13,7 +13,7 @@ QUnit.test('list activity widget with no activity', async function (assert) {
     assert.expect(4);
 
     const pyEnv = await startServer();
-    const { widget: list } = await start({
+    const { target: list } = await start({
         hasView: true,
         View: ListView,
         model: 'res.users',
@@ -28,7 +28,7 @@ QUnit.test('list activity widget with no activity', async function (assert) {
     });
 
     assert.containsOnce(list, '.o_mail_activity .o_activity_color_default');
-    assert.strictEqual(list.$('.o_activity_summary').text(), '');
+    assert.strictEqual(list.querySelector('.o_activity_summary').innerText, '');
 
     assert.verifySteps(['/web/dataset/search_read']);
 });
@@ -56,7 +56,7 @@ QUnit.test('list activity widget with activities', async function (assert) {
         activity_type_id: mailActivityTypeId2,
     });
 
-    const { widget: list } = await start({
+    const { target: list } = await start({
         hasView: true,
         View: ListView,
         model: 'res.users',
@@ -69,13 +69,13 @@ QUnit.test('list activity widget with activities', async function (assert) {
         },
     });
 
-    const $firstRow = list.$('.o_data_row:first');
-    assert.containsOnce($firstRow, '.o_mail_activity .o_activity_color_today.fa-phone');
-    assert.strictEqual($firstRow.find('.o_activity_summary').text(), 'Call with Al');
+    const firstRow = list.querySelector('.o_data_row');
+    assert.containsOnce(firstRow, '.o_mail_activity .o_activity_color_today.fa-phone');
+    assert.strictEqual(firstRow.querySelector('.o_activity_summary').innerText, 'Call with Al');
 
-    const $secondRow = list.$('.o_data_row:nth(1)');
-    assert.containsOnce($secondRow, '.o_mail_activity .o_activity_color_planned.fa-clock-o');
-    assert.strictEqual($secondRow.find('.o_activity_summary').text(), 'Type 2');
+    const secondRow = list.querySelectorAll('.o_data_row')[1];
+    assert.containsOnce(secondRow, '.o_mail_activity .o_activity_color_planned.fa-clock-o');
+    assert.strictEqual(secondRow.querySelector('.o_activity_summary').innerText, 'Type 2');
 
     assert.verifySteps(['/web/dataset/search_read']);
 });
@@ -95,7 +95,7 @@ QUnit.test('list activity widget with exception', async function (assert) {
         activity_exception_icon: 'fa-warning',
     });
 
-    const { widget: list } = await start({
+    const { target: list } = await start({
         hasView: true,
         View: ListView,
         model: 'res.users',
@@ -109,7 +109,7 @@ QUnit.test('list activity widget with exception', async function (assert) {
     });
 
     assert.containsOnce(list, '.o_activity_color_today.text-warning.fa-warning');
-    assert.strictEqual(list.$('.o_activity_summary').text(), 'Warning');
+    assert.strictEqual(list.querySelector('.o_activity_summary').innerText, 'Warning');
 
     assert.verifySteps(['/web/dataset/search_read']);
 });
@@ -146,7 +146,7 @@ QUnit.test('list activity widget: open dropdown', async function (assert) {
         activity_type_id: mailActivityTypeId2,
     });
 
-    const { widget: list } = await start({
+    const { target: list } = await start({
         hasView: true,
         View: ListView,
         model: 'res.users',
@@ -174,21 +174,21 @@ QUnit.test('list activity widget: open dropdown', async function (assert) {
         },
     });
 
-    assert.strictEqual(list.$('.o_activity_summary').text(), 'Call with Al');
+    assert.strictEqual(list.querySelector('.o_activity_summary').innerText, 'Call with Al');
 
     // click on the first record to open it, to ensure that the 'switch_view'
     // assertion is relevant (it won't be opened as there is no action manager,
     // but we'll log the 'switch_view' event)
-    await testUtils.dom.click(list.$('.o_data_cell:first'));
+    await testUtils.dom.click(list.querySelector('.o_data_cell'));
 
     // from this point, no 'switch_view' event should be triggered, as we
     // interact with the activity widget
     assert.step('open dropdown');
-    await testUtils.dom.click(list.$('.o_activity_btn span')); // open the popover
-    await testUtils.dom.click(list.$('.o_mark_as_done:first')); // mark the first activity as done
-    await testUtils.dom.click(list.$('.o_activity_popover_done')); // confirm
+    await testUtils.dom.click(list.querySelector('.o_activity_btn span')); // open the popover
+    await testUtils.dom.click(list.querySelector('.o_mark_as_done')); // mark the first activity as done
+    await testUtils.dom.click(list.querySelector('.o_activity_popover_done')); // confirm
 
-    assert.strictEqual(list.$('.o_activity_summary').text(), 'Meet FP');
+    assert.strictEqual(list.querySelector('.o_activity_summary').innerText, 'Meet FP');
 
     assert.verifySteps([
         '/web/dataset/search_read',
@@ -236,7 +236,7 @@ QUnit.test('list activity exception widget with activity', async function (asser
         activity_exception_decoration: 'warning',
         activity_exception_icon: 'fa-warning',
     });
-    const { widget: list } = await start({
+    const { target: list } = await start({
         hasView: true,
         View: ListView,
         model: 'res.users',
@@ -246,9 +246,9 @@ QUnit.test('list activity exception widget with activity', async function (asser
     });
 
     assert.containsN(list, '.o_data_row', 2, "should have two records");
-    assert.doesNotHaveClass(list.$('.o_data_row:eq(0) .o_activity_exception_cell div'), 'fa-warning',
+    assert.doesNotHaveClass(list.querySelector('.o_data_row .o_activity_exception_cell div'), 'fa-warning',
         "there is no any exception activity on record");
-    assert.hasClass(list.$('.o_data_row:eq(1) .o_activity_exception_cell div'), 'fa-warning',
+    assert.hasClass(list.querySelectorAll('.o_data_row .o_activity_exception_cell div')[1], 'fa-warning',
         "there is an exception on a record");
 });
 
@@ -266,7 +266,7 @@ QUnit.test('fieldmany2many tags email (edition)', async function (assert) {
         partner_ids: [resPartnerId1],
     });
 
-    var { widget: form } = await start({
+    var { target: form } = await start({
         hasView: true,
         View: FormView,
         model: 'mail.message',
@@ -313,10 +313,10 @@ QUnit.test('fieldmany2many tags email (edition)', async function (assert) {
 
     assert.containsN(form, '.o_field_many2manytags[name="partner_ids"] .badge.o_tag_color_0', 2,
         "should contain the second tag");
-    const firstTag = form.$('.o_field_many2manytags[name="partner_ids"] .badge.o_tag_color_0').first();
-    assert.strictEqual(firstTag.find('.o_badge_text').text(), "gold",
+    const firstTag = form.querySelector('.o_field_many2manytags[name="partner_ids"] .badge.o_tag_color_0');
+    assert.strictEqual(firstTag.querySelector('.o_badge_text').innerText, "gold",
         "tag should only show name");
-    assert.hasAttrValue(firstTag.find('.o_badge_text'), 'title', "coucou@petite.perruche",
+    assert.hasAttrValue(firstTag.querySelector('.o_badge_text'), 'title', "coucou@petite.perruche",
         "tag should show email address on mouse hover");
     // should have read resPartnerId2 three times: when opening the dropdown, when opening the modal, and
     // after the save
@@ -335,7 +335,7 @@ QUnit.test('many2many_tags_email widget can load more than 40 records', async fu
         partner_ids: messagePartnerIds,
     });
 
-    const { widget: form } = await start({
+    const { click, target: form } = await start({
         hasView: true,
         View: FormView,
         model: 'mail.message',
@@ -343,17 +343,17 @@ QUnit.test('many2many_tags_email widget can load more than 40 records', async fu
         res_id: mailMessageId1,
     });
 
-    assert.strictEqual(form.$('.o_field_widget[name="partner_ids"] .badge').length, 100);
+    assert.strictEqual(form.querySelectorAll('.o_field_widget[name="partner_ids"] .badge').length, 100);
 
-    await testUtils.form.clickEdit(form);
+    await click('.o_form_button_edit');
 
-    assert.hasClass(form.$('.o_form_view'), 'o_form_editable');
+    assert.hasClass(form.querySelector('.o_form_view'), 'o_form_editable');
 
     // add a record to the relation
     await testUtils.fields.many2one.clickOpenDropdown('partner_ids');
     await testUtils.fields.many2one.clickHighlightedItem('partner_ids');
 
-    assert.strictEqual(form.$('.o_field_widget[name="partner_ids"] .badge').length, 101);
+    assert.strictEqual(form.querySelectorAll('.o_field_widget[name="partner_ids"] .badge').length, 101);
 });
 
 });

--- a/addons/mail/static/tests/qunit_suite_tests/m2x_avatar_user_tests.js
+++ b/addons/mail/static/tests/qunit_suite_tests/m2x_avatar_user_tests.js
@@ -55,7 +55,7 @@ QUnit.module('mail', {}, function () {
         const resPartnerId1 = pyEnv['res.partner'].create({ display_name: 'Partner 1' });
         const resUsersId1 = pyEnv['res.users'].create({ name: "Mario", partner_id: resPartnerId1 });
         const m2xAvatarUserId1 = pyEnv['m2x.avatar.user'].create({ user_ids: [resUsersId1] });
-        const { widget: form } = await start({
+        const { target: form } = await start({
             hasView: true,
             View: FormView,
             model: 'm2x.avatar.user',
@@ -63,7 +63,7 @@ QUnit.module('mail', {}, function () {
             res_id: m2xAvatarUserId1,
         });
 
-        await dom.click(form.$('.o_field_many2manytags.avatar .badge:first .o_m2m_avatar'));
+        await dom.click(form.querySelector('.o_field_many2manytags.avatar .badge .o_m2m_avatar'));
         assert.containsOnce(document.body, '.o_ChatWindow', 'Chat window should be opened');
         assert.strictEqual(
             document.querySelector('.o_ChatWindowHeader_name').textContent,
@@ -73,7 +73,7 @@ QUnit.module('mail', {}, function () {
     });
 
     QUnit.test('many2many_avatar_user in kanban view', async function (assert) {
-        assert.expect(4);
+        assert.expect(5);
 
         const pyEnv = await startServer();
         const resUsersIds = pyEnv['res.users'].create(
@@ -81,7 +81,7 @@ QUnit.module('mail', {}, function () {
         );
         pyEnv['m2x.avatar.user'].create({ user_ids: resUsersIds });
 
-        const { widget: kanban } = await start({
+        const { target: kanban } = await start({
             hasView: true,
             View: KanbanView,
             model: 'm2x.avatar.user',
@@ -106,15 +106,15 @@ QUnit.module('mail', {}, function () {
 
         assert.containsOnce(kanban, '.o_kanban_record .o_field_many2manytags .o_m2m_avatar_empty',
             "should have o_m2m_avatar_empty span");
-        assert.strictEqual(kanban.$('.o_kanban_record .o_field_many2manytags .o_m2m_avatar_empty').text().trim(), "+2",
+        assert.strictEqual(kanban.querySelector('.o_kanban_record .o_field_many2manytags .o_m2m_avatar_empty').innerText.trim(), "+2",
             "should have +2 in o_m2m_avatar_empty");
 
-        kanban.$('.o_kanban_record .o_field_many2manytags .o_m2m_avatar_empty').trigger($.Event('mouseenter'));
+        kanban.querySelector('.o_kanban_record .o_field_many2manytags .o_m2m_avatar_empty').dispatchEvent(new Event('mouseover'));
         await nextTick();
         assert.containsOnce(kanban, '.popover',
             "should open a popover hover on o_m2m_avatar_empty");
-        assert.strictEqual(kanban.$('.popover .popover-body > div').text().trim(), "LuigiTapu",
-            "should have a right text in popover");
+        assert.strictEqual(kanban.querySelector('.popover .popover-body > div').innerText.trim(), 'Luigi', 'should have a right text in popover');
+        assert.strictEqual(kanban.querySelectorAll('.popover .popover-body > div')[1].innerText.trim(), 'Tapu', 'should have a right text in popover');
     });
 
     QUnit.test('many2one_avatar_user widget edited by the smart action "Assign to..."', async function (assert) {
@@ -308,7 +308,7 @@ QUnit.module('mail', {}, function () {
         const pyEnv = await startServer();
         const resUsersId1 = pyEnv['res.users'].create({ name: "Mario" });
         const m2xAvatarUserId1 = pyEnv['m2x.avatar.user'].create({ user_id: resUsersId1 });
-        const { widget: list } = await start({
+        const { target: list } = await start({
             hasView: true,
             View: ListView,
             model: 'm2x.avatar.user',
@@ -316,7 +316,7 @@ QUnit.module('mail', {}, function () {
             res_id: m2xAvatarUserId1,
         });
         assert.strictEqual(
-            list.$('.o_m2o_avatar > img').data('src'),
+            list.querySelector('.o_m2o_avatar > img').getAttribute('data-src'),
             `/web/image/res.users/${resUsersId1}/avatar_128`,
             'Should have correct avatar image'
         );
@@ -328,7 +328,7 @@ QUnit.module('mail', {}, function () {
         const pyEnv = await startServer();
         const resUsersId1 = pyEnv['res.users'].create({ name: "Mario" });
         const m2xAvatarUserId1 = pyEnv['m2x.avatar.user'].create({ user_id: resUsersId1 });
-        const { widget: kanban } = await start({
+        const { target: kanban } = await start({
             hasView: true,
             View: KanbanView,
             model: 'm2x.avatar.user',
@@ -344,7 +344,7 @@ QUnit.module('mail', {}, function () {
             res_id: m2xAvatarUserId1,
         });
         assert.strictEqual(
-            kanban.$('.o_m2o_avatar > img').data('src'),
+            kanban.querySelector('.o_m2o_avatar > img').getAttribute('data-src'),
             `/web/image/res.users/${resUsersId1}/avatar_128`,
             'Should have correct avatar image'
         );
@@ -356,7 +356,7 @@ QUnit.module('mail', {}, function () {
         const pyEnv = await startServer();
         const resUsersId1 = pyEnv['res.users'].create({ name: "Mario" });
         const m2xAvatarUserId1 = pyEnv['m2x.avatar.user'].create({ user_ids: [resUsersId1] });
-        const { widget: form } = await start({
+        const { target: form } = await start({
             hasView: true,
             View: FormView,
             model: 'm2x.avatar.user',
@@ -364,7 +364,7 @@ QUnit.module('mail', {}, function () {
             res_id: m2xAvatarUserId1,
         });
         assert.strictEqual(
-            form.$('.o_field_many2manytags.avatar.o_field_widget .badge:first img').data('src'),
+            form.querySelector('.o_field_many2manytags.avatar.o_field_widget .badge img').getAttribute('data-src'),
             `/web/image/res.users/${resUsersId1}/avatar_128`,
             'Should have correct avatar image'
         );

--- a/addons/test_mail/static/tests/activity_tests.js
+++ b/addons/test_mail/static/tests/activity_tests.js
@@ -107,7 +107,7 @@ QUnit.test('activity view: simple activity rendering', async function (assert) {
             "should do a do_action with correct parameters");
             event.data.options.on_close();
     };
-    var { widget: activity } = await start({
+    var { target } = await start({
         View: ActivityView,
         hasView: true,
         model: 'mail.test.activity',
@@ -122,37 +122,38 @@ QUnit.test('activity view: simple activity rendering', async function (assert) {
             do_action: actionServiceInterceptor,
         },
     });
+    const $activity = $(target);
 
-    assert.containsOnce(activity, 'table',
+    assert.containsOnce($activity, 'table',
         'should have a table');
-    var $th1 = activity.$('table thead tr:first th:nth-child(2)');
+    var $th1 = $activity.find('table thead tr:first th:nth-child(2)');
     assert.containsOnce($th1, 'span:first:contains(Email)', 'should contain "Email" in header of first column');
     assert.containsOnce($th1, '.o_kanban_counter', 'should contain a progressbar in header of first column');
     assert.hasAttrValue($th1.find('.o_kanban_counter_progress .progress-bar:first'), 'data-original-title', '1 Planned',
         'the counter progressbars should be correctly displayed');
     assert.hasAttrValue($th1.find('.o_kanban_counter_progress .progress-bar:nth-child(2)'), 'data-original-title', '1 Today',
         'the counter progressbars should be correctly displayed');
-    var $th2 = activity.$('table thead tr:first th:nth-child(3)');
+    var $th2 = $activity.find('table thead tr:first th:nth-child(3)');
     assert.containsOnce($th2, 'span:first:contains(Call)', 'should contain "Call" in header of second column');
     assert.hasAttrValue($th2.find('.o_kanban_counter_progress .progress-bar:nth-child(3)'), 'data-original-title', '1 Overdue',
         'the counter progressbars should be correctly displayed');
-    assert.containsNone(activity, 'table thead tr:first th:nth-child(4) .o_kanban_counter',
+    assert.containsNone($activity, 'table thead tr:first th:nth-child(4) .o_kanban_counter',
         'should not contain a progressbar in header of 3rd column');
-    assert.ok(activity.$('table tbody tr:first td:first:contains(Office planning)').length,
+    assert.ok($activity.find('table tbody tr:first td:first:contains(Office planning)').length,
         'should contain "Office planning" in first colum of first row');
-    assert.ok(activity.$('table tbody tr:nth-child(2) td:first:contains(Meeting Room Furnitures)').length,
+    assert.ok($activity.find('table tbody tr:nth-child(2) td:first:contains(Meeting Room Furnitures)').length,
         'should contain "Meeting Room Furnitures" in first colum of second row');
 
     var today = activityDateFormat(new Date());
 
-    assert.ok(activity.$('table tbody tr:first td:nth-child(2).today .o_closest_deadline:contains(' + today + ')').length,
+    assert.ok($activity.find('table tbody tr:first td:nth-child(2).today .o_closest_deadline:contains(' + today + ')').length,
         'should contain an activity for today in second cell of first line ' + today);
     var td = 'table tbody tr:nth-child(1) td.o_activity_empty_cell';
-    assert.containsN(activity, td, 2, 'should contain an empty cell as no activity scheduled yet.');
+    assert.containsN($activity, td, 2, 'should contain an empty cell as no activity scheduled yet.');
 
     // schedule an activity (this triggers a do_action)
-    await testUtils.fields.editAndTrigger(activity.$(td + ':first'), null, ['mouseenter', 'click']);
-    assert.containsOnce(activity, 'table tfoot tr .o_record_selector',
+    await testUtils.fields.editAndTrigger($activity.find(td + ':first'), null, ['mouseenter', 'click']);
+    assert.containsOnce($activity, 'table tfoot tr .o_record_selector',
         'should contain search more selector to choose the record to schedule an activity for it');
 });
 
@@ -162,7 +163,7 @@ QUnit.test('activity view: no content rendering', async function (assert) {
     // reset incompatible setup
     pyEnv['mail.activity.type'].unlink(pyEnv['mail.activity.type'].search([]));
 
-    var { widget: activity } = await start({
+    var { target } = await start({
         hasView: true,
         View: ActivityView,
         model: 'mail.test.activity',
@@ -174,10 +175,11 @@ QUnit.test('activity view: no content rendering', async function (assert) {
                 '</templates>' +
             '</activity>',
     });
+    const $activity = $(target);
 
-    assert.containsOnce(activity, '.o_view_nocontent',
+    assert.containsOnce($activity, '.o_view_nocontent',
         "should display the no content helper");
-    assert.strictEqual(activity.$('.o_view_nocontent .o_view_nocontent_empty_folder').text().trim(),
+    assert.strictEqual($activity.find('.o_view_nocontent .o_view_nocontent_empty_folder').text().trim(),
         "No data to display",
         "should display the no content helper text");
 });
@@ -187,7 +189,7 @@ QUnit.test('activity view: batch send mail on activity', async function (assert)
 
     const mailTestActivityIds = pyEnv['mail.test.activity'].search([]);
     const mailTemplateIds = pyEnv['mail.template'].search([]);
-    var { widget: activity } = await start({
+    var { target } = await start({
         hasView: true,
         View: ActivityView,
         model: 'mail.test.activity',
@@ -206,19 +208,20 @@ QUnit.test('activity view: batch send mail on activity', async function (assert)
             return this._super.apply(this, arguments);
         },
     });
-    assert.notOk(activity.$('table thead tr:first th:nth-child(2) span:nth-child(2) .dropdown-menu.show').length,
+    const $activity = $(target);
+    assert.notOk($activity.find('table thead tr:first th:nth-child(2) span:nth-child(2) .dropdown-menu.show').length,
         'dropdown shouldn\'t be displayed');
 
-    testUtils.dom.click(activity.$('table thead tr:first th:nth-child(2) span:nth-child(2) i.fa-ellipsis-v'));
-    assert.ok(activity.$('table thead tr:first th:nth-child(2) span:nth-child(2) .dropdown-menu.show').length,
+    testUtils.dom.click($activity.find('table thead tr:first th:nth-child(2) span:nth-child(2) i.fa-ellipsis-v'));
+    assert.ok($activity.find('table thead tr:first th:nth-child(2) span:nth-child(2) .dropdown-menu.show').length,
         'dropdown should have appeared');
 
-    testUtils.dom.click(activity.$('table thead tr:first th:nth-child(2) span:nth-child(2) .dropdown-menu.show .o_send_mail_template:contains(Template2)'));
-    assert.notOk(activity.$('table thead tr:first th:nth-child(2) span:nth-child(2) .dropdown-menu.show').length,
+    testUtils.dom.click($activity.find('table thead tr:first th:nth-child(2) span:nth-child(2) .dropdown-menu.show .o_send_mail_template:contains(Template2)'));
+    assert.notOk($activity.find('table thead tr:first th:nth-child(2) span:nth-child(2) .dropdown-menu.show').length,
         'dropdown shouldn\'t be displayed');
 
-    testUtils.dom.click(activity.$('table thead tr:first th:nth-child(2) span:nth-child(2) i.fa-ellipsis-v'));
-    testUtils.dom.click(activity.$('table thead tr:first th:nth-child(2) span:nth-child(2) .dropdown-menu.show .o_send_mail_template:contains(Template1)'));
+    testUtils.dom.click($activity.find('table thead tr:first th:nth-child(2) span:nth-child(2) i.fa-ellipsis-v'));
+    testUtils.dom.click($activity.find('table thead tr:first th:nth-child(2) span:nth-child(2) .dropdown-menu.show .o_send_mail_template:contains(Template1)'));
     assert.verifySteps([
         `[[${mailTestActivityIds[0]},${mailTestActivityIds[1]}],${mailTemplateIds[1]}]`, // send mail template 1 on mail.test.activity 1 and 2
         `[[${mailTestActivityIds[0]},${mailTestActivityIds[1]}],${mailTemplateIds[0]}]`, // send mail template 2 on mail.test.activity 1 and 2
@@ -285,8 +288,9 @@ QUnit.test('activity view: activity widget', async function (assert) {
         },
     };
 
-    var { widget: activity } = await start(params);
-    var today = activity.$('table tbody tr:first td:nth-child(2).today');
+    var { target } = await start(params);
+    const activity = $(target);
+    var today = activity.find('table tbody tr:first td:nth-child(2).today');
     var dropdown = today.find('.dropdown-menu.o_activity');
 
     await testUtils.dom.click(today.find('.o_closest_deadline'));
@@ -299,7 +303,7 @@ QUnit.test('activity view: activity widget', async function (assert) {
 
     await testUtils.dom.click(dropdown.find('.o_activity_title_entry[data-activity-id="2"]:first .o_activity_template_preview'));
     await testUtils.dom.click(dropdown.find('.o_activity_title_entry[data-activity-id="2"]:first .o_activity_template_send'));
-    var overdue = activity.$('table tbody tr:first td:nth-child(3).overdue');
+    var overdue = activity.find('table tbody tr:first td:nth-child(3).overdue');
     await testUtils.dom.click(overdue.find('.o_closest_deadline'));
     dropdown = overdue.find('.dropdown-menu.o_activity');
     assert.notOk(dropdown.find('.o_activity_title div div div:first span').length,
@@ -390,7 +394,7 @@ QUnit.test('activity view: search more to schedule an activity for a record of a
                 "should execute an action with correct params");
             ev.data.options.on_close();
     };
-    var { widget: activity } = await start({
+    var { target } = await start({
         hasView: true,
         View: ActivityView,
         model: 'mail.test.activity',
@@ -415,10 +419,11 @@ QUnit.test('activity view: search more to schedule an activity for a record of a
             do_action: actionServiceInterceptor,
         },
     });
+    const $activity = $(target);
 
-    assert.containsOnce(activity, 'table tfoot tr .o_record_selector',
+    assert.containsOnce($activity, 'table tfoot tr .o_record_selector',
         'should contain search more selector to choose the record to schedule an activity for it');
-    await testUtils.dom.click(activity.$('table tfoot tr .o_record_selector'));
+    await testUtils.dom.click($activity.find('table tfoot tr .o_record_selector'));
     // search create dialog
     var $modal = $('.modal-lg');
     assert.strictEqual($modal.find('.o_data_row').length, 3, "all tasks should be available to select");

--- a/addons/test_mail/static/tests/tracking_value_tests.js
+++ b/addons/test_mail/static/tests/tracking_value_tests.js
@@ -46,9 +46,9 @@ QUnit.test('basic rendering of tracking value (float type)', async function (ass
 
     const pyEnv = await startServer();
     const mailTestTrackAllId1 = pyEnv['mail.test.track.all'].create({ float_field: 12.30 });
-    const { click, widget: form } = await this.start({ res_id: mailTestTrackAllId1 });
+    const { click, target: form } = await this.start({ res_id: mailTestTrackAllId1 });
 
-    await testUtils.fields.editInput(form.$('input[name=float_field]'), 45.67);
+    await testUtils.fields.editInput(form.querySelector('input[name=float_field]'), 45.67);
     await click('.o_form_button_save');
     assert.containsOnce(
         document.body,
@@ -97,9 +97,9 @@ QUnit.test('rendering of tracked field of type float: from non-0 to 0', async fu
 
     const pyEnv = await startServer();
     const mailTestTrackAllId1 = pyEnv['mail.test.track.all'].create({ float_field: 1 });
-    const { click, widget: form } = await this.start({ res_id: mailTestTrackAllId1 });
+    const { click, target: form } = await this.start({ res_id: mailTestTrackAllId1 });
 
-    await testUtils.fields.editInput(form.$('input[name=float_field]'), 0);
+    await testUtils.fields.editInput(form.querySelector('input[name=float_field]'), 0);
     await click('.o_form_button_save');
     assert.strictEqual(
         document.querySelector('.o_TrackingValue').textContent,
@@ -113,9 +113,9 @@ QUnit.test('rendering of tracked field of type float: from 0 to non-0', async fu
 
     const pyEnv = await startServer();
     const mailTestTrackAllId1 = pyEnv['mail.test.track.all'].create({ float_field: 0 });
-    const { click, widget: form } = await this.start({ res_id: mailTestTrackAllId1 });
+    const { click, target: form } = await this.start({ res_id: mailTestTrackAllId1 });
 
-    await testUtils.fields.editInput(form.$('input[name=float_field]'), 1);
+    await testUtils.fields.editInput(form.querySelector('input[name=float_field]'), 1);
     await click('.o_form_button_save');
     assert.strictEqual(
         document.querySelector('.o_TrackingValue').textContent,
@@ -129,9 +129,9 @@ QUnit.test('rendering of tracked field of type integer: from non-0 to 0', async 
 
     const pyEnv = await startServer();
     const mailTestTrackAllId1 = pyEnv['mail.test.track.all'].create({ integer_field: 1 });
-    const { click, widget: form } = await this.start({ res_id: mailTestTrackAllId1 });
+    const { click, target: form } = await this.start({ res_id: mailTestTrackAllId1 });
 
-    await testUtils.fields.editInput(form.$('input[name=integer_field]'), 0);
+    await testUtils.fields.editInput(form.querySelector('input[name=integer_field]'), 0);
     await click('.o_form_button_save');
     assert.strictEqual(
         document.querySelector('.o_TrackingValue').textContent,
@@ -145,9 +145,9 @@ QUnit.test('rendering of tracked field of type integer: from 0 to non-0', async 
 
     const pyEnv = await startServer();
     const mailTestTrackAllId1 = pyEnv['mail.test.track.all'].create({ integer_field: 0 });
-    const { click, widget: form } = await this.start({ res_id: mailTestTrackAllId1 });
+    const { click, target: form } = await this.start({ res_id: mailTestTrackAllId1 });
 
-    await testUtils.fields.editInput(form.$('input[name=integer_field]'), 1);
+    await testUtils.fields.editInput(form.querySelector('input[name=integer_field]'), 1);
     await click('.o_form_button_save');
     assert.strictEqual(
         document.querySelector('.o_TrackingValue').textContent,
@@ -161,9 +161,9 @@ QUnit.test('rendering of tracked field of type monetary: from non-0 to 0', async
 
     const pyEnv = await startServer();
     const mailTestTrackAllId1 = pyEnv['mail.test.track.all'].create({ monetary_field: 1 });
-    const { click, widget: form } = await this.start({ res_id: mailTestTrackAllId1 });
+    const { click, target: form } = await this.start({ res_id: mailTestTrackAllId1 });
 
-    await testUtils.fields.editSelect(form.$('div[name=monetary_field] > input'), 0);
+    await testUtils.fields.editSelect(form.querySelector('div[name=monetary_field] > input'), 0);
     await click('.o_form_button_save');
     assert.strictEqual(
         document.querySelector('.o_TrackingValue').textContent,
@@ -177,9 +177,9 @@ QUnit.test('rendering of tracked field of type monetary: from 0 to non-0', async
 
     const pyEnv = await startServer();
     const mailTestTrackAllId1 = pyEnv['mail.test.track.all'].create({ monetary_field: 0 });
-    const { click, widget: form } = await this.start({ res_id: mailTestTrackAllId1 });
+    const { click, target: form } = await this.start({ res_id: mailTestTrackAllId1 });
 
-    await testUtils.fields.editSelect(form.$('div[name=monetary_field] > input'), 1);
+    await testUtils.fields.editSelect(form.querySelector('div[name=monetary_field] > input'), 1);
     await click('.o_form_button_save');
     assert.strictEqual(
         document.querySelector('.o_TrackingValue').textContent,
@@ -193,9 +193,9 @@ QUnit.test('rendering of tracked field of type boolean: from true to false', asy
 
     const pyEnv = await startServer();
     const mailTestTrackAllId1 = pyEnv['mail.test.track.all'].create({ boolean_field: true });
-    const { click, widget: form } = await this.start({ res_id: mailTestTrackAllId1 });
+    const { click, target: form } = await this.start({ res_id: mailTestTrackAllId1 });
 
-    form.$('.custom-checkbox input').click();
+    form.querySelector('.custom-checkbox input').click();
     await click('.o_form_button_save');
     assert.strictEqual(
         document.querySelector('.o_TrackingValue').textContent,
@@ -209,9 +209,9 @@ QUnit.test('rendering of tracked field of type boolean: from false to true', asy
 
     const pyEnv = await startServer();
     const mailTestTrackAllId1 = pyEnv['mail.test.track.all'].create({});
-    const { click, widget: form } = await this.start({ res_id: mailTestTrackAllId1 });
+    const { click, target: form } = await this.start({ res_id: mailTestTrackAllId1 });
 
-    form.$('.custom-checkbox input').click();
+    form.querySelector('.custom-checkbox input').click();
     await click('.o_form_button_save');
     assert.strictEqual(
         document.querySelector('.o_TrackingValue').textContent,
@@ -225,9 +225,9 @@ QUnit.test('rendering of tracked field of type char: from a string to empty stri
 
     const pyEnv = await startServer();
     const mailTestTrackAllId1 = pyEnv['mail.test.track.all'].create({ char_field: 'Marc' });
-    const { click, widget: form } = await this.start({ res_id: mailTestTrackAllId1 });
+    const { click, target: form } = await this.start({ res_id: mailTestTrackAllId1 });
 
-    await testUtils.fields.editInput(form.$('input[name=char_field]'), '');
+    await testUtils.fields.editInput(form.querySelector('input[name=char_field]'), '');
     await click('.o_form_button_save');
     assert.strictEqual(
         document.querySelector('.o_TrackingValue').textContent,
@@ -241,9 +241,9 @@ QUnit.test('rendering of tracked field of type char: from empty string to a stri
 
     const pyEnv = await startServer();
     const mailTestTrackAllId1 = pyEnv['mail.test.track.all'].create({ char_field: '' });
-    const { click, widget: form } = await this.start({ res_id: mailTestTrackAllId1 });
+    const { click, target: form } = await this.start({ res_id: mailTestTrackAllId1 });
 
-    await testUtils.fields.editInput(form.$('input[name=char_field]'), 'Marc');
+    await testUtils.fields.editInput(form.querySelector('input[name=char_field]'), 'Marc');
     await click('.o_form_button_save');
     assert.strictEqual(
         document.querySelector('.o_TrackingValue').textContent,
@@ -257,9 +257,9 @@ QUnit.test('rendering of tracked field of type date: from no date to a set date'
 
     const pyEnv = await startServer();
     const mailTestTrackAllId1 = pyEnv['mail.test.track.all'].create({ date_field: false });
-    const { click, widget: form } = await this.start({ res_id: mailTestTrackAllId1 });
+    const { click, target: form } = await this.start({ res_id: mailTestTrackAllId1 });
 
-    await testUtils.fields.editAndTrigger(form.$('.o_datepicker[name=date_field] .o_datepicker_input'), '12/14/2018', ['change']);
+    await testUtils.fields.editAndTrigger(form.querySelector('.o_datepicker[name=date_field] .o_datepicker_input'), '12/14/2018', ['change']);
     await click('.o_form_button_save');
     assert.strictEqual(
         document.querySelector('.o_TrackingValue').textContent,
@@ -273,9 +273,9 @@ QUnit.test('rendering of tracked field of type date: from a set date to no date'
 
     const pyEnv = await startServer();
     const mailTestTrackAllId1 = pyEnv['mail.test.track.all'].create({ date_field: '2018-12-14' });
-    const { click, widget: form } = await this.start({ res_id: mailTestTrackAllId1 });
+    const { click, target: form } = await this.start({ res_id: mailTestTrackAllId1 });
 
-    await testUtils.fields.editAndTrigger(form.$('.o_datepicker[name=date_field] .o_datepicker_input'), '', ['change']);
+    await testUtils.fields.editAndTrigger(form.querySelector('.o_datepicker[name=date_field] .o_datepicker_input'), '', ['change']);
     await click('.o_form_button_save');
     assert.strictEqual(
         document.querySelector('.o_TrackingValue').textContent,
@@ -289,9 +289,9 @@ QUnit.test('rendering of tracked field of type datetime: from no date and time t
 
     const pyEnv = await startServer();
     const mailTestTrackAllId1 = pyEnv['mail.test.track.all'].create({ datetime_field: false });
-    const { click, widget: form } = await this.start({ res_id: mailTestTrackAllId1 });
+    const { click, target: form } = await this.start({ res_id: mailTestTrackAllId1 });
 
-    await testUtils.fields.editAndTrigger(form.$('.o_datepicker[name=datetime_field] .o_datepicker_input'), '12/14/2018 13:42:28', ['change']);
+    await testUtils.fields.editAndTrigger(form.querySelector('.o_datepicker[name=datetime_field] .o_datepicker_input'), '12/14/2018 13:42:28', ['change']);
     await click('.o_form_button_save');
     assert.strictEqual(
         document.querySelector('.o_TrackingValue').textContent,
@@ -305,9 +305,9 @@ QUnit.test('rendering of tracked field of type datetime: from a set date and tim
 
     const pyEnv = await startServer();
     const mailTestTrackAllId1 = pyEnv['mail.test.track.all'].create({ datetime_field: '2018-12-14 13:42:28 ' });
-    const { click, widget: form } = await this.start({ res_id: mailTestTrackAllId1 });
+    const { click, target: form } = await this.start({ res_id: mailTestTrackAllId1 });
 
-    await testUtils.fields.editAndTrigger(form.$('.o_datepicker[name=datetime_field] .o_datepicker_input'), '', ['change']);
+    await testUtils.fields.editAndTrigger(form.querySelector('.o_datepicker[name=datetime_field] .o_datepicker_input'), '', ['change']);
     await click('.o_form_button_save');
     assert.strictEqual(
         document.querySelector('.o_TrackingValue').textContent,
@@ -321,9 +321,9 @@ QUnit.test('rendering of tracked field of type text: from some text to empty', a
 
     const pyEnv = await startServer();
     const mailTestTrackAllId1 = pyEnv['mail.test.track.all'].create({ text_field: 'Marc' });
-    const { click, widget: form } = await this.start({ res_id: mailTestTrackAllId1 });
+    const { click, target: form } = await this.start({ res_id: mailTestTrackAllId1 });
 
-    await testUtils.fields.editInput(form.$('textarea[name=text_field]'), '');
+    await testUtils.fields.editInput(form.querySelector('textarea[name=text_field]'), '');
     await click('.o_form_button_save');
     assert.strictEqual(
         document.querySelector('.o_TrackingValue').textContent,
@@ -337,9 +337,9 @@ QUnit.test('rendering of tracked field of type text: from empty to some text', a
 
     const pyEnv = await startServer();
     const mailTestTrackAllId1 = pyEnv['mail.test.track.all'].create({ text_field: '' });
-    const { click, widget: form } = await this.start({ res_id: mailTestTrackAllId1 });
+    const { click, target: form } = await this.start({ res_id: mailTestTrackAllId1 });
 
-    await testUtils.fields.editInput(form.$('textarea[name=text_field]'), 'Marc');
+    await testUtils.fields.editInput(form.querySelector('textarea[name=text_field]'), 'Marc');
     await click('.o_form_button_save');
     assert.strictEqual(
         document.querySelector('.o_TrackingValue').textContent,
@@ -353,9 +353,9 @@ QUnit.test('rendering of tracked field of type selection: from a selection to no
 
     const pyEnv = await startServer();
     const mailTestTrackAllId1 = pyEnv['mail.test.track.all'].create({ selection_field: 'first' });
-    const { click, widget: form } = await this.start({ res_id: mailTestTrackAllId1 });
+    const { click, target: form } = await this.start({ res_id: mailTestTrackAllId1 });
 
-    await testUtils.fields.editSelect(form.$('select[name=selection_field]'), '');
+    await testUtils.fields.editSelect(form.querySelector('select[name=selection_field]'), '');
     await click('.o_form_button_save');
     assert.strictEqual(
         document.querySelector('.o_TrackingValue').textContent,
@@ -369,9 +369,9 @@ QUnit.test('rendering of tracked field of type selection: from no selection to a
 
     const pyEnv = await startServer();
     const mailTestTrackAllId1 = pyEnv['mail.test.track.all'].create({});
-    const { click, widget: form } = await this.start({ res_id: mailTestTrackAllId1 });
+    const { click, target: form } = await this.start({ res_id: mailTestTrackAllId1 });
 
-    await testUtils.fields.editSelect(form.$('select[name=selection_field]'), '"first"');
+    await testUtils.fields.editSelect(form.querySelector('select[name=selection_field]'), '"first"');
     await click('.o_form_button_save');
     assert.strictEqual(
         document.querySelector('.o_TrackingValue').textContent,
@@ -386,9 +386,9 @@ QUnit.test('rendering of tracked field of type many2one: from having a related r
     const pyEnv = await startServer();
     const resPartnerId1 = pyEnv['res.partner'].create({ display_name: 'Marc' });
     const mailTestTrackAllId1 = pyEnv['mail.test.track.all'].create({ many2one_field_id: resPartnerId1 });
-    const { click, widget: form } = await this.start({ res_id: mailTestTrackAllId1 });
+    const { click, target: form } = await this.start({ res_id: mailTestTrackAllId1 });
 
-    await testUtils.fields.editAndTrigger(form.$('.o_field_many2one_selection input'), '', ['keyup']);
+    await testUtils.fields.editAndTrigger(form.querySelector('.o_field_many2one_selection input'), '', ['keyup']);
     await click('.o_form_button_save');
     assert.strictEqual(
         document.querySelector('.o_TrackingValue').textContent,


### PR DESCRIPTION
*: hr, test_mail.

This PR prepares the ground for the one introducing the new environment in the
discuss app. Indeed, the createWebClient helper will be used instead of createView/Widget
thus the returned value won't be a Widget anymore but a DOM element. This change impacts
they way the tests were written: JQuery functions have to be transformed to native JavaScript
ones. In order to reduce the noise in the main PR, those changes are done now.

task-2582313

enterprise: https://github.com/odoo/enterprise/pull/27313