### PR TITLE
[FIX] account: fix bug when adding credit note to a vendor's bill

### DIFF
--- a/addons/account/models/account_move.py
+++ b/addons/account/models/account_move.py
@@ -1548,6 +1548,10 @@ class AccountMove(models.Model):
         ''', [tuple(moves.ids)])
         duplicated_moves = self.browse([r[0] for r in self._cr.fetchall()])
         if duplicated_moves:
+            posted_move = duplicated_moves.filtered(lambda r: r.name != '/')
+            amount_total = sum(posted_move.mapped('amount_total')) + self.amount_total
+            if amount_total <= duplicated_moves.reversed_entry_id.amount_total:
+                return
             raise ValidationError(_('Duplicated vendor reference detected. You probably encoded twice the same vendor bill/credit note:\n%s') % "\n".join(
                 duplicated_moves.mapped(lambda m: "%(partner)s - %(ref)s - %(date)s" % {'ref': m.ref, 'partner': m.partner_id.display_name, 'date': format_date(self.env, m.date)})
             ))


### PR DESCRIPTION
**Version:** 13.0

**Current behavior before PR:** If a partial refund has already been issued, you won't be able to post another partial refund. issue: https://github.com/odoo/odoo/issues/92006

**Desired behavior after PR is merged:** If your refund is incomplete, you can post an additional partial refund (including refunds that were posted once but set to draft)




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
