### PR TITLE
[IMP] account, l10n_generic: change default fiscal country

### DIFF
--- a/addons/account/models/account_move.py
+++ b/addons/account/models/account_move.py
@@ -1960,7 +1960,9 @@ class AccountMove(models.Model):
             amls = record.line_ids
             impacted_countries = amls.tax_ids.country_id | amls.tax_line_id.country_id | amls.tax_tag_ids.country_id
             if impacted_countries and impacted_countries != record.tax_country_id:
-                raise ValidationError(_("This entry contains some tax from an unallowed country. Please check its fiscal position and your tax configuration."))
+                if record.fiscal_position_id and impacted_countries != record.fiscal_position_id.country_id:
+                    raise ValidationError(_("This entry contains taxes that are not compatible with your fiscal position. Check the country set in fiscal position and in your tax configuration."))
+                raise ValidationError(_("This entry contains one or more taxes that are incompatible with your fiscal country. Check company fiscal country in the settings and tax country in taxes configuration."))
 
     # -------------------------------------------------------------------------
     # LOW-LEVEL METHODS

--- a/addons/account/models/chart_template.py
+++ b/addons/account/models/chart_template.py
@@ -275,6 +275,13 @@ class AccountChartTemplate(models.Model):
                 except ValueError:
                     pass
 
+        # Set the fiscal country before generating taxes in case the company does not have a country_id set yet
+        if self.country_id:
+            # If this CoA is made for only one country, set it as the fiscal country of the company.
+            company.account_fiscal_country_id = self.country_id
+        elif not company.account_fiscal_country_id:
+            company.account_fiscal_country_id = self.env.ref('base.us')
+
         # Install all the templates objects and generate the real objects
         acc_template_ref, taxes_ref = self._install_template(company, code_digits=self.code_digits)
 
@@ -332,10 +339,6 @@ class AccountChartTemplate(models.Model):
         # set the default taxes on the company
         company.account_sale_tax_id = self.env['account.tax'].search([('type_tax_use', 'in', ('sale', 'all')), ('company_id', '=', company.id)], limit=1).id
         company.account_purchase_tax_id = self.env['account.tax'].search([('type_tax_use', 'in', ('purchase', 'all')), ('company_id', '=', company.id)], limit=1).id
-
-        if self.country_id:
-            # If this CoA is made for only one country, set it as the fiscal country of the company.
-            company.account_fiscal_country_id = self.country_id
 
         return {}
 

--- a/addons/account/models/res_config_settings.py
+++ b/addons/account/models/res_config_settings.py
@@ -126,6 +126,7 @@ class ResConfigSettings(models.TransientModel):
         readonly=False,
         related='company_id.account_cash_basis_base_account_id',
         domain=[('deprecated', '=', False)])
+    account_fiscal_country_id = fields.Many2one(string="Fiscal Country Code", related="company_id.account_fiscal_country_id", readonly=False, store=False)
 
     qr_code = fields.Boolean(string='Display SEPA QR-code', related='company_id.qr_code', readonly=False)
     invoice_is_print = fields.Boolean(string='Print', related='company_id.invoice_is_print', readonly=False)

--- a/addons/account/views/res_config_settings_views.xml
+++ b/addons/account/views/res_config_settings_views.xml
@@ -130,6 +130,19 @@
                                     </div>
                                 </div>
                             </div>
+                            <div class="col-12 col-lg-6 o_setting_box" id="tax_fiscal_country_234">
+                                <div class="o_setting_left_pane"/>
+                                <div class="o_setting_right_pane">
+                                    <span class="o_form_label">Fiscal Country</span>
+                                    <span class="fa fa-lg fa-building-o" title="Values set here are company-specific." role="img" aria-label="Values set here are company-specific." groups="base.group_multi_company"/>
+                                    <div class="text-muted">
+                                        Domestic country of your accounting
+                                    </div>
+                                    <div class="text-muted">
+                                        <field name="account_fiscal_country_id"/>
+                                    </div>
+                                </div>
+                            </div>
                         </div>
                         <h2>Currencies</h2>
                         <div class="row mt16 o_settings_container" name="main_currency_setting_container">

--- a/addons/l10n_generic_coa/data/l10n_generic_coa.xml
+++ b/addons/l10n_generic_coa/data/l10n_generic_coa.xml
@@ -8,6 +8,6 @@
         <field name="cash_account_code_prefix">1015</field>
         <field name="transfer_account_code_prefix">1017</field>
         <field name="currency_id" ref="base.USD"/>
-        <field name="country_id" ref="base.us"/>
+        <field name="country_id" eval="False"/>
     </record>
 </odoo>

--- a/addons/l10n_generic_coa/data/l10n_generic_coa_post.xml
+++ b/addons/l10n_generic_coa/data/l10n_generic_coa_post.xml
@@ -4,7 +4,6 @@
     <!-- Tax template for sale and purchase -->
     <record id="tax_group_15" model="account.tax.group">
         <field name="name">Tax 15%</field>
-        <field name="country_id" ref="base.us"/>
     </record>
 </data>
 <data>


### PR DESCRIPTION
Task ID: 2717840

Currently:
- Generic_coa has the country_id US, which is not valid for non-supported localizations. This creates a bug as the country on taxes and account_fiscal_country_id becomes different.
- Users who only have Invoicing installed can't change the fiscal country setting as it's only available in Accounting.

Desired:
- Set account_fiscal_country_id the same as country_id
- Remove base.us from l10n_generic_coa
- Adjust the error message to make the issue clearer for users
- Allow changing fiscal country in Invoicing


--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
