### PR TITLE
[IMP] website_form_project: prevent project field to be empty in webs…

### DIFF
--- a/addons/website/static/src/components/wysiwyg_adapter/wysiwyg_adapter.js
+++ b/addons/website/static/src/components/wysiwyg_adapter/wysiwyg_adapter.js
@@ -325,7 +325,7 @@ export class WysiwygAdapterComponent extends Wysiwyg {
         const mod = await odoo.loader.modules.get('@website/snippets/s_social_media/options')[Symbol.for('default')];
         mod.clearDbSocialValuesCache();
 
-        const formOptionsMod = await odoo.loader.modules.get('@website/snippets/s_website_form/options')[Symbol.for('default')];
+        const formOptionsMod = await odoo.loader.modules.get('@website/snippets/s_website_form/options');
         formOptionsMod.clearAllFormsInfo();
 
         return super.destroy(...arguments);

--- a/addons/website/static/src/snippets/s_website_form/000.js
+++ b/addons/website/static/src/snippets/s_website_form/000.js
@@ -44,7 +44,7 @@ const { DateTime } = luxon;
         },
     });
 
-    publicWidget.registry.s_website_form = publicWidget.Widget.extend({
+    const WebsiteForm = publicWidget.Widget.extend({
         selector: '.s_website_form form, form.s_website_form', // !compatibility
         events: {
             'click .s_website_form_send, .o_website_form_send': 'send', // !compatibility
@@ -900,3 +900,7 @@ const { DateTime } = luxon;
             fileInputEl.click();
         },
     });
+
+    publicWidget.registry.s_website_form = WebsiteForm;
+
+    export default WebsiteForm;

--- a/addons/website/static/src/snippets/s_website_form/options.js
+++ b/addons/website/static/src/snippets/s_website_form/options.js
@@ -354,7 +354,7 @@ const FieldEditor = FormEditor.extend({
     },
 });
 
-options.registry.WebsiteFormEditor = FormEditor.extend({
+const WebsiteFormEditor = FormEditor.extend({
     events: Object.assign({}, options.Class.prototype.events || {}, {
         'click .toggle-edit-message': '_onToggleEndMessageClick',
     }),
@@ -846,6 +846,8 @@ options.registry.WebsiteFormEditor = FormEditor.extend({
         });
     },
 });
+
+options.registry.WebsiteFormEditor = WebsiteFormEditor;
 
 const authorizedFieldsCache = {};
 
@@ -1669,6 +1671,7 @@ options.registry.DeviceVisibility.include({
     },
 });
 
-export default {
+export {
+    WebsiteFormEditor,
     clearAllFormsInfo,
 };

--- a/addons/website_form_project/__manifest__.py
+++ b/addons/website_form_project/__manifest__.py
@@ -14,12 +14,17 @@ Generate tasks in Project app from a form published on your website. This module
         'data/website_form_project_data.xml',
         'views/project_portal_project_task_template.xml',
         'views/project_portal_project_project_template.xml',
+        'views/project_views.xml',
         ],
     'installable': True,
     'auto_install': True,
     'assets': {
+        'web.assets_tests': [
+            'website_form_project/static/tests/**/*',
+        ],
         'website.assets_wysiwyg': [
             'website_form_project/static/src/js/website_form_project_editor.js',
+            'website_form_project/static/src/snippets/s_website_form_project/options.js',
         ],
         'project.webclient': [
             # In website, there is a patch of the LinkDialog (see

--- a/addons/website_form_project/static/src/js/website_form_project_editor.js
+++ b/addons/website_form_project/static/src/js/website_form_project_editor.js
@@ -25,6 +25,7 @@ FormEditorRegistry.add('create_task', {
         type: 'many2one',
         relation: 'project.project',
         string: _t('Project'),
-        createAction: 'project.open_view_project_all',
+        required: true,
+        createAction: 'website_form_project.create_project_web_form', 
     }],
 });

--- a/addons/website_form_project/static/src/snippets/s_website_form_project/000.js
+++ b/addons/website_form_project/static/src/snippets/s_website_form_project/000.js
@@ -1,0 +1,5 @@
+/** @odoo-module **/
+import WebsiteForm from "@website/snippets/s_website_form/000";
+
+// We do not change any of the functionality of s_website_form thus we just return it
+export default WebsiteForm;

--- a/addons/website_form_project/static/src/snippets/s_website_form_project/options.js
+++ b/addons/website_form_project/static/src/snippets/s_website_form_project/options.js
@@ -1,0 +1,167 @@
+/** @odoo-module **/
+
+import { _t } from '@web/core/l10n/translation';
+import FormEditorRegistry from '@website/js/form_editor_registry';
+import { WebsiteFormEditor } from '@website/snippets/s_website_form/options';
+import options from '@web_editor/js/editor/snippets.options';
+import { ConfirmationDialog } from "@web/core/confirmation_dialog/confirmation_dialog";
+import "@website/js/editor/snippets.options";
+
+const FormProjectEditor = WebsiteFormEditor.include({
+    /**
+     * Error dialog that allows the user to be redirected to a another odoo webpage through a window action
+     *
+     * @param {String} msg the message displayed in the error dialog
+     * @param {String} button_txt the text displayed on the dialog's primary button
+     * @param {String} redirectAction the window action to redirect user to a view
+     * @returns {Promise}
+     *
+     */
+    ErrorWithRedirect: function (msg, button_txt, redirectAction) {
+        return new Promise((resolve, reject) => {
+            this.dialog.add(ConfirmationDialog, {
+                body: msg,
+                confirm: async () => {
+                    await this._redirectToAction(redirectAction);
+                    resolve();
+                },
+                cancel: () => resolve(),
+                confirmLabel: _t(button_txt),
+            });
+        });
+    },
+
+    /**
+     * Returns a promise which is resolved once the records of the field
+     * have been retrieved.
+     *
+     * @private
+     * @override
+     * @param {Object} field
+     * @returns {Promise<Object>}
+     */
+    _fetchFieldRecords: async function (field) {
+        // check whether we are looking for the project_id field
+        if (field.name !== "project_id") {
+            return this._super.apply(this, arguments);
+        } else if (field.relation && field.relation !== 'ir.attachment') {
+            field.records = await this.orm.call(
+                field.relation,
+                'search_read',
+                [field.domain, ['display_name']],
+            );
+        }
+        return field.records;
+    },
+
+    /**
+     * Here we edit the way that the form is being rendered.
+     * The initial if statement ensures that this code only applies on the "create a task" option of the form.
+     * If the "create a task" option is not chosen, the execution is moved to the parent method.
+     *
+     * It is necessary to do this because an error is raised when the form is edited and no project have been
+     * set up. This can only occur when the user has deleted/archived all projects after editing the form
+     * @override
+     */
+    _renderCustomXML: async function (uiFragment) {
+        if (this.modelCantChange) {
+            return;
+        }
+
+        // get the information currently on the form
+        const formKey = this.activeForm.website_form_key;
+        const formInfo = FormEditorRegistry.get(formKey);
+
+        if (formKey == "create_task") {
+            // Add Action select
+            const firstOption = uiFragment.childNodes[0];
+            uiFragment.insertBefore(this.selectActionEl.cloneNode(true), firstOption);
+
+            if (!formInfo || !formInfo.fields) {
+                return;
+            }
+            const proms = formInfo.fields.map(field => this._fetchFieldRecords(field));
+            return Promise.all(proms).then(() => {
+                formInfo.fields.forEach(field => {
+                    let option;
+                    switch (field.type) {
+                        case 'many2one':
+                            option = this._buildSelect(field);
+                            break;
+                        case 'char':
+                            option = this._buildInput(field);
+                            break;
+                    }
+                    if (field.required) {
+                        // We check if the field is required if yes,
+                        // check whether the field is many2one with no records and if not,
+                        // get default value or for many2one fields the first option.
+                        if (!(field.type == 'many2one' && field.records.length == 0)) {
+                            const currentValue = this.$target.find(`.s_website_form_dnone input[name="${field.name}"]`).val();
+                            const defaultValue = field.defaultValue || field.records[0].id;
+                            this._addHiddenField(currentValue || defaultValue, field.name);
+                        }
+                    }
+                    uiFragment.insertBefore(option, firstOption);
+                });
+            });
+        } else {
+            return this._super.apply(this, arguments);
+        }
+    },
+
+    /**
+     * @override
+     * @param {String} value the id of the model we want the form to adopt
+     * Select the model to create with the form.
+     * If the model's website_form_key is "create_task" we check whether its project_id
+     * field is empty and if yes, raise a warning.
+     */
+    selectAction: async function (previewMode, value, params) {
+        if (this.modelCantChange) {
+            return;
+        }
+        // This operation is done to check which action coresponds
+        // to the numeric "value" parameter
+        let nextKey;
+        this.models.forEach(model => {
+            if (String(model.id) == value) {
+                nextKey = model.website_form_key;
+            }
+        })
+
+        if (nextKey == 'create_task') {
+            const formInfo = FormEditorRegistry.get(nextKey);
+            const proms = formInfo.fields.map(field => this._fetchFieldRecords(field));
+            let error;
+
+            await Promise.all(proms).then(() => {
+                formInfo.fields.forEach(field => {
+                    // Check whether the field is the project_id field
+                    // and whether there are any records - if not the warning will be raised
+                    if (field.name == 'project_id' && field.records.length == 0) {
+                        const msg = "You need to have set-up a project in order to select the option to create a task from \
+                                    the website form";
+                        const buttonTxt = "Create Project";
+                        const action = 'website_form_project.create_project_web_form';
+
+                        error = this.ErrorWithRedirect(msg, buttonTxt, action);
+                    }
+                });
+            });
+
+            if (error) {
+                return error;
+            } else {
+                await this._applyFormModel(parseInt(value));
+                this.rerender = true;
+            }
+        } else {
+            this._super.apply(this, arguments);
+        }
+    },
+});
+
+options.registry.form_project_editor = FormProjectEditor;
+
+export default FormProjectEditor;

--- a/addons/website_form_project/static/tests/tours/website_project_tour_edit_form.js
+++ b/addons/website_form_project/static/tests/tours/website_project_tour_edit_form.js
@@ -1,0 +1,69 @@
+/** @odoo-module **/
+
+import wTourUtils from '@website/js/tours/tour_utils';
+
+const enterEditMode = [{
+    content: "Select the contact us form by clicking on an input field",
+    trigger: "iframe #wrap.o_editable section.s_website_form",
+    extra_trigger: "iframe body.editor_enable",
+}, {
+    content: "Verify that the form editor appeared",
+    trigger: '.o_we_customize_panel .snippet-option-WebsiteFormEditor',
+    run: () => null,
+}];
+
+const websiteFormNoProject = [
+    ...enterEditMode,
+{
+    content: "Open the action select",
+    trigger: `we-select:has(we-button:contains("Send an E-mail")) we-toggler`,
+}, {
+    content: "Click on the option",
+    trigger: `we-select we-button:contains("Create a Task")`,
+}, {
+    content: "Click on the 'Cancel' button in the dialog pop-up",
+    trigger: `div.modal-dialog div.modal-content footer.modal-footer button:contains("Cancel")`,
+    timeout: 3000,  // needs a timeout otherwise it fails in this step
+}, {
+    content: "Open the action select again",
+    trigger: `we-select:has(we-button:contains("Send an E-mail")) we-toggler`,
+}, {
+    content: "Click on the option again",
+    trigger: `we-select we-button:contains("Create a Task")`,
+}, {
+    content: "Click on the 'Create Project' button in the dialog pop-up",
+    trigger: `div.modal-dialog div.modal-content footer.modal-footer button:contains("Create Project")`,
+    timeout: 3000,  // needs a timeout otherwise it fails in this step
+}, {
+    content: "Check that we are inside the project form view",
+    trigger: 'body:has(.o_form_view)',
+}];
+
+wTourUtils.registerWebsitePreviewTour('website_form_no_project_tour', {
+    test: true,
+    edition: true,
+    url: '/contactus',
+}, () => websiteFormNoProject);
+
+const formErrorCreateProject = [
+    ...enterEditMode,
+{
+    content: "Open the action select",
+    trigger: `we-select:has(we-button:contains("Send an E-mail")) we-toggler`,
+}, {
+    content: "Click on the option",
+    trigger: `we-select we-button:contains("Create a Task")`,
+}, {
+    content: "Save the page",
+    trigger: 'button[data-action="save"]',
+    extra_trigger: `we-select:has(we-button:contains("test project")) we-toggler`,
+}, {
+    content: 'Wait for reload',
+    trigger: 'body:not(.editor_enable)',
+}];
+
+wTourUtils.registerWebsitePreviewTour('website_form_error_create_project', {
+    test: true,
+    edition: true,
+    url: '/contactus',
+}, () => formErrorCreateProject);

--- a/addons/website_form_project/tests/__init__.py
+++ b/addons/website_form_project/tests/__init__.py
@@ -1,0 +1,1 @@
+from . import test_website_form_project

--- a/addons/website_form_project/tests/test_website_form_project.py
+++ b/addons/website_form_project/tests/test_website_form_project.py
@@ -1,0 +1,37 @@
+# -*- coding: utf-8 -*-
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+import odoo.tests
+from unittest.mock import patch
+from odoo.osv import expression
+
+@odoo.tests.tagged('post_install', '-at_install')
+class TestWebsiteProjectForm(odoo.tests.HttpCase):
+    def test_no_project_error_tour(self):
+        Project = self.env['project.project']
+        Project_search = type(Project).search_fetch
+        existing_project_ids = Project._search([])
+
+        def fake_project_search_fetch(self, domain, fieldnames, offset=0, limit=None, order=None):
+            return Project_search(
+                self,
+                expression.AND([
+                    domain,
+                    [('id', 'not in', list(existing_project_ids))],
+                ]),
+                fieldnames, offset, limit, order
+            )
+
+        # It is necessary to run the tours like these because they require the absence of projects
+        # but demo-data projects are automatically created
+        with patch.object(type(Project), 'search_fetch', fake_project_search_fetch):
+            # The first tour tests whether the pop-up is raised in the absence of projects
+            self.start_tour(self.env['website'].get_client_action_url('/contactus'), 'website_form_no_project_tour', login='admin')
+
+            # The second tour tests whether the pop-up is not shown when a project exists
+            self.env['project.project'].create({
+                'name': 'test project',
+            })
+            current_projects = self.env['project.project'].search([])
+            self.assertEqual(len(list(current_projects)), 1)
+            self.start_tour('/contactus', 'website_form_error_create_project', login='admin')

--- a/addons/website_form_project/views/project_views.xml
+++ b/addons/website_form_project/views/project_views.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <record id="create_project_web_form" model="ir.actions.act_window">
+        <field name="name">Projects</field>
+        <field name="res_model">project.project</field>
+        <field name="domain">[]</field>
+        <field name="view_mode">form</field>
+        <field name="view_id" ref="project.edit_project"/>
+        <field name="target">main</field>
+    </record>
+</odoo>


### PR DESCRIPTION
…ite form

The implemented changes ensure that the user always has a project in the project field in the website form, if the "Create a Task" action is selected.
Previously, the user could leave the field to the "None" choice which meant that the tasks generated by the use of the form were not assigned to anything.
Specifically, the project field became a mandatory field and thus the option "None" is not available anymore. If the user has projects set-up, the first in sequence is displayed by default. If no projects are set-up by the user, the field will remain empty.
In order to make sure that the user does not leave the project field empty (in the case that no projects are set-up), an error is raised upon saving the form informing the user that the project field should have a project and giving them the choice to be redirected to the create new project form.
Additionally, the create project button next to the project field now also redirects the user to the create new project form instead of the project kanban view.

These changes were done in order to make the website form editing more intuitive and less error prone for the users.
The removal of the "None" choice as well as the error pop-up will prevent the users from creating a form which does not link to a project, in an easy to understand way.
Additionally, the inclusion of the "create project" button as well as the redirect in the error pop-up also serve to make the creation of projects quick, simple and non-disrputive to the user's flow.

In order to implement the changes without affecting other form components we extended the functionality of the s_website_form snippet inside the website_form_project module.
We thus create a new snippet to include functionality to the original s_website_form snippet. Two methods were overriden, the cleanForSave and the renderCustomXML method, and a new method called ErrorWithRedirect, which returns the error dialog,  was created.
We also added a new window action that redirects the user to the project form view. This was added in website_form_project/views. That meant that the modules manifest needed to be edited to include this change.
Additionally, the options.js and 000.js files of the s_website_form snippet were modified in order to be able to extend their functionality inside of the website_form_project module.
Finally, a new python unit test was created as well as three test tours, which test the whole functionality of the improvements.

task-2845871

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
