### PR TITLE
[FIX] web: adapt Set Defaults dialog w.r.t. owl 2

### DIFF
--- a/addons/web/static/src/core/debug/debug_menu_items.xml
+++ b/addons/web/static/src/core/debug/debug_menu_items.xml
@@ -2,7 +2,7 @@
 <templates xml:space="preserve">
 
     <t t-name="web.DebugMenu.SetDefaultFooter" owl="1">
-        <button class="btn btn-secondary" t-on-click="() => this.trigger('dialog-closed')">Close</button>
+        <button class="btn btn-secondary" t-on-click="props.close">Close</button>
         <button class="btn btn-secondary" t-on-click="saveDefault">Save default</button>
     </t>
 
@@ -18,8 +18,7 @@
                 <td class="oe_form_required">
                     <select id="formview_default_fields" class="o_input" t-model="state.fieldToSet">
                         <option value=""/>
-                        <option t-foreach="defaultFields" t-as="field"
-                                t-att-value="field.name">
+                        <option t-foreach="defaultFields" t-as="field" t-att-value="field.name" t-key="field.name">
                             <t t-esc="field.string"/> = <t t-esc="field.displayed"/>
                         </option>
                     </select>
@@ -35,8 +34,7 @@
                 <td>
                     <select id="formview_default_conditions" class="o_input" t-model="state.condition">
                         <option value=""/>
-                        <option t-foreach="conditions" t-as="cond"
-                                t-att-value="cond.name + '=' + cond.value">
+                        <option t-foreach="conditions" t-as="cond" t-att-value="cond.name + '=' + cond.value" t-key="cond.name">
                             <t t-esc="cond.string"/>=<t t-esc="cond.displayed"/>
                         </option>
                     </select>

--- a/addons/web/static/src/legacy/debug_manager.js
+++ b/addons/web/static/src/legacy/debug_manager.js
@@ -185,7 +185,7 @@ class SetDefaultDialog extends Dialog {
             true,
             this.state.condition || false,
         ]);
-        this.trigger("dialog-closed");
+        this.props.close();
     }
 }
 SetDefaultDialog.bodyTemplate = "web.DebugMenu.setDefaultBody";
@@ -194,7 +194,7 @@ SetDefaultDialog.title = _lt("Set Default");
 
 // Form view items
 
-function setDefaults({ action, component, env }) {
+export function setDefaults({ action, component, env }) {
     return {
         type: "item",
         description: env._t("Set Defaults"),

--- a/addons/web/static/tests/core/debug/debug_manager_tests.js
+++ b/addons/web/static/tests/core/debug/debug_manager_tests.js
@@ -22,11 +22,13 @@ import {
     getFixture,
     legacyExtraNextTick,
     mount,
+    nextTick,
     patchWithCleanup,
 } from "../../helpers/utils";
 import { createWebClient, doAction, getActionManagerServerData } from "../../webclient/helpers";
 import { openViewItem } from "@web/webclient/debug_items";
 import { editSearchView, editView } from "@web/views/debug_items";
+import { setDefaults } from "@web/legacy/debug_manager";
 
 const { Component, xml } = owl;
 
@@ -493,4 +495,158 @@ QUnit.module("DebugMenu", (hooks) => {
             assert.containsNone(target, ".o_debug_manager .dropdown-item");
         }
     );
+
+    QUnit.test("set defaults: basic rendering", async (assert) => {
+        prepareRegistriesWithCleanup();
+        patchWithCleanup(odoo, {
+            debug: true,
+        });
+
+        registry.category("services").add("user", makeFakeUserService());
+        registry.category("debug").category("form").add("setDefaults", setDefaults);
+
+        const serverData = getActionManagerServerData();
+        serverData.actions[1234] = {
+            id: 1234,
+            xml_id: "action_1234",
+            name: "Partners",
+            res_model: "partner",
+            res_id: 1,
+            type: "ir.actions.act_window",
+            views: [[18, "form"]],
+        };
+        serverData.views["partner,18,form"] = `
+            <form>
+                <field name="m2o"/>
+                <field name="foo"/>
+                <field name="o2m"/>
+            </form>`;
+        serverData.models["ir.ui.view"] = {
+            fields: {},
+            records: [{ id: 18 }],
+        };
+        serverData.models.partner.fields.m2o.depends = [];
+        serverData.models.partner.fields.foo.depends = [];
+        serverData.models.partner.fields.o2m.depends = [];
+        serverData.models.partner.records = [{ id: 1, display_name: "p1", foo: "hello" }];
+
+        const mockRPC = async (route, args) => {
+            if (args.method === "check_access_rights") {
+                return Promise.resolve(true);
+            }
+        };
+        const webClient = await createWebClient({ serverData, mockRPC });
+        await doAction(webClient, 1234);
+        await click(target.querySelector(".o_debug_manager button"));
+        await click(target.querySelector(".o_debug_manager .dropdown-item"));
+        assert.containsOnce(target, ".modal");
+        assert.containsOnce(target, ".modal select#formview_default_fields");
+        assert.containsN(target.querySelector(".modal #formview_default_fields"), "option", 2);
+        const options = target.querySelectorAll(".modal #formview_default_fields option");
+        assert.strictEqual(options[0].value, "");
+        assert.strictEqual(options[1].value, "foo");
+    });
+
+    QUnit.test("set defaults: click close", async (assert) => {
+        prepareRegistriesWithCleanup();
+        patchWithCleanup(odoo, {
+            debug: true,
+        });
+
+        registry.category("services").add("user", makeFakeUserService());
+        registry.category("debug").category("form").add("setDefaults", setDefaults);
+
+        const serverData = getActionManagerServerData();
+        serverData.actions[1234] = {
+            id: 1234,
+            xml_id: "action_1234",
+            name: "Partners",
+            res_model: "partner",
+            res_id: 1,
+            type: "ir.actions.act_window",
+            views: [[18, "form"]],
+        };
+        serverData.views["partner,18,form"] = `
+            <form>
+                <field name="foo"/>
+            </form>`;
+        serverData.models["ir.ui.view"] = {
+            fields: {},
+            records: [{ id: 18 }],
+        };
+        serverData.models.partner.fields.foo.depends = [];
+        serverData.models.partner.records = [{ id: 1, display_name: "p1", foo: "hello" }];
+
+        const mockRPC = async (route, args) => {
+            if (args.method === "set" && args.model === "ir.default") {
+                throw new Error("should not create a default");
+            }
+            if (args.method === "check_access_rights") {
+                return Promise.resolve(true);
+            }
+        };
+        const webClient = await createWebClient({ serverData, mockRPC });
+        await doAction(webClient, 1234);
+        await click(target.querySelector(".o_debug_manager button"));
+        await click(target.querySelector(".o_debug_manager .dropdown-item"));
+        assert.containsOnce(target, ".modal");
+
+        await click(target.querySelector(".modal .modal-footer button"));
+        assert.containsNone(target, ".modal");
+    });
+
+    QUnit.test("set defaults: select and save", async (assert) => {
+        assert.expect(3);
+
+        prepareRegistriesWithCleanup();
+        patchWithCleanup(odoo, {
+            debug: true,
+        });
+
+        registry.category("services").add("user", makeFakeUserService());
+        registry.category("debug").category("form").add("setDefaults", setDefaults);
+
+        const serverData = getActionManagerServerData();
+        serverData.actions[1234] = {
+            id: 1234,
+            xml_id: "action_1234",
+            name: "Partners",
+            res_model: "partner",
+            res_id: 1,
+            type: "ir.actions.act_window",
+            views: [[18, "form"]],
+        };
+        serverData.views["partner,18,form"] = `
+            <form>
+                <field name="foo"/>
+            </form>`;
+        serverData.models["ir.ui.view"] = {
+            fields: {},
+            records: [{ id: 18 }],
+        };
+        serverData.models.partner.fields.foo.depends = [];
+        serverData.models.partner.records = [{ id: 1, display_name: "p1", foo: "hello" }];
+
+        const mockRPC = async (route, args) => {
+            if (args.method === "check_access_rights") {
+                return Promise.resolve(true);
+            }
+            if (args.method === "set" && args.model === "ir.default") {
+                assert.deepEqual(args.args, ["partner", "foo", "hello", true, true, false]);
+                return true;
+            }
+        };
+        const webClient = await createWebClient({ serverData, mockRPC });
+        await doAction(webClient, 1234);
+        await click(target.querySelector(".o_debug_manager button"));
+        await click(target.querySelector(".o_debug_manager .dropdown-item"));
+        assert.containsOnce(target, ".modal");
+
+        const select = target.querySelector(".modal #formview_default_fields");
+        select.value = "foo";
+        select.dispatchEvent(new Event("change"));
+        await nextTick();
+        await click(target.querySelectorAll(".modal .modal-footer button")[1]);
+        assert.containsNone(target, ".modal");
+    });
 });


### PR DESCRIPTION
This dialog hadn't been correctly adapted since the move to owl2.
As a consequence, it couldn't even open itself.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
