### PR TITLE
[FIX] sale: mail confirmation with wrong shipping cost amount

### DIFF
--- a/addons/sale/data/mail_template_data.xml
+++ b/addons/sale/data/mail_template_data.xml
@@ -204,13 +204,17 @@
         <table t-if="hasattr(object, 'carrier_id') and object.carrier_id" width="100%" style="color: #454748; font-size: 12px;">
             <tr>
                 <td>
-                    <strong>Shipping Method:</strong>
-                    <t t-out="object.carrier_id.name or ''"></t>
-                    <t t-if="object.carrier_id.fixed_price == 0.0">
-                        (Free)
-                    </t>
-                    <t t-else="">
-                        (<t t-out="format_amount(object.carrier_id.fixed_price, object.currency_id) or ''">$ 10.00</t>)
+                    <t t-foreach="object.order_line" t-as="line">
+                        <t t-if="line.is_delivery">
+                            <strong>Shipping Method:</strong>
+                            <t t-out="object.carrier_id.name or ''"></t>
+                            <t t-if="line.price_total == 0.0">
+                                (Free)
+                            </t>
+                            <t t-else="">
+                                (<t t-out="format_amount(line.price_total, line.currency_id) or ''">$ 10.00</t>)
+                            </t>
+                        </t>
                     </t>
                 </td>
             </tr>


### PR DESCRIPTION
Steps to reproduce:
- Create a shipping method, with a free product such as the free
 if the order is above $1,
- go to e-commerce and purchase something from the website and
apply the shipping method just created with the free product
- look at the message sent from Odoo, specifically in the
 shipping method area

Current behavior:
You can see the product price of the free product in the
shipping method

Expected behavior:
The shipping method should be shown as free in this section

Explanation:
In the mail template it is always carrier fixed price that is shown 
no matter the type of pricing of the shipping method  settings 
(rules or free if > price). To fix the issue we replace that by the 
sale order delivery line total price 

opw-2860807
