### PR TITLE
[FIX] website_sale:  remove animation when out-of-stock product is added

### DIFF
--- a/addons/website_sale/static/src/js/website_sale_utils.js
+++ b/addons/website_sale/static/src/js/website_sale_utils.js
@@ -33,7 +33,7 @@ const cartHandlerMixin = {
             route: "/shop/cart/update_json",
             params: params,
         }).then(async data => {
-            if (data.cart_quantity !== parseInt($(".my_cart_quantity").text())) {
+            if (data.cart_quantity && (data.cart_quantity !== parseInt($(".my_cart_quantity").text()))) {
                 await animateClone($('header .o_wsale_my_cart').first(), this.$itemImgContainer, 25, 40);
                 updateCartNavBar(data);
             }


### PR DESCRIPTION
Steps to reproduce:
	1) Create a product with 0 on hand qty and under Sales tab,
	"Continue Selling" if Out of Stock unchecked.
	2) Navigate to the website's shop.
	Customize -> Add Feature -> enable Add to Cart.

Current behavior:
From the Shop's screen, the button to add to cart for this product
 is clickable and the animation plays, but no item is added (because
out of stock).

Expected behavior:
There is no animation when an out-of-stock product is added to the cart

This fix completes the fix at commit 8d3a4e1f7094ded889b652e5ec393f6eb2f2b6f6
(pr https://github.com/odoo/odoo/pull/90641) that didn't take into account the possibility
of an empty cart (0) that led to an undefined value of card_quantity in the data returned
from the rpc.

opw-2856711
opw-2745305