### PR TITLE
[FIX] mrp_plm: compare the difference between two BOMs

### DIFF
--- a/addons/mrp/models/mrp_bom.py
+++ b/addons/mrp/models/mrp_bom.py
@@ -143,8 +143,9 @@ class MrpBom(models.Model):
         res = super().copy(default)
         for bom_line in res.bom_line_ids:
             if bom_line.operation_id:
-                operation = res.operation_ids.filtered(lambda op: op.name == bom_line.operation_id.name and op.workcenter_id == bom_line.operation_id.workcenter_id)
-                bom_line.operation_id = operation
+                operation = res.operation_ids.filtered(lambda op: op._get_comparison_values() == bom_line.operation_id._get_comparison_values())
+                # Two operations could have the same values so we take the first one
+                bom_line.operation_id = operation[:1]
         return res
 
     @api.model

--- a/addons/mrp/models/mrp_routing.py
+++ b/addons/mrp/models/mrp_routing.py
@@ -77,3 +77,9 @@ class MrpRoutingWorkcenter(models.Model):
         count_data = dict((item['operation_id'][0], item['operation_id_count']) for item in data)
         for operation in self:
             operation.workorder_count = count_data.get(operation.id, 0)
+
+    def _get_comparison_values(self):
+        if not self:
+            return False
+        self.ensure_one()
+        return tuple(self[key] for key in  ('name', 'company_id', 'workcenter_id', 'time_mode', 'time_cycle_manual'))


### PR DESCRIPTION
Steps to reproduce the product:
- Enable “Work Orders” option in MRP settings
- Create a storable product “P1” with BOM:
    - BOM type: Manufacture this product
    - operations: “OP1”
    - Components: product “C1” consumed in the operation “OP1

- Create an ECO for “P1”:
    - Type: New Product Introduction
    - Apply on; Bill Of materials
    - Click on “Start Revision”

Problem:
A BOM change will be created for the component “C1” where it will be added and removed.

When creating an ECO, a copy of the original BOM will be created,
and then we compare the BOM lines of the two BOMs if they are identical (product, qty and operation)
but as the operation has been duplicated therefore created with a different ID,
the two lines will not be identical and a distorted change in the BOM will be detected

Solution:
- It is better to compare the fields of the operations instead of their ID to detect if a change has been made in the BOM

- When modifying the revision BOM so that a component is consumed in another operation than the original one,
a BOM line changes type “Remove” and “Add” will be added,
because we cannot detect that an update has been made, imagine we have the following BOM:

1:/ old_bom to produce “product A”:

Components:

“Product B” - 1 unit - operation 1 (id = 1)
“Product B” - 1 unit - operation 2 (id= 2)
-------------------------------------------------- -----------------

2:/ new_bom == copy of (old_bom)

Components:

Product B - 1 unit - Operation 1 (id = 3)
Product B - 1 unit - operation 2 (id= 4)


-------------------------------------------
Operation 1 (id=1) == Operation 1 (id=3)
Operation 2 (id = 2) == Operation (id = 4)

So as the product is the same in the two BOM lines, if we change the two operations at the same time,
we cannot check which line exactly was changed.

opw-2823253
opw-2809586
opw-2833083


https://user-images.githubusercontent.com/78867936/168627264-692ec475-9621-429c-904c-195ef9a8c2d5.mp4




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
