### PR TITLE
[FIX] web_editor: prevent media selection during search

### DIFF
--- a/addons/web_editor/static/src/js/wysiwyg/widgets/media.js
+++ b/addons/web_editor/static/src/js/wysiwyg/widgets/media.js
@@ -120,7 +120,14 @@ var SearchableMediaWidget = MediaWidget.extend({
      */
     _onSearchInput: function (ev) {
         this.attachments = [];
-        this.search($(ev.currentTarget).val() || '').then(() => this._renderThumbnails());
+        // Disable user interactions with attachments while updating results.
+        this.$('.o_we_existing_attachments').css('pointer-events', 'none');
+        this.search($(ev.currentTarget).val() || "")
+            .then(() => this._renderThumbnails())
+            .then(() => {
+                // Re-enable user interactions after updating results.
+                this.$(".o_we_existing_attachments").css("pointer-events", "");
+            });
         this.hasSearched = true;
     },
 });


### PR DESCRIPTION
~~When changing media sources filter (All, Illustrations, ...), the~~
~~list of media is regenerated since the results may be different. If~~
~~the user clicks on one media at the right time after changing the~~
~~sources filter (not too fast but not too slow either) it is possible~~
~~to select a media which id is out of sync with the new state of the~~
~~widget, thus prompting `_onAttachmentClick` to provide `undefined`~~
~~to `_selectAttachment`, which ultimately leads to a traceback in~~
~~`_highlightSelected` when accessing `media.id`.~~

~~This commit fixes the traceback by avoiding to call `_selectAttachment`~~
~~when the attachment or media was out of sync with the state of the~~
~~widget and therefore could not be found.~~

When updating the results following a change in the search filter or the
source sources filter (All, Illustrations, ...), the list of media is
regenerated to match the new results. If the user clicks on one media at
the right time after the search is triggered (not too fast but not too
slow either) it is possible to select a media which id is out of sync
with the new state of the widget, thus prompting `_onAttachmentClick` to
provide `undefined` to `_selectAttachment`, which ultimately leads to a
traceback in `_highlightSelected` when accessing either `media.id` or
`attachment.id` depending on the case.

This commit fixes the issue by disabling pointer interactions with
the attachments during the search and rendering update process.