### PR TITLE
[15.0] FIX duplicated-demo-product data

### DIFF
--- a/addons/sale/data/product_product_demo.xml
+++ b/addons/sale/data/product_product_demo.xml
@@ -105,10 +105,6 @@
             <field name="invoice_policy">delivery</field>
         </record>
 
-        <record id="product.product_product_4d" model="product.product">
-            <field name="invoice_policy">delivery</field>
-        </record>
-
         <record id="product.product_product_4c" model="product.product">
             <field name="invoice_policy">delivery</field>
         </record>


### PR DESCRIPTION
Description of the issue/feature this PR addresses: remove duplicate data

Current behavior before PR: duplicate data in product_product_demo cause `WARNING <db_name> odoo.modules.loading: Module sale demo data failed to instal`

Desired behavior after PR is merged: 




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
