### PR TITLE
[IMP] website_slides: style mismatch in full screen

### DIFF
--- a/addons/website_slides/views/website_slides_templates_lesson_fullscreen.xml
+++ b/addons/website_slides/views/website_slides_templates_lesson_fullscreen.xml
@@ -7,7 +7,7 @@
         <link rel="canonical" t-att-href="slide.website_url" />
     </t>
     <t t-call="website.layout">
-        <div class="o_wslides_fs_main d-flex flex-column fw-light"
+        <div class="o_wslides_fs_main d-flex flex-column"
             t-att-data-channel-id="slide.channel_id.id"
             t-att-data-channel-enroll="slide.channel_id.enroll"
             t-att-data-signup-allowed="signup_allowed"


### PR DESCRIPTION
Currently, bold style intensity on text is lost when switching from default
browser mode to full-screen mode for viewing e Learning Course content.

This happens due to the use of the `fw-light` class in full screen.
This class property is font-weight: 300 !important, so it overrides the
font-weight style property in the child element of this class.

This commit solves this issue by removing the `fw-light` class in the
full-screen record set.

task-2850325

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
