### PR TITLE
[FIX] various: fix traceback in survey with demo data

### DIFF
--- a/addons/hr_recruitment_survey/data/survey_demo.xml
+++ b/addons/hr_recruitment_survey/data/survey_demo.xml
@@ -19,6 +19,7 @@
         <field name="title">About you</field>
         <field name="survey_id" ref="survey_recruitment_form"/>
         <field name="is_page" eval="True" />
+        <field name="question_type" eval="False"/>
         <field name="sequence">1</field>
         <field name="description" type="html">
 <p>Please fill information about you: who you are, what are your education, experience, and activities.

--- a/addons/survey/static/src/js/survey_session_manage.js
+++ b/addons/survey/static/src/js/survey_session_manage.js
@@ -524,7 +524,7 @@ publicWidget.registry.SurveySessionManage = publicWidget.Widget.extend(SurveyPre
             delete this.resultsChart;
         }
 
-        if (!this.isStartScreen && this.showBarChart && this.$el.data('questionStatistics')) {
+        if (!this.isStartScreen && this.showBarChart) {
             this.resultsChart = new SurveySessionChart(this, {
                 questionType: this.$el.data('questionType'),
                 answersValidity: this.$el.data('answersValidity'),

--- a/addons/survey/tests/common.py
+++ b/addons/survey/tests/common.py
@@ -300,6 +300,7 @@ class TestSurveyCommon(SurveyCase):
             'survey_id': self.survey.id,
             'sequence': 1,
             'is_page': True,
+            'question_type': False,
         })
         self.question_ft = self.env['survey.question'].with_user(self.survey_manager).create({
             'title': 'Test Free Text',

--- a/addons/survey/tests/test_survey_compute_pages_questions.py
+++ b/addons/survey/tests/test_survey_compute_pages_questions.py
@@ -13,6 +13,7 @@ class TestSurveyComputePagesQuestions(common.TestSurveyCommon):
 
             page_0 = self.env['survey.question'].create({
                 'is_page': True,
+                'question_type': False,
                 'sequence': 1,
                 'title': 'P1',
                 'survey_id': survey.id
@@ -25,6 +26,7 @@ class TestSurveyComputePagesQuestions(common.TestSurveyCommon):
 
             page_1 = self.env['survey.question'].create({
                 'is_page': True,
+                'question_type': False,
                 'sequence': 7,
                 'title': 'P2',
                 'survey_id': survey.id,

--- a/addons/survey/tests/test_survey_flow.py
+++ b/addons/survey/tests/test_survey_flow.py
@@ -31,6 +31,7 @@ class TestSurveyFlow(common.TestSurveyCommon, HttpCase):
             # First page is about customer data
             page_0 = self.env['survey.question'].create({
                 'is_page': True,
+                'question_type': False,
                 'sequence': 1,
                 'title': 'Page1: Your Data',
                 'survey_id': survey.id,
@@ -47,6 +48,7 @@ class TestSurveyFlow(common.TestSurveyCommon, HttpCase):
             # Second page is about tarte al djotte
             page_1 = self.env['survey.question'].create({
                 'is_page': True,
+                'question_type': False,
                 'sequence': 4,
                 'title': 'Page2: Tarte Al Djotte',
                 'survey_id': survey.id,

--- a/addons/survey/tests/test_survey_flow_with_conditions.py
+++ b/addons/survey/tests/test_survey_flow_with_conditions.py
@@ -23,6 +23,7 @@ class TestSurveyFlowWithConditions(common.TestSurveyCommon, HttpCase):
                 'survey_id': survey.id,
                 'sequence': 1,
                 'is_page': True,
+                'question_type': False,
             })
 
             q01 = self._add_question(

--- a/addons/survey/tests/test_survey_invite.py
+++ b/addons/survey/tests/test_survey_invite.py
@@ -30,13 +30,13 @@ class TestSurveyInvite(common.TestSurveyCommon):
             # no page
             self.env['survey.survey'].create({'title': 'Test survey'}),
             # no questions
-            self.env['survey.survey'].create({'title': 'Test survey', 'question_and_page_ids': [(0, 0, {'is_page': True, 'title': 'P0', 'sequence': 1})]}),
+            self.env['survey.survey'].create({'title': 'Test survey', 'question_and_page_ids': [(0, 0, {'is_page': True, 'question_type': False, 'title': 'P0', 'sequence': 1})]}),
             # closed
             self.env['survey.survey'].with_user(self.survey_manager).create({
                 'title': 'S0',
                 'active': False,
                 'question_and_page_ids': [
-                    (0, 0, {'is_page': True, 'title': 'P0', 'sequence': 1}),
+                    (0, 0, {'is_page': True, 'question_type': False, 'title': 'P0', 'sequence': 1}),
                     (0, 0, {'title': 'Q0', 'sequence': 2, 'question_type': 'text_box'})
                 ]
             })

--- a/addons/survey/tests/test_survey_randomize.py
+++ b/addons/survey/tests/test_survey_randomize.py
@@ -12,6 +12,7 @@ class TestSurveyRandomize(TransactionCase):
         page_1 = Question.create({
             'title': 'Page 1',
             'is_page': True,
+            'question_type': False,
             'sequence': 1,
             'random_questions_count': 3
         })
@@ -21,6 +22,7 @@ class TestSurveyRandomize(TransactionCase):
         page_2 = Question.create({
             'title': 'Page 2',
             'is_page': True,
+            'question_type': False,
             'sequence': 100,
             'random_questions_count': 5
         })
@@ -30,6 +32,7 @@ class TestSurveyRandomize(TransactionCase):
         page_3 = Question.create({
             'title': 'Page 2',
             'is_page': True,
+            'question_type': False,
             'sequence': 1000,
             'random_questions_count': 4
         })

--- a/addons/survey/tests/test_survey_security.py
+++ b/addons/survey/tests/test_survey_security.py
@@ -27,7 +27,7 @@ class TestAccess(common.TestSurveyCommon):
         with self.assertRaises(AccessError):
             self.env['survey.survey'].create({'title': 'Test Survey 2'})
         with self.assertRaises(AccessError):
-            self.env['survey.question'].create({'title': 'My Page', 'sequence': 0, 'is_page': True, 'survey_id': self.survey.id})
+            self.env['survey.question'].create({'title': 'My Page', 'sequence': 0, 'is_page': True, 'question_type': False, 'survey_id': self.survey.id})
         with self.assertRaises(AccessError):
             self.env['survey.question'].create({'title': 'My Question', 'sequence': 1, 'page_id': self.page_0.id})
 
@@ -60,7 +60,7 @@ class TestAccess(common.TestSurveyCommon):
         with self.assertRaises(AccessError):
             self.env['survey.survey'].create({'title': 'Test Survey 2'})
         with self.assertRaises(AccessError):
-            self.env['survey.question'].create({'title': 'My Page', 'sequence': 0, 'is_page': True, 'survey_id': self.survey.id})
+            self.env['survey.question'].create({'title': 'My Page', 'sequence': 0, 'is_page': True, 'question_type': False, 'survey_id': self.survey.id})
         with self.assertRaises(AccessError):
             self.env['survey.question'].create({'title': 'My Question', 'sequence': 1, 'page_id': self.page_0.id})
 
@@ -93,7 +93,7 @@ class TestAccess(common.TestSurveyCommon):
         with self.assertRaises(AccessError):
             self.env['survey.survey'].create({'title': 'Test Survey 2'})
         with self.assertRaises(AccessError):
-            self.env['survey.question'].create({'title': 'My Page', 'sequence': 0, 'is_page': True, 'survey_id': self.survey.id})
+            self.env['survey.question'].create({'title': 'My Page', 'sequence': 0, 'is_page': True, 'question_type': False, 'survey_id': self.survey.id})
         with self.assertRaises(AccessError):
             self.env['survey.question'].create({'title': 'My Question', 'sequence': 1, 'page_id': self.page_0.id})
 
@@ -123,7 +123,7 @@ class TestAccess(common.TestSurveyCommon):
     def test_access_survey_survey_manager(self):
         # Create: all
         survey = self.env['survey.survey'].create({'title': 'Test Survey 2'})
-        self.env['survey.question'].create({'title': 'My Page', 'sequence': 0, 'is_page': True, 'survey_id': survey.id})
+        self.env['survey.question'].create({'title': 'My Page', 'sequence': 0, 'is_page': True, 'question_type': False, 'survey_id': survey.id})
         self.env['survey.question'].create({'title': 'My Question', 'sequence': 1, 'survey_id': survey.id})
 
         # Read: all
@@ -142,7 +142,7 @@ class TestAccess(common.TestSurveyCommon):
     def test_access_survey_survey_user(self):
         # Create: own only
         survey = self.env['survey.survey'].create({'title': 'Test Survey 2'})
-        self.env['survey.question'].create({'title': 'My Page', 'sequence': 0, 'is_page': True, 'survey_id': survey.id})
+        self.env['survey.question'].create({'title': 'My Page', 'sequence': 0, 'is_page': True, 'question_type': False, 'survey_id': survey.id})
         self.env['survey.question'].create({'title': 'My Question', 'sequence': 1, 'survey_id': survey.id})
 
         # Read: all
@@ -251,7 +251,7 @@ class TestAccess(common.TestSurveyCommon):
     @users('survey_user')
     def test_access_answers_survey_user(self):
         survey_own = self.env['survey.survey'].create({'title': 'Other'})
-        self.env['survey.question'].create({'title': 'Other', 'sequence': 0, 'is_page': True, 'survey_id': survey_own.id})
+        self.env['survey.question'].create({'title': 'Other', 'sequence': 0, 'is_page': True, 'question_type': False, 'survey_id': survey_own.id})
         question_own = self.env['survey.question'].create({'title': 'Other Question', 'sequence': 1, 'survey_id': survey_own.id})
 
         # Create: own survey only
@@ -294,7 +294,7 @@ class TestAccess(common.TestSurveyCommon):
         admin = self.env.ref('base.user_admin')
         with self.with_user(admin.login):
             survey_other = self.env['survey.survey'].create({'title': 'Other'})
-            self.env['survey.question'].create({'title': 'Other', 'sequence': 0, 'is_page': True, 'survey_id': survey_other.id})
+            self.env['survey.question'].create({'title': 'Other', 'sequence': 0, 'is_page': True, 'question_type': False, 'survey_id': survey_other.id})
             question_other = self.env['survey.question'].create({'title': 'Other Question', 'sequence': 1, 'survey_id': survey_other.id})
             self.assertEqual(survey_other.create_uid, admin)
             self.assertEqual(question_other.create_uid, admin)

--- a/addons/survey/views/survey_templates_user_input_session.xml
+++ b/addons/survey/views/survey_templates_user_input_session.xml
@@ -61,7 +61,7 @@
     <template id="user_input_session_manage_content" name="Survey User Input Session Manage">
         <t t-set="question" t-value="survey.session_question_id" />
         <t t-set="is_scored_question" t-value="any(answer.answer_score for answer in question.suggested_answer_ids)" />
-        <t t-set="show_bar_chart" t-value="not question.is_page and question.question_type in ['simple_choice', 'multiple_choice']" />
+        <t t-set="show_bar_chart" t-value="question.question_type in ['simple_choice', 'multiple_choice']" />
         <t t-set="show_text_answers" t-value="question.question_type in ['char_box', 'date', 'datetime'] and not question.save_as_email and not question.save_as_nickname" />
         <div class="wrap min-vh-100 align-items-center justify-content-center d-flex flex-column o_survey_session_manage invisible"
             t-att-style="'display: none;' if is_rpc_call else ''"

--- a/addons/test_website_slides_full/tests/test_ui_wslides.py
+++ b/addons/test_website_slides_full/tests/test_ui_wslides.py
@@ -70,6 +70,7 @@ class TestUi(TestUICommon):
                     'title': 'Furniture',
                     'sequence': 1,
                     'is_page': True,
+                    'question_type': False,
                     'description': "&lt;p&gt;Test your furniture knowledge!&lt;/p&gt",
                 }), (0, 0, {
                     'title': 'What type of wood is the best for furniture?',

--- a/addons/website_slides_survey/data/survey_demo.xml
+++ b/addons/website_slides_survey/data/survey_demo.xml
@@ -22,6 +22,7 @@
             <field name="survey_id" ref="furniture_certification" />
             <field name="sequence">1</field>
             <field name="is_page" eval="True"/>
+            <field name="question_type" eval="False"/>
             <field name="description">&lt;p&gt;Test your furniture knowledge!&lt;/p&gt;</field>
         </record>
         <!-- Question and predefined answer 1 -->


### PR DESCRIPTION
Currently, in demo data of some surveys, there are records of 'survey.question'
having 'is_page' field value as true and 'question_type' is not defined. When
question type is not defined, default value 'simple_choice' is assigned to the
'question_type' field. Now when we create a live session of that survey and
goes to the page, it tries to read the data for bar chart but data is not
available (undefined) and throws the traceback. This happens  because
question types ('simple_choice', 'multiple_choice') has bar chart.
Previous versions set the  default 'question_type' value to 'text_box',
so no traceback is triggered.

In this PR, we are setting the 'question_type' field value to 'False' in the
demo data record whose 'is_page' field value is 'True'.

taskID- 2841582