### PR TITLE
[FIX] mrp: Null value on required field date_planned_start

### DIFF
--- a/addons/mrp/models/mrp_production.py
+++ b/addons/mrp/models/mrp_production.py
@@ -1231,10 +1231,13 @@ class MrpProduction(models.Model):
             })
             vals['leave_id'] = leave.id
             workorder.write(vals)
-        self.with_context(force_date=True).write({
-            'date_planned_start': self.workorder_ids[0].date_planned_start,
-            'date_planned_finished': self.workorder_ids[-1].date_planned_finished
-        })
+
+        workorder_ids = self.workorder_ids.filtered(lambda wo: wo.date_planned_start)
+        if workorder_ids:
+            self.with_context(force_date=True).write({
+                'date_planned_start': workorder_ids[0].date_planned_start,
+                'date_planned_finished': workorder_ids[-1].date_planned_finished
+            })
 
     def button_unplan(self):
         if any(wo.state == 'done' for wo in self.workorder_ids):


### PR DESCRIPTION
`date_planned_start` in `mrp.production` is a required field.
When planning the production, the value is set to `date_planned_start` from `mrp.workorder`, which can be null.
Therefore, we need to filter out work orders that do not have a `date_planned_start`.
