### PR TITLE
[FIX] hr_holidays: fix the traceback approve allocation

### DIFF
--- a/addons/hr_holidays/views/hr_leave_allocation_views.xml
+++ b/addons/hr_holidays/views/hr_leave_allocation_views.xml
@@ -485,6 +485,9 @@
         <field name="binding_model_id" ref="hr_holidays.model_hr_leave_allocation"/>
         <field name="binding_view_types">list</field>
         <field name="state">code</field>
-        <field name="code">action = records.action_validate()</field>
+         <field name="code">
+            if records:
+                records.action_validate()
+        </field>
     </record>
 </odoo>


### PR DESCRIPTION
Currently traceback occurs if allocation leave is approved.
It has been fixed.