### PR TITLE
[FIX] website_sale : create contact without sales access rights

### DIFF
--- a/addons/website_sale/models/res_partner.py
+++ b/addons/website_sale/models/res_partner.py
@@ -27,7 +27,7 @@ class ResPartner(models.Model):
 
     @api.onchange('property_product_pricelist')
     def _onchange_property_product_pricelist(self):
-        open_order = self.env['sale.order'].search([
+        open_order = self.env['sale.order'].sudo().search([
             ('partner_id', '=', self._origin.id),
             ('pricelist_id', '=', self._origin.property_product_pricelist.id),
             ('pricelist_id', '!=', self.property_product_pricelist.id),


### PR DESCRIPTION
To reproduce
============

- on a database where *sale*, *contacts* and *website_sale* are installed
- create a user without sales access rights but has the right to create a contact (extra rights/create contact)
- connect to this user and try to create a contact

An Access Error is raised.

Purpose
=======

Because the model *website_sale* is installed, the method `_onchange_property_product_pricelist` in `res_partner` is triggred.
In this method we run `search` on `sale.order`, but the user doesn't have the right to read `sale.order` so the error is raised.

Specification
=============

The role of the method `_onchange_property_product_pricelist` is needed when we edit an exisitng contact,
but in our case, we are creating a new one.

To solve issue the method `_onchange_property_product_pricelist` has been modified to do nothing in case of new contact.

opw-2864945
