### PR TITLE
[FIX] mail: fix typo on passing props

### DIFF
--- a/addons/mail/static/src/components/rtc_invitations/rtc_invitations.xml
+++ b/addons/mail/static/src/components/rtc_invitations/rtc_invitations.xml
@@ -5,7 +5,7 @@
         <div class="o_RtcInvitations" t-attf-class="{{ className }}" t-ref="root">
             <t t-if="messaging.ringingThreads">
                 <t t-foreach="messaging.rtcInvitationCards" t-as="rtcInvitationCard" t-key="rtcInvitationCard.localId">
-                    <RtcInvitationCard record="rtcInvitationCards"/>
+                    <RtcInvitationCard record="rtcInvitationCard"/>
                 </t>
             </t>
         </div>


### PR DESCRIPTION
This typo crashed the code because the component expect
receiving the view record as prop.