### PR TITLE
[FIX] hr_expense: fix 'hr.expense' has no attribute 'attach_document'​

### DIFF
--- a/addons/hr_expense/models/hr_expense.py
+++ b/addons/hr_expense/models/hr_expense.py
@@ -120,6 +120,9 @@ class HrExpense(models.Model):
     sample = fields.Boolean()
     label_convert_rate = fields.Char(compute='_compute_label_convert_rate')
 
+    def attach_document(self, **kwargs):
+        pass
+
     @api.depends('product_has_cost')
     def _compute_currency_id(self):
         for expense in self.filtered("product_has_cost"):


### PR DESCRIPTION
In case hr_expense_extract is not installed and we click
'Attach Receipt' on hr_expense form view, we get a traceback.

task - 2870500

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
