### PR TITLE
[14.0][FIX] sale.order.line _compute_analytic_tag_ids recursion

### DIFF
--- a/addons/sale/models/sale.py
+++ b/addons/sale/models/sale.py
@@ -1609,7 +1609,7 @@ class SaleOrderLine(models.Model):
 
     @api.depends('product_id', 'order_id.date_order', 'order_id.partner_id')
     def _compute_analytic_tag_ids(self):
-        for line in self:
+        for line in self.exists():
             if not line.analytic_tag_ids:
                 default_analytic_account = line.env['account.analytic.default'].sudo().account_get(
                     product_id=line.product_id.id,


### PR DESCRIPTION
**Description of the issue/feature this PR addresses:**
To do it simpler, just open an Odoo shell.
Try to delete some SO (with lines): `env['sale.order'].search([('state', '=', 'draft')], limit=100).unlink()`.
You'll have a traceback due to max recursion depth with Python.
It's because on `sale.order.line`, the field `order_id` has `ondelete="cascade"` so the delete of these lines is done on Postgres side.
So when the recompute is triggered, lines don't exist anymore.

And the `if` part [here](https://github.com/odoo/odoo/blame/b9355299ca33710a265eb9386f3c71a6b6e4e560/addons/sale/models/sale.py#L1613) trigger the infinie loop.

**Current behavior before PR:**
Traceback due to infinite loop/recursion

**Desired behavior after PR is merged:**
No infinite loop/recursion.

Ticket number: #2859995


--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
