### PR TITLE
[FIX] website_slides: remove extra join course link

### DIFF
--- a/addons/website_slides/views/website_slides_templates_lesson_fullscreen.xml
+++ b/addons/website_slides/views/website_slides_templates_lesson_fullscreen.xml
@@ -155,7 +155,7 @@
                                     </li>
                                 </div>
                             </t>
-                            <div class="o_wslides_js_course_join o_wslides_no_access pl-0">
+                            <div t-else="" class="o_wslides_js_course_join o_wslides_no_access pl-0">
                                 <li t-if="slide.channel_id.enroll == 'public'" class="o_wslides_fs_slide_link mb-1">
                                     <i class="fa fa-download mr-1"/>
                                     <t t-call="website_slides.join_course_link"/>


### PR DESCRIPTION
The link to join/buy a course was displayed on the slides fullscreen view
sidebar even when already a course member.

Introduced in c45df9ed; already fixed in future versions.

Task-2818136
Part of Task-2663320
