### PR TITLE
[IMP] mail, *: replace target by document

### DIFF
--- a/addons/hr/static/tests/m2x_avatar_employee_tests.js
+++ b/addons/hr/static/tests/m2x_avatar_employee_tests.js
@@ -40,7 +40,7 @@ QUnit.module('hr', {}, function () {
             { employee_id: hrEmployeePublicId2 },
             { employee_id: hrEmployeePublicId1 },
         ]);
-        const { target: list } = await start({
+        await start({
             hasView: true,
             View: ListView,
             model: 'm2x.avatar.employee',
@@ -53,13 +53,13 @@ QUnit.module('hr', {}, function () {
             },
         });
 
-        assert.strictEqual(list.querySelector('.o_data_cell span').innerText, 'Mario');
-        assert.strictEqual(list.querySelectorAll('.o_data_cell span')[1].innerText, 'Luigi');
-        assert.strictEqual(list.querySelectorAll('.o_data_cell span')[2].innerText, 'Mario');
+        assert.strictEqual(document.querySelector('.o_data_cell span').innerText, 'Mario');
+        assert.strictEqual(document.querySelectorAll('.o_data_cell span')[1].innerText, 'Luigi');
+        assert.strictEqual(document.querySelectorAll('.o_data_cell span')[2].innerText, 'Mario');
 
         // click on first employee
         await afterNextRender(() =>
-            dom.click(list.querySelector('.o_data_cell .o_m2o_avatar > img'))
+            dom.click(document.querySelector('.o_data_cell .o_m2o_avatar > img'))
         );
         assert.verifySteps(
             [`read hr.employee.public ${hrEmployeePublicId1}`],
@@ -78,7 +78,7 @@ QUnit.module('hr', {}, function () {
 
         // click on second employee
         await afterNextRender(() =>
-            dom.click(list.querySelectorAll('.o_data_cell .o_m2o_avatar > img')[1]
+            dom.click(document.querySelectorAll('.o_data_cell .o_m2o_avatar > img')[1]
         ));
         assert.verifySteps(
             [`read hr.employee.public ${hrEmployeePublicId2}`],
@@ -98,7 +98,7 @@ QUnit.module('hr', {}, function () {
 
         // click on third employee (same as first)
         await afterNextRender(() =>
-            dom.click(list.querySelectorAll('.o_data_cell .o_m2o_avatar > img')[2])
+            dom.click(document.querySelectorAll('.o_data_cell .o_m2o_avatar > img')[2])
         );
         assert.verifySteps(
             [],
@@ -120,7 +120,7 @@ QUnit.module('hr', {}, function () {
         const resUsersId1 = pyEnv['res.users'].create({ partner_id: resPartnerId1 });
         const hrEmployeePublicId1 = pyEnv['hr.employee.public'].create({ user_id: resUsersId1, user_partner_id: resPartnerId1 });
         pyEnv['m2x.avatar.employee'].create({ employee_id: hrEmployeePublicId1, employee_ids: [hrEmployeePublicId1] });
-        const { target: kanban } = await start({
+        await start({
             hasView: true,
             View: KanbanView,
             model: 'm2x.avatar.employee',
@@ -137,9 +137,9 @@ QUnit.module('hr', {}, function () {
                 </kanban>`,
         });
 
-        assert.strictEqual(kanban.querySelector('.o_kanban_record').innerText.trim(), '');
-        assert.containsOnce(kanban, '.o_m2o_avatar');
-        assert.strictEqual(kanban.querySelector('.o_m2o_avatar > img').getAttribute('data-src'), `/web/image/hr.employee.public/${hrEmployeePublicId1}/avatar_128`);
+        assert.strictEqual(document.querySelector('.o_kanban_record').innerText.trim(), '');
+        assert.containsOnce(document.body, '.o_m2o_avatar');
+        assert.strictEqual(document.querySelector('.o_m2o_avatar > img').getAttribute('data-src'), `/web/image/hr.employee.public/${hrEmployeePublicId1}/avatar_128`);
     });
 
     QUnit.test('many2one_avatar_employee: click on an employee not associated with a user', async function (assert) {
@@ -148,7 +148,7 @@ QUnit.module('hr', {}, function () {
         const pyEnv = await startServer();
         const hrEmployeePublicId1 = pyEnv['hr.employee.public'].create({ name: 'Mario' });
         const m2xHrAvatarUserId1 = pyEnv['m2x.avatar.employee'].create({ employee_id: hrEmployeePublicId1 });
-        const { target: form, widget } = await start({
+        const { widget } = await start({
             hasView: true,
             View: FormView,
             model: 'm2x.avatar.employee',
@@ -183,9 +183,9 @@ QUnit.module('hr', {}, function () {
             }
         }, true);
 
-        assert.strictEqual(form.querySelector('.o_field_widget[name=employee_id]').innerText.trim(), 'Mario');
+        assert.strictEqual(document.querySelector('.o_field_widget[name=employee_id]').innerText.trim(), 'Mario');
 
-        await dom.click(form.querySelector('.o_m2o_avatar > img'));
+        await dom.click(document.querySelector('.o_m2o_avatar > img'));
 
         assert.verifySteps([
             `read m2x.avatar.employee ${m2xHrAvatarUserId1}`,
@@ -206,7 +206,7 @@ QUnit.module('hr', {}, function () {
         const m2xAvatarEmployeeId1 = pyEnv['m2x.avatar.employee'].create(
             { employee_ids: [hrEmployeePublicId1, hrEmployeePublicId2] },
         );
-        const { target: form } = await start({
+        await start({
             hasView: true,
             View: FormView,
             model: 'm2x.avatar.employee',
@@ -221,14 +221,14 @@ QUnit.module('hr', {}, function () {
             res_id: m2xAvatarEmployeeId1,
         });
 
-        assert.containsN(form, '.o_field_many2manytags.avatar.o_field_widget .badge', 2,
+        assert.containsN(document.body, '.o_field_many2manytags.avatar.o_field_widget .badge', 2,
             "should have 2 records");
-        assert.strictEqual(form.querySelector('.o_field_many2manytags.avatar.o_field_widget .badge img').getAttribute('data-src'),
+        assert.strictEqual(document.querySelector('.o_field_many2manytags.avatar.o_field_widget .badge img').getAttribute('data-src'),
             `/web/image/hr.employee.public/${hrEmployeePublicId1}/avatar_128`,
             "should have correct avatar image");
 
-        await dom.click(form.querySelector('.o_field_many2manytags.avatar .badge .o_m2m_avatar'));
-        await dom.click(form.querySelectorAll('.o_field_many2manytags.avatar .badge .o_m2m_avatar')[1]);
+        await dom.click(document.querySelector('.o_field_many2manytags.avatar .badge .o_m2m_avatar'));
+        await dom.click(document.querySelectorAll('.o_field_many2manytags.avatar .badge .o_m2m_avatar')[1]);
 
         assert.verifySteps([
             `read m2x.avatar.employee ${m2xAvatarEmployeeId1}`,
@@ -261,7 +261,7 @@ QUnit.module('hr', {}, function () {
         pyEnv['m2x.avatar.employee'].create(
             { employee_ids: [hrEmployeePublicId1, hrEmployeePublicId2] },
         );
-        const { target: list } = await start({
+        await start({
             hasView: true,
             View: ListView,
             model: 'm2x.avatar.employee',
@@ -274,12 +274,12 @@ QUnit.module('hr', {}, function () {
             },
         });
 
-        assert.containsN(list, '.o_data_cell:first .o_field_many2manytags > span', 2,
+        assert.containsN(document.body, '.o_data_cell:first .o_field_many2manytags > span', 2,
             "should have two avatar");
 
         // click on first employee badge
         await afterNextRender(() =>
-            dom.click(list.querySelector('.o_data_cell .o_m2m_avatar'))
+            dom.click(document.querySelector('.o_data_cell .o_m2m_avatar'))
         );
         assert.verifySteps(
             [`read hr.employee.public ${hrEmployeePublicId1},${hrEmployeePublicId2}`, `read hr.employee.public ${hrEmployeePublicId1}`],
@@ -298,7 +298,7 @@ QUnit.module('hr', {}, function () {
 
         // click on second employee
         await afterNextRender(() =>
-            dom.click(list.querySelectorAll('.o_data_cell .o_m2m_avatar')[1])
+            dom.click(document.querySelectorAll('.o_data_cell .o_m2m_avatar')[1])
         );
         assert.verifySteps(
             [`read hr.employee.public ${hrEmployeePublicId2}`],
@@ -330,7 +330,7 @@ QUnit.module('hr', {}, function () {
         pyEnv['m2x.avatar.employee'].create(
             { employee_ids: [hrEmployeePublicId1, hrEmployeePublicId2] },
         );
-        const { target: kanban } = await start({
+        await start({
             hasView: true,
             View: KanbanView,
             model: 'm2x.avatar.employee',
@@ -358,17 +358,17 @@ QUnit.module('hr', {}, function () {
             },
         });
 
-        assert.containsN(kanban, '.o_kanban_record:first .o_field_many2manytags img.o_m2m_avatar', 2,
+        assert.containsN(document.body, '.o_kanban_record:first .o_field_many2manytags img.o_m2m_avatar', 2,
             "should have 2 avatar images");
-        assert.strictEqual(kanban.querySelector('.o_kanban_record .o_field_many2manytags img.o_m2m_avatar').getAttribute('data-src'),
+        assert.strictEqual(document.querySelector('.o_kanban_record .o_field_many2manytags img.o_m2m_avatar').getAttribute('data-src'),
             `/web/image/hr.employee.public/${hrEmployeePublicId1}/avatar_128`,
             "should have correct avatar image");
-        assert.strictEqual(kanban.querySelectorAll('.o_kanban_record .o_field_many2manytags img.o_m2m_avatar')[1].getAttribute('data-src'),
+        assert.strictEqual(document.querySelectorAll('.o_kanban_record .o_field_many2manytags img.o_m2m_avatar')[1].getAttribute('data-src'),
             `/web/image/hr.employee.public/${hrEmployeePublicId2}/avatar_128`,
             "should have correct avatar image");
 
-        await dom.click(kanban.querySelector('.o_kanban_record .o_m2m_avatar'));
-        await dom.click(kanban.querySelectorAll('.o_kanban_record .o_m2m_avatar')[1]);
+        await dom.click(document.querySelector('.o_kanban_record .o_m2m_avatar'));
+        await dom.click(document.querySelectorAll('.o_kanban_record .o_m2m_avatar')[1]);
 
         assert.verifySteps([
             `read hr.employee.public ${hrEmployeePublicId1},${hrEmployeePublicId2}`,
@@ -390,7 +390,7 @@ QUnit.module('hr', {}, function () {
         const m2xAvatarEmployeeId1 = pyEnv['m2x.avatar.employee'].create(
             { employee_ids: [hrEmployeePublicId1, hrEmployeePublicId2] },
         );
-        const { target: form, widget } = await start({
+        const { widget } = await start({
             hasView: true,
             View: FormView,
             model: 'm2x.avatar.employee',
@@ -425,14 +425,14 @@ QUnit.module('hr', {}, function () {
             }
         }, true);
 
-        assert.containsN(form, '.o_field_many2manytags.avatar.o_field_widget .badge', 2,
+        assert.containsN(document.body, '.o_field_many2manytags.avatar.o_field_widget .badge', 2,
             "should have 2 records");
-        assert.strictEqual(form.querySelector('.o_field_many2manytags.avatar.o_field_widget .badge img').getAttribute('data-src'),
+        assert.strictEqual(document.querySelector('.o_field_many2manytags.avatar.o_field_widget .badge img').getAttribute('data-src'),
             `/web/image/hr.employee.public/${hrEmployeePublicId1}/avatar_128`,
             "should have correct avatar image");
 
-        await dom.click(form.querySelector('.o_field_many2manytags.avatar .badge .o_m2m_avatar'));
-        await dom.click(form.querySelectorAll('.o_field_many2manytags.avatar .badge .o_m2m_avatar')[1]);
+        await dom.click(document.querySelector('.o_field_many2manytags.avatar .badge .o_m2m_avatar'));
+        await dom.click(document.querySelectorAll('.o_field_many2manytags.avatar .badge .o_m2m_avatar')[1]);
 
         assert.verifySteps([
             `read m2x.avatar.employee ${hrEmployeePublicId1}`,

--- a/addons/hr_holidays/static/tests/qunit_suite_tests/components/partner_im_status_icon_tests.js
+++ b/addons/hr_holidays/static/tests/qunit_suite_tests/components/partner_im_status_icon_tests.js
@@ -1,33 +1,21 @@
 /** @odoo-module **/
 
-import {
-    createRootMessagingComponent,
-    start,
-} from '@mail/../tests/helpers/test_utils';
+import { start } from '@mail/../tests/helpers/test_utils';
 
 QUnit.module('hr_holidays', {}, function () {
 QUnit.module('components', {}, function () {
-QUnit.module('partner_im_status_icon_tests.js', {
-    beforeEach() {
-        this.createPartnerImStatusIcon = async (partner, target) => {
-            await createRootMessagingComponent(partner.env, "PartnerImStatusIcon", {
-                props: { partner },
-                target,
-            });
-        };
-    },
-});
+QUnit.module('partner_im_status_icon_tests.js');
 
 QUnit.test('on leave & online', async function (assert) {
     assert.expect(2);
 
-    const { messaging, target } = await start();
+    const { createRootMessagingComponent, messaging } = await start();
     const partner = messaging.models['Partner'].create({
         id: 7,
         name: "Demo User",
         im_status: 'leave_online',
     });
-    await this.createPartnerImStatusIcon(partner, target);
+    await createRootMessagingComponent('PartnerImStatusIcon', { partner });
     assert.hasClass(
         document.querySelector('.o_PartnerImStatusIcon_icon'),
         'o-online',
@@ -43,13 +31,13 @@ QUnit.test('on leave & online', async function (assert) {
 QUnit.test('on leave & away', async function (assert) {
     assert.expect(2);
 
-    const { messaging, target } = await start();
+    const { createRootMessagingComponent, messaging } = await start();
     const partner = messaging.models['Partner'].create({
         id: 7,
         name: "Demo User",
         im_status: 'leave_away',
     });
-    await this.createPartnerImStatusIcon(partner, target);
+    await createRootMessagingComponent('PartnerImStatusIcon', { partner });
     assert.hasClass(
         document.querySelector('.o_PartnerImStatusIcon_icon'),
         'o-away',
@@ -65,13 +53,13 @@ QUnit.test('on leave & away', async function (assert) {
 QUnit.test('on leave & offline', async function (assert) {
     assert.expect(2);
 
-    const { messaging, target } = await start();
+    const { createRootMessagingComponent, messaging } = await start();
     const partner = messaging.models['Partner'].create({
         id: 7,
         name: "Demo User",
         im_status: 'leave_offline',
     });
-    await this.createPartnerImStatusIcon(partner, target);
+    await createRootMessagingComponent('PartnerImStatusIcon', { partner });
     assert.hasClass(
         document.querySelector('.o_PartnerImStatusIcon_icon'),
         'o-offline',

--- a/addons/hr_holidays/static/tests/qunit_suite_tests/components/thread_icon_tests.js
+++ b/addons/hr_holidays/static/tests/qunit_suite_tests/components/thread_icon_tests.js
@@ -1,23 +1,13 @@
 /** @odoo-module **/
 
 import {
-    createRootMessagingComponent,
     start,
     startServer,
 } from '@mail/../tests/helpers/test_utils';
 
 QUnit.module('mail', {}, function () {
 QUnit.module('components', {}, function () {
-QUnit.module('thread_icon_tests.js', {
-    beforeEach() {
-        this.createThreadIcon = async (thread, target) => {
-            await createRootMessagingComponent(thread.env, "ThreadIcon", {
-                props: { thread },
-                target,
-            });
-        };
-    },
-});
+QUnit.module('thread_icon_tests.js');
 
 QUnit.test('thread icon of a chat when correspondent is on leave & online', async function (assert) {
     assert.expect(2);
@@ -34,12 +24,12 @@ QUnit.test('thread icon of a chat when correspondent is on leave & online', asyn
         ],
         channel_type: 'chat',
     });
-    const { messaging, target } = await start();
+    const { createRootMessagingComponent, messaging } = await start();
     const thread = messaging.models['Thread'].findFromIdentifyingData({
         id: mailChannelId1,
         model: 'mail.channel',
     });
-    await this.createThreadIcon(thread, target);
+    await createRootMessagingComponent('ThreadIcon', { thread });
 
     assert.containsOnce(
         document.body,
@@ -68,12 +58,12 @@ QUnit.test('thread icon of a chat when correspondent is on leave & away', async 
         ],
         channel_type: 'chat',
     });
-    const { messaging, target } = await start();
+    const { createRootMessagingComponent, messaging } = await start();
     const thread = messaging.models['Thread'].findFromIdentifyingData({
         id: mailChannelId1,
         model: 'mail.channel',
     });
-    await this.createThreadIcon(thread, target);
+    await createRootMessagingComponent('ThreadIcon', { thread });
 
     assert.containsOnce(
         document.body,
@@ -102,12 +92,12 @@ QUnit.test('thread icon of a chat when correspondent is on leave & offline', asy
         ],
         channel_type: 'chat',
     });
-    const { messaging, target } = await start();
+    const { createRootMessagingComponent, messaging } = await start();
     const thread = messaging.models['Thread'].findFromIdentifyingData({
         id: mailChannelId1,
         model: 'mail.channel',
     });
-    await this.createThreadIcon(thread, target);
+    await createRootMessagingComponent('ThreadIcon', { thread });
 
     assert.containsOnce(
         document.body,

--- a/addons/im_livechat/static/tests/qunit_suite_tests/components/thread_icon_tests.js
+++ b/addons/im_livechat/static/tests/qunit_suite_tests/components/thread_icon_tests.js
@@ -2,23 +2,13 @@
 
 import {
     afterNextRender,
-    createRootMessagingComponent,
     start,
     startServer,
 } from '@mail/../tests/helpers/test_utils';
 
 QUnit.module('im_livechat', {}, function () {
 QUnit.module('components', {}, function () {
-QUnit.module('thread_icon_tests.js', {
-    beforeEach() {
-        this.createThreadIcon = async (thread, target) => {
-            await createRootMessagingComponent(thread.env, "ThreadIcon", {
-                props: { thread },
-                target,
-            });
-        };
-    },
-});
+QUnit.module('thread_icon_tests.js');
 
 QUnit.test('livechat: public website visitor is typing', async function (assert) {
     assert.expect(4);
@@ -33,12 +23,12 @@ QUnit.test('livechat: public website visitor is typing', async function (assert)
         channel_type: 'livechat',
         livechat_operator_id: pyEnv.currentPartnerId,
     });
-    const { messaging, target } = await start();
+    const { createRootMessagingComponent, messaging } = await start();
     const thread = messaging.models['Thread'].findFromIdentifyingData({
         id: mailChannelId1,
         model: 'mail.channel',
     });
-    await this.createThreadIcon(thread, target);
+    await createRootMessagingComponent('ThreadIcon', { thread });
     assert.containsOnce(
         document.body,
         '.o_ThreadIcon',

--- a/addons/im_livechat/static/tests/qunit_suite_tests/components/thread_textual_typing_status_tests.js
+++ b/addons/im_livechat/static/tests/qunit_suite_tests/components/thread_textual_typing_status_tests.js
@@ -2,23 +2,13 @@
 
 import {
     afterNextRender,
-    createRootMessagingComponent,
     start,
     startServer,
 } from '@mail/../tests/helpers/test_utils';
 
 QUnit.module('im_livechat', {}, function () {
 QUnit.module('components', {}, function () {
-QUnit.module('thread_textual_typing_status_tests.js', {
-    beforeEach() {
-        this.createThreadTextualTypingStatusComponent = async (thread, target) => {
-            await createRootMessagingComponent(thread.env, "ThreadTextualTypingStatus", {
-                props: { thread },
-                target,
-            });
-        };
-    },
-});
+QUnit.module('thread_textual_typing_status_tests.js');
 
 QUnit.test('receive visitor typing status "is typing"', async function (assert) {
     assert.expect(2);
@@ -33,12 +23,12 @@ QUnit.test('receive visitor typing status "is typing"', async function (assert) 
         channel_type: 'livechat',
         livechat_operator_id: pyEnv.currentPartnerId,
     });
-    const { messaging, target } = await start();
+    const { createRootMessagingComponent, messaging } = await start();
     const thread = messaging.models['Thread'].findFromIdentifyingData({
         id: mailChannelId1,
         model: 'mail.channel',
     });
-    await this.createThreadTextualTypingStatusComponent(thread, target);
+    await createRootMessagingComponent('ThreadTextualTypingStatus', { thread });
 
     assert.strictEqual(
         document.querySelector('.o_ThreadTextualTypingStatus').textContent,

--- a/addons/mail/static/tests/helpers/test_utils.js
+++ b/addons/mail/static/tests/helpers/test_utils.js
@@ -927,11 +927,11 @@ async function start(param0 = {}) {
         createMessageComponent: getCreateMessageComponent({ env: testEnv, modelManager, target }),
         createMessagingMenuComponent: getCreateMessagingMenuComponent({ env: testEnv, target }),
         createNotificationListComponent: getCreateNotificationListComponent({ env: testEnv, modelManager, target }),
+        createRootMessagingComponent: (componentName, props) => createRootMessagingComponent(testEnv, componentName, { props, target }),
         createThreadViewComponent: getCreateThreadViewComponent({ afterEvent, env: testEnv, target }),
         insertText,
         messaging: modelManager.messaging,
         openDiscuss,
-        target,
     };
 }
 
@@ -1009,7 +1009,6 @@ function pasteFiles(el, files) {
 
 export {
     afterNextRender,
-    createRootMessagingComponent,
     dragenterFiles,
     dropFiles,
     nextAnimationFrame,

--- a/addons/mail/static/tests/qunit_suite_tests/chatter_tests.js
+++ b/addons/mail/static/tests/qunit_suite_tests/chatter_tests.js
@@ -13,7 +13,7 @@ QUnit.test('list activity widget with no activity', async function (assert) {
     assert.expect(4);
 
     const pyEnv = await startServer();
-    const { target: list } = await start({
+    await start({
         hasView: true,
         View: ListView,
         model: 'res.users',
@@ -27,8 +27,8 @@ QUnit.test('list activity widget with no activity', async function (assert) {
         session: { uid: pyEnv.currentUserId },
     });
 
-    assert.containsOnce(list, '.o_mail_activity .o_activity_color_default');
-    assert.strictEqual(list.querySelector('.o_activity_summary').innerText, '');
+    assert.containsOnce(document.body, '.o_mail_activity .o_activity_color_default');
+    assert.strictEqual(document.querySelector('.o_activity_summary').innerText, '');
 
     assert.verifySteps(['/web/dataset/search_read']);
 });
@@ -56,7 +56,7 @@ QUnit.test('list activity widget with activities', async function (assert) {
         activity_type_id: mailActivityTypeId2,
     });
 
-    const { target: list } = await start({
+    await start({
         hasView: true,
         View: ListView,
         model: 'res.users',
@@ -69,11 +69,11 @@ QUnit.test('list activity widget with activities', async function (assert) {
         },
     });
 
-    const firstRow = list.querySelector('.o_data_row');
+    const firstRow = document.querySelector('.o_data_row');
     assert.containsOnce(firstRow, '.o_mail_activity .o_activity_color_today.fa-phone');
     assert.strictEqual(firstRow.querySelector('.o_activity_summary').innerText, 'Call with Al');
 
-    const secondRow = list.querySelectorAll('.o_data_row')[1];
+    const secondRow = document.querySelectorAll('.o_data_row')[1];
     assert.containsOnce(secondRow, '.o_mail_activity .o_activity_color_planned.fa-clock-o');
     assert.strictEqual(secondRow.querySelector('.o_activity_summary').innerText, 'Type 2');
 
@@ -95,7 +95,7 @@ QUnit.test('list activity widget with exception', async function (assert) {
         activity_exception_icon: 'fa-warning',
     });
 
-    const { target: list } = await start({
+    await start({
         hasView: true,
         View: ListView,
         model: 'res.users',
@@ -108,8 +108,8 @@ QUnit.test('list activity widget with exception', async function (assert) {
         },
     });
 
-    assert.containsOnce(list, '.o_activity_color_today.text-warning.fa-warning');
-    assert.strictEqual(list.querySelector('.o_activity_summary').innerText, 'Warning');
+    assert.containsOnce(document.body, '.o_activity_color_today.text-warning.fa-warning');
+    assert.strictEqual(document.querySelector('.o_activity_summary').innerText, 'Warning');
 
     assert.verifySteps(['/web/dataset/search_read']);
 });
@@ -146,7 +146,7 @@ QUnit.test('list activity widget: open dropdown', async function (assert) {
         activity_type_id: mailActivityTypeId2,
     });
 
-    const { target: list } = await start({
+    await start({
         hasView: true,
         View: ListView,
         model: 'res.users',
@@ -174,21 +174,21 @@ QUnit.test('list activity widget: open dropdown', async function (assert) {
         },
     });
 
-    assert.strictEqual(list.querySelector('.o_activity_summary').innerText, 'Call with Al');
+    assert.strictEqual(document.querySelector('.o_activity_summary').innerText, 'Call with Al');
 
     // click on the first record to open it, to ensure that the 'switch_view'
     // assertion is relevant (it won't be opened as there is no action manager,
     // but we'll log the 'switch_view' event)
-    await testUtils.dom.click(list.querySelector('.o_data_cell'));
+    await testUtils.dom.click(document.querySelector('.o_data_cell'));
 
     // from this point, no 'switch_view' event should be triggered, as we
     // interact with the activity widget
     assert.step('open dropdown');
-    await testUtils.dom.click(list.querySelector('.o_activity_btn span')); // open the popover
-    await testUtils.dom.click(list.querySelector('.o_mark_as_done')); // mark the first activity as done
-    await testUtils.dom.click(list.querySelector('.o_activity_popover_done')); // confirm
+    await testUtils.dom.click(document.querySelector('.o_activity_btn span')); // open the popover
+    await testUtils.dom.click(document.querySelector('.o_mark_as_done')); // mark the first activity as done
+    await testUtils.dom.click(document.querySelector('.o_activity_popover_done')); // confirm
 
-    assert.strictEqual(list.querySelector('.o_activity_summary').innerText, 'Meet FP');
+    assert.strictEqual(document.querySelector('.o_activity_summary').innerText, 'Meet FP');
 
     assert.verifySteps([
         '/web/dataset/search_read',
@@ -236,7 +236,7 @@ QUnit.test('list activity exception widget with activity', async function (asser
         activity_exception_decoration: 'warning',
         activity_exception_icon: 'fa-warning',
     });
-    const { target: list } = await start({
+    await start({
         hasView: true,
         View: ListView,
         model: 'res.users',
@@ -245,10 +245,10 @@ QUnit.test('list activity exception widget with activity', async function (asser
             '</tree>',
     });
 
-    assert.containsN(list, '.o_data_row', 2, "should have two records");
-    assert.doesNotHaveClass(list.querySelector('.o_data_row .o_activity_exception_cell div'), 'fa-warning',
+    assert.containsN(document.body, '.o_data_row', 2, "should have two records");
+    assert.doesNotHaveClass(document.querySelector('.o_data_row .o_activity_exception_cell div'), 'fa-warning',
         "there is no any exception activity on record");
-    assert.hasClass(list.querySelectorAll('.o_data_row .o_activity_exception_cell div')[1], 'fa-warning',
+    assert.hasClass(document.querySelectorAll('.o_data_row .o_activity_exception_cell div')[1], 'fa-warning',
         "there is an exception on a record");
 });
 
@@ -275,7 +275,7 @@ QUnit.test('list activity widget: done the activity with "ENTER" keyboard shortc
         activity_type_id: mailActivityTypeId1,
     });
 
-    const { target: list } = await start({
+    await start({
         hasView: true,
         View: ListView,
         model: 'res.users',
@@ -285,8 +285,8 @@ QUnit.test('list activity widget: done the activity with "ENTER" keyboard shortc
             </list>`,
     });
 
-    await testUtils.dom.click(list.querySelector('.o_activity_btn span'));
-    await testUtils.dom.click(list.querySelector('.o_mark_as_done'));
+    await testUtils.dom.click(document.querySelector('.o_activity_btn span'));
+    await testUtils.dom.click(document.querySelector('.o_mark_as_done'));
     pyEnv['res.users'].write([pyEnv.currentUserId], {
         activity_state: '',
     });
@@ -296,7 +296,7 @@ QUnit.test('list activity widget: done the activity with "ENTER" keyboard shortc
         { key: 'Enter' },
     );
 
-    assert.containsOnce(list, '.o_mail_activity .o_activity_color_default');
+    assert.containsOnce(document.body, '.o_mail_activity .o_activity_color_default');
 });
 
 QUnit.test('list activity widget: done and schedule the next activity with "ENTER" keyboard shortcut', async function (assert) {
@@ -322,7 +322,7 @@ QUnit.test('list activity widget: done and schedule the next activity with "ENTE
         activity_type_id: mailActivityTypeId1,
     });
 
-    const { target: list } = await start({
+    await start({
         hasView: true,
         View: ListView,
         model: 'res.users',
@@ -337,8 +337,8 @@ QUnit.test('list activity widget: done and schedule the next activity with "ENTE
         },
     });
 
-    await testUtils.dom.click(list.querySelector('.o_activity_btn span'));
-    await testUtils.dom.click(list.querySelector('.o_mark_as_done'));
+    await testUtils.dom.click(document.querySelector('.o_activity_btn span'));
+    await testUtils.dom.click(document.querySelector('.o_mark_as_done'));
     await testUtils.dom.triggerEvent(
         document.querySelector('.o_activity_popover_done_next'),
         'keydown',
@@ -360,7 +360,7 @@ QUnit.test('fieldmany2many tags email (edition)', async function (assert) {
         partner_ids: [resPartnerId1],
     });
 
-    var { target: form } = await start({
+    await start({
         hasView: true,
         View: FormView,
         model: 'mail.message',
@@ -387,7 +387,7 @@ QUnit.test('fieldmany2many tags email (edition)', async function (assert) {
     });
 
     assert.verifySteps([`[${resPartnerId1}]`]);
-    assert.containsOnce(form, '.o_field_many2manytags[name="partner_ids"] .badge.o_tag_color_0',
+    assert.containsOnce(document.body, '.o_field_many2manytags[name="partner_ids"] .badge.o_tag_color_0',
         "should contain one tag");
 
     // add an other existing tag
@@ -405,9 +405,9 @@ QUnit.test('fieldmany2many tags email (edition)', async function (assert) {
     await testUtils.fields.editInput($('.modal-body.o_act_window input[name="email"]'), 'coucou@petite.perruche');
     await testUtils.dom.click($('.modal-footer .btn-primary'));
 
-    assert.containsN(form, '.o_field_many2manytags[name="partner_ids"] .badge.o_tag_color_0', 2,
+    assert.containsN(document.body, '.o_field_many2manytags[name="partner_ids"] .badge.o_tag_color_0', 2,
         "should contain the second tag");
-    const firstTag = form.querySelector('.o_field_many2manytags[name="partner_ids"] .badge.o_tag_color_0');
+    const firstTag = document.querySelector('.o_field_many2manytags[name="partner_ids"] .badge.o_tag_color_0');
     assert.strictEqual(firstTag.querySelector('.o_badge_text').innerText, "gold",
         "tag should only show name");
     assert.hasAttrValue(firstTag.querySelector('.o_badge_text'), 'title', "coucou@petite.perruche",
@@ -429,7 +429,7 @@ QUnit.test('many2many_tags_email widget can load more than 40 records', async fu
         partner_ids: messagePartnerIds,
     });
 
-    const { click, target: form } = await start({
+    const { click } = await start({
         hasView: true,
         View: FormView,
         model: 'mail.message',
@@ -437,17 +437,17 @@ QUnit.test('many2many_tags_email widget can load more than 40 records', async fu
         res_id: mailMessageId1,
     });
 
-    assert.strictEqual(form.querySelectorAll('.o_field_widget[name="partner_ids"] .badge').length, 100);
+    assert.strictEqual(document.querySelectorAll('.o_field_widget[name="partner_ids"] .badge').length, 100);
 
     await click('.o_form_button_edit');
 
-    assert.hasClass(form.querySelector('.o_form_view'), 'o_form_editable');
+    assert.hasClass(document.querySelector('.o_form_view'), 'o_form_editable');
 
     // add a record to the relation
     await testUtils.fields.many2one.clickOpenDropdown('partner_ids');
     await testUtils.fields.many2one.clickHighlightedItem('partner_ids');
 
-    assert.strictEqual(form.querySelectorAll('.o_field_widget[name="partner_ids"] .badge').length, 101);
+    assert.strictEqual(document.querySelectorAll('.o_field_widget[name="partner_ids"] .badge').length, 101);
 });
 
 });

--- a/addons/mail/static/tests/qunit_suite_tests/components/follower_subtype_tests.js
+++ b/addons/mail/static/tests/qunit_suite_tests/components/follower_subtype_tests.js
@@ -3,7 +3,6 @@
 import { makeDeferred } from '@mail/utils/deferred';
 import {
     afterNextRender,
-    createRootMessagingComponent,
     start,
     startServer,
 } from '@mail/../tests/helpers/test_utils';
@@ -14,17 +13,6 @@ QUnit.module('mail', {}, function () {
 QUnit.module('components', {}, function () {
 QUnit.module('follower_subtype_tests.js', {
     beforeEach() {
-        this.createFollowerSubtypeComponent = async ({ follower, followerSubtype, target }) => {
-            const props = {
-                follower,
-                followerSubtype,
-            };
-            await createRootMessagingComponent(follower.env, "FollowerSubtype", {
-                props,
-                target,
-            });
-        };
-
         // FIXME archs could be removed once task-2248306 is done
         // The mockServer will try to get the list view
         // of every relational fields present in the main view.

--- a/addons/mail/static/tests/qunit_suite_tests/components/follower_tests.js
+++ b/addons/mail/static/tests/qunit_suite_tests/components/follower_tests.js
@@ -3,7 +3,6 @@
 import { insert, replace } from '@mail/model/model_field_command';
 import { makeDeferred } from '@mail/utils/deferred';
 import {
-    createRootMessagingComponent,
     start,
     startServer,
 } from '@mail/../tests/helpers/test_utils';
@@ -12,21 +11,12 @@ import Bus from 'web.Bus';
 
 QUnit.module('mail', {}, function () {
 QUnit.module('components', {}, function () {
-QUnit.module('follower_tests.js', {
-    beforeEach() {
-        this.createFollowerComponent = async (follower, target) => {
-            await createRootMessagingComponent(follower.env, "Follower", {
-                props: { follower },
-                target,
-            });
-        };
-    },
-});
+QUnit.module('follower_tests.js');
 
 QUnit.test('base rendering not editable', async function (assert) {
     assert.expect(5);
 
-    const { messaging, target } = await start();
+    const { createRootMessagingComponent, messaging } = await start();
 
     const thread = messaging.models['Thread'].create({
         hasWriteAccess: false,
@@ -42,7 +32,7 @@ QUnit.test('base rendering not editable', async function (assert) {
         id: 2,
         isActive: true,
     });
-    await this.createFollowerComponent(follower, target);
+    await createRootMessagingComponent('Follower', { follower });
     assert.containsOnce(
         document.body,
         '.o_Follower',
@@ -73,7 +63,7 @@ QUnit.test('base rendering not editable', async function (assert) {
 QUnit.test('base rendering editable', async function (assert) {
     assert.expect(6);
 
-    const { messaging, target } = await start();
+    const { createRootMessagingComponent, messaging } = await start();
     const thread = messaging.models['Thread'].create({
         hasWriteAccess: true,
         id: 100,
@@ -88,7 +78,7 @@ QUnit.test('base rendering editable', async function (assert) {
         id: 2,
         isActive: true,
     });
-    await this.createFollowerComponent(follower, target);
+    await createRootMessagingComponent('Follower', { follower });
     assert.containsOnce(
         document.body,
         '.o_Follower',
@@ -147,7 +137,7 @@ QUnit.test('click on partner follower details', async function (assert) {
     });
     const pyEnv = await startServer();
     const resPartnerId1 = pyEnv['res.partner'].create();
-    const { messaging, target } = await start({ env: { bus } });
+    const { createRootMessagingComponent, messaging } = await start({ env: { bus } });
     const thread = messaging.models['Thread'].create({
         id: resPartnerId1,
         model: 'res.partner',
@@ -162,7 +152,7 @@ QUnit.test('click on partner follower details', async function (assert) {
             name: "François Perusse",
         }),
     });
-    await this.createFollowerComponent(follower, target);
+    await createRootMessagingComponent('Follower', { follower });
     assert.containsOnce(
         document.body,
         '.o_Follower',
@@ -193,7 +183,7 @@ QUnit.test('click on edit follower', async function (assert) {
         res_id: resPartnerId1,
         res_model: 'res.partner',
     });
-    const { click, messaging, target } = await start({
+    const { click, createRootMessagingComponent, messaging } = await start({
         async mockRPC(route, args) {
             if (route.includes('/mail/read_subscription_data')) {
                 assert.step('fetch_subtypes');
@@ -206,7 +196,7 @@ QUnit.test('click on edit follower', async function (assert) {
         model: 'res.partner',
     });
     await thread.fetchData(['followers']);
-    await this.createFollowerComponent(thread.followers[0], target);
+    await createRootMessagingComponent('Follower', { follower: thread.followers[0] });
     assert.containsOnce(
         document.body,
         '.o_Follower',
@@ -235,7 +225,7 @@ QUnit.test('edit follower and close subtype dialog', async function (assert) {
 
     const pyEnv = await startServer();
     const resPartnerId1 = pyEnv['res.partner'].create();
-    const { click, messaging, target } = await start({
+    const { click, createRootMessagingComponent, messaging } = await start({
         async mockRPC(route, args) {
             if (route.includes('/mail/read_subscription_data')) {
                 assert.step('fetch_subtypes');
@@ -265,7 +255,7 @@ QUnit.test('edit follower and close subtype dialog', async function (assert) {
             name: "François Perusse",
         }),
     });
-    await this.createFollowerComponent(follower, target);
+    await createRootMessagingComponent('Follower', { follower });
     assert.containsOnce(
         document.body,
         '.o_Follower',

--- a/addons/mail/static/tests/qunit_suite_tests/components/message_seen_indicator_tests.js
+++ b/addons/mail/static/tests/qunit_suite_tests/components/message_seen_indicator_tests.js
@@ -1,27 +1,13 @@
 /** @odoo-module **/
 
 import {
-    createRootMessagingComponent,
     start,
     startServer,
 } from '@mail/../tests/helpers/test_utils';
 
 QUnit.module('mail', {}, function () {
 QUnit.module('components', {}, function () {
-QUnit.module('message_seen_indicator_tests.js', {
-    beforeEach() {
-        this.createMessageSeenIndicatorComponent = async ({ message, target, thread }, otherProps) => {
-            const props = Object.assign(
-                { message, thread },
-                otherProps
-            );
-            await createRootMessagingComponent(thread.env, "MessageSeenIndicator", {
-                props,
-                target,
-            });
-        };
-    },
-});
+QUnit.module('message_seen_indicator_tests.js');
 
 QUnit.test('rendering when just one has received the message', async function (assert) {
     assert.expect(3);

--- a/addons/mail/static/tests/qunit_suite_tests/components/message_tests.js
+++ b/addons/mail/static/tests/qunit_suite_tests/components/message_tests.js
@@ -4,7 +4,6 @@ import { insert, insertAndReplace, replace } from '@mail/model/model_field_comma
 import { makeDeferred } from '@mail/utils/deferred';
 import {
     afterNextRender,
-    createRootMessagingComponent,
     nextAnimationFrame,
     start,
     startServer,
@@ -496,7 +495,7 @@ QUnit.test('do not show messaging seen indicator if not authored by me', async f
 QUnit.test('do not show messaging seen indicator if before last seen by all message', async function (assert) {
     assert.expect(3);
 
-    const { env, messaging, target } = await start();
+    const { createRootMessagingComponent, messaging } = await start();
     const currentPartner = messaging.models['Partner'].insert({
         id: messaging.currentPartner.id,
         display_name: "Demo User",
@@ -538,9 +537,8 @@ QUnit.test('do not show messaging seen indicator if before last seen by all mess
             thread: replace(thread),
         },
     ]);
-     await createRootMessagingComponent(env, "Message", {
-        props: { record: threadViewer.threadView.messageViews[0] },
-        target,
+     await createRootMessagingComponent("Message", {
+        record: threadViewer.threadView.messageViews[0],
     });
 
     assert.containsOnce(

--- a/addons/mail/static/tests/qunit_suite_tests/components/partner_im_status_icon_tests.js
+++ b/addons/mail/static/tests/qunit_suite_tests/components/partner_im_status_icon_tests.js
@@ -2,33 +2,23 @@
 
 import {
     afterNextRender,
-    createRootMessagingComponent,
     start,
 } from '@mail/../tests/helpers/test_utils';
 
 QUnit.module('mail', {}, function () {
 QUnit.module('components', {}, function () {
-QUnit.module('partner_im_status_icon_tests.js', {
-    beforeEach() {
-        this.createPartnerImStatusIcon = async (partner, target) => {
-            await createRootMessagingComponent(partner.env, "PartnerImStatusIcon", {
-                props: { partner },
-                target,
-            });
-        };
-    },
-});
+QUnit.module('partner_im_status_icon_tests.js');
 
 QUnit.test('initially online', async function (assert) {
     assert.expect(3);
 
-    const { messaging, target } = await start();
+    const { createRootMessagingComponent, messaging } = await start();
     const partner = messaging.models['Partner'].create({
         id: 7,
         name: "Demo User",
         im_status: 'online',
     });
-    await this.createPartnerImStatusIcon(partner, target);
+    await createRootMessagingComponent('PartnerImStatusIcon', { partner });
     assert.strictEqual(
         document.querySelectorAll(`.o_PartnerImStatusIcon`).length,
         1,
@@ -49,13 +39,13 @@ QUnit.test('initially online', async function (assert) {
 QUnit.test('initially offline', async function (assert) {
     assert.expect(1);
 
-    const { messaging, target } = await start();
+    const { createRootMessagingComponent, messaging } = await start();
     const partner = messaging.models['Partner'].create({
         id: 7,
         name: "Demo User",
         im_status: 'offline',
     });
-    await this.createPartnerImStatusIcon(partner, target);
+    await createRootMessagingComponent('PartnerImStatusIcon', { partner });
     assert.strictEqual(
         document.querySelectorAll(`.o_PartnerImStatusIcon.o-offline`).length,
         1,
@@ -66,13 +56,13 @@ QUnit.test('initially offline', async function (assert) {
 QUnit.test('initially away', async function (assert) {
     assert.expect(1);
 
-    const { messaging, target } = await start();
+    const { createRootMessagingComponent, messaging } = await start();
     const partner = messaging.models['Partner'].create({
         id: 7,
         name: "Demo User",
         im_status: 'away',
     });
-    await this.createPartnerImStatusIcon(partner, target);
+    await createRootMessagingComponent('PartnerImStatusIcon', { partner });
     assert.strictEqual(
         document.querySelectorAll(`.o_PartnerImStatusIcon.o-away`).length,
         1,
@@ -83,13 +73,13 @@ QUnit.test('initially away', async function (assert) {
 QUnit.test('change icon on change partner im_status', async function (assert) {
     assert.expect(4);
 
-    const { messaging, target } = await start();
+    const { createRootMessagingComponent, messaging } = await start();
     const partner = messaging.models['Partner'].create({
         id: 7,
         name: "Demo User",
         im_status: 'online',
     });
-    await this.createPartnerImStatusIcon(partner, target);
+    await createRootMessagingComponent('PartnerImStatusIcon', { partner });
     assert.strictEqual(
         document.querySelectorAll(`.o_PartnerImStatusIcon.o-online`).length,
         1,

--- a/addons/mail/static/tests/qunit_suite_tests/components/thread_icon_tests.js
+++ b/addons/mail/static/tests/qunit_suite_tests/components/thread_icon_tests.js
@@ -2,23 +2,13 @@
 
 import {
     afterNextRender,
-    createRootMessagingComponent,
     start,
     startServer,
 } from '@mail/../tests/helpers/test_utils';
 
 QUnit.module('mail', {}, function () {
 QUnit.module('components', {}, function () {
-QUnit.module('thread_icon_tests.js', {
-    async beforeEach() {
-        this.createThreadIcon = async (thread, target) => {
-            await createRootMessagingComponent(thread.env, "ThreadIcon", {
-                props: { thread },
-                target,
-            });
-        };
-    },
-});
+QUnit.module('thread_icon_tests.js');
 
 QUnit.test('chat: correspondent is typing', async function (assert) {
     assert.expect(5);
@@ -35,12 +25,12 @@ QUnit.test('chat: correspondent is typing', async function (assert) {
         ],
         channel_type: 'chat',
     });
-    const { messaging, target } = await start();
+    const { createRootMessagingComponent, messaging } = await start();
     const thread = messaging.models['Thread'].findFromIdentifyingData({
         id: mailChannelId1,
         model: 'mail.channel',
     });
-    await this.createThreadIcon(thread, target);
+    await createRootMessagingComponent('ThreadIcon', { thread });
 
     assert.containsOnce(
         document.body,

--- a/addons/mail/static/tests/qunit_suite_tests/components/thread_textual_typing_status_tests.js
+++ b/addons/mail/static/tests/qunit_suite_tests/components/thread_textual_typing_status_tests.js
@@ -2,7 +2,6 @@
 
 import {
     afterNextRender,
-    createRootMessagingComponent,
     nextAnimationFrame,
     start,
     startServer,
@@ -10,16 +9,7 @@ import {
 
 QUnit.module('mail', {}, function () {
 QUnit.module('components', {}, function () {
-QUnit.module('thread_textual_typing_status_tests.js', {
-    beforeEach() {
-        this.createThreadTextualTypingStatusComponent = async (thread, target) => {
-            await createRootMessagingComponent(thread.env, "ThreadTextualTypingStatus", {
-                props: { thread },
-                target,
-            });
-        };
-    },
-});
+QUnit.module('thread_textual_typing_status_tests.js');
 
 QUnit.test('receive other member typing status "is typing"', async function (assert) {
     assert.expect(2);
@@ -32,12 +22,12 @@ QUnit.test('receive other member typing status "is typing"', async function (ass
             [0, 0, { partner_id: resPartnerId1 }],
         ],
     });
-    const { messaging, target } = await start();
+    const { createRootMessagingComponent, messaging } = await start();
     const thread = messaging.models['Thread'].findFromIdentifyingData({
         id: mailChannelId1,
         model: 'mail.channel',
     });
-    await this.createThreadTextualTypingStatusComponent(thread, target);
+    await createRootMessagingComponent('ThreadTextualTypingStatus', { thread });
 
     assert.strictEqual(
         document.querySelector('.o_ThreadTextualTypingStatus').textContent,
@@ -73,12 +63,12 @@ QUnit.test('receive other member typing status "is typing" then "no longer is ty
             [0, 0, { partner_id: resPartnerId1 }],
         ],
     });
-    const { messaging, target } = await start();
+    const { createRootMessagingComponent, messaging } = await start();
     const thread = messaging.models['Thread'].findFromIdentifyingData({
         id: mailChannelId1,
         model: 'mail.channel',
     });
-    await this.createThreadTextualTypingStatusComponent(thread, target);
+    await createRootMessagingComponent('ThreadTextualTypingStatus', { thread });
 
     assert.strictEqual(
         document.querySelector('.o_ThreadTextualTypingStatus').textContent,
@@ -129,14 +119,14 @@ QUnit.test('assume other member typing status becomes "no longer is typing" afte
             [0, 0, { partner_id: resPartnerId1 }],
         ],
     });
-    const { advanceTime, messaging, target } = await start({
+    const { advanceTime, createRootMessagingComponent, messaging } = await start({
         hasTimeControl: true,
     });
     const thread = messaging.models['Thread'].findFromIdentifyingData({
         id: mailChannelId1,
         model: 'mail.channel',
     });
-    await this.createThreadTextualTypingStatusComponent(thread, target);
+    await createRootMessagingComponent('ThreadTextualTypingStatus', { thread });
 
     assert.strictEqual(
         document.querySelector('.o_ThreadTextualTypingStatus').textContent,
@@ -179,14 +169,14 @@ QUnit.test ('other member typing status "is typing" refreshes 60 seconds timer o
             [0, 0, { partner_id: resPartnerId1 }],
         ],
     });
-    const { advanceTime, messaging, target } = await start({
+    const { advanceTime, createRootMessagingComponent, messaging } = await start({
         hasTimeControl: true,
     });
     const thread = messaging.models['Thread'].findFromIdentifyingData({
         id: mailChannelId1,
         model: 'mail.channel',
     });
-    await this.createThreadTextualTypingStatusComponent(thread, target);
+    await createRootMessagingComponent('ThreadTextualTypingStatus', { thread });
 
     assert.strictEqual(
         document.querySelector('.o_ThreadTextualTypingStatus').textContent,
@@ -251,12 +241,12 @@ QUnit.test('receive several other members typing status "is typing"', async func
             [0, 0, { partner_id: resPartnerId3 }],
         ],
     });
-    const { messaging, target } = await start();
+    const { createRootMessagingComponent, messaging } = await start();
     const thread = messaging.models['Thread'].findFromIdentifyingData({
         id: mailChannelId1,
         model: 'mail.channel',
     });
-    await this.createThreadTextualTypingStatusComponent(thread, target);
+    await createRootMessagingComponent('ThreadTextualTypingStatus', { thread });
 
     assert.strictEqual(
         document.querySelector('.o_ThreadTextualTypingStatus').textContent,

--- a/addons/mail/static/tests/qunit_suite_tests/m2x_avatar_user_tests.js
+++ b/addons/mail/static/tests/qunit_suite_tests/m2x_avatar_user_tests.js
@@ -55,7 +55,7 @@ QUnit.module('mail', {}, function () {
         const resPartnerId1 = pyEnv['res.partner'].create({ display_name: 'Partner 1' });
         const resUsersId1 = pyEnv['res.users'].create({ name: "Mario", partner_id: resPartnerId1 });
         const m2xAvatarUserId1 = pyEnv['m2x.avatar.user'].create({ user_ids: [resUsersId1] });
-        const { target: form } = await start({
+        await start({
             hasView: true,
             View: FormView,
             model: 'm2x.avatar.user',
@@ -63,7 +63,7 @@ QUnit.module('mail', {}, function () {
             res_id: m2xAvatarUserId1,
         });
 
-        await dom.click(form.querySelector('.o_field_many2manytags.avatar .badge .o_m2m_avatar'));
+        await dom.click(document.querySelector('.o_field_many2manytags.avatar .badge .o_m2m_avatar'));
         assert.containsOnce(document.body, '.o_ChatWindow', 'Chat window should be opened');
         assert.strictEqual(
             document.querySelector('.o_ChatWindowHeader_name').textContent,
@@ -81,7 +81,7 @@ QUnit.module('mail', {}, function () {
         );
         pyEnv['m2x.avatar.user'].create({ user_ids: resUsersIds });
 
-        const { target: kanban } = await start({
+        await start({
             hasView: true,
             View: KanbanView,
             model: 'm2x.avatar.user',
@@ -104,17 +104,17 @@ QUnit.module('mail', {}, function () {
                 </kanban>`,
         });
 
-        assert.containsOnce(kanban, '.o_kanban_record .o_field_many2manytags .o_m2m_avatar_empty',
+        assert.containsOnce(document.body, '.o_kanban_record .o_field_many2manytags .o_m2m_avatar_empty',
             "should have o_m2m_avatar_empty span");
-        assert.strictEqual(kanban.querySelector('.o_kanban_record .o_field_many2manytags .o_m2m_avatar_empty').innerText.trim(), "+2",
+        assert.strictEqual(document.querySelector('.o_kanban_record .o_field_many2manytags .o_m2m_avatar_empty').innerText.trim(), "+2",
             "should have +2 in o_m2m_avatar_empty");
 
-        kanban.querySelector('.o_kanban_record .o_field_many2manytags .o_m2m_avatar_empty').dispatchEvent(new Event('mouseover'));
+        document.querySelector('.o_kanban_record .o_field_many2manytags .o_m2m_avatar_empty').dispatchEvent(new Event('mouseover'));
         await nextTick();
-        assert.containsOnce(kanban, '.popover',
+        assert.containsOnce(document.body, '.popover',
             "should open a popover hover on o_m2m_avatar_empty");
-        assert.strictEqual(kanban.querySelector('.popover .popover-body > div').innerText.trim(), 'Luigi', 'should have a right text in popover');
-        assert.strictEqual(kanban.querySelectorAll('.popover .popover-body > div')[1].innerText.trim(), 'Tapu', 'should have a right text in popover');
+        assert.strictEqual(document.querySelector('.popover .popover-body > div').innerText.trim(), 'Luigi', 'should have a right text in popover');
+        assert.strictEqual(document.querySelectorAll('.popover .popover-body > div')[1].innerText.trim(), 'Tapu', 'should have a right text in popover');
     });
 
     QUnit.test('many2one_avatar_user widget edited by the smart action "Assign to..."', async function (assert) {
@@ -308,7 +308,7 @@ QUnit.module('mail', {}, function () {
         const pyEnv = await startServer();
         const resUsersId1 = pyEnv['res.users'].create({ name: "Mario" });
         const m2xAvatarUserId1 = pyEnv['m2x.avatar.user'].create({ user_id: resUsersId1 });
-        const { target: list } = await start({
+        await start({
             hasView: true,
             View: ListView,
             model: 'm2x.avatar.user',
@@ -316,7 +316,7 @@ QUnit.module('mail', {}, function () {
             res_id: m2xAvatarUserId1,
         });
         assert.strictEqual(
-            list.querySelector('.o_m2o_avatar > img').getAttribute('data-src'),
+            document.querySelector('.o_m2o_avatar > img').getAttribute('data-src'),
             `/web/image/res.users/${resUsersId1}/avatar_128`,
             'Should have correct avatar image'
         );
@@ -328,7 +328,7 @@ QUnit.module('mail', {}, function () {
         const pyEnv = await startServer();
         const resUsersId1 = pyEnv['res.users'].create({ name: "Mario" });
         const m2xAvatarUserId1 = pyEnv['m2x.avatar.user'].create({ user_id: resUsersId1 });
-        const { target: kanban } = await start({
+        await start({
             hasView: true,
             View: KanbanView,
             model: 'm2x.avatar.user',
@@ -344,7 +344,7 @@ QUnit.module('mail', {}, function () {
             res_id: m2xAvatarUserId1,
         });
         assert.strictEqual(
-            kanban.querySelector('.o_m2o_avatar > img').getAttribute('data-src'),
+            document.querySelector('.o_m2o_avatar > img').getAttribute('data-src'),
             `/web/image/res.users/${resUsersId1}/avatar_128`,
             'Should have correct avatar image'
         );
@@ -356,7 +356,7 @@ QUnit.module('mail', {}, function () {
         const pyEnv = await startServer();
         const resUsersId1 = pyEnv['res.users'].create({ name: "Mario" });
         const m2xAvatarUserId1 = pyEnv['m2x.avatar.user'].create({ user_ids: [resUsersId1] });
-        const { target: form } = await start({
+        await start({
             hasView: true,
             View: FormView,
             model: 'm2x.avatar.user',
@@ -364,7 +364,7 @@ QUnit.module('mail', {}, function () {
             res_id: m2xAvatarUserId1,
         });
         assert.strictEqual(
-            form.querySelector('.o_field_many2manytags.avatar.o_field_widget .badge img').getAttribute('data-src'),
+            document.querySelector('.o_field_many2manytags.avatar.o_field_widget .badge img').getAttribute('data-src'),
             `/web/image/res.users/${resUsersId1}/avatar_128`,
             'Should have correct avatar image'
         );

--- a/addons/test_mail/static/tests/activity_tests.js
+++ b/addons/test_mail/static/tests/activity_tests.js
@@ -7,13 +7,12 @@ import { start, startServer } from '@mail/../tests/helpers/test_utils';
 import testUtils from 'web.test_utils';
 import domUtils from 'web.dom';
 
-import { getFixture, legacyExtraNextTick, patchWithCleanup, click } from "@web/../tests/helpers/utils";
+import { legacyExtraNextTick, patchWithCleanup, click } from "@web/../tests/helpers/utils";
 import { doAction } from "@web/../tests/webclient/helpers";
 import { session } from '@web/session';
 
 let serverData;
 let pyEnv;
-let target;
 
 QUnit.module('test_mail', {}, function () {
 QUnit.module('activity view', {
@@ -77,7 +76,6 @@ QUnit.module('activity view', {
                 'mail.test.activity,false,search': '<search/>',
             },
         };
-        target = getFixture();
     }
 });
 
@@ -107,7 +105,7 @@ QUnit.test('activity view: simple activity rendering', async function (assert) {
             "should do a do_action with correct parameters");
             event.data.options.on_close();
     };
-    var { target } = await start({
+    await start({
         View: ActivityView,
         hasView: true,
         model: 'mail.test.activity',
@@ -122,7 +120,7 @@ QUnit.test('activity view: simple activity rendering', async function (assert) {
             do_action: actionServiceInterceptor,
         },
     });
-    const $activity = $(target);
+    const $activity = $(document);
 
     assert.containsOnce($activity, 'table',
         'should have a table');
@@ -163,7 +161,7 @@ QUnit.test('activity view: no content rendering', async function (assert) {
     // reset incompatible setup
     pyEnv['mail.activity.type'].unlink(pyEnv['mail.activity.type'].search([]));
 
-    var { target } = await start({
+    await start({
         hasView: true,
         View: ActivityView,
         model: 'mail.test.activity',
@@ -175,7 +173,7 @@ QUnit.test('activity view: no content rendering', async function (assert) {
                 '</templates>' +
             '</activity>',
     });
-    const $activity = $(target);
+    const $activity = $(document);
 
     assert.containsOnce($activity, '.o_view_nocontent',
         "should display the no content helper");
@@ -189,7 +187,7 @@ QUnit.test('activity view: batch send mail on activity', async function (assert)
 
     const mailTestActivityIds = pyEnv['mail.test.activity'].search([]);
     const mailTemplateIds = pyEnv['mail.template'].search([]);
-    var { target } = await start({
+    await start({
         hasView: true,
         View: ActivityView,
         model: 'mail.test.activity',
@@ -208,7 +206,7 @@ QUnit.test('activity view: batch send mail on activity', async function (assert)
             return this._super.apply(this, arguments);
         },
     });
-    const $activity = $(target);
+    const $activity = $(document);
     assert.notOk($activity.find('table thead tr:first th:nth-child(2) span:nth-child(2) .dropdown-menu.show').length,
         'dropdown shouldn\'t be displayed');
 
@@ -288,8 +286,8 @@ QUnit.test('activity view: activity widget', async function (assert) {
         },
     };
 
-    var { target } = await start(params);
-    const activity = $(target);
+    await start(params);
+    const activity = $(document);
     var today = activity.find('table tbody tr:first td:nth-child(2).today');
     var dropdown = today.find('.dropdown-menu.o_activity');
 
@@ -354,17 +352,17 @@ QUnit.test("activity view: no group_by_menu and no comparison_menu", async funct
     await doAction(webClient, 1);
 
     assert.containsN(
-        target,
+        document.body,
         ".o_search_options .dropdown button:visible",
         2,
         "only two elements should be available in view search"
     );
     assert.isVisible(
-        target.querySelector(".o_search_options .dropdown.o_filter_menu > button"),
+        document.querySelector(".o_search_options .dropdown.o_filter_menu > button"),
         "filter should be available in view search"
     );
     assert.isVisible(
-        target.querySelector(".o_search_options .dropdown.o_favorite_menu > button"),
+        document.querySelector(".o_search_options .dropdown.o_favorite_menu > button"),
         "favorites should be available in view search"
     );
 });
@@ -394,7 +392,7 @@ QUnit.test('activity view: search more to schedule an activity for a record of a
                 "should execute an action with correct params");
             ev.data.options.on_close();
     };
-    var { target } = await start({
+    await start({
         hasView: true,
         View: ActivityView,
         model: 'mail.test.activity',
@@ -419,7 +417,7 @@ QUnit.test('activity view: search more to schedule an activity for a record of a
             do_action: actionServiceInterceptor,
         },
     });
-    const $activity = $(target);
+    const $activity = $(document);
 
     assert.containsOnce($activity, 'table tfoot tr .o_record_selector',
         'should contain search more selector to choose the record to schedule an activity for it');
@@ -465,7 +463,7 @@ QUnit.test("Activity view: discard an activity creation dialog", async function 
     await doAction(webClient, 1);
 
     await testUtils.dom.click(
-        target.querySelector(".o_activity_view .o_data_row .o_activity_empty_cell")
+        document.querySelector(".o_activity_view .o_data_row .o_activity_empty_cell")
     );
     await legacyExtraNextTick();
     assert.containsOnce($, ".modal.o_technical_modal", "Activity Modal should be opened");
@@ -509,10 +507,10 @@ QUnit.test('Activity view: many2one_avatar_user widget in activity view', async 
     await doAction(webClient, 1);
 
     await legacyExtraNextTick();
-    assert.containsN(target, '.o_m2o_avatar', 2);
-    assert.containsOnce(target, `tr[data-res-id=${mailTestActivityId1}] .o_m2o_avatar > img[data-src="/web/image/res.users/${resUsersId1}/avatar_128"]`,
+    assert.containsN(document.body, '.o_m2o_avatar', 2);
+    assert.containsOnce(document.body, `tr[data-res-id=${mailTestActivityId1}] .o_m2o_avatar > img[data-src="/web/image/res.users/${resUsersId1}/avatar_128"]`,
         "should have m2o avatar image");
-    assert.containsNone(target, '.o_m2o_avatar > span',
+    assert.containsNone(document.body, '.o_m2o_avatar > span',
         "should not have text on many2one_avatar_user if onlyImage node option is passed");
 });
 
@@ -584,7 +582,7 @@ QUnit.test("Schedule activity dialog uses the same search view as activity view"
     ])
 
     // click on "Schedule activity"
-    await click(target.querySelector(".o_activity_view .o_record_selector"));
+    await click(document.querySelector(".o_activity_view .o_record_selector"));
 
     assert.verifySteps([
         '[[false,"list"],[false,"search"]]',
@@ -604,7 +602,7 @@ QUnit.test("Schedule activity dialog uses the same search view as activity view"
     ])
 
     // click on "Schedule activity"
-    await click(target.querySelector(".o_activity_view .o_record_selector"));
+    await click(document.querySelector(".o_activity_view .o_record_selector"));
 
     assert.verifySteps([
         '[[false,"list"],[1,"search"]]',
@@ -628,28 +626,28 @@ QUnit.test('Activity view: apply progressbar filter', async function (assert) {
 
     await doAction(webClient, 1);
 
-    assert.containsNone(target.querySelector('.o_activity_view thead'),
+    assert.containsNone(document.querySelector('.o_activity_view thead'),
         '.o_activity_filter_planned,.o_activity_filter_today,.o_activity_filter_overdue,.o_activity_filter___false',
         "should not have active filter");
-    assert.containsNone(target.querySelector('.o_activity_view tbody'),
+    assert.containsNone(document.querySelector('.o_activity_view tbody'),
         '.o_activity_filter_planned,.o_activity_filter_today,.o_activity_filter_overdue,.o_activity_filter___false',
         "should not have active filter");
-    assert.strictEqual(target.querySelector('.o_activity_view tbody .o_activity_record').textContent,
+    assert.strictEqual(document.querySelector('.o_activity_view tbody .o_activity_record').textContent,
         'Office planning', "'Office planning' should be first record");
-    assert.containsOnce(target.querySelector('.o_activity_view tbody'), '.planned',
+    assert.containsOnce(document.querySelector('.o_activity_view tbody'), '.planned',
         "other records should be available");
 
-    await testUtils.dom.click(target.querySelector('.o_kanban_counter_progress .progress-bar[data-filter="planned"]'));
-    assert.containsOnce(target.querySelector('.o_activity_view thead'), '.o_activity_filter_planned',
+    await testUtils.dom.click(document.querySelector('.o_kanban_counter_progress .progress-bar[data-filter="planned"]'));
+    assert.containsOnce(document.querySelector('.o_activity_view thead'), '.o_activity_filter_planned',
         "planned should be active filter");
-    assert.containsN(target.querySelector('.o_activity_view tbody'), '.o_activity_filter_planned', 5,
+    assert.containsN(document.querySelector('.o_activity_view tbody'), '.o_activity_filter_planned', 5,
         "planned should be active filter");
-    assert.strictEqual(target.querySelector('.o_activity_view tbody .o_activity_record').textContent,
+    assert.strictEqual(document.querySelector('.o_activity_view tbody .o_activity_record').textContent,
         'Meeting Room Furnitures', "'Office planning' should be first record");
-    const tr = target.querySelectorAll('.o_activity_view tbody tr')[1];
+    const tr = document.querySelectorAll('.o_activity_view tbody tr')[1];
     assert.hasClass(tr.querySelectorAll('td')[1], 'o_activity_empty_cell',
         "other records should be hidden");
-    assert.containsNone(target.querySelector('.o_activity_view tbody'), 'planned',
+    assert.containsNone(document.querySelector('.o_activity_view tbody'), 'planned',
         "other records should be hidden");
 });
 

--- a/addons/test_mail/static/tests/tracking_value_tests.js
+++ b/addons/test_mail/static/tests/tracking_value_tests.js
@@ -46,9 +46,9 @@ QUnit.test('basic rendering of tracking value (float type)', async function (ass
 
     const pyEnv = await startServer();
     const mailTestTrackAllId1 = pyEnv['mail.test.track.all'].create({ float_field: 12.30 });
-    const { click, target: form } = await this.start({ res_id: mailTestTrackAllId1 });
+    const { click } = await this.start({ res_id: mailTestTrackAllId1 });
 
-    await testUtils.fields.editInput(form.querySelector('input[name=float_field]'), 45.67);
+    await testUtils.fields.editInput(document.querySelector('input[name=float_field]'), 45.67);
     await click('.o_form_button_save');
     assert.containsOnce(
         document.body,
@@ -97,9 +97,9 @@ QUnit.test('rendering of tracked field of type float: from non-0 to 0', async fu
 
     const pyEnv = await startServer();
     const mailTestTrackAllId1 = pyEnv['mail.test.track.all'].create({ float_field: 1 });
-    const { click, target: form } = await this.start({ res_id: mailTestTrackAllId1 });
+    const { click } = await this.start({ res_id: mailTestTrackAllId1 });
 
-    await testUtils.fields.editInput(form.querySelector('input[name=float_field]'), 0);
+    await testUtils.fields.editInput(document.querySelector('input[name=float_field]'), 0);
     await click('.o_form_button_save');
     assert.strictEqual(
         document.querySelector('.o_TrackingValue').textContent,
@@ -113,9 +113,9 @@ QUnit.test('rendering of tracked field of type float: from 0 to non-0', async fu
 
     const pyEnv = await startServer();
     const mailTestTrackAllId1 = pyEnv['mail.test.track.all'].create({ float_field: 0 });
-    const { click, target: form } = await this.start({ res_id: mailTestTrackAllId1 });
+    const { click } = await this.start({ res_id: mailTestTrackAllId1 });
 
-    await testUtils.fields.editInput(form.querySelector('input[name=float_field]'), 1);
+    await testUtils.fields.editInput(document.querySelector('input[name=float_field]'), 1);
     await click('.o_form_button_save');
     assert.strictEqual(
         document.querySelector('.o_TrackingValue').textContent,
@@ -129,9 +129,9 @@ QUnit.test('rendering of tracked field of type integer: from non-0 to 0', async 
 
     const pyEnv = await startServer();
     const mailTestTrackAllId1 = pyEnv['mail.test.track.all'].create({ integer_field: 1 });
-    const { click, target: form } = await this.start({ res_id: mailTestTrackAllId1 });
+    const { click } = await this.start({ res_id: mailTestTrackAllId1 });
 
-    await testUtils.fields.editInput(form.querySelector('input[name=integer_field]'), 0);
+    await testUtils.fields.editInput(document.querySelector('input[name=integer_field]'), 0);
     await click('.o_form_button_save');
     assert.strictEqual(
         document.querySelector('.o_TrackingValue').textContent,
@@ -145,9 +145,9 @@ QUnit.test('rendering of tracked field of type integer: from 0 to non-0', async 
 
     const pyEnv = await startServer();
     const mailTestTrackAllId1 = pyEnv['mail.test.track.all'].create({ integer_field: 0 });
-    const { click, target: form } = await this.start({ res_id: mailTestTrackAllId1 });
+    const { click } = await this.start({ res_id: mailTestTrackAllId1 });
 
-    await testUtils.fields.editInput(form.querySelector('input[name=integer_field]'), 1);
+    await testUtils.fields.editInput(document.querySelector('input[name=integer_field]'), 1);
     await click('.o_form_button_save');
     assert.strictEqual(
         document.querySelector('.o_TrackingValue').textContent,
@@ -161,9 +161,9 @@ QUnit.test('rendering of tracked field of type monetary: from non-0 to 0', async
 
     const pyEnv = await startServer();
     const mailTestTrackAllId1 = pyEnv['mail.test.track.all'].create({ monetary_field: 1 });
-    const { click, target: form } = await this.start({ res_id: mailTestTrackAllId1 });
+    const { click } = await this.start({ res_id: mailTestTrackAllId1 });
 
-    await testUtils.fields.editSelect(form.querySelector('div[name=monetary_field] > input'), 0);
+    await testUtils.fields.editSelect(document.querySelector('div[name=monetary_field] > input'), 0);
     await click('.o_form_button_save');
     assert.strictEqual(
         document.querySelector('.o_TrackingValue').textContent,
@@ -177,9 +177,9 @@ QUnit.test('rendering of tracked field of type monetary: from 0 to non-0', async
 
     const pyEnv = await startServer();
     const mailTestTrackAllId1 = pyEnv['mail.test.track.all'].create({ monetary_field: 0 });
-    const { click, target: form } = await this.start({ res_id: mailTestTrackAllId1 });
+    const { click } = await this.start({ res_id: mailTestTrackAllId1 });
 
-    await testUtils.fields.editSelect(form.querySelector('div[name=monetary_field] > input'), 1);
+    await testUtils.fields.editSelect(document.querySelector('div[name=monetary_field] > input'), 1);
     await click('.o_form_button_save');
     assert.strictEqual(
         document.querySelector('.o_TrackingValue').textContent,
@@ -193,9 +193,9 @@ QUnit.test('rendering of tracked field of type boolean: from true to false', asy
 
     const pyEnv = await startServer();
     const mailTestTrackAllId1 = pyEnv['mail.test.track.all'].create({ boolean_field: true });
-    const { click, target: form } = await this.start({ res_id: mailTestTrackAllId1 });
+    const { click } = await this.start({ res_id: mailTestTrackAllId1 });
 
-    form.querySelector('.custom-checkbox input').click();
+    document.querySelector('.custom-checkbox input').click();
     await click('.o_form_button_save');
     assert.strictEqual(
         document.querySelector('.o_TrackingValue').textContent,
@@ -209,9 +209,9 @@ QUnit.test('rendering of tracked field of type boolean: from false to true', asy
 
     const pyEnv = await startServer();
     const mailTestTrackAllId1 = pyEnv['mail.test.track.all'].create({});
-    const { click, target: form } = await this.start({ res_id: mailTestTrackAllId1 });
+    const { click } = await this.start({ res_id: mailTestTrackAllId1 });
 
-    form.querySelector('.custom-checkbox input').click();
+    document.querySelector('.custom-checkbox input').click();
     await click('.o_form_button_save');
     assert.strictEqual(
         document.querySelector('.o_TrackingValue').textContent,
@@ -225,9 +225,9 @@ QUnit.test('rendering of tracked field of type char: from a string to empty stri
 
     const pyEnv = await startServer();
     const mailTestTrackAllId1 = pyEnv['mail.test.track.all'].create({ char_field: 'Marc' });
-    const { click, target: form } = await this.start({ res_id: mailTestTrackAllId1 });
+    const { click } = await this.start({ res_id: mailTestTrackAllId1 });
 
-    await testUtils.fields.editInput(form.querySelector('input[name=char_field]'), '');
+    await testUtils.fields.editInput(document.querySelector('input[name=char_field]'), '');
     await click('.o_form_button_save');
     assert.strictEqual(
         document.querySelector('.o_TrackingValue').textContent,
@@ -241,9 +241,9 @@ QUnit.test('rendering of tracked field of type char: from empty string to a stri
 
     const pyEnv = await startServer();
     const mailTestTrackAllId1 = pyEnv['mail.test.track.all'].create({ char_field: '' });
-    const { click, target: form } = await this.start({ res_id: mailTestTrackAllId1 });
+    const { click } = await this.start({ res_id: mailTestTrackAllId1 });
 
-    await testUtils.fields.editInput(form.querySelector('input[name=char_field]'), 'Marc');
+    await testUtils.fields.editInput(document.querySelector('input[name=char_field]'), 'Marc');
     await click('.o_form_button_save');
     assert.strictEqual(
         document.querySelector('.o_TrackingValue').textContent,
@@ -257,9 +257,9 @@ QUnit.test('rendering of tracked field of type date: from no date to a set date'
 
     const pyEnv = await startServer();
     const mailTestTrackAllId1 = pyEnv['mail.test.track.all'].create({ date_field: false });
-    const { click, target: form } = await this.start({ res_id: mailTestTrackAllId1 });
+    const { click } = await this.start({ res_id: mailTestTrackAllId1 });
 
-    await testUtils.fields.editAndTrigger(form.querySelector('.o_datepicker[name=date_field] .o_datepicker_input'), '12/14/2018', ['change']);
+    await testUtils.fields.editAndTrigger(document.querySelector('.o_datepicker[name=date_field] .o_datepicker_input'), '12/14/2018', ['change']);
     await click('.o_form_button_save');
     assert.strictEqual(
         document.querySelector('.o_TrackingValue').textContent,
@@ -273,9 +273,9 @@ QUnit.test('rendering of tracked field of type date: from a set date to no date'
 
     const pyEnv = await startServer();
     const mailTestTrackAllId1 = pyEnv['mail.test.track.all'].create({ date_field: '2018-12-14' });
-    const { click, target: form } = await this.start({ res_id: mailTestTrackAllId1 });
+    const { click } = await this.start({ res_id: mailTestTrackAllId1 });
 
-    await testUtils.fields.editAndTrigger(form.querySelector('.o_datepicker[name=date_field] .o_datepicker_input'), '', ['change']);
+    await testUtils.fields.editAndTrigger(document.querySelector('.o_datepicker[name=date_field] .o_datepicker_input'), '', ['change']);
     await click('.o_form_button_save');
     assert.strictEqual(
         document.querySelector('.o_TrackingValue').textContent,
@@ -289,9 +289,9 @@ QUnit.test('rendering of tracked field of type datetime: from no date and time t
 
     const pyEnv = await startServer();
     const mailTestTrackAllId1 = pyEnv['mail.test.track.all'].create({ datetime_field: false });
-    const { click, target: form } = await this.start({ res_id: mailTestTrackAllId1 });
+    const { click } = await this.start({ res_id: mailTestTrackAllId1 });
 
-    await testUtils.fields.editAndTrigger(form.querySelector('.o_datepicker[name=datetime_field] .o_datepicker_input'), '12/14/2018 13:42:28', ['change']);
+    await testUtils.fields.editAndTrigger(document.querySelector('.o_datepicker[name=datetime_field] .o_datepicker_input'), '12/14/2018 13:42:28', ['change']);
     await click('.o_form_button_save');
     assert.strictEqual(
         document.querySelector('.o_TrackingValue').textContent,
@@ -305,9 +305,9 @@ QUnit.test('rendering of tracked field of type datetime: from a set date and tim
 
     const pyEnv = await startServer();
     const mailTestTrackAllId1 = pyEnv['mail.test.track.all'].create({ datetime_field: '2018-12-14 13:42:28 ' });
-    const { click, target: form } = await this.start({ res_id: mailTestTrackAllId1 });
+    const { click } = await this.start({ res_id: mailTestTrackAllId1 });
 
-    await testUtils.fields.editAndTrigger(form.querySelector('.o_datepicker[name=datetime_field] .o_datepicker_input'), '', ['change']);
+    await testUtils.fields.editAndTrigger(document.querySelector('.o_datepicker[name=datetime_field] .o_datepicker_input'), '', ['change']);
     await click('.o_form_button_save');
     assert.strictEqual(
         document.querySelector('.o_TrackingValue').textContent,
@@ -321,9 +321,9 @@ QUnit.test('rendering of tracked field of type text: from some text to empty', a
 
     const pyEnv = await startServer();
     const mailTestTrackAllId1 = pyEnv['mail.test.track.all'].create({ text_field: 'Marc' });
-    const { click, target: form } = await this.start({ res_id: mailTestTrackAllId1 });
+    const { click } = await this.start({ res_id: mailTestTrackAllId1 });
 
-    await testUtils.fields.editInput(form.querySelector('textarea[name=text_field]'), '');
+    await testUtils.fields.editInput(document.querySelector('textarea[name=text_field]'), '');
     await click('.o_form_button_save');
     assert.strictEqual(
         document.querySelector('.o_TrackingValue').textContent,
@@ -337,9 +337,9 @@ QUnit.test('rendering of tracked field of type text: from empty to some text', a
 
     const pyEnv = await startServer();
     const mailTestTrackAllId1 = pyEnv['mail.test.track.all'].create({ text_field: '' });
-    const { click, target: form } = await this.start({ res_id: mailTestTrackAllId1 });
+    const { click } = await this.start({ res_id: mailTestTrackAllId1 });
 
-    await testUtils.fields.editInput(form.querySelector('textarea[name=text_field]'), 'Marc');
+    await testUtils.fields.editInput(document.querySelector('textarea[name=text_field]'), 'Marc');
     await click('.o_form_button_save');
     assert.strictEqual(
         document.querySelector('.o_TrackingValue').textContent,
@@ -353,9 +353,9 @@ QUnit.test('rendering of tracked field of type selection: from a selection to no
 
     const pyEnv = await startServer();
     const mailTestTrackAllId1 = pyEnv['mail.test.track.all'].create({ selection_field: 'first' });
-    const { click, target: form } = await this.start({ res_id: mailTestTrackAllId1 });
+    const { click } = await this.start({ res_id: mailTestTrackAllId1 });
 
-    await testUtils.fields.editSelect(form.querySelector('select[name=selection_field]'), '');
+    await testUtils.fields.editSelect(document.querySelector('select[name=selection_field]'), '');
     await click('.o_form_button_save');
     assert.strictEqual(
         document.querySelector('.o_TrackingValue').textContent,
@@ -369,9 +369,9 @@ QUnit.test('rendering of tracked field of type selection: from no selection to a
 
     const pyEnv = await startServer();
     const mailTestTrackAllId1 = pyEnv['mail.test.track.all'].create({});
-    const { click, target: form } = await this.start({ res_id: mailTestTrackAllId1 });
+    const { click } = await this.start({ res_id: mailTestTrackAllId1 });
 
-    await testUtils.fields.editSelect(form.querySelector('select[name=selection_field]'), '"first"');
+    await testUtils.fields.editSelect(document.querySelector('select[name=selection_field]'), '"first"');
     await click('.o_form_button_save');
     assert.strictEqual(
         document.querySelector('.o_TrackingValue').textContent,
@@ -386,9 +386,9 @@ QUnit.test('rendering of tracked field of type many2one: from having a related r
     const pyEnv = await startServer();
     const resPartnerId1 = pyEnv['res.partner'].create({ display_name: 'Marc' });
     const mailTestTrackAllId1 = pyEnv['mail.test.track.all'].create({ many2one_field_id: resPartnerId1 });
-    const { click, target: form } = await this.start({ res_id: mailTestTrackAllId1 });
+    const { click } = await this.start({ res_id: mailTestTrackAllId1 });
 
-    await testUtils.fields.editAndTrigger(form.querySelector('.o_field_many2one_selection input'), '', ['keyup']);
+    await testUtils.fields.editAndTrigger(document.querySelector('.o_field_many2one_selection input'), '', ['keyup']);
     await click('.o_form_button_save');
     assert.strictEqual(
         document.querySelector('.o_TrackingValue').textContent,


### PR DESCRIPTION
*: hr, test_mail.

The target returned by the mail's test utils start method is useless since it's
almost the same thing than querying document. Let's remove it and replace it by
document. This will reduce the diff in the PR introducing the new environment in
the discuss app.

task-2582313

enterprise: https://github.com/odoo/enterprise/pull/27670