### PR TITLE
[FIX] core: ordered to_compute

### DIFF
--- a/odoo/api.py
+++ b/odoo/api.py
@@ -26,7 +26,7 @@ from weakref import WeakSet
 from decorator import decorate
 
 from .exceptions import CacheMiss
-from .tools import frozendict, classproperty, lazy_property, StackMap
+from .tools import frozendict, classproperty, lazy_property, StackMap, OrderedSet
 from .tools.translate import _
 
 _logger = logging.getLogger(__name__)
@@ -821,7 +821,7 @@ class Transaction:
         # fields to protect {field: ids}
         self.protected = StackMap()
         # pending computations {field: ids}
-        self.tocompute = defaultdict(set)
+        self.tocompute = defaultdict(OrderedSet)
         # pending updates {model: {id: {field: value}}}
         self.towrite = defaultdict(lambda: defaultdict(dict))
 


### PR DESCRIPTION
Set order is not randomized for integers (integer hash is the integers
itself and doesnt use pythonhashseed)
but the output may be ordered or not depending of the values:

```python
In [2]: list(set(range(126,130)))
Out[2]: [128, 129, 126, 127]
```
```python
In [3]: list(set(range(130,134)))
Out[3]: [130, 131, 132, 133]
```
This will lead to different results in query count tests depending on
the current value of the sequence.

The proposed solution is to use an Orderedset. We need to keep in
mind that the initialisation/operation on Orderedset may be slower but
this shouldn't represent any significant overhead in this case.