### PR TITLE
[FIX] http_routing: fix translation on additional modules

### DIFF
--- a/addons/http_routing/controllers/main.py
+++ b/addons/http_routing/controllers/main.py
@@ -13,5 +13,5 @@ class Routing(Home):
         IrHttp = request.env['ir.http'].sudo()
         modules = IrHttp.get_translation_frontend_modules()
         if mods:
-            modules += mods
+            modules += mods.split(',') if isinstance(mods, str) else mods
         return WebClient().translations(unique, mods=','.join(modules), lang=lang)


### PR DESCRIPTION
Since commit [1], the translation route has been updated from a JSON to a bare
HTTP endpoint. Consequently, the handling of the `mods` variable (passed into
the request) must be updated (previously, it was a list - thanks to the JSON,
while now it is a string - comma separated string of modules). However, there
are no issues in the codebase until 15.0 as the `mods` is never used until the
commit [2] and thus we can't see incorrect behavior in 13.0 and 14.0 stable
version.

The change originated from the PR [3].

[1]: https://github.com/odoo/odoo/commit/c54caca54df90da5ef6917b4d53c1e016064a820
[2]: https://github.com/odoo/enterprise/commit/d26ae4cb581dea06c6548a64aece1116d0bae0d6
[3]: https://github.com/odoo/odoo/pull/91478

opw-2842699