### PR TITLE
[IMP] hr_expense: Disable quick creation of taxes.

### DIFF
--- a/addons/hr_expense/views/hr_expense_views.xml
+++ b/addons/hr_expense/views/hr_expense_views.xml
@@ -169,7 +169,8 @@
                                         widget="many2many_tags"
                                         attrs="{'readonly': ['|', ('is_editable', '=', False), ('product_has_cost', '=', True)],
                                                 'invisible': [('product_has_tax', '=', False)]}"
-                                        context="{'default_company_id': company_id, 'default_type_tax_use': 'purchase', 'default_price_include': 1}"/>
+                                        context="{'default_company_id': company_id, 'default_type_tax_use': 'purchase', 'default_price_include': 1}"
+                                        options="{'no_create': True}"/>
                                 </div>
                                 <div class="d-flex pt-2">
                                     <span attrs="{'invisible': [('product_has_tax', '=', False)]}" class="oe_inline o_form_label ml-1 mr-1"> ( </span>
@@ -537,7 +538,9 @@
                             </group>
                             <group string="Accounting">
                                 <field name="property_account_expense_id" groups="account.group_account_readonly"/>
-                                <field name="supplier_taxes_id" domain="[('price_include', '=', True)]" widget="many2many_tags" context="{'default_type_tax_use':'purchase'}"/>
+                                <field name="supplier_taxes_id" domain="[('price_include', '=', True)]" widget="many2many_tags" 
+                                       context="{'default_type_tax_use':'purchase', 'default_price_include': 1}" 
+                                       options="{'no_quick_create': True}"/>
                             </group>
                         </group>
                         <notebook>

--- a/addons/sale_expense/views/product_view.xml
+++ b/addons/sale_expense/views/product_view.xml
@@ -16,7 +16,8 @@
                 <field name="list_price" attrs="{'invisible':[('expense_policy', '!=', 'sales_price')]}"/>
             </xpath>
             <xpath expr="//field[@name='supplier_taxes_id']" position="after">
-                <field name="taxes_id" widget="many2many_tags" attrs="{'invisible':[('expense_policy', '=', 'no')]}"/>
+                <field name="taxes_id" widget="many2many_tags" attrs="{'invisible':[('expense_policy', '=', 'no')]}"
+                       options="{'no_quick_create': True}"/>
             </xpath>
         </field>
     </record>


### PR DESCRIPTION
Disable the (quick) creation of taxes in places where it is likely to result in faulty data entry. This forces the user to fill in new tax records consciously.

task-2860025

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
