### PR TITLE
[FIX] base: properly render ProcessingInstruction nodes of views XML

### DIFF
--- a/odoo/addons/base/models/ir_qweb.py
+++ b/odoo/addons/base/models/ir_qweb.py
@@ -1616,6 +1616,9 @@ class IrQWeb(models.AbstractModel):
             if isinstance(item, etree._Comment):
                 if compile_context.get('preserve_comments'):
                     self._append_text(f"<!--{item.text}-->", compile_context)
+            elif isinstance(item, etree._ProcessingInstruction):
+                if compile_context.get('preserve_comments'):
+                    self._append_text(f"<?{item.target} {item.text}?>", compile_context)
             else:
                 body.extend(self._compile_node(item, compile_context, level))
             # comments can also contains tail text

--- a/odoo/addons/base/tests/test_qweb.py
+++ b/odoo/addons/base/tests/test_qweb.py
@@ -1613,6 +1613,48 @@ class TestQWebBasic(TransactionCase):
         expected = markupsafe.Markup('Text 1' + emptyline + emptyline + 'Text 2' + emptyline + 'ok')
         self.assertEqual(self.env['ir.qweb']._render(view1.id).strip(), expected)
 
+    def test_render_comments(self):
+        """ Test the rendering of comments with and without the
+            preserve_comments option.
+        """
+        comment = '<!-- Hello, world! -->'
+        view = self.env['ir.ui.view'].create({
+            'name': 'dummy',
+            'type': 'qweb',
+            'arch': f'<t><p>{comment}</p></t>'
+        })
+        QWeb = self.env['ir.qweb']
+        self.assertEqual(
+            QWeb.with_context(preserve_comments=False)._render(view.id),
+            markupsafe.Markup('<p></p>'),
+            "Should not have the comment")
+        QWeb.clear_caches()
+        self.assertEqual(
+            QWeb.with_context(preserve_comments=True)._render(view.id),
+            markupsafe.Markup(f'<p>{comment}</p>'),
+            "Should have the comment")
+
+    def test_render_processing_instructions(self):
+        """ Test the rendering of processing instructions with and without the
+            preserve_comments option.
+        """
+        p_instruction = '<?hello world?>'
+        view = self.env['ir.ui.view'].create({
+            'name': 'dummy',
+            'type': 'qweb',
+            'arch': f'<t><p>{p_instruction}</p></t>'
+        })
+        QWeb = self.env['ir.qweb']
+        self.assertEqual(
+            QWeb.with_context(preserve_comments=False)._render(view.id),
+            markupsafe.Markup('<p></p>'),
+            "Should not have the processing instruction")
+        QWeb.clear_caches()
+        self.assertEqual(
+            QWeb.with_context(preserve_comments=True)._render(view.id),
+            markupsafe.Markup(f'<p>{p_instruction}</p>'),
+            "Should have the processing instruction")
+
     def test_void_element(self):
         view = self.env['ir.ui.view'].create({
             'name': 'master',


### PR DESCRIPTION
Before this commit, when a view contained a ProcessingInstruction node
`<?XXX YYY?>`, if this was rendered via qweb, it was leading to very
strange results in the form of
```
<<cyfunction ProcessingInstruction at 0x7f538c4902b0>>YYY</<cyfunction ProcessingInstruction at 0x7f538c4902b0>>
```

After this commit, it will lead to "<?XXX YYY?>" being rendered which
will automatically be parsed into an HTML comment if reaching a browser:
```
<!--?XXX YYY?-->
```

Note: this will be rendered only if preserve_comments is set to true.

This was added following [1] which actually led to an issue where some
ProcessingInstruction nodes were rendered by mistake. That was fixed
with [2]. With this commit, that kind of mistake will silently fail
(which may not be good) but will lead to no harm and allows to better
debug such cases (by actually allowing rendering what was in the view).

[1]: https://github.com/odoo/odoo/commit/f67832a3ae0d9a3b5b53129132762e6bc1aed874
[2]: https://github.com/odoo/odoo/commit/de348b3f818adcf2068deb629e612c246a6a4374
