### PR TITLE
[ADD] core: add SharedMemory  (POC)

### DIFF
--- a/addons/crm/tests/test_performances.py
+++ b/addons/crm/tests/test_performances.py
@@ -49,7 +49,7 @@ class TestLeadAssignPerf(TestLeadAssignCommon):
 
         with self.with_user('user_sales_manager'):
             self.env['res.users'].has_group('base.group_user')  # warmup the cache to avoid inconsistency between community an enterprise
-            with self.assertQueryCount(user_sales_manager=1265):
+            with self.assertQueryCount(user_sales_manager=1266):
                 self.env['crm.team'].browse(self.sales_teams.ids)._action_assign_leads(work_days=2)
 
         # teams assign
@@ -175,7 +175,7 @@ class TestLeadAssignPerf(TestLeadAssignCommon):
         leads.flush_recordset()
 
         with self.with_user('user_sales_manager'):
-            with self.assertQueryCount(user_sales_manager=6279):
+            with self.assertQueryCount(user_sales_manager=6280):
                 self.env['crm.team'].browse(sales_teams.ids)._action_assign_leads(work_days=30)
 
         # teams assign

--- a/addons/test_event_full/tests/test_performance.py
+++ b/addons/test_event_full/tests/test_performance.py
@@ -52,7 +52,7 @@ class TestEventPerformance(EventPerformanceCase):
         batch_size = 20
 
         # simple without type involved + website
-        with freeze_time(self.reference_now), self.assertQueryCount(event_user=5368):  # com runbot: 4943 - +1 tef - ent runbot 5368
+        with freeze_time(self.reference_now), self.assertQueryCount(event_user=5369):  # com runbot: 4944 - +1 tef - ent runbot 5369
             self.env.cr._now = self.reference_now  # force create_date to check schedulers
             event_values = [
                 dict(self.event_base_vals,
@@ -89,7 +89,7 @@ class TestEventPerformance(EventPerformanceCase):
         event_type = self.env['event.type'].browse(self.test_event_type.ids)
 
         # complex with type + website
-        with freeze_time(self.reference_now), self.assertQueryCount(event_user=5480):  # com runbot: 5055 - +1 tef - ent runbot 5480
+        with freeze_time(self.reference_now), self.assertQueryCount(event_user=5481):  # com runbot: 5055 - +1 tef - ent runbot 5480
             self.env.cr._now = self.reference_now  # force create_date to check schedulers
             event_values = [
                 dict(self.event_base_vals,
@@ -128,7 +128,7 @@ class TestEventPerformance(EventPerformanceCase):
         has_social = 'social_menu' in self.env['event.event']  # otherwise view may crash in enterprise
 
         # no type, website
-        with freeze_time(self.reference_now), self.assertQueryCount(event_user=667):  # com runbot: 566 - -1 tef - ent runbot: 666
+        with freeze_time(self.reference_now), self.assertQueryCount(event_user=668):  # com runbot: 567 - -1 tef - ent runbot: 667
             self.env.cr._now = self.reference_now  # force create_date to check schedulers
             # Require for `website_menu` to be visible
             # <div name="event_menu_configuration" groups="base.group_no_one">
@@ -150,7 +150,7 @@ class TestEventPerformance(EventPerformanceCase):
         has_social = 'social_menu' in self.env['event.event']  # otherwise view may crash in enterprise
 
         # type and website
-        with freeze_time(self.reference_now), self.assertQueryCount(event_user=693):  # tef only: 593 - com runbot: 596 - ent runbot: 692
+        with freeze_time(self.reference_now), self.assertQueryCount(event_user=694):  # tef only: 603 - com runbot: 599 - ent runbot: 694
             self.env.cr._now = self.reference_now  # force create_date to check schedulers
             # Require for `website_menu` to be visible
             # <div name="event_menu_configuration" groups="base.group_no_one">
@@ -181,7 +181,7 @@ class TestEventPerformance(EventPerformanceCase):
     def test_event_create_single_notype_website(self):
         """ Test a single event creation """
         # simple without type involved + website
-        with freeze_time(self.reference_now), self.assertQueryCount(event_user=352):  # com runbot: 326 - +1 tef - ent runbot 352
+        with freeze_time(self.reference_now), self.assertQueryCount(event_user=353):  # com runbot: 327 - +1 tef - ent runbot 353
             self.env.cr._now = self.reference_now  # force create_date to check schedulers
             event_values = dict(
                 self.event_base_vals,
@@ -212,7 +212,7 @@ class TestEventPerformance(EventPerformanceCase):
         event_type = self.env['event.type'].browse(self.test_event_type.ids)
 
         # complex with type + website
-        with freeze_time(self.reference_now), self.assertQueryCount(event_user=387):  # com runbot: 361 - +1 tef - ent runbot 387
+        with freeze_time(self.reference_now), self.assertQueryCount(event_user=388):  # com runbot: 362 - +1 tef - ent runbot 388
             self.env.cr._now = self.reference_now  # force create_date to check schedulers
             event_values = dict(
                 self.event_base_vals,

--- a/addons/web/views/webclient_templates.xml
+++ b/addons/web/views/webclient_templates.xml
@@ -15,7 +15,7 @@
         <link type="image/x-icon" rel="shortcut icon" t-att-href="x_icon or '/web/static/img/favicon.ico'"/>
         <script id="web.layout.odooscript" type="text/javascript">
             var odoo = {
-                csrf_token: "<t t-esc="request.csrf_token(None)"/>",
+                csrf_token: "<t t-nocache="The csrf token must always be up to date." t-esc="request.csrf_token(None)"/>",
                 debug: "<t t-esc="debug"/>",
             };
         </script>

--- a/addons/web_editor/models/ir_translation.py
+++ b/addons/web_editor/models/ir_translation.py
@@ -29,6 +29,9 @@ class IrTranslation(models.Model):
         assert len(self) == 1 and self.type == 'model_terms'
         mname, fname = self.name.split(',')
         field = self.env[mname]._fields[fname]
+        # Update the write_date (and write_uid) of the related record to ensure that
+        # t-cache is correctly 'invalidate'.
+        self.env[field.model_name].browse(self.res_id).write({})
         if field.translate == xml_translate:
             # wrap value inside a div and parse it as HTML
             div = "<div>%s</div>" % encode(value)

--- a/addons/website/models/website.py
+++ b/addons/website/models/website.py
@@ -154,7 +154,7 @@ class Website(models.Model):
 
     def _compute_menu(self):
         for website in self:
-            menus = self.env['website.menu'].browse(website._get_menu_ids())
+            menus = self.env['website.menu'].browse(website._get_menu_ids_timestamp()[0])
 
             # use field parent_id (1 query) to determine field child_id (2 queries by level)"
             for menu in menus:
@@ -172,8 +172,9 @@ class Website(models.Model):
 
     # self.env.uid for ir.rule groups on menu
     @tools.ormcache('self.env.uid', 'self.id')
-    def _get_menu_ids(self):
-        return self.env['website.menu'].search([('website_id', '=', self.id)]).ids
+    def _get_menu_ids_timestamp(self):
+        menus = self.env['website.menu'].search([('website_id', '=', self.id)])
+        return menus._ids, max(menus.mapped("write_date")).timestamp()
 
     @api.model_create_multi
     def create(self, vals_list):

--- a/addons/website/models/website_page.py
+++ b/addons/website/models/website_page.py
@@ -138,7 +138,7 @@ class Page(models.Model):
             if not pages_linked_to_iruiview and not page.view_id.inherit_children_ids:
                 # If there is no other pages linked to that ir_ui_view, we can delete the ir_ui_view
                 page.view_id.unlink()
-        # Make sure website._get_menu_ids() will be recomputed
+        # Make sure website._get_menu_ids_timestamp() will be recomputed
         self.clear_caches()
         return super(Page, self).unlink()
 

--- a/addons/website/tests/test_views.py
+++ b/addons/website/tests/test_views.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
+from datetime import datetime
 import unittest
 from itertools import zip_longest
 from lxml import etree as ET, html
@@ -217,6 +218,7 @@ class TestViewSaving(TestViewSavingCommon):
         # common text nodes should be be escaped client side
         replacement = u'world &amp;amp; &amp;lt;b&amp;gt;cie'
         view.save(replacement, xpath='/t/p')
+        view.write_date = datetime.now()
         self.assertIn(replacement, view.arch, 'common text node should not be escaped server side')
         self.assertIn(
             replacement,

--- a/addons/website/views/website_templates.xml
+++ b/addons/website/views/website_templates.xml
@@ -128,7 +128,7 @@
     </xpath>
 
     <xpath expr="//header/t[@t-cache]" position="attributes">
-        <attribute name="t-cache">xmlid,website</attribute>
+        <attribute name="t-cache">xmlid,website,website._get_menu_ids_timestamp()</attribute>
     </xpath>
 
     <xpath expr="//header" position="before">

--- a/odoo/addons/base/models/ir_qweb.py
+++ b/odoo/addons/base/models/ir_qweb.py
@@ -1933,8 +1933,6 @@ class IrQWeb(models.AbstractModel):
                     values['__qweb_attrs__'].update(field_attrs)
                 content = self._compile_to_str(content)
                 """, level))
-
-            code.append(indent_code("content = self._compile_to_str(content)", level))
             force_display_dependent = True
         else:
             if expr == T_CALL_SLOT:
@@ -2149,8 +2147,7 @@ class IrQWeb(models.AbstractModel):
             for index, (tagName, asset_attrs, content) in enumerate(t_call_assets_nodes):
                 if index:
                     yield '\\n        '
-                yield '<'
-                yield tagName
+                yield f'<{tagName}'
 
                 attrs = self._post_processing_att(tagName, asset_attrs)
                 for name, value in attrs.items():
@@ -2163,9 +2160,7 @@ class IrQWeb(models.AbstractModel):
                     yield '>'
                     if content:
                       yield content
-                    yield '</'
-                    yield tagName
-                    yield '>'
+                    yield f'</{tagName}>'
                 """, level))
 
         return code

--- a/odoo/addons/base/models/ir_qweb.py
+++ b/odoo/addons/base/models/ir_qweb.py
@@ -607,7 +607,7 @@ class IrQWeb(models.AbstractModel):
             return None, None, None
 
     @QwebTracker.wrap_compile
-    def _compile(self, template):
+    def _compile(self, template, cache=None):
         if isinstance(template, etree._Element):
             self = self.with_context(is_t_cache_disabled=True)
             ref = None
@@ -645,7 +645,7 @@ class IrQWeb(models.AbstractModel):
                 raise QWebException("Error when compiling xml template",
                     self, template, code=code, ref=ref) from e
 
-        code_function, def_name = self._load_values(base_key_cache, generate_functions)
+        code_function, def_name = self._load_values(base_key_cache, generate_functions, cache)
 
         globals_dict = self._prepare_globals()
         globals_dict['__builtins__'] = globals_dict # So that unknown/unsafe builtins are never added.
@@ -1642,7 +1642,7 @@ class IrQWeb(models.AbstractModel):
                                     ref, function_name, cached_values = item
                                     t_nocache_function = values['__qweb_loaded_values'].get(function_name)
                                     if not t_nocache_function:
-                                        t_call_template_functions, def_name = self._compile(ref)
+                                        t_call_template_functions, def_name = self._compile(ref, values.get('__qweb_loaded_values'))
                                         t_nocache_function = t_call_template_functions[function_name]
 
                                     nocache_values = values['__qweb_root_values'].copy()
@@ -2139,7 +2139,7 @@ class IrQWeb(models.AbstractModel):
             template = {template}
             if template.isnumeric():
                 template = int(template)
-            t_call_template_functions, def_name = irQweb._compile(template)
+            t_call_template_functions, def_name = irQweb._compile(template, values.get('__qweb_loaded_values'))
             render_template = t_call_template_functions[def_name]
             yield from render_template(irQweb, t_call_values)
             """, level))
@@ -2259,7 +2259,7 @@ class IrQWeb(models.AbstractModel):
                         ref, function_name, cached_values = item
                         t_nocache_function = loaded_values.get(function_name)
                         if not t_nocache_function:
-                            t_call_template_functions, def_name = self._compile(ref)
+                            t_call_template_functions, def_name = self._compile(ref, values.get('__qweb_loaded_values'))
                             t_nocache_function = t_call_template_functions[function_name]
 
                         nocache_values = values['__qweb_root_values'].copy()

--- a/odoo/addons/base/models/ir_ui_view.py
+++ b/odoo/addons/base/models/ir_ui_view.py
@@ -224,7 +224,7 @@ class View(models.Model):
 
     name = fields.Char(string='View Name', required=True)
     model = fields.Char(index=True)
-    key = fields.Char()
+    key = fields.Char(index=True)
     priority = fields.Integer(string='Sequence', default=16, required=True)
     type = fields.Selection([('tree', 'Tree'),
                              ('form', 'Form'),

--- a/odoo/addons/base/tests/__init__.py
+++ b/odoo/addons/base/tests/__init__.py
@@ -36,6 +36,7 @@ from . import test_qweb
 from . import test_res_config
 from . import test_res_lang
 from . import test_search
+from . import test_shared_memory
 from . import test_translate
 #import test_uninstall  # loop
 from . import test_user_has_group

--- a/odoo/addons/base/tests/test_shared_memory.py
+++ b/odoo/addons/base/tests/test_shared_memory.py
@@ -763,6 +763,8 @@ class TestSharedMemoryLRU(BaseCase):
                 "Read with 'real' sample take %.4f ms by read in multi-process (%d)",
                 (time.time() - start) * 1000 / nb_read, nb_process
             )
+            # Check print stats
+            lru.print_stats()
 
     @mute_logger('odoo.modules.shared_memory')
     def test_performance_reset_sm(self):

--- a/odoo/addons/base/tests/test_shared_memory.py
+++ b/odoo/addons/base/tests/test_shared_memory.py
@@ -1,0 +1,775 @@
+import random
+import string
+import time
+import itertools
+import logging
+from multiprocessing import Process
+from threading import Thread
+from typing import OrderedDict
+
+from odoo.modules.shared_memory import SharedMemoryLRU, LockIdentify
+from odoo.tests.common import BaseCase
+from odoo.tools import mute_logger
+
+
+_logger = logging.getLogger(__name__)
+
+
+class TestLockPID(BaseCase):
+
+    def test_lock_multiprocess_terminate(self):
+        self.skipTest("Create a traceback impossible to mute")
+        lock = LockIdentify()
+        def sleeting():
+            with lock:
+                time.sleep(1)
+
+        process = Process(target=sleeting)
+        process.start()
+        time.sleep(0.1)
+        process.terminate()
+        process.join()
+
+        self.assertTrue(lock._lock.acquire(block=False), "Lock is not release when process is terminated")
+
+    def test_lock_kill(self):
+        # TODO mute the exception
+        lock = LockIdentify()
+        def sleeting():
+            with lock:
+                time.sleep(1)
+
+        process = Process(target=sleeting)
+        process.start()
+        time.sleep(0.1)
+        process.kill()
+        process.join()
+
+        lock.force_release_if_mandatory(process.pid)
+
+        self.assertTrue(lock._lock.acquire(block=False), "Lock is not release when process is killed and force_release_if_mandatory")
+
+class TestSharedMemoryLRU(BaseCase):
+
+    def test_sm_basic_functionality(self):
+        """ Test basic set/get feature of the SharedMemoryLRU """
+        with SharedMemoryLRU(16) as lru:
+            self.assertEqual(list(lru), [])
+            lru["key"] = 10
+            self.assertEqual(lru["key"], 10)
+            with self.assertRaises(KeyError):
+                lru["no exist"]
+
+            del lru["key"]
+
+            for i in range(lru._max_length):
+                lru[i] = f"code_{i}"
+                self.assertEqual(lru[i], f"code_{i}")
+
+            lru[0]  # 0 index become the first of LRU
+
+            lru[lru._max_length] = "code_8"
+            lru[lru._max_length + 1] = "code_9"
+
+            with self.assertRaises(KeyError):
+                lru[1]  # Should be pop because of LRU
+            with self.assertRaises(KeyError):
+                lru[2]  # Should be pop because of LRU
+
+            for i in range(3, lru._max_length + 2):
+                del lru[i]
+                with self.assertRaises(KeyError):
+                    lru[i]
+            del lru[0]
+
+    def test_sm_datastructure_hashtable(self):
+        """ Test internal structure of the SharedMemoryLRU """
+        with SharedMemoryLRU(16) as lru:
+
+            # TODO: hash of key == 0 doesn't work now
+            lru[lru._size] = "test"  # hash & mask = 0, should be at index 0
+            lru[1] = "other"  # hash & mask = 1 should be at index 1
+            lru[lru._size * 2] = "test * 2"  # hash & mask = 0, should be at index 2
+
+            del lru[1]
+
+            # now lru._size * 2 should be in the index 1
+            self.assertEqual(lru._entry_table[1].hash, lru._size * 2)
+            self.assertEqual(lru[lru._size * 2], "test * 2")
+            self.assertEqual(lru[lru._size], "test")
+            self.assertEqual(list(lru), [(lru._size, "test"), (lru._size * 2, "test * 2")])
+
+            lru[lru._size - 1] = "blu"  # hash & mask = 15 should be at index 15
+            lru[(lru._size * 2) - 1] = "bla" # hash & mask = 15 (hash of 31) should be at index 2
+
+            self.assertEqual(lru._entry_table[2].hash, 31, f"{lru._entry_table[lru._size - 1].hash} != {31}")
+            self.assertEqual(lru[(lru._size * 2) - 1], "bla")
+            self.assertEqual(lru[lru._size - 1], "blu")
+
+            del lru[lru._size - 1]  # (lru._size * 2) - 1 should go at index 15
+
+            self.assertEqual(lru[(lru._size * 2) - 1], "bla")
+            self.assertEqual(lru._entry_table[2].hash, 0)
+            self.assertEqual(lru._entry_table[15].hash, 31)
+            self.assertEqual(lru._entry_table[1].hash, lru._size * 2, f"{lru._entry_table[1].hash} != {lru._size * 2}")
+            self.assertEqual(lru[lru._size * 2], "test * 2")
+            self.assertEqual(lru[lru._size], "test")
+
+            # test lru
+            self.assertEqual(list(lru), [(lru._size, "test"), (lru._size * 2, "test * 2"), ((lru._size * 2) - 1, "bla")])
+
+    def test_sm_delete_1(self):
+        """ Test the deletion (to ensure than _pop_lru() works correctly internally) of the SharedMemoryLRU """
+        with SharedMemoryLRU(16) as lru:
+            lru[lru._size] = "test0"  # index 0
+            lru[lru._size * 2] = "test1"  # index 1
+            lru[lru._size * 3] = "test2"  # index 2
+            lru[1] = "test3"  # index 3
+            lru[lru._size - 1] = "test15"  # index 15
+
+            self.assertEqual(list(lru), [
+                (lru._size - 1, "test15"),
+                (1, "test3"),
+                (lru._size * 3, "test2"),
+                (lru._size * 2, "test1"),
+                (lru._size, "test0"),
+            ])
+
+            del lru[lru._size * 2]
+            self.assertEqual(list(lru), [
+                (lru._size - 1, "test15"),
+                (1, "test3"),
+                (lru._size * 3, "test2"),
+                (lru._size, "test0"),
+            ])
+
+            del lru[lru._size - 1]
+            self.assertEqual(list(lru), [
+                (1, "test3"),
+                (lru._size * 3, "test2"),
+                (lru._size, "test0"),
+            ])
+
+            del lru[lru._size]
+            self.assertEqual(list(lru), [
+                (1, "test3"),
+                (lru._size * 3, "test2"),
+            ])
+
+            del lru[1]
+            self.assertEqual(list(lru), [
+                (lru._size * 3, "test2"),
+            ])
+
+            del lru[lru._size * 3]
+            self.assertEqual(list(lru), [])
+
+    def test_sm_delete_2(self):
+        """ Test all possibility of deletion """
+        size_lru = 16
+        keys_values = {
+            size_lru - 1: "h_mask 15 - index 15",
+            (size_lru * 2) - 1: "h_mask 0 - index 0",
+            1: "h_mask 1 - index 1",
+            (size_lru * 3) - 1: "h_mask 0 - index 2",
+            size_lru - 2: "h_mask 14 - index 14",
+            (size_lru * 2) - 2: "h_mask 14 - index 3",
+        }
+
+        for keys in itertools.permutations(keys_values):
+            with self.subTest(keys=keys), SharedMemoryLRU(size_lru) as lru:
+                for key in keys:
+                    lru[key] = keys_values[key]
+                    self.assertEqual(lru[key], keys_values[key])
+
+                for key in keys:
+                    self.assertEqual(lru[key], keys_values[key])
+
+                self.assertEqual(len(lru), len(keys))
+
+                # check lru
+                self.assertEqual(list(reversed([(k, keys_values[k]) for k in keys])), list(lru))
+
+                for i, key in enumerate(keys):
+                    del lru[key]
+                    self.assertEqual(list(reversed([(k, keys_values[k]) for k in keys[i+1:]])), list(lru))
+
+                self.assertEqual(len(lru), 0)
+
+    def test_sm_pop_lru(self):
+        """ Test _pop_lru of the SharedMemoryLRU """
+        with SharedMemoryLRU(16) as lru:  # max_length for LRU == 8
+            lru[lru._size] = "test0"  # index 0
+            lru[lru._size * 2] = "test1"  # index 1
+            lru[lru._size * 3] = "test2"  # index 2
+            lru[1] = "test3"  # index 3
+            lru[lru._size - 1] = "test15"  # index 15
+
+            self.assertEqual(list(lru), [
+                (lru._size - 1, "test15"),
+                (1, "test3"),
+                (lru._size * 3, "test2"),
+                (lru._size * 2, "test1"),
+                (lru._size, "test0"),
+            ])
+
+            lru._lru_pop()
+            self.assertEqual(list(lru), [
+                (lru._size - 1, "test15"),
+                (1, "test3"),
+                (lru._size * 3, "test2"),
+                (lru._size * 2, "test1"),
+            ])
+
+            lru._lru_pop()
+            self.assertEqual(list(lru), [
+                (lru._size - 1, "test15"),
+                (1, "test3"),
+                (lru._size * 3, "test2"),
+            ])
+
+            lru._lru_pop()
+            self.assertEqual(list(lru), [
+                (lru._size - 1, "test15"),
+                (1, "test3"),
+            ])
+
+            lru._lru_pop()
+            self.assertEqual(list(lru), [
+                (lru._size - 1, "test15"),
+            ])
+
+            lru._lru_pop()
+            self.assertEqual(list(lru), [])
+
+    def test_sm_datastructure_lru_1(self):
+        """ Test the LRU feature of the SharedMemory """
+        with SharedMemoryLRU(16) as lru:
+            lru['a'] = "test_a"
+            lru['b'] = "test_b"
+
+            self.assertEqual(list(lru), [('b', "test_b"), ('a', "test_a")])
+            lru['a']
+            self.assertEqual(list(lru), [('a', "test_a"), ('b', "test_b")])
+            lru['a']
+            self.assertEqual(list(lru), [('a', "test_a"), ('b', "test_b")])
+            lru['c'] = "test_c"
+            self.assertEqual(list(lru), [('c', "test_c"), ('a', "test_a"), ('b', "test_b")])
+            lru['d'] = "test_d"
+            self.assertEqual(list(lru), [('d', "test_d"), ('c', "test_c"), ('a', "test_a"), ('b', "test_b")])
+
+    def test_sm_datastructure_lru_2(self):
+        with SharedMemoryLRU(16) as lru:
+            lru['key1'] = 'test1'
+            lru['key2'] = 'test2'
+            self.assertEqual(lru['key2'], 'test2')
+            lru['key2'] = 'test2'  # re-set the root
+            self.assertEqual(list(lru), [('key2', 'test2'), ('key1', 'test1')])
+            self.assertEqual(lru['key1'], 'test1')
+            self.assertEqual(lru['key2'], 'test2')
+
+    def test_sm_memory_exhausted(self):
+        with SharedMemoryLRU(10) as lru:
+            with mute_logger('odoo.service.shared_memory'):
+                with self.assertRaises(MemoryError):
+                    lru['test'] = "a" * lru._sm.size
+            with self.assertRaises(KeyError):
+                lru['test']
+            self.assertEqual(lru._length, 0)
+
+            with self.assertRaises(MemoryError):
+                lru['test'] = "a" * lru._max_size_one_data
+
+    def test_sm_free_data_coherence(self):
+        random.seed(42)
+        with SharedMemoryLRU(30) as lru:
+            for i in range(5_000):
+                key = str(i)
+                value = (str(i) * random.randint(1, 2000))[:(lru._max_size_one_data - 20)]
+                prev = OrderedDict(lru)
+                lru[key] = value
+                while len(prev) >= len(lru):
+                    prev.popitem()
+                prev[key] = value
+                prev.move_to_end(key, False)
+                self.assertEqual(len(lru), len(prev))
+                self.assertEqual(len(lru), len(dict(lru)))
+                self.assertEqual(len(dict(lru)), len(dict(prev)))
+                self.assertEqual(dict(lru), dict(prev))
+
+                # Test coherence between data entry and free data: no overlaps possible
+                filter_sorted_indexes = sorted(filter(lambda i: lru._entry_table[i].prev != -1, range(lru._size)), key=lambda i: -lru._data_idx[i].position)
+                free_sorted_indexes = sorted(range(lru._free_len), key=lambda i: -lru._data_free[i].position)
+                data_entry = data_free = None
+                while filter_sorted_indexes and free_sorted_indexes:
+                    if not data_entry:
+                        data_entry = lru._data_idx[filter_sorted_indexes.pop()]
+                    if not data_free:
+                        data_free = lru._data_free[free_sorted_indexes.pop()]
+
+                    if data_free.size != 0 and (
+                        (data_entry.position <= data_free.position and data_entry.position + data_entry.size > data_free.position)
+                        or (data_entry.position > data_free.position and data_entry.position + data_entry.size < data_free.position)):
+                        assert False, "Overlaps detected between data_free and data_idx"
+
+                    if data_entry.position > data_free.position:
+                        data_free = None
+                    else:
+                        data_entry = None
+
+    def test_sm_long_run_1(self):
+        random.seed(42)
+        with SharedMemoryLRU(50) as lru:
+            for i in range(5_000):
+                if random.random() < 0.8 and lru._length > 1:
+                    # read
+                    index = random.randint(0, lru._length - 1)
+                    prev = list(lru)[index]  # It is slow
+                    self.assertEqual(lru[prev[0]], prev[1])
+                else:
+                    # write
+                    key = str(i)
+                    value = (str(i) * random.randint(1, 2000))[:(lru._max_size_one_data - 20)]
+                    lru[key] = value
+                    self.assertEqual(lru[key], value)
+
+    def test_sm_long_run_2(self):
+        random.seed("test_multi")
+
+        with SharedMemoryLRU(5_000) as lru:
+            for i in range(5_000):
+                key = f'dbname_template_{i % 1500}'
+                try:
+                    if random.random() > 0.8:
+                        raise KeyError()
+                    lru[key]
+                except KeyError:
+                    lru[key] = (
+                    f"""
+                    <th class="text-left">
+                        <strong>{key}</strong>
+                    </th>
+                    <div class="input-group">
+                        <input type="number"
+                            class="o_matrix_input"
+                            t-att-ptav_ids="cell.ptav_ids"
+                            t-att-value="cell.qty"/>
+                    </div>
+                    <span class="o_matrix_cell o_matrix_text_muted o_matrix_nocontent_container"> Not available </span>
+                    def blabla():
+                        return {key}
+                    """ * random.randint(1, 1000))[:lru._max_size_one_data - len(key) - 20]
+
+    def test_sm_multi_thread_long_run(self):
+        nb_thread = 50
+        operation_by_worker = 200
+
+        random.seed("test_multi")
+
+        def simulate_t_cache_usage(lru, prefix):
+            for i in range(operation_by_worker):
+                time.sleep(0.0001 * random.random())  # sleep 0-0.1 ms by operation
+                key = f'dbname_template_{prefix}{i}'
+                try:
+                    lru[key]
+                except KeyError:
+                    time.sleep(0.0002 * random.random())  # sleep 0-0.2 ms by operation
+                    lru[key] = (
+                    f"""
+                    <th class="text-left">
+                        <strong>{key}</strong>
+                    </th>
+                    <div class="input-group">
+                        <input type="number"
+                            class="o_matrix_input"
+                            t-att-ptav_ids="cell.ptav_ids"
+                            t-att-value="cell.qty"/>
+                    </div>
+                    <span class="o_matrix_cell o_matrix_text_muted o_matrix_nocontent_container"> Not available </span>
+                    def blabla():
+                        return {key}
+                    """ * random.randint(1, 200))[:lru._max_size_one_data - len(key) - 20]
+
+
+        with SharedMemoryLRU(5_000) as lru:
+            start = time.time()
+            threads = [Thread(target=simulate_t_cache_usage, args=(lru, f"{i}")) for i in range(nb_thread)]
+            for p in threads:
+                p.start()
+            for p in threads:
+                p.join()
+            _logger.info(
+                "Simulate t-cache usage with %d Threads: %s ms by op (%s)", nb_thread,
+                (time.time() - start) * 1000 / (operation_by_worker * nb_thread),
+                (operation_by_worker * nb_thread)
+            )
+
+    def test_sm_multi_process_long_run(self):
+        nb_process = 50
+        operation_by_worker = 200
+
+        random.seed("test_multi")
+
+        def simulate_t_cache_usage(lru, prefix):
+            for i in range(operation_by_worker):
+                time.sleep(0.0001 * random.random())  # sleep 0-0.1 ms by operation
+                key = f'dbname_template_{prefix}{i}'
+                try:
+                    lru[key]
+                except KeyError:
+                    time.sleep(0.0002 * random.random())  # sleep 0-0.2 ms by operation
+                    lru[key] = (
+                    f"""
+                    <th class="text-left">
+                        <strong>{key}</strong>
+                    </th>
+                    <div class="input-group">
+                        <input type="number"
+                            class="o_matrix_input"
+                            t-att-ptav_ids="cell.ptav_ids"
+                            t-att-value="cell.qty"/>
+                    </div>
+                    <span class="o_matrix_cell o_matrix_text_muted o_matrix_nocontent_container"> Not available </span>
+                    def blabla():
+                        return {key}
+                    """ * random.randint(1, 200))[:lru._max_size_one_data - len(key) - 20]
+
+
+        with SharedMemoryLRU(5_000) as lru:
+            start = time.time()
+            processes = [Process(target=simulate_t_cache_usage, args=(lru, f"{i}")) for i in range(nb_process)]
+            for p in processes:
+                p.start()
+            for p in processes:
+                p.join()
+            _logger.info(
+                "Simulate t-cache usage with %d Processes: %s ms by op (%s)", nb_process,
+                (time.time() - start) * 1000 / (operation_by_worker * nb_process),
+                (operation_by_worker * nb_process)
+            )
+
+    def test_sm_multi_process_coherence(self):
+
+        def method_p1(lru):
+            time.sleep(0.1)
+            lru['test1'] = "abc"
+            self.assertEqual(lru["test2"], "m2")
+
+        def method_p2(lru):
+            lru['test2'] = "m2"
+            time.sleep(0.2)
+            self.assertEqual(lru["test1"], "abc")
+
+        with SharedMemoryLRU(10) as lru:
+            process_1 = Process(target=method_p1, args=(lru,))
+            process_2 = Process(target=method_p2, args=(lru,))
+            process_1.start()
+            process_2.start()
+            process_1.join()
+            process_2.join()
+            self.assertEqual(lru["test1"], "abc")
+            self.assertEqual(lru["test2"], "m2")
+
+    @mute_logger('odoo.modules.shared_memory')
+    def test_sm_multi_process_killed_long_run(self):
+        """ Simulate "real" environment where some process is killed by the PreforkServer
+        during the usage of SM
+        """
+        nb_process = 50
+        operation_by_worker = 1000
+
+        random.seed("test_multi")
+
+        def simulate_usage(lru, prefix):
+            for i in range(operation_by_worker):
+                key = (f'dbname_template_{prefix}{i}', i)
+                try:
+                    lru[key]
+                except KeyError:
+                    lru[key] = (
+                    f"""
+                    <th class="text-left">
+                        <strong>{key}</strong>
+                    </th>
+                    """,) * random.randint(1, 5)
+
+        for _ in range(5):
+            with SharedMemoryLRU(100) as lru:
+                processes = [Process(target=simulate_usage, args=(lru, f"{i}")) for i in range(nb_process)]
+                for p in processes:
+                    p.start()
+
+                for i, p in enumerate(random.sample(processes, len(processes))):
+                    p.kill()
+                    p.join()
+                    lru.hook_process_killed(p.pid)
+                    # Simulate server.py: if it cannot obtain the lock during some period of
+                    # time, restart everything
+                    if not lru.is_alive():
+                        lru._lock._lock.release()
+                    if i % (len(processes) // 5):
+                        with lru._lock:
+                            lru._check_consistence()
+                            rep_lru = repr(lru)
+                            self.assertFalse('<unable to read>' in rep_lru, rep_lru)
+
+    def test_sm_multi_process_killed_consistent(self):
+        """ Test that kill a process when it uses the SharedMemory doesn't let
+        a deadlock it and that SharedMemory keeps the data structure coherent (Clean it)
+        """
+
+        class TestingSharedMemoryLRU(SharedMemoryLRU):
+            def _malloc(self, data):
+                if b'test2' in data:
+                    time.sleep(10)  # Force to take more time to test the kill
+                super()._malloc(data)
+
+        def method_p1(lru):
+            lru['test1'] = "abc" # Step 1
+            time.sleep(0.1)
+            lru['test2'] = "other" # Step 2, it will take 10 sec
+
+        def method_p2(lru):
+            lru['test3'] = "m3" # Step 1
+            time.sleep(0.5)
+            lru['test4'] = "m4" # Step 4
+
+        with TestingSharedMemoryLRU(10) as lru:
+            process_1 = Process(target=method_p1, args=(lru,))
+            process_2 = Process(target=method_p2, args=(lru,))
+            process_1.start()
+            process_2.start()
+
+            time.sleep(0.2)
+            process_1.kill() # During the Step 2 of process_1 (Step 3)
+            lru.hook_process_killed(process_1.pid)
+
+            process_1.join()
+            process_2.join()
+
+            self.assertEqual(list(lru), [("test4", "m4")])
+            self.assertEqual(lru["test4"], "m4")
+            self.assertEqual(len(lru), 1)
+            # The other value has be erase because process 1 has let the SM incoherent
+            with self.assertRaises(KeyError):
+                lru["test1"]
+            with self.assertRaises(KeyError):
+                lru["test2"]
+            with self.assertRaises(KeyError):
+                lru["test3"]
+
+            # check that the SM still work
+            for i in range(10):
+                key, value = str(i), str(i) * 200
+                lru[key] = value
+                self.assertEqual(lru[key], value)
+
+            with self.assertRaises(KeyError):
+                lru["test4"]
+
+    # ------------------- PERFORMANCE TESTING
+
+    def test_performance_mono_process(self):
+
+        with SharedMemoryLRU(4096 * 2) as lru:
+            start = time.time()
+            for i in range(lru._max_length):
+                lru[str(i)] = i
+            _logger.info(
+                "Write without lru_pop: %s ms by write (%s)",
+                (time.time() - start) * 1000 / lru._max_length, lru._max_length
+            )
+
+            start = time.time()
+            for i in range(lru._max_length, lru._max_length * 2):
+                lru[str(i)] = i
+            _logger.info(
+                "Write with lru_pop: %s ms by write (%s)",
+                (time.time() - start) * 1000 / lru._max_length, lru._max_length
+             )
+
+            start = time.time()
+            for i in range(lru._max_length, lru._max_length * 2):
+                lru[str(i)]
+            _logger.info(
+                "Read (existing): %s ms by read (%s)",
+                (time.time() - start) * 1000 / lru._max_length, lru._max_length
+            )
+
+            start = time.time()
+            for i in range(lru._max_length, lru._max_length * 2):
+                del lru[str(i)]
+            _logger.info(
+                "Delete (existing): %s ms by delete (%s)",
+                (time.time() - start) * 1000 / lru._max_length, lru._max_length
+            )
+
+    def test_performance_multi_process(self):
+        nb_process = 8
+        nb_operation = 20_000
+
+        def write_on_lru(lru, prefix, nb):
+            for i in range(nb):
+                lru[prefix + str(i)] = i
+
+        def read_on_lru(lru, prefix, nb):
+            for i in range(nb):
+                lru[prefix + str(i)]
+
+        def delete_on_lru(lru, prefix, nb):
+            for i in range(nb):
+                del lru[prefix + str(i)]
+
+        with SharedMemoryLRU(int(nb_operation * (1 / SharedMemoryLRU.USABLE_FRACTION))) as lru:
+            start = time.time()
+            processes = [
+                Process(target=write_on_lru, args=(lru, f"{i}_", lru._max_length // nb_process)) for i in range(nb_process)]
+            for p in processes:
+                p.start()
+            for p in processes:
+                p.join()
+            _logger.info(
+                "Write without lru_pop: %s ms by write (%s)",
+                (time.time() - start) * 1000 / lru._max_length, lru._max_length
+            )
+
+            self.assertEqual(lru._length, lru._max_length)
+
+            start = time.time()
+            processes = [Process(target=write_on_lru, args=(lru, f"_{i}_", lru._max_length // nb_process)) for i in range(nb_process)]
+            for p in processes:
+                p.start()
+            for p in processes:
+                p.join()
+            _logger.info(
+                "Write with lru_pop: %s ms by write (%s)",
+                (time.time() - start) * 1000 / lru._max_length, lru._max_length
+            )
+
+            self.assertEqual(lru._length, lru._max_length)
+
+            start = time.time()
+            processes = [Process(target=read_on_lru, args=(lru, f"_{i}_", lru._max_length // nb_process)) for i in range(nb_process)]
+            for p in processes:
+                p.start()
+            for p in processes:
+                p.join()
+            _logger.info(
+                "Read (existing): %s ms by read (%s)",
+                (time.time() - start) * 1000 / lru._max_length, lru._max_length
+            )
+
+            self.assertEqual(lru._length, lru._max_length)
+
+            start = time.time()
+            processes = [Process(target=delete_on_lru, args=(lru, f"_{i}_", lru._max_length // nb_process)) for i in range(nb_process)]
+            for p in processes:
+                p.start()
+            for p in processes:
+                p.join()
+            _logger.info(
+                "Delete (existing): %s ms by delete (%s)",
+                (time.time() - start) * 1000 / lru._max_length, lru._max_length
+            )
+
+            self.assertEqual(lru._length, 0)
+
+    def test_performance_real_mono_process(self):
+        # Size sample of t-cache template with demo data and website_sale
+        size_sample = [
+            65294, 13158, 8349, 10537, 9215, 765, 30940, 54101, 12340, 206964,
+            28, 4149, 5826, 21940, 3252, 2184, 3707, 3447, 3746, 2156, 8610, 5271,
+            12380, 3978, 18085, 4632, 5734, 4921,
+        ]
+
+        nb_write = 5_000
+        nb_read = 100_000
+        long_random_string = ''.join(random.choice(string.ascii_lowercase) for _ in range(max(size_sample) * 2))
+        size_sample_i = [random.choice(size_sample) for _ in range(nb_write)]
+        begin_sample_i = [random.randint(0, max(size_sample)) for _ in range(nb_write)]
+        values = [
+            ((f"dbname_template_blablabla_{i}", i), long_random_string[begin_sample_i[i]:begin_sample_i[i] + size_sample_i[i]])
+            for i in range(nb_write)
+        ]
+        with SharedMemoryLRU(int(nb_write * (1 / SharedMemoryLRU.USABLE_FRACTION))) as lru:
+            start = time.time()
+            for _ in range(nb_write):
+                key, value = random.choice(values)
+                lru[key] = value
+            _logger.info("Write with 'real' sample take %.4f ms by write in mono-process", (time.time() - start) * 1000 / nb_write)
+
+            start = time.time()
+            for _ in range(nb_read):
+                key, _value = random.choice(values)
+                try:
+                    v = lru[key]
+                    self.assertEqual(v, _value)
+                except KeyError:
+                    pass
+            _logger.info("Read with 'real' sample take %.4f ms by read in mono-process", (time.time() - start) * 1000 / nb_read)
+
+    def test_performance_real_multi_process(self):
+        # Size sample of t-cache template with demo data and website_sale
+        size_sample = [
+            65294, 13158, 8349, 10537, 9215, 765, 30940, 54101, 12340, 206964,
+            28, 4149, 5826, 21940, 3252, 2184, 3707, 3447, 3746, 2156, 8610, 5271,
+            12380, 3978, 18085, 4632, 5734, 4921,
+        ]
+
+        nb_write = 5_000
+        nb_read = 100_000
+        nb_process = 20
+        long_random_string = ''.join(random.choice(string.ascii_lowercase) for _ in range(max(size_sample) * 2))
+        size_sample_i = [random.choice(size_sample) for _ in range(nb_write)]
+        begin_sample_i = [random.randint(0, max(size_sample)) for _ in range(nb_write)]
+        values = [
+            ((f"dbname_template_blablabla_{i}", i), long_random_string[begin_sample_i[i]:begin_sample_i[i] + size_sample_i[i]])
+            for i in range(nb_write)
+        ]
+
+        def write_on_lru(lru):
+            for _ in range(nb_write // nb_process):
+                key, value = random.choice(values)
+                lru[key] = value
+
+        def read_on_lru(lru):
+            for _ in range(nb_read // nb_process):
+                key, _value = random.choice(values)
+                try:
+                    v = lru[key]
+                    self.assertEqual(v, _value)
+                except KeyError:
+                    pass
+
+        with SharedMemoryLRU(int(nb_write * (1 / SharedMemoryLRU.USABLE_FRACTION))) as lru:
+            start = time.time()
+            processes = [Process(target=write_on_lru, args=(lru,)) for i in range(nb_process)]
+            for p in processes:
+                p.start()
+            for p in processes:
+                p.join()
+            _logger.info(
+                "Write with 'real' sample take %.4f ms by write in multi-process (%d)",
+                (time.time() - start) * 1000 / nb_write, nb_process
+            )
+
+            start = time.time()
+            processes = [Process(target=read_on_lru, args=(lru,)) for i in range(nb_process)]
+            for p in processes:
+                p.start()
+            for p in processes:
+                p.join()
+            _logger.info(
+                "Read with 'real' sample take %.4f ms by read in multi-process (%d)",
+                (time.time() - start) * 1000 / nb_read, nb_process
+            )
+
+    @mute_logger('odoo.modules.shared_memory')
+    def test_performance_reset_sm(self):
+        with SharedMemoryLRU(5_000) as lru:
+            start = time.time()
+            nb_time = 100
+            for _ in range(nb_time):
+                lru._consistent.value = False
+                lru._check_consistence()
+            _logger.info("Reset Shared Memory of %d items take %.4f ms by reset", lru._size, (time.time() - start) * 1000 / nb_time)

--- a/odoo/modules/__init__.py
+++ b/odoo/modules/__init__.py
@@ -5,7 +5,7 @@
 
 """
 
-from . import db, graph, loading, migration, module, registry
+from . import db, graph, loading, migration, module, registry, shared_memory
 
 from odoo.modules.loading import load_modules, reset_modules_state
 

--- a/odoo/modules/registry.py
+++ b/odoo/modules/registry.py
@@ -42,6 +42,10 @@ def close_shared_cache():
     if isinstance(shared_cache, SharedMemoryLRU):
         shared_cache.close()
 
+def log_shared_cache_stats(sig=None, frame=None):
+    if isinstance(shared_cache, SharedMemoryLRU):
+        shared_cache.print_stats()
+
 def release_lock_shared_cache(pid):
     if isinstance(shared_cache, SharedMemoryLRU):
         shared_cache.hook_process_killed(pid)

--- a/odoo/modules/shared_memory.py
+++ b/odoo/modules/shared_memory.py
@@ -1,0 +1,517 @@
+import logging
+import marshal
+import os
+import reprlib
+
+from ctypes import Structure, c_bool, c_int32, c_int64, c_ssize_t
+from multiprocessing import Lock, RawValue, RawArray
+from multiprocessing.shared_memory import SharedMemory
+from time import time, time_ns
+
+
+_logger = logging.getLogger(__name__)
+
+
+class LockIdentify:
+    """
+    Lock where the pid process is saved into a Shared Value after that the process acquires the lock.
+    It is to be able to release the lock from another Process (parent process) when the process
+    is killed (the Lock is not release automatically in that case).
+    """
+    def __init__(self) -> None:
+        self._lock = Lock()
+        self._pid = RawValue(c_int64, -1)  # Shared Value to save the pid of the current process using Lock
+
+    def __enter__(self):
+        # TODO: Maybe we should make the pid a lazy property + hook before fork
+        pid = os.getpid() # Make the call before to minimize the Critical Spot
+
+        # CRITICAL SPOT: if the process is killed after it acquired
+        # but before setting the pid, the _lock is locked without knowing
+        # which process took it, then the PreforkServer cannot release it.
+        # See `force_release_if_mandatory` where there is a partial solution to this
+        self._lock.acquire()
+        self._pid.value = pid
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        # CRITICAL SPOT: if the process is killed after resetting the pid
+        # but before releasing, the _lock is locked without knowing
+        # which process took it, then the PreforkServer cannot release it.
+        # See `force_release_if_mandatory` where there is a partial solution for this
+        self._pid.value = -1
+        try:
+            self._lock.release()
+        except ValueError:
+            # On the worst case of the worst case, if we have a ValueError ("release" an already released lock), it seems
+            # that no other process has used the lock between (or it already finished)
+            _logger.error("One process has release the lock when it was used.")
+            raise Exception("One process has release the lock when it was used, it shouldn't happen")
+
+    def force_release_if_mandatory(self, pid: int):
+        """Release the lock if it is locked by the killed process with `pid`
+
+        :param int pid: pid of a killed (mandatory) process
+        """
+        # TODO: it still not a completely safe solution (IMO, there isn't any a complete solution)
+        have_lock = self._lock.acquire(block=False)
+        # Read _pid outside locking section seems "wrong", but we only use it to compare equality,
+        # then the change to get a bad value and take the wrong decision is very "small" (or "inexistant", not sure)
+        if not have_lock and self._pid.value == pid:
+            _logger.info("Force the release of SM lock for pid=%s", pid)
+            self._pid.value = -1
+            self._lock.release()
+
+class _Entry(Structure):
+    """
+    Hash LRU Table entry structure
+    """
+    _fields_ = [
+        ("hash", c_ssize_t),
+        ("prev", c_int32),
+        ("next", c_int32),
+    ]
+
+    def __str__(self) -> str:
+        return f"hash={self.hash}, prev={self.prev}, next={self.next}"
+    __repr__ = __str__
+
+class _DataIndex(Structure):
+    _fields_ = [
+        ("position", c_int64),
+        ("size", c_int64),  # TODO: maybe `end` instead, to avoid useless concat
+    ]
+
+    def __str__(self) -> str:
+        return f"position={self.position}, size={self.size}"
+    __repr__ = __str__
+
+class SharedMemoryLRU:
+
+    # Byte size allocate for each entry of data (key, value). A data entry can still take more space
+    # but this value should match as good as possible the average size of data entry to avoid
+    # losing too much memory (if too high) or losing too many entries (if too low)
+    AVG_SIZE_OF_DATA = 20_000
+    USABLE_FRACTION = 2 / 3  # USABLE_FRACTION is the maximum sm lru load (same as the max of python dict)
+
+    def __init__(self, nb_entry: int):
+        # TODO: AVG_SIZE_OF_DATA and Size of shared cache should be calculate from memory threehold by worker
+        # and data
+        """ Init a Shared Memory which acts as a dict with a lru.
+
+        :param int nb_entry: number of entries in the hash table.
+        :param int total_size: number of bytes take by the Shared Cache (20 MB by default)
+        """
+        byte_size = nb_entry * self.AVG_SIZE_OF_DATA
+        _logger.info("Create Shared Memory of %d entries with %d bytes of data", nb_entry, byte_size)
+
+        # The lock to ensure that only one process at a time can access the critical section
+        self._lock = LockIdentify()
+        # The Raw Shared Memory, will contain only data (key, value)
+        self._sm = SharedMemory(size=byte_size, create=True)
+
+        self._size = nb_entry
+
+        # We cannot take more that 2 % of memory with one data (TODO ?)
+        self._max_size_one_data = byte_size // 50
+        # `self._max_length` should be always < than size.
+        # bigger it is, more there are hash conflict, and then slow down the `_lookup` but decrease the memory cost
+        self._max_length = int(nb_entry * self.USABLE_FRACTION)
+
+        # Allow to know if the Shared Memory is corrupted (`_check_consistence`)
+        # TODO: still useful with the new way to release the lock:
+        # If we force the lock release we can assume that it isn't consistent and delete everything ?
+        self._consistent = RawValue(c_bool, True)
+        # root, length, free_len (see property below)
+        self._head = RawArray(c_int32, [-1, 0, 1])
+        # Hash and the linked list information for each entry index
+        self._entry_table = RawArray(_Entry, [(0, -1, -1)] * nb_entry)
+        # Position info of data for each entry index
+        self._data_idx = RawArray(_DataIndex, [(-1, -1)] * nb_entry)
+        # Position info of free memory blocks
+        self._data_free = RawArray(_DataIndex, [(-1, -1)] * nb_entry)
+        # Number of free memory block (max == size)
+        self._data_free[0] = (0, self._sm.size)
+        # Buffer of shared memory for data (key/value)
+        self._data = self._sm.buf
+
+    _root = property(lambda self: self._head[0], lambda self, x: self._head.__setitem__(0, x))
+    _length = property(lambda self: self._head[1], lambda self, x: self._head.__setitem__(1, x))
+    _free_len = property(lambda self: self._head[2], lambda self, x: self._head.__setitem__(2, x))
+
+    def hook_process_killed(self, pid):
+        """ Release the lock if it is locked by the killed process with `pid`
+
+        :param int pid: pid of a killed (mandatory) process
+        """
+        self._lock.force_release_if_mandatory(pid)
+
+    def is_alive(self):
+        """ Check that the Shared Cache is still 'alive' """
+        acquired = self._lock._lock.acquire(timeout=0.5)
+        if acquired:
+            self._lock._lock.release()
+        return acquired
+
+    def clear(self):
+        """ Clear all the shared memory, shouldn't be use except for testing """
+        with self._lock:
+            self._clear()
+
+    def _clear(self):
+        """ Clear all the shared memory
+
+        ! Need lock !
+        """
+        self._head[:] = [-1, 0, 1]
+        self._entry_table[:] = [(0, -1, -1)] * self._size
+        self._data_idx[:] = [(-1, -1)] * self._size
+        self._data_free[0] = (0, self._sm.size)
+        self._consistent.value = True
+
+    def _check_consistence(self):
+        """ Check that the latest change of the SharedMemory was consistent
+
+        ! Need lock !
+        """
+        if not self._consistent.value:
+            _logger.info("Shared Memory not consistent, clean it")
+            self._clear()
+
+    def _defrag(self):
+        """
+        Defragment the `self._data`, it will result in only one block of free fragment.
+        The `self._entry_table` should already be up-to-date to avoid defragment
+
+        O(log(n) * n), n is `self._max_length` (due to `sorted`)
+
+        ! Need lock !
+        """
+        _logger.debug("Defragment the shared memory, nb fragment = %d", self._free_len)
+        s = time()
+        # Filtered out unused index and sorted by position to ensure that the defragmentation won't override any data
+        current_position = 0
+        used_indices = filter(lambda i: self._entry_table[i].prev != -1 and self._data_idx[i].position != -1, range(self._size))
+        sorted_indexes = sorted(used_indices, key=lambda i: self._data_idx[i].position)
+        for i in sorted_indexes:
+            data_entry = self._data_idx[i]
+            self._data[current_position:current_position + data_entry.size] = self._data[data_entry.position:data_entry.position + data_entry.size]
+            data_entry.position = current_position
+            current_position += data_entry.size
+        self._data_free[0] = (current_position, self._sm.size - current_position)
+        self._free_len = 1
+        _logger.debug("Defragmented the shared memory in %.4f ms, remaining free space : %s", (time() - s), self._data_free[0])
+
+    def _malloc(self, data):
+        """
+        Reserved a free slot of shared memory for the root entry,
+        insert data into it and keep track of this spot.
+        If there isn't enough memory, pop min(10% of entry, enough for this data) and _defrag
+
+        ! Need lock !
+
+        :param bytes data: (key, value) marshalled
+        """
+        size = len(data)
+        nb_free_byte = 0
+        for i in range(self._free_len):
+            data_free_entry = self._data_free[i]
+            if data_free_entry.size >= size:
+                break
+            nb_free_byte += data_free_entry.size
+        else:
+            if nb_free_byte < size:
+                # If nb_free_byte isn't enough,
+                # We pop existing data until we have enough memory
+                for i in range(self._length):
+                    if nb_free_byte >= size and i > self._length // 10:
+                        # At minimum remove 10% of the memory to avoid too many defrag when available memory is the bottleneck
+                        break
+                    nb_free_byte += self._lru_pop()
+                else:
+                    raise MemoryError("Your max_size_one_data is > size_byte, it shouldn't happen")
+                _logger.debug("Pop %s items to be handle to add the new item", i + 1)
+
+            self._defrag()
+            data_free_entry = self._data_free[0]
+
+        mem_pos = data_free_entry.position
+        self._data[mem_pos:(mem_pos + size)] = data
+        # We restrict _malloc for the root entry only,
+        # because an index can already change because of the lru_pop before
+        self._data_idx[self._root] = (mem_pos, size)
+        data_free_entry.size -= size
+        data_free_entry.position += size
+
+    def _free(self, index: int):
+        """
+        It is the opposite of _malloc. Free the memory used by entry at `index`
+        Also, it launches sometime the _defrag if:
+            - No more entry to register free position entry
+            - The first free slot is too _small (heuristic: _small = AVG_SIZE_OF_DATA)
+
+        ! Need lock !
+
+        :param int index: entry index of the data to free
+        """
+        last = self._free_len
+        self._data_free[last] = self._data_idx[index]
+        free_size = self._data_free[last].size
+        new_free_len = last + 1
+        self._data_idx[index] = (-1, -1)
+        # If the first free slot is too _small (heuristic: _small = AVG_SIZE_OF_DATA) and there are a lot of fragments to retrieve:
+        # -> We should _defrag to get an efficient _malloc
+        # Also _defrag directly if there isn't any place in self._data_free
+        if (self._data_free[0].size < self.AVG_SIZE_OF_DATA and new_free_len > self._size // 10) or new_free_len >= self._size:
+            # It will result that self._free_len == 1
+            self._defrag()
+        else:
+            self._free_len = new_free_len
+
+        return free_size  # Return the size freed
+
+    def _lru_pop(self):
+        """
+        Remove the eldest entry/data used (approximately for now,
+        because doesn't update lru if not acquire write lock)
+
+        ! Need lock !
+        """
+        if self._root == -1:
+            raise Exception(f"Try to pop from empty lru ({self._length})")
+        prev_index = self._entry_table[self._root].prev
+        return self._del_index(prev_index, self._entry_table[prev_index])
+
+    def _del_index(self, index: int, entry: _Entry):
+        """
+        Remove the entry at `index` and data linked to.
+        It compacts the hash table to ensure the correctness
+        of the _lookup (linear probing)
+
+        ! Need lock !
+
+        :param int index: index of entry to delete
+        :param _Entry index: entry to delete
+        """
+        if entry.prev == entry.next == index:  # If am the only one
+            self._root = -1
+        else:
+            self._entry_table[entry.next].prev = entry.prev
+            self._entry_table[entry.prev].next = entry.next
+            if self._root == index:
+                self._root = entry.next
+
+        self._entry_table[index] = (0, -1, -1)
+        self._length -= 1
+        free_size = self._free(index)
+
+        # Delete the keys that are between this element and the next free spot, having
+        # an index lower or equal to the position we delete (conflicts handling).
+        def move_index(old_index, new_index):
+            old_entry = self._entry_table[old_index]
+            hash_i, prev_i, next_i = old_entry.hash, old_entry.prev, old_entry.next
+            if self._entry_table[old_index].next == old_index:  # if it is the only one item
+                prev_i = next_i = new_index
+            self._entry_table[prev_i].next = self._entry_table[next_i].prev = new_index
+            self._entry_table[new_index] = (hash_i, prev_i, next_i)
+            self._entry_table[old_index] = (0, -1, -1)
+            self._data_idx[new_index] = self._data_idx[old_index]
+            self._data_idx[old_index] = (-1, -1)
+            if self._root == old_index:
+                self._root = new_index
+
+        index_empty = index
+        for i in range(index + 1, index + self._size):
+            i_mask = i % self._size  # from index -> self._size -> 0 -> index - 1
+            i_entry = self._entry_table[i_mask]
+            if i_entry.prev == -1:
+                break
+            hash_mask = i_entry.hash % self._size
+
+            distance_i = i_mask - hash_mask if i_mask >= hash_mask else self._size - hash_mask + i_mask
+            # distance error of i,
+            # - if 0 then he is at the correct location don't move
+            # - if < than distance_new = not suitable location
+            # else compress
+            if distance_i == 0:
+                continue
+            distance_new = index_empty - hash_mask if index_empty >= hash_mask else self._size - hash_mask + index_empty
+            if distance_new < distance_i:
+                move_index(i_mask, index_empty)
+                index_empty = i_mask
+        else:
+            raise MemoryError("The hashtable seems full, there is an error in the shared memory management itself.")
+
+        return free_size
+
+    def _data_get(self, index: int):
+        """
+        Get (key, value) of entry at `index`.
+
+        ! Need lock !
+        """
+        data_id = self._data_idx[index]
+        # Load the value (not the key) outside the lock should be a good idea (for multi-processing performance).
+        # But because it increases the complexity of data structure (need to have the key length)
+        # and we are forced to copy the bytes outside the lock (or it can change between the release and the marshall.loads)
+        # it isn't more efficient and increases the complexity of the code (need maybe more test) :/
+        return marshal.loads(self._data[data_id.position:data_id.position + data_id.size])
+
+    def _lookup(self, key, hash_: int) -> tuple:
+        """
+        Return the first (index, entry, value) corresponding to (key, hash).
+        If a entry is found, the value is set else it is None.
+
+        ! Need lock !
+         """
+        for i in range(self._size):
+            index = (hash_ + i) % self._size
+            entry = self._entry_table[index]
+            if entry.prev == -1:
+                return index, entry, None
+            if entry.hash == hash_:
+                key_full, val = self._data_get(index)
+                if key_full == key:  # Hash conflict is rare, then it is ok to sometimes load too much.
+                    return index, entry, val
+        raise MemoryError("Hash table full, doesn't make any sense, LRU is broken")
+
+    def __getitem__(self, key):
+        """ Get a value from the key
+
+        :param key: hashable key
+        :raises KeyError: If the key doesn't exist
+        :return: The value unmarshalled
+        """
+        hash_ = hash(key)
+        with self._lock:
+            self._check_consistence()
+            index, entry, val = self._lookup(key, hash_)
+            if val is None:
+                raise KeyError(f"{key} does not exist")
+
+            self._consistent.value = False
+            if self._root != index:
+                # Pop me from my previous location
+                self._entry_table[entry.prev].next = entry.next
+                self._entry_table[entry.next].prev = entry.prev
+                # Put me in front
+                entry.next = self._root
+                entry.prev = self._entry_table[self._root].prev
+                self._entry_table[self._entry_table[self._root].prev].next = index
+                self._entry_table[self._root].prev = index
+                self._root = index
+            self._consistent.value = True
+        return val
+
+    def __setitem__(self, key, value):
+        hash_ = hash(key)
+        data = marshal.dumps((key, value))
+        if len(data) > self._max_size_one_data:
+            raise MemoryError(f"The object of size {len(data)} is too large to put in the Shared Memory (max {self._max_size_one_data} bytes by entry)")
+
+        with self._lock:
+            self._check_consistence()
+            index, entry, val = self._lookup(key, hash_)
+            self._consistent.value = False
+            if self._root == index:  # If I am already the root, just update the hash
+                self._entry_table[index].hash = hash_
+            else:
+                if val is not None:  # Remove previous spot if exist
+                    self._entry_table[entry.prev].next = entry.next
+                    self._entry_table[entry.next].prev = entry.prev
+                if self._root == -1:  # First item set
+                    self._entry_table[index] = (hash_, index, index)
+                else:
+                    old_root_i = self._root
+                    self._entry_table[index] = (hash_, self._entry_table[old_root_i].prev, old_root_i)
+                    self._entry_table[self._entry_table[old_root_i].prev].next = index
+                    self._entry_table[old_root_i].prev = index
+                self._root = index
+
+            if val is None:
+                self._length += 1
+            else:
+                self._free(index)
+            self._malloc(data)  # Malloc use root entry to find index
+
+            if self._length > self._max_length:
+                self._lru_pop()  # Make it after to avoid modifying index
+            self._consistent.value = True
+
+    def __delitem__(self, key):
+        hash_ = hash(key)
+        with self._lock:
+            self._check_consistence()
+            index, entry, val = self._lookup(key, hash_)
+            if val is None:
+                raise KeyError(f"{key} doesn't not exist, cannot delete it")
+            self._del_index(index, entry)
+
+    # --------- Close methods
+
+    def close(self):
+        _logger.debug("Close shared memory")
+        self._sm.close()
+
+    def unlink(self):
+        _logger.info("Unlink shared memory")
+        self.close()
+        del self._head, self._entry_table, self._data_idx, self._data_free, self._data, self._lock
+        self._sm.unlink()
+        del self
+
+    # --------------------- TESTING methods ---------------
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        self.unlink()
+
+    def __len__(self):
+        with self._lock:
+            return self._length
+
+    def __contains__(self, key):
+        try:
+            self[key]
+        except KeyError:
+            return False
+        return True
+
+    # --------------------- DEBUGGING Methods --------------
+
+    def __iter__(self):
+        """ Only use for debugging"""
+        # with self._lock:
+        if self._root == -1:
+            return
+        node_index = self._root
+        for _ in range(self._length + 1):
+            yield self._data_get(node_index)
+            node_index = self._entry_table[node_index].next
+            if node_index == self._root:
+                break
+        else:
+            raise MemoryError(f"Infinite loop detected in the Linked list, {self._root=}:\n" + "\n".join(str(i) + ": " + str(e) for i, e in enumerate(self._entry_table)))
+
+    def __repr__(self) -> str:
+        """ Only use for debugging"""
+        result = []
+        # with self._lock:
+        if self._root == -1:
+            return f'hashtable size: {self._size}, len: {str(self._length)}\n' + '\n'.join(result) + '\n' + "\n".join(str(e) for e in self._data_free[:self._free_len])
+        node_index = self._root
+        for _ in range(self._length + 1):
+            hash_key, nxt = self._entry_table[node_index].hash, self._entry_table[node_index].next
+            try:
+                data = self._data_get(node_index)
+            except (ValueError, EOFError):
+                data = ("<unable to read>", "<unable to read>")
+            result.append(f'key: {data[0]}, hash % size: {hash_key % self._size}, index: {node_index}, {self._entry_table[node_index]}, data_pos={self._data_idx[node_index].position} - data_size={self._data_idx[node_index].size}: {reprlib.repr(data[1])}')
+            node_index = nxt
+            if node_index == self._root:
+                return f'hashtable size: {self._size}, len: {str(self._length)}, {self._root=}\n' + \
+                    '\n'.join(result) + \
+                    f'\nFree spots {self._free_len}:\n' + \
+                    "\n".join(str(e) for e in self._data_free[:self._free_len])
+        raise MemoryError(f"Infinite loop detected in the Linked list, {self._root=}:\n" + "\n".join(str(i) + ": " + str(e) for i, e in enumerate(self._entry_table)))

--- a/odoo/service/server.py
+++ b/odoo/service/server.py
@@ -23,7 +23,7 @@ from werkzeug.debug import DebuggedApplication
 
 import odoo
 from odoo.modules import get_modules
-from odoo.modules.registry import Registry, create_shared_cache, get_shared_cache, unlink_shared_cache, release_lock_shared_cache, close_shared_cache
+from odoo.modules.registry import Registry, create_shared_cache, get_shared_cache, unlink_shared_cache, release_lock_shared_cache, close_shared_cache, log_shared_cache_stats
 from odoo.release import nt_service_name
 from odoo.tools import config
 from odoo.tools import stripped_sys_argv, dumpstacks, log_ormcache_stats
@@ -876,6 +876,7 @@ class PreforkServer(CommonServer):
         signal.signal(signal.SIGTTOU, self.signal_handler)
         signal.signal(signal.SIGQUIT, dumpstacks)
         signal.signal(signal.SIGUSR1, log_ormcache_stats)
+        signal.signal(signal.SIGUSR2, log_shared_cache_stats)
 
         if config['http_enable']:
             # listen to socket

--- a/odoo/tests/common.py
+++ b/odoo/tests/common.py
@@ -51,8 +51,8 @@ import odoo
 from odoo import api
 from odoo.models import BaseModel
 from odoo.exceptions import AccessError
-from odoo.modules.registry import Registry
 from odoo.osv import expression
+from odoo.modules.registry import Registry, get_shared_cache
 from odoo.osv.expression import normalize_domain, TRUE_LEAF, FALSE_LEAF
 from odoo.service import security
 from odoo.sql_db import BaseCursor, Cursor
@@ -830,6 +830,8 @@ class TransactionCase(BaseCase):
 
         self.addCleanup(self.registry.clear_caches)
         self.addCleanup(self.env.clear)
+        shared_cache = get_shared_cache()
+        self.addCleanup(shared_cache.clear)
 
         # flush everything in setUpClass before introducing a savepoint
         self.env.flush_all()

--- a/odoo/tools/profiler.py
+++ b/odoo/tools/profiler.py
@@ -295,11 +295,11 @@ class QwebTracker():
     @classmethod
     def wrap_compile(cls, method_compile):
         @functools.wraps(method_compile)
-        def _tracked_compile(self, template):
+        def _tracked_compile(self, template, cache=None):
             if not self.env.context.get('profile'):
-                return method_compile(self, template)
+                return method_compile(self, template, cache)
 
-            template_functions, def_name = method_compile(self, template)
+            template_functions, def_name = method_compile(self, template, cache)
             render_template = template_functions[def_name]
 
             def profiled_method_compile(self, values):


### PR DESCRIPTION
### Conclusion: -> We should **NOT** merge this (see conclusion + benchmark test)

# Cross Worker Cache

The goal is to make a long term efficient cross-worker/process cache (`key: value`), which shouldn't be invalidate. If we never invalidate, we don't need a notify/listen system to be multi-server "safe".

For now, we want to use it only for the new t-cache feature (https://github.com/odoo/odoo/pull/88276): t-cache use a unique cache key which should never be invalidate (LRU will do the job to pop no-accessible key). t-cache use the `write_date` of record in the t-cache keys, and the `write_date` always increases then we didn't need to invalidate manually the cache when a record change.

## Goals

This cache should:
1. share between process/workers: use a shared memory for the data structure and the key/value should be marshable to be transparently sharable via bytes.
2. be efficient: as a `dict` in term of algorithmic complexity (Hash Table), where the 'set'/'get' is in O(1) (Average Case) (then the cache key should be hashable)
3. have a removal strategy: LRU
4. manage inter-process concurrency 'get'/'set'.
5. be fault tolerant: if a process is killed when it use the cache ('set' or 'get'), the cache should be always usable by other process and coherent.

## HOW TO

### (1) Sharable
We manage the 'sharable' attributes of cache with a the https://docs.python.org/3/library/multiprocessing.shared_memory.html for data (only available in >= Python3.8) and https://docs.python.org/3.8/library/multiprocessing.html#module-multiprocessing.sharedctypes for the data structure information. This sharable memory is create/unlink by the main server (`PreforkServer` for multi-processing and the `ThreadedServer` for the multithreading).

### (2) Efficiency
For efficiency, we construct a Hash Table (with linear probing: https://en.wikipedia.org/wiki/Linear_probing) on top of this Shared Memory and sharedctype (RawArray/RawValue).
Because the data (key/value) has different size, we should sometimes defragment the memory (not great for 'set' performance).
Also, this shared cache is limited by a fixed number of entry (we don't manage resize of the entry table for now) and a fixed memory for key/value data. If some DB use much more the shared cache, it can be unfair between DB (indeed the shared memory is shared between DB - DB name in the key).

### (3) Removal Strategy
Because it doesn't grown with the number of data insert and it is never invalidate, we should get a removal strategy (constraints by the number of entry and the data taken by key/value): we use a double linked list between the Hash Table entry to create a LRU.

### (4) Concurrency
To manage the concurrency and avoid to get corrupted data structure, we want a exclusive access for 'get'/'set' (4) (we don't want a parallel access for 'get' due to its implementation complexity and it needs to write on the data structure for the LRU (3)).

### (5) Fault tolerance

Moreover, the exclusive access should be release when a process is killed (by example, killed by the `PreforkServer` because of timeout) when it currently acquired the access (5).
Also when a Process which is modifying the Shared Memory is killed, we should ensure that the data structure is still coherent and usable. We can easily detect this case with a simple shared boolean (`coherent`) set to `False` before modify, reset to `True` after the modification, and before each usage of the shared cache, check if `coherent` is `True` (if not, reset the shared cache).

### Current issues with (4) (5)

Currently, the goals (4)(5) are complicate to have in the same time, I propose 2 different solutions (none are perfect):

- The first solution is to use a inter-process Lock (https://docs.python.org/3.8/library/multiprocessing.html#multiprocessing.Lock) to manage the exclusive concurrent access. It works fine, but the lock is not release when the process is killed, then the lock is locked forever. To 'solve' this issue, we can add the PID just after acquiring the lock and when the main process detect (or kill itself) one of his child process, it can check if the PID of the lock is equals to the one killed, if it is the case, it releases the Lock. However, if the process is killed between setting his PID and acquire/release the lock, we comeback on the first deadlock situation. We can 'mitigate' this: when one child process is killed if the lock is acquiring by a unknown process, set a timeout. After the timeout expiration, if the PID is still unknown, lock still acquired and the `last_used` of the shared_memory didn't change, consider that the lock should be release.
But it is really correct to read data that can be write in the same time (IMO it doesn't) ? Also with a timeout we cannot ensure that during this time, a alive process didn't get enough CPU to make one operation on the Shared Cache, then the lock will be release where it shouldn't. Also, the timeout choice is completely arbitrary. (**Version in branch bck-30-06-22-02-master-shared-memory-ryv branch**)

- A alternative of the first solution proposed by AL: a interprocess Lock with a PID set after getting the Lock (and release if the dead process has set his PID of the Lock). But instead of the rest of solution: the main server check every X second the access of the Shared Memory with a timeout. If the timeout expired, restart everything (Suicide kill with a restart). More simple than the first solution, but still a timeout. (**Version in this branch**)

- A more robust solution (presented here: https://patents.google.com/patent/US7493618) uses one atomic (Compare-And-Swap operation, CAS) operation to ensure the fault-tolerant and exclusive access feature. But there are no such operation in Python (or I didn't find ?), excepted using 'atomics' library (not standard and not use a lot). Also we cannot bind the CAS of C language (https://en.cppreference.com/w/c/atomic/atomic_compare_exchange) method with ctypes because it is not in the clib and the atomics type are not in the ctypes. But we can use CFFI library to compile on fly the atomic operation needed but it seems very touchy, weird, machine-depend and we should have a compiler C on the machine. (**Version in this master-shared-memory-cffi-version-ryv branch**)

## Open Questions:
- For (4) (5), which solution the best ? None ? We should ensure that it is correct in any case because it is a single point of failure! -> The second solution seems easy and quite robust!
- There is also out-of-the-box alternative: 'memcached', 'redis'. It means more work for infra, it is some message passing solution (slower than the shared memory solution), but it seems more robust. Should we consider it ?
- Alternative of the manual defragment ?
- Should we consider to increase/decrease the entry table on fly ? and the shared memory ? (the first is possible, but the second one seems very complicated)

## Performance tests

_This part is not complete and additional tests can be done to support (des)advantage of the Shared Memory_

We want to test the efficiency of the shared cache for the t-cache feature: during the warm-up (that should be better for the shared cache version) and after the warm-up (to test the efficiency in a long term run).
Testing setup : website_sale, website_blog and website_event installed, we tested it 4 different main routes ('/' (9 call to t-cache), '/shop'  (35 call to t-cache), '/event'  (21 call to t-cache)  and '/blog' (25 call to t-cache)), and we launch the server with 4 workers (number of CPU in my machine). We test 2 scenarios:

### Load at 100 % (4 parallel requests)

- Warm up phase (fetch 3 times each url): 
    - Before: **1.1374 sec**
    - With Shared Memory: **0.9305 sec**
- When it is already warm up (fetch 125 times each url after warm up):
    - Before: **3.5748 sec**
    - With Shared Memory: **4.0843 sec**

The stats of the Shared Memory (see last commit) are :
```
counter statistics: 99.4149 % (ratio), 12233 / 72 (hit / miss), Override: 0 (same value), 0 (other value)
data statistics: 72 items, 0.00 % used (0.91 MB / 214740000.00 MB), mean = 0.012659 MB, min = 0.000303 MB, max = 0.129183 MB, deciles = ['0.000918', '0.002931', '0.003050', '0.003454', '0.004738', '0.007527', '0.010729', '0.014841', '0.032987'] MB
time SET statistics: 72 items, mean = 0.0808, min = 0.0270, max = 0.2130 (i=15), sum = 5.8160, deciles = ['0.043035', '0.050685', '0.055884', '0.068305', '0.075124', '0.080714', '0.091789', '0.101650', '0.131447'] ms
time GET statistics: 12233 items, **mean = 0.0799**, min = 0.0096, max = 6.5712 (i=6953), sum = **977.8135**, deciles = ['0.015985', '0.029626', '0.039514', '0.046269', '0.050308', '0.055967', '0.064554', '0.083336', '0.150478'] ms
```
_The time results wasn't done with the stats active to avoid any additional CPU costs_

### Load at 50 % (2 parallel requests)

- Warm up phase (fetch 3 times each url): 
    - Before: **1.9655 sec** 
    - With Shared Memory: **1.6022 sec** (+- 18.48% faster)
- When it is already warm up (fetch 125 times each url after warm up):
    - Before: **5.9006 sec** (-+ 7.62 % faster)
    - With Shared Memory: **6.3878 sec**

The stats of the Shared Memory (see last commit) are :
```
counter statistics: 99.3906 % (ratio), 12232 / 75 (hit / miss), Override: 3 (same value), 0 (other value)
data statistics: 72 items, 0.00 % used (0.91 MB / 214740000.00 MB), mean = 0.012659 MB, min = 0.000303 MB, max = 0.129183 MB, deciles = ['0.000918', '0.002931', '0.003050', '0.003454', '0.004738', '0.007527', '0.010729', '0.014841', '0.032987'] MB
time SET statistics: 75 items, mean = 0.0736, min = 0.0275, max = 0.2551 (i=7), sum = 5.5216, deciles = ['0.039712', '0.049246', '0.055523', '0.060716', '0.067090', '0.071924', '0.083097', '0.095396', '0.106159'] ms
time GET statistics: 12232 items, **mean = 0.0561**, min = 0.0092, max = 2.7738 (i=4335), sum = **686.0070**, deciles = ['0.015003', '0.025704', '0.033739', '0.041405', '0.043483', '0.046960', '0.053486', '0.064643', '0.108364'] ms
```
_The time results wasn't done with the stats active to avoid any additional CPU costs_

### Result

The version with the Shared Memory out-perform (+-18.48% faster, but it varies a lot depending of the machine) for the warm-up phase (and the gain should be more important when there are more workers). But there are still a extra cost (-+ 7.62 %) to get/set data in the shared memory (sum of GET time is 685 ms (on 8 sec of tests) in the second scenario).

## Conclusion

The Shared Memory can be useful depending of the server situation, but it still add a overhead after warm-up of each workers. If the are lot of workers and they are recycled often (then the warm-up cost are high vs after warm-up, not trivial to calculate), then the Shared Memory can be a good candidate to reduce the load of the server. But it still depends a lot of the infrastructure/server settings and add an extra complexity. It is why, IMO, we shouldn't generalize it and not put it in the main code.