### PR TITLE
[FIX] website_blog: fix blog top banner

### DIFF
--- a/addons/website/controllers/main.py
+++ b/addons/website/controllers/main.py
@@ -648,7 +648,11 @@ class Website(Home):
     @http.route('/website/toggle_switchable_view', type='json', auth='user', website=True)
     def toggle_switchable_view(self, view_key):
         if request.website.user_has_groups('website.group_website_designer'):
-            request.website.viewref(view_key).toggle_active()
+            view = request.website.viewref(view_key)
+            # TODO: In master, set the priority in XML directly.
+            if view_key == 'website_blog.opt_blog_cover_post':
+                view.priority = 17
+            view.toggle_active()
         else:
             return werkzeug.exceptions.Forbidden()
 


### PR DESCRIPTION
Before this commit an error appeared if a block had been set at the top
of the /blog page and the user wished to re-enable the
'Top banner - Name / Latest Post' option. This commit resolves the issue
by giving higher priority to the activated view.

Steps to reproduce the fixed bug:
- Go on /blog page
- Disable the customize option "Top banner - Name / Latest Post"
- Enter in edit mode
- Add a snippet to the top (in the oe_structure)
- Save the page
- Enable the customize option "Top banner - Name / Latest Post"

=> An error happens.

task-2774944