### PR TITLE
[FIX] website_sale: Avoid traceback when adding deleted products to cart

### DIFF
--- a/addons/website_event_sale/models/product.py
+++ b/addons/website_event_sale/models/product.py
@@ -8,3 +8,9 @@ class Product(models.Model):
     _inherit = 'product.product'
 
     event_ticket_ids = fields.One2many('event.event.ticket', 'product_id', string='Event Tickets')
+
+    def _is_add_to_cart_allowed(self):
+        # Allow adding event tickets to the cart regardless of product's rules
+        self.ensure_one()
+        res = super()._is_add_to_cart_allowed()
+        return res or any(event.website_published for event in self.event_ticket_ids.event_id)

--- a/addons/website_sale/models/product.py
+++ b/addons/website_sale/models/product.py
@@ -478,3 +478,7 @@ class Product(models.Model):
         # [1:] to remove the main image from the template, we only display
         # the template extra images here
         return variant_images + self.product_tmpl_id._get_images()[1:]
+
+    def _is_add_to_cart_allowed(self):
+        self.ensure_one()
+        return self.user_has_groups('base.group_system') or (self.sale_ok and self.website_published)

--- a/addons/website_sale/models/sale_order.py
+++ b/addons/website_sale/models/sale_order.py
@@ -158,7 +158,10 @@ class SaleOrder(models.Model):
         SaleOrderLineSudo = self.env['sale.order.line'].sudo().with_context(product_context)
         # change lang to get correct name of attributes/values
         product_with_context = self.env['product.product'].with_context(product_context)
-        product = product_with_context.browse(int(product_id))
+        product = product_with_context.browse(int(product_id)).exists()
+
+        if not product or not product._is_add_to_cart_allowed():
+            raise UserError(_("The given product does not exist therefore it cannot be added to cart."))
 
         try:
             if add_qty:
@@ -180,9 +183,6 @@ class SaleOrder(models.Model):
 
         # Create line if no line with product_id can be located
         if not order_line:
-            if not product:
-                raise UserError(_("The given product does not exist therefore it cannot be added to cart."))
-
             no_variant_attribute_values = kwargs.get('no_variant_attribute_values') or []
             received_no_variant_values = product.env['product.template.attribute.value'].browse([int(ptav['value']) for ptav in no_variant_attribute_values])
             received_combination = product.product_template_attribute_value_ids | received_no_variant_values

--- a/addons/website_sale/models/website.py
+++ b/addons/website_sale/models/website.py
@@ -302,6 +302,9 @@ class Website(models.Model):
 
             request.session['sale_order_id'] = sale_order.id
 
+            # The order was created with SUPERUSER_ID, revert back to request user.
+            sale_order = sale_order.with_user(self.env.user).sudo()
+
         # case when user emptied the cart
         if not request.session.get('sale_order_id'):
             request.session['sale_order_id'] = sale_order.id

--- a/addons/website_sale/tests/__init__.py
+++ b/addons/website_sale/tests/__init__.py
@@ -2,6 +2,7 @@ from . import test_customize
 from . import test_sale_process
 from . import test_sitemap
 from . import test_website_sale_cart_recovery
+from . import test_website_sale_cart
 from . import test_website_sale_mail
 from . import test_website_sale_pricelist
 from . import test_website_sale_product_attribute_value_config

--- a/addons/website_sale/tests/test_sale_process.py
+++ b/addons/website_sale/tests/test_sale_process.py
@@ -59,7 +59,11 @@ class TestWebsiteSaleCheckoutAddress(odoo.tests.TransactionCase):
             'partner_id': partner_id,
             'website_id': self.website.id,
             'order_line': [(0, 0, {
-                'product_id': self.env['product.product'].create({'name': 'Product A', 'list_price': 100}).id,
+                'product_id': self.env['product.product'].create({
+                    'name': 'Product A',
+                    'list_price': 100,
+                    'website_published': True,
+                    'sale_ok': True}).id,
                 'name': 'Product A',
             })]
         })

--- a/addons/website_sale/tests/test_website_sale_cart.py
+++ b/addons/website_sale/tests/test_website_sale_cart.py
@@ -1,0 +1,49 @@
+# coding: utf-8
+
+from odoo.addons.website_sale.controllers.main import WebsiteSale
+from odoo.addons.website.tools import MockRequest
+from odoo.exceptions import UserError
+from odoo.tests.common import SavepointCase, tagged
+
+@tagged('post_install', '-at_install')
+class WebsiteSaleCart(SavepointCase):
+
+    @classmethod
+    def setUpClass(cls):
+        super(WebsiteSaleCart, cls).setUpClass()
+        cls.website = cls.env['website'].browse(1)
+        cls.WebsiteSaleController = WebsiteSale()
+        cls.public_user = cls.env.ref('base.public_user')
+
+    def test_add_cart_deleted_product(self):
+        # Create a published product then unlink it
+        product = self.env['product.product'].create({
+            'name': 'Test Product',
+            'sale_ok': True,
+            'website_published': True,
+        })
+        product_id = product.id
+        product.unlink()
+
+        with self.assertRaises(UserError):
+            with MockRequest(product.with_user(self.public_user).env, website=self.website.with_user(self.public_user)):
+                self.WebsiteSaleController.cart_update_json(product_id=product_id, add_qty=1)
+
+    def test_add_cart_unpublished_product(self):
+        # Try to add an unpublished product
+        product = self.env['product.product'].create({
+            'name': 'Test Product',
+            'sale_ok': True,
+        })
+
+        with self.assertRaises(UserError):
+            with MockRequest(product.with_user(self.public_user).env, website=self.website.with_user(self.public_user)):
+                self.WebsiteSaleController.cart_update_json(product_id=product.id, add_qty=1)
+
+        # public but remove sale_ok
+        product.sale_ok = False
+        product.website_published = True
+
+        with self.assertRaises(UserError):
+            with MockRequest(product.with_user(self.public_user).env, website=self.website.with_user(self.public_user)):
+                self.WebsiteSaleController.cart_update_json(product_id=product.id, add_qty=1)


### PR DESCRIPTION
Prior to this commit an user could try to add a product to cart that does not
exist anymore because it was deleted while the user /shop page wasn't refreshed.

This commit avoids this (rare) use case to happen.

TaskId-2835736
