### PR TITLE
[FIX] website_hr_recruitment: allow portal users to filter by department

### DIFF
--- a/addons/website_hr_recruitment/models/__init__.py
+++ b/addons/website_hr_recruitment/models/__init__.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
+from . import hr_department
 from . import hr_recruitment

--- a/addons/website_hr_recruitment/models/hr_department.py
+++ b/addons/website_hr_recruitment/models/hr_department.py
@@ -1,0 +1,14 @@
+# -*- coding: utf-8 -*-
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from odoo import models
+
+
+class Department(models.Model):
+    _inherit = 'hr.department'
+
+    def name_get(self):
+        # Get department name using superuser, because model is not accessible
+        # for portal users
+        self_sudo = self.sudo()
+        return super(Department, self_sudo).name_get()


### PR DESCRIPTION
Currently, only a public user or an internal user can access HR
department information. This is causing an access rights error when
trying to filter job offers on the website if connected with a portal
user, while there is no error if not connected (public user). We should
have the same behavior for the two cases.

Description of the issue/feature this PR addresses:
opw-2819632

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
