### PR TITLE
cart quantity and wishlist in SessionStorage

### DIFF
--- a/addons/website_event_sale/controllers/main.py
+++ b/addons/website_event_sale/controllers/main.py
@@ -55,6 +55,8 @@ class WebsiteEventSaleController(WebsiteEventController):
                 data['sale_order_id'] = order_sudo.id
                 data['sale_order_line_id'] = cart_data[event_ticket_id]
 
+        request.session['website_sale_cart_quantity'] = order_sudo.cart_quantity
+
         return super()._create_attendees_from_registration_post(event, registration_data)
 
     @route()

--- a/addons/website_sale/controllers/main.py
+++ b/addons/website_sale/controllers/main.py
@@ -499,6 +499,9 @@ class WebsiteSale(http.Controller):
         if order and order.state != 'draft':
             request.session['sale_order_id'] = None
             order = request.website.sale_get_order()
+
+        request.session['website_sale_cart_quantity'] = order.cart_quantity
+
         values = {}
         if access_token:
             abandoned_order = request.env['sale.order'].sudo().search([('access_token', '=', access_token)], limit=1)
@@ -557,6 +560,8 @@ class WebsiteSale(http.Controller):
             **kwargs
         )
 
+        request.session['website_sale_cart_quantity'] = sale_order.cart_quantity
+
         if express:
             return request.redirect("/shop/checkout?express=1")
 
@@ -597,6 +602,8 @@ class WebsiteSale(http.Controller):
             **kw
         )
 
+        request.session['website_sale_cart_quantity'] = order.cart_quantity
+
         if not order.cart_quantity:
             request.website.sale_reset()
             return values
@@ -627,8 +634,9 @@ class WebsiteSale(http.Controller):
 
     @http.route(['/shop/cart/quantity'], type='json', auth="public", methods=['POST'], website=True, csrf=False)
     def cart_quantity(self):
-        cart = request.website.sale_get_order()
-        return cart and cart.cart_quantity or 0
+        if 'website_sale_cart_quantity' not in request.session:
+            return request.website.sale_get_order().cart_quantity
+        return request.session['website_sale_cart_quantity']
 
     # ------------------------------------------------------
     # Checkout

--- a/addons/website_sale/models/sale_order.py
+++ b/addons/website_sale/models/sale_order.py
@@ -124,7 +124,8 @@ class SaleOrder(models.Model):
         self = self.with_company(self.company_id)
 
         if self.state != 'draft':
-            request.session['sale_order_id'] = None
+            request.session.pop('sale_order_id', None)
+            request.session.pop('website_sale_cart_quantity', None)
             raise UserError(_('It is forbidden to modify a sales order which is not in draft status.'))
 
         product = self.env['product.product'].browse(product_id).exists()

--- a/addons/website_sale/static/src/js/website_sale.js
+++ b/addons/website_sale/static/src/js/website_sale.js
@@ -80,6 +80,9 @@ publicWidget.registry.websiteSaleCartLink = publicWidget.Widget.extend({
                 $('.popover').on('mouseleave', function () {
                     self.$el.trigger('mouseleave');
                 });
+                self.cartQty = +$(data).find('.o_wsale_cart_quantity').text();
+                sessionStorage.setItem('website_sale_cart_quantity', self.cartQty);
+                self._updateCartQuantityText();
             });
         }, 300);
     },
@@ -129,10 +132,16 @@ publicWidget.registry.websiteSaleCartLink = publicWidget.Widget.extend({
     /**
      * @private
      */
-    _updateCartQuantityValue() {
-        return this._rpc({route: "/shop/cart/quantity"}).then((cartQty) => {
-            this.cartQty = cartQty;
-        });
+    async _updateCartQuantityValue() {
+        if ('website_sale_cart_quantity' in sessionStorage) {
+            this.cartQty = sessionStorage.getItem('website_sale_cart_quantity');
+        }
+        if (this.el.querySelector('.my_cart_quantity').innerText != this.cartQty) {
+            return this._rpc({route: "/shop/cart/quantity"}).then((cartQty) => {
+                this.cartQty = cartQty;
+                sessionStorage.setItem('website_sale_cart_quantity', this.cartQty);
+            });
+        }
     },
     /**
      * @private
@@ -359,6 +368,7 @@ publicWidget.registry.WebsiteSale = publicWidget.Widget.extend(VariantMixin, car
                 $input.trigger('change');
                 return;
             }
+            sessionStorage.setItem('website_sale_cart_quantity', data.cart_quantity);
             if (!data.cart_quantity) {
                 return window.location = '/shop/cart';
             }

--- a/addons/website_sale/static/src/js/website_sale_utils.js
+++ b/addons/website_sale/static/src/js/website_sale_utils.js
@@ -34,6 +34,7 @@ const cartHandlerMixin = {
             route: "/shop/cart/update_json",
             params: params,
         }).then(async data => {
+            sessionStorage.setItem('website_sale_cart_quantity', data.cart_quantity);
             if (data.cart_quantity && (data.cart_quantity !== parseInt($(".my_cart_quantity").text()))) {
                 await animateClone($('header .o_wsale_my_cart').first(), this.$itemImgContainer, 25, 40);
                 updateCartNavBar(data);

--- a/addons/website_sale/views/templates.xml
+++ b/addons/website_sale/views/templates.xml
@@ -5,14 +5,14 @@
            t-nocache-_icon="_icon"
            t-nocache-_item_class="_item_class"
            t-nocache-_link_class="_link_class">
-            <t t-set="website_sale_order" t-value="website.sale_get_order()" />
+            <t t-set="website_sale_cart_quantity" t-value="request.session['website_sale_cart_quantity'] if 'website_sale_cart_quantity' in request.session else website.sale_get_order().cart_quantity or 0"/>
             <t t-set="show_cart" t-value="true"/>
             <li t-attf-class="#{_item_class} divider d-none"/> <!-- Make sure the cart and related menus are not folded (see autohideMenu) -->
             <li t-attf-class="o_wsale_my_cart align-self-md-start #{not show_cart and 'd-none'} #{_item_class}">
                 <a href="/shop/cart" t-attf-class="#{_link_class}">
                     <i t-if="_icon" class="fa fa-shopping-cart"/>
                     <span t-if="_text">My Cart</span>
-                    <sup class="my_cart_quantity badge badge-primary" t-esc="website_sale_order and website_sale_order.cart_quantity or '0'" t-att-data-order-id="website_sale_order and website_sale_order.id or ''"/>
+                    <sup class="my_cart_quantity badge badge-primary" t-esc="website_sale_cart_quantity" t-att-data-order-id="request.session.get('sale_order_id', '')"/>
                 </a>
             </li>
         </t>
@@ -20,7 +20,7 @@
 
     <template id="header_hide_empty_cart_link" inherit_id="website_sale.header_cart_link" name="Header Hide Empty Cart link" active="False">
         <xpath expr="//t[@t-set='show_cart']" position="after">
-            <t t-set="show_cart" t-value="show_cart and website_sale_order and website_sale_order.cart_quantity" />
+            <t t-set="show_cart" t-value="website_sale_cart_quantity" />
         </xpath>
     </template>
 

--- a/addons/website_sale/views/templates.xml
+++ b/addons/website_sale/views/templates.xml
@@ -1274,8 +1274,8 @@
                     </t>
                 </span>
                 <a role="button" class="btn btn-primary" href="/shop/cart">
-                       View Cart (<t t-esc="website_sale_order.cart_quantity" /> item(s))
-                     </a>
+                    View Cart (<span class="o_wsale_cart_quantity" t-esc="website_sale_order.cart_quantity" /> item(s))
+                </a>
             </div>
         </t>
     </template>

--- a/addons/website_sale_product_configurator/controllers/main.py
+++ b/addons/website_sale_product_configurator/controllers/main.py
@@ -96,4 +96,6 @@ class WebsiteSale(main.WebsiteSale):
                     )
                     option_parent[option['unique_id']] = option_value['line_id']
 
+        request.session['website_sale_cart_quantity'] = order.cart_quantity
+
         return str(order.cart_quantity)

--- a/addons/website_sale_product_configurator/static/src/js/website_sale_options.js
+++ b/addons/website_sale_product_configurator/static/src/js/website_sale_options.js
@@ -116,6 +116,7 @@ publicWidget.registry.WebsiteSale.include({
                         const $quantity = $(".my_cart_quantity");
                         $quantity.parent().parent().removeClass('d-none');
                         $quantity.text(quantity).hide().fadeIn(600);
+                        sessionStorage.setItem('website_sale_cart_quantity', quantity);
                     });
             });
     },

--- a/addons/website_sale_wishlist/static/src/js/website_sale_wishlist.js
+++ b/addons/website_sale_wishlist/static/src/js/website_sale_wishlist.js
@@ -191,6 +191,7 @@ publicWidget.registry.ProductWishlist = publicWidget.Widget.extend(VariantMixin,
                 var cart_alert = $('.wishlist-section').parent().find('#data_warning');
                 cart_alert.html('<button type="button" class="close" data-dismiss="alert" aria-hidden="true">&times;</button> ' + resp.warning);
             }
+            sessionStorage.setItem('website_sale_cart_quantity', resp.cart_quantity);
             $('.my_cart_quantity').html(resp.cart_quantity || '<i class="fa fa-warning" /> ');
         });
     },


### PR DESCRIPTION
Task Purpose:
Improve the performance of /shop by making it entirely cache-able in the qweb cache.
(Currently there is no additional query when nothing is in the cart, otherwise there are 8 queries from template rendering, and 9 queries from js)

pr: use SessionStorage and py session to reduce nb of queries

opw-2737985