### PR TITLE
[FIX] mrp,stock: UI fixes

### DIFF
--- a/addons/mrp/data/mrp_demo.xml
+++ b/addons/mrp/data/mrp_demo.xml
@@ -274,7 +274,6 @@
             <field name="product_uom_id" ref="uom.product_uom_unit"/>
             <field name="sequence">3</field>
             <field name="bom_id" ref="mrp_bom_desk"/>
-            <field name="operation_id" ref="mrp.mrp_routing_workcenter_5"/>
         </record>
 
         <record id="mrp_bom_desk_line_4" model="mrp.bom.line">
@@ -283,7 +282,6 @@
             <field name="product_uom_id" ref="uom.product_uom_unit"/>
             <field name="sequence">4</field>
             <field name="bom_id" ref="mrp_bom_desk"/>
-            <field name="operation_id" ref="mrp.mrp_routing_workcenter_5"/>
         </record>
 
         <!-- Table MO -->

--- a/addons/mrp/i18n/mrp.pot
+++ b/addons/mrp/i18n/mrp.pot
@@ -77,12 +77,6 @@ msgid "%s %s unbuilt in"
 msgstr ""
 
 #. module: mrp
-#: code:addons/mrp/models/mrp_routing.py:0
-#, python-format
-msgid "%s (copy)"
-msgstr ""
-
-#. module: mrp
 #: code:addons/mrp/models/mrp_bom.py:0
 #, python-format
 msgid "%s (new) %s"
@@ -1060,7 +1054,7 @@ msgstr ""
 #: code:addons/mrp/models/mrp_production.py:0
 #, python-format
 msgid ""
-"Component Lots must be unique for mass production. Please review consumption"
+"Component Lots must be unique for mass production. Please review reservation"
 " for:\n"
 msgstr ""
 
@@ -2936,9 +2930,18 @@ msgstr ""
 #. module: mrp
 #: model:ir.model.fields,help:mrp.field_mrp_workcenter__capacity
 msgid ""
-"Number of pieces that can be produced in parallel. In case the work center "
-"has a capacity of 5 and you have to produce 10 units on your work order, the"
-" usual operation time will be multiplied by 2."
+"Number of pieces (in product UoM) that can be produced in parallel "
+" (at the same time) at this work center. For example: the capacity is 5 and "
+"you need to produce 10 units, then the operation time listed on the BOM will "
+"be multiplied by two. However, note that both time before and after production "
+"will only be counted once. "
+msgstr ""
+
+#. module: mrp
+#: model:ir.model.fields,help:mrp.field_mrp_bom__product_qty
+msgid ""
+"This should be the smallest quantity that this product can be produced in. "
+"If the BOM contains operations, make sure the work center capacity is accurate. "
 msgstr ""
 
 #. module: mrp

--- a/addons/mrp/models/mrp_bom.py
+++ b/addons/mrp/models/mrp_bom.py
@@ -42,7 +42,8 @@ class MrpBom(models.Model):
     byproduct_ids = fields.One2many('mrp.bom.byproduct', 'bom_id', 'By-products', copy=True)
     product_qty = fields.Float(
         'Quantity', default=1.0,
-        digits='Unit of Measure', required=True)
+        digits='Unit of Measure', required=True,
+        help="This should be the smallest quantity that this product can be produced in. If the BOM contains operations, make sure the work center capacity is accurate.")
     product_uom_id = fields.Many2one(
         'uom.uom', 'Unit of Measure',
         default=_get_default_product_uom_id, required=True,

--- a/addons/mrp/models/mrp_production.py
+++ b/addons/mrp/models/mrp_production.py
@@ -1982,7 +1982,7 @@ class MrpProduction(models.Model):
         if multiple_lot_components:
             if message:
                 message += "\n"
-            message += _("Component Lots must be unique for mass production. Please review consumption for:\n")
+            message += _("Component Lots must be unique for mass production. Please review reservation for:\n")
             message += "\n".join(component.name for component in multiple_lot_components)
         if message:
             raise UserError(message)

--- a/addons/mrp/models/mrp_routing.py
+++ b/addons/mrp/models/mrp_routing.py
@@ -93,7 +93,7 @@ class MrpRoutingWorkcenter(models.Model):
         if 'bom_id' in self.env.context:
             bom_id = self.env.context.get('bom_id')
             for operation in self:
-                operation.copy({'name': _("%s (copy)", operation.name), 'bom_id': bom_id})
+                operation.copy({'bom_id': bom_id})
             return {
                 'view_mode': 'form',
                 'res_model': 'mrp.bom',

--- a/addons/mrp/models/mrp_workcenter.py
+++ b/addons/mrp/models/mrp_workcenter.py
@@ -32,7 +32,7 @@ class MrpWorkcenter(models.Model):
         help="Description of the Work Center.")
     capacity = fields.Float(
         'Capacity', default=1.0,
-        help="Number of pieces that can be produced in parallel. In case the work center has a capacity of 5 and you have to produce 10 units on your work order, the usual operation time will be multiplied by 2.")
+        help="Number of pieces (in product UoM) that can be produced in parallel (at the same time) at this work center. For example: the capacity is 5 and you need to produce 10 units, then the operation time listed on the BOM will be multiplied by two. However, note that both time before and after production will only be counted once.")
     sequence = fields.Integer(
         'Sequence', default=1, required=True,
         help="Gives the sequence order when displaying a list of work centers.")

--- a/addons/mrp/views/mrp_production_views.xml
+++ b/addons/mrp/views/mrp_production_views.xml
@@ -19,7 +19,7 @@
                     <field name="product_id" readonly="1" optional="show"/>
                     <field name="lot_producing_id" optional="hide"/>
                     <field name="bom_id" readonly="1" optional="hide"/>
-                    <field name="activity_ids" string="Next Activity" widget="list_activity" optional="show" nolabel="1"/>
+                    <field name="activity_ids" string="Next Activity" widget="list_activity" optional="show"/>
                     <field name="origin" optional="show"/>
                     <field name="user_id" optional="hide" widget="many2one_avatar_user"/>
                     <field name="components_availability_state" invisible="1" options='{"lazy": true}'/>

--- a/addons/mrp/views/mrp_routing_views.xml
+++ b/addons/mrp/views/mrp_routing_views.xml
@@ -77,7 +77,7 @@
                             <group name="description">
                                 <field name="active" invisible="1"/>
                                 <field name="name"/>
-                                <field name="sequence" groups="base.group_no_one"/>
+                                <field name="sequence" invisible="1"/>
                                 <field name="bom_id" invisible="context.get('bom_id_invisible', False)" domain="[]"/>
                                 <field name="workcenter_id" context="{'default_company_id': company_id}"/>
                                 <field name="possible_bom_product_template_attribute_value_ids" invisible="1"/>

--- a/addons/stock/i18n/stock.pot
+++ b/addons/stock/i18n/stock.pot
@@ -7349,7 +7349,7 @@ msgstr ""
 #. module: stock
 #: code:addons/stock/wizard/stock_assign_serial_numbers.py:0
 #, python-format
-msgid "The number of Serial Numbers to generate must greater than zero."
+msgid "The number of Serial Numbers to generate must be greater than zero."
 msgstr ""
 
 #. module: stock

--- a/addons/stock/wizard/stock_assign_serial_numbers.py
+++ b/addons/stock/wizard/stock_assign_serial_numbers.py
@@ -26,7 +26,7 @@ class StockAssignSerialNumbers(models.TransientModel):
     def _check_next_serial_count(self):
         for wizard in self:
             if wizard.next_serial_count < 1:
-                raise ValidationError(_("The number of Serial Numbers to generate must greater than zero."))
+                raise ValidationError(_("The number of Serial Numbers to generate must be greater than zero."))
 
     def generate_serial_numbers(self):
         self.ensure_one()


### PR DESCRIPTION
Purpose of this commit to fix the UI in Manufacture app.

So, in this commit done following changes As suggested in Task:
    - Able to expand next activity column of MO list view
    - Added tooltip of capacity field on work center
    - Added quantity tooltip of BOM
    - Removed the 'copy' from the operation name when using the
      'copy existing operation' functionnality in MRP
    - In the mass produce wizard, modified error message when user indicates 0
      quantity and tries to generate SNs -> https://tinyurl.com/yjqh79vt
    - Hide sequence field from the Operation configuration ~(in pop up and form view)~
    - ~expected and real work order time columns make optional=hide in list view~
    - for the mass produce wizard, modified error message when user tries to
      trigger mass produce although several lots reserved per product
    - In demo data for the product Table 9666, removed the consumption steps
      for the bolt and the screw

TaskID - 2689994
PR - #93378