### PR TITLE
[FIX] website_livechat: fix chatbot tour nondeterministic issue

### DIFF
--- a/addons/website_livechat/static/tests/tours/website_livechat_chatbot_flow.js
+++ b/addons/website_livechat/static/tests/tours/website_livechat_chatbot_flow.js
@@ -17,12 +17,6 @@ LivechatButton.LivechatButton.include({
 
         return this._super(...arguments);
     },
-    _renderMessages: function () {
-        this._super(...arguments);
-
-        this._chatWindow.$('.o_livechat_chatbot_main_restart')
-            .addClass('ready');
-    },
     /**
      * Small override that removes current messages when restarting.
      * This allows to easily check for new posted messages without having the old ones "polluting"
@@ -124,7 +118,7 @@ tour.register('website_livechat_chatbot_flow_tour', {
     trigger: messagesContain("Ok bye!"),
     run: () => {}  // last step is displayed
 }, {
-    trigger: '.o_livechat_chatbot_main_restart.ready',
+    trigger: '.o_livechat_chatbot_restart',
     run: 'click'
 }, {
     trigger: messagesContain("Restarting conversation..."),


### PR DESCRIPTION
Followup of: 623fdb15ce9a6f3f586254dca549a72869336729

The previous attempt at fixing the tour issue was non-conclusive as it still
breaks occasionally during runbot nightly builds.

That issue is near-impossible to properly debug, because it *only* happens
during nightly builds (cannot be reproduced locally and cannot be reproduced
with a multi-build configuration on the runbot).

We decided instead to slightly modify the tour step to click on the
"restart button" from the end of the conversation instead of the restart button
from the chat window header.

This should hopefully do the trick.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
