### PR TITLE
[IMP] base{_import}: warns user when importing data in the wrong lang

### DIFF
--- a/addons/base_import/static/src/legacy/scss/base_import.scss
+++ b/addons/base_import/static/src/legacy/scss/base_import.scss
@@ -136,6 +136,15 @@
             @extend .text-danger;
         }
     }
+    .oe_import_lang_warn {
+        a {
+            text-decoration: underline;
+        }
+        a:hover {
+            cursor:pointer;
+            text-decoration: underline;
+        }
+    }
 
     /* ------------- THE CSV TABLE ------------ */
 

--- a/addons/base_import/static/src/legacy/xml/base_import.xml
+++ b/addons/base_import/static/src/legacy/xml/base_import.xml
@@ -225,7 +225,12 @@
                 <span class="o_import_partial_count">0</span>.<br/>
                 You can test or reload your file before resuming the import.
             </div>
-            <div class="oe_import_error_report px-3 py-2"></div>
+            <div class="oe_import_lang_warn alert alert-warning d-none mx-3 my-1 font-weight-bold">
+                The file you are trying to import seems to be in another language
+                (<span class="oe_import_lang_warn_lang"></span>), labels and values may not match.
+                Try <a class="oe_import_lang_warn_action_change_lang">switching to that language</a>.
+            </div>
+            <div class="oe_import_error_report px-3"></div>
             <div class="table-responsive">
                 <table class="table-striped oe_import_grid w-100 overflow-hidden" />
             </div>

--- a/odoo/addons/base/tests/__init__.py
+++ b/odoo/addons/base/tests/__init__.py
@@ -22,6 +22,7 @@ from . import test_ir_mail_server
 from . import test_ir_model
 from . import test_ir_sequence
 from . import test_ir_sequence_date_range
+from . import test_ir_translation
 from . import test_ir_default
 from . import test_mail
 from . import test_menu

--- a/odoo/addons/base/tests/test_ir_translation.py
+++ b/odoo/addons/base/tests/test_ir_translation.py
@@ -1,0 +1,126 @@
+from odoo.tests.common import TransactionCase
+
+
+class TestIrTranslation(TransactionCase):
+    def _assert_detected_lang(self, descr, terms, lg_code_expected, term_ratio_expected=1.):
+        """Execute ir_translation._guess_language_of_terms on the provided terms and asserts that:
+
+        - the detected language is lg_code_expected
+        - the term_ratio is term_ratio_expected with precision of 2 digits
+        :param str descr: test description that will be outputted when an assertion fails
+        :param list(str) terms: list of terms for the language detection
+        :param str lg_code_expected: expected language code to be detected
+        :param float term_ratio_expected: expected term ratio of the detection
+        """
+        actual_lang_code, actual_term_ratio = self.env['ir.translation']._guess_language_of_terms(terms)
+        self.assertEqual(actual_lang_code, lg_code_expected,
+                         f'[{descr}] Expected {lg_code_expected} for terms {terms} but got {actual_lang_code}')
+        self.assertAlmostEqual(
+            term_ratio_expected, actual_term_ratio,
+            msg=f'[{descr}] Ratio ({actual_term_ratio})!={term_ratio_expected} for terms {terms} ({lg_code_expected})',
+            places=2)
+
+    @staticmethod
+    def _transform(terms, transformations):
+        """Transform the terms with the provided transformations
+
+        :param list(str) terms: terms to transform
+        :param list(str) transformations: transformations to apply among upper, lower and spaces
+        :return: transformed terms
+        """
+        if not transformations:
+            return terms
+        for transformation in transformations:
+            if transformation == 'upper':
+                terms = [term.upper() for term in terms]
+            elif transformation == 'lower':
+                terms = [term.lower() for term in terms]
+            elif transformation == 'spaces':
+                terms = [f'  {term.lower()}  ' for term in terms]
+            else:
+                raise NotImplementedError(f'Transformation {transformation} not implemented')
+        return terms
+
+    @staticmethod
+    def _translate_and_transform(trans_by_lg_code, lang_code, terms, transformations=None):
+        """Translate and transform terms
+
+        :param dict trans_by_lg_code: translation mappings (lang_code -> src -> translated_term)
+        :param str lang_code: target language of the translation
+        :param list(str) terms: terms to translate (in en_US contained in trans_by_lg_code as src)
+        :param transformations: transformation to apply (see _transform)
+        """
+        translated_terms = terms
+        if lang_code in trans_by_lg_code:
+            translations = trans_by_lg_code[lang_code]
+            translated_terms = {translations.get(term, term) for term in terms}
+        return TestIrTranslation._transform(translated_terms, transformations)
+
+    def test_guess_language_of_terms(self):
+        """Test the detection of the language based on terms present in the table ir.translation."""
+        Cls = TestIrTranslation
+        IrTranslation = self.env['ir.translation']
+        ResLang = self.env['res.lang']
+        trans_by_lg_code = {
+            'fr_BE': {
+                'Confirm': 'Confirmer',
+                'Cancel': 'Annuler',
+                'Ok': 'Ok',
+                'email': 'e-mail',
+            },
+            'nl_BE': {
+                'Confirm': 'Bevestigen',
+                'Validate': 'Bevestigen',  # Twice "Bevestigen" to test that it is counted only once
+                'Cancel': 'Annuleren',
+                'Ok': 'Ok',
+                'email': 'e-mail',
+            }
+        }
+        # Activate tested language
+        for lg_code in trans_by_lg_code:
+            lang = ResLang.search([('code', '=', lg_code), ('active', '!=', True)])
+            if lang:
+                lang.action_unarchive()
+        # Remove all model translation to avoid interference with the test
+        self.env['ir.translation'].search([('type', '=', 'model')]).unlink()
+        # Create specific translation for the test
+        IrTranslation.create([
+            {
+                'name': 'ir.model.fields,field_description',
+                'lang': lg_code,
+                'src': src,
+                'value': value,
+                'type': 'model',
+            }
+            for lg_code, translations in trans_by_lg_code.items() for src, value in translations.items()
+        ])
+
+        for transformations in [None, ['lower'], ['upper'], ['upper', 'spaces']]:
+            for lang_code in trans_by_lg_code:
+                self._assert_detected_lang(
+                    f'All terms in {lang_code} ({transformations})',
+                    Cls._translate_and_transform(trans_by_lg_code, lang_code, ['Confirm', 'Cancel'],
+                                                 transformations=transformations),
+                    lang_code)
+                self._assert_detected_lang(
+                    f'2/3 in {lang_code} ({transformations})',
+                    Cls._translate_and_transform(trans_by_lg_code, lang_code, ['Confirm', 'Cancel', 'NonExists'],
+                                                 transformations=transformations),
+                    lang_code, term_ratio_expected=0.67)
+            self._assert_detected_lang(f'Mixed languages ({transformations})',
+                                       Cls._transform(['Confirm', 'Confirmer', 'Bevestigen', 'Annuleren'],
+                                                      transformations),
+                                       'nl_BE', term_ratio_expected=0.5)
+            self._assert_detected_lang(
+                f'Shared terms between language with 1 word to decide between languages ({transformations})',
+                Cls._transform(['Ok', 'e-mail', 'Bevestigen'], transformations),
+                'nl_BE')
+            self._assert_detected_lang(
+                f'Mixed languages (base language, {transformations})',
+                Cls._transform(['Confirm', 'Confirmer', 'Bevestigen', 'Cancel'], transformations),
+                'en_US', term_ratio_expected=0.5)
+            self._assert_detected_lang(
+                f'Shared terms between language with one word to decide between languages (base lg, {transformations})',
+                Cls._transform(['Ok', 'email'], transformations),
+                'en_US')
+        self.assertEqual(IrTranslation._guess_language_of_terms(['NonExists1', 'NonExists2'])[0], None)


### PR DESCRIPTION
Warns the user when the matching of the import is only partial and that the
detected language of the file imported is different than the user configured
language. Indeed, the matching is done in the user configured language but the
user often doesn't realize that's the cause. This warning will help the user to
identify the cause more easily.

Technical note:
- the detection of the language of the imported file is based on the
translation in the table ir_translation. It will only succeed if the terms used
in the imported file are present in that table. As the exportation is based on
that table, it should be often the case.
- the detection uses a query based on a field which is not indexed but it is
done in one query (for all terms ~ header of the file imported) and limited
to the model type (which is indexed)

Task-2858014

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
