### PR TITLE
[FIX] mail: remove useless flex grow class from discuss container

### DIFF
--- a/addons/mail/static/src/components/discuss_container/discuss_container.xml
+++ b/addons/mail/static/src/components/discuss_container/discuss_container.xml
@@ -2,7 +2,7 @@
 <templates xml:space="preserve">
 
     <t t-name="mail.DiscussContainer" owl="1">
-        <div class="o_DiscussContainer h-100 d-flex flex-grow-1 flex-column">
+        <div class="o_DiscussContainer h-100 d-flex flex-column">
             <Discuss t-if="messaging and messaging.discuss and messaging.discuss.discussView and messaging.isInitialized" className="'flex-grow-1'" record="messaging.discuss.discussView"/>
             <div t-else="" class="o_DiscussContainer_spinner d-flex flex-grow-1 align-items-center justify-content-center">
                 <i class="o_DiscussContainer_spinnerIcon fa fa-circle-o-notch fa-spin me-2"/>Please wait...


### PR DESCRIPTION
The discuss container used to have a flex parent but hasn't anymore (its parent
is now the actionManagerContainer instead of the discussWidget). The flex-grow
class has now become useless. This PR removes it.
