### PR TITLE
[FIX] base : add unlink access to partner manager

### DIFF
--- a/odoo/addons/base/security/ir.model.access.csv
+++ b/odoo/addons/base/security/ir.model.access.csv
@@ -117,5 +117,5 @@
 "access_base_module_uninstall","access.base.module.uninstall","model_base_module_uninstall","base.group_system",1,1,1,0
 "access_base_language_export","access.base.language.export","model_base_language_export","base.group_user",1,1,1,0
 "access_base_update_translations","access.base.update.translations","model_base_update_translations","base.group_system",1,1,1,0
-"access_base_partner_merge_line","access.base.partner.merge.line","model_base_partner_merge_line","base.group_partner_manager",1,1,1,0
+"access_base_partner_merge_line","access.base.partner.merge.line","model_base_partner_merge_line","base.group_partner_manager",1,1,1,1
 "access_base_partner_merge_automatic_wizard","access.base.partner.merge.automatic.wizard","model_base_partner_merge_automatic_wizard","base.group_partner_manager",1,1,1,0


### PR DESCRIPTION
To reproduce
============

- make sure to have two contacts with same email (duplicate Mitchell for example)
- in 'Contacts', switch to 'list view', selected any two contacts with the checkboxes, go the the 'Action' menu and select 'Merge'
- Click on 'Skip these contacts', then click on 'Deduplicate the other contacts', then check the 'Email' checkbox and click on 'Merge with manual check'.
- click on 'Skip these contacts'

an Access Error is raised

Purpose
=======

Partner Manager doesn't have the unlink access to `partner.merge.line` model, this access wasn't given because it's often unecessary,
but here it's good example where it's needed.

Specification
=============

to solve the issue we give the unlink access to partner manager.

opw-2851507