### PR TITLE
[FIX] web: deploy services once in frontend 

### DIFF
--- a/addons/im_livechat/__manifest__.py
+++ b/addons/im_livechat/__manifest__.py
@@ -214,7 +214,7 @@ Help your customers with this chat, and analyse their feedback.
             'web/static/src/legacy/js/core/misc.js',
             # 'web/static/src/legacy/js/env.js',
             'web/static/src/legacy/js/fields/field_utils.js',
-            'im_livechat/static/src/public/main.js',
+            'im_livechat/static/src/public/*.js',
         ]
     },
     'license': 'LGPL-3',

--- a/addons/im_livechat/__manifest__.py
+++ b/addons/im_livechat/__manifest__.py
@@ -189,6 +189,32 @@ Help your customers with this chat, and analyse their feedback.
             'im_livechat/static/src/scss/im_livechat_bootstrap.scss',
             'im_livechat/static/src/legacy/public_livechat.scss',
             'im_livechat/static/src/legacy/public_livechat_chatbot.scss',
+
+
+            'web/static/src/core/utils/*.scss',
+
+            'mail/static/src/utils/*.js',
+            'mail/static/src/js/emojis.js',
+            'mail/static/src/component_hooks/*.js',
+            'mail/static/src/model/*.js',
+            'mail/static/src/models/*.js',
+            'im_livechat/static/src/models/*.js',
+            'mail/static/src/services/messaging_service.js',
+            # Framework JS
+            'bus/static/src/js/*.js',
+            'bus/static/src/js/services/bus_service.js',
+            'bus/static/src/js/services/legacy/legacy_bus_service.js',
+            'web/static/lib/luxon/luxon.js',
+            'web/static/src/core/**/*',
+            # FIXME: debug menu currently depends on webclient, once it doesn't we don't need to remove the contents of the debug folder
+            ('remove', 'web/static/src/core/debug/**/*'),
+            'web/static/src/env.js',
+            'web/static/src/legacy/js/core/dialog.js',
+            'web/static/src/legacy/js/core/owl_dialog.js',
+            'web/static/src/legacy/js/core/misc.js',
+            # 'web/static/src/legacy/js/env.js',
+            'web/static/src/legacy/js/fields/field_utils.js',
+            'im_livechat/static/src/public/main.js',
         ]
     },
     'license': 'LGPL-3',

--- a/addons/im_livechat/controllers/main.py
+++ b/addons/im_livechat/controllers/main.py
@@ -45,7 +45,7 @@ class LivechatController(http.Controller):
         username = kwargs.get("username", _("Visitor"))
         channel = request.env['im_livechat.channel'].sudo().browse(channel_id)
         info = channel.get_livechat_info(username=username)
-        return request.render('im_livechat.loader', {'info': info, 'web_session_required': True}, headers=[('Content-Type', 'application/javascript')])
+        return request.render('im_livechat.loader', {'info': info}, headers=[('Content-Type', 'application/javascript')])
 
     @http.route('/im_livechat/init', type='json', auth="public", cors="*")
     def livechat_init(self, channel_id):

--- a/addons/im_livechat/static/src/models/messaging.js
+++ b/addons/im_livechat/static/src/models/messaging.js
@@ -1,11 +1,15 @@
 /** @odoo-module **/
 
-import { addFields } from '@mail/model/model_core';
-import { many } from '@mail/model/model_field';
+import { addFields, patchRecordMethods } from '@mail/model/model_core';
+import { attr, many } from '@mail/model/model_field';
+import { clear } from '@mail/model/model_field_command';
 // ensure that the model definition is loaded before the patch
 import '@mail/models/messaging';
 
 addFields('Messaging', {
+    isInPublicLivechat: attr({
+        default: false,
+    }),
     /**
      * All pinned livechats that are known.
      */
@@ -13,4 +17,26 @@ addFields('Messaging', {
         inverse: 'messagingAsPinnedLivechat',
         readonly: true,
     }),
+});
+
+patchRecordMethods('Messaging', {
+     /**
+     * @override
+     */
+    async performInitRpc() {
+        if (this.isInPublicLivechat) {
+            return {};
+        } else {
+            return this._super();
+        }
+    },
+    /**
+     * @override
+     */
+    _computeNotificationHandler() {
+        if (this.isInPublicLivechat) {
+            return clear();
+        }
+        return this._super();
+    },
 });

--- a/addons/im_livechat/static/src/public/main.js
+++ b/addons/im_livechat/static/src/public/main.js
@@ -1,12 +1,13 @@
 /** @odoo-module **/
 
+import LivechatButton from '@im_livechat/legacy/widgets/livechat_button';
+import { isAvailable, options, serverUrl } from 'im_livechat.loaderData';
+
 import { messagingService } from '@mail/services/messaging_service';
 import { makeMessagingToLegacyEnv } from '@mail/utils/make_messaging_to_legacy_env';
 
 import { registry } from '@web/core/registry';
-
-// Wait for legacyEnv being set on `owl.Component.env`
-import '@web/legacy/js/public/public_root_instance';
+import rootWidget from 'root.widget';
 
 const messagingValuesService = {
     start() {
@@ -20,3 +21,13 @@ const serviceRegistry = registry.category('services');
 serviceRegistry.add('messaging', messagingService);
 serviceRegistry.add('messagingValues', messagingValuesService);
 serviceRegistry.add('messaging_service_to_legacy_env', makeMessagingToLegacyEnv(owl.Component.env));
+
+if (isAvailable) {
+    const button = new LivechatButton(
+        rootWidget,
+        serverUrl,
+        options,
+    );
+    button.appendTo(document.body);
+    window.livechat_button = button;
+}

--- a/addons/im_livechat/static/src/public/main.js
+++ b/addons/im_livechat/static/src/public/main.js
@@ -1,0 +1,22 @@
+/** @odoo-module **/
+
+import { messagingService } from '@mail/services/messaging_service';
+import { makeMessagingToLegacyEnv } from '@mail/utils/make_messaging_to_legacy_env';
+
+import { registry } from '@web/core/registry';
+
+// Wait for legacyEnv being set on `owl.Component.env`
+import '@web/legacy/js/public/public_root_instance';
+
+const messagingValuesService = {
+    start() {
+        return {
+            isInPublicLivechat: true,
+        };
+    }
+};
+
+const serviceRegistry = registry.category('services');
+serviceRegistry.add('messaging', messagingService);
+serviceRegistry.add('messagingValues', messagingValuesService);
+serviceRegistry.add('messaging_service_to_legacy_env', makeMessagingToLegacyEnv(owl.Component.env));

--- a/addons/im_livechat/static/src/public/session.js
+++ b/addons/im_livechat/static/src/public/session.js
@@ -1,0 +1,7 @@
+odoo.define('web.session', function (require) {
+
+    const Session = require('web.Session');
+    const { serverUrl } = require('im_livechat.loaderData');
+
+    return new Session(undefined, serverUrl, { use_cors: true });
+});

--- a/addons/im_livechat/views/im_livechat_channel_templates.xml
+++ b/addons/im_livechat/views/im_livechat_channel_templates.xml
@@ -91,26 +91,12 @@
         <template id="loader" name="Livechat : Javascript appending the livechat button">
             <t t-translation="off">
                 window.addEventListener('load', function () {
-                    <t t-if="web_session_required">
-                    odoo.define('web.session', function (require) {
-                        var Session = require('web.Session');
-                        var modules = odoo._modules;
-                        return new Session(undefined, "<t t-esc="info['server_url']"/>", {modules:modules, use_cors: true});
-                    });
-                    </t>
-
-                    odoo.define('im_livechat.livesupport', function (require) {
-            <t t-if="info['available']" t-translation="off">
-                        var rootWidget = require('root.widget');
-                        var LivechatButton = require('@im_livechat/legacy/widgets/livechat_button')[Symbol.for("default")];
-                        var button = new LivechatButton(
-                            rootWidget,
-                            "<t t-esc="info['server_url']"/>",
-                            <t t-out="json.dumps(info.get('options', {}))"/>
-                        );
-                        button.appendTo(document.body);
-                        window.livechat_button = button;
-            </t>
+                    odoo.define('im_livechat.loaderData', function() {
+                        return {
+                            isAvailable: <t t-esc="info['available']"/>,
+                            serverUrl: "<t t-esc="info['server_url']"/>",
+                            options: <t t-esc="json.dumps(info.get('options', {}))"/>,
+                        };
                     });
                 });
             </t>

--- a/addons/mail/static/src/models/messaging.js
+++ b/addons/mail/static/src/models/messaging.js
@@ -34,7 +34,9 @@ registerModel({
             if (!this.exists()) {
                 return;
             }
-            this.notificationHandler.start();
+            if (this.notificationHandler) {
+                this.notificationHandler.start();
+            }
             this.update({ isInitialized: true });
             this.initializedPromise.resolve();
         },
@@ -59,6 +61,15 @@ registerModel({
                 const partner = this.messaging.models['Partner'].insert({ id: partnerId });
                 return partner.getChat();
             }
+        },
+        /**
+         * @returns {Object}
+         */
+        async performInitRpc() {
+            const res = await this.messaging.rpc({
+                route: '/mail/init_messaging',
+            }, { shadow: true });
+            return res;
         },
         /**
          * Display a notification to the user.
@@ -311,6 +322,13 @@ registerModel({
         },
         /**
          * @private
+         * @returns {FieldCommand}
+         */
+        _computeNotificationHandler() {
+            return insertAndReplace();
+        },
+        /**
+         * @private
          */
         _onChangeRingingThreads() {
             if (this.ringingThreads && this.ringingThreads.length > 0) {
@@ -453,7 +471,7 @@ registerModel({
             readonly: true,
         }),
         notificationHandler: one('MessagingNotificationHandler', {
-            default: insertAndReplace(),
+            compute: '_computeNotificationHandler',
             isCausal: true,
             readonly: true,
         }),

--- a/addons/mail/static/src/models/messaging_initializer.js
+++ b/addons/mail/static/src/models/messaging_initializer.js
@@ -35,9 +35,7 @@ registerModel({
             });
             this.messaging.device.start();
             const discuss = this.messaging.discuss;
-            const data = await this.messaging.rpc({
-                route: '/mail/init_messaging',
-            }, { shadow: true });
+            const data = await this.messaging.performInitRpc();
             if (!this.exists()) {
                 return;
             }
@@ -114,7 +112,9 @@ registerModel({
                 this._initCommands();
             }
             // channels when the rest of messaging is ready
-            await this._initChannels(channels);
+            if (channels) {
+                await this._initChannels(channels);
+            }
             if (!this.exists()) {
                 return;
             }
@@ -279,9 +279,11 @@ registerModel({
                     currentUser: insert({ id: currentUserId }),
                 });
             }
-            this.messaging.update({
-                partnerRoot: insert(this.messaging.models['Partner'].convertData(partner_root)),
-            });
+            if (partner_root) {
+                this.messaging.update({
+                    partnerRoot: insert(this.messaging.models['Partner'].convertData(partner_root)),
+                });
+            }
         },
         /**
          * @private

--- a/addons/mail/static/src/models/thread_view_topbar.js
+++ b/addons/mail/static/src/models/thread_view_topbar.js
@@ -399,7 +399,10 @@ registerModel({
                 }
                 return `/mail/channel/${this.thread.id}/guest/${this.messaging.currentGuest.id}/avatar_128?unique=${this.messaging.currentGuest.name}`;
             }
-            return this.messaging.currentPartner.avatarUrl;
+            if (this.messaging.currentPartner) {
+                return this.messaging.currentPartner.avatarUrl;
+            }
+            return '';
         },
         /**
          * @private

--- a/addons/survey/__manifest__.py
+++ b/addons/survey/__manifest__.py
@@ -61,7 +61,6 @@ sent mails with personal token for the invitation of the survey.
     'assets': {
         'survey.survey_assets': [
             'web/static/lib/Chart/Chart.js',
-            'web/static/src/legacy/js/fields/field_utils.js',
             'survey/static/src/js/survey_quick_access.js',
             'survey/static/src/js/survey_timer.js',
             'survey/static/src/js/survey_breadcrumb.js',

--- a/addons/web/__manifest__.py
+++ b/addons/web/__manifest__.py
@@ -237,6 +237,7 @@ This module provides the core of the Odoo Web Client.
             'web/static/src/legacy/js/public/public_widget.js',
             'web/static/src/legacy/legacy_promise_error_handler.js',
             'web/static/src/legacy/legacy_rpc_error_handler.js',
+            'web/static/src/legacy/js/fields/field_utils.js',
 
             ('include', 'web.frontend_legacy'),
         ],

--- a/addons/web/static/src/core/errors/error_service.js
+++ b/addons/web/static/src/core/errors/error_service.js
@@ -63,7 +63,7 @@ function combineErrorNames(uncaughtError, originalError) {
  */
 async function completeUncaughtError(env, uncaughtError, originalError) {
     uncaughtError.name = combineErrorNames(uncaughtError, originalError);
-    if (env.debug.includes("assets")) {
+    if (env.debug && env.debug.includes("assets")) {
         uncaughtError.traceback = await annotateTraceback(originalError);
     } else {
         uncaughtError.traceback = formatTraceback(originalError);

--- a/addons/web/static/src/core/l10n/localization_service.js
+++ b/addons/web/static/src/core/l10n/localization_service.js
@@ -67,6 +67,9 @@ export const localizationService = {
             }
         }
 
+        if (!userLocalization) {
+            return;
+        }
         const dateFormat = strftimeToLuxonFormat(userLocalization.date_format);
         const timeFormat = strftimeToLuxonFormat(userLocalization.time_format);
         const dateTimeFormat = `${dateFormat} ${timeFormat}`;

--- a/addons/web/static/src/env.js
+++ b/addons/web/static/src/env.js
@@ -58,6 +58,7 @@ export const SERVICES_METADATA = {};
  */
 export async function startServices(env) {
     const toStart = new Set();
+    let isStartingService = false;
     serviceRegistry.addEventListener("UPDATE", async (ev) => {
         // Wait for all synchronous code so that if new services that depend on
         // one another are added to the registry, they're all present before we
@@ -74,6 +75,10 @@ export async function startServices(env) {
             const namedService = Object.assign(Object.create(service), { name });
             toStart.add(namedService);
         } else {
+            if (isStartingService) {
+                return;
+            }
+            isStartingService = true;
             await _startServices(env, toStart);
         }
     });

--- a/addons/website_livechat/__manifest__.py
+++ b/addons/website_livechat/__manifest__.py
@@ -42,6 +42,26 @@ Allow website visitors to chat with the collaborators. This module also brings a
             'im_livechat/static/src/legacy/public_livechat.scss',
             'im_livechat/static/src/legacy/public_livechat_chatbot.scss',
             'website_livechat/static/src/legacy/public_livechat.scss',
+
+            'mail/static/src/utils/*.js',
+            'mail/static/src/js/emojis.js',
+            'mail/static/src/component_hooks/*.js',
+            'mail/static/src/model/*.js',
+            'mail/static/src/models/*.js',
+            'im_livechat/static/src/models/*.js',
+            'mail/static/src/services/messaging_service.js',
+            # Framework JS
+            'bus/static/src/js/*.js',
+            'bus/static/src/js/services/bus_service.js',
+            'bus/static/src/js/services/legacy/legacy_bus_service.js',
+            'web/static/lib/luxon/luxon.js',
+            'web/static/src/core/**/*',
+            # FIXME: debug menu currently depends on webclient, once it doesn't we don't need to remove the contents of the debug folder
+            ('remove', 'web/static/src/core/debug/**/*'),
+            'web/static/src/env.js',
+            'web/static/src/legacy/js/core/misc.js',
+            # 'web/static/src/legacy/js/env.js',
+            'im_livechat/static/src/public/main.js',
         ],
         'website.assets_editor': [
             'website_livechat/static/src/js/**/*',


### PR DESCRIPTION
Before this commit, it was possible to deploy services more
than once. This happened in case the root widget was about to
deploy and start the services, and more than one service was
registering itself during a next tick.

Services must be deployed and started only once. This commit
ensures that if many services are added in this scenario, the
services are deployed and started only once.

Task-2878911