### PR TITLE
[FIX] web: mocked `name_get` should return "" instead of "False"

### DIFF
--- a/addons/web/static/tests/helpers/mock_server.js
+++ b/addons/web/static/tests/helpers/mock_server.js
@@ -590,7 +590,7 @@ export class MockServer {
         }
         var records = this.models[model].records;
         var names = ids.map((id) =>
-            id ? [id, records.find((r) => r.id === id).display_name] : [null, "False"]
+            id ? [id, records.find((r) => r.id === id).display_name] : [null, ""]
         );
         return names;
     }

--- a/addons/web/static/tests/legacy/helpers/mock_server.js
+++ b/addons/web/static/tests/legacy/helpers/mock_server.js
@@ -1238,7 +1238,7 @@ var MockServer = Class.extend({
         }
         var records = this.data[model].records;
         var names = _.map(ids, function (id) {
-            return id ? [id, _.findWhere(records, {id: id}).display_name] : [null, "False"];
+            return id ? [id, _.findWhere(records, {id: id}).display_name] : [null, ""];
         });
         return names;
     },

--- a/addons/web/static/tests/legacy/mockserver_tests.js
+++ b/addons/web/static/tests/legacy/mockserver_tests.js
@@ -181,7 +181,31 @@ QUnit.module("MockServer", {
             args: [[undefined, 1]],
             kwargs: {},
         });
-        assert.deepEqual(result, [[null, "False"], [1, "Jean-Michel"]]);
+        assert.deepEqual(result, [[null, ""], [1, "Jean-Michel"]]);
+    });
+
+    QUnit.test("performRpc: name_get with single id 0", async function (assert) {
+        assert.expect(1);
+        const server = new MockServer(this.data, {});
+        const result = await server.performRpc("", {
+            model: "res.partner",
+            method: "name_get",
+            args: [0],
+            kwargs: {},
+        });
+        assert.deepEqual(result, []);
+    });
+
+    QUnit.test("performRpc: name_get with array of id 0", async function (assert) {
+        assert.expect(1);
+        const server = new MockServer(this.data, {});
+        const result = await server.performRpc("", {
+            model: "res.partner",
+            method: "name_get",
+            args: [[0]],
+            kwargs: {},
+        });
+        assert.deepEqual(result, [[null, ""]]);
     });
 
     QUnit.test("performRpc: search with active_test=false", async function (assert) {

--- a/addons/web/static/tests/mock_server_tests.js
+++ b/addons/web/static/tests/mock_server_tests.js
@@ -137,6 +137,110 @@ QUnit.test("performRPC: search_read with active_test=true", async function (asse
     assert.deepEqual(result, [{ id: 1, name: "Jean-Michel" }]);
 });
 
+QUnit.test("performRPC: name_get with no args", async function (assert) {
+    assert.expect(2);
+    const server = new MockServer(this.data, {});
+    try {
+        await server.performRPC("", {
+            model: "res.partner",
+            method: "name_get",
+            args: [],
+            kwargs: {},
+        });
+    } catch (error) {
+        assert.step("name_get failed")
+    }
+    assert.verifySteps(["name_get failed"])
+});
+
+QUnit.test("performRPC: name_get with undefined arg", async function (assert) {
+    assert.expect(1);
+    const server = new MockServer(this.data, {});
+    const result = await server.performRPC("", {
+        model: "res.partner",
+        method: "name_get",
+        args: [undefined],
+        kwargs: {},
+    });
+    assert.deepEqual(result, [])
+});
+
+QUnit.test("performRPC: name_get with a single id", async function (assert) {
+    assert.expect(1);
+    const server = new MockServer(this.data, {});
+    const result = await server.performRPC("", {
+        model: "res.partner",
+        method: "name_get",
+        args: [1],
+        kwargs: {},
+    });
+    assert.deepEqual(result, [[1, "Jean-Michel"]]);
+});
+
+QUnit.test("performRPC: name_get with array of ids", async function (assert) {
+    assert.expect(1);
+    const server = new MockServer(this.data, {});
+    const result = await server.performRPC("", {
+        model: "res.partner",
+        method: "name_get",
+        args: [[1]],
+        kwargs: {},
+    });
+    assert.deepEqual(result, [[1, "Jean-Michel"]]);
+});
+
+QUnit.test("performRPC: name_get with invalid id", async function (assert) {
+    assert.expect(2);
+    const server = new MockServer(this.data, {});
+    try {
+        await server.performRPC("", {
+            model: "res.partner",
+            method: "name_get",
+            args: [11111],
+            kwargs: {},
+        });
+    } catch (error) {
+        assert.step("name_get failed")
+    }
+    assert.verifySteps(["name_get failed"])
+});
+
+QUnit.test("performRPC: name_get with id and undefined id", async function (assert) {
+    assert.expect(1);
+    const server = new MockServer(this.data, {});
+    const result = await server.performRPC("", {
+        model: "res.partner",
+        method: "name_get",
+        args: [[undefined, 1]],
+        kwargs: {},
+    });
+    assert.deepEqual(result, [[null, ""], [1, "Jean-Michel"]]);
+});
+
+QUnit.test("performRPC: name_get with single id 0", async function (assert) {
+    assert.expect(1);
+    const server = new MockServer(this.data, {});
+    const result = await server.performRPC("", {
+        model: "res.partner",
+        method: "name_get",
+        args: [0],
+        kwargs: {},
+    });
+    assert.deepEqual(result, []);
+});
+
+QUnit.test("performRPC: name_get with array of id 0", async function (assert) {
+    assert.expect(1);
+    const server = new MockServer(this.data, {});
+    const result = await server.performRPC("", {
+        model: "res.partner",
+        method: "name_get",
+        args: [[0]],
+        kwargs: {},
+    });
+    assert.deepEqual(result, [[null, ""]]);
+});
+
 QUnit.test("performRPC: read_group, group by date", async function (assert) {
     assert.expect(10);
     const server = new MockServer(this.data, {});


### PR DESCRIPTION
Since 43474916 and ff37a2fe, the function `name_get` now returns an
empty string for missing records. This change was not reflected in
mockServer.

This commit also copies the tests of `name_get` on  the legacy mockServer
to the "new" one. They were missing.

Co-authored-by: Lucas Lefèvre <lul@odoo.com>





--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
