### PR TITLE
[FIX] survey : fix displaying progression when consulting results

### DIFF
--- a/addons/survey/views/survey_templates.xml
+++ b/addons/survey/views/survey_templates.xml
@@ -24,7 +24,7 @@
             <div class="py-3 m-0 p-0 text-right">
                 <div class="o_survey_progress_wrapper d-inline-block pr-5 text-left">
                     <t t-call="survey.survey_progression"
-                        t-if="survey and survey.questions_layout != 'one_page' and answer and answer.state == 'in_progress' and (not question or not question.is_page)">
+                        t-if="survey and survey.questions_layout != 'one_page' and answer and answer.state == 'in_progress' and (not question or not question.is_page) and not survey_form_readonly">
                         <t t-if="survey.questions_layout == 'page_per_section'">
                             <t t-set="page_ids" t-value="survey.page_ids.ids"/>
                             <t t-set="page_number" t-value="page_ids.index(page.id) + (1 if survey.progression_mode == 'number' else 0)"/>


### PR DESCRIPTION
To reproduce
============

- Create a new Survey.
- Add questions under at least two sections.
- In Options, ensure that each section is displayed on its own page.
- Click "Share" and open the share link.
- Partially complete the survey and close the window before submitting.
- From the survey click "See Results". Then choose a response to a question from the partially completed answer.
- A traceback raised

Purpose
=======

On this condition :
https://github.com/odoo/odoo/blob/3602fdfc0ce8ed76a530c8c3cc1d49eecf9d250c/addons/survey/views/survey_templates.xml#L27

we check if we have to display the progression or not, in case of consulting results it doesn't make sense displaying it.
That means the check made in `t-if` was not enough in this case and a condition is missing.

Specification
=============

to solve the issue the condition `not survey_form_readonly` was added

opw-2821478