### PR TITLE
[FIX] mail: check if the user can access to the thread 

### DIFF
--- a/addons/mail/controllers/discuss.py
+++ b/addons/mail/controllers/discuss.py
@@ -412,8 +412,11 @@ class DiscussController(http.Controller):
 
     @http.route('/mail/thread/data', methods=['POST'], type='json', auth='user')
     def mail_thread_data(self, thread_model, thread_id, request_list, **kwargs):
-        res = {}
+        res = {'hasReadAccess': True}
         thread = request.env[thread_model].with_context(active_test=False).search([('id', '=', thread_id)])
+        if not thread:
+            res['hasReadAccess'] = False
+            return res
         if 'activities' in request_list:
             res['activities'] = thread.activity_ids.activity_format()
         if 'attachments' in request_list:

--- a/addons/mail/static/src/models/chatter/chatter.js
+++ b/addons/mail/static/src/models/chatter/chatter.js
@@ -168,7 +168,7 @@ registerModel({
          * @returns {boolean}
          */
         _computeIsDisabled() {
-            return Boolean(!this.thread || this.thread.isTemporary);
+            return Boolean(!this.thread || this.thread.isTemporary || !this.thread.hasReadAccess);
         },
         /**
          * @private

--- a/addons/mail/static/src/models/thread/thread.js
+++ b/addons/mail/static/src/models/thread/thread.js
@@ -635,6 +635,7 @@ registerModel({
                 activities: activitiesData,
                 attachments: attachmentsData,
                 followers: followersData,
+                hasReadAccess,
                 suggestedRecipients: suggestedRecipientsData,
             } = await this.env.services.rpc({
                 route: '/mail/thread/data',
@@ -647,7 +648,7 @@ registerModel({
             if (!this.exists()) {
                 return;
             }
-            const values = {};
+            const values = { hasReadAccess };
             if (activitiesData) {
                 Object.assign(values, {
                     activities: insertAndReplace(activitiesData.map(activityData =>
@@ -1995,6 +1996,10 @@ registerModel({
         guestMembers: many('Guest', {
             sort: '_sortGuestMembers',
         }),
+        /**
+         * States whether the current user has read access for this thread.
+         */
+        hasReadAccess: attr(),
         /**
          * States whether `this` has activities (`mail.activity.mixin` server side).
          */

--- a/addons/mail/static/tests/helpers/mock_server.js
+++ b/addons/mail/static/tests/helpers/mock_server.js
@@ -490,10 +490,10 @@ MockServer.include({
      * @returns {Object}
      */
     async _mockRouteMailThreadData(thread_model, thread_id, request_list) {
-        const res = {};
+        const res = {'hasReadAccess': true};
         const thread = this._mockSearchRead(thread_model, [[['id', '=', thread_id]]], {})[0];
         if (!thread) {
-            console.warn(`mock server: reading data "${request_list}" from invalid thread "${thread_model}_${thread_id}"`);
+            res['hasReadAccess'] = false;
             return res;
         }
         if (request_list.includes('activities')) {


### PR DESCRIPTION
Before this commit, when the user creates a private task and assigns another user to that task and then removes himself and save the task, the current user should no longer have access to that task since the task becomes this private task of the other user assigned on it.
So when the current user changes anything in that task, it will have an `Access Error`. However, if the user tries to remove a follower on that task he will also have a traceback because no thread is found. The reason why no thread is found is that the user has no longer access to the record and so he has no longer access to the chatter.

This commit checks if a thread is found before continuing the process. If no thread is found then the user has no access to the chatter instead of throwing a traceback because no thread is found.

task-2857229