### PR TITLE
[FIX] mail: no traceback on change checkbox of suggested recipient

### DIFF
--- a/addons/mail/static/src/components/composer_suggested_recipient/composer_suggested_recipient.js
+++ b/addons/mail/static/src/components/composer_suggested_recipient/composer_suggested_recipient.js
@@ -70,11 +70,11 @@ export class ComposerSuggestedRecipient extends Component {
                 const adapterParent = standaloneAdapter({ Component });
                 const selectCreateDialog = new FormViewDialog(adapterParent, {
                     context: {
-                        active_id: this.suggestedRecipientInfo.thread.id,
+                        active_id: this.composerSuggestedRecipientView.suggestedRecipientInfo.thread.id,
                         active_model: 'mail.compose.message',
-                        default_email: this.suggestedRecipientInfo.email,
-                        default_name: this.suggestedRecipientInfo.name,
-                        default_lang: this.suggestedRecipientInfo.lang,
+                        default_email: this.composerSuggestedRecipientView.suggestedRecipientInfo.email,
+                        default_name: this.composerSuggestedRecipientView.suggestedRecipientInfo.name,
+                        default_lang: this.composerSuggestedRecipientView.suggestedRecipientInfo.lang,
                         force_email: true,
                         ref: 'compound_context',
                     },
@@ -82,7 +82,7 @@ export class ComposerSuggestedRecipient extends Component {
                     on_saved: this._onDialogSaved.bind(this),
                     res_id: false,
                     res_model: 'res.partner',
-                    title: this.suggestedRecipientInfo.dialogText,
+                    title: this.composerSuggestedRecipientView.suggestedRecipientInfo.dialogText,
                 });
                 selectCreateDialog.open();
             }


### PR DESCRIPTION
Follow-up of #91671 (Task-2817547)

Changes above fixed an issue with composer suggested recipient
feature not properly prompting a dialog to create new partners.

The fix was correct before #90678 (Task-2831082/Task-2849934), but
it needs to be slightly adapted for this small technical changes.
By omiting them, any change of checkbox state results in a crash.

This commit properly adapt code in `_onChangeCheckbox` to take
into account both changes.
