### PR TITLE
[FIX] hr_timesheet : allow project managers to handle timesheets

### DIFF
--- a/addons/hr_timesheet/security/hr_timesheet_security.xml
+++ b/addons/hr_timesheet/security/hr_timesheet_security.xml
@@ -60,7 +60,7 @@
             <field name="name">account.analytic.line.timesheet.manager</field>
             <field name="model_id" ref="analytic.model_account_analytic_line"/>
             <field name="domain_force">[('project_id', '!=', False)]</field>
-            <field name="groups" eval="[(4, ref('group_timesheet_manager'))]"/>
+            <field name="groups" eval="[(4, ref('group_timesheet_manager')), (4, ref('project.group_project_manager'))]"/>
         </record>
 
         <record id="project.group_project_manager" model="res.groups">


### PR DESCRIPTION
Steps to reproduce:
- Install project and timesheet
- Create a project with settings "invited employees only"
- Create a user with administrator project right (and non admin
rights for timesheet)
- Create a task in the new project
- Try to generate a timesheet on the task with the new user (the
user has to not follow the task)

Current behavior:
This generate an access error due to not respecting some rules

Expected behavior:
The timesheet is created

Explanation:
The project admin should be able to handle any timesheet that is
linked to a project to do so we add its group to the rule that gives
access to the model analytic.model_account_analytic_line if there
is a project_id. The steps to reproduce creates a situation where the 
timesheet_line_rule_approver is not respected anymore so by adding
this group rule the timesheet_line_rule_approver does not have to be 
respected anymore.

opw-2861042
