### PR TITLE
[FIX] google_calendar: not sending emails to existing event attendees

### DIFF
--- a/addons/google_calendar/models/google_sync.py
+++ b/addons/google_calendar/models/google_sync.py
@@ -199,7 +199,8 @@ class GoogleSync(models.AbstractModel):
             return
         with google_calendar_token(self.env.user.sudo()) as token:
             if token:
-                google_id = google_service.insert(values, token=token, timeout=timeout)
+                send_updates = self._context.get('send_updates', True)
+                google_id = google_service.with_context(send_updates=send_updates).insert(values, token=token, timeout=timeout)
                 self.write({
                     'google_id': google_id,
                     'need_sync': False,

--- a/addons/google_calendar/models/res_users.py
+++ b/addons/google_calendar/models/res_users.py
@@ -96,13 +96,14 @@ class User(models.Model):
         synced_events = self.env['calendar.event']._sync_google2odoo(events - recurrences, default_reminders=default_reminders)
 
         # Odoo -> Google
+        send_updates = not full_sync
         recurrences = self.env['calendar.recurrence']._get_records_to_sync(full_sync=full_sync)
         recurrences -= synced_recurrences
-        recurrences._sync_odoo2google(calendar_service)
+        recurrences.with_context(send_updates=send_updates)._sync_odoo2google(calendar_service)
         synced_events |= recurrences.calendar_event_ids - recurrences._get_outliers()
         synced_events |= synced_recurrences.calendar_event_ids - synced_recurrences._get_outliers()
         events = self.env['calendar.event']._get_records_to_sync(full_sync=full_sync)
-        (events - synced_events)._sync_odoo2google(calendar_service)
+        (events - synced_events).with_context(send_updates=send_updates)._sync_odoo2google(calendar_service)
 
         return bool(events | synced_events) or bool(recurrences | synced_recurrences)
 

--- a/addons/google_calendar/utils/google_calendar.py
+++ b/addons/google_calendar/utils/google_calendar.py
@@ -58,7 +58,8 @@ class GoogleCalendarService():
 
     @requires_auth_token
     def insert(self, values, token=None, timeout=TIMEOUT):
-        url = "/calendar/v3/calendars/primary/events?sendUpdates=all"
+        send_updates = self._context.get('send_updates', True)
+        url = "/calendar/v3/calendars/primary/events?sendUpdates=%s" % ("all" if send_updates else "none")
         headers = {'Content-type': 'application/json', 'Authorization': 'Bearer %s' % token}
         if not values.get('id'):
             values['id'] = uuid4().hex


### PR DESCRIPTION
Before this commit: syncing with google led to sending emails to
attendees of existing future events on Odoo.

Steps to reproduce the first issue:

	- Install 'google_calendar' module
	- Integrate with Google Calendar in setting
	- Add an event to the Odoo calendar for future date
	- Add one external attendee to the event
	- Sync with Google

	Invitation emails would be sent to the attendees of the events.

Solution

	It's possible to not send emails to the attendees in api calls. So
	the solution is to not send emails to the attendees for the syncing
	time.

opw-2819046


--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
