### PR TITLE
[FIX] delivery: assure stock user can validate pickings

### DIFF
--- a/addons/delivery/models/stock_picking.py
+++ b/addons/delivery/models/stock_picking.py
@@ -125,7 +125,7 @@ class StockPicking(models.Model):
         for pick in self:
             if pick.carrier_id:
                 if pick.carrier_id.integration_level == 'rate_and_ship' and pick.picking_type_code != 'incoming':
-                    pick.send_to_shipper()
+                    pick.sudo().send_to_shipper()
             pick._check_carrier_details_compliance()
         return super(StockPicking, self)._send_confirmation_email()
 


### PR DESCRIPTION
**Description of the issue/feature this PR addresses:**

Steps to reproduce (tested in v14, but I suppose also happens in v13 because the code is the same):
- Delivery module is installed.
- User_1 is stock_manager and sale_manager.
- User_1 creates sale_order and confirms it. Automatically is created a picking P.
- User_2 is stock user/manager but doesn't have sale rights.
- User_2 open picking P and validates it.
 => Error: cannot validate due to access rules.
![Selection_417](https://user-images.githubusercontent.com/25005517/171837054-117f9c19-5a03-40aa-85df-8dd1aaa43d8e.png)

The problem is due because at some point, it tries to read the linked sale order.

See the debug process:

- at the end of button_validate() of stock.picking (module stock):
![Selection_418](https://user-images.githubusercontent.com/25005517/171837383-ec2ee634-f9b3-4d4e-b768-4aea38bd750f.png)
-at the end of _action_done() of stock.picking (module stock):
![Selection_419](https://user-images.githubusercontent.com/25005517/171837523-d537d479-857b-4e6c-90cd-e7e2a84ccbea.png)
- in _send_confirmation_email() method of stock.picking (module delivery):
![Selection_420](https://user-images.githubusercontent.com/25005517/171837701-06529750-54d3-419b-92f2-54edd0d2ee46.png)
- in send_to_shipper() of stock.picking (module delivery):
![Selection_421](https://user-images.githubusercontent.com/25005517/171837823-cf81961c-f583-4ac2-b2eb-49f45a3505e1.png)
- in _compute_amount_total_without_delivery() of sale.order (module delivery):
![Selection_422](https://user-images.githubusercontent.com/25005517/171837954-ffb722fb-5c03-4bba-b550-75749ac12dd7.png)
It's in that place, when doing `self.order_line`, that a read access error is produced.


**Current behavior before PR:** Stock user without sale rights cannot validate a picking coming from a sale order.

**Desired behavior after PR is merged:** Stock user without sale rights can validate a picking coming from a sale order.

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr