### PR TITLE
[FIX] stock: apply decimal accuracy on inventory_quantity_auto_apply

### DIFF
--- a/addons/stock/models/stock_quant.py
+++ b/addons/stock/models/stock_quant.py
@@ -100,7 +100,7 @@ class StockQuant(models.Model):
         help="The product's counted quantity.")
     inventory_quantity_auto_apply = fields.Float(
         'Inventoried Quantity', compute='_compute_inventory_quantity_auto_apply',
-        inverse='_set_inventory_quantity', groups='stock.group_stock_manager'
+        inverse='_set_inventory_quantity', groups='stock.group_stock_manager', digits='Product Unit of Measure'
     )
     inventory_diff_quantity = fields.Float(
         'Difference', compute='_compute_inventory_diff_quantity', store=True,


### PR DESCRIPTION
Description of the issue/feature this PR addresses:

- When you go to the inventory report, the "On hand quantity" (inventory_quantity_auto_apply) values don't follow the decimal accuracy

Current behavior before PR:

- Decimal accuracy is not applied on the "On hand quantity"

Desired behavior after PR is merged:

- Make "On hand quantity" follow the decimal accuracy


--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
