### PR TITLE
[FIX] http_routing, web: fix translation on additional modules

### DIFF
--- a/addons/http_routing/controllers/main.py
+++ b/addons/http_routing/controllers/main.py
@@ -13,7 +13,7 @@ class Routing(Home):
         IrHttp = request.env['ir.http'].sudo()
         modules = IrHttp.get_translation_frontend_modules()
         if mods:
-            modules += mods
+            modules += mods.split(',')
         return WebClient().translations(unique, mods=','.join(modules), lang=lang)
 
 

--- a/addons/web/static/src/legacy/js/core/translation.js
+++ b/addons/web/static/src/legacy/js/core/translation.js
@@ -68,7 +68,7 @@ var TranslationDataBase = Class.extend(/** @lends instance.TranslationDataBase# 
         url += '/' + (cacheId ? cacheId : Date.now());
         const paramsGet = {};
         if (modules) {
-            paramsGet.modules = modules.join(',');
+            paramsGet.mods = modules.join(',');
         }
         if (lang) {
             paramsGet.lang = lang;


### PR DESCRIPTION
Translations from non-standard modules on the website are not properly loaded,
thus no translation is done even though translated terms are valid (e.g.
signing a document shared).

Step to reproduce the issue:
1) Install the sign module & Install French language (or any execpt English)
2) Disable the English language
3) Go to Sign and Share on document
4) Open the link
You will see that the "Click to start" is not translated. Some other strings
too.

Solution: The appeared since commit [1]. In there, we changed the argument key
for additional modules while it was not changed on the backend resulting in
the module translation not loaded. Furthermore, in the backend the additional
modules were appended as if they were a list while it is a string.

[1]: https://github.com/odoo/odoo/commit/8cc066173dfb61bd95b8e1f0716f71f4e251810a

opw-2842699
