### PR TITLE
[FIX] rating: flush rating values before computing rating_last_value

### DIFF
--- a/addons/rating/models/rating_mixin.py
+++ b/addons/rating/models/rating_mixin.py
@@ -29,6 +29,7 @@ class RatingMixin(models.AbstractModel):
     def _compute_rating_last_value(self):
         # Pure SQL instead of calling read_group to allow ordering array_agg
         self.flush(['rating_ids'])
+        self.env['rating.rating'].flush(['consumed', 'rating'])
         if not self.ids:
             self.rating_last_value = 0
             return

--- a/addons/test_mail_full/tests/test_rating.py
+++ b/addons/test_mail_full/tests/test_rating.py
@@ -5,16 +5,14 @@ from datetime import datetime
 
 from odoo.addons.test_mail_full.tests.common import TestMailFullCommon, TestMailFullRecipients
 from odoo.tests import tagged
-from odoo.tests.common import users, warmup
+from odoo.tests.common import HttpCase, users, warmup
 from odoo.tools import mute_logger
 
 
-@tagged('rating')
-class TestRatingFlow(TestMailFullCommon, TestMailFullRecipients):
-
+class TestRatingCommon(TestMailFullCommon, TestMailFullRecipients):
     @classmethod
     def setUpClass(cls):
-        super(TestRatingFlow, cls).setUpClass()
+        super(TestRatingCommon, cls).setUpClass()
 
         cls.record_rating = cls.env['mail.test.rating'].create({
             'customer_id': cls.partner_1.id,
@@ -22,6 +20,9 @@ class TestRatingFlow(TestMailFullCommon, TestMailFullRecipients):
             'user_id': cls.user_admin.id,
         })
 
+
+@tagged('rating')
+class TestRatingFlow(TestRatingCommon):
     def test_initial_values(self):
         record_rating = self.env['mail.test.rating'].browse(self.record_rating.ids)
         self.assertFalse(record_rating.rating_ids)
@@ -74,6 +75,7 @@ class TestRatingFlow(TestMailFullCommon, TestMailFullRecipients):
         self.assertEqual(rating.feedback, 'Top Feedback')
         self.assertEqual(rating.message_id, message)
         self.assertEqual(rating.rating, 5)
+        self.assertEqual(record_rating.rating_last_value, 5)
 
         # apply a rate again (second click with feedback)
         with self.mock_mail_gateway(mail_unlink_sent=False), self.mock_mail_app():
@@ -96,6 +98,7 @@ class TestRatingFlow(TestMailFullCommon, TestMailFullRecipients):
         self.assertEqual(rating.feedback, 'Bad Feedback')
         self.assertEqual(rating.message_id, update_message)
         self.assertEqual(rating.rating, 1)
+        self.assertEqual(record_rating.rating_last_value, 1)
 
     @users('__system__')
     @warmup
@@ -126,7 +129,7 @@ class TestRatingFlow(TestMailFullCommon, TestMailFullRecipients):
             # 3713 requests if only test_mail_full is installed
             # 4110 runbot community
             # 4510 runbot enterprise
-            with self.assertQueryCount(__system__=4510):
+            with self.assertQueryCount(__system__=4511):
                 record_ratings = self.env['mail.test.rating'].create([{
                     'customer_id': partners[idx].id,
                     'name': 'Test Rating',
@@ -148,3 +151,15 @@ class TestRatingFlow(TestMailFullCommon, TestMailFullRecipients):
                 record_ratings._compute_rating_last_value()
                 vals = [val == 5 for val in record_ratings.mapped('rating_last_value')]
                 self.assertTrue(all(vals), "The last rating is kept.")
+
+
+@tagged('rating')
+class TestRatingRoutes(HttpCase, TestRatingCommon):
+    def test_open_rating_route(self):
+        access_token = self.record_rating._rating_get_access_token()
+        self.url_open(f"/rate/{access_token}/5")
+
+        rating = self.record_rating.rating_ids
+        self.assertTrue(rating.consumed)
+        self.assertEqual(rating.rating, 5)
+        self.assertEqual(self.record_rating.rating_last_value, 5)


### PR DESCRIPTION
When submitting a  rating without submitting a feedback, the value of the field "rating_last_value" is not updated, because the rating values are not yet updated in the database when the method _compute_rating_last_value is called.

Steps to reproduce
------------------

The following steps are for an helpdesk ticket, but it should behave the same way on all models implementing the rating mixin.

1. Create a ticket in a team with a stage with the default rating email template.
2. Move it to the stage with the template (it should create a rating email).
3. Use the email to submit a rating.
4. When you get to the feedback page, close it without doing anything.
5. Go to your ticket's form view => the rating you submitted correctly appears in the stat button.
6. Go back to the team, and filter tickets by "No Rating" => your ticket appears, despite having a rating.

Expected behavior
-----------------

The field "rating_last_value" should have the value of the last rating submitted.

Technical
---------

This commit adds a flush right before the SQL query in `_compute_rating_last_value` to make sure the rating values are up to date in the database before the query is executed.
It also updates the test for rating submissions to also check the rating_last_value, and creates a new test for the route currently used in the first step of a rating.

Task-2880707
