### PR TITLE
[FIX] website: make s_map work in sanitized fields

### DIFF
--- a/addons/website/__manifest__.py
+++ b/addons/website/__manifest__.py
@@ -107,9 +107,7 @@
         'views/res_partner_views.xml',
         'wizard/base_language_install_views.xml',
         'wizard/website_robots.xml',
-
-        # Old snippets
-        ],
+    ],
     'demo': [
         'data/website_demo.xml',
     ],
@@ -132,6 +130,10 @@
             'website/static/src/js/show_password.js',
             'website/static/src/js/post_link.js',
             'website/static/src/js/user_custom_javascript.js',
+            # Stable fix, will be replaced by an `ir.asset` in master to be able
+            # to archive and not load that JS file if we have to create a 001.js
+            # and the DB has no snippet using the 000.js left.
+            'website/static/src/snippets/s_map/000.js',
         ],
         'web.assets_frontend_minimal': [
             'website/static/src/js/content/inject_dom.js',

--- a/addons/website/static/src/js/utils.js
+++ b/addons/website/static/src/js/utils.js
@@ -351,6 +351,19 @@ async function svgToPNG(src) {
     }).then(loadedImgEl => toPNGViaCanvas(loadedImgEl));
 }
 
+/**
+ * Generates a Google Maps URL based on the given parameter.
+ *
+ * @param {DOMStringMap} dataset
+ * @returns {string} a Google Maps URL
+ */
+function generateGMapLink(dataset) {
+    return 'https://maps.google.com/maps?q=' + encodeURIComponent(dataset.mapAddress)
+            + '&t=' + encodeURIComponent(dataset.mapType)
+            + '&z=' + encodeURIComponent(dataset.mapZoom)
+            + '&ie=UTF8&iwloc=&output=embed';
+}
+
 return {
     loadAnchors: loadAnchors,
     autocompleteWithPages: autocompleteWithPages,
@@ -359,5 +372,6 @@ return {
     sendRequest: sendRequest,
     websiteDomain: websiteDomain,
     svgToPNG: svgToPNG,
+    generateGMapLink: generateGMapLink,
 };
 });

--- a/addons/website/static/src/snippets/s_map/000.js
+++ b/addons/website/static/src/snippets/s_map/000.js
@@ -1,0 +1,36 @@
+/** @odoo-module **/
+
+import publicWidget from 'web.public.widget';
+import {generateGMapLink} from 'website.utils';
+
+publicWidget.registry.Map = publicWidget.Widget.extend({
+    selector: '.s_map',
+
+    /**
+     * @override
+     */
+    start() {
+        if (!this.el.querySelector('.s_map_embedded')) {
+            // The iframe is not found inside the snippet. This is probably due
+            // the sanitization of a field during the save, like in a product
+            // description field.
+            // In such cases, reconstruct the iframe.
+            const dataset = this.el.dataset;
+            if (dataset.mapAddress) {
+                const iframeEl = document.createElement('iframe');
+                iframeEl.classList.add('s_map_embedded', 'o_not_editable');
+                iframeEl.setAttribute('width', '100%');
+                iframeEl.setAttribute('height', '100%');
+                iframeEl.setAttribute('frameborder', '0');
+                iframeEl.setAttribute('scrolling', 'no');
+                iframeEl.setAttribute('marginheight', '0');
+                iframeEl.setAttribute('marginwidth', '0');
+                iframeEl.setAttribute('src', generateGMapLink(dataset));
+                this.el.querySelector('.s_map_color_filter').before(iframeEl);
+            }
+        }
+        return this._super(...arguments);
+    },
+});
+
+export default publicWidget.registry.Map;

--- a/addons/website/static/src/snippets/s_map/options.js
+++ b/addons/website/static/src/snippets/s_map/options.js
@@ -2,6 +2,7 @@
 
 import {_t} from 'web.core';
 import options from 'web_editor.snippets.options';
+import {generateGMapLink} from 'website.utils';
 
 options.registry.Map = options.Class.extend({
     /**
@@ -62,10 +63,7 @@ options.registry.Map = options.Class.extend({
         const $embedded = this.$target.find('.s_map_embedded');
         const $info = this.$target.find('.missing_option_warning');
         if (dataset.mapAddress) {
-            const url = 'https://maps.google.com/maps?q=' + encodeURIComponent(dataset.mapAddress)
-                + '&t=' + encodeURIComponent(dataset.mapType)
-                + '&z=' + encodeURIComponent(dataset.mapZoom)
-                + '&ie=UTF8&iwloc=&output=embed';
+            const url = generateGMapLink(dataset);
             if (url !== $embedded.attr('src')) {
                 $embedded.attr('src', url);
             }


### PR DESCRIPTION
Before this commit, the `<iframe/>` element of the `s_map` snippet would
be removed from the field value if the field was sanitized.
The map would then not be displayed, obviously.

The way that `s_map` snippet work is simple:
1. The snippet is defined with a hidden `<iframe/>` element
2. The snippet options are stored as data attributes on the `<section/>`
   element.
3. When those options are changed, the iframe `src` is updated and it is
   shown if needed.

The fix is simple, as we already have all the data attributes available,
we just need to recreate that iframe when the snippet is started without
one. It most likely means it got deleted through the sanitization during
the save.

opw-2844010
