### PR TITLE
[FIX] l10n_it_edi: duplicate acc_number import

### DIFF
--- a/addons/l10n_it_edi/models/account_edi_format.py
+++ b/addons/l10n_it_edi/models/account_edi_format.py
@@ -442,10 +442,13 @@ class AccountEdiFormat(models.Model):
                         if invoice_form.partner_id and invoice_form.partner_id.commercial_partner_id:
                             bank = self.env['res.partner.bank'].search([
                                 ('acc_number', '=', elements[0].text),
-                                ('partner_id.id', '=', invoice_form.partner_id.commercial_partner_id.id)
-                                ])
+                                ('partner_id', '=', invoice_form.partner_id.commercial_partner_id.id),
+                                ('company_id', 'in', [invoice_form.company_id.id, False])
+                            ], order='company_id', limit=1)
                         else:
-                            bank = self.env['res.partner.bank'].search([('acc_number', '=', elements[0].text)])
+                            bank = self.env['res.partner.bank'].search([
+                                ('acc_number', '=', elements[0].text), ('company_id', 'in', [invoice_form.company_id.id, False])
+                            ], order='company_id', limit=1)
                         if bank:
                             invoice_form.partner_bank_id = bank
                         else:


### PR DESCRIPTION
An error occurs when importing the Italian edi xml it the partner bank
account number is defined and the database is configured in such a way
that one partner has multiple res.partner.bank records, with the same
acc_number. This is possible in V14, since the constraint is:
'unique(sanitized_acc_number, company_id)'
meaning that the same bank account on the same partner can occur
multiple times (with different company_ids).
Since the domain of the search performed in the import function didn't
specify the company id or a limit, upon assigning the partner_bank_id
with the values from the search, an expected singleton error occurs.

This has been solved by altering the search domain to include only
partner bank accounts where the company id matches that of the invoice
or where the company id is None (which is technically possible, though
unlikely). A limit of one has been added to the search, and the results
are ordered by company_id, which will result in the res.partner.bank
with a company_id being selected before the one with no id.

task-id: 2854284