### PR TITLE
[FIX] base_vat: Fix vat number starting with 'EU' for not-EU companies

### DIFF
--- a/addons/base_vat/models/res_partner.py
+++ b/addons/base_vat/models/res_partner.py
@@ -533,6 +533,11 @@ class ResPartner(models.Model):
             return len(vat) == 11 and vat.isdigit()
         return check_func(vat)
 
+    def format_vat_eu(self, vat):
+        # Foreign companies that trade with non-enterprises in the EU
+        # may have a VATIN starting with "EU" instead of a country code.
+        return vat
+
     def format_vat_ch(self, vat):
         stdnum_vat_format = getattr(stdnum.util.get_cc_module('ch', 'vat'), 'format', None)
         return stdnum_vat_format('CH' + vat)[2:] if stdnum_vat_format else vat

--- a/addons/base_vat/tests/test_validate_ruc.py
+++ b/addons/base_vat/tests/test_validate_ruc.py
@@ -77,6 +77,13 @@ class TestStructure(SavepointCase):
         # (for technical reasons due to ORM and res.company making related fields towards res.partner for country_id and vat)
         test_partner.write({'vat': '0477472701', 'country_id': None})
 
+    def test_vat_eu(self):
+        """ Foreign companies that trade with non-enterprises in the EU may have a VATIN starting with "EU" instead of
+        a country code.
+        """
+        test_partner = self.env['res.partner'].create({'name': "Turlututu", 'country_id': self.env.ref('base.fr').id})
+        test_partner.write({'vat': "EU528003646", 'country_id': None})
+
 
 @tagged('-standard', 'external')
 class TestStructureVIES(TestStructure):


### PR DESCRIPTION
Foreign companies that trade with non-enterprises in the EU may have a VATIN starting with "EU" instead of a country code.

Currently, the user is facing a traceback in this situation since stdnum doesn't have any format method for vat number starting with 'EU'.

ticket: 2877716

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
