### PR TITLE
[IMP] account: journal audit report improvement.

### DIFF
--- a/addons/account/views/account_move_views.xml
+++ b/addons/account/views/account_move_views.xml
@@ -375,6 +375,8 @@
                     <filter string="Report Analytic Accounts" name="analytic_accounts" domain="[('analytic_account_id', 'in', context.get('analytic_ids'))]" invisible="1"/>
                     <group expand="0" string="Group By">
                         <filter string="Journal Entry" name="group_by_move" domain="[]" context="{'group_by': 'move_id'}"/>
+                        <filter string="Taxes" name="group_by_taxes" domain="[]" context="{'group_by': 'tax_ids'}"/>
+                        <filter string="Tax Tags" name="group_by_tax_tags" domain="[]" context="{'group_by': 'tax_tag_ids'}"/>
                         <filter string="Account" name="group_by_account" domain="[]" context="{'group_by': 'account_id'}"/>
                         <filter string="Partner" name="group_by_partner" domain="[]" context="{'group_by': 'partner_id'}"/>
                         <filter string="Journal" name="journal" domain="[]" context="{'group_by': 'journal_id'}"/>


### PR DESCRIPTION
Improve the tax report section of the journal audit by adding a
background color to it, as well as reducing the width of the tables.
Ease the navigation from the journal audit report by adding three
new actions:
    - Taxes in the tax applied section can be clicked to audit them
    - The tax applied and the impacted tax grid sections now have an
      audit button to open a group-by view of journal items grouped
      appropriately according to the information we need.

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
