### PR TITLE
[FIX] web_editor: validate qweb fields upon submission

### DIFF
--- a/addons/web_editor/i18n/web_editor.pot
+++ b/addons/web_editor/i18n/web_editor.pot
@@ -890,6 +890,12 @@ msgid "Install"
 msgstr ""
 
 #. module: web_editor
+#: code:addons/web_editor/models/ir_ui_view.py:0
+#, python-format
+msgid "Invalid field value for %s: %s"
+msgstr ""
+
+#. module: web_editor
 #. openerp-web
 #: code:addons/web_editor/static/src/js/editor/rte.summernote.js:0
 #, python-format

--- a/addons/web_editor/models/ir_qweb.py
+++ b/addons/web_editor/models/ir_qweb.py
@@ -131,7 +131,11 @@ class Integer(models.AbstractModel):
     _description = 'Qweb Field Integer'
     _inherit = 'ir.qweb.field.integer'
 
-    value_from_string = int
+    @api.model
+    def from_html(self, model, field, element):
+        lang = self.user_lang()
+        value = element.text_content().strip()
+        return int(value.replace(lang.thousands_sep, ''))
 
 
 class Float(models.AbstractModel):

--- a/addons/web_editor/tests/test_converter.py
+++ b/addons/web_editor/tests/test_converter.py
@@ -145,6 +145,7 @@ class TestConvertBack(common.TransactionCase):
 
     def test_integer(self):
         self.field_roundtrip('integer', 42)
+        self.field_roundtrip('integer', 42000)
 
     def test_float(self):
         self.field_roundtrip('float', 42.567890)


### PR DESCRIPTION
When editing database fields via the web editor, their value are not checked.
Thus, stack traces can come up to the front-end user.

Step to reproduce the issue:
1) Install the E-Learning module and connect to the website
2) On the main website (not the backend), go to Courses > Edit
3) Edit the Next Rank treshold with any non integer string (e.g.: coucou)
A stracktrace will be shown upon save.

Solution: The issue is that there are no validation on the submitted fields,
this can cause stacktraces. A try-catch was used around the parsing of the
input value to catch and properly raise these exceptions to show clean errors.
On top of this, integers were not properly parsed, they were not taking into
account the `thousands_sep` of the user lang (e.g.: 35,000 for 35000).

opw-2819392
