### PR TITLE
[FIX][gamification]: Validate mail template

### DIFF
--- a/addons/gamification/data/mail_template_data.xml
+++ b/addons/gamification/data/mail_template_data.xml
@@ -105,7 +105,7 @@
             <field name="partner_to">{{ object.user_id.partner_id.id }}</field>
             <field name="body_html" type="html">
 <div>
-    <strong>Reminder <t t-out="object.name or ''"/></strong><br/>
+    <strong>Reminder</strong><br/>
     You have not updated your progress for the goal <t t-out="object.definition_id.name or ''"></t> (currently reached at <t t-out="object.completeness or ''"></t>%) for at least <t t-out="object.remind_update_delay or ''"></t> days. Do not forget to do it.
     <br/><br/>
     Thank you,


### PR DESCRIPTION
'name' field not present in 'gamification.goal' model
which causes error while rendering mail template such that
object 'gamification.goal' has no attribute 'name'
opw-2844136

Description of the issue/feature this PR addresses:

Current behavior before PR:

- While selecting the Language in preview, it renders the mail template and causes validation error such that field 'name' not present in 'gamification.goal'

Desired behavior after PR is merged:

- It renders the mail template properly


--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
