### PR TITLE
[MERGE][FIX] knowledge: fix "move to private" and archive flows

### DIFF
--- a/addons/knowledge/models/knowledge_article.py
+++ b/addons/knowledge/models/knowledge_article.py
@@ -1143,9 +1143,14 @@ class Article(models.Model):
             member_commands = article_sudo._copy_access_from_parents_commands()
             article_sudo.write({'article_member_ids': member_commands})
 
-        # create new root articles: direct children of these articles
-        new_roots_woperm = other_descendants_sudo.filtered(lambda article: article.parent_id in self and not article.internal_permission)
-        new_roots_wperm = other_descendants_sudo.filtered(lambda article: article.parent_id in self and article.internal_permission)
+        # create new root articles: direct children of these articles + the writable_descendants
+        # indeed, those writable descendants are going to be altered the same way as "self"
+        # (archived / moved to private)
+        # -> all their children should be detached
+        new_roots_woperm = other_descendants_sudo.filtered(
+            lambda article: article.parent_id in (self + writable_descendants) and not article.internal_permission)
+        new_roots_wperm = other_descendants_sudo.filtered(
+            lambda article: article.parent_id in (self + writable_descendants) and article.internal_permission)
         if new_roots_wperm:
             new_roots_wperm.write({
                 'is_desynchronized': False,

--- a/addons/knowledge/models/knowledge_article_member.py
+++ b/addons/knowledge/models/knowledge_article_member.py
@@ -58,7 +58,6 @@ class ArticleMember(models.Model):
             for member in self.filtered(lambda member: member.article_id in articles_to_check):
                 deleted_members_by_article[member.article_id.id] |= member
 
-        parents_members_permission = articles_to_check.parent_id._get_article_member_permissions()
         for article in articles_to_check:
             # Check on permission on members
             members_to_check = article.article_member_ids
@@ -67,15 +66,8 @@ class ArticleMember(models.Model):
             if any(m.permission == 'write' for m in members_to_check):
                 continue
 
-            # we need to add the members on parents to check the validity
-            parent_write_members = any(
-                values['permission'] == 'write' for partner_id, values
-                in parents_members_permission[article.parent_id.id].items()
-                if article.parent_id and not article.is_desynchronized
-                and partner_id not in article.article_member_ids.partner_id.ids
-            )
-
-            if not parent_write_members:
+            exclude_memberships = deleted_members_by_article[article.id] if on_unlink else False
+            if not article._has_write_member(exclude_memberships=exclude_memberships):
                 raise ValidationError(
                     _("Article '%s' should always have a writer: inherit write permission, or have a member with write access",
                       article.display_name)

--- a/addons/knowledge/tests/test_knowledge_article_business.py
+++ b/addons/knowledge/tests/test_knowledge_article_business.py
@@ -480,17 +480,18 @@ class TestKnowledgeArticleBusiness(KnowledgeCommonWData):
             })]
         })
 
-        # add 2 extra articles for further checks
-        # - one to which 'employee' only has 'read' access to (as sudo)
-        # - one to which 'employee' does NOT have access to (as sudo)
+        # add 2 extra articles (as sudo) for further checks
+        # - one to which 'employee' only has 'read' access to
+        #   grandchild to article_workspace
+        # - one to which 'employee' does NOT have access to
         #   only "employee2" has access to that one in write mode
         [
-            wkspace_child_read_access,
+            wkspace_grandchild_read_access,
             wkspace_child_no_access,
         ] = self.env['knowledge.article'].sudo().create([{
-            'name': 'Read Child',
+            'name': 'Read Grand Child',
             'internal_permission': 'write',
-            'parent_id': article_workspace.id,
+            'parent_id': workspace_children[0].id,
             'article_member_ids': [(0, 0, {
                 'partner_id': self.partner_employee.id,
                 'permission': 'read',
@@ -524,7 +525,7 @@ class TestKnowledgeArticleBusiness(KnowledgeCommonWData):
             self.assertFalse(bool(workspace_child.article_member_ids))
 
         # 3.children that were not accessible were moved as a root articles...
-        for unreachable_article in wkspace_child_read_access | wkspace_child_no_access:
+        for unreachable_article in wkspace_grandchild_read_access | wkspace_child_no_access:
             self.assertEqual(unreachable_article.category, 'workspace')
             self.assertFalse(bool(unreachable_article.parent_id))
             # ... and kept their access rights for the customer
@@ -533,7 +534,7 @@ class TestKnowledgeArticleBusiness(KnowledgeCommonWData):
             )))
 
         # internal permission should stay untouched for unaccessible children
-        self.assertEqual(wkspace_child_read_access.internal_permission, 'write')
+        self.assertEqual(wkspace_grandchild_read_access.internal_permission, 'write')
         self.assertEqual(wkspace_child_no_access.internal_permission, 'read')
 
         # and that 'Hidden Child' is still accessible for employee2

--- a/addons/knowledge/tests/test_knowledge_article_constraints.py
+++ b/addons/knowledge/tests/test_knowledge_article_constraints.py
@@ -279,6 +279,19 @@ class TestKnowledgeArticleConstraints(KnowledgeCommonWData):
         with self.assertRaises(exceptions.ValidationError, msg='Cannot remove the last writer on an article'):
             article_private._add_members(membership_sudo.partner_id, 'none')
 
+        # add a second member with write access on the workspace article
+        self.article_workspace.sudo().write({
+            'article_member_ids': [(0, 0, {
+                'partner_id': self.user_employee2.partner_id.id,
+                'permission': 'write',
+            })]
+        })
+        # moving the article to private will remove the second member
+        # but should not trigger an error since we also add 'employee' as a write member
+        self.article_workspace.move_to(is_private=True)
+        self.assertEqual(self.article_workspace.category, 'private')
+        self.assertTrue(self.article_workspace._has_write_member())
+
     @mute_logger('odoo.sql_db')
     @users('employee')
     def test_favourite_uniqueness(self):


### PR DESCRIPTION
Fixes several issues into knowledge flows:

Correctly test that the article still has a member when moving to a private
section
Copy member values when detaching unreachable children during archiving
Propagate to children when making an article 'private'
See underlying commits for details.

Task-2859616