### PR TITLE
[FIX] sale_product_configurator: do not allow template change in wizard

### DIFF
--- a/addons/sale_product_configurator/wizard/sale_product_configurator_views.xml
+++ b/addons/sale_product_configurator/wizard/sale_product_configurator_views.xml
@@ -6,7 +6,7 @@
         <field name="arch" type="xml">
             <form js_class="product_configurator_form">
                 <group>
-                    <field name="product_template_id" class="oe_product_configurator_product_template_id" />
+                    <field name="product_template_id" class="oe_product_configurator_product_template_id" options="{'no_open': True}" readonly="1"/>
                     <field name="product_template_attribute_value_ids" invisible="1">
                         <tree limit="10000"/>
                     </field>


### PR DESCRIPTION
Since #73086, product configurator flow uses one single wizard popup
for both product configuration and optional products choice.

Nevertheless, the modal to only customize the product still exists,
and is shown when the user clicks on the pencil icon next to the product,
to edit the product configuration.

It has been recently spotted that this modal behaves strangely and closes
directly when another template is chosen in the dedicated field.

Considering that the correct behavior when choosing another template is to
either make a new line or to change the product directly on the SO line,
this commit makes the field readonly.

This way, when you choose another template with optional products, those
optional products will still be shown correctly (which didn't happen if
you chose another template in the modal to edit the configuration).


--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
