### PR TITLE
[FIX] mass_mailing: keep body of invalid saved mailing

### DIFF
--- a/addons/mass_mailing/static/src/js/mass_mailing_widget.js
+++ b/addons/mass_mailing/static/src/js/mass_mailing_widget.js
@@ -61,9 +61,9 @@ var MassMailingFieldHtml = FieldHtml.extend({
 
         var $editable = this.wysiwyg.getEditable();
         await this.wysiwyg.cleanForSave();
-        return this.wysiwyg.saveModifiedImages(this.$content).then(function () {
+        return this.wysiwyg.saveModifiedImages(this.$content).then(async function () {
             self._isDirty = self.wysiwyg.isDirty();
-            self._doAction();
+            await self._doAction();
 
             const $editorEnable = $editable.closest('.editor_enable');
             $editorEnable.removeClass('editor_enable');

--- a/addons/mass_mailing/static/src/js/tours/mass_mailing_editor_tour.js
+++ b/addons/mass_mailing/static/src/js/tours/mass_mailing_editor_tour.js
@@ -11,18 +11,43 @@ odoo.define('mass_mailing.mass_mailing_editor_tour', function (require) {
     }, {
         trigger: 'button.o_list_button_add',
     }, {
-        trigger: 'input[name="subject"]',
-        run: 'text Test',
-    }, {
         trigger: 'div[name="contact_list_ids"] .o_input_dropdown > input[type="text"]',
     }, {
         trigger: 'li.ui-menu-item',
     }, {
-        trigger: 'iframe #default',
-        run: () => $('iframe').contents().find('o_editable').html('<p><br/></p>'),
+        content: 'choose the theme "empty" to edit the mailing with snippets',
+        trigger: '[name="body_arch"] iframe #empty',
+    }, {
+        content: 'wait for the editor to be rendered',
+        trigger: '[name="body_arch"] iframe .o_editable',
+        run: () => {},
+    }, {
+        content: 'drag the "Title" snippet from the design panel and drop it in the editor',
+        trigger: '[name="body_arch"] iframe #email_designer_default_body [name="Title"] .ui-draggable-handle',
+        run: function (actions) {
+            actions.drag_and_drop('[name="body_arch"] iframe .o_editable', this.$anchor);
+        }
+    }, {
+        content: 'verify that the title was inserted properly in the editor',
+        trigger: '[name="body_arch"] iframe .o_editable h1',
+        run: () => {},
+    }, {
+        trigger: 'button.o_form_button_save',
+    }, {
+        content: 'verify that the save failed (since the field "subject" was not set and it is required)',
+        trigger: 'label.o_field_invalid',
+        run: () => {},
+    }, {
+        content: 'verify that the edited mailing body was not lost during the failed save',
+        trigger: '[name="body_arch"] iframe .o_editable h1',
+        run: () => {},
+    }, {
+        trigger: 'input[name="subject"]',
+        run: 'text Test',
     }, {
         trigger: 'button.o_form_button_save',
     }, {
         trigger: 'iframe.o_readonly',
+        run: () => {},
     }]);
 });

--- a/addons/mass_mailing/tests/test_mailing_ui.py
+++ b/addons/mass_mailing/tests/test_mailing_ui.py
@@ -18,9 +18,12 @@ class TestUi(HttpCaseWithUserDemo):
         # The tour created and saved an email. The edited version should be
         # saved in body_arch, and its transpiled version (see convert_inline)
         # for email client compatibility should be saved in body_html. This
-        # ensures both fields have different values.
-        self.assertEqual(mail.body_arch, '<p><br></p>')
-        self.assertEqual(mail.body_html, '<p style="margin:0px 0 14px 0;box-sizing:border-box;"><br></p>')
+        # ensures both fields have different values (the mailing body should
+        # have been converted to a table in body_html).
+        self.assertIn('data-snippet="s_title"', mail.body_arch)
+        self.assertTrue(mail.body_arch.startswith('<div'))
+        self.assertIn('data-snippet="s_title"', mail.body_html)
+        self.assertTrue(mail.body_html.startswith('<table'))
 
     def test_02_mass_mailing_snippets_menu_tabs(self):
         self.start_tour("/web", 'mass_mailing_snippets_menu_tabs', login="demo")


### PR DESCRIPTION
There was an issue when a mailing save failed: the edited body of the mailing
was lost.

Impacted versions:

  - 15.0 and higher

Steps to reproduce:

  1. Create a mailing "Start from scratch" and add some elements
  2. Do not fill in the subject (or at least one required field)
  3. Save (it should fail because of the empty required field)

Current behavior:

  - The edited template is lost

Expected behavior:

  - Keep the edited template even if the save failed

This commit fixes the problem by properly awaiting the promise _doAction so that
the field's value will be set correctly.

The testing tour `mass_mailing_editor_tour` is updated to check that the
body_arch is kept after a failed save.

This issue was introduced in 15.0 with:
https://github.com/odoo/odoo/commit/95754eb6a464894417e8f763ae0fc4933ca3a157

Task-2856742