### PR TITLE
[FIX] knowledge: fix auto-save issue

### DIFF
--- a/addons/knowledge/__manifest__.py
+++ b/addons/knowledge/__manifest__.py
@@ -50,6 +50,7 @@
             'knowledge/static/src/js/tools/tree_panel_mixin.js',
             'knowledge/static/src/js/widgets/knowledge_permission_panel.js',
             'knowledge/static/src/js/widgets/knowledge_emoji_picker.js',
+            'knowledge/static/src/js/widgets/knowledge_field_html.js',
             'knowledge/static/src/webclient/commands/*.js',
             'knowledge/static/src/models/*/*.js',
             'knowledge/static/src/js/form_controller.js',

--- a/addons/knowledge/static/src/js/knowledge_controller.js
+++ b/addons/knowledge/static/src/js/knowledge_controller.js
@@ -101,11 +101,6 @@ const KnowledgeArticleFormController = FormController.extend({
         return Promise.resolve(true);
     },
 
-    /**
-     * @override
-     */
-    _urgentSave: function () {},
-
     commitAndSaveRecord: async function () {
         console.log('canBeRemoved (before): this.isDirty', this.isDirty(this.handle));
         await this.renderer.commitChanges(this.handle);

--- a/addons/knowledge/static/src/js/knowledge_renderers.js
+++ b/addons/knowledge/static/src/js/knowledge_renderers.js
@@ -46,6 +46,15 @@ const KnowledgeArticleFormRenderer = FormRenderer.extend(KnowledgeTreePanelMixin
         };
     },
     /**
+     * @override
+     */
+    destroy: function () {
+        if (this.timer) {
+            window.clearTimeout(this._onTimeout);
+        }
+        this._super.apply(this, arguments);
+    },
+    /**
      * Called when the chatter triggers a reload on the Form view with the
      * param 'keepChanges=true'. In this case, we only need to update the
      * chatter.
@@ -436,6 +445,38 @@ const KnowledgeArticleFormRenderer = FormRenderer.extend(KnowledgeTreePanelMixin
             'connectWith',
             'section[data-section="workspace"] .o_tree, section[data-section="private"] .o_tree'
         );
+    },
+
+    _onSaving: function () {
+        if (this.timer) {
+            window.clearTimeout(this._onTimeout);
+        }
+        this.$('.o_knowledge_saving').removeClass('d-none');
+        this.$('.o_knowledge_saved').addClass('d-none');
+        this.$('.o_knowledge_save_failed').addClass('d-none');
+    },
+
+    _onSaved: function () {
+        if (this.timer) {
+            window.clearInterval(this._onTimeout);
+        }
+        this.$('.o_knowledge_saving').addClass('d-none');
+        this.$('.o_knowledge_saved').removeClass('d-none');
+        this.$('.o_knowledge_save_failed').addClass('d-none');
+        this.timer = window.setTimeout(this._onTimeout, 3000);
+    },
+
+    _onSaveFailed: function () {
+        if (this.timer) {
+            window.clearInterval(this._onTimeout);
+        }
+        this.$('.o_knowledge_saving').addClass('d-none');
+        this.$('.o_knowledge_saved').addClass('d-none');
+        this.$('.o_knowledge_save_failed').removeClass('d-none');
+    },
+
+    _onTimeout: function () {
+        this.$('.o_knowledge_saved').addClass('d-none');
     },
 });
 

--- a/addons/knowledge/static/src/js/widgets/knowledge_field_html.js
+++ b/addons/knowledge/static/src/js/widgets/knowledge_field_html.js
@@ -1,0 +1,12 @@
+/** @odoo-module **/
+
+import fieldRegistry from 'web.field_registry';
+import FieldHtml from 'web_editor.field.html';
+
+const KnowledgeFieldHtml = FieldHtml.extend({
+    DEBOUNCE: 500, // 500ms
+});
+
+fieldRegistry.add('knowledge_html', KnowledgeFieldHtml);
+
+export default KnowledgeFieldHtml;

--- a/addons/knowledge/static/src/js/widgets/knowledge_field_html.js
+++ b/addons/knowledge/static/src/js/widgets/knowledge_field_html.js
@@ -4,7 +4,23 @@ import fieldRegistry from 'web.field_registry';
 import FieldHtml from 'web_editor.field.html';
 
 const KnowledgeFieldHtml = FieldHtml.extend({
-    DEBOUNCE: 500, // 500ms
+    DEBOUNCE: 1500, // 1500ms,
+    _createWysiwygInstance: async function () {
+        await this._super(...arguments);
+        const editor = this.wysiwyg.odooEditor;
+        editor.addEventListener('historyStep', event => {
+            /**
+             * When a new history step is created, we call the `_onChange` function
+             * that will call the `debounce` function. Eventually, the debounce function
+             * will be executed and the a `field_changed` event will be triggered.
+             */
+            this._onChange();
+        });
+    },
+    /**
+     * @override
+     */
+    _onWysiwygBlur: function () {},
 });
 
 fieldRegistry.add('knowledge_html', KnowledgeFieldHtml);

--- a/addons/knowledge/views/knowledge_article_views.xml
+++ b/addons/knowledge/views/knowledge_article_views.xml
@@ -195,7 +195,7 @@
                                                     </div>
                                                     <!-- Article body -->
                                                     <div class="o_knowledge_editor d-flex flex-grow-1">
-                                                        <field name="body" widget="html" no_label="1" default_focus="1"
+                                                        <field name="body" widget="knowledge_html" no_label="1" default_focus="1"
                                                             options="{'resizable': False, 'knowledge_commands': true}"
                                                             attrs="{'readonly': ['|', ('is_locked', '=', True), ('user_has_write_access', '=', False)]}"/>
                                                     </div>

--- a/addons/knowledge/views/knowledge_article_views.xml
+++ b/addons/knowledge/views/knowledge_article_views.xml
@@ -66,6 +66,15 @@
                                     <div attrs="{'invisible': ['|', ('is_locked', '=', False), ('user_has_write_access', '=', False)]}">
                                         <i class="fa fa-fw fa-lock" title="This article is locked"/>
                                     </div>
+                                    <div class="text-mutted text-nowrap o_knowledge_saving d-none">
+                                        <i class="fa fa-circle-o-notch fa-spin" /> Saving
+                                    </div>
+                                    <div class="text-success text-nowrap o_knowledge_saved d-none">
+                                        <i class="fa fa-fw fa-check-circle" /> Saved
+                                    </div>
+                                    <div class="text-danger text-nowrap o_knowledge_save_failed d-none">
+                                        <i class="fa fa-w fa-times" /> Save failed
+                                    </div>
                                 </div>
                                 <!-- Buttons -->
                                 <div class="d-flex flex-shrink-0 align-items-center pr-2">

--- a/addons/web/static/src/legacy/js/fields/abstract_field.js
+++ b/addons/web/static/src/legacy/js/fields/abstract_field.js
@@ -560,26 +560,29 @@ var AbstractField = Widget.extend({
      * @returns {Promise}
      */
     _setValue: function (value, options) {
+        console.log('calling _setValue');
         // we try to avoid doing useless work, if the value given has not changed.
         if (this._isLastSetValue(value)) {
+            console.log('_isLastSetValue is true');
             return Promise.resolve();
         }
         this.lastSetValue = value;
         try {
             value = this._parseValue(value);
-            this._isValid = true;
         } catch (_e) {
             this._isValid = false;
-            this.trigger_up('set_dirty', {dataPointID: this.dataPointID});
             return Promise.reject({message: "Value set is not valid"});
         }
+        this._isValid = true;
         if (!(options && options.forceChange) && this._isSameValue(value)) {
+            console.log('_setValue: same value');
             return Promise.resolve();
         }
         var self = this;
         return new Promise(function (resolve, reject) {
             var changes = {};
             changes[self.name] = value;
+            console.log('trigger_up field_changed');
             self.trigger_up('field_changed', {
                 dataPointID: self.dataPointID,
                 changes: changes,

--- a/addons/web/static/src/legacy/js/fields/abstract_field_owl.js
+++ b/addons/web/static/src/legacy/js/fields/abstract_field_owl.js
@@ -536,12 +536,12 @@ odoo.define('web.AbstractFieldOwl', function (require) {
             this._lastSetValue = value;
             try {
                 value = this._parseValue(value);
-                this._isValid = true;
             } catch (_e) {
                 this._isValid = false;
-                this.trigger('set-dirty', {dataPointID: this.dataPointId});
                 return Promise.reject({message: "Value set is not valid"});
             }
+            this._isValid = true;
+            console.log('this._isSameValue(value)', this._isSameValue(value));
             if (!(options && options.forceChange) && this._isSameValue(value)) {
                 return Promise.resolve();
             }

--- a/addons/web/static/src/legacy/js/fields/basic_fields.js
+++ b/addons/web/static/src/legacy/js/fields/basic_fields.js
@@ -129,6 +129,7 @@ var DebouncedField = AbstractField.extend({
      */
     commitChanges: function () {
         if (this._isDirty && this.mode === 'edit') {
+            console.log('commit changes: do action');
             return this._doAction();
         }
     },
@@ -145,6 +146,7 @@ var DebouncedField = AbstractField.extend({
      * @private
      */
     _doAction: function () {
+        console.log('calling _doAction');
         // as _doAction may be debounced, it may happen that it is called after
         // the widget has been destroyed, and in this case, we don't want it to
         // do anything (commitChanges ensures that if it has local changes, they

--- a/addons/web/static/src/legacy/js/views/basic/basic_controller.js
+++ b/addons/web/static/src/legacy/js/views/basic/basic_controller.js
@@ -738,6 +738,7 @@ var BasicController = AbstractController.extend(FieldManagerMixin, {
                 this.model.notifyChanges(dataPointID, changes, options);
                 this._confirmChange(dataPointID, Object.keys(changes), event);
             }
+            console.log('_urgentSave is Dirty', this.isDirty());
             if (this.isDirty()) {
                 this._saveRecord(recordID, { reload: false, stayInEdit: true });
             }
@@ -790,12 +791,13 @@ var BasicController = AbstractController.extend(FieldManagerMixin, {
      *
      * @private
      * @param {OdooEvent} ev
+     * @returns {Promise}
      */
     _onFieldChanged: function (ev) {
         if (this.mode === 'readonly' && !('force_save' in ev.data)) {
             ev.data.force_save = true;
         }
-        FieldManagerMixin._onFieldChanged.apply(this, arguments);
+        return FieldManagerMixin._onFieldChanged.apply(this, arguments);
     },
     /**
      * @private

--- a/addons/web/static/src/legacy/js/views/basic/basic_model.js
+++ b/addons/web/static/src/legacy/js/views/basic/basic_model.js
@@ -1118,6 +1118,7 @@ var BasicModel = AbstractModel.extend({
      *   Resolved with the list of field names (whose value has been modified)
      */
     save: function (recordID, options) {
+        console.log('saving the record');
         var self = this;
         function _save() {
             options = options || {};
@@ -1169,6 +1170,7 @@ var BasicModel = AbstractModel.extend({
                 // in the case of a write, only perform the RPC if there are changes to save
                 if (method === 'create' || changedFields.length) {
                     var args = method === 'write' ? [[record.data.id], changes] : [changes];
+                    console.log('new rpc call to save the record')
                     self._rpc({
                             model: record.model,
                             method: method,
@@ -1561,6 +1563,7 @@ var BasicModel = AbstractModel.extend({
         options = options || {};
         record._changes = record._changes || {};
         if (!options.doNotSetDirty) {
+            console.log('_applyChange set record as dirty')
             record._isDirty = true;
         }
         var initialData = {};

--- a/addons/web/static/src/legacy/js/views/field_manager_mixin.js
+++ b/addons/web/static/src/legacy/js/views/field_manager_mixin.js
@@ -44,6 +44,7 @@ var FieldManagerMixin = {
      *   updated
      */
     _applyChanges: function (dataPointID, changes, event) {
+        console.log('_applyChanges in mixin');
         var self = this;
         var options = _.pick(event.data, 'context', 'doNotSetDirty', 'notifyChange', 'viewType', 'allowWarning');
         return this.model.notifyChanges(dataPointID, changes, options)
@@ -109,6 +110,7 @@ var FieldManagerMixin = {
      * just occurred, then confirm the change.
      *
      * @param {OdooEvent} event
+     * @returns {Promise}
      */
     _onFieldChanged: function (event) {
         // in case of field changed in relational record (e.g. in the form view

--- a/addons/web/static/src/legacy/js/views/form/form_controller.js
+++ b/addons/web/static/src/legacy/js/views/form/form_controller.js
@@ -493,8 +493,10 @@ var FormController = BasicController.extend({
      *
      * @override
      */
-    _onBeforeUnload: function () {
-        this._urgentSave(this.handle);
+    _onBeforeUnload: function (event) {
+        if (this.isDirty()) {
+            event.returnValue = _t('You have unsaved changes');
+        }
     },
     /**
      * @private

--- a/addons/web/static/src/legacy/js/views/list/list_controller.js
+++ b/addons/web/static/src/legacy/js/views/list/list_controller.js
@@ -753,7 +753,6 @@ var ListController = BasicController.extend({
     _onBeforeUnload: function () {
         const recordId = this.renderer.getEditableRecordID();
         if (recordId) {
-            this._urgentSave(recordId);
         }
     },
     /**

--- a/addons/web_editor/static/src/js/backend/field_html.js
+++ b/addons/web_editor/static/src/js/backend/field_html.js
@@ -100,8 +100,9 @@ var FieldHtml = basic_fields.DebouncedField.extend(TranslatableFieldMixin, {
         }
         var _super = this._super.bind(this);
         await this.wysiwyg.cleanForSave();
-        this._setValue(this._getValue());
+        await this._setValue(this._getValue());
         return this.wysiwyg.saveModifiedImages(this.$content).then(() => {
+            console.log('is wysiwyg isDirty', this.wysiwyg.isDirty());
             this._isDirty = this.wysiwyg.isDirty();
             _super();
         });
@@ -470,6 +471,7 @@ var FieldHtml = basic_fields.DebouncedField.extend(TranslatableFieldMixin, {
      * @param {OdooEvent} ev
      */
     _onChange: function (ev) {
+        console.log('_onChange');
         this._doDebouncedAction.apply(this, arguments);
     },
     /**

--- a/addons/web_editor/static/src/js/wysiwyg/wysiwyg.js
+++ b/addons/web_editor/static/src/js/wysiwyg/wysiwyg.js
@@ -273,13 +273,6 @@ const Wysiwyg = Widget.extend({
             $(this.odooEditor.document.body).addClass('editor_enable');
             this.snippetsMenu = this._createSnippetsMenuInstance(options);
             await this._insertSnippetMenu();
-
-            this._onBeforeUnload = (event) => {
-                if (this.isDirty()) {
-                    event.returnValue = _t('This document is not saved!');
-                }
-            };
-            window.addEventListener('beforeunload', this._onBeforeUnload);
         }
         if (this.options.getContentEditableAreas) {
             $(this.options.getContentEditableAreas()).find('*').off('mousedown mouseup click');
@@ -677,7 +670,6 @@ const Wysiwyg = Widget.extend({
             window.removeEventListener('online', this._checkConnectionChange);
             window.removeEventListener('offline', this._checkConnectionChange);
         }
-        window.removeEventListener('beforeunload', this._onBeforeUnload);
         this._super();
     },
     /**
@@ -821,7 +813,6 @@ const Wysiwyg = Widget.extend({
         await this.saveModifiedImages(editables.length ? $(editables) : this.$editable);
         await this._saveViewBlocks();
 
-        window.removeEventListener('beforeunload', this._onBeforeUnload);
         if (reload) {
             window.location.reload();
         }
@@ -848,7 +839,6 @@ const Wysiwyg = Widget.extend({
             }
         }).then(function () {
             if (reload !== false) {
-                window.onbeforeunload = null;
                 return self._reload();
             }
         });
@@ -1947,9 +1937,7 @@ const Wysiwyg = Widget.extend({
                 });
             });
         });
-        return Promise.all(defs).then(function () {
-            window.onbeforeunload = null;
-        }).guardedCatch((failed) => {
+        return Promise.all(defs).guardedCatch((failed) => {
             // If there were errors, re-enable edition
             this.cancel(false);
         });

--- a/addons/web_editor/static/src/js/wysiwyg/wysiwyg.js
+++ b/addons/web_editor/static/src/js/wysiwyg/wysiwyg.js
@@ -756,6 +756,7 @@ const Wysiwyg = Widget.extend({
      * @returns {Boolean}
      */
     isDirty: function () {
+        console.log('wysiwyg this._initialValue', this._initialValue);
         return this._initialValue !== (this.getValue() || this.$editable.val());
     },
     /**


### PR DESCRIPTION
When the user edits the document and quits the view, the user changes will be discarded unless the user unfocuses the editor beforehand. This commit will fix the auto-save issue by reducing the debouncing interval from 1000000000ms (default value) to 500ms. The editor should now do intermediate saves when the user stops editing the document for 500ms. This change will mitigate the losses if the user closes the tab or reloads the page.

When the `beforeLeave` event is triggered, the controller will now commit all changes before saving them. This will guarantee that the records associated with the debounced fields will be marked as "dirty" and that the changes will be persisted in db.

task-2857029

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
