### PR TITLE
[POC] core: add support for nested search domains

### DIFF
--- a/addons/account/models/partner.py
+++ b/addons/account/models/partner.py
@@ -183,10 +183,10 @@ class AccountFiscalPosition(models.Model):
             zip_domain = [('zip_from', '<=', zipcode), ('zip_to', '>=', zipcode)]
 
         if state_id:
-            state_domain = [('state_ids', '=', state_id)]
+            state_domain = [('state_ids', 'any', [('id', '=', state_id)])]
 
         domain_country = base_domain + [('country_id', '=', country_id)]
-        domain_group = base_domain + [('country_group_id.country_ids', '=', country_id)]
+        domain_group = base_domain + [('country_group_id.country_ids', 'any', [('id', '=', country_id)])]
 
         # Build domain to search records with exact matching criteria
         fpos = self.search(domain_country + state_domain + zip_domain, limit=1)

--- a/addons/calendar/security/calendar_security.xml
+++ b/addons/calendar/security/calendar_security.xml
@@ -5,7 +5,7 @@
         <record id="calendar_event_rule_my" model="ir.rule">
             <field name="name">Own events</field>
             <field ref="model_calendar_event" name="model_id"/>
-            <field name="domain_force">[('partner_ids', 'in', user.partner_id.id)]</field>
+            <field name="domain_force">[('partner_ids', 'any', [('id', 'in', user.partner_id.id)])]</field>
             <field name="groups" eval="[(4, ref('base.group_portal'))]"/>
         </record>
 
@@ -26,7 +26,7 @@
         <record id="calendar_event_rule_private" model="ir.rule">
             <field ref="model_calendar_event" name="model_id"/>
             <field name="name">Private events</field>
-            <field name="domain_force">['|', ('privacy', '!=', 'private'), '&amp;', ('privacy', '=', 'private'), '|', ('user_id', '=', user.id), ('partner_ids', 'in', user.partner_id.id)]</field>
+            <field name="domain_force">['|', ('privacy', '!=', 'private'), '&amp;', ('privacy', '=', 'private'), '|', ('user_id', '=', user.id), ('partner_ids', 'any', [('id', 'in', user.partner_id.id)])]</field>
             <field name="perm_read" eval="False"/>
             <field name="perm_write" eval="True"/>
             <field name="perm_create" eval="True"/>

--- a/addons/calendar/security/calendar_security.xml
+++ b/addons/calendar/security/calendar_security.xml
@@ -5,7 +5,7 @@
         <record id="calendar_event_rule_my" model="ir.rule">
             <field name="name">Own events</field>
             <field ref="model_calendar_event" name="model_id"/>
-            <field name="domain_force">[('partner_ids', 'any', [('id', 'in', user.partner_id.id)])]</field>
+            <field name="domain_force">[('partner_ids', 'any', user.partner_id)]</field>
             <field name="groups" eval="[(4, ref('base.group_portal'))]"/>
         </record>
 
@@ -26,7 +26,7 @@
         <record id="calendar_event_rule_private" model="ir.rule">
             <field ref="model_calendar_event" name="model_id"/>
             <field name="name">Private events</field>
-            <field name="domain_force">['|', ('privacy', '!=', 'private'), '&amp;', ('privacy', '=', 'private'), '|', ('user_id', '=', user.id), ('partner_ids', 'any', [('id', 'in', user.partner_id.id)])]</field>
+            <field name="domain_force">['|', ('privacy', '!=', 'private'), '&amp;', ('privacy', '=', 'private'), '|', ('user_id', '=', user.id), ('partner_ids', 'any', user.partner_id)]</field>
             <field name="perm_read" eval="False"/>
             <field name="perm_write" eval="True"/>
             <field name="perm_create" eval="True"/>

--- a/addons/delivery_stock_picking_batch/models/stock_picking.py
+++ b/addons/delivery_stock_picking_batch/models/stock_picking.py
@@ -39,7 +39,7 @@ class StockPicking(models.Model):
     def _get_possible_batches_domain(self):
         domain = super()._get_possible_batches_domain()
         if self.picking_type_id.batch_group_by_carrier:
-            domain = expression.AND([domain, [('picking_ids.carrier_id', '=', self.carrier_id.id if self.carrier_id else False)]])
+            domain = expression.AND([domain, [('picking_ids', 'any', [('carrier_id', '=', self.carrier_id.id if self.carrier_id else False)])]])
 
         return domain
 

--- a/addons/gamification/data/gamification_challenge_data.xml
+++ b/addons/gamification/data/gamification_challenge_data.xml
@@ -22,7 +22,7 @@
             <field name="computation_mode">count</field>
             <field name="display_mode">boolean</field>
             <field name="model_id" ref="base.model_res_company"/>
-            <field name="domain">[('user_ids', 'in', [user.id]), ('name', '=', 'YourCompany')]</field>
+            <field name="domain">[('user_ids', 'any', user), ('name', '=', 'YourCompany')]</field>
             <field name="condition">lower</field>
             <field name="action_id" ref="base.action_res_company_form"/>
             <field name="res_id_field">user.company_id.id</field>
@@ -33,7 +33,7 @@
             <field name="computation_mode">count</field>
             <field name="display_mode">boolean</field>
             <field name="model_id" ref="base.model_res_company"/>
-            <field name="domain">[('user_ids', 'in', [user.id]),('logo', '!=', False)]</field>
+            <field name="domain">[('user_ids', 'any', user), ('logo', '!=', False)]</field>
             <field name="action_id" ref="base.action_res_company_form"/>
             <field name="res_id_field">user.company_id.id</field>
         </record>
@@ -54,7 +54,7 @@
             <field name="period">once</field>
             <field name="visibility_mode">personal</field>
             <field name="report_message_frequency">never</field>
-            <field name="user_domain" eval="str([('groups_id.id', '=', ref('base.group_user'))])" />
+            <field name="user_domain" eval="str([('groups_id', '=', ref('base.group_user'))])" />
             <field name="state">inprogress</field>
             <field name="challenge_category">other</field>
         </record>
@@ -64,7 +64,7 @@
             <field name="period">once</field>
             <field name="visibility_mode">personal</field>
             <field name="report_message_frequency">never</field>
-            <field name="user_domain" eval="str([('groups_id.id', '=', ref('base.group_erp_manager'))])" />
+            <field name="user_domain" eval="str([('groups_id', '=', ref('base.group_erp_manager'))])" />
             <field name="state">inprogress</field>
             <field name="challenge_category">other</field>
         </record>

--- a/addons/gamification_sale_crm/data/gamification_sale_crm_data.xml
+++ b/addons/gamification_sale_crm/data/gamification_sale_crm_data.xml
@@ -149,7 +149,7 @@
             <field name="name">Monthly Sales Targets</field>
             <field name="period">monthly</field>
             <field name="visibility_mode">ranking</field>
-            <field name="user_domain" eval="str([('groups_id', 'in', [ref('sales_team.group_sale_salesman')])])" />
+            <field name="user_domain" eval="str([('groups_id', '=', ref('sales_team.group_sale_salesman'))])" />
             <field name="report_message_frequency">weekly</field>
         </record>
 
@@ -157,7 +157,7 @@
             <field name="name">Lead Acquisition</field>
             <field name="period">monthly</field>
             <field name="visibility_mode">ranking</field>
-            <field name="user_domain" eval="str([('groups_id', 'in', [ref('sales_team.group_sale_salesman')])])" />
+            <field name="user_domain" eval="str([('groups_id', '=', ref('sales_team.group_sale_salesman'))])" />
             <field name="report_message_frequency">weekly</field>
         </record>
 

--- a/addons/hr/models/hr_employee.py
+++ b/addons/hr/models/hr_employee.py
@@ -334,7 +334,7 @@ class HrEmployeePrivate(models.Model):
         employee_departments = employees.department_id
         if employee_departments:
             self.env['mail.channel'].sudo().search([
-                ('subscription_department_ids', 'any', [('id', 'in', employee_departments.ids)]),
+                ('subscription_department_ids', 'any', employee_departments),
             ])._subscribe_users_automatically()
         onboarding_notes_bodies = {}
         hr_root_menu = self.env.ref('hr.menu_hr_root')

--- a/addons/hr/models/hr_employee.py
+++ b/addons/hr/models/hr_employee.py
@@ -334,7 +334,7 @@ class HrEmployeePrivate(models.Model):
         employee_departments = employees.department_id
         if employee_departments:
             self.env['mail.channel'].sudo().search([
-                ('subscription_department_ids', 'in', employee_departments.ids)
+                ('subscription_department_ids', 'any', [('id', 'in', employee_departments.ids)]),
             ])._subscribe_users_automatically()
         onboarding_notes_bodies = {}
         hr_root_menu = self.env.ref('hr.menu_hr_root')
@@ -369,7 +369,7 @@ class HrEmployeePrivate(models.Model):
             department_id = vals['department_id'] if vals.get('department_id') else self[:1].department_id.id
             # When added to a department or changing user, subscribe to the channels auto-subscribed by department
             self.env['mail.channel'].sudo().search([
-                ('subscription_department_ids', 'in', department_id)
+                ('subscription_department_ids', 'any', [('id', '=', department_id)]),
             ])._subscribe_users_automatically()
         return res
 

--- a/addons/hr/models/res_users.py
+++ b/addons/hr/models/res_users.py
@@ -286,7 +286,7 @@ class User(models.Model):
             user.employee_id = employee_per_user.get(user)
 
     def _search_company_employee(self, operator, value):
-        return [('employee_ids', 'any', [('id', operator, value)])]
+        return [('employee_ids', operator, value)]
 
     def action_create_employee(self):
         self.ensure_one()

--- a/addons/hr/models/res_users.py
+++ b/addons/hr/models/res_users.py
@@ -286,7 +286,7 @@ class User(models.Model):
             user.employee_id = employee_per_user.get(user)
 
     def _search_company_employee(self, operator, value):
-        return [('employee_ids', operator, value)]
+        return [('employee_ids', 'any', [('id', operator, value)])]
 
     def action_create_employee(self):
         self.ensure_one()

--- a/addons/hr_timesheet/security/hr_timesheet_security.xml
+++ b/addons/hr_timesheet/security/hr_timesheet_security.xml
@@ -37,10 +37,10 @@
             <field name="domain_force">[
                 ('project_id', '!=', False),
                 '|',
-                    ('project_id.message_partner_ids', 'child_of', [user.partner_id.commercial_partner_id.id]),
-                    ('task_id.message_partner_ids', 'child_of', [user.partner_id.commercial_partner_id.id]),
+                    ('project_id.message_partner_ids', 'any', [('id', 'child_of', [user.partner_id.commercial_partner_id.id])]),
+                    ('task_id.message_partner_ids', 'any', [('id', 'child_of', [user.partner_id.commercial_partner_id.id])]),
                 ('project_id.privacy_visibility', '=', 'portal'),
-                ('project_id.collaborator_ids.partner_id', 'in', [user.partner_id.id]),
+                ('project_id.collaborator_ids', 'any', [('partner_id', 'in', [user.partner_id.id])]),
             ]</field>
             <field name="perm_read" eval="True"/>
             <field name="perm_write" eval="True"/>
@@ -57,8 +57,8 @@
                 ('project_id', '!=', False),
                 '|', '|',
                     ('project_id.privacy_visibility', '!=', 'followers'),
-                    ('project_id.message_partner_ids', 'in', [user.partner_id.id]),
-                    ('task_id.message_partner_ids', 'in', [user.partner_id.id])
+                    ('project_id.message_partner_ids', 'any', [('id', 'in', [user.partner_id.id])]),
+                    ('task_id.message_partner_ids', 'any', [('id', 'in', [user.partner_id.id])])
             ]</field>
             <field name="groups" eval="[(4, ref('group_hr_timesheet_user'))]"/>
         </record>
@@ -70,7 +70,7 @@
                 ('project_id', '!=', False),
                 '|',
                     ('project_id.privacy_visibility', '!=', 'followers'),
-                    ('project_id.message_partner_ids', 'in', [user.partner_id.id])
+                    ('project_id.message_partner_ids', 'any', [('id', 'in', [user.partner_id.id])])
             ]</field>
             <field name="groups" eval="[(4, ref('hr_timesheet.group_hr_timesheet_approver'))]" />
         </record>

--- a/addons/hr_timesheet/security/hr_timesheet_security.xml
+++ b/addons/hr_timesheet/security/hr_timesheet_security.xml
@@ -57,8 +57,8 @@
                 ('project_id', '!=', False),
                 '|', '|',
                     ('project_id.privacy_visibility', '!=', 'followers'),
-                    ('project_id.message_partner_ids', 'any', [('id', 'in', [user.partner_id.id])]),
-                    ('task_id.message_partner_ids', 'any', [('id', 'in', [user.partner_id.id])])
+                    ('project_id.message_partner_ids', 'any', user.partner_id),
+                    ('task_id.message_partner_ids', 'any', user.partner_id)
             ]</field>
             <field name="groups" eval="[(4, ref('group_hr_timesheet_user'))]"/>
         </record>
@@ -70,7 +70,7 @@
                 ('project_id', '!=', False),
                 '|',
                     ('project_id.privacy_visibility', '!=', 'followers'),
-                    ('project_id.message_partner_ids', 'any', [('id', 'in', [user.partner_id.id])])
+                    ('project_id.message_partner_ids', 'any', user.partner_id)
             ]</field>
             <field name="groups" eval="[(4, ref('hr_timesheet.group_hr_timesheet_approver'))]" />
         </record>

--- a/addons/hr_timesheet_attendance/security/hr_timesheet_attendance_report_security.xml
+++ b/addons/hr_timesheet_attendance/security/hr_timesheet_attendance_report_security.xml
@@ -20,7 +20,7 @@
             ('project_id', '!=', False),
             '|',
                 ('project_id.privacy_visibility', '!=', 'followers'),
-                ('project_id.message_partner_ids', 'in', [user.partner_id.id])
+                ('project_id.message_partner_ids', 'any', [('id', 'in', [user.partner_id.id])])
         ]</field>
         <field name="groups" eval="[(4, ref('hr_timesheet.group_hr_timesheet_approver'))]"/>
     </record>

--- a/addons/hr_timesheet_attendance/security/hr_timesheet_attendance_report_security.xml
+++ b/addons/hr_timesheet_attendance/security/hr_timesheet_attendance_report_security.xml
@@ -20,7 +20,7 @@
             ('project_id', '!=', False),
             '|',
                 ('project_id.privacy_visibility', '!=', 'followers'),
-                ('project_id.message_partner_ids', 'any', [('id', 'in', [user.partner_id.id])])
+                ('project_id.message_partner_ids', 'any', user.partner_id)
         ]</field>
         <field name="groups" eval="[(4, ref('hr_timesheet.group_hr_timesheet_approver'))]"/>
     </record>

--- a/addons/iap/security/ir_rule.xml
+++ b/addons/iap/security/ir_rule.xml
@@ -5,7 +5,7 @@
       <field name="model_id" ref="model_iap_account"/>
       <field name="groups" eval="[(4, ref('base.group_user'))]"/>
       <!-- partners can CUD services linked to themselves -->
-      <field name="domain_force">['|', ('company_ids', '=', False), ('company_ids', 'in', company_ids)]</field>
+      <field name="domain_force">['|', ('company_ids', '=', False), ('company_ids', 'any', [('id', 'in', company_ids)])]</field>
     </record>
 
 </odoo>

--- a/addons/iap/security/ir_rule.xml
+++ b/addons/iap/security/ir_rule.xml
@@ -5,7 +5,7 @@
       <field name="model_id" ref="model_iap_account"/>
       <field name="groups" eval="[(4, ref('base.group_user'))]"/>
       <!-- partners can CUD services linked to themselves -->
-      <field name="domain_force">['|', ('company_ids', '=', False), ('company_ids', 'any', [('id', 'in', company_ids)])]</field>
+      <field name="domain_force">['|', ('company_ids', '=', False), ('company_ids', 'any', company_ids)]</field>
     </record>
 
 </odoo>

--- a/addons/mail/models/res_groups.py
+++ b/addons/mail/models/res_groups.py
@@ -19,5 +19,6 @@ class ResGroups(models.Model):
             # form: {'group_ids': [(3, 10), (3, 3), (4, 10), (4, 3)]} or {'group_ids': [(6, 0, [ids]}
             user_ids = [command[1] for command in vals['users'] if command[0] == 4]
             user_ids += [id for command in vals['users'] if command[0] == 6 for id in command[2]]
-            self.env['mail.channel'].search([('group_ids', 'in', self._ids)])._subscribe_users_automatically()
+            search_domain = [('group_ids', 'any', [('id', 'in', self._ids)])]
+            self.env['mail.channel'].search(search_domain)._subscribe_users_automatically()
         return res

--- a/addons/mail/models/res_groups.py
+++ b/addons/mail/models/res_groups.py
@@ -19,6 +19,6 @@ class ResGroups(models.Model):
             # form: {'group_ids': [(3, 10), (3, 3), (4, 10), (4, 3)]} or {'group_ids': [(6, 0, [ids]}
             user_ids = [command[1] for command in vals['users'] if command[0] == 4]
             user_ids += [id for command in vals['users'] if command[0] == 6 for id in command[2]]
-            search_domain = [('group_ids', 'any', [('id', 'in', self._ids)])]
+            search_domain = [('group_ids', 'any', self)]
             self.env['mail.channel'].search(search_domain)._subscribe_users_automatically()
         return res

--- a/addons/mail/models/res_users.py
+++ b/addons/mail/models/res_users.py
@@ -86,7 +86,9 @@ class Users(models.Model):
                     )
         # Auto-subscribe to channels unless skip explicitly requested
         if not self.env.context.get('mail_channel_nosubscribe'):
-            self.env['mail.channel'].search([('group_ids.id', 'in', users.groups_id.ids)])._subscribe_users_automatically()
+            self.env['mail.channel'].search([('group_ids', 'any', [
+                ('id', 'in', users.groups_id.ids),
+            ])])._subscribe_users_automatically()
         return users
 
     def write(self, vals):
@@ -118,9 +120,9 @@ class Users(models.Model):
             # form: {'group_ids': [(3, 10), (3, 3), (4, 10), (4, 3)]} or {'group_ids': [(6, 0, [ids]}
             user_group_ids = [command[1] for command in vals['groups_id'] if command[0] == 4]
             user_group_ids += [id for command in vals['groups_id'] if command[0] == 6 for id in command[2]]
-            self.env['mail.channel'].search([('group_ids', 'in', user_group_ids)])._subscribe_users_automatically()
+            self.env['mail.channel'].search([('group_ids', 'any', [('id', 'in', user_group_ids)])])._subscribe_users_automatically()
         elif sel_groups:
-            self.env['mail.channel'].search([('group_ids', 'in', sel_groups)])._subscribe_users_automatically()
+            self.env['mail.channel'].search([('group_ids', 'any', [('id', 'in', sel_groups)])])._subscribe_users_automatically()
         return write_res
 
     def unlink(self):

--- a/addons/mail/models/res_users.py
+++ b/addons/mail/models/res_users.py
@@ -86,7 +86,7 @@ class Users(models.Model):
                     )
         # Auto-subscribe to channels unless skip explicitly requested
         if not self.env.context.get('mail_channel_nosubscribe'):
-            self.env['mail.channel'].search([('group_ids', 'in', users.groups_id.ids)])._subscribe_users_automatically()
+            self.env['mail.channel'].search([('group_ids.id', 'in', users.groups_id.ids)])._subscribe_users_automatically()
         return users
 
     def write(self, vals):

--- a/addons/mrp_subcontracting/models/mrp_bom.py
+++ b/addons/mrp_subcontracting/models/mrp_bom.py
@@ -16,7 +16,7 @@ class MrpBom(models.Model):
     def _bom_subcontract_find(self, product, picking_type=None, company_id=False, bom_type='subcontract', subcontractor=False):
         domain = self._bom_find_domain(product, picking_type=picking_type, company_id=company_id, bom_type=bom_type)
         if subcontractor:
-            domain = AND([domain, [('subcontractor_ids', 'parent_of', subcontractor.ids)]])
+            domain = AND([domain, [('subcontractor_ids', 'any', [('id', 'parent_of', subcontractor.ids)])]])
             return self.search(domain, order='sequence, product_id, id', limit=1)
         else:
             return self.env['mrp.bom']

--- a/addons/mrp_subcontracting/security/mrp_subcontracting_security.xml
+++ b/addons/mrp_subcontracting/security/mrp_subcontracting_security.xml
@@ -25,7 +25,7 @@
     <record model="ir.rule" id="consumption_warning_subcontractor_rule">
         <field name="name">MRP Consumption Warnings Subcontractor</field>
         <field name="model_id" ref="mrp.model_mrp_consumption_warning"/>
-        <field name="domain_force">[('mrp_production_ids', 'in', user.partner_id.commercial_partner_id.production_ids.ids)]</field>
+        <field name="domain_force">[('mrp_production_ids', 'any', [('id', 'in', user.partner_id.commercial_partner_id.production_ids.ids)])]</field>
         <field name="groups" eval="[(4, ref('base.group_portal'))]"/>
     </record>
 
@@ -43,7 +43,7 @@
         '|', 
             '|',
                 ('production_id.subcontractor_id', '=', user.partner_id.commercial_partner_id.id),
-                ('move_orig_ids.production_id.subcontractor_id', 'in', user.partner_id.commercial_partner_id.ids),
+                ('move_orig_ids', 'any', [('production_id.subcontractor_id', 'in', user.partner_id.commercial_partner_id.ids)]),
             ('raw_material_production_id.subcontractor_id', 'in', user.partner_id.commercial_partner_id.ids)
         ]</field>
         <field name="groups" eval="[(4, ref('base.group_portal'))]"/>
@@ -56,7 +56,7 @@
         '|', 
             '|',
                 ('move_id.production_id.subcontractor_id', '=', user.partner_id.commercial_partner_id.id),
-                ('move_id.move_orig_ids.production_id.subcontractor_id', 'in', user.partner_id.commercial_partner_id.ids),
+                ('move_id.move_orig_ids', 'any', [('production_id.subcontractor_id', 'in', user.partner_id.commercial_partner_id.ids)]),
             ('move_id.raw_material_production_id.subcontractor_id', 'in', user.partner_id.commercial_partner_id.ids),
         ]</field>
         <field name="groups" eval="[(4, ref('base.group_portal'))]"/>
@@ -84,8 +84,8 @@
                 '|',
                     '|',
                         '|', 
-                            ('child_ids', 'in', user.partner_id.commercial_partner_id.picking_ids.location_id.ids), 
-                            ('child_ids', 'in', user.partner_id.commercial_partner_id.picking_ids.location_dest_id.ids),
+                            ('child_ids', 'any', [('id', 'in', user.partner_id.commercial_partner_id.picking_ids.location_id.ids)]),
+                            ('child_ids', 'any', [('id', 'in', user.partner_id.commercial_partner_id.picking_ids.location_dest_id.ids)]),
                         '|', 
                             ('id', 'in', user.partner_id.commercial_partner_id.picking_ids.location_id.ids), 
                             ('id', 'in', user.partner_id.commercial_partner_id.picking_ids.location_dest_id.ids),

--- a/addons/mrp_subcontracting/security/mrp_subcontracting_security.xml
+++ b/addons/mrp_subcontracting/security/mrp_subcontracting_security.xml
@@ -25,7 +25,7 @@
     <record model="ir.rule" id="consumption_warning_subcontractor_rule">
         <field name="name">MRP Consumption Warnings Subcontractor</field>
         <field name="model_id" ref="mrp.model_mrp_consumption_warning"/>
-        <field name="domain_force">[('mrp_production_ids', 'any', [('id', 'in', user.partner_id.commercial_partner_id.production_ids.ids)])]</field>
+        <field name="domain_force">[('mrp_production_ids', 'any', user.partner_id.commercial_partner_id.production_ids)]</field>
         <field name="groups" eval="[(4, ref('base.group_portal'))]"/>
     </record>
 
@@ -84,8 +84,8 @@
                 '|',
                     '|',
                         '|', 
-                            ('child_ids', 'any', [('id', 'in', user.partner_id.commercial_partner_id.picking_ids.location_id.ids)]),
-                            ('child_ids', 'any', [('id', 'in', user.partner_id.commercial_partner_id.picking_ids.location_dest_id.ids)]),
+                            ('child_ids', 'any', user.partner_id.commercial_partner_id.picking_ids.location_id),
+                            ('child_ids', 'any', user.partner_id.commercial_partner_id.picking_ids.location_dest_id),
                         '|', 
                             ('id', 'in', user.partner_id.commercial_partner_id.picking_ids.location_id.ids), 
                             ('id', 'in', user.partner_id.commercial_partner_id.picking_ids.location_dest_id.ids),

--- a/addons/mrp_subcontracting_account/security/mrp_subcontracting_account_security.xml
+++ b/addons/mrp_subcontracting_account/security/mrp_subcontracting_account_security.xml
@@ -4,14 +4,14 @@
     <record model="ir.rule" id="analytic_accout_subcontractor_rule">
         <field name="name">Analytic Account Subcontractor</field>
         <field name="model_id" ref="mrp_account.model_account_analytic_account"/>
-        <field name="domain_force">[('bom_ids', 'in', user.partner_id.commercial_partner_id.bom_ids.ids)]</field>
+        <field name="domain_force">[('bom_ids', 'any', [('id', 'in', user.partner_id.commercial_partner_id.bom_ids.ids)])]</field>
         <field name="groups" eval="[(4, ref('base.group_portal'))]"/>
     </record>
 
     <record model="ir.rule" id="analytic_accout_line_subcontractor_rule">
         <field name="name">Analytic Account Line Subcontractor</field>
         <field name="model_id" ref="mrp_account.model_account_analytic_line"/>
-        <field name="domain_force">[('account_id.bom_ids', 'in', user.partner_id.commercial_partner_id.bom_ids.ids)]</field>
+        <field name="domain_force">[('account_id.bom_ids', 'any', [('id', 'in', user.partner_id.commercial_partner_id.bom_ids.ids)])]</field>
         <field name="groups" eval="[(4, ref('base.group_portal'))]"/>
     </record>
 

--- a/addons/mrp_subcontracting_account/security/mrp_subcontracting_account_security.xml
+++ b/addons/mrp_subcontracting_account/security/mrp_subcontracting_account_security.xml
@@ -11,7 +11,7 @@
     <record model="ir.rule" id="analytic_accout_line_subcontractor_rule">
         <field name="name">Analytic Account Line Subcontractor</field>
         <field name="model_id" ref="mrp_account.model_account_analytic_line"/>
-        <field name="domain_force">[('account_id.bom_ids', 'any', [('id', 'in', user.partner_id.commercial_partner_id.bom_ids.ids)])]</field>
+        <field name="domain_force">[('account_id.bom_ids', 'any', user.partner_id.commercial_partner_id.bom_ids)]</field>
         <field name="groups" eval="[(4, ref('base.group_portal'))]"/>
     </record>
 

--- a/addons/product/models/product_pricelist.py
+++ b/addons/product/models/product_pricelist.py
@@ -257,7 +257,7 @@ class Pricelist(models.Model):
             groups = Partner.read_group(domain, ['country_id'], ['country_id'])
             for group in groups:
                 country_id = group['country_id'] and group['country_id'][0]
-                pl = Pricelist.search(pl_domain + [('country_group_ids.country_ids', '=', country_id)], limit=1)
+                pl = Pricelist.search(pl_domain + [('country_group_ids.country_ids', 'any', [('id', '=', country_id)])], limit=1)
                 pl = pl or pl_fallback
                 for pid in Partner.search(group['__domain']).ids:
                     result[pid] = pl

--- a/addons/product/models/res_partner.py
+++ b/addons/product/models/res_partner.py
@@ -27,7 +27,9 @@ class ResPartner(models.Model):
     def _inverse_product_pricelist(self):
         for partner in self:
             pls = self.env['product.pricelist'].search(
-                [('country_group_ids.country_ids.code', '=', partner.country_id and partner.country_id.code or False)],
+                [('country_group_ids.country_ids', 'any', [
+                    ('code', '=', partner.country_id and partner.country_id.code or False)
+                ])],
                 limit=1
             )
             default_for_country = pls

--- a/addons/project/models/project.py
+++ b/addons/project/models/project.py
@@ -1780,14 +1780,13 @@ class Task(models.Model):
         if section_id:
             section_ids.append(section_id)
         section_ids.extend(self.mapped('project_id').ids)
-        search_domain = []
-        if section_ids:
-            search_domain = [('|')] * (len(section_ids) - 1)
-            for section_id in section_ids:
-                search_domain.append(('project_ids', '=', section_id))
-        search_domain += list(domain)
+        project_domain = []
+        project_domain += [('|')] * max(len(section_ids) - 1, 0)
+        project_domain += [('id', '=', id) for id in section_ids]
         # perform search, return the first found
-        return self.env['project.task.type'].search(search_domain, order=order, limit=1).id
+        return self.env['project.task.type'].search([
+            ('project_ids', 'any', project_domain),
+        ] + list(domain), order=order, limit=1).id
 
     # ------------------------------------------------
     # CRUD overrides

--- a/addons/project/security/project_security.xml
+++ b/addons/project/security/project_security.xml
@@ -206,9 +206,9 @@
             ('project_id.privacy_visibility', '=', 'portal'),
             ('active', '=', True),
             '|',
-                ('project_id.message_partner_ids', 'child_of', [user.partner_id.commercial_partner_id.id]),
-                ('message_partner_ids', 'child_of', [user.partner_id.commercial_partner_id.id]),
-            ('project_id.collaborator_ids.partner_id', 'in', [user.partner_id.id]),
+                ('project_id.message_partner_ids', 'any', [('id', 'child_of', user.partner_id.commercial_partner_id.ids)]),
+                ('message_partner_ids', 'any', [('id', 'child_of', user.partner_id.commercial_partner_id.ids)]),
+            ('project_id.collaborator_ids', 'any', [('partner_id', 'in', user.partner_id.ids)]),
         ]</field>
         <field name="groups" eval="[(4, ref('base.group_portal'))]"/>
         <field name="perm_read" eval="False"/>

--- a/addons/sale/security/ir_rules.xml
+++ b/addons/sale/security/ir_rules.xml
@@ -147,14 +147,14 @@
     <record id="account_invoice_send_rule_see_personal" model="ir.rule">
         <field name="name">Personal Invoice Send and Print</field>
         <field name="model_id" ref="account.model_account_invoice_send"/>
-        <field name="domain_force">[('invoice_ids.move_type', 'in', ('out_invoice', 'out_refund')), '|', ('invoice_ids.invoice_user_id', '=', user.id), ('invoice_ids.invoice_user_id', '=', False)]</field>
+        <field name="domain_force">[('invoice_ids', 'any', [('move_type', 'in', ('out_invoice', 'out_refund'))]), '|', ('invoice_ids', 'any', [('invoice_user_id', '=', user.id)]), ('invoice_ids', 'any', [('invoice_user_id', '=', False)])]</field>
         <field name="groups" eval="[(4, ref('sales_team.group_sale_salesman'))]"/>
     </record>
 
     <record id="account_invoice_send_rule_see_all" model="ir.rule">
         <field name="name">All Invoice Send and Print</field>
         <field name="model_id" ref="account.model_account_invoice_send"/>
-        <field name="domain_force">[('invoice_ids.move_type', 'in', ('out_invoice', 'out_refund'))]</field>
+        <field name="domain_force">[('invoice_ids', 'any', [('move_type', 'in', ('out_invoice', 'out_refund'))])]</field>
         <field name="groups" eval="[(4, ref('sales_team.group_sale_salesman_all_leads'))]"/>
     </record>
 

--- a/addons/sale_loyalty/models/sale_order.py
+++ b/addons/sale_loyalty/models/sale_order.py
@@ -606,7 +606,11 @@ class SaleOrder(models.Model):
         coupon_programs = self.applied_coupon_ids.program_id
         # Programs that are automatic and not yet applied
         program_domain = self._get_program_domain()
-        domain = expression.AND([program_domain, [('id', 'not in', points_programs.ids), ('trigger', '=', 'auto'), ('rule_ids.mode', '=', 'auto')]])
+        domain = expression.AND([program_domain, [
+            ('id', 'not in', points_programs.ids),
+            ('trigger', '=', 'auto'),
+            ('rule_ids', 'any', [('mode', '=', 'auto')]),
+        ]])
         automatic_programs = self.env['loyalty.program'].search(domain).filtered(lambda p:
             not p.limit_usage or p.total_order_count < p.max_usage)
 

--- a/addons/sale_timesheet/models/account_move.py
+++ b/addons/sale_timesheet/models/account_move.py
@@ -101,8 +101,8 @@ class AccountMoveLine(models.Model):
         move_line_read_group = self.env['account.move.line'].search_read([
             ('move_id.move_type', '=', 'out_invoice'),
             ('move_id.state', '=', 'draft'),
-            ('sale_line_ids.product_id.invoice_policy', '=', 'delivery'),
-            ('sale_line_ids.product_id.service_type', '=', 'timesheet'),
+            ('sale_line_ids', 'any', [('product_id.invoice_policy', '=', 'delivery')]),
+            ('sale_line_ids', 'any', [('product_id.service_type', '=', 'timesheet')]),
             ('id', 'in', self.ids)],
             ['move_id', 'sale_line_ids'])
 

--- a/addons/sales_team/models/crm_team.py
+++ b/addons/sales_team/models/crm_team.py
@@ -58,7 +58,7 @@ class CrmTeam(models.Model):
         team = self.env['crm.team']
         teams = self.env['crm.team'].search([
             ('company_id', 'in', valid_cids),
-            '|', ('user_id', '=', user.id), ('member_ids', 'any', [('id', 'in', [user.id])]),
+            '|', ('user_id', '=', user.id), ('member_ids', 'any', user),
         ])
         if teams and domain:
             filtered_teams = teams.filtered_domain(domain)

--- a/addons/sales_team/models/crm_team.py
+++ b/addons/sales_team/models/crm_team.py
@@ -58,7 +58,7 @@ class CrmTeam(models.Model):
         team = self.env['crm.team']
         teams = self.env['crm.team'].search([
             ('company_id', 'in', valid_cids),
-             '|', ('user_id', '=', user.id), ('member_ids', 'in', [user.id])
+            '|', ('user_id', '=', user.id), ('member_ids', 'any', [('id', 'in', [user.id])]),
         ])
         if teams and domain:
             filtered_teams = teams.filtered_domain(domain)

--- a/addons/website_event_sale/security/website_event_sale_security.xml
+++ b/addons/website_event_sale/security/website_event_sale_security.xml
@@ -3,7 +3,7 @@
     <record id="event_product_template_public" model="ir.rule">
         <field name="name">Product template linked to event: Public</field>
         <field name="model_id" ref="product.model_product_template"/>
-        <field name="domain_force">[('product_variant_ids.event_ticket_ids.event_id.website_published', '=', True)]</field>
+        <field name="domain_force">[('product_variant_ids.event_ticket_ids', 'any', [('event_id.website_published', '=', True)])]</field>
         <field name="groups" eval="[(4, ref('base.group_public')), (4, ref('base.group_portal'))]"/>
         <field name="perm_read" eval="True"/>
         <field name="perm_write" eval="False"/>

--- a/addons/website_hr_recruitment/security/website_hr_recruitment_security.xml
+++ b/addons/website_hr_recruitment/security/website_hr_recruitment_security.xml
@@ -34,7 +34,7 @@
     <record id="hr_department_public" model="ir.rule">
         <field name="name">Job department: Public</field>
         <field name="model_id" ref="hr.model_hr_department"/>
-        <field name="domain_force">['|', ('jobs_ids.website_published', '=', True), ('child_ids', 'not in', [])]</field>
+        <field name="domain_force">['|', ('jobs_ids', 'any', [('website_published', '=', True)]), ('child_ids', 'any', [('id', 'not in', [])])]</field>
         <field name="groups" eval="[(4, ref('base.group_public'))]"/>
         <field name="perm_read" eval="True"/>
         <field name="perm_write" eval="False"/>

--- a/addons/website_membership/security/website_membership.xml
+++ b/addons/website_membership/security/website_membership.xml
@@ -4,7 +4,7 @@
     <record id="membership_product_product_public" model="ir.rule">
         <field name="name">Product membership: Public</field>
         <field name="model_id" ref="product.model_product_template"/>
-        <field name="domain_force">[('website_published', '=', True), ('product_variant_ids.membership', '=', True)]</field>
+        <field name="domain_force">[('website_published', '=', True), ('product_variant_ids', 'any', [('membership', '=', True)])]</field>
         <field name="groups" eval="[(4, ref('base.group_public')), (4, ref('base.group_portal'))]"/>
         <field name="perm_read" eval="True"/>
         <field name="perm_write" eval="False"/>

--- a/addons/website_slides/models/res_groups.py
+++ b/addons/website_slides/models/res_groups.py
@@ -13,6 +13,6 @@ class UserGroup(models.Model):
         if vals.get('users'):
             # TDE FIXME: maybe directly check users and subscribe them
             self.env['slide.channel'].sudo().search([
-                ('enroll_group_ids', 'any', [('id', 'in', self._ids)]),
+                ('enroll_group_ids', 'any', self),
             ])._add_groups_members()
         return write_res

--- a/addons/website_slides/models/res_groups.py
+++ b/addons/website_slides/models/res_groups.py
@@ -12,5 +12,7 @@ class UserGroup(models.Model):
         write_res = super(UserGroup, self).write(vals)
         if vals.get('users'):
             # TDE FIXME: maybe directly check users and subscribe them
-            self.env['slide.channel'].sudo().search([('enroll_group_ids', 'in', self._ids)])._add_groups_members()
+            self.env['slide.channel'].sudo().search([
+                ('enroll_group_ids', 'any', [('id', 'in', self._ids)]),
+            ])._add_groups_members()
         return write_res

--- a/addons/website_slides/models/res_users.py
+++ b/addons/website_slides/models/res_users.py
@@ -23,7 +23,9 @@ class Users(models.Model):
         if vals.get('groups_id'):
             added_group_ids = [command[1] for command in vals['groups_id'] if command[0] == 4]
             added_group_ids += [id for command in vals['groups_id'] if command[0] == 6 for id in command[2]]
-            self.env['slide.channel'].sudo().search([('enroll_group_ids', 'in', added_group_ids)])._action_add_members(self.mapped('partner_id'))
+            self.env['slide.channel'].sudo().search([
+                ('enroll_group_ids', 'any', [('id', 'in', added_group_ids)]),
+            ])._action_add_members(self.mapped('partner_id'))
         return res
 
     def get_gamification_redirection_data(self):

--- a/addons/website_slides_forum/security/website_slides_forum_security.xml
+++ b/addons/website_slides_forum/security/website_slides_forum_security.xml
@@ -3,7 +3,7 @@
     <record id="website_slides_forum_public" model="ir.rule">
         <field name="name">Website forum: User can only access to forum related to followed courses</field>
         <field name="model_id" ref="website_forum.model_forum_forum"/>
-        <field name="domain_force">['&amp;', ('slide_channel_ids', 'any', [('website_published', '=', True)]), '|', ('slide_channel_ids', 'any', [('visibility', '=', 'public')]), ('slide_channel_ids.partner_ids', 'any', [('id', 'in', user.partner_id.id)])]</field>
+        <field name="domain_force">['&amp;', ('slide_channel_ids', 'any', [('website_published', '=', True)]), '|', ('slide_channel_ids', 'any', [('visibility', '=', 'public')]), ('slide_channel_ids.partner_ids', 'any', user.partner_id)]</field>
         <field name="groups" eval="[(4, ref('base.group_public')), (4, ref('base.group_portal')), (4, ref('base.group_user'))]"/>
     </record>
     <record id="website_slides_forum_website_slides_officer" model="ir.rule">
@@ -16,7 +16,7 @@
     <record id="website_slides_forum_public_post" model="ir.rule">
         <field name="name">Website forum post: User can only access to post linked to forum related to followed courses</field>
         <field name="model_id" ref="website_forum.model_forum_post"/>
-        <field name="domain_force">['&amp;', ('forum_id.slide_channel_ids', 'any', [('website_published', '=', True)]), '|', ('forum_id.slide_channel_ids', 'any', [('visibility', '=', 'public')]), ('forum_id.slide_channel_ids.partner_ids', 'any', [('id', 'in', user.partner_id.id)])]</field>
+        <field name="domain_force">['&amp;', ('forum_id.slide_channel_ids', 'any', [('website_published', '=', True)]), '|', ('forum_id.slide_channel_ids', 'any', [('visibility', '=', 'public')]), ('forum_id.slide_channel_ids.partner_ids', 'any', user.partner_id)]</field>
         <field name="groups" eval="[(4, ref('base.group_public')), (4, ref('base.group_portal')), (4, ref('base.group_user'))]"/>
     </record>
     <record id="website_slides_forum_website_slides_officer_post" model="ir.rule">
@@ -29,7 +29,7 @@
     <record id="website_slides_forum_public_tag" model="ir.rule">
         <field name="name">Website slides forum tag: User can only access to tag linked to forum related to followed courses</field>
         <field name="model_id" ref="website_forum.model_forum_tag"/>
-        <field name="domain_force">['&amp;', ('forum_id.slide_channel_ids', 'any', [('website_published', '=', True)]), '|', ('forum_id.slide_channel_ids', 'any', [('visibility', '=', 'public')]), ('forum_id.slide_channel_ids.partner_ids', 'any', [('id', 'in', user.partner_id.id)])]</field>
+        <field name="domain_force">['&amp;', ('forum_id.slide_channel_ids', 'any', [('website_published', '=', True)]), '|', ('forum_id.slide_channel_ids', 'any', [('visibility', '=', 'public')]), ('forum_id.slide_channel_ids.partner_ids', 'any', user.partner_id)]</field>
         <field name="groups" eval="[(4, ref('base.group_public')), (4, ref('base.group_portal')), (4, ref('base.group_user'))]"/>
     </record>
     <record id="website_slides_forum_website_slides_officer_tag" model="ir.rule">

--- a/addons/website_slides_forum/security/website_slides_forum_security.xml
+++ b/addons/website_slides_forum/security/website_slides_forum_security.xml
@@ -3,7 +3,7 @@
     <record id="website_slides_forum_public" model="ir.rule">
         <field name="name">Website forum: User can only access to forum related to followed courses</field>
         <field name="model_id" ref="website_forum.model_forum_forum"/>
-        <field name="domain_force">['&amp;', ('slide_channel_ids.website_published', '=', True), '|', ('slide_channel_ids.visibility', '=', 'public'), ('slide_channel_ids.partner_ids', 'in', user.partner_id.id)]</field>
+        <field name="domain_force">['&amp;', ('slide_channel_ids', 'any', [('website_published', '=', True)]), '|', ('slide_channel_ids', 'any', [('visibility', '=', 'public')]), ('slide_channel_ids.partner_ids', 'any', [('id', 'in', user.partner_id.id)])]</field>
         <field name="groups" eval="[(4, ref('base.group_public')), (4, ref('base.group_portal')), (4, ref('base.group_user'))]"/>
     </record>
     <record id="website_slides_forum_website_slides_officer" model="ir.rule">
@@ -16,7 +16,7 @@
     <record id="website_slides_forum_public_post" model="ir.rule">
         <field name="name">Website forum post: User can only access to post linked to forum related to followed courses</field>
         <field name="model_id" ref="website_forum.model_forum_post"/>
-        <field name="domain_force">['&amp;', ('forum_id.slide_channel_ids.website_published', '=', True), '|', ('forum_id.slide_channel_ids.visibility', '=', 'public'), ('forum_id.slide_channel_ids.partner_ids', 'in', user.partner_id.id)]</field>
+        <field name="domain_force">['&amp;', ('forum_id.slide_channel_ids', 'any', [('website_published', '=', True)]), '|', ('forum_id.slide_channel_ids', 'any', [('visibility', '=', 'public')]), ('forum_id.slide_channel_ids.partner_ids', 'any', [('id', 'in', user.partner_id.id)])]</field>
         <field name="groups" eval="[(4, ref('base.group_public')), (4, ref('base.group_portal')), (4, ref('base.group_user'))]"/>
     </record>
     <record id="website_slides_forum_website_slides_officer_post" model="ir.rule">
@@ -29,7 +29,7 @@
     <record id="website_slides_forum_public_tag" model="ir.rule">
         <field name="name">Website slides forum tag: User can only access to tag linked to forum related to followed courses</field>
         <field name="model_id" ref="website_forum.model_forum_tag"/>
-        <field name="domain_force">['&amp;', ('forum_id.slide_channel_ids.website_published', '=', True), '|', ('forum_id.slide_channel_ids.visibility', '=', 'public'), ('forum_id.slide_channel_ids.partner_ids', 'in', user.partner_id.id)]</field>
+        <field name="domain_force">['&amp;', ('forum_id.slide_channel_ids', 'any', [('website_published', '=', True)]), '|', ('forum_id.slide_channel_ids', 'any', [('visibility', '=', 'public')]), ('forum_id.slide_channel_ids.partner_ids', 'any', [('id', 'in', user.partner_id.id)])]</field>
         <field name="groups" eval="[(4, ref('base.group_public')), (4, ref('base.group_portal')), (4, ref('base.group_user'))]"/>
     </record>
     <record id="website_slides_forum_website_slides_officer_tag" model="ir.rule">

--- a/odoo/addons/base/security/base_security.xml
+++ b/odoo/addons/base/security/base_security.xml
@@ -183,7 +183,7 @@
             <field name="name">user rule</field>
             <field name="model_id" ref="model_res_users"/>
             <field eval="True" name="global"/>
-            <field name="domain_force">['|', ('share', '=', False), ('company_ids', 'in', company_ids)]</field>
+            <field name="domain_force">['|', ('share', '=', False), ('company_ids', 'any', [('id', 'in', company_ids)])]</field>
         </record>
 
         <record id="change_password_own_rule" model="ir.rule">

--- a/odoo/addons/base/security/base_security.xml
+++ b/odoo/addons/base/security/base_security.xml
@@ -183,7 +183,7 @@
             <field name="name">user rule</field>
             <field name="model_id" ref="model_res_users"/>
             <field eval="True" name="global"/>
-            <field name="domain_force">['|', ('share', '=', False), ('company_ids', 'any', [('id', 'in', company_ids)])]</field>
+            <field name="domain_force">['|', ('share', '=', False), ('company_ids', 'any', company_ids)]</field>
         </record>
 
         <record id="change_password_own_rule" model="ir.rule">

--- a/odoo/addons/base/tests/__init__.py
+++ b/odoo/addons/base/tests/__init__.py
@@ -56,3 +56,4 @@ from . import test_cloc
 from . import test_profiler
 from . import test_pdf
 from . import test_neutralize
+from . import test_one2many

--- a/odoo/addons/base/tests/test_expression.py
+++ b/odoo/addons/base/tests/test_expression.py
@@ -1514,7 +1514,7 @@ class TestOne2many(TransactionCase):
             ))
             ORDER BY "res_partner"."display_name", "res_partner"."id"
         ''']):
-            self.Partner.search([('bank_ids', 'any', [('id', 'in', self.partner.bank_ids.ids)])])
+            self.Partner.search([('bank_ids', 'any', self.partner.bank_ids)])
 
         with self.assertQueries(['''
             SELECT "res_partner".id
@@ -1563,7 +1563,7 @@ class TestOne2many(TransactionCase):
             ))
             ORDER BY "res_partner"."display_name", "res_partner"."id"
         ''']):
-            self.Partner.search([('bank_ids', 'any', [('id', 'in', self.partner.bank_ids.ids)])])
+            self.Partner.search([('bank_ids', 'any', self.partner.bank_ids)])
 
         with self.assertQueries(['''
             SELECT "res_partner".id
@@ -1640,7 +1640,7 @@ class TestOne2many(TransactionCase):
             ))
             ORDER BY "res_partner"."display_name", "res_partner"."id"
         ''']):
-            self.Partner.search([('child_ids.bank_ids', 'any', [('id', 'in', self.partner.bank_ids.ids)])])
+            self.Partner.search([('child_ids.bank_ids', 'any', self.partner.bank_ids)])
 
     def test_autojoin_mixed(self):
         self.patch(self.Partner._fields['child_ids'], 'auto_join', True)

--- a/odoo/addons/base/tests/test_one2many.py
+++ b/odoo/addons/base/tests/test_one2many.py
@@ -1,0 +1,423 @@
+# -*- coding: utf-8 -*-
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from itertools import combinations
+from odoo.osv.expression import invert_domain
+from odoo.tests.common import TransactionCase
+
+
+###############################################################################
+# Common base class implementing search and filtered_domain checks            #
+###############################################################################
+
+
+class SearchCase(TransactionCase):
+    def check_consistency(self, expected, searched, filtered, domain):
+        tests = {
+            'expected': True,
+            'searched': expected == searched,
+            'filtered': expected == filtered,
+        }
+
+        right = ' and '.join([key for key, value in tests.items() if value])
+        wrong = ' and '.join([key for key, value in tests.items() if not value])
+        message = f'The {wrong} results are inconsistent with the {right} results for domain {domain}'
+        self.assertTrue(all(test for test in tests.values()), message)
+
+    def execute_test(self, domain, expected):
+        base_domain = [('id', 'in', self.parents.ids)]
+        inverted_domain = invert_domain(domain)
+
+        searched = self.parent_model.search(base_domain + domain)
+        filtered = self.parents.filtered_domain(domain)
+        self.check_consistency(expected, searched, filtered, domain)
+
+        expected = self.parents - expected
+        searched = self.parent_model.search(base_domain + inverted_domain)
+        filtered = self.parents.filtered_domain(inverted_domain)
+        self.check_consistency(expected, searched, filtered, inverted_domain)
+
+
+###############################################################################
+# Abstract bases with test definitions                                        #
+###############################################################################
+
+
+class TestOne2ManyBase:
+    '''
+    This class defines a set of tests where parent records are searched on a
+    condition in function of their related records. Between these parent and
+    related records a one2many relationship exists (de facto, as such the
+    multiplicity of the underlying field can also be many2many).
+
+    A set of n parent records are created as part of the class setup, where the
+    parent at index i has exactly i related records.
+    '''
+    @classmethod
+    def prepare_data(cls, n=2):
+        cls.path = f'{cls.parent_field}'
+        cls.parents = cls.parent_model.create([
+            cls.get_parent_values({cls.parent_field: [
+                (0, 0, cls.get_child_values(count, index))
+                for index in range(count)
+            ]}, count) for count in range(n + 1)
+        ])
+
+    @classmethod
+    def get_child_values(cls, count, index):
+        child_name = cls.parent_model[cls.parent_field]._name.split('.')[-1]
+        return {'name': f'parent-{count}-{child_name}-{index}'}
+
+    @classmethod
+    def get_parent_values(cls, values, count):
+        parent_name = cls.parent_model._name.split('.')[-1]
+        return {'name': f'{parent_name}-{count}', **values}
+
+    def test_00_equals(self):
+        subdomain = [('id', '=', self.parents[1].mapped(self.path)[0].id)]
+        domain = [(self.path, 'any', subdomain)]
+        self.execute_test(domain, self.parents[1])
+
+    def test_01_not_equals(self):
+        subdomain = [('id', '!=', self.parents[1].mapped(self.path)[0].id)]
+        domain = [(self.path, 'any', subdomain)]
+        self.execute_test(domain, self.parents[2])
+
+        subdomain = [('id', '!=', self.parents[2].mapped(self.path)[0].id)]
+        domain = [(self.path, 'any', subdomain)]
+        self.execute_test(domain, self.parents[1:3])
+
+    def test_02_equals_false(self):
+        domain = [(self.path, 'any', [('id', '=', False)])]
+        self.execute_test(domain, self.parent_model)
+
+    def test_03_not_equals_false(self):
+        domain = [(self.path, 'any', [('id', '!=', False)])]
+        self.execute_test(domain, self.parents[1:3])
+
+        domain = [(self.path, '!=', False)]
+        self.execute_test(domain, self.parents[1:3])
+
+    def test_04_all_equals_false(self):
+        domain = [(self.path, 'all', [('id', '=', False)])]
+        self.execute_test(domain, self.parents[0])
+
+        domain = [(self.path, '=', False)]
+        self.execute_test(domain, self.parents[0])
+
+    def test_05_all_not_equals_false(self):
+        domain = [(self.path, 'all', [('id', '!=', False)])]
+        self.execute_test(domain, self.parents)
+
+
+class TestMany2ManyBase:
+    '''
+    This class defines a set of tests where parent records are searched on a
+    condition in function of their related records. Between these parent and
+    related records a many2many relationship exists.
+
+    Parent records are created, as part of the class setup, related to each
+    possible subset of n related records.
+    '''
+    @classmethod
+    def prepare_data(cls, n):
+        cls.path = f'{cls.parent_field}'
+        cls.children = cls.parent_model[cls.parent_field].create([{
+            **cls.get_child_values(i),
+        } for i in range(0, n)])
+        cls.parents = cls.parent_model.create([
+            cls.get_parent_values({cls.parent_field: [(6, 0, [
+                cls.children[j].id
+                for j in range(0, n) if (1 << j) & i
+            ])]}, i) for i in range(0, 2**n)
+        ])
+
+    @classmethod
+    def get_child_values(cls, index):
+        child_name = cls.parent_model[cls.parent_field]._name.split('.')[-1]
+        return {'name': f'{child_name}-child-{index}'}
+
+    @classmethod
+    def get_parent_values(cls, values, index):
+        parent_name = cls.parent_model._name.split('.')[-1]
+        return {'name': f'{parent_name}-parent-{index}', **values}
+
+    @classmethod
+    def get_parents(cls, children=None):
+        def test_parent(parent):
+            return all(c.id in parent[cls.parent_field].ids for c in children)
+        children = children or cls.parent_model[cls.parent_field]
+        return cls.parents.filtered(test_parent)
+
+    def test_00_any_id_equals(self):
+        domain = [(self.path, 'any', [('id', '=', self.children[0].id)])]
+        self.execute_test(domain, self.get_parents(self.children[0]))
+
+    def test_01_any_id_not_equals(self):
+        domain = [(self.path, 'any', [('id', '!=', self.children[0].id)])]
+        result = self.get_parents(self.children[1]) | self.get_parents(self.children[2])
+        self.execute_test(domain, result)
+
+    def test_02_any_id_equals_false(self):
+        domain = [(self.path, 'any', [('id', '=', False)])]
+        self.execute_test(domain, self.parent_model)
+
+    def test_03_any_id_not_equals_false(self):
+        domain = [(self.path, 'any', [('id', '!=', False)])]
+        self.execute_test(domain, self.parents[1:8])
+
+        domain = [(self.path, '!=', False)]
+        self.execute_test(domain, self.parents[1:8])
+
+    def test_04_all_id_equals_false(self):
+        domain = [(self.path, 'all', [('id', '=', False)])]
+        self.execute_test(domain, self.parents[0])
+
+        domain = [(self.path, '=', False)]
+        self.execute_test(domain, self.parents[0])
+
+    def test_05_all_id_not_equals_false(self):
+        domain = [(self.path, 'all', [('id', '!=', False)])]
+        self.execute_test(domain, self.parents)
+
+    def test_06_in(self):
+        subdomain = [('id', 'in', self.children[1:3].ids)]
+        domain = [(self.path, 'any', subdomain)]
+        result = self.get_parents(self.children[1]) | self.get_parents(self.children[2])
+        self.execute_test(domain, result)
+
+    def test_07_not_in(self):
+        subdomain = [('id', 'not in', self.children[1:3].ids)]
+        domain = [(self.path, 'any', subdomain)]
+        self.execute_test(domain, self.get_parents(self.children[0]))
+
+
+class TestSubfield:
+    '''
+    This class defines a set of tests where parent records are searched on a
+    condition in function of a field of their related records. Between the
+    parent and their related records a one2many relationship exists. Different
+    records related to the same parent record can still have the same value for
+    the field being searched.
+
+    Parent records are created, as part of the class setup, for all possible
+    combinations of field values (with repetition) up to a predefined maximum
+    number of related records.
+
+    For example, if the values for the searchable field are 1 and 2, and the
+    predefined limit is 2, then parents will be created for the following
+    combinations of values:
+    (), (2), (2, 2), (1), (1, 2), (1, 1)
+    '''
+    @classmethod
+    def prepare_data(cls, params, limit=2):
+        cls.params = params
+        cls.limit = limit
+        cls.path = f'{cls.parent_field}.{cls.child_field}'
+        cls.parents = cls.parent_model.create([
+            cls.get_parent_values({
+                cls.parent_field: [
+                    (0, 0, {
+                        **cls.get_child_values(param, k),
+                        cls.child_field: param,
+                    })
+                    for index, param in enumerate(params)
+                    for k in range(0, counts[index])
+                ],
+            }, params, counts)
+            for counts in cls.combinations()
+        ])
+
+    @classmethod
+    def combinations(cls):
+        return (
+            tuple(totals[i] - totals[i - 1] - 1 for i in range(1, len(totals)))
+            for totals in ((-1, *offsets) for offsets in combinations(
+                range(len(cls.params) + cls.limit), len(cls.params)
+            ))
+        )
+
+    @classmethod
+    def get_parent_values(cls, values, params, counts):
+        name = cls.parent_model._name.split('.')[-1]
+        return {
+            'name': name + ''.join(str(count) for count in counts),
+            **values,
+        }
+
+    @classmethod
+    def get_parents(cls, n=None, m=None):
+        return cls.parents.browse([
+            cls.parents[index].id
+            for index, combination in enumerate(cls.combinations())
+            if (n is None or n == combination[0])
+            and (m is None or m == combination[1])
+        ])
+
+    def test_00_equals_false(self):
+        subdomain = [(self.child_field, '=', False)]
+        domain = [(self.parent_field, 'any', subdomain)]
+        self.execute_test(domain, self.parent_model)
+
+    def test_01_not_equals_false(self):
+        subdomain = [(self.child_field, '!=', False)]
+        domain = [(self.parent_field, 'any', subdomain)]
+        result = self.parents - self.get_parents(n=0, m=0)
+        self.execute_test(domain, result)
+
+    def test_02_equals(self):
+        subdomain = [(self.child_field, '=', self.params[0])]
+        domain = [(self.parent_field, 'any', subdomain)]
+        self.execute_test(domain, self.parents - self.get_parents(n=0))
+
+    def test_03_not_equals(self):
+        subdomain = [(self.child_field, '!=', self.params[0])]
+        domain = [(self.parent_field, 'any', subdomain)]
+        self.execute_test(domain, self.parents - self.get_parents(m=0))
+
+    def test_04_all_equals(self):
+        subdomain = [(self.child_field, '=', self.params[0])]
+        domain = [(self.parent_field, 'all', subdomain)]
+        self.execute_test(domain, self.get_parents(m=0))
+
+    def test_05_all_not_equals(self):
+        subdomain = [(self.child_field, '!=', self.params[0])]
+        domain = [(self.parent_field, 'all', subdomain)]
+        self.execute_test(domain, self.get_parents(n=0))
+
+
+###############################################################################
+# Test classes                                                                #
+###############################################################################
+
+
+class TestOne2Many(SearchCase, TestOne2ManyBase):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.parent_model = cls.env['res.partner']
+        cls.parent_field = 'child_ids'
+        cls.prepare_data(2)
+
+
+class TestMany2Many(SearchCase, TestMany2ManyBase):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.parent_model = cls.env['res.partner.category']
+        cls.parent_field = 'partner_ids'
+        cls.prepare_data(3)
+
+
+class TestOne2ManySubfield(SearchCase, TestSubfield):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.parent_model = cls.env['res.partner']
+        cls.parent_field = 'child_ids'
+        cls.child_field = 'type'
+        cls.prepare_data(['invoice', 'delivery'])
+
+    @classmethod
+    def get_child_values(cls, param, count):
+        return {'name': 'Child partner'}
+
+
+class TestOne2ManySubfieldWithAutojoin(SearchCase, TestSubfield):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.parent_model = cls.env['res.partner']
+        cls.parent_field = 'user_ids'
+        cls.child_field = 'signature'
+        cls.user_counter = 0
+        cls.prepare_data(['<p>Kind regards</p>', '<p>Salutations</p>'])
+
+    @classmethod
+    def get_child_values(cls, param, count):
+        login = f'user{cls.user_counter}'
+        cls.user_counter += 1
+        return {'login': login}
+
+
+class TestMany2ManySubfield(SearchCase, TestSubfield):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.parent_model = cls.env['res.partner.category']
+        cls.parent_field = 'partner_ids'
+        cls.child_field = 'type'
+        cls.prepare_data(['invoice', 'delivery'], 2)
+        assert len(cls.parents) == 6
+
+    @classmethod
+    def get_child_values(cls, param, count):
+        return {'name': 'Test partner'}
+
+
+class TestMany2One2ManySubfield(SearchCase, TestSubfield):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.parent_model = cls.env['res.users']
+        cls.parent_field = 'company_id.child_ids'
+        cls.child_field = 'report_header'
+        cls.company_counter = 0
+        cls.prepare_data(['<p>Company A</p>', '<p>Company B</p>'], 3)
+        assert len(cls.parents) == 10
+
+    @classmethod
+    def get_child_values(cls, param, count):
+        counter = cls.company_counter
+        cls.company_counter += 1
+        return {'name': 'child_company' + str(counter)}
+
+    @classmethod
+    def get_parent_values(cls, values, params, counts):
+        commands = values[cls.parent_field]
+        path = cls.parent_field.split('.')
+        unique_id = ''.join(str(count) for count in counts)
+        company = cls.parent_model[path[0]].create({
+            'name': 'company' + unique_id,
+            path[1]: commands,
+        })
+        return super().get_parent_values({
+            'login': 'user' + unique_id,
+            'company_ids': [(4, company.id)],
+            path[0]: company.id,
+        }, params, counts)
+
+
+class TestOne2Many2ManySubfield(SearchCase, TestSubfield):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.parent_model = cls.env['res.users']
+        cls.parent_field = 'child_ids.child_ids'
+        cls.child_field = 'type'
+        cls.partner_counter = 0
+        cls.prepare_data(['invoice', 'delivery'], 3)
+        assert len(cls.parents) == 10
+
+    @classmethod
+    def get_child_values(cls, param, count):
+        counter = cls.partner_counter
+        cls.partner_counter += 1
+        return {'name': f'child_partner-{param}-{counter}'}
+
+    @classmethod
+    def get_parent_values(cls, values, params, counts):
+        # The implementation from the parent class will prefill the parent
+        # dictionary with an entry for child_ids.child_ids which we need to
+        # convert to an appropriate entry for child_ids.
+        commands = values[cls.parent_field]
+        path = cls.parent_field.split('.')
+        unique_id = ''.join(str(count) for count in counts)
+        partner = cls.parent_model[path[0]].create({
+            'name': 'partner' + unique_id,
+            path[1]: commands,
+        })
+        return super().get_parent_values({
+            'login': 'user' + unique_id,
+            path[0]: [(4, partner.id)],
+        }, params, counts)

--- a/odoo/addons/base/tests/test_one2many.py
+++ b/odoo/addons/base/tests/test_one2many.py
@@ -191,6 +191,16 @@ class TestMany2ManyBase:
         domain = [(self.path, 'any', subdomain)]
         self.execute_test(domain, self.get_parents(self.children[0]))
 
+    def test_08_any(self):
+        domain = [(self.path, 'any', self.children[1:3])]
+        result = self.get_parents(self.children[1]) | self.get_parents(self.children[2])
+        self.execute_test(domain, result)
+
+    def test_09_all(self):
+        domain = [(self.path, 'all', self.children[1:3])]
+        result = self.parents - self.get_parents(self.children[0])
+        self.execute_test(domain, result)
+
 
 class TestSubfield:
     '''

--- a/odoo/addons/base/tests/test_one2many.py
+++ b/odoo/addons/base/tests/test_one2many.py
@@ -410,14 +410,14 @@ class TestOne2Many2ManySubfield(SearchCase, TestSubfield):
         # The implementation from the parent class will prefill the parent
         # dictionary with an entry for child_ids.child_ids which we need to
         # convert to an appropriate entry for child_ids.
-        commands = values[cls.parent_field]
         path = cls.parent_field.split('.')
         unique_id = ''.join(str(count) for count in counts)
-        partner = cls.parent_model[path[0]].create({
-            'name': 'partner' + unique_id,
-            path[1]: commands,
-        })
+        commands = [(0, 0, {
+            'name': command[2]['name'] + '_parent',
+            path[1]: [command],
+        }) for command in values.pop(cls.parent_field)]
         return super().get_parent_values({
             'login': 'user' + unique_id,
-            path[0]: [(4, partner.id)],
+            path[0]: commands,
+            **values,
         }, params, counts)

--- a/odoo/fields.py
+++ b/odoo/fields.py
@@ -4288,9 +4288,10 @@ class One2many(_RelationalMulti):
 
     def get_domain_list(self, records):
         comodel = records.env.registry[self.comodel_name]
-        inverse_field = comodel._fields[self.inverse_name]
         domain = super(One2many, self).get_domain_list(records)
-        if inverse_field.type == 'many2one_reference':
+        if self.store:
+            inverse_field = comodel._fields[self.inverse_name]
+        if self.store and inverse_field.type == 'many2one_reference':
             domain = domain + [(inverse_field.model_field, '=', records._name)]
         return domain
 

--- a/odoo/models.py
+++ b/odoo/models.py
@@ -6117,7 +6117,7 @@ class BaseModel(metaclass=MetaModel):
                     real_records = self - new_records
                     records = model.browse()
                     if real_records and key.type in ('one2many', 'many2many'):
-                        records = model.search([(key.name, 'any', [('id', 'in', real_records.ids)])], order='id')
+                        records = model.search([(key.name, 'any', real_records)], order='id')
                     elif real_records:
                         records = model.search([(key.name, 'in', real_records.ids)], order='id')
                     if new_records:

--- a/odoo/models.py
+++ b/odoo/models.py
@@ -5457,11 +5457,15 @@ class BaseModel(metaclass=MetaModel):
                     elif field and field.type in ('date', 'datetime'):
                         data = [Datetime.to_datetime(d) for d in data]
 
-                    if comparator == 'any':
+                    is_subquery_operator = comparator in ('any', 'all', 'not any', 'not all')
+                    if is_subquery_operator and isinstance(value, BaseModel):
+                        matches = data & value
+                    elif is_subquery_operator:
                         matches = data.filtered_domain(value)
+
+                    if comparator == 'any':
                         ok = len(matches) > 0
                     elif comparator == 'all':
-                        matches = data.filtered_domain(value)
                         ok = len(matches) == len(data)
                     elif comparator == '=':
                         ok = value in data

--- a/odoo/models.py
+++ b/odoo/models.py
@@ -6112,10 +6112,9 @@ class BaseModel(metaclass=MetaModel):
                     new_records = self.filtered(lambda r: not r.id)
                     real_records = self - new_records
                     records = model.browse()
-                    if real_records:
-                        # FIXME Using the new relational field syntax here
-                        # would break cache invalidation, since the following
-                        # line depends on ignoring the field domain.
+                    if real_records and key.type in ('one2many', 'many2many'):
+                        records = model.search([(key.name, 'any', [('id', 'in', real_records.ids)])], order='id')
+                    elif real_records:
                         records = model.search([(key.name, 'in', real_records.ids)], order='id')
                     if new_records:
                         cache_records = self.env.cache.get_records(model, key)

--- a/odoo/osv/expression.py
+++ b/odoo/osv/expression.py
@@ -682,7 +682,8 @@ class expression(object):
                     domain = [(domain[0][0], TERM_OPERATORS_NEGATION[domain[0][1]], domain[0][2])]
                 elif use_inverted_domain:
                     domain = invert_domain(domain)
-                use_inverted_search = operator in ('not any', 'all')
+
+            use_inverted_search = operator in ('not any', 'all')
 
             # ----------------------------------------
             # FIELD NOT FOUND
@@ -746,7 +747,8 @@ class expression(object):
                     # compatibility until completion of domain translations.
                     emit_deprecation_notice(field, leaf)
                 right_ids = comodel.with_context(**field.context)._search([(path[1], operator, right)], order='id')
-                push((path[0], 'any', [('id', 'in', right_ids)]), model, alias)
+                new_operator = ['any', 'all'][use_inverted_search]
+                push((path[0], new_operator, [('id', 'in', right_ids)]), model, alias)
 
             elif not field.store:
                 # Non-stored field should provide an implementation of search.

--- a/odoo/osv/expression.py
+++ b/odoo/osv/expression.py
@@ -675,6 +675,8 @@ class expression(object):
             comodel = model.env.get(getattr(field, 'comodel_name', None))
 
             if len(path) == 1 and operator in SUBQUERY_OPERATORS:
+                if isinstance(right, BaseModel):
+                    right = [('id', 'in', right._ids)]
                 domain = (field.get_domain_list(model) or []) + right
                 is_simple_id_domain = len(domain) == 1 and domain[0][0] == 'id' and domain[0][1] not in HIERARCHY_FUNCS
                 use_inverted_domain = operator in ('all', 'not all')


### PR DESCRIPTION
This PR aims to improve the correctness and expressivity of domains including conditions on relational fields. The proposed implementation allows a new syntax where conditions on relational fields can be expressed in terms of a domain on the comodel using a subquery operator. Subquery operators include `any` and `all` (respectively expressing the condition that at least one or all related records must meet the conditions in the domain) and their logical inverses `not any` and `not all`. Some examples:

```python
# These can be expressed using the old syntax (using search)
[('x2many_ids', 'any', [('field', '=', value)])]
[('x2many_ids', 'not all', [('field', '=', value)])]
[('x2many_ids', 'any', ['|', ('active', '=', True), ('visible', '=', True)])]

# These could not previously be expressed (using search)
[('x2many_ids', 'all', [('field', '=', value)])]
[('x2many_ids', 'not any', [('field', '=', value)])]
[('x2many_ids', 'any', ['&', ('active', '=', True), ('visible', '=', True)])]
[('x2many_ids', 'all', ['|', ('active', '=', True), ('visible', '=', True)])]
```

The new implementation can be considered more correct because of the clearer semantics, but also because of a number of inconsistencies that existed between the `search` and `filtered_domain` implementations:

1) When using the logical not on a one2many or a many2many leaf. In general `filtered_domain` will adhere to commonly accepted logical not semantics (any record not matched by the original leaf will match the inverted one) while the orm `search` does not. This happens because the orm transforms inverted leafs by negating the operator inside the leaf. This does not generally work when multiple values can match the condition.

2) Using negative operators. A similar inconsistency is caused by the logic used by the `filtered_domain` method. Negative operators such as `!=` and `not in` are implemented by inverting the results of their positive counterparts (any record is matched by the `filtered_domain` method if it is not matched by the corresponding positive operator). Approximately, the positive operators can be used for matching any related record, while for the negative ones all related records have to meet the condition.
    
    Additionally, when both these situations occur together for the same leaf, the inconsistency is lifted. However, semantically the results could still be considered wrong. Using the equals operator as an example, the current search semantics can be summarized as follows:

    For the orm `search` method:
    * `[('x2many_ids.field', '=', value)]` -> any =
    * `[('x2many_ids.field', '!=', value)]` -> any !=
    * `['!', ('x2many_ids.field', '=', value)]` -> any !=
    * `['!', ('x2many_ids.field', '!=', value)]` -> any =

    For the python side `filtered_domain` method:
    * `[('x2many_ids.field', '=', value)]` -> any =
    * `[('x2many_ids.field', '!=', value)]` -> all !=
    * `['!', ('x2many_ids.field', '=', value)]` -> all !=
    * `['!', ('x2many_ids.field', '!=', value)]` -> any =

    Where any and all follow their traditional (python) semantics. Expressing the condition in terms of a nested field is necessary for the inconsistency to occur. These observations hold for fields `field` of any type: this means it also holds for cases where `field` is a relational field (note that `value` should not be `False` or `[]`, these cases are handled separately).

3) Note that, as a consequence of the above, there also exists a self-contradiction in the handling of x2many fields by the `search` method. This happens because the `search` method adheres to the same semantics as the `filtered_domain` method for conditions on non-nested fields. Again, for the `search` method, we get:

    * `[('x2many_ids', '!=', value)]` -> all !=
    * `[('x2many_ids.nested_x2many_ids', '!=', value)]` -> any !=

4) A less severe inconsistency occurs when specifying conditions on one2many or many2many fields that use a comodel domain as part of their definition. When using search this domain is ignored while it is taken into consideration when using `filtered_domain`.