### PR TITLE
[FIX] base, website: allow restricted users to apply shapes on images

### DIFF
--- a/addons/test_website_modules/tests/__init__.py
+++ b/addons/test_website_modules/tests/__init__.py
@@ -2,3 +2,4 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 from . import test_configurator
+from . import test_controllers

--- a/addons/test_website_modules/tests/test_controllers.py
+++ b/addons/test_website_modules/tests/test_controllers.py
@@ -1,0 +1,152 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from base64 import b64encode
+
+from odoo import Command, tests
+from odoo.addons.base.tests.common import HttpCaseWithUserDemo
+from odoo.tools import mute_logger
+from odoo.tools.json import scriptsafe as json_safe
+
+
+@tests.tagged('-at_install', 'post_install')
+class TestWebEditorController(HttpCaseWithUserDemo):
+
+    def test_modify_image(self):
+        gif_base64 = b"R0lGODdhAQABAIAAAP///////ywAAAAAAQABAAACAkQBADs="
+        attachment = self.env['ir.attachment'].create({
+            'name': 'test.gif',
+            'mimetype': 'image/gif',
+            'datas': gif_base64,
+            'public': True,
+            'res_model': 'ir.ui.view',
+            'res_id': 0,
+        })
+
+        def modify(login, name, expect_fail=False):
+            self.authenticate(login, login)
+            svg = b'<svg viewBox="0 0 400 400"><!-- %s --><image url="data:image/gif;base64,%s" /></svg>' % (name.encode('ascii'), gif_base64)
+            params = {
+                'name': name,
+                'mimetype': 'image/svg+xml',
+                'data': b64encode(svg).decode('ascii')
+            }
+            if attachment.res_id:
+                params['res_model'] = attachment.res_model
+                params['res_id'] = attachment.res_id
+            response = self.url_open(
+                f'/web_editor/modify_image/{attachment.id}',
+                headers={'Content-Type': 'application/json'},
+                data=json_safe.dumps({
+                    "params": params,
+                }),
+            )
+            self.assertEqual(200, response.status_code, "Expect response")
+            if expect_fail:
+                return json_safe.loads(response.content)
+            url = json_safe.loads(response.content).get('result')
+            self.assertTrue(url.endswith(name), "Expect name in URL")
+            response = self.url_open(url)
+            self.assertEqual(200, response.status_code, "Expect response")
+            self.assertTrue('image/svg+xml' in response.headers.get('Content-Type'), "Expect SVG mimetype")
+            self.assertEqual(svg, response.content, "Expect unchanged SVG")
+
+        # Admin can modify page
+        modify('admin', 'page-admin.gif')
+
+        # Base user cannot modify page
+        self.user_demo.write({
+            'groups_id': [
+                Command.clear(),
+                Command.link(self.env.ref('base.group_user').id),
+            ]
+        })
+        with mute_logger('odoo.http'):
+            json = modify('demo', 'page-demofail.gif', True)
+        self.assertFalse(json.get('result'), "Expect no URL when called with insufficient rights")
+
+        # Restricted editor with event right cannot modify page
+        self.user_demo.write({
+            'groups_id': [
+                Command.clear(),
+                Command.link(self.env.ref('base.group_user').id),
+                Command.link(self.env.ref('website.group_website_restricted_editor').id),
+                Command.link(self.env.ref('event.group_event_manager').id),
+            ]
+        })
+        with mute_logger('odoo.http'):
+            json = modify('demo', 'page-demofail2.gif', True)
+        self.assertFalse(json.get('result'), "Expect no URL when called with insufficient rights")
+
+        # Website designer can modify page
+        self.user_demo.write({
+            'groups_id': [
+                Command.clear(),
+                Command.link(self.env.ref('base.group_user').id),
+                Command.link(self.env.ref('website.group_website_designer').id),
+            ]
+        })
+        modify('demo', 'page-demo.gif')
+
+        # Portal user cannot modify page
+        with mute_logger('odoo.http'):
+            json = modify('portal', 'page-portalfail.gif', True)
+        self.assertEqual('odoo.exceptions.AccessError', json['error']['data']['name'], "Expect access error")
+
+        event = self.env['event.event'].search([], limit=1)
+        attachment.res_model = 'event.event'
+        attachment.res_id = event.id
+
+        # Admin can modify event
+        modify('admin', 'event-admin.gif')
+
+        # Base user cannot modify event
+        self.user_demo.write({
+            'groups_id': [
+                Command.clear(),
+                Command.link(self.env.ref('base.group_user').id),
+            ]
+        })
+        with mute_logger('odoo.http'):
+            json = modify('demo', 'event-demofail.gif', True)
+        self.assertFalse(json.get('result'), "Expect no URL when called with insufficient rights")
+
+        # Restricted editor with sales rights cannot modify event
+        self.user_demo.write({
+            'groups_id': [
+                Command.clear(),
+                Command.link(self.env.ref('base.group_user').id),
+                Command.link(self.env.ref('website.group_website_restricted_editor').id),
+                Command.link(self.env.ref('sales_team.group_sale_manager').id),
+            ]
+        })
+        with mute_logger('odoo.http'):
+            json = modify('demo', 'event-demofail2.gif', True)
+        self.assertFalse(json.get('result'), "Expect no URL when called with insufficient rights")
+
+        # Restricted editor with event rights can modify event
+        self.user_demo.write({
+            'groups_id': [
+                Command.clear(),
+                Command.link(self.env.ref('base.group_user').id),
+                Command.link(self.env.ref('website.group_website_restricted_editor').id),
+                Command.link(self.env.ref('event.group_event_manager').id),
+            ]
+        })
+        modify('demo', 'event-demo.gif')
+
+        # Website designer cannot modify event
+        self.user_demo.write({
+            'groups_id': [
+                Command.clear(),
+                Command.link(self.env.ref('base.group_user').id),
+                Command.link(self.env.ref('website.group_website_designer').id),
+            ]
+        })
+        with mute_logger('odoo.http'):
+            json = modify('demo', 'event-demofail3.gif', True)
+        self.assertFalse(json.get('result'), "Expect no URL when called with insufficient rights")
+
+        # Portal user cannot modify event
+        with mute_logger('odoo.http'):
+            json = modify('portal', 'event-portalfail.gif', True)
+        self.assertEqual('odoo.exceptions.AccessError', json['error']['data']['name'], "Expect access error")

--- a/addons/web_editor/controllers/main.py
+++ b/addons/web_editor/controllers/main.py
@@ -560,6 +560,7 @@ class Web_Editor(http.Controller):
         """
         self._clean_context()
         attachment = request.env['ir.attachment'].browse(attachment.id)
+
         fields = {
             'original_id': attachment.id,
             'datas': data,
@@ -574,11 +575,27 @@ class Web_Editor(http.Controller):
             fields['res_id'] = res_id
         if fields['mimetype'] == 'image/webp':
             fields['name'] = re.sub(r'\.(jpe?g|png)$', '.webp', fields['name'], flags=re.I)
+
         existing_attachment = get_existing_attachment(request.env['ir.attachment'], fields)
         if existing_attachment and not existing_attachment.url:
             attachment = existing_attachment
         else:
-            attachment = attachment.copy(fields)
+            # Restricted editors can handle attachments related to records to
+            # which they have access.
+            # Would user be able to read fields of original record?
+            if attachment.res_model and attachment.res_id:
+                request.env[attachment.res_model].browse(attachment.res_id).check_access_rights('read')
+
+            # Would user be able to write fields of target record?
+            # Rights check works with res_id=0 because browse(0) returns an
+            # empty record set.
+            request.env[fields['res_model']].browse(fields['res_id']).check_access_rights('write')
+
+            # Sudo and SUPERUSER_ID because restricted editor will not be able
+            # to copy the record and the mimetype will be forced to plain text.
+            attachment = attachment.with_user(SUPERUSER_ID).sudo().copy(fields)
+            attachment = attachment.with_user(request.env.user.id).sudo(False)
+
         if alt_data:
             for size, per_type in alt_data.items():
                 reference_id = attachment.id
@@ -601,6 +618,7 @@ class Web_Editor(http.Controller):
                         'res_model': 'ir.attachment',
                         'mimetype': 'image/jpeg',
                     }])
+
         if attachment.url:
             # Don't keep url if modifying static attachment because static images
             # are only served from disk and don't fallback to attachments.
@@ -613,8 +631,10 @@ class Web_Editor(http.Controller):
                 url_fragments = attachment.url.split('/')
                 url_fragments.insert(-1, str(attachment.id))
                 attachment.url = '/'.join(url_fragments)
+
         if attachment.public:
             return attachment.image_src
+
         attachment.generate_access_token()
         return '%s?access_token=%s' % (attachment.image_src, attachment.access_token)
 


### PR DESCRIPTION
This is a followup on [1].

Restricted users are not allowed to apply shapes on images because:
- it involves the duplication of the image attachment, and
- SVGs mimetype is kept only for users allowed to write views.

This commit verifies that the user has restricted edition rights and
makes it possible for them to apply shapes on images.

Steps to reproduce:
- Install eCommerce.
- Create a user with sales administrator rights.
- Connect as that user.
- Go to a product page.
- Edit.
- Drop a "Text - Image" block.
- Set a shape on the image.
- Save.
=> Did trigger an error popup.

[1]: https://github.com/odoo/odoo/commit/d5aa54ca108eb99c7eb855a7d456bfe2f208a8eb

task-2830084
