### PR TITLE
[IMP] mail: allow admins to remove channels they're not members of

### DIFF
--- a/addons/mail/security/ir.model.access.csv
+++ b/addons/mail/security/ir.model.access.csv
@@ -13,7 +13,8 @@ access_mail_notification_portal,mail.notification.portal,model_mail_notification
 access_mail_notification_user,mail.notification.user,model_mail_notification,base.group_user,1,1,1,0
 access_mail_notification_system, mail.notification.system,model_mail_notification,base.group_system,1,1,1,1
 access_mail_channel_all,mail.group.all,model_mail_channel,,1,0,0,0
-access_mail_channel_user,mail.group.user,model_mail_channel,base.group_user,1,1,1,1
+access_mail_channel_user,mail.group.user,model_mail_channel,base.group_user,1,1,1,0
+access_mail_channel_admin,mail.group.system,model_mail_channel,base.group_system,1,1,1,1
 access_mail_channel_partner_public,mail.channel.partner.public,model_mail_channel_partner,base.group_public,1,0,0,0
 access_mail_channel_partner_portal,mail.channel.partner.portal,model_mail_channel_partner,base.group_portal,1,1,1,1
 access_mail_channel_partner_user,mail.channel.partner.user,model_mail_channel_partner,base.group_user,1,1,1,1

--- a/addons/mail/security/mail_security.xml
+++ b/addons/mail/security/mail_security.xml
@@ -13,6 +13,13 @@
             <field name="perm_create" eval="False"/>
         </record>
 
+        <record id="mail_channel_admin" model="ir.rule">
+            <field name="name">Mail.channel: admin full access</field>
+            <field name="model_id" ref="model_mail_channel"/>
+            <field name="groups" eval="[Command.link(ref('base.group_system'))]"/>
+            <field name="domain_force">[(1, '=', 1)]</field>
+        </record>
+
         <record id="ir_rule_mail_channel_partner_group_user" model="ir.rule">
             <field name="name">mail.channel.partner: write its own entries</field>
             <field name="model_id" ref="model_mail_channel_partner"/>
@@ -25,6 +32,13 @@
             <field name="perm_write" eval="True"/>
             <field name="perm_create" eval="False"/>
             <field name="perm_unlink" eval="True"/>
+        </record>
+
+        <record id="ir_rule_mail_channel_partner_group_system" model="ir.rule">
+            <field name="name">mail.channel.partner: admin can manipulate all entries</field>
+            <field name="model_id" ref="model_mail_channel_partner"/>
+            <field name="groups" eval="[Command.link(ref('base.group_system'))]"/>
+            <field name="domain_force">[(1, '=', 1)]</field>
         </record>
 
         <record id="ir_rule_mail_notifications_group_user" model="ir.rule">

--- a/addons/mail/tests/test_mail_channel.py
+++ b/addons/mail/tests/test_mail_channel.py
@@ -85,8 +85,9 @@ class TestChannelAccessRights(MailCommon):
         # Employee update employee-based group: ok
         group_groups.write({'name': 'modified'})
 
-        # Employee unlink employee-based group: ok
-        group_groups.unlink()
+        # Employee unlink employee-based group: ko
+        with self.assertRaises(AccessError):
+            group_groups.unlink()
 
         # Employee cannot read a private group
         with self.assertRaises(AccessError):

--- a/addons/test_discuss_full/tests/test_performance.py
+++ b/addons/test_discuss_full/tests/test_performance.py
@@ -58,7 +58,7 @@ class TestDiscussFullPerformance(TransactionCase):
     def test_init_messaging(self):
         """Test performance of `_init_messaging`."""
         channel_general = self.env.ref('mail.channel_all_employees')  # Unfortunately #general cannot be deleted. Assertions below assume data from a fresh db with demo.
-        self.env['mail.channel'].search([('id', '!=', channel_general.id)]).unlink()
+        self.env['mail.channel'].sudo().search([('id', '!=', channel_general.id)]).unlink()
         user_root = self.env.ref('base.user_root')
         # create public channels
         channel_channel_public_1 = self.env['mail.channel'].browse(self.env['mail.channel'].channel_create(name='public 1', privacy='public')['id'])

--- a/addons/test_mail/tests/test_mail_thread_internals.py
+++ b/addons/test_mail/tests/test_mail_thread_internals.py
@@ -267,7 +267,7 @@ class TestDiscuss(TestMailCommon, TestRecipients):
         channel_message = self.env['mail.message'].sudo().search([('model', '=', 'mail.channel'), ('res_id', 'in', channel.ids)])
         self.assertEqual(len(channel_message), 1, "Test message should have been posted")
 
-        channel.unlink()
+        channel.sudo().unlink()
         remaining_message = channel_message.exists()
         self.assertEqual(len(remaining_message), 0, "Test message should have been deleted")
 


### PR DESCRIPTION
The only mail.channel rule was that a user only had access to channels they're members of, or can subscribe to (public, or group based).

This rule applied to admins as well, forcing them to switch to super-admin mode in order to manage mail channels.

This is undesirable on lots of axis:

- superadmin mode is a bit of a last-ditch feature, as a result it's somewhat hidden
- there is a much higher risk of screwing up as superadmin mode basically lifts all the access rules, which can have correctness implications
- auditing completely breaks down when using superadmin mode, as the real identity of the user is lost
