### PR TITLE
[IMP] hr: improves department kanban view

### DIFF
--- a/addons/hr/static/src/scss/hr.scss
+++ b/addons/hr/static/src/scss/hr.scss
@@ -41,7 +41,10 @@
 .o_kanban_dashboard.o_hr_department_kanban {
     &.o_kanban_ungrouped {
         .o_kanban_record {
-            width: 350px;
+            width: 450px;
+            .o_kanban_primary_bottom.bottom_block {
+                background-color: unset !important;
+            }
         }
     }
     .o_kanban_group {

--- a/addons/hr/views/hr_department_views.xml
+++ b/addons/hr/views/hr_department_views.xml
@@ -66,13 +66,18 @@
                     <field name="company_id"/>
                     <field name="manager_id"/>
                     <field name="color"/>
+                    <field name="total_employee"/>
                     <templates>
                         <t t-name="kanban-box">
                             <div t-attf-class="#{!selection_mode ? kanban_color(record.color.raw_value) : ''}">
                                 <div t-attf-class="o_kanban_card_header">
                                     <div class="o_kanban_card_header_title">
                                         <div class="o_primary"><a type="edit"><field name="name"/></a></div>
-                                        <div class="o_secondary"><field name="company_id" groups="base.group_multi_company"/></div>
+                                        <div class="o_secondary" groups="base.group_multi_company">
+                                            <small>
+                                                <i class="fa fa-building-o" role="img" aria-label="Company" title="Company"/> <field name="company_id"/>
+                                            </small>
+                                        </div>
                                     </div>
                                     <div class="o_kanban_manage_button_section" t-if="!selection_mode">
                                         <a class="o_kanban_manage_toggle_button" href="#"><i class="fa fa-ellipsis-v" role="img" aria-label="Manage" title="Manage"/></a>
@@ -80,10 +85,12 @@
                                 </div>
                                 <div class="container o_kanban_card_content" t-if="!selection_mode">
                                     <div class="row o_kanban_card_upper_content">
-                                        <div class="col-4 o_kanban_primary_left">
-                                            <button class="btn btn-primary" name="%(act_employee_from_department)d" type="action">Employees</button>
+                                        <div class="col-6 o_kanban_primary_left">
+                                            <button class="btn btn-primary" name="%(act_employee_from_department)d" type="action">
+                                                <t t-out="record.total_employee.raw_value"/> Employees
+                                            </button>
                                         </div>
-                                        <div class="col-8 o_kanban_primary_right">
+                                        <div class="col-6 o_kanban_primary_right">
                                         </div>
                                     </div>
                                 </div>

--- a/addons/hr_expense/views/hr_department_views.xml
+++ b/addons/hr_expense/views/hr_department_views.xml
@@ -13,13 +13,10 @@
 
                 <xpath expr="//div[hasclass('o_kanban_primary_right')]" position="inside">
                     <div t-if="record.expense_sheets_to_approve_count.raw_value > 0" class="row ml16">
-                        <div class="col-9">
+                        <div class="col">
                             <a name="%(action_hr_expense_sheet_department_to_approve)d" type="action">
-                                Expense Reports
+                                <t t-esc="record.expense_sheets_to_approve_count.raw_value"/> Expense Reports
                             </a>
-                        </div>
-                        <div class="col-3 text-right">
-                            <t t-esc="record.expense_sheets_to_approve_count.raw_value"/>
                         </div>
                     </div>
                 </xpath>

--- a/addons/hr_holidays/views/hr_views.xml
+++ b/addons/hr_holidays/views/hr_views.xml
@@ -30,23 +30,17 @@
 
                 <xpath expr="//div[hasclass('o_kanban_primary_right')]" position="inside">
                     <div t-if="record.leave_to_approve_count.raw_value > 0" class="row ml16">
-                        <div class="col-9">
+                        <div class="col">
                             <a name="%(hr_leave_action_action_approve_department)d" type="action">
-                                Time Off Requests
+                                <field name="leave_to_approve_count"/> Time Off Requests
                             </a>
-                        </div>
-                        <div class="col-3 text-right">
-                            <field name="leave_to_approve_count"/>
                         </div>
                     </div>
                     <div t-if="record.allocation_to_approve_count.raw_value > 0" class="row ml16">
-                        <div class="col-9">
+                        <div class="col">
                             <a name="%(hr_leave_allocation_action_approve_department)d" type="action">
-                                Allocation Requests
+                                <field name="allocation_to_approve_count"/> Allocation Requests
                             </a>
-                        </div>
-                        <div class="col-3 text-right">
-                            <field name="allocation_to_approve_count"/>
                         </div>
                     </div>
                 </xpath>

--- a/addons/hr_recruitment/views/hr_department_views.xml
+++ b/addons/hr_recruitment/views/hr_department_views.xml
@@ -15,13 +15,10 @@
 
                 <xpath expr="//div[hasclass('o_kanban_primary_right')]" position="inside">
                     <div t-if="record.new_applicant_count.raw_value > 0" class="row ml16">
-                        <div class="col-9">
+                        <div class="col">
                             <a name="%(hr_applicant_action_from_department)d" type="action">
-                                New Applicants
+                                <field name="new_applicant_count"/> New Applicants
                             </a>
-                        </div>
-                        <div class="col-3 text-right">
-                            <field name="new_applicant_count"/>
                         </div>
                     </div>
                 </xpath>


### PR DESCRIPTION
The recruitment kanban view was redesigned and it looks good, so it was
decided to implement the same design on the department kanban view. This commit
adds the number of employees to the "Employees" button and makes the kanban
cards wider.

task-2849418

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
