### PR TITLE
[FIX] loyalty: remove the deleted mail template from default_get

### DIFF
--- a/addons/sale_loyalty/models/loyalty_card.py
+++ b/addons/sale_loyalty/models/loyalty_card.py
@@ -13,7 +13,7 @@ class LoyaltyCard(models.Model):
     def _get_default_template(self):
         default_template = super()._get_default_template()
         if not default_template:
-            default_template = self.env.ref('sale_loyalty.mail_template_sale_loyalty', raise_if_not_found=False)
+            default_template = self.env.ref('loyalty.mail_template_loyalty_card', raise_if_not_found=False)
         return default_template
 
     def _get_mail_partner(self):


### PR DESCRIPTION
Before this commit, generate coupon and send mail there is an empty note and False template due to invalid template_id in default_get so it logged empty message in the chatter.

So in this commit, added default right template reference as default template.

task-2858277