### PR TITLE
[FIX] delivery: commodity product country code

### DIFF
--- a/addons/delivery/models/delivery_carrier.py
+++ b/addons/delivery/models/delivery_carrier.py
@@ -356,7 +356,7 @@ class DeliveryCarrier(models.Model):
         for line in order.order_line.filtered(lambda line: not line.is_delivery and not line.display_type):
             unit_quantity = line.product_uom._compute_quantity(line.product_uom_qty, line.product_id.uom_id)
             rounded_qty = max(1, float_round(unit_quantity, precision_digits=0))
-            country_of_origin = line.product_id.country_of_origin or order.warehouse_id.partner_id.country_id.code
+            country_of_origin = line.product_id.country_of_origin.code or order.warehouse_id.partner_id.country_id.code
             commodities.append(DeliveryCommodity(line.product_id, amount=rounded_qty, monetary_value=line.price_reduce_taxinc, country_of_origin=country_of_origin))
 
         return commodities
@@ -370,7 +370,7 @@ class DeliveryCarrier(models.Model):
             else:
                 unit_quantity = line.product_uom_id._compute_quantity(line.product_uom_qty, line.product_id.uom_id)
             rounded_qty = max(1, float_round(unit_quantity, precision_digits=0))
-            country_of_origin = line.product_id.country_of_origin or line.picking_id.picking_type_id.warehouse_id.partner_id.country_id.code
+            country_of_origin = line.product_id.country_of_origin.code or line.picking_id.picking_type_id.warehouse_id.partner_id.country_id.code
             commodities.append(DeliveryCommodity(line.product_id, amount=rounded_qty, monetary_value=line.sale_price, country_of_origin=country_of_origin))
 
         return commodities


### PR DESCRIPTION
Commodity now uses product county of origin code instead of
country of origin field directly since its a res.country model
and breaks the request if set on a product

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
