### PR TITLE
[IMP] web, sign: makes automatic signature default

### DIFF
--- a/addons/sale/static/tests/tours/sale_signature.js
+++ b/addons/sale/static/tests/tours/sale_signature.js
@@ -18,15 +18,6 @@ tour.register('sale_signature', {
         trigger: 'a:contains("Sign")',
     },
     {
-        content: "check submit is disabled",
-        trigger: '.o_portal_sign_submit:disabled',
-        run: function () {},
-    },
-    {
-        content: "click Auto",
-        trigger: '.o_web_sign_auto_button',
-    },
-    {
         content: "check submit is enabled",
         trigger: '.o_portal_sign_submit:enabled',
         run: function () {},

--- a/addons/web/static/src/legacy/xml/name_and_signature.xml
+++ b/addons/web/static/src/legacy/xml/name_and_signature.xml
@@ -41,7 +41,7 @@
         <div class="o_web_sign_name_and_signature">
             <div class="o_web_sign_name_group form-group">
                 <label class="col-form-label" t-att-for="'o_web_sign_name_input_' + widget.htmlId">Full Name</label>
-                <input type="text" name="signer" t-att-id="'o_web_sign_name_input_' + widget.htmlId" class="o_web_sign_name_input form-control" t-att-value="widget.defaultName" placeholder="Your name" required=""/>
+                <input type="text" name="signer" t-att-id="'o_web_sign_name_input_' + widget.htmlId" class="o_web_sign_name_input form-control" t-att-value="widget.defaultName" placeholder="Type your name to sign" required=""/>
             </div>
 
             <!--
@@ -53,13 +53,13 @@
                 <div class="card-header">
                     <div class="row no-gutters">
                         <div class="col-auto">
-                            <a role="button" href="#" t-attf-class="o_web_sign_draw_button mr-2 btn btn-light {{ widget.signMode === 'draw' ? 'active': '' }}">
-                                Draw
+                            <a role="button" href="#" t-attf-class="o_web_sign_auto_button mr-2 btn btn-light {{ widget.signMode === 'auto' ? 'active': '' }}">
+                                Auto
                             </a>
                         </div>
                         <div class="col-auto">
-                            <a role="button" href="#" t-attf-class="o_web_sign_auto_button mr-2 btn btn-light {{ widget.signMode === 'auto' ? 'active': '' }}">
-                                Auto
+                            <a role="button" href="#" t-attf-class="o_web_sign_draw_button mr-2 btn btn-light {{ widget.signMode === 'draw' ? 'active': '' }}">
+                                Draw
                             </a>
                         </div>
                         <div class="col-auto">

--- a/addons/web/static/tests/legacy/widgets/name_and_signature_tests.js
+++ b/addons/web/static/tests/legacy/widgets/name_and_signature_tests.js
@@ -1,0 +1,80 @@
+odoo.define('web.name_and_signature_tests', function (require) {
+    "use strict";
+
+    const { NameAndSignature } = require("web.name_and_signature");
+    const testUtils = require("web.test_utils");
+    const MockedNameAndSignature = NameAndSignature.extend({
+        events: {
+            ...NameAndSignature.prototype.events,
+            'signature_changed': () => {},
+        },
+        _onChangeSignature: () => {},
+        _drawCurrentName: () => {},
+    });
+
+    async function MockedNameAndSignatureGenerator (options) {
+        const parent = $("#qunit-fixture");
+        const mockedNameAndSignature = new MockedNameAndSignature(parent, options);
+        await testUtils.mock.addMockEnvironment(mockedNameAndSignature, {
+            mockRPC: function (route, args) {
+                if (route == "/web/sign/get_fonts/") {
+                    return Promise.resolve();
+                }
+            }
+        });
+        await mockedNameAndSignature.appendTo(parent);
+        await mockedNameAndSignature.resetSignature();
+        return mockedNameAndSignature;
+    }
+
+    QUnit.module('widgets', {}, function () {
+        QUnit.module('name_and_signature', {
+            beforeEach: function () {
+                this.defaultName = 'Don Toliver'
+            },
+        }, function () {
+            QUnit.test("test name_and_signature widget", async function (assert) {
+                assert.expect(5);
+                const nameAndSignature = await MockedNameAndSignatureGenerator({
+                    defaultName: this.defaultName
+                });
+                assert.equal(nameAndSignature.signMode, 'auto');
+                const nameInput = nameAndSignature.$el.find('.o_web_sign_name_input');
+                assert.ok(nameInput.length);
+                assert.equal(this.defaultName, nameInput.val());
+                const drawButton = nameAndSignature.$el.find('.o_web_sign_draw_button');
+                assert.ok(drawButton.length);
+                await drawButton.click();
+                assert.equal(nameAndSignature.signMode, 'draw');
+            });
+
+            QUnit.test("test name_and_signature widget without name", async function (assert) {
+                assert.expect(4);
+                const nameAndSignature = await MockedNameAndSignatureGenerator({});
+                assert.equal(nameAndSignature.signMode, 'auto');
+                assert.ok(nameAndSignature.signatureAreaHidden);
+                const nameInput = nameAndSignature.$el.find('.o_web_sign_name_input');
+                assert.ok(nameInput.length);
+                await nameInput.val(this.defaultName).trigger('input');
+                assert.notOk(nameAndSignature.signatureAreaHidden);
+            });
+
+            QUnit.test("test name_and_signature widget with noInputName and default name", async function (assert) {
+                assert.expect(1);
+                const nameAndSignature = await MockedNameAndSignatureGenerator({
+                    noInputName: true,
+                    defaultName: this.defaultName
+                });
+                assert.equal(nameAndSignature.signMode, 'auto');
+            });
+
+            QUnit.test("test name_and_signature widget with noInputName", async function (assert) {
+                assert.expect(1);
+                const nameAndSignature = await MockedNameAndSignatureGenerator({
+                    noInputName: true,
+                });
+                assert.equal(nameAndSignature.signMode, 'draw');
+            });
+        });
+    });
+});


### PR DESCRIPTION
In order to make the process of signing faster, automatic mode should be the
default one. This commit implements this behavior and adds tests for it.

task-2862209

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
