### PR TITLE
[FIX] pos_hr: update order's cashier on validation

### DIFF
--- a/addons/pos_hr/static/src/js/PaymentScreen.js
+++ b/addons/pos_hr/static/src/js/PaymentScreen.js
@@ -1,0 +1,18 @@
+odoo.define('pos_hr.PaymentScreen', function (require) {
+    'use strict';
+
+    const PaymentScreen = require('point_of_sale.PaymentScreen');
+    const Registries = require('point_of_sale.Registries');
+
+    const PosHrPaymentScreen = (PaymentScreen_) =>
+          class extends PaymentScreen_ {
+              async _finalizeValidation() {
+                  this.currentOrder.employee = this.env.pos.get_cashier();
+                  await super._finalizeValidation();
+              }
+          };
+
+    Registries.Component.extend(PaymentScreen, PosHrPaymentScreen);
+
+    return PaymentScreen;
+});

--- a/addons/pos_hr/views/point_of_sale.xml
+++ b/addons/pos_hr/views/point_of_sale.xml
@@ -10,6 +10,7 @@
             <script type="text/javascript" src="/pos_hr/static/src/js/HeaderLockButton.js"></script>
             <script type="text/javascript" src="/pos_hr/static/src/js/CashierName.js"></script>
             <script type="text/javascript" src="/pos_hr/static/src/js/LoginScreen.js"></script>
+            <script type="text/javascript" src="/pos_hr/static/src/js/PaymentScreen.js"></script>
         </xpath>
     </template>
 


### PR DESCRIPTION
Module `pos_hr` allows to switch between cashiers (`hr.employee`) during the
same POS session. The current cashier is printed on receipt and saved in
backend. The story becomes more complicated if order is created by one
cashier (e.g. Mitchel Admin), but validated by another (e.g. Mark Demo). In that
case both receipt and backend must show the cashier who validated the
order (i.e. Mark Demo). However, it wasn't the case before this patch: the receipt got Mark
Demo as cashier and Mitchel Admin was saved in backend.

Fix it by updating employee value on order validation.

opw-2855234

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
