### PR TITLE
[FIX] base: add get_extension helper

### DIFF
--- a/odoo/addons/base/models/ir_http.py
+++ b/odoo/addons/base/models/ir_http.py
@@ -22,7 +22,7 @@ from odoo import api, http, models, tools, SUPERUSER_ID
 from odoo.exceptions import AccessDenied, AccessError
 from odoo.http import request, content_disposition
 from odoo.tools import consteq, pycompat
-from odoo.tools.mimetypes import guess_mimetype
+from odoo.tools.mimetypes import get_extension, guess_mimetype
 from odoo.modules.module import get_resource_path, get_module_path
 
 from odoo.http import ALLOWED_DEBUG_MODES
@@ -393,7 +393,7 @@ class IrHttp(models.AbstractModel):
             mimetype = guess_mimetype(decoded_content, default=default_mimetype)
 
         # extension
-        has_extension = bool(mimetypes.guess_type(filename)[0])
+        has_extension = get_extension(filename) or mimetypes.guess_type(filename)[0]
         if not has_extension:
             extension = mimetypes.guess_extension(mimetype)
             if extension:

--- a/odoo/addons/base/tests/test_mimetypes.py
+++ b/odoo/addons/base/tests/test_mimetypes.py
@@ -2,7 +2,7 @@ import base64
 import unittest
 
 from odoo.tests.common import BaseCase
-from odoo.tools.mimetypes import guess_mimetype
+from odoo.tools.mimetypes import guess_mimetype, get_extension
 
 PNG = b'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAIAAACQd1PeAAAADElEQVQI12P4//8/AAX+Av7czFnnAAAAAElFTkSuQmCC'
 GIF = b"R0lGODdhAQABAIAAAP///////ywAAAAAAQABAAACAkQBADs="
@@ -73,6 +73,20 @@ class test_guess_mimetype(BaseCase):
         content = base64.b64decode(ZIP)
         mimetype = guess_mimetype(content, default='test')
         self.assertEqual(mimetype, 'application/zip')
+
+
+    def test_mimetype_get_extension(self):
+        self.assertEqual(get_extension('filename.Abc'), '.abc')
+        self.assertEqual(get_extension('filename.scss'), '.scss')
+        self.assertEqual(get_extension('filename.torrent'), '.torrent')
+        self.assertEqual(get_extension('.htaccess'), '.htaccess')
+        # enough to suppose that extension is present and don't suffix the filename
+        self.assertEqual(get_extension('filename.tar.gz'), '.gz')
+        self.assertEqual(get_extension('filename'), '')
+        self.assertEqual(get_extension('filename.'), '')
+        self.assertEqual(get_extension('filename.not_alnum'), '')
+        self.assertEqual(get_extension('filename.with space'), '')
+        self.assertEqual(get_extension('filename.notAnExtension'), '')
 
 
 

--- a/odoo/tools/mimetypes.py
+++ b/odoo/tools/mimetypes.py
@@ -184,3 +184,13 @@ else:
         if mimetype == 'image/svg':
             return 'image/svg+xml'
         return mimetype
+
+def get_extension(filename):
+    """ Return the extension the current filename based on the heuristic that
+    ext is less than or equal to 10 chars and is alphanumeric.
+
+    :param str filename: filename to try and guess a extension for
+    :returns: detected extension or ``
+    """
+    ext = '.' in filename and filename.split('.')[-1]
+    return ext and len(ext) <= 10 and ext.isalnum() and '.' + ext.lower() or ''


### PR DESCRIPTION
Since PR #90855, we add extension if mimetypes doesn't match the type.
Since guess_type don't know some extension, we prefer considere all string
of less of 8 char as an extension before to fallback on the mimetypes lib.

With this commit, a filename filename.scss will be considered with an
extension .scss by our own helper instead of a fallback on .bin or .a as
returned by guess_extension of mimetype.





--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
