### PR TITLE
[FIX] account: prevent deletion partner child of a company

### DIFF
--- a/addons/account/i18n/account.pot
+++ b/addons/account/i18n/account.pot
@@ -8530,6 +8530,12 @@ msgid "Reconciliation on Bank Statements"
 msgstr ""
 
 #. module: account
+#: code:addons/account/models/partner.py:0
+#, python-format
+msgid "Record cannot be deleted. Partner used in Accounting"
+msgstr ""
+
+#. module: account
 #: model_terms:ir.ui.view,arch_db:account.res_config_settings_view_form
 msgid "Record transactions in foreign currencies"
 msgstr ""

--- a/addons/account/models/account_move.py
+++ b/addons/account/models/account_move.py
@@ -135,9 +135,9 @@ class AccountMove(models.Model):
     partner_id = fields.Many2one('res.partner', readonly=True, tracking=True,
         states={'draft': [('readonly', False)]},
         domain="['|', ('company_id', '=', False), ('company_id', '=', company_id)]",
-        string='Partner', change_default=True)
+        string='Partner', change_default=True, ondelete="restrict")
     commercial_partner_id = fields.Many2one('res.partner', string='Commercial Entity', store=True, readonly=True,
-        compute='_compute_commercial_partner_id')
+        compute='_compute_commercial_partner_id', ondelete="restrict")
 
     # === Amount fields ===
     amount_untaxed = fields.Monetary(string='Untaxed Amount', store=True, readonly=True, tracking=True,

--- a/addons/account/models/partner.py
+++ b/addons/account/models/partner.py
@@ -6,7 +6,7 @@ import logging
 
 from odoo import api, fields, models, _
 from odoo.tools import DEFAULT_SERVER_DATETIME_FORMAT
-from odoo.exceptions import ValidationError
+from odoo.exceptions import ValidationError, UserError
 from odoo.addons.base.models.res_partner import WARNING_MESSAGE, WARNING_HELP
 from psycopg2 import sql, DatabaseError
 
@@ -513,6 +513,17 @@ class ResPartner(models.Model):
                 elif is_supplier and 'supplier_rank' not in vals:
                     vals['supplier_rank'] = 1
         return super().create(vals_list)
+
+    def unlink(self):
+        """
+        Prevent the deletion of a partner "Individual", child of a company if:
+        - partner in 'account.move'
+        - state: all states (draft and posted)
+        """
+        moves = self.sudo().env['account.move'].search_count([('partner_id', 'in', self.ids), ('state', 'in', ['draft', 'posted'])])
+        if moves:
+            raise UserError(_("Record cannot be deleted. Partner used in Accounting"))
+        return super(ResPartner, self).unlink()
 
     def _increase_rank(self, field):
         if self.ids and field in ['customer_rank', 'supplier_rank']:


### PR DESCRIPTION
Steps to reproduce:
- Create a partner-individual, assign to a company
- Create an invoice and set the new partner as the customer
- Go to the partner view
- Delete it

Issue:
- It is possible to delete it

Cause:
The constraint in "account.move.line" uses the "commercial_partner_id" as the partner

Solution:
- Prevent the unlink if the partner is used in 'account.move' -> To delete in Master
- add "ondelete='restrict' for partner and commercial_parner in 'account.move'

opw-2858789