### PR TITLE
[FIX] sale_project_account: Analytic account is overridden

### DIFF
--- a/addons/sale_project_account/models/__init__.py
+++ b/addons/sale_project_account/models/__init__.py
@@ -2,3 +2,4 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 from . import project
+from . import account_move

--- a/addons/sale_project_account/models/account_move.py
+++ b/addons/sale_project_account/models/account_move.py
@@ -1,0 +1,13 @@
+# -*- coding: utf-8 -*-
+
+from odoo import models
+
+
+class AccountMoveLine(models.Model):
+    _inherit = 'account.move.line'
+
+    def _compute_analytic_account_id(self):
+        # when a project creates an aml, it adds an analytic account to it. the following filter is to save this
+        # analytic account from being overridden by analytic default rules and lack thereof
+        project_amls = self.filtered(lambda aml: aml.analytic_account_id and any(aml.sale_line_ids.project_id))
+        super(AccountMoveLine, self - project_amls)._compute_analytic_account_id()


### PR DESCRIPTION
Steps to reproduce:

1- install sales ,accounting, project, timesheets
2- create a new service product p1 that triggers a project and a task
3- create a new sales order so with p1 and validate 1 hour in the task
4- create an invoice from so, an anayltic account is added
5- edit any field of product_id, account_id, partner_id, date
6- the analytic default rule is applied (in this case none) so the
anayltic account is removed

Bug:

the `compute_analytic_account_id` method forces the analytic default
rule even if the field is already set before the changes

Fix:
apply analytic default rule only if the analytic acount is not set and
if it is not a project generated move

OPW-2833912

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
