### PR TITLE
[FIX] mass_mailing: properly allow global customize separator colors

### DIFF
--- a/addons/mass_mailing/static/src/js/mass_mailing_design_constants.js
+++ b/addons/mass_mailing/static/src/js/mass_mailing_design_constants.js
@@ -28,7 +28,7 @@ export const PRIORITY_STYLES = {
     'a:not(.btn)': [],
     'a.btn.btn-primary': [],
     'a.btn.btn-secondary': [],
-    'hr': [],
+    'hr': ['border-top-color'],
 };
 export const RE_CSS_TEXT_MATCH = /([^{]+)([^}]+)/;
 export const RE_SELECTOR_ENDS_WITH_GT_STAR = />\s*\*\s*$/;
@@ -75,7 +75,7 @@ export const splitCss = css => {
                     if (!stylesToWrite[selectorToWriteTo]) {
                         stylesToWrite[selectorToWriteTo] = [];
                     }
-                    stylesToWrite[selectorToWriteTo].push([style, styles[style]]);
+                    stylesToWrite[selectorToWriteTo].push([style, styles[style] + (styles.getPropertyPriority(style) === 'important' ? ' !important' : '')]);
                 }
             }
         }


### PR DESCRIPTION
The design tab allows the customization of the separators' colors but this is currently broken because it gets overridden by the default style of the snippet, which has higher specificity. Besides, the priority of styles was lost.

Enterprise PR: https://github.com/odoo/enterprise/pull/27711

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
