### PR TITLE
[FIX] sale: taxes don't change when fiscal position changes

### DIFF
--- a/addons/sale/models/sale_order_line.py
+++ b/addons/sale/models/sale_order_line.py
@@ -144,7 +144,7 @@ class SaleOrderLine(models.Model):
         for line in self:
             line.price_reduce_taxexcl = line.price_subtotal / line.product_uom_qty if line.product_uom_qty else 0.0
 
-    @api.depends('product_id')
+    @api.depends('product_id', 'order_id.fiscal_position_id')
     def _compute_tax_id(self):
         for line in self:
             line = line.with_company(line.company_id)


### PR DESCRIPTION
Steps to reproduce:

1- install sale, accounting
2- create a fiscal position fp that maps t1 to t2
3- create a product p with t1
4- create a sales order and add p
5- choose fp
6- taxes are not recomputed

Bug:

in c10db4492e01d4a506cb5ea1ac3067f0f1f4bb2d _compute_tax_id
was converted to a compute method, and it's onchange method
was removed. so it is not triggered when the user changes
the fiscal position anymore

Fix:
add `order_id.fiscal_position_id` to the depended on fields,
so it recomputes whenever it changes.

OPW-2852202

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
