### PR TITLE
[FIX] stock: display graph on forecasted report

### DIFF
--- a/addons/stock/static/src/js/report_stock_forecasted.js
+++ b/addons/stock/static/src/js/report_stock_forecasted.js
@@ -109,6 +109,7 @@ const ReplenishReport = clientAction.extend({
                 modelName: model,
                 domain: this._getReportDomain(),
                 hasActionMenus: false,
+                context: {fill_temporal: false},
             };
             const graphView = new GraphView(viewInfo, params);
             return graphView.getController(this);


### PR DESCRIPTION
In some cases, an unexpected line "Undefined" is displayed on the graph
of the Forecasted Report

To reproduce the issue:
1. Create a storable product P
2. Process a receipt R01 with 1 x P
3. Process a delivery D01 with 1 x P
4. Create and confirm a planned receipt R02:
    - Scheduled date: In 7 days
    - Operations: 1 x P
5. On the form of P, open the On Hand page
6. Back to the form of P, open Forecasted page

Error: An unexpected line "Undefined" is displayed on the graph and is
always equal to zero

Suppose the user does the same as above without the step 5: there won't
be any unexpected line on the graph. Here are the explanations: after
step 3, a quant for P exists and its quantity is zero. So, suppose the
user doesn't open the "On Hand page" and directly opens the Forecasted
Report. Considering its definition:
https://github.com/odoo/odoo/blob/a9dc406b52a3702f6901f686503e8d841f81724e/addons/stock/report/report_stock_quantity.py#L41
Four things happen (we only consider the state `forecast`):
- The SM of R01 is propagated from `today minus 3 months` to `yesterday`
- Same for SM of D01
- The quant is propagated from `today minus 3 months` to `today plus 3
months`
- The SM of R02 is propagated from `in 7 days` to `today plus 3 months`

-> Thanks to the quant, there are some data between `yesterday` and `in
7 days`

Let's now consider the step 5. Opening the page leads to:
https://github.com/odoo/odoo/blob/b22a23435a0cc42b7084ded21dbd4ef3a4a2113e/addons/stock/models/stock_quant.py#L621-L630
where, in `_quant_tasks`, we unlink the zero quants:
https://github.com/odoo/odoo/blob/b22a23435a0cc42b7084ded21dbd4ef3a4a2113e/addons/stock/models/stock_quant.py#L562-L565
Therefore, in the `report.stock.quantity`, we are creating a hole
between `yesterday` and `in 7 days`. When performing the RPC
`read_group` to get the graph data, a key-context is defined
(`fill_temporal`). Thanks to this, the hole is filled by the server but
the generated data do not mean anything:
https://github.com/odoo/odoo/blob/80ec56bd246869567c3bbc746be1ebce52970a63/odoo/models.py#L2005-L2007
i.e., the value of `empty_item` is:
```py
{'id': False, 'date_count': 0, 'product_qty': False, 'product_id':
False}
```
Later on, on JS-side, when processing the `read_group` result:
https://github.com/odoo/odoo/blob/ee84815f2b57ed7ba096d3390aa8c6509e3f7845/addons/web/static/src/js/views/graph/graph_model.js#L235-L241
We are grouping by date and by product. As explained above, some data
have an undefined `product_id` so, in such case, `labels` will contain a
date and an `undefined` value. This explains why we have two lines on
the graph:
- one for the product P
- one for the data generated by the server to fill the hole in the dates
range

OPW-2800818