### PR TITLE
[FIX] project: Creating a stage from a sub task

### DIFF
--- a/addons/project/views/project_views.xml
+++ b/addons/project/views/project_views.xml
@@ -903,7 +903,7 @@
                                     <field name="date_deadline" attrs="{'invisible': [('is_closed', '=', True)]}" optional="show"/>
                                     <field name="tag_ids" widget="many2many_tags" options="{'color_field': 'color'}" optional="hide"/>
                                     <field name="kanban_state" widget="state_selection" optional="hide"/>
-                                    <field name="stage_id" optional="show"/>
+                                    <field name="stage_id" optional="show" context="{'default_project_id': project_id}"/>
                                     <button name="action_open_task" type="object" title="View Task" string="View Task" class="btn btn-link pull-right"/>
                                 </tree>
                             </field>


### PR DESCRIPTION
Steps to reproduce the bug:

- Let's consider a project P with a task T
- P has has two stages S1 and S2
- From T, create a new sub task ST1 with a new stage S3
- From T, create an other new sub task ST2 and try to select S3 as stage

Bug:

ST3 was not displayed in the available stages

Fix:

The stage ST3 is available for every task or sub task

opw:2873640