### PR TITLE
[IMP] web_tour: make tour actions dispatch native events

### DIFF
--- a/addons/web_tour/static/src/js/running_tour_action_helper.js
+++ b/addons/web_tour/static/src/js/running_tour_action_helper.js
@@ -110,7 +110,7 @@ var RunningTourActionHelper = core.Class.extend({
             values.$element.focusInEnd();
             values.$element.trigger($.Event( "keyup", {key: '_', keyCode: 95}));
         }
-        values.$element.trigger("change");
+        values.$element[0].dispatchEvent(new Event("change", { bubbles: true, cancelable: false }));
     },
     _text_blur: function (values, text) {
         this._text(values, text);


### PR DESCRIPTION
Previously, the tour action helpers were using jQuery's trigger method.
One limitation of that, is that it only calls event listeners that were
registered with jQuery itself (see
https://learn.jquery.com/events/triggering-event-handlers/)

This used to be fine as most of our event listeners used to be added
through jQuery. Considering we are now writing more and more parts of
the interface in owl, which uses native event listeners, this solution
is no longer sufficient.

This commit converts all calls to jQuery's trigger method to use
HTMLElement.dispatchEvent instead.
