### PR TITLE
[FIX] stock: check serial lot name properly for double usage

### DIFF
--- a/addons/stock/models/stock_move_line.py
+++ b/addons/stock/models/stock_move_line.py
@@ -135,14 +135,14 @@ class StockMoveLine(models.Model):
 
             message = None
             if self.lot_name or self.lot_id:
-                move_lines_to_check = self._get_similar_move_lines() - self
+                move_lines_to_check = self._get_similar_move_lines() - self._origin
                 if self.lot_name:
                     counter = Counter([line.lot_name for line in move_lines_to_check])
-                    if counter.get(self.lot_name) and counter[self.lot_name] > 1:
+                    if counter.get(self.lot_name) and counter[self.lot_name] > 0:
                         message = _('You cannot use the same serial number twice. Please correct the serial numbers encoded.')
                 elif self.lot_id:
                     counter = Counter([line.lot_id.id for line in move_lines_to_check])
-                    if counter.get(self.lot_id.id) and counter[self.lot_id.id] > 1:
+                    if counter.get(self.lot_id.id) and counter[self.lot_id.id] > 0:
                         message = _('You cannot use the same serial number twice. Please correct the serial numbers encoded.')
 
             if message:


### PR DESCRIPTION
**Description of the issue/feature this PR addresses:**
The check was not working as assuming to have more than one when we do not count ourselves is wrong.
Besides as we do not get back the newId record from the method `_get_similar_move_lines` anymore we just remove the original record as it is currently changed anyway.

**Current behavior before PR:**
The check was not working at all

**Desired behavior after PR is merged:**
Finally the check is working again


--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
