### PR TITLE
[FIX] tests: increase navigation timeout

### DIFF
--- a/odoo/tests/common.py
+++ b/odoo/tests/common.py
@@ -1331,7 +1331,7 @@ class ChromeBrowser:
 
     def navigate_to(self, url, wait_stop=False):
         self._logger.info('Navigating to: "%s"', url)
-        nav_result = self._websocket_request('Page.navigate', params={'url': url})
+        nav_result = self._websocket_request('Page.navigate', params={'url': url}, timeout=15.0)
         self._logger.info("Navigation result: %s", nav_result)
         if wait_stop:
             frame_id = nav_result['frameId']


### PR DESCRIPTION
When instrumenting the Chrome Browser and asking to navigate to a
location, it happens that the 10 seconds timeout is exceeded.

This happens particularly when executing qunit tests by navigating to
`/web/tests`. This route has an average loading time around 7 seconds
but when the runbot is loaded, it can exceed 10 seconds.

With this commit, the timeout is set to 15s. It would be better to split
the qunit tests by module in order to avoid the huge assets bundle
generation.

