### PR TITLE
[FIX][14.0] hr_holidays: domain conflict of field `responsible_id`

### DIFF
--- a/addons/hr_holidays/views/hr_leave_type_views.xml
+++ b/addons/hr_holidays/views/hr_leave_type_views.xml
@@ -52,7 +52,7 @@
                         <group name="allocation_validation" string="Allocation Requests">
                             <field name="allocation_type" widget="radio" force_save="1"/>
                             <field name="allocation_validation_type" string="Approval" widget="radio" attrs="{'invisible': [('allocation_type', '!=', 'fixed_allocation')]}"/>
-                            <field name="responsible_id" domain="[('share', '=', False)]"
+                            <field name="responsible_id"
                                 attrs="{
                                 'invisible': [('leave_validation_type', 'in', ['no_validation', 'manager']), '|', ('allocation_type', '=', 'no'), ('allocation_validation_type', '=', 'manager')],
                                 'required': ['|', ('leave_validation_type', 'in', ['hr', 'both']), '&amp;', ('allocation_type', 'in', ['fixed_allocation', 'fixed']), ('allocation_validation_type', 'in', ['hr', 'both'])]}"/>


### PR DESCRIPTION
The purpose of this PR is to remove the domain on the view of the
`responsible_id` field because it is unnecessary and causes conflict.

In the python code the `responsible_id` field already has a domain to
filter out the users who belong to the 'All Approver' group, so having
the domain (share=false) on view is not necessary and it distorts the
meaning of that field.

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
