### PR TITLE
[IMP] portal: adds access_token to pager urls in portal

### DIFF
--- a/addons/portal/controllers/portal.py
+++ b/addons/portal/controllers/portal.py
@@ -89,9 +89,26 @@ def get_records_pager(ids, current):
     if current.id in ids and (hasattr(current, 'website_url') or hasattr(current, 'access_url')):
         attr_name = 'access_url' if hasattr(current, 'access_url') else 'website_url'
         idx = ids.index(current.id)
+        prev_record = idx != 0 and current.browse(ids[idx - 1])
+        next_record = idx < len(ids) - 1 and current.browse(ids[idx + 1])
+
+        if prev_record and prev_record[attr_name] and attr_name == "access_url":
+            prev_url = '%s?access_token=%s' % (prev_record[attr_name], prev_record._portal_ensure_token())
+        elif prev_record and prev_record[attr_name]:
+            prev_url = prev_record[attr_name]
+        else:
+            prev_url = prev_record
+
+        if next_record and next_record[attr_name] and attr_name == "access_url":
+            next_url = '%s?access_token=%s' % (next_record[attr_name], next_record._portal_ensure_token())
+        elif next_record and next_record[attr_name]:
+            next_url = next_record[attr_name]
+        else:
+            next_url = next_record
+
         return {
-            'prev_record': idx != 0 and getattr(current.browse(ids[idx - 1]), attr_name),
-            'next_record': idx < len(ids) - 1 and getattr(current.browse(ids[idx + 1]), attr_name),
+            'prev_record': prev_url,
+            'next_record': next_url,
         }
     return {}
 


### PR DESCRIPTION
A backport of 

- #76673

Done in master but which issue affects prior versions as well.

Within portal, subscriptions/sales orders presented in list view have their URL
containing the access_token as a GET param. However, when clicking on a
subscription and using the pager to navigate between records, the access_token
is not present in the URL. In order to keep consistency between the links and
views, this PR adds the access_token as a GET param in the pager as well.

task-2512070

closes odoo/odoo#76673

Related: odoo/upgrade#2752
Related: odoo/enterprise#20357
Signed-off-by: Arnaud Joset <arj@odoo.com>


TT36920 cc @Tecnativa



--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
