### PR TITLE
[IMP] point_of_sale: warning with cash payment methods

### DIFF
--- a/addons/point_of_sale/models/pos_payment_method.py
+++ b/addons/point_of_sale/models/pos_payment_method.py
@@ -25,7 +25,7 @@ class PosPaymentMethod(models.Model):
     is_cash_count = fields.Boolean(string='Cash', compute="_compute_is_cash_count", store=True)
     journal_id = fields.Many2one('account.journal',
         string='Journal',
-        domain=[('type', 'in', ('cash', 'bank'))],
+        domain=['|', '&', ('type', '=', 'cash'), ('pos_payment_method_ids', '=', False), ('type', '=', 'bank')],
         ondelete='restrict',
         help='Leave empty to use the receivable account of customer.\n'
              'Defines the journal where to book the accumulated payments (or individual payment if Identify Customer is true) after closing the session.\n'

--- a/addons/point_of_sale/tests/common.py
+++ b/addons/point_of_sale/tests/common.py
@@ -263,6 +263,11 @@ class TestPoSCommon(ValuationReconciliationTestCommon):
         cls.cash_split_pm1 = cls.cash_pm1.copy(default={
             'name': 'Split (Cash) PM',
             'split_transactions': True,
+            'journal_id': cls.env['account.journal'].create({
+                                'name': "Cash",
+                                'code': "CSH %s" % config.id,
+                                'type': 'cash',
+                            }).id
         })
         cls.bank_split_pm1 = cls.bank_pm1.copy(default={
             'name': 'Split (Bank) PM',

--- a/addons/point_of_sale/tests/test_anglo_saxon.py
+++ b/addons/point_of_sale/tests/test_anglo_saxon.py
@@ -31,7 +31,13 @@ class TestAngloSaxonCommon(common.TransactionCase):
         self.category.property_stock_valuation_account_id = account_valuation
         self.category.property_stock_journal = self.env['account.journal'].create({'name': 'Stock journal', 'type': 'sale', 'code': 'STK00'})
         self.pos_config = self.env.ref('point_of_sale.pos_config_main')
-        self.pos_config = self.pos_config.copy({'name': 'New POS config'})
+        self.cash_journal = self.env['account.journal'].create(
+            {'name': 'CASH journal', 'type': 'cash', 'code': 'CSH02'})
+        self.cash_payment_method = self.env['pos.payment.method'].create({
+            'name': 'Cash Test',
+            'journal_id': self.cash_journal.id,
+        })
+        self.pos_config = self.pos_config.copy({'name': 'New POS config', 'payment_method_ids': self.cash_payment_method})
         self.product = self.env['product.product'].create({
             'name': 'New product',
             'standard_price': 100,

--- a/addons/point_of_sale/tests/test_pos_basic_config.py
+++ b/addons/point_of_sale/tests/test_pos_basic_config.py
@@ -845,7 +845,17 @@ class TestPoSBasicConfig(TestPoSCommon):
             self.assertEqual(session.cash_register_balance_start, pos_data['amount_paid'])
 
         pos01_config = self.config
-        pos02_config = pos01_config.copy()
+        self.cash_journal = self.env['account.journal'].create(
+            {'name': 'CASH journal', 'type': 'cash', 'code': 'CSH00'})
+        self.cash_payment_method = self.env['pos.payment.method'].create({
+            'name': 'Cash Test',
+            'journal_id': self.cash_journal.id,
+            'receivable_account_id': pos01_config.payment_method_ids.filtered(lambda s: s.is_cash_count)[
+                1].receivable_account_id.id
+        })
+        pos02_config = pos01_config.copy({
+            'payment_method_ids': self.cash_payment_method
+        })
         pos01_data = {'config': pos01_config, 'p_qty': 1, 'amount_paid': 0}
         pos02_data = {'config': pos02_config, 'p_qty': 3, 'amount_paid': 0}
 

--- a/addons/point_of_sale/views/pos_payment_method_views.xml
+++ b/addons/point_of_sale/views/pos_payment_method_views.xml
@@ -12,6 +12,7 @@
                     <div class="oe_title">
                         <label for="name"/>
                         <h1><field name="name" placeholder="e.g. Cash" class="oe_inline"/></h1>
+                        <field name="image" class="oe_avatar" widget='image'/>
                     </div>
                     <group name="Payment methods">
                         <field name="hide_use_payment_terminal" invisible="1"/>
@@ -21,7 +22,6 @@
                             <field name="outstanding_account_id" groups="account.group_account_readonly" attrs="{'invisible': [('type', '!=', 'bank')]}" placeholder="Leave empty to use the default account from the company setting" />
                             <field name="receivable_account_id" groups="account.group_account_readonly" attrs="{'invisible': [('split_transactions', '=', True)]}" placeholder="Leave empty to use the default account from the company setting" />
                             <field name="company_id" readonly="1" groups="base.group_multi_company" />
-                            <field name="image"/>
                         </group>
                         <group attrs="{'invisible': ['|', ('hide_use_payment_terminal', '=', False), ('type', 'in', ['cash', 'pay_later'])]}">
                             <div colspan="2">
@@ -54,6 +54,7 @@
                 <field name="outstanding_account_id" groups="account.group_account_readonly" optional="hide" attrs="{'invisible': [('type', '!=', 'bank')]}" />
                 <field name="receivable_account_id" groups="account.group_account_readonly" optional="hide" attrs="{'invisible': [('split_transactions', '=', True)]}" />
                 <field name="company_id" groups="base.group_multi_company" />
+                <field name="config_ids" widget="many2many_tags"/>
             </tree>
         </field>
     </record>
@@ -67,6 +68,9 @@
                 <field name="receivable_account_id" groups="account.group_account_readonly" />
                 <group expand="1" string="Group By">
                     <filter name="group_by_receivable_account" string="Account" domain="[]"  context="{'group_by':'receivable_account_id'}"/>
+                    <filter name="group_by_pos_config" string="Point of Sale" domain="[]" context="{'group_by':'config_ids'}"/>
+                    <filter name="group_by_method_name" string="Method Name" domain="[]" context="{'group_by':'name'}"/>
+                    <filter name="group_by_journal_id" string="Journal" domain="[]" context="{'group_by':'journal_id'}"/>
                 </group>
                 <filter string="Archived" name="active" domain="[('active', '=', False)]"/>
             </search>

--- a/addons/pos_loyalty/tests/test_frontend.py
+++ b/addons/pos_loyalty/tests/test_frontend.py
@@ -629,7 +629,17 @@ class TestUi(TestPointOfSaleHttpCommon):
             ]
         })
 
-        self.main_pos_config2 = self.main_pos_config.copy()
+        self.cash_journal = self.env['account.journal'].create(
+            {'name': 'CASH journal', 'type': 'cash', 'code': 'CSH00'})
+        self.cash_payment_method = self.env['pos.payment.method'].create({
+            'name': 'Cash Test',
+            'journal_id': self.cash_journal.id,
+            'receivable_account_id': self.main_pos_config.payment_method_ids.filtered(lambda s: s.is_cash_count).receivable_account_id.id
+        })
+
+        self.main_pos_config2 = self.main_pos_config.copy({
+            'payment_method_ids': self.cash_payment_method
+        })
 
         loyalty_program = self.env['loyalty.program'].create({
             'name': 'Coupon Program - Pricelist',
@@ -699,7 +709,18 @@ class TestUi(TestPointOfSaleHttpCommon):
             }
         )
 
-        self.main_pos_config2 = self.main_pos_config.copy()
+        self.cash_journal = self.env['account.journal'].create(
+            {'name': 'CASH journal', 'type': 'cash', 'code': 'CSHDI'})
+        self.cash_payment_method = self.env['pos.payment.method'].create({
+            'name': 'Cash Test',
+            'journal_id': self.cash_journal.id,
+            'receivable_account_id': self.main_pos_config.payment_method_ids.filtered(
+                lambda s: s.is_cash_count).receivable_account_id.id
+        })
+
+        self.main_pos_config2 = self.main_pos_config.copy({
+            'payment_method_ids': self.cash_payment_method
+        })
         self.main_pos_config2.write({
             'module_pos_discount' : True,
             'discount_product_id': self.discount_product.id,

--- a/addons/pos_restaurant/tests/test_frontend.py
+++ b/addons/pos_restaurant/tests/test_frontend.py
@@ -123,8 +123,8 @@ class TestFrontend(odoo.tests.HttpCase):
             'journal_id': test_sale_journal.id,
             'invoice_journal_id': test_sale_journal.id,
             'payment_method_ids': [(0, 0, {
-                'name': 'Cash restaurant',
-                'split_transactions': True,
+                'name': 'Cash',
+                'split_transactions': False,
                 'receivable_account_id': account_receivable.id,
                 'journal_id': cash_journal.id,
             })],


### PR DESCRIPTION
Currently, it is possible to assign the same "Cash" payment method to multiple PoS.
At the moment, when creating a new PoS, Odoo tends to assign it by default. Although this is highly not recommended as it can only lead to incorrect cash control (two PoS devices rarely share the same till and therefore needs their own cash payment method).

This commit makes sure payment methods of type Cash aren't set by default when creating new PoS.
it also blocks the user from setting the same Cash payment method to multiple PoS configs.

task-id: 2857417

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
