### PR TITLE
[IMP] project: rework documents management 

### DIFF
--- a/addons/project/models/project.py
+++ b/addons/project/models/project.py
@@ -1499,9 +1499,13 @@ class Task(models.Model):
         if not self._check_recursion():
             raise ValidationError(_('Error! You cannot create a recursive hierarchy of tasks.'))
 
+    def _get_attachments_search_domain(self):
+        self.ensure_one()
+        return [('res_id', '=', self.id), ('res_model', '=', 'project.task')]
+
     def _compute_attachment_ids(self):
         for task in self:
-            attachment_ids = self.env['ir.attachment'].search([('res_id', '=', task.id), ('res_model', '=', 'project.task')]).ids
+            attachment_ids = self.env['ir.attachment'].search(task._get_attachments_search_domain()).ids
             message_attachment_ids = task.mapped('message_ids.attachment_ids').ids  # from mail_thread
             task.attachment_ids = [(6, 0, list(set(attachment_ids) - set(message_attachment_ids)))]
 

--- a/addons/project/views/res_config_settings_views.xml
+++ b/addons/project/views/res_config_settings_views.xml
@@ -96,7 +96,7 @@
                                 </div>
                             </div>
                         </div>
-                        <h2>Analytics</h2>
+                        <h2 name="section_analytics">Analytics</h2>
                         <div class="row mt16 o_settings_container" name="analytic">
                             <div class="col-12 col-lg-6 o_setting_box">
                                 <div class="o_setting_left_pane">

--- a/addons/sale_timesheet/views/project_task_views.xml
+++ b/addons/sale_timesheet/views/project_task_views.xml
@@ -94,6 +94,16 @@
                     </a>
                 </div> 
             </xpath>
+        </field>
+    </record>
+
+    <!-- We do a separate inheritance from the base view for the SO button to give the buttons a deterministic order using priorities -->
+    <record id="project_project_view_kanban_inherit_sale_timesheet_so_button" model="ir.ui.view">
+        <field name="name">project.project.kanban.inherit.sale.timesheet.so.button</field>
+        <field name="model">project.project</field>
+        <field name="inherit_id" ref="project.view_project_kanban"/>
+        <field name="priority">30</field>
+        <field name="arch" type="xml">
             <xpath expr="//div[hasclass('o_kanban_manage_view')]" position="inside">
                 <div t-if="record.allow_billable.raw_value and record.sale_order_id.raw_value and record.pricing_type.raw_value != 'task_rate'"
                     role="menuitem"


### PR DESCRIPTION
This PR:
- gives a name to the Analytics section in the settingsto allow us to change its name easily with an xpath.
- extracts the attachments domain in tasks so that it can be overriden in documents_project to exclude attachements linked to a document.
- creates a new view inheritance inheriting the base kanban view, so that we can give the order we want to the buttons deterministically.

See the enterprise PR for more info.

Related: https://github.com/odoo/enterprise/pull/26696
Related: https://github.com/odoo/upgrade/pull/3557

Task-2802803