### PR TITLE
[FIX] accessing unlinked moves from cache

### DIFF
--- a/addons/purchase_stock/models/purchase.py
+++ b/addons/purchase_stock/models/purchase.py
@@ -228,9 +228,9 @@ class PurchaseOrder(models.Model):
                 else:
                     picking = pickings[0]
                 moves = order.order_line._create_stock_moves(picking)
-                moves = moves.filtered(lambda x: x.state not in ('done', 'cancel'))._action_confirm()
+                moves = moves.filtered(lambda x: x.state not in ('done', 'cancel'))._action_confirm().exists()
                 seq = 0
-                for move in sorted(moves, key=lambda move: move.date):
+                for move in sorted(moves, key=lambda _m: _m.date):
                     seq += 5
                     move.sequence = seq
                 moves._action_assign()


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
fix accessing unlinked moves from cache

Current behavior before PR:
raising MissingError on Purchase order confirmation for orders over > 400 lines

Desired behavior after PR is merged:
fix it 



--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
