### PR TITLE
[FIX] website: prevent sidebar to be over the content

### DIFF
--- a/addons/website/static/src/js/editor/snippets.options.js
+++ b/addons/website/static/src/js/editor/snippets.options.js
@@ -548,6 +548,21 @@ options.Class.include({
         const enableXmlIDs = xmlID.split(/\s*,\s*/);
         const disableXmlIDs = allXmlIDs.filter(xmlID => !enableXmlIDs.includes(xmlID));
 
+        if (params.name === 'header_sidebar_opt') {
+            // When the user selects sidebar as header, make sure that the
+            // header position is regular.
+            // TODO we should avoid having that `if` in the generic option
+            // class (maybe simply use data-trigger but the header template
+            // option as no associated data-js to hack). To adapt in master.
+            await new Promise(resolve => {
+                this.trigger_up('action_demand', {
+                    actionName: 'toggle_page_option',
+                    params: [{name: 'header_overlay', value: false}],
+                    onSuccess: () => resolve(),
+                });
+            });
+        }
+
         return this._rpc({
             route: '/website/theme_customize',
             params: {
@@ -1939,6 +1954,25 @@ options.registry.TopMenuVisibility = VisibilityPageOptionUpdate.extend({
             });
         }
         return _super(...arguments);
+    },
+    /**
+     * @override
+     */
+    _computeWidgetVisibility(widgetName, params) {
+        if (widgetName === 'header_visibility_opt') {
+            return this.$target[0].classList.contains('o_header_sidebar') ? '' : 'true';
+        }
+        return this._super(...arguments);
+    },
+    /**
+     * @override
+     */
+    _renderCustomXML(uiFragment) {
+        // TODO in master: put this in the XML.
+        const weSelectEl = uiFragment.querySelector('we-select#option_header_visibility');
+        if (weSelectEl) {
+            weSelectEl.dataset.name = 'header_visibility_opt';
+        }
     },
 });
 


### PR DESCRIPTION
[FIX] website: prevent the sidebar from being over the content

With this commit, users can no longer have headers that have the sidebar
template and the over the content option at the same time.

Steps to reproduce the problem:
 - Edit a website
 - Edit the navbar
 - Set Header Position to Over the Content
 - Change the navbar template to Sidebar

The navbar is not displayed properly and there is a margin on the left
that should not be there.

task-2877421
--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
