### PR TITLE
[IMP] l10n_fr_facturx_chorus_pro: new module for Chorus PRO

### DIFF
--- a/addons/account_edi_facturx/data/facturx_templates.xml
+++ b/addons/account_edi_facturx/data/facturx_templates.xml
@@ -131,6 +131,8 @@
 
                     <!-- Partners. -->
                     <ram:ApplicableHeaderTradeAgreement>
+                        <ram:BuyerReference t-esc="buyer_reference or record.ref"/>
+
                         <!-- Seller. -->
                         <ram:SellerTradeParty>
                             <!-- Address. -->
@@ -161,8 +163,12 @@
 
                         <!-- Reference. -->
                         <ram:BuyerOrderReferencedDocument>
-                            <ram:IssuerAssignedID t-esc="record.payment_reference if record.payment_reference else record.name"/>
+                            <ram:IssuerAssignedID t-esc="purchase_order_reference or record.payment_reference or record.name"/>
                         </ram:BuyerOrderReferencedDocument>
+
+                        <ram:ContractReferencedDocument t-if="contract_reference">
+                            <ram:IssuerAssignedID t-esc="contract_reference"/>
+                        </ram:ContractReferencedDocument>
                     </ram:ApplicableHeaderTradeAgreement>
 
                     <!-- Delivery. Don't make a dependency with sale only for one field. -->

--- a/addons/account_edi_facturx/models/account_edi_format.py
+++ b/addons/account_edi_facturx/models/account_edi_format.py
@@ -95,6 +95,10 @@ class AccountEdiFormat(models.Model):
             'invoice_line_values': [],
             'seller_specified_legal_organization': seller_siret,
             'buyer_specified_legal_organization': buyer_siret,
+            # Chorus PRO fields
+            'buyer_reference': 'buyer_reference' in invoice._fields and invoice.buyer_reference or '',
+            'contract_reference': 'contract_reference' in invoice._fields and invoice.contract_reference or '',
+            'purchase_order_reference': 'purchase_order_reference' in invoice._fields and invoice.purchase_order_reference or '',
         }
         # Tax lines.
         # The old system was making one total "line" per tax in the xml, by using the tax_line_id.

--- a/addons/l10n_fr_facturx_chorus_pro/__init__.py
+++ b/addons/l10n_fr_facturx_chorus_pro/__init__.py
@@ -1,0 +1,4 @@
+# -*- coding: utf-8 -*-
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from . import models

--- a/addons/l10n_fr_facturx_chorus_pro/__manifest__.py
+++ b/addons/l10n_fr_facturx_chorus_pro/__manifest__.py
@@ -1,0 +1,20 @@
+# -*- coding: utf-8 -*-
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+{
+    'name': 'France - Factur-X integration with Chorus Pro',
+    'version': '1.0',
+    'category': 'Accounting/Localizations/EDI',
+    'description': """
+Add supports to fill three optional fields used when using Chorus Pro, especially when invoicing public services.
+""",
+    'depends': [
+        'account',
+        'account_edi_facturx',
+        'l10n_fr'
+    ],
+    'data': [
+        'views/account_move_views.xml',
+    ],
+    'license': 'LGPL-3',
+}

--- a/addons/l10n_fr_facturx_chorus_pro/i18n/fr.po
+++ b/addons/l10n_fr_facturx_chorus_pro/i18n/fr.po
@@ -1,0 +1,83 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+# 	* l10n_fr_facturx_chorus_pro
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 14.0+e\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2022-06-07 11:33+0000\n"
+"PO-Revision-Date: 2022-06-07 11:33+0000\n"
+"Last-Translator: \n"
+"Language-Team: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: \n"
+
+#. module: l10n_fr_facturx_chorus_pro
+#: model:ir.model.fields,help:l10n_fr_facturx_chorus_pro.field_account_bank_statement_line__purchase_order_reference
+#: model:ir.model.fields,help:l10n_fr_facturx_chorus_pro.field_account_move__purchase_order_reference
+#: model:ir.model.fields,help:l10n_fr_facturx_chorus_pro.field_account_payment__purchase_order_reference
+msgid "'Engagement Juridique' in Chorus PRO."
+msgstr "'Engagement Juridique' dans Chorus PRO."
+
+#. module: l10n_fr_facturx_chorus_pro
+#: model:ir.model.fields,help:l10n_fr_facturx_chorus_pro.field_account_bank_statement_line__buyer_reference
+#: model:ir.model.fields,help:l10n_fr_facturx_chorus_pro.field_account_move__buyer_reference
+#: model:ir.model.fields,help:l10n_fr_facturx_chorus_pro.field_account_payment__buyer_reference
+msgid "'Service Exécutant' in Chorus PRO."
+msgstr "'Service Exécutant' dans Chorus PRO."
+
+#. module: l10n_fr_facturx_chorus_pro
+#: model:ir.model.fields,help:l10n_fr_facturx_chorus_pro.field_account_bank_statement_line__contract_reference
+#: model:ir.model.fields,help:l10n_fr_facturx_chorus_pro.field_account_move__contract_reference
+#: model:ir.model.fields,help:l10n_fr_facturx_chorus_pro.field_account_payment__contract_reference
+msgid "'Numéro de Marché' in Chorus PRO."
+msgstr "'Numéro de Marché' dans Chorus PRO."
+
+#. module: l10n_fr_facturx_chorus_pro
+#: model:ir.model.fields,field_description:l10n_fr_facturx_chorus_pro.field_account_bank_statement_line__buyer_reference
+#: model:ir.model.fields,field_description:l10n_fr_facturx_chorus_pro.field_account_move__buyer_reference
+#: model:ir.model.fields,field_description:l10n_fr_facturx_chorus_pro.field_account_payment__buyer_reference
+msgid "Buyer reference"
+msgstr "Service Exécutant"
+
+#. module: l10n_fr_facturx_chorus_pro
+#: model_terms:ir.ui.view,arch_db:l10n_fr_facturx_chorus_pro.view_move_form_inherit_chorus_pro
+msgid "Chorus Pro"
+msgstr ""
+
+#. module: l10n_fr_facturx_chorus_pro
+#: model:ir.model.fields,field_description:l10n_fr_facturx_chorus_pro.field_account_bank_statement_line__contract_reference
+#: model:ir.model.fields,field_description:l10n_fr_facturx_chorus_pro.field_account_move__contract_reference
+#: model:ir.model.fields,field_description:l10n_fr_facturx_chorus_pro.field_account_payment__contract_reference
+msgid "Contract Reference"
+msgstr "Numéro de Marché"
+
+#. module: l10n_fr_facturx_chorus_pro
+#: model:ir.model.fields,field_description:l10n_fr_facturx_chorus_pro.field_account_move__display_name
+msgid "Display Name"
+msgstr "Nom affiché"
+
+#. module: l10n_fr_facturx_chorus_pro
+#: model:ir.model.fields,field_description:l10n_fr_facturx_chorus_pro.field_account_move__id
+msgid "ID"
+msgstr ""
+
+#. module: l10n_fr_facturx_chorus_pro
+#: model:ir.model,name:l10n_fr_facturx_chorus_pro.model_account_move
+msgid "Journal Entry"
+msgstr "Pièce comptable"
+
+#. module: l10n_fr_facturx_chorus_pro
+#: model:ir.model.fields,field_description:l10n_fr_facturx_chorus_pro.field_account_move____last_update
+msgid "Last Modified on"
+msgstr "Dernière modification le"
+
+#. module: l10n_fr_facturx_chorus_pro
+#: model:ir.model.fields,field_description:l10n_fr_facturx_chorus_pro.field_account_bank_statement_line__purchase_order_reference
+#: model:ir.model.fields,field_description:l10n_fr_facturx_chorus_pro.field_account_move__purchase_order_reference
+#: model:ir.model.fields,field_description:l10n_fr_facturx_chorus_pro.field_account_payment__purchase_order_reference
+msgid "Purchase order reference"
+msgstr "Engagement Juridique"

--- a/addons/l10n_fr_facturx_chorus_pro/i18n/l10n_fr_facturx_chorus_pro.pot
+++ b/addons/l10n_fr_facturx_chorus_pro/i18n/l10n_fr_facturx_chorus_pro.pot
@@ -1,0 +1,83 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+# 	* l10n_fr_facturx_chorus_pro
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 14.0+e\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2022-06-07 11:31+0000\n"
+"PO-Revision-Date: 2022-06-07 11:31+0000\n"
+"Last-Translator: \n"
+"Language-Team: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: \n"
+
+#. module: l10n_fr_facturx_chorus_pro
+#: model:ir.model.fields,help:l10n_fr_facturx_chorus_pro.field_account_bank_statement_line__purchase_order_reference
+#: model:ir.model.fields,help:l10n_fr_facturx_chorus_pro.field_account_move__purchase_order_reference
+#: model:ir.model.fields,help:l10n_fr_facturx_chorus_pro.field_account_payment__purchase_order_reference
+msgid "'Engagement Juridique' in Chorus PRO."
+msgstr ""
+
+#. module: l10n_fr_facturx_chorus_pro
+#: model:ir.model.fields,help:l10n_fr_facturx_chorus_pro.field_account_bank_statement_line__buyer_reference
+#: model:ir.model.fields,help:l10n_fr_facturx_chorus_pro.field_account_move__buyer_reference
+#: model:ir.model.fields,help:l10n_fr_facturx_chorus_pro.field_account_payment__buyer_reference
+msgid "'Service Exécutant' in Chorus PRO."
+msgstr ""
+
+#. module: l10n_fr_facturx_chorus_pro
+#: model:ir.model.fields,help:l10n_fr_facturx_chorus_pro.field_account_bank_statement_line__contract_reference
+#: model:ir.model.fields,help:l10n_fr_facturx_chorus_pro.field_account_move__contract_reference
+#: model:ir.model.fields,help:l10n_fr_facturx_chorus_pro.field_account_payment__contract_reference
+msgid "'Numéro de Marché' in Chorus PRO."
+msgstr ""
+
+#. module: l10n_fr_facturx_chorus_pro
+#: model:ir.model.fields,field_description:l10n_fr_facturx_chorus_pro.field_account_bank_statement_line__buyer_reference
+#: model:ir.model.fields,field_description:l10n_fr_facturx_chorus_pro.field_account_move__buyer_reference
+#: model:ir.model.fields,field_description:l10n_fr_facturx_chorus_pro.field_account_payment__buyer_reference
+msgid "Buyer reference"
+msgstr ""
+
+#. module: l10n_fr_facturx_chorus_pro
+#: model_terms:ir.ui.view,arch_db:l10n_fr_facturx_chorus_pro.view_move_form_inherit_chorus_pro
+msgid "Chorus Pro"
+msgstr ""
+
+#. module: l10n_fr_facturx_chorus_pro
+#: model:ir.model.fields,field_description:l10n_fr_facturx_chorus_pro.field_account_bank_statement_line__contract_reference
+#: model:ir.model.fields,field_description:l10n_fr_facturx_chorus_pro.field_account_move__contract_reference
+#: model:ir.model.fields,field_description:l10n_fr_facturx_chorus_pro.field_account_payment__contract_reference
+msgid "Contract Reference"
+msgstr ""
+
+#. module: l10n_fr_facturx_chorus_pro
+#: model:ir.model.fields,field_description:l10n_fr_facturx_chorus_pro.field_account_move__display_name
+msgid "Display Name"
+msgstr ""
+
+#. module: l10n_fr_facturx_chorus_pro
+#: model:ir.model.fields,field_description:l10n_fr_facturx_chorus_pro.field_account_move__id
+msgid "ID"
+msgstr ""
+
+#. module: l10n_fr_facturx_chorus_pro
+#: model:ir.model,name:l10n_fr_facturx_chorus_pro.model_account_move
+msgid "Journal Entry"
+msgstr ""
+
+#. module: l10n_fr_facturx_chorus_pro
+#: model:ir.model.fields,field_description:l10n_fr_facturx_chorus_pro.field_account_move____last_update
+msgid "Last Modified on"
+msgstr ""
+
+#. module: l10n_fr_facturx_chorus_pro
+#: model:ir.model.fields,field_description:l10n_fr_facturx_chorus_pro.field_account_bank_statement_line__purchase_order_reference
+#: model:ir.model.fields,field_description:l10n_fr_facturx_chorus_pro.field_account_move__purchase_order_reference
+#: model:ir.model.fields,field_description:l10n_fr_facturx_chorus_pro.field_account_payment__purchase_order_reference
+msgid "Purchase order reference"
+msgstr ""

--- a/addons/l10n_fr_facturx_chorus_pro/models/__init__.py
+++ b/addons/l10n_fr_facturx_chorus_pro/models/__init__.py
@@ -1,0 +1,4 @@
+# -*- coding: utf-8 -*-
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from . import account_move

--- a/addons/l10n_fr_facturx_chorus_pro/models/account_move.py
+++ b/addons/l10n_fr_facturx_chorus_pro/models/account_move.py
@@ -1,0 +1,10 @@
+# -*- coding: utf-8 -*-
+from odoo import fields, models
+
+
+class AccountMove(models.Model):
+    _inherit = "account.move"
+
+    buyer_reference = fields.Char(help="'Service Exécutant' in Chorus PRO.")
+    contract_reference = fields.Char(help="'Numéro de Marché' in Chorus PRO.")
+    purchase_order_reference = fields.Char(help="'Engagement Juridique' in Chorus PRO.")

--- a/addons/l10n_fr_facturx_chorus_pro/views/account_move_views.xml
+++ b/addons/l10n_fr_facturx_chorus_pro/views/account_move_views.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <data>
+        <record id="view_move_form_inherit_chorus_pro" model="ir.ui.view">
+            <field name="name">account.move.form.inherit.chorus.pro</field>
+            <field name="model">account.move</field>
+            <field name="inherit_id" ref="account.view_move_form"/>
+            <field name="arch" type="xml">
+                <xpath expr="//group[@name='accounting_info_group']" position="after">
+                    <group name="accounting_info_group_chorus_pro" string="Chorus Pro" attrs="{'invisible': [('move_type', 'not in', ('out_invoice', 'out_refund'))]}">
+                        <field name="buyer_reference"/>
+                        <field name="contract_reference"/>
+                        <field name="purchase_order_reference"/>
+                    </group>
+                </xpath>
+            </field>
+        </record>
+    </data>
+</odoo>


### PR DESCRIPTION
Add a new module that makes three new fields available on the invoices.
These fields are required when using facturx to send invoices to
public services through Chorus PRO.

The original template is updated to make it easier when integrating
the ubl refactoring coming soon, and avoid template issues that would
happen with an inherit if the inheriting module isn't updated after the
refactoring deployment.

opw-2714544
--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
