### PR TITLE
[FIX] sale_timesheet: Fix allocated hours in task

### DIFF
--- a/addons/sale_timesheet/models/sale_order.py
+++ b/addons/sale_timesheet/models/sale_order.py
@@ -211,16 +211,13 @@ class SaleOrderLine(models.Model):
     ###########################################
 
     def _convert_qty_company_hours(self, dest_company):
-        company_time_uom_id = dest_company.project_time_mode_id
-        planned_hours = 0.0
-        product_uom = self.product_uom
-        if product_uom == self.env.ref('uom.product_uom_unit'):
-            product_uom = self.env.ref('uom.product_uom_hour')
-        if product_uom.category_id == company_time_uom_id.category_id:
-            if product_uom != company_time_uom_id:
-                planned_hours = product_uom._compute_quantity(self.product_uom_qty, company_time_uom_id)
-            else:
-                planned_hours = self.product_uom_qty
+        uom_hour = self.env.ref('uom.product_uom_hour')
+        # sale order line may be stored in a different unit of measure, so first
+        # we convert all of them to the reference unit
+        # if the sol has no product_uom_id then we take the one of the project
+        planned_hours = self.product_uom_qty * (self.product_uom or dest_company.project_time_mode_id).factor_inv
+        # Now convert to the unit of measure to hours
+        planned_hours *= uom_hour.factor
         return planned_hours
 
     def _timesheet_create_project(self):

--- a/addons/sale_timesheet/tests/test_sale_service.py
+++ b/addons/sale_timesheet/tests/test_sale_service.py
@@ -598,8 +598,8 @@ class TestSaleService(TestCommonSaleTimesheet):
         planned_hours_for_uom = {
             'day': 8.0,
             'hour': 1.0,
-            'unit': 1.0,
-            'gram': 0.0,
+            'unit': 8.0,
+            'gram': 0.008,
         }
 
         project = self.project_global.copy({'tasks': False})


### PR DESCRIPTION
before this commit when task and project are created from SO and product
available in SO has a unit of measure as unit then created task allocated
hours is qty in SO hours and allocated hours in the project is 8*qty hours.

so, in this commit set allocated hours in the task as 8*qty.

task - 2858529