### PR TITLE
[FIX] mail: force partner's lang for button in emails

### DIFF
--- a/addons/mail/models/mail_thread.py
+++ b/addons/mail/models/mail_thread.py
@@ -2260,9 +2260,17 @@ class MailThread(models.AbstractModel):
         if not partners_data:
             return True
 
+        if not force_email_lang:
+            # use partner_id's email when the field exists
+            try:
+                force_email_lang = self.partner_id.lang
+            except AttributeError:
+                pass
+
         model = msg_vals.get('model') if msg_vals else message.model
-        model_name = model_description or (self.env['ir.model']._get(model).display_name if model else False) # one query for display name
-        recipients_groups_data = self._notify_get_recipients_classify(partners_data, model_name, msg_vals=msg_vals)
+        model_name = model_description or (self.env['ir.model'].with_context(lang=force_email_lang or self.env.lang)._get(model).display_name if model else False) # one query for display name
+        recipients_groups_data = self.with_context(lang=force_email_lang or self.env.lang)\
+                                     ._notify_get_recipients_classify(partners_data, model_name, msg_vals=msg_vals)
 
         if not recipients_groups_data:
             return True

--- a/addons/test_mail/models/test_mail_corner_case_models.py
+++ b/addons/test_mail/models/test_mail_corner_case_models.py
@@ -64,6 +64,7 @@ class MailTestLang(models.Model):
     name = fields.Char()
     email_from = fields.Char()
     customer_id = fields.Many2one('res.partner')
+    partner_id = fields.Many2one('res.partner')
     lang = fields.Char('Lang')
 
     def _notify_get_recipients_groups(self, msg_vals=None):

--- a/addons/test_mail/tests/test_message_post.py
+++ b/addons/test_mail/tests/test_message_post.py
@@ -713,6 +713,39 @@ class TestMessagePostLang(TestMailCommon, TestRecipients):
         self.assertIn('Hello', body, 'Body of posted message should be present')
 
     @users('employee')
+    def test_layout_email_lang_partner(self):
+        # Similar to test_layout_email_lang_context, but
+        # current user's lang is English
+        # partner's lang is Spanish
+        test_records = self.test_records.with_user(self.env.user)
+        test_records[1].message_subscribe(self.partner_2.ids)
+        test_records[1].partner_id = self.partner_2
+        test_records[1].partner_id.lang = 'es_ES'
+
+        with self.mock_mail_gateway():
+            test_records[1].message_post(
+                body='<p>Hello</p>',
+                email_layout_xmlid='mail.test_layout',
+                message_type='comment',
+                subject='Subject',
+                subtype_xmlid='mail.mt_comment',
+            )
+
+        customer_email = self._find_sent_mail_wemail(self.partner_2.email_formatted)
+        self.assertTrue(customer_email)
+        body = customer_email['body']
+        # check notification layout translation
+        self.assertIn('Spanish Layout para', body, 'Layout content should be translated')
+        self.assertNotIn('English Layout for', body)
+        self.assertIn('Spanish Layout para Spanish description', body, 'Model name should be translated')
+        self.assertIn('SpanishView Spanish description', body, '"View document" should be translated')
+        self.assertNotIn('View %s' % test_records[1]._description, body)
+        self.assertIn('TestSpanishStuff', body, 'Groups-based action names should be translated')
+        self.assertNotIn('TestStuff', body)
+        # check content
+        self.assertIn('Hello', body, 'Body of posted message should be present')
+
+    @users('employee')
     def test_layout_email_lang_template(self):
         test_records = self.test_records.with_user(self.env.user)
         test_template = self.test_template.with_user(self.env.user)


### PR DESCRIPTION
Since recent changes in saas~15.2 [1], button titles are generated in
`_notify_get_recipients_groups`. Because partner's lang wasn't used, the buttons
were translated to user's lang.

Fix it by forcing partner's lang in base model `mail.thread`.

opw-2868954

[1]: https://github.com/odoo/odoo/commit/75979fccdff49723314ad76d576e65df570de740

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
