### PR TITLE
[FIX] stock_account: create AML for SML owned by company

### DIFF
--- a/addons/stock_account/models/stock_move.py
+++ b/addons/stock_account/models/stock_move.py
@@ -472,7 +472,7 @@ class StockMove(models.Model):
         if self.product_id.type != 'product':
             # no stock valuation for consumable products
             return False
-        if self.restrict_partner_id:
+        if self.restrict_partner_id and self.restrict_partner_id != self.company_id.partner_id:
             # if the move isn't owned by the company, we don't make any valuation
             return False
 

--- a/addons/stock_account/tests/test_stockvaluation.py
+++ b/addons/stock_account/tests/test_stockvaluation.py
@@ -3713,3 +3713,34 @@ class TestStockValuation(SavepointCase):
         self.assertEqual(self.product1.with_context(to_date=Datetime.to_string(date1)).value_svl, 100)
         self.assertEqual(self.product1.with_context(to_date=Datetime.to_string(date2)).quantity_svl, 5)
         self.assertEqual(self.product1.with_context(to_date=Datetime.to_string(date2)).value_svl, 50)
+
+    def test_fifo_and_sml_owned_by_company(self):
+        """
+        When receiving a FIFO product, if the picking is owned by the company,
+        there should be a SVL and an account move linked to the product SM
+        """
+        self.product1.categ_id.property_cost_method = 'fifo'
+
+        receipt = self.env['stock.picking'].create({
+            'location_id': self.supplier_location.id,
+            'location_dest_id': self.stock_location.id,
+            'picking_type_id': self.env.ref('stock.picking_type_in').id,
+            'owner_id': self.env.company.partner_id.id,
+        })
+
+        move = self.env['stock.move'].create({
+            'picking_id': receipt.id,
+            'name': 'IN 1 @ 10',
+            'location_id': self.supplier_location.id,
+            'location_dest_id': self.stock_location.id,
+            'product_id': self.product1.id,
+            'product_uom': self.uom_unit.id,
+            'product_uom_qty': 1.0,
+            'price_unit': 10,
+        })
+        receipt.action_confirm()
+        move.quantity_done = 1
+        receipt.button_validate()
+
+        self.assertEqual(move.stock_valuation_layer_ids.value, 10)
+        self.assertEqual(move.stock_valuation_layer_ids.account_move_id.amount_total, 10)


### PR DESCRIPTION
If a picking is owned by the company and if the user receives a FIFO
product, a SVL will be created without any journal entry

To reproduce the issue:
(Need account_accountant)
1. In Settings, enable "Consignment"
2. Create a product category PC:
    - Costing Method: FIFO
    - Inventory Valuation: Automated
3. Create a product P:
    - Type: Storable
    - Category: PC
    - Cost: 1
4. Create and validate a receipt:
    - Owner: <The company of the picking>
    - With: 1 x P
5. Open the generated SVL

Error: There isn't any journal entry associated with the SVL

When validating the picking, a method filters the SML that will be
considered during the SVL creation process. This method filters out the
SML that has an owner and if this owner is not the company:
https://github.com/odoo/odoo/blob/f8e2f2a4836d23fe507cad3bd5cac92d41ca91a3/addons/stock_account/models/stock_move.py#L69-L70

However, the filter in the journal entries creation is not that accurate
and does not correspond to its comment line:
https://github.com/odoo/odoo/blob/f8e2f2a4836d23fe507cad3bd5cac92d41ca91a3/addons/stock_account/models/stock_move.py#L475-L476

OPW-2859144