### PR TITLE
[IMP] sale_stock: avoid using replace in views

### DIFF
--- a/addons/sale_stock/views/stock_views.xml
+++ b/addons/sale_stock/views/stock_views.xml
@@ -22,7 +22,8 @@
             <field name="inherit_id" ref="sale.product_template_form_view_sale_order_button"/>
             <field name="model">product.template</field>
             <field name="arch" type="xml">
-                <xpath expr="//button[@name='action_view_sales']" position="replace" />
+                <xpath expr="//button[@name='action_view_sales']" position="attributes" />
+                    <attribute name="invisible">1</attribute>
             </field>
         </record>
 


### PR DESCRIPTION
Maybe a custom module wants to use/reference this button.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr