### PR TITLE
[FIX] web_editor: prevent loading linkDialogCommand in website

### DIFF
--- a/addons/web_editor/__manifest__.py
+++ b/addons/web_editor/__manifest__.py
@@ -26,9 +26,6 @@ Odoo Web Editor widget.
             'web_editor/static/src/xml/*.xml',
         ],
         'web_editor.assets_wysiwyg': [
-            # dependency
-            'web/core/commands/default_providers',
-
             # lib
             'web_editor/static/lib/cropperjs/cropper.css',
             'web_editor/static/lib/cropperjs/cropper.js',
@@ -58,7 +55,6 @@ Odoo Web Editor widget.
             'web_editor/static/lib/odoo-editor/src/commands/toggleList.js',
 
             # utils
-            'web_editor/static/src/js/wysiwyg/linkDialogCommand.js',
             'web_editor/static/src/js/wysiwyg/PeerToPeer.js',
 
             # odoo utils
@@ -94,6 +90,7 @@ Odoo Web Editor widget.
             'web_editor/static/lib/odoo-editor/src/utils/utils.js',
         ],
         'web.assets_backend': [
+            'web_editor/static/src/js/wysiwyg/linkDialogCommand.js',
             'web_editor/static/src/scss/web_editor.common.scss',
             'web_editor/static/src/scss/web_editor.backend.scss',
 

--- a/addons/web_editor/static/src/js/wysiwyg/linkDialogCommand.js
+++ b/addons/web_editor/static/src/js/wysiwyg/linkDialogCommand.js
@@ -2,7 +2,6 @@
 
 import { registry } from '@web/core/registry'
 import { HotkeyCommandItem } from '@web/core/commands/default_providers'
-import Wysiwyg from 'web_editor.wysiwyg'
 
 // The only way to know if an editor is under focus when the command palette
 // open is to look if there in a selection within a wysiwyg editor in the page.
@@ -14,6 +13,10 @@ let sessionActionLabel = [];
 const commandProviderRegistry = registry.category("command_provider");
 commandProviderRegistry.add("link dialog", {
     async provide(env, { sessionId }) {
+        const Wysiwyg = odoo.__DEBUG__.services['web_editor.wysiwyg'];
+        if (!Wysiwyg) {
+            return [];
+        }
         let [lastSessionId, action, label] = sessionActionLabel;
         if (lastSessionId !== sessionId) {
             const wysiwyg = [...Wysiwyg.activeWysiwygs].find((wysiwyg) => {


### PR DESCRIPTION
Before this commit, the file `linkDialogCommand.js` was in the bundle
`web_editor.assets_wysiwyg`. That bundle was loaded with the same
file in the backend and frontend.
That file has a dependency with another file that should only be loaded
in the backend.

After this commit, the file will only be loaded in the backend.




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
