### PR TITLE
[FIX] web_tour: observe iframe without body

### DIFF
--- a/addons/web_tour/static/src/js/tour_service.js
+++ b/addons/web_tour/static/src/js/tour_service.js
@@ -185,7 +185,7 @@ return session.is_bound.then(function () {
                                 const iframeEl = findIframe(mutations);
                                 if (iframeEl) {
                                     iframeEl.addEventListener('load', () => {
-                                        observer.observe(iframeEl.contentDocument.body, observerOptions);
+                                        observer.observe(iframeEl.contentDocument, observerOptions);
                                     });
                                     // If the iframe was added without a src,
                                     // its load event was immediately fired and


### PR DESCRIPTION
In mass mailing, when an iframe is loaded, the `contentDocument.body` could
be `undefined` this caused a traceback when trying to observe the
iframe.

Observing the `contentDocument` is safer as it will always be defined.

task-2869490





--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
