### PR TITLE
[FIX] mrp: picking_type_id should only be editable in draft state

### DIFF
--- a/addons/mrp/models/mrp_production.py
+++ b/addons/mrp/models/mrp_production.py
@@ -78,7 +78,8 @@ class MrpProduction(models.Model):
     picking_type_id = fields.Many2one(
         'stock.picking.type', 'Operation Type',
         domain="[('code', '=', 'mrp_operation'), ('company_id', '=', company_id)]",
-        default=_get_default_picking_type, required=True, check_company=True)
+        default=_get_default_picking_type, required=True, check_company=True,
+        readonly=True, states={'draft': [('readonly', False)]})
     location_src_id = fields.Many2one(
         'stock.location', 'Components Location',
         default=_get_default_location_src_id,


### PR DESCRIPTION
Steps to follow:

  - Go to manufacturing > Operations > Manufacturing orders
  - Use studio to add the `picking_type_id` field to the list view
  - Check a checkbox next to a record not in draft state
  - Edit the picking_type_id

-> No error is displayed, it should only be editable if the record is in draft stage

This also applies to the unit of measure

opw-2853486