### PR TITLE
[IMP] point_of_sale,pos_restaurant: use company's barcode nomenclature

### DIFF
--- a/addons/point_of_sale/data/point_of_sale_data.xml
+++ b/addons/point_of_sale/data/point_of_sale_data.xml
@@ -26,7 +26,6 @@
 
         <record model="pos.config" id="pos_config_main">
             <field name="name">Shop</field>
-            <field name="barcode_nomenclature_id" ref="barcodes.default_barcode_nomenclature"/>
         </record>
 
         <record id="product_product_consumable" model="product.product">

--- a/addons/point_of_sale/models/pos_config.py
+++ b/addons/point_of_sale/models/pos_config.py
@@ -109,9 +109,6 @@ class PosConfig(models.Model):
     available_pricelist_ids = fields.Many2many('product.pricelist', string='Available Pricelists', default=_default_pricelist,
         help="Make several pricelists available in the Point of Sale. You can also apply a pricelist to specific customers from their contact form (in Sales tab). To be valid, this pricelist must be listed here as an available pricelist. Otherwise the default pricelist will apply.")
     company_id = fields.Many2one('res.company', string='Company', required=True, default=lambda self: self.env.company)
-    barcode_nomenclature_id = fields.Many2one('barcode.nomenclature', string='Barcode Nomenclature',
-        help='Defines what kind of barcodes are available and how they are assigned to products, customers and cashiers.',
-        default=lambda self: self.env.company.nomenclature_id, required=True)
     group_pos_manager_id = fields.Many2one('res.groups', string='Point of Sale Manager Group', default=_get_group_pos_manager,
         help='This field is there to pass the id of the pos manager group to the point of sale client.')
     group_pos_user_id = fields.Many2one('res.groups', string='Point of Sale User Group', default=_get_group_pos_user,

--- a/addons/point_of_sale/models/pos_session.py
+++ b/addons/point_of_sale/models/pos_session.py
@@ -1652,7 +1652,7 @@ class PosSession(models.Model):
                 'domain': [('id', '=', self.company_id.id)],
                 'fields': [
                     'currency_id', 'email', 'website', 'company_registry', 'vat', 'name', 'phone', 'partner_id',
-                    'country_id', 'state_id', 'tax_calculation_rounding_method'
+                    'country_id', 'state_id', 'tax_calculation_rounding_method', 'nomenclature_id'
                 ],
             }
         }

--- a/addons/point_of_sale/models/res_config_settings.py
+++ b/addons/point_of_sale/models/res_config_settings.py
@@ -40,6 +40,7 @@ class ResConfigSettings(models.TransientModel):
     update_stock_quantities = fields.Selection(related="company_id.point_of_sale_update_stock_quantities", readonly=False)
     account_default_pos_receivable_account_id = fields.Many2one(string='Default Account Receivable (PoS)', related='company_id.account_default_pos_receivable_account_id', readonly=False)
     is_default_pricelist_displayed = fields.Boolean(compute="_compute_pos_pricelist_id", compute_sudo=True)
+    barcode_nomenclature_id = fields.Many2one('barcode.nomenclature', related='company_id.nomenclature_id', readonly=False)
 
     # pos.config fields
     pos_module_pos_discount = fields.Boolean(related='pos_config_id.module_pos_discount', readonly=False)
@@ -50,7 +51,6 @@ class ResConfigSettings(models.TransientModel):
     pos_allowed_pricelist_ids = fields.Many2many('product.pricelist', compute='_compute_pos_allowed_pricelist_ids')
     pos_amount_authorized_diff = fields.Float(related='pos_config_id.amount_authorized_diff', readonly=False)
     pos_available_pricelist_ids = fields.Many2many('product.pricelist', string='Available Pricelists', compute='_compute_pos_available_pricelist_ids', readonly=False, store=True, pos='available_pricelist_ids')
-    pos_barcode_nomenclature_id = fields.Many2one(related='pos_config_id.barcode_nomenclature_id', readonly=False)
     pos_cash_control = fields.Boolean(related='pos_config_id.cash_control')
     pos_cash_rounding = fields.Boolean(related='pos_config_id.cash_rounding', readonly=False, string="Cash Rounding (PoS)")
     pos_company_has_template = fields.Boolean(related='pos_config_id.company_has_template')

--- a/addons/point_of_sale/static/src/js/Chrome.js
+++ b/addons/point_of_sale/static/src/js/Chrome.js
@@ -211,7 +211,7 @@ odoo.define('point_of_sale.Chrome', function(require) {
         }
 
         setupBarcodeParser() {
-            const barcode_parser = new BarcodeParser({ nomenclature_id: this.env.pos.config.barcode_nomenclature_id });
+            const barcode_parser = new BarcodeParser({ nomenclature_id: this.env.pos.company.nomenclature_id });
             this.env.barcode_reader.set_barcode_parser(barcode_parser);
             return barcode_parser.is_loaded();
         }

--- a/addons/point_of_sale/tests/test_frontend.py
+++ b/addons/point_of_sale/tests/test_frontend.py
@@ -45,7 +45,6 @@ class TestPointOfSaleHttpCommon(AccountTestInvoicingHttpCommon):
         })
         cls.main_pos_config = env['pos.config'].create({
             'name': 'Shop',
-            'barcode_nomenclature_id': env.ref('barcodes.default_barcode_nomenclature').id,
         })
 
         env['res.partner'].create({

--- a/addons/point_of_sale/views/res_config_settings_views.xml
+++ b/addons/point_of_sale/views/res_config_settings_views.xml
@@ -626,12 +626,13 @@
                             </div>
                             <div class="o_setting_right_pane">
                                 <span class="o_form_label">Barcodes</span>
+                                <i class="fa fa-info-circle mr-1" title="This setting is common to all PoS." pos-data-toggle="tooltip"/>
                                 <div class="text-muted">
                                     Use barcodes to scan products, customer cards, etc.
                                 </div>
                                 <div class="content-group mt16 row">
-                                    <label for="pos_barcode_nomenclature_id" string="Barcode Nomenclature" class="col-lg-3 o_light_label"/>
-                                    <field name="pos_barcode_nomenclature_id"/>
+                                    <label for="barcode_nomenclature_id" string="Barcode Nomenclature" class="col-lg-3 o_light_label"/>
+                                    <field name="barcode_nomenclature_id"/>
                                 </div>
                             </div>
                         </div>

--- a/addons/pos_restaurant/data/pos_restaurant_demo.xml
+++ b/addons/pos_restaurant/data/pos_restaurant_demo.xml
@@ -195,7 +195,6 @@
         <!-- Pos Config -->
         <record model="pos.config" id="pos_config_restaurant">
             <field name="name">Bar</field>
-            <field name="barcode_nomenclature_id" ref="barcodes.default_barcode_nomenclature"/>
             <field name="module_pos_restaurant">True</field>
             <field name="is_table_management">True</field>
             <field name="iface_splitbill">True</field>

--- a/addons/pos_restaurant/tests/test_frontend.py
+++ b/addons/pos_restaurant/tests/test_frontend.py
@@ -18,7 +18,6 @@ class TestFrontend(odoo.tests.HttpCase):
 
         pos_config = self.env['pos.config'].create({
             'name': 'Bar',
-            'barcode_nomenclature_id': self.env.ref('barcodes.default_barcode_nomenclature').id,
             'module_pos_restaurant': True,
             'is_table_management': True,
             'iface_splitbill': True,


### PR DESCRIPTION
This change removes the `barcode_nomenclature_id` in the `pos.config`.
Each pos session now starts based on the company's barcode nomenclature.

Task-ID: 2849415

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
