### PR TITLE
[FIX] mass_mailing: Allow reply_to mode 'email' for mailing contacts

### DIFF
--- a/addons/mass_mailing/models/mailing.py
+++ b/addons/mass_mailing/models/mailing.py
@@ -239,7 +239,7 @@ class MassMailing(models.Model):
         that mailing_model being mailing.list means contacting mailing.contact
         (see mailing_model_name versus mailing_model_real). """
         for mailing in self:
-            if mailing.mailing_model_id.model in ['res.partner', 'mailing.list']:
+            if mailing.mailing_model_id.model in ['res.partner', 'mailing.list', 'mailing.contact']:
                 mailing.reply_to_mode = 'email'
             else:
                 mailing.reply_to_mode = 'thread'


### PR DESCRIPTION
See ticket 2803314 for steps to reproduce the issue.

Before this commit:
When creating a mail template for a marketing campaign targeting mailing
contact, the reply_to_mode would be set to 'thread', and the reply_to
field would be read-only. Since there is no way to target a mailing
list from a marketing campaign (see the domain on marketing.campaign's
model_id), and there is no default followers mailing.contact, email
responses would be "lost".

After this commit:
The reply_to_mode is set to 'email', and the reply_to is set
accordingly