### PR TITLE
[FIX] website_forum: post image in forum with 30 karma

### DIFF
--- a/addons/website_forum/models/forum.py
+++ b/addons/website_forum/models/forum.py
@@ -401,7 +401,7 @@ class Post(models.Model):
                 match = re.escape(match)  # replace parenthesis or special char in regex
                 content = re.sub(match, match[:3] + 'rel="nofollow" ' + match[3:], content)
 
-        if self.env.user.karma <= forum.karma_editor:
+        if self.env.user.karma < forum.karma_editor:
             filter_regexp = r'(<img.*?>)|(<a[^>]*?href[^>]*?>)|(<[a-z|A-Z]+[^>]*style\s*=\s*[\'"][^\'"]*\s*background[^:]*:[^url;]*url)'
             content_match = re.search(filter_regexp, content, re.I)
             if content_match:


### PR DESCRIPTION
Users with 30 karma cannot use images in their forum post

Steps to reproduce:
1. Install the Forum app
2. Change the portal user's karma to 30 (you can use this command in
psql: `UPDATE public.res_users SET karma=30 WHERE id=7;`)
3. Connect as portal
4. Go to the forum and create a new post
5. Add a title and an image to the post and validate it
6. An error message is displayed preventing the user from posting the
image even though he should be able to

Solution:
Adapt the condition on the user's karma

opw-2648770