### PR TITLE
[FIX] pos_restaurant: stop closing paymentscreen while paying

### DIFF
--- a/addons/pos_restaurant/static/src/js/Chrome.js
+++ b/addons/pos_restaurant/static/src/js/Chrome.js
@@ -76,7 +76,8 @@ odoo.define('pos_restaurant.chrome', function (require) {
                 this.showScreen('FloorScreen', { floor: table ? table.floor : null });
             }
             _shouldResetIdleTimer() {
-                return super._shouldResetIdleTimer() && this.env.pos.config.iface_floorplan && this.mainScreen.name !== 'FloorScreen';
+                const stayPaymentScreen = this.mainScreen.name === 'PaymentScreen' && this.env.pos.get_order().paymentlines.length > 0;
+                return super._shouldResetIdleTimer() && !stayPaymentScreen && this.mainScreen.name !== 'FloorScreen';
             }
             __showScreen() {
                 super.__showScreen(...arguments);


### PR DESCRIPTION
Current behavior:
If you stay in idle too long on the payment screen while doing a
payment the screen would go back to the floor screen

Steps to reproduce:
- Have PoS installed and setup restaurant
- Go in the PoS restaurant
- Go in any table add some product and go to payment screen
- Click on any payment method
- Wait some time and you should go back to the floor screen

opw-2849939
--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
