### PR TITLE
[FIX] mail: show popover in discuss public view

### DIFF
--- a/addons/mail/static/src/public/discuss_public_boot.js
+++ b/addons/mail/static/src/public/discuss_public_boot.js
@@ -5,6 +5,7 @@ import { makeMessagingToLegacyEnv } from '@mail/utils/make_messaging_to_legacy_e
 
 import { DialogManagerContainer } from '@mail/components/dialog_manager_container/dialog_manager_container';
 import { DiscussPublicViewContainer } from '@mail/components/discuss_public_view_container/discuss_public_view_container';
+import { PopoverManagerContainer } from '@mail/components/popover_manager_container/popover_manager_container';
 import { messagingService } from '@mail/services/messaging_service';
 
 import { processTemplates } from '@web/core/assets';
@@ -54,6 +55,7 @@ Component.env = legacyEnv;
     mainComponentsRegistry.add('DiscussPublicViewContainer', { Component: DiscussPublicViewContainer });
     // needed by the attachment viewer
     mainComponentsRegistry.add('DialogManagerContainer', { Component: DialogManagerContainer });
+    mainComponentsRegistry.add('PopoverManagerContainer', { Component: PopoverManagerContainer });
 
     await legacySession.is_bound;
     Object.assign(odoo, {


### PR DESCRIPTION
Follow-up of
https://github.com/odoo/odoo/pull/92896
Task-2871688

PR above introduced PopoverManager, but forgot to include it in the
public discuss view. As a result, no popover view were working.
For example, clicking on the Emoji button in the composer was not
showing the emoji list in a popover view.
