### PR TITLE
[FIX] account: unreconcile stmt line when reseting invoice to draft

### DIFF
--- a/addons/account/models/account_move.py
+++ b/addons/account/models/account_move.py
@@ -2426,6 +2426,8 @@ class AccountMove(models.Model):
             # We remove all the analytics entries for this journal
             move.mapped('line_ids.analytic_line_ids').unlink()
 
+        rec_partial_reconcile = self.mapped('line_ids').matched_credit_ids + self.mapped('line_ids').matched_debit_ids
+        (rec_partial_reconcile.credit_move_id + rec_partial_reconcile.debit_move_id).mapped('statement_line_id').button_cancel_reconciliation()
         self.mapped('line_ids').remove_move_reconcile()
         self.write({'state': 'draft'})
 

--- a/addons/account/tests/test_bank_statement_reconciliation.py
+++ b/addons/account/tests/test_bank_statement_reconciliation.py
@@ -120,3 +120,24 @@ class TestBankStatementReconciliation(AccountingTestCase):
         })
         statement.button_open()
         statement.button_confirm_bank()
+
+    def test_undo_reconciliation_when_reset_invoice_to_draft(self):
+        """
+        Test if a statement line is reconciled after reseting to draft its related invoice
+        """
+        invoice_lines = self.create_invoice(100), self.create_invoice(200)
+        st_lines = self.create_statement_line(100), self.create_statement_line(200)
+
+        for st_line, inv_line in zip(st_lines, invoice_lines):
+            st_line.process_reconciliation(counterpart_aml_dicts=[{
+                'move_line': inv_line,
+                'credit': 100,
+                'debit': 0,
+                'name': inv_line.name,
+            }])
+
+        self.assertTrue(st_lines[0].statement_id.all_lines_reconciled)
+
+        invoice_lines[0].move_id.button_draft()
+
+        self.assertTrue(not st_lines[0].statement_id.all_lines_reconciled)


### PR DESCRIPTION
Make a statement line unreconciled when its related invoice
is reset to draft

Steps to reproduce:

- Create an invoice for price X and confirm
- Create a bank statement with line for amount X
- Reconcile
- Reset the invoice to draft
- Go back to the statement
-> The statement line is still marked as reconciled
   (the cancel reconciliation button is still there)

With this commit, we undo the reconciliation of the statement line
related to the invoice when calling button_draft method on the invoice.

opw-2853130.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
