### PR TITLE
[FIX] account: more robust _get_move_display_name

### DIFF
--- a/addons/account/models/account_move.py
+++ b/addons/account/models/account_move.py
@@ -1985,7 +1985,7 @@ class AccountMove(models.Model):
                 draft_name += ' (* %s)' % str(self.id)
             else:
                 draft_name += ' ' + self.name
-        return (draft_name or self.name) + (show_ref and self.ref and ' (%s%s)' % (self.ref[:50], '...' if len(self.ref) > 50 else '') or '')
+        return (draft_name or self.name or '') + (show_ref and self.ref and ' (%s%s)' % (self.ref[:50], '...' if len(self.ref) > 50 else '') or '')
 
     def _get_invoice_delivery_partner_id(self):
         ''' Hook allowing to retrieve the right delivery address depending of installed modules.


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
Traceback if non draft move has no name.

TypeError: unsupported operand type(s) for +: 'bool' and 'str'

TODO: check with BA how they managed to create a move with no name

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
