### PR TITLE
[FIX] sale: change of ordered quantity for service and ordered_timesheet

### DIFF
--- a/addons/sale/models/sale_order.py
+++ b/addons/sale/models/sale_order.py
@@ -591,7 +591,7 @@ class SaleOrder(models.Model):
         self and self.activity_unlink(['sale.mail_act_sale_upsell'])
         for order in self:
             ref = "<a href='#' data-oe-model='%s' data-oe-id='%d'>%s</a>"
-            order_ref = ref % (order._name, order.id, order.name)
+            order_ref = ref % (order._name, order.id or order._origin.id, order.name)
             customer_ref = ref % (order.partner_id._name, order.partner_id.id, order.partner_id.display_name)
             order.activity_schedule(
                 'sale.mail_act_sale_upsell',


### PR DESCRIPTION
Steps to reproduce:

-Install sales
-Create  a service product with policy ordered_timesheet and that create a
task and project
-Create an SO with this product for more than 1 hour and confirm it
-Add a timesheet in the corresponding task with the number of hours
-Go back to the sale order and change the number of ordered quantity
to a lower number

Current behavior:
An error with a traceback

Expected behavior:
No error and the creation of an upselling activity for this so

Explanation:
When changing the ordered quantity the record is a NewId and using its id
creates an error in the create_upsell_activity function as it is expecting
a number and not NewId. Thus we use _origin if there is no id to have the
SO id of the NewId.

opw-2848382