### PR TITLE
[FIX] account_edi,base: don't assume res_ids is a list

### DIFF
--- a/odoo/addons/base/models/ir_actions_report.py
+++ b/odoo/addons/base/models/ir_actions_report.py
@@ -764,6 +764,8 @@ class IrActionsReport(models.Model):
         self.ensure_one()
         if not data:
             data = {}
+        if isinstance(res_ids, int):
+            res_ids = [res_ids]
         data.setdefault('report_type', 'pdf')
         self_sudo = self.sudo()
 


### PR DESCRIPTION
https://github.com/odoo/odoo/pull/85150 introduced the method
_render_qweb_pdf_prepare_streams called from _render_qweb_pdf
giving it its res_ids.
Two places in this method are assuming res_ids will be a list, but
it is not always the case. Plenty of call to _render_qweb_pdf is
giving it a single id as a parameter.

Adapt those two parts so that it handles both single int and list of
ints properly, avoiding tracebacks.


--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
