### PR TITLE
[IMP] web: search: domain evaluation uses action context

### DIFF
--- a/addons/web/static/src/legacy/js/control_panel/control_panel_model_extension.js
+++ b/addons/web/static/src/legacy/js/control_panel/control_panel_model_extension.js
@@ -429,7 +429,10 @@ odoo.define("web/static/src/js/control_panel/control_panel_model_extension.js", 
             const groups = this._getGroups();
             const userContext = this.env.session.user_context;
             try {
-                return Domain.prototype.stringToArray(this._getDomain(groups), userContext);
+                return Domain.prototype.stringToArray(
+                    this._getDomain(groups),
+                    Object.assign({}, this.actionContext, userContext)
+                );
             } catch (err) {
                 throw new Error(
                     `${this.env._t("Control panel model extension failed to evaluate domain")}:/n${JSON.stringify(err)}`

--- a/addons/web/static/src/search/search_model.js
+++ b/addons/web/static/src/search/search_model.js
@@ -1423,7 +1423,9 @@ export class SearchModel extends EventBus {
         let domain;
         try {
             domain = Domain.and(domains);
-            return params.raw ? domain : domain.toList(this.userService.context);
+            return params.raw ? domain : domain.toList(
+                Object.assign({}, this.globalContext, this.userService.context)
+            );
         } catch (error) {
             throw new Error(
                 `${this.env._t("Failed to evaluate the domain")} ${domain.toString()}.\n${

--- a/addons/web/static/tests/legacy/control_panel/control_panel_tests.js
+++ b/addons/web/static/tests/legacy/control_panel/control_panel_tests.js
@@ -281,5 +281,27 @@ odoo.define('web.control_panel_tests', function (require) {
                 "hasn't autofocused search field");
         });
 
+        QUnit.test("dynamic domains evaluation using global context", async function (assert) {
+            const arch = `
+                <search>
+                    <filter name="filter" domain="[('date_deadline', '&lt;', context.get('my_date'))]"/>
+                </search>
+            `;
+            const context = {
+                search_default_filter: true,
+                my_date: "2021-09-17",
+            };
+            const fields = this.fields;
+            const searchMenuTypes = ['filter'];
+            const controlPanel = await createControlPanel({
+                cpModelConfig: { arch, fields, searchMenuTypes, context },
+                cpProps: { fields, searchMenuTypes },
+            });
+            assert.deepEqual(
+                controlPanel.getQuery().domain,
+                [['date_deadline', '<', "2021-09-17"]]
+            );
+        });
+
     });
 });

--- a/addons/web/static/tests/search/search_model_tests.js
+++ b/addons/web/static/tests/search/search_model_tests.js
@@ -870,4 +870,23 @@ QUnit.module("Search", (hooks) => {
             model.toggleSearchItem(i + 1);
         }
     });
+
+    QUnit.test("dynamic domains evaluation using global context", async function (assert) {
+        const searchViewArch = `
+            <search>
+                <filter name="filter" domain="[('date_deadline', '&lt;', context.get('my_date'))]"/>
+            </search>
+        `;
+
+        const model = await makeSearchModel({
+            serverData,
+            searchViewArch,
+            context: {
+                "my_date": "2021-09-17"
+            }
+        });
+
+        model.toggleSearchItem(1);
+        assert.deepEqual(model.domain, [['date_deadline', '<', "2021-09-17"]]);
+    });
 });


### PR DESCRIPTION
It is now possible to get access to the action context keys when the
search filters are evaluated. This means that a search arch filter like

    <filter name="my_filter" domain="[('my_field', '=', context.get("my_value))]"/>

can be safely evaluated if "my_value" is in the action context (or in
the user context or is builtin as before).