### PR TITLE
account: Fix propagation of tax fields to reconciliation widget

### DIFF
--- a/addons/account/models/account_reconcile_model.py
+++ b/addons/account/models/account_reconcile_model.py
@@ -474,7 +474,11 @@ class AccountReconcileModel(models.Model):
             'analytic_account_id': counterpart_vals.get('analytic_account_id'),
             'analytic_tag_ids': counterpart_vals.get('analytic_tag_ids', []),
             'reconcile_model_id': self.id,
-            'journal_id': counterpart_vals['journal_id']
+            'journal_id': counterpart_vals['journal_id'],
+            'tax_exigible': counterpart_vals.get('tax_exigible'),
+            'tax_repartition_line_id': counterpart_vals.get('tax_repartition_line_id'),
+            'tax_ids': counterpart_vals.get('tax_ids', []),
+            'tax_tag_ids': counterpart_vals.get('tax_tag_ids', []),
         }
 
     ####################################################


### PR DESCRIPTION
Description of the issue/feature this PR addresses:

If the reconciliation model is set to apply a tax on a counterpart
line, the tax values need to be propagated to the reconciliation
widget.

Current behavior before PR:

Taxes are not set on the generated journal entry.

Desired behavior after PR is merged:

Taxes and its tags are set on the generated journal entry.

OPW-2854377


--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
