### PR TITLE
[FIX] l10n_ec,pe,ar,cl: when installing demo data, use the fiscal cou…

### DIFF
--- a/addons/l10n_ar/demo/account_demo.py
+++ b/addons/l10n_ar/demo/account_demo.py
@@ -37,7 +37,7 @@ class AccountChartTemplate(models.Model):
     def _get_demo_data_move(self):
         cid = self.env.company.id
         model, data = super()._get_demo_data_move()
-        if self.env.company.country_code == "AR":
+        if self.env.company.account_fiscal_country_id.code == "AR":
             data[f'{cid}_demo_invoice_5']['l10n_latam_document_number'] = '1-1'
             data[f'{cid}_demo_invoice_equipment_purchase']['l10n_latam_document_number'] = '1-2'
         return model, data

--- a/addons/l10n_cl/demo/account_demo.py
+++ b/addons/l10n_cl/demo/account_demo.py
@@ -30,7 +30,7 @@ class AccountChartTemplate(models.Model):
         ref = self.env.ref
         cid = self.env.company.id
         model, data = super()._get_demo_data_move()
-        if self.env.company.country_code == "CL":
+        if self.env.company.account_fiscal_country_id.code == "CL":
             foreign = ref('l10n_cl.dc_fe_dte').id
             self.env['account.journal'].search([
                 ('type', '=', 'purchase'),

--- a/addons/l10n_ec/demo/account_demo.py
+++ b/addons/l10n_ec/demo/account_demo.py
@@ -14,7 +14,7 @@ class AccountChartTemplate(models.Model):
         ref = self.env.ref
         cid = self.env.company.id
         model, data = super()._get_demo_data_move()
-        if self.env.company.country_id.code == 'EC':
+        if self.env.company.account_fiscal_country_id.code == 'EC':
             document_type = ref('l10n_ec.ec_dt_18', False) and ref('l10n_ec.ec_dt_18').id or False
             data[f'{cid}_demo_invoice_1']['l10n_latam_document_type_id'] = document_type
             data[f'{cid}_demo_invoice_2']['l10n_latam_document_type_id'] = document_type

--- a/addons/l10n_pe/demo/account_demo.py
+++ b/addons/l10n_pe/demo/account_demo.py
@@ -10,7 +10,7 @@ class AccountChartTemplate(models.Model):
     def _get_demo_data_move(self):
         cid = self.env.company.id
         model, data = super()._get_demo_data_move()
-        if self.env.company.country_code == "PE":
+        if self.env.company.account_fiscal_country_id.code == "PE":
             document_type = self.env.ref('l10n_pe.document_type01')
             data[f'{cid}_demo_invoice_1']['l10n_latam_document_type_id'] = document_type.id
             data[f'{cid}_demo_invoice_1']['l10n_latam_document_number'] = 'FFI-000001'


### PR DESCRIPTION
…ntry instead

Because of the change in order of operations, for the main company
when we install e.g. l10n_ec, the CoA installed is the Ecuadorian
one, which makes the fiscal country EC, but the country_id still US.

We suspect https://github.com/odoo/odoo/blob/7cb109e7b0ee2e46cef79ec7d3076d16715567f9/addons/account/models/chart_template.py#L278
for the change in behaviour as the generic coa does not have US as
company anymore and that somehow led for the sales journal to
require to use document types.  (there we use the fiscal country which
is set to Ecuador)

The solution anyhow here, is that for the demo data, we should
use the fiscal country as well to see if we need to add the
document type to the demo invoices or not.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
