### PR TITLE
[FIX] hr_work_entry_contract: Fix `is_unforeseen_is_leave` constraint…

### DIFF
--- a/addons/hr_work_entry_contract/data/hr_work_entry_data.xml
+++ b/addons/hr_work_entry_contract/data/hr_work_entry_data.xml
@@ -44,7 +44,8 @@
             <field name="is_leave">True</field>
             <field name="color">5</field>
         </record>
-
+    </data>
+    <data noupdate="1">
         <record id="hr_work_entry.work_entry_type_attendance" model="hr.work.entry.type">
             <field name="is_leave">False</field>
         </record>


### PR DESCRIPTION
… violation

The constraint is added in `hr_payroll`, checking that if `is_unforeseen`
is True, then so must be `is_leave`. To reproduce the error simply install
`hr_payroll`, edit Work Entry Type Attendance to set as unforeseen absence
and upgrade the module `hr_work_entry_contract`.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
