### PR TITLE
[FIX] pos_mercury: don't crash when swiping without adding a line first

### DIFF
--- a/addons/pos_mercury/static/src/js/pos_mercury.js
+++ b/addons/pos_mercury/static/src/js/pos_mercury.js
@@ -431,7 +431,7 @@ PaymentScreenWidget.include({
                         if (swipe_pending_line) {
                             order.select_paymentline(swipe_pending_line);
                         } else {
-                            order.add_paymentline(self.payment_methods_by_id[parsed_result.payment_method_id]);
+                            order.add_paymentline(self.pos.payment_methods_by_id[parsed_result.payment_method_id]);
                         }
 
                         order.selected_paymentline.paid = true;


### PR DESCRIPTION
Small oversight introduced in b234e97f87c. Before this patch swiping
without selecting the mercury/vantiv payment method first resulted in
an error and potential double-charges.

opw-2792847