### PR TITLE
[FIX] purchase: display bank account correctly on vendor bill when the vendor is a person attached to a company 

### DIFF
--- a/addons/purchase/models/purchase.py
+++ b/addons/purchase/models/purchase.py
@@ -547,7 +547,12 @@ class PurchaseOrder(models.Model):
             raise UserError(_('Please define an accounting purchase journal for the company %s (%s).') % (self.company_id.name, self.company_id.id))
 
         partner_invoice_id = self.partner_id.address_get(['invoice'])['invoice']
-        partner_bank_id = self.partner_id.bank_ids.filtered_domain(['|', ('company_id', '=', False), ('company_id', '=', self.company_id.id)])[:1]
+
+        if self.partner_id.company_type == 'person' and self.partner_id.parent_id:
+            partner_bank_id = self.partner_id.parent_id.bank_ids.filtered_domain(['|', ('company_id', '=', False), ('company_id', '=', self.company_id.id)])[:1]
+        else:
+            partner_bank_id = self.partner_id.bank_ids.filtered_domain(['|', ('company_id', '=', False), ('company_id', '=', self.company_id.id)])[:1]
+            
         invoice_vals = {
             'ref': self.partner_ref or '',
             'move_type': move_type,

--- a/addons/purchase/models/purchase.py
+++ b/addons/purchase/models/purchase.py
@@ -552,7 +552,7 @@ class PurchaseOrder(models.Model):
             partner_bank_id = self.partner_id.parent_id.bank_ids.filtered_domain(['|', ('company_id', '=', False), ('company_id', '=', self.company_id.id)])[:1]
         else:
             partner_bank_id = self.partner_id.bank_ids.filtered_domain(['|', ('company_id', '=', False), ('company_id', '=', self.company_id.id)])[:1]
-            
+
         invoice_vals = {
             'ref': self.partner_ref or '',
             'move_type': move_type,


### PR DESCRIPTION
Description of the issue/feature this PR addresses:

When creating a vendor bill using the auto-complete feature for a purchase made to a person of a company, the bank account number field would not fill automatically

Database (V14): sircle.odoo.com

Exact steps (or video) to reproduce the issue (on customer DB): https://watch.screencastify.com/v/3O3fOCMTW0ocV8z4iizH

Same behaviour on runbot: - V14: https://watch.screencastify.com/v/xCj1kqQgcvE6nRhyDgFU

                                              - V15: https://watch.screencastify.com/v/nMv143kCPV7b1yGn5coN
Exact steps (or video) of correct behavior (on runbot V13): https://watch.screencastify.com/v/LV3jtdze0y1lMbhefP2y

Other info : I've noticed that the old number was still on the contact of the company (see screenshot in chatter). After removing it, I have the same behaviour, except that once I add the PO to the bill, the right account number disappears.

Current behavior before PR:

The "bank account number" field remains empty

Desired behavior after PR is merged:

The bank account number of the parent company automatically populate the field when the purchase order is selected.

Steps to solve the problem:

Added a check to the invoice generation in the purchase module. If the partner_id is a person and belong to a company, use that bank account. If not, use the bank account of the partner_id.

--
I confirm I have signed the CLA and read the PR guidelines at [www.odoo.com/submit-pr](http://www.odoo.com/submit-pr)