### PR TITLE
[REM] im_livechat: removing Attachments xml template

### DIFF
--- a/addons/im_livechat/static/src/legacy/public_livechat.xml
+++ b/addons/im_livechat/static/src/legacy/public_livechat.xml
@@ -475,19 +475,6 @@
     </t>
 
     <!--
-        @param {Array} attachments
-    -->
-    <t t-name="im_livechat.legacy.mail.composer.Attachments">
-        <div t-if="attachments.length > 0" class="o_attachments o_attachments_list">
-            <t t-foreach="attachments" t-as='attachment'>
-                <t t-call="im_livechat.legacy.mail.Attachment">
-                     <t t-set="editable" t-value="true"/>
-                </t>
-            </t>
-        </div>
-    </t>
-
-    <!--
         @param {Object} attachment
         @param {integer} attachment.id
         @param {string} attachment.name


### PR DESCRIPTION
The Attachments xml template is not used anymore,
It can be deleted safely

Task-2825235