### PR TITLE
Fix invalid syntax error in report file name translation to French

### DIFF
--- a/addons/stock/i18n/fr.po
+++ b/addons/stock/i18n/fr.po
@@ -153,8 +153,13 @@ msgid "&gt;"
 msgstr "&gt;"
 
 #. module: stock
-#: model:ir.actions.report,print_report_name:stock.action_report_inventory
+#: model:ir.actions.report,print_report_name
 msgid "'Count Sheet'"
+msgstr "'Feuille de comptage'"
+
+#. module: stock
+#: model:stock.action_report_inventory
+msgid "Count Sheet"
 msgstr "Feuille de comptage"
 
 #. module: stock


### PR DESCRIPTION
Cont Sheet report name and print report name are translated to the same string in french language which lead to an invalid syntax error:
Traceback (most recent call last):  

      File "/home/lubuntu/odoo-15.0/addons/web/controllers/main.py", line 2034, in report_download
        report_name = safe_eval(report.print_report_name, {'object': obj, 'time': time})
      File "/home/lubuntu/odoo-15.0/odoo/tools/safe_eval.py", line 328, in safe_eval
        c = test_expr(expr, _SAFE_OPCODES, mode=mode)
      File "/home/lubuntu/odoo-15.0/odoo/tools/safe_eval.py", line 184, in test_expr
        code_obj = compile(expr, "", mode)
      File "<string>", line 1
        Feuille de comptage
                ^
    SyntaxError: invalid syntax

To fix the error, we separate the translation and add `''` to the translated value of the print report name

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
