### PR TITLE
[IMP] calendar: improve the mail templates related to appointment 

### DIFF
--- a/addons/calendar/data/mail_template_data.xml
+++ b/addons/calendar/data/mail_template_data.xml
@@ -54,7 +54,7 @@
             ><t t-out="'Reschedule' if is_online and target_customer else 'View'">View</t></a>
     </div>
     <table border="0" cellpadding="0" cellspacing="0"><tr>
-        <td width="130px;">
+        <td width="130px;" style="min-width: 130px;">
             <div style="border-top-start-radius: 3px; border-top-end-radius: 3px; font-size: 12px; border-collapse: separate; text-align: center; font-weight: bold; color: #ffffff; min-height: 18px; background-color: #875A7B; border: 1px solid #875A7B;">
                 <t t-out="format_datetime(dt=object.event_id.start, tz=object.mail_tz if not object.event_id.allday else None, dt_format='EEEE', lang_code=object.env.lang) or ''">Tuesday</t>
             </div>
@@ -108,7 +108,12 @@
                     </li>
                 </ul></li>
                 <t t-if="object.event_id.videocall_location">
-                    <li>Meeting URL: <a t-att-href="object.event_id.videocall_location" target="_blank" t-out="object.event_id.videocall_location or ''">https://meet.jit.si/odoo-xyz</a></li>
+                    <li>
+                        How to Join:
+                        <t t-if="object.get_base_url() in object.event_id.videocall_location"> Join with Odoo Discuss</t>
+                        <t t-else=""> Join at</t><br/>
+                        <a t-att-href="object.event_id.videocall_location" target="_blank" t-out="object.event_id.videocall_location or ''">www.mycompany.com/calendar/join_videocall/xyz</a>
+                    </li>
                 </t>
                 <t t-if="not is_html_empty(object.event_id.description)">
                     <li>Description of the event:
@@ -182,7 +187,7 @@
             View</a>
     </div>
     <table border="0" cellpadding="0" cellspacing="0"><tr>
-        <td width="130px;">
+        <td width="130px;" style="min-width: 130px;">
             <div style="border-top-start-radius: 3px; border-top-end-radius: 3px; font-size: 12px; border-collapse: separate; text-align: center; font-weight: bold; color: #ffffff; min-height: 18px; background-color: #875A7B; border: 1px solid #875A7B;">
                 <t t-out='format_datetime(dt=object.event_id.start, tz=object.mail_tz if not object.event_id.allday else None, dt_format="EEEE", lang_code=object.env.lang) or ""'>Tuesday</t>
             </div>
@@ -233,7 +238,12 @@
                     </li>
                 </ul></li>
                 <t t-if="object.event_id.videocall_location">
-                    <li>Meeting URL: <a t-att-href="object.event_id.videocall_location" target="_blank" t-out="object.event_id.videocall_location or ''">https://meet.jit.si/odoo-xyz</a></li>
+                    <li>
+                        How to Join:
+                        <t t-if="object.get_base_url() in object.event_id.videocall_location"> Join with Odoo Discuss</t>
+                        <t t-else=""> Join at</t><br/>
+                        <a t-att-href="object.event_id.videocall_location" target="_blank" t-out="object.event_id.videocall_location or ''">www.mycompany.com/calendar/join_videocall/xyz</a>
+                    </li>
                 </t>
                 <t t-if="not is_html_empty(object.event_id.description)">
                     <li>Description of the event:
@@ -283,7 +293,7 @@
             View</a>
     </div>
     <table border="0" cellpadding="0" cellspacing="0"><tr>
-        <td width="130px;">
+        <td width="130px;" style="min-width: 130px;">
             <div style="border-top-start-radius: 3px; border-top-end-radius: 3px; font-size: 12px; border-collapse: separate; text-align: center; font-weight: bold; color: #ffffff; min-height: 18px; background-color: #875A7B; border: 1px solid #875A7B;">
                 <t t-out='format_datetime(dt=object.event_id.start, tz=object.mail_tz if not object.event_id.allday else None, dt_format="EEEE", lang_code=object.env.lang) or ""'>Tuesday</t>
             </div>
@@ -334,7 +344,12 @@
                     </li>
                 </ul></li>
                 <t t-if="object.event_id.videocall_location">
-                    <li>Meeting URL: <a t-attf-href="{{ object.event_id.videocall_location }}" target="_blank" t-out="object.event_id.videocall_location or ''">https://meet.jit.si/odoo-xyz</a></li>
+                    <li>
+                        How to Join:
+                        <t t-if="object.get_base_url() in object.event_id.videocall_location"> Join with Odoo Discuss</t>
+                        <t t-else=""> Join at</t><br/>
+                        <a t-att-href="object.event_id.videocall_location" target="_blank" t-out="object.event_id.videocall_location or ''">www.mycompany.com/calendar/join_videocall/xyz</a>
+                    </li>
                 </t>
                 <t t-if="not is_html_empty(object.event_id.description)">
                     <li>Description of the event:
@@ -373,7 +388,7 @@
     <div>
         <table border="0" cellpadding="0" cellspacing="0">
             <tr>
-                <td width="130px;">
+                <td width="130px;" style="min-width: 130px;">
                     <div style="border-top-start-radius: 3px; border-top-end-radius: 3px; font-size: 12px; border-collapse: separate; text-align: center; font-weight: bold; color: #ffffff; min-height: 18px; background-color: #875A7B; border: 1px solid #875A7B;">
                         <t t-out="format_datetime(dt=object.start, tz=mail_tz if not object.allday else None, dt_format='EEEE', lang_code=object.env.lang) "></t>
                     </div>
@@ -407,10 +422,11 @@
                             <t t-out="object.description">Internal meeting for discussion for new pricing for product and services.</t></li>
                         </t>
                         <t t-if="object.videocall_location">
-                            <li>Meeting URL:
-                                <a t-att-href="object.videocall_location" target="_blank">
-                                    <t t-out="object.videocall_location or ''"></t>
-                                </a>
+                            <li>
+                                How to Join:
+                                <t t-if="object.get_base_url() in object.videocall_location"> Join with Odoo Discuss</t>
+                                <t t-else=""> Join at</t><br/>
+                                <a t-att-href="object.videocall_location" target="_blank" t-out="object.videocall_location or ''">www.mycompany.com/calendar/join_videocall/xyz</a>
                             </li>
                         </t>
                         <t t-if="object.location">

--- a/addons/calendar/models/calendar_event.py
+++ b/addons/calendar/models/calendar_event.py
@@ -40,7 +40,6 @@ SORT_ALIASES = {
     'start_date': 'sort_start',
 }
 
-DISCUSS_ROUTE = 'calendar/join_videocall'
 
 def get_weekday_occurence(date):
     """
@@ -63,6 +62,8 @@ class Meeting(models.Model):
     _description = "Calendar Event"
     _order = "start desc"
     _inherit = ["mail.thread"]
+
+    DISCUSS_ROUTE = 'calendar/join_videocall'
 
     @api.model
     def default_get(self, fields):
@@ -377,7 +378,7 @@ class Meeting(models.Model):
     @api.depends('videocall_location')
     def _compute_videocall_source(self):
         for event in self:
-            if event.videocall_location and DISCUSS_ROUTE in event.videocall_location:
+            if event.videocall_location and self.DISCUSS_ROUTE in event.videocall_location:
                 event.videocall_source = 'discuss'
             else:
                 event.videocall_source = 'custom'
@@ -391,12 +392,12 @@ class Meeting(models.Model):
         """
         if not self.access_token:
             self.access_token = uuid.uuid4().hex
-        self.videocall_location = f"{self.get_base_url()}/{DISCUSS_ROUTE}/{self.access_token}"
+        self.videocall_location = f"{self.get_base_url()}/{self.DISCUSS_ROUTE}/{self.access_token}"
 
     @api.model
     def get_discuss_videocall_location(self):
         access_token = uuid.uuid4().hex
-        return f"{self.get_base_url()}/{DISCUSS_ROUTE}/{access_token}"
+        return f"{self.get_base_url()}/{self.DISCUSS_ROUTE}/{access_token}"
 
     # ------------------------------------------------------------
     # CRUD


### PR DESCRIPTION
This PR has two Commits:
1.  [IMP] calendar: improve the mail templates related to appointment]
    
     This commit done below changes:

     - Change the "Meeting URL" label to "How to Join".
  
    - Adds the label "Join with Odoo Discuss" instead of the simply showing
      the meeting URL in calendar  event related mail templates, and moves
      the meeting URL to the bottom of this label.
  
    - To avoid a tiny calendar badge, add style `min-width: 130px;` to the
      calendar badge.

2. [IMP] calendar: make 'DISCUSS_ROUTE' a class property
    
     This commit done below change:

        When an online appointment (having no location set in it's appointment type) is
        booked, we need automatically generate the `videocall_location` so that in the
        confirmation email received by customers already has a link to join. For
        building this URL, we need to use 'DISCUSS_ROUTE' when appointment is being
        created (see the linked ENT PR).
     
        For making `'DISCUSS_ROUTE'` easily accessible, instead of keeping it as a global
        variable, we now make it a class property of the model `calendar.event`.

task-2821957

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
