### PR TITLE
[FIX] website: fix wrong translation check due to transifex change

### DIFF
--- a/addons/website/static/tests/tours/configurator_translation.js
+++ b/addons/website/static/tests/tours/configurator_translation.js
@@ -52,11 +52,17 @@ tour.register('configurator_translation', {
         trigger: 'body.editor_started',
         timeout: 30000,
     }, {
-        // Check the content of the save button to make sure
-        // the website is in French. (The editor should be in the website's
-        // default language, which should be french in this test.)
+        // Check the content of the save button to make sure the website is in
+        // French. (The editor should be in the website's default language,
+        // which should be french in this test.)
+        // Also note that sometimes the translation is being changed on
+        // Transifex from "Sauvegarder" to "Sauver" or the other way around.
+        // TODO: Strengthen this tour by creating a new fake language and some
+        //       translations for the checked terms. See what's done in `Sign`
+        //       `test_translate_sign_instructions` tour with the `Parseltongue`
+        //       language.
         content: "exit edit mode",
-        trigger: '.o_we_website_top_actions button.btn-primary:contains("Sauvegarder")',
+        trigger: '.o_we_website_top_actions button.btn-primary:contains("Sauvegarder"), .o_we_website_top_actions button.btn-primary:contains("Sauver")',
     }, {
          content: "wait for editor to be closed",
          trigger: 'body:not(.editor_enable)',


### PR DESCRIPTION
Somehow the already translated term `Save` in french was translated
again from `Sauvegarder` to `Sauver`.

We already faced that issue when forward porting the tour as that
translation was not the same between versions, see [1].

The tour should be adapted to create a new fake language and some
translations for it (the ones being checked in the tour) to make it more
robust and not impacted by the real translation from transifex.
It would also makes the test faster as it wouldn't have to load a real
language which has a lot of translations.

As this is blocking and preventing any r+ in saas-15.3 a day before the
saas-15.4 freeze/release, this quick fix is introduced in the meantime.

[1]: https://github.com/odoo/odoo/pull/84528#issuecomment-1041323974
