### PR TITLE
[IMP] account: improve tax name search

### DIFF
--- a/addons/account/models/account_tax.py
+++ b/addons/account/models/account_tax.py
@@ -8,6 +8,7 @@ from odoo.tools import frozendict
 
 from collections import defaultdict
 import math
+import re
 
 
 TYPE_TAX_USE = [
@@ -85,6 +86,10 @@ class AccountTax(models.Model):
         return self.env.ref('account.tax_group_taxes')
 
     name = fields.Char(string='Tax Name', required=True)
+    name_searchable = fields.Char(store=False, search='_search_name',
+          help="This dummy field lets us use another search method on the field 'name'."
+               "This allows more freedom on how to search the 'name' compared to 'filter_domain'."
+               "See '_search_name' and '_parse_name_search' for why this is not possible with 'filter_domain'.")
     type_tax_use = fields.Selection(TYPE_TAX_USE, string='Tax Type', required=True, default="sale",
         help="Determines where the tax is selectable. Note : 'None' means a tax can't be used by itself, however it can still be used in a group. 'adjustment' is used to perform tax adjustment.")
     tax_scope = fields.Selection([('service', 'Services'), ('consu', 'Goods')], string="Tax Scope", help="Restrict the use of taxes to a type of product.")
@@ -174,6 +179,27 @@ class AccountTax(models.Model):
             ]
 
         return rslt
+
+    @staticmethod
+    def _parse_name_search(name):
+        """
+        Parse the name to search the taxes faster.
+        Technical:  0EUM    => 0%E%U%M
+                    21M     => 2%1%M%   where the % represents 0, 1 or multiple characters in a SQL 'LIKE' search.
+        Examples:   0EUM    => VAT 0% EU M.
+                    21M     => 21% M , 21% EU M and 21% M.Cocont.
+        """
+        name = re.sub(r"\W+", "", name)  # Remove non-alphanumeric characters.
+        return '%'.join(list(name))
+
+    @api.model
+    def name_search(self, name='', args=None, operator='ilike', limit=100):
+        return super().name_search(name=AccountTax._parse_name_search(name), args=args, operator=operator, limit=limit)
+
+    def _search_name(self, operator, value):
+        if operator not in ("ilike", "like") or not isinstance(value, str):
+            return super()._search_name(operator, value)
+        return [('name', operator, AccountTax._parse_name_search(value))]
 
     def _check_repartition_lines(self, lines):
         self.ensure_one()

--- a/addons/account/views/account_tax_views.xml
+++ b/addons/account/views/account_tax_views.xml
@@ -92,7 +92,7 @@
             <field name="model">account.tax</field>
             <field name="arch" type="xml">
                 <search string="Search Taxes">
-                    <field name="name" filter_domain="['|', ('name','ilike',self), ('description','ilike',self)]" string="Tax"/>
+                    <field name="name_searchable" string="Name"/>
                     <field name="company_id" groups="base.group_multi_company"/>
                     <filter string="Sale" name="sale" domain="[('type_tax_use','=','sale')]" />
                     <filter string="Purchase" name="purchase" domain="[('type_tax_use','=','purchase')]" />


### PR DESCRIPTION
This PR improves tax name search by ignoring punctuation and spaces.
This allows faster searching for taxes (while editing an invoice line or
while configuring them)

Example:
Searching for `21M` should match `21% M.` , `21% EU M.` and `21% M.Cocont`.
Searching for `0EUT` should match `0% EU T`.

Task id: 2851341

Old PR with remarks: https://github.com/odoo/odoo/pull/91667

