### PR TITLE
[FIX] point_of_sale: unlink move lines before creating custom ones

### DIFF
--- a/addons/point_of_sale/models/pos_order.py
+++ b/addons/point_of_sale/models/pos_order.py
@@ -1105,13 +1105,12 @@ class PosOrderLine(models.Model):
                 pickings_to_confirm.action_confirm()
                 tracked_lines = order.lines.filtered(lambda l: l.product_id.tracking != 'none')
                 lines_by_tracked_product = groupby(sorted(tracked_lines, key=lambda l: l.product_id.id), key=lambda l: l.product_id.id)
-                mls_to_unlink = self.env['stock.move.line']
                 for product, lines in lines_by_tracked_product:
                     lines = self.env['pos.order.line'].concat(*lines)
                     moves = pickings_to_confirm.move_lines.filtered(lambda m: m.product_id.id == product)
-                    mls_to_unlink |= moves.move_line_ids
+                    moves.move_line_ids.unlink()
                     moves._add_mls_related_to_order(lines, are_qties_done=False)
-                mls_to_unlink.unlink()
+                    moves._recompute_state()
         return True
 
     def _is_product_storable_fifo_avco(self):


### PR DESCRIPTION
As we are trying to create custom move lines before unlinking the
reserved ones, we can be unable to reserve the lot we need if already in
another move line.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
