### PR TITLE
[FIX] mrp: add domain in `copy existing operation` action

### DIFF
--- a/addons/mrp/static/src/js/mrp_field_one2many_with_copy.js
+++ b/addons/mrp/static/src/js/mrp_field_one2many_with_copy.js
@@ -60,6 +60,7 @@ var MrpFieldOne2ManyWithCopy = FieldOne2Many.extend({
             type: 'ir.actions.act_window',
             res_model: 'mrp.routing.workcenter',
             views: [[false, 'list'], [false, 'form']],
+            domain: ['|', ['bom_id', '=', false], ['bom_id.active', '=', true]],
             context: {
                 tree_view_ref: 'mrp.mrp_routing_workcenter_copy_to_bom_tree_view',
                 bom_id: this.recordData.id,


### PR DESCRIPTION
Currently, when a BOM is archived via the ECO mechanism, its operations are
still selectable via the `copy existing operation` action on the BOM.

In this commit, we have added domain in `copy existing operation` action.

TaskID - 2845022
PR - #92746