### PR TITLE
[I18N] account: propely translate Invoice PDF for all languages

### DIFF
--- a/addons/account/i18n/account.pot
+++ b/addons/account/i18n/account.pot
@@ -692,7 +692,7 @@ msgstr ""
 #: model_terms:ir.ui.view,arch_db:account.report_invoice_document
 msgid ""
 "<span groups=\"account.group_show_line_subtotals_tax_excluded\">Amount</span>\n"
-"                                    <span groups=\"account.group_show_line_subtotals_tax_included\">Total Price</span>"
+"                                       <span groups=\"account.group_show_line_subtotals_tax_included\">Total Price</span>"
 msgstr ""
 
 #. module: account

--- a/addons/account/i18n/ar.po
+++ b/addons/account/i18n/ar.po
@@ -510,10 +510,10 @@ msgstr ""
 #: model_terms:ir.ui.view,arch_db:account.report_invoice_document
 msgid ""
 "<span groups=\"account.group_show_line_subtotals_tax_excluded\">Amount</span>\n"
-"                                    <span groups=\"account.group_show_line_subtotals_tax_included\">Total Price</span>"
+"                                       <span groups=\"account.group_show_line_subtotals_tax_included\">Total Price</span>"
 msgstr ""
 "<span groups=\"account.group_show_line_subtotals_tax_excluded\">المبلغ</span>\n"
-"                                    <span groups=\"account.group_show_line_subtotals_tax_included\">السعر الإجمالي</span>"
+"                                       <span groups=\"account.group_show_line_subtotals_tax_included\">السعر الإجمالي</span>"
 
 #. module: account
 #: model_terms:ir.ui.view,arch_db:account.account_journal_dashboard_kanban_view

--- a/addons/account/i18n/az.po
+++ b/addons/account/i18n/az.po
@@ -357,7 +357,7 @@ msgstr ""
 #: model_terms:ir.ui.view,arch_db:account.report_invoice_document
 msgid ""
 "<span groups=\"account.group_show_line_subtotals_tax_excluded\">Amount</span>\n"
-"                                    <span groups=\"account.group_show_line_subtotals_tax_included\">Total Price</span>"
+"                                       <span groups=\"account.group_show_line_subtotals_tax_included\">Total Price</span>"
 msgstr ""
 
 #. module: account

--- a/addons/account/i18n/bs.po
+++ b/addons/account/i18n/bs.po
@@ -336,7 +336,7 @@ msgstr ""
 #: model_terms:ir.ui.view,arch_db:account.report_invoice_document
 msgid ""
 "<span groups=\"account.group_show_line_subtotals_tax_excluded\">Amount</span>\n"
-"                                    <span groups=\"account.group_show_line_subtotals_tax_included\">Total Price</span>"
+"                                       <span groups=\"account.group_show_line_subtotals_tax_included\">Total Price</span>"
 msgstr ""
 
 #. module: account

--- a/addons/account/i18n/ca.po
+++ b/addons/account/i18n/ca.po
@@ -817,10 +817,10 @@ msgstr "<span class=\"text-nowrap\">2,350.00</span>"
 #: model_terms:ir.ui.view,arch_db:account.report_invoice_document
 msgid ""
 "<span groups=\"account.group_show_line_subtotals_tax_excluded\">Amount</span>\n"
-"                                    <span groups=\"account.group_show_line_subtotals_tax_included\">Total Price</span>"
+"                                       <span groups=\"account.group_show_line_subtotals_tax_included\">Total Price</span>"
 msgstr ""
 "<span groups=\"account.group_show_line_subtotals_tax_excluded\">Import</span>\n"
-"                                    <span groups=\"account.group_show_line_subtotals_tax_included\">Preu total</span>"
+"                                       <span groups=\"account.group_show_line_subtotals_tax_included\">Preu total</span>"
 
 #. module: account
 #: model_terms:ir.ui.view,arch_db:account.account_journal_dashboard_kanban_view

--- a/addons/account/i18n/cs.po
+++ b/addons/account/i18n/cs.po
@@ -792,10 +792,10 @@ msgstr "<span class=\"text-nowrap\">2,350.00</span>"
 #: model_terms:ir.ui.view,arch_db:account.report_invoice_document
 msgid ""
 "<span groups=\"account.group_show_line_subtotals_tax_excluded\">Amount</span>\n"
-"                                    <span groups=\"account.group_show_line_subtotals_tax_included\">Total Price</span>"
+"                                       <span groups=\"account.group_show_line_subtotals_tax_included\">Total Price</span>"
 msgstr ""
 "<span groups=\"account.group_show_line_subtotals_tax_excluded\">Množství</span>\n"
-"                                    <span groups=\"account.group_show_line_subtotals_tax_included\">Celková cena</span>"
+"                                       <span groups=\"account.group_show_line_subtotals_tax_included\">Celková cena</span>"
 
 #. module: account
 #: model_terms:ir.ui.view,arch_db:account.account_journal_dashboard_kanban_view

--- a/addons/account/i18n/da.po
+++ b/addons/account/i18n/da.po
@@ -460,10 +460,10 @@ msgstr ""
 #: model_terms:ir.ui.view,arch_db:account.report_invoice_document
 msgid ""
 "<span groups=\"account.group_show_line_subtotals_tax_excluded\">Amount</span>\n"
-"                                    <span groups=\"account.group_show_line_subtotals_tax_included\">Total Price</span>"
+"                                       <span groups=\"account.group_show_line_subtotals_tax_included\">Total Price</span>"
 msgstr ""
 "<span groups=\"account.group_show_line_subtotals_tax_excluded\">Beløb</span>\n"
-"                                    <span groups=\"account.group_show_line_subtotals_tax_included\">Total pris</span>"
+"                                       <span groups=\"account.group_show_line_subtotals_tax_included\">Total pris</span>"
 
 #. module: account
 #: model_terms:ir.ui.view,arch_db:account.account_journal_dashboard_kanban_view

--- a/addons/account/i18n/de.po
+++ b/addons/account/i18n/de.po
@@ -864,10 +864,10 @@ msgstr "<span class=\"text-nowrap\">2.350,00</span>"
 #: model_terms:ir.ui.view,arch_db:account.report_invoice_document
 msgid ""
 "<span groups=\"account.group_show_line_subtotals_tax_excluded\">Amount</span>\n"
-"                                    <span groups=\"account.group_show_line_subtotals_tax_included\">Total Price</span>"
+"                                       <span groups=\"account.group_show_line_subtotals_tax_included\">Total Price</span>"
 msgstr ""
 "<span groups=\"account.group_show_line_subtotals_tax_excluded\">Betrag</span>\n"
-"                                <span groups=\"account.group_show_line_subtotals_tax_included\">Gesamtpreis</span>"
+"                                       <span groups=\"account.group_show_line_subtotals_tax_included\">Gesamtpreis</span>"
 
 #. module: account
 #: model_terms:ir.ui.view,arch_db:account.account_journal_dashboard_kanban_view

--- a/addons/account/i18n/el.po
+++ b/addons/account/i18n/el.po
@@ -734,7 +734,7 @@ msgstr ""
 #: model_terms:ir.ui.view,arch_db:account.report_invoice_document
 msgid ""
 "<span groups=\"account.group_show_line_subtotals_tax_excluded\">Amount</span>\n"
-"                                    <span groups=\"account.group_show_line_subtotals_tax_included\">Total Price</span>"
+"                                       <span groups=\"account.group_show_line_subtotals_tax_included\">Total Price</span>"
 msgstr ""
 "<span groups=\"account.group_show_line_subtotals_tax_excluded\">Ποσό</span>\n"
 "<span groups=\"account.group_show_line_subtotals_tax_included\">Συνολική Τιμή</span>"

--- a/addons/account/i18n/es.po
+++ b/addons/account/i18n/es.po
@@ -879,10 +879,10 @@ msgstr "<span class=\"text-nowrap\">2,350.00</span>"
 #: model_terms:ir.ui.view,arch_db:account.report_invoice_document
 msgid ""
 "<span groups=\"account.group_show_line_subtotals_tax_excluded\">Amount</span>\n"
-"                                    <span groups=\"account.group_show_line_subtotals_tax_included\">Total Price</span>"
+"                                       <span groups=\"account.group_show_line_subtotals_tax_included\">Total Price</span>"
 msgstr ""
 "<span groups=\"account.group_show_line_subtotals_tax_excluded\">Importe</span>\n"
-"                                    <span groups=\"account.group_show_line_subtotals_tax_included\">Precio Total</span>"
+"                                       <span groups=\"account.group_show_line_subtotals_tax_included\">Precio Total</span>"
 
 #. module: account
 #: model_terms:ir.ui.view,arch_db:account.account_journal_dashboard_kanban_view

--- a/addons/account/i18n/et.po
+++ b/addons/account/i18n/et.po
@@ -346,7 +346,7 @@ msgstr ""
 #: model_terms:ir.ui.view,arch_db:account.report_invoice_document
 msgid ""
 "<span groups=\"account.group_show_line_subtotals_tax_excluded\">Amount</span>\n"
-"                                    <span groups=\"account.group_show_line_subtotals_tax_included\">Total Price</span>"
+"                                       <span groups=\"account.group_show_line_subtotals_tax_included\">Total Price</span>"
 msgstr ""
 
 #. module: account

--- a/addons/account/i18n/fa.po
+++ b/addons/account/i18n/fa.po
@@ -366,7 +366,7 @@ msgstr ""
 #: model_terms:ir.ui.view,arch_db:account.report_invoice_document
 msgid ""
 "<span groups=\"account.group_show_line_subtotals_tax_excluded\">Amount</span>\n"
-"                                    <span groups=\"account.group_show_line_subtotals_tax_included\">Total Price</span>"
+"                                       <span groups=\"account.group_show_line_subtotals_tax_included\">Total Price</span>"
 msgstr ""
 
 #. module: account

--- a/addons/account/i18n/fi.po
+++ b/addons/account/i18n/fi.po
@@ -355,7 +355,7 @@ msgstr ""
 #: model_terms:ir.ui.view,arch_db:account.report_invoice_document
 msgid ""
 "<span groups=\"account.group_show_line_subtotals_tax_excluded\">Amount</span>\n"
-"                                    <span groups=\"account.group_show_line_subtotals_tax_included\">Total Price</span>"
+"                                       <span groups=\"account.group_show_line_subtotals_tax_included\">Total Price</span>"
 msgstr ""
 
 #. module: account

--- a/addons/account/i18n/fr.po
+++ b/addons/account/i18n/fr.po
@@ -990,10 +990,10 @@ msgstr "<span class=\"text-nowrap\">2.350,00</span>"
 #: model_terms:ir.ui.view,arch_db:account.report_invoice_document
 msgid ""
 "<span groups=\"account.group_show_line_subtotals_tax_excluded\">Amount</span>\n"
-"                                    <span groups=\"account.group_show_line_subtotals_tax_included\">Total Price</span>"
+"                                       <span groups=\"account.group_show_line_subtotals_tax_included\">Total Price</span>"
 msgstr ""
 "<span groups=\"account.group_show_line_subtotals_tax_excluded\">Montant</span>\n"
-"                                    <span groups=\"account.group_show_line_subtotals_tax_included\">Prix Total</span>"
+"                                       <span groups=\"account.group_show_line_subtotals_tax_included\">Prix Total</span>"
 
 #. module: account
 #: model_terms:ir.ui.view,arch_db:account.account_journal_dashboard_kanban_view

--- a/addons/account/i18n/gu.po
+++ b/addons/account/i18n/gu.po
@@ -343,7 +343,7 @@ msgstr ""
 #: model_terms:ir.ui.view,arch_db:account.report_invoice_document
 msgid ""
 "<span groups=\"account.group_show_line_subtotals_tax_excluded\">Amount</span>\n"
-"                                    <span groups=\"account.group_show_line_subtotals_tax_included\">Total Price</span>"
+"                                       <span groups=\"account.group_show_line_subtotals_tax_included\">Total Price</span>"
 msgstr ""
 
 #. module: account

--- a/addons/account/i18n/he.po
+++ b/addons/account/i18n/he.po
@@ -425,10 +425,10 @@ msgstr ""
 #: model_terms:ir.ui.view,arch_db:account.report_invoice_document
 msgid ""
 "<span groups=\"account.group_show_line_subtotals_tax_excluded\">Amount</span>\n"
-"                                    <span groups=\"account.group_show_line_subtotals_tax_included\">Total Price</span>"
+"                                       <span groups=\"account.group_show_line_subtotals_tax_included\">Total Price</span>"
 msgstr ""
 "<span groups=\"account.group_show_line_subtotals_tax_excluded\">סכום</span>\n"
-"                                    <span groups=\"account.group_show_line_subtotals_tax_included\">Total Price</span>"
+"                                       <span groups=\"account.group_show_line_subtotals_tax_included\">Total Price</span>"
 
 #. module: account
 #: model_terms:ir.ui.view,arch_db:account.account_journal_dashboard_kanban_view

--- a/addons/account/i18n/hr.po
+++ b/addons/account/i18n/hr.po
@@ -770,10 +770,10 @@ msgstr ""
 #: model_terms:ir.ui.view,arch_db:account.report_invoice_document
 msgid ""
 "<span groups=\"account.group_show_line_subtotals_tax_excluded\">Amount</span>\n"
-"                                    <span groups=\"account.group_show_line_subtotals_tax_included\">Total Price</span>"
+"                                       <span groups=\"account.group_show_line_subtotals_tax_included\">Total Price</span>"
 msgstr ""
 "<span groups=\"account.group_show_line_subtotals_tax_excluded\">Iznos</span>\n"
-"                                    <span groups=\"account.group_show_line_subtotals_tax_included\">Ukupna cijena</span>"
+"                                       <span groups=\"account.group_show_line_subtotals_tax_included\">Ukupna cijena</span>"
 
 #. module: account
 #: model_terms:ir.ui.view,arch_db:account.account_journal_dashboard_kanban_view

--- a/addons/account/i18n/hu.po
+++ b/addons/account/i18n/hu.po
@@ -753,7 +753,7 @@ msgstr "<span class=\"text-nowrap\">2,350.00</span>"
 #: model_terms:ir.ui.view,arch_db:account.report_invoice_document
 msgid ""
 "<span groups=\"account.group_show_line_subtotals_tax_excluded\">Amount</span>\n"
-"                                    <span groups=\"account.group_show_line_subtotals_tax_included\">Total Price</span>"
+"                                       <span groups=\"account.group_show_line_subtotals_tax_included\">Total Price</span>"
 msgstr ""
 
 #. module: account

--- a/addons/account/i18n/is.po
+++ b/addons/account/i18n/is.po
@@ -337,7 +337,7 @@ msgstr ""
 #: model_terms:ir.ui.view,arch_db:account.report_invoice_document
 msgid ""
 "<span groups=\"account.group_show_line_subtotals_tax_excluded\">Amount</span>\n"
-"                                    <span groups=\"account.group_show_line_subtotals_tax_included\">Total Price</span>"
+"                                       <span groups=\"account.group_show_line_subtotals_tax_included\">Total Price</span>"
 msgstr ""
 
 #. module: account

--- a/addons/account/i18n/it.po
+++ b/addons/account/i18n/it.po
@@ -787,10 +787,10 @@ msgstr "<span class=\"text-nowrap\">2.350,00</span>"
 #: model_terms:ir.ui.view,arch_db:account.report_invoice_document
 msgid ""
 "<span groups=\"account.group_show_line_subtotals_tax_excluded\">Amount</span>\n"
-"                                    <span groups=\"account.group_show_line_subtotals_tax_included\">Total Price</span>"
+"                                       <span groups=\"account.group_show_line_subtotals_tax_included\">Total Price</span>"
 msgstr ""
 "<span groups=\"account.group_show_line_subtotals_tax_excluded\">Importo</span>\n"
-"                                    <span groups=\"account.group_show_line_subtotals_tax_included\">Prezzo totale</span>"
+"                                       <span groups=\"account.group_show_line_subtotals_tax_included\">Prezzo totale</span>"
 
 #. module: account
 #: model_terms:ir.ui.view,arch_db:account.account_journal_dashboard_kanban_view

--- a/addons/account/i18n/ja.po
+++ b/addons/account/i18n/ja.po
@@ -352,7 +352,7 @@ msgstr ""
 #: model_terms:ir.ui.view,arch_db:account.report_invoice_document
 msgid ""
 "<span groups=\"account.group_show_line_subtotals_tax_excluded\">Amount</span>\n"
-"                                    <span groups=\"account.group_show_line_subtotals_tax_included\">Total Price</span>"
+"                                       <span groups=\"account.group_show_line_subtotals_tax_included\">Total Price</span>"
 msgstr ""
 
 #. module: account

--- a/addons/account/i18n/km.po
+++ b/addons/account/i18n/km.po
@@ -338,7 +338,7 @@ msgstr ""
 #: model_terms:ir.ui.view,arch_db:account.report_invoice_document
 msgid ""
 "<span groups=\"account.group_show_line_subtotals_tax_excluded\">Amount</span>\n"
-"                                    <span groups=\"account.group_show_line_subtotals_tax_included\">Total Price</span>"
+"                                       <span groups=\"account.group_show_line_subtotals_tax_included\">Total Price</span>"
 msgstr ""
 
 #. module: account

--- a/addons/account/i18n/ko.po
+++ b/addons/account/i18n/ko.po
@@ -343,7 +343,7 @@ msgstr ""
 #: model_terms:ir.ui.view,arch_db:account.report_invoice_document
 msgid ""
 "<span groups=\"account.group_show_line_subtotals_tax_excluded\">Amount</span>\n"
-"                                    <span groups=\"account.group_show_line_subtotals_tax_included\">Total Price</span>"
+"                                       <span groups=\"account.group_show_line_subtotals_tax_included\">Total Price</span>"
 msgstr ""
 
 #. module: account

--- a/addons/account/i18n/lb.po
+++ b/addons/account/i18n/lb.po
@@ -409,7 +409,7 @@ msgstr ""
 #: model_terms:ir.ui.view,arch_db:account.report_invoice_document
 msgid ""
 "<span groups=\"account.group_show_line_subtotals_tax_excluded\">Amount</span>\n"
-"                                    <span groups=\"account.group_show_line_subtotals_tax_included\">Total Price</span>"
+"                                       <span groups=\"account.group_show_line_subtotals_tax_included\">Total Price</span>"
 msgstr ""
 
 #. module: account

--- a/addons/account/i18n/lt.po
+++ b/addons/account/i18n/lt.po
@@ -462,7 +462,7 @@ msgstr ""
 #: model_terms:ir.ui.view,arch_db:account.report_invoice_document
 msgid ""
 "<span groups=\"account.group_show_line_subtotals_tax_excluded\">Amount</span>\n"
-"                                    <span groups=\"account.group_show_line_subtotals_tax_included\">Total Price</span>"
+"                                       <span groups=\"account.group_show_line_subtotals_tax_included\">Total Price</span>"
 msgstr ""
 "<span groups=\"account.group_show_line_subtotals_tax_excluded\">Suma</span>\n"
 "<span groups=\"account.group_show_line_subtotals_tax_included\">Visa kaina</span>"

--- a/addons/account/i18n/mn.po
+++ b/addons/account/i18n/mn.po
@@ -782,10 +782,10 @@ msgstr ""
 #: model_terms:ir.ui.view,arch_db:account.report_invoice_document
 msgid ""
 "<span groups=\"account.group_show_line_subtotals_tax_excluded\">Amount</span>\n"
-"                                    <span groups=\"account.group_show_line_subtotals_tax_included\">Total Price</span>"
+"                                       <span groups=\"account.group_show_line_subtotals_tax_included\">Total Price</span>"
 msgstr ""
 "<span groups=\"account.group_show_line_subtotals_tax_excluded\">Дүн</span>\n"
-"                                    <span groups=\"account.group_show_line_subtotals_tax_included\">Нийт үнэ</span>"
+"                                       <span groups=\"account.group_show_line_subtotals_tax_included\">Нийт үнэ</span>"
 
 #. module: account
 #: model_terms:ir.ui.view,arch_db:account.account_journal_dashboard_kanban_view

--- a/addons/account/i18n/nb.po
+++ b/addons/account/i18n/nb.po
@@ -720,10 +720,10 @@ msgstr ""
 #: model_terms:ir.ui.view,arch_db:account.report_invoice_document
 msgid ""
 "<span groups=\"account.group_show_line_subtotals_tax_excluded\">Amount</span>\n"
-"                                    <span groups=\"account.group_show_line_subtotals_tax_included\">Total Price</span>"
+"                                       <span groups=\"account.group_show_line_subtotals_tax_included\">Total Price</span>"
 msgstr ""
 "<span groups=\"account.group_show_line_subtotals_tax_excluded\">Beløp</span>\n"
-"                                    <span groups=\"account.group_show_line_subtotals_tax_included\">Totalpris</span>"
+"                                       <span groups=\"account.group_show_line_subtotals_tax_included\">Totalpris</span>"
 
 #. module: account
 #: model_terms:ir.ui.view,arch_db:account.account_journal_dashboard_kanban_view

--- a/addons/account/i18n/nl.po
+++ b/addons/account/i18n/nl.po
@@ -813,10 +813,10 @@ msgstr "<span class=\"text-nowrap\">2,350.00</span>"
 #: model_terms:ir.ui.view,arch_db:account.report_invoice_document
 msgid ""
 "<span groups=\"account.group_show_line_subtotals_tax_excluded\">Amount</span>\n"
-"                                    <span groups=\"account.group_show_line_subtotals_tax_included\">Total Price</span>"
+"                                       <span groups=\"account.group_show_line_subtotals_tax_included\">Total Price</span>"
 msgstr ""
 "<span groups=\"account.group_show_line_subtotals_tax_excluded\">Bedrag</span>\n"
-"                                    <span groups=\"account.group_show_line_subtotals_tax_included\">Totale Prijs</span>"
+"                                       <span groups=\"account.group_show_line_subtotals_tax_included\">Totale Prijs</span>"
 
 #. module: account
 #: model_terms:ir.ui.view,arch_db:account.account_journal_dashboard_kanban_view

--- a/addons/account/i18n/pl.po
+++ b/addons/account/i18n/pl.po
@@ -788,10 +788,10 @@ msgstr ""
 #: model_terms:ir.ui.view,arch_db:account.report_invoice_document
 msgid ""
 "<span groups=\"account.group_show_line_subtotals_tax_excluded\">Amount</span>\n"
-"                                    <span groups=\"account.group_show_line_subtotals_tax_included\">Total Price</span>"
+"                                       <span groups=\"account.group_show_line_subtotals_tax_included\">Total Price</span>"
 msgstr ""
 "<span groups=\"account.group_show_line_subtotals_tax_excluded\">Kwota</span>\n"
-"                                    <span groups=\"account.group_show_line_subtotals_tax_included\">Cena całkowita</span>"
+"                                       <span groups=\"account.group_show_line_subtotals_tax_included\">Cena całkowita</span>"
 
 #. module: account
 #: model_terms:ir.ui.view,arch_db:account.account_journal_dashboard_kanban_view

--- a/addons/account/i18n/pt.po
+++ b/addons/account/i18n/pt.po
@@ -405,7 +405,7 @@ msgstr ""
 #: model_terms:ir.ui.view,arch_db:account.report_invoice_document
 msgid ""
 "<span groups=\"account.group_show_line_subtotals_tax_excluded\">Amount</span>\n"
-"                                    <span groups=\"account.group_show_line_subtotals_tax_included\">Total Price</span>"
+"                                       <span groups=\"account.group_show_line_subtotals_tax_included\">Total Price</span>"
 msgstr ""
 
 #. module: account

--- a/addons/account/i18n/pt_BR.po
+++ b/addons/account/i18n/pt_BR.po
@@ -825,10 +825,10 @@ msgstr ""
 #: model_terms:ir.ui.view,arch_db:account.report_invoice_document
 msgid ""
 "<span groups=\"account.group_show_line_subtotals_tax_excluded\">Amount</span>\n"
-"                                    <span groups=\"account.group_show_line_subtotals_tax_included\">Total Price</span>"
+"                                       <span groups=\"account.group_show_line_subtotals_tax_included\">Total Price</span>"
 msgstr ""
 "<span groups=\"account.group_show_line_subtotals_tax_excluded\">Quantidade</span>\n"
-"                                    <span groups=\"account.group_show_line_subtotals_tax_included\">Preço Total</span>"
+"                                       <span groups=\"account.group_show_line_subtotals_tax_included\">Preço Total</span>"
 
 #. module: account
 #: model_terms:ir.ui.view,arch_db:account.account_journal_dashboard_kanban_view

--- a/addons/account/i18n/ro.po
+++ b/addons/account/i18n/ro.po
@@ -776,10 +776,10 @@ msgstr ""
 #: model_terms:ir.ui.view,arch_db:account.report_invoice_document
 msgid ""
 "<span groups=\"account.group_show_line_subtotals_tax_excluded\">Amount</span>\n"
-"                                    <span groups=\"account.group_show_line_subtotals_tax_included\">Total Price</span>"
+"                                       <span groups=\"account.group_show_line_subtotals_tax_included\">Total Price</span>"
 msgstr ""
 "<span groups=\"account.group_show_line_subtotals_tax_excluded\">Valoare </span>\n"
-"<span groups=\"account.group_show_line_subtotals_tax_included\">Preț total</span>"
+"                                       <span groups=\"account.group_show_line_subtotals_tax_included\">Preț total</span>"
 
 #. module: account
 #: model_terms:ir.ui.view,arch_db:account.account_journal_dashboard_kanban_view

--- a/addons/account/i18n/ru.po
+++ b/addons/account/i18n/ru.po
@@ -791,10 +791,10 @@ msgstr ""
 #: model_terms:ir.ui.view,arch_db:account.report_invoice_document
 msgid ""
 "<span groups=\"account.group_show_line_subtotals_tax_excluded\">Amount</span>\n"
-"                                    <span groups=\"account.group_show_line_subtotals_tax_included\">Total Price</span>"
+"                                       <span groups=\"account.group_show_line_subtotals_tax_included\">Total Price</span>"
 msgstr ""
 "<span groups=\"account.group_show_line_subtotals_tax_excluded\">Сумма</span>\n"
-"                                    <span groups=\"account.group_show_line_subtotals_tax_included\">Итого</span>"
+"                                       <span groups=\"account.group_show_line_subtotals_tax_included\">Итого</span>"
 
 #. module: account
 #: model_terms:ir.ui.view,arch_db:account.account_journal_dashboard_kanban_view

--- a/addons/account/i18n/sk.po
+++ b/addons/account/i18n/sk.po
@@ -340,7 +340,7 @@ msgstr ""
 #: model_terms:ir.ui.view,arch_db:account.report_invoice_document
 msgid ""
 "<span groups=\"account.group_show_line_subtotals_tax_excluded\">Amount</span>\n"
-"                                    <span groups=\"account.group_show_line_subtotals_tax_included\">Total Price</span>"
+"                                       <span groups=\"account.group_show_line_subtotals_tax_included\">Total Price</span>"
 msgstr ""
 
 #. module: account

--- a/addons/account/i18n/sr.po
+++ b/addons/account/i18n/sr.po
@@ -336,7 +336,7 @@ msgstr ""
 #: model_terms:ir.ui.view,arch_db:account.report_invoice_document
 msgid ""
 "<span groups=\"account.group_show_line_subtotals_tax_excluded\">Amount</span>\n"
-"                                    <span groups=\"account.group_show_line_subtotals_tax_included\">Total Price</span>"
+"                                       span groups=\"account.group_show_line_subtotals_tax_included\">Total Price</span>"
 msgstr ""
 
 #. module: account

--- a/addons/account/i18n/sv.po
+++ b/addons/account/i18n/sv.po
@@ -783,10 +783,10 @@ msgstr "<span class=\"text-nowrap\">2,350.00</span>"
 #: model_terms:ir.ui.view,arch_db:account.report_invoice_document
 msgid ""
 "<span groups=\"account.group_show_line_subtotals_tax_excluded\">Amount</span>\n"
-"                                    <span groups=\"account.group_show_line_subtotals_tax_included\">Total Price</span>"
+"                                       <span groups=\"account.group_show_line_subtotals_tax_included\">Total Price</span>"
 msgstr ""
 "<span groups=\"account.group_show_line_subtotals_tax_excluded\">Belopp</span>\n"
-"                                    <span groups=\"account.group_show_line_subtotals_tax_included\">Total kostnad</span>"
+"                                       <span groups=\"account.group_show_line_subtotals_tax_included\">Total kostnad</span>"
 
 #. module: account
 #: model_terms:ir.ui.view,arch_db:account.account_journal_dashboard_kanban_view

--- a/addons/account/i18n/th.po
+++ b/addons/account/i18n/th.po
@@ -345,7 +345,7 @@ msgstr ""
 #: model_terms:ir.ui.view,arch_db:account.report_invoice_document
 msgid ""
 "<span groups=\"account.group_show_line_subtotals_tax_excluded\">Amount</span>\n"
-"                                    <span groups=\"account.group_show_line_subtotals_tax_included\">Total Price</span>"
+"                                       <span groups=\"account.group_show_line_subtotals_tax_included\">Total Price</span>"
 msgstr ""
 
 #. module: account

--- a/addons/account/i18n/tr.po
+++ b/addons/account/i18n/tr.po
@@ -805,10 +805,10 @@ msgstr "<span class=\"text-nowrap\">2,350.00</span>"
 #: model_terms:ir.ui.view,arch_db:account.report_invoice_document
 msgid ""
 "<span groups=\"account.group_show_line_subtotals_tax_excluded\">Amount</span>\n"
-"                                    <span groups=\"account.group_show_line_subtotals_tax_included\">Total Price</span>"
+"                                       <span groups=\"account.group_show_line_subtotals_tax_included\">Total Price</span>"
 msgstr ""
 "<span groups=\"account.group_show_line_subtotals_tax_excluded\">Tutar</span>\n"
-"                                    <span groups=\"account.group_show_line_subtotals_tax_included\">Toplam Fiyat</span>"
+"                                       <span groups=\"account.group_show_line_subtotals_tax_included\">Toplam Fiyat</span>"
 
 #. module: account
 #: model_terms:ir.ui.view,arch_db:account.account_journal_dashboard_kanban_view

--- a/addons/account/i18n/uk.po
+++ b/addons/account/i18n/uk.po
@@ -801,10 +801,10 @@ msgstr "<span class=\"text-nowrap\">2,350.00</span>"
 #: model_terms:ir.ui.view,arch_db:account.report_invoice_document
 msgid ""
 "<span groups=\"account.group_show_line_subtotals_tax_excluded\">Amount</span>\n"
-"                                    <span groups=\"account.group_show_line_subtotals_tax_included\">Total Price</span>"
+"                                       <span groups=\"account.group_show_line_subtotals_tax_included\">Total Price</span>"
 msgstr ""
 "<span groups=\"account.group_show_line_subtotals_tax_excluded\">Сума</span>\n"
-"                                    <span groups=\"account.group_show_line_subtotals_tax_included\">Разом</span>"
+"                                       <span groups=\"account.group_show_line_subtotals_tax_included\">Разом</span>"
 
 #. module: account
 #: model_terms:ir.ui.view,arch_db:account.account_journal_dashboard_kanban_view

--- a/addons/account/i18n/vi.po
+++ b/addons/account/i18n/vi.po
@@ -800,10 +800,10 @@ msgstr "<span class=\"text-nowrap\">2,350.00</span>"
 #: model_terms:ir.ui.view,arch_db:account.report_invoice_document
 msgid ""
 "<span groups=\"account.group_show_line_subtotals_tax_excluded\">Amount</span>\n"
-"                                    <span groups=\"account.group_show_line_subtotals_tax_included\">Total Price</span>"
+"                                       <span groups=\"account.group_show_line_subtotals_tax_included\">Total Price</span>"
 msgstr ""
 "<span groups=\"account.group_show_line_subtotals_tax_excluded\">Số tiền</span>\n"
-"                                    <span groups=\"account.group_show_line_subtotals_tax_included\">Tổng tiền</span>"
+"                                       <span groups=\"account.group_show_line_subtotals_tax_included\">Tổng tiền</span>"
 
 #. module: account
 #: model_terms:ir.ui.view,arch_db:account.account_journal_dashboard_kanban_view

--- a/addons/account/i18n/zh_CN.po
+++ b/addons/account/i18n/zh_CN.po
@@ -830,10 +830,10 @@ msgstr "<span class=\"text-nowrap\">2,350.00</span>"
 #: model_terms:ir.ui.view,arch_db:account.report_invoice_document
 msgid ""
 "<span groups=\"account.group_show_line_subtotals_tax_excluded\">Amount</span>\n"
-"                                    <span groups=\"account.group_show_line_subtotals_tax_included\">Total Price</span>"
+"                                       <span groups=\"account.group_show_line_subtotals_tax_included\">Total Price</span>"
 msgstr ""
 "<span groups=\"account.group_show_line_subtotals_tax_excluded\">金额</span>\n"
-"                                    <span groups=\"account.group_show_line_subtotals_tax_included\">总价</span>"
+"                                       <span groups=\"account.group_show_line_subtotals_tax_included\">总价</span>"
 
 #. module: account
 #: model_terms:ir.ui.view,arch_db:account.account_journal_dashboard_kanban_view

--- a/addons/account/i18n/zh_TW.po
+++ b/addons/account/i18n/zh_TW.po
@@ -782,10 +782,10 @@ msgstr "<span class=\"text-nowrap\">2,350.00</span>"
 #: model_terms:ir.ui.view,arch_db:account.report_invoice_document
 msgid ""
 "<span groups=\"account.group_show_line_subtotals_tax_excluded\">Amount</span>\n"
-"                                    <span groups=\"account.group_show_line_subtotals_tax_included\">Total Price</span>"
+"                                       <span groups=\"account.group_show_line_subtotals_tax_included\">Total Price</span>"
 msgstr ""
 "<span groups=\"account.group_show_line_subtotals_tax_excluded\">金額</span>\n"
-"                                    <span groups=\"account.group_show_line_subtotals_tax_included\">總價</span>"
+"                                       <span groups=\"account.group_show_line_subtotals_tax_included\">總價</span>"
 
 #. module: account
 #: model_terms:ir.ui.view,arch_db:account.account_journal_dashboard_kanban_view


### PR DESCRIPTION
Step to reproduce the issue:
1) Print an invoice linked to a company with any language != en_US (e.g.: es).

Solution: Following commit [1], the alignement of the concerned lines in the
XML has been changed (adding one `\t`). Consequently, the translations could
not be applied as the ID had changed.

[1]: https://github.com/odoo/odoo/commit/72379768080cfd05666e5b7bfbea6a976b2ea263

opw-2860541
