### PR TITLE
[IMP] base: On profile, open lang wizard instead of technical view

### DIFF
--- a/addons/hr/views/res_users.xml
+++ b/addons/hr/views/res_users.xml
@@ -34,7 +34,7 @@
                 <field name="tz" position="after">
                     <field name="is_system" invisible="1"/>
                 </field>
-                <xpath expr="//button[@name='%(base.res_lang_act_window)d']" position="attributes">
+                <xpath expr="//button[@name='%(base.action_view_base_language_install)d']" position="attributes">
                     <attribute name="attrs">{'invisible': [('is_system', '=', False)]}</attribute>
                 </xpath>
             </field>

--- a/odoo/addons/base/views/res_users_views.xml
+++ b/odoo/addons/base/views/res_users_views.xml
@@ -244,10 +244,10 @@
                                             <field name="lang" required="1"/>
                                             <button
                                                 type="action"
-                                                name="%(base.res_lang_act_window)d"
+                                                name="%(base.action_view_base_language_install)d"
                                                 class="oe_edit_only btn-sm btn-link mb4 fa fa-globe"
-                                                aria-label="More languages"
-                                                title="More languages"/>
+                                                aria-label="Add a language"
+                                                title="Add a language"/>
                                         </div>
                                         <field name="tz" widget="timezone_mismatch" options="{'tz_offset_field': 'tz_offset'}" />
                                         <field name="tz_offset" invisible="1"/>
@@ -446,11 +446,11 @@
                                         <field name="lang" required="1" readonly="0"/>
                                         <button
                                             type="action"
-                                            name="%(base.res_lang_act_window)d"
+                                            name="%(base.action_view_base_language_install)d"
                                             class="oe_edit_only btn-sm btn-link mb4 fa fa-globe"
-                                            aria-label="More languages"
+                                            aria-label="Add a language"
                                             groups="base.group_system"
-                                            title="More languages"
+                                            title="Add a language"
                                         />
                                     </div>
                                     <field name="tz" widget="timezone_mismatch" options="{'tz_offset_field': 'tz_offset'}" readonly="0"/>


### PR DESCRIPTION
Step to  reproduce:
- Go to 'My Preference' or User profile as admin
- Click on the world icon to add a language

Old Behaviour:
- Open the technical view of languages

New Behaviour:
- Open a wizard to add a a language

taskid-2774319


--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
