### PR TITLE
[IMP] web: correctly cache assets frontend templates

### DIFF
--- a/addons/http_routing/models/ir_http.py
+++ b/addons/http_routing/models/ir_http.py
@@ -23,6 +23,7 @@ from odoo import api, models, exceptions, tools, http
 from odoo.addons.base.models import ir_http
 from odoo.addons.base.models.ir_http import RequestUID
 from odoo.addons.base.models.ir_qweb import QWebException
+from odoo.addons.web.controllers.utils import HomeStaticTemplateHelpers
 from odoo.http import request
 from odoo.osv import expression
 from odoo.tools import config, ustr, pycompat
@@ -299,6 +300,7 @@ class IrHttp(models.AbstractModel):
             'translationURL': '/website/translations',
             'cache_hashes': {
                 'translations': translation_hash,
+                'web.assets_frontend': HomeStaticTemplateHelpers.get_qweb_templates_checksum(debug=request.session.debug, bundle='web.assets_frontend'),
             },
         })
         return session_info

--- a/addons/web/static/src/core/assets.js
+++ b/addons/web/static/src/core/assets.js
@@ -3,6 +3,7 @@
 import { memoize } from "./utils/functions";
 import { browser } from "./browser/browser";
 import { registry } from "./registry";
+import { session } from "@web/session";
 
 class AssetsLoadingError extends Error {}
 
@@ -74,9 +75,8 @@ export const loadCSS = memoize(function loadCSS(url) {
  *      the owl templates or an empty string if the bundle has none.
  */
 export const fetchAndProcessTemplates = memoize(async function fetchAndProcessTemplates(bundle) {
-    // TODO: quid of the "unique" in the URL? We can't have one cache_hash
-    // for each and every bundle I'm guessing.
-    const bundleURL = `/web/webclient/qweb/${Date.now()}?bundle=${bundle}`;
+    const unicityHash = (session.cache_hashes && session.cache_hashes[bundle]) || Date.now();
+    const bundleURL = `/web/webclient/qweb/${unicityHash}?bundle=${bundle}`;
     const templates = await (await browser.fetch(bundleURL)).text();
     if (!templates) {
         return "";


### PR DESCRIPTION
Previously, the assets frontend templates were not properly cached,
because no cache hash was generated for them. This commit fixes that by
adding the assets_frontend cache hash to the session_info and using the
cache hash for the requested bundle in fetchAndProcessTemplates when
available.
