### PR TITLE
[FIX] pos_restaurant: get table draft orders without employee

### DIFF
--- a/addons/pos_restaurant/models/pos_order.py
+++ b/addons/pos_restaurant/models/pos_order.py
@@ -174,7 +174,7 @@ class PosOrder(models.Model):
                 order['partner_id'] = order['partner_id'][0]
             if order['table_id']:
                 order['table_id'] = order['table_id'][0]
-            if order['employee_id']:
+            if 'employee_id' in order:
                 order['employee_id'] = order['employee_id'][0] if order['employee_id'] else False
 
             if not 'lines' in order:


### PR DESCRIPTION
Before this commit: In the PoS Restaurant, if the employee is not
installed, the orders wouldn't contain employee_id, and UI couldn't get
table draft orders.

Steps to reproduce the first issue:

	- Install the' Point of Sale' module
	- Make sure Employees (hr) isn't installed
	- Create a PoS with "Is a Bar/Restaurant" enabled
	- Open a PoS session in the incognito window
	- Add the product to the orders for different tables
	- Close the incognito window and open the session again

	It couldn't get table draft orders from the back-end.

Solution

	It must check that "employee_id" exist in the dictionary.

opw-2856653


--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
