### PR TITLE
[WIP] core: allow hiding fields from export dialogs

### DIFF
--- a/odoo/addons/base/models/ir_model.py
+++ b/odoo/addons/base/models/ir_model.py
@@ -477,6 +477,7 @@ class IrModelFields(models.Model):
                                        store=True, string="Related field", ondelete='cascade')
     required = fields.Boolean()
     readonly = fields.Boolean()
+    exportable = fields.Boolean(default=True)
     index = fields.Boolean(string='Indexed')
     translate = fields.Boolean(string='Translatable', help="Whether values for this field can be translated (enables the translation mechanism for that field)")
     size = fields.Integer()
@@ -999,6 +1000,7 @@ class IrModelFields(models.Model):
             'on_delete': field.ondelete if field.type == 'many2one' else None,
             'related': field.related or None,
             'readonly': bool(field.readonly),
+            'exportable': bool(field.exportable),
             'required': bool(field.required),
             'selectable': bool(field.search or field.store),
             'size': getattr(field, 'size', None),

--- a/odoo/fields.py
+++ b/odoo/fields.py
@@ -283,6 +283,7 @@ class Field(MetaField('DummyField', (object,), {})):
     invisible = False                   # whether the field is invisible
     readonly = False                    # whether the field is readonly
     required = False                    # whether the field is required
+    exportable = True                   # whether the field is exportable
     states = None                       # set readonly and required depending on state
     groups = None                       # csv list of group xml ids
     change_default = False              # whether the field may trigger a "user-onchange"
@@ -405,6 +406,9 @@ class Field(MetaField('DummyField', (object,), {})):
         if name == 'state':
             # by default, `state` fields should be reset on copy
             attrs['copy'] = attrs.get('copy', False)
+        if attrs.get('exportable'):
+            attrs['exportable'] = attrs.get('exportable', False)
+
         if attrs.get('compute'):
             # by default, computed fields are not stored, computed in superuser
             # mode if stored, not copied (unless stored and explicitly not
@@ -815,6 +819,7 @@ class Field(MetaField('DummyField', (object,), {})):
     _description_related = property(attrgetter('related'))
     _description_company_dependent = property(attrgetter('company_dependent'))
     _description_readonly = property(attrgetter('readonly'))
+    _description_exportable = property(attrgetter('exportable'))
     _description_required = property(attrgetter('required'))
     _description_states = property(attrgetter('states'))
     _description_groups = property(attrgetter('groups'))
@@ -4127,6 +4132,7 @@ class Id(Field):
     store = True
     readonly = True
     prefetch = False
+    exportable = True
 
     def update_db(self, model, columns):
         pass                            # this column is created with the table


### PR DESCRIPTION
Description of the issue/feature this PR addresses: Odoo has been growing and more and more technical fields have been added who either contain rather sensitive data or nothing useful for exporting. See also the discussion at https://twitter.com/ggellatly/status/1524145898380738561

Current behavior before PR: Every single field in Odoo is by default shown in the export dialog causing an overload of info with quite often content shown that has no use (or should even be hidden for semi-security reasons).

Desired behavior after PR is merged:
By adding an attribute `exportable` on the `ir.model.fields` we can custom define which fields we want to be exportable or not.
For example: by default on the `sale.order` model the field `access_token` is by default exportable. If you'd flag the field as non-exportable it would no longer show up and thus not leak (rather sensitive) data:
```
# -*- coding: utf-8 -*-

from odoo import models, fields, api


class SaleOrder(models.Model):
    _inherit = 'sale.order'

    access_token = fields.Char(
        exportable=False
    )
```

By adding this configurable flag a developer could override any field and simply add the `exportable` flag which is set to `False`.




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
