### PR TITLE
[REF] web_editor: remove unused variable

### DIFF
--- a/addons/web_editor/static/src/js/wysiwyg/widgets/media.js
+++ b/addons/web_editor/static/src/js/wysiwyg/widgets/media.js
@@ -118,17 +118,14 @@ var SearchableMediaWidget = MediaWidget.extend({
     /**
      * @private
      */
-    _onSearchInput: function (ev) {
+    _onSearchInput: async function (ev) {
         this.attachments = [];
         // Disable user interactions with attachments while updating results.
         this.$('.o_we_existing_attachments').css('pointer-events', 'none');
-        this.search($(ev.currentTarget).val() || "")
-            .then(() => this._renderThumbnails())
-            .then(() => {
-                // Re-enable user interactions after updating results.
-                this.$(".o_we_existing_attachments").css("pointer-events", "");
-            });
-        this.hasSearched = true;
+        await this.search($(ev.currentTarget).val() || '');
+        await this._renderThumbnails();
+        // Re-enable user interactions with attachments after updating results.
+        this.$('.o_we_existing_attachments').css('pointer-events', '');
     },
 });
 


### PR DESCRIPTION
The `hasSearch` variable on `this` was not used anywhere and, if it was,
its semantic was arguable because it was set true as soon as the search
was fired rather than when the search had returned.

I'm taking this opportunity to use async/await as it's *way* better here.