### PR TITLE
[FIX] l10n_it_stock_ddt: apply pricelist in Delivery slip

### DIFF
--- a/addons/l10n_it_stock_ddt/report/l10n_it_ddt_report.xml
+++ b/addons/l10n_it_stock_ddt/report/l10n_it_ddt_report.xml
@@ -120,7 +120,7 @@
                                             <span t-field="move.product_uom" groups="uom.group_uom"/>
                                         </td>
                                         <td>
-                                            <t t-set="lst_price" t-value="move.product_id.lst_price * move.product_qty"/>
+                                            <t t-set="lst_price" t-value="(move.sale_line_id.price_unit if move.sale_line_id.price_unit else move.product_id.lst_price) * move.product_qty"/>
                                             <span t-esc="lst_price"  t-options='{"widget": "monetary", "display_currency": o.company_id.currency_id}'/>
                                             <t t-set="total_value" t-value="total_value + lst_price"/>
                                         </td>


### PR DESCRIPTION
To reproduce
============

- create Italian company with Italian accounting and `l10n_it_stock_ddt` module
- create Italien customer with a pricelist.
- create Quotation for this costumer conataining a product where the pricelist is applied.
- confirm it and go to delivery
- validate the delivery then print it.

prices printed are those original of the product (the pricelist is not applied)

Purpose
=======

When printing we use `move.product_id.lst_price` which is the original price of the product.

Specification
=============

to solve the issue we must use `move.price_unit` instead, which is the price after applying the pricelist.

opw-2859946