### PR TITLE
[FIX] pos_restaurant: add return in Order's initialize function

### DIFF
--- a/addons/pos_restaurant/static/src/js/floors.js
+++ b/addons/pos_restaurant/static/src/js/floors.js
@@ -54,6 +54,7 @@ models.Order = models.Order.extend({
         }
         this.customer_count = this.customer_count || 1;
         this.save_to_db();
+        return this;
     },
     export_as_JSON: function() {
         var json = _super_order.export_as_JSON.apply(this,arguments);

--- a/doc/cla/corporate/niboosolutions.md
+++ b/doc/cla/corporate/niboosolutions.md
@@ -1,0 +1,15 @@
+Belgium, 2022-06-208
+
+Niboo Solutions agrees to the terms of the Odoo Corporate Contributor License
+Agreement v1.0.
+
+I declare that I am authorized and able to make this agreement and sign this
+declaration.
+
+Signed,
+
+Roland Bura rbu.hoplyt.com https://github.com/RolandHop
+
+List of contributors:
+
+Roland Bura rbu.hoplyt.com https://github.com/RolandHop


### PR DESCRIPTION
**Missing return in pos_restaurant Order's initialize**

Impacted versions:
 
 - 15.0
 
Steps to reproduce:
 
 1. Install module point_of_sale
 2. Install module pos_restaurant
 3. Install module pos_coupon
 4. Install a custom module
 
Current behavior:
 
 - Can not open a point of sale anymore since the function initialize in pos_coupon (located here : addons/pos_coupon/static/src/js/coupon.js line 255) requires an Order object that it tries to get using super and gets nothing since there is a missing return.
 
Expected behavior:
 
 - The call to the super should return an Order object. And thus the point of sale should open.