### PR TITLE
[FIX] payment: compute related_partner_ids only for draft payments

### DIFF
--- a/addons/payment/models/account_payment.py
+++ b/addons/payment/models/account_payment.py
@@ -20,7 +20,7 @@ class AccountPayment(models.Model):
             ('partner_id', 'in', related_partner_ids),
         ]""",
         help="Note that tokens from acquirers set to only authorize transactions (instead of capturing the amount) are not available.")
-    related_partner_ids = fields.Many2many('res.partner', compute='_compute_related_partners')
+    related_partner_ids = fields.Many2many('res.partner', compute='_compute_related_partners', compute_sudo=True)
 
     def _get_payment_chatter_link(self):
         self.ensure_one()


### PR DESCRIPTION
`related_partner_ids` is used in the form view of account.payment
https://github.com/odoo/odoo/blob/43fccd7aaa83117c95babc52d60dd1c26b28335a/addons/payment/views/account_payment_views.xml#L14
It is only needed for electronic payments to display the payment token
ids (as part of its domain)
https://github.com/odoo/odoo/blob/45f5167b956521f0a183ff1b1cc75fa1b273866c/addons/payment/models/account_payment.py#L13-L21
and for draft payments only.
https://github.com/odoo/odoo/blob/43fccd7aaa83117c95babc52d60dd1c26b28335a/addons/payment/views/account_payment_views.xml#L16

Before this change the form view will fail when partner_id has a company
that is not in the context. This is not incorrect, but it is unexpected
as `related_partner_ids` is not needed to just show the form view. A way
to reproduce the issue is to confirm a payment, then change the partner
company to a company not accessible for current user.

This causes issues during migrations: the form view for the failing
payments is displayed just fine for versions <=13.0

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
