### PR TITLE
[IMP][15.0] base: helpstring not true

### DIFF
--- a/odoo/addons/base/i18n/base.pot
+++ b/odoo/addons/base/i18n/base.pot
@@ -25339,8 +25339,12 @@ msgstr ""
 #. module: base
 #: model:ir.model.fields,help:base.field_res_currency__inverse_rate
 #: model:ir.model.fields,help:base.field_res_currency_rate__company_rate
-#: model:ir.model.fields,help:base.field_res_currency_rate__inverse_company_rate
 msgid "The currency of rate 1 to the rate of the currency."
+msgstr ""
+
+#. module: base
+#: model:ir.model.fields,help:base.field_res_currency_rate__inverse_company_rate
+msgid "The rate of the current currency against a currency with an exchange rate of 1."
 msgstr ""
 
 #. module: base

--- a/odoo/addons/base/models/res_currency.py
+++ b/odoo/addons/base/models/res_currency.py
@@ -330,7 +330,7 @@ class CurrencyRate(models.Model):
         compute="_compute_inverse_company_rate",
         inverse="_inverse_inverse_company_rate",
         group_operator="avg",
-        help="The currency of rate 1 to the rate of the currency.",
+        help="The rate of the current currency against a currency with an exchange rate of 1.",
     )
     currency_id = fields.Many2one('res.currency', string='Currency', readonly=True, required=True, ondelete="cascade")
     company_id = fields.Many2one('res.company', string='Company',


### PR DESCRIPTION
Description of the issue/feature this PR addresses:

Fix helpstring of 2 duplicate fields

**Actual:**
company_rate ( help="The currency of rate 1 to the rate of the currency.")
inverse_company_rate: ( help="The currency of rate 1 to the rate of the currency." )

**Expect:**
==> inverse_company_rate:  ( help="The rate of the current currency against a currency with an exchange rate of 1." )

![base](https://user-images.githubusercontent.com/99851330/170213558-45d50cab-f2f7-4bca-96b9-f3d77bccd2ef.png)


--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
