### PR TITLE
[FIX] web : set color to match background

### DIFF
--- a/addons/web/static/src/scss/layout_boxed.scss
+++ b/addons/web/static/src/scss/layout_boxed.scss
@@ -72,10 +72,12 @@
     /* compat 12.0 */
     .page > table:not(.o_main_table) tr td:last-child {
         background-color: gray('200');
+        color: $o-default-report-primary-color;
     }
     /* compat 12.0 */
     .row:not(#total) > div > table tbody tr:not(:last-child) td:last-child {
         background-color: gray('200');
+        color: $o-default-report-primary-color;
     }
     /*Total table*/
     /* row div rule compat 12.0 */


### PR DESCRIPTION
To reproduce
============

- choose boxed layout as document layout in settings
- enable packages in inventory
- set Incoming Shipments of warehouse on 3 steps
- enable detailed operations of *PACK* operation
- create a pack transfer
- in detailed operations tab, set destination pack
- validate the transfer and print the delivery slip

on PDF the line of destination pack is white text on clear gray (unreadable)

Purpose
=======

on that line two style classes are applied and both of them are changing the background color,

`.o_line_section` :
https://github.com/odoo/odoo/blob/9ce6136be700ae426b8910efd2357d16e2f49d7d/addons/web/static/src/scss/layout_boxed.scss#L61-L64
`.page > table:not(.o_main_table) tr td:last-child` :
https://github.com/odoo/odoo/blob/9ce6136be700ae426b8910efd2357d16e2f49d7d/addons/web/static/src/scss/layout_boxed.scss#L73-L75

We are taking the background color from one and the text color from the other one that don't match.

Specification
=============

to solve the issue we set the text color on `.page > table:not(.o_main_table) tr td:last-child` so that when this style class is
applied it has it's own text color, that matches the background, and doesn't take it from an other class.

opw-2841460