### PR TITLE
[FIX][14.0] website_forum: fix tag click event not found records.

### DIFF
--- a/addons/website_forum/controllers/main.py
+++ b/addons/website_forum/controllers/main.py
@@ -179,9 +179,9 @@ class WebsiteForum(WebsiteProfile):
         return request.render("website_forum.faq_karma", values)
 
     @http.route('/forum/get_tags', type='http', auth="public", methods=['GET'], website=True, sitemap=False)
-    def tag_read(self, query='', limit=25, **post):
+    def tag_read(self, query='', limit=25, forum='', **post):
         data = request.env['forum.tag'].search_read(
-            domain=[('name', '=ilike', (query or '') + "%")],
+            domain=[('name', '=ilike', (query or '') + "%"), ('forum_id', '=', int(forum))],
             fields=['id', 'name'],
             limit=int(limit),
         )

--- a/addons/website_forum/models/forum.py
+++ b/addons/website_forum/models/forum.py
@@ -223,7 +223,7 @@ class Forum(models.Model):
         for tag in (tag for tag in tags.split(',') if tag):
             if tag.startswith('_'):  # it's a new tag
                 # check that not already created meanwhile or maybe excluded by the limit on the search
-                tag_ids = Tag.search([('name', '=', tag[1:])])
+                tag_ids = Tag.search([('name', '=', tag[1:]), ('forum_id', '=', self.id)])
                 if tag_ids:
                     existing_keep.append(int(tag_ids[0]))
                 else:

--- a/addons/website_forum/static/src/js/website_forum.js
+++ b/addons/website_forum/static/src/js/website_forum.js
@@ -88,6 +88,7 @@ publicWidget.registry.websiteForum = publicWidget.Widget.extend({
                     return {
                         query: term,
                         limit: 50,
+                        forum: $('#wrapwrap').data('forum_id'),
                     };
                 },
                 results: function (data) {


### PR DESCRIPTION
Odoo design each tag to belong to a forum. But when chosing a tag for the post if the tag already exists in another forum,
Odoo will always use that tag for the current post without creating a new tag for the forum.
Should have caused the phenomenon when clicking on a tag that is reused by the article as another forum's tag,
the system will mistakenly identify the forum and give no data or give incorrect post data.

Solution: When adding tags to posts, identify whether the new tag belongs to the current forum or not. If not on the current forum, then create new. If it belongs, then update the tag's id to the post

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
