### PR TITLE
[FIX] pos_coupon:  Inheritance in constructor of Order Model.

### DIFF
--- a/addons/pos_coupon/static/src/js/coupon.js
+++ b/addons/pos_coupon/static/src/js/coupon.js
@@ -253,8 +253,8 @@ odoo.define('pos_coupon.pos', function (require) {
         // OVERIDDEN METHODS
 
         initialize: function () {
-            let res = _order_super.initialize.apply(this, arguments);
-            res.on(
+            _order_super.initialize.apply(this, arguments);
+            this.on(
                 'update-rewards',
                 () => {
                     if (!this.pos.config.use_coupon_programs) return;
@@ -266,11 +266,11 @@ odoo.define('pos_coupon.pos', function (require) {
                         this.trigger('rewards-updated');
                     }).catch(() => { /* catch the reject of dp when calling `add` to avoid unhandledrejection */ });
                 },
-                res
+                this
             );
-            res.on('reset-coupons', res.resetCoupons, res);
-            res._initializePrograms();
-            return res;
+            this.on('reset-coupons', this.resetCoupons, this);
+            this._initializePrograms();
+            return this;
         },
         init_from_JSON: function (json) {
             this.bookedCouponCodes = this.bookedCouponCodes ? this.order.bookedCouponCodes : {};


### PR DESCRIPTION
- Order initialize method is returning always the object `this` but
modules like
https://github.com/odoo/odoo/blob/114968c4a8e46b6b9e8df12b32eb4df88e57307c/addons/pos_hr/static/src/js/models.js#L83
https://github.com/odoo/odoo/blob/114968c4a8e46b6b9e8df12b32eb4df88e57307c/addons/pos_restaurant/static/src/js/floors.js#L51

Does not return them, so instead of using the result of the super, better lean on `this` object that ensure access to
object and its properties.


--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
