### PR TITLE
[FIX] hr_holidays: right repsonsible for leave approval activity

### DIFF
--- a/addons/hr_holidays/models/hr_leave_allocation.py
+++ b/addons/hr_holidays/models/hr_leave_allocation.py
@@ -516,7 +516,7 @@ class HolidaysAllocation(models.Model):
             partners_to_subscribe = set()
             if holiday.employee_id.user_id:
                 partners_to_subscribe.add(holiday.employee_id.user_id.partner_id.id)
-            if holiday.validation_type == 'hr':
+            if holiday.validation_type == 'officer':
                 partners_to_subscribe.add(holiday.employee_id.parent_id.user_id.partner_id.id)
                 partners_to_subscribe.add(holiday.employee_id.leave_manager_id.partner_id.id)
             holiday.message_subscribe(partner_ids=tuple(partners_to_subscribe))
@@ -701,10 +701,7 @@ class HolidaysAllocation(models.Model):
         self.ensure_one()
         responsible = self.env.user
 
-        if self.validation_type == 'manager' or (self.validation_type == 'both' and self.state == 'confirm'):
-            if self.employee_id.leave_manager_id:
-                responsible = self.employee_id.leave_manager_id
-        elif self.validation_type == 'hr' or (self.validation_type == 'both' and self.state == 'validate1'):
+        if self.validation_type == 'officer':
             if self.holiday_status_id.responsible_id:
                 responsible = self.holiday_status_id.responsible_id
 

--- a/addons/hr_holidays/views/hr_leave_type_views.xml
+++ b/addons/hr_holidays/views/hr_leave_type_views.xml
@@ -51,7 +51,8 @@
                             <field name="leave_validation_type" string="Approval" widget="radio"/>
                             <field name="responsible_id" domain="[('share', '=', False)]"
                                 attrs="{
-                                'invisible': [('leave_validation_type', 'in', ['no_validation', 'manager']), '|', ('requires_allocation', '=', 'no'), ('allocation_validation_type', '=', 'officer')]}"/>
+                                'invisible': [('leave_validation_type', 'in', ['no_validation', 'manager']), '|', ('requires_allocation', '=', 'no'), ('allocation_validation_type', '!=', 'officer')],
+                                'required': ['|',('leave_validation_type', 'in', ['both', 'hr']), ('requires_allocation', '=', 'yes'), ('allocation_validation_type', '=', 'officer')]}"/>
                             <field name="request_unit" widget="radio-inline"/>
                             <field name="support_document" string="Allow To Join Supporting Document" />
                             <field name="time_type" required="1"/>


### PR DESCRIPTION
Steps to reproduce:
- Create a Time off Type for which an allocation can be requested
by the employee and approved by the time off officer
- Set a Time Off approver on the employee
- Create an allocation

Current behavior:
The allocation approval activity is assigned to the employee

Expected behavior:
The allocation approval activity is assigned to the time off officer

Problem
The function _get_responsible_for_approval used the validation types
of v14 instead of the one of v15.

XML modification:
While using the form for the time off types I notice that the logic
was incomplete for the "responsible time off officer" invisible and
required fields. the field can not be invisible if the approved by
time off officer is set and it should be required to avoid errors.

opw-2849972
