### PR TITLE
[IMP] base, mail, test_{crm_full|mail}: improves notification

### DIFF
--- a/addons/mail/controllers/mail.py
+++ b/addons/mail/controllers/mail.py
@@ -123,6 +123,9 @@ class MailController(http.Controller):
             'active_id': res_id,
             'action': record_action.get('id'),
         }
+        menu_id = request.env['ir.ui.menu']._get_best_menu_root_for_model(model)
+        if menu_id:
+            url_params['menu_id'] = menu_id
         view_id = record_sudo.get_formview_id()
         if view_id:
             url_params['view_id'] = view_id

--- a/addons/test_crm_full/tests/test_performance.py
+++ b/addons/test_crm_full/tests/test_performance.py
@@ -42,7 +42,7 @@ class TestCrmPerformance(CrmPerformanceCase):
         country_be = self.env.ref('base.be')
         lang_be_id = self.env['res.lang']._lang_get_id('fr_BE')
 
-        with freeze_time(self.reference_now), self.assertQueryCount(user_sales_leads=194):  # tcf 193 / com 194
+        with freeze_time(self.reference_now), self.assertQueryCount(user_sales_leads=195):  # tcf 194 / com 195
             self.env.cr._now = self.reference_now  # force create_date to check schedulers
             crm_values = [
                 {'country_id': country_be.id,
@@ -107,7 +107,7 @@ class TestCrmPerformance(CrmPerformanceCase):
         country_be = self.env.ref('base.be')
         lang_be_id = self.env['res.lang']._lang_get_id('fr_BE')
 
-        with freeze_time(self.reference_now), self.assertQueryCount(user_sales_leads=31):  # tcf 30 / com 31
+        with freeze_time(self.reference_now), self.assertQueryCount(user_sales_leads=33):  # tcf 32 / com 33
             self.env.cr._now = self.reference_now  # force create_date to check schedulers
             crm_values = [
                 {'country_id': country_be.id,
@@ -127,7 +127,7 @@ class TestCrmPerformance(CrmPerformanceCase):
     @warmup
     def test_lead_create_single_partner(self):
         """ Test multiple lead creation (import) """
-        with freeze_time(self.reference_now), self.assertQueryCount(user_sales_leads=32):  # tcf 31 / com 32
+        with freeze_time(self.reference_now), self.assertQueryCount(user_sales_leads=33):  # tcf 32 / com 33
             self.env.cr._now = self.reference_now  # force create_date to check schedulers
             crm_values = [
                 {'partner_id': self.partners[0].id,

--- a/addons/test_mail/tests/test_performance.py
+++ b/addons/test_mail/tests/test_performance.py
@@ -870,7 +870,7 @@ class TestMailComplexPerformance(BaseMailPerformance):
         customer_id = self.customer.id
         user_id = self.user_portal.id
 
-        with self.assertQueryCount(__system__=56, employee=57):  # tm 56/57
+        with self.assertQueryCount(__system__=59, employee=60):  # tm 59/60
             rec = self.env['mail.test.ticket'].create({
                 'name': 'Test',
                 'container_id': container_id,

--- a/odoo/addons/base/tests/test_menu.py
+++ b/odoo/addons/base/tests/test_menu.py
@@ -1,6 +1,8 @@
 # -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
+from unittest.mock import Mock
+
 from odoo.tests.common import TransactionCase
 
 
@@ -28,3 +30,64 @@ class TestMenu(TransactionCase):
 
         orphans =  Menu.search([('id', 'in', all_ids), ('parent_id', '=', False)], order="id")
         self.assertEqual([child1.id, child2.id], orphans.ids)
+
+    def test_best_root_menu_for_model(self):
+        Menu = self.env['ir.ui.menu']
+        Action = self.env['ir.actions.act_window']
+
+        def _new_menu(name, parent_id=None, action=None):
+            inst = Menu.create({'name': name, 'parent_id': parent_id})
+            if action:
+                inst.action = action
+            return inst
+
+        new_menu = Mock(side_effect=_new_menu)
+
+        def new_action(name, res_model, view_mode=None, domain=None, context=None):
+            return Action.create({
+                'name': name,
+                'res_model': res_model,
+                'view_mode': view_mode,
+                'domain': domain,
+                'context': context or {},
+                'type': 'ir.actions.act_window',
+            })
+
+        # Remove all menus and setup test menu with known results
+        Menu.search([]).unlink()
+
+        menu_root_invoicing = new_menu('Invoicing')
+        menu_invoicing_customer = new_menu('Customers', parent_id=menu_root_invoicing.id)
+        new_menu('Customers', parent_id=menu_invoicing_customer.id,
+                 action=new_action('Customers', res_model='res.partner', view_mode='kanban,tree,form',
+                                   context="""{
+                                       'search_default_customer': 1,
+                                       'res_partner_search_mode': 'customer', 
+                                       'default_is_company': True, 
+                                       'default_customer_rank': 1
+                                   }"""))
+        menu_root_contact = new_menu('Contacts')
+        new_menu('Contacts', parent_id=menu_root_contact.id,
+                 action=new_action('Contacts', res_model='res.partner', view_mode='kanban,tree,form,activity',
+                                   context="{'default_is_company': "+(' '*1000)+"True"+('\n'*1000)+"}", domain='[]'))
+        menu_root_sales = new_menu('Sales')
+        menu_sales_orders = new_menu('Orders', parent_id=menu_root_sales.id)
+        new_menu('Customers', parent_id=menu_sales_orders.id,
+                 action=new_action('Customers', res_model='res.partner', view_mode='kanban,tree,form',
+                                   context="""{
+                                            'search_default_customer': 1,
+                                            'res_partner_search_mode': 'customer', 
+                                            'default_is_company': True, 
+                                            'default_customer_rank': 1
+                                        }"""))
+        menu_root_settings = new_menu('Settings')
+        menu_settings_user_and_companies = new_menu('Users & Companies', parent_id=menu_root_settings.id)
+        new_menu('Companies', parent_id=menu_settings_user_and_companies.id,
+                 action=new_action('Companies', res_model='res.company', view_mode='tree,kanban,form'))
+
+        self.assertEqual(len(Menu._visible_menu_ids()), new_menu.call_count)
+        self.assertEqual(Menu._get_best_menu_root_for_model('res.partner'), menu_root_contact.id)
+        self.assertEqual(Menu._get_best_menu_root_for_model('res.bank'), None)
+        self.assertEqual(Menu._get_best_menu_root_for_model('res.company'), menu_root_settings.id)
+
+        self.registry.reset_changes()


### PR DESCRIPTION
It improves the notification of created item by adding a notification body to
ease the identification of the item created. For example, when creating a task,
the project name is included in the notification body.

It also improves link redirection in the message by restoring the menu, easing
the user to take action. For example, when clicking on "view task" in the
message, it restores the Project menu.

Technical note:
About the notification body:
- as mail_thread takes the message to be sent to followers, the body message is
common for all recipients. And as there might be multiple causes why a specific
recipient is notified, we had to make the message generic. That's why the
message can include multiple reasons not tailored to each recipient.
- _get_auto_subscription_subtypes is used to determine parent model because it
is cached even if we only need a small portion of its return.
- to determine the parent model instance, getattr on thread is used instead of
val_list because the logic to link the parent model instance to the created
instance is handled by the model class (often by setting values from the
context and not from val_list).
- Fetching the parent model increases a bit the number of queries in tests.

About the context restoration:
- when redirecting to the page to view a model from a link in a message, we try
to find the best menu root to display to the user based on the
ir.actions.act_window linked to menu items (matching the target res_model of the
action with the model we want to display) and the access right of the user. The
method that computes the best root menu is based on cached data in ir_ui_menu.

Task-2834445

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
