### PR TITLE
[IMP] mail: open dm chat on mention or member click

### DIFF
--- a/addons/mail/static/src/components/channel_member/channel_member.scss
+++ b/addons/mail/static/src/components/channel_member/channel_member.scss
@@ -1,3 +1,7 @@
+.o_ChannelMember:hover {
+    background-color: gray('300');
+}
+
 .o_ChannelMember_avatar {
     object-fit: cover;
 }

--- a/addons/mail/static/src/components/channel_member/channel_member.xml
+++ b/addons/mail/static/src/components/channel_member/channel_member.xml
@@ -2,8 +2,8 @@
 <templates xml:space="preserve">
 
     <t t-name="mail.ChannelMember" owl="1">
-        <div class="o_ChannelMember d-flex align-items-center mx-3 my-1" t-attf-class="{{ className }}" t-att-data-partner-local-id="channelMemberView.channelMember.partner.localId" t-ref="root">
-            <div class="o_ChannelMember_avatarContainer position-relative flex-shrink-0 o_cursor_pointer" t-on-click="channelMemberView.onClickMemberAvatar">
+        <div class="o_ChannelMember d-flex align-items-center mx-2 p-2" t-att-class="{'o_cursor_pointer': channelMemberView.hasOpenChat}" t-attf-class="{{ className }}" t-att-data-partner-local-id="channelMemberView.channelMember.partner.localId" t-att-title="channelMemberView.memberTitleText" t-on-click="channelMemberView.onClickMember" t-ref="root">
+            <div class="o_ChannelMember_avatarContainer position-relative flex-shrink-0">
                 <img class="o_ChannelMember_avatar rounded-circle w-100 h-100" t-attf-src="/mail/channel/{{ channelMemberView.channelMember.channel.id }}/partner/{{ channelMemberView.channelMember.partner.id }}/avatar_128" alt="Avatar"/>
 
                 <t t-if="channelMemberView.personaImStatusIconView">
@@ -13,11 +13,12 @@
                             'o-isDeviceSmall': messaging.device.isSmall,
                             'small': !messaging.device.isSmall,
                         }"
+                        hasOpenChat="channelMemberView.hasOpenChat"
                         record="channelMemberView.personaImStatusIconView"
                     />
                 </t>
             </div>
-            <span class="o_ChannelMember_name ms-2 flex-column-1 text-truncate o_cursor_pointer" t-on-click="channelMemberView.onClickMemberName">
+            <span class="o_ChannelMember_name ms-2 flex-column-1 text-truncate">
                 <t t-esc="channelMemberView.channelMember.partner.nameOrDisplayName"/>
             </span>
         </div>

--- a/addons/mail/static/src/components/message/message.xml
+++ b/addons/mail/static/src/components/message/message.xml
@@ -34,7 +34,7 @@
                     <div class="o_Message_sidebar d-flex justify-content-center flex-shrink-0" t-att-class="{ 'o-message-squashed align-items-start': messageView.isSquashed }">
                         <t t-if="!messageView.isSquashed">
                             <div class="o_Message_authorAvatarContainer o_Message_sidebarItem position-relative mx-1">
-                                <img class="o_Message_authorAvatar w-100 h-100 rounded-circle" t-att-class="{ 'o_Message_authorRedirect o_cursor_pointer': messageView.hasAuthorOpenChat, o_redirect: messageView.hasAuthorOpenChat }" t-att-src="messageView.message.avatarUrl" role="button" tabindex="0" t-on-click="messageView.onClickAuthorAvatar" t-att-title="messageView.hasAuthorOpenChat ? messageView.authorAvatarTitleText : ''" t-att-alt="messageView.hasAuthorOpenChat ? messageView.authorAvatarTitleText : ''"/>
+                                <img class="o_Message_authorAvatar w-100 h-100 rounded-circle" t-att-class="{ 'o_cursor_pointer': messageView.hasAuthorOpenChat, o_redirect: messageView.hasAuthorOpenChat }" t-att-src="messageView.message.avatarUrl" t-att-role="messageView.hasAuthorOpenChat ? 'button' : ''" t-att-tabindex="messageView.hasAuthorOpenChat ? '0' : ''" t-on-click="messageView.onClickAuthorAvatar" t-att-title="messageView.authorTitleText" t-att-alt="messageView.authorTitleText"/>
                                 <t t-if="messageView.personaImStatusIconView">
                                     <PersonaImStatusIcon
                                         className="'o_Message_personaImStatusIcon d-flex align-items-center justify-content-center'"
@@ -66,7 +66,7 @@
                         <t t-if="!messageView.isSquashed">
                             <div class="o_Message_header d-flex flex-wrap align-items-baseline ms-2">
                                 <t t-if="messageView.message.author">
-                                    <strong class="o_Message_authorName o_Message_authorRedirect o_redirect o_cursor_pointer text-truncate" role="link" tabindex="0" t-on-click="messageView.onClickAuthorName" title="Open profile">
+                                    <strong class="o_Message_authorName o_redirect text-truncate" t-att-class="{'o_cursor_pointer': messageView.hasAuthorOpenChat}" t-att-role="messageView.hasAuthorOpenChat ? 'button' : ''" t-att-tabindex="messageView.hasAuthorOpenChat ? '0' : ''" t-on-click="messageView.onClickAuthorName" t-att-title="messageView.authorTitleText">
                                         <t t-if="messageView.message.originThread">
                                             <t t-esc="messageView.message.originThread.getMemberName(messageView.message.author)"/>
                                         </t>

--- a/addons/mail/static/src/models/channel_member_view.js
+++ b/addons/mail/static/src/models/channel_member_view.js
@@ -1,32 +1,38 @@
 /** @odoo-module **/
 
 import { registerModel } from '@mail/model/model_core';
-import { one } from '@mail/model/model_field';
+import { attr, one } from '@mail/model/model_field';
 import { clear, insertAndReplace } from '@mail/model/model_field_command';
+import { isEventHandled } from '@mail/utils/utils'
 
 registerModel({
     name: 'ChannelMemberView',
     identifyingFields: ['channelMemberListCategoryViewOwner', 'channelMember'],
     recordMethods: {
         /**
-         * Handles click on the avatar of the channel member in the member list
-         * of this channel.
+         * Handles click on channel member in the member list of this channel.
+         *
+         * @param {MouseEvent} ev
          */
-        onClickMemberAvatar() {
-            if (!this.channelMember.partner) {
+        onClickMember(ev) {
+            if (isEventHandled(ev, 'PersonaImStatusIcon.Click') || !this.channelMember.partner) {
                 return;
             }
             this.channelMember.partner.openChat();
         },
         /**
-         * Handles click on the name of the channel member in the member list of
-         * this channel.
+         * @private
+         * @returns {Boolean}
          */
-        onClickMemberName() {
-            if (!this.channelMember.partner) {
-                return;
-            }
-            this.channelMember.partner.openProfile();
+        _computeHasOpenChat() {
+            return this.channelMember.partner ? true : false;
+        },
+        /**
+         * @private
+         * @returns {string}
+         */
+        _computeMemberTitleText() {
+            return this.hasOpenChat ? this.env._t("Open chat") : '';
         },
         /**
          * @private
@@ -46,6 +52,12 @@ registerModel({
             inverse: 'channelMemberViews',
             readonly: true,
             required: true,
+        }),
+        hasOpenChat: attr({
+            compute: '_computeHasOpenChat',
+        }),
+        memberTitleText: attr({
+            compute: '_computeMemberTitleText',
         }),
         personaImStatusIconView: one('PersonaImStatusIconView', {
             compute: '_computePersonaImStatusIconView',

--- a/addons/mail/static/tests/qunit_suite_tests/components/channel_member_list_tests.js
+++ b/addons/mail/static/tests/qunit_suite_tests/components/channel_member_list_tests.js
@@ -202,5 +202,36 @@ QUnit.test('Load more button should load more members', async function (assert) 
     );
 });
 
+QUnit.test('chat with member should be opened after clicking on channel member', async function (assert) {
+    assert.expect(1);
+
+    const pyEnv = await startServer();
+    const resPartnerId1 = pyEnv['res.partner'].create({ name: "Demo" });
+    const mailChannelId1 = pyEnv['mail.channel'].create({
+        channel_last_seen_partner_ids: [
+            [0, 0, { partner_id: pyEnv.currentPartnerId }],
+            [0, 0, { partner_id: resPartnerId1 }],
+        ],
+        channel_type: 'group',
+        public: 'private',
+    });
+    const { click, messaging, openDiscuss } = await start({
+        discuss: {
+            context: {
+                active_id: `mail.channel_${mailChannelId1}`,
+            },
+        },
+    });
+    await openDiscuss();
+
+    await click('.o_ThreadViewTopbar_showMemberListButton');
+    await click(`.o_ChannelMember[data-partner-local-id="${messaging.models['Partner'].findFromIdentifyingData({ id: resPartnerId1 }).localId}"]`);
+    assert.containsOnce(
+        document.body,
+        `.o_ThreadView[data-correspondent-id="${resPartnerId1}"]`,
+        "Chat with member Demo should be opened",
+    );
+});
+
 });
 });


### PR DESCRIPTION
**Current behavior before PR:**

Access the DM chat to a user when clicking on its `@mention`
(DM or chatter) or member name (in Discuss).
The same goes for `@mention` to channels

**Desired behavior after PR is merged:**

- DM to Author should be opened after clicking on his name
- DM to Author should be opened after clicking on his mention
- DM to channel should be opened after clicking on it's mention
- There should be a grey background hover effect on channel members in
  members list

Task-2631948

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
