### PR TITLE
Revert "[IMP] account_invoice: prevent erasing of a tax line entry if…

### DIFF
--- a/addons/account/models/account_move.py
+++ b/addons/account/models/account_move.py
@@ -980,25 +980,25 @@ class AccountMove(models.Model):
             self.invoice_date_due = new_terms_lines[-1].date_maturity
 
     def _recompute_dynamic_lines(self, recompute_all_taxes=False, recompute_tax_base_amount=False):
-        ''' Recompute all lines that depend on others.
+        ''' Recompute all lines that depend of others.
 
-        For example, tax lines depends on base lines (lines having tax_ids set). This is also the case of cash rounding
-        lines that depend on base lines or tax lines depending on the cash rounding strategy. When a payment term is set,
+        For example, tax lines depends of base lines (lines having tax_ids set). This is also the case of cash rounding
+        lines that depend of base lines or tax lines depending the cash rounding strategy. When a payment term is set,
         this method will auto-balance the move with payment term lines.
 
         :param recompute_all_taxes: Force the computation of taxes. If set to False, the computation will be done
-                                    or not depending on the field 'recompute_tax_line' in lines.
+                                    or not depending of the field 'recompute_tax_line' in lines.
         '''
         for invoice in self:
             # Dispatch lines and pre-compute some aggregated values like taxes.
-            if (
-                recompute_all_taxes
-                or any(line.recompute_tax_line for line in invoice.line_ids)
-                or invoice.line_ids.tax_ids.flatten_taxes_hierarchy()._origin > invoice.line_ids.tax_line_id._origin
-            ):
-                invoice.line_ids.recompute_tax_line = False
-                invoice._recompute_tax_lines()
+            for line in invoice.line_ids:
+                if line.recompute_tax_line:
+                    recompute_all_taxes = True
+                    line.recompute_tax_line = False
 
+            # Compute taxes.
+            if recompute_all_taxes:
+                invoice._recompute_tax_lines()
             if recompute_tax_base_amount:
                 invoice._recompute_tax_lines(recompute_tax_base_amount=True)
 
@@ -3589,7 +3589,7 @@ class AccountMoveLine(models.Model):
             if line.parent_state == 'posted':
                 if line.move_id.restrict_mode_hash_table and set(vals).intersection(INTEGRITY_HASH_LINE_FIELDS):
                     raise UserError(_("You cannot edit the following fields due to restrict mode being activated on the journal: %s.") % ', '.join(INTEGRITY_HASH_LINE_FIELDS))
-                if any(key in vals for key in ('tax_ids', 'tax_line_id')):
+                if any(key in vals for key in ('tax_ids', 'tax_line_ids')):
                     raise UserError(_('You cannot modify the taxes related to a posted journal item, you should reset the journal entry to draft to do so.'))
             if 'statement_line_id' in vals and line.payment_id:
                 # In case of an internal transfer, there are 2 liquidity move lines to match with a bank statement

--- a/addons/account/tests/test_account_move_entry.py
+++ b/addons/account/tests/test_account_move_entry.py
@@ -656,18 +656,3 @@ class TestAccountMove(AccountTestInvoicingCommon):
         self.assertEqual(self._get_cache_count(), 1)
         self.env['account.move.line'].invalidate_cache(ids=lines.ids)
         self.assertEqual(self._get_cache_count(), 0)
-
-    def test_misc_prevent_edit_tax_on_posted_moves(self):
-        # You cannot remove journal items if the related journal entry is posted.
-        self.test_move.action_post()
-        with self.assertRaisesRegex(UserError, "You cannot modify the taxes related to a posted journal item"),\
-             self.cr.savepoint():
-            self.test_move.line_ids.filtered(lambda l: l.tax_ids).tax_ids = False
-
-        with self.assertRaisesRegex(UserError, "You cannot modify the taxes related to a posted journal item"),\
-             self.cr.savepoint():
-            self.test_move.line_ids.filtered(lambda l: l.tax_line_id).tax_line_id = False
-
-        # You can remove journal items if the related journal entry is draft.
-        self.test_move.button_draft()
-        self.assertTrue(self.test_move.line_ids.unlink())

--- a/addons/account/tests/test_account_move_in_invoice.py
+++ b/addons/account/tests/test_account_move_in_invoice.py
@@ -1996,15 +1996,3 @@ class TestAccountMoveInInvoiceOnchanges(AccountTestInvoicingCommon):
                 'credit': value['debit'],
             })
         self.assertRecordValues(reversed_caba_move.line_ids, expected_values)
-
-    def test_in_invoice_line_tax_line_delete(self):
-        with Form(self.invoice) as invoice_form:
-            lines_count = len(invoice_form.line_ids)
-            with invoice_form.line_ids.edit(0) as line_form:
-                tax = line_form.tax_line_id
-            invoice_form.line_ids.remove(0)
-            # check that the tax line is recreated
-            self.assertEqual(len(invoice_form.line_ids), lines_count)
-
-        # Assert the tax line is recreated for the tax
-        self.assertIn(tax, self.invoice.line_ids.tax_line_id)


### PR DESCRIPTION
… there is a tax related to it in the invoice"

This reverts commit ac3cf2ed59c1dd5a6c91da201a0d4093212b26ae.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
