### PR TITLE
[IMP] account: sets sequence safe dates in automatic entry wizard

### DIFF
--- a/addons/account/static/src/components/grouped_view_widget/grouped_view_widget.js
+++ b/addons/account/static/src/components/grouped_view_widget/grouped_view_widget.js
@@ -20,9 +20,7 @@ class ShowGroupedList extends Component {
     }
 
     formatData(props) {
-        this.data = props.record.data[props.name]
-            ? JSON.parse(props.record.data[props.name])
-            : { groups_vals: [], options: { discarded_number: "", columns: [] } };
+        this.data = props.record.data[props.name] || { groups_vals: [], options: { discarded_number: "", columns: [] } };
     }
 }
 ShowGroupedList.template = "account.GroupedListTemplate";

--- a/addons/account/tests/test_transfer_wizard.py
+++ b/addons/account/tests/test_transfer_wizard.py
@@ -5,7 +5,6 @@ from odoo.tests import tagged, Form
 from odoo.tools import format_date
 from freezegun import freeze_time
 import time
-import json
 
 
 @tagged('post_install', '-at_install')
@@ -375,8 +374,7 @@ class TestTransferWizard(AccountTestInvoicingCommon):
                 self.assertRecordValues(new_moves, [{'date': fields.Date.from_string(wizard_date)},
                                                     {'date': fields.Date.from_string(expected_date)},
                                                     ])
-                preview_move_data = json.loads(wizard.preview_move_data)
-                self.assertRegex(preview_move_data['groups_vals'][1]['group_name'],
+                self.assertRegex(wizard.preview_move_data['groups_vals'][1]['group_name'],
                                  '%s, .*' % format_date(self.env, fields.Date.from_string(expected_date)))
         # test having yearly reset sequence on misc journal
 

--- a/addons/account/wizard/accrued_orders.py
+++ b/addons/account/wizard/accrued_orders.py
@@ -2,7 +2,7 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 from dateutil.relativedelta import relativedelta
 from markupsafe import escape
-import json
+
 from odoo import models, fields, api, _, Command
 from odoo.tools import format_date
 from odoo.exceptions import UserError
@@ -57,15 +57,14 @@ class AccruedExpenseRevenue(models.TransientModel):
         check_company=True,
         domain=_get_account_domain,
     )
-    preview_data = fields.Text(compute='_compute_preview_data')
+    preview_data = fields.Binary(compute='_compute_preview_data')
     display_amount = fields.Boolean(compute='_compute_display_amount')
 
     @api.depends('date', 'amount')
     def _compute_display_amount(self):
         single_order = len(self._context['active_ids']) == 1
         for record in self:
-            preview_data = json.loads(self.preview_data)
-            lines = preview_data.get('groups_vals', [])[0].get('items_vals', [])
+            lines = self.preview_data.get('groups_vals', [])[0].get('items_vals', [])
             record.display_amount = record.amount or (single_order and not lines)
 
     @api.depends('date')
@@ -97,12 +96,12 @@ class AccruedExpenseRevenue(models.TransientModel):
                 {'field': 'debit', 'label': _('Debit'), 'class': 'text-end text-nowrap'},
                 {'field': 'credit', 'label': _('Credit'), 'class': 'text-end text-nowrap'},
             ]
-            record.preview_data = json.dumps({
+            record.preview_data = {
                 'groups_vals': preview_vals,
                 'options': {
                     'columns': preview_columns,
                 },
-            })
+            }
 
     def _compute_move_vals(self):
         def _get_aml_vals(order, balance, amount_currency, account_id, label="", analytic_distribution=None):


### PR DESCRIPTION
Currently, when a user wants to set cut-offs or change period of a move by the
automatic entry wizard, the system blocks the user if original move's date is in the
locked period.

With this commit, the date of the adjustment entries are selected by bill algo to be
sequence and lock safe.

Task: [2823170](https://www.odoo.com/web#id=2823170&menu_id=3940&cids=1&action=333&active_id=967&model=project.task&view_type=form)

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
