### PR TITLE
[FIX][15.0] Ignore stdnum error on _fix_vat_number

### DIFF
--- a/addons/base_vat/models/res_partner.py
+++ b/addons/base_vat/models/res_partner.py
@@ -593,7 +593,11 @@ class ResPartner(models.Model):
         format_func_name = 'format_vat_' + vat_country
         format_func = getattr(self, format_func_name, None) or stdnum_vat_fix_func
         if format_func:
-            vat_number = format_func(vat_number)
+            try:
+                vat_number = format_func(vat_number)
+            except InvalidComponent:
+                # Prevent populating errors from stdnum
+                pass
         return vat_country.upper() + vat_number
 
     @api.model_create_multi


### PR DESCRIPTION
Prevent population of stdnum errors when the lib doesn't has the proper module.

**Description of the issue/feature this PR addresses:**
Unable to create a contact with this VAT: EU528003646

**Current behavior before PR:**
Error thrown from stdnum library because stdnum library doesn't have any components for "EU" code.

**Desired behavior after PR is merged:**
Let me create the contact with this VAT.
Some VAT from EU has "EU" on the start of the VAT.

**Trackeback:**
```
RPC_ERROR
Odoo Server Error
Traceback (most recent call last):
  File "/opt/odoo/custom/src/odoo/odoo/addons/base/models/ir_http.py", line 237, in _dispatch
    result = request.dispatch()
  File "/opt/odoo/custom/src/odoo/odoo/http.py", line 687, in dispatch
    result = self._call_function(**self.params)
  File "/opt/odoo/custom/src/odoo/odoo/http.py", line 359, in _call_function
    return checked_call(self.db, *args, **kwargs)
  File "/opt/odoo/custom/src/odoo/odoo/service/model.py", line 94, in wrapper
    return f(dbname, *args, **kwargs)
  File "/opt/odoo/custom/src/odoo/odoo/http.py", line 348, in checked_call
    result = self.endpoint(*a, **kw)
  File "/opt/odoo/custom/src/odoo/odoo/http.py", line 916, in __call__
    return self.method(*args, **kw)
  File "/opt/odoo/custom/src/odoo/odoo/http.py", line 535, in response_wrap
    response = f(*args, **kw)
  File "/opt/odoo/auto/addons/web/controllers/main.py", line 1347, in call_kw
    return self._call_kw(model, method, args, kwargs)
  File "/opt/odoo/auto/addons/web/controllers/main.py", line 1339, in _call_kw
    return call_kw(request.env[model], method, args, kwargs)
  File "/opt/odoo/custom/src/odoo/odoo/api.py", line 462, in call_kw
    result = _call_kw_model_create(method, model, args, kwargs)
  File "/opt/odoo/custom/src/odoo/odoo/api.py", line 442, in _call_kw_model_create
    result = method(recs, *args, **kwargs)
  File "<decorator-gen-195>", line 2, in create
  File "/opt/odoo/custom/src/odoo/odoo/api.py", line 412, in _model_create_multi
    return create(self, [arg])
  File "/opt/odoo/auto/addons/base_vat/models/res_partner.py", line 604, in create
    values['vat'] = self._fix_vat_number(values['vat'], country_id)
  File "/opt/odoo/auto/addons/base_vat/models/res_partner.py", line 596, in _fix_vat_number
    vat_number = format_func(vat_number)
  File "/usr/local/lib/python3.8/site-packages/stdnum/eu/vat.py", line 79, in compact
    raise InvalidComponent()
Exception

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/opt/odoo/custom/src/odoo/odoo/http.py", line 643, in _handle_exception
    return super(JsonRequest, self)._handle_exception(exception)
  File "/opt/odoo/custom/src/odoo/odoo/http.py", line 301, in _handle_exception
    raise exception.with_traceback(None) from new_cause
stdnum.exceptions.InvalidComponent: One of the parts of the number are invalid or unknown.
```


MT-874 @moduon

OPW-2877716

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
