### PR TITLE
[FIX] mass_mailing_sms: Allow users to translate mailing fields

### DIFF
--- a/addons/mass_mailing_sms/models/mailing_mailing.py
+++ b/addons/mass_mailing_sms/models/mailing_mailing.py
@@ -32,7 +32,7 @@ class Mailing(models.Model):
     # even when 'mass_mailing_sms' removed (see 'mailing_mailing_view_form_sms' for more details).                    
     sms_subject = fields.Char('Title', help='For an email, the subject your recipients will see in their inbox.\n'
                               'For an SMS, the internal title of the message.',
-                              related='subject', translate=True, readonly=False)
+                              related='subject', translate=False, readonly=False)
     # sms options
     body_plaintext = fields.Text('SMS Body', compute='_compute_body_plaintext', store=True, readonly=False)
     sms_template_id = fields.Many2one('sms.template', string='SMS Template', ondelete='set null')


### PR DESCRIPTION
Steps:
    - Go to Email Marketing
    - Create new mailing with a random mailing list & subject
    - Click on `Please update translations of : Title`
    - Traceback

Traceback is coming from an assert in ir_translation

https://github.com/odoo/odoo/blob/48391324450c5b6370f63068daeb534a33545302/odoo/addons/base/models/ir_translation.py#L748

In this case `fld.translate` is equal to `False`, the reason is because

sms_subject is translatable unlike its parent field `subject`

https://github.com/odoo/odoo/blob/c9905ceb3172d8e80e3aff4ae9bc925dcb6b6519/addons/mass_mailing_sms/models/mailing_mailing.py#L33-L35

https://github.com/odoo/odoo/blob/4cebf53aa89c21ef255f5d5da450fdf98c4c9ac1/addons/mass_mailing/models/mailing.py#L68


opw-2845678