### PR TITLE
[IMP] payment: Allow specifying extra 'allowed states' to `_set_{stat…

### DIFF
--- a/addons/payment/models/const.py
+++ b/addons/payment/models/const.py
@@ -1,0 +1,22 @@
+SET_STATE_MAPPING = {
+    'pending': {
+        'a': ('draft',),
+        't': 'pending',
+    },
+    'authorized': {
+        'a': ('draft', 'pending',),
+        't': 'authorized',
+    },
+    'done': {
+        'a': ('draft', 'pending', 'authorized', 'error',),
+        't': 'done',
+    },
+    'canceled': {
+        'a': ('draft', 'pending', 'authorized'),
+        't': 'cancel',
+    },
+    'error': {
+        'a': ('draft', 'pending', 'authorized', 'done',),
+        't': 'error',
+    },
+}


### PR DESCRIPTION
…e}` methods

Before the transition between states of a transaction where hard coded and
independent of the acquirer. This presented a problem when an acquirer
had a custom flow.
Now we allow customization by acquirer for transition between states of a
transaction.

Task - 2869678

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
