### PR TITLE
[IMP] project : add and modify commands in the palette

### DIFF
--- a/addons/project/static/src/views/fields/project_task_priority_switch_field.js
+++ b/addons/project/static/src/views/fields/project_task_priority_switch_field.js
@@ -1,0 +1,32 @@
+/** @odoo-module **/
+
+import { sprintf } from "@web/core/utils/strings";
+import { registry } from "@web/core/registry";
+import { PriorityField } from "@web/views/fields/priority/priority_field";
+import { useCommand } from "@web/core/commands/command_hook";
+import { useState } from "@odoo/owl";
+
+export class PrioritySwitchField extends PriorityField {
+    setup() {
+        this.state = useState({
+            index: -1,
+        });
+        if (this.props.record.activeFields[this.props.name].viewType !== "form") {
+            return;
+        }
+
+        for (const [id, name] of this.options) {
+            useCommand(
+                sprintf(this.env._t("Set priority as %s"), name),
+                () => this.props.update(id),
+                {
+                    category: "smart_action",
+                    hotkey: "alt+r",
+                    isAvailable: () => this.props.value !== id,
+                }
+            );
+        }
+    }
+}
+
+registry.category("fields").add("priority_switch", PrioritySwitchField);

--- a/addons/project/views/project_views.xml
+++ b/addons/project/views/project_views.xml
@@ -1090,7 +1090,7 @@
                         <button name="action_assign_to_me" string="Assign to Me" type="object" attrs="{'invisible': &quot;['|', ('user_ids', 'in', uid), ('user_ids', '=', [])]&quot;}" data-hotkey="q"/>
                         <button name="action_assign_to_me" string="Assign to Me" type="object" class="oe_highlight" attrs="{'invisible' : &quot;['|', ('user_ids', 'in', uid), ('user_ids', '!=', [])]&quot;}" data-hotkey="q"/>
                         <field name="stage_id" widget="statusbar" options="{'clickable': '1', 'fold_field': 'fold'}" attrs="{'invisible': [('project_id', '=', False), ('stage_id', '=', False)]}"/>
-                        <field name="personal_stage_type_id" widget="statusbar" options="{'clickable': '1', 'fold_field': 'fold'}" attrs="{'invisible': [('project_id', '!=', False)]}" domain="[('user_id', '=', uid)]"/>
+                        <field name="personal_stage_type_id" widget="statusbar" options="{'clickable': '1', 'fold_field': 'fold'}" attrs="{'invisible': [('project_id', '!=', False)]}" domain="[('user_id', '=', uid)]" string="Personal Stage"/>
                     </header>
                     <div class="alert alert-info oe_edit_only mb-0" role="status" attrs="{'invisible': ['|', ('recurring_task', '=', False), ('recurrence_id', '=', False)]}" groups="project.group_project_recurring_tasks">
                         <p>Edit recurring task</p>
@@ -1151,7 +1151,7 @@
                     <div class="oe_title pe-0">
                         <h1 class="d-flex justify-content-between align-items-center">
                             <div class="d-flex w-100">
-                                <field name="priority" widget="priority" class="me-3"/>
+                                <field name="priority" widget="priority_switch" class="me-3"/>
                                 <field name="name" class="o_task_name text-truncate" placeholder="Task Title..."/>
                             </div>
                             <field name="kanban_state" widget="state_selection" class=""/>

--- a/addons/web/static/src/core/commands/command_service.js
+++ b/addons/web/static/src/core/commands/command_service.js
@@ -21,6 +21,7 @@ import { Component, xml, EventBus } from "@odoo/owl";
 /**
  * @typedef {import("../hotkeys/hotkey_service").HotkeyOptions & {
  *  category?: string;
+ *  isAvailable: ()=>(boolean);
  * }} CommandOptions
  */
 

--- a/addons/web/static/src/core/commands/default_providers.js
+++ b/addons/web/static/src/core/commands/default_providers.js
@@ -38,12 +38,15 @@ const commandCategoryRegistry = registry.category("command_categories");
 const commandProviderRegistry = registry.category("command_provider");
 commandProviderRegistry.add("command", {
     provide: (env, options = {}) => {
-        const commands = env.services.command.getCommands(options.activeElement).map((cmd) => {
-            cmd.category = commandCategoryRegistry.contains(cmd.category)
-                ? cmd.category
-                : "default";
-            return cmd;
-        });
+        const commands = env.services.command
+            .getCommands(options.activeElement)
+            .map((cmd) => {
+                cmd.category = commandCategoryRegistry.contains(cmd.category)
+                    ? cmd.category
+                    : "default";
+                return cmd;
+            })
+            .filter((command) => command.isAvailable === undefined || command.isAvailable());
 
         return commands.map((command) => ({
             Component: command.hotkey ? HotkeyCommandItem : DefaultCommandItem,

--- a/addons/web/static/src/views/fields/state_selection/state_selection_field.js
+++ b/addons/web/static/src/views/fields/state_selection/state_selection_field.js
@@ -4,42 +4,34 @@ import { useCommand } from "@web/core/commands/command_hook";
 import { Dropdown } from "@web/core/dropdown/dropdown";
 import { DropdownItem } from "@web/core/dropdown/dropdown_item";
 import { registry } from "@web/core/registry";
+import { sprintf } from "@web/core/utils/strings";
 import { _lt } from "@web/core/l10n/translation";
 import { standardFieldProps } from "../standard_field_props";
 import { formatSelection } from "../formatters";
-
 import { Component } from "@odoo/owl";
 
 export class StateSelectionField extends Component {
     setup() {
-        if (this.props.record.activeFields[this.props.name].viewType === "form") {
-            const commandName = this.env._t("Set kanban state...");
-            useCommand(
-                commandName,
-                () => {
-                    return {
-                        placeholder: commandName,
-                        providers: [
-                            {
-                                provide: () =>
-                                    this.options.map((value) => ({
-                                        name: value[1],
-                                        action: () => {
-                                            this.props.update(value[0]);
-                                        },
-                                    })),
-                            },
-                        ],
-                    };
-                },
-                { category: "smart_action", hotkey: "alt+shift+r" }
-            );
-        }
         this.colorPrefix = "o_status_";
         this.colors = {
             blocked: "red",
             done: "green",
         };
+        if (this.props.record.activeFields[this.props.name].viewType !== "form") {
+            return;
+        }
+        const hotkeys = ["D", "F", "G"];
+        for (const [index, [value, label]] of this.options.entries()) {
+            useCommand(
+                sprintf(this.env._t("Set kanban state as %s"), label),
+                () => this.props.update(value),
+                {
+                    category: "smart_action",
+                    hotkey: "alt+" + hotkeys[index],
+                    isAvailable: () => this.props.value !== value,
+                }
+            );
+        }
     }
     get options() {
         return this.props.record.fields[this.props.name].selection.map(([state, label]) => {

--- a/addons/web/static/tests/core/commands/command_service_tests.js
+++ b/addons/web/static/tests/core/commands/command_service_tests.js
@@ -169,6 +169,33 @@ QUnit.test("useCommand hook when the activeElement change", async (assert) => {
     );
 });
 
+QUnit.test("useCommand hook with isAvailable", async (assert) => {
+    let available = false;
+    class MyComponent extends TestComponent {
+        setup() {
+            useCommand("Take the throne", () => {}, {
+                isAvailable: () => {
+                    return available;
+                },
+            });
+        }
+    }
+    await mount(MyComponent, target, { env });
+
+    triggerHotkey("control+k");
+    await nextTick();
+    assert.containsOnce(target, ".o_command_palette");
+    assert.containsNone(target, ".o_command");
+
+    triggerHotkey("escape");
+    await nextTick();
+    available = true;
+    triggerHotkey("control+k");
+    await nextTick();
+    assert.containsOnce(target, ".o_command_palette");
+    assert.containsOnce(target, ".o_command");
+});
+
 QUnit.test("command with hotkey", async (assert) => {
     assert.expect(2);
 

--- a/addons/web/static/tests/views/fields/state_selection_field_tests.js
+++ b/addons/web/static/tests/views/fields/state_selection_field_tests.js
@@ -431,7 +431,7 @@ QUnit.module("Fields", (hooks) => {
     });
 
     QUnit.test(
-        'StateSelectionField edited by the smart action "Set kanban state..."',
+        'StateSelectionField edited by the smart actions "Set kanban state as <state name>"',
         async function (assert) {
             await makeView({
                 type: "form",
@@ -448,20 +448,23 @@ QUnit.module("Fields", (hooks) => {
 
             triggerHotkey("control+k");
             await nextTick();
-            const idx = [...target.querySelectorAll(".o_command")]
-                .map((el) => el.textContent)
-                .indexOf("Set kanban state...ALT + SHIFT + R");
+            var commandTexts = [...target.querySelectorAll(".o_command")].map(
+                (el) => el.textContent
+            );
+            assert.ok(commandTexts.includes("Set kanban state as NormalALT + D"));
+            const idx = commandTexts.indexOf("Set kanban state as DoneALT + G");
             assert.ok(idx >= 0);
 
             await click([...target.querySelectorAll(".o_command")][idx]);
             await nextTick();
-            assert.deepEqual(
-                [...target.querySelectorAll(".o_command")].map((el) => el.textContent),
-                ["Normal", "Blocked", "Done"]
-            );
-            await click(target, "#o_command_2");
-            await nextTick();
             assert.containsOnce(target, ".o_status_green");
+
+            triggerHotkey("control+k");
+            await nextTick();
+            commandTexts = [...target.querySelectorAll(".o_command")].map((el) => el.textContent);
+            assert.ok(commandTexts.includes("Set kanban state as NormalALT + D"));
+            assert.ok(commandTexts.includes("Set kanban state as BlockedALT + F"));
+            assert.notOk(commandTexts.includes("Set kanban state as DoneALT + G"));
         }
     );
 


### PR DESCRIPTION
- Add 'Move to next stage':

Stage and Personal Stage both have a status bar widget.
Yet, when this widget creates a command in the registry,
it stores it at the same key. So it overrides the last saved.
This is the reason why this command was not available.
An improvement to come in the framework js aims to not create
commands for invisible fields. As, in our case, only one will be visible
at a time, the conflict will be resolved.

- Change the 'set priority' command
to 'set priority as normal/important' :

Depending on the priority of the ticket, the command will display
'Set priority as [the other priority]'.
This improvement comes with a migration script to change 'High/Low'
into 'Important/Normal'.

- Transform the 'Set kanban state' command into three commands

Only two of them are now displayed,
depending on the current kanban state of the task.

task-2857447

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
