### PR TITLE
[FIX] purchase_stock: wrong amount in price difference account

### DIFF
--- a/addons/purchase_stock/models/account_invoice.py
+++ b/addons/purchase_stock/models/account_invoice.py
@@ -100,19 +100,16 @@ class AccountMove(models.Model):
 
                 price_unit = line.price_unit * (1 - (line.discount or 0.0) / 100.0)
                 if line.tax_ids:
-                    if line.discount and line.quantity:
-                        # We do not want to round the price unit since :
-                        # - It does not follow the currency precision
-                        # - It may include a discount
-                        # Since compute_all still rounds the total, we use an ugly workaround:
-                        # multiply then divide the price unit.
-                        price_unit *= line.quantity
-                        price_unit = line.tax_ids.with_context(round=False, force_sign=move._get_tax_force_sign()).compute_all(
-                            price_unit, currency=move.currency_id, quantity=1.0, is_refund=move.move_type == 'in_refund')['total_excluded']
-                        price_unit /= line.quantity
-                    else:
-                        price_unit = line.tax_ids.compute_all(
-                            price_unit, currency=move.currency_id, quantity=1.0, is_refund=move.move_type == 'in_refund')['total_excluded']
+                    # We do not want to round the price unit since :
+                    # - It does not follow the currency precision
+                    # - It may include a discount
+                    # Since compute_all still rounds the total, we use an ugly workaround:
+                    # shift the decimal part using a fixed quantity to avoid rounding issues
+                    prec = 1e+6
+                    price_unit *= prec
+                    price_unit = line.tax_ids.with_context(round=False, force_sign=move._get_tax_force_sign()).compute_all(
+                        price_unit, currency=move.currency_id, quantity=1.0, is_refund=move.move_type == 'in_refund')['total_excluded']
+                    price_unit /= prec
 
                 price_unit_val_dif = price_unit - valuation_price_unit
                 price_subtotal = line.quantity * price_unit_val_dif


### PR DESCRIPTION
1. Activate anglo saxon accounting
2. Create product with automated inventory valuation and standard pricing
3. Set decimal accuracy to 6
4. Set product cost price to 0,01719
5. Create PO for 30.000 items -> price = 0,01782 -> total = 534,6
6. Receive goods -> stock journal entry = 515,7 (based on the cost, ok)
7. Create vendor bill

Price difference is incorrect if you have a tax rate in the vendor bill
`price_unit_val_dif` will be rounded to 0.02
Multiplied by a great quantity the result will be wrong (84.30)
Without using the tax rate the price difference amount is the expected one

This will partially revert 643d91ef5ebfb29fde142294ced82c470d42c136
to improve the original fix
Instead of using the quantity, this rely on the 'Decimal Digits'
precision (price_unit_prec) to temporarly remove the decimal part and
make the computation without rounding
price_unit_prec should be expected to be between 2 and 6

opw-2849074

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
