### PR TITLE
[IMP] mail: add hover download button on image attachments

### DIFF
--- a/addons/mail/static/src/components/attachment_image/attachment_image.xml
+++ b/addons/mail/static/src/components/attachment_image/attachment_image.xml
@@ -20,15 +20,14 @@
                             <i class="fa fa-spin fa-spinner"/>
                         </div>
                     </t>
-                    <t t-if="attachmentImage.attachment.isDeletable">
-                        <div class="o_AttachmentImage_imageOverlay position-absolute top-0 bottom-0 start-0 end-0 text-right p-2 text-white opacity-0 opacity-100-hover">
-                            <div class="o_AttachmentImage_action o_AttachmentImage_actionUnlink btn btn-sm btn-dark rounded opacity-75 opacity-100-hover"
-                                t-att-class="{'o-pretty': attachmentImage.attachmentList.composerViewOwner}" t-on-click="attachmentImage.onClickUnlink" title="Remove"
-                            >
-                                <i class="fa fa-trash"/>
-                            </div>
+                    <div class="o_AttachmentImage_imageOverlay position-absolute top-0 bottom-0 start-0 end-0 p-2 text-white opacity-0 opacity-100-hover d-flex align-items-end flax-wrap flex-column">
+                        <div t-if="attachmentImage.attachment.isDeletable" class="o_AttachmentImage_action o_AttachmentImage_actionUnlink btn btn-sm btn-dark rounded opacity-75 opacity-100-hover" t-att-class="{'o-pretty': attachmentImage.attachmentList.composerViewOwner}" t-on-click="attachmentImage.onClickUnlink" title="Remove">
+                            <i class="fa fa-trash"/>
                         </div>
-                    </t>
+                        <div t-if="attachmentImage.hasDownloadButton" class="o_AttachmentImage_action o_AttachmentImage_actionDownload btn btn-sm btn-dark rounded opacity-75 opacity-100-hover mt-auto" t-on-click="attachmentImage.onClickDownload" title="Download">
+                            <i class="fa fa-download"/>
+                        </div>
+                    </div>
                 </div>
             </div>
         </t>

--- a/addons/mail/static/tests/qunit_suite_tests/components/message_tests.js
+++ b/addons/mail/static/tests/qunit_suite_tests/components/message_tests.js
@@ -698,6 +698,36 @@ QUnit.test('prevent attachment delete on non-authored message in channels', asyn
     );
 });
 
+QUnit.test('allow attachment image download on message', async function (assert) {
+    assert.expect(1);
+
+    const pyEnv = await startServer();
+    const mailChannelId1 = pyEnv['mail.channel'].create({});
+    const irAttachmentId1 = pyEnv['ir.attachment'].create({
+        name: "Blah.jpg",
+        mimetype: 'image/jpeg',
+    });
+    pyEnv['mail.message'].create({
+        attachment_ids: [irAttachmentId1],
+        body: '<p>Test</p>',
+        model: 'mail.channel',
+        res_id: mailChannelId1,
+    });
+    const { openDiscuss } = await start({
+        discuss: {
+            context: {
+                active_id: mailChannelId1,
+            },
+        },
+    });
+    await openDiscuss();
+    assert.containsOnce(
+        document.body,
+        '.o_AttachmentImage_actionDownload',
+        "should have download attachment button"
+    );
+});
+
 QUnit.test('subtype description should be displayed if it is different than body', async function (assert) {
     assert.expect(2);
 


### PR DESCRIPTION
**Current behavior before PR:**

Improve how image attachments are downloaded from the chatter by adding the
`download` button when hovering image files

**Desired behavior after PR is merged:**

add a `Download` button (icon) on the bottom right corner of image attachments
on hover

Task-2802810

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
