### PR TITLE
[FIX] website: resolve bug when removing a popup

### DIFF
--- a/addons/website/static/src/snippets/s_popup/options.js
+++ b/addons/website/static/src/snippets/s_popup/options.js
@@ -24,7 +24,7 @@ options.registry.SnippetPopup = options.Class.extend({
                 iframe.src = media.dataset.oeExpression || media.dataset.src; // TODO still oeExpression to remove someday
             });
         });
-        this.$target.on('hidden.bs.modal.SnippetPopup', () => {
+        this.$target.on('hide.bs.modal.SnippetPopup', () => {
             this.trigger_up('snippet_option_visibility_update', {show: false});
             this._removeIframeSrc();
         });


### PR DESCRIPTION
This commits provides a solution to the traceback appearing when
removing a popup under certain conditions.

Steps to reproduce the bug:
- Drag and drop a popup snippet
- Drag and drop 2 or more text-image in the popup
- Delete the popup
=> traceback

the solution is to trigger snippet_option_visibility_update at event hide.bs.modal.SnippetPopup rather than at event hidden.bs.modal.SnippetPopup so we don't wait until the hide animation is finished to trigger

task-2824253