### PR TITLE
[FIX] web_editor: Fix style formating traceback

### DIFF
--- a/addons/web_editor/static/lib/odoo-editor/src/commands/commands.js
+++ b/addons/web_editor/static/lib/odoo-editor/src/commands/commands.js
@@ -284,11 +284,11 @@ export function applyInlineStyle(editor, applyStyle, style, shouldApply=true) {
     const [
         normalizedStartContainer,
         normalizedStartOffset
-    ] = getNormalizedCursorPosition(startContainer, startOffset)
+    ] = getNormalizedCursorPosition(startContainer, startOffset);
     const [
         normalizedEndContainer,
         normalizedEndOffset
-    ] = getNormalizedCursorPosition(endContainer, endOffset)
+    ] = getNormalizedCursorPosition(endContainer, endOffset);
     const selectedTextNodes = getSelectedNodes(editor.editable).filter(node => {
         const atLeastOneCharFromNodeInSelection = !(
             (node === normalizedEndContainer && normalizedEndOffset === 0) ||
@@ -308,7 +308,7 @@ export function applyInlineStyle(editor, applyStyle, style, shouldApply=true) {
                     ancestor = ancestor.parentElement;
                 }
             }
-        } else{
+        } else {
             isApplied = isFormat[style] && isFormat[style](node);
         }
         return shouldApply ? !isApplied : isApplied;
@@ -346,7 +346,7 @@ export function applyInlineStyle(editor, applyStyle, style, shouldApply=true) {
             newParent.appendChild(textNode);
         }
         applyStyle(textNode.parentElement);
-        changedElements.push(textNode.parentElement)
+        changedElements.push(textNode.parentElement);
     }
     if (selectedTextNodes[0] && selectedTextNodes[0].textContent === '\u200B') {
         setSelection(selectedTextNodes[0], 0);
@@ -385,7 +385,8 @@ const styles = {
     switchDirection: {
         is: editable => isSelectionFormat(editable, 'switchDirection'),
     },
-}
+};
+
 export function toggleFormat(editor, format) {
     const selection = editor.document.getSelection();
     if (!selection.rangeCount) return;

--- a/addons/web_editor/static/lib/odoo-editor/src/commands/commands.js
+++ b/addons/web_editor/static/lib/odoo-editor/src/commands/commands.js
@@ -403,12 +403,12 @@ export function toggleFormat(editor, format) {
     const {anchorNode, anchorOffset, focusNode, focusOffset} = editor.document.getSelection();
     const style = styles[format];
     const selectedTextNodes = getSelectedNodes(editor.editable)
-        .filter(n => n.nodeType === Node.TEXT_NODE && n.nodeValue.trim().length);
+        .filter(n => n.nodeType === Node.TEXT_NODE && n.nodeValue.length);
     const isAlreadyFormatted = style.is(editor.editable);
     let changedElements = [];
     if (isAlreadyFormatted && style.name === 'textDecorationLine') {
-        const decoratedPairs = new Set(selectedTextNodes.map(n => [closestElement(n, `[style*="text-decoration-line: ${style.value}"]`), n]));
-        for (const [closestDecorated, textNode] of decoratedPairs) {
+        for (const textNode of selectedTextNodes) {
+            const closestDecorated = closestElement(textNode, `[style*="text-decoration-line: ${style.value}"]`);
             if (closestDecorated) {
                 const splitResult = splitAroundUntil(textNode, closestDecorated);
                 const decorationToRemove = splitResult[0] || splitResult[1] || closestDecorated;

--- a/addons/web_editor/static/lib/odoo-editor/test/spec/format.test.js
+++ b/addons/web_editor/static/lib/odoo-editor/test/spec/format.test.js
@@ -1,4 +1,4 @@
-import { BasicEditor, testEditor } from '../utils.js';
+import { BasicEditor, testEditor, setTestSelection, Direction } from '../utils.js';
 import { applyInlineStyle } from '../../src/commands/commands.js';
 
 const bold = async editor => {
@@ -279,6 +279,62 @@ describe('Format', () => {
                 contentBefore: `<p>${s(`ab[cde]fg`)}</p>`,
                 stepFunction: strikeThrough,
                 contentAfter: `<p>${s(`ab[`)}cde]${s(`fg`)}</p>`,
+            });
+        });
+        it('should make a few characters strikeThrough then remove style inside', async () => {
+            await testEditor(BasicEditor, {
+                contentBefore: `<p>ab[c d]ef</p>`,
+                stepFunction: async editor => {
+                    await strikeThrough(editor);
+                    const styleSpan = editor.editable.querySelector('span[style="text-decoration-line: line-through;"]').childNodes[0];
+                    const selection = {
+                        anchorNode: styleSpan,
+                        anchorOffset: 1,
+                        focusNode: styleSpan,
+                        focusOffset: 2,
+                        direction: Direction.FORWARD,
+                    };
+                    await setTestSelection(selection);
+                    await strikeThrough(editor);
+                },
+                contentAfter: `<p>ab${s(`c[`)} ]${s(`d`)}ef</p>`,
+            });
+        });
+        it('should make strikeThrough then more then remove', async () => {
+            await testEditor(BasicEditor, {
+                contentBefore: `<p>abc[ ]def</p>`,
+                stepFunction: async editor => {
+                    await strikeThrough(editor);
+                    const pElem = editor.editable.querySelector('p').childNodes;
+                    const selection = {
+                        anchorNode: pElem[0],
+                        anchorOffset: 2,
+                        focusNode: pElem[2],
+                        focusOffset: 1,
+                        direction: Direction.FORWARD,
+                    };
+                    await setTestSelection(selection);
+                    await strikeThrough(editor);
+                },
+                contentAfter: `<p>ab${s(`[c d]`)}ef</p>`,
+            });
+            await testEditor(BasicEditor, {
+                contentBefore: `<p>abc[ ]def</p>`,
+                stepFunction: async editor => {
+                    await strikeThrough(editor);
+                    const pElem = editor.editable.querySelector('p').childNodes;
+                    const selection = {
+                        anchorNode: pElem[0],
+                        anchorOffset: 2,
+                        focusNode: pElem[2],
+                        focusOffset: 1,
+                        direction: Direction.FORWARD,
+                    };
+                    await setTestSelection(selection);
+                    await strikeThrough(editor);
+                    await strikeThrough(editor);
+                },
+                contentAfter: `<p>ab[c d]ef</p>`,
             });
         });
         it('should make two paragraphs strikeThrough', async () => {

--- a/addons/web_editor/static/lib/odoo-editor/test/spec/format.test.js
+++ b/addons/web_editor/static/lib/odoo-editor/test/spec/format.test.js
@@ -43,7 +43,7 @@ describe('Format', () => {
             await testEditor(BasicEditor, {
                 contentBefore: `<p>${b(`[abc`)}</p><p>${b(`def]`)}</p>`,
                 stepFunction: bold,
-                contentBefore: `<p>${notB(`[abc`)}</p><p>${notB(`def]`, 400)}</p>`,
+                contentAfter: `<p>${notB(`[abc`)}</p><p>${notB(`def]`, 400)}</p>`,
             });
         });
         it('should make a whole heading bold after a triple click', async () => {
@@ -127,7 +127,7 @@ describe('Format', () => {
             await testEditor(BasicEditor, {
                 contentBefore: `<p>${i(`[abc`)}</p><p>${i(`def]`)}</p>`,
                 stepFunction: italic,
-                contentBefore: `<p>${notI(`[abc`)}</p><p>${notI(`def]`)}</p>`,
+                contentAfter: `<p>${notI(`[abc`)}</p><p>${notI(`def]`)}</p>`,
             });
         });
         it('should make a whole heading italic after a triple click', async () => {

--- a/addons/web_editor/static/lib/odoo-editor/test/utils.js
+++ b/addons/web_editor/static/lib/odoo-editor/test/utils.js
@@ -2,7 +2,7 @@ import { OdooEditor } from '../src/OdooEditor.js';
 import { sanitize } from '../src/utils/sanitize.js';
 import { insertText as insertTextSel } from '../src/utils/utils.js';
 
-const Direction = {
+export const Direction = {
     BACKWARD: 'BACKWARD',
     FORWARD: 'FORWARD',
 };


### PR DESCRIPTION
In some case, when removing format on element with multiple textNode,
the code generate a traceback.

The loops in `toggleFormat` provide a limit element `closestDecorated` to
the `splitAroundUntil` util? However this limit element can be split and
dumped by the format removal. In this case the reference was never encountered
in the DOM by the `splitAroundUntil` code and will bubble all the way to the
`<html>` TAG an try to split it, which generate an error.

We Fix it by getting the `closestDecorated` in every loop.

task-2850686



--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
