### PR TITLE
[FIX] point_of_sale: add index on order_id of pos.order.line

### DIFF
--- a/addons/point_of_sale/models/pos_order.py
+++ b/addons/point_of_sale/models/pos_order.py
@@ -749,7 +749,7 @@ class PosOrderLine(models.Model):
     price_subtotal_incl = fields.Float(string='Subtotal', digits=0,
         readonly=True, required=True)
     discount = fields.Float(string='Discount (%)', digits=0, default=0.0)
-    order_id = fields.Many2one('pos.order', string='Order Ref', ondelete='cascade', required=True)
+    order_id = fields.Many2one('pos.order', string='Order Ref', ondelete='cascade', required=True, index=True)
     tax_ids = fields.Many2many('account.tax', string='Taxes', readonly=True)
     tax_ids_after_fiscal_position = fields.Many2many('account.tax', compute='_get_tax_ids_after_fiscal_position', string='Taxes to Apply')
     pack_lot_ids = fields.One2many('pos.pack.operation.lot', 'pos_order_line_id', string='Lot/serial Number')


### PR DESCRIPTION
SELECT "pos_order_line".id
FROM   "pos_order_line"
WHERE  ("pos_order_line"."order_id" in (list of ids))

On a database with 400.000 pos.order.line the query went from more than 300ms to 1ms.

Added value: the impact on cpu consumption on the customers database after adding the index manually:
![image](https://user-images.githubusercontent.com/10863541/171397834-847133ac-9eef-47d6-8d44-28a5a98007c6.png)



--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
