### PR TITLE
[FIX] website_sale: allow calling _cart_update when product is already

### DIFF
--- a/addons/website_sale/models/sale_order.py
+++ b/addons/website_sale/models/sale_order.py
@@ -160,7 +160,7 @@ class SaleOrder(models.Model):
         product_with_context = self.env['product.product'].with_context(product_context)
         product = product_with_context.browse(int(product_id)).exists()
 
-        if not product or not product._is_add_to_cart_allowed():
+        if not product or (not line_id and not product._is_add_to_cart_allowed()):
             raise UserError(_("The given product does not exist therefore it cannot be added to cart."))
 
         try:

--- a/addons/website_sale/tests/test_website_sale_cart.py
+++ b/addons/website_sale/tests/test_website_sale_cart.py
@@ -47,3 +47,19 @@ class WebsiteSaleCart(SavepointCase):
         with self.assertRaises(UserError):
             with MockRequest(product.with_user(self.public_user).env, website=self.website.with_user(self.public_user)):
                 self.WebsiteSaleController.cart_update_json(product_id=product.id, add_qty=1)
+
+    def test_update_pricelist_with_invalid_product(self):
+        product = self.env['product.product'].create({
+            'name': 'Test Product',
+        })
+
+        # Should not raise an exception
+        website = self.website.with_user(self.public_user)
+        with MockRequest(product.with_user(self.public_user).env, website=website):
+            order = website.sale_get_order(force_create=True)
+            order.write({
+                'order_line': [(0, 0, {
+                    'product_id': product.id,
+                })]
+            })
+            website.sale_get_order(update_pricelist=True)


### PR DESCRIPTION
in cart

Due to a recent change in eCommerce the products that can be added to
the cart have been more restricted.
However some modules, for example sale_coupon, add some lines regardless
of those rules.
This commit allows these lines to be kept when there is a pricelist
change.
