### PR TITLE
[FIX] base_import: properly display controlpanel buttons

### DIFF
--- a/addons/base_import/static/src/legacy/js/import_action.js
+++ b/addons/base_import/static/src/legacy/js/import_action.js
@@ -168,18 +168,14 @@ var DataImport = AbstractAction.extend({
         this.setup_float_format_picker();
         this.setup_date_format_picker();
         this.setup_sheets_picker();
+        this.renderButtons();
+        this.controlPanelProps.cp_content = { $buttons: this.$buttons };
 
         return Promise.all([
             this._super(),
             self.create_model().then(function (id) {
                 self.id = id;
                 self.$('input[name=import_id]').val(id);
-
-                self.renderButtons();
-                var status = {
-                    cp_content: {$buttons: self.$buttons},
-                };
-                self.updateControlPanel(status);
             }),
         ]);
     },


### PR DESCRIPTION
Problem: open any (multi record) view, open the "favorites" menu and
select the import action. The import client action now opens, but no
button is visible in the control panel.

Since a recent owl update, the import client action did not display its
control panel buttons (upload file, cancel, ...). This is caused by an
unfortunate situation: the control panel buttons are rendered, but after
the control panel was rendered, so owl does not add them in the DOM.  It
worked by chance before: the props were completely reactive, and the
code actually modifies in place some object received in props. So, a
render was forced on the controlpanel, which means that it properly
picked up the buttons.

Now, this render was accidental, so the new owl code is actually
correct. This commit fixes the issue by simply rendering the buttons
before the controlpanel is even rendered, so it now works as expected.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
