### PR TITLE
[FIX] account,sale: show sales from archived partner

### DIFF
--- a/addons/account/models/partner.py
+++ b/addons/account/models/partner.py
@@ -473,9 +473,10 @@ class ResPartner(models.Model):
     def action_view_partner_invoices(self):
         self.ensure_one()
         action = self.env.ref('account.action_move_out_invoice_type').read()[0]
+        all_child = self.with_context(active_test=False).search([('id', 'child_of', self.ids)])
         action['domain'] = [
             ('type', 'in', ('out_invoice', 'out_refund')),
-            ('partner_id', 'child_of', self.id),
+            ('partner_id', 'in', all_child.ids)
         ]
         action['context'] = {'default_type':'out_invoice', 'type':'out_invoice', 'journal_type': 'sale', 'search_default_unpaid': 1}
         return action

--- a/addons/sale/models/res_partner.py
+++ b/addons/sale/models/res_partner.py
@@ -43,3 +43,9 @@ class ResPartner(models.Model):
             ('state', 'in', ['sent', 'sale', 'done'])
         ], limit=1)
         return can_edit_vat and not bool(has_so)
+
+    def action_view_sale_order(self):
+        action = self.env.ref('sale.act_res_partner_2_sale_order').read()[0]
+        all_child = self.with_context(active_test=False).search([('id', 'child_of', self.ids)])
+        action['domain'] = [('partner_id', 'in', all_child.ids)]
+        return action

--- a/addons/sale/views/res_partner_views.xml
+++ b/addons/sale/views/res_partner_views.xml
@@ -4,7 +4,7 @@
             <field name="name">Quotations and Sales</field>
             <field name="res_model">sale.order</field>
             <field name="view_mode">tree,form,graph</field>
-            <field name="context">{'search_default_partner_id': active_id, 'default_partner_id': active_id}</field>
+            <field name="context">{'default_partner_id': active_id}</field>
             <field name="groups_id" eval="[(4, ref('sales_team.group_sale_salesman'))]"/>
             <field name="help" type="html">
               <p class="o_view_nocontent_smiling_face">
@@ -40,7 +40,7 @@
             <field name="groups_id" eval="[(4, ref('sales_team.group_sale_salesman'))]"/>
             <field name="arch" type="xml">
                 <div name="button_box" position="inside">
-                    <button class="oe_stat_button" type="action" name="%(sale.act_res_partner_2_sale_order)d" 
+                    <button class="oe_stat_button" type="object" name="action_view_sale_order"
                         groups="sales_team.group_sale_salesman"
                         icon="fa-usd">
                         <field string="Sales" name="sale_order_count" widget="statinfo"/>


### PR DESCRIPTION
Current behavior:
If you made a sales with a partner wich is part of a company.
And then archive that partner and click on the sales smart button
from the company the sales from that partner wouldn't appear in
the list. The problem is the same for the invoices

Steps to reproduce:
- Install sales and contacts
- Create a sale for a partner (e.g. Edwin Hansen from Gemini)
- Archive that partner
- Go in the company view, click on sales button
- The sale from the archived partner do not appear in the
  company sales list

opw-2850115
--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
