### PR TITLE
[FIX] website_sale: fix display of content in cart popover

### DIFF
--- a/addons/website_sale/static/src/scss/website_sale.scss
+++ b/addons/website_sale/static/src/scss/website_sale.scss
@@ -422,11 +422,11 @@ ul.wizard {
     max-width: 500px;
     min-width: 250px;
     max-height: 90%;
-    overflow: auto;
+    overflow-x: hidden;
+    overflow-y: auto;
 
     .cart_line {
         border-bottom: 1px #EEE solid;
-        max-width: 90%;
     }
 }
 


### PR DESCRIPTION
Current behavior before PR:

The product title overlaps the product image in cart popover.

Steps to reproduce:
- Add some products to cart.
- Hover the cart icon.

![Screenshot from 2022-05-18 10-11-31](https://user-images.githubusercontent.com/66666640/168949658-17908e6d-148e-4b1d-a364-ec5d1863a85b.png)


Desired behavior after PR is merged:

![Screenshot from 2022-05-18 10-11-53](https://user-images.githubusercontent.com/66666640/168949703-18d70075-b328-4b9a-805d-98aaecb304ee.png)

![Screenshot from 2022-05-18 10-18-04](https://user-images.githubusercontent.com/66666640/168950227-8d9e9325-8312-4d25-9c86-8db2042b14d8.png)





--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
