### PR TITLE
[FIX] point_of_sale,pos_restaurant: fix auto FloorScreen when idle

### DIFF
--- a/addons/point_of_sale/static/src/js/Chrome.js
+++ b/addons/point_of_sale/static/src/js/Chrome.js
@@ -244,6 +244,7 @@ odoo.define('point_of_sale.Chrome', function(require) {
         }
         __closeTempScreen() {
             this.tempScreen.isShown = false;
+            this.tempScreen.name = null;
         }
         __showScreen({ detail: { name, props = {} } }) {
             const component = this.constructor.components[name];

--- a/addons/pos_restaurant/static/src/js/Chrome.js
+++ b/addons/pos_restaurant/static/src/js/Chrome.js
@@ -65,6 +65,10 @@ odoo.define('pos_restaurant.chrome', function (require) {
                 }
             }
             _actionAfterIdle() {
+                // We also need to check if the action still need to be triggered
+                if (!this._shouldResetIdleTimer()) {
+                    return;
+                }
                 if (this.tempScreen.isShown) {
                     this.trigger('close-temp-screen');
                 }


### PR DESCRIPTION
- Restaurant shops should automatically go back to floor screen when
idle. However, after https://github.com/odoo/odoo/pull/89712, this
feature is broken when pos_hr is also installed - the screen doesn't
automatically go back to floor screen.
A simple fix is to clear the tempScreen name when the shown tempScreen
is closed. Note that this change is fine because when tempScreen is closed
(!isShown), the `tempScreen.name` information has no use.

- Once the `idleTimer` is set, it is never removed. This means that
even if the conditions to go back to the FloorScreen at the current
time T are not satisfied, the `_actionAfterIdle` is still run.
Checking if the action can be done once triggered fix the issue.

A proper solution in the link module between `pos_hr` and `pos_restaurant`  for the `idleTimer` in master would be to remove its content once we are opening a `TempScreen` (with the same conditions) and to put it back when closing it. 


Related PR: https://github.com/odoo/odoo/pull/91592