### PR TITLE
[FIX] mail: do not ignore email sent by mailing list

### DIFF
--- a/addons/mail/__manifest__.py
+++ b/addons/mail/__manifest__.py
@@ -40,6 +40,7 @@
         'security/ir.model.access.csv',
         'views/discuss_public_templates.xml',
         'views/mail_alias_views.xml',
+        'views/mail_gateway_allowed_views.xml',
         'views/mail_guest_views.xml',
         'views/mail_message_reaction_views.xml',
         'views/res_users_views.xml',

--- a/addons/mail/models/__init__.py
+++ b/addons/mail/models/__init__.py
@@ -20,6 +20,7 @@ from . import mail_activity_type
 from . import mail_activity
 from . import mail_blacklist
 from . import mail_followers
+from . import mail_gateway_allowed
 from . import mail_message_reaction
 from . import mail_message_subtype
 from . import mail_message

--- a/addons/mail/models/mail_gateway_allowed.py
+++ b/addons/mail/models/mail_gateway_allowed.py
@@ -1,0 +1,31 @@
+# -*- coding: utf-8 -*-
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+
+from odoo import api, fields, models, tools
+
+
+class MailGatewayAllowed(models.Model):
+    """List of trusted email address which won't have the quota restriction.
+
+    The incoming emails have a restriction of the number of records they can
+    create with alias, defined by the 2 systems parameters;
+    - mail.gateway.loop.minutes
+    - mail.gateway.loop.threshold
+
+    But we might have some legit use cases for which we want to receive a ton of emails
+    from an automated-source. This model stores those trusted source and this restriction
+    won't apply to them.
+    """
+
+    _description = 'Mail Gateway Allowed'
+    _name = 'mail.gateway.allowed'
+
+    email = fields.Char('Email')
+    email_normalized = fields.Char(
+        string='Normalized Email', compute='_compute_email_normalized', store=True, index=True)
+
+    @api.depends('email')
+    def _compute_email_normalized(self):
+        for record in self:
+            record.email_normalized = tools.email_normalize(record.email)

--- a/addons/mail/models/mail_thread_blacklist.py
+++ b/addons/mail/models/mail_thread_blacklist.py
@@ -126,7 +126,7 @@ class MailBlackListMixin(models.AbstractModel):
             raise AccessError(_("You do not have the access right to unblacklist emails. Please contact your administrator."))
 
     @api.model
-    def _routing_detect_loop_from_records_domain(self, email_from_normalized):
+    def _detect_loop_sender_domain(self, email_from_normalized):
         """Return the domain to be used to detect duplicated records created by alias.
 
         :param email_from_normalized: FROM of the incoming email, normalized

--- a/addons/mail/security/ir.model.access.csv
+++ b/addons/mail/security/ir.model.access.csv
@@ -23,6 +23,7 @@ access_mail_channel_rtc_session_system,mail.channel.rtc.session.system,model_mai
 access_mail_alias_all,mail.alias.all,model_mail_alias,,1,0,0,0
 access_mail_alias_user,mail.alias.user,model_mail_alias,base.group_user,1,0,0,0
 access_mail_alias_system,mail.alias.system,model_mail_alias,base.group_system,1,1,1,1
+access_mail_gateway_allowed_system,mail.gateway.allowed.system,model_mail_gateway_allowed,base.group_system,1,1,1,1
 access_mail_message_reaction_all,mail.message.reaction.all,model_mail_message_reaction,,0,0,0,0
 access_mail_message_reaction_system,mail.message.reaction.system,model_mail_message_reaction,base.group_system,1,1,1,1
 access_mail_message_subtype_all,mail.message.subtype.all,model_mail_message_subtype,,1,0,0,0

--- a/addons/mail/views/mail_gateway_allowed_views.xml
+++ b/addons/mail/views/mail_gateway_allowed_views.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<odoo>
+    <record id="mail_gateway_allowed_view_tree" model="ir.ui.view">
+        <field name="name">mail.gateway.allowed.view.tree</field>
+        <field name="model">mail.gateway.allowed</field>
+        <field name="arch" type="xml">
+            <tree string="Mail Gateway Allowed" editable="top">
+                <field name="email"/>
+                <field name="email_normalized"/>
+            </tree>
+        </field>
+    </record>
+
+    <record id="mail_gateway_allowed_view_search" model="ir.ui.view">
+        <field name="name">mail.gateway.allowed.view.search</field>
+        <field name="model">mail.gateway.allowed</field>
+        <field name="arch" type="xml">
+            <search>
+                <field name="email"/>
+            </search>
+        </field>
+    </record>
+
+    <record id="mail_gateway_allowed_action" model="ir.actions.act_window">
+        <field name="name">Mail Gateway Allowed</field>
+        <field name="res_model">mail.gateway.allowed</field>
+        <field name="view_mode">tree</field>
+    </record>
+</odoo>

--- a/addons/mail/views/mail_menus.xml
+++ b/addons/mail/views/mail_menus.xml
@@ -39,6 +39,11 @@
         action="mail_channel_partner_action"
         sequence="21"
         groups="base.group_no_one"/>
+    <menuitem id="mail_gateway_allowed_menu"
+        parent="base.menu_email"
+        action="mail_gateway_allowed_action"
+        sequence="22"
+        groups="base.group_no_one"/>
 
     <!-- Under Technical/Discuss -->
     <menuitem name="Discuss"


### PR DESCRIPTION
Bug
===
Since 9c1cdd330e51d28fd935e3a285d4ceacf1fb165e we ignore all incoming
emails sent by mailing lists.

They are real use case when people want to be able to receive email
from mailing list (e.g. if they subscribed to an automated service,
or if someone is in leave and has done a auto-replier for that, etc).
