### PR TITLE
[FIX] hr_holidays: Bug can't automation remove event on calendar when an approved leave application is refused

### DIFF
--- a/addons/hr_holidays/models/hr_leave.py
+++ b/addons/hr_holidays/models/hr_leave.py
@@ -893,9 +893,8 @@ class HolidaysRequest(models.Model):
                                 no_mail_to_attendees=True,
                                 active_model=self._name
                             ).create(meeting_values)
-        Holiday = self.env['hr.leave']
-        for meeting in meetings:
-            Holiday.browse(meeting.res_id).meeting_id = meeting
+            for holiday, meeting in zip(meeting_holidays, meetings):
+                holiday.meeting_id = meeting
 
     def _prepare_holidays_meeting_values(self):
         result = defaultdict(list)


### PR DESCRIPTION
Steps:
- Environment: 14.0
- Create a vacation registration at the Time-off module > Review of Vacation is completed.
- On the Company's Calendar there is this Holiday schedule.
- Go to Time-off to Reject > Set to draft > Delete above schedule.

Current behavior:
- On the general calendar of the company, there is still this Leave slip.

Expected behavior:
- Automatically delete leave on General Calendar when rejecting Leave slip.


--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
