### PR TITLE
[FIX] models.py: do not propagate `view_ref` context

### DIFF
--- a/odoo/addons/base/models/ir_ui_view.py
+++ b/odoo/addons/base/models/ir_ui_view.py
@@ -1182,8 +1182,11 @@ actual arch.
                     if missing_view_types:
                         comodel = self.env[field.comodel_name].sudo(False)
                         refs = self._get_view_refs(node)
-                        if refs:
-                            comodel = comodel.with_context(**refs)
+                        # Do not propagate <view_type>_view_ref of parent call to `_get_view`
+                        comodel = comodel.with_context(**{
+                            f'{view_type}_view_ref': refs.get(f'{view_type}_view_ref')
+                            for view_type in missing_view_types
+                        })
                         for view_type in missing_view_types:
                             subarch, _subview = comodel._get_view(view_type=view_type)
                             node.append(subarch)

--- a/odoo/addons/base/tests/test_views.py
+++ b/odoo/addons/base/tests/test_views.py
@@ -2343,6 +2343,31 @@ class TestViews(ViewCase):
             'A <graph> can only contains <field> nodes, found a <label>'
         )
 
+    def test_view_ref(self):
+        view = self.assertValid(
+            """
+                <form>
+                    <field name="groups_id" class="canary"/>
+                </form>
+            """
+        )
+        self.env["ir.model.data"].create({
+            'module': 'base',
+            'name': 'test_views_test_view_ref',
+            'model': 'ir.ui.view',
+            'res_id': view.id,
+        })
+        view_data = self.env['ir.ui.view'].with_context(form_view_ref='base.test_views_test_view_ref').get_view()
+        self.assertEqual(view.id, view_data['id'], "The view returned should be test_views_test_view_ref")
+        view_data = self.env['ir.ui.view'].with_context(form_view_ref='base.test_views_test_view_ref').get_view(view.id)
+        tree = etree.fromstring(view_data['arch'])
+        field_groups_id = tree.xpath('//field[@name="groups_id"]')[0]
+        self.assertEqual(
+            len(field_groups_id.xpath(".//*[@class='canary']")),
+            0,
+            "The view test_views_test_view_ref should not be in the views of the many2many field groups_id"
+        )
+
     def assertValid(self, arch, name='valid view', inherit_id=False):
         return self.View.create({
             'name': name,

--- a/odoo/models.py
+++ b/odoo/models.py
@@ -1667,11 +1667,6 @@ class BaseModel(metaclass=MetaModel):
             view_ref_key = view_type + '_view_ref'
             view_ref = self._context.get(view_ref_key)
             if view_ref:
-                # Do not propagate <view_type>_view_ref
-                # so these context keys are not used when fetching the subviews of one2many/many2many fields
-                context = dict(self._context)
-                context.pop(view_ref_key)
-                View = View.with_context(context)
                 if '.' in view_ref:
                     module, view_ref = view_ref.split('.', 1)
                     query = "SELECT res_id FROM ir_model_data WHERE model='ir.ui.view' AND module=%s AND name=%s"


### PR DESCRIPTION
When fetching the views of a one2many/many2many fields
in a form view, do not propagate the context keys
`form_view_ref`, `tree_view_ref`, ...

It was supposed to be already handled,
but the keys were not removed when the arg `view_id`
is passed to `_get_view`.