### PR TITLE
[FIX] odoo: rlimit cannot be set at runtime on macOS Monterey (12.0+)

### DIFF
--- a/odoo/service/server.py
+++ b/odoo/service/server.py
@@ -77,8 +77,8 @@ def memory_info(process):
 
 
 def set_limit_memory_hard():
-    if os.name == 'posix' and config['limit_memory_hard']:
-        rlimit = resource.RLIMIT_RSS if platform.system() == 'Darwin' else resource.RLIMIT_AS
+    if platform.system() == 'Linux' and config['limit_memory_hard']:
+        rlimit = resource.RLIMIT_AS
         soft, hard = resource.getrlimit(rlimit)
         resource.setrlimit(rlimit, (config['limit_memory_hard'], hard))
 


### PR DESCRIPTION
When attempting to run the Odoo server on macOS Monterey (currently
12.4), it crashes with the following traceback:

```
Traceback (most recent call last):
  File "/Users/app/Code/odoo/odoo-bin", line 8, in <module>
    odoo.cli.main()
  File "/Users/app/Code/odoo/odoo/cli/command.py", line 61, in main
    o.run(args)
  File "/Users/app/Code/odoo/odoo/cli/server.py", line 179, in run
    main(args)
  File "/Users/app/Code/odoo/odoo/cli/server.py", line 173, in main
    rc = odoo.service.server.start(preload=preload, stop=stop)
  File "/Users/app/Code/odoo/odoo/service/server.py", line 1342, in start
    rc = server.run(preload, stop)
  File "/Users/app/Code/odoo/odoo/service/server.py", line 553, in run
    self.start(stop=stop)
  File "/Users/app/Code/odoo/odoo/service/server.py", line 491, in start
    set_limit_memory_hard()
  File "/Users/app/Code/odoo/odoo/service/server.py", line 83, in set_limit_memory_hard
    resource.setrlimit(rlimit, (config['limit_memory_hard'], hard))
ValueError: current limit exceeds maximum limit
```

Actually, this issue is not specific to Odoo but affects Python on macOS
as a whole (see [1] and [2]).

As our memory management is based on Linux - which is our primary
deployment target - and non-POSIX systems were already excluded, this
commit escapes the rlimit modification on non-Linux systems to prevent
this kind of issue.

References:
[1] https://bugs.python.org/issue34602
[2] https://github.com/python/cpython/pull/14546

Related issue:
https://github.com/odoo/odoo/issues/79112
