### PR TITLE
[FIX] account: correct regex extraction reconciliation

### DIFF
--- a/addons/account/models/account_reconcile_model.py
+++ b/addons/account/models/account_reconcile_model.py
@@ -350,7 +350,8 @@ class AccountReconcileModel(models.Model):
                 if match:
                     sign = 1 if residual_balance > 0.0 else -1
                     try:
-                        extracted_balance = float(re.sub(r'\D' + self.decimal_separator, '', match.group(1)).replace(self.decimal_separator, '.'))
+                        extracted_match_group = re.sub(r'[^\d' + self.decimal_separator + ']', '', match.group(1))
+                        extracted_balance = float(extracted_match_group.replace(self.decimal_separator, '.'))
                         balance = copysign(extracted_balance * sign, residual_balance)
                     except ValueError:
                         balance = 0


### PR DESCRIPTION
Steps to repdroduce:
- In Reconciliation Models create a new rule
- Add two new lines with a "From Label" type and respectively set the "Amount" field to:
Koerperschaftst.{5,10}\s([\d\,\.]+)
Solid.Zuschl.KSt.{5,10}\s([\d\,\.]+)
- Change the "Decimal Separator" to a comma ","
- In Bank statement, create a new one with the following label:
Stnr 330/5707/3700 Koerperschaftst. 1.Vj.22 1.250,00 Solid.Zuschl.KSt 1.Vj.22 50,00 - FOLGELASTSCHRIFT
- Reoncile by using the button corresponding to the new rule

Issue:
-> "1.250,00" won't extracted contrarily to the "50,00"

Cause:
In:  https://github.com/odoo/odoo/blob/affdd8d6276cb3c3aea9b994fa2427a6e97de691/addons/account/models/account_reconcile_model.py#L353
Our scenario: float("1.250.00") -> will throw an error

Solution:
Clean the match group to only keep the numebers and the decimal_separator

opw-2794209