### PR TITLE
[FIX] knowledge: make restricted articles break the heritage chain

### DIFF
--- a/addons/knowledge/tests/common.py
+++ b/addons/knowledge/tests/common.py
@@ -206,6 +206,7 @@ class KnowledgeArticlePermissionsCase(KnowledgeCommon):
         #   - Readonly            read    (+manager-write)
         #   - Writable            " (w)   (+portal-read)
         #     - Writable child    " (w)
+        #       - Child           "
         #     - Nyarlathotep      DESYNC  read, manager-write
         #       - Child           "
         # READABLE ROOT           read    (+manager-write)
@@ -311,6 +312,11 @@ class KnowledgeArticlePermissionsCase(KnowledgeCommon):
         cls.article_write_contents_children = cls.env['knowledge.article'].create([
             {'name': 'Child of writable through inheritance',
              'parent_id': cls.article_write_contents[2].id,
+            },
+        ])
+        cls.article_write_contents_children += cls.env['knowledge.article'].create([
+            {'name': 'Child of child of writable through inheritance',
+             'parent_id': cls.article_write_contents_children[0].id,
             },
         ])
         cls.article_write_desync = cls.env['knowledge.article'].create([

--- a/addons/knowledge/tests/test_knowledge_article_permissions.py
+++ b/addons/knowledge/tests/test_knowledge_article_permissions.py
@@ -269,12 +269,23 @@ class TestKnowledgeArticlePermissionsTools(KnowledgeArticlePermissionsCase):
                            {self.partner_employee_manager: 'write'})
 
         # remove partner employee manager that has rights based on inheritance
+        writable_children = self.article_write_contents_children.with_env(self.env)
+        for child in writable_children:
+            self.assertIn(
+                self.partner_employee_manager.id,
+                child._get_article_member_permissions()[child.id],
+                'Share Panel: if an article inherits a permission, its children should inherit that permission too')
         manager_member = writable_root.article_member_ids.filtered(lambda m: m.partner_id == self.partner_employee_manager)
         writable._remove_member(manager_member)
         self.assertTrue(writable.is_desynchronized,
                         'Permission: when removing a member having inherited rights it has be be desynchronized')
         self.assertMembers(writable, 'write',
                            {self.partner_portal: 'read'})
+        for child in writable_children:
+            self.assertNotIn(
+                self.partner_employee_manager.id,
+                child._get_article_member_permissions()[child.id],
+                'Share Panel: when removing a member having inherited rights, the member should be removed from the children that inherited that right')
 
         # resync
         writable.restore_article_access()
@@ -326,12 +337,36 @@ class TestKnowledgeArticlePermissionsTools(KnowledgeArticlePermissionsCase):
                            {self.partner_portal: 'none'})
 
         # downgrade a permission, should desynchronize from parent
+        writable_children = self.article_write_contents_children.with_env(self.env)
+        for child in writable_children:
+            self.assertEqual(
+                child._get_article_member_permissions()[child.id][self.partner_employee_manager.id]['permission'],
+                'write',
+                'Share Panel: if an article inherits a permission, its children should inherit that permission too')
+        writable_root._set_member_permission(manager_member_root, 'write')
         writable._set_member_permission(manager_member_root, 'read', is_based_on=True)
         self.assertTrue(writable.is_desynchronized,
                         'Permission: when removing a member having inherited rights it has be be desynchronized')
         self.assertMembers(writable, 'write',
                            {self.partner_portal: 'none',
                             self.partner_employee_manager: 'read'})
+        for child in writable_children:
+            self.assertEqual(
+                child._get_article_member_permissions()[child.id][self.partner_employee_manager.id]['permission'],
+                'read',
+                'Share Panel: when downgrading a member having inherited rights, the member should be downgraded from the children that inherited that right')
+
+        # adding a member to parent, should not be inherited by children
+        writable_root._add_members(self.partner_employee2, 'read')
+        self.assertNotIn(
+            self.partner_employee2.id,
+            writable._get_article_member_permissions()[writable.id],
+            'Share Panel: when adding a member on a parent of a desynced article, the member should not be added on the desynced article')
+        for child in writable_children:
+            self.assertNotIn(
+                self.partner_employee2.id,
+                child._get_article_member_permissions()[child.id],
+                'Share Panel: when adding a member on a parent of a desynced article, the member should not be added on the children of the desynced article')
 
     @mute_logger('odoo.addons.base.models.ir_rule')
     @users('employee')


### PR DESCRIPTION
Description of the issue:
=========================

Suppose we have 3 articles with the following structure:

root
 L child
   L grand child

When granting the "write" permission to a user in "root", this user
will inherit this permission in "child" and in "grand child".
When we then restrict this user with the "no access" permission in
child, this permission is inherited by grand-child (correct).
However, the "internal member" permission in "grand child" is still
inherited from "root" (incorrect: should be inherited from "child" as
well, as "child" is now desynchronized from "root").
Then, when a member is invited in the root article, the right is not
herited by "child" nor "grand child" (correct). However, this
permission is shown as being inherited from "root" in the permission
panel in "grand child" (incorrect: "grand child" does not have this
permission, and is in fact inherited from "child" as expected).

Solution:
=========
1. Add 'parent_id.inherited_permission_parent_id' as field on which
    "_compute_inherited_permission" depends on, so that the "internal
    member" permission is correctly updated when restricting a user
    in an article in which his permission was inherited from a parent
    article.

2. Add the boolean "article_is_desynchronized" check in the inner
    join condition of the recursive SQL request used to fetch the
    permissions of an article and its parents.
    This boolean check allows to prune the recursion when an article
    is desynchronized, so that the permissions of the parents of this
    desynchronized article are not fetched, since they are not
    inherited in the desynchronized articles nor in its children.

Some tests have been added to ensure the correct behaviour of the
share panel and internal permission inheritance. Especially, the
scenarios described in the description of the issue are checked.

Task-2866950
