### PR TITLE
[IMP] mail, *: res.users.settings improvements

### DIFF
--- a/addons/im_livechat/static/src/models/discuss.js
+++ b/addons/im_livechat/static/src/models/discuss.js
@@ -2,6 +2,7 @@
 
 import { addFields, patchRecordMethods } from '@mail/model/model_core';
 import { one } from '@mail/model/model_field';
+import { insertAndReplace } from '@mail/model/model_field_command';
 // ensure that the model definition is loaded before the patch
 import '@mail/models/discuss';
 
@@ -22,6 +23,7 @@ addFields('Discuss', {
      * Discuss sidebar category for `livechat` channel threads.
      */
     categoryLivechat: one('DiscussSidebarCategory', {
+        default: insertAndReplace(),
         inverse: 'discussAsLivechat',
         isCausal: true,
     }),

--- a/addons/im_livechat/static/src/models/discuss_sidebar_category.js
+++ b/addons/im_livechat/static/src/models/discuss_sidebar_category.js
@@ -2,6 +2,7 @@
 
 import { addFields, patchIdentifyingFields, patchRecordMethods } from '@mail/model/model_core';
 import { one } from '@mail/model/model_field';
+import { clear } from '@mail/model/model_field_command';
 // ensure that the model definition is loaded before the patch
 import '@mail/models/discuss_sidebar_category';
 
@@ -19,10 +20,39 @@ patchIdentifyingFields('DiscussSidebarCategory', identifyingFields => {
 patchRecordMethods('DiscussSidebarCategory', {
     /**
      * @override
+     * @private
+     * @returns {boolean|FieldCommand}
+     */
+    _computeIsServerOpen() {
+        // there is no server state for non-users (guests)
+        if (!this.messaging.currentUser) {
+            return clear();
+        }
+        if (!this.messaging.currentUser.res_users_settings_id) {
+            return clear();
+        }
+        if (this.discussAsLivechat) {
+            return this.messaging.currentUser.res_users_settings_id.is_discuss_sidebar_category_livechat_open;
+        }
+        return this._super();
+    },
+    /**
+     * @override
      */
     _computeName() {
         if (this.discussAsLivechat) {
             return this.env._t("Livechat");
+        }
+        return this._super();
+    },
+    /**
+     * @override
+     * @private
+     * @returns {string|FieldCommand}
+     */
+    _computeServerStateKey() {
+        if (this.discussAsLivechat) {
+            return 'is_discuss_sidebar_category_livechat_open';
         }
         return this._super();
     },

--- a/addons/im_livechat/static/src/models/messaging_initializer.js
+++ b/addons/im_livechat/static/src/models/messaging_initializer.js
@@ -1,7 +1,7 @@
 /** @odoo-module **/
 
 import { patchRecordMethods } from '@mail/model/model_core';
-import { insert, insertAndReplace } from '@mail/model/model_field_command';
+import { insert } from '@mail/model/model_field_command';
 // ensure that the model definition is loaded before the patch
 import '@mail/models/messaging_initializer';
 
@@ -15,20 +15,6 @@ patchRecordMethods('MessagingInitializer', {
         } else {
             return this._super();
         }
-    },
-    /**
-     * @override
-     * @param {Object} resUsersSettings
-     * @param {boolean} resUsersSettings.is_discuss_sidebar_category_livechat_open
-     */
-    _initResUsersSettings({ is_discuss_sidebar_category_livechat_open }) {
-        this.messaging.discuss.update({
-            categoryLivechat: insertAndReplace({
-                isServerOpen: is_discuss_sidebar_category_livechat_open,
-                serverStateKey: 'is_discuss_sidebar_category_livechat_open',
-            }),
-        });
-        this._super(...arguments);
     },
     /**
      * @override

--- a/addons/im_livechat/static/src/models/messaging_notification_handler.js
+++ b/addons/im_livechat/static/src/models/messaging_notification_handler.js
@@ -7,19 +7,6 @@ import '@mail/models/messaging_notification_handler';
 patchRecordMethods('MessagingNotificationHandler', {
     /**
      * @override
-     * @param {object} settings
-     * @param {boolean} [settings.is_discuss_sidebar_category_livechat_open]
-    */
-    _handleNotificationResUsersSettings(settings) {
-        if ('is_discuss_sidebar_category_livechat_open' in settings) {
-            this.messaging.discuss.categoryLivechat.update({
-                isServerOpen: settings.is_discuss_sidebar_category_livechat_open,
-            });
-        }
-        this._super(settings);
-    },
-    /**
-     * @override
      */
     _handleNotificationChannelPartnerTypingStatus({ channel_id, is_typing, livechat_username, partner_id, partner_name }) {
         const channel = this.messaging.models['Thread'].findFromIdentifyingData({

--- a/addons/im_livechat/static/src/models/res_users_settings.js
+++ b/addons/im_livechat/static/src/models/res_users_settings.js
@@ -1,0 +1,11 @@
+/** @odoo-module **/
+
+import { addFields } from '@mail/model/model_core';
+import { attr } from '@mail/model/model_field';
+import '@mail/models/res_users_settings'; // ensure the model definition is loaded before the patch
+
+addFields('res.users.settings', {
+    is_discuss_sidebar_category_livechat_open: attr({
+        default: true,
+    }),
+});

--- a/addons/im_livechat/static/tests/qunit_suite_tests/components/discuss_sidebar_category_tests.js
+++ b/addons/im_livechat/static/tests/qunit_suite_tests/components/discuss_sidebar_category_tests.js
@@ -325,6 +325,10 @@ QUnit.test('livechat - states: close from the bus', async function (assert) {
         channel_type: 'livechat',
         livechat_operator_id: pyEnv.currentPartnerId,
     });
+    const resUsersSettingsId1 = pyEnv['res.users.settings'].create({
+        user_id: pyEnv.currentUserId,
+        is_discuss_sidebar_category_livechat_open: true,
+    });
     const { messaging } = await this.start();
 
     assert.containsOnce(
@@ -338,7 +342,8 @@ QUnit.test('livechat - states: close from the bus', async function (assert) {
     );
 
     await afterNextRender(() => {
-        pyEnv['bus.bus']._sendone(pyEnv.currentPartner, 'res.users.settings/changed', {
+        pyEnv['bus.bus']._sendone(pyEnv.currentPartner, 'res.users.settings/insert', {
+            id: resUsersSettingsId1,
             'is_discuss_sidebar_category_livechat_open': false,
         });
     });
@@ -367,7 +372,7 @@ QUnit.test('livechat - states: open from the bus', async function (assert) {
         channel_type: 'livechat',
         livechat_operator_id: pyEnv.currentPartnerId,
     });
-    pyEnv['res.users.settings'].create({
+    const resUsersSettingsId1 = pyEnv['res.users.settings'].create({
         user_id: pyEnv.currentUserId,
         is_discuss_sidebar_category_livechat_open: false,
     });
@@ -384,7 +389,8 @@ QUnit.test('livechat - states: open from the bus', async function (assert) {
     );
 
     await afterNextRender(() => {
-        pyEnv['bus.bus']._sendone(pyEnv.currentPartner, "res.users.settings/changed", {
+        pyEnv['bus.bus']._sendone(pyEnv.currentPartner, 'res.users.settings/insert', {
+            id: resUsersSettingsId1,
             'is_discuss_sidebar_category_livechat_open': true,
         });
     });

--- a/addons/mail/models/res_users_settings_volumes.py
+++ b/addons/mail/models/res_users_settings_volumes.py
@@ -26,12 +26,15 @@ class ResUsersSettingsVolumes(models.Model):
         return [{
             'id': volume_setting.id,
             'volume': volume_setting.volume,
-            'guest': [('insert-and-replace', {
+            'guest_id': [('insert-and-replace', {
                 'id': volume_setting.guest_id.id,
                 'name': volume_setting.guest_id.name,
             })] if volume_setting.guest_id else [('clear',)],
-            'partner': [('insert-and-replace', {
+            'partner_id': [('insert-and-replace', {
                 'id': volume_setting.partner_id.id,
                 'name': volume_setting.partner_id.name,
-            })] if volume_setting.partner_id else [('clear',)]
+            })] if volume_setting.partner_id else [('clear',)],
+            'user_setting_id': [('insert-and-replace', {
+                'id': volume_setting.user_setting_id.id,
+            })],
         } for volume_setting in self]

--- a/addons/mail/static/src/models/discuss.js
+++ b/addons/mail/static/src/models/discuss.js
@@ -364,6 +364,7 @@ registerModel({
          * Discuss sidebar category for `channel` type channel threads.
          */
         categoryChannel: one('DiscussSidebarCategory', {
+            default: insertAndReplace(),
             inverse: 'discussAsChannel',
             isCausal: true,
         }),
@@ -371,6 +372,7 @@ registerModel({
          * Discuss sidebar category for `chat` type channel threads.
          */
         categoryChat: one('DiscussSidebarCategory', {
+            default: insertAndReplace(),
             inverse: 'discussAsChat',
             isCausal: true,
         }),

--- a/addons/mail/static/src/models/guest.js
+++ b/addons/mail/static/src/models/guest.js
@@ -46,8 +46,8 @@ registerModel({
         rtcSessions: many('RtcSession', {
             inverse: 'guest',
         }),
-        volumeSetting: one('VolumeSetting', {
-            inverse: 'guest',
+        volumeSetting: one('res.users.settings.volumes', {
+            inverse: 'guest_id',
         }),
     },
 });

--- a/addons/mail/static/src/models/messaging.js
+++ b/addons/mail/static/src/models/messaging.js
@@ -481,6 +481,7 @@ registerModel({
          */
         starred: one('Thread'),
         userSetting: one('UserSetting', {
+            default: insertAndReplace(),
             isCausal: true,
         }),
     },

--- a/addons/mail/static/src/models/messaging_initializer.js
+++ b/addons/mail/static/src/models/messaging_initializer.js
@@ -105,13 +105,7 @@ registerModel({
             });
             // init mail user settings
             if (current_user_settings) {
-                this._initResUsersSettings(current_user_settings);
-            } else {
-                this.messaging.update({
-                    userSetting: insertAndReplace({
-                        id: -1, // fake id for guest
-                    }),
-                });
+                this.messaging.models['res.users.settings'].insert(current_user_settings);
             }
             // various suggestions in no particular order
             this._initCannedResponses(shortcodes);
@@ -223,46 +217,6 @@ registerModel({
                     message.update({ author: replace(this.messaging.currentPartner) });
                 }
             }));
-        },
-        /**
-         * @param {object} resUsersSettings
-         * @param {integer} resUsersSettings.id
-         * @param {boolean} resUsersSettings.is_discuss_sidebar_category_channel_open
-         * @param {boolean} resUsersSettings.is_discuss_sidebar_category_chat_open
-         * @param {boolean} resUsersSettings.use_push_to_talk
-         * @param {String} resUsersSettings.push_to_talk_key
-         * @param {number} resUsersSettings.voice_active_duration
-         * @param {Object} [resUsersSettings.volume_settings]
-         */
-        _initResUsersSettings({
-            id,
-            is_discuss_sidebar_category_channel_open,
-            is_discuss_sidebar_category_chat_open,
-            use_push_to_talk,
-            push_to_talk_key,
-            voice_active_duration,
-            volume_settings = [],
-        }) {
-            this.messaging.currentUser.update({ resUsersSettingsId: id });
-            this.messaging.update({
-                userSetting: insertAndReplace({
-                    id,
-                    usePushToTalk: use_push_to_talk,
-                    pushToTalkKey: push_to_talk_key,
-                    voiceActiveDuration: voice_active_duration,
-                    volumeSettings: volume_settings,
-                }),
-            });
-            this.messaging.discuss.update({
-                categoryChannel: insertAndReplace({
-                    isServerOpen: is_discuss_sidebar_category_channel_open,
-                    serverStateKey: 'is_discuss_sidebar_category_channel_open',
-                }),
-                categoryChat: insertAndReplace({
-                    isServerOpen: is_discuss_sidebar_category_chat_open,
-                    serverStateKey: 'is_discuss_sidebar_category_chat_open',
-                }),
-            });
         },
         /**
          * @private

--- a/addons/mail/static/src/models/messaging_notification_handler.js
+++ b/addons/mail/static/src/models/messaging_notification_handler.js
@@ -109,16 +109,16 @@ registerModel({
                             return this.messaging.models['Message'].insert(message.payload);
                         case 'mail.channel.rtc.session/insert':
                             return this.messaging.models['RtcSession'].insert(message.payload);
-                        case 'res.users.settings/changed':
-                            return this._handleNotificationResUsersSettings(message.payload);
                         case 'mail.channel.rtc.session/peer_notification':
                             return this._handleNotificationRtcPeerToPeer(message.payload);
                         case 'mail.channel/rtc_sessions_update':
                             return this._handleNotificationRtcSessionUpdate(message.payload);
                         case 'mail.channel.rtc.session/ended':
                             return this._handleNotificationRtcSessionEnded(message.payload);
-                        case 'res.users.settings/volumes_update':
-                            return this._handleNotificationVolumeSettingUpdate(message.payload);
+                        case 'res.users.settings/insert':
+                            return this.messaging.models['res.users.settings'].insert(message.payload);
+                        case 'res.users.settings.volumes/insert':
+                            return this.messaging.models['res.users.settings.volumes'].insert(message.payload);
                         default:
                             return this._handleNotification(message);
                     }
@@ -382,33 +382,6 @@ registerModel({
         },
         /**
          * @private
-         * @param {object} settings
-         * @param {boolean} settings.use_push_to_talk
-         * @param {String} settings.push_to_talk_key
-         * @param {number} settings.voice_active_duration
-         * @param {boolean} [settings.is_discuss_sidebar_category_channel_open]
-         * @param {boolean} [settings.is_discuss_sidebar_category_chat_open]
-         * @param {Object} [payload.volume_settings]
-         */
-        _handleNotificationResUsersSettings(settings) {
-            if ('is_discuss_sidebar_category_channel_open' in settings) {
-                this.messaging.discuss.categoryChannel.update({
-                    isServerOpen: settings.is_discuss_sidebar_category_channel_open,
-                });
-            }
-            if ('is_discuss_sidebar_category_chat_open' in settings) {
-                this.messaging.discuss.categoryChat.update({
-                    isServerOpen: settings.is_discuss_sidebar_category_chat_open,
-                });
-            }
-            this.messaging.userSetting.update({
-                usePushToTalk: settings.use_push_to_talk,
-                pushToTalkKey: settings.push_to_talk_key,
-                voiceActiveDuration: settings.voice_active_duration,
-            });
-        },
-        /**
-         * @private
          * @param {Object} data
          */
         _handleNotificationNeedaction(data) {
@@ -447,16 +420,6 @@ registerModel({
                 sticky,
                 title,
                 type: warning ? 'warning' : 'danger',
-            });
-        },
-        /**
-         * @private
-         * @param {Object} data
-         * @param {Object} [data.volumeSettings]
-         */
-        async _handleNotificationVolumeSettingUpdate({ volumeSettings }) {
-            this.messaging && this.messaging.userSetting.update({
-                volumeSettings: volumeSettings,
             });
         },
         /**

--- a/addons/mail/static/src/models/partner.js
+++ b/addons/mail/static/src/models/partner.js
@@ -436,8 +436,8 @@ registerModel({
         user: one('User', {
             inverse: 'partner',
         }),
-        volumeSetting: one('VolumeSetting', {
-            inverse: 'partner',
+        volumeSetting: one('res.users.settings.volumes', {
+            inverse: 'partner_id',
         }),
     },
 });

--- a/addons/mail/static/src/models/res_users_settings.js
+++ b/addons/mail/static/src/models/res_users_settings.js
@@ -1,0 +1,40 @@
+/** @odoo-module **/
+
+import { registerModel } from '@mail/model/model_core';
+import { attr, many, one } from '@mail/model/model_field';
+
+/**
+ * Mirrors the fields of the python model res.users.settings.
+ */
+registerModel({
+    name: 'res.users.settings',
+    identifyingFields: ['id'],
+    fields: {
+        id: attr({
+            readonly: true,
+            required: true,
+        }),
+        is_discuss_sidebar_category_channel_open: attr({
+            default: true,
+        }),
+        is_discuss_sidebar_category_chat_open: attr({
+            default: true,
+        }),
+        push_to_talk_key: attr(),
+        use_push_to_talk: attr({
+            default: false,
+        }),
+        user_id: one('User', {
+            inverse: 'res_users_settings_id',
+            required: true,
+        }),
+        voice_active_duration: attr(),
+        /**
+         * States the volume chosen by the current user for each other user.
+         */
+        volume_settings_ids: many('res.users.settings.volumes', {
+            inverse: 'user_setting_id',
+            isCausal: true,
+        }),
+    },
+});

--- a/addons/mail/static/src/models/res_users_settings_volumes.js
+++ b/addons/mail/static/src/models/res_users_settings_volumes.js
@@ -4,20 +4,19 @@ import { registerModel } from '@mail/model/model_core';
 import { attr, one } from '@mail/model/model_field';
 import { OnChange } from '@mail/model/model_onchange';
 
+/**
+ * Mirrors the fields of the python model res.users.settings.volumes.
+ */
 registerModel({
-    name: 'VolumeSetting',
+    name: 'res.users.settings.volumes',
     identifyingFields: ['id'],
     recordMethods: {
         /**
          * @private
          */
         _onChangeVolume() {
-            let rtcSessions;
-            if (this.partner) {
-                rtcSessions = this.partner.rtcSessions;
-            } else if (this.guest) {
-                rtcSessions = this.guest.rtcSessions;
-            } else {
+            const { rtcSessions } = this.partner_id || this.guest_id;
+            if (!rtcSessions) {
                 return;
             }
             for (const rtcSession of rtcSessions) {
@@ -28,18 +27,19 @@ registerModel({
         },
     },
     fields: {
-        guest: one('Guest', {
+        guest_id: one('Guest', {
             inverse: 'volumeSetting',
         }),
         id: attr({
             readonly: true,
             required: true,
         }),
-        partner: one('Partner', {
+        partner_id: one('Partner', {
             inverse: 'volumeSetting',
         }),
-        userSetting: one('UserSetting', {
-            inverse: 'volumeSettings',
+        user_setting_id: one('res.users.settings', {
+            inverse: 'volume_settings_ids',
+            readonly: true,
             required: true,
         }),
         volume: attr({

--- a/addons/mail/static/src/models/user.js
+++ b/addons/mail/static/src/models/user.js
@@ -195,9 +195,8 @@ registerModel({
         partner: one('Partner', {
             inverse: 'user',
         }),
-        /**
-         * Id of this user's res.users.settings record.
-         */
-        resUsersSettingsId: attr(),
+        res_users_settings_id: one('res.users.settings', {
+            inverse: 'user_id',
+        }),
     },
 });

--- a/addons/mail/static/tests/helpers/model_definitions_setup.js
+++ b/addons/mail/static/tests/helpers/model_definitions_setup.js
@@ -16,7 +16,8 @@ addModelNamesToFetch([
     'ir.attachment', 'ir.model', 'ir.model.fields', 'mail.activity', 'mail.activity.type',
     'mail.channel', 'mail.channel.partner', 'mail.followers', 'mail.message', 'mail.message.subtype',
     'mail.notification', 'mail.shortcode', 'mail.template', 'mail.tracking.value',
-    'res.company', 'res.country', 'res.partner', 'res.users', 'res.users.settings', 'res.groups'
+    'res.company', 'res.country', 'res.partner', 'res.users', 'res.users.settings', 'res.groups',
+    'res.users.settings.volumes'
 ]);
 
 addFakeModel('res.fake', {

--- a/addons/mail/static/tests/qunit_suite_tests/components/discuss_sidebar_category_tests.js
+++ b/addons/mail/static/tests/qunit_suite_tests/components/discuss_sidebar_category_tests.js
@@ -314,14 +314,15 @@ QUnit.test('channel - states: close from the bus', async function (assert) {
 
     const pyEnv = await startServer();
     const mailChannelId1 = pyEnv['mail.channel'].create();
-    pyEnv['res.users.settings'].create({
+    const resUsersSettingsId1 = pyEnv['res.users.settings'].create({
         user_id: pyEnv.currentUserId,
         is_discuss_sidebar_category_channel_open: true,
     });
     const { messaging } = await this.start();
 
     await afterNextRender(() => {
-        pyEnv['bus.bus']._sendone(pyEnv.currentPartner, "res.users.settings/changed", {
+        pyEnv['bus.bus']._sendone(pyEnv.currentPartner, 'res.users.settings/insert', {
+            id: resUsersSettingsId1,
             'is_discuss_sidebar_category_channel_open': false,
         });
     });
@@ -342,14 +343,15 @@ QUnit.test('channel - states: open from the bus', async function (assert) {
 
     const pyEnv = await startServer();
     const mailChannelId1 = pyEnv['mail.channel'].create();
-    pyEnv['res.users.settings'].create({
+    const resUsersSettingsId1 = pyEnv['res.users.settings'].create({
         user_id: pyEnv.currentUserId,
         is_discuss_sidebar_category_channel_open: false,
     });
     const { messaging } = await this.start();
 
     await afterNextRender(() => {
-        pyEnv['bus.bus']._sendone(pyEnv.currentPartner, "res.users.settings/changed", {
+        pyEnv['bus.bus']._sendone(pyEnv.currentPartner, 'res.users.settings/insert', {
+            id: resUsersSettingsId1,
             'is_discuss_sidebar_category_channel_open': true,
         });
     });
@@ -682,14 +684,15 @@ QUnit.test('chat - states: close from the bus', async function (assert) {
         channel_type: 'chat',
         public: 'private',
     });
-    pyEnv['res.users.settings'].create({
+    const resUsersSettingsId1 = pyEnv['res.users.settings'].create({
         user_id: pyEnv.currentUserId,
         is_discuss_sidebar_category_chat_open: true,
     });
     const { messaging } = await this.start();
 
     await afterNextRender(() => {
-        pyEnv['bus.bus']._sendone(pyEnv.currentPartner, "res.users.settings/changed", {
+        pyEnv['bus.bus']._sendone(pyEnv.currentPartner, 'res.users.settings/insert', {
+            id: resUsersSettingsId1,
             'is_discuss_sidebar_category_chat_open': false,
         });
     });
@@ -713,14 +716,15 @@ QUnit.test('chat - states: open from the bus', async function (assert) {
         channel_type: 'chat',
         public: 'private',
     });
-    pyEnv['res.users.settings'].create({
+    const resUsersSettingsId1 = pyEnv['res.users.settings'].create({
         user_id: pyEnv.currentUserId,
         is_discuss_sidebar_category_chat_open: false,
     });
     const { messaging } = await this.start();
 
     await afterNextRender(() => {
-        pyEnv['bus.bus']._sendone(pyEnv.currentPartner, "res.users.settings/changed", {
+        pyEnv['bus.bus']._sendone(pyEnv.currentPartner, 'res.users.settings/insert', {
+            id: resUsersSettingsId1,
             'is_discuss_sidebar_category_chat_open': true,
         });
     });

--- a/addons/mail/tests/test_res_users_settings.py
+++ b/addons/mail/tests/test_res_users_settings.py
@@ -35,8 +35,11 @@ class TestResUsersSettings(MailCommon):
         with self.assertBus(
                 [(self.cr.dbname, 'res.partner', self.partner_employee.id)],
                 [{
-                    "type": "res.users.settings/changed",
-                    "payload": {"is_discuss_sidebar_category_chat_open": True}
+                    'type': 'res.users.settings/insert',
+                    'payload': {
+                        'id': settings.id,
+                        'is_discuss_sidebar_category_chat_open': True,
+                    },
                 }]):
             settings.set_res_users_settings({'is_discuss_sidebar_category_chat_open': True})
 

--- a/addons/test_discuss_full/tests/test_performance.py
+++ b/addons/test_discuss_full/tests/test_performance.py
@@ -802,8 +802,8 @@ class TestDiscussFullPerformance(TransactionCase):
                 'is_discuss_sidebar_category_livechat_open': True,
                 'push_to_talk_key': False,
                 'use_push_to_talk': False,
-                'user_id': (self.users[0].id, 'Ernest Employee'),
+                'user_id': [('insert-and-replace', {'id': self.users[0].id})],
                 'voice_active_duration': 0,
-                'volume_settings': [],
+                'volume_settings_ids': [('insert', [])],
             },
         }


### PR DESCRIPTION
\* = im_livechat, test_discuss_full

Various improvements to user settings, including:

+ Introduce new js models `res.users.settings` and `res.users.settings.volumes`
to mirror the python models.
+ Avoid reformatting server data and simplify the way notifications are handled.
+ Clean dead code (unused convertData).
+ Reword and add documentation.

Enterprise: https://github.com/odoo/enterprise/pull/28291