### PR TITLE
[FIX] web_editor: prevent traceback on reduce empty array

### DIFF
--- a/addons/web_editor/static/src/js/backend/convert_inline.js
+++ b/addons/web_editor/static/src/js/backend/convert_inline.js
@@ -168,7 +168,7 @@ function bootstrapToTable($editable) {
             // 1. Replace generic "col" classes with specific "col-n", computed
             //    by sharing the available space between them.
             const flexColumns = bootstrapColumns.filter(column => !/\d/.test(column.className.match(RE_COL_MATCH)[0] || '0'));
-            const colTotalSize = bootstrapColumns.map(child => _getColumnSize(child)).reduce((a, b) => a + b);
+            const colTotalSize = bootstrapColumns.map(child => _getColumnSize(child)).reduce((a, b) => a + b, 0);
             const colSize = Math.max(1, Math.round((12 - colTotalSize) / flexColumns.length));
             for (const flexColumn of flexColumns) {
                 flexColumn.classList.remove(flexColumn.className.match(RE_COL_MATCH)[0].trim());


### PR DESCRIPTION
The mailing html converter uses the `reduce` method of `Array` to compute column size when converting Bootstrap grids to tables. However, if that array is empty, given that no initial value was passed, the call caused a traceback. This is fixed by providing an initial value of zero as should be expected.

task-2853723

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
