### PR TITLE
[FIX] account: tax info not propagated in writeoff suggestion

### DIFF
--- a/addons/account/models/account_reconcile_model.py
+++ b/addons/account/models/account_reconcile_model.py
@@ -461,20 +461,14 @@ class AccountReconcileModel(models.Model):
         return lines_vals_list + writeoff_vals_list
 
     def _prepare_widget_writeoff_vals(self, st_line_id, write_off_vals):
-        fixed_write_off_vals = dict(write_off_vals, currency_id=st_line_id.company_id.currency_id.id)
-        counterpart_vals = st_line_id._prepare_counterpart_move_line_vals(fixed_write_off_vals)
-
+        counterpart_vals = st_line_id._prepare_counterpart_move_line_vals({
+                **write_off_vals,
+                'currency_id': st_line_id.company_id.currency_id.id,
+            })
         return {
-            'name': counterpart_vals['name'],
+            **counterpart_vals,
             'balance': counterpart_vals['amount_currency'],
-            'debit': counterpart_vals['debit'],
-            'credit': counterpart_vals['credit'],
-            'account_id': counterpart_vals['account_id'],
-            'currency_id': counterpart_vals['currency_id'],
-            'analytic_account_id': counterpart_vals.get('analytic_account_id'),
-            'analytic_tag_ids': counterpart_vals.get('analytic_tag_ids', []),
             'reconcile_model_id': self.id,
-            'journal_id': counterpart_vals['journal_id']
         }
 
     ####################################################


### PR DESCRIPTION
In a CH company
Have a Reconciliation model based on the default
'Invoices Matching Rule' with:
- Amount matching 90%
- Partner is Set & matched disabled
- Counterpart value set with:
  - Amount type: percentage of balance
  - Amount: 100
  - Taxes: set a tax
  - Tax included in price: true

Create an invoice [INV] for 105chf
Create a bank statement line with:
- Partner: unset
- Label: [INV]
- Amount: 100

Validate statement and hit reconcile
The system will use the reconciliation model to automatically fill the
writeoff

Issue: applying the suggested writoff will not fill the tax tags so the
tax report will be wrong


--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
