### PR TITLE
[FIX] mail: correct mistakes introduced with new environment

### DIFF
--- a/addons/knowledge/static/src/components/permission_panel/permission_panel.js
+++ b/addons/knowledge/static/src/components/permission_panel/permission_panel.js
@@ -253,7 +253,7 @@ class PermissionPanel extends Component {
             const userId = userIds && userIds.length === 1 ? userIds[0] : false;
 
             if (userId) {
-                const messaging = await Component.env.services.messaging.get();
+                const messaging = await this.env.services.messaging.get();
                 messaging.openChat({
                     userId: userId
                 });

--- a/addons/mail/static/src/components/chat_window_manager_container/chat_window_manager_container.js
+++ b/addons/mail/static/src/components/chat_window_manager_container/chat_window_manager_container.js
@@ -5,7 +5,7 @@ import { useModels } from '@mail/component_hooks/use_models';
 import '@mail/components/chat_window_manager/chat_window_manager';
 import { getMessagingComponent } from "@mail/utils/messaging_component";
 
-const { Component, useSubEnv } = owl;
+const { Component } = owl;
 
 export class ChatWindowManagerContainer extends Component {
 
@@ -13,9 +13,6 @@ export class ChatWindowManagerContainer extends Component {
      * @override
      */
     setup() {
-        // for now, the legacy env is needed for internal functions such as
-        // `useModels` to work
-        useSubEnv(Component.env);
         useModels();
         super.setup();
     }

--- a/addons/mail/static/src/main.js
+++ b/addons/mail/static/src/main.js
@@ -19,7 +19,7 @@ const serviceRegistry = registry.category('services');
 serviceRegistry.add('messaging', messagingService);
 serviceRegistry.add('messagingValues', messagingValuesService);
 serviceRegistry.add('systray_service', systrayService);
-serviceRegistry.add('messaging_to_legacy_env', makeMessagingToLegacyEnv(owl.Component.env));
+serviceRegistry.add('messaging_service_to_legacy_env', makeMessagingToLegacyEnv(owl.Component.env));
 
 registry.category('actions').add('mail.action_discuss', DiscussContainer);
 

--- a/addons/mail/static/src/models/messaging_notification_handler.js
+++ b/addons/mail/static/src/models/messaging_notification_handler.js
@@ -92,7 +92,7 @@ registerModel({
                         case 'res.users/connection':
                             return this._handleNotificationPartnerUserConnection(message.payload);
                         case 'mail.activity/updated':
-                            return this.env.bus.trigger('activity_updated', message.payload);
+                            return owl.Component.env.bus.trigger('activity_updated', message.payload);
                         case 'mail.channel/unpin':
                             return this._handleNotificationChannelUnpin(message.payload);
                         case 'mail.channel/joined':

--- a/addons/mail/static/src/models/thread.js
+++ b/addons/mail/static/src/models/thread.js
@@ -1724,7 +1724,7 @@ registerModel({
                             return;
                         }
                         await this.fetchData(['followers']);
-                        this.env.bus.trigger('Thread:promptAddFollower-closed');
+                        owl.Component.env.bus.trigger('Thread:promptAddFollower-closed');
                     },
                 }
             );

--- a/addons/mail/static/src/public/discuss_public_boot.js
+++ b/addons/mail/static/src/public/discuss_public_boot.js
@@ -75,11 +75,8 @@ Component.env = legacyEnv;
     mapLegacyEnvToWowlEnv(Component.env, env);
     odoo.isReady = true;
     await mount(MainComponentsContainer, document.body, { env, templates, dev: env.debug });
-    createDiscussPublicView();
-})();
 
-async function createDiscussPublicView() {
-    const messaging = await Component.env.services.messaging.get();
+    const messaging = await env.services.messaging.get();
     messaging.models['Thread'].insert(messaging.models['Thread'].convertData(data.channelData));
     const discussPublicView = messaging.models['DiscussPublicView'].create(data.discussPublicViewData);
     if (discussPublicView.shouldDisplayWelcomeViewInitially) {
@@ -87,4 +84,4 @@ async function createDiscussPublicView() {
     } else {
         discussPublicView.switchToThreadView();
     }
-}
+})();


### PR DESCRIPTION
Some mistakes slipped into the PR introducing the new environment in the discuss
app. This PR fixes those mistakes :

- triggers on this.env.bus that were listen on core.bus
- inconsistent service names between discuss_public_boot/main
- call to Component.env.services.messaging while messaging was available in this.env
- remaining useSubEnv in container that were not needed anymore