### PR TITLE
[FIX] point_of_sale: correctly create ML with tracked product

### DIFF
--- a/addons/point_of_sale/models/pos_order.py
+++ b/addons/point_of_sale/models/pos_order.py
@@ -1110,7 +1110,7 @@ class PosOrderLine(models.Model):
                     lines = self.env['pos.order.line'].concat(*lines)
                     moves = pickings_to_confirm.move_lines.filtered(lambda m: m.product_id in tracked_lines.product_id)
                     mls_to_unlink |= moves.move_line_ids
-                    moves._add_mls_related_to_order(lines, are_qties_done=False)
+                    moves[0]._add_mls_related_to_order(lines, are_qties_done=False)
                 mls_to_unlink.unlink()
         return True
 


### PR DESCRIPTION
Current behavior:
When selling a tracked product in PoS and selecting the Ship later
option if you configured the 3 steps delivery you were able to
validate the first picking but not the second.

Steps to reproduce:
- Have PoS installed
- Create a product tracked by lot and update it's quantity
- Set the 3 steps delivery route in the PoS
- Start a PoS session and sell the tracked product
- Go in the PoS orders
- Go in the order you juste made and go in the pickings
- Go in the first picking, validate it
- Go in the second picking, try to validate it
- You get a message "It is not possible to unreserve ..."

opw-2854159
--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
