### PR TITLE
[FIX] mrp_subcontracting{_purchase}: small UX fixes

### DIFF
--- a/addons/mrp/models/mrp_production.py
+++ b/addons/mrp/models/mrp_production.py
@@ -1488,6 +1488,7 @@ class MrpProduction(models.Model):
 
     def _generate_backorder_productions(self, close_mo=True):
         backorders = self.env['mrp.production']
+        bo_to_assign = self.env['mrp.production']
         for production in self:
             if production.backorder_sequence == 0:  # Activate backorder naming
                 production.backorder_sequence = 1
@@ -1516,6 +1517,8 @@ class MrpProduction(models.Model):
                         new_moves_vals.append(move_vals[0])
                 self.env['stock.move'].create(new_moves_vals)
             backorders |= backorder_mo
+            if backorder_mo.picking_type_id.reservation_method == 'at_confirm':
+                bo_to_assign |= backorder_mo
 
             # We need to adapt `duration_expected` on both the original workorders and their
             # backordered workorders. To do that, we use the original `duration_expected` and the
@@ -1531,6 +1534,7 @@ class MrpProduction(models.Model):
             self.move_raw_ids.filtered(lambda m: not m.additional)._do_unreserve()
             self.move_raw_ids.filtered(lambda m: not m.additional)._action_assign()
         backorders.action_confirm()
+        bo_to_assign.action_assign()
 
         # Remove the serial move line without reserved quantity. Post inventory will assigned all the non done moves
         # So those move lines are duplicated.

--- a/addons/mrp_subcontracting/models/stock_move.py
+++ b/addons/mrp_subcontracting/models/stock_move.py
@@ -144,6 +144,10 @@ class StockMove(models.Model):
                 'is_subcontract': True,
                 'location_id': move.picking_id.partner_id.with_company(move.company_id).property_stock_subcontractor.id
             })
+            if float_compare(move.product_qty, 0, precision_rounding=move.product_uom.rounding) <= 0:
+                # If a subcontracted amount is decreased, don't create a MO that would be for a negative value.
+                # We don't care if the MO decreases even when done since everything is handled through picking
+                continue
             move_to_not_merge |= move
         for picking, subcontract_details in subcontract_details_per_picking.items():
             picking._subcontracted_produce(subcontract_details)

--- a/addons/mrp_subcontracting/models/stock_move.py
+++ b/addons/mrp_subcontracting/models/stock_move.py
@@ -16,6 +16,17 @@ class StockMove(models.Model):
         compute='_compute_show_subcontracting_details_visible'
     )
 
+    def _compute_display_assign_serial(self):
+        super(StockMove, self)._compute_display_assign_serial()
+        for move in self:
+            if not move.is_subcontract:
+                continue
+            productions = move._get_subcontract_production()
+            if not productions or move.has_tracking != 'serial':
+                continue
+            if productions._has_tracked_component() or productions[:1].consumption != 'strict':
+                move.display_assign_serial = False
+
     def _compute_show_subcontracting_details_visible(self):
         """ Compute if the action button in order to see moves raw is visible """
         self.show_subcontracting_details_visible = False
@@ -37,7 +48,8 @@ class StockMove(models.Model):
         for move in self:
             if not move.is_subcontract:
                 continue
-            if not move._get_subcontract_production()._has_tracked_component():
+            productions = move._get_subcontract_production()
+            if not productions._has_tracked_component() and productions[:1].consumption == 'strict':
                 continue
             move.show_details_visible = True
         return res
@@ -73,7 +85,7 @@ class StockMove(models.Model):
         subcontracted product. Otherwise use standard behavior.
         """
         self.ensure_one()
-        if self._subcontrating_should_be_record() or self._subcontrating_can_be_record():
+        if self.state != 'done' and (self._subcontrating_should_be_record() or self._subcontrating_can_be_record()):
             return self._action_record_components()
         action = super(StockMove, self).action_show_details()
         if self.is_subcontract and all(p._has_been_recorded() for p in self._get_subcontract_production()):

--- a/addons/mrp_subcontracting/models/stock_picking.py
+++ b/addons/mrp_subcontracting/models/stock_picking.py
@@ -148,6 +148,9 @@ class StockPicking(models.Model):
     def _subcontracted_produce(self, subcontract_details):
         self.ensure_one()
         for move, bom in subcontract_details:
+            if float_compare(move.product_qty, 0, precision_rounding=move.product_uom.rounding) <= 0:
+                # If a subcontracted amount is decreased, don't create a MO that would be for a negative value.
+                continue
             mo = self.env['mrp.production'].with_company(move.company_id).create(self._prepare_subcontract_mo_vals(move, bom))
             self.env['stock.move'].create(mo._get_moves_raw_values())
             self.env['stock.move'].create(mo._get_moves_finished_values())

--- a/addons/mrp_subcontracting/models/stock_picking.py
+++ b/addons/mrp_subcontracting/models/stock_picking.py
@@ -12,6 +12,13 @@ from dateutil.relativedelta import relativedelta
 class StockPicking(models.Model):
     _inherit = 'stock.picking'
 
+    # override existing field domains to prevent suboncontracting production lines from showing in Detailed Operations tab
+    move_line_nosuggest_ids = fields.One2many(
+        domain=['&', '|', ('location_dest_id.usage', '!=', 'production'), ('move_id.picking_code', '!=', 'outgoing'),
+                     '|', ('product_qty', '=', 0.0), '&', ('product_qty', '!=', 0.0), ('qty_done', '!=', 0.0)])
+    move_line_ids_without_package = fields.One2many(
+        domain=['&', '|', ('location_dest_id.usage', '!=', 'production'), ('move_id.picking_code', '!=', 'outgoing'),
+                     '|', ('package_level_id', '=', False), ('picking_type_entire_packs', '=', False)])
     display_action_record_components = fields.Selection(
         [('hide', 'Hide'), ('facultative', 'Facultative'), ('mandatory', 'Mandatory')],
         compute='_compute_display_action_record_components')

--- a/addons/mrp_subcontracting_purchase/tests/test_mrp_subcontracting_purchase.py
+++ b/addons/mrp_subcontracting_purchase/tests/test_mrp_subcontracting_purchase.py
@@ -2,6 +2,7 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 from odoo import Command
+from odoo.exceptions import UserError
 
 from odoo.addons.mrp_subcontracting.tests.common import TestMrpSubcontractingCommon
 
@@ -33,3 +34,51 @@ class MrpSubcontractingPurchaseTest(TestMrpSubcontractingCommon):
         action2 = picking.action_view_subcontracting_source_purchase()
         po_action2 = self.env[action2['res_model']].browse(action2['res_id'])
         self.assertEqual(po_action2, po)
+
+    def test_decrease_qty(self):
+        """ Tests when a PO for a subcontracted product has its qty decreased after confirmation
+        """
+
+        product_qty = 5.0
+        po = self.env['purchase.order'].create({
+            'partner_id': self.subcontractor_partner1.id,
+            'order_line': [Command.create({
+                'name': 'finished',
+                'product_id': self.finished.id,
+                'product_qty': product_qty,
+                'product_uom': self.finished.uom_id.id,
+                'price_unit': 50.0}
+            )],
+        })
+
+        po.button_confirm()
+        receipt = po.picking_ids
+        sub_mo = receipt._get_subcontract_production()
+        self.assertEqual(len(receipt), 1, "A receipt should have been created")
+        self.assertEqual(receipt.move_lines.product_qty, product_qty, "Qty of subcontracted product to receive is incorrect")
+        self.assertEqual(len(sub_mo), 1, "A subcontracting MO should have been created")
+        self.assertEqual(sub_mo.product_qty, product_qty, "Qty of subcontracted product to produce is incorrect")
+
+        # create a neg qty to proprogate to receipt
+        lower_qty = product_qty - 1.0
+        po.order_line.product_qty = lower_qty
+        sub_mos = receipt._get_subcontract_production()
+        self.assertEqual(receipt.move_lines.product_qty, lower_qty, "Qty of subcontracted product to receive should update (not validated yet)")
+        self.assertEqual(len(sub_mos), 1, "Original subcontract MO should have absorbed qty change")
+        self.assertEqual(sub_mo.product_qty, lower_qty, "Qty of subcontract MO should update (none validated yet)")
+
+        # increase qty again
+        po.order_line.product_qty = product_qty
+        sub_mos = receipt._get_subcontract_production()
+        self.assertEqual(sum(receipt.move_lines.mapped('product_qty')), product_qty, "Qty of subcontracted product to receive should update (not validated yet)")
+        self.assertEqual(len(sub_mos), 2, "A new subcontracting MO should have been created")
+
+        # check that a neg qty can't proprogate once receipt is done
+        for move in receipt.move_lines:
+            move.move_line_ids.qty_done = move.product_qty
+        receipt.button_validate()
+        self.assertEqual(receipt.state, 'done')
+        self.assertEqual(sub_mos[0].state, 'done')
+        self.assertEqual(sub_mos[1].state, 'done')
+        with self.assertRaises(UserError):
+            po.order_line.product_qty = lower_qty


### PR DESCRIPTION
This PR fixes a couple of small bugs:

---

**Fixes a few incorrect subcontracting UX behaviors:**
- When subcontract BOM is flexible, the record burger should always show
  so user can more easily record varying quantities
- When `show_operations=True` then `action_assign_serial` button in
  Operations tab should only show if subcontract BOM is NOT strict AND
  has no tracked components (instead of always showing regardless of BoM
  consumption and its components)
- When a subcontract receipt is backordered, the Done moves should no
  longer return `_action_record_components`.
- When 'show_operations=True' for receipts, we shouldn't display the
  subcontracting component lines in the Detailed Operations tab

---

**mrp_subcontracting{_purchase}: handle subcontract qty decrease**

Steps to reproduce:
- create a subcontracted product (i.e. create subcontract BoM)
- create and confirm PO for subcontracted product (qty > 1)
- try to decrease PO qty for subcontracted product

Expected Result:
Since receipt is not yet validated, the qty in the receipt should
decrease (it will in the subcontract MO as well, but this doesn't matter
since no one should work directly with the MO)

Actual Result:
A validation error occurs saying the qty to produce must be non-negative

We allow neg demand qtys to be proprogated from SOs and POs since
https://github.com/odoo/odoo/pull/76752 . While we added in a check to
make sure MOs are not created when a neg qty change is proprogated, we
forgot to add a check for subcontracted created MOs, hence the
validation error (i.e. the neg qty change is trying to create a
subcontracted MO of a neg amount.)

---

**mrp{_subcontracting}: auto assign backorders linked moves** <= diff sol for saas-15.2 onwards due to bo mechanism change

Previous fix: https://github.com/odoo/odoo/pull/84631 missed the case
when raw_move_ids have already done move_orig_ids (i.e. when 2/3 step
MOs or subcontracting w/ resupply contractor). This made it so when
MOs are backordered, these moves would not be reserved even though they
were in the original MO.

We fix this so now we always assign backorder MOs when the reservation
method is 'at_confirm' so we follow the previously existing (expected)
behavior.

Note that this fix is very similar to other fix
https://github.com/odoo/odoo/pull/79873

Task: 2777571

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
