### PR TITLE
[FIX] website_sale_stock: use website warehouse on sale order

### DIFF
--- a/addons/website_sale/models/sale_order.py
+++ b/addons/website_sale/models/sale_order.py
@@ -29,6 +29,19 @@ class SaleOrder(models.Model):
     website_id = fields.Many2one('website', string='Website', readonly=True,
                                  help='Website through which this order was placed.')
 
+    @api.model_create_multi
+    def create(self, vals_list):
+        for vals in vals_list:
+            if vals.get('website_id'):
+                website = self.env['website'].browse(vals['website_id'])
+                if 'company_id' in vals:
+                    company = self.env['res.company'].browse(vals['company_id'])
+                    if website.company_id.id != company.id:
+                        raise ValueError(_("The company of the website you are trying to sale from (%s) is different than the one you want to use (%s)") % (website.company_id.name, company.name))
+                else:
+                    vals['company_id'] = website.company_id.id
+        return super().create(vals_list)
+
     def _compute_user_id(self):
         """Do not assign self.env.user as salesman for e-commerce orders
         Leave salesman empty if no salesman is specified on partner or website

--- a/addons/website_sale_stock/models/sale_order.py
+++ b/addons/website_sale_stock/models/sale_order.py
@@ -10,6 +10,21 @@ class SaleOrder(models.Model):
 
     warning_stock = fields.Char('Warning')
 
+    def _get_warehouse_available(self):
+        self.ensure_one()
+        warehouse = self.website_id._get_warehouse_available()
+        if not warehouse and self.user_id and self.company_id:
+            warehouse = self.user_id.with_company(self.company_id.id)._get_default_warehouse_id()
+        if not warehouse:
+            warehouse = self.env.user._get_default_warehouse_id()
+        return warehouse
+
+    def _compute_warehouse_id(self):
+        website_orders = self.filtered('website_id')
+        super(SaleOrder, self - website_orders)._compute_warehouse_id()
+        for order in website_orders:
+            order.warehouse_id = order._get_warehouse_available()
+
     def _cart_update(self, product_id=None, line_id=None, add_qty=0, set_qty=0, **kwargs):
         values = super(SaleOrder, self)._cart_update(product_id, line_id, add_qty, set_qty, **kwargs)
         line_id = values.get('line_id')


### PR DESCRIPTION
Steps to reproduce:

  - Create 2 warehouse (WH1 and WH2)
  - Ensure warehouse order is WH1 then WH2
  - Set warehouse WH2 on website
  - Go to portal as guest (in incognito window)
  - Add product to cart
  - As admin (in main window), open quotation in
    backend and ensure warehouse_id is set to WH2
  - Go back to shop and confirm cart (in incognito window)
  - Fill partner address and click next
  - As admin (in main window), open quotation in backend

Issue:

  Wrong warehouse set on order (WH1).

Cause:

  When updating partner, it trigger the compute
  of user_id that trigger compute of warehouse_id.
  Since compute method is in `sale_stock` module,
  it does not take into account the website config and
  user `_get_default_warehouse_id` method from current
  user.
  Therefore it don't use the same logic as creation of
  sale order from website (by adding item in cart)
  by using `_get_warehouse_available` method from
  current website to set warehouse on order.
  Note: When user logged, since partner already set, the
  warehouse set is the right one since not recomputing.

Solution:

  If order has a `website_id`, use `_get_warehouse_available`
  to compute warehouse and fallback on `_get_default_warehouse_id`.

opw-2851944