### PR TITLE
[IMP] account: improve tax name search

### DIFF
--- a/addons/account/views/account_tax_views.xml
+++ b/addons/account/views/account_tax_views.xml
@@ -92,7 +92,7 @@
             <field name="model">account.tax</field>
             <field name="arch" type="xml">
                 <search string="Search Taxes">
-                    <field name="name" filter_domain="['|', ('name','ilike',self), ('description','ilike',self)]" string="Tax"/>
+                    <field name="name_searchable" string="Name"/>
                     <field name="company_id" groups="base.group_multi_company"/>
                     <filter string="Sale" name="sale" domain="[('type_tax_use','=','sale')]" />
                     <filter string="Purchase" name="purchase" domain="[('type_tax_use','=','purchase')]" />


### PR DESCRIPTION
This PR improves tax name search by ignoring punctuation and spaces.
This allows faster searching for taxes (while editing an invoice line or
while configuring them)

Example:
Searching for `21M` should match `21% M.` , `21% EU M.` and `21% M.Cocont`.
Searching for `0EUT` should match `0% EU T`.


Task id: 2851341