### PR TITLE
[FIX] pos_stripe: Add a link to Stripe connect

### DIFF
--- a/addons/pos_stripe/models/pos_payment_method.py
+++ b/addons/pos_stripe/models/pos_payment_method.py
@@ -21,9 +21,6 @@ class PosPaymentMethod(models.Model):
 
     @api.constrains('stripe_serial_number')
     def _check_stripe_serial_number(self):
-        if not self.sudo()._get_stripe_secret_key():
-            raise ValidationError(_('Complete the Stripe onboarding.'))
-
         for payment_method in self:
             if not payment_method.stripe_serial_number:
                 continue
@@ -109,3 +106,14 @@ class PosPaymentMethod(models.Model):
 
         _logger.error("Unexpected stripe_capture_payment response: %s", resp.status_code)
         raise UserError(_("Unexpected error between us and Stripe."))
+
+    def action_stripe_key(self):
+        res_id = self.env['payment.acquirer'].search([('provider', '=', 'stripe')], limit=1).id
+        # Redirect
+        return {
+            'name': _('Stripe'),
+            'res_model': 'payment.acquirer',
+            'type': 'ir.actions.act_window',
+            'view_mode': 'form',
+            'res_id': res_id,
+        }

--- a/addons/pos_stripe/views/pos_payment_method_views.xml
+++ b/addons/pos_stripe/views/pos_payment_method_views.xml
@@ -8,6 +8,9 @@
             <xpath expr="//field[@name='use_payment_terminal']" position="after">
                 <!-- Stripe -->
                 <field name="stripe_serial_number" attrs="{'invisible': [('use_payment_terminal', '!=', 'stripe')], 'required': [('use_payment_terminal', '=', 'stripe')]}"/>
+                <div class="mt16" attrs="{'invisible': [('use_payment_terminal', '!=', 'stripe')], 'required': [('use_payment_terminal', '=', 'stripe')]}">
+                    <button name="action_stripe_key" type="object" icon="fa-arrow-right" string="Don't forget to complete Stripe connect before using this payment method." class="btn-link"/>
+                </div>
             </xpath>
         </field>
     </record>


### PR DESCRIPTION
We need to complete the onboarding of Stripe connect or
record the secret key

Actually there are not a direct link to payment from POS

So we add a link from the Stripe payment method to Stripe view form

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
