### PR TITLE
[IMP] mail: move discuss widget logic into model part2

### DIFF
--- a/addons/mail/static/src/components/discuss/discuss.js
+++ b/addons/mail/static/src/components/discuss/discuss.js
@@ -1,6 +1,5 @@
 /** @odoo-module **/
 
-import { useComponentToModel } from '@mail/component_hooks/use_component_to_model';
 import { useUpdateToModel } from '@mail/component_hooks/use_update_to_model';
 import { registerMessagingComponent } from '@mail/utils/messaging_component';
 import { LegacyComponent } from '@web/legacy/legacy_component';
@@ -11,7 +10,6 @@ export class Discuss extends LegacyComponent {
      * @override
      */
     setup() {
-        useComponentToModel({ fieldName: 'component' });
         useUpdateToModel({ methodName: 'onComponentUpdate' });
     }
 

--- a/addons/mail/static/src/models/discuss_view.js
+++ b/addons/mail/static/src/models/discuss_view.js
@@ -45,8 +45,16 @@ registerModel({
          * Handles OWL update on the discuss component.
          */
         onComponentUpdate() {
-            if (this.discuss.thread) {
-                this.component.trigger('o-push-state-action-manager');
+            if (this.discuss.thread && this.actionManager) {
+                if (this.lastPushStateActiveThread !== this.discuss.thread) {
+                    this.actionManager.do_push_state({
+                        action: this.actionId,
+                        active_id: this.discuss.activeId,
+                    });
+                    this.update({
+                        lastPushStateActiveThread: replace(this.discuss.thread),
+                    });
+                }
             }
             if (
                 this.discuss.thread &&
@@ -143,7 +151,16 @@ registerModel({
         },
     },
     fields: {
-        component: attr(),
+        /**
+         * Used to push state when changing active thread.
+         * The id of the action which opened discuss.
+         */
+        actionId: attr(),
+        /**
+         * Used to push state when changing active thread.
+         * The actionManager passed to the discuss widget.
+         */
+        actionManager: attr(),
         discuss: one('Discuss', {
             inverse: 'discussView',
             readonly: true,
@@ -159,6 +176,7 @@ registerModel({
             inverse: 'discussViewOwnerAsInbox',
             isCausal: true,
         }),
+        lastPushStateActiveThread: one('Thread'),
         /**
          * Useful to display rainbow man on inbox.
          */

--- a/addons/mail/static/tests/helpers/test_utils.js
+++ b/addons/mail/static/tests/helpers/test_utils.js
@@ -557,7 +557,7 @@ function getCreateThreadViewComponent({ afterEvent, env, target }) {
 
 function getOpenDiscuss({ afterNextRender, discuss, selector, widget }) {
     return async function openDiscuss() {
-        DiscussWidget.prototype._pushStateActionManager = () => {};
+        widget.do_push_state = () => {};
         const discussWidget = new DiscussWidget(widget, discuss);
         await discussWidget.appendTo($(selector));
         await afterNextRender(() => discussWidget.on_attach_callback());

--- a/addons/mail/static/tests/qunit_suite_tests/components/discuss_tests.js
+++ b/addons/mail/static/tests/qunit_suite_tests/components/discuss_tests.js
@@ -2564,7 +2564,7 @@ QUnit.test('composer state: attachments save and restore', async function (asser
         { name: "General" },
         { name: "Special" },
     ]);
-    const { discussWidget, messaging } = await this.start({
+    const { messaging } = await this.start({
         discuss: {
             params: {
                 default_active_id: `mail.channel_${mailChannelId1}`,
@@ -2582,7 +2582,7 @@ QUnit.test('composer state: attachments save and restore', async function (asser
             name: 'text.txt',
         });
         inputFiles(
-            discussWidget.discuss.threadView.composerView.fileUploader.fileInput,
+            messaging.discuss.threadView.composerView.fileUploader.fileInput,
             [file]
         );
     });
@@ -2608,7 +2608,7 @@ QUnit.test('composer state: attachments save and restore', async function (asser
     ];
     await afterNextRender(() =>
         inputFiles(
-            discussWidget.discuss.threadView.composerView.fileUploader.fileInput,
+            messaging.discuss.threadView.composerView.fileUploader.fileInput,
             files
         )
     );
@@ -3881,7 +3881,7 @@ QUnit.test('warning on send with shortcut when attempting to post message with s
 
     const pyEnv = await startServer();
     const mailChannelId1 = pyEnv['mail.channel'].create();
-    const { discussWidget } = await this.start({
+    const { messaging } = await this.start({
         discuss: {
             context: {
                 active_id: `mail.channel_${mailChannelId1}`,
@@ -3920,7 +3920,7 @@ QUnit.test('warning on send with shortcut when attempting to post message with s
     });
     await afterNextRender(() =>
         inputFiles(
-            discussWidget.discuss.threadView.composerView.fileUploader.fileInput,
+            messaging.discuss.threadView.composerView.fileUploader.fileInput,
             [file]
         )
     );


### PR DESCRIPTION
This PR prepares the ground for the one introducing the new environment in the discuss
app. Indeed, the discuss widget will be removed since it was used as an action. This widget
basically handle two things: rainbowman on empty inbox/push state. This second part focuses
on the push state aspect.

task-2582313