### PR TITLE
[IMP] mail: move discuss widget logic in discuss view - part1

### DIFF
--- a/addons/mail/static/src/components/discuss/discuss.js
+++ b/addons/mail/static/src/components/discuss/discuss.js
@@ -1,6 +1,7 @@
 /** @odoo-module **/
 
-import { useUpdate } from '@mail/component_hooks/use_update';
+import { useComponentToModel } from '@mail/component_hooks/use_component_to_model';
+import { useUpdateToModel } from '@mail/component_hooks/use_update_to_model';
 import { registerMessagingComponent } from '@mail/utils/messaging_component';
 import { LegacyComponent } from '@web/legacy/legacy_component';
 
@@ -10,25 +11,8 @@ export class Discuss extends LegacyComponent {
      * @override
      */
     setup() {
-        this._updateLocalStoreProps();
-        // bind since passed as props
-        useUpdate({ func: () => this._update() });
-    }
-
-    _update() {
-        if (this.discussView.discuss.thread) {
-            this.trigger('o-push-state-action-manager');
-        }
-        if (
-            this.discussView.discuss.thread &&
-            this.discussView.discuss.thread === this.messaging.inbox &&
-            this.discussView.discuss.threadView &&
-            this._lastThreadCache === this.discussView.discuss.threadView.threadCache.localId &&
-            this._lastThreadCounter > 0 && this.discussView.discuss.thread.counter === 0
-        ) {
-            this.trigger('o-show-rainbow-man');
-        }
-        this._updateLocalStoreProps();
+        useComponentToModel({ fieldName: 'component' });
+        useUpdateToModel({ methodName: 'onComponentUpdate' });
     }
 
     //--------------------------------------------------------------------------
@@ -41,35 +25,6 @@ export class Discuss extends LegacyComponent {
     get discussView() {
         return this.props.record;
     }
-
-    //--------------------------------------------------------------------------
-    // Private
-    //--------------------------------------------------------------------------
-
-    /**
-     * @private
-     */
-    _updateLocalStoreProps() {
-        /**
-         * Locally tracked store props `activeThreadCache`.
-         * Useful to set scroll position from last stored one and to display
-         * rainbox man on inbox.
-         */
-        this._lastThreadCache = (
-            this.discussView.discuss.threadView &&
-            this.discussView.discuss.threadView.threadCache &&
-            this.discussView.discuss.threadView.threadCache.localId
-        );
-        /**
-         * Locally tracked store props `threadCounter`.
-         * Useful to display the rainbow man on inbox.
-         */
-        this._lastThreadCounter = (
-            this.discussView.discuss.thread &&
-            this.discussView.discuss.thread.counter
-        );
-    }
-
 }
 
 Object.assign(Discuss, {

--- a/addons/mail/static/src/widgets/discuss/discuss.js
+++ b/addons/mail/static/src/widgets/discuss/discuss.js
@@ -81,17 +81,9 @@ export const DiscussWidget = AbstractAction.extend({
             this._pushStateActionManager();
             this._lastPushStateActiveThread = this.discuss.thread;
         };
-        this._showRainbowManEventListener = ev => {
-            ev.stopPropagation();
-            this._showRainbowMan();
-        };
         this.el.addEventListener(
             'o-push-state-action-manager',
             this._pushStateActionManagerEventListener
-        );
-        this.el.addEventListener(
-            'o-show-rainbow-man',
-            this._showRainbowManEventListener
         );
 
         this.app = new App(DiscussContainer, {
@@ -116,10 +108,6 @@ export const DiscussWidget = AbstractAction.extend({
             'o-push-state-action-manager',
             this._pushStateActionManagerEventListener
         );
-        this.el.removeEventListener(
-            'o-show-rainbow-man',
-            this._showRainbowManEventListener
-        );
     },
 
     //--------------------------------------------------------------------------
@@ -133,15 +121,6 @@ export const DiscussWidget = AbstractAction.extend({
         this.actionManager.do_push_state({
             action: this.action.id,
             active_id: this.discuss.activeId,
-        });
-    },
-    /**
-     * @private
-     */
-    _showRainbowMan() {
-        this.trigger_up('show_effect', {
-            message: this.env._t("Congratulations, your inbox is empty!"),
-            type: 'rainbow_man',
         });
     },
 });


### PR DESCRIPTION
Component logic should be handled by their models. The discuss_view model has been
introduced, but the logic of discuss is still handled by it's widget. Let's move it
inside discuss_view.
