### PR TITLE
[FIX] [14.0] Use move date when reversing exchange

### DIFF
--- a/addons/account/models/account_full_reconcile.py
+++ b/addons/account/models/account_full_reconcile.py
@@ -27,9 +27,8 @@ class AccountFullReconcile(models.Model):
         res = super().unlink()
 
         # Reverse all exchange moves at once.
-        today = fields.Date.context_today(self)
         default_values_list = [{
-            'date': today,
+            'date': move.date,
             'ref': _('Reversal of: %s') % move.name,
         } for move in moves_to_reverse]
         moves_to_reverse._reverse_moves(default_values_list, cancel=True)


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
Date of the reversal exchange moves are set on **today**.

Current behavior before PR:
When deleting a full reconcile move with exchange moves linked to it, the date of the reversal move of the exchange uses today as the default date.

Desired behavior after PR is merged:
Use the same date as the exchange move.

OPW-2856385
MT-719
@moduon 

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
