### PR TITLE
[FIX] various: fix traceback in survey with demo data

### DIFF
--- a/addons/survey/static/src/js/survey_session_manage.js
+++ b/addons/survey/static/src/js/survey_session_manage.js
@@ -513,7 +513,7 @@ publicWidget.registry.SurveySessionManage = publicWidget.Widget.extend(SurveyPre
             delete this.resultsChart;
         }
 
-        if (!this.isStartScreen && this.showBarChart) {
+        if (!this.isStartScreen && this.showBarChart && this.$el.data('questionStatistics')) {
             this.resultsChart = new SurveySessionChart(this, {
                 questionType: this.$el.data('questionType'),
                 answersValidity: this.$el.data('answersValidity'),

--- a/addons/survey/views/survey_templates_user_input_session.xml
+++ b/addons/survey/views/survey_templates_user_input_session.xml
@@ -62,7 +62,7 @@
     <template id="user_input_session_manage_content" name="Survey User Input Session Manage">
         <t t-set="question" t-value="survey.session_question_id" />
         <t t-set="is_scored_question" t-value="any(answer.answer_score for answer in question.suggested_answer_ids)" />
-        <t t-set="show_bar_chart" t-value="question.question_type in ['simple_choice', 'multiple_choice']" />
+        <t t-set="show_bar_chart" t-value="not question.is_page and question.question_type in ['simple_choice', 'multiple_choice']" />
         <t t-set="show_text_answers" t-value="question.question_type in ['char_box', 'date', 'datetime'] and not question.save_as_email and not question.save_as_nickname" />
         <div class="wrap min-vh-100 align-items-center justify-content-center d-flex flex-column o_survey_session_manage"
             t-att-style="'display: none;' if is_rpc_call else ''"


### PR DESCRIPTION
Right now, in demo data of some surveys, there are records of 'survey.question'
having 'is_page' field value as true and 'question_type' is not defined. When
question type is not defined, default value 'simple_choice' is assigned to the
'question_type' field. Now when we create a live session of that survey and
goes to the page, it tries to read the data for bar chart but data is not
available (undefined) and throws the traceback. This happens  because
question types ('simple_choice', 'multiple_choice') has bar chart.

In this PR, we are setting the 'question_type' field value to 'False' in the
demo data record whose 'is_page' field value is 'True'.

taskID- 2841582