### PR TITLE
[FIX] delivery: tax calculations are wrong on delivery products

### DIFF
--- a/addons/delivery/models/delivery_carrier.py
+++ b/addons/delivery/models/delivery_carrier.py
@@ -157,6 +157,17 @@ class DeliveryCarrier(models.Model):
         self.ensure_one()
         if hasattr(self, '%s_rate_shipment' % self.delivery_type):
             res = getattr(self, '%s_rate_shipment' % self.delivery_type)(order)
+            # apply fiscal position
+            company = self.company_id or order.company_id or self.env.company
+            res['price'] = self.product_id._get_tax_included_unit_price(
+                company,
+                company.currency_id,
+                order.date_order,
+                'sale',
+                fiscal_position=order.fiscal_position_id,
+                product_price_unit=res['price'],
+                product_currency=company.currency_id
+            )
             # apply margin on computed price
             res['price'] = float(res['price']) * (1.0 + (self.margin / 100.0))
             # save the real price in case a free_over rule overide it to 0

--- a/addons/delivery/tests/test_delivery_cost.py
+++ b/addons/delivery/tests/test_delivery_cost.py
@@ -138,3 +138,64 @@ class TestDeliveryCost(common.TransactionCase):
         self.default_delivery_policy = self.SaleConfigSetting.create({})
 
         self.default_delivery_policy.execute()
+
+    def test_01_taxes_on_delivery_cost(self):
+
+        # Creating taxes and fiscal position
+
+        tax_price_include = self.env['account.tax'].create({
+            'name': '10% inc',
+            'type_tax_use': 'sale',
+            'amount_type': 'percent',
+            'amount': 10,
+            'price_include': True,
+            'include_base_amount': True,
+        })
+        tax_price_exclude = self.env['account.tax'].create({
+            'name': '15% exc',
+            'type_tax_use': 'sale',
+            'amount_type': 'percent',
+            'amount': 15,
+        })
+
+        fiscal_position = self.env['account.fiscal.position'].create({
+            'name': 'fiscal_pos_a',
+            'tax_ids': [
+                (0, None, {
+                    'tax_src_id': tax_price_include.id,
+                    'tax_dest_id': tax_price_exclude.id,
+                }),
+            ],
+        })
+
+        # Setting tax on delivery product
+        self.normal_delivery.product_id.taxes_id = tax_price_include
+
+        # Create sales order
+        order_form = Form(self.env['sale.order'].with_context(tracking_disable=True))
+        order_form.partner_id = self.partner_18
+        order_form.pricelist_id = self.pricelist
+        order_form.fiscal_position_id = fiscal_position
+
+        # Try adding delivery product as a normal product
+        with order_form.order_line.new() as line:
+            line.product_id = self.normal_delivery.product_id
+            line.product_uom_qty = 1.0
+            line.product_uom = self.product_uom_unit
+        sale_order = order_form.save()
+
+        self.assertRecordValues(sale_order.order_line, [{'price_subtotal': 9.09, 'price_total': 10.45}])
+
+        # Now trying to add the delivery line using the delivery wizard, the results should be the same as before
+        delivery_wizard = Form(self.env['choose.delivery.carrier'].with_context(default_order_id=sale_order.id,
+                          default_carrier_id=self.normal_delivery.id))
+        choose_delivery_carrier = delivery_wizard.save()
+        choose_delivery_carrier.button_confirm()
+
+        line = self.SaleOrderLine.search([
+            ('order_id', '=', sale_order.id),
+            ('product_id', '=', self.normal_delivery.product_id.id),
+            ('is_delivery', '=', True)
+        ])
+
+        self.assertRecordValues(line, [{'price_subtotal': 9.09, 'price_total': 10.45}])


### PR DESCRIPTION
Steps to reproduce:

1- install sale, accounting
2- create a fiscal position fp that maps
tax inc t1 to any other tax t2
3- create a delivery product dp with t1 and mark it "can be sold"
4- create a new delivery method with dp
5- in a new sales order, choose fp, click on add delivery
6- the unit_price is wrong, it hasn't mapped t1 to t2
7- try adding the delivery as a product in a new sales order line
8- the unit_price is correct and the taxes are correctly calculated

Bug:

 `_create_delivery_line` is not using the same logic used
 when normally adding a sales order line although technically
 delivery product is still a product

Fix:

remove the tax handling from `_create_delivery_line` and use
`product_id_change` onchange method to handle calculations in the
 same streamlined way

OPW-2806965

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
