### PR TITLE
[FIX] website_crm: allow creation of opportunity

### DIFF
--- a/addons/website_crm/models/crm_lead.py
+++ b/addons/website_crm/models/crm_lead.py
@@ -51,7 +51,11 @@ class Lead(models.Model):
                             request.website.crm_default_team_id.id
         values['user_id'] = values.get('user_id') or \
                             request.website.crm_default_user_id.id
-        values['type'] = 'lead' if self.with_user(SUPERUSER_ID).env['res.users'].has_group('crm.group_use_lead') else 'opportunity'
+        if values.get('team_id'):
+            values['type'] = 'lead' if self.env['crm.team'].sudo().browse(values['team_id']).use_leads else 'opportunity'
+        else:
+            values['type'] = 'lead' if self.with_user(SUPERUSER_ID).env['res.users'].has_group('crm.group_use_lead') else 'opportunity'
+
         return values
 
 


### PR DESCRIPTION
Steps to reproduce:
- In CRM seetings, activate Leads
- Create a sales team with "Pipeline" selected in Sales Teams Settings
- Set a form. The action is "create opportunity" and the Sales Team is the one you created
- Send a form

Issue:
A lead will be created. Not opportunity.

Solution:
Fetch the info related to the team

opw-2856520