### PR TITLE
[FIX] account_move: allow journal's default accounts with type_contro…

### DIFF
--- a/addons/account/models/account_move.py
+++ b/addons/account/models/account_move.py
@@ -3952,16 +3952,15 @@ class AccountMoveLine(models.Model):
             if account.allowed_journal_ids and journal not in account.allowed_journal_ids:
                 raise UserError(_('You cannot use this account (%s) in this journal, check the field \'Allowed Journals\' on the related account.', account.display_name))
 
-            failed_check = False
-            if (journal.type_control_ids - journal.default_account_id.user_type_id) or journal.account_control_ids:
-                failed_check = True
-                if journal.type_control_ids:
-                    failed_check = account.user_type_id not in (journal.type_control_ids - journal.default_account_id.user_type_id)
-                if failed_check and journal.account_control_ids:
-                    failed_check = account not in journal.account_control_ids
+            if account in (journal.default_account_id, journal.suspense_account_id):
+                continue
 
-            if failed_check:
-                raise UserError(_('You cannot use this account (%s) in this journal, check the section \'Control-Access\' under tab \'Advanced Settings\' on the related journal.', account.display_name))
+            is_account_control_ok = not journal.account_control_ids or account in journal.account_control_ids
+            is_type_control_ok = not journal.type_control_ids or account.user_type_id in journal.type_control_ids
+
+            if not is_account_control_ok or not is_type_control_ok:
+                raise UserError(_("You cannot use this account (%s) in this journal, check the section 'Control-Access' under "
+                                  "tab 'Advanced Settings' on the related journal.", account.display_name))
 
     @api.constrains('account_id', 'tax_ids', 'tax_line_id', 'reconciled')
     def _check_off_balance(self):

--- a/addons/account/tests/test_account_journal.py
+++ b/addons/account/tests/test_account_journal.py
@@ -58,6 +58,38 @@ class TestAccountJournal(AccountTestInvoicingCommon):
         self.company_data['default_journal_misc'].account_control_ids |= self.company_data['default_account_expense']
         self.env['account.move'].create(move_vals)
 
+    def test_default_account_type_control_create_journal_entry(self):
+        move_vals = {
+            'line_ids': [
+                (0, 0, {
+                    'name': 'debit',
+                    'account_id': self.company_data['default_account_revenue'].id,
+                    'debit': 100.0,
+                    'credit': 0.0,
+                }),
+                (0, 0, {
+                    'name': 'credit',
+                    'account_id': self.company_data['default_account_expense'].id,
+                    'debit': 0.0,
+                    'credit': 100.0,
+                }),
+            ],
+        }
+
+        # Set the 'default_account_id' on the journal and make sure it will not raise an error,
+        # even if it is not explicitly included in the 'type_control_ids'.
+        self.company_data['default_journal_misc'].default_account_id = self.company_data['default_account_expense'].id
+
+        # Should fail because 'default_account_revenue' type is not allowed.
+        self.company_data['default_journal_misc'].type_control_ids |= self.company_data['default_account_receivable'].user_type_id
+        with self.assertRaises(UserError), self.cr.savepoint():
+            self.env['account.move'].create(move_vals)
+
+        # Should pass because both account types are allowed.
+        # 'default_account_revenue' explicitly and 'default_account_expense' implicitly.
+        self.company_data['default_journal_misc'].type_control_ids |= self.company_data['default_account_revenue'].user_type_id
+        self.env['account.move'].create(move_vals)
+
     def test_account_control_existing_journal_entry(self):
         self.env['account.move'].create({
             'line_ids': [


### PR DESCRIPTION
…l_ids

Fixes a bug introduced by this commit : https://github.com/odoo/odoo/commit/aba9ef6a27eca5f70ab7be87a929846988710048

The problem was that once the type_control_ids were activated,
it would always raise an error due to the journal's default_account_id.

This issue was raised by a community member in this PR : https://github.com/odoo/odoo/pull/92390

A test is also included to prevent having the same issue in the future.

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
