### PR TITLE
[FIX] product: add the product’s company to the context

### DIFF
--- a/addons/product/views/product_views.xml
+++ b/addons/product/views/product_views.xml
@@ -112,7 +112,7 @@
                                 colspan="4"
                                 attrs="{'invisible':['|', ('type', 'not in', ['product', 'consu']), ('product_variant_count', '>', 1), ('is_product_variant', '=', False)]}"
                                 groups="product.group_stock_packaging">
-                                <field name="packaging_ids" nolabel="1" context="{'tree_view_ref':'product.product_packaging_tree_view2', 'form_view_ref':'product.product_packaging_form_view2'}"/>
+                                <field name="packaging_ids" nolabel="1" context="{'tree_view_ref':'product.product_packaging_tree_view2', 'form_view_ref':'product.product_packaging_form_view2', 'default_company_id': company_id}"/>
                             </group>
                         </page>
                     </notebook>
@@ -220,6 +220,7 @@
                         <widget name="web_ribbon" title="Archived" bg_color="bg-danger" attrs="{'invisible': [('active', '=', True)]}"/>
                         <field name="active" invisible="1"/>
                         <field name="id" invisible="1"/>
+                        <field name="company_id" invisible="1"/>
                         <field name="image_1920" widget="image" class="oe_avatar" options="{'preview_image': 'image_128'}"/>
                         <div class="oe_title">
                             <label class="oe_edit_only" for="name" string="Product Name"/>
@@ -262,7 +263,7 @@
                             </group>
                             <group name="packaging" string="Packaging" groups="product.group_stock_packaging">
                                 <field name="packaging_ids" nolabel="1"
-                                    context="{'tree_view_ref':'product.product_packaging_tree_view2', 'form_view_ref':'product.product_packaging_form_view2'}"/>
+                                    context="{'tree_view_ref':'product.product_packaging_tree_view2', 'form_view_ref':'product.product_packaging_form_view2', 'default_company_id': company_id}"/>
                             </group>
                         </group>
                     </sheet>


### PR DESCRIPTION
Steps to reproduce the bug:
- Enable “Product Packagings” in the settings
- Create a storable product
- Set the company field
- Go to the inventory tab:
    - Click on add packaging

Problem
The company field is not set automatically

opw-2864554




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
