### PR TITLE
[MERGE][FIX] knowledge: fix "move to private" and archive flows

### DIFF
--- a/addons/knowledge/models/knowledge_article.py
+++ b/addons/knowledge/models/knowledge_article.py
@@ -8,7 +8,7 @@ from markupsafe import Markup
 from werkzeug.urls import url_join
 
 from odoo import Command, fields, models, api, _
-from odoo.exceptions import AccessError, ValidationError
+from odoo.exceptions import AccessError, ValidationError, UserError
 from odoo.osv import expression
 from odoo.tools import get_lang
 
@@ -707,6 +707,10 @@ class Article(models.Model):
         parent = self.browse(parent_id)
         before_article = self.browse(before_article_id)
 
+        if is_private:
+            # making an article private requires a lot of extra-processing, use specific method
+            return self._make_private(parent=parent, sequence=before_article.sequence or False)
+
         values = {'parent_id': parent_id}
         if before_article:
             values['sequence'] = before_article.sequence
@@ -714,43 +718,10 @@ class Article(models.Model):
             # be sure to have an internal permission on the article if moved outside
             # of an hierarchy
             values.update({
-                'internal_permission': 'none' if is_private else 'write',
+                'internal_permission': 'write',
                 'is_desynchronized': False
             })
 
-        # if set as standalone private: remove members, ensure current user is the
-        # only member -> require sudo to bypass member ACLs
-        if not parent and is_private:
-            # explicitly check for rights before going into sudo
-            try:
-                self.check_access_rights('write')
-                (self + parent).check_access_rule('write')
-            except:
-                raise AccessError(
-                    _("You are not allowed to move this article under article %(parent_name)s",
-                      parent_name=parent.display_name)
-                )
-            self_sudo = self.sudo()
-            self_member = self_sudo.article_member_ids.filtered(lambda m: m.partner_id == self.env.user.partner_id)
-
-            if self_member:
-                write_member_command = [(1, self_member.id, {'permission': 'write'})]
-            else:
-                write_member_command = [(0, 0, {
-                    'partner_id': self.env.user.partner_id.id,
-                    'permission': 'write'
-                })]
-            # has to be done in 2 separate write operations:
-            # first add or update the new membership with 'write' access
-            self_sudo.write({'article_member_ids': write_member_command})
-
-            # then remove other members as the article is moved to private
-            # this helps avoiding a temporary state where we don't have a writer on the article (see '_has_write_member')
-            values['article_member_ids'] = [
-                (2, member.id)
-                for member in self_sudo.article_member_ids if member.partner_id != self.env.user.partner_id
-            ]
-            return self_sudo.write(values)
         return self.write(values)
 
     def _resequence(self):
@@ -1174,6 +1145,81 @@ class Article(models.Model):
             })
 
         return writable_descendants
+
+    def _make_private(self, parent=False, sequence=False):
+        """ Set as private: remove members, ensure current user is the only member
+        Requires a sudo to bypass member ACLs after checking write access on the article.
+
+        Children articles to which the user also has a write access to are made private as well.
+        Other articles are detached, see '_detach_unwritable_descendants' for details.
+
+        :param <knowledge.article> parent: an optional parent to move the article under
+        :param int sequence: an optional specific sequence to set for the article """
+
+        self.ensure_one()
+
+        parent = parent or self.env['knowledge.article']
+        # explicitly check for rights before going into sudo
+        try:
+            self.check_access_rights('write')
+            (self + parent).check_access_rule('write')
+        except (AccessError, UserError):
+            raise AccessError(
+                _("You are not allowed to make '%(article_name)s' private.", article_name=self.display_name)
+            )
+
+        # first detach unwritable children (see '_detach_unwritable_descendants' docstring)
+        writable_descendants = self._detach_unwritable_descendants()
+
+        self_sudo = self.sudo()
+        write_member_commands = []
+        article_values = {
+            # reset internal permission if parent is set (will inherit) or force private (aka 'none')
+            'internal_permission': False if parent else 'none',
+            # cannot be desync when made private as we wipe members access
+            'is_desynchronized': False,
+            'parent_id': parent.id if parent else False,
+        }
+
+        if not parent:
+            # make sure the current user is the only member left with write access to the article
+            # if we have a parent, this is not necessary as we will inherit members access from him
+            self_member = self_sudo.article_member_ids.filtered(lambda m: m.partner_id == self.env.user.partner_id)
+            if self_member:
+                write_member_commands = [(1, self_member.id, {'permission': 'write'})]
+            else:
+                write_member_commands = [(0, 0, {
+                    'partner_id': self.env.user.partner_id.id,
+                    'permission': 'write'
+                })]
+            # has to be done in 2 separate write operations:
+            # first add or update the new membership with 'write' access
+            # this helps avoiding a temporary state where we don't have a writer on the article
+            # (see '_has_write_member')
+            self_sudo.write({'article_member_ids': write_member_commands})
+
+        # then remove other members as the article is moved to private
+        members_to_remove = self_sudo.article_member_ids
+        if not parent:
+            members_to_remove = members_to_remove.filtered(
+                lambda member: member.partner_id != self.env.user.partner_id
+            )
+
+        article_values['article_member_ids'] = [
+            (2, member.id)
+            for member in members_to_remove
+        ]
+
+        self_sudo.write(article_values)
+
+        # remove all specific memberships configurations on children
+        # they will inherit the (only) 'write' member from their parent now, making them private
+        writable_descendants.write({
+            'internal_permission': False,
+            'article_member_ids': [(5, 0)],
+        })
+
+        return True
 
     def _copy_access_from_parents_commands(self, force_partners=False, force_member_permission=False):
         """ Prepare commands for all inherited accesses from parents on the article in order

--- a/addons/knowledge/models/knowledge_article.py
+++ b/addons/knowledge/models/knowledge_article.py
@@ -644,26 +644,7 @@ class Article(models.Model):
           * unreachable descendants (none, read) are set as free articles without
             root;
         """
-        all_descendants_sudo = self.sudo()._get_descendants()
-        writable_descendants = all_descendants_sudo.with_env(self.env)._filter_access_rules_python('write')
-        other_descendants_sudo = all_descendants_sudo - writable_descendants
-
-        # copy rights to allow breaking the hierarchy while keeping access for members
-        for article_sudo in other_descendants_sudo:
-            member_commands = article_sudo._copy_access_from_parents_commands()
-            article_sudo.write({'article_member_ids': member_commands})
-
-        # create new root articles: direct children of archived articles that are not archived
-        new_roots_woperm = other_descendants_sudo.filtered(lambda article: article.parent_id in self and not article.internal_permission)
-        new_roots_wperm = other_descendants_sudo.filtered(lambda article: article.parent_id in self and article.internal_permission)
-        if new_roots_wperm:
-            new_roots_wperm.write({'parent_id': False})
-        for new_root in new_roots_woperm:
-            new_root.write({
-                'internal_permission': new_root.inherited_permission,
-                'parent_id': False,
-            })
-
+        writable_descendants = self._detach_unwritable_descendants()
         return super(Article, self + writable_descendants).action_archive()
 
     # ------------------------------------------------------------
@@ -1158,6 +1139,41 @@ class Article(models.Model):
             'internal_permission': new_internal_permission,
             'is_desynchronized': True,
         })
+
+    def _detach_unwritable_descendants(self):
+        """ When taking specific actions on an article, notably archiving or making it private, we
+        want to be able to 'detach' the unaccessible children and set them as free (root) articles.
+
+        Indeed, when making private / archiving , you should not change the current access level
+        of children articles.
+
+        This method takes care of correctly detaching those children and returns a subset of children
+        to which the user effectively has write access to.
+
+        :return <knowledge.article> children: the children articles which were not detached, meaning
+          that the current user has a write access level to them. """
+
+        all_descendants_sudo = self.sudo()._get_descendants()
+        writable_descendants = all_descendants_sudo.with_env(self.env)._filter_access_rules_python('write')
+        other_descendants_sudo = all_descendants_sudo - writable_descendants
+
+        # copy rights to allow breaking the hierarchy while keeping access for members
+        for article_sudo in other_descendants_sudo:
+            member_commands = article_sudo._copy_access_from_parents_commands()
+            article_sudo.write({'article_member_ids': member_commands})
+
+        # create new root articles: direct children of these articles
+        new_roots_woperm = other_descendants_sudo.filtered(lambda article: article.parent_id in self and not article.internal_permission)
+        new_roots_wperm = other_descendants_sudo.filtered(lambda article: article.parent_id in self and article.internal_permission)
+        if new_roots_wperm:
+            new_roots_wperm.write({'parent_id': False})
+        for new_root in new_roots_woperm:
+            new_root.write({
+                'internal_permission': new_root.inherited_permission,
+                'parent_id': False,
+            })
+
+        return writable_descendants
 
     def _copy_access_from_parents_commands(self, force_partners=False, force_member_permission=False):
         """ Prepare commands for all inherited accesses from parents on the article in order

--- a/addons/knowledge/models/knowledge_article.py
+++ b/addons/knowledge/models/knowledge_article.py
@@ -139,17 +139,7 @@ class Article(models.Model):
         Ǹote: computation is done in Py instead of using optimized SQL queries
         because value are not yet in DB at this point."""
         for article in self:
-            def has_write_member(a, child_members=False):
-                if not child_members:
-                    child_members = self.env['knowledge.article.member']
-                article_members = a.article_member_ids
-                if any(m.permission == 'write' and m.partner_id not in child_members.mapped('partner_id')
-                       for m in article_members):
-                    return True
-                if a.parent_id and not a.is_desynchronized:
-                    return has_write_member(a.parent_id, article_members | child_members)
-                return False
-            if article.inherited_permission != 'write' and not has_write_member(article):
+            if article.inherited_permission != 'write' and not article._has_write_member():
                 raise ValidationError(_("The article '%s' needs at least one member with 'Write' access.", article.display_name))
 
     @api.constrains('parent_id')
@@ -760,15 +750,24 @@ class Article(models.Model):
                 )
             self_sudo = self.sudo()
             self_member = self_sudo.article_member_ids.filtered(lambda m: m.partner_id == self.env.user.partner_id)
-            member_command = [(2, member.id) for member in self_sudo.article_member_ids if member.partner_id != self.env.user.partner_id]
+
             if self_member:
-                member_command.append((1, self_member.id, {'permission': 'write'}))
+                write_member_command = [(1, self_member.id, {'permission': 'write'})]
             else:
-                member_command.append((0, 0, {
+                write_member_command = [(0, 0, {
                     'partner_id': self.env.user.partner_id.id,
                     'permission': 'write'
-                }))
-            values['article_member_ids'] = member_command
+                })]
+            # has to be done in 2 separate write operations:
+            # first add or update the new membership with 'write' access
+            self_sudo.write({'article_member_ids': write_member_command})
+
+            # then remove other members as the article is moved to private
+            # this helps avoiding a temporary state where we don't have a writer on the article (see '_has_write_member')
+            values['article_member_ids'] = [
+                (2, member.id)
+                for member in self_sudo.article_member_ids if member.partner_id != self.env.user.partner_id
+            ]
             return self_sudo.write(values)
         return self.write(values)
 
@@ -1072,6 +1071,34 @@ class Article(models.Model):
             current_membership = self.article_member_ids.filtered(lambda m: m.partner_id == member.partner_id)
             if current_membership:
                 self.sudo().write({'article_member_ids': [(2, current_membership.id)]})
+
+    def _has_write_member(self, child_members=False, exclude_memberships=False):
+        """ Method allowing to check if this article still has at least one member with write access.
+        Typically used during constraints checks.
+
+        Please note that this method is *not* optimized and should be avoided by using
+        '_get_article_member_permissions' instead when possible.
+
+        :param <knowledge.article.member> child_members: used when checking recursively through
+          article parents, we only check for the most specific access for a given partner.
+        :param <knowledge.article.member> exclude_memberships: memberships that should not be
+          considered when checking for a writer, useful when unlinking members. """
+
+        self.ensure_one()
+
+        if not child_members:
+            child_members = self.env['knowledge.article.member']
+
+        article_members = self.article_member_ids
+        if exclude_memberships:
+            article_members -= exclude_memberships
+
+        if any(m.permission == 'write' and m.partner_id not in child_members.mapped('partner_id')
+                for m in article_members):
+            return True
+        if self.parent_id and not self.is_desynchronized:
+            return self.parent_id._has_write_member(article_members | child_members)
+        return False
 
     def _add_members(self, partners, permission, force_update=True):
         """ Adds new members to the current article with the given permission.

--- a/addons/knowledge/models/knowledge_article.py
+++ b/addons/knowledge/models/knowledge_article.py
@@ -1121,6 +1121,10 @@ class Article(models.Model):
         This method takes care of correctly detaching those children and returns a subset of children
         to which the user effectively has write access to.
 
+        As the children are moved to "root" articles, we also reset their potential "desynchronized"
+        status.
+        Indeed, a root article cannot be desyncronized (see SQL constraints).
+
         :return <knowledge.article> children: the children articles which were not detached, meaning
           that the current user has a write access level to them. """
 
@@ -1129,7 +1133,8 @@ class Article(models.Model):
         other_descendants_sudo = all_descendants_sudo - writable_descendants
 
         # copy rights to allow breaking the hierarchy while keeping access for members
-        for article_sudo in other_descendants_sudo:
+        # we only do this on synchronized articles as desynchronized one do not inherit from parent
+        for article_sudo in other_descendants_sudo.filtered(lambda article: not article.is_desynchronized):
             member_commands = article_sudo._copy_access_from_parents_commands()
             article_sudo.write({'article_member_ids': member_commands})
 
@@ -1137,9 +1142,13 @@ class Article(models.Model):
         new_roots_woperm = other_descendants_sudo.filtered(lambda article: article.parent_id in self and not article.internal_permission)
         new_roots_wperm = other_descendants_sudo.filtered(lambda article: article.parent_id in self and article.internal_permission)
         if new_roots_wperm:
-            new_roots_wperm.write({'parent_id': False})
+            new_roots_wperm.write({
+                'is_desynchronized': False,
+                'parent_id': False
+            })
         for new_root in new_roots_woperm:
             new_root.write({
+                'is_desynchronized': False,
                 'internal_permission': new_root.inherited_permission,
                 'parent_id': False,
             })

--- a/addons/knowledge/models/knowledge_article.py
+++ b/addons/knowledge/models/knowledge_article.py
@@ -650,7 +650,8 @@ class Article(models.Model):
 
         # copy rights to allow breaking the hierarchy while keeping access for members
         for article_sudo in other_descendants_sudo:
-            article_sudo._copy_access_from_parents()
+            member_commands = article_sudo._copy_access_from_parents_commands()
+            article_sudo.write({'article_member_ids': member_commands})
 
         # create new root articles: direct children of archived articles that are not archived
         new_roots_woperm = other_descendants_sudo.filtered(lambda article: article.parent_id in self and not article.internal_permission)
@@ -1147,7 +1148,7 @@ class Article(models.Model):
         """
         self.ensure_one()
         new_internal_permission = force_internal_permission or self.inherited_permission
-        members_commands = self._copy_access_from_parents(
+        members_commands = self._copy_access_from_parents_commands(
             force_partners=force_partners,
             force_member_permission=force_member_permission
         )
@@ -1158,9 +1159,9 @@ class Article(models.Model):
             'is_desynchronized': True,
         })
 
-    def _copy_access_from_parents(self, force_partners=False, force_member_permission=False):
-        """ Copies copy all inherited accesses from parents on the article and
-        de-synchronize the article from its parent, allowing custom access management.
+    def _copy_access_from_parents_commands(self, force_partners=False, force_member_permission=False):
+        """ Prepare commands for all inherited accesses from parents on the article in order
+        to be able to de-synchronize the article from its parent, allowing custom access management.
         We allow to force permission of given partners.
 
         :param string force_internal_permission: force a new internal permission
@@ -1168,6 +1169,7 @@ class Article(models.Model):
           permission;
         :param <res.partner> force_partners: force permission of new members
           related to those partners;
+        :return list member_commands: commands to be applied on the 'article_member_ids' field
         """
         self.ensure_one()
         members_permission = self._get_article_member_permissions()[self.id]

--- a/addons/knowledge/models/knowledge_article.py
+++ b/addons/knowledge/models/knowledge_article.py
@@ -1138,9 +1138,14 @@ class Article(models.Model):
             member_commands = article_sudo._copy_access_from_parents_commands()
             article_sudo.write({'article_member_ids': member_commands})
 
-        # create new root articles: direct children of these articles
-        new_roots_woperm = other_descendants_sudo.filtered(lambda article: article.parent_id in self and not article.internal_permission)
-        new_roots_wperm = other_descendants_sudo.filtered(lambda article: article.parent_id in self and article.internal_permission)
+        # create new root articles: direct children of these articles + the writable_descendants
+        # indeed, those writable descendants are going to be altered the same way as "self"
+        # (archived / moved to private)
+        # -> all their children should be detached
+        new_roots_woperm = other_descendants_sudo.filtered(
+            lambda article: article.parent_id in (self + writable_descendants) and not article.internal_permission)
+        new_roots_wperm = other_descendants_sudo.filtered(
+            lambda article: article.parent_id in (self + writable_descendants) and article.internal_permission)
         if new_roots_wperm:
             new_roots_wperm.write({
                 'is_desynchronized': False,

--- a/addons/knowledge/models/knowledge_article_member.py
+++ b/addons/knowledge/models/knowledge_article_member.py
@@ -58,7 +58,6 @@ class ArticleMember(models.Model):
             for member in self.filtered(lambda member: member.article_id in articles_to_check):
                 deleted_members_by_article[member.article_id.id] |= member
 
-        parents_members_permission = articles_to_check.parent_id._get_article_member_permissions()
         for article in articles_to_check:
             # Check on permission on members
             members_to_check = article.article_member_ids
@@ -67,15 +66,8 @@ class ArticleMember(models.Model):
             if any(m.permission == 'write' for m in members_to_check):
                 continue
 
-            # we need to add the members on parents to check the validity
-            parent_write_members = any(
-                values['permission'] == 'write' for partner_id, values
-                in parents_members_permission[article.parent_id.id].items()
-                if article.parent_id and not article.is_desynchronized
-                and partner_id not in article.article_member_ids.partner_id.ids
-            )
-
-            if not parent_write_members:
+            exclude_memberships = deleted_members_by_article[article.id] if on_unlink else False
+            if not article._has_write_member(exclude_memberships=exclude_memberships):
                 raise ValidationError(
                     _("Article '%s' should always have a writer: inherit write permission, or have a member with write access",
                       article.display_name)

--- a/addons/knowledge/tests/test_knowledge_article_business.py
+++ b/addons/knowledge/tests/test_knowledge_article_business.py
@@ -480,17 +480,18 @@ class TestKnowledgeArticleBusiness(KnowledgeCommonWData):
             })]
         })
 
-        # add 2 extra articles for further checks
-        # - one to which 'employee' only has 'read' access to (as sudo)
-        # - one to which 'employee' does NOT have access to (as sudo)
+        # add 2 extra articles (as sudo) for further checks
+        # - one to which 'employee' only has 'read' access to
+        #   grandchild to article_workspace
+        # - one to which 'employee' does NOT have access to
         #   only "employee2" has access to that one in write mode
         [
-            wkspace_child_read_access,
+            wkspace_grandchild_read_access,
             wkspace_child_no_access,
         ] = self.env['knowledge.article'].sudo().create([{
-            'name': 'Read Child',
+            'name': 'Read Grand Child',
             'internal_permission': 'write',
-            'parent_id': article_workspace.id,
+            'parent_id': workspace_children[0].id,
             'article_member_ids': [(0, 0, {
                 'partner_id': self.partner_employee.id,
                 'permission': 'read',
@@ -524,7 +525,7 @@ class TestKnowledgeArticleBusiness(KnowledgeCommonWData):
             self.assertFalse(bool(workspace_child.article_member_ids))
 
         # 3.children that were not accessible were moved as a root articles...
-        for unreachable_article in wkspace_child_read_access | wkspace_child_no_access:
+        for unreachable_article in wkspace_grandchild_read_access | wkspace_child_no_access:
             self.assertEqual(unreachable_article.category, 'workspace')
             self.assertFalse(bool(unreachable_article.parent_id))
             # ... and kept their access rights for the customer
@@ -533,7 +534,7 @@ class TestKnowledgeArticleBusiness(KnowledgeCommonWData):
             )))
 
         # internal permission should stay untouched for unaccessible children
-        self.assertEqual(wkspace_child_read_access.internal_permission, 'write')
+        self.assertEqual(wkspace_grandchild_read_access.internal_permission, 'write')
         self.assertEqual(wkspace_child_no_access.internal_permission, 'read')
 
         # and that 'Hidden Child' is still accessible for employee2

--- a/addons/knowledge/tests/test_knowledge_article_constraints.py
+++ b/addons/knowledge/tests/test_knowledge_article_constraints.py
@@ -279,6 +279,19 @@ class TestKnowledgeArticleConstraints(KnowledgeCommonWData):
         with self.assertRaises(exceptions.ValidationError, msg='Cannot remove the last writer on an article'):
             article_private._add_members(membership_sudo.partner_id, 'none')
 
+        # add a second member with write access on the workspace article
+        self.article_workspace.sudo().write({
+            'article_member_ids': [(0, 0, {
+                'partner_id': self.user_employee2.partner_id.id,
+                'permission': 'write',
+            })]
+        })
+        # moving the article to private will remove the second member
+        # but should not trigger an error since we also add 'employee' as a write member
+        self.article_workspace.move_to(is_private=True)
+        self.assertEqual(self.article_workspace.category, 'private')
+        self.assertTrue(self.article_workspace._has_write_member())
+
     @mute_logger('odoo.sql_db')
     @users('employee')
     def test_favourite_uniqueness(self):


### PR DESCRIPTION
Fixes several issues into knowledge flows:
- Correctly test that the article still has a member when moving to a private
  section
- Copy member values when detaching unreachable children during archiving
- Propagate to children when making an article 'private'

See underlying commits for details.

Task-2859616