### PR TITLE
[FIX] website: fix conditional visibility based on file upload

### DIFF
--- a/addons/website/i18n/website.pot
+++ b/addons/website/i18n/website.pot
@@ -5551,12 +5551,18 @@ msgid "Is not equal to"
 msgstr ""
 
 #. module: website
+#. openerp-web
+#: code:addons/website/static/src/snippets/s_website_form/options.js:0
 #: model_terms:ir.ui.view,arch_db:website.s_website_form_options
+#, python-format
 msgid "Is not set"
 msgstr ""
 
 #. module: website
+#. openerp-web
+#: code:addons/website/static/src/snippets/s_website_form/options.js:0
 #: model_terms:ir.ui.view,arch_db:website.s_website_form_options
+#, python-format
 msgid "Is set"
 msgstr ""
 

--- a/addons/website/static/src/snippets/s_website_form/000.js
+++ b/addons/website/static/src/snippets/s_website_form/000.js
@@ -540,6 +540,10 @@ odoo.define('website.s_website_form', function (require) {
                     return value >= comparable;
                 case 'less or equal':
                     return value <= comparable;
+                case 'fileSet':
+                    return value.name !== '';
+                case '!fileSet':
+                    return value.name === '';
             }
             // Date & Date Time comparison requires formatting the value
             if (value.includes(':')) {

--- a/addons/website/static/src/snippets/s_website_form/options.js
+++ b/addons/website/static/src/snippets/s_website_form/options.js
@@ -1170,6 +1170,8 @@ options.registry.WebsiteFieldEditor = FieldEditor.extend({
                 return dependencyEl && dependencyEl.dataset.target && dependencyEl.dataset.target.includes('#datepicker');
             case 'hidden_condition_datetime_opt':
                 return dependencyEl && dependencyEl.dataset.target && dependencyEl.dataset.target.includes('#datetimepicker');
+            case 'hidden_condition_file_opt':
+                return dependencyEl && dependencyEl.type === 'file';
             case 'hidden_condition_opt':
                 return this.$target[0].classList.contains('s_website_form_field_hidden_if');
             case 'char_input_type_opt':
@@ -1205,6 +1207,14 @@ options.registry.WebsiteFieldEditor = FieldEditor.extend({
      * @override
      */
     _renderCustomXML: async function (uiFragment) {
+        // Create the file visibility selector.
+        uiFragment.querySelector('we-row[data-name="hidden_condition_opt"]').append($(`
+            <we-select data-name="hidden_condition_file_opt" data-attribute-name="visibilityComparator" data-no-preview="true">
+                <we-button data-select-data-attribute="fileSet">${_t("Is set")}</we-button>
+                <we-button data-select-data-attribute="!fileSet">${_t("Is not set")}</we-button>
+            </we-select>
+        `)[0]);
+
         // Update available visibility dependencies
         const selectDependencyEl = uiFragment.querySelector('we-select[data-name="hidden_condition_opt"]');
         if (selectDependencyEl) {
@@ -1265,6 +1275,8 @@ options.registry.WebsiteFieldEditor = FieldEditor.extend({
                     } else if (['text', 'email', 'tel', 'url', 'search', 'password', 'number'].includes(dependencyEl.type)
                             || dependencyEl.nodeName === 'TEXTAREA') {
                         this.$target[0].dataset.visibilityComparator = 'equal';
+                    } else if (dependencyEl.type === 'file') {
+                        this.$target[0].dataset.visibilityComparator = 'fileSet';
                     }
                 }
             }


### PR DESCRIPTION
At the moment, if we try to make a website field conditionally visible
based on whether a file has been uploaded, the field never appears, even
after the file has been uploaded.

#### Steps to reproduce issue
- Create a new fresh DB with the website app.
- Go to the Contact Us page, click on 'Edit'.
- Add a File Upload field
- Add another field, and set it to be conditionally visible on the
  File Upload field.

see https://drive.google.com/file/d/1duaj9ViC3xScRhCN_7klJUcpE6Ir1tln/view

#### Fix
- Create visibility comparators for files (fileSet / file!set), which check whether the `value.name` property is set / not set.

Related support ticket: opw-2856054