### PR TITLE
[IMP][14.0] purchase: change the text

### DIFF
--- a/addons/purchase/static/src/xml/purchase_dashboard.xml
+++ b/addons/purchase/static/src/xml/purchase_dashboard.xml
@@ -56,7 +56,7 @@
                 </thead>
                 <tbody>
                     <tr>
-                        <td class="o_text">Lead Time to Purchase</td>
+                        <td class="o_text">Avg time to confirm orders</td>
                         <td><span><t t-esc="values['all_avg_days_to_purchase']"/> &#160;Days</span></td>
                         <td class="o_text">RFQs Sent Last 7 Days</td>
                         <td><span><t t-esc="values['all_sent_rfqs']"/></span></td>


### PR DESCRIPTION
Purpose of this PR to change the text: 'Lead Time to Purchase' to 'Avg time to confirm orders'

Actually the formula is averaging the confirmation date of the purchase orders



--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
