### PR TITLE
[FIX] expense: reset amount when product has no predefined cost

### DIFF
--- a/addons/hr_expense/models/hr_expense.py
+++ b/addons/hr_expense/models/hr_expense.py
@@ -297,6 +297,12 @@ class HrExpense(models.Model):
         self.analytic_account_id = self.analytic_account_id or rec.analytic_id.id
         self.analytic_tag_ids = self.analytic_tag_ids or rec.analytic_tag_ids.ids
 
+    @api.onchange('product_id')
+    def _onchange_product_id(self):
+        if not (self.product_id and self.product_has_cost):
+            # reset to zero to invite user to input the value
+            self.total_amount = 0
+
     @api.constrains('product_id', 'product_uom_id')
     def _check_product_uom_category(self):
         for expense in self:


### PR DESCRIPTION
Odoo v15 allows user to input total amount manually. To avoid user confusion, we
must reset value to zero on switching from fixed price product to a custom price.

This patch is a fine-tuning of a previous fix about expense taxes: https://github.com/odoo/odoo/commit/7cdaf331934fed6516c8405145b76a61eece254b

opw-2856201