### PR TITLE
[MERGE] knowledge: improve chatter usage and implementation after first user testing

### DIFF
--- a/addons/knowledge/models/knowledge_article.py
+++ b/addons/knowledge/models/knowledge_article.py
@@ -20,6 +20,7 @@ class Article(models.Model):
     _description = "Knowledge Article"
     _inherit = ['mail.thread', 'mail.activity.mixin']
     _order = "favorite_count, create_date desc, id desc"
+    _mail_post_access = 'read'
 
     active = fields.Boolean(default=True)
     name = fields.Char(string="Title", default=lambda self: _('New Article'), required=True, tracking=20)

--- a/addons/knowledge/models/knowledge_article.py
+++ b/addons/knowledge/models/knowledge_article.py
@@ -1413,6 +1413,15 @@ class Article(models.Model):
     # MAILING
     # ------------------------------------------------------------
 
+    def _mail_track(self, tracked_fields, initial):
+        changes, tracking_value_ids = super(Article, self)._mail_track(tracked_fields, initial)
+        if {'parent_id', 'root_article_id'} & changes and not self.user_has_write_access:
+            partner_name = self.env.user.partner_id.display_name
+            message_body = _("Logging changes from %(partner_name)s without write access on article %(article_name)s due to hierarchy tree update",
+                partner_name=partner_name, article_name=self.display_name)
+            self._track_set_log_message("<p>%s</p>" % message_body)
+        return changes, tracking_value_ids
+
     def _send_invite_mail(self, partners):
         # TDE NOTE: try to cleanup and batchize
         self.ensure_one()

--- a/addons/knowledge/static/src/js/knowledge_controller.js
+++ b/addons/knowledge/static/src/js/knowledge_controller.js
@@ -19,7 +19,6 @@ const KnowledgeArticleFormController = FormController.extend({
         'click i.o_toggle_favorite': '_onToggleFavorite',
         'input .o_breadcrumb_article_name': '_adjustInputSize',
     }),
-
     custom_events: Object.assign({}, FormController.prototype.custom_events, {
         create: '_onCreate',
         duplicate: '_onDuplicate',
@@ -28,7 +27,6 @@ const KnowledgeArticleFormController = FormController.extend({
         reload_tree: '_onReloadTree',
         emoji_click: '_onEmojiClick',
     }),
-
     /**
      * Register the fact that the current @see FormController is one from
      * Knowledge in order not to try and search for a matching record for
@@ -50,14 +48,28 @@ const KnowledgeArticleFormController = FormController.extend({
         this._super.apply(this, arguments);
         this.onFieldSavedListeners = new Map();
     },
-
+    /**
+     * @override
+     */
+    saveRecord: async function () {
+        const modifiedFields = await this._super(...arguments);
+        const { data } = this.model.get(this.handle);
+        for (const field of modifiedFields) {
+            if (this.onFieldSavedListeners.has(field)) {
+                this.onFieldSavedListeners.get(field).forEach(listener => {
+                    listener.call(this, data[field]);
+                });
+            }
+        }
+        return modifiedFields;
+    },
     /**
      * @override
      * @returns {Promise}
      */
     start: function () {
         return this._super.apply(this, arguments).then(() => {
-            this.onFieldSaved('icon', unicode => {
+            this._onFieldSaved('icon', unicode => {
                 const { id } = this.getState();
                 this.renderer._setEmoji(id, unicode);
             });
@@ -66,6 +78,18 @@ const KnowledgeArticleFormController = FormController.extend({
 
     // Listeners:
 
+    /**
+     * @param {Event} event
+     */
+    _adjustInputSize: function (event) {
+        event.target.setAttribute('size', event.target.value.length);
+    },
+    _onAddCover: async function() {
+        if (this.mode === 'readonly') {
+            await this._setMode('edit');
+        }
+        this.$('.o_input_file').click();
+    },
     _onAddRandomIcon: function() {
         this.trigger_up('field_changed', {
             dataPointID: this.handle,
@@ -74,50 +98,13 @@ const KnowledgeArticleFormController = FormController.extend({
             }
         });
     },
-
-    _onAddCover: async function() {
-        if (this.mode === 'readonly') {
-            await this._setMode('edit');
-        }
-        this.$('.o_input_file').click();
-    },
-
-    /**
-     * When the user clicks on a field in readonly mode, a new 'quick_edit' event
-     * will be triggered. To prevent the view from switching to the edit mode when
-     * the article is locked, we will overwrite the `_onQuickEdit` handler. This
-     * function will now ignore the event if the article is locked.
-     * @override
-     */
-    _onQuickEdit: function () {
-        const { data } = this.model.get(this.handle);
-        if (data.is_locked) {
-            return;
-        }
-        this._super.apply(this, arguments);
-    },
-
-    /**
-     * Callback function called when the user renames the active article.
-     * The function will update the name of the articles in the aside block.
-     * @param {Event} event
-     */
-    _onRename: async function (event) {
-        var name = event.currentTarget.value;
-        if (name.length === 0) {
-            name = _t('New Article');
-        }
-        const id = await this._getId();
-        await this._rename(id, name);
-    },
-
     /**
      * When the user clicks on the name of the article, checks if the article
      * name hasn't been set yet. If it hasn't, it will look for a title in the
      * body of the article and set it as the name of the article.
      * @param {Event} event
      */
-     _onArticleBreadcrumbClick: async function (event) {
+    _onArticleBreadcrumbClick: async function (event) {
         const name = event.currentTarget.value;
         if (name === _t('New Article')) {
             const $articleTitle = this.$('.o_knowledge_editor h1');
@@ -133,14 +120,12 @@ const KnowledgeArticleFormController = FormController.extend({
             }
         }
     },
-
     /**
-     * @param {Event} event
+     * @param {OdooEvent} event
      */
-    _adjustInputSize: function (event) {
-        event.target.setAttribute('size', event.target.value.length);
+    _onCreate: async function (event) {
+        await this._create(event.data);
     },
-
     /**
      * @param {OdooEvent} event
      */
@@ -151,21 +136,78 @@ const KnowledgeArticleFormController = FormController.extend({
             additional_context: { res_id }
         });
     },
-
     /**
-     * @param {OdooEvent} event
+     * @param {Event} event
      */
-    _onCreate: async function (event) {
-        await this._create(event.data);
+    _onEmojiClick: async function (event) {
+        const { id } = this.getState();
+        const { articleId, unicode } = event.data;
+        if (articleId === id) {
+            this.trigger_up('field_changed', {
+                dataPointID: this.handle,
+                changes: {
+                    icon: unicode
+                }
+            });
+        } else {
+            const result = await this._rpc({
+                model: 'knowledge.article',
+                method: 'write',
+                args: [[articleId], { icon: unicode }],
+            });
+            if (result) {
+                this.renderer._setEmoji(articleId, unicode);
+            }
+        }
     },
-
+    /**
+     * @override
+     * @param {Event} event
+     */
+    _onFieldChanged: async function (event) {
+        this._super(...arguments);
+        const { changes } = event.data;
+        for (const field of this._getFieldsToForceSave()) {
+            if (changes.hasOwnProperty(field)) {
+                await this.saveRecord(this.handle, {
+                    reload: false,
+                    stayInEdit: true
+                });
+                return;
+            }
+        }
+    },
+    /**
+     * @param {String} name - field name
+     * @param {Function} callback
+     */
+    _onFieldSaved: function (name, callback) {
+        if (this.onFieldSavedListeners.has(name)) {
+            this.onFieldSavedListeners.get(name).push(callback);
+        } else {
+            this.onFieldSavedListeners.set(name, [callback]);
+        }
+    },
+    /**
+     * When the user clicks on a field in readonly mode, a new 'quick_edit' event
+     * will be triggered. To prevent the view from switching to the edit mode when
+     * the article is locked, we will overwrite the `_onQuickEdit` handler. This
+     * function will now ignore the event if the article is locked.
+     * @override
+     */
+    _onQuickEdit: function () {
+        const { data } = this.model.get(this.handle);
+        if (data.is_locked) {
+            return;
+        }
+        this._super.apply(this, arguments);
+    },
     /**
      * @param {Event} event
      */
     _onMove: function (event) {
         this._confirmMove(event.data);
     },
-
     /**
      * Opens the "Move To" modal
      * @param {OdooEvent} event
@@ -197,7 +239,6 @@ const KnowledgeArticleFormController = FormController.extend({
         });
         dialog.open();
     },
-
     /**
      * @param {Event} event
      */
@@ -205,7 +246,19 @@ const KnowledgeArticleFormController = FormController.extend({
         // TODO JBN: Create a widget for the tree and reload it without reloading the whole view.
         this.reload();
     },
-
+    /**
+     * Callback function called when the user renames the active article.
+     * The function will update the name of the articles in the aside block.
+     * @param {Event} event
+     */
+    _onRename: async function (event) {
+        var name = event.currentTarget.value;
+        if (name.length === 0) {
+            name = _t('New Article');
+        }
+        const id = await this._getId();
+        await this._rename(id, name);
+    },
     /**
      * @param {Event} event
      */
@@ -215,7 +268,6 @@ const KnowledgeArticleFormController = FormController.extend({
             searchValue: "?",
         });
     },
-
     /**
      * @param {Event} event
      */
@@ -237,68 +289,9 @@ const KnowledgeArticleFormController = FormController.extend({
             this.renderer._setTreeFavoriteListener();
             this.renderer._renderEmojiPicker($dom);
         });
-   },
-
-    /**
-     * @param {Event} event
-     */
-    _onEmojiClick: async function (event) {
-        const { id } = this.getState();
-        const { articleId, unicode } = event.data;
-        if (articleId === id) {
-            this.trigger_up('field_changed', {
-                dataPointID: this.handle,
-                changes: {
-                    icon: unicode
-                }
-            });
-        } else {
-            const result = await this._rpc({
-                model: 'knowledge.article',
-                method: 'write',
-                args: [[articleId], { icon: unicode }],
-            });
-            if (result) {
-                this.renderer._setEmoji(articleId, unicode);
-            }
-        }
     },
+
     // API calls:
-
-    /**
-     * @param {Object} data
-     * @param {String} data.category
-     * @param {integer} data.target_parent_id
-     */
-    _create: async function (data) {
-        const articleId = await this._rpc({
-            model: 'knowledge.article',
-            method: 'article_create',
-            args: [[]],
-            kwargs: {
-                is_private: data.category === 'private',
-                parent_id: data.target_parent_id ? data.target_parent_id : false
-            },
-        });
-        if (!articleId) {
-            return;
-        }
-        this.do_action('knowledge.ir_actions_server_knowledge_home_page', {
-            stackPosition: 'replaceCurrentAction',
-            additional_context: {
-                res_id: articleId
-            }
-        });
-    },
-
-    /**
-     * @param {integer} id - Target id
-     * @param {string} name - Target Name
-     */
-    _rename: async function (id, name) {
-        this.$(`.o_knowledge_tree .o_article[data-article-id="${id}"] > .o_article_handle > .o_article_name`).text(name);
-        this.$(`.o_breadcrumb_article_name`).val(name);
-    },
 
     /**
      * @param {Object} data
@@ -348,7 +341,48 @@ const KnowledgeArticleFormController = FormController.extend({
             });
         }
     },
-
+    /**
+     * @param {Object} data
+     * @param {String} data.category
+     * @param {integer} data.target_parent_id
+     */
+    _create: async function (data) {
+        const articleId = await this._rpc({
+            model: 'knowledge.article',
+            method: 'article_create',
+            args: [[]],
+            kwargs: {
+                is_private: data.category === 'private',
+                parent_id: data.target_parent_id ? data.target_parent_id : false
+            },
+        });
+        if (!articleId) {
+            return;
+        }
+        this.do_action('knowledge.ir_actions_server_knowledge_home_page', {
+            stackPosition: 'replaceCurrentAction',
+            additional_context: {
+                res_id: articleId
+            }
+        });
+    },
+    /**
+     * @returns {Array[String]}
+     */
+    _getFieldsToForceSave: function () {
+        return ['full_width', 'icon', 'cover'];
+    },
+    /**
+     * @returns {integer}
+     */
+    _getId: async function () {
+        let state = this.getState();
+        if (typeof state.id === 'undefined') {
+            await this.saveRecord(this.handle);
+            state = this.getState();
+        }
+        return state.id;
+    },
     /**
      * @param {Object} data
      * @param {integer} data.article_id
@@ -373,7 +407,14 @@ const KnowledgeArticleFormController = FormController.extend({
             data.onReject();
         })
     },
-
+    /**
+     * @param {integer} id - Target id
+     * @param {string} name - Target Name
+     */
+    _rename: async function (id, name) {
+        this.$(`.o_knowledge_tree .o_article[data-article-id="${id}"] > .o_article_handle > .o_article_name`).text(name);
+        this.$(`.o_breadcrumb_article_name`).val(name);
+    },
     /**
      * @param {integer} id - article id
      * @returns {Promise}
@@ -384,71 +425,6 @@ const KnowledgeArticleFormController = FormController.extend({
             method: 'action_toggle_favorite',
             args: [id]
         });
-    },
-
-    /**
-     * @returns {Array[String]}
-     */
-    _getFieldsToForceSave: function () {
-        return ['full_width', 'icon', 'cover'];
-    },
-
-    /**
-     * @override
-     * @param {Event} event
-     */
-    _onFieldChanged: async function (event) {
-        this._super(...arguments);
-        const { changes } = event.data;
-        for (const field of this._getFieldsToForceSave()) {
-            if (changes.hasOwnProperty(field)) {
-                await this.saveRecord(this.handle, {
-                    reload: false,
-                    stayInEdit: true
-                });
-                return;
-            }
-        }
-    },
-
-    /**
-     * @override
-     */
-    saveRecord: async function () {
-        const modifiedFields = await this._super(...arguments);
-        const { data } = this.model.get(this.handle);
-        for (const field of modifiedFields) {
-            if (this.onFieldSavedListeners.has(field)) {
-                this.onFieldSavedListeners.get(field).forEach(listener => {
-                    listener.call(this, data[field]);
-                });
-            }
-        }
-        return modifiedFields;
-    },
-
-    /**
-     * @param {String} name - field name
-     * @param {Function} callback
-     */
-    onFieldSaved: function (name, callback) {
-        if (this.onFieldSavedListeners.has(name)) {
-            this.onFieldSavedListeners.get(name).push(callback);
-        } else {
-            this.onFieldSavedListeners.set(name, [callback]);
-        }
-    },
-
-    /**
-     * @returns {integer}
-     */
-    _getId: async function () {
-        let state = this.getState();
-        if (typeof state.id === 'undefined') {
-            await this.saveRecord(this.handle);
-            state = this.getState();
-        }
-        return state.id;
     },
 });
 

--- a/addons/knowledge/static/src/js/knowledge_controller.js
+++ b/addons/knowledge/static/src/js/knowledge_controller.js
@@ -49,6 +49,19 @@ const KnowledgeArticleFormController = FormController.extend({
         this.onFieldSavedListeners = new Map();
     },
     /**
+     * If a reload is called with param 'keepChanges', only the chatter needs
+     * to be updated, no need for a full reload
+     *
+     * @override
+     */
+    reload: function (params) {
+        if (params && params.keepChanges) {
+            return this.renderer.updateChatter();
+        } else {
+            return this._super.apply(this, arguments);
+        }
+    },
+    /**
      * @override
      */
     saveRecord: async function () {

--- a/addons/knowledge/static/src/js/knowledge_renderers.js
+++ b/addons/knowledge/static/src/js/knowledge_renderers.js
@@ -46,6 +46,21 @@ const KnowledgeArticleFormRenderer = FormRenderer.extend(KnowledgeTreePanelMixin
         };
     },
     /**
+     * Called when the chatter triggers a reload on the Form view with the
+     * param 'keepChanges=true'. In this case, we only need to update the
+     * chatter.
+     *
+     * @returns {Promise}
+     */
+    updateChatter: function () {
+        if (this._chatterContainerComponent && this.state.res_id) {
+            const props = this._makeChatterContainerProps();
+            return this._chatterContainerComponent.update(props);
+        }
+        this._closeChatter();
+        return Promise.resolve();
+    },
+    /**
      * @private
      */
     _closeChatter: function () {

--- a/addons/knowledge/static/src/scss/knowledge_views.scss
+++ b/addons/knowledge/static/src/scss/knowledge_views.scss
@@ -178,6 +178,7 @@
         }
         .o_knowledge_chatter {
             border-left: 1px solid $border-color;
+            min-width: 400px;
         }
     }
 }

--- a/addons/knowledge/static/src/scss/knowledge_views.scss
+++ b/addons/knowledge/static/src/scss/knowledge_views.scss
@@ -129,14 +129,6 @@
         li.nav-item {
             display: none;
         }
-        .o_FormRenderer_chatterContainer {
-            max-width: unset;
-            &.o-aside {
-                width: auto;
-                padding: 1rem;
-                border: none;
-            }
-        }
     }
 
     .dropdown-menu.o_article_emoji_dropdown_panel {

--- a/addons/knowledge/views/knowledge_article_views.xml
+++ b/addons/knowledge/views/knowledge_article_views.xml
@@ -69,17 +69,17 @@
                                 </div>
                                 <!-- Buttons -->
                                 <div class="d-flex flex-shrink-0 align-items-center pr-2">
-                                    <a type="button" role="button" class="btn btn-secondary btn-create text-capitalize mr-1" data-hotkey="c">
+                                    <a type="button" role="button" class="btn btn-light btn-create text-capitalize mr-1" data-hotkey="c">
                                         <i class="fa fa-plus-circle"/> Create
                                     </a>
                                     <div class="btn-group" role="toolbar" aria-label="options">
                                         <div class="o-dropdown dropdown o-dropdown--no-caret">
-                                            <a type="button" role="button" class="btn btn-secondary btn-share dropdown-toggle mr-1"
+                                            <a type="button" role="button" class="btn btn-light btn-share dropdown-toggle mr-1"
                                                data-toggle="dropdown" aria-haspopup="true" aria-expanded="false" data-hotkey="s"
                                                attrs="{'invisible': [('id', '=', False)]}">
                                                 <i class="fa fa-share-alt"/> Share
                                             </a>
-                                            <a type="button" role="button" class="btn btn-secondary btn-chatter mr-1" data-hotkey="d"
+                                            <a type="button" role="button" class="btn btn-light btn-chatter mr-1" data-hotkey="d"
                                                 attrs="{'invisible': [('id', '=', False)]}">
                                                 <i class="rounded-circle text-center fa fa-comments" title="Open chatter"/>
                                             </a>
@@ -97,7 +97,7 @@
                                     </div>
                                     <div class="btn-group" role="toolbar" aria-label="options">
                                         <div class="o-dropdown dropdown o-dropdown--no-caret">
-                                            <a type="button" role="button" class="btn btn-secondary dropdown-toggle" data-toggle="dropdown"
+                                            <a type="button" role="button" class="btn btn-light dropdown-toggle" data-toggle="dropdown"
                                                aria-haspopup="true" aria-expanded="false" data-hotkey="p">
                                                 <i class="fa fa-ellipsis-v"/>
                                             </a>

--- a/addons/knowledge/views/knowledge_article_views.xml
+++ b/addons/knowledge/views/knowledge_article_views.xml
@@ -79,7 +79,8 @@
                                                attrs="{'invisible': [('id', '=', False)]}">
                                                 <i class="fa fa-share-alt"/> Share
                                             </a>
-                                            <a type="button" role="button" class="btn btn-secondary btn-chatter mr-1" data-hotkey="d">
+                                            <a type="button" role="button" class="btn btn-secondary btn-chatter mr-1" data-hotkey="d"
+                                                attrs="{'invisible': [('id', '=', False)]}">
                                                 <i class="rounded-circle text-center fa fa-comments" title="Open chatter"/>
                                             </a>
                                             <div class="o_knowledge_share_panel dropdown-menu" role="menu">
@@ -203,13 +204,7 @@
                                         </div>
                                         <!-- Chatter -->
                                         <div class="o_knowledge_chatter col-12 col-lg-4 position-relative d-none d-print-none p-0">
-                                            <div class="o_scroll_view_lg">
-                                                <div class="oe_chatter">
-                                                    <field name="message_follower_ids" groups="base.group_user"/>
-                                                    <field name="activity_ids"/>
-                                                    <field name="message_ids"/>
-                                                </div>
-                                            </div>
+                                            <div class="o_scroll_view_lg o_knowledge_chatter_container"/>
                                         </div>
                                     </div>
                                 </div>

--- a/addons/mail/static/src/models/composer_view.js
+++ b/addons/mail/static/src/models/composer_view.js
@@ -519,7 +519,7 @@ registerModel({
                 default_model: this.composer.activeThread.model,
                 default_partner_ids: this.composer.recipients.map(partner => partner.id),
                 default_res_id: this.composer.activeThread.id,
-                mail_post_autofollow: true,
+                mail_post_autofollow: this.composer.activeThread.hasWriteAccess,
             };
 
             const action = {
@@ -579,7 +579,7 @@ registerModel({
                         subtype_xmlid: composer.isLog ? 'mail.mt_note' : 'mail.mt_comment',
                     });
                     if (!composer.isLog) {
-                        params.context = { mail_post_autofollow: true };
+                        params.context = { mail_post_autofollow: this.composer.activeThread.hasWriteAccess };
                     }
                 }
                 if (this.threadView && this.threadView.replyingToMessageView && this.threadView.thread !== this.messaging.inbox) {


### PR DESCRIPTION
Improvements to the chatter in Knowledge after the first merge.

Fix the issue where the chatter would not render properly if a tracked file was
modified (this sends a message in the chatter and it was not properly
reloaded).

Prevent the full reload of the view in cases where only the chatter needs to be
reloaded. In Knowledge, if the param `keepChanges` is set to `true`, only the 
chatter will be updated.

Update the style of the chatter button to add more contrast when the chatter is
toggled on. Added a minimal size for the width of the chatter in side mode so
that thread messages don't become too small.

Add `_mail_post_access = 'read'` to the model in order to allow
someone with read access to post chatter messages. This is useful when a private
article is shared with read only access rights.

Add an explicit message along with a tracked field change in case the change is
caused by a user which does not have 'write' access on the modified article.

Task-2858428
