### PR TITLE
[FIX] `event`: do not fail if mail.template is missing

### DIFF
--- a/addons/event/models/event_registration.py
+++ b/addons/event/models/event_registration.py
@@ -229,13 +229,13 @@ class EventRegistration(models.Model):
             message loaded by default
         """
         self.ensure_one()
-        template = self.env.ref('event.event_registration_mail_template_badge')
+        template = self.env.ref('event.event_registration_mail_template_badge', raise_if_not_found=False)
         compose_form = self.env.ref('mail.email_compose_message_wizard_form')
         ctx = dict(
             default_model='event.registration',
             default_res_id=self.id,
             default_use_template=bool(template),
-            default_template_id=template.id,
+            default_template_id=template and template.id,
             default_composition_mode='comment',
             custom_layout="mail.mail_notification_light",
         )


### PR DESCRIPTION
**Steps to reproduce:**

1. Delete the mail.template "Event: Registration Badge".
2. Go to any event.registration record.
3. Click on Send by Mail button.

**Current behavior before PR:**

An error is raised

```
ValueError: External ID not found in the system: event.event_registration_mail_template_badge
```

**Desired behavior after PR is merged:**

No error should be raised. Just fallback to a composer without template.



ping @tde-banana-odoo 

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
