### PR TITLE
[FIX] website: hide install button for non-installable themes

### DIFF
--- a/addons/website/views/website_views.xml
+++ b/addons/website/views/website_views.xml
@@ -359,7 +359,8 @@
                                     <button type="object" name="button_remove_theme" class="btn btn-secondary">Remove theme</button>
                                 </div>
                                 <div t-else="" class="o_button_area">
-                                    <button type="object" name="button_choose_theme" class="btn btn-primary">Use this theme</button>
+                                    <button type="object" name="button_choose_theme" class="btn btn-primary"
+                                            t-if="record.state.raw_value !== 'uninstallable'">Use this theme</button>
                                     <hr t-if="record.url.value"/>
                                     <button role="button" type="edit" t-if="record.url.value" class="btn btn-secondary">Live Preview</button>
                                 </div>


### PR DESCRIPTION
Description of the issue/feature this PR addresses:

Current behavior before PR:

Currently, the 'Use this theme' button is still displayed in Pick a
Theme list even with themes that cannot be installed.

Desired behavior after PR is merged:
This button needs to be hidden for themes that are set to installable=False to avoid confusion.




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
