### PR TITLE
[FIX] website: fix "over the content" option not saved

### DIFF
--- a/addons/web/static/src/legacy/js/public/public_root.js
+++ b/addons/web/static/src/legacy/js/public/public_root.js
@@ -297,6 +297,7 @@ export const PublicRoot = publicWidget.RootWidget.extend({
         ev.data.callback({
             model: m[1],
             id: m[2] | 0,
+            viewid: parseInt(document.documentElement.dataset.viewid),
         });
     },
     /**

--- a/addons/website/static/src/js/menu/content.js
+++ b/addons/website/static/src/js/menu/content.js
@@ -991,6 +991,15 @@ var ContentMenu = websiteNavbarData.WebsiteNavbarActionWidget.extend({
         // If simulate is true, it means we want the option to be toggled but
         // not saved on the server yet
         if (!forceSave) {
+            // Add the 'o_dirty' class on an editable element specific to the
+            // page to notify the editor that the page should be saved,
+            // otherwise it won't save anything if it doesn't detect any change
+            // inside the #wrapwrap. (e.g. the header "over the content" option
+            // which adds a class on the #wrapwrap itself and not inside it).
+            const pageEl = document.querySelector(`.o_editable[data-oe-model="ir.ui.view"][data-oe-id="${mo.viewid}"]`);
+            if (pageEl) {
+                pageEl.classList.add('o_dirty');
+            }
             return Promise.resolve();
         }
 

--- a/addons/website/static/src/js/tours/tour_utils.js
+++ b/addons/website/static/src/js/tours/tour_utils.js
@@ -132,7 +132,7 @@ function clickOnEdit(position = "bottom") {
 function clickOnSnippet(snippet, position = "bottom") {
     return {
         trigger: snippet.id ? `#wrapwrap .${snippet.id}` : snippet,
-        extra_trigger: "body.editor_enable",
+        extra_trigger: "body.editor_enable #oe_snippets.o_loaded",
         content: Markup(_t("<b>Click on a snippet</b> to access its options menu.")),
         position: position,
         run: "click",

--- a/addons/website/static/tests/tours/website_page_options.js
+++ b/addons/website/static/tests/tours/website_page_options.js
@@ -1,0 +1,57 @@
+/** @odoo-module **/
+
+import tour from 'web_tour.tour';
+import wTourUtils from 'website.tour_utils';
+
+tour.register("website_page_options", {
+    test: true,
+    url: "/?enable_editor=1",
+}, [
+    wTourUtils.clickOnSnippet({id: 'o_header_standard', name: 'Header'}),
+    wTourUtils.changeOption('TopMenuVisibility', 'we-select:has([data-visibility]) we-toggler'),
+    wTourUtils.changeOption('TopMenuVisibility', 'we-button[data-visibility="transparent"]'),
+    // It's important to test saving right after changing that option only as
+    // this is why this test was made in the first place: the page was not
+    // marked as dirty when that option was the only one that was changed.
+    ...wTourUtils.clickOnSave(),
+    {
+        content: "Check that the header is transparent",
+        trigger: '#wrapwrap.o_header_overlay',
+        run: () => null, // it's a check
+    },
+    wTourUtils.clickOnEdit(),
+    wTourUtils.clickOnSnippet({id: 'o_header_standard', name: 'Header'}),
+    wTourUtils.changeOption('topMenuColor', 'we-select.o_we_so_color_palette'),
+    wTourUtils.changeOption('topMenuColor', 'button[data-color="black-50"]'),
+    ...wTourUtils.clickOnSave(),
+    {
+        content: "Check that the header is in black-50",
+        trigger: 'header#top.bg-black-50',
+        run: () => null, // it's a check
+    },
+    wTourUtils.clickOnEdit(),
+    wTourUtils.clickOnSnippet({id: 'o_header_standard', name: 'Header'}),
+    wTourUtils.changeOption('TopMenuVisibility', 'we-select:has([data-visibility]) we-toggler'),
+    wTourUtils.changeOption('TopMenuVisibility', 'we-button[data-visibility="hidden"]'),
+    ...wTourUtils.clickOnSave(),
+    {
+        content: "Check that the header is hidden",
+        trigger: '#wrapwrap:has(header#top.d-none.o_snippet_invisible)',
+        run: () => null, // it's a check
+    },
+    wTourUtils.clickOnEdit(),
+    {
+        content: "Click on 'header' in the invisible elements list",
+        extra_trigger: '#oe_snippets.o_loaded',
+        trigger: '.o_we_invisible_el_panel .o_we_invisible_entry',
+    },
+    wTourUtils.clickOnSnippet({id: 'o_footer', name: 'Footer'}),
+    wTourUtils.changeOption('HideFooter', 'we-button[data-name="hide_footer_page_opt"] we-checkbox'),
+    ...wTourUtils.clickOnSave(),
+    {
+        content: "Check that the footer is hidden and the header is visible",
+        trigger: '#wrapwrap:has(.o_footer.d-none.o_snippet_invisible)',
+        extra_trigger: '#wrapwrap header#top:not(.d-none)',
+        run: () => null, // it's a check
+    },
+]);

--- a/addons/website/tests/test_ui.py
+++ b/addons/website/tests/test_ui.py
@@ -299,3 +299,6 @@ class TestUi(odoo.tests.HttpCase):
 
     def test_18_website_snippets_menu_tabs(self):
         self.start_tour("/?enable_editor=1", "website_snippets_menu_tabs", login="admin")
+
+    def test_19_website_page_options(self):
+        self.start_tour("/?enable_editor=1", "website_page_options", login="admin")


### PR DESCRIPTION
Since this commit [1], when you select the Header position option and
set it to "Over The Content", the change is not saved if you did not
edit something else in the page too.

Indeed, now that the "save" works correctly (and that it no longer saves
the page every time). It does not detect the change made by this option
which is to add a class on the '#wrapwrap' element. (The editor looks
for changes inside the wrapwrap but not on it).

With this commit, we add the 'o_dirty' class on the '#wrap' when a page
option is changed in order to notify the editor that the page should be
saved when the "save" button is clicked.

[1]: https://github.com/odoo/odoo/commit/bab673488e185ddd7792aedecc3870663290fed3

task-2871426

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
