### PR TITLE
[FIX] website_mass_mailing: social links in Email Marketing header snippets appeared twice

### DIFF
--- a/addons/website_mass_mailing/views/snippets_templates.xml
+++ b/addons/website_mass_mailing/views/snippets_templates.xml
@@ -100,26 +100,6 @@
 
 <!-- Extend default mass_mailing snippets with website feature -->
 
-<template id="s_mail_block_header_social" inherit_id="mass_mailing.s_mail_block_header_social">
-    <xpath expr="//td[hasclass('o_mail_logo_container')]" position="after">
-        <td width="30%" class="text-right o_mail_no_resize">
-            <div class="o_mail_header_social">
-                <t t-call="mass_mailing.social_links"/>
-            </div>
-        </td>
-    </xpath>
-</template>
-
-<template id="s_mail_block_header_text_social" inherit_id="mass_mailing.s_mail_block_header_text_social">
-    <xpath expr="//table//td" position="after">
-        <td width="30%" class="text-right o_mail_no_resize">
-            <div class="o_mail_header_social">
-                <t t-call="mass_mailing.social_links"/>
-            </div>
-        </td>
-    </xpath>
-</template>
-
 <template id="s_mail_block_footer_social" inherit_id="mass_mailing.s_mail_block_footer_social">
     <xpath expr="//td[hasclass('o_mail_footer_links')]" position="inside">
         <t> | <a role="button" href="/contactus" class="btn btn-link">Contact</a></t>

--- a/doc/cla/corporate/acsone.md
+++ b/doc/cla/corporate/acsone.md
@@ -31,3 +31,4 @@ Benoit Aimont benoit.aimont@acsone.eu https://github.com/baimont
 Bejaoui Souheil souheil.bejaoui@acsone.eu https://github.com/sbejaoui
 Nans Lefebvre nans.lefebvre@acsone.eu https://github.com/len-foss
 Régis Pirard regis.pirard@acsone.eu https://github.com/regispirard
+Marie Lejeune marie.lejeune@acsone.eu https://github.com/marielejeune


### PR DESCRIPTION
Description of the issue/feature this PR addresses:

social links (such as facebook, linkedin,...) in Email Marketing header snippets appeared twice
inside the same snippet. Concerned snippets are s_mail_block_header_social and s_mail_block_header_text_social

Desired behavior after PR is merged:

In each snippet, social links will appear only once



--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
