### PR TITLE
[FIX] project: prevent menu_service from loading

### DIFF
--- a/addons/project/__manifest__.py
+++ b/addons/project/__manifest__.py
@@ -107,7 +107,6 @@
         ],
         'project.webclient': [
             ('include', 'web.assets_backend'),
-            ('remove', 'web/static/src/webclient/menus/*.js'),
 
             # Remove Longpolling bus and packages needed this bus
             ('remove', 'bus/static/src/js/services/assets_watchdog_service.js'),

--- a/addons/project/views/project_sharing_templates.xml
+++ b/addons/project/views/project_sharing_templates.xml
@@ -18,6 +18,9 @@
             <t t-set="head_project_sharing">
                 <script type="text/javascript">
                     odoo.__session_info__ = <t t-out="json.dumps(session_info)"/>;
+                    // Prevent the menu_service to load anything. In an ideal world, Project Sharing assets would only contain
+                    // what is genuinely necessary, and not the whole backend.
+                    odoo.loadMenusPromise = Promise.resolve();
                     odoo.loadTemplatesPromise = fetch(`/web/webclient/qweb/${odoo.__session_info__.cache_hashes.qweb}?bundle=project.assets_qweb`).then(doc => doc.text());
                 </script>
                 <base target="_parent"/>


### PR DESCRIPTION
Continuity of b859d78c. The assets generated for project sharing feature
suffer from the same issue than `point_of_sale`. In master, we have to
properly declare every file we need instead of realying on the whole
`web.assets_backend`.

Part of task 2860257


--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
