### PR TITLE
[FIX] web: owl_compatibility: force status 1 on attach callback

### DIFF
--- a/addons/web/static/src/legacy/js/owl_compatibility.js
+++ b/addons/web/static/src/legacy/js/owl_compatibility.js
@@ -689,6 +689,7 @@ odoo.define('web.OwlCompatibility', function (require) {
                     cb();
                 }
             });
+            this.node.status = 1;
             this.status = "mounted";
         }
 


### PR DESCRIPTION
When a widget is detached form the DOM, we manually set the owl status of
the corresponding node to 0 (new), but we before this commit, we didn't reset it
to 1 (mounted) when the widget was re-attached. As a consequence, event handlers
were not bound anymore.

_Steps to reproduce:_
  - Open Inventory
  - Click on Products > Lots/Serial Numbers
  - Open a product
  - Click on the Traceability smart button
  - Click on a reference (eg: Inventory Adjustment)
  - Click on the Traceability Report breadcrumb
  -> Breadcrumbs are not working anymore

opw-2838994