### PR TITLE
[FIX] web_editor: fix success button edition

### DIFF
--- a/addons/web_editor/static/src/js/wysiwyg/widgets/link.js
+++ b/addons/web_editor/static/src/js/wysiwyg/widgets/link.js
@@ -54,6 +54,20 @@ const Link = Widget.extend({
             // alpha -> epsilon classes. This is currently done by removing
             // all btn-* classes anyway.
         ];
+        // Manage the case where there is a button that is not of any type among
+        // those declared above.
+        const types = this.colorsData.map(el => `btn-${el.type}`);
+        const className = this._link.className;
+        const classArray = className ? className.split(' ') : [];
+        if (classArray && !classArray.find(cl => types.includes(cl))) {
+            const btn = classArray.find(cl => cl.startsWith('btn-')) || `btn-${classArray[0]}`;
+            const colorData = btn.split('btn-')[1];
+            this.colorsData.unshift({
+                type: colorData,
+                label: '/',
+                btnPreview: colorData,
+            });
+        }
 
         this.editable = editable;
         this.$editable = $(editable);


### PR DESCRIPTION
Before this PR, when selecting a button with the btn-success class, the editor did not work correctly. This was due to the fact that it was designed to handle primary, secondary, link or custom buttons but not success buttons. This PR adds the management of this type of button.

Steps to reproduce to see the bug fixed:
 - Drop a block with a <a> with the btn-success class
 - Click on the button to edit it
 - The link tool part in the editor does not work properly

task-2802139
--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
