### PR TITLE
[FIX] web_editor: delete range while keeping space

### DIFF
--- a/addons/web_editor/static/lib/odoo-editor/src/OdooEditor.js
+++ b/addons/web_editor/static/lib/odoo-editor/src/OdooEditor.js
@@ -49,6 +49,8 @@ import {
     unwrapContents,
     peek,
     rightPos,
+    prepareUpdate,
+    boundariesOut,
 } from './utils/utils.js';
 import { editorCommands } from './commands/commands.js';
 import { Powerbox } from './powerbox/Powerbox.js';
@@ -1333,7 +1335,9 @@ export class OdooEditor extends EventTarget {
             closestBlock(end) !== closestBlock(range.commonAncestorContainer) ;
         let next = nextLeaf(end, this.editable);
         const splitEndTd = closestElement(end, 'td') && end.nextSibling;
+        const restore = prepareUpdate(...boundariesOut(range.startContainer), ...boundariesOut(range.endContainer));
         const contents = range.extractContents();
+        restore();
         setSelection(start, nodeSize(start));
         range = getDeepRange(this.editable, { sel });
         // Restore unremovables removed by extractContents.


### PR DESCRIPTION
Before this commit, whenever the user removed a word at the end of a
paragraph, if a space was at the end of the new paragraph, the space
was also removed but shouldn't.

task-2809312





--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
