### PR TITLE
[IMP] tests: Show tests progress

### DIFF
--- a/odoo/tests/loader.py
+++ b/odoo/tests/loader.py
@@ -74,7 +74,7 @@ def run_suite(suite, module_name=None):
     module.current_test = module_name
     threading.current_thread().testing = True
 
-    results = OdooTestResult()
+    results = OdooTestResult(suite_tests_count=suite.countTestCases())
     suite(results)
 
     threading.current_thread().testing = False

--- a/odoo/tests/runner.py
+++ b/odoo/tests/runner.py
@@ -4,6 +4,7 @@ import time
 import unittest
 
 from .. import sql_db
+from ..tools import config
 
 
 _logger = logging.getLogger(__name__)
@@ -89,9 +90,14 @@ class OdooTestResult(unittest.result.TestResult):
 
     def stopTest(self, test):
         super().stopTest(test)
-        self.log(logging.DEBUG, '%s Finished (%.3fs, %d queries)',
+        queries = sql_db.sql_counter - self.queries_start
+        if config.options['max_cron_threads'] == 0 and queries:
+            self.log(logging.DEBUG, '%s Finished (%.3fs, %d queries)',
                  self.getDescription(test), time.time() - self.time_start,
-                 sql_db.sql_counter - self.queries_start, test=test)
+                 queries, test=test)
+        else:
+            self.log(logging.DEBUG, '%s Finished (%.3fs)',
+                     self.getDescription(test), time.time() - self.time_start, test=test)
 
     def addError(self, test, err):
         if self._soft_fail:


### PR DESCRIPTION
Waiting for the tests when you don't know how much longer is boring. Also, with knowing how many tests would run, one can manage time better. It also logs the elapsed time and query count for each test, although, it is not reliable because cron jobs and bus can interfere with the results.


--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
