### PR TITLE
[FIX] product,*: empty group in view

### DIFF
--- a/addons/product/views/product_views.xml
+++ b/addons/product/views/product_views.xml
@@ -100,7 +100,7 @@
                         </page>
                         <page string="Sales" attrs="{'invisible':[('sale_ok','=',False)]}" name="sales" invisible="1">
                             <group name="sale">
-                                <group string="Upsell &amp; Cross-Sell" name="upsell"/>
+                                <group string="Upsell &amp; Cross-Sell" name="upsell" invisible="1"/>
                             </group>
                             <group>
                                 <group string="Sales Description" name="description">

--- a/addons/sale_product_configurator/views/sale_views.xml
+++ b/addons/sale_product_configurator/views/sale_views.xml
@@ -5,6 +5,9 @@
         <field name="model">product.template</field>
         <field name="inherit_id" ref="product.product_template_form_view"/>
         <field name="arch" type="xml">
+            <group name="upsell" position="attributes">
+                <attribute name="invisible">0</attribute>
+            </group>
             <group name="upsell" position="inside">
                 <field name="optional_product_ids"
                     widget="many2many_tags"

--- a/addons/website_sale/views/product_views.xml
+++ b/addons/website_sale/views/product_views.xml
@@ -133,6 +133,9 @@
             <div name="button_box" position="inside">
                 <field name="is_published" widget="website_redirect_button" attrs="{'invisible': [('sale_ok','=',False)]}"/>
             </div>
+            <group name="upsell" position="attributes">
+                <attribute name="invisible">0</attribute>
+            </group>
             <xpath expr="//group[@name='upsell']" position="inside">
                 <field name="accessory_product_ids" widget="many2many_tags" attrs="{'invisible': [('sale_ok','=',False)]}"
                        placeholder="Suggested accessories in the eCommerce cart"/>


### PR DESCRIPTION
Since #75862, the group "Upsell & Cross Sell" was shown in the "Sales"
tab of the product views, even if empty (its content is only defined in modules
sale_product_configurator & website_sale).

This commit makes sure that the group is invisible while it has no content.





--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
