### PR TITLE
[FIX] sale: email template shows free shipping over an amount

### DIFF
--- a/addons/sale/data/mail_template_data.xml
+++ b/addons/sale/data/mail_template_data.xml
@@ -214,11 +214,11 @@
                 <td>
                     <span style="font-weight:bold;">Shipping Method:</span>
                     <t t-out="object.carrier_id.name or ''"></t>
-                    <t t-if="object.carrier_id.fixed_price == 0.0 or object.amount_delivery == 0.0">
+                    <t t-if="object.amount_delivery == 0.0">
                         (Free)
                     </t>
                     <t t-else="">
-                        (<t t-out="format_amount(object.carrier_id.fixed_price, object.currency_id) or ''">$ 10.00</t>)
+                        (<t t-out="format_amount(object.amount_delivery, object.currency_id) or ''">$ 10.00</t>)
                     </t>
                 </td>
             </tr>


### PR DESCRIPTION
Reason: this fix is a patch for previous PR: https://github.com/odoo/odoo/pull/91009
As it should only depend on amount_delivery instead of fixed_price

Fix: clean the redundant condition and modify the delivery price
rendering in the else part


--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
