### PR TITLE
[FIX] account: draft move lines shouldn't be marked as reconciled

### DIFF
--- a/addons/account/models/account_move.py
+++ b/addons/account/models/account_move.py
@@ -3328,7 +3328,7 @@ class AccountMoveLine(models.Model):
             #computing the `reconciled` field.
             reconciled = False
             digits_rounding_precision = line.move_id.company_id.currency_id.rounding
-            if float_is_zero(amount, precision_rounding=digits_rounding_precision):
+            if float_is_zero(amount, precision_rounding=digits_rounding_precision) and line.move_id.state not in ('draft', 'cancel'):
                 if line.currency_id and line.amount_currency:
                     if float_is_zero(amount_residual_currency, precision_rounding=line.currency_id.rounding):
                         reconciled = True

--- a/addons/account/tests/test_reconciliation.py
+++ b/addons/account/tests/test_reconciliation.py
@@ -503,9 +503,11 @@ class TestReconciliationExec(TestReconciliation):
             credit_line_vals['amount_currency'] = -debit_line_vals['amount_currency']
             vals = {
                 'journal_id': self.bank_journal_euro.id,
-                'line_ids': [(0,0, debit_line_vals), (0, 0, credit_line_vals)]
+                'line_ids': [(0, 0, debit_line_vals), (0, 0, credit_line_vals)]
             }
-            return self.env['account.move'].create(vals).id
+            move = self.env['account.move'].create(vals)
+            move.action_post()
+            return move.id
         move_list_vals = [
             ('1', -1.83, 0, self.currency_swiss_id),
             ('2', 728.35, 795.05, self.currency_swiss_id),
@@ -587,7 +589,7 @@ class TestReconciliationExec(TestReconciliation):
                 'line_ids': [(0,0, debit_line_vals), (0, 0, credit_line_vals)]
             }
         move_ids += self.env['account.move'].create(vals)
-
+        move_ids.action_post()
         account_move_line = move_ids.mapped('line_ids').filtered(lambda l: l.account_id == self.account_rcv)
         writeoff_vals = [{
                 'account_id': self.account_rcv.id,

--- a/addons/account/tests/test_reconciliation_heavy_load.py
+++ b/addons/account/tests/test_reconciliation_heavy_load.py
@@ -73,7 +73,7 @@ class TestReconciliationHeavyLoad(AccountingTestCase):
         line_ids.append((0, False, values))
 
         move.write({'line_ids': line_ids})
-
+        move.action_post()
         move.line_ids.reconcile()
 
         self.assertTrue(all(move.line_ids.mapped('reconciled')))


### PR DESCRIPTION
**Description of the issue/feature this PR addresses:**

If a move if in draft (or canceled), it doesn't make sense be marked as reconciled. The `api.depends` already have `'move_id.state'`, so it makes sense to check the state.

**Current behavior before PR:**

Some draft moves are marked as reconciled.

**Desired behavior after PR is merged:**

Draft moves are unreconciled.


--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr