### PR TITLE
[FIX] hr_holidays: exclude cancelled time off by default in report

### DIFF
--- a/addons/hr_holidays/report/hr_leave_report_calendar.py
+++ b/addons/hr_holidays/report/hr_leave_report_calendar.py
@@ -66,6 +66,7 @@ class LeaveReportCalendar(models.Model):
                 ON cc.id = co.resource_calendar_id
         WHERE 
             hl.state IN ('confirm', 'validate', 'validate1')
+            AND hl.active IS TRUE
         );
         """)
 


### PR DESCRIPTION
Prior to this commit cancelled time off were included in the leave
report calendar model and were shown as regular time offs.
They will now be hidden.
