### PR TITLE
[FIX] hr_timesheet_attendance: fix the timesheet attendance report

### DIFF
--- a/addons/hr_timesheet_attendance/report/hr_timesheet_attendance_report.py
+++ b/addons/hr_timesheet_attendance/report/hr_timesheet_attendance_report.py
@@ -45,7 +45,7 @@ class TimesheetAttendance(models.Model):
                     NULL AS attendance,
                     ts.unit_amount AS timesheet,
                     ts.date AS date,
-                    NULL AS company_id
+                    ts.company_id AS company_id
                 FROM account_analytic_line AS ts
                 WHERE ts.project_id IS NOT NULL
             ) AS t


### PR DESCRIPTION
Attendance report is calculated from the timesheets of all the companies
when multi-company is enabled but only one company is allowed. This commit fixes it.

Steps to reproduce:
 - Create two companies
 - Create an employee with a user allowed in both companies
 - Create timesheets in both companies for that employee
 - Allow only one of the two companies
 - Check the Timesheet Attendance report -> timesheets from both companies are counted

This issue arrived from this commit:
https://github.com/odoo/odoo/commit/c69fe38b946089919c8939bbd9d1adc2602ddd2c

task-2782768