### PR TITLE
[REM] base, *: remove binary_field_real_user from context

### DIFF
--- a/addons/hr/models/hr_employee.py
+++ b/addons/hr/models/hr_employee.py
@@ -505,19 +505,6 @@ class HrEmployeePrivate(models.Model):
             'template': '/hr/static/xls/hr_employee.xls'
         }]
 
-    def _post_author(self):
-        """
-        When a user updates his own employee's data, all operations are performed
-        by super user. However, tracking messages should not be posted as OdooBot
-        but as the actual user.
-        This method is used in the overrides of `_message_log` and `message_post`
-        to post messages as the correct user.
-        """
-        real_user = self.env.context.get('binary_field_real_user')
-        if self.env.is_superuser() and real_user:
-            self = self.with_user(real_user)
-        return self
-
     def _get_unusual_days(self, date_from, date_to=None):
         # Checking the calendar directly allows to not grey out the leaves taken
         # by the employee or fallback to the company calendar
@@ -532,13 +519,6 @@ class HrEmployeePrivate(models.Model):
 
     def _phone_get_number_fields(self):
         return ['mobile_phone']
-
-    def _message_log(self, **kwargs):
-        return super(HrEmployeePrivate, self._post_author())._message_log(**kwargs)
-
-    @api.returns('mail.message', lambda value: value.id)
-    def message_post(self, **kwargs):
-        return super(HrEmployeePrivate, self._post_author()).message_post(**kwargs)
 
     def _mail_get_partner_fields(self, introspect_fields=False):
         return ['user_partner_id']

--- a/addons/portal/controllers/portal.py
+++ b/addons/portal/controllers/portal.py
@@ -332,7 +332,7 @@ class CustomerPortal(Controller):
         # Avoid using sudo or creating access_token when not necessary: internal
         # users can create attachments, as opposed to public and portal users.
         if not request.env.user._is_internal():
-            IrAttachment = IrAttachment.sudo().with_context(binary_field_real_user=IrAttachment.env.user)
+            IrAttachment = IrAttachment.sudo()
             access_token = IrAttachment._generate_access_token()
 
         # At this point the related message does not exist yet, so we assign

--- a/addons/web_editor/controllers/main.py
+++ b/addons/web_editor/controllers/main.py
@@ -756,12 +756,11 @@ class Web_Editor(http.Controller):
             name = '_'.join([media[id]['query'], url.split('/')[-1]])
             # Need to bypass security check to write image with mimetype image/svg+xml
             # ok because svgs come from whitelisted origin
-            context = {'binary_field_real_user': request.env['res.users'].sudo().browse([SUPERUSER_ID])}
-            attachment = request.env['ir.attachment'].sudo().with_context(context).create({
+            attachment = request.env['ir.attachment'].with_user(SUPERUSER_ID).create({
                 'name': name,
                 'mimetype': req.headers['content-type'],
-                'datas': b64encode(req.content),
                 'public': True,
+                'raw': req.content,
                 'res_model': 'ir.ui.view',
                 'res_id': 0,
             })

--- a/addons/web_editor/tests/test_controller.py
+++ b/addons/web_editor/tests/test_controller.py
@@ -68,9 +68,7 @@ class TestController(HttpCase):
   <rect x="80" y="80" width="300" height="300" style="fill:#383E45;" />
 </svg>
         """
-        # Need to bypass security check to write image with mimetype image/svg+xml
-        context = {'binary_field_real_user': self.env['res.users'].sudo().browse([1])}
-        attachment = self.env['ir.attachment'].sudo().with_context(context).create({
+        attachment = self.env['ir.attachment'].create({
             'name': 'test.svg',
             'mimetype': 'image/svg+xml',
             'datas': binascii.b2a_base64(svg, newline=False),

--- a/odoo/addons/base/models/ir_attachment.py
+++ b/odoo/addons/base/models/ir_attachment.py
@@ -353,12 +353,9 @@ class IrAttachment(models.Model):
         xml_like = 'ht' in mimetype or ( # hta, html, xhtml, etc.
                 'xml' in mimetype and    # other xml (svg, text/xml, etc)
                 not 'openxmlformats' in mimetype)  # exception for Office formats
-        user = self.env.context.get('binary_field_real_user', self.env.user)
-        if not isinstance(user, self.pool['res.users']):
-            raise UserError(_("binary_field_real_user should be a res.users record."))
         force_text = xml_like and (
             self.env.context.get('attachments_mime_plainxml') or
-            not self.env['ir.ui.view'].with_user(user).check_access_rights('write', False))
+            not self.env['ir.ui.view'].sudo(False).check_access_rights('write', False))
         if force_text:
             values['mimetype'] = 'text/plain'
         if not self.env.context.get('image_no_postprocess'):

--- a/odoo/addons/base/models/res_users.py
+++ b/odoo/addons/base/models/res_users.py
@@ -102,7 +102,7 @@ def check_identity(fn):
 
         w = self.sudo().env['res.users.identitycheck'].create({
             'request': json.dumps([
-                { # strip non-jsonable keys (e.g. mapped to recordsets like binary_field_real_user)
+                { # strip non-jsonable keys (e.g. mapped to recordsets)
                     k: v for k, v in self.env.context.items()
                     if _jsonable(v)
                 },
@@ -617,7 +617,7 @@ class Users(models.Model):
                     if values['company_id'] not in self.env.user.company_ids.ids:
                         del values['company_id']
                 # safe fields only, so we write as super-user to bypass access rights
-                self = self.sudo().with_context(binary_field_real_user=self.env.user)
+                self = self.sudo()
 
         if 'groups_id' in values:
             default_user = self.env.ref('base.default_user', raise_if_not_found=False)

--- a/odoo/fields.py
+++ b/odoo/fields.py
@@ -2383,9 +2383,8 @@ class Binary(Field):
             return
         # create the attachments that store the values
         env = record_values[0][0].env
-        env['ir.attachment'].sudo().with_context(
-            binary_field_real_user=env.user,
-        ).create([{
+        env['ir.attachment'].sudo().create([
+            {
                 'name': self.name,
                 'res_model': self.model_name,
                 'res_field': self.name,


### PR DESCRIPTION
Formerly, using sudo() on a record had the effect of replacing the current user with the superuser. But sometimes, knowing who the "real user" was was necessary, so we needed to store it somewhere. This is basically why the key `binary_field_real_user` was introduced in the context: to keep track of who the user was before switching to sudo mode.

Since 1e6c3bec2c5ca621344b09e58dbed535e80fb343, however, switching to sudo mode no longer changes the current user; meaning that the `binary_field_real_user` is no longer necessary.

This commit removes the remaining occurrences of the now useless `binary_field_real_user` from the code.

\* = hr, portal, web_editor

Enterprise: https://github.com/odoo/enterprise/pull/27649
