### PR TITLE
[FIX] product: disable company creation via list view

### DIFF
--- a/addons/product/views/product_pricelist_views.xml
+++ b/addons/product/views/product_pricelist_views.xml
@@ -82,7 +82,7 @@
                     <field name="date_start" optional="show"/>
                     <field name="date_end" optional="show"/>
                     <field name="applied_on" invisible="1"/>
-                    <field name="company_id" groups="base.group_multi_company" optional="show" options="{'no_create_edit':1, 'no_open': 1}"/>
+                    <field name="company_id" groups="base.group_multi_company" optional="show" options="{'no_create':1, 'no_open': 1}"/>
                 </tree>
             </field>
         </record>

--- a/addons/product/views/product_template_views.xml
+++ b/addons/product/views/product_template_views.xml
@@ -11,7 +11,7 @@
                 <field name="default_code" optional="show"/>
                 <field name="barcode" optional="hide" attrs="{'readonly': [('product_variant_count', '>', 1)]}"/>
                 <field name="name"/>
-                <field name="company_id" options="{'no_create_edit': True}"
+                <field name="company_id" options="{'no_create': True}"
                     groups="base.group_multi_company" optional="hide"/>
                 <field name="list_price" string="Sales Price" optional="show"/>
                 <field name="standard_price" optional="show" readonly="1"/>


### PR DESCRIPTION
List of companies is a quite delicate configuration, which must be done by Admin
via`Settings > Companies` menu. Inline creation should be always disabled for
`company_id` field. Few such cases were presented probably because of
ambiguous setting name `no_create_edit`: it disabled "Create & Edit" button, but not
"Create" button.

STEPS:

-Go to Sales -> Products and go to the List view.
-Select one Product and try to change their Company
-You'll be able create a new company.

opw-2861853

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
