### PR TITLE
[FIX] web: adapting to Chrome sizing computation changes in tests

### DIFF
--- a/addons/web/static/tests/helpers/test_utils_dom.js
+++ b/addons/web/static/tests/helpers/test_utils_dom.js
@@ -136,9 +136,8 @@ function triggerMouseEvent($el, type) {
         throw new Error(`no target found to trigger MouseEvent`);
     }
     const rect = el.getBoundingClientRect();
-    // little fix since it seems on chrome, it triggers 1px too on the left
-    const left = rect.x + 1;
-    const top = rect.y;
+    const left = rect.x + rect.width / 2;
+    const top = rect.y + rect.height / 2;
     return triggerEvent($el, type, {
         which: 1,
         pageX: left, layerX: left, screenX: left,

--- a/addons/web/static/tests/views/list_tests.js
+++ b/addons/web/static/tests/views/list_tests.js
@@ -1940,8 +1940,8 @@ QUnit.module('Views', {
 
         assert.strictEqual(list.$('table').width(), list.$('.o_list_view').width());
         const largeCells = list.$('.o_data_cell.large');
-        assert.strictEqual(largeCells[0].offsetWidth, largeCells[1].offsetWidth);
-        assert.strictEqual(largeCells[1].offsetWidth, largeCells[2].offsetWidth);
+        assert.ok(Math.abs(largeCells[0].offsetWidth - largeCells[1].offsetWidth) <= 1);
+        assert.ok(Math.abs(largeCells[1].offsetWidth - largeCells[2].offsetWidth) <= 1);
         assert.ok(list.$('.o_data_cell:not(.large)')[0].offsetWidth < largeCells[0].offsetWidth);
 
         list.destroy();
@@ -2406,7 +2406,7 @@ QUnit.module('Views', {
 
         const fooWidth = list.$('th[data-name="foo"]')[0].offsetWidth;
         const textWidth = list.$('th[data-name="text"]')[0].offsetWidth;
-        assert.strictEqual(fooWidth, textWidth, "both columns should have been given the same width");
+        assert.ok(Math.abs(fooWidth - textWidth) <= 1, "both columns should have been given the same width");
 
         const firstRowHeight = list.$('.o_data_row:nth(0)')[0].offsetHeight;
         const secondRowHeight = list.$('.o_data_row:nth(1)')[0].offsetHeight;


### PR DESCRIPTION
This PR adapts tests and/or helpers to recent Chrome's sizing computation returning a slightly different value (in the order of a fraction of a pixel). Sadly, due to rounding, this difference has an impact on exact sizing assertions.