### PR TITLE
[FIX] mail: can save/discard suggested recipient dialog

### DIFF
--- a/addons/mail/static/src/components/composer_suggested_recipient/composer_suggested_recipient.js
+++ b/addons/mail/static/src/components/composer_suggested_recipient/composer_suggested_recipient.js
@@ -4,30 +4,9 @@ import { useUpdate } from '@mail/component_hooks/use_update';
 import { registerMessagingComponent } from '@mail/utils/messaging_component';
 
 import { FormViewDialog } from 'web.view_dialogs';
-import { ComponentAdapter } from 'web.OwlCompatibility';
+import { standaloneAdapter } from 'web.OwlCompatibility';
 
 const { Component, useRef } = owl;
-
-class FormViewDialogComponentAdapter extends ComponentAdapter {
-
-    async renderWidget() {
-        // Ensure the dialog is properly reconstructed. Without this line, it is
-        // impossible to open the dialog again after having it closed a first
-        // time, because the DOM of the dialog has disappeared.
-        await this.onWillStart();
-        this.props.setFormViewDialogWidget(this.widget);
-    }
-
-    updateWidget() {
-        // This component should never be re-rendered but because shouldUpdate was removed,
-        // when the Composer is rerendered, so is the ComposerSuggestedRecipients even
-        // though its props haven't changed and there is nothing to do.
-    }
-
-    get widgetArgs() {
-        return [this.props.params];
-    }
-}
 
 export class ComposerSuggestedRecipient extends Component {
 
@@ -39,29 +18,11 @@ export class ComposerSuggestedRecipient extends Component {
         this.id = _.uniqueId('o_ComposerSuggestedRecipient_');
         useUpdate({ func: () => this._update() });
         /**
-         * Form view dialog class. Useful to reference it in the template.
-         */
-        this.FormViewDialog = FormViewDialog;
-        /**
          * Reference of the checkbox. Useful to know whether it was checked or
          * not, to properly update the corresponding state in the record or to
          * prompt the user with the partner creation dialog.
          */
         this._checkboxRef = useRef('checkbox');
-        /**
-         * Reference of the partner creation dialog. Useful to open it, for
-         * compatibility with old code.
-         */
-        this.setFormViewDialogWidget = (widget) => {
-            this._dialogWidget = widget;
-        };
-        /**
-         * Whether the dialog is currently open. `_dialogRef` cannot be trusted
-         * to know if the dialog is open due to manually calling `open` and
-         * potential out of sync with component adapter.
-         */
-        this._isDialogOpen = false;
-        this._onDialogSaved = this._onDialogSaved.bind(this);
     }
 
     //--------------------------------------------------------------------------
@@ -102,12 +63,25 @@ export class ComposerSuggestedRecipient extends Component {
             // Recipients must always be partners. On selecting a suggested
             // recipient that does not have a partner, the partner creation form
             // should be opened.
-            if (isChecked && this._dialogWidget && !this._isDialogOpen) {
-                this._isDialogOpen = true;
-                this._dialogWidget.on('closed', this, () => {
-                    this._isDialogOpen = false;
+            if (isChecked) {
+                const adapterParent = standaloneAdapter({ Component });
+                const selectCreateDialog = new FormViewDialog(adapterParent, {
+                    context: {
+                        active_id: this.suggestedRecipientInfo.thread.id,
+                        active_model: 'mail.compose.message',
+                        default_email: this.suggestedRecipientInfo.email,
+                        default_name: this.suggestedRecipientInfo.name,
+                        default_lang: this.suggestedRecipientInfo.lang,
+                        force_email: true,
+                        ref: 'compound_context',
+                    },
+                    disable_multiple_selection: true,
+                    on_saved: this._onDialogSaved.bind(this),
+                    res_id: false,
+                    res_model: 'res.partner',
+                    title: this.suggestedRecipientInfo.dialogText,
                 });
-                this._dialogWidget.open();
+                selectCreateDialog.open();
             }
         }
     }
@@ -125,7 +99,6 @@ export class ComposerSuggestedRecipient extends Component {
 }
 
 Object.assign(ComposerSuggestedRecipient, {
-    components: { FormViewDialogComponentAdapter },
     props: {
         suggestedRecipientInfoLocalId: String,
     },

--- a/addons/mail/static/src/components/composer_suggested_recipient/composer_suggested_recipient.xml
+++ b/addons/mail/static/src/components/composer_suggested_recipient/composer_suggested_recipient.xml
@@ -14,28 +14,6 @@
                         </t>
                     </label>
                 </div>
-                <t t-if="!suggestedRecipientInfo.partner">
-                    <FormViewDialogComponentAdapter
-                        Component="FormViewDialog"
-                        setFormViewDialogWidget="setFormViewDialogWidget"
-                        params="{
-                            context: {
-                                active_id: suggestedRecipientInfo.thread.id,
-                                active_model: 'mail.compose.message',
-                                default_email: suggestedRecipientInfo.email,
-                                default_name: suggestedRecipientInfo.name,
-                                default_lang: suggestedRecipientInfo.lang,
-                                force_email: true,
-                                ref: 'compound_context',
-                            },
-                            disable_multiple_selection: true,
-                            on_saved: _onDialogSaved,
-                            res_id: false,
-                            res_model: 'res.partner',
-                            title: suggestedRecipientInfo.dialogText,
-                        }"
-                    />
-                </t>
             </div>
         </t>
     </t>


### PR DESCRIPTION
Since the migration from owl1 to owl2, a crash occured when clicking
save or discard in the partner dialog opened from mail composer's
suggested recipient.

This commit fixes the issue by simplifying the way we open that
dialog. With owl2, we introduced a standaloneAdapter which allows
to directly instantiate legacy dialogs inside owl components.

Task 2817547

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
