### PR TITLE
[FIX] product_margin: product read_group computed field no aggr


### DIFF
--- a/addons/product_margin/models/product_product.py
+++ b/addons/product_margin/models/product_product.py
@@ -59,7 +59,7 @@ class ProductProduct(models.Model):
         def truncate_aggr(field):
             field_no_aggr, _sep, agg = field.partition(':')
             if field_no_aggr in fields_list:
-                if agg != 'sum':
+                if agg and agg != 'sum':
                     raise NotImplementedError('Aggregate functions other than \':sum\' are not allowed.')
                 return field_no_aggr
             return field


### PR DESCRIPTION
Small fixup to f4166c6bac.

We now allow :sum method aggregator for non-stored computed field from
product.product added by product_margin, but we should still allow to
get the field without aggregator.

This is only for 15.0, this will be fixed in f4166c6bac forward-port
that have not yet been merged.

opw-2738456

pr note: addendum to #92488