### PR TITLE
[FIX] mail, test_mail_full: remove an obsolete method

### DIFF
--- a/addons/mail/models/mail_channel.py
+++ b/addons/mail/models/mail_channel.py
@@ -1170,17 +1170,6 @@ class Channel(models.Model):
                     ])
         return self.search_read(domain, ['id', 'name', 'public', 'channel_type'], limit=limit)
 
-    @api.model
-    def channel_fetch_listeners(self, uuid):
-        """ Return the id, name and email of partners listening to the given channel """
-        self._cr.execute("""
-            SELECT P.id, P.name, P.email
-            FROM mail_channel_partner CP
-                INNER JOIN res_partner P ON CP.partner_id = P.id
-                INNER JOIN mail_channel C ON CP.channel_id = C.id
-            WHERE C.uuid = %s""", (uuid,))
-        return self._cr.dictfetchall()
-
     def channel_fetch_preview(self):
         """ Return the last message of the given channels """
         if not self:

--- a/addons/mail/static/tests/helpers/mock_server.js
+++ b/addons/mail/static/tests/helpers/mock_server.js
@@ -180,9 +180,6 @@ MockServer.include({
             const ids = args.args[0];
             return this._mockMailChannelChannelFetched(ids);
         }
-        if (args.model === 'mail.channel' && args.method === 'channel_fetch_listeners') {
-            return [];
-        }
         if (args.model === 'mail.channel' && args.method === 'channel_fetch_preview') {
             const ids = args.args[0];
             return this._mockMailChannelChannelFetchPreview(ids);

--- a/addons/test_mail_full/tests/test_odoobot.py
+++ b/addons/test_mail_full/tests/test_odoobot.py
@@ -30,9 +30,8 @@ class TestOdoobot(TestMailCommon, TestRecipients):
     @mute_logger('odoo.addons.mail.models.mail_mail')
     def test_fetch_listener(self):
         channel = self.user_employee.with_user(self.user_employee)._init_odoobot()
-        partners = self.env['mail.channel'].channel_fetch_listeners(channel.uuid)
         odoobot = self.env.ref("base.partner_root")
-        odoobot_in_fetch_listeners = [partner for partner in partners if partner['id'] == odoobot.id]
+        odoobot_in_fetch_listeners = self.env['mail.channel.partner'].search([('channel_id', '=', channel.id), ('partner_id', '=', odoobot.id)])
         self.assertEqual(len(odoobot_in_fetch_listeners), 1, 'odoobot should appear only once in channel_fetch_listeners')
 
     @mute_logger('odoo.addons.mail.models.mail_mail')


### PR DESCRIPTION
**Before this commit:**

There is an obsolete method 'channel_fetch_listeners' which is not needed now.

**After this commit:**

Removed this obsolete method.

**Task**-2827899