### PR TITLE
[FIX] sale: translate down payment product name

### DIFF
--- a/addons/sale/i18n/sale.pot
+++ b/addons/sale/i18n/sale.pot
@@ -1446,6 +1446,12 @@ msgid "Down Payments"
 msgstr ""
 
 #. module: sale
+#: code:addons/sale/wizard/sale_make_invoice_advance.py:0
+#, python-format
+msgid "Down payment"
+msgstr ""
+
+#. module: sale
 #: model:ir.model.fields.selection,name:sale.selection__sale_advance_payment_inv__advance_payment_method__fixed
 msgid "Down payment (fixed amount)"
 msgstr ""

--- a/addons/sale/wizard/sale_make_invoice_advance.py
+++ b/addons/sale/wizard/sale_make_invoice_advance.py
@@ -186,7 +186,7 @@ class SaleAdvancePaymentInv(models.TransientModel):
 
     def _prepare_deposit_product(self):
         return {
-            'name': 'Down payment',
+            'name': _('Down payment'),
             'type': 'service',
             'invoice_policy': 'order',
             'property_account_income_id': self.deposit_account_id.id,

--- a/doc/cla/individual/domenicostragapede.md
+++ b/doc/cla/individual/domenicostragapede.md
@@ -1,0 +1,7 @@
+Italy, 2021-05-30
+
+I hereby agree to the terms of the Odoo Individual Contributor License Agreement v1.0.
+I declare that I am authorized and able to make this agreement and sign this declaration.
+
+Signed,
+Domenico Stragapede domenico_stragapede@libero.it https://github.com/domenicostragapede


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
Translate the product name "Down payment" when it is created "on the fly" from wizard.

Current behavior before PR: 
The down payment product has a "Down Payment" name, regardless the language used.

Desired behavior after PR is merged:
The name of the product is translated into the correct system language.

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
