### PR TITLE
[FIX] delivery: real cost not set to 0 for ecommerce

### DIFF
--- a/addons/delivery/models/sale_order.py
+++ b/addons/delivery/models/sale_order.py
@@ -112,7 +112,7 @@ class SaleOrder(models.Model):
             'is_delivery': True,
         }
         if carrier.invoice_policy == 'real':
-            values['price_unit'] = 0
+            values['price_unit'] = 0 if 'website_id' not in self.env.context else price_unit
             values['name'] += _(' (Estimated Cost: %s )') % self._format_currency_amount(price_unit)
         else:
             values['price_unit'] = price_unit


### PR DESCRIPTION
How to reproduce the bug ?

- install ecommerce and fedex
- publish a fedex delivery method with a policy
  set to real cost (you can change the policy on an
  existing method).
- go to website and add an item in your basket
- click on the basket to check it ou
- once you are on the screen to select the delivery
  method, click on the fedex one.

What is the bug ?

When you have a "real cost" delivery method available on your website,
the delivery cost is set to 0 exactly like a normal quotation. However,
on the website, once you validate your basket on the delivery/payment
method, the cost must be added since it is not possible to add it after.

opw-2835118

Signed-off-by: Adrien Minet <admi@odoo.com>

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
