### PR TITLE
[13.0][FIX] purchase_stock: Use hook method

### DIFF
--- a/addons/purchase_stock/models/purchase.py
+++ b/addons/purchase_stock/models/purchase.py
@@ -369,7 +369,7 @@ class PurchaseOrderLine(models.Model):
         self.ensure_one()
         line = self[0]
         order = line.order_id
-        price_unit = line.price_unit
+        price_unit = line._prepare_compute_all_values()['price_unit']
         price_unit_prec = self.env['decimal.precision'].precision_get('Product Price')
         if line.taxes_id:
             qty = line.product_qty or 1

--- a/addons/purchase_stock/models/stock.py
+++ b/addons/purchase_stock/models/stock.py
@@ -41,7 +41,7 @@ class StockMove(models.Model):
             price_unit_prec = self.env['decimal.precision'].precision_get('Product Price')
             line = self.purchase_line_id
             order = line.order_id
-            price_unit = line.price_unit
+            price_unit = line._prepare_compute_all_values()['price_unit']
             if line.taxes_id:
                 qty = line.product_qty or 1
                 price_unit = line.taxes_id.with_context(round=False).compute_all(price_unit, currency=line.order_id.currency_id, quantity=qty)['total_void']


### PR DESCRIPTION
Trying again as in

- https://github.com/odoo/odoo/pull/29983

Summary:

- This uses the hook method introduced in ce1f1b6 for consistency when used on modules
that modify this behavior.


TT36816 cc @Tecnativa

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
