### PR TITLE
[FIX] website: consider configured email_to on the contact us  page

### DIFF
--- a/addons/website/static/src/snippets/s_website_form/000.js
+++ b/addons/website/static/src/snippets/s_website_form/000.js
@@ -143,6 +143,24 @@ odoo.define('website.s_website_form', function (require) {
                 // customizations that use the current behavior as a feature.
                 for (const name of fieldNames) {
                     const fieldEl = this.$target[0].querySelector(`[name="${name}"]`);
+
+                    // In general, we want the data-for and prefill values to
+                    // take priority over set default values. The 'email_to'
+                    // field is however treated as an exception at the moment
+                    // so that values set by users are always used.
+                    if (name === 'email_to' && fieldEl.value
+                            // The following value is the default value that
+                            // is set if the form is edited in any way. (see the
+                            // website.form_editor_registry module in editor
+                            // assets bundle).
+                            // TODO that value should probably never be forced
+                            // unless explicitely manipulated by the user or on
+                            // custom form addition but that seems risky to
+                            // change as a stable fix.
+                            && fieldEl.value !== 'info@yourcompany.example.com') {
+                        continue;
+                    }
+
                     let newValue;
                     if (dataForValues && dataForValues[name]) {
                         newValue = dataForValues[name];

--- a/addons/website/static/src/snippets/s_website_form/options.js
+++ b/addons/website/static/src/snippets/s_website_form/options.js
@@ -615,6 +615,12 @@ options.registry.WebsiteFormEditor = FormEditor.extend({
                     // get default value or for many2one fields the first option.
                     const currentValue = this.$target.find(`.s_website_form_dnone input[name="${field.name}"]`).val();
                     const defaultValue = field.defaultValue || field.records[0].id;
+                    // TODO this code is not rightfully placed (even maybe
+                    // from the original form feature in older versions). It
+                    // changes the $target while this method is only about
+                    // declaring the option UI. This for example forces the
+                    // 'email_to' value to a dummy value on contact us form just
+                    // by clicking on it.
                     this._addHiddenField(currentValue || defaultValue, field.name);
                 }
                 uiFragment.insertBefore(option, firstOption);

--- a/addons/website/static/tests/tours/website_form_editor.js
+++ b/addons/website/static/tests/tours/website_form_editor.js
@@ -551,5 +551,72 @@ odoo.define('website.tour.form_editor', function (require) {
         }
     ]);
 
+    function editContactUs(steps) {
+        return [
+            {
+                content: "Enter edit mode",
+                trigger: 'a[data-action=edit]',
+            }, {
+                content: "Select the contact us form by clicking on an input field",
+                trigger: '.s_website_form input',
+                extra_trigger: '#oe_snippets .oe_snippet_thumbnail',
+                run: 'click',
+            },
+            ...steps,
+            {
+                content: 'Save the page',
+                trigger: 'button[data-action=save]',
+            },
+            {
+                content: 'Wait for reload',
+                trigger: 'body:not(.editor_enable)',
+            },
+        ];
+    }
+
+    tour.register('website_form_contactus_edition_with_email', {
+        test: true,
+        url: '/contactus',
+    }, editContactUs([
+        {
+            content: 'Change the Recipient Email',
+            trigger: '[data-field-name="email_to"] input',
+            run: 'text test@test.test',
+        },
+    ]));
+    tour.register('website_form_contactus_edition_no_email', {
+        test: true,
+        url: '/contactus',
+    }, editContactUs([
+        {
+            content: "Change a random option",
+            trigger: '[data-set-mark] input',
+            run: 'text_blur **',
+        },
+    ]));
+    tour.register('website_form_contactus_submit', {
+        test: true,
+        url: '/contactus',
+    }, [
+        // As the demo portal user, only two inputs needs to be filled to send
+        // the email
+        {
+            content: "Fill in the subject",
+            trigger: 'input[name="subject"]',
+        },
+        {
+            content: 'Fill in the message',
+            trigger: 'textarea[name="description"]',
+        },
+        {
+            content: 'Send the form',
+            trigger: '.s_website_form_send',
+        },
+        {
+            content: 'Check form is submitted without errors',
+            trigger: '#wrap:has(h1:contains("Thank You!"))',
+        },
+    ]);
+
     return {};
 });

--- a/addons/website/tests/test_website_form_editor.py
+++ b/addons/website/tests/test_website_form_editor.py
@@ -4,9 +4,27 @@
 import odoo.tests
 
 
-@odoo.tests.tagged('post_install','-at_install')
+@odoo.tests.tagged('post_install', '-at_install')
 class TestWebsiteFormEditor(odoo.tests.HttpCase):
     def test_tour(self):
         self.start_tour("/", 'website_form_editor_tour', login="admin")
         self.start_tour("/", 'website_form_editor_tour_submit')
         self.start_tour("/", 'website_form_editor_tour_results', login="admin")
+
+    def test_website_form_contact_us_edition_with_email(self):
+        self.start_tour('/contactus', 'website_form_contactus_edition_with_email', login="admin")
+        self.start_tour('/contactus', 'website_form_contactus_submit', login="portal")
+        mail = self.env['mail.mail'].search([], order='id desc', limit=1)
+        self.assertEqual(
+            mail.email_to,
+            'test@test.test',
+            'The email was edited, the form should have been sent to the configured email')
+
+    def test_website_form_contact_us_edition_no_email(self):
+        self.start_tour('/contactus', 'website_form_contactus_edition_no_email', login="admin")
+        self.start_tour('/contactus', 'website_form_contactus_submit', login="portal")
+        mail = self.env['mail.mail'].search([], order='id desc', limit=1)
+        self.assertEqual(
+            mail.email_to,
+            self.env.company.email,
+            'The email was not edited, the form should still have been sent to the company email')


### PR DESCRIPTION
Configuring the email_to field on the contact us page was not working
anymore. The email was always sent to the company email whatever the
user chooses in edit mode. This was due to [1] which gave the priority
to the data-for and prefill system over default values. While this makes
sense in general (e.g. if the URL on the contact us page contains
?name=John, then the form is prefill with "John" whatever the value that
is set as default), it does not make sense for the email_to field which
is always prefilled with the company email.

The data-for/prefill system priority probably has to be reviewed in the
future. Meanwhile, this commit will make the email_to field as an
exception for this system and only use the data-for value if nothing
has been configured by the user.

This commit also handles another case. Indeed "if nothing has been
configured by the users" is currently kinda broken as just clicking on
the form and saving will force the value "info@yourcompany.example.com"
as the email_to value... thus making the form use it instead of the
company email. We will make that as an exception of the exception: use
the data-for value (company email) if what was configured by the user is
the dummy default value "info@yourcompany.example.com".

A test for each of those two exceptions has been added (only the first
test breaks before this commit as [1] made the second test pass by
chance).

[1]: https://github.com/odoo/odoo/commit/7b23d3aacd22f87cb0c22ecd0478eba4a17b4bf3

opw-2842211