### PR TITLE
[FIX] mrp,purchase_stock,stock: avoid new param

### DIFF
--- a/addons/mrp/models/stock_orderpoint.py
+++ b/addons/mrp/models/stock_orderpoint.py
@@ -3,7 +3,7 @@
 
 from odoo import _, api, fields, models
 from odoo.tools.float_utils import float_is_zero
-
+from odoo.osv.expression import AND
 
 class StockWarehouseOrderpoint(models.Model):
     _inherit = 'stock.warehouse.orderpoint'
@@ -13,12 +13,12 @@ class StockWarehouseOrderpoint(models.Model):
         'mrp.bom', string='Bill of Materials', check_company=True,
         domain="[('type', '=', 'normal'), '&', '|', ('company_id', '=', company_id), ('company_id', '=', False), '|', ('product_id', '=', product_id), '&', ('product_id', '=', False), ('product_tmpl_id', '=', product_tmpl_id)]")
 
-    def _get_replenishment_order_notification(self, written_after):
+    def _get_replenishment_order_notification(self):
         self.ensure_one()
-        production = self.env['mrp.production'].search([
-            ('orderpoint_id', 'in', self.ids),
-            ('write_date', '>', written_after)
-        ], order='create_date desc', limit=1)
+        domain = [('orderpoint_id', 'in', self.ids)]
+        if self.env.context.get('written_date'):
+            domain = AND([domain, [('write_date', '>', self.env.context.get('written_after'))]])
+        production = self.env['mrp.production'].search(domain, limit=1)
         if production:
             action = self.env.ref('mrp.action_mrp_production_form')
             return {
@@ -34,7 +34,7 @@ class StockWarehouseOrderpoint(models.Model):
                     'sticky': False,
                 }
             }
-        return super()._get_replenishment_order_notification(written_after)
+        return super()._get_replenishment_order_notification()
 
     @api.depends('route_id')
     def _compute_show_bom(self):

--- a/addons/purchase_stock/models/stock.py
+++ b/addons/purchase_stock/models/stock.py
@@ -4,7 +4,7 @@
 from odoo import api, fields, models, _
 from odoo.tools.float_utils import float_round, float_is_zero
 from odoo.exceptions import UserError
-
+from odoo.osv.expression import AND
 
 class StockPicking(models.Model):
     _inherit = 'stock.picking'
@@ -237,12 +237,12 @@ class Orderpoint(models.Model):
 
         return result
 
-    def _get_replenishment_order_notification(self, written_after):
+    def _get_replenishment_order_notification(self):
         self.ensure_one()
-        order = self.env['purchase.order.line'].search([
-            ('orderpoint_id', 'in', self.ids),
-            ('write_date', '>', written_after)
-        ], limit=1).order_id
+        domain = [('orderpoint_id', 'in', self.ids)]
+        if self.env.context.get('written_date'):
+            domain = AND([domain, [('write_date', '>', self.env.context.get('written_after'))]])
+        order = self.env['purchase.order.line'].search(domain, limit=1).order_id
         if order:
             action = self.env.ref('purchase.action_rfq_form')
             return {
@@ -258,7 +258,7 @@ class Orderpoint(models.Model):
                     'sticky': False,
                 }
             }
-        return super()._get_replenishment_order_notification(written_after)
+        return super()._get_replenishment_order_notification()
 
     def _prepare_procurement_values(self, date=False, group=False):
         values = super()._prepare_procurement_values(date=date, group=group)

--- a/addons/stock/models/stock_orderpoint.py
+++ b/addons/stock/models/stock_orderpoint.py
@@ -216,7 +216,7 @@ class StockWarehouseOrderpoint(models.Model):
         self._procure_orderpoint_confirm(company_id=self.env.company)
         notification = False
         if len(self) == 1:
-            notification = self._get_replenishment_order_notification(now)
+            notification = self.with_context(written_after=now)._get_replenishment_order_notification()
         # Forced to call compute quantity because we don't have a link.
         self._compute_qty()
         self.filtered(lambda o: o.create_uid.id == SUPERUSER_ID and o.qty_to_order <= 0.0 and o.trigger == 'manual').unlink()
@@ -425,12 +425,12 @@ class StockWarehouseOrderpoint(models.Model):
             'trigger': 'manual',
         }
 
-    def _get_replenishment_order_notification(self, written_after):
+    def _get_replenishment_order_notification(self):
         self.ensure_one()
-        move = self.env['stock.move'].search([
-            ('orderpoint_id', 'in', self.ids),
-            ('write_date', '>', written_after)
-        ], limit=1)
+        domain = [('orderpoint_id', 'in', self.ids)]
+        if self.env.context.get('written_date'):
+            domain = expression.AND([domain, [('write_date', '>', self.env.context.get('written_after'))]])
+        move = self.env['stock.move'].search(domain, limit=1)
         if move.picking_id:
             return {
                 'type': 'ir.actions.client',


### PR DESCRIPTION
following commit 55398263f9297ab2709e4c4c2a9c6c3ee7f59c8a
Introduce a new param to fix a notification issue. However
we could use the context instead of a new parameter in order
to avoid breaking the customization.

Linked to PR #88303 discussion
