### PR TITLE
[IMP] l10n_it_edi: hook to manage unsupported documents types

### DIFF
--- a/addons/l10n_it_edi/models/account_edi_format.py
+++ b/addons/l10n_it_edi/models/account_edi_format.py
@@ -341,7 +341,7 @@ class AccountEdiFormat(models.Model):
             document_type = elements[0].text if elements else ''
             if document_type and document_type in ['TD04', 'TD08']:
                 move_type = 'in_refund'
-            elif document_type and document_type not in ['TD01', 'TD07']:
+            elif document_type and document_type not in self.get_unsupported_document_types():
                 _logger.info('Document type not managed: %s. Invoice type is set by default.', elements[0].text)
 
             simplified = self._l10n_it_is_simplified_document_type(document_type)
@@ -671,3 +671,6 @@ class AccountEdiFormat(models.Model):
             invoices += new_invoice
 
         return invoices
+
+    def get_unsupported_document_types(self):
+        return ['TD01', 'TD07']

--- a/doc/cla/corporate/rapsodoo.md
+++ b/doc/cla/corporate/rapsodoo.md
@@ -23,3 +23,4 @@ Andrea Patusso andrea.patusso@rapsodoo.com https://github.com/AndreaPatusso
 Valentina Maltese valentina.maltese@rapsodoo.com https://github.com/ValentinaMal
 Tommaso Bellelli tommaso.bellelli@rapsodoo.com https://github.com/tommasobellelli
 Saydigital info@rapsodoo.com https://github.com/saydigital
+Valerio Belcastro valerio.belcastro@rapsodoo.com https://github.com/valeriobelcastro


### PR DESCRIPTION
The need for this change is to extend the document types to manage. So far the DOCUMENT TYPE code TD10-TD11-TD12-TD16-TD17-TD18-TD19-TD20-TD21-TD22-TD23-TD24 are unsupported. With this PR we have the ability to add new controls and behaviors.
we manage the message, the function is executed and at the end we integrate the invoice with the additional data.




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
