### PR TITLE
[REV] sale: revert d04bc2e5cae7673a9e26c67467fc2039e4c30ede

### DIFF
--- a/addons/sale/report/sale_report_views.xml
+++ b/addons/sale/report/sale_report_views.xml
@@ -91,14 +91,4 @@
         <field name="context">{'search_default_Sales':1, 'group_by_no_leaf':1,'group_by':[]}</field>
         <field name="help">This report performs analysis on your quotations and sales orders. Analysis check your sales revenues and sort it by different group criteria (salesman, partner, product, etc.) Use this report to perform analysis on sales not having invoiced yet. If you want to analyse your turnover, you should use the Invoice Analysis report in the Accounting application.</field>
     </record>
-
-    <record id="action_order_report_all" model="ir.actions.act_window">
-        <field name="name">Sales Analysis</field>
-        <field name="res_model">sale.report</field>
-        <field name="view_mode">list</field>
-        <field name="view_id"></field>  <!-- force empty -->
-        <field name="search_view_id" ref="view_order_product_search"/>
-        <field name="context">{'search_default_Sales':1,'group_by':[]}</field>
-        <field name="help">This report performs analysis on your quotations and sales orders. Analysis check your sales revenues and sort it by different group criteria (salesman, partner, product, etc.) Use this report to perform analysis on sales not having invoiced yet. If you want to analyse your turnover, you should use the Invoice Analysis report in the Accounting application.</field>
-    </record>
 </odoo>


### PR DESCRIPTION
This reverts commit d04bc2e5cae7673a9e26c67467fc2039e4c30ede.

The new action used the same xmlid as the above one, leading to a
list view when opening the sale report, which isn't what we want.

Considering the bug "fixed" by the bugfix is not only present in sales
but also in accounting and is not critical, this should stay like it
was before.

Fixes #91727




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
