### PR TITLE
[FIX] web: breaking test since Chrome 94+

### DIFF
--- a/addons/web/static/src/core/utils/scrolling.js
+++ b/addons/web/static/src/core/utils/scrolling.js
@@ -32,7 +32,7 @@ export function scrollTo(element, options = { scrollable: null, isAnchor: false 
         if (elementBottom > scrollBottom && !options.isAnchor) {
             // The scroll place the element at the bottom border of the scrollable
             scrollable.scrollTop +=
-                elementTop - scrollBottom + element.getBoundingClientRect().height;
+                elementTop - scrollBottom + Math.ceil(element.getBoundingClientRect().height);
         } else if (elementTop < scrollTop || options.isAnchor) {
             // The scroll place the element at the top of the scrollable
             scrollable.scrollTop -= scrollTop - elementTop;

--- a/addons/web/static/tests/legacy/views/calendar_tests.js
+++ b/addons/web/static/tests/legacy/views/calendar_tests.js
@@ -4107,12 +4107,9 @@ QUnit.module('Views', {
         var $initCell = calendar.$('.fc-time-grid .fc-minor[data-time="06:30:00"] .fc-widget-content:last-child');
         var $endCell = calendar.$('.fc-time-grid .fc-minor[data-time="10:30:00"] .fc-widget-content:last-child');
 
-        var left = $initCell.offset().left;
-        var top = $initCell.offset().top;
-        testUtils.dom.triggerPositionalMouseEvent(left, top, "mousedown");
-        top = $endCell.offset().top;
-        testUtils.dom.triggerPositionalMouseEvent(left, top, "mousemove");
-        testUtils.dom.triggerPositionalMouseEvent(left, top, "mouseup");
+        testUtils.dom.triggerMouseEvent($initCell, "mousedown");
+        testUtils.dom.triggerMouseEvent($endCell, "mousemove");
+        testUtils.dom.triggerMouseEvent($endCell, "mouseup");
         await testUtils.nextTick();
 
         assert.verifySteps(['do_action']);


### PR DESCRIPTION
Since Chrome 94, some element's sizing computation returns a slightly
different value (in the order of a fraction of a pixel). Sadly, due to
rounding, this difference has an impact on exact sizing assertion.
