### PR TITLE
[IMP] sales_team: display action helper if no member there

### DIFF
--- a/addons/crm/views/crm_team_member_views.xml
+++ b/addons/crm/views/crm_team_member_views.xml
@@ -61,10 +61,9 @@
     <record id="sales_team.crm_team_member_action" model="ir.actions.act_window">
         <field name="help" type="html">
             <p class="o_view_nocontent_smiling_face">
-                Create a new salesman
+                Add a Team Member
             </p><p>
-                Link salespersons to sales teams. Set their monthly lead capacity
-                and configure automatic lead assignment.
+                Team Members are salespersons assigned to specific teams.
             </p>
         </field>
     </record>

--- a/addons/sales_team/models/crm_team_member.py
+++ b/addons/sales_team/models/crm_team_member.py
@@ -13,7 +13,7 @@ class CrmTeamMember(models.Model):
     _check_company_auto = True
 
     crm_team_id = fields.Many2one(
-        'crm.team', string='Sales Team',
+        'crm.team', string='Sales Team', group_expand='_read_group_crm_team_id',
         default=False,  # TDE: temporary fix to activate depending computed fields
         check_company=True, index=True, ondelete="cascade", required=True)
     user_id = fields.Many2one(
@@ -178,6 +178,13 @@ class CrmTeamMember(models.Model):
                 for membership in self
             ])
         return super(CrmTeamMember, self).write(values)
+
+    @api.model
+    def _read_group_crm_team_id(self, teams, domain, order):
+        """Read group customization in order to display all the teams in
+        Kanban view, even if they are empty.
+        """
+        return self.env['crm.team'].search([], order=order)
 
     def _synchronize_memberships(self, user_team_ids):
         """ Synchronize memberships: archive other memberships.


### PR DESCRIPTION
Current behavior before PR:
- it was not showing action content helper when no member
is there in kanban view

Desired behavior after PR is merged:
- it will show  Action content helper and Team's groupBy
in kanban view even if there is no member available

Task: https://www.odoo.com/web#id=2583755&menu_id=4720&cids=2&action=4043&model=project.task&view_type=form


--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
