### PR TITLE
[FXI] point_of_sale: fix session closing when an invoice is refunded

### DIFF
--- a/addons/point_of_sale/models/pos_session.py
+++ b/addons/point_of_sale/models/pos_session.py
@@ -690,7 +690,7 @@ class PosSession(models.Model):
             account_id = commercial_partner.property_account_receivable_id.id
             receivable_lines = MoveLine.create(vals)
             for receivable_line in receivable_lines:
-                if (not receivable_line.reconciled):
+                if receivable_line._has_residual_to_reconcile():
                     key = (commercial_partner.id, account_id)
                     if key not in invoice_receivable_lines:
                         invoice_receivable_lines[key] = receivable_line

--- a/addons/point_of_sale/tests/test_pos_basic_config.py
+++ b/addons/point_of_sale/tests/test_pos_basic_config.py
@@ -294,6 +294,32 @@ class TestPoSBasicConfig(TestPoSCommon):
         self.assertTrue(invoice_receivable_line.reconciled)
         self.assertTrue(receivable_line.reconciled)
 
+    def test_return_order_invoiced(self):
+        self.open_new_session()
+
+        # create order
+        orders = [self.create_ui_order_data([(self.product1, 10)], payments=[(self.cash_pm, 100)], customer=self.customer, is_invoiced=True, uid='666-666-666')]
+        self.env['pos.order'].create_from_ui(orders)
+        order = self.pos_session.order_ids.filtered(lambda order: '666-666-666' in order.pos_reference)
+
+        # refund
+        order.refund()
+        refund_order = self.pos_session.order_ids.filtered(lambda order: order.state == 'draft')
+
+        # pay the refund
+        context_make_payment = {"active_ids": [refund_order.id], "active_id": refund_order.id}
+        make_payment = self.env['pos.make.payment'].with_context(context_make_payment).create({
+            'payment_method_id': self.cash_pm.id,
+            'amount': -100,
+        })
+        make_payment.check()
+
+        # invoice refund
+        refund_order.action_pos_order_invoice()
+
+        # close the session -- just verify, that there are no errors
+        self.pos_session.action_pos_session_validate()
+
     def test_return_order(self):
         """ Test return order
 


### PR DESCRIPTION
Definition of reconciled line is recently changed [1] and draft records are not
marked as reconciled anymore. However POS session closing still needs old
definition of reconciled line, because state of the related journal entry is
still draft and hence `reconciled` value is always equal to `False`.

Fix it by making small refactoring and using old definition of the `reconciled` field.

STEPS

1. POS -> Open Session -> Order -> Invoiced
2. Backend -> Open Order - Return Products -> Payment -> Invoiced

BEFORE: error *You are trying to reconcile some entries that are already
reconciled.*
AFTER: POS Session is closed successfully

opw-2859747
