### PR TITLE
[FIX] point_of_sale: prevent pos from crashing with archived product

### DIFF
--- a/addons/point_of_sale/static/src/js/models.js
+++ b/addons/point_of_sale/static/src/js/models.js
@@ -2415,7 +2415,9 @@ exports.Order = Backbone.Model.extend({
         var orderlines = json.lines;
         for (var i = 0; i < orderlines.length; i++) {
             var orderline = orderlines[i][2];
-            this.add_orderline(new exports.Orderline({}, {pos: this.pos, order: this, json: orderline}));
+            if(this.pos.db.get_product_by_id(orderline.product_id)){
+                this.add_orderline(new exports.Orderline({}, {pos: this.pos, order: this, json: orderline}));
+            }
         }
 
         var paymentlines = json.statement_ids;


### PR DESCRIPTION
Current behavior:
If you create an order in a PoS then go in the backend and archive
any of the product in the order. If you try to go back in the PoS
session it will crash

Steps to reproduce:
- Open PoS session and create an order with some products
- Leave the session and archive atleast one of these products
- Go back to the session, the session crash

opw-2854018
--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
