### PR TITLE
[FIX] website: allow height control over inline embed code snippets

### DIFF
--- a/addons/website/static/src/js/editor/snippets.editor.js
+++ b/addons/website/static/src/js/editor/snippets.editor.js
@@ -67,7 +67,17 @@ weSnippetEditor.SnippetsMenu.include({
         });
         FontFamilyPickerUserValueWidget.prototype.fontVariables = fontVariables;
 
-        return this._super(...arguments);
+        const ret = this._super(...arguments);
+
+        // TODO adapt in master. This patches the embed code snippet
+        // in stable versions.
+        const $sbody = this.$snippets.find('[data-snippet="s_embed_code"]');
+        if ($sbody.length) {
+            $sbody[0].classList.remove('o_half_screen_height');
+            $sbody[0].classList.add('pt64', 'pb64');
+        }
+
+        return ret;
     },
     /**
      * Depending of the demand, reconfigure they gmap key or configure it
@@ -212,7 +222,7 @@ weSnippetEditor.SnippetsMenu.include({
     /**
      * Activates the button to animate text if the selection is in an
      * animated text element or deactivates the button if not.
-     * 
+     *
      * @private
      */
     _toggleAnimatedTextButton() {
@@ -226,7 +236,7 @@ weSnippetEditor.SnippetsMenu.include({
     /**
      * Displays the button that allows to highlight the animated text if there
      * is animated text in the page.
-     * 
+     *
      * @private
      */
     _toggleHighlightAnimatedTextButton() {

--- a/addons/website/views/snippets/s_embed_code.xml
+++ b/addons/website/views/snippets/s_embed_code.xml
@@ -1,6 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <odoo>
 
+<!-- TODO adapt in master: this is patched in JS to remove the min-height -->
+<!-- class and use padding classes -->
 <template name="Embed Code" id="s_embed_code">
     <section class="s_embed_code o_half_screen_height text-center">
         <div class="s_embed_code_embedded container o_not_editable">


### PR DESCRIPTION
The embed code snippet (introduced at [1]) comes with a default
"half-screen" min-height. Since [2] (patched with [3]), the min-height
option is not shown anymore for snippets which are dropped in other
snippets ("inline" snippets)... and [4] actually made the embed code
snippet an "inline" one later on. The problem is that once dropped as
an "inline" one, the embed code snippet had thus a "half-screen"
min-height which was impossible to remove.

This commit patches the snippet so that it does not use a default
"half-screen" min-height but default paddings which work both as
"main" and "inline" snippets. The user can still use the min-height
option by himself if he wants to.

[1]: https://github.com/odoo/odoo/commit/2cc481d1a62202ade4c1ca8f846c962f9f2cc34d
[2]: https://github.com/odoo/odoo/commit/58503a248e7ab6b66d61d00869cdae6719e5a068
[3]: https://github.com/odoo/odoo/commit/bebb45e6d5e8224f2d534d5644b9af45fea903b1
[4]: https://github.com/odoo/odoo/commit/6336d1ba35f36733958cab48c1d90b6e3c0505d2

opw-2870772
