### PR TITLE
[FIX] mrp: freeze time for the BoM tests

### DIFF
--- a/addons/mrp/tests/test_bom.py
+++ b/addons/mrp/tests/test_bom.py
@@ -1,12 +1,15 @@
 # -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
-from odoo import exceptions, Command
+from odoo import exceptions, Command, fields
 from odoo.tests import Form
 from odoo.addons.mrp.tests.common import TestMrpCommon
 from odoo.tools import float_compare, float_round, float_repr
 
+from freezegun import freeze_time
 
+
+@freeze_time(fields.Date.today())
 class TestBoM(TestMrpCommon):
 
     def test_01_explode(self):


### PR DESCRIPTION
In some cases, `test_replenishment` fails "for no reason".

Two notions are needed to understand the issue:
The class of the method `test_replenishment` is a `TransactionCase`. So,
once initialized, a SQL transaction is started and is the same for all
tests:
https://github.com/odoo/odoo/blob/3d9a835379d07142748a366285894a5d0f6ded71/odoo/tests/common.py#L693-L696
Also, in a SQL request, the method `now()` does not really return the
current date:
> Notice that NOW() and its related functions return the start time of
the current transaction. In other words, the return values of the
function calls are the same within a transaction.
(https://www.postgresqltutorial.com/postgresql-date-functions/postgresql-now/)

So, suppose it's the end of day D01 and we start all the tests of the
class `TestBoM`. A SQL transaction is created and the tests are executed
one by one so it takes time: it is now the next day D02 and
`test_replenishment` is executed. At some point, it leads to:
https://github.com/odoo/odoo/blob/9ca9bcc51fa289ddb0548f81a795755d196e31ca/addons/stock/models/stock_orderpoint.py#L328-L333
i.e., we are reading the report `'report.stock.quantity'` at date
"`today()` + 3 months", which means "D02 + 3 months". However, the
report is a SQL view and is defined on an interval of "today +- 3
months". Here is the issue: we use `now()` to get the value of today.
For instance:
https://github.com/odoo/odoo/blob/2f0ad2c150e65806c5f0f3ca66f702cc74619074/addons/stock/report/report_stock_quantity.py#L96-L104
As explained above, `now()` returns the start time of the current
transaction: D01. Therefore, the report is defined until D01 + 3 months.
As a result, D02 + 3 months is outside of the range, the `read_group`
does not return anything, there isn't any need and the orderpoint is not
created -> the test will fail.