### PR TITLE
[FIX] web_editor: allow to manage all types of buttons

### DIFF
--- a/addons/web_editor/static/src/js/wysiwyg/widgets/link.js
+++ b/addons/web_editor/static/src/js/wysiwyg/widgets/link.js
@@ -125,7 +125,7 @@ const Link = Widget.extend({
         for (const option of this._getLinkOptions()) {
             const $option = $(option);
             const value = $option.is('input') ? $option.val() : $option.data('value');
-            let active = false;
+            let active = true;
             if (value) {
                 const subValues = value.split(',');
                 let subActive = true;
@@ -134,8 +134,6 @@ const Link = Widget.extend({
                     subActive = subActive && classPrefix.test(this.data.iniClassName);
                 }
                 active = subActive;
-            } else {
-                active = !this.data.iniClassName || this.data.iniClassName.includes('btn-link') || !this.data.iniClassName.includes('btn-');
             }
             this._setSelectOption($option, active);
         }

--- a/addons/website_mass_mailing/static/tests/tours/newsletter_block.js
+++ b/addons/website_mass_mailing/static/tests/tours/newsletter_block.js
@@ -1,0 +1,60 @@
+/** @odoo-module */
+
+import tour from 'web_tour.tour';
+import wTourUtils from 'website.tour_utils';
+
+tour.register('newsletter_block_edition', {
+    test: true,
+    url: '/?enable_editor=1',
+}, [
+    // Put a Newsletter block.
+    wTourUtils.dragNDrop({
+        id: 's_newsletter_block',
+        name: 'Newsletter block',
+    }),
+    {
+        content: 'Wait for the list id to be set.',
+        trigger: '.s_newsletter_subscribe_form[data-list-id]:not([data-list-id="0"])',
+    },
+    ...wTourUtils.clickOnSave(),
+    // Subscribe to the newsletter.
+    {
+        content: 'Wait for the email to be loaded in the newsletter input',
+        trigger: '.s_newsletter_block .js_subscribe_btn',
+        extra_trigger: '.s_newsletter_block input:propValue(admin@yourcompany.example.com)',
+    },
+    // Change the link style.
+    wTourUtils.clickOnEdit(),
+    {
+        content: 'Wait for the editor to be fully started',
+        trigger: '#oe_snippets',
+    },
+    {
+        content: 'Click on the Thanks button',
+        trigger: '.s_newsletter_block .js_subscribed_btn',
+    },
+    {
+        content: 'Click on the link style button',
+        trigger: '[data-original-title="Link Style"]',
+    },
+    {
+        content: 'Click on the primary style button',
+        trigger: '[data-value="primary"]',
+    },
+    {
+        content: 'Change the shape of the button',
+        trigger: '[data-original-title="Link Shape"]',
+    },
+    {
+        content: 'Click on the flat shape button',
+        trigger: '[data-value="flat"]',
+    },
+    ...wTourUtils.clickOnSave(),
+    // Check if the button style is correct (make sure that the 'btn-success'
+    // class which is not suggested as a valid style in the editor panel did not
+    // prevent to edit the button).
+    {
+        content: 'Check that the link style is correct',
+        trigger: '.s_newsletter_block .js_subscribed_btn.btn.btn-primary.flat:not(.btn-success)',
+    },
+]);

--- a/addons/website_mass_mailing/tests/test_snippets.py
+++ b/addons/website_mass_mailing/tests/test_snippets.py
@@ -14,3 +14,6 @@ class TestSnippets(odoo.tests.HttpCase):
         mailing_list = self.env['mailing.list'].search([], limit=1)
         emails = mailing_list.contact_ids.mapped('email')
         self.assertIn("hello@world.com", emails)
+
+    def test_02_newsletter_block_edition(self):
+        self.start_tour("/?enable_editor=1", "newsletter_block_edition", login='admin')


### PR DESCRIPTION
Before this commit, some types of buttons were not managed by the
editor, only the primary, secondary and link buttons were supported.
However, if there is another type of btn in the DOM, the editor must be
able to handle it. This commit allows to manage all types of buttons in
the editor.

Steps to reproduce the fixed bug:
 - Drop a block with a <a> with the btn-success class
 - Click on the button to edit it
 - The link tool part in the editor does not work properly
or
 - Drop the newsletter block
 - Save and register to the newsletter
 - Edit the new "Thanks" button
 - The link tool part in the editor does not work properly

opw-2802139


Original PR at https://github.com/odoo/odoo/pull/91539