### PR TITLE
[Fix] change_volume_dimension_unit_to_inch

### DIFF
--- a/addons/product/models/product_template.py
+++ b/addons/product/models/product_template.py
@@ -316,7 +316,7 @@ class ProductTemplate(models.Model):
         """
         product_length_in_feet_param = self.env['ir.config_parameter'].sudo().get_param('product.volume_in_cubic_feet')
         if product_length_in_feet_param == '1':
-            return self.env.ref('uom.product_uom_foot')
+            return self.env.ref('uom.product_uom_inch')
         else:
             return self.env.ref('uom.product_uom_millimeter')
 


### PR DESCRIPTION
Due to the fact that the only avaliable volume unit in odoo 15 is feet for imperial system,
Users can not create packages that have less then 1 foot dimension. This commit changes feet
to inches, so the lowest volume for package can be 1 inch^3 instead of 1 foot^3



--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
