### PR TITLE
[FIX]l10n_eg_edi_eta: Add auto-init to avoid compute timing out

### DIFF
--- a/addons/l10n_eg_edi_eta/models/account_move.py
+++ b/addons/l10n_eg_edi_eta/models/account_move.py
@@ -5,6 +5,7 @@ import json
 
 from odoo import api, models, fields, _
 from odoo.exceptions import ValidationError, UserError
+from odoo.tools.sql import column_exists, create_column
 from datetime import datetime
 
 _logger = logging.getLogger(__name__)
@@ -18,6 +19,13 @@ class AccountMove(models.Model):
     l10n_eg_eta_json_doc_id = fields.Many2one('ir.attachment', copy=False)
     l10n_eg_signing_time = fields.Datetime('Signing Time', copy=False)
     l10n_eg_is_signed = fields.Boolean(copy=False)
+
+    def _auto_init(self):
+        if not column_exists(self.env.cr, "account_move", "l10n_eg_uuid"):
+            create_column(self.env.cr, "account_move", "l10n_eg_uuid", "VARCHAR")
+            # Since l10n_eg_uuid columns does not exist we can assume l10n_eg_submission_number doesn't exist either
+            create_column(self.env.cr, "account_move", "l10n_eg_submission_number", "VARCHAR")
+        return super()._auto_init()
 
     @api.depends('l10n_eg_eta_json_doc_id.raw')
     def _compute_eta_response_data(self):


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
On installation, _compute_eta_response_data may cause a time out in databases with high number of account.move records
Current behavior before PR:
_compute_eta_response_data causes time out when account.move > 350k
Desired behavior after PR is merged:
_compute_eta_response_data no longer causing time out on installation



--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
