### PR TITLE
[IMP] crm: void helper wording

### DIFF
--- a/addons/crm/models/crm_team.py
+++ b/addons/crm/models/crm_team.py
@@ -608,13 +608,15 @@ class Team(models.Model):
             user_team_id = self.search([('id', '=', user_team_id)], limit=1).id
         else:
             user_team_id = self.search([], limit=1).id
-            action['help'] = _("""<p class='o_view_nocontent_smiling_face'>Add new opportunities</p><p>
-    Looks like you are not a member of a Sales Team. You should add yourself
-    as a member of one of the Sales Team.
-</p>""")
+            action['help'] = "<p class='o_view_nocontent_smiling_face'>%s</p><p>" % _("Create an Opportunity")
             if user_team_id:
-                action['help'] += _("<p>As you don't belong to any Sales Team, Odoo opens the first one by default.</p>")
-
+                if self.user_has_groups('sales_team.group_sale_manager'):
+                    action['help'] += "<p>%s</p>" % _("""As you are a member of no Sales Team, you are showed the Pipeline of the <b>first team by default.</b>
+                                        To work with the CRM, you should <a name="%d" type="action" tabindex="-1">join a team.</a>""",
+                                        self.env.ref('sales_team.crm_team_action_config').id)
+                else:
+                    action['help'] += "<p>%s</p>" % _("""As you are a member of no Sales Team, you are showed the Pipeline of the <b>first team by default.</b>
+                                        To work with the CRM, you should join a team.""")
         action_context = safe_eval(action['context'], {'uid': self.env.uid})
         if user_team_id:
             action_context['default_team_id'] = user_team_id


### PR DESCRIPTION
In the current version, the wording of the helper in CRM does not have a
hyperlink to redirect to the sales team if the user does not have a member
of any sales team.

This commit Improve the wording of the helper and also add the hyperlink to
redirect the sales team if the user does not have a member of any sales team
and has enough access rights.

task-2846401

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
