### PR TITLE
[FIX] sale_management: admin doesn't have access to sale.order.templa…

### DIFF
--- a/addons/sale_management/security/ir.model.access.csv
+++ b/addons/sale_management/security/ir.model.access.csv
@@ -1,6 +1,7 @@
 id,name,model_id:id,group_id:id,perm_read,perm_write,perm_create,perm_unlink
 access_sale_order_template,sale.order.template,model_sale_order_template,sales_team.group_sale_salesman,1,0,0,0
 access_sale_order_template_manager,sale.order.template,model_sale_order_template,sales_team.group_sale_manager,1,1,1,1
+access_sale_order_template_system,sale.order.template,model_sale_order_template,base.group_system,1,0,0,0
 access_sale_order_template_line,sale.order.template.line,model_sale_order_template_line,sales_team.group_sale_salesman,1,0,0,0
 access_sale_order_template_line_manager,sale.order.template.line,model_sale_order_template_line,sales_team.group_sale_manager,1,1,1,1
 access_sale_order_template_option,sale.order.template.option,model_sale_order_template_option,sales_team.group_sale_salesman,1,0,0,0


### PR DESCRIPTION
…te model

If a default template is specified in a given database (it is the case by default
on runbot databases because of sale_quotation_builder), the webclient will
try to fetch its display_name (through a name_get rpc).

As this happens even if the default_sale_order_template_id field is hidden
in the view, administrators without sales rights were not able to open the settings,
because they didn't have read rights on sale.order.template model.

This commit makes sure that settings users are able to open the settings
independently of their level of rights for the Sales scope (salesman/sales manager).

Fixes #84597


--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
