### PR TITLE
2/3 Step Production Fixes (MTO + RR)

### DIFF
--- a/addons/mrp/models/mrp_production.py
+++ b/addons/mrp/models/mrp_production.py
@@ -1097,13 +1097,13 @@ class MrpProduction(models.Model):
         self.ensure_one()
         procurement_moves = self.procurement_group_id.stock_move_ids
         child_moves = procurement_moves.move_orig_ids
-        return (procurement_moves | child_moves).created_production_id.procurement_group_id.mrp_production_ids - self
+        return (procurement_moves | child_moves).created_production_id.procurement_group_id.mrp_production_ids.filtered(lambda p: p.origin != self.origin) - self
 
     def _get_sources(self):
         self.ensure_one()
         dest_moves = self.procurement_group_id.mrp_production_ids.move_dest_ids
         parent_moves = self.procurement_group_id.stock_move_ids.move_dest_ids
-        return (dest_moves | parent_moves).group_id.mrp_production_ids - self
+        return (dest_moves | parent_moves).group_id.mrp_production_ids.filtered(lambda p: p.origin != self.origin) - self
 
     def action_view_mrp_production_childs(self):
         self.ensure_one()

--- a/addons/mrp/tests/test_warehouse_multistep_manufacturing.py
+++ b/addons/mrp/tests/test_warehouse_multistep_manufacturing.py
@@ -580,3 +580,31 @@ class TestMultistepManufacturingWarehouse(TestMrpCommon):
         picking = pickings[1]
         self.assertEqual(len(picking.move_lines), 1)
         picking.product_id = self.complex_product
+
+    def test_child_parent_relationship_on_backorder_creation(self):
+        """ Test Child Mo and Source Mo in 2/3-step production for reorder
+            rules in backorder using order points with the help of run scheduler """
+
+        with Form(self.warehouse) as warehouse:
+            warehouse.manufacture_steps = 'pbm_sam'
+
+        rr_form = Form(self.env['stock.warehouse.orderpoint'])
+        rr_form.product_id = self.finished_product
+        rr_form.product_min_qty = 20
+        rr_form.product_max_qty = 40
+        rr_form.save()
+
+        self.env['procurement.group'].run_scheduler()
+
+        mo = self.env['mrp.production'].search([('product_id', '=', self.finished_product.id)])
+        mo_form = Form(mo)
+        mo_form.qty_producing = 20
+        mo = mo_form.save()
+
+        action = mo.button_mark_done()
+        backorder = Form(self.env['mrp.production.backorder'].with_context(**action['context']))
+        backorder.save().action_backorder()
+
+        self.assertEqual(mo.mrp_production_child_count, 0, "Children MOs counted as existing where there should be none")
+        self.assertEqual(mo.mrp_production_source_count, 0, "Source MOs counted as existing where there should be none")
+        self.assertEqual(mo.mrp_production_backorder_count, 2)


### PR DESCRIPTION
**FIX] mrp: child/parent MO show when back-order created in 2/3 Step Production**

**Steps to reproduce the bug:**
    - Enable 'Multi-Step Routes' option in Inventory settings
    - Edit warehouse and update Manufacture = 'Pick components, manufacture and then store products (3 steps)'
    - Create a storable product 'P1' with BOM:
        - BOM type: Manufacture this product
        - operations: “OP1”
        - Components: product 'C1' consumed in the operation 'OP1'
    - Set Reordering rules for product 'P1'
    - Run Scheduler and MO will be generated with order points
    - Edit MO and add Producing Quantity less than to produce
    - Validate the MO and create back-order.
    
  **Current behaviour:**
    - child/parent MO were getting visible when back-order was created in 2/3 Step Production.
    
   **Expected behaviour:**
    - No child/parent MO visible until child/parent relations are there
    
 **Task: 2846768**

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
