### PR TITLE
[FIX] models: apply limit to read_group fill

### DIFF
--- a/odoo/models.py
+++ b/odoo/models.py
@@ -2403,6 +2403,8 @@ class BaseModel(MetaModel('DummyModel', (object,), {'_register': False})):
                 domain, groupby_fields[0], groupby[len(annotated_groupbys):],
                 aggregated_fields, count_field, result, read_group_order=order,
             )
+            if limit and limit < len(result):
+                result = sorted(result, key=lambda res: not res[groupby_fields[0]+'_count'])[:limit]
         return result
 
     def _read_group_resolve_many2one_fields(self, data, fields):


### PR DESCRIPTION
Apply the limit of read_group on the results of read_group_fill_results
to ensure that the read_group result match the argument limit.

Step to reproduce:
- Go to timesheet
- Group by project
- Reduce the number of shown project

Current behaviour:
- All project are shown but only the number asked are filled

Behaviour after PR:
- Only the asked number of project is filled.

opw-2773830


--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
