### PR TITLE
[FIX] privacy_lookup: fix xml id not found error

### DIFF
--- a/addons/privacy_lookup/models/res_partner.py
+++ b/addons/privacy_lookup/models/res_partner.py
@@ -9,7 +9,7 @@ class ResPartner(models.Model):
 
     def action_privacy_lookup(self):
         self.ensure_one()
-        action = self.env['ir.actions.act_window']._for_xml_id('privacy.action_privacy_lookup_wizard')
+        action = self.env['ir.actions.act_window']._for_xml_id('privacy_lookup.action_privacy_lookup_wizard')
         action['context'] = {
             'default_email': self.email,
             'default_name': self.name,


### PR DESCRIPTION
In privacy_lookup, an action is called with a XML id that is not existing.
This commit fixes the traceback received by pointing to the correct XML id.

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
