### PR TITLE
[BUG] base: inherits and default values

### DIFF
--- a/odoo/addons/test_new_api/tests/test_onchange.py
+++ b/odoo/addons/test_new_api/tests/test_onchange.py
@@ -1150,6 +1150,16 @@ class TestComputeOnchange2(TransactionCase):
         self.assertEqual(form.bar, "foor")
         self.assertEqual(form.baz, "baz")
 
+    def test_onchange_default_on_inherits(self):
+        message = self.env.ref('test_new_api.message_0_0')
+        form = Form(
+            self.env['test_new_api.emailmessage'].with_context(
+                default_message=message.id,
+            )
+        )
+        self.assertEqual(form.label, message.label)
+        self.assertEqual(form.message, message)
+
     def test_onchange_once(self):
         """ Modifies `foo` field which will trigger an onchange method and
         checks it was triggered only one time. """


### PR DESCRIPTION
Add unit tests to prove a bug. No fix yet..

The added test is self explainatory, but here's some more context:

[EmailMessage](https://github.com/odoo/odoo/blob/c0ce5619ada6952261fd44f28108108040629d81/odoo/addons/test_new_api/models/test_new_api.py#L216) inherits from [Message](https://github.com/odoo/odoo/blob/c0ce5619ada6952261fd44f28108108040629d81/odoo/addons/test_new_api/models/test_new_api.py#L127) through its `message` field.



It's impossible to set a default value for this field, as it gets set back to `False` during the `onchange`.
It's even worse, the results are unpredictable. Related inherited fields will reference the value of the parent `message`, but the message itself will be `False`. (see `self.assertEqual(form.label, message.label)`)


I couldn't find a fix yet, but I tracked it down to this:

- https://github.com/odoo/odoo/blob/c0ce5619ada6952261fd44f28108108040629d81/odoo/models.py#L6415-L6418

Which makes the `record`, `snapshot0` and `snapshot1` to have a `NewId` value for `message` in the end, that gets converted to `False` during `convert_to_write`


--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
