### PR TITLE
[FIX] website_event_questions: support searching on attendees answers

### DIFF
--- a/addons/website_event_questions/models/event_registration.py
+++ b/addons/website_event_questions/models/event_registration.py
@@ -1,7 +1,8 @@
 # -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
-from odoo import fields, models
+from odoo import api, fields, models
+from odoo.osv import expression
 
 
 class EventRegistration(models.Model):
@@ -37,3 +38,22 @@ class EventRegistrationAnswer(models.Model):
              )
             for reg in self
         ]
+
+    @api.model
+    def _name_search(self, name='', args=None, operator='ilike', limit=100, name_get_uid=None):
+        """ Search records whose selected answer or text answer are matching the ``name`` argument. """
+        if name and operator == 'ilike':
+            if not args:
+                args = []
+
+            # search on both selected answer OR text answer (combined with passed args)
+            selected_answer_domain = [('value_answer_id', operator, name)]
+            text_answer_domain = [('value_text_box', operator, name)]
+            domain = expression.AND([args, expression.OR([
+                selected_answer_domain,
+                text_answer_domain,
+            ])])
+        else:
+            domain = args or []
+
+        return self._search(domain, limit=limit, access_rights_uid=name_get_uid)

--- a/addons/website_event_questions/tests/test_event_internals.py
+++ b/addons/website_event_questions/tests/test_event_internals.py
@@ -75,3 +75,61 @@ class TestEventData(TestEventQuestionCommon):
                 (0, 0, {'question_id': self.event_question_2.id, 'value_answer_id': 7}),
                 (0, 0, {'question_id': self.event_question_3.id, 'value_text_box': 'Free Text'})]}
         ])
+
+    def test_registration_answer_search(self):
+        """ Test our custom name_search implementation in 'event.registration.answer'.
+        We search on both the 'value_answer_id' and 'value_text_box' fields to allow users to easily
+        filter registrations based on the selected answers of the attendees. """
+
+        event = self.env['event.event'].create({
+            'name': 'Test Event',
+            'event_type_id': self.event_type_complex.id,
+            'date_begin': FieldsDatetime.to_string(datetime.today() + timedelta(days=1)),
+            'date_end': FieldsDatetime.to_string(datetime.today() + timedelta(days=15)),
+        })
+
+        [registration_1, registration_2, registration_3] = self.env['event.registration'].create([{
+            'event_id': event.id,
+            'partner_id': self.env.user.partner_id.id,
+            'registration_answer_ids': [
+                (0, 0, {
+                    'question_id': self.event_question_1.id,
+                    'value_answer_id': self.event_question_1.answer_ids[0].id,
+                }),
+            ]
+        }, {
+            'event_id': event.id,
+            'partner_id': self.env.user.partner_id.id,
+            'registration_answer_ids': [
+                (0, 0, {
+                    'question_id': self.event_question_1.id,
+                    'value_answer_id': self.event_question_1.answer_ids[1].id,
+                }),
+                (0, 0, {
+                    'question_id': self.event_question_3.id,
+                    'value_text_box': "My Answer",
+                }),
+            ]
+        }, {
+            'event_id': event.id,
+            'partner_id': self.env.user.partner_id.id,
+            'registration_answer_ids': [
+                (0, 0, {
+                    'question_id': self.event_question_3.id,
+                    'value_text_box': "Answer2",
+                }),
+            ]
+        }])
+
+        search_res = self.env['event.registration'].search([
+            ('registration_answer_ids', 'ilike', 'Answer1')
+        ])
+        # should fetch "registration_1" because the answer to the first question is "Q1-Answer1"
+        self.assertEqual(search_res, registration_1)
+
+        search_res = self.env['event.registration'].search([
+            ('registration_answer_ids', 'ilike', 'Answer2')
+        ])
+        # should fetch "registration_2" because the answer to the first question is "Q1-Answer2"
+        # should fetch "registration_3" because the answer to the third question is "Answer2" (as free text)
+        self.assertEqual(search_res, registration_2 | registration_3)


### PR DESCRIPTION
Since: a0092d0011ec62de62e46dfa57cd16ff83bd7201

Users can see attendees' selected answers in the registrations list view using
an optional field ("registration_answer_ids").

However, searching on this field is currently not correctly supported as the
"event.registration.answer" model does not implement it (no "_rec_name" and no
"_name_search" override).

This commit adds a "_name_search" override to allow users to search on both
"value_answer_id" and "value_text_box" fields.
This makes it easy to search for all attendees that have filled in a specific
answer, allowing a better organization of the event based on question results.

Side-note: This commit will not be forward-ported up to master and will instead
be replaced by the new "_rec_names_search" attribute introduced in:
3155c3e425581b71491844e7f9a3dd76a9f245a4

Task-2868203
