### PR TITLE
[FIX] im_livechat: disable attachment upload via drag and drop

### DIFF
--- a/addons/im_livechat/static/src/bugfix/bugfix.js
+++ b/addons/im_livechat/static/src/bugfix/bugfix.js
@@ -64,3 +64,22 @@ registerClassPatchModel('mail.message', 'im_livechat/static/src/models/message/m
 });
 
 });
+
+odoo.define('im_livechat/static/src/models/composer/composer.js', function (require) {
+'use strict';
+
+const { registerInstancePatchModel } = require('mail/static/src/model/model_core.js');
+
+registerInstancePatchModel('mail.composer', 'im_livechat/static/src/models/composer/composer.js', {
+    /**
+     * @override
+     */
+    _computeHasDropZone() {
+        if (this.thread && this.thread.channel_type === 'livechat') {
+            return false;
+        }
+        return this._super();
+    },
+});
+
+});

--- a/addons/im_livechat/static/src/components/composer/composer_tests.js
+++ b/addons/im_livechat/static/src/components/composer/composer_tests.js
@@ -61,6 +61,24 @@ QUnit.test('livechat: no add attachment button', async function (assert) {
     );
 });
 
+QUnit.test('livechat: disable attachment upload via drag and drop', async function (assert) {
+    assert.expect(2);
+
+    await this.start();
+    const thread = this.env.models['mail.thread'].create({
+        channel_type: 'livechat',
+        id: 10,
+        model: 'mail.channel',
+    });
+    await this.createComposerComponent(thread.composer);
+    assert.containsOnce(document.body, '.o_Composer', "should have a composer");
+    assert.containsNone(
+        document.body,
+        '.o_Composer_dropZone',
+        "composer linked to livechat should not have a dropzone"
+    );
+});
+
 });
 });
 });

--- a/addons/mail/static/src/components/composer/composer.xml
+++ b/addons/mail/static/src/components/composer/composer.xml
@@ -13,7 +13,7 @@
             t-on-keydown="_onKeydown"
         >
             <t t-if="composer">
-                <t t-if="isDropZoneVisible.value">
+                <t t-if="isDropZoneVisible.value and composer.hasDropZone">
                     <DropZone
                         class="o_Composer_dropZone"
                         t-on-o-dropzone-files-dropped="_onDropZoneFilesDropped"

--- a/addons/mail/static/src/models/composer/composer.js
+++ b/addons/mail/static/src/models/composer/composer.js
@@ -540,6 +540,14 @@ function factory(dependencies) {
          * @private
          * @return {boolean}
          */
+        _computeHasDropZone() {
+            return true;
+        }
+
+        /**
+         * @private
+         * @return {boolean}
+         */
         _computeHasSuggestions() {
             return this.mainSuggestedRecords.length > 0 || this.extraSuggestedRecords.length > 0;
         }
@@ -1169,6 +1177,13 @@ function factory(dependencies) {
                 'suggestionDelimiter',
             ],
         }),
+        hasDropZone: attr({
+            compute: '_computeHasDropZone',
+            dependencies: [
+                'thread',
+                'threadChannelType',
+            ],
+        }),
         /**
          * This field determines whether some attachments linked to this
          * composer are being uploaded.
@@ -1422,6 +1437,9 @@ function factory(dependencies) {
         }),
         thread: one2one('mail.thread', {
             inverse: 'composer',
+        }),
+        threadChannelType: attr({
+            related: 'thread.channel_type',
         }),
     };
 


### PR DESCRIPTION
**Current behavior before PR:**

Attachments are not properly supported in livechat, so there is no point in
allowing attachments to be uploaded via drag and drop.

**Desired behavior after PR is merged:**

Disable attachment upload via drag and drop in livechat channels.

**Task**-2824502