### PR TITLE
[IMP] website: add lazyloading on iframe

### DIFF
--- a/addons/website/models/ir_qweb.py
+++ b/addons/website/models/ir_qweb.py
@@ -50,7 +50,7 @@ class QWeb(models.AbstractModel):
 
         atts = super(QWeb, self)._post_processing_att(tagName, atts, options)
 
-        if tagName == 'img' and 'loading' not in atts:
+        if tagName in ('iframe', 'img') and 'loading' not in atts:
             atts['loading'] = 'lazy'  # default is auto
 
         if options.get('inherit_branding') or options.get('rendering_bundle') or \

--- a/addons/website/tests/template_qweb_test.xml
+++ b/addons/website/tests/template_qweb_test.xml
@@ -24,6 +24,7 @@
     <body>
         <img src="http://test.external.link/img.png"/>
         <img src="/website/static/img.png"/>
+        <iframe src="http://test.external.link/iframe"></iframe>
         <a href="http://test.external.link/link">x</a>
         <a href="/web/content/local_link">x</a>
         <span t-attf-style="background-image: url('/web/image/2')" t-att-empty="False">xxx</span>

--- a/addons/website/tests/test_qweb.py
+++ b/addons/website/tests/test_qweb.py
@@ -68,6 +68,7 @@ class TestQweb(TransactionCaseWithUserDemo):
     <body>
         <img src="http://test.external.link/img.png" loading="lazy"/>
         <img src="http://test.cdn/website/static/img.png" loading="lazy"/>
+        <iframe src="http://test.external.link/iframe" loading="lazy"></iframe>
         <a href="http://test.external.link/link">x</a>
         <a href="http://test.cdn/web/content/local_link">x</a>
         <span style="background-image: url('http://test.cdn/web/image/2')">xxx</span>


### PR DESCRIPTION
By default with eager loading technique, loading web pages when the content 
contains many iframes is quite slow. That's why we need to improve with lazy 
loading technique.

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
