### PR TITLE
[FIX] account: product price rounded as accounting value

### DIFF
--- a/addons/account/models/product.py
+++ b/addons/account/models/product.py
@@ -101,6 +101,8 @@ class ProductProduct(models.Model):
             taxes_before_included = all(tax.price_include for tax in flattened_taxes_before_fp)
 
             if set(product_taxes.ids) != set(product_taxes_after_fp.ids) and taxes_before_included:
+                prec = 1e+6
+                product_price_unit *= prec
                 taxes_res = flattened_taxes_before_fp.compute_all(
                     product_price_unit,
                     quantity=1.0,
@@ -123,6 +125,7 @@ class ProductProduct(models.Model):
                         tax = self.env['account.tax'].browse(tax_res['id'])
                         if tax.price_include:
                             product_price_unit += tax_res['amount']
+                product_price_unit /= prec
 
         # Apply currency rate.
         if currency != product_currency:


### PR DESCRIPTION
1. Create a Fiscal position: Taxes 21% included in price > Taxes to
apply 21% excluded

2. Create pricelist A:
  - use "Formula" > -0,50 € > Based on the public pricelist
  - "Discount Policy" > Included in the price

3. Create another pricelist B:
  - use "Formula" > 10% discount > Based on pricelist above (-0,50)
  - "Discount Policy" > Show to the customer

4. Create a product [TEST] with sales price 9,50€

5. Create a Customer [DEMO] with the Fiscal Position we just created AND
Pricelist 10% discount

6. Activate fiscal position and pricelists in the POS

Create a SO for customer [DEMO], with our product [TEST]
User will see
- Untaxed unit price 6.70
- Taxes 1.41
- Total 8.11

Then create a similar sale in POS
The price is not the same

- Untaxed unit price 6.69
- Taxes: 1.40
- Total 8.09

This occurs because during the several steps in which the price is
computed we round the product price following the currency rounding and
not the product price decimal digits

opw-2811855

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
