### PR TITLE
[FIX] Tax lines reset when editing tax values or tax groups in V13 and V14

### DIFF
--- a/addons/account/models/account_move.py
+++ b/addons/account/models/account_move.py
@@ -991,10 +991,23 @@ class AccountMove(models.Model):
         '''
         for invoice in self:
             # Dispatch lines and pre-compute some aggregated values like taxes.
+
+            # determine required tax_lines by finding all non-zero tax amounts
+            lines_with_taxes = invoice.line_ids.filtered(
+                lambda l: l.tax_ids and l.move_id.currency_id.compare_amounts(l.price_subtotal, l.price_total))
+
+            needed_taxes = lines_with_taxes.tax_ids._origin.flatten_taxes_hierarchy().filtered(
+                lambda tax: (
+                        tax.amount_type == 'fixed' and not invoice.company_id.currency_id.is_zero(tax.amount)
+                        or not float_is_zero(tax.amount, precision_digits=4)
+                )
+            )
+            current_taxes = invoice.line_ids.tax_line_id._origin
+
             if (
                 recompute_all_taxes
                 or any(line.recompute_tax_line for line in invoice.line_ids)
-                or invoice.line_ids.tax_ids.flatten_taxes_hierarchy()._origin > invoice.line_ids.tax_line_id._origin
+                or needed_taxes > current_taxes
             ):
                 invoice.line_ids.recompute_tax_line = False
                 invoice._recompute_tax_lines()

--- a/addons/account/tests/test_account_move_in_invoice.py
+++ b/addons/account/tests/test_account_move_in_invoice.py
@@ -2008,3 +2008,43 @@ class TestAccountMoveInInvoiceOnchanges(AccountTestInvoicingCommon):
 
         # Assert the tax line is recreated for the tax
         self.assertIn(tax, self.invoice.line_ids.tax_line_id)
+
+    def test_bill_amount_should_be_editable(self):
+        tax0 = self.env['account.tax'].create({
+            'name': 'test_tax_0',
+            'amount_type': 'percent',
+            'amount': 0.0,
+            'type_tax_use': 'purchase',
+        })
+        invoice_form = Form(self.env['account.move'].with_context(default_type='in_invoice'))
+        invoice_form.partner_id = self.partner_a
+        # Both 15% default tax and 0% tax, will have only one tax line for the 15%
+        with invoice_form.invoice_line_ids.new() as line:
+            line.name = 'test_line_1'
+            line.account_id = self.company_data['default_account_expense']
+            line.tax_ids.add(tax0)
+            line.price_unit = 200.0
+        # only the default 15% tax is set
+        with invoice_form.invoice_line_ids.new() as line:
+            line.name = 'test_line_2'
+            line.account_id = self.company_data['default_account_expense']
+            line.price_unit = 100.0
+        # no tax because of zero price
+        with invoice_form.invoice_line_ids.new() as line:
+            line.name = 'test_line_3'
+            line.account_id = self.company_data['default_account_expense']
+            line.price_unit = 0.0
+
+        invoice = invoice_form.save()
+
+        # mimic the behavior editing taxes with `tax_group_widget`
+        with invoice_form:
+            with invoice_form.line_ids.edit(0) as tax_line_form:
+                tax_line_form.debit = 500.0
+
+        # make sure taxes are not recompute
+        self.assertRecordValues(invoice.line_ids.filtered(lambda line: line.tax_line_id),
+                                [{
+                                    'debit': 500,
+                                    'tax_line_id': self.company_data['default_tax_purchase'].id,
+                                }])


### PR DESCRIPTION


Before this fix, when there is a 0% tax in an invoice/bill, the taxes recalculate everytime anything changes,
this will reset edits on taxes (specially manual edit of total taxes are wiped)

Task: 2859732






--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
