### PR TITLE
[FIX] stock: display the customer address instead of the delivery address

### DIFF
--- a/addons/stock/report/report_deliveryslip.xml
+++ b/addons/stock/report/report_deliveryslip.xml
@@ -33,9 +33,9 @@
                                 <span><strong>Customer Address:</strong></span>
                             </div>
                             <div t-if="partner" name="partner_header">
-                                <div t-field="partner.self"
+                                <div t-field="partner.commercial_partner_id"
                                     t-options='{"widget": "contact", "fields": ["address", "name", "phone"], "no_marker": True, "phone_icons": True}'/>
-                                <p t-if="partner.sudo().vat"><t t-esc="o.company_id.country_id.vat_label or 'Tax ID'"/>: <span t-field="partner.sudo().vat"/></p>
+                                <p t-if="partner.sudo().commercial_partner_id.vat"><t t-esc="o.company_id.country_id.vat_label or 'Tax ID'"/>: <span t-field="partner.sudo().commercial_partner_id.vat"/></p>
                             </div>
                         </div>
                     </div>


### PR DESCRIPTION
Reproduction:
1. Install Inventory and Sales, enable customer address in the setting
of Sale
2. Create a quotation, choose a customer which has different contact
address and delivery address, add a storable product.
3. Confirm the order and click the delivery in the status bar
4. Click print->delivery slip, the Customer Address and Delivery Address
are the same

Reason: The Customer Address isn’t correct in the template

Fix: replace the partner setting in the customer address part as either
the partner or its parent partner_id, e.g. the commercial_partner_id

opw-2851158


--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
