### PR TITLE
[FIX] website_event_sale: correct price

### DIFF
--- a/addons/website_event_sale/tests/__init__.py
+++ b/addons/website_event_sale/tests/__init__.py
@@ -1,4 +1,6 @@
 # -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
+from . import common
 from . import test_frontend_buy_tickets
+from . import test_website_event_sale_pricelist

--- a/addons/website_event_sale/tests/common.py
+++ b/addons/website_event_sale/tests/common.py
@@ -1,0 +1,54 @@
+# -*- coding: utf-8 -*-
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from datetime import timedelta
+
+from odoo.fields import Datetime
+from odoo.tests.common import TransactionCase
+
+
+class TestWebsiteEventSaleCommon(TransactionCase):
+
+    def setUp(self):
+        super().setUp()
+
+        self.event = self.env['event.event'].create({
+            'date_begin': (Datetime.today() + timedelta(days=5)).strftime('%Y-%m-%d 07:00:00'),
+            'date_end': (Datetime.today() + timedelta(days=5)).strftime('%Y-%m-%d 16:30:00'),
+            'name': 'Pycon',
+            'user_id': self.env.ref('base.user_admin').id,
+            'website_published': True,
+        })
+        self.ticket = self.env['event.event.ticket'].create([{
+            'event_id': self.event.id,
+            'name': 'Standard',
+            'product_id': self.env.ref('event_sale.product_product_event').id,
+            'price': 100,
+        }])
+        self.currency_test = self.env['res.currency'].create({
+            'name': 'eventX',
+            'rate': 10,
+            'rounding': 0.01,
+            'symbol': 'EX',
+        })
+        self.partner = self.env['res.partner'].create({'name': 'test'})
+        self.new_company = self.env['res.company'].create({
+            'currency_id': self.env.ref('base.EUR').id,
+            'name': 'Great Company EUR',
+            'partner_id': self.partner.id,
+        })
+        self.env['res.currency.rate'].create({
+            'company_id': self.new_company.id,
+            'currency_id': self.currency_test.id,
+            'name': '2022-01-01',
+            'rate': 10,
+        })
+
+        self.current_website = self.env['website'].get_current_website()
+        self.pricelist = self.current_website.get_current_pricelist()
+
+        self.so = self.env['sale.order'].create({
+            'company_id': self.new_company.id,
+            'partner_id': self.partner.id,
+            'pricelist_id': self.pricelist.id,
+        })

--- a/addons/website_event_sale/tests/test_website_event_sale_pricelist.py
+++ b/addons/website_event_sale/tests/test_website_event_sale_pricelist.py
@@ -1,0 +1,69 @@
+# -*- coding: utf-8 -*-
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from odoo.addons.website_sale.controllers.main import WebsiteSale
+from odoo.addons.website.tools import MockRequest
+from odoo.addons.website_event_sale.tests.common import TestWebsiteEventSaleCommon
+from odoo.tests import tagged
+
+
+@tagged('post_install', '-at_install')
+class TestWebsiteEventPriceList(TestWebsiteEventSaleCommon):
+
+    @classmethod
+    def setUpClass(cls):
+        super(TestWebsiteEventPriceList, cls).setUpClass()
+
+        cls.WebsiteSaleController = WebsiteSale()
+
+    def test_pricelist_different_currency(self):
+
+        so_line = self.env['sale.order.line'].create({
+            'event_id': self.event.id,
+            'event_ticket_id': self.ticket.id,
+            'name': self.event.name,
+            'order_id': self.so.id,
+            'product_id': self.ticket.product_id.id,
+            'product_uom_qty': 1,
+        })
+        # set pricelist to 0 - currency: company
+        self.pricelist.write({
+            'currency_id': self.new_company.currency_id.id,
+            'discount_policy': 'with_discount',
+            'item_ids': [(5, 0, 0), (0, 0, {
+                'applied_on': '3_global',
+                'compute_price': 'percentage',
+                'percent_price': 0,
+            })],
+            'name': 'With Discount Included',
+        })
+        with MockRequest(self.env, sale_order_id=self.so.id, website=self.current_website):
+            self.WebsiteSaleController.pricelist('With Discount Included')
+            self.so._cart_update(line_id=so_line.id, product_id=self.ticket.product_id.id, set_qty=1)
+        self.assertEqual(so_line.price_reduce, 100)
+
+        # set pricelist to 10% - without discount
+        self.pricelist.write({
+            'currency_id': self.currency_test.id,
+            'discount_policy': 'without_discount',
+            'item_ids': [(5, 0, 0), (0, 0, {
+                'applied_on': '3_global',
+                'compute_price': 'percentage',
+                'percent_price': 10,
+            })],
+            'name': 'Without Discount Included',
+        })
+        with MockRequest(self.env, sale_order_id=self.so.id, website=self.current_website):
+            self.WebsiteSaleController.pricelist('Without Discount Included')
+            self.so._cart_update(line_id=so_line.id, product_id=self.ticket.product_id.id, set_qty=1)
+        self.assertEqual(so_line.price_reduce, 900, 'Incorrect amount based on the pricelist and its currency.')
+
+        # set pricelist to 10% - with discount
+        self.pricelist.write({
+            'discount_policy': 'with_discount',
+            'name': 'With Discount Included',
+        })
+        with MockRequest(self.env, sale_order_id=self.so.id, website=self.current_website):
+            self.WebsiteSaleController.pricelist('With Discount Included')
+            self.so._cart_update(line_id=so_line.id, product_id=self.ticket.product_id.id, set_qty=1)
+        self.assertEqual(so_line.price_reduce, 900, 'Incorrect amount based on the pricelist and its currency.')


### PR DESCRIPTION
Steps to reproduce:
- Create a price list with different currency and discount with "show price and discount to the customer"
- On the website select this pricelist and register for the event.

Issue:
 The price in the cart is shown in the main currency

Cause:
When "without_discount" (show discount in price) is enabled, the price fetched is the one of the main currency

Solution:
the ticket.price and the booth.price are computed with the product.list_price (which is the not converted base price). The ticket.price_reduce and the booth.price_reduce are computed with the product.price (which is converted and discounted).

In our case, when we are in the with_discount situation we only use the [ticket booth].price_reduce which is therefore not a problem.

For the the without_discount, the price_unit is based on the [ticket booth].price. This is why we need to convert this price to compare it to the price_reduce and to be able to get the discount from it.

opw-2766997