### PR TITLE
[FIX] account: set copy to false to paired_internal_transfer_payment_id

### DIFF
--- a/addons/account/models/account_payment.py
+++ b/addons/account/models/account_payment.py
@@ -50,7 +50,7 @@ class AccountPayment(models.Model):
     qr_code = fields.Char(string="QR Code",
         compute="_compute_qr_code",
         help="QR-code report URL to use to generate the QR-code to scan with a banking app to perform this payment.")
-    paired_internal_transfer_payment_id = fields.Many2one('account.payment', copy=False
+    paired_internal_transfer_payment_id = fields.Many2one('account.payment', copy=False ,
         help="When an internal transfer is posted, a paired payment is created. "
         "They are cross referenced trough this field")
 

--- a/addons/account/models/account_payment.py
+++ b/addons/account/models/account_payment.py
@@ -50,7 +50,7 @@ class AccountPayment(models.Model):
     qr_code = fields.Char(string="QR Code",
         compute="_compute_qr_code",
         help="QR-code report URL to use to generate the QR-code to scan with a banking app to perform this payment.")
-    paired_internal_transfer_payment_id = fields.Many2one('account.payment', copy=False ,
+    paired_internal_transfer_payment_id = fields.Many2one('account.payment', copy=False,
         help="When an internal transfer is posted, a paired payment is created. "
         "They are cross referenced trough this field")
 

--- a/addons/account/models/account_payment.py
+++ b/addons/account/models/account_payment.py
@@ -50,7 +50,7 @@ class AccountPayment(models.Model):
     qr_code = fields.Char(string="QR Code",
         compute="_compute_qr_code",
         help="QR-code report URL to use to generate the QR-code to scan with a banking app to perform this payment.")
-    paired_internal_transfer_payment_id = fields.Many2one('account.payment',
+    paired_internal_transfer_payment_id = fields.Many2one('account.payment', copy=False
         help="When an internal transfer is posted, a paired payment is created. "
         "They are cross referenced trough this field")
 


### PR DESCRIPTION
#92926: Confirm Internal transfer (duplicate from exists once) doesn't create the second payment in the destination journal.

Description of the issue/feature this PR addresses:
Steps to reproduce:

1. Go to Invoicing app, From customer menu open payments.
2. Create a new internal transfer from Bank to Cash and confirm it.
3. From actions, select duplicate. a new internal transfer will be created.
4. confirm the new internal transfer.

Check the journal entries created, You will find only the first payment from source journal.

Current behavior before PR:
Once the internal transfer confirmed, only first payment created and the second payment is not created in the destination journal.

Desired behavior after PR is merged:
The second payment should be created and reconciled with the first payment.
--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
