### PR TITLE
[FIX] sale: incorrect order total

### DIFF
--- a/addons/sale/models/sale_order_line.py
+++ b/addons/sale/models/sale_order_line.py
@@ -61,7 +61,7 @@ class SaleOrderLine(models.Model):
             price = line.price_unit * (1 - (line.discount or 0.0) / 100.0)
             taxes = line.tax_id.compute_all(price, line.order_id.currency_id, line.product_uom_qty, product=line.product_id, partner=line.order_id.partner_shipping_id)
             line.update({
-                'price_tax': taxes['total_included'] - taxes['total_excluded'],
+                'price_tax': sum(t.get('amount', 0.0) for t in taxes.get('taxes', [])),
                 'price_total': taxes['total_included'],
                 'price_subtotal': taxes['total_excluded'],
             })


### PR DESCRIPTION
With Rounding Method: Round Globally
Create a Sales order as follows:
Product A, qty 1, price 10.74, tax 21% not included
Product B, qty 2, price 0.83, tax 21% not included

The order amounts will be calculated as:

Untaxed Amount  $ 12.40
Taxes   $ 2.61
Total $ 15.00

Issue: The total is not the sum of the previous values

opw-2846713

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
