### PR TITLE
[IMP] survey: allow matrix answers to trigger conditional questions

### DIFF
--- a/addons/survey/controllers/main.py
+++ b/addons/survey/controllers/main.py
@@ -272,14 +272,15 @@ class Survey(http.Controller):
             triggering_answer_by_question, triggered_questions_by_answer, selected_answers = answer_sudo._get_conditional_values()
             data.update({
                 'triggering_answer_by_question': {
-                    question.id: triggering_answer_by_question[question].id for question in triggering_answer_by_question.keys()
-                    if triggering_answer_by_question[question]
+                    question.id: (answer.id, row.id)
+                    for question, (answer, row) in triggering_answer_by_question.items()
+                    if answer
                 },
                 'triggered_questions_by_answer': {
-                    answer.id: triggered_questions_by_answer[answer].ids
-                    for answer in triggered_questions_by_answer.keys()
+                    "%s,%s" % (answer.id, row.id) if row else "%s" % answer.id: questions.ids
+                    for (answer, row), questions in triggered_questions_by_answer.items()
                 },
-                'selected_answers': selected_answers.ids
+                'selected_answers': [(answer.id, row.id) for (answer, row) in selected_answers]
             })
 
         if not answer_sudo.is_session_answer and survey_sudo.is_time_limited and answer_sudo.start_datetime:

--- a/addons/survey/views/survey_question_views.xml
+++ b/addons/survey/views/survey_question_views.xml
@@ -205,9 +205,14 @@
                                     <field name="is_conditional" attrs="{'invisible': [('questions_selection', '=', 'random')]}"/>
                                     <field name="triggering_question_id" options="{'no_open': True, 'no_create': True}"
                                         attrs="{'invisible': [('is_conditional','=', False)], 'required': [('is_conditional','=', True)]}"/>
+                                    <field name="triggering_question_type" invisible="1"/>
+                                    <field name="triggering_row_id" options="{'no_open': True, 'no_create': True}"
+                                        attrs="{'invisible': [('triggering_question_type', '!=', 'matrix')],
+                                               'required': [('triggering_question_type','=', 'matrix')]}"/>
                                     <field name="triggering_answer_id" options="{'no_open': True, 'no_create': True}"
-                                        attrs="{'invisible': ['|', ('is_conditional','=', False), ('triggering_question_id','=', False)],
-                                                'required': [('is_conditional','=', True)]}"/>
+                                        attrs="{'invisible': ['|', ('triggering_question_id','=', False),
+                                               '&amp;', ('triggering_question_type','=', 'matrix'), ('triggering_row_id','=', False)],
+                                               'required': [('is_conditional','=', True)]}"/>
                                 </group>
                             </group>
                             <group>

--- a/addons/survey/views/survey_templates.xml
+++ b/addons/survey/views/survey_templates.xml
@@ -577,9 +577,11 @@
                         <td t-att-class="'o_survey_matrix_btn text-primary position-relative %s'
                         % ('o_survey_selected' if answer else '')">
                             <input t-att-type="'checkbox' if question.matrix_subtype == 'multiple' else 'radio'"
-                                   t-att-name="'%s_%s' % (question.id, row_label.id)" t-att-value='col_label.id'
+                                   t-att-name="'%s_%s' % (question.id, row_label.id)"
+                                   t-att-value='col_label.id'
                                    t-att-checked="'checked' if answer else None"
                                    t-att-data-row-id="row_label.id"
+                                   t-att-data-suggested-answer="'%s,%s' % (col_label.id, row_label.id)"
                                    t-att-data-selection-key="letters[item_idx] if useKeySelection else ''"
                                    class="o_survey_form_choice_item d-none"/>
                             <i t-att-class="'o_survey_matrix_empty_checkbox fa fa-%s position-relative'


### PR DESCRIPTION
PURPOSE:
Allow users to display questions based on answers provided through a
matrix-type question.

When checking the "is conditional" checkbox in the options of a question,
The user can now select a matrix-type question as triggering question. When
such a question is selected, the user can choose the row and the answer
of the matrix question that will trigger the question.

To be able to handle these matrices row's answers, selected answers are now
represented by a pair (suggested answer, matrix row), where the matrix row
is empty for non-matrix-type questions, when fetching data related to
conditional questions.

Task-2846710