### PR TITLE
[FIX] portal: fix inherit for config settings view

### DIFF
--- a/addons/portal/views/res_config_settings_views.xml
+++ b/addons/portal/views/res_config_settings_views.xml
@@ -6,7 +6,7 @@
             <field name="name">res.config.settings.view.form.inherit.portal</field>
             <field name="model">res.config.settings</field>
             <field name="priority" eval="40"/>
-            <field name="inherit_id" ref="base.res_config_settings_view_form"/>
+            <field name="inherit_id" ref="base_setup.res_config_settings_view_form"/>
             <field name="arch" type="xml">
                 <xpath expr="//button[@name=%(base.action_apikeys_admin)d]//ancestor::div[hasclass('o_setting_box')]" position="inside">
                     <div groups="base.group_no_one">


### PR DESCRIPTION
base_setup is the module that adds the buttons
https://github.com/odoo/odoo/blob/354433e7ba5b5f81f83368e497a8bed5059c91d5/addons/base_setup/views/res_config_settings_views.xml#L182

Without this change some DBs fail to upgrade
```
Traceback (most recent call last):
  File "/tmp/tmpsm7tdgh3/migrations/base/tests/test_mock_crawl.py", line 193, in crawl_menu
    self.mock_action(action_vals)
  File "/tmp/tmpsm7tdgh3/migrations/base/tests/test_mock_crawl.py", line 267, in mock_action
    views = get_views(
  File "/home/odoo/src/odoo/saas-15.2/odoo/models.py", line 1626, in load_views
    result['fields_views'] = {
  File "/home/odoo/src/odoo/saas-15.2/odoo/models.py", line 1627, in <dictcomp>
    v_type: self.fields_view_get(v_id, v_type if v_type != 'list' else 'tree',
  File "/home/odoo/src/odoo/saas-15.2/odoo/addons/base/models/res_config.py", line 393, in fields_view_get
    ret_val = super(ResConfigSettings, self).fields_view_get(
  File "/home/odoo/src/odoo/saas-15.2/addons/web/models/models.py", line 249, in fields_view_get
    r = super().fields_view_get(view_id, view_type, toolbar, submenu)
  File "/home/odoo/src/odoo/saas-15.2/odoo/models.py", line 1712, in fields_view_get
    result = self._fields_view_get(view_id=view_id, view_type=view_type, toolbar=toolbar, submenu=submenu)
  File "/home/odoo/src/odoo/saas-15.2/odoo/models.py", line 1672, in _fields_view_get
    result['arch'] = view.get_combined_arch()
  File "/home/odoo/src/odoo/saas-15.2/odoo/addons/base/models/ir_ui_view.py", line 954, in get_combined_arch
    return etree.tostring(self._get_combined_arch(), encoding='unicode')
  File "/home/odoo/src/odoo/saas-15.2/odoo/addons/base/models/ir_ui_view.py", line 984, in _get_combined_arch
    arch = root.with_prefetch(tree_views._prefetch_ids)._combine(hierarchy)
  File "/home/odoo/src/odoo/saas-15.2/odoo/addons/base/models/ir_ui_view.py", line 925, in _combine
    combined_arch = view.apply_inheritance_specs(combined_arch, arch)
  File "/home/odoo/src/odoo/saas-15.2/odoo/addons/base/models/ir_ui_view.py", line 862, in apply_inheritance_specs
    self._raise_view_error(str(e), specs_tree)
  File "/home/odoo/src/odoo/saas-15.2/odoo/addons/base/models/ir_ui_view.py", line 739, in _raise_view_error
    raise err from from_exception
ValueError: Element '<xpath expr="//button[@name=75]//ancestor::div[hasclass(&https://github.com/odoo-dev/odoo/pull/39;o_setting_box&https://github.com/odoo-dev/odoo/pull/39;)]">' cannot be located in parent view
```
The `base` view has no such buttons
https://github.com/odoo/odoo/blob/15.0/odoo/addons/base/views/res_config_settings_views.xml

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
