### PR TITLE
[FIX] web_editor: remove style of a link

### DIFF
--- a/addons/web_editor/static/src/js/wysiwyg/widgets/link.js
+++ b/addons/web_editor/static/src/js/wysiwyg/widgets/link.js
@@ -198,7 +198,7 @@ const Link = Widget.extend({
             href: data.url,
             target: data.isNewWindow ? '_blank' : '',
         });
-        if (data.classes) {
+        if (typeof data.classes === "string") {
             data.classes = data.classes.replace(/o_default_snippet_text/, '');
             attrs.class = `${data.classes}`;
         }


### PR DESCRIPTION
Before this commit
When removing the style of a link in an html_field, the style was
not removed.

After this commit
When removing the style of a link in an html_field, the style is
removed.

task-2857072





--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
