### PR TITLE
[IMP] base: allow to create External ID from the record + tz

### DIFF
--- a/addons/web/static/src/core/debug/debug_menu_items.xml
+++ b/addons/web/static/src/core/debug/debug_menu_items.xml
@@ -72,7 +72,12 @@
                 </tr>
                 <tr>
                     <th>XML ID:</th>
-                    <td><t t-esc="state.xmlid or '/'"/></td>
+                    <td>
+                        <t t-esc="state.xmlid or '/'"/>
+                        <t t-if="!state.xmlid">
+                            <a t-on-click="onClickCreateXmlid"> (create)</a>
+                        </t>
+                    </td>
                 </tr>
                 <tr>
                     <th>No Update:</th>

--- a/addons/web/static/src/legacy/debug_manager.js
+++ b/addons/web/static/src/legacy/debug_manager.js
@@ -61,8 +61,8 @@ class GetMetadataDialog extends Component {
         this.state.creator = formatMany2one(metadata.create_uid);
         this.state.lastModifiedBy = formatMany2one(metadata.write_uid);
         this.state.noupdate = metadata.noupdate;
-        this.state.create_date = formatDateTime(parseDateTime(metadata.create_date));
-        this.state.write_date = formatDateTime(parseDateTime(metadata.write_date));
+        this.state.create_date = formatDateTime(parseDateTime(metadata.create_date), { timezone: true });
+        this.state.write_date = formatDateTime(parseDateTime(metadata.write_date), { timezone: true });
     }
 }
 GetMetadataDialog.template = "web.DebugMenu.GetMetadataDialog";

--- a/addons/web/static/src/legacy/debug_manager.js
+++ b/addons/web/static/src/legacy/debug_manager.js
@@ -2,9 +2,11 @@
 
 import { _lt } from "@web/core/l10n/translation";
 import { Dialog } from "@web/core/dialog/dialog";
+import { FormViewDialog } from 'web.view_dialogs';
 import { formatDateTime, parseDateTime } from "@web/core/l10n/dates";
 import { formatMany2one } from "@web/fields/formatters";
 import { registry } from "@web/core/registry";
+import { standaloneAdapter } from 'web.OwlCompatibility';
 
 const { Component, onWillStart, useState } = owl;
 
@@ -19,6 +21,25 @@ class GetMetadataDialog extends Component {
 
     async onWillStart() {
         await this.getMetadata();
+    }
+
+    async onClickCreateXmlid() {
+        const context = Object.assign({}, this.context, {
+            default_module: '__custom__',
+            default_res_id: this.state.id,
+            default_model: this.props.res_model,
+        });
+        const adapterParent = standaloneAdapter({ Component });
+        const dialog = new FormViewDialog(adapterParent, {
+            context: context,
+            on_saved: () => this.getMetadata(),
+            disable_multiple_selection: true,
+            res_model: 'ir.model.data',
+        });
+        dialog.on('dialog_form_loaded', this, () => {
+            dialog.$el.find('[name="name"]').focus();
+        });
+        await dialog.open();
     }
 
     async toggleNoupdate() {

--- a/odoo/addons/base/models/ir_model.py
+++ b/odoo/addons/base/models/ir_model.py
@@ -2,6 +2,7 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 import itertools
 import logging
+import random
 import re
 import psycopg2
 from ast import literal_eval
@@ -1958,6 +1959,13 @@ class IrModelData(models.Model):
         if raise_on_access_error:
             raise AccessError(_('Not enough access rights on the external ID:') + ' %s.%s' % (module, xml_id))
         return model, False
+
+    @api.returns('self', lambda value: value.id)
+    def copy(self, default=None):
+        self.ensure_one()
+        rand = "%04x" % random.getrandbits(16)
+        default = dict(default or {}, name="%s_%s" % (self.name, rand))
+        return super().copy(default)
 
     def unlink(self):
         """ Regular unlink method, but make sure to clear the caches. """


### PR DESCRIPTION
This PR has 3 purposes:
- Allow to create xmlid from record
- Allow to duplicate an xmlid
- Display datetime with user tz instead of utc

Not in this PR
- Be sure to have the first xmlid and not the last
    -> seems already the case, I cannot reproduce locally and don't find example anymore on prod.

Task-internal-process