### PR TITLE
[FIX] website: fix / optimize canonical url

### DIFF
--- a/addons/website/models/website.py
+++ b/addons/website/models/website.py
@@ -988,7 +988,14 @@ class Website(models.Model):
             path = urls.url_quote_plus(request.httprequest.path, safe='/')
         lang_path = ('/' + lang.url_code) if lang != self.default_lang_id else ''
         canonical_query_string = '?%s' % urls.url_encode(canonical_params) if canonical_params else ''
-        return self.get_base_url() + lang_path + path + canonical_query_string
+
+        if lang_path and path == '/':
+            # We want `/fr_BE` not `/fr_BE/` for correct canonical on homepage
+            localized_path = lang_path
+        else:
+            localized_path = lang_path + path
+
+        return self.get_base_url() + localized_path + canonical_query_string
 
     def _get_canonical_url(self, canonical_params):
         """Returns the canonical URL for the current request."""

--- a/addons/website/tests/test_base_url.py
+++ b/addons/website/tests/test_base_url.py
@@ -62,4 +62,4 @@ class TestBaseUrl(TestUrlCommon):
         self._assertCanonical('/?debug=1', self.domain + '/')
         self._assertCanonical('/a-page', self.domain + '/a-page')
         self._assertCanonical('/en_US', self.domain + '/')
-        self._assertCanonical('/fr_FR', self.domain + '/fr/')
+        self._assertCanonical('/fr_FR', self.domain + '/fr')

--- a/addons/website/tests/test_lang_url.py
+++ b/addons/website/tests/test_lang_url.py
@@ -20,7 +20,7 @@ class TestLangUrl(HttpCase):
 
     def test_01_url_lang(self):
         with MockRequest(self.env, website=self.website):
-            self.assertEqual(url_lang('', '[lang]'), '/[lang]/hello/', "`[lang]` is used to be replaced in the url_return after installing a language, it should not be replaced or removed.")
+            self.assertEqual(url_lang('', '[lang]'), '/[lang]/hello', "`[lang]` is used to be replaced in the url_return after installing a language, it should not be replaced or removed.")
 
     def test_02_url_redirect(self):
         url = '/fr_WHATEVER/contactus'

--- a/addons/website/tools.py
+++ b/addons/website/tools.py
@@ -90,7 +90,7 @@ def MockRequest(
         env=env,
         httprequest=Mock(
             host='localhost',
-            path='/hello/',
+            path='/hello',
             app=odoo.http.root,
             environ={'REMOTE_ADDR': '127.0.0.1'},
             cookies=cookies or {},

--- a/addons/website/views/website_templates.xml
+++ b/addons/website/views/website_templates.xml
@@ -103,13 +103,14 @@
             </t>
         </t>
 
-        <t t-if="request and request.is_frontend_multilang and website">
+        <!-- `alternate`/`canonical` mainly useful to crawlers/bots/SEO tools, which test the website as public user -->
+        <t t-if="request and request.is_frontend_multilang and website and website.is_public_user()">
             <t t-set="alternate_languages" t-value="website._get_alternate_languages(canonical_params=canonical_params)"/>
             <t t-foreach="alternate_languages" t-as="lg">
                 <link rel="alternate" t-att-hreflang="lg['hreflang']" t-att-href="lg['href']"/>
             </t>
         </t>
-        <link t-if="request and website" rel="canonical" t-att-href="website._get_canonical_url(canonical_params=canonical_params)"/>
+        <link t-if="request and website and website.is_public_user()" rel="canonical" t-att-href="website._get_canonical_url(canonical_params=canonical_params)"/>
 
         <link rel="preconnect" href="https://fonts.gstatic.com/" crossorigin=""/>
     </xpath>


### PR DESCRIPTION
Homepage was never considered as canonical due to the trailing /
domain.com/fr/ != domain.com/fr

Now _get_canonical_url_localized for homepage is fixed.

Remove all computation related to canonical that is usless for connected user.
(fwd-port of #88011)
