### PR TITLE
[FIX] purchase_stock: keep qty on return

### DIFF
--- a/addons/purchase_stock/models/purchase.py
+++ b/addons/purchase_stock/models/purchase.py
@@ -262,13 +262,14 @@ class PurchaseOrderLine(models.Model):
                             pass
                         elif (
                             move.location_dest_id.usage == "internal"
-                            and move.to_refund
+                            and move.location_id.usage != "supplier"
                             and move.location_dest_id
                             not in self.env["stock.location"].search(
                                 [("id", "child_of", move.warehouse_id.view_location_id.id)]
                             )
                         ):
-                            total -= move.product_uom._compute_quantity(move.product_uom_qty, line.product_uom, rounding_method='HALF-UP')
+                            if move.to_refund:
+                                total -= move.product_uom._compute_quantity(move.product_uom_qty, line.product_uom, rounding_method='HALF-UP')
                         else:
                             total += move.product_uom._compute_quantity(move.product_uom_qty, line.product_uom, rounding_method='HALF-UP')
                 line.qty_received = total


### PR DESCRIPTION
When purchase is returned, the product may move to internal location first. If
option `Update quantities on SO/PO` is active, it does decrease the qty. However, when the
option is disabled, it increase the qty instead of doing nothing.

Fix it by making a proper if-else block structure

STEPS:

- Create a PO, confirm it and receive the product
- On the transfer, make a return to a location that is not a child of your warehouse (PhysicalLocations/W/...), for instance, choose the location Physical Locations/Subcontracting Location
- Untick the "Update quantities on SO/PO" (visible in debug), and validate the return transfer
- Check your initial PO

BEFORE: the received quantities have been updated, even if we asked not to do it
AFTER: the received quantities is not changed

opw-2858390

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
