### PR TITLE
[FIX] purchase_product_matrix: test breaking in newer Chrome (rounding)

### DIFF
--- a/addons/purchase_product_matrix/static/tests/section_and_note_widget_tests.js
+++ b/addons/purchase_product_matrix/static/tests/section_and_note_widget_tests.js
@@ -250,7 +250,7 @@ QUnit.module('section_and_note: purchase_product_matrix', {
         // move first row below second
         const $firstHandle = form.$('.o_data_row:nth(0) .o_row_handle');
         const $secondHandle = form.$('.o_data_row:nth(1) .o_row_handle');
-        await testUtils.dom.dragAndDrop($firstHandle, $secondHandle);
+        await testUtils.dom.dragAndDrop($firstHandle, $secondHandle, { position: 'bottom' });
 
         assert.strictEqual(form.$('.o_data_row').text(), 'TableChair');
 

--- a/addons/sale/static/tests/product_configurator_tests.js
+++ b/addons/sale/static/tests/product_configurator_tests.js
@@ -90,7 +90,7 @@ odoo.define('sale.product_configurator_tests', function (require) {
             // move first row below second
             const $firstHandle = form.$('.o_data_row:nth(0) .o_row_handle');
             const $secondHandle = form.$('.o_data_row:nth(1) .o_row_handle');
-            await testUtils.dom.dragAndDrop($firstHandle, $secondHandle);
+            await testUtils.dom.dragAndDrop($firstHandle, $secondHandle, { position: 'bottom' });
 
             assert.strictEqual(form.$('.o_data_row').text(), 'TableChair');
 

--- a/addons/sale_product_configurator/static/tests/product_configurator.test.js
+++ b/addons/sale_product_configurator/static/tests/product_configurator.test.js
@@ -298,7 +298,7 @@ QUnit.module('Product Configurator', {
         // move first row below second
         const $firstHandle = form.$('.o_data_row:nth(0) .o_row_handle');
         const $secondHandle = form.$('.o_data_row:nth(1) .o_row_handle');
-        await testUtils.dom.dragAndDrop($firstHandle, $secondHandle);
+        await testUtils.dom.dragAndDrop($firstHandle, $secondHandle, { position: 'bottom' });
 
         assert.strictEqual(form.$('.o_data_row').text(), 'Customizable Desk (2)Customizable Desk (1)');
 


### PR DESCRIPTION
Since (at least) Chrome 94+, some element's sizing computation returns a
slightly different value (in the order of a fraction of a pixel). Sadly,
due to rounding, this difference has an impact on exact sizing
assertion.

Specifically in these drag-and-drop tests, it prevents the sorting from
being triggered as the "mouse" doesn't pass beyond the center of the
destination element (aka. next row).

By setting the position to `bottom`, this commit mitigates this issue by
making sure to pass that boundary, just like a real-user would do.