### PR TITLE
[FIX] mail: new messages extra domain

### DIFF
--- a/addons/mail/static/src/models/thread_cache/thread_cache.js
+++ b/addons/mail/static/src/models/thread_cache/thread_cache.js
@@ -53,7 +53,7 @@ function factory(dependencies) {
             }
             const messageIds = this.fetchedMessages.map(message => message.id);
             const fetchedMessages = this._loadMessages({
-                extraDomain: [['id', '>', Math.max(...messageIds)]],
+                extraDomain: [['id', '>', Math.max(...messageIds, 0)]],
                 limit: false,
             });
             for (const threadView of this.threadViews) {


### PR DESCRIPTION
**Description of the issue/feature this PR addresses:**
A default `MAX(id)` was added in the `extraDomain` when there are no messages to create it

This validation already existed but was omitted in the refactoring
https://github.com/odoo/odoo/commit/8d3413ff647de8d98c6858062dd07dde4160af95#diff-d7e561fc21c94117dfe35dd989ef80b0c56cc5d0235ea01d456e6b613d2e5419L77

**Current behavior before PR:**
If there are no `messageIds`, the method `loadNewMessages` returns id > null
and this domain returns 0 records
https://github.com/odoo/odoo/blob/7d992af9561c499ef1912453f3b697bad18e441f/addons/mail/static/src/models/thread_cache/thread_cache.js#L55
**Desired behavior after PR is merged:**

Create the `extraDomain` with a default `MAX(id)` when there are no messages to create it and 
continue with the normal flow of `loadMessages`

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
