### PR TITLE
[FIX] web: jquery swipe call

### DIFF
--- a/addons/web/views/webclient_templates.xml
+++ b/addons/web/views/webclient_templates.xml
@@ -224,6 +224,7 @@
         <script type="text/javascript" src="/base/static/src/js/res_config_settings.js"></script>
 
         <script type="text/javascript" src="/web/static/lib/jquery.scrollTo/jquery.scrollTo.js"></script>
+        <script type="text/javascript" src="/web/static/lib/jquery.touchSwipe/jquery.touchSwipe.js"></script>
         <script type="text/javascript" src="/web/static/lib/fuzzy-master/fuzzy.js"></script>
 
         <script type="text/javascript" charset="utf-8">
@@ -721,8 +722,6 @@
             <t t-set="title">Web Mobile Tests</t>
             <t t-set="head">
                 <t t-call="web.js_tests_assets"/>
-                <script type="text/javascript" src="/web/static/lib/jquery.touchSwipe/jquery.touchSwipe.js"></script>
-
                 <script type="text/javascript" src="/base/static/tests/base_settings_mobile_tests.js"></script>
 
                 <script type="text/javascript" src="/web/static/tests/chrome/action_manager_mobile_tests.js"></script>


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
The 'swipe' method of the jquery extension does not exist.

Current behavior before PR:
When using a kanban on a mobile device with desktop mode enabled a javascript exception is thrown indicating that the "swipe" method does not exist.

Desired behavior after PR is merged:
The jquery.swipe library is loaded.

Steps to reproduce the bug:
- Open an Odoo website on a mobile device
- Enable 'Desktop mode' in the browser
- Go, for example, to CRM application

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
