### PR TITLE
[FIX] l10n_ec: change loading order of files

### DIFF
--- a/addons/l10n_ec/__manifest__.py
+++ b/addons/l10n_ec/__manifest__.py
@@ -63,7 +63,6 @@ Master Data:
         "data/l10n_latam_identification_type_data.xml",
         "data/res_partner_data.xml",
         # Other data
-        "data/account_chart_template_configure_data.xml",
         "data/l10n_latam.document.type.csv",
         "data/l10n_ec.sri.payment.csv",
         "views/account_tax_view.xml",
@@ -71,6 +70,8 @@ Master Data:
         "views/l10n_ec_sri_payment.xml",
         "views/account_journal_view.xml",
         "security/ir.model.access.csv",
+        # Try loading CoA
+        "data/account_chart_template_configure_data.xml",
     ],
     "demo": [
         "demo/demo_company.xml",


### PR DESCRIPTION
There was a problem loading the demo data, because at the
installation of the CoA, the document types had not been loaded
yet.  By changing the order in which the files are loaded
in the manifest, we make sure that the when we upgrade the demo
data to Ecuadorian standards that the right document type is set.
(as it will be there because it will be loaded before the loading
of the demo data)

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
