### PR TITLE
[FIX] base_address_extended: avoid useless recomputes

### DIFF
--- a/addons/base_address_extended/__init__.py
+++ b/addons/base_address_extended/__init__.py
@@ -7,4 +7,5 @@ from odoo import api, SUPERUSER_ID
 
 def _update_street_format(cr, registry):
     env = api.Environment(cr, SUPERUSER_ID, {})
-    env['res.partner'].search([])._compute_street_data()
+    specific_countries = env['res.country'].search([('street_format', '!=', '%(street_number)s/%(street_number2)s %(street_name)s')])
+    env['res.partner'].search([('country_id', 'in', specific_countries.ids)])._compute_street_data()


### PR DESCRIPTION
This post-init hook was added with commit [1] to recompute street fields
in case the street format associated to the country of the partner was
different from the default value '%(street_number)s/%(street_number2)s
%(street_name)s'.

We should restrict the recomptute to the concerned countries to avoid
useless multiple writes on partners having already correct computed
values.

[1]:https://github.com/odoo/odoo/commit/7d73a5e7d54fcc0e970cc865239e070d060ad6dc

Description of the issue/feature this PR addresses:
opw-2791748

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
