### PR TITLE
[FIX] mail: scroll to bottom assertion in Chrome 94+

### DIFF
--- a/addons/mail/static/src/components/chat_window_manager/chat_window_manager_tests.js
+++ b/addons/mail/static/src/components/chat_window_manager/chat_window_manager_tests.js
@@ -6,6 +6,7 @@ const {
     afterEach,
     afterNextRender,
     beforeEach,
+    isScrolledToBottom,
     nextAnimationFrame,
     start,
 } = require('mail/static/src/utils/test_utils.js');
@@ -1028,7 +1029,7 @@ QUnit.test('[technical] chat window: scroll conservation on toggle home menu', a
                 thread &&
                 thread.model === 'mail.channel' &&
                 thread.id === 20 &&
-                scrollTop === messageList.scrollHeight - messageList.clientHeight
+                isScrolledToBottom(messageList)
             );
         },
     });
@@ -1799,7 +1800,7 @@ QUnit.test('chat window with a thread: keep scroll position in message list on f
                 thread &&
                 thread.model === 'mail.channel' &&
                 thread.id === 20 &&
-                scrollTop === messageList.scrollHeight - messageList.clientHeight
+                isScrolledToBottom(messageList)
             );
         },
     });
@@ -1885,9 +1886,8 @@ QUnit.test('chat window should scroll to the newly posted message just after pos
         )
     );
     const messageList = document.querySelector('.o_MessageList');
-    assert.strictEqual(
-        messageList.scrollHeight - messageList.scrollTop,
-        messageList.clientHeight,
+    assert.ok(
+        isScrolledToBottom(messageList),
         "chat window should scroll to the newly posted message just after posting it"
     );
 });
@@ -2038,7 +2038,7 @@ QUnit.test('[technical] chat window with a thread: keep scroll position in messa
                 thread &&
                 thread.model === 'mail.channel' &&
                 thread.id === 20 &&
-                scrollTop === messageList.scrollHeight - messageList.clientHeight
+                isScrolledToBottom(messageList)
             );
         },
     });

--- a/addons/mail/static/src/components/discuss/tests/discuss_tests.js
+++ b/addons/mail/static/src/components/discuss/tests/discuss_tests.js
@@ -7,6 +7,7 @@ const {
     afterEach,
     afterNextRender,
     beforeEach,
+    isScrolledToBottom,
     nextAnimationFrame,
     start,
 } = require('mail/static/src/utils/test_utils.js');
@@ -1715,7 +1716,7 @@ QUnit.test('auto-scroll to bottom of thread', async function (assert) {
                     thread &&
                     thread.model === 'mail.channel' &&
                     thread.id === 20 &&
-                    scrollTop === messageList.scrollHeight - messageList.clientHeight
+                    isScrolledToBottom(messageList)
                 );
             },
         },
@@ -1728,9 +1729,8 @@ QUnit.test('auto-scroll to bottom of thread', async function (assert) {
         "should have 25 messages"
     );
     const messageList = document.querySelector(`.o_Discuss_thread .o_ThreadView_messageList`);
-    assert.strictEqual(
-        messageList.scrollTop,
-        messageList.scrollHeight - messageList.clientHeight,
+    assert.ok(
+        isScrolledToBottom(messageList),
         "should have scrolled to bottom of thread"
     );
 });
@@ -1763,7 +1763,7 @@ QUnit.test('load more messages from channel (auto-load on scroll)', async functi
                     thread &&
                     thread.model === 'mail.channel' &&
                     thread.id === 20 &&
-                    scrollTop === messageList.scrollHeight - messageList.clientHeight
+                    isScrolledToBottom(messageList)
                 );
             },
         },
@@ -1852,7 +1852,7 @@ QUnit.test('new messages separator [REQUIRE FOCUS]', async function (assert) {
                     thread &&
                     thread.model === 'mail.channel' &&
                     thread.id === 20 &&
-                    scrollTop === messageList.scrollHeight - messageList.clientHeight
+                    isScrolledToBottom(messageList)
                 );
             },
         },
@@ -1922,7 +1922,7 @@ QUnit.test('new messages separator [REQUIRE FOCUS]', async function (assert) {
                 thread &&
                 thread.model === 'mail.channel' &&
                 thread.id === 20 &&
-                scrollTop === messageList.scrollHeight - messageList.clientHeight
+                isScrolledToBottom(messageList)
             );
         },
     });
@@ -1994,9 +1994,8 @@ QUnit.test('restore thread scroll position', async function (assert) {
         .o_Discuss_thread
         .o_ThreadView_messageList
     `);
-    assert.strictEqual(
-        initialMessageList.scrollTop,
-        initialMessageList.scrollHeight - initialMessageList.clientHeight,
+    assert.ok(
+        isScrolledToBottom(initialMessageList),
         "should have scrolled to bottom of channel 11 initially"
     );
 
@@ -2039,7 +2038,7 @@ QUnit.test('restore thread scroll position', async function (assert) {
                 thread &&
                 thread.model === 'mail.channel' &&
                 thread.id === 12 &&
-                scrollTop === messageList.scrollHeight - messageList.clientHeight
+                isScrolledToBottom(messageList)
             );
         },
     });
@@ -2102,14 +2101,13 @@ QUnit.test('restore thread scroll position', async function (assert) {
                 thread &&
                 thread.model === 'mail.channel' &&
                 thread.id === 12 &&
-                scrollTop === messageList.scrollHeight - messageList.clientHeight
+                isScrolledToBottom(messageList)
             );
         },
     });
     const messageList = document.querySelector('.o_ThreadView_messageList');
-    assert.strictEqual(
-        messageList.scrollTop,
-        messageList.scrollHeight - messageList.clientHeight,
+    assert.ok(
+        isScrolledToBottom(messageList),
         "should have recovered scroll position of channel 12 (scroll to bottom)"
     );
 });
@@ -3687,7 +3685,7 @@ QUnit.test('load recent messages from thread (already loaded some old messages)'
                 thread &&
                 thread.model === 'mail.channel' &&
                 thread.id === 20 &&
-                scrollTop === messageList.scrollHeight - messageList.clientHeight
+                isScrolledToBottom(messageList)
             );
         },
     });
@@ -4018,7 +4016,7 @@ QUnit.test('all messages in "Inbox" in "History" after marked all as read', asyn
                     thread.model === 'mail.box' &&
                     thread.id === 'inbox' &&
                     orderedMessages.length === 30 &&
-                    scrollTop === messageList.scrollHeight - messageList.clientHeight
+                    isScrolledToBottom(messageList)
                 );
             },
         },
@@ -4051,7 +4049,7 @@ QUnit.test('all messages in "Inbox" in "History" after marked all as read', asyn
                 thread.model === 'mail.box' &&
                 thread.id === 'history' &&
                 orderedMessages.length === 30 &&
-                scrollTop === messageList.scrollHeight - messageList.clientHeight
+                isScrolledToBottom(messageList)
             );
         },
     });

--- a/addons/mail/static/src/components/thread_view/thread_view_tests.js
+++ b/addons/mail/static/src/components/thread_view/thread_view_tests.js
@@ -10,6 +10,7 @@ const {
     beforeEach,
     createRootComponent,
     dragenterFiles,
+    isScrolledToBottom,
     start,
 } = require('mail/static/src/utils/test_utils.js');
 
@@ -833,9 +834,8 @@ QUnit.test('should scroll to bottom on receiving new message if the list is init
         predicate: data => threadViewer === data.threadViewer,
     });
     const initialMessageList = document.querySelector('.o_ThreadView_messageList');
-    assert.strictEqual(
-        initialMessageList.scrollTop,
-        initialMessageList.scrollHeight - initialMessageList.clientHeight,
+    assert.ok(
+        isScrolledToBottom(initialMessageList),
         "should have scrolled to bottom of channel 20 initially"
     );
 
@@ -857,9 +857,8 @@ QUnit.test('should scroll to bottom on receiving new message if the list is init
         predicate: data => threadViewer === data.threadViewer,
     });
     const messageList = document.querySelector('.o_ThreadView_messageList');
-    assert.strictEqual(
-        messageList.scrollTop,
-        messageList.scrollHeight - messageList.clientHeight,
+    assert.ok(
+        isScrolledToBottom(messageList),
         "should scroll to bottom on receiving new message because the list is initially scrolled to bottom"
     );
 });
@@ -904,9 +903,8 @@ QUnit.test('should not scroll on receiving new message if the list is initially 
         predicate: data => threadViewer === data.threadViewer,
     });
     const initialMessageList = document.querySelector('.o_ThreadView_messageList');
-    assert.strictEqual(
-        initialMessageList.scrollTop,
-        initialMessageList.scrollHeight - initialMessageList.clientHeight,
+    assert.ok(
+        isScrolledToBottom(initialMessageList),
         "should have scrolled to bottom of channel 20 initially"
     );
 

--- a/addons/mail/static/src/utils/test_utils.js
+++ b/addons/mail/static/src/utils/test_utils.js
@@ -748,6 +748,23 @@ function pasteFiles(el, files) {
 }
 
 //------------------------------------------------------------------------------
+// Public: DOM utilities
+//------------------------------------------------------------------------------
+
+/**
+ * Determine if a DOM element has been totally scrolled
+ *
+ * A 1px margin of error is given to accomodate subpixel rounding issues and
+ * Element.scrollHeight value being either int or decimal
+ *
+ * @param {DOM.Element} el
+ * @returns {boolean}
+ */
+function isScrolledToBottom(el) {
+    return Math.abs(el.scrollHeight - el.clientHeight - el.scrollTop) <= 1;
+}
+
+//------------------------------------------------------------------------------
 // Export
 //------------------------------------------------------------------------------
 
@@ -758,6 +775,7 @@ return {
     createRootComponent,
     dragenterFiles,
     dropFiles,
+    isScrolledToBottom,
     nextAnimationFrame,
     nextTick,
     pasteFiles,

--- a/addons/mail/static/src/widgets/form_renderer/form_renderer_tests.js
+++ b/addons/mail/static/src/widgets/form_renderer/form_renderer_tests.js
@@ -6,6 +6,7 @@ const {
     afterEach,
     afterNextRender,
     beforeEach,
+    isScrolledToBottom,
     nextAnimationFrame,
     start,
 } = require('mail/static/src/utils/test_utils.js');
@@ -846,9 +847,8 @@ QUnit.test('Form view not scrolled when switching record', async function (asser
             'scroll'
         );
     });
-    assert.strictEqual(
-        controllerContentEl.scrollTop,
-        controllerContentEl.scrollHeight - controllerContentEl.clientHeight,
+    assert.ok(
+        isScrolledToBottom(controllerContentEl),
         "The controller container should be scrolled to its bottom"
     );
 


### PR DESCRIPTION
Since (at least) Chrome 94+, some element's sizing computation returns a
slightly different value (in the order of a fraction of a pixel). Sadly,
due to rounding, this difference has an impact on exact sizing
assertion.

As the difference is *really* small, introducing a margin of error (i.e.
<= 1px) looks reasonnable ; as implemented in this commit. More
specifically as Element.scrollHeight can have either an int or a decimal
value (cf. fractional-scaling), this commit allows to property handle
both usecases.

Reference:
https://developer.mozilla.org/en-US/docs/Web/API/Element/scrollHeight#determine_if_an_element_has_been_totally_scrolled