### PR TITLE
[FIX] payment_mollie: mollie shows 404 page when only one payment method is active

### DIFF
--- a/addons/payment_mollie/models/payment_transaction.py
+++ b/addons/payment_mollie/models/payment_transaction.py
@@ -39,7 +39,14 @@ class PaymentTransaction(models.Model):
         # The acquirer reference is set now to allow fetching the payment status after redirection
         self.acquirer_reference = payment_data.get('id')
 
-        return {'api_url': payment_data["_links"]["checkout"]["href"]}
+        # Extract the checkout URL from the payment data and add it with its query parameters to the
+        # rendering values. Passing the query parameters separately is necessary to prevent them
+        # from being stripped off when redirecting the user to the checkout URL, which can happen
+        # when only one payment method is enabled on Mollie and query parameters are provided.
+        checkout_url = payment_data["_links"]["checkout"]["href"]
+        parsed_url = urls.url_parse(checkout_url)
+        url_params = urls.url_decode(parsed_url.query)
+        return {'api_url': checkout_url, 'url_params': url_params}
 
     def _mollie_prepare_payment_request_payload(self):
         """ Create the payload for the payment request based on the transaction values.

--- a/addons/payment_mollie/views/payment_mollie_templates.xml
+++ b/addons/payment_mollie/views/payment_mollie_templates.xml
@@ -3,7 +3,11 @@
 
     <template id="redirect_form">
         <!-- Mollie generates a unique URL for each payment request -->
-        <form t-att-action="api_url" method="get"></form>
+        <form t-att-action="api_url" method="get">
+            <t t-foreach="url_params" t-as="param">
+                <input type="hidden" t-att-name="param" t-att-value="url_params[param]" />
+            </t>
+        </form>
     </template>
 
 </odoo>


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
Mollie shows a 404 page when only one payment method is active

Mollie supports multiple payment methods, these payment methods can be
enabled/disabled from the mollie dashboard. When you activate only one payment
method from the mollie dashboard, you will get a 404 page instead of a payment page.
This commit will fix that issue by providing the necessary query parameters in the URL.

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
