### PR TITLE
[FIX] purchase_stock: days to purchase not used in orderpoint action

### DIFF
--- a/addons/mrp/models/stock_rule.py
+++ b/addons/mrp/models/stock_rule.py
@@ -166,7 +166,10 @@ class StockRule(models.Model):
         delay += security_delay
         if not bypass_delay_description:
             delay_description.append((_('Manufacture Security Lead Time'), _('+ %d day(s)', security_delay)))
-        return delay, delay_description
+        days_to_order = values.get('days_to_order', product.product_tmpl_id.days_to_prepare_mo)
+        if not bypass_delay_description:
+            delay_description.append((_('Days to Supply Components'), _('+ %d day(s)', days_to_order)))
+        return delay + days_to_order, delay_description
 
     def _push_prepare_move_copy_values(self, move_to_copy, new_date):
         new_move_vals = super(StockRule, self)._push_prepare_move_copy_values(move_to_copy, new_date)

--- a/addons/purchase_stock/models/stock.py
+++ b/addons/purchase_stock/models/stock.py
@@ -246,6 +246,7 @@ class Orderpoint(models.Model):
             if 'buy' in orderpoint.rule_ids.mapped('action'):
                 orderpoint.days_to_order = orderpoint.company_id.days_to_purchase
         return res
+
     @api.depends('route_id')
     def _compute_show_suppplier(self):
         buy_route = []

--- a/addons/purchase_stock/models/stock_rule.py
+++ b/addons/purchase_stock/models/stock_rule.py
@@ -169,7 +169,10 @@ class StockRule(models.Model):
         security_delay = buy_rule.picking_type_id.company_id.po_lead
         if not bypass_delay_description:
             delay_description.append((_('Purchase Security Lead Time'), _('+ %d day(s)', security_delay)))
-        return delay + supplier_delay + security_delay, delay_description
+        days_to_order = values.get('days_to_order', buy_rule.company_id.days_to_purchase)
+        if not bypass_delay_description:
+            delay_description.append((_('Days to Purchase'), _('+ %d day(s)', days_to_order)))
+        return delay + supplier_delay + security_delay + days_to_order, delay_description
 
     @api.model
     def _get_procurements_to_merge_groupby(self, procurement):

--- a/addons/stock/models/stock_rule.py
+++ b/addons/stock/models/stock_rule.py
@@ -350,7 +350,6 @@ class StockRule(models.Model):
         :rtype: tuple[int, list[str, str]]
         """
         delay = sum(self.filtered(lambda r: r.action in ['pull', 'pull_push']).mapped('delay'))
-        days_to_order = values.get('days_to_order', 0)
         if self.env.context.get('bypass_delay_description'):
             delay_description = []
         else:
@@ -359,8 +358,7 @@ class StockRule(models.Model):
                 for rule in self
                 if rule.action in ['pull', 'pull_push'] and rule.delay
             ]
-            delay_description.append((_('Days to Order'), _('+ %d day(s)', days_to_order)))
-        return delay + days_to_order, delay_description
+        return delay, delay_description
 
 
 class ProcurementGroup(models.Model):


### PR DESCRIPTION
Since https://github.com/odoo/odoo/pull/86682, when a user opens
the replenishment view, the Days to Purchase are not taken into
consideration when calculating the forecast of a product.
This was due to the fact that the Days to Purchase are now taken from the
orderpoint and not from the company settings. This is fixed by taking
the company setting if no value from the orderpoint is sent to the
method. Since the default value is different if it is a buy route or a manufacturing
route, the calculation is moved from stock to purchase_stock and mrp.

Task-ID: 2871408

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
