### PR TITLE
[IMP] mail: dont patch window in patchUiSIze

### DIFF
--- a/addons/mail/static/tests/helpers/patch_ui_size.js
+++ b/addons/mail/static/tests/helpers/patch_ui_size.js
@@ -1,7 +1,7 @@
 /** @odoo-module **/
 
 import { browser } from '@web/core/browser/browser';
-import { getMediaQueryLists, MEDIAS_BREAKPOINTS, SIZES } from '@web/core/ui/ui_service';
+import { MEDIAS_BREAKPOINTS, SIZES, uiService } from '@web/core/ui/ui_service';
 import { patchWithCleanup } from "@web/../tests/helpers/utils";
 
 import config from 'web.config';
@@ -87,15 +87,14 @@ function patchUiSize({ height, size, width }) {
     }
     size = size === undefined ? getSizeFromWidth(width) : size;
     width = width || getWidthFromSize(size);
-    const MEDIAS = getMediaQueryLists();
 
     patchWithCleanup(browser, {
         innerWidth: width,
         innerHeight: height || browser.innerHeight,
     });
-    patchWithCleanup(window.MediaQueryList.prototype, {
-        get matches() {
-            return this.media === MEDIAS[size].media;
+    patchWithCleanup(uiService, {
+        getSize() {
+            return size;
         },
     });
     legacyPatchUiSize(height, size, width);

--- a/addons/web/static/src/core/ui/ui_service.js
+++ b/addons/web/static/src/core/ui/ui_service.js
@@ -67,7 +67,13 @@ export const MEDIAS_BREAKPOINTS = [
     });
 }
 
+// window size handling.
+const MEDIAS = getMediaQueryLists();
+
 export const uiService = {
+    getSize() {
+        return MEDIAS.findIndex(media => media.matches);
+    },
     start(env) {
         let ui = {};
 
@@ -137,20 +143,14 @@ export const uiService = {
             },
         });
 
-        // window size handling
-        const MEDIAS = getMediaQueryLists();
-        function getSize() {
-            return MEDIAS.findIndex((media) => media.matches);
-        }
-
         // listen to media query status changes
         function updateSize() {
-            ui.size = getSize();
+            ui.size = this.getSize();
         }
-        browser.addEventListener("resize", debounce(updateSize, 100));
+        browser.addEventListener("resize", debounce(updateSize.bind(this), 100));
 
         Object.assign(ui, {
-            size: getSize(),
+            size: this.getSize(),
         });
         Object.defineProperty(ui, "isSmall", {
             get() {


### PR DESCRIPTION
Patching the window object is not robust and can lead to errors.
In order to make patchUiSize more robust, patching of window have
been replaced by a patch of the uiService.