### PR TITLE
[IMP] sale_crm: remove custom filter

### DIFF
--- a/addons/sale_crm/models/crm_lead.py
+++ b/addons/sale_crm/models/crm_lead.py
@@ -73,7 +73,6 @@ class CrmLead(models.Model):
         """ Prepares the context for a new quotation (sale.order) by sharing the values of common fields """
         self.ensure_one()
         quotation_context = {
-            'search_default_partner_id': self.partner_id.id,
             'default_opportunity_id': self.id,
             'default_partner_id': self.partner_id.id,
             'default_campaign_id': self.campaign_id.id,


### PR DESCRIPTION
This commit removes the default filter `Customer` from `crm_lead` in `sale_crm`.

task-2859354

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
