### PR TITLE
[IMP] web: added node option for field debounce

### DIFF
--- a/addons/mail/static/src/js/field_char.js
+++ b/addons/mail/static/src/js/field_char.js
@@ -1,5 +1,6 @@
 /** @odoo-module **/
 
+import { debounce } from "@web/core/utils/timing";
 import { FieldChar } from 'web.basic_fields';
 
 FieldChar.include({
@@ -10,12 +11,16 @@ FieldChar.include({
 
     /**
      * Support a key-based onchange in text field.
-     * The _triggerOnchange method is debounced to run 2 seconds after typing ends.
+     * The _triggerOnchange method is debounced to run after given debouce delay
+     * (or 2 seconds by default) on typing ends.
      *
      */
     init: function () {
         this._super.apply(this, arguments);
-        this._triggerOnchange = _.debounce(this._triggerOnchange, 2000);
+        if (this.nodeOptions.keydown_debounce_delay === undefined) {
+            this.nodeOptions.keydown_debounce_delay = 2000;
+        }
+        this._triggerOnchange = debounce(this._triggerOnchange, this.nodeOptions.keydown_debounce_delay);
     },
 
 
@@ -44,7 +49,7 @@ FieldChar.include({
 
     /**
      * Triggers the 'change' event to refresh the value.
-     * This method is debounced to run 2 seconds after typing ends.
+     * This method is debounced to run after given debouce delay on typing ends.
      * (to avoid spamming the server while the user is typing his message)
      *
      * @private

--- a/addons/mail/static/src/js/field_emojis_common.js
+++ b/addons/mail/static/src/js/field_emojis_common.js
@@ -1,5 +1,6 @@
 /** @odoo-module **/
 
+import { debounce } from "@web/core/utils/timing";
 import emojis from '@mail/js/emojis';
 import MailEmojisMixin from '@mail/js/emojis_mixin';
 import core from 'web.core';
@@ -17,7 +18,10 @@ var FieldEmojiCommon = {
      */
     init: function () {
         this._super.apply(this, arguments);
-        this._triggerOnchange = _.debounce(this._triggerOnchange, 2000);
+        if (this.nodeOptions.keydown_debounce_delay === undefined) {
+            this.nodeOptions.keydown_debounce_delay = 2000;
+        }
+        this._triggerOnchange = debounce(this._triggerOnchange, this.nodeOptions.keydown_debounce_delay);
         this.emojis = emojis;
     },
 
@@ -89,7 +93,7 @@ var FieldEmojiCommon = {
 
     /**
      * Triggers the 'change' event to refresh the value.
-     * This method is debounced to run 2 seconds after typing ends.
+     * This method is debounced to run after given debouce delay on typing ends.
      * (to avoid spamming the server while the user is typing his message)
      *
      * @private


### PR DESCRIPTION
This PR introduces a node option `keydown_debounce_delay` on the
character field and on emoji mixin, so that user can define the custom
debounce delay (in milliseconds) instead of fixed 2000 ms for
triggering an onchange on the field. Note that this delay will be
applied only when `onchange_on_keydown` node option is also provided.

Also, we've utilized the odoo's debounce instead of the one provided by
underscore js, for 2 reasons:

1 - odoo's debounce is already well tested (see the file
    /web/static/tests/core/utils/timing_tests.js)
2 - to take a step forward for reducing external lib dependency

Task: https://www.odoo.com/web#id=2821978&menu_id=4720&cids=2&action=4043&model=project.task&view_type=form

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
