### PR TITLE
[FIX] point_of_sale: fix auto floorscreen when idle:

### DIFF
--- a/addons/point_of_sale/static/src/js/Chrome.js
+++ b/addons/point_of_sale/static/src/js/Chrome.js
@@ -244,6 +244,7 @@ odoo.define('point_of_sale.Chrome', function(require) {
         }
         __closeTempScreen() {
             this.tempScreen.isShown = false;
+            this.tempScreen.name = null;
         }
         __showScreen({ detail: { name, props = {} } }) {
             const component = this.constructor.components[name];


### PR DESCRIPTION
Restaurant shops should automatically go back to floor screen when
idle. However, after https://github.com/odoo/odoo/pull/89712, this
feature is broken when pos_hr is also installed - the screen doesn't
automatically go back to floor screen.

A simple fix is to clear the tempScreen name when the shown tempScreen
is closed.

Note that this change is fine because when tempScreen is closed
(!isShown), the `tempScreen.name` information has no use.

Description of the issue/feature this PR addresses:

Current behavior before PR:
https://youtu.be/OIj6OM6TZhw

Desired behavior after PR is merged:

now it goes to floors Screen again!


--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
