### PR TITLE
[FIX] website: avoid KeyError when using website configurator

### DIFF
--- a/addons/website/models/website.py
+++ b/addons/website/models/website.py
@@ -342,9 +342,12 @@ class Website(models.Model):
 
     @api.model
     def configurator_recommended_themes(self, industry_id, palette):
-        domain = [('name', '=like', 'theme%'), ('name', 'not in', ['theme_default', 'theme_common'])]
+        domain = [('name', '=like', 'theme%'), ('name', 'not in', ['theme_default', 'theme_common']), ('state', '!=', 'uninstallable')]
         client_themes = request.env['ir.module.module'].search(domain).mapped('name')
-        client_themes_img = dict([(t, http.addons_manifest[t].get('images_preview_theme', {})) for t in client_themes])
+        client_themes_img = dict([
+            (t, http.addons_manifest[t].get('images_preview_theme', {}))
+            for t in client_themes if t in http.addons_manifest
+        ])
         themes_suggested = self._website_api_rpc(
             '/api/website/2/configurator/recommended_themes/%s' % industry_id,
             {'client_themes': client_themes_img}


### PR DESCRIPTION
Currently, when building a website by using the website configurator,
it will raise a `KeyError` error if your addons contain a theme that is
in a state that cannot be installed. The reason is that now modules that
are set `'installable': False` in the manifest will not appear in
`http.addons_manifest`, so accessing `http.addons_manifest[key]` in [1]
will cause an error.

To fix this we are only filtering out `client_themes` that don't have a
state of `uninstallable`.

Steps to reproduce:
- The addons contains a theme installable=False.
- Build a website using website configurator.
- KeyError is raised.

[1]: https://github.com/odoo/odoo/commit/d310a7adc64dd727c9241af7a7b14614522be02c

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
