### PR TITLE
[FIX] sale_product_configurator: do not reset product on edition cancel

### DIFF
--- a/addons/sale_product_configurator/static/src/js/product_configurator_widget.js
+++ b/addons/sale_product_configurator/static/src/js/product_configurator_widget.js
@@ -193,6 +193,7 @@ ProductConfiguratorWidget.include({
             this._super.apply(this, arguments);
             return;
         }
+        this.restoreProductTemplateId = this.recordData.product_template_id;
         // If line has been set up through the product_configurator:
         this._openProductConfigurator({
                 configuratorMode: 'edit',

--- a/addons/sale_product_matrix/static/src/js/product_matrix_configurator.js
+++ b/addons/sale_product_matrix/static/src/js/product_matrix_configurator.js
@@ -54,6 +54,7 @@ ProductConfiguratorWidget.include({
             if (result && result[0].product_add_mode === 'matrix') {
                 self._openGridConfigurator(productTemplateId, self.dataPointID, true);
             } else {
+                self.restoreProductTemplateId = self.recordData.product_template_id;
                 // Call super only if product_add_mode different than matrix
                 // to avoid product configurator opening (which is the default case).
                 self._openProductConfigurator({


### PR DESCRIPTION
After opening the wizard in "edit" mode (through the pencil icon shown next
to the product in edit mode), if you clicked either on the "Cancel" button
 or on the "X" to leave/close the wizard, the product was reset on the SOline.

Cancelling a modification should keep the state before the modification and
not reset the line.

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
