### PR TITLE
[FIX] hr_gamification: make count of employees per badge more efficient

### DIFF
--- a/addons/hr_gamification/models/gamification.py
+++ b/addons/hr_gamification/models/gamification.py
@@ -25,11 +25,12 @@ class GamificationBadge(models.Model):
 
     @api.depends('owner_ids.employee_id')
     def _compute_granted_employees_count(self):
+        badge_data = self.env['gamification.badge.user'].read_group(
+            [('badge_id', 'in', self.ids), ('employee_id', '!=', False)], ['badge_id'], ['badge_id']
+        )
+        badge_count = {c['badge_id'][0]: c['badge_id_count'] for c in badge_data}
         for badge in self:
-            badge.granted_employees_count = self.env['gamification.badge.user'].search_count([
-                ('badge_id', '=', badge.id),
-                ('employee_id', '!=', False)
-            ])
+            badge.granted_employees_count = badge_count.get(badge.id, 0)
 
     def get_granted_employees(self):
         employee_ids = self.mapped('owner_ids.employee_id').ids


### PR DESCRIPTION
A query was made for each badge, which was heavily slowing down the
kanban view on databases with a lot of employees/badges.

The count is now done in a single `read_group`.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
