### PR TITLE
[FIX] pos_gift_card: check for already used gift cards

### DIFF
--- a/addons/pos_gift_card/i18n/pos_gift_card.pot
+++ b/addons/pos_gift_card/i18n/pos_gift_card.pot
@@ -253,6 +253,13 @@ msgid "This gift card has already been sold"
 msgstr ""
 
 #. module: pos_gift_card
+#. openerp-web
+#: code:addons/pos_gift_card/static/src/js/models.js:0
+#, python-format
+msgid "This gift card is already applied"
+msgstr ""
+
+#. module: pos_gift_card
 #: model:ir.model.fields,help:pos_gift_card.field_pos_config__gift_card_product_id
 msgid "This product is used as reference on customer receipts."
 msgstr ""

--- a/addons/pos_gift_card/static/src/js/models.js
+++ b/addons/pos_gift_card/static/src/js/models.js
@@ -2,6 +2,8 @@ odoo.define("pos_gift_card.gift_card", function (require) {
   "use strict";
 
   const models = require("point_of_sale.models");
+  const core = require('web.core');
+  const _t = core._t;
 
   models.load_fields("pos.order.line", "generated_gift_card_ids");
   models.load_fields("pos.order.line", "redeem_pos_order_line_ids");
@@ -35,6 +37,9 @@ odoo.define("pos_gift_card.gift_card", function (require) {
         orderline.generated_gift_card_ids = [options.generated_gift_card_ids];
       }
       if (options && options.gift_card_id) {
+        if (orderline.order.orderlines.find((line) => line.gift_card_id === options.gift_card_id)) {
+            throw new Error(_t('This gift card is already applied'));
+        }
         orderline.gift_card_id = options.gift_card_id;
       }
     },


### PR DESCRIPTION
Gift card is a sort of advance payment. Once applied on an order, it reduces
total amount of that order. Obviously, it should not reduces the amount twice.
So, we need to add a check for that.

opw-2838997

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
