### PR TITLE
[FIX] website_event_questions: support searching on attendees answers

### DIFF
--- a/addons/website_event_questions/models/event_registration.py
+++ b/addons/website_event_questions/models/event_registration.py
@@ -14,6 +14,7 @@ class EventRegistrationAnswer(models.Model):
     """ Represents the user input answer for a single event.question """
     _name = 'event.registration.answer'
     _description = 'Event Registration Answer'
+    _rec_names_search = ['value_answer_id', 'value_text_box']
 
     question_id = fields.Many2one(
         'event.question', ondelete='restrict', required=True,


### PR DESCRIPTION
Since: a0092d0011ec62de62e46dfa57cd16ff83bd7201

Users can see attendees' selected answers in the registrations list view using
an optional field ("registration_answer_ids").

However, searching on this field is currently not correctly supported as the
"event.registration.answer" model does not implement it (no "_rec_name" and no
"_rec_names_search").

This commit adds a "_rec_names_search" attribute to allow users to search on
both "value_answer_id" and "value_text_box" fields.
This makes it easy to search for all attendees that have filled in a specific
answer, allowing a better organization of the event based on question results.

Task-2868203
