### PR TITLE
[FIX] core: recompute fields triggered by indirectly modified relational fields

### DIFF
--- a/odoo/addons/test_new_api/models/test_new_api.py
+++ b/odoo/addons/test_new_api/models/test_new_api.py
@@ -1351,6 +1351,12 @@ class ComputeContainer(models.Model):
 
     name = fields.Char()
     member_ids = fields.One2many('test_new_api.compute.member', 'container_id')
+    member_count = fields.Integer(compute='_compute_member_count', store=True)
+
+    @api.depends('member_ids')
+    def _compute_member_count(self):
+        for record in self:
+            record.member_count = len(record.member_ids)
 
 
 class ComputeMember(models.Model):

--- a/odoo/addons/test_new_api/tests/test_one2many.py
+++ b/odoo/addons/test_new_api/tests/test_one2many.py
@@ -256,6 +256,18 @@ class One2manyCase(TransactionCase):
         # at this point, member.container_id must be computed for member to
         # appear in container.member_ids
         self.assertEqual(container.member_ids, member)
+        self.assertEqual(container.member_count, 1)
+
+        # Changing member.name will trigger recomputing member.container_id,
+        # container.member_ids and container.member_count. Since we are setting
+        # the name to bar, it will be detached from container, resulting in a
+        # member_count of zero on the container.
+        member.name = 'Bar'
+        self.assertEqual(container.member_count, 0)
+
+        # Reattach member to container again
+        member.name = 'Foo'
+        self.assertEqual(container.member_count, 1)
 
     def test_reward_line_delete(self):
         order = self.env['test_new_api.order'].create({


### PR DESCRIPTION
The cache currently fails to correctly invalidate relational fields that depend on a non-relational field. Two passes of invalidation are done, to reflect dependencies on both the old and the new written values. In the first pass only relational fields are considered, as explained in the comments:

> It is best explained with a simple example: consider two sales orders SO1 and SO2. The computed total amount on sales orders indirectly depends on the many2one field 'order_id' linking lines to their sales order.  Now consider the following code:
>
> line = so1.line_ids[0]      # pick a line from SO1
> line.order_id = so2         # move the line to SO2
>
> In this situation, the total amount must be recomputed on *both* sales order: the line's order before the modification, and the line's order after the modification.

The written values can be seen as the roots of a dependency forest (a collection of dependency trees). Before this commit all non-relational roots and their corresponding trees were filtered out during the first pass. However, this approach is wrong, as relational fields can also depend on non-relational fields. Instead, the complete dependency forest has to be traversed, skipping invalidation for non-relational fields during the first pass.

The test that was previously included accidentally succeeded because of a separate and unrelated bug in the orm domain parser: in certain one2many or many2many leafs the domain parser would not take into consideration the domain included in the definition of the field. As a result, the test still passed on accident, because the records that no longer matched the domain after the write were still invalidated during the second pass.

The problem can clearly be demonstrated, however, when the dependency is generated by a compute function.
