### PR TITLE
[IMP] hr_timesheet: change settings description

### DIFF
--- a/addons/hr_timesheet/views/res_config_settings_views.xml
+++ b/addons/hr_timesheet/views/res_config_settings_views.xml
@@ -81,7 +81,8 @@
                                 <label for="reminder_user_allow"/>
                                 <span class="fa fa-lg fa-building-o " title="Values set here are company-specific." groups="base.group_multi_company"/>
                                 <div class="text-muted">
-                                    Send a periodical email reminder to timesheets users
+                                    Send a periodical email reminder to timesheets users<br/>
+                                    that still have timesheets to encode
                                 </div>
                             </div>
                         </div>
@@ -93,7 +94,8 @@
                                 <label for="reminder_manager_allow"/>
                                 <span class="fa fa-lg fa-building-o " title="Values set here are company-specific." groups="base.group_multi_company"/>
                                 <div class="text-muted">
-                                    Send a periodical email reminder to timesheets managers
+                                    Send a periodical email reminder to timesheets managers<br/>
+                                    that still have timesheets to validate
                                 </div>
                             </div>
                         </div>


### PR DESCRIPTION
Change descriptions in settings:
'Employee reminder' > '...timesheets users that still have timesheets to encode'
'Manager reminder' > '... timesheets managers that still have timesheets to validate'

task-2859663

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
