### PR TITLE
[FIX] knowledge: add dependencies to /article dialog

### DIFF
--- a/addons/knowledge/static/src/js/wysiwyg/knowledge_article_link.js
+++ b/addons/knowledge/static/src/js/wysiwyg/knowledge_article_link.js
@@ -6,6 +6,9 @@ import { _t } from 'web.core';
 
 const KnowledgeArticleLinkModal = Dialog.extend({
     template: 'knowledge.wysiwyg_article_link_modal',
+    xmlDependencies: Dialog.prototype.xmlDependencies.concat(
+        ['/knowledge/static/src/xml/knowledge_editor.xml']
+    ),
     /**
      * @override
      * @param {Widget} parent


### PR DESCRIPTION
[FIX] knowledge: add dependencies to /article dialog

- What is broken:

The /article command of the editor when editing a page on `website` has a
traceback and the dialog does not open.

- The fix:

Add a xmlDependency to the KnowledgeArticleLinkModal so that the modal can be
used in website to select the desired article when using the /article command.

Task-2674460