### PR TITLE
[FIX] account: fix accounting dashboard bar graphs

### DIFF
--- a/addons/account/models/account_journal_dashboard.py
+++ b/addons/account/models/account_journal_dashboard.py
@@ -138,7 +138,7 @@ class account_journal(models.Model):
 
     def get_bar_graph_datas(self):
         data = []
-        today = fields.Datetime.now(self)
+        today = fields.Date.today()
         data.append({'label': _('Due'), 'value':0.0, 'type': 'past'})
         day_of_week = int(format_datetime(today, 'e', locale=get_lang(self.env).code))
         first_day_of_week = today + timedelta(days=-day_of_week+1)
@@ -160,24 +160,29 @@ class account_journal(models.Model):
         (select_sql_clause, query_args) = self._get_bar_graph_select_query()
         query = ''
         start_date = (first_day_of_week + timedelta(days=-7))
+        weeks = []
         for i in range(0,6):
             if i == 0:
                 query += "("+select_sql_clause+" and invoice_date_due < '"+start_date.strftime(DF)+"')"
+                weeks.append((start_date.min, start_date))
             elif i == 5:
                 query += " UNION ALL ("+select_sql_clause+" and invoice_date_due >= '"+start_date.strftime(DF)+"')"
+                weeks.append((start_date, start_date.max))
             else:
                 next_date = start_date + timedelta(days=7)
                 query += " UNION ALL ("+select_sql_clause+" and invoice_date_due >= '"+start_date.strftime(DF)+"' and invoice_date_due < '"+next_date.strftime(DF)+"')"
+                weeks.append((start_date, next_date))
                 start_date = next_date
         # Ensure results returned by postgres match the order of data list
-        query += " ORDER BY aggr_date ASC"
         self.env.cr.execute(query, query_args)
         query_results = self.env.cr.dictfetchall()
         is_sample_data = True
         for index in range(0, len(query_results)):
             if query_results[index].get('aggr_date') != None:
                 is_sample_data = False
-                data[index]['value'] = query_results[index].get('total')
+                aggr_date = query_results[index]['aggr_date']
+                week_index = next(i for i in range(0, len(weeks)) if weeks[i][0] <= aggr_date < weeks[i][1])
+                data[week_index]['value'] = query_results[index].get('total')
 
         [graph_title, graph_key] = self._graph_title_and_key()
 


### PR DESCRIPTION
The Customer Invoices and Vendor Bills bar graphs in the accounting
dashboard skip empty weeks so the following weeks will be displayed
sooner

Steps to reproduce:
1. Install Accounting
2. Go to the accounting dashboard
3. The bar graph of Customer Invoices is not correct: it ends with empty
weeks but they should be in between the data

Solution:
Use a fallback date in the sql query so that whenever there are no moves
in a certain week, we can know which week it was in order to sort the
results by date

Problem:
The SQL query didn't return any date for empty weeks so sorting the
result by date would leave some weeks out of the bar graph

opw-2844159