### PR TITLE
[IMP] mail: remove useless min-height 0 on DiscussContainer

### DIFF
--- a/addons/mail/static/src/components/discuss_container/discuss_container.scss
+++ b/addons/mail/static/src/components/discuss_container/discuss_container.scss
@@ -1,3 +1,0 @@
-.o_DiscussContainer {
-    min-height: 0;
-}


### PR DESCRIPTION
DiscussContainer is specific component for content of Discuss app
in "whole screen" client action. The parent is not flex, so
it needs `h-100` to take the whole screen.

Consequently, `min-height: 0` is useless, hence this commit
removes it.