### PR TITLE
[FIX] hr_contract: wrong _description for hr.payroll.structure.type

### DIFF
--- a/addons/hr_contract/i18n/hr_contract.pot
+++ b/addons/hr_contract/i18n/hr_contract.pot
@@ -235,11 +235,15 @@ msgid "Contract Start Date"
 msgstr ""
 
 #. module: hr_contract
-#: model:ir.model,name:hr_contract.model_hr_contract_type
 #: model:ir.model,name:hr_contract.model_hr_payroll_structure_type
+#: model:ir.model.fields,field_description:hr_contract.field_hr_payroll_structure_type__name
+msgid "Salary Structure Type"
+msgstr ""
+
+#. module: hr_contract
+#: model:ir.model,name:hr_contract.model_hr_contract_type
 #: model:ir.model.fields,field_description:hr_contract.field_hr_contract__contract_type_id
 #: model:ir.model.fields,field_description:hr_contract.field_hr_contract_history__contract_type_id
-#: model:ir.model.fields,field_description:hr_contract.field_hr_payroll_structure_type__name
 msgid "Contract Type"
 msgstr ""
 

--- a/addons/hr_contract/models/hr_contract_type.py
+++ b/addons/hr_contract/models/hr_contract_type.py
@@ -12,9 +12,9 @@ class ContractType(models.Model):
 
 class HrPayrollStructureType(models.Model):
     _name = 'hr.payroll.structure.type'
-    _description = 'Contract Type'
+    _description = 'Salary Structure Type'
 
-    name = fields.Char('Contract Type')
+    name = fields.Char('Salary Structure Type')
     default_resource_calendar_id = fields.Many2one(
         'resource.calendar', 'Default Working Hours',
         default=lambda self: self.env.company.resource_calendar_id)


### PR DESCRIPTION
1. `_description` of the `hr.payroll.structure.type` should be "Salary Structure Type" instead of "Contract Type".
2. The field `name`'s string of the `hr.payroll.structure.type` should also be "Salary Structure Type" instead of "Contract Type".




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
