### PR TITLE
[FIX] web_editor: allow moving gradient color steps for text colors

### DIFF
--- a/addons/web_editor/static/src/js/wysiwyg/wysiwyg.js
+++ b/addons/web_editor/static/src/js/wysiwyg/wysiwyg.js
@@ -1256,7 +1256,12 @@ const Wysiwyg = Widget.extend({
     },
     _configureToolbar: function (options) {
         const $toolbar = this.toolbar.$el;
-        $toolbar.find('.btn-group').on('mousedown', e => e.preventDefault());
+        $toolbar.find('.btn-group').on('mousedown', e => {
+            // Do not prevent events on popovers.
+            if (!e.target.closest('.dropdown-menu')) {
+                e.preventDefault();
+            }
+        });
         const openTools = e => {
             e.preventDefault();
             e.stopImmediatePropagation();


### PR DESCRIPTION
Since [1] gradient color steps cannot be moved anymore for the text
foreground and background colors.

This was already modified in [2] but it did not address the case of the
color palettes.

This commit makes sure that the mousedown events are not prevented
within the color palettes that are spawned within the toolbar.

Steps to reproduce:
- Drop a "Text - Image" snippet.
- Select the text header line.
- Apply a custom text gradient.
- Add an intermediary color step.
- Try to move the new color step.
=> Color step could not be moved.

[1]: https://github.com/odoo/odoo/commit/57701b2125f7de4fc543bd9c10642a5c11fa32b8
[2]: https://github.com/odoo/odoo/commit/84fd0b0a1bc1d874e7d6d6ff10b4fb6351f5a1af

task-2862233

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
