### PR TITLE
[FIX] web: restore traceback when an error occurs in a publicWidget

### DIFF
--- a/addons/web/static/src/legacy/js/public/public_root.js
+++ b/addons/web/static/src/legacy/js/public/public_root.js
@@ -82,10 +82,8 @@ export const PublicRoot = publicWidget.RootWidget.extend({
      * @override
      */
     start: function () {
-        var defs = [
-            this._super.apply(this, arguments),
-            this._startWidgets()
-        ];
+        var def = this._super.apply(this, arguments);
+        this._startWidgets();
 
         // Display image thumbnail
         this.$(".o_image[data-mimetype^='image']").each(function () {
@@ -107,7 +105,7 @@ export const PublicRoot = publicWidget.RootWidget.extend({
 
         this.$el.children().on('error.datetimepicker', this._onDateTimePickerError.bind(this));
 
-        return Promise.all(defs);
+        return def;
     },
 
     //--------------------------------------------------------------------------


### PR DESCRIPTION
Since this commit [1], when an error occurs in a public widget, the
error is displayed in the developer console but does not trigger a
traceback anymore. This commit allows to restore tracebacks for errors
in public widgets. The problem was that when the public root started the
widgets, if one of these widgets caused an error, the public root
crashed. This is not what we want, if a widget crashes, public root
should not crash.

[1]: https://github.com/odoo/odoo/commit/64fc704527105afc8f06cafe8428e5c30c3ee097

task-2833446