### PR TITLE
[IMP][14.0] calendar: recurring calendar events

### DIFF
--- a/addons/calendar/models/calendar_event.py
+++ b/addons/calendar/models/calendar_event.py
@@ -771,8 +771,7 @@ class Meeting(models.Model):
         for event, vals in zip(recurring_events, recurring_vals):
             recurrence_values = {field: vals.pop(field) for field in recurrence_fields if field in vals}
             if vals.get('recurrency'):
-                detached_events = event._apply_recurrence_values(recurrence_values)
-                detached_events.active = False
+                event._apply_recurrence_values(recurrence_values)
 
         events.filtered(lambda event: event.start > fields.Datetime.now()).attendee_ids._send_mail_to_attendees('calendar.calendar_template_meeting_invitation')
         events._sync_activities(fields={f for vals in vals_list for f in vals.keys()})


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
Don't set 'active=False' with calendar event with repeat count of 1

Current behavior before PR:
With a recurring weekly calendar event with a repeat count of 1, and for iterating on days in the past, the calendar event will be set 'active=False'


![calendar_1](https://user-images.githubusercontent.com/41574005/170417409-b84e5510-f1ab-4c64-8388-d84def84d7ad.png)

![calendar_2](https://user-images.githubusercontent.com/41574005/170417956-44be2354-22c1-4acb-a880-6fc8cbb32c58.png)

![calendar_3](https://user-images.githubusercontent.com/41574005/170417964-89fa4fdc-a6f6-443b-865f-9bd50c7ed74d.png)


Desired behavior after PR is merged: 

Don't set 'active=False'






--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
