### PR TITLE
[FIX] mrp: unbuild from partially-done MO

### DIFF
--- a/addons/mrp/models/mrp_unbuild.py
+++ b/addons/mrp/models/mrp_unbuild.py
@@ -3,7 +3,7 @@
 
 from odoo import api, fields, models, _
 from odoo.exceptions import AccessError, UserError
-from odoo.tools import float_compare, float_round
+from odoo.tools import float_compare, float_round, float_is_zero
 
 
 class MrpUnbuild(models.Model):
@@ -190,7 +190,14 @@ class MrpUnbuild(models.Model):
         for unbuild in self:
             if unbuild.mo_id:
                 finished_moves = unbuild.mo_id.move_finished_ids.filtered(lambda move: move.state == 'done')
-                factor = unbuild.product_qty / unbuild.mo_id.product_uom_id._compute_quantity(unbuild.mo_id.product_qty, unbuild.product_uom_id)
+                qty_produced = 0
+                for line in finished_moves.move_line_ids:
+                    if line.product_id != unbuild.mo_id.product_id:
+                        continue
+                    qty_produced += line.product_uom_id._compute_quantity(line.qty_done, unbuild.product_uom_id)
+                if float_is_zero(qty_produced, precision_rounding=unbuild.product_uom_id.rounding):
+                    return moves
+                factor = unbuild.product_qty / qty_produced
                 for product in finished_moves.product_id:
                     product_moves = finished_moves.filtered(lambda m: m.product_id == product)
                     qty = sum(product_moves.mapped('product_uom_qty'))
@@ -208,7 +215,14 @@ class MrpUnbuild(models.Model):
         for unbuild in self:
             if unbuild.mo_id:
                 raw_moves = unbuild.mo_id.move_raw_ids.filtered(lambda move: move.state == 'done')
-                factor = unbuild.product_qty / unbuild.mo_id.product_uom_id._compute_quantity(unbuild.mo_id.product_qty, unbuild.product_uom_id)
+                qty_produced = 0
+                for line in unbuild.mo_id.move_finished_ids.move_line_ids:
+                    if line.product_id != unbuild.mo_id.product_id or line.state != 'done':
+                        continue
+                    qty_produced += line.product_uom_id._compute_quantity(line.qty_done, unbuild.product_uom_id)
+                if float_is_zero(qty_produced, precision_rounding=unbuild.product_uom_id.rounding):
+                    return moves
+                factor = unbuild.product_qty / qty_produced
                 for product in raw_moves.product_id:
                     product_moves = raw_moves.filtered(lambda m: m.product_id == product)
                     qty = sum(product_moves.mapped('product_uom_qty'))


### PR DESCRIPTION
To reproduce the issue:
(enable debug mode)
1. Create three storable products P1, P2
2. Update the available qty of P2: 10
3. Create a BoM:
    - Product: 1 x P1
    - Components: 1 x P2
4. Create and confirm a MO with 10 x P1
5. Produce 6 x P1
6. Post the inventory
7. Cancel the MO
    - It should be mark as done
8. Process an unbuild order based on the MO and for 2 x P1
9. Check the SM of the unbuild order

Error: The quantity is incorrect: 1.2 instead of 2

When generating the moves of the unbuild order, a factor is applied on
the SMs of the MO. However, we use the initial qty of the MO (i.e., 10)
to compute this factor. Therefore, because we want to unbuild 2 x P1,
the factor is equal to `2 / 10 = 0.2`. Then, because we produced 6 x P1,
it gives `6 x 0.2 = 1.2`.

The factor should be based on the actual produced quantity.

OPW-2781308