### PR TITLE
[FIX] account: make action consistent with smart button value

### DIFF
--- a/addons/account/models/partner.py
+++ b/addons/account/models/partner.py
@@ -470,7 +470,7 @@ class ResPartner(models.Model):
             ('move_type', 'in', ('out_invoice', 'out_refund')),
             ('partner_id', 'child_of', self.id),
         ]
-        action['context'] = {'default_move_type':'out_invoice', 'move_type':'out_invoice', 'journal_type': 'sale', 'search_default_unpaid': 1}
+        action['context'] = {'default_move_type':'out_invoice', 'move_type':'out_invoice', 'journal_type': 'sale', 'search_default_unpaid': 1, 'active_test': False}
         return action
 
     def can_edit_vat(self):


### PR DESCRIPTION
Total invoiced is computed with `active_test=False` [1], however the
corresponding action didn't have that context. Since Odoo 14 `child_of` domain
filters out unaccessible records (including archived ones) [2].

Fix it by adding the context to the action.

STEPS:

1. Have a active contact that has an amount invoiced (invoices pointing to this contact name).
2. Click through on the amount invoiced button, and receive a list of relevant invoices.
3. Now go back to the contact, and archive the contact.
4. The smart button containing the amount invoiced stays the same.
5. Click through on the smart button again

BEFORE: no invoices
AFTER : listed invoices corresponds to the computed total value

[1]: https://github.com/odoo/odoo/blob/574ca75ab6fa583aabc0c1cfc65206e72864e546/addons/account/models/partner.py#L379
[2]: https://github.com/odoo/odoo/commit/3e1b960acf3f6a726338476ba9e62e5ef5c84ef9

opw-2853525

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
