### PR TITLE
[FIX][gamification]: Validate mail template

### DIFF
--- a/addons/gamification/data/mail_template_data.xml
+++ b/addons/gamification/data/mail_template_data.xml
@@ -105,7 +105,7 @@
             <field name="partner_to">{{ object.user_id.partner_id.id }}</field>
             <field name="body_html" type="html">
 <div>
-    <strong>Reminder <t t-out="object.name or ''"/></strong><br/>
+    <strong>Reminder</strong><br/>
     You have not updated your progress for the goal <t t-out="object.definition_id.name or ''"></t> (currently reached at <t t-out="object.completeness or ''"></t>%) for at least <t t-out="object.remind_update_delay or ''"></t> days. Do not forget to do it.
     <br/><br/>
     Thank you,

--- a/addons/gamification/i18n/gamification.pot
+++ b/addons/gamification/i18n/gamification.pot
@@ -109,7 +109,7 @@ msgstr ""
 #: model:mail.template,body_html:gamification.email_template_goal_reminder
 msgid ""
 "<div>\n"
-"    <strong>Reminder <t t-out=\"object.name or ''\"/></strong><br/>\n"
+"    <strong>Reminder</strong><br/>\n"
 "    You have not updated your progress for the goal <t t-out=\"object.definition_id.name or ''\"/> (currently reached at <t t-out=\"object.completeness or ''\"/>%) for at least <t t-out=\"object.remind_update_delay or ''\"/> days. Do not forget to do it.\n"
 "    <br/><br/>\n"
 "    Thank you,\n"


### PR DESCRIPTION
Description of the issue/feature this PR addresses:

- `name` field not present in `gamification.goal` model
which causes error while rendering mail template such that
object `gamification.goal` has no attribute `name`
opw-2844136

Current behavior before PR:

- While selecting the Language in preview, it renders the mail template and causes validation error such that field 'name' not present in `gamification.goal`


Desired behavior after PR is merged:

- It renders the mail template properly


--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
