### PR TITLE
[ADD] payment_authorize: add refund for Authorize.

### DIFF
--- a/addons/payment/models/payment_transaction.py
+++ b/addons/payment/models/payment_transaction.py
@@ -697,7 +697,7 @@ class PaymentTransaction(models.Model):
         :param str state_message: The reason for which the transaction is set in 'cancel' state
         :return: None
         """
-        allowed_states = ('draft', 'pending', 'authorized')
+        allowed_states = ('draft', 'pending', 'authorized', 'done')  # 'done' for Authorize refunds.
         target_state = 'cancel'
         txs_to_process = self._update_state(allowed_states, target_state, state_message)
         # Cancel the existing payments

--- a/addons/payment_authorize/const.py
+++ b/addons/payment_authorize/const.py
@@ -1,0 +1,10 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+# Mapping of payment status on Authorize side to transaction statuses.
+# See https://developer.authorize.net/api/reference/index.html#transaction-reporting-get-transaction-details.
+TRANSACTION_STATUS_MAPPING = {
+    'authorized': ['authorizedPendingCapture', 'capturedPendingSettlement'],
+    'captured': ['settledSuccessfully'],
+    'voided': ['voided'],
+    'refunded': ['refundPendingSettlement', 'refundSettledSuccessfully'],
+}

--- a/addons/payment_authorize/models/payment_acquirer.py
+++ b/addons/payment_authorize/models/payment_acquirer.py
@@ -58,6 +58,7 @@ class PaymentAcquirer(models.Model):
         super()._compute_feature_support_fields()
         self.filtered(lambda acq: acq.provider == 'authorize').update({
             'support_manual_capture': True,
+            'support_refund': 'full_only',
             'support_tokenization': True,
         })
 

--- a/addons/payment_authorize/tests/__init__.py
+++ b/addons/payment_authorize/tests/__init__.py
@@ -2,3 +2,4 @@
 
 from . import common
 from . import test_authorize
+from . import test_refund_flows

--- a/addons/payment_authorize/tests/test_refund_flows.py
+++ b/addons/payment_authorize/tests/test_refund_flows.py
@@ -1,0 +1,79 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from unittest.mock import patch
+
+from odoo.tests import tagged
+from odoo.tools import mute_logger
+
+from odoo.addons.payment_authorize.tests.common import AuthorizeCommon
+
+
+@tagged('post_install', '-at_install')
+class TestRefundFlows(AuthorizeCommon):
+
+    def test_refunding_voided_tx_cancels_it(self):
+        """ Test that refunding a transaction that has been voided from Authorize.net side cancels
+        it on Odoo. """
+        source_tx = self._create_transaction('direct', state='done')
+        with patch(
+            'odoo.addons.payment_authorize.models.authorize_request.AuthorizeAPI'
+            '.get_transaction_details',
+            return_value={'transaction': {'transactionStatus': 'voided'}},
+        ):
+            source_tx._send_refund_request(amount_to_refund=source_tx.amount)
+        self.assertEqual(source_tx.state, 'cancel')
+
+    def test_refunding_refunded_tx_creates_refund_tx(self):
+        """ Test that refunding a transaction that has been refunded from Authorize.net side creates
+        a refund transaction on Odoo. """
+        source_tx = self._create_transaction('direct', state='done')
+        with patch(
+            'odoo.addons.payment_authorize.models.authorize_request.AuthorizeAPI'
+            '.get_transaction_details',
+            return_value={'transaction': {'transactionStatus': 'refundSettledSuccessfully'}},
+        ):
+            source_tx._send_refund_request(amount_to_refund=source_tx.amount)
+        refund_tx = self.env['payment.transaction'].search(
+            [('source_transaction_id', '=', source_tx.id)]
+        )
+        self.assertTrue(refund_tx)
+
+    @mute_logger('odoo.addons.payment_authorize.models.payment_transaction')
+    def test_refunding_authorized_tx_voids_it(self):
+        """ Test that refunding a transaction that is still authorized on Authorize.net side voids
+        it instead. """
+        source_tx = self._create_transaction('direct', state='done')
+        with patch(
+            'odoo.addons.payment_authorize.models.authorize_request.AuthorizeAPI'
+            '.get_transaction_details',
+            return_value={'transaction': {'transactionStatus': 'authorizedPendingCapture'}},
+        ), patch(
+            'odoo.addons.payment_authorize.models.authorize_request.AuthorizeAPI.void'
+        ) as void_mock, patch(
+            'odoo.addons.payment.models.payment_transaction.PaymentTransaction'
+            '._handle_notification_data'
+        ):
+            source_tx._send_refund_request(amount_to_refund=source_tx.amount)
+        self.assertEqual(void_mock.call_count, 1)
+
+    @mute_logger('odoo.addons.payment_authorize.models.payment_transaction')
+    def test_refunding_captured_tx_refunds_it_and_creates_refund_tx(self):
+        """ Test that refunding a transaction that is captured on Authorize.net side captures it and
+        create a refund transaction on Odoo. """
+        source_tx = self._create_transaction('direct', state='done')
+        with patch(
+            'odoo.addons.payment_authorize.models.authorize_request.AuthorizeAPI'
+            '.get_transaction_details',
+            return_value={'transaction': {'transactionStatus': 'settledSuccessfully'}},
+        ), patch(
+            'odoo.addons.payment_authorize.models.authorize_request.AuthorizeAPI.refund'
+        ) as refund_mock, patch(
+            'odoo.addons.payment.models.payment_transaction.PaymentTransaction'
+            '._handle_notification_data'
+        ):
+            source_tx._send_refund_request(amount_to_refund=source_tx.amount)
+        self.assertEqual(refund_mock.call_count, 1)
+        refund_tx = self.env['payment.transaction'].search(
+            [('source_transaction_id', '=', source_tx.id)]
+        )
+        self.assertTrue(refund_tx)


### PR DESCRIPTION
Users can now ask for a refund from Odoo for their transactions done
through Authorize.net. A refund will be triggered from Odoo when
necessary.
Only full refunds are possible.
Note that unsettled transactions will be voided as they cannot be
refunded.

Task - 2678757

Continuation of https://github.com/odoo/odoo/pull/79417

See also
 - https://github.com/odoo/documentation/pull/2091