### PR TITLE
[FIX] 14.0 pos: updatePricelist -> no undefined fiscal pos

### DIFF
--- a/addons/point_of_sale/static/src/js/models.js
+++ b/addons/point_of_sale/static/src/js/models.js
@@ -3528,11 +3528,10 @@ exports.Order = Backbone.Model.extend({
             (position) => position.id === this.pos.config.default_fiscal_position_id[0]
         );
         if (newClient) {
-            newClientFiscalPosition = newClient.property_account_position_id
-                ? this.pos.fiscal_positions.find(
+            newClientFiscalPosition =
+                this.pos.fiscal_positions.find(
                       (position) => position.id === newClient.property_account_position_id[0]
-                  )
-                : defaultFiscalPosition;
+                  ) || defaultFiscalPosition;
             newClientPricelist =
                 this.pos.pricelists.find(
                     (pricelist) => pricelist.id === newClient.property_product_pricelist[0]


### PR DESCRIPTION
Description of the issue/feature this PR addresses:

Fix a problem with fiscal positions in PoS

Current behavior before PR:

When changing customer (and using fiscal positions in the pos), if the customer does not have a pricelist (or is not in the list for the current pos), sets the pricelist to an undefined one.

Desired behavior after PR is merged:

The configured default pricelist will be used in that case.


--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
