### PR TITLE
[FIX] mrp_subcontracting: fix BoM structure subcontractor costs

### DIFF
--- a/addons/mrp_subcontracting/report/mrp_report_bom_structure.py
+++ b/addons/mrp_subcontracting/report/mrp_report_bom_structure.py
@@ -14,7 +14,7 @@ class ReportBomStructure(models.AbstractModel):
             'partner_id': seller.name.id,
             'quantity': bom_quantity,
             'uom': bom.product_uom_id.name,
-            'prod_cost': seller.price / ratio_uom_seller,
+            'prod_cost': seller.price / ratio_uom_seller * bom_quantity,
             'bom_cost': seller.price / ratio_uom_seller * bom_quantity,
             'level': level or 0
         }
@@ -25,7 +25,7 @@ class ReportBomStructure(models.AbstractModel):
             bom_quantity = bom.product_qty * factor
             seller = product._select_seller(quantity=bom_quantity, uom_id=bom.product_uom_id, params={'subcontractor_ids': bom.subcontractor_ids})
             if seller:
-                price += seller.product_uom._compute_price(seller.price, product.uom_id)
+                price += seller.product_uom._compute_price(seller.price, product.uom_id) * bom_quantity
         return price
 
     def _get_bom(self, bom_id=False, product_id=False, line_qty=False, line_id=False, level=False):
@@ -41,6 +41,7 @@ class ReportBomStructure(models.AbstractModel):
             if seller:
                 res['subcontracting'] = self._get_subcontracting_line(bom, seller, level, bom_quantity)
                 res['total'] += res['subcontracting']['bom_cost']
+                res['bom_cost'] += res['subcontracting']['bom_cost']
         return res
 
     def _get_sub_lines(self, bom, product_id, line_qty, line_id, level, child_bom_ids, unfolded):

--- a/addons/mrp_subcontracting/tests/test_subcontracting.py
+++ b/addons/mrp_subcontracting/tests/test_subcontracting.py
@@ -582,13 +582,39 @@ class TestSubcontractingFlows(TestMrpSubcontractingCommon):
             'name': self.subcontractor_partner1.id,
             'price': 5,
         })
+        self.env['product.supplierinfo'].create({
+            'product_tmpl_id': self.comp2.product_tmpl_id.id,
+            'name': self.subcontractor_partner1.id,
+            'price': 1,
+            'min_qty': 5,
+        })
         self.assertTrue(supplier.is_subcontractor)
         self.comp1.standard_price = 5
         report_values = self.env['report.mrp.report_bom_structure']._get_report_data(self.bom.id, searchQty=1, searchVariant=False)
         subcontracting_values = report_values['lines']['subcontracting']
         self.assertEqual(subcontracting_values['name'], self.subcontractor_partner1.display_name)
-        self.assertEqual(subcontracting_values['bom_cost'], 10)
         self.assertEqual(report_values['lines']['total'], 20)  # 10 For subcontracting + 5 for comp1 + 5 for subcontracting of comp2_bom
+        self.assertEqual(report_values['lines']['bom_cost'], 20)
+        self.assertEqual(subcontracting_values['bom_cost'], 10)
+        self.assertEqual(subcontracting_values['prod_cost'], 10)
+        self.assertEqual(report_values['lines']['components'][0]['total'], 5)
+        self.assertEqual(report_values['lines']['components'][1]['total'], 5)
+        report_values = self.env['report.mrp.report_bom_structure']._get_report_data(self.bom.id, searchQty=3, searchVariant=False)
+        subcontracting_values = report_values['lines']['subcontracting']
+        self.assertEqual(report_values['lines']['total'], 60)  # 30 for subcontracting + 15 for comp1 + 15 for subcontracting of comp2_bom
+        self.assertEqual(report_values['lines']['bom_cost'], 60)
+        self.assertEqual(subcontracting_values['bom_cost'], 30)
+        self.assertEqual(subcontracting_values['prod_cost'], 30)
+        self.assertEqual(report_values['lines']['components'][0]['total'], 15)
+        self.assertEqual(report_values['lines']['components'][1]['total'], 15)
+        report_values = self.env['report.mrp.report_bom_structure']._get_report_data(self.bom.id, searchQty=5, searchVariant=False)
+        subcontracting_values = report_values['lines']['subcontracting']
+        self.assertEqual(report_values['lines']['total'], 80)  # 50 for subcontracting + 25 for comp1 + 5 for subcontracting of comp2_bom
+        self.assertEqual(report_values['lines']['bom_cost'], 80)
+        self.assertEqual(subcontracting_values['bom_cost'], 50)
+        self.assertEqual(subcontracting_values['prod_cost'], 50)
+        self.assertEqual(report_values['lines']['components'][0]['total'], 25)
+        self.assertEqual(report_values['lines']['components'][1]['total'], 5)
 
     def test_several_backorders(self):
         def process_picking(picking, qty):


### PR DESCRIPTION
BoM Structure & Cost report has different errors:
- The product cost of a subcontractor included in a product doesn't
scale with the quantity of the product (Issue 1)
- The BoM cost of a product composed of a subcontractor doesn't include
the subcontractor price (Issue 2)
- The BoM cost of a component composed of a subcontractor doesn't scale
with the quantity for the subcontractor price (Issue 3)

Steps to reproduce:
1. Install mrp_subcontracting_purchase
2. Create a product 'TEST 1', in the Purchase tab specify 'Azure
Interior' as vendor with price 5$
3. Create a bill of material for the product 'TEST 1' with BoM type
'subcontracting', subcontractor 'Azure Interior' and product 'Bolt' as
component
4. Create another product 'TEST 2', in the Purchase tab specify 'Azure
Interior' as vendor with price 8$
5. Create a bill of material for the product 'TEST 2' with BoM type
'subcontracting', subcontractor 'Azure Interior' and product 'TEST 1'
as component
6. Go to the BoM Structure and Cost of product 'TEST 1'
7. The product BoM Cost doesn't include the subcontractor price (it
should be the sum of its components) (Issue 1)
8. Increase the quantity of the product by 1
9. The subcontractor's product cost doesn't change (it should increase
with the quantity) (Issue 2)
10. Go to the BoM Structure and Cost of product 'TEST 2'
11. Increase the quantity of the product by 1
12. The BoM Cost of component 'TEST 1' only counts the subcontractor
price once (it should be the sum of its components) (Issue 3)

Solution:
Scale the subcontractor product cost with the quantity, update the
BoM cost of a product with the subcontractor price (in `_get_bom`) and
scale the subcontractor price with the quantity (in `_get_price`)

opw-2844482