### PR TITLE
[FIX] payment: if image is missing icon view will crash

### DIFF
--- a/addons/payment/views/payment_templates.xml
+++ b/addons/payment/views/payment_templates.xml
@@ -266,7 +266,7 @@
             <t t-set="MAX_ICONS" t-value="3"/>
             <!-- === Icons === -->
             <!-- Only shown if in the first 3 icons -->
-            <t t-foreach="acquirer.payment_icon_ids" t-as="icon">
+            <t t-foreach="acquirer.payment_icon_ids.filtered(lambda r: r.image_payment_form)" t-as="icon">
                 <li t-attf-class="list-inline-item{{'' if (icon_index &lt; MAX_ICONS) else ' d-none'}}">
                     <span t-esc="icon.image_payment_form"
                           t-options="{'widget': 'image', 'alt-field': 'name'}"


### PR DESCRIPTION
**Description of the issue/feature this PR addresses:**

As we assume that the `image_payment_form` is always a binary it might not be the case in several use cases like a new payment icon without a picture assigned to a payment method, migration where the binary was not computed, a deleted payment icon image via the user interface, etc.). 

This scenario will lead to a view crash and needs to be avoided.


**Current behavior before PR:**
```python
TypeError: argument should be a bytes-like object or ASCII string, not 'bool'
```
**Desired behavior after PR is merged:**

No view crash 😉 




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
