### PR TITLE
[FIX] hr_expense: fix error when click smart button 'Expenses' in Sale Order

### DIFF
--- a/odoo/addons/base/models/ir_actions.py
+++ b/odoo/addons/base/models/ir_actions.py
@@ -247,7 +247,7 @@ class IrActionsActWindow(models.Model):
                         ctx = safe_eval(values.get('context', '{}'), eval_ctx)
                     except:
                         ctx = {}
-                    values['help'] = self.with_context(**ctx).env[model].get_empty_list_help(values.get('help', ''))
+                    values['help'] = self.with_context(**ctx).env[model].get_empty_list_help(values.get('help', '') or '')
         return result
 
     @api.model_create_multi


### PR DESCRIPTION
Version: 14.0

Description of the issue/feature this PR addresses:

![Screenshot (7)](https://user-images.githubusercontent.com/85299950/172522760-aed6a984-06b4-4e5d-bed8-370007011a4b.png)

![Screenshot (8)](https://user-images.githubusercontent.com/85299950/172522783-16f94b2c-056a-4757-9ba0-7706c7196008.png)

![Screenshot (9)](https://user-images.githubusercontent.com/85299950/172522794-7b3e5e05-17c1-46a5-8bbb-6894999e3988.png)

Current behavior before PR:` error when click smart button 'Expenses' in Sale Order`

Desired behavior after PR is merged: `fix this errors`




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
