### PR TITLE
[FIX] point_of_sale: prevent using POS in superuser mode

### DIFF
--- a/addons/point_of_sale/i18n/point_of_sale.pot
+++ b/addons/point_of_sale/i18n/point_of_sale.pot
@@ -5172,6 +5172,12 @@ msgid "You should assign a Point of Sale to your session."
 msgstr ""
 
 #. module: point_of_sale
+#: code:addons/point_of_sale/models/pos_config.py:0
+#, python-format
+msgid "You should leave superuser mode before opening POS"
+msgstr ""
+
+#. module: point_of_sale
 #. openerp-web
 #: code:addons/point_of_sale/static/src/js/chrome.js:0
 #, python-format

--- a/addons/point_of_sale/models/pos_config.py
+++ b/addons/point_of_sale/models/pos_config.py
@@ -6,6 +6,7 @@ from uuid import uuid4
 import pytz
 
 from odoo import api, fields, models, _
+from odoo.tools import config
 from odoo.exceptions import ValidationError, UserError
 
 
@@ -550,6 +551,8 @@ class PosConfig(models.Model):
         :returns: dict
         """
         self.ensure_one()
+        if self.env.su and not config['test_enable']:
+            raise UserError(_("You should leave superuser mode before opening POS"))
         # check all constraints, raises if any is not met
         self._validate_fields(set(self._fields) - {"cash_control"})
         return {


### PR DESCRIPTION
Superuser is a special archived user OdooBot.
POS loads all active users on initialization and hence not OdooBot.
This leads to an error.
We don't really need to support superuser mode in POS, so simple block `open_ui`
method in that case.

opw-2850879
