### PR TITLE
[IMP] point_of_sale: fine-grained rendering

### DIFF
--- a/addons/point_of_sale/static/src/entry/chrome_adapter.js
+++ b/addons/point_of_sale/static/src/entry/chrome_adapter.js
@@ -49,6 +49,7 @@ export class ChromeAdapter extends Component {
         const updateUI = debounce(() => {
             if (this.env.isMobile !== currentIsMobile) {
                 currentIsMobile = this.env.isMobile;
+                // Make sure to render the full UI when switching to mobile view.
                 this.render(true);
             }
         }, 15);

--- a/addons/point_of_sale/static/src/js/Chrome.js
+++ b/addons/point_of_sale/static/src/js/Chrome.js
@@ -72,7 +72,7 @@ odoo.define('point_of_sale.Chrome', function(require) {
 
             this.previous_touch_y_coordinate = -1;
 
-            const pos = reactive(this.env.pos, batched(() => this.render(true)))
+            const pos = reactive(this.env.pos, batched(() => this.render()))
             useSubEnv({ pos });
 
             onMounted(() => {
@@ -194,7 +194,6 @@ odoo.define('point_of_sale.Chrome', function(require) {
             if (this.env.pos.config.limited_products_loading && this.env.pos.config.product_load_background) {
                 this.env.pos.loadProductsBackground().then(() => {
                     this.env.pos.isEveryProductLoaded = true;
-                    this.render(true);
                 });
             }
         }

--- a/addons/point_of_sale/static/src/js/PosComponent.js
+++ b/addons/point_of_sale/static/src/js/PosComponent.js
@@ -13,6 +13,11 @@ odoo.define('point_of_sale.PosComponent', function (require) {
                     console.log('Rendered:', this.constructor.name);
                 }
             });
+            if (this.env.pos) {
+                owl.useSubEnv({
+                    pos: owl.useState(this.env.pos),
+                });
+            }
         }
         /**
          * This function is available to all Components that inherit this class.

--- a/addons/point_of_sale/static/src/js/Screens/PartnerListScreen/PartnerDetailsEdit.js
+++ b/addons/point_of_sale/static/src/js/Screens/PartnerListScreen/PartnerDetailsEdit.js
@@ -13,10 +13,11 @@ odoo.define('point_of_sale.PartnerDetailsEdit', function(require) {
             super.setup();
             this.intFields = ['country_id', 'state_id', 'property_product_pricelist'];
             const partner = this.props.partner;
-            this.changes = {
+            this.changes = owl.useState({
                 'country_id': partner.country_id && partner.country_id[0],
                 'state_id': partner.state_id && partner.state_id[0],
-            };
+            });
+
             if (!partner.property_product_pricelist)
                 this.changes['property_product_pricelist'] = this.env.pos.default_pricelist.id;
 
@@ -79,8 +80,6 @@ odoo.define('point_of_sale.PartnerDetailsEdit', function(require) {
                 if (loadedImage) {
                     const resizedImage = await this._resizeImage(loadedImage, 800, 600);
                     this.changes.image_1920 = resizedImage.toDataURL();
-                    // Rerender to reflect the changes in the screen
-                    this.render(true);
                 }
             }
         }

--- a/addons/point_of_sale/static/src/js/Screens/PartnerListScreen/PartnerListScreen.js
+++ b/addons/point_of_sale/static/src/js/Screens/PartnerListScreen/PartnerListScreen.js
@@ -37,14 +37,14 @@ odoo.define('point_of_sale.PartnerListScreen', function(require) {
             // to Observer proxy. Not sure of the side-effects of making
             // a persistent object, such as pos, into Observer. But it
             // is better to be safe.
-            this.state = {
+            this.state = owl.useState({
                 query: null,
                 selectedPartner: this.props.partner,
                 detailIsShown: false,
                 editModeProps: {
                     partner: null,
                 },
-            };
+            });
             this.updatePartnerList = debounce(this.updatePartnerList, 70);
             onWillUnmount(this.updatePartnerList.cancel);
             onMounted(() => {
@@ -57,7 +57,6 @@ odoo.define('point_of_sale.PartnerListScreen', function(require) {
         back() {
             if(this.state.detailIsShown) {
                 this.state.detailIsShown = false;
-                this.render(true);
             } else {
                 this.props.resolve({ confirmed: false, payload: false });
                 this.trigger('close-temp-screen');
@@ -69,7 +68,6 @@ odoo.define('point_of_sale.PartnerListScreen', function(require) {
         }
         activateEditMode() {
             this.state.detailIsShown = true;
-            this.render(true);
         }
         // Getters
 
@@ -121,7 +119,6 @@ odoo.define('point_of_sale.PartnerListScreen', function(require) {
         _clearSearch() {
             this.searchWordInputRef.el.value = '';
             this.state.query = '';
-            this.render(true);
         }
         // We declare this event handler as a debounce function in
         // order to lower its trigger rate.
@@ -129,8 +126,6 @@ odoo.define('point_of_sale.PartnerListScreen', function(require) {
             this.state.query = event.target.value;
             if (event.code === 'Enter') {
                 this._onPressEnterKey();
-            } else {
-                this.render(true);
             }
         }
         clickPartner(partner) {
@@ -178,7 +173,6 @@ odoo.define('point_of_sale.PartnerListScreen', function(require) {
             let result = await this.getNewPartners();
             this.env.pos.db.add_partners(result);
             if (!this.env.pos.isEveryPartnerLoaded) await this.env.pos.updateIsEveryPartnerLoaded();
-            this.render(true);
             return result;
         }
         async getNewPartners() {

--- a/addons/point_of_sale/static/src/js/Screens/PaymentScreen/PaymentScreen.js
+++ b/addons/point_of_sale/static/src/js/Screens/PaymentScreen/PaymentScreen.js
@@ -97,7 +97,6 @@ odoo.define('point_of_sale.PaymentScreen', function (require) {
         toggleIsToInvoice() {
             // click_invoice
             this.currentOrder.set_to_invoice(!this.currentOrder.is_to_invoice());
-            this.render(true);
         }
         openCashbox() {
             this.env.proxy.printer.open_cashbox();
@@ -121,7 +120,6 @@ odoo.define('point_of_sale.PaymentScreen', function (require) {
         toggleIsToShip() {
             // click_ship
             this.currentOrder.set_to_ship(!this.currentOrder.is_to_ship());
-            this.render(true);
         }
         deletePaymentLine(event) {
             var self = this;
@@ -136,13 +134,11 @@ odoo.define('point_of_sale.PaymentScreen', function (require) {
                 line.payment_method.payment_terminal.send_payment_cancel(this.currentOrder, cid).then(function() {
                     self.currentOrder.remove_paymentline(line);
                     NumberBuffer.reset();
-                    self.render(true);
                 })
             }
             else if (line.get_payment_status() !== 'waitingCancel') {
                 this.currentOrder.remove_paymentline(line);
                 NumberBuffer.reset();
-                this.render(true);
             }
         }
         selectPaymentLine(event) {
@@ -150,7 +146,6 @@ odoo.define('point_of_sale.PaymentScreen', function (require) {
             const line = this.paymentLines.find((line) => line.cid === cid);
             this.currentOrder.select_paymentline(line);
             NumberBuffer.reset();
-            this.render(true);
         }
         async validateOrder(isForceValidate) {
             if(this.env.pos.config.cash_rounding) {

--- a/addons/point_of_sale/static/src/js/Screens/ProductScreen/ProductsWidget.js
+++ b/addons/point_of_sale/static/src/js/Screens/ProductScreen/ProductsWidget.js
@@ -72,7 +72,6 @@ odoo.define('point_of_sale.ProductsWidget', function(require) {
             this.state.searchWord = '';
         }
         _updateProductList(event) {
-            this.render(true);
             this.trigger('switch-category', 0);
         }
     }

--- a/addons/pos_mercury/static/src/js/PaymentScreen.js
+++ b/addons/pos_mercury/static/src/js/PaymentScreen.js
@@ -373,7 +373,6 @@ odoo.define('pos_mercury.PaymentScreen', function (require) {
 
                                 NumberBuffer.reset();
                                 order.trigger('change', order); // needed so that export_to_JSON gets triggered
-                                self.render();
 
                                 if (response.message === 'PARTIAL AP') {
                                     def.resolve({
@@ -458,7 +457,6 @@ odoo.define('pos_mercury.PaymentScreen', function (require) {
             remove_paymentline_by_ref(line) {
                 this.env.pos.get_order().remove_paymentline(line);
                 NumberBuffer.reset();
-                this.render();
             }
 
             do_reversal(line, is_voidsale, old_deferred, retry_nr) {
@@ -591,7 +589,6 @@ odoo.define('pos_mercury.PaymentScreen', function (require) {
                 if (res && paymentMethod.pos_mercury_config_id) {
                     order.selected_paymentline.mercury_swipe_pending = true;
                     order.trigger('change', order);
-                    this.render();
                 }
             }
         };

--- a/addons/pos_restaurant/static/src/js/Screens/FloorScreen/FloorScreen.js
+++ b/addons/pos_restaurant/static/src/js/Screens/FloorScreen/FloorScreen.js
@@ -282,12 +282,10 @@ odoo.define('pos_restaurant.FloorScreen', function (require) {
         async changeShape() {
             if (!this.selectedTable) return;
             this.selectedTable.shape = this.selectedTable.shape === 'square' ? 'round' : 'square';
-            this.render();
             await this._save(this.selectedTable);
         }
         async setTableColor(color) {
             this.selectedTable.color = color;
-            this.render();
             await this._save(this.selectedTable);
         }
         async setFloorColor(color) {

--- a/addons/pos_restaurant/static/src/js/Screens/SplitBillScreen/SplitBillScreen.js
+++ b/addons/pos_restaurant/static/src/js/Screens/SplitBillScreen/SplitBillScreen.js
@@ -27,7 +27,6 @@ odoo.define('pos_restaurant.SplitBillScreen', function(require) {
                         temporary: true,
                     }
                 );
-                this.render();
             });
         }
         get currentOrder() {


### PR DESCRIPTION
owl internally converts reactive props to become a reactive state
to attain fine-grained reactivity -- meaning, local or carefully
targetted rerendering. In order to achieve similar fine-grained
rerendering using a global state (no passing of reactive props),
we cast the global state from `env` as the state of each component,
and put it in a sub environment. This results to having a localized
`env.pos` that contains the local `render` callback which results
to finer rerendering.

Additionally, we get rid of unnecessary `render()` and `render(true)`
calls.

Check the following videos comparing which components rerender
after some actions.

 - Before: https://youtu.be/7_uFYQ53mu4
 - After: https://youtu.be/gwFg0DnAIII

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
