### PR TITLE
[FIX] sale_make_invoice_advance: referrer not being set on the invoice

### DIFF
--- a/addons/sale/wizard/sale_make_invoice_advance.py
+++ b/addons/sale/wizard/sale_make_invoice_advance.py
@@ -100,6 +100,8 @@ class SaleAdvancePaymentInv(models.TransientModel):
                 'analytic_account_id': order.analytic_account_id.id or False,
             })],
         }
+        if hasattr(order, 'referrer_id'):
+            invoice_vals['referrer_id'] = order.referrer_id.id
 
         return invoice_vals
 


### PR DESCRIPTION
**The Issue:**
After creating a sale order, then create a new invoice with a down payment (percentage option), the invoice doesn't have the referrer_id even though that it was set on the sale order.

**The fix**
Adding the referrer_id to the invoice created from a sale order.

opw-2820420