### PR TITLE
[IMP] hr_expense: rename default Expense product

### DIFF
--- a/addons/hr_expense/data/hr_expense_data.xml
+++ b/addons/hr_expense/data/hr_expense_data.xml
@@ -2,7 +2,7 @@
 <odoo>
     <data noupdate="1">
         <record id="product_product_fixed_cost" model="product.product">
-            <field name="name">Expenses</field>
+            <field name="name">Expenses (Fixed Cost)</field>
             <field name="list_price">0.0</field>
             <field name="standard_price">1.0</field>
             <field name="type">service</field>


### PR DESCRIPTION
Both default expenses product were called Expenses, which was confusing
as it was not possible to distinguish them at first glance.

Here the expense product with a fixed cost is renamed to make it more
clear.

TaskID: 2862104