### PR TITLE
[IMP] pos_epson: Better error message on PoS start

### DIFF
--- a/addons/point_of_sale/static/src/css/pos.css
+++ b/addons/point_of_sale/static/src/css/pos.css
@@ -2481,6 +2481,7 @@ td {
     font-weight: normal;
     font-size: 18px;
     margin: 16px;
+    white-space: pre-line;
 }
 
 .pos .popup-lg .body {

--- a/addons/pos_epson_printer/static/src/js/printers.js
+++ b/addons/pos_epson_printer/static/src/js/printers.js
@@ -24,7 +24,11 @@ var EpsonPrinter = core.Class.extend(PrinterMixin, {
         } else {
             Gui.showPopup('ErrorPopup', {
                 'title': _t('Connection to the printer failed'),
-                'body':  _t('Please check if the printer is still connected, if the configured IP address is correct and if your printer supports the ePOS protocol.'),
+                'body': _t('Please check if the printer is still connected, if the configured IP address is correct and if your printer supports the ePOS protocol. \n' +
+                    'Some browsers don\'t allow HTTP calls from websites to devices in the network (for security reasons). ' +
+                    'If it is the case, you will need to follow Odoo\'s documentation for ' +
+                    '\'Self-signed certificate for ePOS printers\' and \'Secure connection (HTTPS)\' to solve the issue'
+                ),
             });
         }
     },


### PR DESCRIPTION
Chrome did an update on which LAN devices are not accessible trough websites (but would still be accessible in `localhost`) ending in CORS error when trying to reach the device. More information:
https://developer.chrome.com/blog/private-network-access-update/

Before this commit:
A lot of customers were confused as of why their printers suddenly stop working without any changes.

After this commit:
The error message have been improved to also guide people to solve this issue (creating an HTTPS certificate).
Note that it is not possible from the JS code to say if they are concerned by this issue or not as the error given does not specify explicitly if it is a CORS error or something else, see:
https://stackoverflow.com/a/6734427

OPW-2850019
& many more like:
OPW-2856164
OPW-2858658
OPW-2857076
