### PR TITLE
[FIX] project: allow adding a task from another project in dependencies

### DIFF
--- a/addons/project/models/project.py
+++ b/addons/project/models/project.py
@@ -1016,10 +1016,10 @@ class Task(models.Model):
     # Tracking of this field is done in the write function
     depend_on_ids = fields.Many2many('project.task', relation="task_dependencies_rel", column1="task_id",
                                      column2="depends_on_id", string="Blocked By", tracking=True, copy=False,
-                                     domain="[('allow_task_dependencies', '=', True), ('id', '!=', id)]")
+                                     domain="[('project_id', '!=', False), ('id', '!=', id)]")
     dependent_ids = fields.Many2many('project.task', relation="task_dependencies_rel", column1="depends_on_id",
                                      column2="task_id", string="Block", copy=False,
-                                     domain="[('allow_task_dependencies', '=', True), ('id', '!=', id)]")
+                                     domain="[('project_id', '!=', False), ('id', '!=', id)]")
     dependent_tasks_count = fields.Integer(string="Dependent Tasks", compute='_compute_dependent_tasks_count')
 
     # recurrence fields


### PR DESCRIPTION
Before this commit, it is not possible to add a task from another
project in the dependency of a task if the other project has not the
feature enabled. This restriction is not really wished since the user
could want blocks a main task with a task in a sub project in which
the feature is not enabled for instance.

To avoid enabling the feature to the another project to allow the user
selecting a task from a project in which the feature is not enabled,
this commit updates the domain to allow that and so, the user will be
able to select any task from any project even if the project of the
task selected has not the feature enabled.
