### PR TITLE
[FIX] hr_recruitment: allow Interviewers to use Activities

### DIFF
--- a/addons/hr_recruitment/security/hr_recruitment_security.xml
+++ b/addons/hr_recruitment/security/hr_recruitment_security.xml
@@ -53,7 +53,13 @@
     <record id="mail_message_interviewer_rule" model="ir.rule">
         <field name="name">Interviewer: No Applicant Chatter</field>
         <field name="model_id" ref="mail.model_mail_message"/>
-        <field name="domain_force">[('model', '!=', 'hr.applicant')]</field>
+        <field name="domain_force">[
+            '|',
+                ('model', '!=', 'hr.applicant'),
+                '&amp;',
+                    ('model', '=', 'hr.applicant'),
+                    ('mail_activity_type_id', '!=', False)
+        ]</field>
         <field name="perm_write" eval="False"/>
         <field name="perm_create" eval="False"/>
         <field name="perm_unlink" eval="False"/>

--- a/addons/hr_recruitment/static/src/scss/hr_applicant.scss
+++ b/addons/hr_recruitment/static/src/scss/hr_applicant.scss
@@ -1,8 +1,7 @@
 .o_applicant_interviewer_form {
     .o_ChatterTopbar_buttonSendMessage,
     .o_ChatterTopbar_buttonLogNote,
-    .o_ChatterTopbar_buttonScheduleActivity,
-    .o_MessageList {
+    .o_MessageList_empty {
         display: none;
     }
 }


### PR DESCRIPTION
The Interviewers couldn't mark Activities as done, as they didn't have
access to the mail.message on the application.

TaskID: 2857423

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
