### PR TITLE
[FIX] web: enable fast clicking on fields in editable lists

### DIFF
--- a/addons/web/static/src/js/views/list/list_editable_renderer.js
+++ b/addons/web/static/src/js/views/list/list_editable_renderer.js
@@ -96,6 +96,7 @@ ListRenderer.include({
         this.currentRow = null;
         this.currentFieldIndex = null;
         this.isResizing = false;
+        this.isSelectingRow = false;
         this.eventListeners = [];
     },
     /**
@@ -1261,7 +1262,7 @@ ListRenderer.include({
     _selectCell: function (rowIndex, fieldIndex, options) {
         options = options || {};
         // Do nothing if the user tries to select current cell
-        if (!options.force && rowIndex === this.currentRow && fieldIndex === this.currentFieldIndex) {
+        if (this.isSelectingRow || (!options.force && rowIndex === this.currentRow && fieldIndex === this.currentFieldIndex)) {
             return Promise.resolve();
         }
         var wrap = options.wrap === undefined ? true : options.wrap;
@@ -1269,6 +1270,7 @@ ListRenderer.include({
 
         // Select the row then activate the widget in the correct cell
         var self = this;
+        this.isSelectingRow = true;
         return this._selectRow(rowIndex).then(function () {
             var record = self._getRecord(recordID);
             if (fieldIndex >= (self.allFieldWidgets[record.id] || []).length) {
@@ -1289,6 +1291,12 @@ ListRenderer.include({
                 return Promise.reject();
             }
             self.currentFieldIndex = fieldIndex;
+        }).then(function() {
+            self.isSelectingRow = false;
+            return Promise.resolve();
+        }, function() {
+            self.isSelectingRow = false;
+            return Promise.reject();
         });
     },
     /**


### PR DESCRIPTION
When clicking multiple times too fast on a single row of an editable list, we
can raise an exception. Too fast usually too fast compared to the saving time
of a row (e.g. this behavior is easy to spot when a row contains an image).

Step to reproduce the issue:
1) Install the Studio and Sales app
2) Edit the Sales Order form thanks to Studio and update the Order Lines list
view
3) Add an image and a checkbox
4) Create a new Sales Order and add two Order Lines (at least one must have an
image)
5) Edit the description of the line which contains an image and quickly click
two times on the other row (to edit it)
You will see an exception.
The same behavior can be created when making javascript click two times on an
unselected row.

Solution: The issue is that the state of the UI takes times (because of
callbacks) to register which row/column is selected. Normally, the list
prevents from clicking on an already clicked row but as this update takes time,
we can launch another click event to select a row while it is being processed (
remember that this process take some time). To cope with this, we can add a
flag to prevent a click while a click is already being processed.

opw-2743044
