### PR TITLE
[IMP] pos: mobile number added to customer list

### DIFF
--- a/addons/point_of_sale/static/src/css/pos.css
+++ b/addons/point_of_sale/static/src/css/pos.css
@@ -1823,7 +1823,8 @@ td {
     padding: 12px 8px;
 }
 
-.pos .partnerlist-screen .fa.fa-phone,
+.pos .partnerlist-screen .fa.fa.fa-phone,
+.pos .partnerlist-screen .fa.fa-mobile,
 .pos .partnerlist-screen .fa.fa-paper-plane-o {
     margin-right: 4px;
 }

--- a/addons/point_of_sale/static/src/xml/Screens/PartnerListScreen/PartnerDetailsEdit.xml
+++ b/addons/point_of_sale/static/src/xml/Screens/PartnerListScreen/PartnerDetailsEdit.xml
@@ -89,6 +89,12 @@
                                t-att-value="props.partner.phone || ''" />
                     </div>
                     <div class="partner-detail">
+                        <span class="label">Mobile</span>
+                        <input class="detail" name="mobile" type="tel"
+                               t-on-change="captureChange"
+                               t-att-value="props.partner.mobile || ''" />
+                    </div>
+                    <div class="partner-detail">
                         <span class="label">Barcode</span>
                         <input class="detail barcode" name="barcode" t-on-change="captureChange"
                                t-att-value="props.partner.barcode || ''" />

--- a/addons/point_of_sale/static/src/xml/Screens/PartnerListScreen/PartnerLine.xml
+++ b/addons/point_of_sale/static/src/xml/Screens/PartnerListScreen/PartnerLine.xml
@@ -23,6 +23,9 @@
                 <div t-if="props.partner.phone">
                     <i class="fa fa-phone"/><t t-esc="props.partner.phone"/>
                 </div>
+                <div t-if="props.partner.mobile">
+                    <i class="fa fa-mobile fa-lg"/><t t-esc="props.partner.mobile"/>
+                </div>
                 <div t-if="props.partner.email" class="email-field">
                     <i class="fa fa-paper-plane-o"/><t t-esc="props.partner.email" />
                 </div>

--- a/addons/point_of_sale/static/src/xml/Screens/PartnerListScreen/PartnerListScreen.xml
+++ b/addons/point_of_sale/static/src/xml/Screens/PartnerListScreen/PartnerListScreen.xml
@@ -22,7 +22,7 @@
                         <t t-if="!env.isMobile"> Discard</t>
                     </div>
                     <div class="top-right-buttons">
-                    <div t-if="state.detailIsShown" class="button more-info">
+                    <div t-if="state.detailIsShown &amp;&amp; state.editModeProps.partner.id" class="button more-info">
                         <a t-att-href="partnerLink" target="_blank"> More info</a>
                     </div>
                     <div class="search-bar-container sb-partner" t-if="!state.detailIsShown">


### PR DESCRIPTION
Before, the customer list displayed both customer's email address and phone number, but only the landline, when available.
So if only a mobile number was set on the res.partner, no phone number was displayed in PoS.

This improvement adds the mobile number to the customer list.
The mobile number is only displayed when available.
    
task-2817067
