### PR TITLE
[FIX] sale: SO amendments after invoicing change the unit price

### DIFF
--- a/addons/sale/models/sale_order_line.py
+++ b/addons/sale/models/sale_order_line.py
@@ -731,6 +731,10 @@ class SaleOrderLine(models.Model):
     @api.depends('product_id', 'product_uom', 'product_uom_qty')
     def _compute_price_unit(self):
         for line in self:
+            # check if there is already invoiced amount. if so, the price shouldn't change as it might have been
+            # manually edited
+            if line.qty_invoiced > 0:
+                continue
             if not line.product_uom or not line.product_id or not line.order_id.pricelist_id:
                 line.price_unit = 0.0
             else:


### PR DESCRIPTION
Steps to reproduce:

1- install sale, invoicing
2- create a product p with price pr
3- create a new Sales Order SO with p and edit the price
to any other price than pr
4-  create an invoice
5- go to SO, reduce quantity to 0 ( customer returns the item )
6- the unit price is set back to pr and there is no way to edit it

Bug:

in 836f463c9778195a00bcf2f5290ddef18d8e75d5 the `_compute_price_unit`
method was changed from onchange to depends which caused the edits now
to be commited to memory.
While it can be beneficial for other flows, for this specific use case,
it is not

Fix:
make an exception for lines with already invoiced quantities

OPW-2830824