### PR TITLE
[FIX] website: start animations when the elements are on the page

### DIFF
--- a/addons/website/static/src/js/editor/snippets.options.js
+++ b/addons/website/static/src/js/editor/snippets.options.js
@@ -3093,10 +3093,10 @@ options.registry.WebsiteAnimate = options.Class.extend({
         // Trigger a DOM reflow.
         void this.$target[0].offsetWidth;
         this.$target.addClass('o_animating');
-        $scrollingElement[0].classList.add('o_wanim_overflow_x_hidden');
+        $scrollingElement[0].classList.add('o_wanim_overflow_xy_hidden');
         this.$target.css('animation-name', '');
         this.$target.one('webkitAnimationEnd oanimationend msAnimationEnd animationend', () => {
-            $scrollingElement[0].classList.remove('o_wanim_overflow_x_hidden');
+            $scrollingElement[0].classList.remove('o_wanim_overflow_xy_hidden');
             this.$target.removeClass('o_animating');
         });
     },

--- a/addons/website/static/src/scss/website.scss
+++ b/addons/website/static/src/scss/website.scss
@@ -1511,8 +1511,11 @@ ul.o_checklist > li.o_checked::after {
 .o_animate_preview {
     visibility: visible;
 }
-.o_wanim_overflow_x_hidden {
+.o_wanim_overflow_xy_hidden {
     overflow-x: hidden !important;
+    .o_footer_slideout {
+        overflow-y: hidden !important;
+    }
 }
 .o_animated_text {
     display: inline-block;


### PR DESCRIPTION
This commit ensures that the visitor can see an element before starting
its animation.

Steps to reproduce the fixed bug:
 - Enter edit mode
 - click on the footer
 - choose a slideout effect other than "Regular"
 - set an animation to an item inside the footer and select "Everytime"
 in Animation Launch

=> the element is animated only once on page load (because the footer is
actually directly in the viewport but behind the content of the page)

task-2878421
--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
