### PR TITLE
[FIX] point_of_sale: stop changing weight of tracked product

### DIFF
--- a/addons/point_of_sale/static/src/js/models.js
+++ b/addons/point_of_sale/static/src/js/models.js
@@ -1931,7 +1931,9 @@ exports.Orderline = Backbone.Model.extend({
         }
 
         // Set the quantity of the line based on number of pack lots.
-        this.pack_lot_lines.set_quantity_by_lot();
+        if(!this.product.to_weight){
+            this.pack_lot_lines.set_quantity_by_lot();
+        }
     },
     set_product_lot: function(product){
         this.has_product_lot = product.tracking !== 'none';


### PR DESCRIPTION
Current behavior:
When using IoT-scale device to determine the weight of a product in PoS
if the product was tracked by lot the weight would always go back to 1

Steps to reproduce:
- Have PoS installed and activate PoS IoT
- To simulate the IoT you can modify the weight on this line
https://github.com/odoo/odoo/blob/ff58fb0fb588092f1d02500cd000d20a3f8b67b7/addons/point_of_sale/static/src/js/Screens/ProductScreen/ProductScreen.js#L140
(e.g. change weight with 5)
- Create a product with UoM in Kg, and tracked by lots
- Start PoS session and add the new product to the order
- The quantity is not correct

opw-2862429
--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
