### PR TITLE
[FIX] models: fixed trackback on uninstalling the application

### DIFF
--- a/odoo/models.py
+++ b/odoo/models.py
@@ -5117,7 +5117,8 @@ Fields:
         result = {record.id: [] for record in self}
         domain = [('model', '=', self._name), ('res_id', 'in', self.ids)]
         for data in self.env['ir.model.data'].sudo().search_read(domain, ['module', 'name', 'res_id'], order='id'):
-            result[data['res_id']].append('%(module)s.%(name)s' % data)
+            if data['res_id'] in result.keys():
+                result[data['res_id']].append('%(module)s.%(name)s' % data)
         return result
 
     def get_external_id(self):


### PR DESCRIPTION
currently, uninstalling the application throws an error and
it happens because some record doesn't contains the res_id in record

so after this commit, uninstalling the application does not produce an error

task-2858277

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
