### PR TITLE
[FIX] crm, project: fixing some non-total order

### DIFF
--- a/addons/crm/models/crm_lead.py
+++ b/addons/crm/models/crm_lead.py
@@ -908,7 +908,7 @@ class Lead(models.Model):
         stage_ids = stages._search(search_domain, order=order, access_rights_uid=SUPERUSER_ID)
         return stages.browse(stage_ids)
 
-    def _stage_find(self, team_id=False, domain=None, order='sequence', limit=1):
+    def _stage_find(self, team_id=False, domain=None, order='sequence, id', limit=1):
         """ Determine the stage of the current lead with its teams, the given domain and the given team_id
             :param team_id
             :param domain : base search domain for stage
@@ -1401,7 +1401,7 @@ class Lead(models.Model):
 
         # check if the stage is in the stages of the Sales Team. If not, assign the stage with the lowest sequence
         if merged_data.get('team_id'):
-            team_stage_ids = self.env['crm.stage'].search(['|', ('team_id', '=', merged_data['team_id']), ('team_id', '=', False)], order='sequence')
+            team_stage_ids = self.env['crm.stage'].search(['|', ('team_id', '=', merged_data['team_id']), ('team_id', '=', False)], order='sequence, id')
             if merged_data.get('stage_id') not in team_stage_ids.ids:
                 merged_data['stage_id'] = team_stage_ids[0].id if team_stage_ids else False
 
@@ -1943,9 +1943,9 @@ class Lead(models.Model):
                 if field == 'stage_id' and value in won_stage_ids:
                     won_leads.add(lead_id)
                 leads_fields.add(field)
-
+        leads_fields = sorted(leads_fields)
         # get all variable related records from frequency table, no matter the team_id
-        frequencies = self.env['crm.lead.scoring.frequency'].search([('variable', 'in', list(leads_fields))], order="team_id asc")
+        frequencies = self.env['crm.lead.scoring.frequency'].search([('variable', 'in', list(leads_fields))], order="team_id asc, id")
 
         # get all team_ids from frequencies
         frequency_teams = frequencies.mapped('team_id')
@@ -2228,7 +2228,7 @@ class Lead(models.Model):
                 else:
                     lead_frequency_values[field] = value
             leads_frequency_values_by_team[team_id].append(lead_frequency_values)
-        leads_pls_fields = list(leads_pls_fields)
+        leads_pls_fields = sorted(leads_pls_fields)
 
         # get new frequencies
         new_frequencies_by_team = {}
@@ -2337,7 +2337,7 @@ class Lead(models.Model):
         :return: won count, lost count and total count for all records in frequencies
         """
         # TODO : check if we need to handle specific team_id stages [for lost count] (if first stage in sequence is team_specific)
-        first_stage_id = self.env['crm.stage'].search([('team_id', '=', False)], order='sequence', limit=1)
+        first_stage_id = self.env['crm.stage'].search([('team_id', '=', False)], order='sequence, id', limit=1)
         if str(first_stage_id.id) not in team_results.get('stage_id', []):
             return 0, 0, 0
         stage_result = team_results['stage_id'][str(first_stage_id.id)]
@@ -2351,7 +2351,7 @@ class Lead(models.Model):
         pls_fields = leads_pls_fields.copy()
         frequencies = dict((field, {}) for field in pls_fields)
 
-        stage_ids = self.env['crm.stage'].search_read([], ['sequence', 'name', 'id'], order='sequence')
+        stage_ids = self.env['crm.stage'].search_read([], ['sequence', 'name', 'id'], order='sequence, id')
         stage_sequences = {stage['id']: stage['sequence'] for stage in stage_ids}
 
         # Increment won / lost frequencies by criteria (field / value couple)
@@ -2432,7 +2432,7 @@ class Lead(models.Model):
             self.flush(['probability'])
             query = """SELECT id, probability, %s
                         FROM %s
-                        WHERE %s order by team_id asc"""
+                        WHERE %s order by team_id asc, id desc"""
             query = sql.SQL(query % (str_fields, from_clause, where_clause)).format(*args)
             self._cr.execute(query, where_params)
             lead_results = self._cr.dictfetchall()
@@ -2443,7 +2443,7 @@ class Lead(models.Model):
                             FROM %s
                             LEFT JOIN crm_tag_rel rel ON crm_lead.id = rel.lead_id
                             LEFT JOIN crm_tag t ON rel.tag_id = t.id
-                            WHERE %s order by crm_lead.team_id asc"""
+                            WHERE %s order by crm_lead.team_id asc, crm_lead.id"""
                 args.append(sql.Identifier('tag_id'))
                 query = sql.SQL(query % (from_clause, where_clause)).format(*args)
                 self._cr.execute(query, where_params)

--- a/addons/project/models/project.py
+++ b/addons/project/models/project.py
@@ -1537,7 +1537,7 @@ class Task(models.Model):
     # Case management
     # ----------------------------------------
 
-    def stage_find(self, section_id, domain=[], order='sequence'):
+    def stage_find(self, section_id, domain=[], order='sequence, id'):
         """ Override of the base.stage method
             Parameter of the stage search taken from the lead:
             - section_id: if set, stages must belong to this section or


### PR DESCRIPTION
Non total order can lead to randomized order in some case, making some
test behaviour random and/or difficult to debug.

Adding some fallback 'id' order shouldn't hurt