### PR TITLE
[FIX] make sure the thanks button of the newsletter snippet is hidden before save

### DIFF
--- a/addons/website/static/src/scss/website.edit_mode.scss
+++ b/addons/website/static/src/scss/website.edit_mode.scss
@@ -248,3 +248,16 @@ body.editor_enable {
         }
     }
 }
+
+// TODO Put the following rules in a file that is not sent to the visitors
+// in the right app (website_mass_mailing).
+body.editor_enable {
+    .s_newsletter_subscribe_form {
+        .o_enable_preview {
+            display: block !important;
+        }
+        .o_disable_preview {
+            display: none !important;
+        }
+    }
+}

--- a/addons/website_mass_mailing/i18n/website_mass_mailing.pot
+++ b/addons/website_mass_mailing/i18n/website_mass_mailing.pot
@@ -110,6 +110,13 @@ msgstr ""
 
 #. module: website_mass_mailing
 #. openerp-web
+#: code:addons/website_mass_mailing/static/src/js/website_mass_mailing.editor.js:0
+#, python-format
+msgid "Display Thanks Button"
+msgstr ""
+
+#. module: website_mass_mailing
+#. openerp-web
 #: code:addons/website_mass_mailing/static/src/js/website_mass_mailing.js:0
 #, python-format
 msgid ""

--- a/addons/website_mass_mailing/static/src/js/website_mass_mailing.editor.js
+++ b/addons/website_mass_mailing/static/src/js/website_mass_mailing.editor.js
@@ -55,6 +55,18 @@ options.registry.mailing_list_subscribe = options.Class.extend({
         return def;
     },
     /**
+     * @see this.selectClass for parameters
+     */
+    toggleThanksButton(previewMode, widgetValue, params) {
+        const subscribeBtnEl = this.$target[0].querySelector('.js_subscribe_btn');
+        const thanksBtnEl = this.$target[0].querySelector('.js_subscribed_btn');
+
+        thanksBtnEl.classList.toggle('o_disable_preview', !widgetValue);
+        thanksBtnEl.classList.toggle('o_enable_preview', widgetValue);
+        subscribeBtnEl.classList.toggle('o_enable_preview', !widgetValue);
+        subscribeBtnEl.classList.toggle('o_disable_preview', widgetValue);
+    },
+    /**
      * @override
      */
     onBuilt: function () {
@@ -63,6 +75,42 @@ options.registry.mailing_list_subscribe = options.Class.extend({
         this.select_mailing_list('click').guardedCatch(function () {
             self.getParent()._onRemoveClick($.Event( "click" ));
         });
+    },
+    /**
+     * @override
+     */
+    cleanForSave() {
+        const previewClasses = ['o_disable_preview', 'o_enable_preview'];
+        this.$target[0].querySelector('.js_subscribe_btn').classList.remove(...previewClasses);
+        this.$target[0].querySelector('.js_subscribed_btn').classList.remove(...previewClasses);
+    },
+
+    //--------------------------------------------------------------------------
+    // Private
+    //--------------------------------------------------------------------------
+
+    /**
+     * @override
+     */
+    _computeWidgetState(methodName, params) {
+        if (methodName !== 'toggleThanksButton') {
+            return this._super(...arguments);
+        }
+        const subscribeBtnEl = this.$target[0].querySelector('.js_subscribe_btn');
+        return subscribeBtnEl && subscribeBtnEl.classList.contains('o_disable_preview') ?
+            'true' : '';
+    },
+    /**
+     * @override
+     */
+    _renderCustomXML(uiFragment) {
+        const checkboxEl = document.createElement('we-checkbox');
+        checkboxEl.setAttribute('string', _t("Display Thanks Button"));
+        checkboxEl.dataset.toggleThanksButton = 'true';
+        checkboxEl.dataset.noPreview = 'true';
+        // Prevent this option from triggering a refresh of the public widget.
+        checkboxEl.dataset.noWidgetRefresh = 'true';
+        uiFragment.appendChild(checkboxEl);
     },
 });
 
@@ -137,14 +185,17 @@ options.registry.newsletter_popup = options.registry.mailing_list_subscribe.exte
         var self = this;
         var content = this.$target.data('content');
         if (content) {
+            const $layout = $('<div/>', {html: content});
+            const previewClasses = ['o_disable_preview', 'o_enable_preview'];
+            $layout[0].querySelector('.js_subscribe_btn').classList.remove(...previewClasses);
+            $layout[0].querySelector('.js_subscribed_btn').classList.remove(...previewClasses);
             this.trigger_up('get_clean_html', {
-                $layout: $('<div/>').html(content),
+                $layout: $layout,
                 callback: function (html) {
                     self.$target.data('content', html);
                 },
             });
         }
-        this._super.apply(this, arguments);
     },
     /**
      * @override

--- a/addons/website_mass_mailing/static/src/js/website_mass_mailing.js
+++ b/addons/website_mass_mailing/static/src/js/website_mass_mailing.js
@@ -17,6 +17,8 @@ const session = require('web.session');
 
 var _t = core._t;
 
+let alertReCaptchaDisplayed;
+
 publicWidget.registry.subscribe = publicWidget.Widget.extend({
     selector: ".js_subscribe",
     disabledInEditableMode: false,
@@ -48,7 +50,7 @@ publicWidget.registry.subscribe = publicWidget.Widget.extend({
         var self = this;
         var def = this._super.apply(this, arguments);
 
-        if (!this._recaptcha && this.editableMode && session.is_admin) {
+        if (!this._recaptcha && this.editableMode && session.is_admin && !alertReCaptchaDisplayed) {
             this.displayNotification({
                 type: 'info',
                 message: _t("Do you want to install Google reCAPTCHA to secure your newsletter subscriptions?"),
@@ -79,6 +81,7 @@ publicWidget.registry.subscribe = publicWidget.Widget.extend({
                     });
                 }}],
             });
+            alertReCaptchaDisplayed = true;
         }
 
         this.$popup = this.$target.closest('.o_newsletter_modal');

--- a/addons/website_mass_mailing/static/src/js/website_mass_mailing.js
+++ b/addons/website_mass_mailing/static/src/js/website_mass_mailing.js
@@ -47,7 +47,6 @@ publicWidget.registry.subscribe = publicWidget.Widget.extend({
      * @override
      */
     start: function () {
-        var self = this;
         var def = this._super.apply(this, arguments);
 
         if (!this._recaptcha && this.editableMode && session.is_admin && !alertReCaptchaDisplayed) {
@@ -91,23 +90,50 @@ publicWidget.registry.subscribe = publicWidget.Widget.extend({
             return def;
         }
 
-        var always = function (data) {
-            var isSubscriber = data.is_subscriber;
-            self.$('.js_subscribe_btn').prop('disabled', isSubscriber);
-            self.$('input.js_subscribe_email')
-                .val(data.email || "")
-                .prop('disabled', isSubscriber);
-            // Compat: remove d-none for DBs that have the button saved with it.
-            self.$target.removeClass('d-none');
-            self.$('.js_subscribe_btn').toggleClass('d-none', !!isSubscriber);
-            self.$('.js_subscribed_btn').toggleClass('d-none', !isSubscriber);
-        };
+        if (this.editableMode) {
+            // Since there is an editor option to choose whether "Thanks" button
+            // should be visible or not, we should not vary its visibility here.
+            return def;
+        }
+        const always = this._updateView.bind(this);
         return Promise.all([def, this._rpc({
             route: '/website_mass_mailing/is_subscriber',
             params: {
                 'list_id': this.$target.data('list-id'),
             },
         }).then(always).guardedCatch(always)]);
+    },
+    /**
+     * @override
+     */
+    destroy() {
+        this._updateView({is_subscriber: false});
+        this._super.apply(this, arguments);
+    },
+
+    //--------------------------------------------------------------------------
+    // Private
+    //--------------------------------------------------------------------------
+
+    /**
+     * Modifies the elements to have the view of a subscriber/non-subscriber.
+     *
+     * @param {Object} data
+     */
+    _updateView(data) {
+        const isSubscriber = data.is_subscriber;
+        const subscribeBtnEl = this.$target[0].querySelector('.js_subscribe_btn');
+        const thanksBtnEl = this.$target[0].querySelector('.js_subscribed_btn');
+        const emailInputEl = this.$target[0].querySelector('input.js_subscribe_email');
+
+        subscribeBtnEl.disabled = isSubscriber;
+        emailInputEl.value = data.email || '';
+        emailInputEl.disabled = isSubscriber;
+        // Compat: remove d-none for DBs that have the button saved with it.
+        this.$target[0].classList.remove('d-none');
+
+        subscribeBtnEl.classList.toggle('d-none', !!isSubscriber);
+        thanksBtnEl.classList.toggle('d-none', !isSubscriber);
     },
 
     //--------------------------------------------------------------------------


### PR DESCRIPTION
Before this commit the "Thanks" button of the newsletter block could be
saved as visible. This meant that a visitor who did not subscribe to the
newsletter would see the "Thanks" button on loading before it
disappeared. This commit solves this problem by hiding the button before
saving.

opw-2802139
--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
