### PR TITLE
[FIX] account: properly handle move without sequence_number

### DIFF
--- a/addons/account/models/sequence_mixin.py
+++ b/addons/account/models/sequence_mixin.py
@@ -161,7 +161,7 @@ class SequenceMixin(models.AbstractModel):
         if self.id or self.id.origin:
             where_string += " AND id != %(id)s "
             param['id'] = self.id or self.id.origin
-        if with_prefix:
+        if with_prefix is not None:
             where_string += " AND sequence_prefix = %(with_prefix)s "
             param['with_prefix'] = with_prefix
 
@@ -270,7 +270,7 @@ class SequenceMixin(models.AbstractModel):
             seq = format_values.pop('seq')
             batch = batched[(format, frozendict(format_values))]
             batch['seq_list'].append(seq)
-            if batch['last_rec'].sequence_number < record.sequence_number:
+            if batch['last_rec'].sequence_number <= record.sequence_number:
                 batch['last_rec'] = record
 
         for values in batched.values():


### PR DESCRIPTION
Since Odoo v15, user can rename invoice to a custom value. Odoo automatically
detects `sequence_number` for the new name. If no number is detected, the
`sequence_number` is set to zero. In this edge case, method
`_is_end_of_seq_chain` doesn't work and raises an exception, because `last_rec` is
empty, while `_get_last_sequence` has constrain `self.ensure_one()`.

Fix it by allowing `last_rec` with zero `sequence_number`.

STEPS:

* Create invoice
* Confirm
* Reset to Draft
* Rename invoice to "Test"
* Save
* Try to delete the invoice

BEFORE: ensure_one error

Once it's fixed, we face another problem: User Error *You cannot delete this entry, as it
has already consumed a sequence number and is not the last one in the chain. You
should probably revert it instead.*

It happens because `sequence_prefix` is computed as empty string, while
`_get_last_sequence` method ignores empty values. Fix it by allowing search by
empty string too.

AFTER the two changes user can delete draft invoice

opw-2861841