### PR TITLE
[FIX] sale: allow down payment sections to be properly translated

### DIFF
--- a/addons/sale/models/sale.py
+++ b/addons/sale/models/sale.py
@@ -1138,6 +1138,7 @@ Reason(s) of this behavior could be:
 
         :param optional_values: any parameter that should be added to the returned down payment section
         """
+        context = {'lang': self.partner_id.lang}
         down_payments_section_line = {
             'display_type': 'line_section',
             'name': _('Down Payments'),
@@ -1148,6 +1149,7 @@ Reason(s) of this behavior could be:
             'price_unit': 0,
             'account_id': False
         }
+        del context
         if optional_values:
             down_payments_section_line.update(optional_values)
         return down_payments_section_line


### PR DESCRIPTION
When generating an SO, the down payment section is translated into the language
of the current user instead of the language of the partner.

Step to reproduce the issue:
1) Install the Sales module
2) Install another language (e.g.: French) and change the language of a partner
to this language.
3) Create a quotation for the partner which you just changed its language (and
confirm it)
4) Create an invoice (down payment) of 50% for example (confirm the invoice)
5) Create another invoice to complete the payment (confirm it too)
6) Go the latest invoice and print it
You should see that the "Down Payments" section is kept in English instead of
the other language (e.g. French).

Solution: The issue is simply that the translation of the concerned term is
translated using the lang of the user instead of the lang of the partner. To
fix this, we must update the current context to change the lang to the partner
language (defaulting to the user language if the partner has no lang).

opw-2865865
