### PR TITLE
[FIX] web, partner_autocomplete: fix placeholder inside widgets

### DIFF
--- a/addons/partner_autocomplete/static/tests/partner_autocomplete_tests.js
+++ b/addons/partner_autocomplete/static/tests/partner_autocomplete_tests.js
@@ -150,7 +150,7 @@ odoo.define('partner_autocomplete.tests', function (require) {
     });
 
     QUnit.test("Partner autocomplete : Company type = Individual", function (assert) {
-        assert.expect(2);
+        assert.expect(3);
         var done = assert.async();
         createView({
             View: FormView,
@@ -159,7 +159,8 @@ odoo.define('partner_autocomplete.tests', function (require) {
             arch:
                 '<form>' +
                 '<field name="company_type"/>' +
-                '<field name="name" widget="field_partner_autocomplete"/>' +
+                '<field id="individual" name="name" widget="field_partner_autocomplete" placeholder="e.g. Some Individual" attrs="{\'required\': True, \'invisible\': False}"/>' +
+                '<field id="company" name="name" widget="field_partner_autocomplete" placeholder="e.g. Some Company" attrs="{\'required\': False, \'invisible\': True}"/>' +
                 '<field name="website"/>' +
                 '<field name="image_1920" widget="image"/>' +
                 '</form>',
@@ -171,6 +172,7 @@ odoo.define('partner_autocomplete.tests', function (require) {
             // Check input exists
             var $input = form.$(".o_field_partner_autocomplete > input:visible");
             assert.strictEqual($input.length, 1, "there should be an <input/> for the Partner field");
+            assert.strictEqual($input.attr("placeholder"), "e.g. Some Individual", "placeholder should match the one of the XML node");
 
             // Change input val and assert nothing happens
             testUtils.fields.editInput($input, "odoo")
@@ -185,7 +187,7 @@ odoo.define('partner_autocomplete.tests', function (require) {
 
 
     QUnit.test("Partner autocomplete : Company type = Company / Name search", async function (assert) {
-        assert.expect(17);
+        assert.expect(18)
         var fields = this.data['res.partner'].fields;
         var form = await createView({
             View: FormView,
@@ -194,7 +196,8 @@ odoo.define('partner_autocomplete.tests', function (require) {
             arch:
                 '<form>' +
                 '<field name="company_type"/>' +
-                '<field name="name" widget="field_partner_autocomplete"/>' +
+                '<field id="individual" name="name" widget="field_partner_autocomplete" placeholder="e.g. Some Individual" attrs="{\'required\': False, \'invisible\': True}"/>' +
+                '<field id="company" name="name" widget="field_partner_autocomplete" placeholder="e.g. Some Company" attrs="{\'required\': True, \'invisible\': False}"/>' +
                 '<field name="website"/>' +
                 '<field name="image_1920" widget="image"/>' +
                 '<field name="phone"/>' +
@@ -222,6 +225,7 @@ odoo.define('partner_autocomplete.tests', function (require) {
             // Check input exists
             var $input = form.$(".o_field_partner_autocomplete > input:visible");
             assert.strictEqual($input.length, 1, "there should be an <input/> for the field");
+            assert.strictEqual($input.attr("placeholder"), "e.g. Some Company", "placeholder should match the one of the XML node");
 
             // Change input val and assert changes
             await testUtils.fields.editInput($input, "odoo");
@@ -231,7 +235,7 @@ odoo.define('partner_autocomplete.tests', function (require) {
             assert.strictEqual($dropdown.children().length, 1, "there should be only ne proposition");
 
             await testUtils.dom.click($dropdown.find("a").first());
-            $input = form.$(".o_field_partner_autocomplete > input");
+            $input = form.$(".o_field_partner_autocomplete > input:visible");
             assert.strictEqual($input.val(), "Odoo", "Input value should have been updated to \"Odoo\"");
             assert.strictEqual(form.$("input.o_field_widget").val(), "odoo.com", "website value should have been updated to \"odoo.com\"");
 

--- a/addons/web/static/src/js/fields/basic_fields.js
+++ b/addons/web/static/src/js/fields/basic_fields.js
@@ -268,7 +268,7 @@ var InputField = DebouncedField.extend({
         this.$input = $input || $("<input/>");
         this.$input.addClass('o_input');
 
-        var inputAttrs = { placeholder: this.attrs.placeholder || "" };
+        var inputAttrs = { placeholder: (this.__node && this.__node.attrs.placeholder) || this.attrs.placeholder || "" };
         var inputVal;
         if (this.nodeOptions.isPassword) {
             inputAttrs = _.extend(inputAttrs, { type: 'password', autocomplete: this.attrs.autocomplete || 'new-password' });

--- a/addons/web/static/src/js/views/basic/basic_renderer.js
+++ b/addons/web/static/src/js/views/basic/basic_renderer.js
@@ -750,7 +750,9 @@ var BasicRenderer = AbstractRenderer.extend(WidgetAdapterMixin, {
         }
         this.allFieldWidgets[record.id].push(widget);
 
-        widget.__node = node; // TODO get rid of this if possible one day
+        // TODO get rid of this if possible one day
+        // BUT used by widgets to access some attributes of the node not accessible otherwise
+        widget.__node = node;
 
         // Prepare widget rendering and save the related promise
         var $el = $('<div>');


### PR DESCRIPTION
When multiple structured widgets (e.g. those creating DIVs on top of the usual
input [1]) for the same field (e.g. through the invisible attribute) are
created, the placeholder is not properly transmitted to the lower level
`input` (which is inside the div).

Step to reproduce the issue (in v15):
1. Install Contact module
2. Go to Settings > Contacts and activate "Partner Autocomplete"
3. Go on the form to create a new Contact and before inputting a name, switch
between company and individual (with the radio button)
You will see that the placeholder never changes, while it should state
"Lumber Inc" when ticking Company

Solution: The attributes passed onto a widget are given by the state of the
renderer, which is stored as a dictionnary (field_name: attributes).
Consequently, when you have multiple fields with the same name (e.g. when you
use multiple fields with `invisible` attributes to control which field is shown
), the information are overwritten in the dictionary. In the other hand, when
creating a widget, the main HTML element of it is post processed by the
renderer to add some properties of the XML node directly (e.g. placeholder,
style, etc. cfr [2]). However, some widget creates a structure (e.g. a div
wrapping an input) and the placeholder of the inner elements are defined by the
attributes of the widget (thus, passed by the state of the renderer, not the
node, which means this information may not be linked to the XML node directly,
as information may be overriden in the state).

[1]: https://github.com/odoo/odoo/blob/c8c3aa96e18827c3c032540b92e95b27bbed0fc3/addons/partner_autocomplete/static/src/js/partner_autocomplete_fieldchar.js#L99
[2]: https://github.com/odoo/odoo/blob/c8c3aa96e18827c3c032540b92e95b27bbed0fc3/addons/web/static/src/js/views/basic/basic_renderer.js#L466

opw-2801527