### PR TITLE
[IMP] im_livechat: unpin read livechat sessions after one day

### DIFF
--- a/addons/im_livechat/models/mail_channel_member.py
+++ b/addons/im_livechat/models/mail_channel_member.py
@@ -1,5 +1,7 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
+from datetime import datetime, timedelta
+
 from odoo import api, models
 
 
@@ -8,15 +10,13 @@ class ChannelMember(models.Model):
 
     @api.autovacuum
     def _gc_unpin_livechat_sessions(self):
-        """ Unpin livechat sessions with no activity for at least one day to
+        """ Unpin read livechat sessions with no activity for at least one day to
             clean the operator's interface """
-        self.env.cr.execute("""
-            UPDATE mail_channel_member
-            SET is_pinned = false
-            WHERE id in (
-                SELECT cm.id FROM mail_channel_member cm
-                INNER JOIN mail_channel c on c.id = cm.channel_id
-                WHERE c.channel_type = 'livechat' AND cm.is_pinned is true AND
-                    cm.write_date < current_timestamp - interval '1 day'
-            )
-        """)
+        members = self.env['mail.channel.member'].search([
+            ('is_pinned', '=', True),
+            ('last_seen_dt', '<=', datetime.now() - timedelta(days=1)),
+            ('channel_id.channel_type', '=', 'livechat'),
+        ])
+        sessions_to_be_unpinned = members.filtered(lambda m: m.message_unread_counter == 0)
+        sessions_to_be_unpinned.write({'is_pinned': False})
+        self.env['bus.bus']._sendmany([(member.partner_id, 'mail.channel/unpin', {'id': member.channel_id.id}) for member in sessions_to_be_unpinned])

--- a/addons/mail/models/mail_channel.py
+++ b/addons/mail/models/mail_channel.py
@@ -989,6 +989,7 @@ class Channel(models.Model):
         member.write({
             'fetched_message_id': last_message.id,
             'seen_message_id': last_message.id,
+            'last_seen_dt': fields.Datetime.now(),
         })
 
     def channel_fetched(self):

--- a/addons/mail/models/mail_channel_member.py
+++ b/addons/mail/models/mail_channel_member.py
@@ -28,6 +28,7 @@ class ChannelMember(models.Model):
     is_minimized = fields.Boolean("Conversation is minimized")
     is_pinned = fields.Boolean("Is pinned on the interface", default=True)
     last_interest_dt = fields.Datetime("Last Interest", default=fields.Datetime.now, help="Contains the date and time of the last interesting event that happened in this channel for this partner. This includes: creating, joining, pinning, and new message posted.")
+    last_seen_dt = fields.Datetime("Last seen date")
     # RTC
     rtc_session_ids = fields.One2many(string="RTC Sessions", comodel_name='mail.channel.rtc.session', inverse_name='channel_member_id')
     rtc_inviting_session_id = fields.Many2one('mail.channel.rtc.session', string='Ringing session')

--- a/addons/mail/views/mail_channel_member_views.xml
+++ b/addons/mail/views/mail_channel_member_views.xml
@@ -24,7 +24,15 @@
                         <field name="partner_id"/>
                         <field name="guest_id"/>
                         <field name="channel_id"/>
+                        <field name="custom_channel_name"/>
+                        <field name="fetched_message_id"/>
                         <field name="seen_message_id"/>
+                        <field name="message_unread_counter"/>
+                        <field name="fold_state"/>
+                        <field name="is_minimized"/>
+                        <field name="is_pinned"/>
+                        <field name="last_interest_dt"/>
+                        <field name="last_seen_dt"/>
                         <field name="rtc_inviting_session_id"/>
                     </group>
                 </sheet>
@@ -33,7 +41,7 @@
     </record>
 
     <record id="mail_channel_member_action" model="ir.actions.act_window">
-        <field name="name">Channels/Partner</field>
+        <field name="name">Channels/Member</field>
         <field name="res_model">mail.channel.member</field>
         <field name="view_mode">tree,form</field>
     </record>


### PR DESCRIPTION
**Current behavior before PR:**

Make sure `livechat` operators are not buried under a huge pile of old sessions.

**Desired behavior after PR is merged:**

Unpin read `livechat` sessions 24 hours after the last message has been read by
the operator.

Task-2446972

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
