### PR TITLE
[FIX] mail: don't trust attachment content-type

### DIFF
--- a/addons/test_mail/data/test_mail_data.py
+++ b/addons/test_mail/data/test_mail_data.py
@@ -1013,3 +1013,22 @@ Remote-MTA: 10.245.192.40
 
 
 --_av-UfLe6y6qxNo54-urtAxbJQ--"""
+
+
+MAIL_WRONG_CONTENT_CHARSET = """\
+Return-Path: <whatever-2a840@postmaster.twitter.com>
+To: gaston.lagaffe@example.com
+Received: by mail1.openerp.com (Postfix, from userid 10002)
+    id 5DF9ABFB2A; Fri, 10 Aug 2012 16:16:39 +0200 (CEST)
+From: spirou@example.com
+Subject: Ze Subject
+MIME-Version: 1.0
+Content-Type: multipart/alternative;
+    boundary="----=_Part_4200734_24778174.1344608186754"
+------=_Part_4200734_24778174.1344608186754
+Content-Type: text/plain; charset=US-ASCII
+Content-Transfer-Encoding: quoted-printable
+
+Tonton, ton th=C3=A9 t'a-t-il ot=C3=A9 ta toux ?
+------=_Part_4200734_24778174.1344608186754
+"""

--- a/addons/test_mail/tests/test_mail_gateway.py
+++ b/addons/test_mail/tests/test_mail_gateway.py
@@ -89,6 +89,11 @@ class TestEmailParsing(TestMailCommon):
         res = self.env['mail.thread'].message_parse(self.from_string(mail))
         self.assertIn('<pre>\nPlease call me as soon as possible this afternoon!\n\n--\nSylvie\n</pre>', res['body'])
 
+    def test_message_parse_wrong_content_charset(self):
+        mail = test_mail_data.MAIL_WRONG_CONTENT_CHARSET
+        res = self.env['mail.thread'].message_parse(self.from_string(mail))
+        self.assertIn("Tonton, ton thé t'a-t-il oté ta toux ?", res['body'])
+
     def test_message_parse_xhtml(self):
         # Test that the parsing of XHTML mails does not fail
         self.env['mail.thread'].message_parse(self.from_string(test_mail_data.MAIL_XHTML))


### PR DESCRIPTION
Some mail client send wrong content-type charset for attachments,
advertising US-ASCCI instead of UTF-8. Using `get_content()` with no
argument, python replaces the incorrect bytes by tofu (the black "?"
character).

In this commit, if the given charset is invalid, we fallback on utf-8
replacing the still incorrect characters by tofu.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
