### PR TITLE
[IMP] account: improve how taxes are displayed at onboarding

### DIFF
--- a/addons/account/models/company.py
+++ b/addons/account/models/company.py
@@ -503,7 +503,7 @@ class ResCompany(models.Model):
 
         company = self.env.company
         company.sudo().set_onboarding_step_done('account_setup_taxes_state')
-        view_id_list = self.env.ref('account.view_tax_tree').id
+        view_id_list = self.env.ref('account.view_onboarding_tax_tree').id
         view_id_form = self.env.ref('account.view_tax_form').id
 
         return {

--- a/addons/account/views/account_tax_views.xml
+++ b/addons/account/views/account_tax_views.xml
@@ -19,6 +19,18 @@
             </field>
         </record>
 
+        <record id="view_onboarding_tax_tree" model="ir.ui.view">
+            <field name="name">account.onboarding.tax.tree</field>
+            <field name="model">account.tax</field>
+            <field name="inherit_id" ref="account.view_tax_tree" />
+            <field name="mode">primary</field>
+            <field name="arch" type="xml">
+                <xpath expr="//tree" position="attributes">
+                    <attribute name="default_order">active desc, type_tax_use desc, amount desc, sequence</attribute>
+                </xpath>
+            </field>
+        </record>
+
         <record id="tax_repartition_line_tree" model="ir.ui.view">
             <field name="name">account.tax.repartition.line.tree</field>
             <field name="model">account.tax.repartition.line</field>


### PR DESCRIPTION
This PR aims at improving the display of taxes at onboarding only.

Many active and inactive taxes are mixed in complicated localizations (e.g. Belgium),
even though most of those inactive taxes are useless for most of the users that are
going through the onboarding.

To achieve this, we should change the default sort on the list view as follows:
1. Active
2. Tax type
3. Tax amount (to group them together by amount, even if the column is hidden by default in the view)

Task id: 2846605