### PR TITLE
[TEST] point_of_sale: test fixed tax included

### DIFF
--- a/addons/point_of_sale/tests/common.py
+++ b/addons/point_of_sale/tests/common.py
@@ -305,6 +305,7 @@ class TestPoSCommon(TransactionCase):
                 'name': f'Tax {percentage}%',
                 'amount': percentage,
                 'price_include': price_include,
+                'amount_type': 'percent',
                 'include_base_amount': False,
                 'invoice_repartition_line_ids': [
                     (0, 0, {
@@ -333,10 +334,47 @@ class TestPoSCommon(TransactionCase):
                     }),
                 ],
             })
+        def create_tax_fixed(amount, price_include=False):
+            return self.env['account.tax'].create({
+                'name': f'Tax fixed amount {amount}',
+                'amount': amount,
+                'price_include': price_include,
+                'include_base_amount': price_include,
+                'amount_type': 'fixed',
+                'invoice_repartition_line_ids': [
+                    (0, 0, {
+                        'factor_percent': 100,
+                        'repartition_type': 'base',
+                        'tag_ids': [(6, 0, self.tax_tag_invoice_base.ids)],
+                    }),
+                    (0, 0, {
+                        'factor_percent': 100,
+                        'repartition_type': 'tax',
+                        'account_id': self.tax_received_account.id,
+                        'tag_ids': [(6, 0, self.tax_tag_invoice_tax.ids)],
+                    }),
+                ],
+                'refund_repartition_line_ids': [
+                    (0, 0, {
+                        'factor_percent': 100,
+                        'repartition_type': 'base',
+                        'tag_ids': [(6, 0, self.tax_tag_refund_base.ids)],
+                    }),
+                    (0, 0, {
+                        'factor_percent': 100,
+                        'repartition_type': 'tax',
+                        'account_id': self.tax_received_account.id,
+                        'tag_ids': [(6, 0, self.tax_tag_refund_tax.ids)],
+                    }),
+                ],
+            })
 
+        tax_fixed006 = create_tax_fixed(0.06, price_include=True)
+        tax_fixed012 = create_tax_fixed(0.12, price_include=True)
         tax7 = create_tax(7, price_include=False)
         tax10 = create_tax(10, price_include=True)
         tax21 = create_tax(21, price_include=True)
+
 
         tax_group_7_10 = tax7.copy()
         with Form(tax_group_7_10) as tax:
@@ -349,6 +387,8 @@ class TestPoSCommon(TransactionCase):
             'tax7': tax7,
             'tax10': tax10,
             'tax21': tax21,
+            'tax_fixed006': tax_fixed006,
+            'tax_fixed012': tax_fixed012,
             'tax_group_7_10': tax_group_7_10
         }
 


### PR DESCRIPTION
After a fix made in rev:bd621fd456811e7f3ce646e3ecade5e9e4a826e8

It was not possible to generate an invoice from the POS when you have a
fixed tax included applied on a base amount with tax included.

As it was not detected by a test, we are now creating a test with this
use case.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
