### PR TITLE
15.0 fix pos lot product qty should not reset after pack lot line edit

### DIFF
--- a/addons/point_of_sale/static/src/js/models.js
+++ b/addons/point_of_sale/static/src/js/models.js
@@ -1924,7 +1924,12 @@ exports.Orderline = Backbone.Model.extend({
         }
 
         // Set the quantity of the line based on number of pack lots.
-        this.pack_lot_lines.set_quantity_by_lot();
+        // But only if product tracking is not 'lot' since in that
+        // case product qty != number of pack lots (only 1 lot number)
+        // (setPackLotLines is used for both trackings 'lot' and 'serial')
+        if (this.product.tracking !== 'lot') {
+            this.pack_lot_lines.set_quantity_by_lot();
+        }
     },
     set_product_lot: function(product){
         this.has_product_lot = product.tracking !== 'none';

--- a/doc/cla/individual/antoine-hnkx.md
+++ b/doc/cla/individual/antoine-hnkx.md
@@ -1,0 +1,11 @@
+Belgium, 2022-05-31
+
+I hereby agree to the terms of the Odoo Individual Contributor License
+Agreement v1.0.
+
+I declare that I am authorized and able to make this agreement and sign this
+declaration.
+
+Signed,
+
+Antoine Honinckx antoine.honinckx@gmail.com https://github.com/antoine-hnkx


### PR DESCRIPTION
Impacted versions:
- 15.0

Steps to reproduce:
1. Configure a product to be available in the point of sale app
2. Configure the same product with tracking => "By lots" (Stock tab)
4. Inside PoS, create a new order and add a new order line for the configured product. A popup should open to add the lot number.
5. Add a lot number (Example: 12345)
6. Change order line qty to something else than 1 (Example: 3)
7. Click on the order line button to edit the lot number (green lines icon)
8. Edit the lot number (Example: 123456)
9. Click "OK"
10. Notice that the qty of the order line is set to 1

This behavior is suited for product tracked by serial numbers since the qty is always equal to the number of serial numbers but that should not be the case for products tracked by lots since it only allows 1 lot number per order line.

The same code is reused for setting pack lot lines (lot & serial numbers) but it seems there was a missing check to not reset the qty if tracked by lot. I should be able to edit the lot name of a product tracked by lots after setting the qty without it being overridden with the value 1. (In this case, 1 is the number of lot lines and it's always 1 since only 1 is allowed per orderline)

Current behavior before PR:
The popup let's me modify the unique pack lot line of the order line (since it's tracked by lot => only 1 line allowed) but then after updating it sets the qty of the orderline back to 1.

Desired behavior after PR is merged:
The popup should open and let me modify the lot number without reseting the qty to 1 if product is tracked by lot.

Support ticket reference: #2869780

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
