### PR TITLE
[FIX] portal: prevent traceback if no subtype set on message

### DIFF
--- a/addons/portal/models/mail_message.py
+++ b/addons/portal/models/mail_message.py
@@ -19,7 +19,7 @@ class MailMessage(models.Model):
         message_subtype_note_id = self.env['ir.model.data'].xmlid_to_res_id('mail.mt_note')
         IrAttachmentSudo = self.env['ir.attachment'].sudo()
         for vals in vals_list:
-            vals['is_message_subtype_note'] = message_subtype_note_id and vals.get('subtype_id', [False])[0] == message_subtype_note_id
+            vals['is_message_subtype_note'] = message_subtype_note_id and (vals.get('subtype_id') or [False])[0] == message_subtype_note_id
             for attachment in vals.get('attachment_ids', []):
                 if not attachment.get('access_token'):
                     attachment['access_token'] = IrAttachmentSudo.browse(attachment['id']).generate_access_token()[0]

--- a/addons/portal/tests/__init__.py
+++ b/addons/portal/tests/__init__.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
+from . import test_message_format_portal
 from . import test_tours

--- a/addons/portal/tests/test_message_format_portal.py
+++ b/addons/portal/tests/test_message_format_portal.py
@@ -1,0 +1,41 @@
+# -*- coding: utf-8 -*-
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from odoo.tools import mute_logger
+from odoo.tests import common, tagged
+
+
+@tagged('mail_message')
+class TestMessageFormatPortal(common.SavepointCase):
+
+    @mute_logger('odoo.models.unlink')
+    def test_mail_message_format(self):
+        """ Test the specific message formatting for the portal.
+        Notably the flag that tells if the message is of subtype 'note'. """
+
+        partner = self.env['res.partner'].create({'name': 'Partner'})
+        message_no_subtype = self.env['mail.message'].create([{
+            'model': 'res.partner',
+            'res_id': partner.id,
+        }])
+        formatted_result = message_no_subtype.portal_message_format()
+        # no defined subtype -> should return False
+        self.assertFalse(formatted_result[0].get('is_message_subtype_note'))
+
+        message_comment = self.env['mail.message'].create([{
+            'model': 'res.partner',
+            'res_id': partner.id,
+            'subtype_id': self.env['ir.model.data'].xmlid_to_res_id('mail.mt_comment'),
+        }])
+        formatted_result = message_comment.portal_message_format()
+        # subtype is a comment -> should return False
+        self.assertFalse(formatted_result[0].get('is_message_subtype_note'))
+
+        message_note = self.env['mail.message'].create([{
+            'model': 'res.partner',
+            'res_id': partner.id,
+            'subtype_id': self.env['ir.model.data'].xmlid_to_res_id('mail.mt_note'),
+        }])
+        formatted_result = message_note.portal_message_format()
+        # subtype is note -> should return True
+        self.assertTrue(formatted_result[0].get('is_message_subtype_note'))


### PR DESCRIPTION
This is a small fixup of a recent commit [1].

If no subtype is set on one message read, we should correctly return
False and not a TypeError.

[1]:https://github.com/odoo/odoo/commit/f74434c6f4303650e886d99fb950c763f2d4cc6e

Description of the issue/feature this PR addresses:
opw-2841209
opw-2857082
opw-2857248
opw-2862073
opw-2867385
opw-2867900
opw-2837720

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
