### PR TITLE
[FIX] account: don't show cancelled unreconciled entries

### DIFF
--- a/addons/account/static/src/xml/account_reconciliation.xml
+++ b/addons/account/static/src/xml/account_reconciliation.xml
@@ -61,7 +61,7 @@
                     rel="do_action"
                     data-action_name="Unreconciled Entries"
                     data-model="account.move.line"
-                    data-context="{'search_default_unreconciled': 1}">unreconciled entries</a></li>
+                    data-context="{'search_default_unreconciled': 1, 'search_default_posted': 1}">unreconciled entries</a></li>
             </ul>
         </p>
     </t>


### PR DESCRIPTION
Filter the cancelled entries when displaying unreconciled
entries in manual reconciliation widget.

Steps:

- Create an invoice, confirm and register payment
- Go to the journal entry JE related to the payment
- Reset to draft and cancel JE
- Go to Accounting->Reconciliation->Check all unreconciled entries
-> The journal item related to JE is displayed, it should not be

We add a domain in order to filter draft and cancelled entries in the view.

opw-2742085

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
