### PR TITLE
[FIX] web_editor: media dialog should always clean extra class

### DIFF
--- a/addons/web_editor/static/src/js/wysiwyg/widgets/media.js
+++ b/addons/web_editor/static/src/js/wysiwyg/widgets/media.js
@@ -491,7 +491,6 @@ var FileWidget = SearchableMediaWidget.extend({
                         attrs.push(key);
                     }
                 });
-                self.$media.removeClass('o_cropped_img_to_save');
                 _.each(attrs, function (attr) {
                     self.$media.removeData(attr);
                     self.$media.removeAttr('data-' + attr);

--- a/addons/web_editor/static/src/js/wysiwyg/widgets/media_dialog.js
+++ b/addons/web_editor/static/src/js/wysiwyg/widgets/media_dialog.js
@@ -164,6 +164,7 @@ var MediaDialog = Dialog.extend({
             if (self.activeWidget !== self.initiallyActiveWidget) {
                 self._clearWidgets();
             }
+            self.media.classList.remove('o_cropped_img_to_save');
             // Restore classes if the media was replaced (when changing type)
             if (self.media !== data) {
                 var oldClasses = self.media && _.toArray(self.media.classList);


### PR DESCRIPTION
Since [1], crop dialog is adding an extra class to mark the image for later
creation. But when we change marked image with any other media like
icon, document, or video from media dialog. The extra class is still there
so in this case editor will try to create an attachment for changed media
on save.

After this commit media dialog will always remove that extra class.

[1]: https://github.com/odoo/odoo/commit/a473453b3166a381130d9bd6ec4851b9e1ecab26
