### PR TITLE
[FIX][13.0][product] improve performance avoiding to call unlink when unnecessary

### DIFF
--- a/addons/product/models/product_attribute.py
+++ b/addons/product/models/product_attribute.py
@@ -349,7 +349,8 @@ class ProductTemplateAttributeLine(models.Model):
             # re-use a value that was archived at a previous step.
             ptav_to_activate.write({'ptav_active': True})
             ptav_to_unlink.write({'ptav_active': False})
-        ptav_to_unlink.unlink()
+        if ptav_to_unlink:
+            ptav_to_unlink.unlink()
         ProductTemplateAttributeValue.create(ptav_to_create)
         self.product_tmpl_id._create_variant_ids()
 


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
When https://github.com/odoo/odoo/blob/13.0/addons/product/models/product_attribute.py#L352 is called with ptav_to_unlink empty causes https://github.com/odoo/odoo/blob/13.0/addons/product/models/product.py#L386 to be called empty as well, which in turn causes the flush method to be called in self, where self is an empty recordset.

This flush method on an empty recordset in https://github.com/odoo/odoo/blob/13.0/addons/product/models/product_attribute.py#L250 causes, in turn, a cascade of unnecessary queries that negatively affects performance.

Desired behavior after PR is merged:
The unlink should only occur when there are actually records to unlink


--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
