### PR TITLE
[FIX] website_sale_stock: use website's warehouse for ecommerce

### DIFF
--- a/addons/website_sale_stock/models/sale_order.py
+++ b/addons/website_sale_stock/models/sale_order.py
@@ -38,6 +38,16 @@ class SaleOrder(models.Model):
             self.warning_stock = ''
         return warn
 
+    @api.depends('user_id', 'company_id')
+    def _compute_warehouse_id(self):
+        if 'website_id' not in self.env.context:
+            super(SaleOrder, self)._compute_warehouse_id()
+        else:
+            website_id = self.env.context['website_id']
+            website = self.env['website'].browse(website_id)
+            for order in self:
+                order.warehouse_id = website._get_warehouse_available()
+
 
 class SaleOrderLine(models.Model):
     _inherit = 'sale.order.line'


### PR DESCRIPTION
Steps to reproduce issue:
- Install website_sale_stock and sale_management (with demo data)
- Create warehouse # 1 (on top of the demo ones, so that warehouse with ID=1 is not the one we will use)
- Create website # 1 go to settings/Website, set website # 1 to use warehouse # 1
- Create web product # 1, set qty on hand in warehouse # 1 to something > 0, apply, make sure the "continue selling if out of stock" is disabled.
- Go to website 1, order web product # 1 (it doesn't show out of stock, because the warehouse is correct)
- Confirm cart, input address, and confirm it

Before this commit:
- The warehouse_id on the SO is switched to the one with ID=1, the cart is emptied because the product is not present in that warehouse

After this commit:
- The warehouse_id on the SO stays to the warehouse_id set for the website

Related tickets: 2851371,2851944
For more context:
- The steps in video form: https://drive.google.com/file/d/1cpaBi6DspbLVzbdHeatsF2168BR8369b/view
- see commit f9f68adb2cdfdfd16bc24c82acae015ddfb9b83a where the _compute_warehouse_id method replaced the _get_default_warehouse_id method

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
