### PR TITLE
[REF] models: Create UNLOGGED table for transient models

### DIFF
--- a/odoo/models.py
+++ b/odoo/models.py
@@ -2939,7 +2939,7 @@ class BaseModel(metaclass=MetaModel):
                     (field.name, make_type(field), field.string)
                     for field in sorted(self._fields.values(), key=lambda f: f.column_order)
                     if field.name != 'id' and field.store and field.column_type
-                ])
+                ], self.is_transient())
 
             if self._parent_store:
                 if not tools.column_exists(cr, self._table, 'parent_path'):
@@ -2959,7 +2959,10 @@ class BaseModel(metaclass=MetaModel):
                     continue
                 if field.manual and not update_custom_fields:
                     continue            # don't update custom fields
-                new = field.update_db(self, columns)
+                if field.type == 'many2many':
+                    new = field.update_db(self, columns, self.is_transient())
+                else:
+                    new = field.update_db(self, columns)
                 if new and field.compute:
                     fields_to_compute.append(field)
 

--- a/odoo/tools/sql.py
+++ b/odoo/tools/sql.py
@@ -65,13 +65,13 @@ SQL_ORDER_BY_TYPE = defaultdict(lambda: 9, {
     'float8': 8,        # 8 bytes aligned on 8 bytes
 })
 
-def create_model_table(cr, tablename, comment=None, columns=()):
+def create_model_table(cr, tablename, comment=None, columns=(), is_transient=None):
     """ Create the table for a model. """
     colspecs = ['id SERIAL NOT NULL'] + [
         '"{}" {}'.format(columnname, columntype)
         for columnname, columntype, columncomment in columns
     ]
-    cr.execute('CREATE TABLE "{}" ({}, PRIMARY KEY(id))'.format(tablename, ", ".join(colspecs)))
+    cr.execute('CREATE {} TABLE "{}" ({}, PRIMARY KEY(id))'.format("UNLOGGED" if is_transient else "", tablename, ", ".join(colspecs)))
 
     queries, params = [], []
     if comment:


### PR DESCRIPTION
Transient models are actually "transient"

It means, the records will be deleted soon
and the already inserted ones are used only in the life of the wizard

But using a normal table it is consuming disk I/O because of the WAL

Using unlogged table:
    - https://www.postgresql.org/docs/current/sql-createtable.html
    - Data written to unlogged tables is not written to the write-ahead log (see Chapter 30),
        which makes them considerably faster than ordinary tables.
        However, they are not crash-safe: an unlogged table is automatically truncated after a crash or unclean shutdown.

if the server is shutdown so the wizard will die too
So there are no references to the current transient data

Opening a new wizard a new record will be created when the server is up again

So, using UNLOGGED tables for the transient model is a safe way to save resources usage
and improve the performance