### PR TITLE
[FIX] project: fix deletion of column in task kanban

### DIFF
--- a/addons/project/static/src/js/project_kanban.js
+++ b/addons/project/static/src/js/project_kanban.js
@@ -56,8 +56,8 @@ var ProjectKanbanView = KanbanView.extend({
 
 KanbanColumn.include({
     _onDeleteColumn: function (event) {
-        event.preventDefault();
-        if (this.modelName === 'project.task') {
+        if (this.modelName === 'project.task' && this.groupedBy === 'stage_id') {
+            event.preventDefault();
             this.trigger_up('kanban_column_delete_wizard');
             return;
         }


### PR DESCRIPTION
Upon deleting a column in the project task view a popup will be
displayed warning the user that the stage will not be deleted but
instead archived.
Prior to this commit that popup would be displayed regardless of the
group by option that is selected. However this could lead to issues when
opening the archive wizard with an id from another record.
