### PR TITLE
[MERGE] barcodes: simplify and improve barcode implementation

### DIFF
--- a/addons/barcodes/static/src/barcode_handlers.js
+++ b/addons/barcodes/static/src/barcode_handlers.js
@@ -1,0 +1,30 @@
+/** @odoo-module **/
+
+import { registry } from "@web/core/registry";
+import { getVisibleElements } from "@web/core/utils/ui";
+
+export const barcodeAutoClick = {
+    dependencies: ["ui", "barcode"],
+    start(env, { ui, barcode }) {
+
+        barcode.bus.addEventListener("barcode_scanned", (ev) => {
+            const barcode = ev.detail.barcode;
+            if (!barcode.startsWith("O-BTN.")) {
+                return;
+            }
+            let targets = [];
+            try {
+                // the scanned barcode could be anything, and could crash the queryselectorall
+                // function
+                targets = getVisibleElements(ui.activeElement, `[barcode_trigger=${barcode.slice(6)}]`);
+            } catch (_e) {
+                console.warn(`Barcode '${barcode}' is not valid`)
+            }
+            for (let elem of targets) {
+                elem.click();
+            }
+        });
+    }
+};
+
+registry.category("services").add("barcode_autoclick", barcodeAutoClick);

--- a/addons/barcodes/static/src/barcode_service.js
+++ b/addons/barcodes/static/src/barcode_service.js
@@ -1,0 +1,153 @@
+/** @odoo-module **/
+
+import { isBrowserChrome, isMobileOS } from "@web/core/browser/feature_detection";
+import { registry } from "@web/core/registry";
+import { session } from "@web/session";
+
+const { EventBus, whenReady } = owl;
+
+function isSpecialKey(key) {
+    return (key === "ArrowLeft" || key === "ArrowRight" ||
+        key === "ArrowUp" || key === "ArrowDown" ||
+        key === "Escape" || key === "Tab" ||
+        key === "Backspace" || key === "Delete" ||
+        key === "Home" || key === "End" ||
+        key === "PageUp" || key === "PageDown" ||
+        key === "Shift" || /F\d\d?/.test(key));
+}
+
+function isEditable(element) {
+    return element.matches('input,textarea,[contenteditable="true"]');
+}
+
+function makeBarcodeInput() {
+    const inputEl = document.createElement('input');
+    inputEl.setAttribute("style", "position:fixed;top:50%;transform:translateY(-50%);z-index:-1;opacity:0");
+    inputEl.setAttribute("autocomplete", "off");
+    inputEl.setAttribute("inputmode", "none"); // magic! prevent native keyboard from popping
+    inputEl.classList.add("o-barcode-input");
+    inputEl.setAttribute('name', 'barcode');
+    return inputEl;
+}
+
+export const barcodeService = {
+    // Keys from a barcode scanner are usually processed as quick as possible,
+    // but some scanners can use an intercharacter delay (we support <= 50 ms)
+    maxTimeBetweenKeysInMs: session.max_time_between_keys_in_ms || 55,
+
+    // this is done here to make it easily mockable in mobile tests
+    isMobileChrome: isMobileOS() && isBrowserChrome(),
+
+    start() {
+        const bus = new EventBus();
+        const endRegexp = /[\n\r\t]+/;
+        const barcodeRegexp = /(.{3,})[\n\r\t]*/;
+        let timeout = null;
+        let blurTimeout = null;
+
+        // To be able to receive the barcode value, an input must be focused.
+        // On mobile devices, this causes the virtual keyboard to open.
+        // Unfortunately it is not possible to avoid this behavior...
+        // To avoid keyboard flickering at each detection of a barcode value,
+        // we want to keep it open for a while (800 ms).
+        const inputTimeOut = 8000;
+
+        let bufferedBarcode = "";
+        let currentTarget = null;
+        let barcodeInput = null;
+
+        function handleBarcode(barcode, target) {
+            bus.trigger('barcode_scanned', {barcode,target});
+            if (target.getAttribute('barcode_events') === "true") {
+                $(target).trigger('barcode_scanned', barcode);
+            }
+        }
+
+        /**
+         * check if we have a barcode, and trigger appropriate events
+         */
+        function checkBarcode() {
+            const str = barcodeInput ? barcodeInput.value : bufferedBarcode;
+            const match = str.match(barcodeRegexp);
+            if (match) {
+                const barcode = match[1];
+                handleBarcode(barcode, currentTarget);
+            }
+            if (barcodeInput) {
+                blurBarcodeInput();
+            }
+            bufferedBarcode = "";
+            currentTarget = null;
+        }
+
+        function keydownHandler(ev) {
+            // Don't catch non-printable keys for which Firefox triggers a keypress
+            if (isSpecialKey(ev.key)) {
+                return;
+            }
+            // Don't catch keypresses which could have a UX purpose (like shortcuts)
+            if (ev.ctrlKey || ev.metaKey || ev.altKey) {
+                return;
+            }
+
+            currentTarget = ev.target;
+            // Don't catch events targeting elements that are editable because we
+            // have no way of redispatching 'genuine' key events. Resent events
+            // don't trigger native event handlers of elements. So this means that
+            // our fake events will not appear in eg. an <input> element.
+            if (currentTarget !== barcodeInput && isEditable(currentTarget) &&
+                !currentTarget.dataset.enableBarcode &&
+                currentTarget.getAttribute("barcode_events") !== "true") {
+                return;
+            }
+
+            if (ev.key !== "Enter" && ev.key !== "Unidentified") {
+                bufferedBarcode += ev.key;
+            }
+            clearTimeout(timeout);
+            if (String.fromCharCode(ev.which).match(endRegexp)) {
+                checkBarcode();
+            } else {
+                timeout = setTimeout(checkBarcode, barcodeService.maxTimeBetweenKeysInMs);
+            }
+        }
+
+        function mobileChromeHandler(ev) {
+            if (ev.key === "Unidentified") {
+                return;
+            }
+            if ($(document.activeElement).not('input:text, textarea, [contenteditable], ' +
+                '[type="email"], [type="number"], [type="password"], [type="tel"], [type="search"]').length) {
+                barcodeInput.focus();
+            }
+            keydownHandler(ev);
+            clearTimeout(blurTimeout);
+            // if the barcode input doesn't receive keydown for a while, remove it.
+            blurTimeout = setTimeout(() => blurBarcodeInput(), inputTimeOut);
+        }
+
+        function blurBarcodeInput() {
+            barcodeInput.value = "";
+            // fixme: blurring the input should not be necessary, but for some
+            // reason, doing it fix some weird scrolling issue in a mobile (non
+            // native) device. 
+            barcodeInput.blur();
+        }
+
+        whenReady(() => {
+            const isMobileChrome = barcodeService.isMobileChrome;
+            if (isMobileChrome) {
+                barcodeInput = makeBarcodeInput();
+                document.body.appendChild(barcodeInput);
+            }
+            const handler = isMobileChrome ? mobileChromeHandler : keydownHandler;
+            document.body.addEventListener('keydown', handler);
+        });
+
+        return {
+            bus,
+        };
+    },
+};
+
+registry.category("services").add("barcode", barcodeService);

--- a/addons/barcodes/static/src/barcode_service.js
+++ b/addons/barcodes/static/src/barcode_service.js
@@ -43,14 +43,6 @@ export const barcodeService = {
         const endRegexp = /[\n\r\t]+/;
         const barcodeRegexp = /(.{3,})[\n\r\t]*/;
         let timeout = null;
-        let blurTimeout = null;
-
-        // To be able to receive the barcode value, an input must be focused.
-        // On mobile devices, this causes the virtual keyboard to open.
-        // Unfortunately it is not possible to avoid this behavior...
-        // To avoid keyboard flickering at each detection of a barcode value,
-        // we want to keep it open for a while (800 ms).
-        const inputTimeOut = 8000;
 
         let bufferedBarcode = "";
         let currentTarget = null;
@@ -74,7 +66,7 @@ export const barcodeService = {
                 handleBarcode(barcode, currentTarget);
             }
             if (barcodeInput) {
-                blurBarcodeInput();
+                barcodeInput.value = "";
             }
             bufferedBarcode = "";
             currentTarget = null;
@@ -121,17 +113,6 @@ export const barcodeService = {
                 barcodeInput.focus();
             }
             keydownHandler(ev);
-            clearTimeout(blurTimeout);
-            // if the barcode input doesn't receive keydown for a while, remove it.
-            blurTimeout = setTimeout(() => blurBarcodeInput(), inputTimeOut);
-        }
-
-        function blurBarcodeInput() {
-            barcodeInput.value = "";
-            // fixme: blurring the input should not be necessary, but for some
-            // reason, doing it fix some weird scrolling issue in a mobile (non
-            // native) device. 
-            barcodeInput.blur();
         }
 
         whenReady(() => {

--- a/addons/barcodes/static/src/barcode_service.js
+++ b/addons/barcodes/static/src/barcode_service.js
@@ -9,7 +9,7 @@ const { EventBus, whenReady } = owl;
 function isSpecialKey(key) {
     return (key === "ArrowLeft" || key === "ArrowRight" ||
         key === "ArrowUp" || key === "ArrowDown" ||
-        key === "Escape" || key === "Tab" ||
+        key === "Escape" ||
         key === "Backspace" || key === "Delete" ||
         key === "Home" || key === "End" ||
         key === "PageUp" || key === "PageDown" ||

--- a/addons/barcodes/static/src/js/barcode_events.js
+++ b/addons/barcodes/static/src/js/barcode_events.js
@@ -1,210 +1,24 @@
-odoo.define('barcodes.BarcodeEvents', function(require) {
-"use strict";
+/** @odoo-module **/
 
-var config = require('web.config');
-var core = require('web.core');
-var session = require('web.session');
+/**
+ * BarcodeEvents has been removed and replaced by the barcode service.
+ * 
+ * This file is a temporary service to remap barcode events from new barcode
+ * service to core.bus (which was the purpose of BarcodeEvents).
+ * 
+ * @TODO: remove this as soon as all barcode code is using new barcode service
+ */
 
-var BarcodeEvents = core.Class.extend({
-    timeout: null,
-    key_pressed: {},
-    buffered_key_events: [],
-    // Regexp to match a barcode input and extract its payload
-    // Note: to build in init() if prefix/suffix can be configured
-    regexp: /(.{3,})[\n\r\t]*/,
-    // By knowing the terminal character we can interpret buffered keys
-    // as a barcode as soon as it's encountered (instead of waiting x ms)
-    suffix: /[\n\r\t]+/,
-    // Keys from a barcode scanner are usually processed as quick as possible,
-    // but some scanners can use an intercharacter delay (we support <= 50 ms)
-    max_time_between_keys_in_ms: session.max_time_between_keys_in_ms || 55,
-    // To be able to receive the barcode value, an input must be focused.
-    // On mobile devices, this causes the virtual keyboard to open.
-    // Unfortunately it is not possible to avoid this behavior...
-    // To avoid keyboard flickering at each detection of a barcode value,
-    // we want to keep it open for a while (800 ms).
-    inputTimeOut: 800,
+import { registry } from "@web/core/registry";
+import core from "web.core";
 
-    init: function() {
-        this.__handler = _.bind(this.handler, this);
-        // Bind event handler once the DOM is loaded
-        // TODO: find a way to be active only when there are listeners on the bus
-        $(() => this.start());
-
-        // Mobile device detection
-        this.isChromeMobile = config.device.isMobileDevice && navigator.userAgent.match(/Chrome/i);
+export const barcodeRemapperService = {
+    dependencies: ["barcode"],
+    start(env, { barcode }) {
+        barcode.bus.addEventListener("barcode_scanned", ev => {
+            const { barcode, target } = ev.detail;
+            core.bus.trigger('barcode_scanned', barcode, target);
+        });
     },
-
-    getCurrentString() {
-        if (this.$barcodeInput) {
-            return this.$barcodeInput.val();
-        }
-        return this.buffered_key_events.reduce(function(memo, e) { return memo + e.key }, '');
-    },
-
-    handle_buffered_keys: function() {
-        let str = this.getCurrentString();
-        var match = str.match(this.regexp);
-
-        if (match) {
-            var barcode = match[1];
-
-            // Send the target in case there are several barcode widgets on the same page (e.g.
-            // registering the lot numbers in a stock picking)
-            core.bus.trigger('barcode_scanned', barcode, this.buffered_key_events[0].target);
-
-            // Dispatch a barcode_scanned DOM event to elements that have barcode_events="true" set.
-            if (this.buffered_key_events[0].target.getAttribute("barcode_events") === "true")
-                $(this.buffered_key_events[0].target).trigger('barcode_scanned', barcode);
-        }
-
-        this.buffered_key_events = [];
-    },
-
-    element_is_editable: function(element) {
-        return $(element).is('input,textarea,[contenteditable="true"]');
-    },
-
-    // This checks that a keypress event is either ESC, TAB, an arrow
-    // key or a function key. This is Firefox specific, in Chrom{e,ium}
-    // keypress events are not fired for these types of keys, only
-    // keyup/keydown.
-    is_special_key: function(e) {
-        if (e.key === "ArrowLeft" || e.key === "ArrowRight" ||
-            e.key === "ArrowUp" || e.key === "ArrowDown" ||
-            e.key === "Escape" || e.key === "Tab" ||
-            e.key === "Backspace" || e.key === "Delete" ||
-            e.key === "Home" || e.key === "End" ||
-            e.key === "PageUp" || e.key === "PageDown" ||
-            e.key === "Shift" ||
-            e.key === "Unidentified" || /F\d\d?/.test(e.key)) {
-            return true;
-        } else {
-            return false;
-        }
-    },
-
-    handler: function(e){
-        // Don't catch non-printable keys for which Firefox triggers a keypress
-        if (this.is_special_key(e)) {
-            return;
-        }
-        // Don't catch keypresses which could have a UX purpose (like shortcuts)
-        if (e.ctrlKey || e.metaKey || e.altKey) {
-            return;
-        }
-        // Don't catch events targeting elements that are editable because we
-        // have no way of redispatching 'genuine' key events. Resent events
-        // don't trigger native event handlers of elements. So this means that
-        // our fake events will not appear in eg. an <input> element.
-        if ((this.element_is_editable(e.target) && !$(e.target).data('enableBarcode')) && e.target.getAttribute("barcode_events") !== "true") {
-            return;
-        }
-
-        // Catch and buffer the event
-        if (e.key !== "Enter") {
-            this.buffered_key_events.push(e);
-        }
-
-        // Handle buffered keys immediately if the keypress marks the end
-        // of a barcode or after x milliseconds without a new keypress
-        clearTimeout(this.timeout);
-        if (String.fromCharCode(e.which).match(this.suffix)) {
-            this.handle_buffered_keys();
-        } else {
-            this.timeout = setTimeout(_.bind(this.handle_buffered_keys, this), this.max_time_between_keys_in_ms);
-        }
-    },
-
-    /**
-     * Try to detect the barcode value by listening all keydown events:
-     * Checks if a dom element who may contains text value has the focus.
-     * If not, it's probably because these events are triggered by a barcode scanner.
-     * To be able to handle this value, a focused input will be created.
-     *
-     * This function also has the responsibility to detect the end of the barcode value.
-     * (1) In most of cases, an optional key (tab or enter) is sent to mark the end of the value.
-     * So, we direclty handle the value.
-     * (2) If no end key is configured, we have to calculate the delay between each keydowns.
-     * 'max_time_between_keys_in_ms' depends of the device and may be configured.
-     * Exceeded this timeout, we consider that the barcode value is entirely sent.
-     *
-     * @private
-     * @param  {jQuery.Event} e keydown event
-     */
-    _listenBarcodeScanner: function (e) {
-        if ($(document.activeElement).not('input:text, textarea, [contenteditable], ' +
-            '[type="email"], [type="number"], [type="password"], [type="tel"], [type="search"]').length) {
-            this.$barcodeInput.focus();
-        }
-        if (this.$barcodeInput.is(":focus")) {
-            this.handler(e);
-            // if the barcode input doesn't receive keydown for a while, remove it.
-            this.__blurBarcodeInput();
-        }
-    },
-
-    /**
-     * Removes the value and focus from the barcode input.
-     * If nothing happens, the focus will be lost and
-     * the virtual keyboard on mobile devices will be closed.
-     *
-     * @private
-     */
-    _blurBarcodeInput: function () {
-        // Close the virtual keyboard on mobile browsers
-        // FIXME: actually we can't prevent keyboard from opening
-        this.$barcodeInput.val('').blur();
-    },
-
-    start: function(){
-        // Chrome Mobile isn't triggering keypress event.
-        // This is marked as Legacy in the DOM-Level-3 Standard.
-        // See: https://www.w3.org/TR/uievents/#legacy-keyboardevent-event-types
-        // This fix is only applied for Google Chrome Mobile but it should work for
-        // all other cases.
-        // In master, we could remove the behavior with keypress and only use keydown.
-        if (this.isChromeMobile) {
-            // Creates an input who will receive the barcode scanner value.
-            this.$barcodeInput = $('<input/>', {
-                name: 'barcode',
-                type: 'text',
-                css: {
-                    'position': 'fixed',
-                    'top': '50%',
-                    'transform': 'translateY(-50%)',
-                    'z-index': '-1',
-                    'opacity': '0',
-                },
-            });
-            // Avoid to show autocomplete for a non appearing input
-            this.$barcodeInput.attr('autocomplete', 'off');
-
-            this.__blurBarcodeInput = _.debounce(this._blurBarcodeInput, this.inputTimeOut);
-
-
-            $('body').append(this.$barcodeInput);
-            core.bus.on('barcode_scanned', null, () => this._blurBarcodeInput());
-
-            $('body').on("keydown", this._listenBarcodeScanner.bind(this));
-        } else {
-            $('body').bind("keydown", this.__handler);
-        }
-    },
-
-    stop: function(){
-        $('body').off("keydown", this.__handler);
-    },
-});
-
-return {
-    /** Singleton that emits barcode_scanned events on core.bus */
-    BarcodeEvents: new BarcodeEvents(),
-    /**
-     * List of barcode prefixes that are reserved for internal purposes
-     * @type Array
-     */
-    ReservedBarcodePrefixes: ['O-CMD'],
 };
-
-});
+registry.category("services").add("barcode_remapper", barcodeRemapperService);

--- a/addons/barcodes/static/src/js/barcode_events.js
+++ b/addons/barcodes/static/src/js/barcode_events.js
@@ -3,20 +3,9 @@ odoo.define('barcodes.BarcodeEvents', function(require) {
 
 var config = require('web.config');
 var core = require('web.core');
-var mixins = require('web.mixins');
 var session = require('web.session');
 
-
-// For IE >= 9, use this, new CustomEvent(), instead of new Event()
-function CustomEvent ( event, params ) {
-    params = params || { bubbles: false, cancelable: false, detail: undefined };
-    var evt = document.createEvent( 'CustomEvent' );
-    evt.initCustomEvent( event, params.bubbles, params.cancelable, params.detail );
-    return evt;
-   }
-CustomEvent.prototype = window.Event.prototype;
-
-var BarcodeEvents = core.Class.extend(mixins.PropertiesMixin, {
+var BarcodeEvents = core.Class.extend({
     timeout: null,
     key_pressed: {},
     buffered_key_events: [],
@@ -37,38 +26,24 @@ var BarcodeEvents = core.Class.extend(mixins.PropertiesMixin, {
     inputTimeOut: 800,
 
     init: function() {
-        mixins.PropertiesMixin.init.call(this);
-        // Keep a reference of the handler functions to use when adding and removing event listeners
-        this.__keydown_handler = _.bind(this.keydown_handler, this);
-        this.__keyup_handler = _.bind(this.keyup_handler, this);
         this.__handler = _.bind(this.handler, this);
         // Bind event handler once the DOM is loaded
         // TODO: find a way to be active only when there are listeners on the bus
-        $(_.bind(this.start, this, false));
+        $(() => this.start());
 
         // Mobile device detection
         this.isChromeMobile = config.device.isMobileDevice && navigator.userAgent.match(/Chrome/i);
+    },
 
-        // Creates an input who will receive the barcode scanner value.
-        this.$barcodeInput = $('<input/>', {
-            name: 'barcode',
-            type: 'text',
-            css: {
-                'position': 'fixed',
-                'top': '50%',
-                'transform': 'translateY(-50%)',
-                'z-index': '-1',
-                'opacity': '0',
-            },
-        });
-        // Avoid to show autocomplete for a non appearing input
-        this.$barcodeInput.attr('autocomplete', 'off');
-
-        this.__blurBarcodeInput = _.debounce(this._blurBarcodeInput, this.inputTimeOut);
+    getCurrentString() {
+        if (this.$barcodeInput) {
+            return this.$barcodeInput.val();
+        }
+        return this.buffered_key_events.reduce(function(memo, e) { return memo + e.key }, '');
     },
 
     handle_buffered_keys: function() {
-        var str = this.buffered_key_events.reduce(function(memo, e) { return memo + String.fromCharCode(e.which) }, '');
+        let str = this.getCurrentString();
         var match = str.match(this.regexp);
 
         if (match) {
@@ -81,46 +56,9 @@ var BarcodeEvents = core.Class.extend(mixins.PropertiesMixin, {
             // Dispatch a barcode_scanned DOM event to elements that have barcode_events="true" set.
             if (this.buffered_key_events[0].target.getAttribute("barcode_events") === "true")
                 $(this.buffered_key_events[0].target).trigger('barcode_scanned', barcode);
-        } else {
-            this.resend_buffered_keys();
         }
 
         this.buffered_key_events = [];
-    },
-
-    resend_buffered_keys: function() {
-        var old_event, new_event;
-        for(var i = 0; i < this.buffered_key_events.length; i++) {
-            old_event = this.buffered_key_events[i];
-
-            if(old_event.which !== 13) { // ignore returns
-                // We do not create a 'real' keypress event through
-                // eg. KeyboardEvent because there are several issues
-                // with them that make them very different from
-                // genuine keypresses. Chrome per example has had a
-                // bug for the longest time that causes keyCode and
-                // charCode to not be set for events created this way:
-                // https://bugs.webkit.org/show_bug.cgi?id=16735
-                var params = {
-                    'bubbles': old_event.bubbles,
-                    'cancelable': old_event.cancelable,
-                };
-                new_event = $.Event('keypress', params);
-                new_event.viewArg = old_event.viewArg;
-                new_event.ctrl = old_event.ctrl;
-                new_event.alt = old_event.alt;
-                new_event.shift = old_event.shift;
-                new_event.meta = old_event.meta;
-                new_event.char = old_event.char;
-                new_event.key = old_event.key;
-                new_event.charCode = old_event.charCode;
-                new_event.keyCode = old_event.keyCode || old_event.which; // Firefox doesn't set keyCode for keypresses, only keyup/down
-                new_event.which = old_event.which;
-                new_event.dispatched_by_barcode_reader = true;
-
-                $(old_event.target).trigger(new_event);
-            }
-        }
     },
 
     element_is_editable: function(element) {
@@ -138,6 +76,7 @@ var BarcodeEvents = core.Class.extend(mixins.PropertiesMixin, {
             e.key === "Backspace" || e.key === "Delete" ||
             e.key === "Home" || e.key === "End" ||
             e.key === "PageUp" || e.key === "PageDown" ||
+            e.key === "Shift" ||
             e.key === "Unidentified" || /F\d\d?/.test(e.key)) {
             return true;
         } else {
@@ -145,46 +84,27 @@ var BarcodeEvents = core.Class.extend(mixins.PropertiesMixin, {
         }
     },
 
-    // The keydown and keyup handlers are here to disallow key
-    // repeat. When preventDefault() is called on a keydown event
-    // the keypress that normally follows is cancelled.
-    keydown_handler: function(e){
-        if (this.key_pressed[e.which]) {
-            e.preventDefault();
-        } else {
-            this.key_pressed[e.which] = true;
-        }
-    },
-
-    keyup_handler: function(e){
-        this.key_pressed[e.which] = false;
-    },
-
     handler: function(e){
-        // Don't catch events we resent
-        if (e.dispatched_by_barcode_reader)
-            return;
         // Don't catch non-printable keys for which Firefox triggers a keypress
-        if (this.is_special_key(e))
+        if (this.is_special_key(e)) {
             return;
+        }
         // Don't catch keypresses which could have a UX purpose (like shortcuts)
-        if (e.ctrlKey || e.metaKey || e.altKey)
+        if (e.ctrlKey || e.metaKey || e.altKey) {
             return;
-        // Don't catch Return when nothing is buffered. This way users
-        // can still use Return to 'click' on focused buttons or links.
-        if (e.which === 13 && this.buffered_key_events.length === 0)
-            return;
+        }
         // Don't catch events targeting elements that are editable because we
         // have no way of redispatching 'genuine' key events. Resent events
         // don't trigger native event handlers of elements. So this means that
         // our fake events will not appear in eg. an <input> element.
-        if ((this.element_is_editable(e.target) && !$(e.target).data('enableBarcode')) && e.target.getAttribute("barcode_events") !== "true")
+        if ((this.element_is_editable(e.target) && !$(e.target).data('enableBarcode')) && e.target.getAttribute("barcode_events") !== "true") {
             return;
+        }
 
         // Catch and buffer the event
-        this.buffered_key_events.push(e);
-        e.preventDefault();
-        e.stopImmediatePropagation();
+        if (e.key !== "Enter") {
+            this.buffered_key_events.push(e);
+        }
 
         // Handle buffered keys immediately if the keypress marks the end
         // of a barcode or after x milliseconds without a new keypress
@@ -215,37 +135,12 @@ var BarcodeEvents = core.Class.extend(mixins.PropertiesMixin, {
     _listenBarcodeScanner: function (e) {
         if ($(document.activeElement).not('input:text, textarea, [contenteditable], ' +
             '[type="email"], [type="number"], [type="password"], [type="tel"], [type="search"]').length) {
-            $('body').append(this.$barcodeInput);
             this.$barcodeInput.focus();
         }
         if (this.$barcodeInput.is(":focus")) {
-            // Handle buffered keys immediately if the keypress marks the end
-            // of a barcode or after x milliseconds without a new keypress.
-            clearTimeout(this.timeout);
-            // On chrome mobile, e.which only works for some special characters like ENTER or TAB.
-            if (String.fromCharCode(e.which).match(this.suffix)) {
-                this._handleBarcodeValue(e);
-            } else {
-                this.timeout = setTimeout(this._handleBarcodeValue.bind(this, e),
-                    this.max_time_between_keys_in_ms);
-            }
+            this.handler(e);
             // if the barcode input doesn't receive keydown for a while, remove it.
             this.__blurBarcodeInput();
-        }
-    },
-
-    /**
-     * Retrieves the barcode value from the temporary input element.
-     * This checks this value and trigger it on the bus.
-     *
-     * @private
-     * @param  {jQuery.Event} keydown event
-     */
-    _handleBarcodeValue: function (e) {
-        var barcodeValue = this.$barcodeInput.val();
-        if (barcodeValue.match(this.regexp)) {
-            core.bus.trigger('barcode_scanned', barcodeValue, $(e.target).parent()[0]);
-            this._blurBarcodeInput();
         }
     },
 
@@ -262,7 +157,7 @@ var BarcodeEvents = core.Class.extend(mixins.PropertiesMixin, {
         this.$barcodeInput.val('').blur();
     },
 
-    start: function(prevent_key_repeat){
+    start: function(){
         // Chrome Mobile isn't triggering keypress event.
         // This is marked as Legacy in the DOM-Level-3 Standard.
         // See: https://www.w3.org/TR/uievents/#legacy-keyboardevent-event-types
@@ -270,20 +165,35 @@ var BarcodeEvents = core.Class.extend(mixins.PropertiesMixin, {
         // all other cases.
         // In master, we could remove the behavior with keypress and only use keydown.
         if (this.isChromeMobile) {
+            // Creates an input who will receive the barcode scanner value.
+            this.$barcodeInput = $('<input/>', {
+                name: 'barcode',
+                type: 'text',
+                css: {
+                    'position': 'fixed',
+                    'top': '50%',
+                    'transform': 'translateY(-50%)',
+                    'z-index': '-1',
+                    'opacity': '0',
+                },
+            });
+            // Avoid to show autocomplete for a non appearing input
+            this.$barcodeInput.attr('autocomplete', 'off');
+
+            this.__blurBarcodeInput = _.debounce(this._blurBarcodeInput, this.inputTimeOut);
+
+
+            $('body').append(this.$barcodeInput);
+            core.bus.on('barcode_scanned', null, () => this._blurBarcodeInput());
+
             $('body').on("keydown", this._listenBarcodeScanner.bind(this));
         } else {
-            $('body').bind("keypress", this.__handler);
-        }
-        if (prevent_key_repeat === true) {
-            $('body').bind("keydown", this.__keydown_handler);
-            $('body').bind('keyup', this.__keyup_handler);
+            $('body').bind("keydown", this.__handler);
         }
     },
 
     stop: function(){
-        $('body').off("keypress", this.__handler);
-        $('body').off("keydown", this.__keydown_handler);
-        $('body').off('keyup', this.__keyup_handler);
+        $('body').off("keydown", this.__handler);
     },
 });
 

--- a/addons/barcodes/static/src/js/barcode_field.js
+++ b/addons/barcodes/static/src/js/barcode_field.js
@@ -4,18 +4,13 @@ odoo.define('barcodes.field', function(require) {
 var AbstractField = require('web.AbstractField');
 var basicFields = require('web.basic_fields');
 var fieldRegistry = require('web.field_registry');
-var BarcodeEvents = require('barcodes.BarcodeEvents').BarcodeEvents;
 
 // Field in which the user can both type normally and scan barcodes
 
 var FieldFloatScannable = basicFields.FieldFloat.extend({
     events: _.extend({}, basicFields.FieldFloat.prototype.events, {
-        // The barcode_events component intercepts keypresses and releases them when it
-        // appears they are not part of a barcode. But since released keypresses don't
-        // trigger native behaviour (like characters input), we must simulate it.
-        keypress: '_onKeypress',
+        barcode_scanned: '_onBarcodeScan',
     }),
-
     //--------------------------------------------------------------------------
     // Private
     //--------------------------------------------------------------------------
@@ -35,28 +30,11 @@ var FieldFloatScannable = basicFields.FieldFloat.extend({
     // Handlers
     //--------------------------------------------------------------------------
 
-    /**
-     * @private
-     * @param {KeyboardEvent} e
-     */
-    _onKeypress: function (e) {
-        /* only simulate a keypress if it has been previously prevented */
-        if (e.dispatched_by_barcode_reader !== true) {
-            if (!BarcodeEvents.is_special_key(e)) {
-                e.preventDefault();
-            }
-            return;
-        }
-        var character = String.fromCharCode(e.which);
-        var current_str = e.target.value;
-        var str_before_carret = current_str.substring(0, e.target.selectionStart);
-        var str_after_carret = current_str.substring(e.target.selectionEnd);
-        e.target.value = str_before_carret + character + str_after_carret;
-        var new_carret_index = str_before_carret.length + character.length;
-        e.target.setSelectionRange(new_carret_index, new_carret_index);
-        // trigger an 'input' event to notify the widget that it's value changed
-        $(e.target).trigger('input');
-    },
+    _onBarcodeScan() {
+        // trigger an 'input' event to make sure that the widget is call
+        // notifyChanges
+        this.$input.trigger('input');
+    }
 });
 
 // Field to use scan barcodes

--- a/addons/barcodes/static/src/js/barcode_field.js
+++ b/addons/barcodes/static/src/js/barcode_field.js
@@ -22,7 +22,7 @@ var FieldFloatScannable = basicFields.FieldFloat.extend({
     _renderEdit: function () {
         var self = this;
         return Promise.resolve(this._super()).then(function () {
-            self.$input.data('enableBarcode', true);
+            self.$input[0].dataset.enableBarcode = true;
         });
     },
 

--- a/addons/barcodes/static/src/js/barcode_form_view.js
+++ b/addons/barcodes/static/src/js/barcode_form_view.js
@@ -1,7 +1,6 @@
 odoo.define('barcodes.FormView', function (require) {
 "use strict";
 
-var BarcodeEvents = require('barcodes.BarcodeEvents'); // handle to trigger barcode on bus
 var concurrency = require('web.concurrency');
 var core = require('web.core');
 var Dialog = require('web.Dialog');
@@ -9,6 +8,8 @@ var FormController = require('web.FormController');
 var FormRenderer = require('web.FormRenderer');
 
 var _t = core._t;
+
+const reservedBarcodePrefixes = ['O-CMD', 'O-BTN'];
 
 
 FormController.include({
@@ -308,7 +309,7 @@ FormController.include({
     _barcodeScanned: function (barcode, target) {
         var self = this;
         return this.barcodeMutex.exec(function () {
-            var prefixed = _.any(BarcodeEvents.ReservedBarcodePrefixes,
+            var prefixed = _.any(reservedBarcodePrefixes,
                     function (reserved) {return barcode.indexOf(reserved) === 0;});
             var hasCommand = false;
             var defs = [];
@@ -490,7 +491,5 @@ FormRenderer.include({
         return $button;
     }
 });
-
-BarcodeEvents.ReservedBarcodePrefixes.push('O-BTN');
 
 });

--- a/addons/barcodes/static/src/js/barcode_form_view.js
+++ b/addons/barcodes/static/src/js/barcode_form_view.js
@@ -4,11 +4,10 @@ odoo.define('barcodes.FormView', function (require) {
 var concurrency = require('web.concurrency');
 var core = require('web.core');
 var FormController = require('web.FormController');
-var FormRenderer = require('web.FormRenderer');
 
 var _t = core._t;
 
-const reservedBarcodePrefixes = ['O-CMD', 'O-BTN'];
+const reservedBarcodePrefixes = ['O-CMD'];
 
 
 FormController.include({
@@ -342,85 +341,6 @@ FormController.include({
             });
         });
     },
-});
-
-
-FormRenderer.include({
-
-    //--------------------------------------------------------------------------
-    // Private
-    //--------------------------------------------------------------------------
-    /**
-     * trigger_up 'activeBarcode' to Add barcode event handler
-     *
-     * @private
-     * @param {jQueryElement} $button
-     * @param {Object} node
-     */
-    _barcodeButtonHandler: function ($button, node) {
-        var commands = {};
-        commands.barcode = function () {return Promise.resolve();};
-        commands['O-BTN.' + node.attrs.barcode_trigger] = function () {
-            if (!$button.hasClass('o_invisible_modifier')) {
-                $button.click();
-            }
-            return Promise.resolve();
-        };
-        var name = node.attrs.name;
-        if (node.attrs.string) {
-            name = name + '_' + node.attrs.string;
-        }
-
-        this.trigger_up('activeBarcode', {
-            name: name,
-            commands: commands
-        });
-    },
-    /**
-     * Add barcode event handler
-     *
-     * @override
-     * @private
-     * @param {Object} node
-     * @returns {jQueryElement}
-     */
-    _renderHeaderButton: function (node) {
-        var $button = this._super.apply(this, arguments);
-        if (node.attrs.barcode_trigger) {
-            this._barcodeButtonHandler($button, node);
-        }
-        return $button;
-    },
-    /**
-     * Add barcode event handler
-     *
-     * @override
-     * @private
-     * @param {Object} node
-     * @returns {jQueryElement}
-     */
-    _renderStatButton: function (node) {
-        var $button = this._super.apply(this, arguments);
-        if (node.attrs.barcode_trigger) {
-            this._barcodeButtonHandler($button, node);
-        }
-        return $button;
-    },
-    /**
-     * Add barcode event handler
-     *
-     * @override
-     * @private
-     * @param {Object} node
-     * @returns {jQueryElement}
-     */
-    _renderTagButton: function (node) {
-        var $button = this._super.apply(this, arguments);
-        if (node.attrs.barcode_trigger) {
-            this._barcodeButtonHandler($button, node);
-        }
-        return $button;
-    }
 });
 
 });

--- a/addons/barcodes/static/tests/barcode_mobile_tests.js
+++ b/addons/barcodes/static/tests/barcode_mobile_tests.js
@@ -23,7 +23,6 @@ odoo.define('barcodes.barcode_mobile_tests', function (require) {
         triggerEvent(target, 'keydown', {
             key: char,
             keyCode: keycode,
-            which: keycode,
         });
     }
     

--- a/addons/barcodes/static/tests/barcode_mobile_tests.js
+++ b/addons/barcodes/static/tests/barcode_mobile_tests.js
@@ -1,20 +1,51 @@
-odoo.define('barcodes.barcode_mobile_tests', function () {
+odoo.define('barcodes.barcode_mobile_tests', function (require) {
     "use strict";
 
-    QUnit.module('Barcodes', {}, function () {
+    const {barcodeService} = require("@barcodes/barcode_service");
+    const {barcodeRemapperService} = require("@barcodes/js/barcode_events");
+    const { makeTestEnv } = require("@web/../tests/helpers/mock_env");
+    const { registry } = require("@web/core/registry");
+    var testUtils = require('web.test_utils');
+
+    const maxTimeBetweenKeysInMs = barcodeService.maxTimeBetweenKeysInMs;
+    const isMobileChrome = barcodeService.isMobileChrome;
+    var triggerEvent = testUtils.dom.triggerEvent;
+
+    function triggerKeyDown(char, target = document.body) {
+        let keycode;
+        if (char === 'Enter') {
+            keycode = $.ui.keyCode.ENTER;
+        } else if (char === "Tab") {
+            keycode = $.ui.keyCode.TAB;
+        } else {
+            keycode = char.charCodeAt(0);
+        }
+        triggerEvent(target, 'keydown', {
+            key: char,
+            keyCode: keycode,
+            which: keycode,
+        });
+    }
+    
+    QUnit.module('Barcodes', {
+        before() {
+            barcodeService.maxTimeBetweenKeysInMs = 0;
+            barcodeService.isMobileChrome = true;
+            registry.category("services").add("barcode", barcodeService, { force: true});
+            // remove this one later
+            registry.category("services").add("barcode_remapper", barcodeRemapperService);
+            this.env = makeTestEnv();
+        },
+        after() {
+            barcodeService.maxTimeBetweenKeysInMs = maxTimeBetweenKeysInMs;
+            barcodeService.isMobileChrome = isMobileChrome;
+        },
+    }, function () {
 
         QUnit.module('Barcodes Mobile');
 
         QUnit.test('barcode field automatically focus behavior', function (assert) {
             assert.expect(10);
-
-            // Mock Chrome mobile environment
-            var barcodeEvents = odoo.__DEBUG__.services["barcodes.BarcodeEvents"].BarcodeEvents;
-            var __isChromeMobile = barcodeEvents.isChromeMobile;
-            barcodeEvents.isChromeMobile = true;
-            // Rebind keyboard events
-            barcodeEvents.stop();
-            barcodeEvents.start();
 
             var $form = $(
                 '<form>' +
@@ -34,12 +65,13 @@ odoo.define('barcodes.barcode_mobile_tests', function () {
             $('#qunit-fixture').append($form);
 
             // Some elements doesn't need to keep the focus
-            $('body').keydown();
+            triggerKeyDown('a', document.body)
             assert.strictEqual(document.activeElement.name, 'barcode',
                 "hidden barcode input should have the focus");
 
             var $element = $form.find('select');
-            $element.focus().keydown();
+            $element.focus();
+            triggerKeyDown('b', $element[0]);
             assert.strictEqual(document.activeElement.name, 'barcode',
                 "hidden barcode input should have the focus");
 
@@ -49,7 +81,9 @@ odoo.define('barcodes.barcode_mobile_tests', function () {
                 'text', 'explicit_text'];
             for (var i = 0; i < keepFocusedElements.length; ++i) {
                 $element = $form.find('input[name=' + keepFocusedElements[i] + ']');
-                $element.focus().keydown();
+                $element.focus();
+                triggerKeyDown('c', $element[0]);
+    
                 assert.strictEqual(document.activeElement, $element[0],
                     "input " + keepFocusedElements[i] + " should keep focus");
             }
@@ -60,16 +94,12 @@ odoo.define('barcodes.barcode_mobile_tests', function () {
                 "textarea should keep focus");
             // contenteditable elements
             $element = $form.find('[contenteditable=true]');
-            $element.focus().keydown();
+            $element.focus();
+            triggerKeyDown('d', $element[0]);
             assert.strictEqual(document.activeElement, $element[0],
                 "contenteditable should keep focus");
 
             $('#qunit-fixture').empty();
-            barcodeEvents.isChromeMobile = __isChromeMobile;
-            // Rebind keyboard events
-            barcodeEvents.stop();
-            barcodeEvents.start();
-
             document.querySelector('input[name=barcode]').remove();
         });
     });

--- a/addons/barcodes/static/tests/barcode_tests.js
+++ b/addons/barcodes/static/tests/barcode_tests.js
@@ -32,7 +32,6 @@ function simulateBarCode(chars, target = document.body) {
         triggerEvent(target, 'keydown', {
             key: char,
             keyCode: keycode,
-            which: keycode,
         });
     }
 }

--- a/addons/point_of_sale/static/src/js/Chrome.js
+++ b/addons/point_of_sale/static/src/js/Chrome.js
@@ -3,7 +3,6 @@ odoo.define('point_of_sale.Chrome', function(require) {
 
     const { loadCSS } = require('web.ajax');
     const { useListener } = require("@web/core/utils/hooks");
-    const { BarcodeEvents } = require('barcodes.BarcodeEvents');
     const BarcodeParser = require('barcodes.BarcodeParser');
     const PosComponent = require('point_of_sale.PosComponent');
     const NumberBuffer = require('point_of_sale.NumberBuffer');
@@ -20,7 +19,6 @@ odoo.define('point_of_sale.Chrome', function(require) {
         onError,
         onMounted,
         onWillDestroy,
-        onWillUnmount,
         useExternalListener,
         useRef,
         useState,
@@ -83,12 +81,6 @@ odoo.define('point_of_sale.Chrome', function(require) {
                 $(window).off();
                 $('html').off();
                 $('body').off();
-                // The above lines removed the bindings, but we really need them for the barcode
-                BarcodeEvents.start();
-            });
-
-            onWillUnmount(() => {
-                BarcodeEvents.stop();
             });
 
             onWillDestroy(() => {

--- a/addons/point_of_sale/static/src/js/Misc/NumberBuffer.js
+++ b/addons/point_of_sale/static/src/js/Misc/NumberBuffer.js
@@ -3,7 +3,7 @@ odoo.define('point_of_sale.NumberBuffer', function(require) {
 
     const { useListener } = require("@web/core/utils/hooks");
     const { parse } = require('web.field_utils');
-    const { BarcodeEvents } = require('barcodes.BarcodeEvents');
+    const { barcodeService } = require('@barcodes/barcode_service');
     const { _t } = require('web.core');
     const { Gui } = require('point_of_sale.Gui');
 
@@ -162,7 +162,7 @@ odoo.define('point_of_sale.NumberBuffer', function(require) {
             this.config = config;
             this.decimalPoint = config.decimalPoint || this.defaultDecimalPoint;
             this.maxTimeBetweenKeys = this.config.useWithBarcode
-                ? BarcodeEvents.max_time_between_keys_in_ms
+                ? barcodeService.maxTimeBetweenKeysInMs
                 : 0;
         }
         _onKeyboardInput(event) {


### PR DESCRIPTION
Simplify and improve barcode implementation

This PR rework the way barcode is implemented. It introduces a new `barcode_service`, which basically replaces `barcode_events`. The barcode service is meant to be the reference for all code that needs to detect a barcode.

While we are at it, this PR improves the code, remove dead code, and simplify the implementation. It will be followed by a rework for the barcode widgets and barcode handlers, to make them work with the new owl views.
