### PR TITLE
[FIX] crm: fix perf in phone/mobile search

### DIFF
--- a/addons/crm/models/crm_lead.py
+++ b/addons/crm/models/crm_lead.py
@@ -5,6 +5,7 @@ import logging
 import threading
 from datetime import date, datetime, timedelta
 from psycopg2 import sql
+import re
 
 from odoo import api, fields, models, tools, SUPERUSER_ID
 from odoo.osv import expression
@@ -451,6 +452,7 @@ class Lead(models.Model):
                 lead.ribbon_message = False
 
     def _search_phone_mobile_search(self, operator, value):
+        value = re.sub(r'[^\d+]+', '', value)
         if len(value) <= 2:
             raise UserError(_('Please enter at least 3 digits when searching on phone / mobile.'))
 

--- a/addons/crm/tests/test_crm_lead.py
+++ b/addons/crm/tests/test_crm_lead.py
@@ -8,6 +8,7 @@ from odoo.addons.crm.models.crm_lead import PARTNER_FIELDS_TO_SYNC, PARTNER_ADDR
 from odoo.addons.crm.tests.common import TestCrmCommon, INCOMING_EMAIL
 from odoo.addons.phone_validation.tools.phone_validation import phone_format
 from odoo.tests.common import Form, users
+from odoo.exceptions import UserError
 
 
 class TestCRMLead(TestCrmCommon):
@@ -496,3 +497,7 @@ class TestCRMLead(TestCrmCommon):
         self.assertEqual(lead_1, self.env['crm.lead'].search([
             ('phone_mobile_search', 'like', '+32485001122')
         ]))
+        with self.assertRaises(UserError):
+            self.env['crm.lead'].search([
+                ('phone_mobile_search', 'like', 'tests@example.com')
+            ])


### PR DESCRIPTION
Odoo v14 replaces all non-digit characters on searching by virtual phone/mobile
field. When user types just letters, it led to an sql query with ids of all
leads.

Fix it by replacing non-digit characters first. If there are less than 2
characters, UserError will be raised

---

opw-2770521

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
