### PR TITLE
[FIX] website: prevent deadlock on editor save when an option is focused

### DIFF
--- a/addons/website/static/src/js/editor/editor_menu.js
+++ b/addons/website/static/src/js/editor/editor_menu.js
@@ -119,7 +119,15 @@ var EditorMenu = Widget.extend({
         }
         var self = this;
         this._saving = true;
-        this.trigger_up('edition_will_stopped');
+        this.trigger_up('edition_will_stopped', {
+            // TODO adapt in master, this was added as a stable fix. This
+            // trigger to 'edition_will_stopped' was left by mistake
+            // during an editor refactoring + revert fail. It stops the public
+            // widgets at the wrong time, potentially dead-locking the editor.
+            // 'ready_to_clean_for_save' is the one in charge of stopping the
+            // widgets at the proper time.
+            noWidgetsStop: true,
+        });
         return this.wysiwyg.save(false).then(function (result) {
             var $wrapwrap = $('#wrapwrap');
             self.editable($wrapwrap).removeClass('o_editable');

--- a/addons/website/static/src/js/menu/edit.js
+++ b/addons/website/static/src/js/menu/edit.js
@@ -185,6 +185,12 @@ var EditPageMenu = websiteNavbarData.WebsiteNavbarActionWidget.extend({
      */
     _onEditionWillStop: function (ev) {
         this.$editorMessageElements && this.$editorMessageElements.removeAttr('data-editor-message');
+
+        if (ev.data.noWidgetsStop) {
+            // TODO adapt in master, this was added as a stable fix.
+            return;
+        }
+
         this.trigger_up('widgets_stop_request', {
             $target: this._targetForEdition(),
         });


### PR DESCRIPTION
For some editor options, interacting with them and clicking on the
editor save button while they were still focused caused a deadlock.

As an example:

- Drag & drop the "Dynamic Products" snippet
- Change the "Speed" option value and keep the input focused
- Click on the editor "Save" button
=> Deadlock

Funny enough: if you click slowly (mousedown -> wait -> mouseup), the
bug does not happen.

This was because this happened in that case:

1) Mousedown on the save button.
2) Focusout of the option's input -> the option's method is called.
3) The DOM is edited and the public widgets are restarted, which is an
   async operation. The dynamic products widget starts an RPC to render
   its content.
4) Mouseup (click) on the save button.
5) The editor immediately asks to destroy public widgets, this is a
   synchronous operation.
6) The rpc made at (3) finishes... but the result never reaches the
   widget as the ajax service does not let it be done for destroyed
   widgets (and the widget was destroyed at (5)).
7) The editor starts saving the content.

   => The editor gets stuck because before saving the content it waits
      for the general mutex of the editor to be unlocked... which is
      never the case because it is waiting for (3) to finish but never
      is marked as finished because the rpc is ignored at (6).

The problem actually is step (5) which should not happen. Indeed
destroying the public widgets is already done by another portion of
code at the appropriate time during the editor panel 'cleanForSave'.
That part was indeed indirectly and recently fixed by [1], ensuring
destroying widgets is only started when the general mutex is already
unlocked.

So, currently, the public widgets are destroyed two times: one too soon
which happens to work by chance most of the time and one at the proper
time (but which did nothing since a while because widgets were already
destroyed). This too-soon step (5) exists since [2] and was apparently
added alongside the existing mechanism for no apparent reason. It was
actually already done in 13.0, but as the editor panel was totally
different at the time, with no mutex ensuring the order of operations,
there should not be any problem having a random double widget destroy.
If a bug actually is reported, this could be backported.

This commit disables the public widget destruction made at step (5)
with a minimal stable diff.

[1]: https://github.com/odoo/odoo/commit/508332963202090bace0a3c877574132063c29a6
[2]: https://github.com/odoo/odoo/commit/f296992317e96562c66bd7ad59a5080d6c551ed5

Related to opw-2767903
