### PR TITLE
[FIX] hr_contract: fix access error when archiving employee

### DIFF
--- a/addons/hr_contract/wizard/hr_departure_wizard.py
+++ b/addons/hr_contract/wizard/hr_departure_wizard.py
@@ -14,7 +14,7 @@ class HrDepartureWizard(models.TransientModel):
     def action_register_departure(self):
         """If set_date_end is checked, set the departure date as the end date to current running contract,
         and cancel all draft contracts"""
-        current_contract = self.employee_id.contract_id
+        current_contract = self.sudo().employee_id.contract_id
         if current_contract and current_contract.date_start > self.departure_date:
             raise UserError(_("Departure date can't be earlier than the start date of current contract."))
 
@@ -22,4 +22,4 @@ class HrDepartureWizard(models.TransientModel):
         if self.set_date_end:
             self.employee_id.contract_ids.filtered(lambda c: c.state == 'draft').write({'state': 'cancel'})
             if current_contract:
-                self.employee_id.contract_id.write({'date_end': self.departure_date})
+                self.sudo().employee_id.contract_id.write({'date_end': self.departure_date})


### PR DESCRIPTION
Scenario:
hr_contract is installed and employee/officer without rights on contract
tries to archive an employee.

Before the fix:
An employee/officer without rights on contract gets the following access error:
Due to security restrictions, you are not allowed to access 'Employee Contract' (hr.contract) records.
This is because the action tries to access employee's contract and set
date_end on it.

After the fix an employee/officer without rights on contract can archive
an employee without access error.

task - 2811165
