### PR TITLE
[FIX] web_editor: remove duplicated SCSS rules

### DIFF
--- a/addons/web_editor/static/src/scss/web_editor.common.scss
+++ b/addons/web_editor/static/src/scss/web_editor.common.scss
@@ -830,33 +830,6 @@ section, .oe_img_bg, [data-oe-shape-data] {
     @extend %o-we-background-layer;
 }
 
-.o_full_screen_height {
-    display: flex;
-    flex-direction: column;
-    justify-content: space-around;
-    min-height: 100vh !important;
-}
-.o_half_screen_height {
-    @extend .o_full_screen_height;
-    min-height: 55vh !important;
-}
-
-// TODO remove cover_full and cover_mid classes (kept for compatibility for now)
-.cover_full {
-    @extend .o_full_screen_height;
-}
-.cover_mid {
-    @extend .o_half_screen_height;
-}
-
-// Smaller container
-.o_container_small {
-    @extend .container;
-    @include media-breakpoint-up(lg) {
-        max-width: map-get($container-max-widths, md);
-    }
-}
-
 // Gradient
 // TODO should be in the editor lib since it is handled there... but could not
 // find the right place for it.


### PR DESCRIPTION
**`/!\` WIP: need more investigation, more cleaning and maybe to do in master-only to be safe... `/!\`**

Two sets of SCSS rules were duplicated:
- container width (o_container_small)
- block min height (o_full_screen_height, etc)

Here is a series of events:

1. Commit [1] moved the definition of the block min height option as
   part of the ScrollButton option. At that time, both sets of SCSS
   rules lie in website.

2. Commit [2] breaks commit [1] and moves the sets of SCSS rule to a
   web_editor file so they can be shared between mass_mailing and
   website. However:

   - The block min height scss rules that were shared are not used by
     mass_mailing at all. Instead the option logic was duplicated and
     tweaked with its own classnames. The rules are thus shared for
     no reason.

3. Commit [3] reverts part of commit [2] and restores commit [1].
   However:

   - The container width rules are back in website but kept in the
     shared editor file too. The related option is however back in
     website only. This commit thus removes the rules from the
     shared file. However, the mass mailing options still seem to
     mention the classes in their JS for no reason...

   - The block min height rules are back in website but kept in the
     shared editor file too. As mentioned at step (2), they should
     never have been shared anyway. This commit removes the rules
     from the shared file.

[1]: https://github.com/odoo/odoo/commit/85ae7fe56e93fcc18b3842e6c116bcb6968988e3
[2]: https://github.com/odoo/odoo/commit/4f7cd33d0fd69ee5984d0968233ffc73d7751030
[3]: https://github.com/odoo/odoo/commit/def4f06e733e394829ec2a10d8febd938e43bae4

opw-2870772