### PR TITLE
[FIX] point_of_sale: prevent crash with float quantity when edit lot

### DIFF
--- a/addons/point_of_sale/static/src/js/models.js
+++ b/addons/point_of_sale/static/src/js/models.js
@@ -1882,6 +1882,7 @@ exports.Orderline = Backbone.Model.extend({
     getPackLotLinesToEdit: function(isAllowOnlyOneLot) {
         const currentPackLotLines = this.pack_lot_lines.models;
         let nExtraLines = Math.abs(this.quantity) - currentPackLotLines.length;
+        nExtraLines = Math.ceil(nExtraLines);
         nExtraLines = nExtraLines > 0 ? nExtraLines : 1;
         const tempLines = currentPackLotLines
             .map(lotLine => ({


### PR DESCRIPTION
Current behavior:
In the PoS if you add a tracked product that uses "kg" as uom
and change the quantity to any float value. After that, if you try
to modify the lot number you get an error.

Steps to reproduce:
- Have PoS installed
- Create a tracked product that use kg as uom
- Open PoS session
- Add the product to the order and modify the quantity to any float
  value
- Click on the green lines to edit the lot number
- You get an error

opw-2861426
--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
