### PR TITLE
[IMP] website_{slides, profile}: improve karma card and misc usability

### DIFF
--- a/addons/website_profile/static/src/js/website_profile.js
+++ b/addons/website_profile/static/src/js/website_profile.js
@@ -116,6 +116,19 @@ publicWidget.registry.websiteProfileEditor = publicWidget.Widget.extend({
     },
 });
 
+publicWidget.registry.websiteProfileNextRankCard = publicWidget.Widget.extend({
+    selector: '.o_wprofile_progress_circle',
+
+    /**
+     * @override
+     */
+    start: function () {
+        this.$('g[data-bs-toggle="tooltip"]').tooltip();
+        return this._super.apply(this, arguments);
+    },
+
+});
+
 return publicWidget.registry.websiteProfile;
 
 });

--- a/addons/website_profile/static/src/scss/website_profile.scss
+++ b/addons/website_profile/static/src/scss/website_profile.scss
@@ -125,6 +125,17 @@ $owprofile-color-bg: mix($body-bg, #efeff4);
 
     .o_pc_overlay {
         @include o-position-absolute(0,0,0,0);
+        // Allow hover effect on svg paths in order to display bootstrap tooltip,
+        // by pushing the absolute div behind it
+        z-index: -1;
+
+        h4 {
+            width: 60%;
+            // only apply ellipsis when in non-edit mode, that way the editor can see the full value
+            &:not(.o_editable) {
+                @include o-text-overflow();
+            }
+        }
     }
 
     @keyframes progress {
@@ -254,4 +265,12 @@ $owprofile-color-bg: mix($body-bg, #efeff4);
 // Own profile border
 .o_wprofile_border_focus {
     border-left: 4px solid map-get($theme-colors, 'secondary');
+}
+
+// Edition mode
+.editor_enable {
+    // Allow to edit rank picture in edit mode
+    .o_wprofile_progress_circle .o_pc_overlay {
+        z-index: initial;
+    }
 }

--- a/addons/website_profile/views/website_profile.xml
+++ b/addons/website_profile/views/website_profile.xml
@@ -234,7 +234,7 @@
 
                 <!-- ========== SIDEBAR ========== -->
                 <div class="col-12 col-md-4 col-lg-3 mt-3 mt-md-0">
-                    <div class="o_wprofile_sidebar bg-white px-3 py-2 py-md-3 mb-3 mb-md-5">
+                    <div class="o_wprofile_sidebar px-3 py-2 py-md-3 mb-3 mb-md-5">
                         <div class="o_wprofile_sidebar_top d-flex justify-content-between">
                             <div t-if="user.rank_id" class="d-flex align-items-center">
                                 <small class="fw-bold me-2">Current rank:</small>
@@ -315,8 +315,11 @@
                 <t t-else="">
                     <t t-set="user_points" t-value="0"/>
                 </t>
-                <path class="o_pc_circle_bg" d="M18 2.0845 a 15.9155 15.9155 0 0 1 0 31.831 a 15.9155 15.9155 0 0 1 0 -31.831" />
-                <path class="o_pc_circle" t-attf-stroke-dasharray="#{user_points}, 100" d="M18 2.0845 a 15.9155 15.9155 0 0 1 0 31.831 a 15.9155 15.9155 0 0 1 0 -31.831" stroke="url(#gradient)" mask="url(#mask)"/>
+                <g data-bs-toggle="tooltip" data-bs-delay="0"
+                    t-attf-title="{{ '%s/%s xp' % (user.karma, next_rank_id.karma_min) if next_rank_id else ''}}">
+                    <path class="o_pc_circle_bg" d="M18 2.0845 a 15.9155 15.9155 0 0 1 0 31.831 a 15.9155 15.9155 0 0 1 0 -31.831" />
+                    <path class="o_pc_circle" t-attf-stroke-dasharray="#{user_points}, 100" d="M18 2.0845 a 15.9155 15.9155 0 0 1 0 31.831 a 15.9155 15.9155 0 0 1 0 -31.831" stroke="url(#gradient)" mask="url(#mask)"/>
+                </g>
                 <mask id="mask">
                     <polygon points="0,0 17.2,0 17.2,10 18,10 18,0 36,0 36,36 0,36" fill="white"/>
                 </mask>
@@ -326,25 +329,21 @@
                 </linearGradient>
             </svg>
             <div class="o_pc_overlay d-flex flex-column align-items-center justify-content-center">
-                <img class="img-fluid"
-                    t-att-src="website.image_url(next_rank_id if next_rank_id else user.rank_id, 'image_128')"
-                    t-att-alt="(next_rank_id.name if next_rank_id else user.rank_id.name) + ' badge'"
-                    t-att-style="'max-width: ' + (img_max_width if img_max_width else '50%;')"/>
-                <h4 class=" mb-0">
-                    <span t-if="next_rank_id" t-field="next_rank_id.name"/>
-                    <span t-else="" t-field="user.rank_id.name"/>
-                </h4>
-                <small>
-                    <span class="fw-bold text-primary"
-                        t-field="user.karma"
-                        t-options="{'format_decimalized_number': True, 'precision_digits': 2}"/> /
-                    <span t-if="next_rank_id" class="fw-bold"
-                        t-field="next_rank_id.karma_min"
-                        t-options="{'format_decimalized_number': True, 'precision_digits': 2}"/>
-                    <span t-else="" class="fw-bold"
-                        t-field="user.rank_id.karma_min"
-                        t-options="{'format_decimalized_number': True, 'precision_digits': 2}"/>
-                     xp
+                <t t-set="rank_id" t-value="next_rank_id if next_rank_id else user.rank_id"/>
+                <div t-field="rank_id.image_1920"
+                    t-attf-style="max-width: {{img_max_width or '50%'}};"
+                    t-options="{'widget': 'image', 'preview_image': 'image_128'}"/>
+                <h4 class="text-center" t-field="rank_id.name"/>
+                <small class="w-50 text-center">
+                    <t t-set="karma_value" t-value="next_rank_id.karma_min - user.karma if next_rank_id else user.karma"/>
+                    <t t-if="next_rank_id">
+                        Get
+                        <span class="fw-bold text-primary" t-out="karma_value" t-options="{'widget': 'integer', 'format_decimalized_number': True, 'precision_digits': 2}"/> xp
+                        to level up!
+                    </t>
+                    <t t-else="">
+                        <span class="fw-bold text-primary" t-out="karma_value" t-options="{'widget': 'integer', 'format_decimalized_number': True, 'precision_digits': 2}"/> xp
+                    </t>
                 </small>
             </div>
         </div>
@@ -358,14 +357,11 @@
                         <div class="card">
                             <div class="card-body p-2 pe-3">
                                 <div class="d-flex align-items-center">
-                                    <img t-if="not badge.badge_id.image_1920 and badge.badge_id.level"
-                                        width="38" height="38"
-                                        t-attf-src="/website_profile/static/src/img/badge_#{badge.badge_id.level}.svg"
-                                        class="o_object_fit_cover me-0"
-                                        t-att-alt="badge.badge_id.name"/>
+                                    <div t-if="badge.badge_id.image_1920 and badge.badge_id.level" t-field="badge.badge_id.image_1920"
+                                        t-options="{'widget': 'image', 'preview_image': 'image_128', 'class': 'o_object_fit_cover me-0', 'style': 'height: 38px; width: 38px'}"/>
                                     <img t-else=""
                                         width="38" height="38"
-                                        t-att-src="website.image_url(badge.badge_id, 'image_128')"
+                                        t-attf-src="/website_profile/static/src/img/badge_#{badge.badge_id.level}.svg"
                                         class="o_object_fit_cover me-0"
                                         t-att-alt="badge.badge_id.name"/>
                                     <div class="flex-grow-1 col-md-10 p-0">
@@ -417,7 +413,8 @@
                                 <t t-foreach="ranks" t-as="rank">
                                     <li t-attf-class="list-group-item">
                                         <div class="d-flex align-items-center">
-                                            <img t-att-src="website.image_url(rank, 'image_128')" class="me-2 o_image_40_cover" alt="Rank badge"/>
+                                            <div t-field="rank.image_1920"
+                                                t-options="{'widget': 'image', 'preview_image': 'image_128', 'class': 'me-2 o_image_40_cover'}"/>
                                             <div class="flex-grow-1">
                                                 <h5 class="mt-0 mb-0" t-field="rank.name"/>
                                                 <span class="badge text-bg-success"><span t-field="rank.karma_min"/></span> point<span t-if="rank.karma_min">s</span>
@@ -464,7 +461,8 @@
     <template id="badge_header">
         <img t-if="not badge.image_1920 and badge.level" t-attf-src="/website_profile/static/src/img/badge_#{badge.level}.svg"
                 class="my-1 me-1 wprofile_badge_img" t-att-alt="badge.name"/>
-        <img t-else="" t-att-src="website.image_url(badge, 'image_1024')" class="my-1 me-1 wprofile_badge_img" t-att-alt="badge.name"/>
+        <div t-else="" t-field="badge.image_1920"
+            t-options="{'widget': 'image', 'preview_image': 'image_1024', 'class': 'my-1 me-1 wprofile_badge_img'}"/>
         <a t-if="badge_url" t-att-href="badge_url">
             <h6 t-field="badge.name" class="d-inline my-0"/>
         </a>

--- a/addons/website_slides/static/src/scss/website_slides.scss
+++ b/addons/website_slides/static/src/scss/website_slides.scss
@@ -232,8 +232,8 @@ $line-height-truncate: 1.25em;
 // **************************************************
 .o_wslides_home_main {
     .o_wslides_home_aside_loggedin {
+        background: none;
         @include media-breakpoint-up(lg) {
-            background: none;
             border: none;
         }
     }
@@ -245,7 +245,6 @@ $line-height-truncate: 1.25em;
     .o_wprofile_progress_circle {
         margin-left: auto;
         margin-right: auto;
-        max-width: 200px;
     }
 }
 

--- a/addons/website_slides/views/website_slides_templates_homepage.xml
+++ b/addons/website_slides/views/website_slides_templates_homepage.xml
@@ -340,7 +340,7 @@
             </div>
         </a>
         <div class="card-body d-flex flex-column p-3">
-            <a class="card-title h5 mb-2 o_wslides_desc_truncate_2" t-attf-href="/slides/#{slug(channel)}" t-esc="channel.name"/>
+            <a class="card-title h5 mb-2 o_wslides_desc_truncate_2" t-attf-href="/slides/#{slug(channel)}" t-field="channel.name"/>
             <span t-if="not channel.is_published" class="badge text-bg-danger p-1">Unpublished</span>
             <div class="card-text d-flex flex-column flex-grow-1 mt-1">
                 <div class="fw-light o_wslides_desc_truncate_3" t-field="channel.description_short"/>
@@ -495,11 +495,9 @@
         <t t-foreach="challenges" t-as="challenge">
             <t t-set="challenge_done" t-value="challenge in challenges_done if challenges_done else False"/>
             <div t-attf-class="d-flex mb-3 align-items-center #{'o_wslides_entry_muted' if not challenge_done else ''}">
-                <img class="me-2"
-                    style="max-height: 36px;"
-                    t-att-src="website.image_url(challenge.reward_id, 'image_128') if challenge.reward_id.image_1920 else
-                               '/website_profile/static/src/img/badge_%s.svg' % (challenge.reward_id.level)"
-                    t-att-alt="challenge.reward_id.name"/>
+                <div t-if="challenge.reward_id.image_1920" t-field="challenge.reward_id.image_1920"
+                    t-options="{'widget': 'image', 'preview_image': 'image_128', 'class': 'me-2', 'style': 'max-height: 36px'}"/>
+                <img t-else="" t-attf-src="'/website_profile/static/src/img/badge_%s.svg' % (challenge.reward_id.level)" t-att-alt="challenge.reward_id.name" style="max-height: 36px" class="me-2"/>
                 <div class="flex-grow-1">
                     <b class="text_small_caps" t-esc="challenge.reward_id.name"/><br/>
                     <span class="text-muted" t-esc="challenge.reward_id.description"/>


### PR DESCRIPTION
Currently, there are severlar issues with the karma card, like:
1/ improve karma display
2/ images of the rank and badges are can be changed by user, but
   after saving the changes are discarded

Apart from that, in the course navbar, the hard-coded white
text color is given, due to which in some themes the text
becomes invisible. And in the courses cards below navbar,
the course title is not editable.

This PR improves the following points:

1/ adds a tooltip on the progress bar that shows "2500/10000 xp".
   Displays the left xp needed to complete the next rank and adds a
   tooltip that shows 'Earn 7500 more karma to reach the next rank".
   If there is no next rank, displays total xp without tooltip.
2/ makes the images editable (in karma card as well as in the
   user profile and in '/profile/ranks_badges' page)
3/ makes the rank title editable
4/ removes the hard-coded white text color from the course
   navbar and make the course title editable

taskID-2853264