### PR TITLE
[FIX] core: decrement master release version

### DIFF
--- a/odoo/release.py
+++ b/odoo/release.py
@@ -12,7 +12,7 @@ RELEASE_LEVELS_DISPLAY = {ALPHA: ALPHA,
 # properly comparable using normal operators, for example:
 #  (6,1,0,'beta',0) < (6,1,0,'candidate',1) < (6,1,0,'candidate',2)
 #  (6,1,0,'candidate',2) < (6,1,0,'final',0) < (6,1,2,'final',0)
-version_info = (16, 1, 0, ALPHA, 1, '')
+version_info = (15, 5, 0, ALPHA, 1, '')
 version = '.'.join(str(s) for s in version_info[:2]) + RELEASE_LEVELS_DISPLAY[version_info[3]] + str(version_info[4] or '') + version_info[5]
 series = serie = major_version = '.'.join(str(s) for s in version_info[:2])
 


### PR DESCRIPTION
Even though the release process changed a bit, it seems that only the
MINOR version number should be incremented in the master branch until
the next major release.

This avoid confusion when writing upgrade scripts, it should work in any
case and it leaves more room from process improvement.

