### PR TITLE
[FIX] website: place snippets correctly after install

### DIFF
--- a/addons/website/views/snippets/snippets.xml
+++ b/addons/website/views/snippets/snippets.xml
@@ -166,14 +166,14 @@
 </template>
 
 <template id="external_snippets" inherit_id="website.snippets" priority="8">
-    <xpath expr="//div[@id='snippet_effect']//t[@t-snippet][last()]" position="after">
+    <xpath expr="//div[@id='snippet_effect']/div[hasclass('o_panel_body')]" position="inside">
         <t t-install="website_event" string="Events" t-thumbnail="/website/static/src/img/snippets_thumbs/s_event_upcoming_snippet.svg"/>
         <t id="newsletter_popup_snippet" t-install="mass_mailing" string="Newsletter Popup" t-thumbnail="/website/static/src/img/snippets_thumbs/newsletter_subscribe_popup.svg"/>
         <t t-install="website_mail_group" string="Discussion Group" t-thumbnail="/website/static/src/img/snippets_thumbs/s_group.svg"/>
         <t t-install="website_twitter" string="Twitter Scroller" t-thumbnail="/website/static/src/img/snippets_thumbs/s_twitter_scroll.svg"/>
         <t t-install="website_payment" string="Donation" t-thumbnail="/website/static/src/img/snippets_thumbs/s_donation.svg"/>
     </xpath>
-    <xpath expr="//div[@id='snippet_content']//t[@t-snippet][last()]" position="after">
+    <xpath expr="//div[@id='snippet_content']/div[hasclass('o_panel_body')]" position="inside">
         <t id="newsletter_snippet" t-install="mass_mailing" string="Newsletter" t-thumbnail="/website/static/src/img/snippets_thumbs/s_newsletter_subscribe_form.svg"/>
         <t t-install="website_payment" string="Donation Button" t-thumbnail="/website/static/src/img/snippets_thumbs/s_donation_button.svg"/>
     </xpath>


### PR DESCRIPTION
Before this commit, after the user installed the website_payment module,
the donation blocks were not well placed in the editor (after the
uninstalled modules). This commit solves this problem by placing them at
the end of the already installed blocks.
Steps to reproduce the fixed issue:
 - Install website
 - Enter edit mode
 - Click on "Install" for the "Donation Button" snippet

=>After install, the snippet still appears after uninstalled modules.

task-2767716
--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
