### PR TITLE
[FIX] project: remove unnecessary condition in `_onDeleteColumn`

### DIFF
--- a/addons/project/static/src/js/project_kanban.js
+++ b/addons/project/static/src/js/project_kanban.js
@@ -63,7 +63,7 @@ const ProjectTaskKanbanColumn = KanbanColumn.extend({
      * @private
      */
     _onDeleteColumn: function (event) {
-        if (this.modelName === 'project.task' && this.groupedBy === 'stage_id') {
+        if (this.groupedBy === 'stage_id') {
             event.preventDefault();
             this.trigger_up('kanban_column_delete_wizard');
             return;


### PR DESCRIPTION
This commit removes the unnecessary condition on modelName as the code
stands in `ProjectTaskKanbanColumn` which is only used in the
`project.task` kanban view.


--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
