### PR TITLE
[FIX] base_automation: fix traceback value in error dialog

### DIFF
--- a/addons/base_automation/static/src/js/base_automation_error_dialog.js
+++ b/addons/base_automation/static/src/js/base_automation_error_dialog.js
@@ -1,11 +1,11 @@
 /** @odoo-module */
 
-import { ErrorDialog } from "@web/core/errors/error_dialogs";
+import { RPCErrorDialog } from "@web/core/errors/error_dialogs";
 import session from "web.session";
 import { registry } from "@web/core/registry";
 import { useService } from "@web/core/utils/hooks";
 
-export class BaseAutomationErrorDialog extends ErrorDialog {
+export class BaseAutomationErrorDialog extends RPCErrorDialog {
     setup() {
         super.setup(...arguments);
         const { id, name } = this.props.data.context.base_automation;
@@ -50,6 +50,7 @@ export class BaseAutomationErrorDialog extends ErrorDialog {
             views: [[false, "form"]],
             type: "ir.actions.act_window",
             view_mode: "form",
+            target: "new",
         });
         this.close();
     }


### PR DESCRIPTION
RPC call may fail because of error in `base.automation` handler. In this case
the response contains attribute `exception_class=base_automation` to handle
error via custom dialog `BaseAutomationErrorDialog`, which provides extra
buttons (disable/edit Automated Action).

1.

`BaseAutomationErrorDialog` was incorrectly inherited from ErrorDialog, which
cannot extract traceback from `data.debug` value of jsonrpc. Fix it by replacing
it RPCErrorDialog.

RPCErrorDialog: https://github.com/odoo/odoo/blob/a75fcbe03f31fd10a74e609672b64dad165e68d7/addons/web/static/src/core/errors/error_dialogs.js#L62-L70

2.

Button `Edit Action` didn't work, because it tries the same rpc call before
navigating to the action. For example, it would repeat rpc call to create a
record, which doesn't work because of broken automated action.

It happens because form changes are saved automatically since Odoo v15.

Fix it by omitting `clearUncommittedChanges`. This way we may loose user input.
This could be improving by reimplementing Odoo v14 behaviour, when user is asked
to confirm discarding unsaved changes.

opw-2845893