### PR TITLE
[IMP] mail, test_discuss_full: only return ids of public partners

### DIFF
--- a/addons/mail/models/mail_guest.py
+++ b/addons/mail/models/mail_guest.py
@@ -102,7 +102,7 @@ class MailGuest(models.Model):
                 'id': partner_root.id,
                 'name': partner_root.name,
             },
-            'public_partners': [],
+            'publicPartners': [],
             'shortcodes': [],
             'starred_counter': False,
         }

--- a/addons/mail/models/res_users.py
+++ b/addons/mail/models/res_users.py
@@ -154,7 +154,7 @@ class Users(models.Model):
             'menu_id': self.env['ir.model.data']._xmlid_to_res_id('mail.menu_root_discuss'),
             'needaction_inbox_counter': self.partner_id._get_needaction_count(),
             'partner_root': partner_root.sudo().mail_partner_format().get(partner_root),
-            'public_partners': list(self.env.ref('base.group_public').sudo().with_context(active_test=False).users.partner_id.mail_partner_format().values()),
+            'publicPartners': [('insert', [{'id': p.id} for p in self.env.ref('base.group_public').sudo().with_context(active_test=False).users.partner_id])],
             'shortcodes': self.env['mail.shortcode'].sudo().search_read([], ['source', 'substitution']),
             'starred_counter': self.partner_id._get_starred_count(),
         }

--- a/addons/mail/static/src/models/messaging_initializer.js
+++ b/addons/mail/static/src/models/messaging_initializer.js
@@ -60,7 +60,7 @@ registerModel({
          * @param {Object} param0.current_user_settings
          * @param {integer} [param0.needaction_inbox_counter=0]
          * @param {Object} param0.partner_root
-         * @param {Object[]} param0.public_partners
+         * @param {Array[]} param0.publicPartners
          * @param {Object[]} [param0.shortcodes=[]]
          * @param {integer} [param0.starred_counter=0]
          */
@@ -75,7 +75,7 @@ registerModel({
             menu_id,
             needaction_inbox_counter = 0,
             partner_root,
-            public_partners,
+            publicPartners,
             shortcodes = [],
             starred_counter = 0
         }) {
@@ -86,8 +86,8 @@ registerModel({
                 current_partner,
                 current_user_id,
                 partner_root,
-                public_partners,
             });
+            this.messaging.update({ publicPartners });
             // mailboxes after partners and before other initializers that might
             // manipulate threads or messages
             this._initMailboxes({
@@ -271,14 +271,12 @@ registerModel({
          * @param {Object} current_partner
          * @param {integer} current_user_id
          * @param {Object} partner_root
-         * @param {Object[]} [public_partners=[]]
          */
         _initPartners({
             currentGuest,
             current_partner,
             current_user_id: currentUserId,
             partner_root,
-            public_partners = [],
         }) {
             if (currentGuest) {
                 this.messaging.update({ currentGuest: insert(currentGuest) });
@@ -292,9 +290,6 @@ registerModel({
             }
             this.messaging.update({
                 partnerRoot: insert(this.messaging.models['Partner'].convertData(partner_root)),
-                publicPartners: insert(public_partners.map(
-                    publicPartner => this.messaging.models['Partner'].convertData(publicPartner)
-                )),
             });
         },
         /**

--- a/addons/mail/static/tests/helpers/mock_server.js
+++ b/addons/mail/static/tests/helpers/mock_server.js
@@ -2415,7 +2415,7 @@ MockServer.include({
             menu_id: false, // not useful in QUnit tests
             needaction_inbox_counter: this._mockResPartner_GetNeedactionCount(user.partner_id),
             partner_root: this._mockResPartnerMailPartnerFormat(this.partnerRootId).get(this.partnerRootId),
-            public_partners: [...this._mockResPartnerMailPartnerFormat(this.publicPartnerId).values()],
+            publicPartners: [['insert', [{ 'id': this.publicPartnerId }]]],
             shortcodes: this._mockSearchRead('mail.shortcode', [[], ['source', 'substitution']], {}),
             starred_counter: this._getRecords('mail.message', [['starred_partner_ids', 'in', user.partner_id]]).length,
         };

--- a/addons/test_discuss_full/tests/test_performance.py
+++ b/addons/test_discuss_full/tests/test_performance.py
@@ -99,7 +99,7 @@ class TestDiscussFullPerformance(TransactionCase):
         self.maxDiff = None
         self.users[0].flush()
         self.users[0].invalidate_cache()
-        with self.assertQueryCount(emp=85):  # 84 ent
+        with self.assertQueryCount(emp=82):
             init_messaging = self.users[0].with_user(self.users[0])._init_messaging()
 
         self.assertEqual(init_messaging, {
@@ -755,17 +755,9 @@ class TestDiscussFullPerformance(TransactionCase):
                 'out_of_office_date_end': False,
                 'user_id': False,
             },
-            'public_partners': [{
-                'active': False,
-                'display_name': 'Public user',
-                'email': False,
+            'publicPartners': [('insert', [{
                 'id': self.env.ref('base.public_partner').id,
-                'im_status': 'im_partner',
-                'is_internal_user': False,
-                'name': 'Public user',
-                'out_of_office_date_end': False,
-                'user_id': self.env.ref('base.public_user').id,
-            }],
+            }])],
             'currentGuest': False,
             'current_partner': {
                 'active': True,


### PR DESCRIPTION
Other data are not actually used. This will improve performance a bit (less
queries, less data to return) until the need to return this list goes away (it
requires a bigger refactoring).

The public partners part of the RPC goes from 320ms to 25ms for 2000 public users. Size of response is much smaller too.

task-2847983