### PR TITLE
[FIX] web_editor: hide media options on editable root media elements

### DIFF
--- a/addons/web_editor/static/src/js/editor/image_processing.js
+++ b/addons/web_editor/static/src/js/editor/image_processing.js
@@ -343,7 +343,13 @@ function isImageSupportedForProcessing(mimetype) {
  * @returns {Boolean}
  */
 function isImageSupportedForStyle(img) {
-    return img.parentElement && !img.parentElement.dataset.oeType;
+    return img.parentElement && !img.parentElement.dataset.oeType
+        // Editable root elements are technically *potentially* supported here
+        // (if the edited attributes are not computed inside the related view,
+        // they could technically be saved... but as we cannot tell the computed
+        // ones apart from the "static" ones, we choose to not support edition
+        // at all in those "root" cases).
+        && !img.dataset.oeXpath;
 }
 
 return {

--- a/addons/web_editor/static/src/js/editor/snippets.editor.js
+++ b/addons/web_editor/static/src/js/editor/snippets.editor.js
@@ -2113,9 +2113,19 @@ var SnippetsMenu = Widget.extend({
             // TODO: adapt in master - used to hide XML 'img' options when image
             // is not supported.
             const xmlImageOption = !$style[0].hasAttribute('data-js') && (selector.indexOf('img') !== -1);
-            const nonSupportedImageSelector = '[data-oe-type="image"] > img';
+            const nonSupportedImageSelector = '[data-oe-type="image"] > img, [data-oe-xpath]';
             if (xmlImageOption && !noCheck) {
                 exclude = [exclude, nonSupportedImageSelector].filter(value => !!value).join(', ');
+            } else if (['ReplaceMedia', 'FontawesomeTools', 'WebsiteAnimate'].includes(optionID)) {
+                // TODO adapt in master: editable root elements are technically
+                // *potentially* supported (if the edited attributes are not
+                // computed inside the related view, they could technically be
+                // saved... but as we cannot tell the computed ones apart from
+                // the "static" ones, we choose to not support edition at all in
+                // those "root" cases). Here we explicitely exclude some options
+                // but we could exclude them all or do something smarter in
+                // future versions.
+                exclude = [exclude, '[data-oe-xpath]'].filter(value => !!value).join(', ');
             }
             var option = {
                 'option': optionID,

--- a/addons/web_editor/static/src/js/wysiwyg/wysiwyg.js
+++ b/addons/web_editor/static/src/js/wysiwyg/wysiwyg.js
@@ -38,7 +38,9 @@ const endPos = OdooEditorLib.endPos;
 
 var id = 0;
 const faZoomClassRegex = RegExp('fa-[0-9]x');
-const mediaSelector = 'img, .fa, .o_image, .media_iframe_video';
+const basicMediaSelector = 'img, .fa, .o_image, .media_iframe_video';
+// TODO review in master (see isImageSupportedForStyle).
+const mediaSelector = basicMediaSelector.split(',').map(s => `${s}:not([data-oe-xpath])`).join(',');
 
 // Time to consider a user offline in ms. This fixes the problem of the
 // navigator closing rtc connection when the mac laptop screen is closed.

--- a/addons/web_editor/views/snippets.xml
+++ b/addons/web_editor/views/snippets.xml
@@ -378,6 +378,7 @@
 
     <!-- Replace a media -->
     <!-- TODO probably review this system once the new editor is merged to not duplicate the selector, etc -->
+    <!-- TODO adapt in master, this was patched in js to add data-exclude -->
     <div data-js="ReplaceMedia" data-selector="img, .media_iframe_video, span.fa, i.fa">
         <we-row string="Media">
             <we-button class="o_we_bg_brand_primary" data-replace-media="true" data-no-preview="true">Replace</we-button>
@@ -414,6 +415,7 @@
         </we-button-group>
     </div>
 
+    <!-- TODO adapt in master, this was patched in js to add data-exclude -->
     <div data-selector="img">
         <we-input string="Description" class="o_we_large"
             data-select-attribute="" data-attribute-name="alt"
@@ -513,6 +515,7 @@
         <t t-call="web_editor.snippet_options_image_optimization_widgets"/>
     </div>
 
+    <!-- TODO adapt in master, this was patched in js to add data-exclude -->
     <div data-js="ImageTools" data-selector="img">
         <we-row string="Transform">
             <we-button class="fa fa-fw fa-crop" data-crop="true" data-no-preview="true" title="Crop Image"/>
@@ -533,6 +536,7 @@
         </we-button-group>
     </div>
 
+    <!-- TODO adapt in master, this was patched in js to add data-exclude -->
     <div data-selector="span.fa, i.fa, img">
         <we-select string="Alignment" data-state-to-first-class="true">
             <we-button data-select-class="" title="Unalign">None</we-button>


### PR DESCRIPTION
This works follows [1] which already hid lots of options which were not
supposed to show up on some images. That concerned mainly t-field images
and others. This commit is about media elements (images, icons, ...)
which are editable roots, meaning they carry the branding of the portion
of the view they belong to.

In 14.0, such root media elements were simply not editable. Indeed, the
media tools (which were amongst text tools of summernote) simply did not
show up. With the new editor of 15.0, all media options were converted
as "snippet" options for the website editor. The system being entirely
different, explicit conditions for the options to not appear had to be
made.

Technically, some of those options may work on editable roots. With [2],
the "class" and "style" attributes are savable on such items... unless
they are computed. In the future, we may allow more attributes. The
problem in allowing some options to appear (depending if they work on
a given element) is that it would require:
- knowing which attributes an option modifies (class? style? others?)
- knowing which attributes are computed in the qweb view

We may consider improving all of that in future versions, but in stable,
we decided to simply hide all media options on editable roots.
Theoretically, some non-media options could still appear on non-media
editable root elements and not work... but probably no standard option
matches this case.

[1]: https://github.com/odoo/odoo/commit/e707789d43a5754dc2a28192e5502cc14eaca73f
[2]: https://github.com/odoo/odoo/commit/8579c0cae839c615415120b79d6ec22c71f7affd

opw-2817765
opw-2854285
opw-2864584
