### PR TITLE
[IMP] mail: adjust legacyPatchUiSize docstring

### DIFF
--- a/addons/mail/static/tests/helpers/patch_ui_size.js
+++ b/addons/mail/static/tests/helpers/patch_ui_size.js
@@ -40,8 +40,9 @@ function getSizeFromWidth(width) {
 
 /**
  * Patch legacy objects referring to the ui size. This function must be removed
- * when switching to the new environment in the discuss app. This will impact
- * env.browser.innerWidth, env.device.isMobile and config.device.{size_class/isMobile}.
+ * when the wowl env will be available in the form_renderer (currently the form
+ * renderer relies on config). This will impact env.browser.innerWidth,
+ * env.device.isMobile and config.device.{size_class/isMobile}.
  *
  * @param {number} size
  * @param {number} width


### PR DESCRIPTION
patchUiSize used to patch both legacy and wowl sizes (browser, env.device, ...).
Now that the wowl env is used in the discuss app, patching the legacy sizes is
useless. This PR cleans this dead code.