### PR TITLE
[FIX] bus: restore _daemonic workaround

### DIFF
--- a/addons/bus/models/bus.py
+++ b/addons/bus/models/bus.py
@@ -123,7 +123,7 @@ class ImDispatch:
         # it will handle a longpolling request
         if not odoo.evented:
             current = threading.current_thread()
-            current.daemon = True
+            current._daemonic = True
             # rename the thread to avoid tests waiting for a longpolling
             current.name = f"openerp.longpolling.request.{current.ident}"
 


### PR DESCRIPTION
In fixing leftover jammy warnings in #92078 I mistakenly updated the
setting of `_daemonic` to the public `daemon`, missing that it was a
dedicated and explicit workaround for Python's checks (cf
d03b4f867539298019576e74c638a0148fe87bc2).
