### PR TITLE
[FIX] mrp_account: access product variant without traceback

### DIFF
--- a/addons/mrp_account/views/product_views.xml
+++ b/addons/mrp_account/views/product_views.xml
@@ -5,6 +5,7 @@
             <field name="model">product.template</field>
             <field name="priority">3</field>
             <field name="inherit_id" ref="product.product_template_only_form_view" />
+            <field name="groups_id" eval="[(4, ref('mrp.group_mrp_manager'))]"/>
             <field name="arch" type="xml">
                 <xpath expr="//span[@name='update_cost_price']" position="inside">
                     <button name="button_bom_cost"
@@ -21,6 +22,7 @@
             <field name="model">product.product</field>
             <field name="priority">4</field>
             <field name="inherit_id" ref="product.product_normal_form_view"/>
+            <field name="groups_id" eval="[(4, ref('mrp.group_mrp_manager'))]"/>
             <field name="arch" type="xml">
                 <xpath expr="//span[@name='update_cost_price']" position="inside">
                     <button name="button_bom_cost"
@@ -37,6 +39,7 @@
             <field name="name">product.product.product.view.form.easy.bom.inherit</field>
             <field name="model">product.product</field>
             <field name="inherit_id" ref="product.product_variant_easy_edit_view"/>
+            <field name="groups_id" eval="[(4, ref('mrp.group_mrp_manager'))]"/>
             <field name="arch" type="xml">
                 <data>
                 <xpath expr="//div[@name='update_cost_price']" position="inside">


### PR DESCRIPTION
Steps to reproduce the bug:
- Create a storable product “P1” with BOM
- remove MRP access to Marc Demo
- connect with Marc
- Go to inventory > Master data > product variant > product “P1”
- try to open the product variant view

Problem:
Traceback is triggered, because we use the "bom_count" field in the domain
without checking if the user has access to MRP

opw-2856146
opw-2842434




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
