### PR TITLE
Created 3 helper method for the _post() method

### DIFF
--- a/addons/account/models/account_move.py
+++ b/addons/account/models/account_move.py
@@ -2947,6 +2947,10 @@ class AccountMove(models.Model):
                 move.date = move._get_accounting_date(move.invoice_date or move.date, affects_tax_report)
                 move.with_context(check_move_validity=False)._onchange_currency()
 
+    def _post_check_localization(self):
+        """Individual checks on accounting localizations can be placed here.
+        """
+        return
 
     def post(self):
         warnings.warn(
@@ -3024,6 +3028,9 @@ class AccountMove(models.Model):
 
             # When the accounting date is prior to a lock date, change it automatically upon posting.
             move._post_check_lock_date()
+
+            # Other localization checks
+            move._post_check_localization()
 
         # Create the analytic lines in batch is faster as it leads to less cache invalidation.
         to_post.mapped('line_ids').create_analytic_lines()


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
Created 3 helper method for the _post() method:

**_post_check_invoice_non_negative**: moved a check outside from the post(), to be able to overwritten by any accounting localization. (In hungary we need to disable this.)

**_post_check_lock_date**: moved the accounting date modification outside from the post(), to be able to overwritten by any accounting localization. (In hungary we need to disable this.)

**_post_check_localization**: created an empty method to be used in any accounting localization to be super easy to create invoice checks during the posting.

Current behavior before PR:
For the hungarian localization we need to adjust the operation of the _post() method. There are two things what needs to be disabled. But it is not easy to implement these without the complete monkey patch of the _post() method.

Desired behavior after PR is merged:
Accounting localizations should be more easy to implement.



--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
