### PR TITLE
[FIX] point_of_sale: move refreshTotalDueOfPartner in correct module

### DIFF
--- a/addons/point_of_sale/static/src/js/models.js
+++ b/addons/point_of_sale/static/src/js/models.js
@@ -1001,16 +1001,6 @@ class PosGlobalState extends PosModel {
         });
         this._loadProductProduct(product);
     }
-    async refreshTotalDueOfPartner(partner) {
-        const partnerWithUpdatedTotalDue = await this.env.services.rpc({
-            model: 'res.partner',
-            method: 'search_read',
-            fields: ['total_due'],
-            domain: [['id', '=', partner.id]],
-        });
-        this.db.update_partners(partnerWithUpdatedTotalDue);
-        return partnerWithUpdatedTotalDue;
-    }
 }
 PosGlobalState.prototype.electronic_payment_interfaces = {};
 Registries.Model.add(PosGlobalState);


### PR DESCRIPTION
The function 'refreshTotalDueOfPartner' is declared in module
point_of_sale, it cannot work from there as it is using a field that
does not exist in this module, and is only called in pos_settle_due.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
