### PR TITLE
[FIX][14.0] discuss: error breadcrumb

### DIFF
--- a/addons/mail/static/src/widgets/discuss/discuss.js
+++ b/addons/mail/static/src/widgets/discuss/discuss.js
@@ -147,6 +147,7 @@ const DiscussWidget = AbstractAction.extend({
             'o-update-control-panel',
             this._updateControlPanelEventListener
         );
+        this._lastPushStateActiveThread = null;
     },
 
     //--------------------------------------------------------------------------


### PR DESCRIPTION
Before this commit
When discuss is the final state, the system will not change the browser url.

After this commit:
Browser url will be correct when using breadcrumb

Step 1: open discuss inbox/history
Step 2: open record from inbox/history
Step 3: use breadcrumb to back discuss
Now, browser's url is wrong.




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
