### PR TITLE
[FIX] web: remove default_ fields from button context

### DIFF
--- a/addons/mail/wizard/mail_compose_message.py
+++ b/addons/mail/wizard/mail_compose_message.py
@@ -334,6 +334,7 @@ class MailComposer(models.TransientModel):
                 'subject': record.subject or False,
                 'body_html': record.body or False,
                 'model_id': model.id or False,
+                'use_default_to': True,
             }
             template = self.env['mail.template'].create(values)
 

--- a/addons/web/static/src/webclient/actions/action_service.js
+++ b/addons/web/static/src/webclient/actions/action_service.js
@@ -1200,7 +1200,8 @@ function makeActionManager(env) {
             activeCtx.active_id = params.resId;
             activeCtx.active_ids = [params.resId];
         }
-        action.context = makeContext([currentCtx, params.buttonContext, activeCtx, action.context]);
+        const buttonContext = Object.fromEntries(Object.entries(params.buttonContext).filter(e => !e[0].startsWith('default_')));
+        action.context = makeContext([currentCtx, buttonContext, activeCtx, action.context]);
         // in case an effect is returned from python and there is already an effect
         // attribute on the button, the priority is given to the button attribute
         const effect = params.effect ? evaluateExpr(params.effect) : action.effect;


### PR DESCRIPTION
If you send an email from CRM and the address you are trying to send the
email to is not linked to a partner, a new partner will be created and
it will use the default_ fields in the context which may not be valid
for the partner

Steps to reproduce:
1. Install CRM and open the app
2. Trigger the list view of the pipeline
3. Select any opportunity with the email 'ErikNFrench@armyspy.com' and
click on 'EMAIL' in the top left
4. Give a subject to the email and select the template 'Welcome Demo'
5. Send the email
6. An error is thrown

Solution:
Remove the fields beginning with `default_` from the action context

Problem:
Trying to create a partner with default_type in the context will try to
give this type to the partner but 'opportunity' is not a valid partner
type

opw-2827177