### PR TITLE
[FIX] pos_loyalty: fix runbot error

### DIFF
--- a/addons/point_of_sale/static/tests/tours/helpers/ProductScreenTourMethods.js
+++ b/addons/point_of_sale/static/tests/tours/helpers/ProductScreenTourMethods.js
@@ -261,7 +261,7 @@ odoo.define('point_of_sale.tour.ProductScreenTourMethods', function (require) {
                 res.push(...this._do.pressNumpad('Qty'));
                 res.push(...this._check.modeIsActive('Qty'));
             }
-            for (let char of quantity.toString()) {
+            for (let char of (quantity.toString() == '1' ? '' : quantity.toString())) {
                 if ('.0123456789'.includes(char)) {
                     res.push(...this._do.pressNumpad(char));
                 } else if ('-'.includes(char)) {

--- a/addons/pos_loyalty/static/src/js/tours/PosLoyaltyRewardButtonTour.js
+++ b/addons/pos_loyalty/static/src/js/tours/PosLoyaltyRewardButtonTour.js
@@ -98,9 +98,11 @@ PosLoyalty.exec.finalizeOrder('Cash', '10');
 
 // Promotion: 2 items of shelves, get desk_pad/monitor_stand free
 // This is the 5th order.
-ProductScreen.exec.addOrderline('Wall Shelf Unit', '1');
+ProductScreen.do.clickDisplayedProduct('Wall Shelf Unit');
+ProductScreen.check.selectedOrderlineHas('Wall Shelf Unit', '1.00');
 PosLoyalty.check.isRewardButtonHighlighted(false);
-ProductScreen.exec.addOrderline('Small Shelf', '1');
+ProductScreen.do.clickDisplayedProduct('Small Shelf');
+ProductScreen.check.selectedOrderlineHas('Small Shelf', '1.00');
 PosLoyalty.check.isRewardButtonHighlighted(true);
 // Click reward product. Should be automatically added as reward.
 ProductScreen.do.clickDisplayedProduct('Desk Pad');


### PR DESCRIPTION
Use of `addOrderline` presses the numpad, after clicking the product,
even if the quantity of the product being added is only 1. Because of
this, there might be a rogue press which calls `_updateSelectedOrderline`
at the wrong timing. This can be proven by looking at the screenshot where
the quantity of `Small Shelf` is 11, not 1. In this particular failing tour,
the sequence of steps properly aligned resulting to this runbot issue. To
make sure runbot isn't failing randomly, we replace `addOrderline` with
manual `click product` and `orderline check`.

Runbot: 3883, 3884, 3886

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
