### PR TITLE
[FIX] mail: auto reload form on attachment changed through activity

### DIFF
--- a/addons/mail/static/src/components/activity/activity.js
+++ b/addons/mail/static/src/components/activity/activity.js
@@ -128,8 +128,9 @@ class Activity extends Component {
      * @param {Object} ev.detail
      * @param {mail.attachment} ev.detail.attachment
      */
-    _onAttachmentCreated(ev) {
-        this.activity.markAsDone({ attachments: [ev.detail.attachment] });
+    async _onAttachmentCreated(ev) {
+        await this.activity.markAsDone({ attachments: [ev.detail.attachment] });
+        this.trigger('o-attachments-changed');
     }
 
     /**


### PR DESCRIPTION
Before this commit the feature to auto-reload on attachment changed only worked
through composer or attachment box, now also works with "upload file" activity.