### PR TITLE
[FIX] website_sale_delivery_mondialrelay : delivery error for saleorder without delivery

### DIFF
--- a/addons/website_sale_delivery_mondialrelay/controllers/controllers.py
+++ b/addons/website_sale_delivery_mondialrelay/controllers/controllers.py
@@ -80,7 +80,7 @@ class PaymentPortalMondialRelay(PaymentPortal):
     @http.route()
     def shop_payment_transaction(self, *args, **kwargs):
         order = request.website.sale_get_order()
-        if order.partner_shipping_id.is_mondialrelay and not order.carrier_id.is_mondialrelay:
+        if order.partner_shipping_id.is_mondialrelay and order.carrier_id and not order.carrier_id.is_mondialrelay and order.delivery_set:
             raise ValidationError(_('Point Relais® can only be used with the delivery method Mondial Relay.'))
         elif not order.partner_shipping_id.is_mondialrelay and order.carrier_id.is_mondialrelay:
             raise ValidationError(_('Delivery method Mondial Relay can only ship to Point Relais®.'))


### PR DESCRIPTION
Steps to reproduce:
- Install ecommerce and the website_sale_delivery_mondialrelay module
- Publish the mondialrelay shipping method
- Go to the website shop
- Start a cart with an object that can be delivered (e.g. a table)
- Process to checkout
- Select mondial relay shipping method and a relay depot
- Don't click on Pay Now but go back to your cart and make it empty
- Add a non deliverable item to the cart (e.g. a warranty)
- Process to checkout and try to pay

Current behavior:
There is an error message related to mondial relay

Expected behavior:
There is no error message

Explanation:
The sale order keeps the partner_shipping_id even if it does not
contain any delivarable item. The mondial relay error message can
be sent for any order without checking that the order
is supposed to be delivered. To solve the issue we just add a
condition so that only orders with delivery can receive this message.

opw-2869883