### PR TITLE
[FIX] http_routing: add lang prefix to translationURL

### DIFF
--- a/addons/http_routing/models/ir_http.py
+++ b/addons/http_routing/models/ir_http.py
@@ -297,8 +297,14 @@ class IrHttp(models.AbstractModel):
         lang = user_context.get('lang')
         translation_hash = request.env['ir.translation'].get_web_translations_hash(modules, lang)
 
+        translationURL = '/website/translations'
+        if getattr(request, 'lang', False):
+            # avoid 303 redirect in case we are on translated version
+            lang_code = request.lang._get_cached('url_code')
+            translationURL = url_lang(translationURL, lang_code)
+
         session_info.update({
-            'translationURL': '/website/translations',
+            'translationURL': translationURL,
             'cache_hashes': {
                 'translations': translation_hash,
             },


### PR DESCRIPTION
On loading translations via /website/translations/, it first redirects to a
prefixed url (e.g. `/fr/website/translations/`). However,
`/website/translations/` gives actual response immediatly if current language is
the default one.

Such behavior may leads to a cache problem on switching from default language to
another one: instead of redirecting to `/fr/...`, browser uses cached response
for default language.

Fix it by providing prefixed translationURL. This also makes tiny performance
improvement by avoiding one extra query.

To reproducte:
* install modules Sale and Website
* create a sale order and click "Customer Preview" to redirect to portal page
* F12 -> [x] Disable cache
* english version
* refresh
* click sign button
* F12 -> [ ] Disable cache
* switch to french
* click sign button

(debug assets mode must be disabled)

opw-2873624
