### PR TITLE
[FIX] base: round TWD at unit's place

### DIFF
--- a/odoo/addons/base/data/res_currency_data.xml
+++ b/odoo/addons/base/data/res_currency_data.xml
@@ -1370,7 +1370,7 @@
             <field name="name">TWD</field>
             <field name="full_name">New Taiwan dollar</field>
             <field name="symbol">NT$</field>
-            <field name="rounding">0.01</field>
+            <field name="rounding">1.00</field>
             <field name="active" eval="False"/>
             <field name="currency_unit_label">Dollars</field>
             <field name="currency_subunit_label">Cents</field>


### PR DESCRIPTION
Issue:

 - Rounding should be done at the unit's place for New Taiwan dollar.

Solution:

 - Round TWD at unit's place

X-origianl-commit: f9638a7