### PR TITLE
[FIX] hr_holidays: fix  error with serbian localization

### DIFF
--- a/addons/hr_holidays/static/src/bugfix/bugfix.js
+++ b/addons/hr_holidays/static/src/bugfix/bugfix.js
@@ -53,7 +53,10 @@ registerInstancePatchModel('mail.partner', 'hr_holidays/static/src/models/partne
         if (currentDate.getFullYear() !== date.getFullYear()) {
             options.year = 'numeric';
         }
-        const localeCode = this.env.messaging.locale.language.replace(/_/g,'-');
+        let localeCode = this.env.messaging.locale.language.replace(/_/g,'-');
+        if (localeCode == "sr@latin") {
+            localeCode = "sr-Latn-RS";
+        }
         const formattedDate = date.toLocaleDateString(localeCode, options);
         return _.str.sprintf(this.env._t("Out of office until %s"), formattedDate);
     },


### PR DESCRIPTION
STEPS:
* switch to serbian language
* start chat with a user who is out of office
* refresh page

BEFORE: Incorrect locale information provided
AFTER: no errors

Similar change for web module in v15: https://github.com/odoo/odoo/commit/1bb9cb89c8b5b5c55299afd3c53df14c3aea5ee7

opw-2859402

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
