### PR TITLE
[FIX] microsoft_calendar: Bug microsoft calendar

### DIFF
--- a/addons/microsoft_calendar/tests/test_microsoft_service.py
+++ b/addons/microsoft_calendar/tests/test_microsoft_service.py
@@ -38,7 +38,7 @@ class TestMicrosoftService(TransactionCase):
         self.call_without_sync_token = call(
             "/v1.0/me/calendarView/delta",
             {
-                'startDateTime': fields.Datetime.subtract(fields.Datetime.now(), years=3).strftime("%Y-%m-%dT00:00:00Z"),
+                'startDateTime': fields.Datetime.subtract(fields.Datetime.now(), years=2).strftime("%Y-%m-%dT00:00:00Z"),
                 'endDateTime': fields.Datetime.add(fields.Datetime.now(), years=3).strftime("%Y-%m-%dT00:00:00Z"),
             },
             {**self.header, 'Prefer': self.header_prefer},
@@ -224,7 +224,7 @@ class TestMicrosoftService(TransactionCase):
         mock_do_request.assert_called_with(
             "/v1.0/me/events/123/instances",
             {
-                'startDateTime': fields.Datetime.subtract(fields.Datetime.now(), years=3).strftime("%Y-%m-%dT00:00:00Z"),
+                'startDateTime': fields.Datetime.subtract(fields.Datetime.now(), years=2).strftime("%Y-%m-%dT00:00:00Z"),
                 'endDateTime': fields.Datetime.add(fields.Datetime.now(), years=3).strftime("%Y-%m-%dT00:00:00Z"),
             },
             {**self.header, 'Prefer': self.header_prefer},

--- a/addons/microsoft_calendar/utils/microsoft_calendar.py
+++ b/addons/microsoft_calendar/utils/microsoft_calendar.py
@@ -57,7 +57,7 @@ class MicrosoftCalendarService():
         }
         if not params:
             params = {
-                'startDateTime': fields.Datetime.subtract(fields.Datetime.now(), years=3).strftime("%Y-%m-%dT00:00:00Z"),
+                'startDateTime': fields.Datetime.subtract(fields.Datetime.now(), years=2).strftime("%Y-%m-%dT00:00:00Z"),
                 'endDateTime': fields.Datetime.add(fields.Datetime.now(), years=3).strftime("%Y-%m-%dT00:00:00Z"),
             }
 


### PR DESCRIPTION
Impacted versions: 14.0

Current behavior before PR: Error when syncing Odoo's calendar with microsoft Calendar `odoo.addons.microsoft_account.models.microsoft_service: Bad microsoft request : b'{"error":{"code":"ErrorInvalidRequest","message":"Your request can\'t be completed. The range between the start and end dates is greater than the allowed range. Maximum number of years: 5"}}' !`

Reason: Microsoft currently only enables calendar retrieval for around 5 years, but Odoo takes 6 years, resulting in an error.

Desired behavior after PR is merged: fix this error.




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
