### PR TITLE
[FIX] mail: change incorrect component names

### DIFF
--- a/addons/mail/static/src/components/rtc_configuration_menu/rtc_configuration_menu.xml
+++ b/addons/mail/static/src/components/rtc_configuration_menu/rtc_configuration_menu.xml
@@ -10,7 +10,7 @@
                         <select name="inputDevice" class="o_RtcConfigurationMenu_optionDeviceSelect" t-att-value="messaging.userSetting.audioInputDeviceId" t-on-change="rtcConfigurationMenu.onChangeSelectAudioInput">
                             <option value="">Browser default</option>
                             <t t-if="state.userDevices" t-foreach="state.userDevices" t-as="device" t-key="device_index">
-                                <RtcConfigurationMenuDeviceComponent device="device"/>
+                                <RtcConfigurationMenuDevice device="device"/>
                             </t>
                         </select>
                     </div>

--- a/addons/mail/static/src/components/rtc_configuration_menu_device/rtc_configuration_menu_device.xml
+++ b/addons/mail/static/src/components/rtc_configuration_menu_device/rtc_configuration_menu_device.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <templates xml:space="preserve">
 
-    <t t-name="mail.RtcConfigurationMenuDeviceComponent" owl="1">
+    <t t-name="mail.RtcConfigurationMenuDevice" owl="1">
         <t t-if="props.device.kind === 'audioinput'">
             <option t-att-value="props.device.deviceId" t-attf-class="{{ className }}" t-ref="root"><t t-esc="props.device.label"/></option>
         </t>


### PR DESCRIPTION
Before this commit, the name of the component incorrect names were used
instead of `RtcConfigurationMenuDeviceComponent`.

This commit fixes this issue.
