### PR TITLE
[REV] sale_timesheet_margin: disables onchanges on service products

### DIFF
--- a/addons/sale_timesheet_margin/models/sale_order_line.py
+++ b/addons/sale_timesheet_margin/models/sale_order_line.py
@@ -8,10 +8,9 @@ class SaleOrderLine(models.Model):
     @api.depends('analytic_line_ids.amount', 'qty_delivered_method')
     def _compute_purchase_price(self):
         timesheet_sols = self.filtered(
-            lambda sol: sol.qty_delivered_method == 'timesheet' and not sol.product_id.standard_price and not sol.product_id.service_policy == 'ordered_timesheet'
+            lambda sol: sol.qty_delivered_method == 'timesheet' and not sol.product_id.standard_price
         )
-        already_computed_service = self.filtered(lambda sol: sol.create_date is not False and sol.product_id.service_policy == 'ordered_timesheet')
-        super(SaleOrderLine, self - timesheet_sols - already_computed_service)._compute_purchase_price()
+        super(SaleOrderLine, self - timesheet_sols)._compute_purchase_price()
         if timesheet_sols:
             group_amount = self.env['account.analytic.line'].read_group(
                 [('so_line', 'in', timesheet_sols.ids), ('project_id', '!=', False)],


### PR DESCRIPTION
Revert
"[FIX] sale_timesheet_margin: prevent cost override on product service"

This reverts commit e260a97392e698c88741be713a6b8cc2dc3c74a1.

After discussing with @thcl-odoo, it was determined that it is better to
revert this commit as it is affecting all service products.
Also, the desired behavior is that users should change the cost on
the product form, not on Sales Orders

now purchase price compute is skipped for all service products when this module is installed. and the fix in e260a97392e698c88741be713a6b8cc2dc3c74a1 is unnecessary anymore anyways

OPW-2857506