### PR TITLE
[FIX] l10n_pe: create related field directly to speed it up

### DIFF
--- a/addons/l10n_pe/models/account_move.py
+++ b/addons/l10n_pe/models/account_move.py
@@ -1,8 +1,23 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 from odoo import models, fields
+from odoo.tools.sql import column_exists, create_column
 
 
 class AccountMoveLine(models.Model):
     _inherit = "account.move.line"
 
     l10n_pe_group_id = fields.Many2one("account.group", related="account_id.group_id", store=True)
+
+    def _auto_init(self):
+        """
+        Create column to stop ORM from computing it himself (too slow)
+        """
+        if not column_exists(self.env.cr, self._table, 'l10n_pe_group_id'):
+            create_column(self.env.cr, self._table, 'l10n_pe_group_id', 'int4')
+            self.env.cr.execute("""
+                UPDATE account_move_line line
+                SET l10n_pe_group_id = account.group_id
+                FROM account_account account
+                WHERE account.id = line.account_id
+            """)
+        return super()._auto_init()


### PR DESCRIPTION
Odoo ORM has special optimization for installing module with a stored related
fields, but it requires the final field be not computed [1] (I'm not sure why),
which is not the case for the `group_id` field. Since `account.move.line` table
may have millions of records, we have to optimize the installation and fill
`l10n_pe_group_id` via a single sql query.

[1]: https://github.com/odoo/odoo/blob/0aff8bb9484a23c0d875d3b12259dd4e0d51e716/odoo/fields.py#L818

opw-2762510

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
