### PR TITLE
[FIX] google_calendar: allow to sync a private contact

### DIFF
--- a/addons/calendar/views/calendar_views.xml
+++ b/addons/calendar/views/calendar_views.xml
@@ -130,6 +130,7 @@
                         <field name="partner_ids" widget="many2manyattendee"
                             placeholder="Select attendees..."
                             context="{'force_email':True}"
+                            domain="[('type','!=','private')]"
                             class="oe_inline o_calendar_attendees"
                         />
                         <div name="send_buttons" class="sm-2">

--- a/addons/google_calendar/models/calendar.py
+++ b/addons/google_calendar/models/calendar.py
@@ -140,7 +140,7 @@ class Meeting(models.Model):
         if google_event.exists(self.env):
             existing_attendees = self.browse(google_event.odoo_id(self.env)).attendee_ids
         attendees_by_emails = {tools.email_normalize(a.email): a for a in existing_attendees}
-        partners = self.env['mail.thread']._mail_find_partner_from_emails(emails, records=self, force_create=True)
+        partners = self.env['mail.thread']._mail_find_partner_from_emails(emails, records=self, force_create=True, extra_domain=[('type', '!=', 'private')])
         for attendee in zip(emails, partners, google_attendees):
             email = attendee[0]
             if email in attendees_by_emails:

--- a/addons/google_calendar/models/calendar_recurrence_rule.py
+++ b/addons/google_calendar/models/calendar_recurrence_rule.py
@@ -89,7 +89,7 @@ class RecurrenceRule(models.Model):
         # We update the attendee status for all events in the recurrence
         google_attendees = gevent.attendees or []
         emails = [a.get('email') for a in google_attendees]
-        partners = self.env['mail.thread']._mail_find_partner_from_emails(emails, records=self, force_create=True)
+        partners = self.env['mail.thread']._mail_find_partner_from_emails(emails, records=self, force_create=True, extra_domain=[('type', '!=', 'private')])
         existing_attendees = self.calendar_event_ids.attendee_ids
         for attendee in zip(emails, partners, google_attendees):
             email = attendee[0]

--- a/addons/google_calendar/tests/test_sync_google2odoo.py
+++ b/addons/google_calendar/tests/test_sync_google2odoo.py
@@ -13,6 +13,13 @@ from odoo import Command
 
 class TestSyncGoogle2Odoo(TestSyncGoogle):
 
+    def setUp(self):
+        super().setUp()
+        self.private_partner = self.env['res.partner'].create({
+            'name': 'Private Contact',
+            'email': 'private_email@example.com',
+            'type': 'private',
+        })
 
     @property
     def now(self):
@@ -1117,3 +1124,65 @@ class TestSyncGoogle2Odoo(TestSyncGoogle):
         self.assertTrue(event, "It should have created an event")
         self.assertEqual(event.show_as, 'free')
         self.assertGoogleAPINotCalled
+
+    @patch_api
+    def test_private_partner_single_event(self):
+        values = {
+            'id': 'oj44nep1ldf8a3ll02uip0c9aa',
+            'description': 'Small mini desc',
+            'organizer': {'email': 'odoocalendarref@gmail.com', 'self': True},
+            'summary': 'Pricing new update',
+            'visibility': 'public',
+            'attendees': [{
+                'displayName': 'Mitchell Admin',
+                'email': 'admin@yourcompany.example.com',
+                'responseStatus': 'needsAction'
+            }, {
+                'displayName': 'Attendee',
+                'email': self.private_partner.email,
+                'responseStatus': 'needsAction'
+            }, ],
+            'reminders': {'useDefault': True},
+            'start': {
+                'dateTime': '2020-01-13T16:55:00+01:00',
+                'timeZone': 'Europe/Brussels'
+            },
+            'end': {
+                'dateTime': '2020-01-13T19:55:00+01:00',
+                'timeZone': 'Europe/Brussels'
+            },
+        }
+
+        self.env['calendar.event']._sync_google2odoo(GoogleEvent([values]))
+        event = self.env['calendar.event'].search([('google_id', '=', values.get('id'))])
+        private_attendee = event.attendee_ids.filtered(lambda e: e.email == self.private_partner.email)
+        self.assertNotEqual(self.private_partner.id, private_attendee.partner_id.id)
+        self.assertNotEqual(private_attendee.partner_id.type, 'private')
+        self.assertGoogleAPINotCalled()
+
+    @patch_api
+    def test_recurrence_private_contact(self):
+        recurrence_id = 'oj44nep1ldf8a3ll02uip0c9aa'
+        values = {
+            'id': recurrence_id,
+            'description': 'Small mini desc',
+            'organizer': {'email': 'odoocalendarref@gmail.com', 'self': True},
+            'summary': 'Pricing new update',
+            'visibility': 'public',
+            'attendees': [{
+                'displayName': 'Attendee',
+                'email': self.private_partner.email,
+                'responseStatus': 'needsAction'
+            }, ],
+            'recurrence': ['RRULE:FREQ=WEEKLY;WKST=SU;COUNT=3;BYDAY=MO'],
+            'reminders': {'useDefault': True},
+            'start': {'date': '2020-01-6'},
+            'end': {'date': '2020-01-7'},
+        }
+        self.env['calendar.recurrence']._sync_google2odoo(GoogleEvent([values]))
+        recurrence = self.env['calendar.recurrence'].search([('google_id', '=', values.get('id'))])
+        events = recurrence.calendar_event_ids
+        private_attendees = events.mapped('attendee_ids').filtered(lambda e: e.email == self.private_partner.email)
+        self.assertTrue(all([a.partner_id.id != self.private_partner.id for a in private_attendees]))
+        self.assertTrue(all([a.partner_id.type != 'private' for a in private_attendees]))
+        self.assertGoogleAPINotCalled()


### PR DESCRIPTION
Before this commit: if a user is the attendee of an event containing
a private contact, the user couldn't sync with google calendar. Because
of the "res.partner.rule.private.employee" record rule restriction.

Steps to reproduce the issue:
 1. Create users A and B
 2. Enable "Access to Private Addresses" for user A and disable it for B
 3. Login with user A
 4. Integrate with Google Calendar in setting
 5. Create a contact with private address (type = 'private')
 6. Sync with Google Calendar in the calendar module
 7. Create an event with user B and the private contact as attendees
 8. Reset account of google calendar from user A setting
 9. Login with user B
 10. Try to sync with Google Calendar

 => You will receive an access error

The solution is to give access for accessing to the private contact
email address.

opw-2850552

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
