### PR TITLE
[FIX] payment: fix misplaced sudo

### DIFF
--- a/addons/payment/models/account_payment.py
+++ b/addons/payment/models/account_payment.py
@@ -44,8 +44,8 @@ class AccountPayment(models.Model):
 
     def _compute_amount_available_for_refund(self):
         for payment in self:
-            tx = payment.payment_transaction_id
-            if tx.acquirer_id.sudo().support_refund and tx.operation != 'refund':
+            tx_sudo = payment.payment_transaction_id.sudo()
+            if tx_sudo.acquirer_id.support_refund and tx_sudo.operation != 'refund':
                 # Only consider refund transactions that are confirmed by summing the amounts of
                 # payments linked to such refund transactions. Indeed, should a refund transaction
                 # be stuck forever in a transient state (due to webhook failure, for example), the


### PR DESCRIPTION
On 02eba891cb8cd58985837090f2b60cf263bce065
we changed
https://github.com/odoo/odoo/blob/b5cf1ee3e21f2e60b8edd64f24c04c952fb7df3f/addons/payment/models/account_payment.py#L47
to
https://github.com/odoo/odoo/blob/02eba891cb8cd58985837090f2b60cf263bce065/addons/payment/models/account_payment.py#L47-L48
Effectively moving the place where `sudo` is called.

This causes issues during migration of some DBs
upg-328570

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
