### PR TITLE
[FIX] mail: allow tracking values not loaded into registry

### DIFF
--- a/addons/mail/models/mail_tracking_value.py
+++ b/addons/mail/models/mail_tracking_value.py
@@ -64,7 +64,7 @@ class MailTracking(models.Model):
             })
         elif col_info['type'] == 'selection':
             values.update({
-                'old_value_char': initial_value and dict(col_info['selection'])[initial_value] or '',
+                'old_value_char': initial_value and dict(col_info['selection']).get(initial_value, initial_value) or '',
                 'new_value_char': new_value and dict(col_info['selection'])[new_value] or ''
             })
         elif col_info['type'] == 'many2one':

--- a/addons/test_mail/models/test_mail_corner_case_models.py
+++ b/addons/test_mail/models/test_mail_corner_case_models.py
@@ -24,3 +24,12 @@ class MailTestFieldType(models.Model):
         if not self._context.get('default_type'):
             self = self.with_context(default_type='first')
         return super(MailTestFieldType, self).create(vals_list)
+
+class MailTestSelectionTracking(models.Model):
+    """ Test tracking for selection fields """
+    _description = 'Test Selection Tracking'
+    _name = 'mail.test.track.selection'
+    _inherit = ['mail.thread']
+
+    name = fields.Char()
+    type = fields.Selection([('first', 'First'), ('second', 'Second')], tracking=True)

--- a/addons/test_mail/security/ir.model.access.csv
+++ b/addons/test_mail/security/ir.model.access.csv
@@ -20,3 +20,5 @@ access_mail_test_cc_portal,mail.test.cc.portal,model_mail_test_cc,base.group_por
 access_mail_test_cc_user,mail.test.cc.user,model_mail_test_cc,base.group_user,1,1,1,1
 access_mail_test_multi_company_user,mail.test.multi.company.user,model_mail_test_multi_company,base.group_user,1,1,1,1
 access_mail_test_multi_company_portal,mail.test.multi.company.portal,model_mail_test_multi_company,base.group_portal,1,0,0,0
+access_mail_test_track_selection_portal,mail.test.track.selection.portal,model_mail_test_track_selection,base.group_portal,0,0,0,0
+access_mail_test_track_selection_user,mail.test.track.selection.user,model_mail_test_track_selection,base.group_user,1,1,1,1


### PR DESCRIPTION
Use `dict.get()` instead of a subscriptable call. This way we let through
selection values that are not loaded into the registry, instead of raising an error.

This is especially useful in the upgrade environment
where such values may be unavailable (because of being
lambda-defined in a custom module for instance). 

Aims to generically fix the following tracebacks during an upgrade:

```
Traceback (most recent call last):
  File "/home/odoo/src/odoo/14.0/odoo/service/server.py", line 1201, in preload_registries
    registry = Registry.new(dbname, update_module=update_module)
  File "/home/odoo/src/odoo/14.0/odoo/modules/registry.py", line 89, in new
    odoo.modules.load_modules(registry._db, force_demo, status, update_module)
  File "/home/odoo/src/odoo/14.0/odoo/modules/loading.py", line 475, in load_modules
    migrations.migrate_module(package, 'end')
  File "/home/odoo/src/odoo/14.0/odoo/modules/migration.py", line 180, in migrate_module
    migrate(self.cr, installed_version)
  File "/tmp/tmpy41hhfba/migrations/mrp/saas~13.4.2.0/end-migrate.py", line 375, in migrate
    util.recompute_fields(cr, "mrp.production", ["state", "production_location_id"], strategy="commit")
  File "/tmp/tmpy41hhfba/migrations/util/orm.py", line 188, in recompute_fields
    cr.commit()
  File "<decorator-gen-7>", line 2, in commit
  File "/home/odoo/src/odoo/14.0/odoo/sql_db.py", line 101, in check
    return f(self, *args, **kwargs)
  File "/home/odoo/src/odoo/14.0/odoo/sql_db.py", line 445, in commit
    self.precommit.run()
  File "/home/odoo/src/odoo/14.0/odoo/tools/misc.py", line 1154, in run
    func()
  File "/home/odoo/src/odoo/14.0/addons/mail/models/mail_thread.py", line 550, in _finalize_tracking
    tracking = records.with_context(context).message_track(fnames, initial_values)
  File "/home/odoo/src/odoo/14.0/addons/mail/models/mail_thread.py", line 611, in message_track
    tracking[record.id] = record._message_track(tracked_fields, initial_values[record.id])
  File "/home/odoo/src/odoo/14.0/addons/mail/models/mail_thread.py", line 641, in _message_track
    return self._mail_track(tracked_fields, initial)
  File "/home/odoo/src/odoo/14.0/addons/mail/models/models.py", line 47, in _mail_track
    tracking = self.env['mail.tracking.value'].create_tracking_values(initial_value, new_value, col_name, col_info, tracking_sequence, self._name)
  File "/home/odoo/src/odoo/14.0/addons/mail/models/mail_tracking_value.py", line 71, in create_tracking_values
    'old_value_char': initial_value and dict(col_info['selection'])[initial_value] or '',
KeyError: 'picking_except'
```


--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
