### PR TITLE
[IMP] base: communicate access group inheritance warning(s)

### DIFF
--- a/odoo/addons/base/views/res_users_views.xml
+++ b/odoo/addons/base/views/res_users_views.xml
@@ -363,7 +363,7 @@
             <field name="view_mode">tree,kanban,form</field>
             <field name="view_id" ref="view_users_tree"/>
             <field name="search_view_id" ref="view_users_search"/>
-            <field name="context">{'search_default_filter_no_share': 1}</field>
+            <field name="context">{'search_default_filter_no_share': 1, 'show_user_group_warning': True}</field>
             <field name="help">Create and manage users that will connect to the system. Users can be deactivated should there be a period of time during which they will/should not connect to the system. You can assign them groups in order to give them specific access to the applications they need to use in the system.</field>
         </record>
         <record id="action_res_users_view1" model="ir.actions.act_window.view">


### PR DESCRIPTION
Due to the group inheritance mechanism, if we try to "downgrade" the group
on a user's form view, after saving the record, sometimes the changes
may be reset automatically. This is very confusing because users can
not easily understand what is happening and why.

This commit improves the behavior by providing a proper warning string
to the user on the fly when the groups are changed (which can potentially
be reset upon saving). For a better understanding of possible scenarios
and the warning linked with them, see the test-cases that explain
everything with visual hierarchy.

Task: https://www.odoo.com/web#id=2646704&menu_id=4720&cids=2&action=4043&model=project.task&view_type=form


--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
