### PR TITLE
[FIX] knowledge: unarchive multiple articles

### DIFF
--- a/addons/knowledge/models/knowledge_article.py
+++ b/addons/knowledge/models/knowledge_article.py
@@ -716,8 +716,10 @@ class Article(models.Model):
         return self.with_context(res_id=False).action_home_page()
 
     def action_unarchive(self):
-        super(Article, self).action_unarchive()
-        return self.with_context(res_id=self.id).action_home_page()
+        res = super(Article, self).action_unarchive()
+        if len(self) == 1:
+            return self.with_context(res_id=self.id).action_home_page()
+        return res
 
     # ------------------------------------------------------------
     # SEQUENCE / ORDERING


### PR DESCRIPTION
Right now, when we unarchive a single article, it is unarchived properly
and after it is unarchived, we are redirected back to the home page of the
particular unarchived article. But when we try to unarchive multiple articles,
it throws a traceback.

The PR handles the traceback by not redirecting back to the home page
when unarchiving multiple articles. Otherwise, it will work as it currently does

taskID: 2869659