### PR TITLE
[FIX] mrp: prevent byproduct missing record error

### DIFF
--- a/addons/mrp/models/mrp_production.py
+++ b/addons/mrp/models/mrp_production.py
@@ -727,6 +727,9 @@ class MrpProduction(models.Model):
                     raise ValidationError(_("The component %s should not be the same as the product to produce.") % production.product_id.display_name)
 
     def write(self, vals):
+        if 'move_byproduct_ids' in vals and 'move_finished_ids' not in vals:
+            vals['move_finished_ids'] = vals['move_byproduct_ids']
+            del vals['move_byproduct_ids']
         if 'workorder_ids' in self:
             production_to_replan = self.filtered(lambda p: p.is_planned)
         res = super(MrpProduction, self).write(vals)

--- a/addons/mrp/tests/test_byproduct.py
+++ b/addons/mrp/tests/test_byproduct.py
@@ -69,6 +69,7 @@ class TestMrpByProduct(common.TransactionCase):
         # I consume and produce the production of products.
         # I create record for selecting mode and quantity of products to produce.
         mo_form = Form(mnf_product_a)
+        mnf_product_a.move_byproduct_ids.quantity_done = 2
         mo_form.qty_producing = 2.00
         mnf_product_a = mo_form.save()
         # I finish the production order.


### PR DESCRIPTION
Before this commit, there was a bug with MO by-product moves:

     - With a newly created MO, confirm MO and after manually add `Produced` 
       quantity in By-Products and change quantity producing in MO and  save the
       record then it raises the missing record error.
 
same issues was fixed here https://github.com/odoo/odoo/commit/c1768d00e8eb76af32ead10f75ce3d09a5aefac9
but forgot to fix same in write method.
so this commit is fix same but in write method

TaskID - 2799848
PR - #92728