### PR TITLE
[FIX] sale_timesheet: delete service tracking for non service products

### DIFF
--- a/addons/sale/i18n/sale.pot
+++ b/addons/sale/i18n/sale.pot
@@ -4104,6 +4104,15 @@ msgid ""
 msgstr ""
 
 #. module: sale
+#: code:addons/sale/models/product_product.py:0
+#: code:addons/sale/models/product_template.py:0
+#, python-format
+msgid ""
+"You cannot change the product's type because it is already used in sales "
+"orders."
+msgstr ""
+
+#. module: sale
 #: code:addons/sale/models/sale.py:0
 #, python-format
 msgid ""

--- a/addons/sale/models/product_product.py
+++ b/addons/sale/models/product_product.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 from datetime import timedelta, time
-from odoo import api, fields, models
+from odoo import api, fields, models, _
 from odoo.tools.float_utils import float_round
 
 
@@ -33,6 +33,14 @@ class ProductProduct(models.Model):
                 continue
             product.sales_count = float_round(r.get(product.id, 0), precision_rounding=product.uom_id.rounding)
         return r
+
+    @api.onchange('type')
+    def _onchange_type(self):
+        if self._origin and self.sales_count > 0:
+            return {'warning': {
+                'title': _("Warning"),
+                'message': _("You cannot change the product's type because it is already used in sales orders.")
+            }}
 
     def action_view_sales(self):
         action = self.env.ref('sale.report_all_channels_sales_action').read()[0]

--- a/addons/sale/models/product_template.py
+++ b/addons/sale/models/product_template.py
@@ -137,6 +137,11 @@ class ProductTemplate(models.Model):
             if not self.invoice_policy:
                 self.invoice_policy = 'order'
             self.service_type = 'manual'
+        if self._origin and self.sales_count > 0:
+            res['warning'] = {
+                'title': _("Warning"),
+                'message': _("You cannot change the product's type because it is already used in sales orders.")
+            }
         return res
 
     @api.model

--- a/addons/sale_timesheet/models/product.py
+++ b/addons/sale_timesheet/models/product.py
@@ -103,8 +103,18 @@ class ProductTemplate(models.Model):
             self.service_policy = 'ordered_timesheet'
         elif self.type == 'consu' and not self.invoice_policy and self.service_policy == 'ordered_timesheet':
             self.invoice_policy = 'order'
+
+        if self.type != 'service':
+            self.service_tracking = 'no'
         return res
 
+    def write(self, values):
+        if 'type' in values and values['type'] != 'service':
+            values.update({
+                'service_tracking': 'no',
+                'project_id': False
+            })
+        return super(ProductTemplate, self).write(values)
 
 class ProductProduct(models.Model):
     _inherit = 'product.product'
@@ -118,3 +128,18 @@ class ProductProduct(models.Model):
             self.project_template_id = False
         elif self.service_tracking in ['task_in_project', 'project_only']:
             self.project_id = False
+
+    @api.onchange('type')
+    def _onchange_type(self):
+        res = super(ProductProduct, self)._onchange_type()
+        if self.type != 'service':
+            self.service_tracking = 'no'
+        return res
+
+    def write(self, values):
+        if 'type' in values and values['type'] != 'service':
+            values.update({
+                'service_tracking': 'no',
+                'project_id': False
+            })
+        return super(ProductProduct, self).write(values)


### PR DESCRIPTION
Steps to reproduce the product:
- Create a new product:
- Select “Service” type
- Go to the Sales tab:
    - Select "Create a task in an existing project" in the `service
    tracking` field
     - the `project` field becomes visible
- Change the Type of the product to “Consumable”
- Try to save

Problem:
The field `project` remains visible and as it is a required field,
we have to fill it in before being able to save the product.
While it is a feature only for service-type products

Solution:
- The `project` field is based on the `service_tracking` field
to become invisible or not. So when the product is not of service type,
we must remove the tracking service so that the project field
becomes invisible.

- Prevent the user from changing the type of products already used in
a sale order

opw-[2858064](https://www.odoo.com/web#id=2858064&view_type=form&model=project.task)




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
