### PR TITLE
[IMP] project: make orders give them recurrence to the tasks they create

### DIFF
--- a/addons/project/models/project_task_recurrence.py
+++ b/addons/project/models/project_task_recurrence.py
@@ -250,9 +250,10 @@ class ProjectTaskRecurrence(models.Model):
             new_task = self.env['project.task'].sudo().create(create_values)
             recurrence._create_subtasks(task, new_task, depth=3)
 
-    def _set_next_recurrence_date(self):
+    def _set_next_recurrence_date(self, date_start=None):
         today = fields.Date.today()
-        tomorrow = today + relativedelta(days=1)
+        if not date_start:
+            date_start = today + relativedelta(days=1)
         for recurrence in self.filtered(
             lambda r:
             r.repeat_type == 'after' and r.recurrence_left >= 0
@@ -262,7 +263,7 @@ class ProjectTaskRecurrence(models.Model):
             if recurrence.repeat_type == 'after' and recurrence.recurrence_left == 0:
                 recurrence.next_recurrence_date = False
             else:
-                next_date = self._get_next_recurring_dates(tomorrow, recurrence.repeat_interval, recurrence.repeat_unit, recurrence.repeat_type, recurrence.repeat_until, recurrence.repeat_on_month, recurrence.repeat_on_year, recurrence._get_weekdays(), recurrence.repeat_day, recurrence.repeat_week, recurrence.repeat_month, count=1)
+                next_date = self._get_next_recurring_dates(date_start, recurrence.repeat_interval, recurrence.repeat_unit, recurrence.repeat_type, recurrence.repeat_until, recurrence.repeat_on_month, recurrence.repeat_on_year, recurrence._get_weekdays(), recurrence.repeat_day, recurrence.repeat_week, recurrence.repeat_month, count=1)
                 recurrence.next_recurrence_date = next_date[0] if next_date else False
 
     @api.model


### PR DESCRIPTION
On SO confirmation:
- If all of the following conditions are met,
set the end_date of the Subscription
as the repeat_until date of the Task:
The Product is recurrent and creates a Task,
The Task Template is recurrent,
The end_date field is set on the Subscription.

- If all of the following conditions are met,
apply the Subscription's recurrence to the Task's:
The Product is recurrent and creates a Task,
There is no Task Template on the Product.

- If the Subscription is closed, set the recurring_task
field of the related Task to false.

task-2868306