### PR TITLE
[FIX] website_event_questions : set the answers as readonly from attendees list view

### DIFF
--- a/addons/website_event_questions/views/event_registration_views.xml
+++ b/addons/website_event_questions/views/event_registration_views.xml
@@ -31,7 +31,7 @@
         <field name="inherit_id" ref="event.view_event_registration_tree"/>
         <field name="arch" type="xml">
             <field name="state" position="before">
-                <field name="registration_answer_ids" string="Selected Answers" widget="many2many_tags" optional="hide"/>
+                <field name="registration_answer_ids" string="Selected Answers" widget="many2many_tags" optional="hide" readonly="1"/>
             </field>
         </field>
     </record>


### PR DESCRIPTION
The users shouldn't be able to edit the answers from the attendees as they don't know
what questions they are answering to or the type of response expected.

opw-2845524