### PR TITLE
[IMP] website: add the email of when a user fill the website form

### DIFF
--- a/addons/website/controllers/form.py
+++ b/addons/website/controllers/form.py
@@ -173,6 +173,10 @@ class WebsiteForm(http.Controller):
                 except ValueError:
                     error_fields.append(field_name)
 
+                if dest_model._name == 'mail.mail' and field_name == 'email_from':
+                    # Always add the email in the custom message
+                    custom_fields.append((_('email'), field_value))
+
             # If it's a custom field
             elif field_name != 'context':
                 custom_fields.append((field_name, field_value))


### PR DESCRIPTION
Purpose
=======
When a public user fill a form on Website (e.g. /contactus), an email
will be sent. The email filled in the form will be used as the "email
from", but if no mail server match this email address it will be
encapsulated into "`notifications@mycompany.com`".

The email is still present in the "Reply-To" header, we want to add it
at the end of the email, so the receiver has this information easily.

Task-2833093