### PR TITLE
[FIX] stock_rule: Remove force_company from product_context

### DIFF
--- a/addons/stock/models/stock_rule.py
+++ b/addons/stock/models/stock_rule.py
@@ -602,6 +602,7 @@ class ProcurementGroup(models.Model):
             for location_id, location_res in location_data.items():
                 location_orderpoints = location_res['orderpoints']
                 product_context = dict(self._context, location=location_orderpoints[0].location_id.id)
+                product_context.pop('force_company', None)
                 substract_quantity = location_orderpoints._quantity_in_progress()
 
                 for group in location_res['groups']:


### PR DESCRIPTION
**Description of the issue/feature this PR addresses:**
When running the scheduler for locations that doesn't belong to our company, the _force_company_ context will prevent us from correctly reading the stock_quants with the method  `Product._product_available()` .

**Current behavior before PR:**
It will result in the scheduler always creating an RFQ for the maximum quantity specified in the reordering rule.

As you can see on the video: https://watch.screencastify.com/v/GrRM1kJMwhUwfnd1qABO
You have the main company on the Left (without _force_company_ in context), and the second company on the Right (with _force_company_ in context).
The location Partner Location/SUB TEST does not belong to either of the company. Hence the stock quant is not on our company either.
When the stock_quant are 'full' for the 2 products on the 2 companies, and we run the scheduler:
 - the second company (on the right) will generate an RFQ even though we have sufficient stock on location.
 - the first company (on the left) will not generate an RFQ (normal behavior)

**Desired behavior after PR is merged:**
_force_company_ is not needed for the product_context as the _location_ already restrict the method from accessing quants/moves that belong to other company `Product._product_available()`.
As you can see on this video: https://watch.screencastify.com/v/qqHeefVIGng6NDZciKmq
After removing _force_company_ from the _product_context_, both company correctly evaluate the needed quantity.

**OPW-2857371**

For odoo:13.0 only
--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
