### PR TITLE
[FIX] point_of_sale: prevent menu_service from loading

### DIFF
--- a/addons/point_of_sale/__manifest__.py
+++ b/addons/point_of_sale/__manifest__.py
@@ -175,7 +175,6 @@
         ],
         'point_of_sale.pos_assets_backend': [
             ('include', 'web.assets_backend'),
-            ('remove', 'web/static/src/webclient/menus/menu_service.js'),
             ('remove', 'web/static/src/core/errors/error_handlers.js'),
             ('remove', 'web/static/src/legacy/legacy_rpc_error_handler.js'),
         ],

--- a/addons/point_of_sale/views/pos_assets_index.xml
+++ b/addons/point_of_sale/views/pos_assets_index.xml
@@ -32,6 +32,9 @@
                 'login_number': login_number,
                 'debug': debug,
             })"/>;
+            // Prevent the menu_service to load anything. In an ideal world, POS assets would only contain
+            // what is genuinely necessary, and not the whole backend.
+            odoo.loadMenusPromise = Promise.resolve();
             odoo.loadTemplatesPromise = fetch(`/web/webclient/qweb/${odoo.__session_info__.cache_hashes.qweb}?bundle=web.assets_qweb`).then(doc => doc.text());
         </script>
 


### PR DESCRIPTION
This commit is a copy of 7ddcebfc, which was reverted in dfcfe63c.

Before this commit, the menu_service was not included into the
`pos.assets_backend` bundle which was fine until we had to add
a dependency to `menu_service` in a file which is included in
`web.assets_backend`. Since pos.assets_backend imports pratically
all `web.assets_backend` bundle, there was dependencies errors.

The sublient issue is that the pos bundle was built relying on a
specific feature (the primary copy of Qweb templates) which was
dropped when we introduced the new assets manager (8cc06617).

There a two other approaches that we could consider:
- Create a new bundle `web.assets_backend_primary` that would be
  called separately by `web.assets_backend`and `pos_assets_backend`,
  it would mimic the dropped behaviour
- Change the `pos_assets_backend` to manually call every specific
  element they need to function, which would prevent the depepdencies
  issues

Unfortunately, both solutions are not realistic on a stable release,
which is why we chose to reintroduce this patch, and will fix the POS
bundle properly in master, where the side-effects can be handled.

After this commit, there are no dependency issues, and the menus
are not loaded, as expected and as before.

Part of task 2860257

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
