### PR TITLE
[FIX][14.0] account: Cannot create a journal item with the account type of journal's default account

### DIFF
--- a/addons/account/models/account_move.py
+++ b/addons/account/models/account_move.py
@@ -3943,7 +3943,8 @@ class AccountMoveLine(models.Model):
             if (journal.type_control_ids - journal.default_account_id.user_type_id) or journal.account_control_ids:
                 failed_check = True
                 if journal.type_control_ids:
-                    failed_check = account.user_type_id not in (journal.type_control_ids - journal.default_account_id.user_type_id)
+                    failed_check = account.user_type_id != journal.default_account_id.user_type_id and \
+                                   account.user_type_id not in (journal.type_control_ids - journal.default_account_id.user_type_id)
                 if failed_check and journal.account_control_ids:
                     failed_check = account not in journal.account_control_ids
 


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
- For example, I have a journal with more than 1 account types allowed, and 1 of them is the account type of the default/outstanding debit/credit account:
![image](https://user-images.githubusercontent.com/45560757/170903223-949e0ee9-507e-4efd-9a4d-1002cb1dd2ee.png)
- Then, if I try to create a journal item (manually or via payment...) for that journal, I got the error:
![image](https://user-images.githubusercontent.com/45560757/170903498-99aafd94-6e7e-4ca7-bc9e-9c06a05e7517.png)

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
