### PR TITLE
[13.0][FIX] sale: confirmation template values

### DIFF
--- a/addons/sale/data/mail_data.xml
+++ b/addons/sale/data/mail_data.xml
@@ -234,6 +234,7 @@
                     ${object.partner_invoice_id.country_id.name or ''}
                 </td>
             </tr>
+            % if transaction:
             <tr>
                 <td>
                     <strong>Payment Method:</strong>
@@ -245,6 +246,7 @@
                      (${format_amount(transaction.amount, object.currency_id)})
                 </td>
             </tr>
+            % endif
         </table>
     </div>
     % endif
@@ -263,16 +265,22 @@
                 </td>
             </tr>
         </table>
-        % if object.carrier_id:
+        % set delivery_line = object.order_line.filtered('is_delivery')
+        % if object.carrier_id and delivery_line:
+            % if object.user_id.has_group('account.group_show_line_subtotals_tax_excluded'):
+                % set delivery_price = delivery_line.price_reduce_taxexcl
+            % else:
+                % set delivery_price = delivery_line.price_reduce_taxinc
+            % endif
         <table width="100%" style="color: #454748; font-size: 12px;">
             <tr>
                 <td>
                     <strong>Shipping Method:</strong>
                     ${object.carrier_id.name}
-                    % if object.carrier_id.fixed_price == 0.0:
+                    % if delivery_price == 0.0:
                         (Free)
                     % else:
-                        (${format_amount(object.carrier_id.fixed_price, object.currency_id)})
+                        (${format_amount(delivery_price, object.currency_id)})
                     % endif
                 </td>
             </tr>


### PR DESCRIPTION
The template doesn't consider variable delivery costs depending on
carrier rules, so it throws missleading information to the customer.

opw-2860807

Affected versions: 13.0, 14.0, 15.0, master

Steps to reproduce the problem:

- Create a shipping method with a fixed price of 5€ wich is free above 20€.
- Make a sale order with an amount above 20€.
- Add the shipping method to the order: the price will be 0€ following the rule we set up.
- Send the confirmation email.

What's wrong?:

- In the email the customer receives it's said that the amount of the shipping is going to be 5€.
- The customer calls in anger as he was supposed to enjoy a free shipping.

Expected behavior:

- The mail template computes the shipping costs correctly.

cc @Tecnativa TT36922

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
