### PR TITLE
2/3 Step Production Fixes ( child/parent MO show when back-order created [mrp]  )

### DIFF
--- a/addons/mrp/models/mrp_production.py
+++ b/addons/mrp/models/mrp_production.py
@@ -270,12 +270,14 @@ class MrpProduction(models.Model):
     @api.depends('procurement_group_id.stock_move_ids.created_production_id.procurement_group_id.mrp_production_ids')
     def _compute_mrp_production_child_count(self):
         for production in self:
-            production.mrp_production_child_count = len(production.procurement_group_id.stock_move_ids.created_production_id.procurement_group_id.mrp_production_ids - production)
+            production.mrp_production_child_count = len(production.procurement_group_id.stock_move_ids.created_production_id.procurement_group_id.mrp_production_ids.filtered
+            (lambda p: p.origin != production.origin and p.id != production.id))
 
     @api.depends('move_dest_ids.group_id.mrp_production_ids')
     def _compute_mrp_production_source_count(self):
         for production in self:
-            production.mrp_production_source_count = len(production.procurement_group_id.mrp_production_ids.move_dest_ids.group_id.mrp_production_ids - production)
+            production.mrp_production_source_count = len(production.procurement_group_id.mrp_production_ids.move_dest_ids.group_id.mrp_production_ids.filtered
+            (lambda p: p.origin != production.origin and p.id != production.id))
 
     @api.depends('procurement_group_id.mrp_production_ids')
     def _compute_mrp_production_backorder(self):
@@ -1089,7 +1091,8 @@ class MrpProduction(models.Model):
 
     def action_view_mrp_production_childs(self):
         self.ensure_one()
-        mrp_production_ids = self.procurement_group_id.stock_move_ids.created_production_id.procurement_group_id.mrp_production_ids.ids
+        mrp_production_ids = self.procurement_group_id.stock_move_ids.created_production_id.procurement_group_id.mrp_production_ids.filtered(
+            lambda p: p.origin != self.origin and p.id != self.id).ids
         action = {
             'res_model': 'mrp.production',
             'type': 'ir.actions.act_window',
@@ -1109,7 +1112,8 @@ class MrpProduction(models.Model):
 
     def action_view_mrp_production_sources(self):
         self.ensure_one()
-        mrp_production_ids = self.procurement_group_id.mrp_production_ids.move_dest_ids.group_id.mrp_production_ids.ids
+        mrp_production_ids = self.procurement_group_id.mrp_production_ids.move_dest_ids.group_id.mrp_production_ids.filtered(
+            lambda p: p.origin != self.origin and p.id != self.id).ids
         action = {
             'res_model': 'mrp.production',
             'type': 'ir.actions.act_window',

--- a/addons/mrp/tests/test_warehouse_multistep_manufacturing.py
+++ b/addons/mrp/tests/test_warehouse_multistep_manufacturing.py
@@ -580,3 +580,31 @@ class TestMultistepManufacturingWarehouse(TestMrpCommon):
         picking = pickings[1]
         self.assertEqual(len(picking.move_lines), 1)
         picking.product_id = self.complex_product
+
+    def test_child_parent_relationship_on_backorder_creation(self):
+        """ Test Child Mo and Source Mo in 2/3-step production for reorder
+            rules in backorder using order points with the help of run scheduler """
+
+        with Form(self.warehouse) as warehouse:
+            warehouse.manufacture_steps = 'pbm_sam'
+
+        rr_form = Form(self.env['stock.warehouse.orderpoint'])
+        rr_form.product_id = self.finished_product
+        rr_form.product_min_qty = 20
+        rr_form.product_max_qty = 40
+        rr_form.save()
+
+        self.env['procurement.group'].run_scheduler()
+
+        mo = self.env['mrp.production'].search([('product_id', '=', self.finished_product.id)])
+        mo_form = Form(mo)
+        mo_form.qty_producing = 20
+        mo = mo_form.save()
+
+        action = mo.button_mark_done()
+        backorder = Form(self.env['mrp.production.backorder'].with_context(**action['context']))
+        backorder.save().action_backorder()
+
+        self.assertEqual(mo.mrp_production_child_count, 0, "There is no child Mo but still count is %s" %(mo.mrp_production_child_count))
+        self.assertEqual(mo.mrp_production_source_count, 0, "There is no Source Mo but still count is %s" %(mo.mrp_production_source_count))
+        self.assertEqual(mo.mrp_production_backorder_count, 2)

--- a/addons/sale_mrp/tests/test_multistep_manufacturing.py
+++ b/addons/sale_mrp/tests/test_multistep_manufacturing.py
@@ -149,3 +149,16 @@ class TestMultistepManufacturing(TestMrpCommon):
 
         self.assertEqual(self.sale_order.action_view_mrp_production()['res_id'], mo.id)
         self.assertEqual(mo.action_view_sale_orders()['res_id'], self.sale_order.id)
+
+    def test_pre_and_post_production_pickings_shown_on_so(self):
+        """ Test Pre Production and Post Production Pickings Shown On SO """
+
+        with Form(self.warehouse) as warehouse:
+            warehouse.manufacture_steps = 'pbm_sam'
+            warehouse.delivery_steps = 'pick_pack_ship'
+
+        self.sale_order.action_confirm()
+        mo = self.env['mrp.production'].search([('product_id', '=', self.product_manu.id)])
+
+        self.assertEqual(self.sale_order.delivery_count, 3, "There are no manufacturing transfers but still the count is %s" %(mo.mrp_production_child_count))
+        self.assertEqual(self.sale_order.mrp_production_count, 1)


### PR DESCRIPTION
**FIX] mrp: child/parent MO show when back-order created in 2/3 Step Production**

**Steps to reproduce the bug:**
    - Enable 'Multi-Step Routes' option in Inventory settings
    - Edit warehouse and update Manufacture = 'Pick components, manufacture and then store products (3 steps)'
    - Create a storable product 'P1' with BOM:
        - BOM type: Manufacture this product
        - operations: “OP1”
        - Components: product 'C1' consumed in the operation 'OP1'
    - Set Reordering rules for product 'P1'
    - Run Scheduler and MO will be generated with order points
    - Edit MO and add Producing Quantity less than to produce
    - Validate the MO and create back-order.
    
  **Current behaviour:**
    - child/parent MO were getting visible when back-order was created in 2/3 Step Production.
    
   **Expected behaviour:**
    - No child/parent MO visible until child/parent relations are there
    
 **Task: 2846768**


**[FIX] sale_mrp: Issue with MTO : pre and post production pickings shown on SO**

  **Steps to reproduce the bug:**
    - Enable 'Multi-Step Routes' option in Inventory settings
    - Edit warehouse and update Manufacture = '3 steps', Outgoing Shipments  = '3 steps'
    - Create a storable product 'P1' and add routes(MTO and Manufacture) with BOM:
        - BOM type: Manufacture this product
        - operations: “OP1”
        - Components: product 'C1' consumed in the operation 'OP1' add routes(MTO and Buy)
    - Create Sale Order and add product 'P1'
    - Confirm the sale order
    
  **Current behaviour:**
    - Transfers related to MO are getting visible in delivery of sale order
    
  **Expected behaviour:**
    - No Transfers relate to MO need to be visible in delivery of sale order
  
  **Task: 2846768**

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
