### PR TITLE
[IMP] stock: add location constrain to orderpoint

### DIFF
--- a/addons/stock/models/stock_orderpoint.py
+++ b/addons/stock/models/stock_orderpoint.py
@@ -148,6 +148,13 @@ class StockWarehouseOrderpoint(models.Model):
         if any(orderpoint.product_id.uom_id.category_id != orderpoint.product_uom.category_id for orderpoint in self):
             raise ValidationError(_('You have to select a product unit of measure that is in the same category as the default unit of measure of the product'))
 
+    @api.constrains('warehouse_id', 'location_id')
+    def _check_location(self):
+        for record in self:
+            loc_wh = record.location_id.warehouse_id
+            if loc_wh and loc_wh != record.warehouse_id:
+                raise ValidationError(_("Location %s doesn't belong to warehouse %s"), record.location_id.name, record.warehouse_id.name)
+
     @api.depends('location_id', 'company_id')
     def _compute_warehouse_id(self):
         for orderpoint in self:


### PR DESCRIPTION
Model `stock.warehouse.orderpoint` has fields `location_id` and `warehouse_id`,
which must match each other. It's already done via `domain` value in the view
[1], however user may still make a mess on importing Reordering Rules. That
inconsistency leads to an error `No rule has been found to replenish ... Verify
the routes configuration on the product`. That error message is quite confusing
and doesn't point what exactly is wrong with the configuration. So, improve UX
by adding the constrain

[1]: https://github.com/odoo/odoo/blob/8e2625c8ee4c169ffa0561874164eedec47df97c/addons/stock/views/stock_orderpoint_views.xml#L179

opw-2844926

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
