### PR TITLE
[FIX] tool: Function sleep not available in time library

### DIFF
--- a/odoo/tools/safe_eval.py
+++ b/odoo/tools/safe_eval.py
@@ -413,7 +413,7 @@ dateutil = wrap_module(dateutil, {
     for mod in mods
 })
 json = wrap_module(__import__('json'), ['loads', 'dumps'])
-time = wrap_module(__import__('time'), ['time', 'strptime', 'strftime'])
+time = wrap_module(__import__('time'), ['time', 'strptime', 'strftime', 'sleep'])
 pytz = wrap_module(__import__('pytz'), [
     'utc', 'UTC', 'timezone',
 ])


### PR DESCRIPTION
Since this commit https://github.com/odoo/odoo/commit/06a8c5264eb6e87c29ad1d23a14e12dd45aa281c
the function sleep was not available when executing python code in safe_eval

opw:2858779