### PR TITLE
[FIX] mail: display follower subtypes order by sequence

### DIFF
--- a/addons/mail/static/src/model/model_field_relation_set.js
+++ b/addons/mail/static/src/model/model_field_relation_set.js
@@ -68,10 +68,7 @@ export class RelationSet {
                             const valA = followRelations(a, relatedPath);
                             const valB = followRelations(b, relatedPath);
                             switch (compareMethod) {
-                                case 'defined-first': {
-                                    if (!valA && !valB) {
-                                        return 0;
-                                    }
+                                case 'truthy-first': {
                                     if (!valA) {
                                         return 1;
                                     }
@@ -81,6 +78,9 @@ export class RelationSet {
                                     break;
                                 }
                                 case 'case-insensitive-asc': {
+                                    if (typeof valA !== 'string' || typeof valB !== 'string') {
+                                        break;
+                                    }
                                     const cleanedValA = cleanSearchTerm(valA);
                                     const cleanedValB = cleanSearchTerm(valB);
                                     if (cleanedValA === cleanedValB) {
@@ -89,11 +89,25 @@ export class RelationSet {
                                     return cleanedValA < cleanedValB ? -1 : 1;
                                 }
                                 case 'smaller-first':
+                                    if (typeof valA !== 'number' || typeof valB !== 'number') {
+                                        break;
+                                    }
                                     if (valA === valB) {
                                         break;
                                     }
                                     return valA - valB;
                                 case 'greater-first':
+                                    if (typeof valA !== 'number' || typeof valB !== 'number') {
+                                        break;
+                                    }
+                                    if (valA === valB) {
+                                        break;
+                                    }
+                                    return valB - valA;
+                                case 'most-recent-first':
+                                    if (!(valA instanceof Date) || !(valB instanceof Date)) {
+                                        break;
+                                    }
                                     if (valA === valB) {
                                         break;
                                     }

--- a/addons/mail/static/src/model/model_field_relation_set.js
+++ b/addons/mail/static/src/model/model_field_relation_set.js
@@ -77,6 +77,15 @@ export class RelationSet {
                                     }
                                     break;
                                 }
+                                case 'falsy-first': {
+                                    if (!valA) {
+                                        return -1;
+                                    }
+                                    if (!valB) {
+                                        return 1;
+                                    }
+                                    break;
+                                }
                                 case 'case-insensitive-asc': {
                                     if (typeof valA !== 'string' || typeof valB !== 'string') {
                                         break;

--- a/addons/mail/static/src/models/channel.js
+++ b/addons/mail/static/src/models/channel.js
@@ -52,7 +52,7 @@ registerModel({
          */
         _sortMembers() {
             return [
-                ['defined-first', 'name'],
+                ['truthy-first', 'name'],
                 ['case-insensitive-asc', 'name'],
             ];
         },

--- a/addons/mail/static/src/models/discuss_sidebar_category.js
+++ b/addons/mail/static/src/models/discuss_sidebar_category.js
@@ -238,16 +238,16 @@ registerModel({
             switch (this.sortComputeMethod) {
                 case 'name':
                     return [
-                        ['defined-first', 'channel'],
-                        ['defined-first', 'channel.displayName'],
+                        ['truthy-first', 'channel'],
+                        ['truthy-first', 'channel.displayName'],
                         ['case-insensitive-asc', 'channel.displayName'],
                         ['smaller-first', 'channel.id'],
                     ];
                 case 'last_action':
                     return [
-                        ['defined-first', 'channel'],
-                        ['defined-first', 'channel.lastInterestDateTime'],
-                        ['greater-first', 'channel.lastInterestDateTime'],
+                        ['truthy-first', 'channel'],
+                        ['truthy-first', 'channel.lastInterestDateTime'],
+                        ['most-recent-first', 'channel.lastInterestDateTime'],
                         ['greater-first', 'channel.id'],
                     ];
             }

--- a/addons/mail/static/src/models/follower_subtype.js
+++ b/addons/mail/static/src/models/follower_subtype.js
@@ -57,6 +57,8 @@ registerModel({
         parentModel: attr(),
         // AKU FIXME: use relation instead
         resModel: attr(),
-        sequence: attr(),
+        sequence: attr({
+            default: 1,
+        }),
     },
 });

--- a/addons/mail/static/src/models/follower_subtype_list.js
+++ b/addons/mail/static/src/models/follower_subtype_list.js
@@ -49,6 +49,12 @@ registerModel({
          */
         _sortFollowerSubtypeViews() {
             return [
+                ['falsy-first', 'subtype.parentModel'],
+                ['case-insensitive-asc', 'subtype.parentModel'],
+                ['falsy-first', 'subtype.resModel'],
+                ['case-insensitive-asc', 'subtype.resModel'],
+                ['smaller-first', 'subtype.isInternal'],
+                ['smaller-first', 'subtype.sequence'],
                 ['smaller-first', 'subtype.id'],
             ];
         },

--- a/addons/mail/static/src/models/thread.js
+++ b/addons/mail/static/src/models/thread.js
@@ -1655,7 +1655,7 @@ registerModel({
          */
         _sortGuestMembers() {
             return [
-                ['defined-first', 'name'],
+                ['truthy-first', 'name'],
                 ['case-insensitive-asc', 'name'],
             ];
         },
@@ -1665,7 +1665,7 @@ registerModel({
          */
         _sortPartnerMembers() {
             return [
-                ['defined-first', 'nameOrDisplayName'],
+                ['truthy-first', 'nameOrDisplayName'],
                 ['case-insensitive-asc', 'nameOrDisplayName'],
             ];
         },


### PR DESCRIPTION
Before this fix, follower subtypes were displayed by order of id,
whereas in DiscussController.read_subscription_data(),
it was ordered by :
\- parent_mode
\- res_mode
\- internal
\- sequence

See : https://github.com/odoo/odoo/blob/fc115ebdf7c3783f9eaabba71eccce23c676d957/addons/mail/controllers/discuss.py#L471-472
In this commit, we just reproduce the same order.

Also, for `parentModel` and `resModel`, we want the record
with their values unset to come first.
We added 'undefined-first',
as this sort order might be needed for other models.

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
