### PR TITLE
[FIX] l10n_it: fix migration script

### DIFF
--- a/addons/l10n_it/migrations/15.0.0.3/post-migrate.py
+++ b/addons/l10n_it/migrations/15.0.0.3/post-migrate.py
@@ -5,7 +5,7 @@ def migrate(cr, version):
 
     cr.execute("""
         INSERT INTO account_account_account_tag
-        SELECT account.id, template_tag.account_account_tag_id
+        SELECT DISTINCT account.id, template_tag.account_account_tag_id
         FROM account_account_template AS template
         JOIN account_account AS account
             ON account.code LIKE CONCAT(template.code, '%')
@@ -14,4 +14,5 @@ def migrate(cr, version):
         JOIN res_company ON res_company.id = account.company_id
         JOIN res_country ON res_country.id = res_company.account_fiscal_country_id
             AND res_country.code = 'IT'
+        ON CONFLICT DO NOTHING
     """)


### PR DESCRIPTION
This migration script assigns the tags associated to an account's templates to the account itself. It can fail in the following cases:

1. The account already has this tag
2. The account is associated with multiple templates, and two or more of them share the same tag.

Fixed by adding an `ON CONFLICT DO NOTHING` clause. A `DISTINCT` clause was also added which, while redundant, is more efficient in case 2.