### PR TITLE
[FIX] project: fixed traceback when clicking on blocking stat button

### DIFF
--- a/addons/project/models/project.py
+++ b/addons/project/models/project.py
@@ -2164,7 +2164,7 @@ class Task(models.Model):
             action['res_id'] = self.dependent_ids.id
             action['views'] = [(False, 'form')]
         else:
-            action['domain'] = [('depend_on_ids', '=', self.id)],
+            action['domain'] = [('depend_on_ids', '=', self.id)]
             action['name'] = _('Dependent Tasks')
             action['view_mode'] = 'tree,form,kanban,calendar,pivot,graph,activity'
         return action


### PR DESCRIPTION
currently, clicking on the blocking stat button throws an error when
there is more the 1 task in project

so this commit fixes the issue by changing the domain of action so that
clicking on blocking stat button doesn't throws an error when the project
have more than one blocking task

task-2834743

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
