### PR TITLE
[FIX] hr_expense: fix expense total computation

### DIFF
--- a/addons/hr_expense/tests/test_expenses.py
+++ b/addons/hr_expense/tests/test_expenses.py
@@ -350,3 +350,31 @@ class TestExpenses(TestExpenseCommon):
         move = self.env['account.payment'].browse(action['res_id']).move_id
         move.button_cancel()
         self.assertEqual(sheet.state, 'cancel', 'Sheet state must be cancel when the payment linked to that sheet is canceled')
+
+    def test_expense_amount_total_signed_compute(self):
+        sheet = self.env['hr.expense.sheet'].create({
+            'company_id': self.env.company.id,
+            'employee_id': self.expense_employee.id,
+            'name': 'test sheet',
+            'expense_line_ids': [
+                (0, 0, {
+                    'name': 'expense_1',
+                    'date': '2016-01-01',
+                    'product_id': self.product_a.id,
+                    'unit_amount': 10.0,
+                    'employee_id': self.expense_employee.id
+                }),
+            ],
+        })
+
+
+        #actions
+        sheet.action_submit_sheet()
+        sheet.approve_expense_sheets()
+        sheet.action_sheet_move_create()
+        action_data = sheet.action_register_payment()
+        wizard = Form(self.env['account.payment.register'].with_context(action_data['context'])).save()
+        action = wizard.action_create_payments()
+
+        move = self.env['account.payment'].browse(action['res_id']).move_id
+        self.assertEqual(move.amount_total_signed, 10.0, 'The total amount of the payment move is not correct')

--- a/addons/hr_expense/wizard/account_payment_register.py
+++ b/addons/hr_expense/wizard/account_payment_register.py
@@ -26,6 +26,8 @@ class AccountPaymentRegister(models.TransientModel):
             expenses = vals['batch']['lines'].expense_id
             if expenses:
                 payment.line_ids.write({'expense_id': expenses[0].id})
+                receivable_lines = payment.line_ids.filtered(lambda line: line.account_id.user_type_id.type in ('receivable', 'payable'))
+                receivable_lines.write({'exclude_from_invoice_tab': True})
         return payments
 
     def _reconcile_payments(self, to_process, edit_mode=False):


### PR DESCRIPTION
### Current behavior
The amount shown for an expense is equals to 0 instead of the real price.

### Steps
- Install Expenses, Accounting
- Create an expense and finish the flow (register payment included)
- In Accounting app, go to Vendors > Payments
- In this view, amount is equals to 0 but the amount is correct in individual view

### Note
Since this commit [1], `expense_id` is added on move.line so that `_payment_state_matters` now returns True [2]. We are now entering this condition [3].

This causes some issues when recording payments for our expense. Indeed, the 2 lines (credit + debit) enter this condition [4] but debit line should be treated by this block [5] otherwise the 2 lines cancel each other out.

### Solution
Add `exclude_from_invoice_tab = True` receivable/payable expense payment lines

[1] : https://github.com/odoo/odoo/commit/16459957d23f4bdfddfe96d72ef96cbdc6fec539#diff-5bee371350ae80995abbea23e800bfb1c52f968db6c9dc59f2681ac415d34103R27-R28
[2] : https://github.com/odoo/odoo/blob/1e3a9c90908f37d19f4aa1bbcb81568dea9fd451/addons/hr_expense/models/account_move_line.py#L9-L13
[3] : https://github.com/odoo/odoo/blob/d6ca59ed9bf6877ee6b1b311223472adfa4db549/addons/account/models/account_move.py#L1419
[4] : https://github.com/odoo/odoo/blob/d6ca59ed9bf6877ee6b1b311223472adfa4db549/addons/account/models/account_move.py#L1422
[5] : https://github.com/odoo/odoo/blob/d6ca59ed9bf6877ee6b1b311223472adfa4db549/addons/account/models/account_move.py#L1434-L1438

OPW-2838105
