### PR TITLE
[FIX] mail: ChatWindow hidden in mobile

### DIFF
--- a/addons/mail/static/src/components/messaging_menu/messaging_menu.xml
+++ b/addons/mail/static/src/components/messaging_menu/messaging_menu.xml
@@ -16,7 +16,7 @@
                     </t>
                 </a>
                 <t t-if="messagingMenu.isOpen">
-                    <div class="o_MessagingMenu_dropdownMenu dropdown-menu dropdown-menu-right d-flex flex-column mt-0 py-0 overflow-auto" t-att-class="{ 'o-isDeviceSmall fixed-bottom flex-grow-1 w-100 m-0 border-0': messaging.device.isSmall, 'border': !messaging.device.isSmall, 'o-messaging-not-initialized align-items-center justify-content-center': !messaging.isInitialized }" role="menu">
+                    <div class="o_MessagingMenu_dropdownMenu dropdown-menu dropdown-menu-right d-flex flex-column mt-0 py-0 overflow-auto" t-att-class="{ 'o-isDeviceSmall position-fixed bottom-0 start-0 end-0 flex-grow-1 w-100 m-0 border-0': messaging.device.isSmall, 'border': !messaging.device.isSmall, 'o-messaging-not-initialized align-items-center justify-content-center': !messaging.isInitialized }" role="menu">
                         <t t-if="!messaging.isInitialized">
                             <span><i class="o_MessagingMenu_dropdownLoadingIcon fa fa-circle-o-notch fa-spin me-1"/>Please wait...</span>
                         </t>


### PR DESCRIPTION
The commit 6bf4d3cdceeb972733c1f680f2ad8a11495e6e9c
introduces an issue where the ChatWindow was hidden by the MessagingMenu
in mobile.

This commit fixes this issue.

task-2857078

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
