### PR TITLE
[FIX] web: pivot,graph view measures dropdown is now scrollable

### DIFF
--- a/addons/web/static/src/scss/graph_view.scss
+++ b/addons/web/static/src/scss/graph_view.scss
@@ -79,3 +79,8 @@
         }
     }
 }
+
+.o_graph_measures_list {
+    max-height: calc(100vh - #{$o-navbar-height} - 100px);
+    overflow-y: auto;
+}

--- a/addons/web/static/src/scss/pivot_view.scss
+++ b/addons/web/static/src/scss/pivot_view.scss
@@ -107,3 +107,8 @@
         cursor: default;
     }
 }
+
+.o_pivot_measures_list {
+    max-height: calc(100vh - #{$o-navbar-height} - 100px);
+    overflow-y: auto;
+}


### PR DESCRIPTION
Steps to follow

  - Go to Sales > Reporting > Sales
  - Switch to the pivot view
  - Click on the Measures button
  - Reduce the vertical height of the browser
  - The dropdown entries are not scrollable

opw-2855411