### PR TITLE
[FIX] l10n_it_edi_sdicoop: empty invoice company

### DIFF
--- a/addons/l10n_it_edi_sdicoop/models/account_edi_format.py
+++ b/addons/l10n_it_edi_sdicoop/models/account_edi_format.py
@@ -51,8 +51,7 @@ class AccountEdiFormat(models.Model):
                     # should not happen as the file has been checked by SdiCoop
                     _logger.info('Received file badly formatted, skipping: \n %s', file)
                     continue
-
-                invoice = self.env['account.move'].create({'move_type': 'in_invoice'})
+                invoice = self.env['account.move'].with_company(company).create({'move_type': 'in_invoice'})
                 attachment = self.env['ir.attachment'].create({
                     'name': fattura['filename'],
                     'raw': file,


### PR DESCRIPTION
When the cron is fetching the xml from the database, an empty invoice
with the xml as an attachment is created. The reason for this is so
that, if the import fails, there is at least a file accessible on the
invoice for the purposes of debugging.

When the cron's fetching function loops through the proxy users for each
company, fetching the results from the proxy server for each company in
turn. However when the empty invoice is created, the company is not
provided, and thus the context company is used (that of the cron), which
is not necessarily correct. This commit uses the company of the proxy to
create the empty invoice (which in turn selects the correct journal etc.
for the empty invoice).




ticket-id: 2854284
