### PR TITLE
[FIX] mail: properly await createThreadViewComponent

### DIFF
--- a/addons/mail/static/src/components/thread_view/thread_view_tests.js
+++ b/addons/mail/static/src/components/thread_view/thread_view_tests.js
@@ -735,9 +735,7 @@ QUnit.test('basic rendering of canceled notification', async function (assert) {
     });
     await this.afterEvent({
         eventName: 'o-thread-view-hint-processed',
-        func: () => {
-            this.createThreadViewComponent(threadViewer.threadView);
-        },
+        func: () => this.createThreadViewComponent(threadViewer.threadView),
         message: "thread become loaded with messages",
         predicate: ({ hint, threadViewer }) => {
             return (
@@ -968,9 +966,7 @@ QUnit.test("delete all attachments of message without content should no longer d
     // wait for messages of the thread to be loaded
     await this.afterEvent({
         eventName: 'o-thread-view-hint-processed',
-        func: () => {
-            this.createThreadViewComponent(threadViewer.threadView);
-        },
+        func: () => this.createThreadViewComponent(threadViewer.threadView),
         message: "thread become loaded with messages",
         predicate: ({ hint, threadViewer }) => {
             return (
@@ -1026,9 +1022,7 @@ QUnit.test('delete all attachments of a message with some text content should st
     // wait for messages of the thread to be loaded
     await this.afterEvent({
         eventName: 'o-thread-view-hint-processed',
-        func: () => {
-            this.createThreadViewComponent(threadViewer.threadView);
-        },
+        func: () => this.createThreadViewComponent(threadViewer.threadView),
         message: "thread become loaded with messages",
         predicate: ({ hint, threadViewer }) => {
             return (
@@ -1091,9 +1085,7 @@ QUnit.test('delete all attachments of a message with tracking fields should stil
     // wait for messages of the thread to be loaded
     await this.afterEvent({
         eventName: 'o-thread-view-hint-processed',
-        func: () => {
-            this.createThreadViewComponent(threadViewer.threadView);
-        },
+        func: () => this.createThreadViewComponent(threadViewer.threadView),
         message: "thread become loaded with messages",
         predicate: ({ hint, threadViewer }) => {
             return (
@@ -1527,9 +1519,7 @@ QUnit.test('show empty placeholder when thread contains no message', async funct
     });
     await this.afterEvent({
         eventName: 'o-thread-view-hint-processed',
-        func: () => {
-            this.createThreadViewComponent(threadViewer.threadView);
-        },
+        func: () => this.createThreadViewComponent(threadViewer.threadView),
         message: "should wait until thread becomes loaded with messages",
         predicate: ({ hint, threadViewer }) => {
             return (
@@ -1571,9 +1561,7 @@ QUnit.test('show empty placeholder when thread contains only empty messages', as
     });
     await this.afterEvent({
         eventName: 'o-thread-view-hint-processed',
-        func: () => {
-            this.createThreadViewComponent(threadViewer.threadView);
-        },
+        func: () => this.createThreadViewComponent(threadViewer.threadView),
         message: "thread become loaded with messages",
         predicate: ({ hint, threadViewer }) => {
             return (
@@ -1620,9 +1608,7 @@ QUnit.test('message with subtype should be displayed (and not considered as empt
     });
     await this.afterEvent({
         eventName: 'o-thread-view-hint-processed',
-        func: () => {
-            this.createThreadViewComponent(threadViewer.threadView);
-        },
+        func: () => this.createThreadViewComponent(threadViewer.threadView),
         message: "should wait until thread becomes loaded with messages",
         predicate: ({ hint, threadViewer }) => {
             return (
@@ -1675,9 +1661,7 @@ QUnit.test('[technical] message list with a full page of empty messages should s
     });
     await this.afterEvent({
         eventName: 'o-thread-view-hint-processed',
-        func: () => {
-            this.createThreadViewComponent(threadViewer.threadView, { order: 'asc' }, { isFixedSize: true });
-        },
+        func: () => this.createThreadViewComponent(threadViewer.threadView, { order: 'asc' }, { isFixedSize: true }),
         message: "should wait until thread becomes loaded with messages",
         predicate: ({ hint, threadViewer }) => {
             return (


### PR DESCRIPTION
Inner `afterNextRender` could potentially resolve/reject after the test has
already ended due to missing await (arrow function with bracket is sync).

This will prevent tests from overlapping each other.