### PR TITLE
[FIX] pos_restaurant: customer count not showing

### DIFF
--- a/addons/pos_restaurant/static/src/js/floors.js
+++ b/addons/pos_restaurant/static/src/js/floors.js
@@ -330,16 +330,8 @@ const PosRestaurantPosGlobalState = (PosGlobalState) => class PosRestaurantPosGl
         }
     }
 
-    // get the list of orders associated to a table. FIXME: should be O(1)
     get_table_orders(table) {
-        var orders   = this.get_order_list();
-        var t_orders = [];
-        for (var i = 0; i < orders.length; i++) {
-            if (orders[i].table === table) {
-                t_orders.push(orders[i]);
-            }
-        }
-        return t_orders;
+        return this.orders.filter(o => o.table.id === table.id);
     }
 
     // get customer count at table


### PR DESCRIPTION
The customer count and the filling of a table was broken due to the introducing of OWL 2.0:
- the comparison of two proxy objects is not reliable, thus we use the id instead
- it was working before due to some luck but not anymore, thus we properly fix `get_table_orders(table)`
which finally return the order of the `table` param instead of the current table
