### PR TITLE
[FIX] hr_recruitment: kanban record with long title overflow

### DIFF
--- a/addons/hr_recruitment/views/hr_job_views.xml
+++ b/addons/hr_recruitment/views/hr_job_views.xml
@@ -30,7 +30,7 @@
                             <div class="o_kanban_card_header">
                                 <div class="o_kanban_card_header_title">
                                     <div class="o_primary col-12">
-                                        <span><t t-esc="record.name.value"/></span>
+                                        <span class="o_text_overflow"><t t-esc="record.name.value"/></span>
                                     </div>
                                     <div class="o_kanban_record_subtitle col-12 text-muted">
                                         <field name="user_id" />

--- a/addons/web/static/src/scss/kanban_view.scss
+++ b/addons/web/static/src/scss/kanban_view.scss
@@ -89,6 +89,8 @@
 
         .o_kanban_record_title {
             @include o-kanban-record-title($font-size: 13px);
+            overflow-wrap: break-word;
+            word-wrap: break-word;
         }
 
         .o_kanban_record_subtitle {
@@ -349,6 +351,8 @@
         .oe_kanban_details {
             width: 100%;
 
+            overflow-wrap: break-word;
+            word-wrap: break-word;
             // Useful for the class 'o_text_overflow'
             min-width: 0;
 


### PR DESCRIPTION
Reproduction:
1. Install recruitment
2. Create a new job position with an extra-long title
3. Save and the title of this record is exceed the kanban card

Reason: CSS style doesn’t take account of long title

Fix:  Backported the overflow changes in V15 and added o_text_overflow
to the title of the job's kanban view, so the title does not exceed the
border of the kanban card

opw-2849601

overflow change in V15: https://github.com/odoo/odoo/commit/a0ebb4609848a65f9b6a14a94030ad3144a95038

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
