### PR TITLE
[FIX] stock,mrp: render control panel components

### DIFF
--- a/addons/mrp/static/src/js/mrp_bom_report.js
+++ b/addons/mrp/static/src/js/mrp_bom_report.js
@@ -130,6 +130,13 @@ var MrpBomReport = stock_report_generic.extend({
         };
         return this.updateControlPanel(status);
     },
+    getControlPanelProps: function() {
+        this.renderSearch();
+        return {
+            $buttons: this.$buttonsPanel,
+            $searchview: this.$searchView
+        }
+    },
     renderSearch: function () {
         this.$buttonsPanel = $(QWeb.render('mrp.button', {'is_variant_applied': this.data.is_variant_applied}));
         this.$buttonsPanel.find('.o_mrp_bom_print').on('click', this._onClickPrint.bind(this));

--- a/addons/stock/static/src/js/stock_traceability_report_backend.js
+++ b/addons/stock/static/src/js/stock_traceability_report_backend.js
@@ -48,9 +48,13 @@ var stock_report_generic = AbstractAction.extend({
         });
     },
     start: async function() {
-        this.controlPanelProps.cp_content = { $buttons: this.$buttons };
+        const props = this.getControlPanelProps();
+        this.controlPanelProps.cp_content = props;
         await this._super(...arguments);
         this.set_html();
+    },
+    getControlPanelProps: function() {
+        return { $buttons: this.$buttons }
     },
     // Fetches the html and is previous report.context if any, else create it
     get_html: async function() {


### PR DESCRIPTION
Since 362f6b6d5bc45b4361414334ad8ea662868d81a6, the control panel of an
action can be rendered only the first time the dom is mounted. Any
further remount won't rerenders do anything. The bom report needs to add
some buttons and a searchView. Previously, those widgets was mounted in
the set_html _after_ the first mount of the controlPanel. This report is
an extend of the stock traceability which also adds some buttons. In
this case the buttons are rendered correctly because they are added
_before_ the first controlPanel mount.

This commit makes the extra widgets to be rendered in the control panel
generated in a new specific method overridable in the bom report file

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
