### PR TITLE
[FIX] web: invalid image placeholder resizing

### DIFF
--- a/addons/mail/controllers/discuss.py
+++ b/addons/mail/controllers/discuss.py
@@ -183,7 +183,7 @@ class DiscussController(http.Controller):
             raise NotFound()
 
         return request.env['ir.binary']._get_image_stream_from(
-            attachment_sudo, width=width, height=height
+            attachment_sudo, width=int(width), height=int(height)
         ).get_response(as_attachment=kwargs.get('download'))
 
     # --------------------------------------------------------------------------

--- a/addons/web/controllers/binary.py
+++ b/addons/web/controllers/binary.py
@@ -142,7 +142,7 @@ class Binary(http.Controller):
                 width, height = image_guess_size_from_field_name(field)
             record = request.env.ref('web.image_placeholder').sudo()
             stream = request.env['ir.binary']._get_image_stream_from(
-                record, 'raw', width=width, height=height, crop=crop,
+                record, 'raw', width=int(width), height=int(height), crop=crop,
             )
 
         send_file_kwargs = {'as_attachment': download}

--- a/addons/website_slides/controllers/main.py
+++ b/addons/website_slides/controllers/main.py
@@ -821,7 +821,7 @@ class WebsiteSlides(WebsiteProfile):
             raise werkzeug.exceptions.NotFound()
 
         return request.env['ir.binary']._get_image_stream_from(
-            slide, field, width=width, height=int(height), crop=int(crop)
+            slide, field, width=int(width), height=int(height), crop=int(crop)
         ).get_response()
 
     # SLIDE.SLIDE UTILS


### PR DESCRIPTION
Access `/web/image/82303?height=16`, traceback because the placeholder
image cannot be resized to `"16"`.
