### PR TITLE
[MOV] im_livechat: moving AttachmentPreview xml template

### DIFF
--- a/addons/im_livechat/controllers/main.py
+++ b/addons/im_livechat/controllers/main.py
@@ -29,6 +29,7 @@ class LivechatController(http.Controller):
     def load_templates(self, **kwargs):
         templates = [
             'im_livechat/static/src/legacy/public_livechat.xml',
+            'im_livechat/static/src/legacy/widgets/attachment_preview.xml',
             'im_livechat/static/src/legacy/public_livechat_chatbot.xml',
         ]
         return [tools.file_open(tmpl, 'rb').read() for tmpl in templates]

--- a/addons/im_livechat/static/src/legacy/public_livechat.xml
+++ b/addons/im_livechat/static/src/legacy/public_livechat.xml
@@ -489,30 +489,6 @@
 
     <!--
         @param {Object} attachment
-        @param {integer} attachment.id
-        @param {string} attachment.name
-        @param {string} attachment.url
-        @param {boolean} [isDeletable=false]
-    -->
-    <t t-name="im_livechat.legacy.mail.AttachmentPreview">
-        <div class="o_attachment" t-att-title="attachment.name">
-            <div class="o_attachment_wrap">
-                <div class="o_image_box">
-                    <div class="o_attachment_image" t-attf-style="background-image:url('/web/image/#{attachment.id}/160x160/?crop=true')"/>
-                    <div t-attf-class="o_image_overlay o_attachment_view"  t-att-data-id="attachment.id">
-                        <span t-if="isDeletable" class="fa fa-times o_attachment_delete_cross" t-att-title="'Delete ' + attachment.name" t-att-data-id="attachment.id" t-att-data-name="attachment.name"/>
-                        <span class="o_attachment_title text-white"><t t-esc="attachment.name"/></span>
-                        <a class="o_attachment_download" t-att-href='attachment.url'>
-                            <i t-attf-class="fa fa-download text-white" t-att-title="'Download ' + attachment.name" role="img" aria-label="Download"></i>
-                        </a>
-                    </div>
-                </div>
-            </div>
-        </div>
-    </t>
-
-    <!--
-        @param {Object} attachment
         @param {string} attachment.filename
         @param {integer} attachment.id
         @param {string} [attachment.mimetype]

--- a/addons/im_livechat/static/src/legacy/widgets/attachment_preview.xml
+++ b/addons/im_livechat/static/src/legacy/widgets/attachment_preview.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<templates xml:space="preserve">
+    <!--
+        @param {Object} attachment
+        @param {integer} attachment.id
+        @param {string} attachment.name
+        @param {string} attachment.url
+        @param {boolean} [isDeletable=false]
+    -->
+    <t t-name="im_livechat.legacy.mail.AttachmentPreview">
+        <div class="o_attachment" t-att-title="attachment.name">
+            <div class="o_attachment_wrap">
+                <div class="o_image_box">
+                    <div class="o_attachment_image" t-attf-style="background-image:url('/web/image/#{attachment.id}/160x160/?crop=true')"/>
+                    <div t-attf-class="o_image_overlay o_attachment_view"  t-att-data-id="attachment.id">
+                        <span t-if="isDeletable" class="fa fa-times o_attachment_delete_cross" t-att-title="'Delete ' + attachment.name" t-att-data-id="attachment.id" t-att-data-name="attachment.name"/>
+                        <span class="o_attachment_title text-white"><t t-esc="attachment.name"/></span>
+                        <a class="o_attachment_download" t-att-href='attachment.url'>
+                            <i t-attf-class="fa fa-download text-white" t-att-title="'Download ' + attachment.name" role="img" aria-label="Download"></i>
+                        </a>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </t>
+</templates>


### PR DESCRIPTION
The goal is to split the public_livechat.xml file into multiple parts,
and move each template into its own file located in `im_livechat/static/src/legacy/widgets/`

Task-2825235