### PR TITLE
[FIX] core: use newer registry after signaling

### DIFF
--- a/odoo/http.py
+++ b/odoo/http.py
@@ -1339,8 +1339,7 @@ class Request:
         request to ``_serve_ir_http``.
         """
         try:
-            self.registry = Registry(self.db)
-            self.registry.check_signaling()
+            self.registry = Registry(self.db).check_signaling()
         except (AttributeError, psycopg2.OperationalError, psycopg2.ProgrammingError):
             # psycopg2 error or attribute error while constructing
             # the registry. That means either


### PR DESCRIPTION
Create an empty database and start 2 http workers, go on the web app
menu and install website (don't install website via -i). Once website is
installed, you are redirected on `/website/configurator` but the route
does not exist and it fails with a 500 internal server error.

The problem is due to an invalid registry manipulation introduced in the
saas-15.3's httpocalypse. When new modules are installed the registry
must be reloaded in all workers. The function that determine if the
registry must be reloaded and reloads it is `check_signaling`.

When the current registry is up-to-date, it is returned as-is by
`check_signaling`. When it is outdated, `check_signaling` creates and
returns a new fresh registry; it does not nor discard nor change
in-place the previous (outdated) registry, it is up to the callee to
discard the previous registry itself.