### PR TITLE
[IMP] packaging: add a script to install packages

### DIFF
--- a/setup/debinstall.sh
+++ b/setup/debinstall.sh
@@ -1,0 +1,17 @@
+#!/bin/sh
+#
+# Install Debian packages needed to run Odoo.
+
+if [ "$(id -u)" -ne "0" ]; then
+   echo "This script must be run as root" >&2
+   exit 1
+fi
+
+script_path=$(realpath "$0")
+script_dir=$(dirname "$script_path")
+control_path=$(realpath "$script_dir/../debian/control")
+
+apt-get update
+sed -n '/^Depends:/,/^[A-Z]/p' "$control_path" \
+| awk '/^ [a-z]/ { gsub(/,/,"") ; print $1 }' | sort -u \
+| DEBIAN_FRONTEND=noninteractive xargs apt-get install -y -qq


### PR DESCRIPTION
This is the long awaited small POSIX shell script that installs Debian
packages needed to run Odoo.

At the first time it was intended to be a small Perl script as Perl is
available everywhere. Finally it turned out that a POSIX shell script is
smaller, easier to read and could be run everywhere.

