### PR TITLE
[IMP] mail: place the rtc overlay inside the participant card frame

### DIFF
--- a/addons/mail/static/src/components/rtc_call_participant_card/rtc_call_participant_card.scss
+++ b/addons/mail/static/src/components/rtc_call_participant_card/rtc_call_participant_card.scss
@@ -6,16 +6,11 @@
     padding: map-get($spacers, 1);
     display: flex;
     position: relative;
-}
-
-.o_RtcCallParticipantCard_avatarFrame {
-    display: flex;
-    user-select: none;
     aspect-ratio: 16/9;
-
-    &.o-isMinimized {
-        aspect-ratio: 1;
-    }
+    display: flex;
+    position: relative;
+    justify-content: center;
+    flex-direction: column;
 }
 
 .o_RtcCallParticipantCard_avatarImage {
@@ -47,16 +42,6 @@
     85% { border: 5px solid gray('700') }
 }
 
-.o_RtcCallParticipantCard_container {
-    margin: map-get($spacers, 0);
-    width: 100% - map-get($spacers, 0);
-    height: 100% - map-get($spacers, 0);
-    display: flex;
-    position: relative;
-    justify-content: center;
-    flex-direction: column;
-}
-
 .o_RtcCallParticipantCard_liveIndicator {
     display: flex;
     margin-inline-end: 5%;
@@ -71,11 +56,14 @@
     padding: map-get($spacers, 1);
 }
 
-.o_RtcCallParticipantCard_overlayBottom {
+.o_RtcCallParticipantCard_overlay {
     position: absolute;
     display: flex;
     pointer-events: none;
-    margin: map-get($spacers, 1);
+    margin: Min(5%, map-get($spacers, 2));
+}
+
+.o_RtcCallParticipantCard_overlayBottom {
     max-width: 50%;
     overflow: hidden;
     bottom: 0;
@@ -83,10 +71,7 @@
 }
 
 .o_RtcCallParticipantCard_overlayTop {
-    position: absolute;
-    display: flex;
     flex-direction: row-reverse;
-    margin: map-get($spacers, 2);
     right: 0%;
     top: 0%;
 }
@@ -138,10 +123,6 @@
 
 .o_RtcCallParticipantCard_connectionState {
     color: theme-color('warning');
-}
-
-.o_RtcCallParticipantCard_container {
-    border-radius: $o-mail-rounded-rectangle-border-radius-sm;
 }
 
 .o_RtcCallParticipantCard_liveIndicator {

--- a/addons/mail/static/src/components/rtc_call_participant_card/rtc_call_participant_card.xml
+++ b/addons/mail/static/src/components/rtc_call_participant_card/rtc_call_participant_card.xml
@@ -3,98 +3,94 @@
 
     <t t-name="mail.RtcCallParticipantCard" owl="1">
         <t t-if="callParticipantCard">
-            <div class="o_RtcCallParticipantCard"
+            <div class="o_RtcCallParticipantCard mh-100 mw-100 align-items-center"
                 t-att-class="{
                     'o-isClickable': callParticipantCard.invitedGuest or callParticipantCard.invitedPartner or !callParticipantCard.isMinimized,
                     'o-isTalking': !callParticipantCard.isMinimized and callParticipantCard.isTalking,
                     'o-isInvitation': callParticipantCard.isInvitation,
                 }"
+                t-att-title="callParticipantCard.name"
+                t-att-aria-label="callParticipantCard.name"
                 t-attf-class="{{ className }}"
+                t-on-click="callParticipantCard.onClick"
                 t-on-contextmenu="callParticipantCard.onContextMenu"
                 t-ref="root"
             >
-                <div class="o_RtcCallParticipantCard_container align-items-center"
-                     t-att-title="callParticipantCard.name"
-                     t-att-aria-label="callParticipantCard.name"
-                     t-on-click="callParticipantCard.onClick"
-                >
-                    <!-- card -->
-                    <t t-if="callParticipantCard.rtcVideoView">
-                        <RtcVideo record="callParticipantCard.rtcVideoView"/>
-                    </t>
-                    <t t-else="">
-                        <div class="o_RtcCallParticipantCard_avatarFrame mh-100 mw-100 h-100 align-items-center justify-content-center" t-att-class="{ 'o-isMinimized': callParticipantCard.isMinimized }" draggable="false">
-                            <img alt="Avatar"
-                                 t-att-class="{
-                                    'o-isTalking': callParticipantCard.isTalking,
-                                    'o-isInvitation': callParticipantCard.isInvitation,
-                                 }"
-                                 class="o_RtcCallParticipantCard_avatarImage h-100 rounded-circle"
-                                 t-att-src="callParticipantCard.avatarUrl"
-                                 draggable="false"
-                            />
-                        </div>
-                    </t>
+                <!-- card -->
+                <t t-if="callParticipantCard.rtcVideoView">
+                    <RtcVideo record="callParticipantCard.rtcVideoView"/>
+                </t>
+                <t t-else="">
+                    <div class="o_RtcCallParticipantCard_avatarFrame d-flex align-items-center justify-content-center h-100 w-100" t-att-class="{ 'o-isMinimized': callParticipantCard.isMinimized }" draggable="false">
+                        <img alt="Avatar"
+                             t-att-class="{
+                                'o-isTalking': callParticipantCard.isTalking,
+                                'o-isInvitation': callParticipantCard.isInvitation,
+                             }"
+                             class="o_RtcCallParticipantCard_avatarImage h-100 rounded-circle"
+                             t-att-src="callParticipantCard.avatarUrl"
+                             draggable="false"
+                        />
+                    </div>
+                </t>
 
-                    <t t-if="callParticipantCard.rtcSession">
-                        <!-- overlay -->
-                        <span class="o_RtcCallParticipantCard_overlayBottom">
-                            <t t-if="!callParticipantCard.isMinimized">
-                                <span class="o_RtcCallParticipantCard_name" t-esc="callParticipantCard.name"/>
-                            </t>
-                            <t t-if="callParticipantCard.rtcSession.isScreenSharingOn and callParticipantCard.isMinimized and !callParticipantCard.rtcSession.channel.rtc">
-                                <span class="o_RtcCallParticipantCard_liveIndicator badge-pill o-isMinimized" title="live" aria-label="live">
-                                    LIVE
-                                </span>
-                            </t>
-                        </span>
-                        <div class="o_RtcCallParticipantCard_overlayTop">
-                            <t t-if="callParticipantCard.rtcSession.isSelfMuted and !callParticipantCard.rtcSession.isDeaf">
-                                <span class="o_RtcCallParticipantCard_overlayTopElement" t-att-class="{'o-isMinimized': callParticipantCard.isMinimized }" title="muted" aria-label="muted">
-                                    <i class="fa fa-microphone-slash"/>
-                                </span>
-                            </t>
-                            <t t-if="callParticipantCard.rtcSession.isDeaf">
-                                <span class="o_RtcCallParticipantCard_overlayTopElement" t-att-class="{'o-isMinimized': callParticipantCard.isMinimized }" title="deaf" aria-label="deaf">
-                                    <i class="fa fa-deaf"/>
-                                </span>
-                            </t>
-                            <t t-if="callParticipantCard.rtcSession.channel.rtc and callParticipantCard.rtcSession.isAudioInError">
-                                <span class="o_RtcCallParticipantCard_overlayTopElement text-danger" title="Issue with audio">
-                                    <i class="fa fa-exclamation-triangle"/>
-                                </span>
-                            </t>
-                            <t t-if="callParticipantCard.rtcSession.channel.rtc and !callParticipantCard.rtcSession.rtcAsCurrentSession and !['connected', 'completed'].includes(callParticipantCard.rtcSession.connectionState)">
-                                <span class="o_RtcCallParticipantCard_overlayTopElement" t-att-title="callParticipantCard.rtcSession.connectionState">
-                                    <i class="fa fa-exclamation-triangle o_RtcCallParticipantCard_connectionState"/>
-                                </span>
-                            </t>
-                            <t t-if="callParticipantCard.rtcSession.isScreenSharingOn and !callParticipantCard.isMinimized and !callParticipantCard.rtcSession.channel.rtc">
-                                <span class="o_RtcCallParticipantCard_liveIndicator badge-pill" title="live" aria-label="live">
-                                    LIVE
-                                </span>
-                            </t>
-                        </div>
-
-                        <!-- volume popover -->
-                        <t t-if="!callParticipantCard.rtcSession.isOwnSession">
-                            <Popover>
-                                <i class="o_RtcCallParticipantCard_volumeMenuAnchor" t-on-click="callParticipantCard.onClickVolumeAnchor" t-ref="volumeMenuAnchor"/>
-                                <t t-set-slot="opened">
-                                    <div class="d-flex flex-column">
-                                        <input type="range" min="0.0" max="1" step="0.01" t-att-value="callParticipantCard.rtcSession.volume" t-on-change="callParticipantCard.onChangeVolume"/>
-                                        <t t-if="callParticipantCard.hasConnectionInfo">
-                                            <hr class="o_RtcCallParticipantCard_volumeMenuAnchor_separator w-100"/>
-                                            <div t-esc="callParticipantCard.inboundConnectionTypeText"/>
-                                            <div t-esc="callParticipantCard.outboundConnectionTypeText"/>
-                                        </t>
-                                    </div>
-                                </t>
-                            </Popover>
+                <t t-if="callParticipantCard.rtcSession">
+                    <!-- overlay -->
+                    <span class="o_RtcCallParticipantCard_overlay o_RtcCallParticipantCard_overlayBottom">
+                        <t t-if="!callParticipantCard.isMinimized">
+                            <span class="o_RtcCallParticipantCard_name" t-esc="callParticipantCard.name"/>
                         </t>
-                    </t>
+                        <t t-if="callParticipantCard.rtcSession.isScreenSharingOn and callParticipantCard.isMinimized and !callParticipantCard.rtcSession.channel.rtc">
+                            <span class="o_RtcCallParticipantCard_liveIndicator badge-pill o-isMinimized" title="live" aria-label="live">
+                                LIVE
+                            </span>
+                        </t>
+                    </span>
+                    <div class="o_RtcCallParticipantCard_overlay o_RtcCallParticipantCard_overlayTop">
+                        <t t-if="callParticipantCard.rtcSession.isSelfMuted and !callParticipantCard.rtcSession.isDeaf">
+                            <span class="o_RtcCallParticipantCard_overlayTopElement" t-att-class="{'o-isMinimized': callParticipantCard.isMinimized }" title="muted" aria-label="muted">
+                                <i class="fa fa-microphone-slash"/>
+                            </span>
+                        </t>
+                        <t t-if="callParticipantCard.rtcSession.isDeaf">
+                            <span class="o_RtcCallParticipantCard_overlayTopElement" t-att-class="{'o-isMinimized': callParticipantCard.isMinimized }" title="deaf" aria-label="deaf">
+                                <i class="fa fa-deaf"/>
+                            </span>
+                        </t>
+                        <t t-if="callParticipantCard.rtcSession.channel.rtc and callParticipantCard.rtcSession.isAudioInError">
+                            <span class="o_RtcCallParticipantCard_overlayTopElement text-danger" title="Issue with audio">
+                                <i class="fa fa-exclamation-triangle"/>
+                            </span>
+                        </t>
+                        <t t-if="callParticipantCard.rtcSession.channel.rtc and !callParticipantCard.rtcSession.rtcAsCurrentSession and !['connected', 'completed'].includes(callParticipantCard.rtcSession.connectionState)">
+                            <span class="o_RtcCallParticipantCard_overlayTopElement" t-att-title="callParticipantCard.rtcSession.connectionState">
+                                <i class="fa fa-exclamation-triangle o_RtcCallParticipantCard_connectionState"/>
+                            </span>
+                        </t>
+                        <t t-if="callParticipantCard.rtcSession.isScreenSharingOn and !callParticipantCard.isMinimized and !callParticipantCard.rtcSession.channel.rtc">
+                            <span class="o_RtcCallParticipantCard_liveIndicator badge-pill" title="live" aria-label="live">
+                                LIVE
+                            </span>
+                        </t>
+                    </div>
 
-                </div>
+                    <!-- volume popover -->
+                    <t t-if="!callParticipantCard.rtcSession.isOwnSession">
+                        <Popover>
+                            <i class="o_RtcCallParticipantCard_volumeMenuAnchor" t-on-click="callParticipantCard.onClickVolumeAnchor" t-ref="volumeMenuAnchor"/>
+                            <t t-set-slot="opened">
+                                <div class="d-flex flex-column">
+                                    <input type="range" min="0.0" max="1" step="0.01" t-att-value="callParticipantCard.rtcSession.volume" t-on-change="callParticipantCard.onChangeVolume"/>
+                                    <t t-if="callParticipantCard.hasConnectionInfo">
+                                        <hr class="o_RtcCallParticipantCard_volumeMenuAnchor_separator w-100"/>
+                                        <div t-esc="callParticipantCard.inboundConnectionTypeText"/>
+                                        <div t-esc="callParticipantCard.outboundConnectionTypeText"/>
+                                    </t>
+                                </div>
+                            </t>
+                        </Popover>
+                    </t>
+                </t>
             </div>
         </t>
     </t>

--- a/addons/mail/static/src/components/rtc_call_viewer/rtc_call_viewer.scss
+++ b/addons/mail/static/src/components/rtc_call_viewer/rtc_call_viewer.scss
@@ -9,11 +9,9 @@
     justify-content: center;
     flex-direction: column;
     height: 50%;
-    min-height: 50%;
 
     &.o-isMinimized {
         height: 20%;
-        min-height: 20%;
     }
 
     &.o-fullScreen {

--- a/addons/mail/static/src/components/rtc_call_viewer/rtc_call_viewer.xml
+++ b/addons/mail/static/src/components/rtc_call_viewer/rtc_call_viewer.xml
@@ -12,7 +12,7 @@
                 <t t-if="rtcCallViewer.layout !== 'tiled'">
                     <div class="o_RtcCallViewer_mainParticipantContainer justify-content-center mw-100 mh-100">
                         <t t-if="rtcCallViewer.mainParticipantCard">
-                            <RtcCallParticipantCard className="'o_RtcCallViewer_participantCard w-100'" record="rtcCallViewer.mainParticipantCard"/>
+                            <RtcCallParticipantCard className="'o_RtcCallViewer_participantCard'" record="rtcCallViewer.mainParticipantCard"/>
                         </t>
                     </div>
                 </t>
@@ -30,7 +30,7 @@
                             <t t-if="!rtcCallViewer.filterVideoGrid or (participantCard.rtcSession and participantCard.rtcSession.videoStream)">
                                 <!-- maybe filter focused partner out? -->
                                 <RtcCallParticipantCard
-                                    className="'o_RtcCallViewer_participantCard o_RtcCallViewer_gridTile mw-100'"
+                                    className="'o_RtcCallViewer_participantCard o_RtcCallViewer_gridTile'"
                                     record="participantCard"
                                 />
                             </t>


### PR DESCRIPTION
Before this commit, the overlay with status icons of the participant
card was at the border of the whole card, which made it difficult to
see in some situations, like when focusing on one participant.

This commit places the overlay over the main frame of the card.

part of task-2692836
