### PR TITLE
[FIX] sale_management: avoid reordering of order lines

### DIFF
--- a/addons/web/static/src/legacy/js/fields/relational_fields.js
+++ b/addons/web/static/src/legacy/js/fields/relational_fields.js
@@ -1872,10 +1872,11 @@ var FieldX2Many = AbstractField.extend(WidgetAdapterMixin, {
         // validated by the model, trigger the change on the last record
         // (without the option, s.t. the potential onchange on parent record
         // is triggered)
+        var len = ev.data.recordIds.length - 1
         var recordId = recordIds.pop();
         var proms = recordIds.map(function (recordId, index) {
             var data = {};
-            data[handleField] = offset + index;
+            data[handleField] = offset - len + index;
             return self._setValue({
                 operation: 'UPDATE',
                 id: recordId,
@@ -1894,7 +1895,7 @@ var FieldX2Many = AbstractField.extend(WidgetAdapterMixin, {
                 }
             }
             var data = {};
-            data[handleField] = offset + recordIds.length;
+            data[handleField] = offset;
             self._setValue({
                 operation: 'UPDATE',
                 id: recordId,

--- a/addons/web/static/src/legacy/js/views/basic/basic_renderer.js
+++ b/addons/web/static/src/legacy/js/views/basic/basic_renderer.js
@@ -529,7 +529,7 @@ var BasicRenderer = AbstractRenderer.extend(WidgetAdapterMixin, {
 
         this.trigger_up('resequence_records', {
             handleField: this.handleField,
-            offset: _.min(sequences),
+            offset: _.max(sequences),
             recordIds: recordIds,
         });
     },

--- a/addons/web/static/tests/legacy/fields/relational_fields/field_one2many_tests.js
+++ b/addons/web/static/tests/legacy/fields/relational_fields/field_one2many_tests.js
@@ -704,7 +704,7 @@ QUnit.module('fields', {}, function () {
             );
 
             assert.strictEqual(nbConfirmChange, 1, "should have confirmed changes only once");
-            assert.verifySteps(["0", "1"],
+            assert.verifySteps(["8", "9"],
                 "sequences values should be incremental starting from the previous minimum one");
 
             assert.strictEqual(form.$('td.o_data_cell:not(.o_handle_cell)').text(), "blipyopkawa",
@@ -715,8 +715,8 @@ QUnit.module('fields', {}, function () {
             assert.deepEqual(_.map(this.data.turtle.records, function (turtle) {
                 return _.pick(turtle, 'id', 'turtle_foo', 'turtle_int');
             }), [
-                    { id: 1, turtle_foo: "yop", turtle_int: 1 },
-                    { id: 2, turtle_foo: "blip", turtle_int: 0 },
+                    { id: 1, turtle_foo: "yop", turtle_int: 9 },
+                    { id: 2, turtle_foo: "blip", turtle_int: 8 },
                     { id: 3, turtle_foo: "kawa", turtle_int: 21 }
                 ], "should have save the changed sequence");
 
@@ -946,7 +946,7 @@ QUnit.module('fields', {}, function () {
                 res_id: 1,
                 mockRPC: function (route, args) {
                     if (args.method === 'write') {
-                        assert.deepEqual(args.args[1].turtles, [[1, 2, { "turtle_int": 1 }], [1, 1, { "turtle_int": 2 }], [1, 3, { "turtle_int": 3 }]],
+                        assert.deepEqual(args.args[1].turtles, [[1, 2, { "turtle_int": -1 }], [1, 1, { "turtle_int": 0 }], [1, 3, { "turtle_int": 1 }]],
                             "should change all lines that have changed (the first one doesn't change because it has the same sequence)");
                     }
                     return this._super.apply(this, arguments);
@@ -1128,7 +1128,7 @@ QUnit.module('fields', {}, function () {
                 { position: 'top' }
             );
 
-            assert.equal(form.$('.o_field_one2many .o_list_char').text(), "#20#30#31#32#33#34#35#36#37#38",
+            assert.equal(form.$('.o_field_one2many .o_list_char').text(), "#20#22#21#23#24#25#26#27#28#29",
                 "should display the records in order after resequence (display record with turtle_int=0)");
 
             // Drag and drop the third line in second position
@@ -1138,11 +1138,11 @@ QUnit.module('fields', {}, function () {
                 { position: 'top' }
             );
 
-            assert.equal(form.$('.o_field_one2many .o_list_char').text(), "#20#39#40#41#42#43#44#45#46#47",
+            assert.equal(form.$('.o_field_one2many .o_list_char').text(), "#20#21#22#23#24#25#26#27#28#29",
                 "should display the records in order after resequence (display record with turtle_int=0)");
 
             await testUtils.dom.click(form.$('.o_form_label'));
-            assert.equal(form.$('.o_field_one2many .o_list_char').text(), "#20#39#40#41#42#43#44#45#46#47",
+            assert.equal(form.$('.o_field_one2many .o_list_char').text(), "#20#21#22#23#24#25#26#27#28#29",
                 "should display the records in order after resequence");
 
             await testUtils.form.clickDiscard(form);
@@ -1722,13 +1722,13 @@ QUnit.module('fields', {}, function () {
                     "sequences values should be apply from the begin index to the drop index");
             }
             assert.deepEqual(_.pluck(form.model.get(form.handle).data.turtles.data, 'data'), [
-                { id: 3, turtle_foo: "kawa", turtle_int: 2 },
-                { id: 7, turtle_foo: "a4", turtle_int: 3 },
-                { id: 1, turtle_foo: "yop", turtle_int: 4 },
-                { id: 2, turtle_foo: "blip", turtle_int: 5 },
-                { id: 5, turtle_foo: "a2", turtle_int: 6 },
-                { id: 6, turtle_foo: "a3", turtle_int: 7 },
-                { id: 4, turtle_foo: "a1", turtle_int: 8 }
+                { id: 3, turtle_foo: "kawa", turtle_int: 15 },
+                { id: 7, turtle_foo: "a4", turtle_int: 16 },
+                { id: 1, turtle_foo: "yop", turtle_int: 17 },
+                { id: 2, turtle_foo: "blip", turtle_int: 18 },
+                { id: 5, turtle_foo: "a2", turtle_int: 19 },
+                { id: 6, turtle_foo: "a3", turtle_int: 20 },
+                { id: 4, turtle_foo: "a1", turtle_int: 21 }
             ], "sequences must be apply correctly");
 
             form.destroy();
@@ -1777,7 +1777,7 @@ QUnit.module('fields', {}, function () {
                 { position: 'top' }
             );
 
-            assert.verifySteps(["0", "1"],
+            assert.verifySteps(["8", "9"],
                 "sequences values should be incremental starting from the previous minimum one");
 
             assert.strictEqual(form.$('td.o_data_cell:not(.o_handle_cell)').text(), "blipMy little Foo Valueyop",
@@ -8969,9 +8969,9 @@ QUnit.module('fields', {}, function () {
                     if (args.method === 'write') {
                         assert.deepEqual(args.args[1], {
                             turtles: [
-                                [1, 2, {turtle_int: 0}],
-                                [1, 3, {turtle_int: 1}],
-                                [1, 1, {turtle_int: 2}],
+                                [1, 2, {turtle_int: 19}],
+                                [1, 3, {turtle_int: 20}],
+                                [1, 1, {turtle_int: 21}],
                             ],
                         });
                     }
@@ -10017,12 +10017,12 @@ QUnit.module('fields', {}, function () {
             assert.deepEqual(_.map(this.data.turtle.records, function (turtle) {
                 return _.pick(turtle, 'id', 'turtle_int');
             }), [
-                {id: 1, turtle_int: 2},
-                {id: 2, turtle_int: 3},
-                {id: 3, turtle_int: 4},
-                {id: 4, turtle_int: 1},
-                {id: 5, turtle_int: 5},
-                {id: 6, turtle_int: 6},
+                {id: 1, turtle_int: 0},
+                {id: 2, turtle_int: 1},
+                {id: 3, turtle_int: 2},
+                {id: 4, turtle_int: -1},
+                {id: 5, turtle_int: 3},
+                {id: 6, turtle_int: 4},
             ], "should have saved the updated turtle_int sequence");
 
             form.destroy();

--- a/addons/web/static/tests/legacy/views/list_tests.js
+++ b/addons/web/static/tests/legacy/views/list_tests.js
@@ -7256,8 +7256,8 @@ QUnit.module('Views', {
                   '</tree>',
             mockRPC: function (route, args) {
                 if (route === '/web/dataset/resequence') {
-                    assert.strictEqual(args.offset, -4,
-                        "should write the sequence starting from the lowest current one");
+                    assert.strictEqual(args.offset, 17,
+                        "should write the sequence starting from the highest current one");
                     assert.strictEqual(args.field, 'int_field',
                         "should write the right field as sequence");
                     assert.deepEqual(args.ids, [4, 2 , 3],
@@ -7325,7 +7325,7 @@ QUnit.module('Views', {
                             context: {},
                             model: "foo",
                             ids: [4, 3],
-                            offset: 13,
+                            offset: 14,
                             field: "int_field",
                         });
                     }
@@ -7334,7 +7334,7 @@ QUnit.module('Views', {
                             context: {},
                             model: "foo",
                             ids: [4, 2],
-                            offset: 12,
+                            offset: 14,
                             field: "int_field",
                         });
                     }
@@ -7342,8 +7342,8 @@ QUnit.module('Views', {
                         assert.deepEqual(args, {
                             context: {},
                             model: "foo",
-                            ids: [2, 4],
-                            offset: 12,
+                            ids: [1, 2, 4, 3],
+                            offset: 15,
                             field: "int_field",
                         });
                     }
@@ -7352,7 +7352,7 @@ QUnit.module('Views', {
                             context: {},
                             model: "foo",
                             ids: [4, 2],
-                            offset: 12,
+                            offset: 17,
                             field: "int_field",
                         });
                     }
@@ -7416,8 +7416,8 @@ QUnit.module('Views', {
                   '</tree>',
             mockRPC: function (route, args) {
                 if (route === '/web/dataset/resequence') {
-                    assert.strictEqual(args.offset, 1,
-                        "should write the sequence starting from the lowest current one");
+                    assert.strictEqual(args.offset, 3,
+                        "should write the sequence starting from the highest current one");
                     assert.strictEqual(args.field, 'int_field',
                         "should write the right field as sequence");
                     assert.deepEqual(args.ids, [4, 2, 3],
@@ -7552,8 +7552,8 @@ QUnit.module('Views', {
             mockRPC: function (route, args) {
                 if (route === '/web/dataset/resequence') {
                     var _super = this._super.bind(this);
-                    assert.strictEqual(args.offset, 1,
-                        "should write the sequence starting from the lowest current one");
+                    assert.strictEqual(args.offset, 3,
+                        "should write the sequence starting from the highest current one");
                     assert.strictEqual(args.field, 'int_field',
                         "should write the right field as sequence");
                     assert.deepEqual(args.ids, [4, 2, 3],


### PR DESCRIPTION
How to reproduce the bug ?

- install the Sales app
- create a quotation template of at least 2 different items
- change the order of at least one element (eg. move the last element
to the first position) and save
- create a quotation and use the template that you have just created
- at the end of the order lines, add a new section and an item
- save the quotation

What is the bug ?

The order lines of a quotation template or a quotation use a number to
determinate their ordering. By default, all these numbers are the same.
They are only modified when you manually change the order of the
elements.
The bug appears because, when you use a quotation template where the
elements have been reordered and that you add elements (either a section
or an item) to the order lines of the quotation, their sequence numbers
are the default ones. Because of that, when you save the quotation, the
elements are reorganised and the added elements are moved after the
first element of the quotation template.

Signed-off-by: Adrien Minet <admi@odoo.com>

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
