### PR TITLE
[FIX] microsoft_calendar: fix the DateTime range

### DIFF
--- a/addons/microsoft_calendar/tests/test_microsoft_service.py
+++ b/addons/microsoft_calendar/tests/test_microsoft_service.py
@@ -38,8 +38,8 @@ class TestMicrosoftService(TransactionCase):
         self.call_without_sync_token = call(
             "/v1.0/me/calendarView/delta",
             {
-                'startDateTime': fields.Datetime.subtract(fields.Datetime.now(), years=3).strftime("%Y-%m-%dT00:00:00Z"),
-                'endDateTime': fields.Datetime.add(fields.Datetime.now(), years=3).strftime("%Y-%m-%dT00:00:00Z"),
+                'startDateTime': fields.Datetime.subtract(fields.Datetime.now(), years=2).strftime("%Y-%m-%dT00:00:00Z"),
+                'endDateTime': fields.Datetime.add(fields.Datetime.now(), years=2).strftime("%Y-%m-%dT00:00:00Z"),
             },
             {**self.header, 'Prefer': self.header_prefer},
             method="GET", timeout=DEFAULT_TIMEOUT,
@@ -224,8 +224,8 @@ class TestMicrosoftService(TransactionCase):
         mock_do_request.assert_called_with(
             "/v1.0/me/events/123/instances",
             {
-                'startDateTime': fields.Datetime.subtract(fields.Datetime.now(), years=3).strftime("%Y-%m-%dT00:00:00Z"),
-                'endDateTime': fields.Datetime.add(fields.Datetime.now(), years=3).strftime("%Y-%m-%dT00:00:00Z"),
+                'startDateTime': fields.Datetime.subtract(fields.Datetime.now(), years=2).strftime("%Y-%m-%dT00:00:00Z"),
+                'endDateTime': fields.Datetime.add(fields.Datetime.now(), years=2).strftime("%Y-%m-%dT00:00:00Z"),
             },
             {**self.header, 'Prefer': self.header_prefer},
             method='GET', timeout=DEFAULT_TIMEOUT,

--- a/addons/microsoft_calendar/utils/microsoft_calendar.py
+++ b/addons/microsoft_calendar/utils/microsoft_calendar.py
@@ -57,8 +57,8 @@ class MicrosoftCalendarService():
         }
         if not params:
             params = {
-                'startDateTime': fields.Datetime.subtract(fields.Datetime.now(), years=3).strftime("%Y-%m-%dT00:00:00Z"),
-                'endDateTime': fields.Datetime.add(fields.Datetime.now(), years=3).strftime("%Y-%m-%dT00:00:00Z"),
+                'startDateTime': fields.Datetime.subtract(fields.Datetime.now(), years=2).strftime("%Y-%m-%dT00:00:00Z"),
+                'endDateTime': fields.Datetime.add(fields.Datetime.now(), years=2).strftime("%Y-%m-%dT00:00:00Z"),
             }
 
         # get the first page of events


### PR DESCRIPTION
Before this commit, the DateTime range for getting events was six years,
while the Microsoft range limit is five years.

opw-2819858

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
