### PR TITLE
[REV][FIX] account: Fix journal dashboard graph query

### DIFF
--- a/addons/account/models/account_journal_dashboard.py
+++ b/addons/account/models/account_journal_dashboard.py
@@ -173,7 +173,6 @@ class account_journal(models.Model):
                 query += " UNION ALL ("+select_sql_clause+" and invoice_date_due >= '"+start_date.strftime(DF)+"' and invoice_date_due < '"+next_date.strftime(DF)+"')"
                 weeks.append((start_date, next_date))
                 start_date = next_date
-        # Ensure results returned by postgres match the order of data list
         self.env.cr.execute(query, query_args)
         query_results = self.env.cr.dictfetchall()
         is_sample_data = True


### PR DESCRIPTION
Revert of commit bac93bf56ff67a89f9381137b0c67642a302e6bb

Steps:

- Three Vendor Bills posted and not paid:
    - 1. due date today - 2 weeks
    - 2. due date today
    - 3. due date today + 3 weeks
- Go to Accounting Dashboard
-> The graph displays the three bills in each three
   first columns, which is wrong.

This is because before the mentioned commit, the query result
was display like this:

[{VB 1}, {}, {}, {VB 2}, {}, {VB 3}]

And after, as it add the order based on aggr_date ASC to the query,
the query result looks like this:

[{VB 1}, {VB 2}, {VB 3}, {}, {}, {}]

As the bug mentioned on the issue 2702707 was not reproductible
on runbot, it is better to revert the commit, as it leds to a
more significant bug.

opw-2782117

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
