### PR TITLE
[FIX] account: keep statement line note

### DIFF
--- a/addons/account/models/account_move.py
+++ b/addons/account/models/account_move.py
@@ -3531,7 +3531,9 @@ class AccountMove(models.Model):
     def _compute_narration(self):
         use_invoice_terms = self.env['ir.config_parameter'].sudo().get_param('account.use_invoice_terms')
         for move in self:
-            if not use_invoice_terms or not move.is_sale_document(include_receipts=True):
+            if not move.is_sale_document(include_receipts=True):
+                continue
+            if not use_invoice_terms:
                 move.narration = False
             else:
                 lang = move.partner_id.lang or self.env.user.lang

--- a/addons/account/tests/test_account_bank_statement.py
+++ b/addons/account/tests/test_account_bank_statement.py
@@ -1573,3 +1573,30 @@ class TestAccountBankStatementLine(TestAccountBankStatementCommon):
         self.assertRecordValues(statement.line_ids, [{
             'partner_id': False,
         }])
+
+    def test_statement_line_note_onchange_partner(self):
+        """
+        Check if narration field stays as it is when changing the partner
+        in reconciliation widget.
+        """
+        bank_stmt = self.env['account.bank.statement'].create({
+            'company_id': self.env.company.id,
+            'journal_id': self.bank_journal_1.id,
+            'name': 'test',
+        })
+
+        bank_stmt_line = self.env['account.bank.statement.line'].create({
+            'payment_ref': 'testLine',
+            'statement_id': bank_stmt.id,
+            'narration': 'This is a note',
+            'amount': 100,
+        })
+
+        bank_stmt_line.partner_id = self.partner_b
+
+        self.assertRecordValues(bank_stmt_line, [{
+            'payment_ref': 'testLine',
+            'statement_id': bank_stmt.id,
+            'narration': '<p>This is a note</p>',
+            'amount': 100,
+        }])


### PR DESCRIPTION
We keep the statement line note when changing
the partner in reconciliation widget

Steps:

- Create a Bank Statement, a Bank Statement
  Line BSL with a note (field narration)
- Open the reconciliation widget, change/set the partner
  and go back to statement.
-> The note on BSL is empty

With this commit we allow narration computation
only for sale documents.

opw-2832287

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
