### PR TITLE
[FIX] base: support company_dependent for html fields

### DIFF
--- a/odoo/addons/base/models/ir_property.py
+++ b/odoo/addons/base/models/ir_property.py
@@ -17,6 +17,7 @@ TYPE2FIELD = {
     'date': 'value_datetime',
     'datetime': 'value_datetime',
     'selection': 'value_text',
+    'html': 'value_text',
 }
 
 TYPE2CLEAN = {
@@ -29,6 +30,7 @@ TYPE2CLEAN = {
     'binary': lambda val: val or False,
     'date': lambda val: val.date() if val else False,
     'datetime': lambda val: val or False,
+    'html': lambda val: val or False,
 }
 
 
@@ -56,6 +58,7 @@ class Property(models.Model):
                              ('date', 'Date'),
                              ('datetime', 'DateTime'),
                              ('selection', 'Selection'),
+                             ('html', 'Html'),
                              ],
                             required=True,
                             default='many2one',


### PR DESCRIPTION
Issue:

 Html fields cannot add company_dependent

Cause:

 Neven have html type for company property

Solution:

 Add html type inside ir.property

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
