### PR TITLE
[FIX] web_editor: avoid flicker when browsing through items images

### DIFF
--- a/addons/web_editor/static/src/js/editor/snippets.options.js
+++ b/addons/web_editor/static/src/js/editor/snippets.options.js
@@ -4972,6 +4972,7 @@ const ImageHandlerOption = SnippetOptionWidget.extend({
         weightEl.classList.add('o_we_image_weight', 'o_we_tag', 'd-none');
         weightEl.title = _t("Size");
         this.$weight = $(weightEl);
+        await this._applyOptions(false);
     },
 
     //--------------------------------------------------------------------------


### PR DESCRIPTION
Since [1] when selecting item images, the 'Blocks' tab is displayed
while the options are refreshed. This is visible because the image
selection awaits an RPC which therefore allows the browser to render
the 'Blocks' tab selected version of the display.

This commit prevents the return to the 'Blocks' tab to be rendered by
waiting for the image info to be obtained on start.

Steps to reproduce:
- Drop an "Items" block.
- Click on an image.
- Click on another image.
=> The options panel flickers on the 'Blocks' tab before showing the
second image's options.

[1]: https://github.com/odoo/odoo/commit/0acc5e784b15d9c963660da3781763448503f33e

task-2821398

Co-authored-by: Benoit Socias <bso@odoo.com>