### PR TITLE
[FIX] website: fix animation in tabs and accordion blocks

### DIFF
--- a/addons/website/static/src/js/content/snippets.animation.js
+++ b/addons/website/static/src/js/content/snippets.animation.js
@@ -1201,7 +1201,7 @@ registry.WebsiteAnimate = publicWidget.Widget.extend({
         this.__onScrollWebsiteAnimate = _.throttle(this._onScrollWebsiteAnimate.bind(this), 200);
         this.$scrollingElement[0].addEventListener('scroll', this.__onScrollWebsiteAnimate, {capture: true});
 
-        $(window).on('resize.o_animate, shown.bs.modal.o_animate, slid.bs.carousel.o_animate', () => {
+        $(window).on('resize.o_animate, shown.bs.modal.o_animate, slid.bs.carousel.o_animate, shown.bs.tab.o_animate, shown.bs.collapse.o_animate', () => {
             this.windowsHeight = $(window).height();
             this._scrollWebsiteAnimate(this.$scrollingElement[0]);
         }).trigger("resize");


### PR DESCRIPTION
Before this commit, animated elements did not animate in a tab that just
opened. Exact same problem was also happening with the accordion block.

Steps to reproduce the issue (with the tabs block) :

- Create a tabs block.
- Add some content with animation on each tab.
- Save.
- When you refresh, the first animation loads.
- Switch tab to another animation and wait - it won't load.
- Scroll up or down -> animation will show up.

opw-2813435

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
