### PR TITLE
[FIX] purchase: fix bank info on vendor bill based on po

### DIFF
--- a/addons/purchase/models/purchase.py
+++ b/addons/purchase/models/purchase.py
@@ -547,7 +547,7 @@ class PurchaseOrder(models.Model):
             raise UserError(_('Please define an accounting purchase journal for the company %s (%s).') % (self.company_id.name, self.company_id.id))
 
         partner_invoice_id = self.partner_id.address_get(['invoice'])['invoice']
-        partner_bank_id = self.partner_id.bank_ids.filtered_domain(['|', ('company_id', '=', False), ('company_id', '=', self.company_id.id)])[:1]
+        partner_bank_id = self.partner_id.commercial_partner_id.bank_ids.filtered_domain(['|', ('company_id', '=', False), ('company_id', '=', self.company_id.id)])[:1]
         invoice_vals = {
             'ref': self.partner_ref or '',
             'move_type': move_type,


### PR DESCRIPTION
Steps to reproduce:

        - Install puchases, accounting, contact
        - Create a new company with a bank account
        - Create a new person contact linked to the previous company
        - Make a purchase order from that person
        - Make a vendor bill using the auto-complete as the previous PO

Issue:

        The bank account field is not filled

Cause:

        The _prepare_invoice function tries to grab the bank information
        from the contact on the PO. But in the case of a person of a company,
        this information is stored in the parent company. Resulting in an empty
        value

Solution:

        Add a check to see if the partner_id is a person assigned to a company,
        if yes, grab the bank information from the parent company, else,
        keep the previous behaviour.

opw-2849706


