### PR TITLE
[FIX] point_of_sale: get the archived products in pos UI for a refund

### DIFF
--- a/addons/point_of_sale/models/pos_session.py
+++ b/addons/point_of_sale/models/pos_session.py
@@ -1956,7 +1956,7 @@ class PosSession(models.Model):
         params = self._loader_params_product_product()
         # custom_search_params will take priority
         params['search_params'] = {**params['search_params'], **custom_search_params}
-        products = self.env['product.product'].search_read(**params['search_params'])
+        products = self.env['product.product'].with_context(active_test=False).search_read(**params['search_params'])
         if len(products) > 0:
             self._process_pos_ui_product_product(products)
         return products


### PR DESCRIPTION
Before this commit: If one of the PoS order lines' products were
archived, when clicking on the "Refund", it wouldn't show any line and
got an error.

Steps to reproduce the first issue:

	- Install the' Point of Sale' module
	- Open a PoS session
	- Add a product to the order
	- Validate the order and close the session
	- Archive that product_product
	- Clear your browser cache
	- Open a new PoS session
	- click on the "Refund" 

	You get an error, and it wouldn't show any order lines.


Solution

	An archived product shouldn't be shown on the PoS UI, but it should
    be available for the refund if it exists in one of the order lines.
    So the solution is to modify the domain to get archived products if
    needed for the refund. 


opw-2849240

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
