### PR TITLE
[IMP] web: CP add custom placeholder by namespace

### DIFF
--- a/addons/knowledge/static/src/webclient/commands/knowledge_providers.js
+++ b/addons/knowledge/static/src/webclient/commands/knowledge_providers.js
@@ -25,6 +25,7 @@ commandSetupRegistry.add("?", {
     debounceDelay: 200,
     emptyMessage: _lt("No article found."),
     name: _lt("articles"),
+    placeholder: _lt("Search for an article..."),
 });
 
 const commandProviderRegistry = registry.category("command_provider");

--- a/addons/mail/static/src/webclient/commands/mail_providers.js
+++ b/addons/mail/static/src/webclient/commands/mail_providers.js
@@ -18,11 +18,13 @@ commandSetupRegistry.add("@", {
     debounceDelay: 200,
     emptyMessage: _lt("No user found"),
     name: _lt("users"),
+    placeholder: _lt("Search for a user..."),
 });
 commandSetupRegistry.add("#", {
     debounceDelay: 200,
     emptyMessage: _lt("No channel found"),
     name: _lt("channels"),
+    placeholder: _lt("Search for a channel..."),
 });
 
 const commandProviderRegistry = registry.category("command_provider");

--- a/addons/web/static/src/core/commands/command_palette.js
+++ b/addons/web/static/src/core/commands/command_palette.js
@@ -39,6 +39,7 @@ const FUZZY_NAMESPACES = ["default"];
  *  categories: string[];
  *  debounceDelay: number;
  *  emptyMessage: string;
+ *  placeholder: string;
  * }} NamespaceConfig
  */
 
@@ -46,7 +47,6 @@ const FUZZY_NAMESPACES = ["default"];
  * @typedef {{
  *  configByNamespace?: {[namespace]: NamespaceConfig};
  *  FooterComponent?: Component;
- *  placeholder?: string;
  *  providers: Provider[];
  *  searchValue?: string;
  * }} CommandPaletteConfig
@@ -138,7 +138,6 @@ export class CommandPalette extends Component {
     async setCommandPaletteConfig(config) {
         this.configByNamespace = config.configByNamespace || {};
         this.state.FooterComponent = config.FooterComponent;
-        this.state.placeholder = config.placeholder || DEFAULT_PLACEHOLDER.toString();
 
         this.providersByNamespace = { default: [] };
         for (const provider of config.providers) {
@@ -320,6 +319,7 @@ export class CommandPalette extends Component {
             namespaceConfig.debounceDelay || 0
         );
         this.state.namespace = namespace;
+        this.state.placeholder = namespaceConfig.placeholder || DEFAULT_PLACEHOLDER.toString();
     }
 
     processSearchValue(searchValue) {

--- a/addons/web/static/src/core/commands/command_service.js
+++ b/addons/web/static/src/core/commands/command_service.js
@@ -99,7 +99,7 @@ export const commandService = {
 
             for (const [
                 namespace,
-                { emptyMessage, debounceDelay },
+                { emptyMessage, debounceDelay, placeholder },
             ] of commandSetupRegistry.getEntries()) {
                 if (namespace in configByNamespace) {
                     if (emptyMessage) {
@@ -108,6 +108,9 @@ export const commandService = {
                     if (debounceDelay !== undefined) {
                         configByNamespace[namespace].debounceDelay = debounceDelay;
                     }
+                    if (placeholder) {
+                        configByNamespace[namespace].placeholder = placeholder;
+                    }
                 }
             }
 
@@ -115,7 +118,6 @@ export const commandService = {
                 {
                     configByNamespace,
                     FooterComponent: DefaultFooter,
-                    placeholder: env._t("Search for a command..."),
                     providers: commandProviderRegistry.getAll(),
                 },
                 config

--- a/addons/web/static/src/core/commands/default_providers.js
+++ b/addons/web/static/src/core/commands/default_providers.js
@@ -13,6 +13,7 @@ const { Component } = owl;
 const commandSetupRegistry = registry.category("command_setup");
 commandSetupRegistry.add("default", {
     emptyMessage: _lt("No command found"),
+    placeholder: _lt("Search for a command..."),
 });
 
 export class HotkeyCommandItem extends Component {

--- a/addons/web/static/src/core/debug/debug_menu.js
+++ b/addons/web/static/src/core/debug/debug_menu.js
@@ -42,12 +42,12 @@ export class DebugMenu extends DebugMenuBasic {
                 const configByNamespace = {
                     default: {
                         categories: defaultCategories,
-                        emptyMessage: this.env._t("No command found"),
+                        emptyMessage: this.env._t("No debug command found"),
+                        placeholder: this.env._t("Choose a debug command..."),
                     },
                 };
                 const commandPaletteConfig = {
                     configByNamespace,
-                    placeholder: this.env._t("Choose a debug command..."),
                     providers: [provider],
                 };
                 return this.command.openPalette(commandPaletteConfig);

--- a/addons/web/static/src/webclient/menus/menu_providers.js
+++ b/addons/web/static/src/webclient/menus/menu_providers.js
@@ -18,6 +18,7 @@ const commandSetupRegistry = registry.category("command_setup");
 commandSetupRegistry.add("/", {
     emptyMessage: _lt("No menu found"),
     name: _lt("menus"),
+    placeholder: _lt("Search for a menu..."),
 });
 
 const commandProviderRegistry = registry.category("command_provider");

--- a/addons/web/static/tests/core/commands/command_palette_tests.js
+++ b/addons/web/static/tests/core/commands/command_palette_tests.js
@@ -262,9 +262,22 @@ QUnit.test("concurrency with custom debounce delay", async (assert) => {
 
 QUnit.test("custom placeholder", async (assert) => {
     await mount(TestComponent, target, { env });
+    const configByNamespace = {
+        default: {
+            placeholder: "default placeholder",
+        },
+        "@": {
+            placeholder: "@ placeholder",
+        },
+    };
     const config = {
-        placeholder: "placeholder test",
-        providers: [],
+        configByNamespace,
+        providers: [
+            {
+                namespace: "@",
+                provide: () => [],
+            },
+        ],
     };
     env.services.dialog.add(CommandPalette, {
         config,
@@ -275,7 +288,13 @@ QUnit.test("custom placeholder", async (assert) => {
     assert.containsOnce(target, ".o_command_palette_listbox_empty");
     assert.strictEqual(
         target.querySelector(".o_command_palette_search input").placeholder,
-        "placeholder test"
+        "default placeholder"
+    );
+
+    await editSearchBar("@");
+    assert.strictEqual(
+        target.querySelector(".o_command_palette_search input").placeholder,
+        "@ placeholder"
     );
 });
 
@@ -1179,6 +1198,7 @@ QUnit.test("multi level command", async (assert) => {
     const configByNamespace = {
         default: {
             emptyMessage: "Empty Default",
+            placeholder: "placeholder test",
         },
     };
     const commands = [
@@ -1199,7 +1219,6 @@ QUnit.test("multi level command", async (assert) => {
     const config = {
         configByNamespace,
         FooterComponent,
-        placeholder: "placeholder test",
         providers,
     };
     env.services.dialog.add(CommandPalette, {

--- a/addons/web/static/tests/core/commands/command_service_tests.js
+++ b/addons/web/static/tests/core/commands/command_service_tests.js
@@ -685,9 +685,13 @@ QUnit.test("multi level commands", async (assert) => {
     clearRegistryWithCleanup(commandProviderRegistry);
     const defaultNames = ["John", "Snow"];
     const otherNames = ["Cersei", "Lannister"];
-
+    const configByNamespace = {
+        default: {
+            placeholder: "Who is the next King ?",
+        },
+    };
     const action = () => ({
-        placeholder: "Who is the next King ?",
+        configByNamespace,
         providers: [
             {
                 provide: () =>
@@ -753,8 +757,13 @@ QUnit.test("multi level commands with hotkey", async (assert) => {
     clearRegistryWithCleanup(commandProviderRegistry);
 
     const otherNames = ["Cersei", "Lannister"];
+    const configByNamespace = {
+        default: {
+            placeholder: "Who is the next King ?",
+        },
+    };
     const action = () => ({
-        placeholder: "Who is the next King ?",
+        configByNamespace,
         providers: [
             {
                 provide: () =>


### PR DESCRIPTION
This commit adds the possibility to have a custom placeholder in the
command palette depending on the namespace.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
