### PR TITLE
[FIX] tools: prevent tracebacks from PDF read errors

### DIFF
--- a/odoo/tools/pdf.py
+++ b/odoo/tools/pdf.py
@@ -15,6 +15,8 @@ from reportlab.lib.units import cm
 from reportlab.lib.utils import ImageReader
 from reportlab.pdfgen import canvas
 
+from odoo.exceptions import UserError
+
 try:
     from fontTools.ttLib import TTFont
 except ImportError:
@@ -94,7 +96,14 @@ def add_banner(pdf_stream, text=None, logo=False, thickness=2 * cm):
     :return (BytesIO):              The modified PDF stream.
     """
 
-    old_pdf = PdfFileReader(pdf_stream, strict=False, overwriteWarnings=False)
+    try:
+        old_pdf = PdfFileReader(pdf_stream, strict=False, overwriteWarnings=False)
+        old_pdf.getNumPages()
+    except Exception:
+        # Import is done here to prevent circular import issues.
+        from odoo.tools.translate import _
+        raise UserError(_("Error when reading the original PDF for: %r.\nPlease make sure the file is valid.", text[:100]))
+
     packet = io.BytesIO()
     can = canvas.Canvas(packet)
     odoo_logo = Image.open(file_open('base/static/img/main_partner-image.png', mode='rb'))


### PR DESCRIPTION
Until now, an invalid PDF file would generate a traceback
during the export, which is not very user friendly.

The goal here is simply to catch those errors and display
a slightly more helpful message.

Copy of the traceback:

```python
Traceback (most recent call last):
  File "/home/odoo/src/odoo/saas-15.2/addons/web/controllers/main.py", line 2039, in report_download
    response = self.report_routes(reportname, docids=docids, converter=converter, context=context)
  File "/home/odoo/src/odoo/saas-15.2/odoo/http.py", line 535, in response_wrap
    response = f(*args, **kw)
  File "/home/odoo/src/odoo/saas-15.2/addons/web/controllers/main.py", line 1968, in report_routes
    pdf = report.with_context(context)._render_qweb_pdf(docids, data=data)[0]
  File "/home/odoo/src/odoo/saas-15.2/addons/account/models/ir_actions_report.py", line 49, in _render_qweb_pdf
    return super()._render_qweb_pdf(res_ids=res_ids, data=data)
  File "/home/odoo/src/odoo/saas-15.2/odoo/addons/base/models/ir_actions_report.py", line 832, in _render_qweb_pdf
    stream = self_sudo._retrieve_stream_from_attachment(attachment)
  File "/home/odoo/src/odoo/saas-15.2/addons/account/models/ir_actions_report.py", line 57, in _retrieve_stream_from_attachment
    return pdf.add_banner(stream, record.name, logo=True)
  File "/home/odoo/src/odoo/saas-15.2/odoo/tools/pdf.py", line 103, in add_banner
    for p in range(old_pdf.getNumPages()):
  File "/usr/lib/python3/dist-packages/PyPDF2/pdf.py", line 1155, in getNumPages
    self._flatten()
  File "/usr/lib/python3/dist-packages/PyPDF2/pdf.py", line 1505, in _flatten
    catalog = self.trailer["/Root"].getObject()
  File "/usr/lib/python3/dist-packages/PyPDF2/generic.py", line 520, in __getitem__
    return dict.__getitem__(self, key).getObject()
  File "/usr/lib/python3/dist-packages/PyPDF2/generic.py", line 182, in getObject
    return self.pdf.getObject(self).getObject()
  File "/usr/lib/python3/dist-packages/PyPDF2/pdf.py", line 1599, in getObject
    idnum, generation = self.readObjectHeader(self.stream)
  File "/usr/lib/python3/dist-packages/PyPDF2/pdf.py", line 1667, in readObjectHeader
    return int(idnum), int(generation)
ValueError: invalid literal for int() with base 10: b'ndobj'
```

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
