### PR TITLE
[FIX] project: use website lang for portal sharing view

### DIFF
--- a/addons/project/controllers/portal.py
+++ b/addons/project/controllers/portal.py
@@ -169,6 +169,11 @@ class ProjectCustomerPortal(CustomerPortal):
         user_context = request.session.get_context() if request.session.uid else {}
         mods = conf.server_wide_modules or []
         qweb_checksum = HomeStaticTemplateHelpers.get_qweb_templates_checksum(debug=request.session.debug, bundle="project.assets_qweb")
+        if request.env.lang:
+            lang = request.env.lang
+            session_info['user_context']['lang'] = lang
+            # Update Cache
+            user_context['lang'] = lang
         lang = user_context.get("lang")
         translation_hash = request.env['ir.translation'].get_web_translations_hash(mods, lang)
         cache_hashes = {

--- a/addons/project/views/project_sharing_templates.xml
+++ b/addons/project/views/project_sharing_templates.xml
@@ -9,7 +9,8 @@
     </template>
 
     <template id="project_sharing" name="Project Sharing View">
-        <iframe width="100%" height="100%" frameborder="0" t-attf-src="/my/project/{{ project_id }}/project_sharing"/>
+        <!--    We need to forward the request lang to ensure that the lang set on the portal match the lang delivered -->
+        <iframe width="100%" height="100%" frameborder="0" t-attf-src="/{{ request.context['lang'] }}/my/project/{{ str(project_id) }}/project_sharing"/>
     </template>
 
     <template id="project_sharing_embed" name="Project Sharing View Embed">


### PR DESCRIPTION
Step to reproduce:
- Have a least 2 lang with portal lang set to langA
- Log in as portal user
- In portal change lang to langB
- Go to portal sharing view

Current behaviour:
- Iframe does not get info from the request and use the user's
 lang

Behaviour after PR:
- If there is a lang set on the website (in url) we use this one
instead.


--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
