### PR TITLE
[FIX] sale: allow deleting notes/sections on confirmed order

### DIFF
--- a/addons/sale/models/sale.py
+++ b/addons/sale/models/sale.py
@@ -1809,10 +1809,11 @@ class SaleOrderLine(models.Model):
 
         Lines cannot be deleted if the order is confirmed; downpayment
         lines who have not yet been invoiced bypass that exception.
+        Also, allow deleting UX lines (notes/sections).
         :rtype: recordset sale.order.line
         :returns: set of lines that cannot be deleted
         """
-        return self.filtered(lambda line: line.state in ('sale', 'done') and (line.invoice_lines or not line.is_downpayment))
+        return self.filtered(lambda line: line.state in ('sale', 'done') and (line.invoice_lines or not line.is_downpayment) and not line.display_type)
 
     def unlink(self):
         if self._check_line_unlink():


### PR DESCRIPTION
Lines cannot be deleted if the order is confirmed. However, notes/sections lines
still might be changed. So, let delete such lines too.

STEPS:

1. Create SO, add product and add note
2. Confirm SO
3. Remove note

---

opw-2852676

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
