### PR TITLE
[FIX] account: 'Tax Included in Price' not checked

### DIFF
--- a/addons/account/models/account_reconcile_model.py
+++ b/addons/account/models/account_reconcile_model.py
@@ -383,6 +383,8 @@ class AccountReconcileModel(models.Model):
                 # only allow to set the force_tax_included field if we have one tax selected
                 if line.force_tax_included:
                     tax = tax[0].with_context(force_price_include=True)
+                    if self._context.get('show_force_tax_included'):
+                        writeoff_line['force_tax_included'] = True
                 tax_vals_list = self._get_taxes_move_lines_dict(tax, writeoff_line)
                 lines_vals_list += tax_vals_list
                 if not line.force_tax_included:


### PR DESCRIPTION
Create a reconciliation model 'TEST' with counterpart values applying a
tax and 'Tax Included in Price' active
Make an invoice for 110
Make a Bank statement for 100, click 'Reconcile', add the invoice, edit
the invoice amount to match the original 110
Click on 'Open Balance', under 'Manual Operations' click on 'TEST'.

The data from the reconciliation model will load but the checkbox 'Tax
included in Price' will be unchecked even if the tax is correctly
calculated as included in price

opw-2854377

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
