### PR TITLE
[IMP] web: update owl from 2.0.0-beta-7 to 2.0.0-beta-8

### DIFF
--- a/addons/web/static/src/search/with_search/with_search.js
+++ b/addons/web/static/src/search/with_search/with_search.js
@@ -96,7 +96,7 @@ WithSearch.props = {
     // search view description
     searchViewArch: { type: String, optional: true },
     searchViewFields: { type: Object, optional: true },
-    searchViewId: { type: [Number, false], optional: true },
+    searchViewId: { type: [Number, Boolean], optional: true },
 
     irFilters: { type: Array, element: Object, optional: true },
     loadIrFilters: { type: Boolean, optional: true },

--- a/addons/web/static/tests/core/dialog_tests.js
+++ b/addons/web/static/tests/core/dialog_tests.js
@@ -70,7 +70,7 @@ QUnit.module("Components", (hooks) => {
             `;
 
         const env = await makeTestEnv();
-        parent = await mount(Parent, target, { env, props: {} });
+        parent = await mount(Parent, target, { env, props: { close: () => {} } });
         assert.containsOnce(target, ".o_dialog");
         assert.containsOnce(
             target,


### PR DESCRIPTION
Release notes:
https://github.com/odoo/owl/releases/tag/v2.0.0-beta-8

Fixes
-----

- portal: allow use of expression to describe portal target
- compiler: fix issue with identifiers with same name
- reactivity: fix memory leak
- app: validate props for root component in dev mode

Improvements
------------

- component: display nice error for wrong child component
- props_validation: have clearer error messages
- component: only useState on props that are already reactive
- compiler: add better support for "in" and "new" operators in templates
- misc: export the validate function
- app: add setting to warn if no static props object
- add static App.registerTemplate and update Portal to use it
- add basic infrastructure to buid owl-runtime without compiler

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
