### PR TITLE
[FIX] knowledge: ignore field html editor style

### DIFF
--- a/addons/knowledge/__manifest__.py
+++ b/addons/knowledge/__manifest__.py
@@ -36,7 +36,6 @@
     'post_init_hook': '_init_private_article_per_user',
     'assets': {
         'web.assets_backend': [
-            ('remove', 'web_editor/static/src/scss/web_editor.backend.scss'),
             'web/static/fonts/fonts.scss',
             'knowledge/static/src/components/*/*.scss',
             'knowledge/static/src/components/*/*.js',

--- a/addons/knowledge/static/src/scss/knowledge_editor.scss
+++ b/addons/knowledge/static/src/scss/knowledge_editor.scss
@@ -18,6 +18,11 @@ $o-knowledge-font-configs: (
 
 .o_knowledge_editor {
     min-height: 100%;
+    font-family: "Roboto", "Odoo Unicode Support Noto", sans-serif;
+    font-weight: 400;
+    font-size: 1rem;
+    line-height: 1.5;
+    color: #212529;
     .oe_form_field {
         display: flex;
         flex-direction: column;
@@ -29,11 +34,6 @@ $o-knowledge-font-configs: (
     }
     .note-editable,
     .o_readonly {
-        font-family: "Roboto", "Odoo Unicode Support Noto", sans-serif;
-        font-weight: 400;
-        font-size: 1rem;
-        line-height: 1.5;
-        color: #212529;
         flex-grow: 1;
         padding-top: 1rem !important;
 


### PR DESCRIPTION
[FIX] knowledge: restore web_editor.backend style

- What is Broken ?

The file `web_editor.backend.scss` was incorrectly removed for every module by
the Knowledge `__manifest__`.
i.e.: The iframe in `mass_mailing` became too small, breaking the mailing preview.

- Fix 

The file is restored.

Task-2853336