### PR TITLE
[IMP] mail: move logic from discuss widget to discuss component

### DIFF
--- a/addons/mail/static/src/components/discuss/discuss.js
+++ b/addons/mail/static/src/components/discuss/discuss.js
@@ -10,6 +10,8 @@ export class Discuss extends LegacyComponent {
      * @override
      */
     setup() {
+        this.lastPushStateActiveThread = null;
+        this.actionManager = this.props.actionManager;
         this._updateLocalStoreProps();
         // bind since passed as props
         useUpdate({ func: () => this._update() });
@@ -17,7 +19,14 @@ export class Discuss extends LegacyComponent {
 
     _update() {
         if (this.discussView.discuss.thread) {
-            this.trigger('o-push-state-action-manager');
+            if (this.lastPushStateActiveThread === this.discussView.discuss.thread) {
+                return;
+            }
+            this.actionManager.do_push_state({
+                action: this.discussView.actionId,
+                active_id: this.discussView.discuss.activeId,
+            });
+            this.lastPushStateActiveThread = this.discussView.discuss.thread;
         }
         if (
             this.discussView.discuss.thread &&
@@ -26,7 +35,10 @@ export class Discuss extends LegacyComponent {
             this._lastThreadCache === this.discussView.discuss.threadView.threadCache.localId &&
             this._lastThreadCounter > 0 && this.discussView.discuss.thread.counter === 0
         ) {
-            this.trigger('o-show-rainbow-man');
+            this.env.bus.trigger('show-effect', {
+                message: this.env._t("Congratulations, your inbox is empty!"),
+                type: 'rainbow_man',
+            });
         }
         this._updateLocalStoreProps();
     }
@@ -73,7 +85,10 @@ export class Discuss extends LegacyComponent {
 }
 
 Object.assign(Discuss, {
-    props: { record: Object },
+    props: {
+        actionManager: Object,
+        record: Object,
+    },
     template: 'mail.Discuss',
 });
 

--- a/addons/mail/static/src/components/discuss_container/discuss_container.js
+++ b/addons/mail/static/src/components/discuss_container/discuss_container.js
@@ -4,6 +4,7 @@ import { useModels } from '@mail/component_hooks/use_models';
 import { useUpdate } from '@mail/component_hooks/use_update';
 // ensure component is registered before-hand
 import '@mail/components/discuss/discuss';
+import { insertAndReplace } from '@mail/model/model_field_command';
 import { getMessagingComponent } from "@mail/utils/messaging_component";
 
 const { Component, onWillUnmount } = owl;
@@ -14,6 +15,7 @@ export class DiscussContainer extends Component {
      * @override
      */
     setup() {
+        console.log(this.props.actionManager)
         // for now, the legacy env is needed for internal functions such as
         // `useModels` to work
         this.env = Component.env;
@@ -21,6 +23,27 @@ export class DiscussContainer extends Component {
         super.setup();
         useUpdate({ func: () => this._update() });
         onWillUnmount(() => this._willUnmount());
+        this.env.services.messaging.modelManager.messagingCreatedPromise.then(async () => {
+            const { action } = this.props;
+            const initActiveId =
+                (action.context && action.context.active_id) ||
+                (action.params && action.params.default_active_id) ||
+                'mail.box_inbox';
+            this.discuss = this.messaging.discuss;
+            this.discuss.update({
+                discussView: insertAndReplace({ actionId: action.id }),
+                initActiveId,
+            });
+            // Wait for messaging to be initialized to make sure the system
+            // knows of the "init thread" if it exists.
+            await this.messaging.initializedPromise;
+            if (!this.discuss.isInitThreadHandled) {
+                this.discuss.update({ isInitThreadHandled: true });
+                if (!this.discuss.thread) {
+                    this.discuss.openInitThread();
+                }
+            }
+        });
     }
 
     _update() {

--- a/addons/mail/static/src/components/discuss_container/discuss_container.xml
+++ b/addons/mail/static/src/components/discuss_container/discuss_container.xml
@@ -3,7 +3,7 @@
 
     <t t-name="mail.DiscussContainer" owl="1">
         <div class="o_DiscussContainer d-flex flex-grow-1 flex-column">
-            <Discuss t-if="messaging and messaging.discuss and messaging.discuss.discussView and messaging.isInitialized" className="'flex-grow-1'" record="messaging.discuss.discussView"/>
+            <Discuss t-if="messaging and messaging.discuss and messaging.discuss.discussView and messaging.isInitialized" actionManager="props.actionManager" className="'flex-grow-1'" record="messaging.discuss.discussView"/>
             <div t-else="" class="o_DiscussContainer_spinner d-flex flex-grow-1 align-items-center justify-content-center">
                 <i class="o_DiscussContainer_spinnerIcon fa fa-circle-o-notch fa-spin me-2"/>Please wait...
             </div>

--- a/addons/mail/static/src/models/discuss_view.js
+++ b/addons/mail/static/src/models/discuss_view.js
@@ -111,6 +111,7 @@ registerModel({
         },
     },
     fields: {
+        actionId: attr(),
         mobileAddItemHeaderAutocompleteInputView: one('AutocompleteInputView', {
             compute: '_computeMobileAddItemHeaderAutocompleteInputView',
             inverse: 'discussViewOwnerAsMobileAddItemHeader',


### PR DESCRIPTION
This PR prepares the ground for the introduction of the new environment in the
discuss app. The discuss widget will disappear in favor of the DiscussContainer
being added in the action registry. The logic present in the discuss widget will
be moved to the Discuss/DiscussContainer component. In order to reduce the noise
in the main PR, those changes are done now.

task-2582313