### PR TITLE
[FIX] ir.ui.view: do not inline automatically form views

### DIFF
--- a/addons/web/static/tests/helpers/mock_server.js
+++ b/addons/web/static/tests/helpers/mock_server.js
@@ -303,7 +303,7 @@ export class MockServer {
                     !node.getAttribute("invisible")
                 ) {
                     const inlineViewTypes = Array.from(node.children).map((c) => c.tagName);
-                    const missingViewtypes = inlineViewTypes.includes("form") ? [] : ["form"];
+                    const missingViewtypes = [];
                     const mode = node.getAttribute("mode") || "kanban,tree";
                     if (!intersection(inlineViewTypes, mode.split(",")).length) {
                         // TODO: use a kanban view by default in mobile

--- a/odoo/addons/base/models/ir_ui_view.py
+++ b/odoo/addons/base/models/ir_ui_view.py
@@ -1173,8 +1173,6 @@ actual arch.
                     # in the main form view.
                     current_view_types = [el.tag for el in node.xpath("./*[descendant::field]")]
                     missing_view_types = []
-                    if 'form' not in current_view_types:
-                        missing_view_types.append('form')
                     if not any(view_type in current_view_types for view_type in node.get('mode', 'kanban,tree').split(',')):
                         missing_view_types.append(
                             node.get('mode', 'kanban' if node_info.get('mobile') else 'tree').split(',')[0]


### PR DESCRIPTION
odoo/odoo#87522 introduced the concept to automatically
inline tree, kanban and form views under one2many/many2many fields
within form views.
The goal being for the web client to make less `get_views` calls.

However, currently, automatically inlined form views
under one2many/many2many fields leads
to more triggered onchanges than before,
triggering more field computations than before,
potentially leading to performance issues
as more fields are computed than before.
Besides,  they are not visible in the tree/kanban view
and their computation can therefore be considered useless.

At worst, it can even causes bugs, by triggering computation
in places they were not used / do not handle correctly,
as explained in
https://github.com/odoo/odoo/pull/87522#issuecomment-1132554918
odoo/odoo#91878

This revision reverts the behavior to automatically inline
form views, while keeping the inlining of kanban/tree views.

However, by reverting this, we re-introduce a limitation
of the web client behavior regarding onchanges,
explained in odoo/odoo#91935.

This is therefore not perfect,
but at least the previous behavior is back.

In the future, work will be done to re-introduce the automatically
inlined form view, while solving both issues:
 - Do not trigger more onchanges than necessary,
 - Solve the limitation of the web client shown in odoo/odoo#91935