### PR TITLE
[FIX] website, test_website: fallback on exact search if max reached

### DIFF
--- a/addons/test_website/models/__init__.py
+++ b/addons/test_website/models/__init__.py
@@ -1,1 +1,2 @@
 from . import model
+from . import website

--- a/addons/test_website/models/model.py
+++ b/addons/test_website/models/model.py
@@ -1,14 +1,33 @@
 # -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
-from odoo import fields, models
+from odoo import api, fields, models
 
 
 class TestModel(models.Model):
     """ Add website option in server actions. """
 
     _name = 'test.model'
-    _inherit = ['website.seo.metadata', 'website.published.mixin']
+    _inherit = [
+        'website.seo.metadata',
+        'website.published.mixin',
+        'website.searchable.mixin',
+    ]
     _description = 'Website Model Test'
 
     name = fields.Char(required=1)
+
+    @api.model
+    def _search_get_detail(self, website, order, options):
+        return {
+            'model': 'test.model',
+            'base_domain': [],
+            'search_fields': ['name'],
+            'fetch_fields': ['name'],
+            'mapping': {
+                'name': {'name': 'name', 'type': 'text', 'match': True},
+                'website_url': {'name': 'name', 'type': 'text', 'truncate': False},
+            },
+            'icon': 'fa-check-square-o',
+            'order': 'name asc, id desc',
+        }

--- a/addons/test_website/models/website.py
+++ b/addons/test_website/models/website.py
@@ -1,0 +1,14 @@
+# -*- coding: utf-8 -*-
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from odoo import models
+
+
+class Website(models.Model):
+    _inherit = "website"
+
+    def _search_get_details(self, search_type, order, options):
+        result = super()._search_get_details(search_type, order, options)
+        if search_type in ['test']:
+            result.append(self.env['test.model']._search_get_detail(self, order, options))
+        return result

--- a/addons/test_website/tests/__init__.py
+++ b/addons/test_website/tests/__init__.py
@@ -4,6 +4,7 @@
 from . import test_controller_args
 from . import test_custom_snippet
 from . import test_error
+from . import test_fuzzy
 from . import test_image_upload_progress
 from . import test_is_multilang
 from . import test_media

--- a/addons/test_website/tests/test_fuzzy.py
+++ b/addons/test_website/tests/test_fuzzy.py
@@ -1,0 +1,74 @@
+# -*- coding: utf-8 -*-
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+import logging
+
+from odoo.addons.website.controllers.main import Website
+from odoo.addons.website.tools import MockRequest
+import odoo.tests
+from odoo.tests.common import TransactionCase
+
+_logger = logging.getLogger(__name__)
+
+@odoo.tests.tagged('-at_install', 'post_install')
+class TestAutoComplete(TransactionCase):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.website = cls.env['website'].browse(1)
+        cls.WebsiteController = Website()
+
+    def _autocomplete(self, term, expected_count, expected_fuzzy_term):
+        """ Calls the autocomplete for a given term and performs general checks """
+        with MockRequest(self.env, website=self.website):
+            suggestions = self.WebsiteController.autocomplete(
+                search_type="test", term=term, max_nb_chars=50, options={},
+            )
+        self.assertEqual(expected_count, suggestions['results_count'], "Wrong number of suggestions")
+        self.assertEqual(expected_fuzzy_term, suggestions.get('fuzzy_search', 'Not found'), "Wrong fuzzy match")
+
+    def test_01_many_records(self):
+        # REF1000~REF3999
+        data = [{
+            'name': 'REF%s' % count,
+            'is_published': True,
+        } for count in range(1000, 4000)]
+        self.env['test.model'].create(data)
+        # NUM1000~NUM1998
+        data = [{
+            'name': 'NUM%s' % count,
+            'is_published': True,
+        } for count in range(1000, 1999)]
+        self.env['test.model'].create(data)
+        # There are more than 1000 "R*" records
+        # => Find exact match through the fallback
+        self._autocomplete('REF3000', 1, False)
+        # => No exact match => Find fuzzy within first 1000 (distance=3: replace D by F, move 3, add 1)
+        self._autocomplete('RED3000', 1, 'ref1003')
+        # => Find exact match through the fallback
+        self._autocomplete('REF300', 10, False)
+        # => Find exact match through the fallback
+        self._autocomplete('REF1', 1000, False)
+        # => No exact match => Nothing close enough (min distance=5)
+        self._autocomplete('REFX', 0, "Not found")
+        # => Find exact match through the fallback - unfortunate because already in the first 1000 records
+        self._autocomplete('REF1230', 1, False)
+        # => Find exact match through the fallback
+        self._autocomplete('REF2230', 1, False)
+
+        # There are less than 1000 "N*" records
+        # => Fuzzy within N* (distance=1: add 1)
+        self._autocomplete('NUM000', 1, "num1000")
+        # => Exact match (distance=0 shortcut logic)
+        self._autocomplete('NUM100', 10, False)
+        # => Exact match (distance=0 shortcut logic)
+        self._autocomplete('NUM199', 9, False)
+        # => Exact match (distance=0 shortcut logic)
+        self._autocomplete('NUM1998', 1, False)
+        # => Fuzzy within N* (distance=1: replace 1 by 9)
+        self._autocomplete('NUM1999', 1, 'num1199')
+        # => Fuzzy within N* (distance=1: add 1)
+        self._autocomplete('NUM200', 1, 'num1200')
+
+        # There are no "X*" records
+        self._autocomplete('XEF1000', 0, "Not found")

--- a/addons/website/models/website.py
+++ b/addons/website/models/website.py
@@ -1779,7 +1779,14 @@ class Website(models.Model):
                 fields_domain.append([(field, '=ilike', '%%>%s%%' % first)]) # HTML
             domain.append(OR(fields_domain))
             domain = AND(domain)
-            records = model.search_read(domain, fields, limit=1000)
+            perf_limit = 1000
+            records = model.search_read(domain, fields, limit=perf_limit)
+            if len(records) == perf_limit:
+                # Exact match might have been missed because the fetched
+                # results are limited for performance reasons.
+                exact_records, _ = model._search_fetch(search_detail, search, 1, None)
+                if exact_records:
+                    yield search
             for record in records:
                 for field, value in record.items():
                     if isinstance(value, str):


### PR DESCRIPTION
For performance reasons, when fuzzy search was introduces it was
decided to limit the number of records used for finding fuzzy terms to
1000.  Because of this, when a database contains more than 1000
products matching words that start with the same letter, further
products are not examined. This can lead to searches not finding an
existing exact match.

This commit introduces a fallback mechanism so that, if we are in a
situation where the maximum number of examined records was fetched, we
also explicitly check for a possible exact match across all records.

Steps to reproduce:
- Do not install the pg_trgm extension.
- Have more than 1000 products containing searchable words (name,
description...) starting with the same letter.
- Add one more such product (so that it is not in the 1000 first ones).
- Search for that last product by correctly typing the word.
=> Exact match was not returned.

task-2870947

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
