### PR TITLE
[FIX] point_of_sale: prevent saving finalized orders in unpaid_orders

### DIFF
--- a/addons/point_of_sale/static/src/js/models.js
+++ b/addons/point_of_sale/static/src/js/models.js
@@ -2206,7 +2206,7 @@ class Order extends PosModel {
         }
     }
     save_to_db(){
-        if (!this.temporary && !this.locked) {
+        if (!this.temporary && !this.locked && !this.finalized) {
             this.pos.db.save_unpaid_order(this);
         }
     }


### PR DESCRIPTION
Before this commit: when you validate an order, it first be removed
from unpaid orders in the browser, but then it'll save in the unpaid
order. The problem is that when you close the session just after
validating an order and before clicking on the new order button, the
order will show on the new session.

Steps to reproduce the first issue:

	- Install the' Point of Sale' module
	- Open a PoS session
	- Add a product to the order
	- Process order payment and validate the order
	- Stay in the receipt screen and refresh the page

	The last order is still seen as open on the register.

Solution

	[BUG] The paid order is still there and is now back in product
	screen.

opw-2856557


--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
