### PR TITLE
[FIX] web_editor, website_sale, website_slides: restore defaults before applying preset color

### DIFF
--- a/addons/web_editor/static/src/scss/web_editor.common.scss
+++ b/addons/web_editor/static/src/scss/web_editor.common.scss
@@ -653,6 +653,9 @@ blockquote {
                 }
             }
         }
+        .dropdown-menu .dropdown-item-text .text-muted {
+            color: $text-muted !important;
+        }
     }
 }
 @for $index from 1 through length($o-color-combinations) {

--- a/addons/web_editor/static/src/scss/web_editor.variables.scss
+++ b/addons/web_editor/static/src/scss/web_editor.variables.scss
@@ -572,6 +572,7 @@ $o-color-extras-nesting-selector: '&, .o_colored_level &';
     @if type-of($-related-color) == 'number' {
         // This is a preset to be applied, just extend it. This should probably
         // be avoided and use the class in XML if possible.
+        @extend .o_cc;
         @extend .o_cc#{$-related-color};
     } @else {
         @include o-bg-color(o-color($-related-color), $with-extras: $with-extras, $background: $background, $important: false);

--- a/addons/website_sale/static/src/snippets/s_products_searchbar/000.js
+++ b/addons/website_sale/static/src/snippets/s_products_searchbar/000.js
@@ -110,6 +110,17 @@ publicWidget.registry.productsSearchBar = publicWidget.Widget.extend({
                 currency: res['currency'],
                 widget: this,
             }));
+
+            // TODO adapt directly in the template in master
+            const mutedItemTextEl = this.$menu.find('span.dropdown-item-text.text-muted')[0];
+            if (mutedItemTextEl) {
+                const newItemTextEl = document.createElement('span');
+                newItemTextEl.classList.add('dropdown-item-text');
+                mutedItemTextEl.after(newItemTextEl);
+                mutedItemTextEl.classList.remove('dropdown-item-text');
+                newItemTextEl.appendChild(mutedItemTextEl);
+            }
+
             this.$menu.css('min-width', this.autocompleteMinWidth);
 
             // Handle the case where the searchbar is in a mega menu by making

--- a/addons/website_sale/static/src/xml/website_sale_utils.xml
+++ b/addons/website_sale/static/src/xml/website_sale_utils.xml
@@ -5,6 +5,8 @@
 <div t-name="website_sale.productsSearchBar.autocomplete"
     class="dropdown-menu show w-100">
     <t t-if="!products.length">
+        <!-- TODO adapt in master, this is patched in JS so that text-muted -->
+        <!-- is not on the same element as dropdown-item-text -->
         <span class="dropdown-item-text text-muted">No results found. Please try another search.</span>
     </t>
     <a t-foreach="products" t-as="product"

--- a/addons/website_slides/static/src/scss/website_slides.scss
+++ b/addons/website_slides/static/src/scss/website_slides.scss
@@ -94,6 +94,19 @@ $o-wslides-fs-side-width: 300px;
     .o_wslides_home_nav {
         top: -40px;
 
+        // TODO Remove me in master
+        [style*="background: white"] .nav-link {
+            color: $navbar-light-color !important;
+
+            @include hover-focus {
+                color: $navbar-light-hover-color !important;
+            }
+
+            &.disabled {
+                color: $navbar-light-disabled-color !important;
+            }
+        }
+
         @include media-breakpoint-up(lg) {
             font-size: 1rem;
 

--- a/addons/website_slides/views/website_slides_templates_homepage.xml
+++ b/addons/website_slides/views/website_slides_templates_homepage.xml
@@ -20,6 +20,7 @@
                 </div>
             </section>
             <div class="container mt16 o_wslides_home_nav position-relative">
+                <!-- TODO Remove inline style in master -->
                 <nav class="navbar navbar-expand-lg navbar-light shadow-sm" style="background: white!important">
                     <form method="GET" class="form-inline o_wslides_nav_navbar_right order-lg-3" t-attf-action="/slides/all" role="search">
                         <div class="input-group">
@@ -181,6 +182,7 @@
             </section>
             <div class="container mt16 o_wslides_home_nav position-relative">
                 <!-- Navbar dynamically composed using displayed channel tag groups. -->
+                <!-- TODO Remove inline style in master -->
                 <nav class="navbar navbar-expand-md navbar-light shadow-sm pl-0" style="background: white!important">
                     <div class="navbar-nav border-right">
                         <a class="nav-link nav-item px-3" href="/slides"><i class="fa fa-chevron-left"/></a>


### PR DESCRIPTION
Before this commit when a search bar was within a navigation bar, its
autocompletion popover was using the text color according to the
navbar's background color determined by the theme. For dark themes, this
made the autocompletion appear almost as white on white.

This commit uses the defaults before applying a specific preset color
so that the dropdown menu style within the navbar uses the original
color.
It also resets the `text-muted` style used in "No results" message.

This PR also fixes an unreadable text in the Courses page's navigation bar.

Steps to reproduce:
- Select a dark palette (e.g. one that makes the navigation bars black).
- Drop a "Products Search" block.
- Reset its background color.
- Pick a color combination with a dark background.
=> The autocompletion's "No results" message is shown without contrast.

task-2855511

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
