### PR TITLE
[IMP] mail, hr_expense: show expense attachments on sheet

### DIFF
--- a/addons/hr_expense/models/hr_expense.py
+++ b/addons/hr_expense/models/hr_expense.py
@@ -1094,6 +1094,17 @@ class HrExpenseSheet(models.Model):
     # Mail Thread
     # --------------------------------------------
 
+    def _get_mail_thread_data_attachments(self):
+        """
+        In order to see in the sheet attachment preview the corresponding
+        expenses' attachments, the latter attachments are added to the fetched data for the sheet record.
+        """
+        self.ensure_one()
+        res = super()._get_mail_thread_data_attachments()
+        expense_ids = self.expense_line_ids
+        expense_attachments = self.env['ir.attachment'].search([('res_id', 'in', expense_ids.ids), ('res_model', '=', 'hr.expense')], order='id desc')
+        return res | expense_attachments
+
     def _track_subtype(self, init_values):
         self.ensure_one()
         if 'state' in init_values and self.state == 'approve':

--- a/addons/hr_expense/views/hr_expense_views.xml
+++ b/addons/hr_expense/views/hr_expense_views.xml
@@ -796,6 +796,7 @@
                         </page>
                      </notebook>
                 </sheet>
+                <div class="o_attachment_preview"/>
                 <div class="oe_chatter">
                     <field name="message_follower_ids"/>
                     <field name="activity_ids"/>

--- a/addons/mail/controllers/discuss.py
+++ b/addons/mail/controllers/discuss.py
@@ -431,31 +431,8 @@ class DiscussController(http.Controller):
 
     @http.route('/mail/thread/data', methods=['POST'], type='json', auth='user')
     def mail_thread_data(self, thread_model, thread_id, request_list, **kwargs):
-        res = {'hasWriteAccess': False}
         thread = request.env[thread_model].with_context(active_test=False).search([('id', '=', thread_id)])
-        try:
-            thread.check_access_rights("write")
-            thread.check_access_rule("write")
-            res['hasWriteAccess'] = True
-        except AccessError:
-            pass
-        if 'activities' in request_list:
-            res['activities'] = thread.activity_ids.activity_format()
-        if 'attachments' in request_list:
-            res['attachments'] = thread.env['ir.attachment'].search([('res_id', '=', thread.id), ('res_model', '=', thread._name)], order='id desc')._attachment_format(commands=True)
-        if 'followers' in request_list:
-            res['followers'] = [{
-                'id': follower.id,
-                'partner_id': follower.partner_id.id,
-                'name': follower.name,
-                'display_name': follower.display_name,
-                'email': follower.email,
-                'is_active': follower.is_active,
-                'partner': follower.partner_id.mail_partner_format()[follower.partner_id],
-            } for follower in thread.message_follower_ids]
-        if 'suggestedRecipients' in request_list:
-            res['suggestedRecipients'] = thread._message_get_suggested_recipients()[thread.id]
-        return res
+        return thread._get_mail_thread_data(request_list)
 
     @http.route('/mail/thread/messages', methods=['POST'], type='json', auth='user')
     def mail_thread_messages(self, thread_model, thread_id, max_id=None, min_id=None, limit=30, **kwargs):


### PR DESCRIPTION
Purpose: Before it was hard to view expense attachments from sheet record.
To do so, the user should have gone through clicking on each expense first and
checking attachments, or could have clicked on a attachments smart button on embedded
expense table, which is redirecting to another view that only displays attachments for the one expense only.
Thus, checking all the attachments from sheet was an tedious task.

After this commit, the user can see in the sheet attachment preview all the associated expenses' attachments.

To make it possible, we ovveride 'mail.thread' method that is called to
fetch the data for the chatter. In the override, we check whether the model is
sheet, and fetch extra, associated expenses'attachments.

task - 2320177

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
