### PR TITLE
[FIX] website_sale: recently viewd multi company

### DIFF
--- a/addons/website_sale/controllers/main.py
+++ b/addons/website_sale/controllers/main.py
@@ -1227,7 +1227,7 @@ class WebsiteSale(http.Controller):
                 ['product_id', 'visit_datetime:max'], ['product_id'], limit=max_number_of_product_for_carousel, orderby='visit_datetime DESC')
             products_ids = [product['product_id'][0] for product in products]
             if products_ids:
-                viewed_products = request.env['product.product'].with_context(display_default_code=False).browse(products_ids)
+                viewed_products = request.env['product.product'].with_context(display_default_code=False).search([('id', 'in', products_ids)])
 
                 FieldMonetary = request.env['ir.qweb.field.monetary']
                 monetary_options = {

--- a/addons/website_sale/tests/test_website_sale_visitor.py
+++ b/addons/website_sale/tests/test_website_sale_visitor.py
@@ -40,3 +40,27 @@ class WebsiteSaleVisitorTests(TransactionCase):
 
         self.assertEqual(len(Visitor.search([])), 1, "No visitor should be created after visiting another tracked product")
         self.assertEqual(len(Track.search([])), 2, "A track should be created after visiting another tracked product")
+
+    def test_recently_viewed_company_changed(self):
+        # Test that, by changing the company of a tracked product, the recently viewed product do not crash
+        new_company = self.env['res.company'].create({
+            'name': 'Test Company',
+        })
+        public_user = self.env.ref('base.public_user')
+
+        product = self.env['product.product'].create({
+            'name': 'Test Product',
+            'website_published': True,
+            'sale_ok': True,
+        })
+
+        self.website = self.website.with_user(public_user).with_context(website_id=self.website.id)
+        with MockRequest(self.website.env, website=self.website):
+            self.cookies = self.WebsiteSaleController.products_recently_viewed_update(product.id)
+        product.product_tmpl_id.company_id = new_company
+        product.product_tmpl_id.flush(['company_id'], product.product_tmpl_id)
+        # import pdb; pdb.set_trace()
+        with MockRequest(self.website.env, website=self.website, cookies=self.cookies):
+            # Should not raise an error
+            res = self.WebsiteSaleController.products_recently_viewed()
+            self.assertTrue('products' not in res or len(res['products']) == 0)


### PR DESCRIPTION
If a user has a website.track with a product from another company than
the one he is currently using, an access rule error will popup.

Several scenarios can trigger this error, but the easiest one would be:

- Activate recently viewed products in the e-commerce.
- Create a product and publish it.
- The portal user visits it and a website.track linked to that product
is created.
- From backend, change the company of the product to one that is
unreachable for the portal user or the website environment he is in.
- Now when the portal user visits another product, an error will show up
warning about the unability to load the recently viewed product.

So only products in the context of the request should be loaded as
recently viewed.

cc @Tecnativa TT36698

ping @pedrobaeza @sergio-teruel 

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
