### PR TITLE
[IMP] mrp: use prefetch for recursive quantities computation

### DIFF
--- a/addons/mrp/models/product.py
+++ b/addons/mrp/models/product.py
@@ -136,18 +136,33 @@ class ProductProduct(models.Model):
         """
         bom_kits = self.env['mrp.bom']._get_product2bom(self, bom_type='phantom')
         kits = self.filtered(lambda p: bom_kits.get(p))
-        res = super(ProductProduct, self - kits)._compute_quantities_dict(lot_id, owner_id, package_id, from_date=from_date, to_date=to_date)
+        regular_products = self - kits
+        res = (
+            super(ProductProduct, regular_products)._compute_quantities_dict(lot_id, owner_id, package_id, from_date=from_date, to_date=to_date)
+            if regular_products
+            else {}
+        )
         qties = self.env.context.get("mrp_compute_quantities", {})
         qties.update(res)
+        # pre-compute bom lines and identify missing kit components to prefetch
+        bom_sub_lines_per_kit = {}
+        prefetch_component_ids = set()
         for product in bom_kits:
-            boms, bom_sub_lines = bom_kits[product].explode(product, 1)
+            __, bom_sub_lines = bom_kits[product].explode(product, 1)
+            bom_sub_lines_per_kit[product] = bom_sub_lines
+            for bom_line, __ in bom_sub_lines:
+                if bom_line.product_id.id not in qties:
+                    prefetch_component_ids.add(bom_line.product_id.id)
+        # compute kit quantities
+        for product in bom_kits:
+            bom_sub_lines = bom_sub_lines_per_kit[product]
             ratios_virtual_available = []
             ratios_qty_available = []
             ratios_incoming_qty = []
             ratios_outgoing_qty = []
             ratios_free_qty = []
             for bom_line, bom_line_data in bom_sub_lines:
-                component = bom_line.product_id.with_context(mrp_compute_quantities=qties)
+                component = bom_line.product_id.with_context(mrp_compute_quantities=qties).with_prefetch(prefetch_component_ids)
                 if component.type != 'product' or float_is_zero(bom_line_data['qty'], precision_rounding=bom_line.product_uom_id.rounding):
                     # As BoMs allow components with 0 qty, a.k.a. optionnal components, we simply skip those
                     # to avoid a division by zero. The same logic is applied to non-storable products as those


### PR DESCRIPTION
**Description of the issue/feature this PR addresses:**

1) Avoid calling super() on an empty recordset, in case all products are kits. Even on an empty recordset, some queries would be fired. This PR avoids them.

2) Use prefetch to read kit components quantity fields, to make use of the recorset optimizations that ends up saving sql queries. Otherwise, component quantities were computed on-demand one by one.

**Current behavior before PR:**

In case of kit products, whose components weren't included in `self`, their quantity fields were [read (thus, computed) on demand, one by one](https://github.com/odoo/odoo/blob/0f9f8409b379e3a0af28cecd3ed26829b9b26032/addons/mrp/models/product.py#L161-L171)

This is highly inefficient because each record computation will fire up several sql queries to read quants, and stock moves.

**Desired behavior after PR is merged:**

All non-cached components are identified beforehand, in order to leverage prefetching.

**Metrics**

On a production database with 3866 products, 855 of which are saleable and many are kits with recursive boms.

```py
from timeit import timeit
products = env['product.product'].search([('sale_ok', '=', True)])  # 855 products
timeit(lambda: products.read(['virtual_available']) and env.cache.invalidate(), number=100)
```

```
before: 234s (2340ms / iteration)
after: 68s (680ms / iteration)
```

and also the case of a single kit product composed of a 2 level recursive bom

```py
from timeit import timeit
products = env['product.product'].browse(10893)
timeit(lambda: products.read(['virtual_available']) and env.cache.invalidate(), number=100)
```

```
before: 4.64s (46ms / iteration)
after: 2.40s (24ms / iteration)
```




---

**NOTE**: In case of kits with recursive boms (kits with kits as components), the result is still not perfect but much better than before. We still end up in a recursive computation scenario, but at least now on each iteration all non-cached components are computed together, at once, leveraging the recorset optimizations (`read_group`, etc..)

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
