### PR TITLE
[IMP] account: improve Journal Items UX

### DIFF
--- a/addons/account/models/account_move.py
+++ b/addons/account/models/account_move.py
@@ -5711,7 +5711,7 @@ class AccountMoveLine(models.Model):
         return ids
 
     def open_reconcile_view(self):
-        action = self.env['ir.actions.act_window']._for_xml_id('account.action_account_moves_all_a')
+        action = self.env['ir.actions.act_window']._for_xml_id('account.action_account_moves_all_grouped_matching')
         ids = self._reconciled_lines()
         action['domain'] = [('id', 'in', ids)]
         return action

--- a/addons/account/models/account_move.py
+++ b/addons/account/models/account_move.py
@@ -5716,6 +5716,16 @@ class AccountMoveLine(models.Model):
         action['domain'] = [('id', 'in', ids)]
         return action
 
+    def open_move(self):
+        return {
+            'type': 'ir.actions.act_window',
+            'res_model': 'account.move',
+            'view_mode': 'form',
+            'res_id': self.move_id.id,
+            'views': [(False, 'form')],
+        }
+
+
     def action_automatic_entry(self):
         action = self.env['ir.actions.act_window']._for_xml_id('account.account_automatic_entry_wizard_action')
         # Force the values of the move line in the context to avoid issues

--- a/addons/account/views/account_move_views.xml
+++ b/addons/account/views/account_move_views.xml
@@ -329,10 +329,24 @@
                     <field name="tax_audit"/>
                     <field name="move_id"/>
                 </field>
-                <field name="date_maturity" position="replace"/>
-                <field name="analytic_account_id" position="replace"/>
-                <field name="debit" position="replace"/>
-                <field name="credit" position="replace"/>
+                <field name="date_maturity" position="attributes">
+                    <attribute name="optional">hide</attribute>
+                </field>
+                <field name="analytic_account_id" position="attributes">
+                    <attribute name="optional">hide</attribute>
+                </field>
+                <field name="debit" position="attributes">
+                    <attribute name="optional">show</attribute>
+                </field>
+                <field name="credit" position="attributes">
+                    <attribute name="optional">show</attribute>
+                </field>
+                <field name="journal_id" position="attributes">
+                    <attribute name="optional">show</attribute>
+                </field>
+                <field name="move_id" position="attributes">
+                    <attribute name="optional">hide</attribute>
+                </field>
             </field>
         </record>
 

--- a/addons/account/views/account_move_views.xml
+++ b/addons/account/views/account_move_views.xml
@@ -741,7 +741,7 @@
                                     icon="fa-bars"
                                     type="object"
                                     attrs="{'invisible': ['|', '|', ('move_type', '!=', 'entry'), ('id', '=', False), ('has_reconciled_entries', '=', False)]}"
-                                    string="Reconciled Entries">
+                                    string="Reconciled Items">
                             </button>
                             <button name="open_created_caba_entries"
                                     class="oe_stat_button"
@@ -1107,9 +1107,6 @@
                                 </group>
                             </page>
                             <page id="aml_tab" string="Journal Items" groups="account.group_account_readonly">
-                                <div class="alert alert-info text-center mb-0" role="alert" attrs="{'invisible': ['|', ('payment_state', '!=', 'invoicing_legacy'), ('move_type', '=', 'entry')]}">
-                                    <span>This entry has been generated through the Invoicing app, before installing Accounting. Its balance has been imported separately.</span>
-                                </div>
                                 <field name="line_ids"
                                        mode="tree,kanban"
                                        context="{'default_move_type': context.get('default_move_type'), 'line_ids': line_ids, 'journal_id': journal_id, 'default_partner_id': commercial_partner_id, 'default_currency_id': currency_id or company_currency_id}"
@@ -1123,6 +1120,7 @@
                                                }"
                                                domain="[('deprecated', '=', False), ('company_id', '=', parent.company_id)]" />
                                         <field name="partner_id"
+                                               optional="show"
                                                domain="['|', ('parent_id', '=', False), ('is_company', '=', True)]"
                                                attrs="{'column_invisible': [('parent.move_type', '!=', 'entry')]}"/>
                                         <field name="name" widget="section_and_note_text" optional="show"/>
@@ -1240,6 +1238,9 @@
                                       </group>
                                     </form>
                                 </field>
+                                <div class="alert alert-info text-center mb-0" role="alert" attrs="{'invisible': ['|', ('payment_state', '!=', 'invoicing_legacy'), ('move_type', '=', 'entry')]}">
+                                    <span>This entry has been generated through the Invoicing app, before installing Accounting. Its balance has been imported separately.</span>
+                                </div>
                             </page>
                             <page id="other_tab" string="Other Info" name="other_info"
                                   attrs="{'invisible': [('move_type', 'not in', ('out_invoice', 'out_refund', 'in_invoice', 'in_refund'))]}">
@@ -1426,6 +1427,15 @@
 
         <record id="action_account_moves_all_a" model="ir.actions.act_window">
             <field name="context">{'journal_type':'general', 'search_default_group_by_move': 1, 'search_default_posted':1, 'name_groupby':1, 'create':0}</field>
+            <field name="name">Journal Items</field>
+            <field name="res_model">account.move.line</field>
+            <field name="domain">[('display_type', 'not in', ('line_section', 'line_note'))]</field>
+            <field name="view_id" ref="view_move_line_tree_grouped"/>
+            <field name="view_mode">tree,pivot,graph,kanban</field>
+        </record>
+
+        <record id="action_account_moves_all_grouped_matching" model="ir.actions.act_window">
+            <field name="context">{'journal_type':'general', 'search_default_group_by_matching': 1, 'search_default_posted':1, 'expand':'1'}</field>
             <field name="name">Journal Items</field>
             <field name="res_model">account.move.line</field>
             <field name="domain">[('display_type', 'not in', ('line_section', 'line_note'))]</field>

--- a/addons/account/views/account_move_views.xml
+++ b/addons/account/views/account_move_views.xml
@@ -150,9 +150,9 @@
             <field name="model">account.move.line</field>
             <field eval="100" name="priority"/>
             <field name="arch" type="xml">
-                <tree string="Journal Items" create="false" edit="false" sample="1">
-                    <field name="date" optional="show"/>
-                    <field name="company_id" groups="base.group_multi_company"/>
+                <tree string="Journal Items" create="false" edit="false" multi_edit="1" sample="1">
+                    <field name="date" readonly="1"/>
+                    <field name="company_id" groups="base.group_multi_company" optional="hide"/>
                     <field name="journal_id" options='{"no_open":True}'/>
                     <field name="move_id" optional="show"/>
                     <field name="account_id" options="{'no_open': True}" groups="account.group_account_readonly"/>
@@ -161,19 +161,41 @@
                     <field name="ref" optional="show"/>
                     <field name="name" optional="show"/>
                     <field name="analytic_account_id" groups="account.group_account_readonly" optional="show" attrs="{'readonly':[('parent_state','=','posted')]}"/>
-                    <field name="analytic_tag_ids" widget="many2many_tags" groups="analytic.group_analytic_tags" optional="hide"/>
-                    <field name="tax_ids" widget="many2many_tags" width="0.5" optional="show"/>
-                    <field name="debit" sum="Total Debit"/>
-                    <field name="credit" sum="Total Credit"/>
-                    <field name="amount_currency" groups="base.group_multi_currency" optional="hide"/>
+                    <field name="analytic_tag_ids" widget="many2many_tags" groups="analytic.group_analytic_tags" optional="hide" readonly="1"/>
+                    <field name="tax_ids" widget="many2many_tags" width="0.5" optional="show" readonly="1"/>
+                    <field name="debit" sum="Total Debit" readonly="1"/>
+                    <field name="credit" sum="Total Credit" readonly="1"/>
+                    <field name="amount_currency" groups="base.group_multi_currency" optional="hide" readonly="1"/>
                     <field name="currency_id" readonly="1" groups="base.group_multi_currency" optional="hide" string="Original Currency"/>
-                    <field name="tax_tag_ids" widget="many2many_tags" width="0.5" optional="hide"/>
-                    <field name="matching_number" optional="show"/>
+                    <field name="tax_tag_ids" string="Tax Grids" widget="many2many_tags" width="0.5" optional="hide"/>
                     <field name="reconcile_model_id" invisible="1"/>
                     <field name="reconciled" invisible="1"/>
                     <field name="date_maturity" optional="hide"/>
                     <field name="company_currency_id" invisible="1"/>
                     <field name="parent_state" invisible="1"/>
+                    <field name="tax_line_id" optional="hide" readonly="1"/>
+                    <field name="balance" sum="Total Balance" optional="hide" readonly="1"/>
+                    <field name="matching_number" optional="show"/>
+                    <field name="product_id" optional="hide"/>
+                    <button name="open_move" title="Open Journal Entry" type="object" icon="fa-edit"/>
+                    <groupby name="move_id">
+                        <field name="state" invisible="1"/>
+                        <field name="move_type" invisible="1"/>
+                        <field name="statement_id" invisible="1"/>
+                        <field name="payment_id" invisible="1"/>
+                        <button name="edit" type="edit" icon="fa-edit" title="Edit" attrs="{'invisible': ['&amp;', ('move_type', '=', 'entry'), '|', ('statement_id', '!=', False), ('payment_id', '!=', False)]}"/>
+                        <button name="open_bank_statement_view" type="object" icon="fa-edit" title="Edit" attrs="{'invisible': ['|', ('move_type', '!=', 'entry'), ('statement_id', '=', False)]}"/>
+                        <button name="open_payment_view" type="object" icon="fa-edit" title="Edit" attrs="{'invisible': ['|', ('move_type', '!=', 'entry'), ('payment_id', '=', False)]}"/>
+                    </groupby>
+                    <groupby name="account_id">
+                        <button name="edit" type="edit" icon="fa-edit" title="Edit"/>
+                    </groupby>
+                    <groupby name="partner_id">
+                        <button name="edit" type="edit" icon="fa-edit" title="Edit"/>
+                    </groupby>
+                    <groupby name="journal_id">
+                        <button name="edit" type="edit" icon="fa-edit" title="Edit"/>
+                    </groupby>
                 </tree>
             </field>
         </record>
@@ -192,7 +214,7 @@
                            domain="[('company_id', '=', company_id)]"
                            groups="account.group_account_readonly"/>
                     <field name="statement_id" invisible="1"/>
-                    <field name="partner_id" optional="hide" readonly="1"/>
+                    <field name="partner_id" optional="hide"/>
                     <field name="ref" optional="hide"/>
                     <field name="name"/>
                     <field name="reconciled" invisible="1"/>
@@ -221,9 +243,6 @@
                         <button name="edit" type="edit" icon="fa-edit" title="Edit" attrs="{'invisible': ['&amp;', ('move_type', '=', 'entry'), '|', ('statement_id', '!=', False), ('payment_id', '!=', False)]}"/>
                         <button name="open_bank_statement_view" type="object" icon="fa-edit" title="Edit" attrs="{'invisible': ['|', ('move_type', '!=', 'entry'), ('statement_id', '=', False)]}"/>
                         <button name="open_payment_view" type="object" icon="fa-edit" title="Edit" attrs="{'invisible': ['|', ('move_type', '!=', 'entry'), ('payment_id', '=', False)]}"/>
-                        <button name="action_post" states="draft" icon="fa-check" title="Post" type="object" groups="account.group_account_invoice"/>
-                        <button name="%(action_view_account_move_reversal)d" states="posted" title="Reverse" icon="fa-undo" type="action" groups="account.group_account_invoice"/>
-                        <button name="action_duplicate" icon="fa-files-o" title="Duplicate" type="object" groups="account.group_account_invoice"/>
                     </groupby>
                 </tree>
             </field>
@@ -379,6 +398,9 @@
                         <filter string="Partner" name="group_by_partner" domain="[]" context="{'group_by': 'partner_id'}"/>
                         <filter string="Journal" name="journal" domain="[]" context="{'group_by': 'journal_id'}"/>
                         <filter string="Date" name="groupby_date" domain="[]" context="{'group_by': 'date'}"/>
+                        <filter string="Taxes" name="group_by_taxes" domain="[]" context="{'group_by': 'tax_ids'}"/>
+                        <filter string="Tax Grid" name="group_by_tax_grid" domain="[]" context="{'group_by': 'tax_tag_ids'}"/>
+                        <filter string="Matching #" name="group_by_matching" domain="[]" context="{'group_by': 'full_reconcile_id'}"/>
                     </group>
                 </search>
             </field>
@@ -1408,7 +1430,7 @@
             <field name="res_model">account.move.line</field>
             <field name="domain">[('display_type', 'not in', ('line_section', 'line_note'))]</field>
             <field name="view_id" ref="view_move_line_tree_grouped"/>
-            <field name="view_mode">tree,pivot,graph,form,kanban</field>
+            <field name="view_mode">tree,pivot,graph,kanban</field>
         </record>
 
         <record id="action_account_moves_journal_sales" model="ir.actions.act_window">
@@ -1481,7 +1503,7 @@
             <field name="res_model">account.move.line</field>
             <field name="domain">[('display_type', 'not in', ('line_section', 'line_note')), ('parent_state', '!=', 'cancel')]</field>
             <field name="view_id" ref="view_move_line_tree"/>
-            <field name="view_mode">tree,pivot,graph,form,kanban</field>
+            <field name="view_mode">tree,pivot,graph,kanban</field>
         </record>
 
         <!-- account.move (Journal Entry) -->


### PR DESCRIPTION
Improvements to the Journal Items list view:
- readonly set on multiple fields
- hide/optional show by default on multiple fields
- "Tax Grid" string set on tax_tag_ids for more clarity
- Added multiple fields to the "simple" list view for more consistency
    with the grouped list view
- Added an edit button on some "group by" lines to edit the
    corresponding field
- Removed the Revert and Duplicate button from the "grouped by" view
    (on the group by line)
- Added a button to open the corresponding Journal Entry, and removed
    the Journal Item form access. The Journal Item form should not be
    accessible anymore.
- Show the total sum for Balance
- Added the "Tax Grid" group by

Improvements to the account move form:
- "Reconciled Entries" button -> "Reconciled Items", and goes now to the
    Journal Items list view grouped by Matching number
- Removed the unwanted margin next to the "Journal Items" table (in the
    "Journal Items" tab)
- The partner can be hidden, in the Journal Items list view

Improvements to the Journal Items for Tax Audit:
- Small changes to show and hide some fields by default,
    and add some in the view.

task-2855459