### PR TITLE
[FIX] hr_timesheet: prevent trace back when opening report

### DIFF
--- a/addons/hr_timesheet/report/timesheets_analysis_report.py
+++ b/addons/hr_timesheet/report/timesheets_analysis_report.py
@@ -58,10 +58,10 @@ class TimesheetsAnalysisReport(models.Model):
 
     @api.model
     def _get_view(self, view_id=None, view_type='form', **options):
-        result = super()._get_view(view_id, view_type, **options)
+        arch, view = super()._get_view(view_id, view_type, **options)
         if view_type in ["pivot", "graph"] and self.env.company.timesheet_encode_uom_id == self.env.ref("uom.product_uom_day"):
-            result["arch"] = self.env["account.analytic.line"]._apply_time_label(result["arch"], related_model=self._name)
-        return result
+            arch = self.env["account.analytic.line"]._apply_time_label(arch, related_model=self._name)
+        return arch, view
 
     def init(self):
         tools.drop_view_if_exists(self.env.cr, self._table)


### PR DESCRIPTION
Prior to this commit, when running the `timesheets.analysis.report`, a
traceback was thrown `TypeError: tuple indices must be integers or slices,
not str`.

After this commit, not traceback is thrown.

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
