### PR TITLE
[FIX] l10n_it_edi: imap seen/unseen flag more compatible


### DIFF
--- a/addons/l10n_it_edi/models/ir_mail_server.py
+++ b/addons/l10n_it_edi/models/ir_mail_server.py
@@ -65,9 +65,9 @@ class FetchmailServer(models.Model):
 
                     # To leave the mail in the state in which they were.
                     if "Seen" not in data[1].decode("utf-8"):
-                        imap_server.store(uid, '+FLAGS', '\\Seen')
+                        imap_server.uid('STORE', uid, '+FLAGS', '(\\Seen)')
                     else:
-                        imap_server.store(uid, '-FLAGS', '\\Seen')
+                        imap_server.uid('STORE', uid, '-FLAGS', '(\\Seen)')
 
                     # See details in message_process() in mail_thread.py
                     if isinstance(message, xmlrpclib.Binary):


### PR DESCRIPTION

In 64ce5b642 the usage of imagelib was changed to match the one of
general fetchmail so the flag sent to IMAP server was (\Seen) and not
\Seen which is often accepted but not always.

From recent reports, it seems that the method `uid` and `store` may have
some difference (base on using message-id rather than UID) so this
commit is reverting 64ce5b642 and using the parenthesis around the flag
explicitely.

opw-2853609
