### PR TITLE
[FIX][14.0] sale_stock_margin: Fix only one currency rate per day allowed!

### DIFF
--- a/addons/sale_stock_margin/tests/test_sale_stock_margin.py
+++ b/addons/sale_stock_margin/tests/test_sale_stock_margin.py
@@ -172,8 +172,13 @@ class TestSaleStockMargin(TestStockValuationCommon):
         other_currency = self.env.ref('base.EUR') if company_currency == self.env.ref('base.USD') else self.env.ref('base.USD')
 
         date = fields.Date.today()
-        ResCurrencyRate.create({'currency_id': company_currency.id, 'rate': 1, 'name': date})
-        other_currency_rate = ResCurrencyRate.search([('name', '=', date), ('currency_id', '=', other_currency.id)])
+        currency_rates = ResCurrencyRate.search([('name', '=', date)])
+        currency_rate = currency_rates.filtered(lambda r: r.currency_id.id == company_currency.id)
+        if currency_rate:
+            currency_rate.rate = 1
+        else:
+            ResCurrencyRate.create({'currency_id': company_currency.id, 'rate': 1, 'name': date})
+        other_currency_rate = currency_rates.filtered(lambda r: r.currency_id.id == other_currency.id)
         if other_currency_rate:
             other_currency_rate.rate = 2
         else:


### PR DESCRIPTION
This PR
-------
Current:
Create a new rate when not sure if that currency has a rate that day => May cause error `Only
one currency rate per day allowed!` in `base` module
Solution:
Check if the company currency has a rate for that day before creating a new one

Note:
In fact with the first run automation test -> no error
But second time running automation test -> `l10n_generic_coa` is installed -> Change company
currency to USD
In `base` module created rate for USD (06/06/YYYY) (xid=rateUSDbis) -> second time running automation test in `sale_stock_margin` on 06/06 -> error


--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
