### PR TITLE
[FIX] website: `og:url` should be localized

### DIFF
--- a/addons/website/models/mixins.py
+++ b/addons/website/models/mixins.py
@@ -3,8 +3,10 @@
 
 import logging
 
+from werkzeug.urls import url_join
 
 from odoo import api, fields, models, _
+from odoo.addons.http_routing.models.ir_http import url_for
 from odoo.http import request
 from odoo.osv import expression
 from odoo.exceptions import AccessError
@@ -50,7 +52,7 @@ class SeoMetadata(models.AbstractModel):
             'og:type': 'website',
             'og:title': title,
             'og:site_name': company.name,
-            'og:url': request.httprequest.url,
+            'og:url': url_join(request.httprequest.url_root, url_for(request.httprequest.path)),
             'og:image': img,
         }
         # Default meta for Twitter


### PR DESCRIPTION
Before this commit, with a website using multiple languages, when sharing
any link with a language other than the original language on Facebook,
the content of Optimize SEO always receives the value of the default
language. The reason is that `og:url` does not change according to the
language of the website, so we need to localize `og:url` to fix this.

Steps to reproduce:
1. Set up 2 different languages for your website (e.g. English, Vietnamese).
 Set the default language for your website to English.
2. Create a page, promote seo this page for both languages.
3. Share this link on Facebook with Vietnamese language, see the title
and description on preview are still in English.


--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
