### PR TITLE
14.0 sale fix invoice referrer not being set amay

### DIFF
--- a/addons/sale/wizard/sale_make_invoice_advance.py
+++ b/addons/sale/wizard/sale_make_invoice_advance.py
@@ -88,6 +88,7 @@ class SaleAdvancePaymentInv(models.TransientModel):
             'campaign_id': order.campaign_id.id,
             'medium_id': order.medium_id.id,
             'source_id': order.source_id.id,
+            'referrer_id': order.referrer_id.id,
             'invoice_line_ids': [(0, 0, {
                 'name': name,
                 'price_unit': amount,

--- a/addons/sale/wizard/sale_make_invoice_advance.py
+++ b/addons/sale/wizard/sale_make_invoice_advance.py
@@ -88,7 +88,7 @@ class SaleAdvancePaymentInv(models.TransientModel):
             'campaign_id': order.campaign_id.id,
             'medium_id': order.medium_id.id,
             'source_id': order.source_id.id,
-            'referrer_id': order.referrer_id.id if order.referrer_id else None,
+            'referrer_id': order.referrer_id.id if hasattr(order, 'referrer_id') else None,
             'invoice_line_ids': [(0, 0, {
                 'name': name,
                 'price_unit': amount,

--- a/addons/sale/wizard/sale_make_invoice_advance.py
+++ b/addons/sale/wizard/sale_make_invoice_advance.py
@@ -88,7 +88,6 @@ class SaleAdvancePaymentInv(models.TransientModel):
             'campaign_id': order.campaign_id.id,
             'medium_id': order.medium_id.id,
             'source_id': order.source_id.id,
-            'referrer_id': order.referrer_id.id if hasattr(order, 'referrer_id') else None,
             'invoice_line_ids': [(0, 0, {
                 'name': name,
                 'price_unit': amount,
@@ -101,6 +100,8 @@ class SaleAdvancePaymentInv(models.TransientModel):
                 'analytic_account_id': order.analytic_account_id.id or False,
             })],
         }
+        if hasattr(order, 'referrer_id'):
+            invoice_vals['referrer_id'] = order.referrer_id.id
 
         return invoice_vals
 

--- a/addons/sale/wizard/sale_make_invoice_advance.py
+++ b/addons/sale/wizard/sale_make_invoice_advance.py
@@ -88,7 +88,7 @@ class SaleAdvancePaymentInv(models.TransientModel):
             'campaign_id': order.campaign_id.id,
             'medium_id': order.medium_id.id,
             'source_id': order.source_id.id,
-            'referrer_id': order.referrer_id.id,
+            'referrer_id': order.referrer_id.id if order.referrer_id else None,
             'invoice_line_ids': [(0, 0, {
                 'name': name,
                 'price_unit': amount,


### PR DESCRIPTION
**The Issue:**
After creating a sale order, then create a new invoice with a down payment (percentage option), the invoice doesn't have the referrer_id even though that it was set on the sale order.

**The fix**
Adding the referrer_id to the invoice created from a sale order.


opw-2820420