### PR TITLE
[IMP] hr_skills_slides: duplicate course lines

### DIFF
--- a/addons/hr_skills_slides/models/slide_channel.py
+++ b/addons/hr_skills_slides/models/slide_channel.py
@@ -10,12 +10,19 @@ class SlideChannelPartner(models.Model):
 
     def _recompute_completion(self):
         res = super(SlideChannelPartner, self)._recompute_completion()
-        partner_has_completed = {channel_partner.partner_id.id: channel_partner.channel_id for channel_partner in self}
+        partner_has_completed = {channel_partner.partner_id.id: channel_partner.channel_id for channel_partner in self.filtered('completed')}
         employees = self.env['hr.employee'].sudo().search([('user_id.partner_id', 'in', list(partner_has_completed.keys()))])
+        if not employees:
+            return res
+        line_type = self.env.ref('hr_skills_slides.resume_type_training', raise_if_not_found=False)
+        resume_line_vals = []
         for employee in employees:
-            line_type = self.env.ref('hr_skills_slides.resume_type_training', raise_if_not_found=False)
+            # If an employee has completed a course once, and new content is added afterwards, course is still considered
+            # as completed for an employee, so do not add duplicate skill(resume line) for the same course
             channel = partner_has_completed[employee.user_id.partner_id.id]
-            self.env['hr.resume.line'].create({
+            if employee.resume_line_ids.filtered(lambda skill: skill.display_type == 'course' and skill.channel_id == channel):
+                continue
+            resume_line_vals.append({
                 'employee_id': employee.id,
                 'name': channel.name,
                 'date_start': fields.Date.today(),
@@ -25,4 +32,6 @@ class SlideChannelPartner(models.Model):
                 'display_type': 'course',
                 'channel_id': channel.id
             })
+        if resume_line_vals:
+            self.env['hr.resume.line'].create(resume_line_vals)
         return res


### PR DESCRIPTION
Currently, in `hr_skill_slides`, it create a new record whenever you reopen
a course you have Completed or not.

This commit avoids the duplicate course lines and creates a record when a course
is completed in `hr_skills_slides` by checking the employee's current course line.

task-2869305

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
