### PR TITLE
[FIX] account: partner inconsistencies on invoices

### DIFF
--- a/addons/account/models/account_move.py
+++ b/addons/account/models/account_move.py
@@ -3003,6 +3003,12 @@ class AccountMove(models.Model):
         })
 
         for move in to_post:
+            # Fix inconsistencies that may occure if the OCR has been editing the invoice at the same time of a user. We force the
+            # partner on the lines to be the same as the one on the move, because that's the only one the user can see/edit.
+            wrong_lines = move.is_invoice() and move.line_ids.filtered(lambda aml: aml.partner_id != move.commercial_partner_id)
+            if wrong_lines:
+                wrong_lines.write({'partner_id': move.commercial_partner_id.id})
+
             move.message_subscribe([p.id for p in [move.partner_id] if p not in move.sudo().message_partner_ids])
 
             # Compute 'ref' for 'out_invoice'.


### PR DESCRIPTION
How to reproduce:
Have 2 different tabs open on the same draft invoice
Tab 1: add a new invoice line
Tab 2: change the partner
Tab 1: save
Tab 2: save

Before the fix:
The new invoice line from tab 1 has the partner from before the change,
but the other lines have been updated to the new partner.

Expected:
All invoice lines have the same partner as the invoice itself

This use case can be reproduced like this manually, but it can happen
easily even on one tab because the OCR acts like the second tab if users
start to edit the invoice before it is scanned.

Note that in a perfect world, a warning would be raised to prevent any
loss/mischief due to concurrent editions of the same record but that's
beyond the scope of a bugfix made on a stable version.

opw-2777390
opw-2762347
opw-2741859





--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
