### PR TITLE
[IMP] base: mark phone and mobile fields unaccent=False

### DIFF
--- a/odoo/addons/base/models/res_partner.py
+++ b/odoo/addons/base/models/res_partner.py
@@ -200,8 +200,8 @@ class Partner(models.Model):
     email_formatted = fields.Char(
         'Formatted Email', compute='_compute_email_formatted',
         help='Format email address "Name <email@domain>"')
-    phone = fields.Char()
-    mobile = fields.Char()
+    phone = fields.Char(unaccent=False)
+    mobile = fields.Char(unaccent=False)
     is_company = fields.Boolean(string='Is a Company', default=False,
         help="Check if the contact is a company, otherwise it is a person")
     is_public = fields.Boolean(compute='_compute_is_public')


### PR DESCRIPTION
Set `phone` and `mobile` fields on `res.partner` to unaccent=False since phone numbers are unlikely to have any accent. This will also make it easier to add indexes on these fields in the future.

Part of task-2832241