### PR TITLE
[FIX] (test_)sale(_product_configurators): fix nightly race condition

### DIFF
--- a/addons/sale/static/tests/tours/sale_signature.js
+++ b/addons/sale/static/tests/tours/sale_signature.js
@@ -46,6 +46,15 @@ tour.register('sale_signature', {
     {
         content: "check it's confirmed",
         trigger: '#quote_content:contains("Thank You")',
+    }, {
+        trigger: '#quote_content',
+        run: function () {
+            window.location.href = window.location.origin + '/web';
+        },  // Avoid race condition at the end of the tour by returning to the home page.
     },
+    {
+        trigger: 'nav',
+        run: function() {},
+    }
 ]);
 });

--- a/addons/test_sale_product_configurators/static/tests/tours/product_configurator_edition_ui.js
+++ b/addons/test_sale_product_configurators/static/tests/tours/product_configurator_edition_ui.js
@@ -142,4 +142,12 @@ tour.register('sale_product_configurator_edition_tour', {
     trigger: 'td.o_data_cell:contains("tour success")',
     extra_trigger: 'div[name="order_line"]',
     run: function (){}
+}, {
+    trigger: 'td.o_data_cell',
+    run: function () {
+        window.location.href = window.location.origin + '/web';
+    },  // Avoid race condition at the end of the tour by returning to the home page.
+}, {
+    trigger: '.o_navbar',
+    run: function() {},  // Check the home page is loaded
 }]);

--- a/addons/test_sale_product_configurators/static/tests/tours/product_configurator_single_custom_attribute_ui.js
+++ b/addons/test_sale_product_configurators/static/tests/tours/product_configurator_single_custom_attribute_ui.js
@@ -57,4 +57,12 @@ tour.register('sale_product_configurator_single_custom_attribute_tour', {
     run: function () {
         //check
     }
+}, {
+    trigger: '.configurator_container',
+    run: function () {
+        window.location.href = window.location.origin + '/web';
+    }
+}, {
+    trigger: '.o_navbar',
+    run: function() {},  // Check the home page is loaded
 }]);


### PR DESCRIPTION
Fix some uncommon nightly error on the runbot where a race condition
happened when the tour finished too soon. The test is successful but
during the browser cleanup, things are still happening.

task-2832564

See also:
- https://github.com/odoo/enterprise/pull/27600
