### PR TITLE
[FIX] base: force to specify the language when installing a new language

### DIFF
--- a/odoo/addons/base/wizard/base_language_install.py
+++ b/odoo/addons/base/wizard/base_language_install.py
@@ -20,7 +20,7 @@ class BaseLanguageInstall(models.TransientModel):
     # add a context on the field itself, to be sure even inactive langs are displayed
     lang_ids = fields.Many2many('res.lang', 'res_lang_install_rel',
                                 'language_wizard_id', 'lang_id', 'Languages',
-                                default=_default_lang_ids, context={'active_test': False})
+                                default=_default_lang_ids, context={'active_test': False}, required=True)
     overwrite = fields.Boolean('Overwrite Existing Terms',
                                default=True,
                                help="If you check this box, your customized translations will be overwritten and replaced by the official ones.")


### PR DESCRIPTION
Before this commit, the user could try to install a language without
specifying which language he want to install, resulting in a traceback.
This commit forces to specify which language you want to install. The
bug appeared with this commit [1] which allows to install several
languages at the same time.

[1]: https://github.com/odoo/odoo/commit/47041f2d45915e2ed74c4317f9aafe3dfa840f0a

task-2878405
--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
