### PR TITLE
[FIX] account: reconciliation on reversed move

### DIFF
--- a/addons/account/models/account_move.py
+++ b/addons/account/models/account_move.py
@@ -2504,7 +2504,7 @@ class AccountMove(models.Model):
             reverse_moves.with_context(move_reverse_cancel=cancel)._post(soft=False)
             for move, reverse_move in zip(self, reverse_moves):
                 group = defaultdict(list)
-                for line in move.line_ids + reverse_move.line_ids:
+                for line in (move.line_ids + reverse_move.line_ids).filtered(lambda l: not l.reconciled):
                     group[(line.account_id, line.currency_id)].append(line.id)
                 for (account, dummy), line_ids in group.items():
                     if account.reconcile or account.internal_type == 'liquidity':


### PR DESCRIPTION
With this commit, we make sure that all lines are fully reconciled when
reversing a move.

Steps to reproduce:

- Create a Journal Entry, with eg a line with 300$ debit/credit and two others
lines to make the journal entry fully balanced

|   Account   |   Partner   |   Debit   |   Credit   |
|-------------|-------------|-----------|------------|
|  Account X  |             |   300.0   |     0.0    |
|  Account Y  |  partner A  |     0.0   |   100.0    |
|  Account Y  |  partner B  |     0.0   |   200.0    |

- Then reverse the move
-> Only one line is marked as fully reconciled, the other one is marked
as partially reconciled.

This is because each line was passed in the reconcile method with
all the counterpart lines, even those which didn't belong to it.
Therefore, all the firsts lines was marked as partially reconciled
until the last one, which passed with the only counterpart line
left.

With this commit, we group the lines and counterpart lines by account,
and reconcile them.

This is a correction of this commit 6481eb720f36f3e81c2ec8371cccdd893a5e8ddf
which introduced a bug in l10n_mx, when unreconciling moves with tax 0%,
here are the steps to reproduce this bug:

- With l10n_mx installed
- Create an invoice with tax 0%
- Confirm and register payment
- Try to unreconcile the payment
-> We get an UserError : "You are trying to reconcile some entries that
  are already reconciled"

This happened because in the first fix, we didn't filtered the already
reconciled moves. Also, it's reproductible in 15 but change is made here
in order to keep consistency between versions.

opw-2810392
opw-2851999

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
