### PR TITLE
[FIX] sale: prevent wizard opening if the discount isn’t changed

### DIFF
--- a/addons/sale/static/src/js/sale_order_view.js
+++ b/addons/sale/static/src/js/sale_order_view.js
@@ -27,6 +27,7 @@ odoo.define('sale.SaleOrderView', function (require) {
         _onOpenDiscountWizard(ev) {
             const orderLines = this.renderer.state.data.order_line.data.filter(line => !line.data.display_type);
             const recordData = ev.target.recordData;
+            if (recordData.discount === orderLines[0].data.discount) return;
             const isEqualDiscount = orderLines.slice(1).every(line => line.data.discount === recordData.discount);
             if (orderLines.length >= 3 && recordData.sequence === orderLines[0].data.sequence && isEqualDiscount) {
                 Dialog.confirm(this, _t("Do you want to apply this discount to all order lines?"), {


### PR DESCRIPTION
**Steps to reproduce the bug:**
- Install rental app
- Go to the sales settings and enable the “discount” option
- Create a new rental order
- add 3 products and one of them must be rentable
- save
- edit the rental date of the rentable product

**Problem:**
A wizard that asks to apply the discount to all lines is displayed, while we have not changed the discount field

since this commit:
https://github.com/odoo/enterprise/pull/25874/commits/c934267a17e7df71f7a129c0b4cb51f56e1efe93#diff-60c63f93d325ddf63bde80d039a8805fe69b7eea99fbb87e5769178f3fc0fd93R19

When the date is modified, the discount field is reset to 0 in the modified line to avoid applying the pricelist.

Then, we check that the discount field has been modified to call the function that creates the wizard:
https://github.com/odoo/odoo/blob/696ea173d3f6cb1230444c34d6f19bc4519fda04/addons/sale/static/src/js/product_discount_widget.js#L26-L27

and as all lines have the same discount "0", the popup will be displayed: https://github.com/odoo/odoo/blob/696ea173d3f6cb1230444c34d6f19bc4519fda04/addons/sale/static/src/js/sale_order_view.js#L30

**Solution:**
Check that the first order line discount has been changed before displaying the wizard

opw-2844932

https://user-images.githubusercontent.com/78867936/172654322-339cdb50-151e-4445-a224-961020768972.mp4


--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
