### PR TITLE
[FIX] website_livechat: fix chatbot tour race condition

### DIFF
--- a/addons/website_livechat/static/tests/tours/website_livechat_chatbot_flow.js
+++ b/addons/website_livechat/static/tests/tours/website_livechat_chatbot_flow.js
@@ -17,6 +17,12 @@ LivechatButton.LivechatButton.include({
 
         return this._super(...arguments);
     },
+    _renderMessages: function () {
+        this._super(...arguments);
+
+        this._chatWindow.$('.o_livechat_chatbot_main_restart')
+            .addClass('ready');
+    },
     /**
      * Small override that removes current messages when restarting.
      * This allows to easily check for new posted messages without having the old ones "polluting"
@@ -118,7 +124,7 @@ tour.register('website_livechat_chatbot_flow_tour', {
     trigger: messagesContain("Ok bye!"),
     run: () => {}  // last step is displayed
 }, {
-    trigger: '.o_livechat_chatbot_main_restart',
+    trigger: '.o_livechat_chatbot_main_restart.ready',
     run: 'click'
 }, {
     trigger: messagesContain("Restarting conversation..."),


### PR DESCRIPTION
In some cases, the runbot tour was clicking on the "restart" conversation
button before we had the chance to register the click event on it.

This small commit adds a "ready" class on the button when we have correctly
registered the click event, and makes the tour stop wait for that class before
clicking to restart.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
