### PR TITLE
[FIX] account: account_id must be editable in mobile view

### DIFF
--- a/addons/account/views/account_move_views.xml
+++ b/addons/account/views/account_move_views.xml
@@ -1031,7 +1031,7 @@
                                             </group>
                                             <group>
                                                 <field name="analytic_tag_ids" groups="analytic.group_analytic_tags" widget="many2many_tags"/>
-                                                <field name="account_id" options="{'no_create': True}" domain="[('company_id', '=', company_id)]" readonly="1"/>
+                                                <field name="account_id" options="{'no_create': True}" domain="[('company_id', '=', company_id)]" />
                                                 <field name="tax_ids" widget="many2many_tags"/>
                                                 <field name="analytic_account_id" groups="analytic.group_analytic_accounting"/>
                                             </group>


### PR DESCRIPTION
How to reproduce ?

- Change dimensions of the browser view to mobile view.
- Install the account app
- Create a new invoice
- Click on Add to add an item to the invoice
- On the ne dialog fram, select a product to add

What is the bug ?

If you use the account app on a large screen where you can add items
directly on the invoice, you can modify the account journal of the item.
However, when you use the mobile version of a small screen where you
have to add products through a dialog frame, the account journal of the
item cannot be modified.

opw-2850587

Signed-off-by: Adrien Minet <admi@odoo.com>

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
