### PR TITLE
[FIX] hr_holidays: right responsible for validation type set

### DIFF
--- a/addons/hr_holidays/models/hr_leave_allocation.py
+++ b/addons/hr_holidays/models/hr_leave_allocation.py
@@ -690,7 +690,7 @@ class HolidaysAllocation(models.Model):
         self.ensure_one()
         responsible = self.env.user
 
-        if self.validation_type == 'officer':
+        if self.validation_type == 'officer' or self.validation_type == 'set':
             if self.holiday_status_id.responsible_id:
                 responsible = self.holiday_status_id.responsible_id
 


### PR DESCRIPTION
Steps to reproduce:
- Create a Time off Type for which an allocation can be requested
by the employee and with approval "Set by Time Officer"
- Set a Time Off approver on the employee
- Create an allocation

Current behavior:
The allocation approval activity is assigned to the employee

Expected behavior:
The allocation approval activity is assigned to the time off officer

Explanation:
The first fix commit c2bac984f2de160008b27fb52b1d0ae7abd02abb didn't
take into consideration the "Set by Time Officer" approval, we add
here this possible value "set" in order to have a complete fix.

opw-2849972

previous pr: https://github.com/odoo/odoo/pull/91291