### PR TITLE
[MOV] im_livechat: moving MessagesSeparator xml template

### DIFF
--- a/addons/im_livechat/controllers/main.py
+++ b/addons/im_livechat/controllers/main.py
@@ -29,6 +29,7 @@ class LivechatController(http.Controller):
     def load_templates(self, **kwargs):
         templates = [
             'im_livechat/static/src/legacy/public_livechat.xml',
+            'im_livechat/static/src/legacy/widgets/messages_separator.xml',
             'im_livechat/static/src/legacy/public_livechat_chatbot.xml',
         ]
         return [tools.file_open(tmpl, 'rb').read() for tmpl in templates]

--- a/addons/im_livechat/static/src/legacy/public_livechat.xml
+++ b/addons/im_livechat/static/src/legacy/public_livechat.xml
@@ -448,12 +448,6 @@
         </div>
     </t>
 
-    <t t-name="im_livechat.legacy.mail.MessagesSeparator">
-        <div class="o_thread_new_messages_separator">
-            <span class="o_thread_separator_label">New messages</span>
-        </div>
-    </t>
-
     <!--
         @param {mail.model.Message} message
     -->

--- a/addons/im_livechat/static/src/legacy/widgets/messages_separator.xml
+++ b/addons/im_livechat/static/src/legacy/widgets/messages_separator.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<templates xml:space="preserve">
+    <t t-name="im_livechat.legacy.mail.MessagesSeparator">
+        <div class="o_thread_new_messages_separator">
+            <span class="o_thread_separator_label">New messages</span>
+        </div>
+    </t>
+</templates>


### PR DESCRIPTION
The goal is to split the public_livechat.xml file into multiple parts,
and move each template into its own file located in `im_livechat/static/src/legacy/widgets/`

Task-2825235