### PR TITLE
Fix subcontractiong MTO rule type

### DIFF
--- a/addons/mrp_subcontracting/models/stock_warehouse.py
+++ b/addons/mrp_subcontracting/models/stock_warehouse.py
@@ -69,7 +69,7 @@ class StockWarehouse(models.Model):
             'subcontracting_mto_pull_id': {
                 'depends': ['subcontracting_to_resupply'],
                 'create_values': {
-                    'procure_method': 'make_to_order',
+                    'procure_method': 'mts_else_mto',
                     'company_id': self.company_id.id,
                     'action': 'pull',
                     'auto': 'manual',


### PR DESCRIPTION
This leads to mto to trigger (purchase) even if the product exists in the stock. Problem also exists in 14.0 15.0...

Description of the issue/feature this PR addresses:
This leads to mto to trigger (purchase) even if the product exists in the stock.

Current behavior before PR:
 trigger (purchase) even if the product exists in the stock.

Desired behavior after PR is merged:
use the stock if the product exists in the stock.




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
