### PR TITLE
[FIX] l10n_pk: add default POS account

### DIFF
--- a/addons/l10n_pk/data/l10n_pk_chart_data.xml
+++ b/addons/l10n_pk/data/l10n_pk_chart_data.xml
@@ -8,5 +8,6 @@
         <field name="property_account_income_categ_id" ref="l10n_pk_3111001" />
         <field name="property_account_expense_categ_id" ref="l10n_pk_4111001" />
         <field name="account_journal_suspense_account_id" ref="l10n_pk_2226000"/>
+        <field name="default_pos_receivable_account_id" ref="l10n_pk_1121001"/>
     </record>
 </odoo>


### PR DESCRIPTION
An error is thrown when trying to close a POS session in the Pakistan
localization

Steps to reproduce:
1. Install POS and Pakistan localization
2. Switch to PK Company
3. Go to Point of Sale > Configuration > Payment Methods and create a
new payment method with journal 'Cash'
4. Go to Configuration > Point of Sale and create a new point of sale
with sales journal 'Customer Invoices'
5. Open a POS session in the new POS and sell any item
6. Try to close the session, an error occurs telling you to close the
session in the back-end
7. Try to close the session, an error occurs and the message is
displayed

Solution:
Add a default POS account in the Pakistan module

Problem:
The function `_get_receivable_account` didn't find any account so it was
not possible to create the account move lines related to the POS session

opw-2857669