### PR TITLE
[FIX] account: latest statement on bank journal dashboard

### DIFF
--- a/addons/account/models/account_journal.py
+++ b/addons/account/models/account_journal.py
@@ -816,5 +816,5 @@ class AccountJournal(models.Model):
         '''
         self.ensure_one()
         last_statement_domain = (domain or []) + [('journal_id', '=', self.id)]
-        last_st_line = self.env['account.bank.statement.line'].search(last_statement_domain, order='date desc, id desc', limit=1)
-        return last_st_line.statement_id
+        last_statement = self.env['account.bank.statement'].search(last_statement_domain, order='date desc, id desc', limit=1)
+        return last_statement

--- a/addons/account/models/account_journal_dashboard.py
+++ b/addons/account/models/account_journal_dashboard.py
@@ -99,7 +99,7 @@ class account_journal(models.Model):
         locale = get_lang(self.env).code
 
         #starting point of the graph is the last statement
-        last_stmt = self._get_last_bank_statement(domain=[('move_id.state', '=', 'posted')])
+        last_stmt = self._get_last_bank_statement(domain=[('state', 'in', ['posted', 'confirm'])])
 
         last_balance = last_stmt and last_stmt.balance_end_real or 0
         data.append(build_graph_data(today, last_balance))
@@ -233,7 +233,7 @@ class account_journal(models.Model):
         sum_draft = sum_waiting = sum_late = 0.0
         if self.type in ('bank', 'cash'):
             last_statement = self._get_last_bank_statement(
-                domain=[('move_id.state', '=', 'posted')])
+                domain=[('state', 'in', ['posted', 'confirm'])])
             last_balance = last_statement.balance_end
             has_at_least_one_statement = bool(last_statement)
             bank_account_balance, nb_lines_bank_account_balance = self._get_journal_bank_account_balance(

--- a/addons/account/tests/test_account_journal_dashboard.py
+++ b/addons/account/tests/test_account_journal_dashboard.py
@@ -92,3 +92,106 @@ class TestAccountJournalDashboard(AccountTestInvoicingCommon):
         dashboard_data = journal.get_journal_dashboard_datas()
         self.assertEqual(dashboard_data['number_late'], 2)
         self.assertIn('78.42', dashboard_data['sum_late'])
+
+    def test_last_statement(self):
+        bank_journal = self.company_data['default_journal_bank']
+
+        invoices = self.env['account.move'].create([
+            {
+            'move_type': 'out_invoice',
+            'partner_id': self.partner_a.id,
+            'invoice_date': '2022-05-17',
+            'date': '2022-05-17',
+            'invoice_line_ids': [(0, 0, {
+                'product_id': self.product_a.id,
+                'quantity': 1.0,
+                'name': 'product test 1',
+                'price_unit': 500.0,
+            })]
+            },
+            {
+            'move_type': 'out_invoice',
+            'partner_id': self.partner_a.id,
+            'invoice_date': '2022-05-18',
+            'date': '2022-05-18',
+            'invoice_line_ids': [(0, 0, {
+                'product_id': self.product_a.id,
+                'quantity': 1.0,
+                'name': 'product test 1',
+                'price_unit': 700.0,
+            })]
+            },
+            {
+            'move_type': 'out_invoice',
+            'partner_id': self.partner_a.id,
+            'invoice_date': '2022-05-17',
+            'date': '2022-05-17',
+            'invoice_line_ids': [(0, 0, {
+                'product_id': self.product_a.id,
+                'quantity': 1.0,
+                'name': 'product test 1',
+                'price_unit': 900.0,
+            })]
+            },
+        ])
+
+        invoices.action_post()
+
+        payments = self.env['account.payment'].create([
+            {
+                'amount': 500.0,
+                'payment_type': 'inbound',
+                'partner_type': 'customer',
+                'partner_id': self.partner_a.id,
+                'journal_id': bank_journal.id,
+                'date': '2022-05-17',
+            },
+            {
+                'amount': 700.0,
+                'payment_type': 'inbound',
+                'partner_type': 'customer',
+                'partner_id': self.partner_a.id,
+                'journal_id': bank_journal.id,
+                'date': '2022-05-18',
+            },
+            {
+                'amount': 500.0,
+                'payment_type': 'inbound',
+                'partner_type': 'customer',
+                'partner_id': self.partner_a.id,
+                'journal_id': bank_journal.id,
+                'date': '2022-05-17',
+            },
+        ])
+        payments.action_post()
+
+        for invoice, payment in zip(invoices, payments):
+            (invoice + payment.move_id).line_ids\
+                .filtered(lambda line: line.account_internal_type == 'receivable')\
+                .reconcile()
+
+        # Create statements in bank journal.
+        statements = self.env['account.bank.statement'].create([
+            {
+            'name': 'BNK1_1',
+            'date': '2022-05-17',
+            'journal_id': bank_journal.id,
+            'line_ids': [
+                (0, 0, {'date': '2022-05-17', 'payment_ref': invoices[0].name, 'amount': 500.0}),
+                (0, 0, {'date': '2022-05-18', 'payment_ref': invoices[1].name, 'amount': 700.0}),
+            ],
+            'balance_end_real': 1200.0,
+            },
+            {
+            'name': 'BNK1_2',
+            'date': '2022-05-17',
+            'journal_id': bank_journal.id,
+            'line_ids': [(0, 0, {'date': '2022-05-17', 'payment_ref': invoices[2].name, 'amount': 900.0})],
+            'balance_end_real': 2100.0,
+            }
+        ])
+
+        statements.button_post()
+
+        dashboard = bank_journal.get_journal_dashboard_datas()
+        self.assertTrue(dashboard['last_balance'] == dashboard['account_balance'])


### PR DESCRIPTION
Display the latest statement on journal dashboard.

Steps to reproduce:

- Create a bank statement for date X, with a line with date X + 1 day,
  confirm, reconcile and validate
- Create an other bank statement for date X, with a line with date X,
  confirm, reconcile and validate.
- Go to Accounting Dashboard
-> The latest statement is the first we created, instead of the last one

The reason is, the last statement was display depending on the
statements lines.

With this commit we return the last statement depending on the
order declared on account.bank.statement model.

opw-2752699

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
