### PR TITLE
[FIX] account: fix payment widget (exchange difference) 

### DIFF
--- a/addons/account/static/src/xml/account_payment.xml
+++ b/addons/account/static/src/xml/account_payment.xml
@@ -40,26 +40,32 @@
                         <td t-if="!line.is_exchange">
                             <i class="o_field_widget text-left o_payment_label">Paid on <t t-esc="line.date"></t></i>
                         </td>
-                        <td t-if="line.is_exchange">
-                            <i class="o_field_widget text-left o_payment_label text-muted">Exchange Difference</i>
+                        <td t-if="line.is_exchange" colspan="2">
+                            <i class="o_field_widget text-left text-muted text-left">
+                                <span class="oe_form_field oe_form_field_float oe_form_field_monetary font-weight-bold">
+                                    <t t-if="line.position === 'before'">
+                                        <t t-esc="line.currency"/>
+                                    </t>
+                                    <t t-esc="line.amount"/>
+                                    <t t-if="line.position === 'after'">
+                                        <t t-esc="line.currency"/>
+                                    </t>
+                                </span>
+                                <span>Exchange Difference</span>
+                            </i>
                         </td>
                     </t>
-                        <td style="text-align:right;">
-                            <span class="oe_form_field oe_form_field_float oe_form_field_monetary" style="margin-left: -10px;">
-                                <t t-if="line.position === 'before'">
-                                    <t t-esc="line.currency"/>
-                                </t>
-                                <t t-if="!line.is_exchange">
-                                    <t t-esc="line.amount"/>
-                                </t>
-                                <t t-if="line.is_exchange">
-                                    <i class="text-muted"><t t-esc="line.amount"/></i>
-                                </t>
-                                <t t-if="line.position === 'after'">
-                                    <t t-esc="line.currency"/>
-                                </t>
-                            </span>
-                        </td>
+                    <td t-if="!line.is_exchange" style="text-align:right;">
+                        <span class="oe_form_field oe_form_field_float oe_form_field_monetary" style="margin-left: -10px;">
+                            <t t-if="line.position === 'before'">
+                                <t t-esc="line.currency"/>
+                            </t>
+                            <t t-esc="line.amount"/>
+                            <t t-if="line.position === 'after'">
+                                <t t-esc="line.currency"/>
+                            </t>
+                        </span>
+                    </td>
                     </tr>
                 </t>
             </table>

--- a/addons/account/tests/test_account_move_reconcile.py
+++ b/addons/account/tests/test_account_move_reconcile.py
@@ -1896,9 +1896,13 @@ class TestAccountMoveReconcile(AccountTestInvoicingCommon):
             {'amount_residual': 1.71,       'amount_residual_currency': 0.09,       'reconciled': False},
             {'amount_residual': 0.0,        'amount_residual_currency': 0.0,        'reconciled': True},
         ])
+        payment_exchange_id = inv2_rec_line.matched_credit_ids.filtered(lambda x: x.id != res['partials'].id)
+
         self.assert_invoice_outstanding_reconciled_widget(inv2, {
             refund1.id: 28.46,
             pay1.move_id.id: 1907.17,
+            res['partials'].exchange_move_id.id: 312.54,
+            payment_exchange_id[0].exchange_move_id.id: 6.34,
         })
 
         # 4th reconciliation inv2 + pay2
@@ -1940,10 +1944,15 @@ class TestAccountMoveReconcile(AccountTestInvoicingCommon):
             {'amount_residual': 0.0,        'amount_residual_currency': 0.0,        'reconciled': True},
             {'amount_residual': 0.0,        'amount_residual_currency': 0.0,        'reconciled': True},
         ])
+        payment_exchange_id = inv2_rec_line.matched_credit_ids.filtered(lambda x: x.id != res['partials'].id)
+
         self.assert_invoice_outstanding_reconciled_widget(inv2, {
             refund1.id: 28.46,
             pay1.move_id.id: 1907.17,
             pay2.move_id.id: 0.09,
+            res['partials'].exchange_move_id.id: 0.06,
+            payment_exchange_id[0].exchange_move_id.id: 6.34,
+            payment_exchange_id[1].exchange_move_id.id: 312.54,
         })
         self.assert_invoice_outstanding_to_reconcile_widget(inv2, {})
 
@@ -2113,6 +2122,7 @@ class TestAccountMoveReconcile(AccountTestInvoicingCommon):
         ])
         self.assert_invoice_outstanding_reconciled_widget(inv2, {
             pay1.move_id.id: 1907.17,
+            res['partials'].exchange_move_id.id: 312.54,
         })
         self.assert_invoice_outstanding_to_reconcile_widget(inv2, {
             refund1.id: 28.46,
@@ -2205,11 +2215,15 @@ class TestAccountMoveReconcile(AccountTestInvoicingCommon):
             {'amount_residual': 0.0,        'amount_residual_currency': 0.0,        'reconciled': True},
             {'amount_residual': 0.0,        'amount_residual_currency': 0.0,        'reconciled': True},
         ])
+        payment_exchange_id = inv2_rec_line.matched_credit_ids.filtered(lambda x: x.id != res['partials'].id)
 
         self.assert_invoice_outstanding_reconciled_widget(inv2, {
             refund1.id: 28.46,
             pay1.move_id.id: 1907.17,
             pay2.move_id.id: 0.09,
+            res['partials'].exchange_move_id.id: 0.06,
+            payment_exchange_id[0].exchange_move_id.id: 312.54,
+            payment_exchange_id[1].exchange_move_id.id: 6.34,
         })
         self.assert_invoice_outstanding_to_reconcile_widget(inv2, {})
 


### PR DESCRIPTION
Task 2843455

When an exchange difference is linked to a payment, not an invoice,
it is not displayed in the payment widget even though an exchange
difference move is created and matched with the invoice.
- Exchange difference should be displayed when it's linked to the payment as well.
-  Exchange difference line should have a different design to emphasize that it's just for information, not something to be added to the total.




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
