### PR TITLE
[IMP] website: push 404 event to plausible

### DIFF
--- a/addons/website/static/src/js/plausible.js
+++ b/addons/website/static/src/js/plausible.js
@@ -25,7 +25,7 @@ publicWidget.registry.o_plausible_push = publicWidget.Widget.extend({
      * `data-event-params`
      */
     _push() {
-        const evName = this.$el.data('event-name');
+        const evName = this.$el.data('event-name').toString();
         const evParams = this.$el.data('event-params') || {};
         window.plausible(evName, {props: evParams});
     },

--- a/addons/website/views/website_templates.xml
+++ b/addons/website/views/website_templates.xml
@@ -2174,6 +2174,12 @@
     </t>
 </template>
 
+<template id="404_plausible" inherit_id="http_routing.404" name="Plausible 404">
+    <div id='wrap' position="inside">
+        <input t-if='website.plausible_shared_key' type='hidden' class='js_plausible_push' data-event-name='404' t-attf-data-event-params='{"path": "#{request.httprequest.path}"}' />
+    </div>
+</template>
+
 <template id="protected_403" name="Page Protected">
     <t t-call="website.login_layout">
         <div class="container">


### PR DESCRIPTION
This Goal will help end user to find most 404 hits and fix the
legits one...
Fixing typo, creating missing redirect, or fixing code.

We need to cast the event-name since plausible only accept 'string'
as custom event name, so if we push 404 instead of '404' the event
crash.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
