### PR TITLE
[IMP] knowledge: improve design and sidebar

### DIFF
--- a/addons/knowledge/static/src/components/permission_panel/permission_panel.scss
+++ b/addons/knowledge/static/src/components/permission_panel/permission_panel.scss
@@ -3,6 +3,7 @@
     .o_company_icon {
         width: 30px;
         height: 30px;
+        object-fit: cover;
     }
     .active {
         background: #cceaf9;

--- a/addons/knowledge/static/src/js/knowledge_frontend.js
+++ b/addons/knowledge/static/src/js/knowledge_frontend.js
@@ -21,6 +21,8 @@ publicWidget.registry.KnowledgeWidget = publicWidget.Widget.extend(KnowledgeTree
         return this._super.apply(this, arguments).then(() => {
             const id = this.$el.data('article-id');
             this._renderTree(id, '/knowledge/tree_panel/portal');
+            this._setResizeListener();
+            this.$el.removeClass('d-none');
         });
     },
 

--- a/addons/knowledge/static/src/js/knowledge_renderers.js
+++ b/addons/knowledge/static/src/js/knowledge_renderers.js
@@ -328,6 +328,9 @@ const KnowledgeArticleFormRenderer = FormRenderer.extend(KnowledgeTreePanelMixin
             helper: 'clone',
             cursor: 'grabbing',
             cancel: '.readonly',
+            start: () => {
+                this.trigger_up('drag');
+            },
             /**
              * @param {Event} event
              * @param {Object} ui
@@ -341,6 +344,7 @@ const KnowledgeArticleFormRenderer = FormRenderer.extend(KnowledgeTreePanelMixin
 
                 const data = {
                     article_id: $li.data('article-id'),
+                    article_name: $li.find(".o_article_name").first().text().trim(),
                     oldCategory: $li.data('category'),
                     newCategory: $section.data('section')
                 };
@@ -360,16 +364,13 @@ const KnowledgeArticleFormRenderer = FormRenderer.extend(KnowledgeTreePanelMixin
                         if (typeof id !== 'undefined') {
                             const $parent = this.$(`.o_article[data-article-id="${id}"]`);
                             if (!$parent.children('ul').is(':parent')) {
-                                const $caret = $parent.find('> .o_article_handle > .o_article_caret');
-                                $caret.remove();
+                                $parent.find('> .o_article_handle > .o_article_caret').addClass("invisible");
+                                $parent.removeClass("o_article_has_child");
                             }
                         }
                         if ($parent.length > 0) {
-                            const $handle = $parent.children('.o_article_handle:first');
-                            if ($handle.children('.o_article_caret').length === 0) {
-                                const $caret = $(QWeb.render('knowledge.knowledge_article_caret', {}));
-                                $handle.prepend($caret);
-                            }
+                            $parent.find('> .o_article_handle > .o_article_caret').removeClass("invisible");
+                            $parent.addClass("o_article_has_child");
                         }
                         $li.data('parent-id', $parent.data('article-id'));
                         $li.attr('data-parent-id', $parent.data('article-id'));

--- a/addons/knowledge/static/src/js/knowledge_renderers.js
+++ b/addons/knowledge/static/src/js/knowledge_renderers.js
@@ -274,33 +274,6 @@ const KnowledgeArticleFormRenderer = FormRenderer.extend(KnowledgeTreePanelMixin
         emojis.text(emoji || '');
     },
     /**
-     * Enables the user to resize the aside block.
-     * Note: When the user grabs the resizer, a new listener will be attached
-     * to the document. The listener will be removed as soon as the user releases
-     * the resizer to free some resources.
-     */
-    _setResizeListener: function () {
-        /**
-         * @param {PointerEvent} event
-         */
-        const onPointerMove = _.throttle(event => {
-            event.preventDefault();
-            this.el.style.setProperty('--default-sidebar-size', `${event.pageX}px`);
-        }, 100);
-        /**
-         * @param {PointerEvent} event
-         */
-        const onPointerUp = event => {
-            $(document).off('pointermove', onPointerMove);
-        };
-        const $resizer = this.$('.o_knowledge_article_form_resizer');
-        $resizer.on('pointerdown', event => {
-            event.preventDefault();
-            $(document).on('pointermove', onPointerMove);
-            $(document).one('pointerup', onPointerUp);
-        });
-    },
-    /**
      * Initializes the drag-and-drop behavior of the tree listing all articles.
      * Once this function is called, the user will be able to move an article
      * in the tree hierarchy by dragging an article around.

--- a/addons/knowledge/static/src/js/tools/tree_panel_mixin.js
+++ b/addons/knowledge/static/src/js/tools/tree_panel_mixin.js
@@ -39,6 +39,39 @@ export default {
     },
 
     /**
+     * Enables the user to resize the aside block.
+     * Note: When the user grabs the resizer, a new listener will be attached
+     * to the document. The listener will be removed as soon as the user releases
+     * the resizer to free some resources.
+     */
+    _setResizeListener: function () {
+        // Initialise to previously scrolled value
+        if (localStorage.getItem('sidebarSize')) {
+            this.el.style.setProperty('--default-sidebar-size', `${localStorage.getItem('sidebarSize')}px`);
+        }
+        /**
+         * @param {PointerEvent} event
+         */
+        const onPointerMove = _.throttle(event => {
+            event.preventDefault();
+            this.el.style.setProperty('--default-sidebar-size', `${event.pageX}px`);
+        }, 100);
+        /**
+         * @param {PointerEvent} event
+         */
+        const onPointerUp = event => {
+            $(document).off('pointermove', onPointerMove);
+            localStorage.setItem('sidebarSize', event.pageX);
+        };
+        const $resizer = this.$('.o_knowledge_article_form_resizer');
+        $resizer.on('pointerdown', event => {
+            event.preventDefault();
+            $(document).on('pointermove', onPointerMove);
+            $(document).one('pointerup', onPointerUp);
+        });
+    },
+
+    /**
      * Initializes the drag-and-drop behavior of the favorite.
      * Once this function is called, the user will be able to reorder their favorites.
      * When a favorite is reordered, the script will send an rpc call to the server

--- a/addons/knowledge/static/src/js/widgets/knowledge_dialogs.js
+++ b/addons/knowledge/static/src/js/widgets/knowledge_dialogs.js
@@ -27,7 +27,7 @@ const MoveArticleToDialog = Dialog.extend({
         this.props = props;
         // Set template variables:
         const { state } = props;
-        this.article_name = state.data.display_name;
+        this.article_name = state.data.name;
     },
 
     /**

--- a/addons/knowledge/static/src/scss/knowledge_frontend.scss
+++ b/addons/knowledge/static/src/scss/knowledge_frontend.scss
@@ -50,6 +50,17 @@
         width: var(--sidebar-size);
         transition: width 0.15s linear;
 
+        // Force same style in portal and website
+        font-size: 1rem;
+
+        .o_section_header {
+            font-size: 1.3125rem;
+        }
+
+        .knowledge_search_bar {
+            font-size: 0.875rem;
+        }
+
         li {
             padding: 0.2em 0;
             position: relative;
@@ -71,9 +82,15 @@
 
             &:before {
                 @include o-position-absolute($top: 1em, $left: 0);
-                width: .6em;
+                width: 1.8em;
                 height: 1px;
                 margin: auto;
+            }
+
+            &.o_article_has_child:before {
+                @include o-position-absolute($top: 1em, $left: 0);
+                width: .6em;
+                height: 1px;
             }
 
             &:after {

--- a/addons/knowledge/static/src/scss/knowledge_frontend.scss
+++ b/addons/knowledge/static/src/scss/knowledge_frontend.scss
@@ -1,4 +1,6 @@
 .o_knowledge_form_view {
+    --default-sidebar-size: 300px;
+    --sidebar-size: clamp(200px, var(--default-sidebar-size), var(--breakpoint-sm));
     // Header
     // --------------------------------------------------------------------------
     .o_knowledge_header {
@@ -112,6 +114,30 @@
             cursor: pointer;
             color: inherit;
             text-decoration: none;
+        }
+    }
+
+    // = Resizer
+    // --------------------------------------------------------------------------
+    .o_knowledge_article_form_resizer {
+        // Use '$spacers' measures to match surrounding elements padding
+        $-resizer-spacing: map-get($spacers, 1);
+        $-resizer-line-width: map-get($spacers, 1);
+
+        @include o-position-absolute(0, auto, 0, $-resizer-spacing * -1);
+        cursor: ew-resize;
+        touch-action: none;
+
+        span {
+            @include o-position-absolute(0, auto, 0, $-resizer-spacing + ($-resizer-line-width * -0.5));
+        }
+    }
+}
+
+@include media-breakpoint-down(xs) {
+    .o_knowledge_form_view {
+        .o_knowledge_aside {
+            width: 100%;
         }
     }
 }

--- a/addons/knowledge/static/src/scss/knowledge_views.scss
+++ b/addons/knowledge/static/src/scss/knowledge_views.scss
@@ -1,6 +1,6 @@
 .o_knowledge_form_view {
     --default-sidebar-size: 300px;
-    --sidebar-size: clamp(300px, var(--default-sidebar-size), 50vw);
+    --sidebar-size: clamp(200px, var(--default-sidebar-size), var(--breakpoint-sm));
 
     $o-knowledge-bg--active: #cceaf9; // TMP -> should match $o-searchpanel-active-bg
 
@@ -10,6 +10,20 @@
 
     // = Navbar
     // --------------------------------------------------------------------------
+    .o_breadcrumb_article_name_container,
+    span.o_breadcrumb_article_name {
+        white-space: pre;
+    }
+
+    input.o_breadcrumb_article_name {
+        position: absolute;
+        inset: 0;
+    }
+
+    .min-w-0 {
+        min-width: 0;
+    }
+
     .o_breadcrumb_article_name:not(:focus) {
         --o-input-border-color: transparent;
     }
@@ -76,9 +90,15 @@
 
             &:before {
                 @include o-position-absolute($top: 1em, $left: 0);
-                width: .6em;
+                width: 1.8em;
                 height: 1px;
                 margin: auto;
+            }
+
+            &.o_article_has_child:before {
+                @include o-position-absolute($top: 1em, $left: 0);
+                width: .6em;
+                height: 1px;
             }
 
             &:after {
@@ -109,7 +129,7 @@
     // --------------------------------------------------------------------------
     .o_knowledge_article_form_resizer {
         // Use '$spacers' measures to match surrounding elements padding
-        $-resizer-spacing: map-get($spacers, 3);
+        $-resizer-spacing: map-get($spacers, 1);
         $-resizer-line-width: map-get($spacers, 1);
 
         @include o-position-absolute(0, auto, 0, $-resizer-spacing * -1);

--- a/addons/knowledge/static/src/xml/knowledge_templates.xml
+++ b/addons/knowledge/static/src/xml/knowledge_templates.xml
@@ -1,10 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <templates>
-    <t t-name="knowledge.knowledge_article_caret">
-        <button class="o_article_caret btn btn-link text-muted p-0">
-            <i class="align-self-center fa fa-fw fa-caret-down"/>
-        </button>
-    </t>
     <t t-name="knowledge.knowledge_breadcrumb_item">
         <li class="breadcrumb-item">
             <a href="#" t-out="payload.title" t-att-data-controller-id="payload.controllerID"/>

--- a/addons/knowledge/views/knowledge_article_views.xml
+++ b/addons/knowledge/views/knowledge_article_views.xml
@@ -33,15 +33,15 @@
                             </div>
                         </div>
                     </aside>
-                    <div class="flex-grow-1 position-relative">
+                    <div class="flex-grow-1 position-relative min-w-0">
                         <div class="o_knowledge_article_form_resizer d-none d-sm-block" />
                         <div class="d-flex flex-column h-100">
                             <!-- Article header -->
                             <div class="o_knowledge_header d-sm-flex border-bottom justify-content-between d-print-none">
-                                <div class="d-flex align-items-center">
+                                <div class="d-flex align-items-center min-w-0">
                                     <!-- Breadcrumbs -->
-                                    <ol class="breadcrumb align-items-center p-3" role="navigation">
-                                        <li class="breadcrumb-item d-flex align-items-center">
+                                    <ol class="breadcrumb align-items-center p-3 min-w-0" role="navigation">
+                                        <li class="breadcrumb-item d-flex align-items-center overflow-hidden">
                                             <div class="o_knowledge_icon pr-1" attrs="{'invisible': [('icon', '=', False)]}">
                                                 <div class="o_article_emoji_dropdown dropdown">
                                                     <a href="#" class="o_article_editable_emoji o_article_emoji dropdown-toggle o-no-caret"
@@ -53,8 +53,11 @@
                                                         aria-labelledby="o_article_emoji" />
                                                 </div>
                                             </div>
-                                            <field attrs="{'readonly': ['|', ('is_locked', '=', True), ('user_has_write_access', '=', False)]}"
-                                                   class="o_breadcrumb_article_name o_input" name="name"/>
+                                            <div class="position-relative">
+                                                <span class="o_breadcrumb_article_name_container px-1"/>
+                                                <field attrs="{'readonly': ['|', ('is_locked', '=', True), ('user_has_write_access', '=', False)]}"
+                                                   class="o_breadcrumb_article_name o_input px-1" name="name"/>
+                                            </div>
                                         </li>
                                     </ol>
                                     <i class="fa fa-star o_toggle_favorite o_cursor_pointer"
@@ -103,27 +106,27 @@
                                             </a>
                                             <div class="o_knowledge_more_options_panel dropdown-menu" role="menu">
                                                 <a class="dropdown-item btn-duplicate" href="#" role="button">
-                                                    <i class="fa fa-fw fa-copy"/> Duplicate
+                                                    <i class="fa fa-fw fa-lg fa-copy"/> Duplicate
                                                 </a>
                                                 <div attrs="{'invisible': [('user_has_write_access', '=', False)]}">
                                                     <a class="dropdown-item btn-move" href="#" role="button">
-                                                        <i class="fa fa-fw fa-angle-double-right"/> Move To
+                                                        <i class="fa fa-fw fa-lg fa-angle-double-right"/> Move To
                                                     </a>
                                                     <button class="dropdown-item btn-lock" href="#" type="object" name="action_set_lock"
                                                         attrs="{'invisible': [('is_locked', '=', True)]}">
-                                                        <i class="fa fa-fw fa-lock"/> Lock
+                                                        <i class="fa fa-fw fa-lg fa-lock"/> Lock
                                                     </button>
                                                     <button class="dropdown-item btn-lock" href="#" type="object" name="action_set_unlock"
                                                         attrs="{'invisible': [('is_locked', '=', False)]}">
-                                                        <i class="fa fa-fw fa-unlock"/> Unlock
+                                                        <i class="fa fa-fw fa-lg fa-unlock"/> Unlock
                                                     </button>
                                                     <button class="dropdown-item" type="object" name="action_article_archive"
                                                             attrs="{'invisible': [('active', '=', False)]}">
-                                                        <i class="fa fa-fw fa-archive"/> Archive
+                                                        <i class="fa fa-fw fa-lg fa-archive"/> Archive
                                                     </button>
                                                     <button class="dropdown-item" type="object" name="action_unarchive"
                                                             attrs="{'invisible': [('active', '=', True)]}">
-                                                        <i class="fa fa-fw fa-archive"/> Unarchive
+                                                        <i class="fa fa-fw fa-lg fa-archive"/> Unarchive
                                                     </button>
                                                     <div class="dropdown-divider"/>
                                                     <div class="px-3">

--- a/addons/knowledge/views/knowledge_templates_common.xml
+++ b/addons/knowledge/views/knowledge_templates_common.xml
@@ -20,15 +20,14 @@
             <t t-set="readonly" t-value="portal_readonly_mode or not article.user_has_write_access"/>
             <t t-set="favorite" t-value="favorites.filtered(lambda f: f.article_id == article) if favorites else False"/>
             <!-- readonly is used to for the drag and drop cancel.-->
-            <li t-attf-class="o_article #{ 'readonly' if readonly else '' }" t-attf-id="article_#{article.id}"
+            <li t-attf-class="o_article #{'readonly' if readonly else '' } #{'o_article_has_child' if article.child_ids else ''}" t-attf-id="article_#{article.id}"
                 t-att-data-article-id="article.id" t-att-data-parent-id="article.parent_id.id"
                 t-att-data-favorite-article-id="favorite.id if favorite else False"
                 t-att-data-category="article.category">
                 <t t-set="isActive" t-value="article.id == active_article.id if active_article else False"/>
                 <div t-attf-class="#{ '' if readonly else 'o_article_handle' } d-flex align-items-center #{ 'o_article_active font-weight-bold' if isActive else 'text-muted' }">
-                    <button t-if="not hideChildren and article.child_ids" class="o_article_caret btn btn-link text-muted p-0" type="button">
-                        <i t-if="article.child_ids" t-att-class="'align-self-center fa fa-fw fa-caret-' + ('down' if article.id in unfolded_articles else 'right')"/>
-                        <i t-else="" class="pl-3 align-self-center"/>
+                    <button t-if="not hideChildren" t-attf-class="o_article_caret btn btn-link text-muted p-0 border-0 #{'' if article.child_ids else 'invisible'}" type="button">
+                        <i t-att-class="'align-self-center fa fa-fw fa-caret-' + ('down' if article.id in unfolded_articles else 'right')"/>
                     </button>
                     <t t-call="knowledge.articles_template_name"/>
                 </div>

--- a/addons/knowledge/views/knowledge_templates_frontend.xml
+++ b/addons/knowledge/views/knowledge_templates_frontend.xml
@@ -11,10 +11,10 @@
 
     <template id="knowledge_article_view_frontend" name="Knowledge Portal">
         <t t-call="knowledge.layout">
-            <div class="container-fluid h-100 o_knowledge_form_view" t-att-data-article-id="article.id if article else False">
-                <div class="row h-100">
-                    <div t-att-class="'p-0 overflow-auto' + (' col-sm-2' if show_sidebar else ' d-none')">
-                        <div t-att-class="'o_knowledge_aside border-bottom border-right flex-column h-100 w-100' + (' d-flex' if show_sidebar else ' d-none')">
+            <div class="container-fluid h-100 o_knowledge_form_view p-0 d-none" t-att-data-article-id="article.id if article else False">
+                <div class="d-sm-flex h-100">
+                    <aside t-att-class="'o_knowledge_aside' + (' flex-shrink-0 p-0' if show_sidebar else ' d-none')">
+                        <div class="d-flex flex-column h-100">
                             <div class="p-3">
                                 <input type="text" class="form-control knowledge_search_bar" placeholder="Search an Article..."/>
                             </div>
@@ -29,8 +29,9 @@
                                 </div>
                             </div>
                         </div>
-                    </div>
-                    <div t-att-class="('col-sm-10' if show_sidebar else 'col-sm-12') + ' p-0 overflow-auto'">
+                    </aside>
+                    <div class="flex-grow-1 position-relative">
+                        <div class="o_knowledge_article_form_resizer d-none d-sm-block" />
                         <div class="d-flex flex-column h-100">
                             <!-- Article header -->
                             <div class="o_knowledge_header d-sm-flex flex-row justify-content-between border-bottom">
@@ -79,6 +80,9 @@
                                     </div>
                                 </div>
                             </div>
+                        </div>
+                        <div class="o_knowledge_article_form_resizer d-print-none d-none d-sm-block px-3 opacity-75 opacity-100-hover">
+                            <span class="bg-300 pl-1"/>
                         </div>
                     </div>
                 </div>

--- a/addons/knowledge/views/knowledge_templates_frontend.xml
+++ b/addons/knowledge/views/knowledge_templates_frontend.xml
@@ -90,7 +90,7 @@
         <t t-call="knowledge.knowledge_article_tree_favorites" />
         <t t-set="visible_articles" t-value="(workspace_articles | shared_articles)"/>
         <section t-if="visible_articles">
-            <div class="h4 mb-0">Shared with you</div>
+            <div class="o_section_header mb-0">Shared with you</div>
             <ul class="o_tree o_tree_workspace m-0 px-0 py-2">
                 <t t-call="knowledge.articles_template">
                     <t t-set="articles" t-value="visible_articles"/>

--- a/addons/website_knowledge/views/knowledge_templates_frontend.xml
+++ b/addons/website_knowledge/views/knowledge_templates_frontend.xml
@@ -16,7 +16,7 @@
             <t t-set="published_articles" t-value="all_articles.filtered(lambda a: a.website_published)"/>
             <t t-set="visible_articles" t-value="all_articles.filtered(lambda a: not a.website_published)"/>
             <section t-if="published_articles">
-                <div class="h4 mb-0">Public articles</div>
+                <div class="o_section_header mb-0">Public articles</div>
                 <ul class="o_tree o_tree_workspace m-0 px-0 py-2">
                     <t t-call="knowledge.articles_template">
                         <t t-set="articles" t-value="published_articles"/>
@@ -24,7 +24,7 @@
                 </ul>
             </section>
             <section t-if="visible_articles">
-                <div class="h4 mb-0">Shared with you</div>
+                <div class="o_section_header mb-0">Shared with you</div>
                 <ul class="o_tree o_tree_workspace m-0 px-0 py-2">
                     <t t-call="knowledge.articles_template">
                         <t t-set="articles" t-value="visible_articles"/>


### PR DESCRIPTION
- Change the indentation of the articles names in the sidebar, so
that articles of the same level (parent/1st child/2nd child, ...)
are aligned

- Make the size of the input match exactly the length of the article
name: previously, the input size was set using the size attribute,
which approximates the length using the number of characters of the
name and a mean character width value. This resulted in cropped names
if there was a majority of large characters, or in a too large input
if it was the opposite. The name was also cropped when entering the
edition mode.
The input size now matches exactly the article name, at any time

- Change the range of the allowed width for the resizable sidebar:
allows users to make it smaller than before, but not as wide
(users could resize it to take the half of the screen width, which
was too much considered it is a sidebar)

- Change wording of messages shown when trying to move an article:
adds the article name in the message, and the destination in the
title to make it easier for the user

- Make icons bigger in the options panel

- Avoid changing the look of the sidebar when installing website:
fixes the font-size in the sidebar so that the search bar, section
headers and article names are not too large when installing website.

- Fix broken logos in the permission panel: mimicks the behavior
of the many2one_avatar widget by zooming in the image to fill the
container, instead of stretching the image.

- Fix hidden article names in the sidebar: shows the article names in
the sidebar even when the window size is small.


- Add resizable sidebar in frontend: allows visitors to resize the
sidebar, the same way users can do it in backend, as visitors can also
have small screens

- Keep selected sidebar size: when an user changes the size of the
sidebar, the selected width is stored in localStorage so that it can be
set automatically when the user selects another article or reloads the
page
