### PR TITLE
[FIX] mrp: remove `immediate_transfer` key on MO creation

### DIFF
--- a/addons/mrp/models/stock_picking.py
+++ b/addons/mrp/models/stock_picking.py
@@ -46,7 +46,10 @@ class StockPickingType(models.Model):
             remaining.count_mo_late = False
 
     def get_mrp_stock_picking_action_picking_type(self):
-        return self._get_action('mrp.mrp_production_action_picking_deshboard')
+        action = self.env.ref('mrp.mrp_production_action_picking_deshboard').read()[0]
+        if self:
+            action['display_name'] = self.display_name
+        return action
 
 class StockPicking(models.Model):
     _inherit = 'stock.picking'


### PR DESCRIPTION
**Steps to reproduce the bug:**
- Enable the `Multi-Step Routes` option in the settings
- Go to inventory > warehouses > Select 2-step manufacturing
- Go to inventory overview > Click on Manufacturing
- Create a MO > confirm
- Go to the created picking

**Problem:**
The state is “ready” instead of “waiting” because the picking is created in immediate transfer:
https://github.com/odoo/odoo/blob/fd6aa428ce7b7ab03ba920b1c020f5862f56f731/addons/stock/models/stock_picking.py#L137

So when we compute the state, as the picking is in immediate transfer and the “stock.move” is confirmed, the picking status will be `assigned`('ready')

https://github.com/odoo/odoo/blob/8c4819882011ba6bbeefe97931a26a96e60d38a3/addons/stock/models/stock_picking.py#L431

Solution:
No need to call the `get_action` function to fill the context, we can return the action directly

opw-2876050




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
