### PR TITLE
[FIX] knowledge: fix confirm dialog in permission panel

### DIFF
--- a/addons/knowledge/static/src/components/permission_panel/permission_panel.js
+++ b/addons/knowledge/static/src/components/permission_panel/permission_panel.js
@@ -1,7 +1,7 @@
 /** @odoo-module **/
 
 import { session } from "@web/session";
-import { Dialog } from "@web/core/dialog/dialog";
+import Dialog from 'web.Dialog';
 import { _lt } from "@web/core/l10n/translation";
 import { _t } from 'web.core';
 import { useService } from '@web/core/utils/hooks';


### PR DESCRIPTION
The owl dialog was imported in the permission panel file but the usage was
the legacy way to display a dialog.
This commit import the legacy dialog.

Task-2674460