### PR TITLE
[FIX] core: add support for vnd.ms-outlook mimetype

### DIFF
--- a/odoo/http.py
+++ b/odoo/http.py
@@ -1198,6 +1198,9 @@ mimetypes.add_type('application/vnd.ms-fontobject', '.eot')
 mimetypes.add_type('application/x-font-ttf', '.ttf')
 # Add potentially missing (detected on windows) svg mime types
 mimetypes.add_type('image/svg+xml', '.svg')
+# Add potentially missing MS mime types
+mimetypes.add_type('application/vnd.ms-outlook', '.msg')
+
 
 class Response(werkzeug.wrappers.Response):
     """ Response object passed through controller route chain.


### PR DESCRIPTION
On downloading file from `ir.attachment`, user is expected that the file will be
properly handled by OS. That's why Odoo may add a missing extension to the
filename. Since recent changes [1] `mimetypes.guess_type` is used instead of
`os.path.splitext`. In some cases `mimetypes.guess_type` may not properly guess
the mimetype, which may lead to a wrong file extension.

This commit adds support for MS Outlook files by registering *.msg extension.

STEPS:
* upload outlook mail file (*.msg) via Documents app
* download the file

BEFORE: Downloaded file gets extra extension for filename: **name.msg.doc**.

AFTER:  Downloaded file has original filename extension: **name.msg**.

Note, that this doesn't fix mimetype value in the `ir.attachment` record. It may
be computed as **application/msword**. Fixing that seems risky for stable
version and should be done in master instead.

[1]: https://github.com/odoo/odoo/pull/90855

opw-2850479