### PR TITLE
[FIX] l10n_din5008_purchase: print correct order date

### DIFF
--- a/addons/l10n_din5008_purchase/models/purchase.py
+++ b/addons/l10n_din5008_purchase/models/purchase.py
@@ -23,8 +23,10 @@ class PurchaseOrder(models.Model):
                 data.append((_("Purchase Representative"), record.user_id.name))
             if record.partner_ref:
                 data.append((_("Order Reference"), record.partner_ref))
-            if record.date_order:
-                data.append((_("Order Date"), format_date(self.env, record.date_order)))
+            if record.date_approve:
+                data.append((_("Order Date"), format_date(self.env, record.date_approve)))
+            elif record.date_order:
+                data.append((_("Order Deadline"), format_date(self.env, record.date_order)))
             if record.incoterm_id:
                 data.append((_("Incoterm"), record.incoterm_id.code))
 


### PR DESCRIPTION
Steps to reproduce the bug:
- Set the "external_layout_din5008` in the layout field
- Go to any confirmed PO
- Print the purchase order
- Check the Order date

Problem:
The deadline order date is printed instead of the approved date

Solution:
The order date on the Purchase Order report should be the confirmation
date if available, in case it's unavailable print the order deadline.

FYI: https://github.com/odoo/odoo/commit/9255d3d7d9bddf52d48df0ec81ac6bdeddbfec29

opw-2857216




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
