### PR TITLE
[FIX] google_drive: use OAuth2 consent flow

### DIFF
--- a/addons/google_drive/controllers/__init__.py
+++ b/addons/google_drive/controllers/__init__.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
-from . import controllers
-from . import models
+from . import main

--- a/addons/google_drive/controllers/main.py
+++ b/addons/google_drive/controllers/main.py
@@ -1,0 +1,29 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from odoo import _, http
+from odoo.http import request
+
+from werkzeug.exceptions import Forbidden
+from werkzeug.urls import url_encode
+
+import logging
+import werkzeug
+
+_logger = logging.getLogger(__name__)
+
+
+class GoogleDriveController(http.Controller):
+    @http.route(['/google_drive/confirm'], type='http', auth='user')
+    def google_drive_confirm(self, code=None, state=None, error=None, **kwargs):
+        if not request.env.is_admin():
+            _logger.error('Google Drive: Access Denied to non-system user on /google_drive/confirm')
+            raise Forbidden()
+
+        if error:
+            return _('An error occurred during the setup of Google Drive: %s', error)
+
+        refresh_token = request.env['google.drive.config']._request_token('authorization_code', code=code)
+        request.env['ir.config_parameter'].sudo().set_param('google_drive_refresh_token', refresh_token['refresh_token'])
+
+        settings_menu = request.env.ref('base.menu_administration')
+        return werkzeug.utils.redirect('/web#%s' % url_encode({'menu_id': settings_menu.id}))

--- a/addons/google_drive/i18n/google_drive.pot
+++ b/addons/google_drive/i18n/google_drive.pot
@@ -79,6 +79,18 @@ msgid "Add a new template"
 msgstr ""
 
 #. module: google_drive
+#: code:addons/google_drive/controllers/main.py:0
+#, python-format
+msgid "An error occurred during the setup of Google Drive: %s"
+msgstr ""
+
+#. module: google_drive
+#: code:addons/google_drive/models/google_drive.py:0
+#, python-format
+msgid "An error occurred when fetching token"
+msgstr ""
+
+#. module: google_drive
 #: model_terms:ir.ui.view,arch_db:google_drive.google_drive_config_view_search
 msgid "Archived"
 msgstr ""

--- a/addons/google_drive/models/res_config_settings.py
+++ b/addons/google_drive/models/res_config_settings.py
@@ -3,19 +3,19 @@
 
 from odoo import api, fields, models, _
 
+from werkzeug.urls import url_encode, url_join
+
 
 class ResConfigSettings(models.TransientModel):
     _inherit = "res.config.settings"
 
-    google_drive_authorization_code = fields.Char(string='Authorization Code', config_parameter='google_drive_authorization_code')
-    google_drive_uri = fields.Char(compute='_compute_drive_uri', string='URI', help="The URL to generate the authorization code from Google")
+    google_drive_authorization_code = fields.Char(string='Authorization Code', config_parameter='google_drive_authorization_code')  # TODO remove in master
+    google_drive_uri = fields.Char(compute='_compute_drive_uri', string='URI', help="The URL to generate the authorization code from Google")  # TODO remove in master
     is_google_drive_token_generated = fields.Boolean(string='Refresh Token Generated')
 
     @api.depends('google_drive_authorization_code')
     def _compute_drive_uri(self):
-        google_drive_uri = self.env['google.service']._get_google_token_uri('drive', scope=self.env['google.drive.config'].get_google_scope())
-        for config in self:
-            config.google_drive_uri = google_drive_uri
+        self.google_drive_uri = False
 
     def get_values(self):
         res = super(ResConfigSettings, self).get_values()
@@ -23,24 +23,27 @@ class ResConfigSettings(models.TransientModel):
         res.update(is_google_drive_token_generated=bool(refresh_token))
         return res
 
-    def confirm_setup_token(self):
-        params = self.env['ir.config_parameter'].sudo()
-        authorization_code_before = params.get_param('google_drive_authorization_code')
-        authorization_code = self.google_drive_authorization_code
-        if authorization_code != authorization_code_before:
-            refresh_token = (
-                self.env['google.service'].generate_refresh_token('drive', authorization_code)
-                if authorization_code else False
-            )
-            params.set_param('google_drive_refresh_token', refresh_token)
+    def confirm_setup_token(self):  # TODO remove in master
+        pass
 
     def action_setup_token(self):
-        self.ensure_one()
-        template = self.env.ref('google_drive.google_drive_auth_code_wizard')
+        ConfigParam = self.env['ir.config_parameter'].sudo()
+        base_url = ConfigParam.get_param('web.base.url')
+        client_id = ConfigParam.get_param('google_drive_client_id')
+        redirect_uri = url_join(base_url, '/google_drive/confirm')
+
+        scope = self.env['google.drive.config'].get_google_scope()
+        auth_url = 'https://accounts.google.com/o/oauth2/v2/auth?%s' % url_encode({
+            'client_id': client_id,
+            'redirect_uri': redirect_uri,
+            'response_type': 'code',
+            'access_type': 'offline',
+            'prompt': 'consent',
+            'scope': scope,
+        })
+
         return {
-            'name': _('Set up refresh token'),
-            'type': 'ir.actions.act_window',
-            'res_model': 'res.config.settings',
-            'views': [(template.id, 'form')],
-            'target': 'new',
+            'type': 'ir.actions.act_url',
+            'target': 'self',
+            'url': auth_url,
         }

--- a/addons/google_drive/views/res_config_settings_views.xml
+++ b/addons/google_drive/views/res_config_settings_views.xml
@@ -46,6 +46,7 @@
         </field>
     </record>
 
+    <!-- TODO: delete in master -->
     <record id="google_drive_auth_code_wizard" model="ir.ui.view">
         <field name="name">google.drive.authorization.wizard</field>
         <field name="model">res.config.settings</field>


### PR DESCRIPTION
As Google is deprecating the Out-Of-Band flow on 3rd October 2022[1],
here we are adapting to use a more secure authorization method.

[1]: https://developers.googleblog.com/2022/02/making-oauth-flows-safer.html#disallowed-oob

TaskID: 2867215