### PR TITLE
[FIX] portal: use correct author for comments on shared records

### DIFF
--- a/addons/portal/controllers/mail.py
+++ b/addons/portal/controllers/mail.py
@@ -16,11 +16,11 @@ from odoo.exceptions import AccessError, MissingError, UserError
 
 def _check_special_access(res_model, res_id, token='', _hash='', pid=False):
     record = request.env[res_model].browse(res_id).sudo()
-    if token:  # Token Case: token is the global one of the document
+    if _hash and pid:  # Signed Token Case: hash implies token is signed by partner pid
+        return consteq(_hash, record._sign_token(pid))
+    elif token:  # Token Case: token is the global one of the document
         token_field = request.env[res_model]._mail_post_token_field
         return (token and record and consteq(record[token_field], token))
-    elif _hash and pid:  # Signed Token Case: hash implies token is signed by partner pid
-        return consteq(_hash, record._sign_token(pid))
     else:
         raise Forbidden()
 
@@ -65,8 +65,11 @@ def _message_post_helper(res_model, res_id, message, token='', _hash=False, pid=
     # deduce author of message
     author_id = request.env.user.partner_id.id if request.env.user.partner_id else False
 
+    # Signed Token Case: author_id is forced
+    if _hash and pid:
+        author_id = pid
     # Token Case: author is document customer (if not logged) or itself even if user has not the access
-    if token:
+    elif token:
         if request.env.user._is_public():
             # TODO : After adding the pid and sign_token in access_url when send invoice by email, remove this line
             # TODO : Author must be Public User (to rename to 'Anonymous')
@@ -74,9 +77,6 @@ def _message_post_helper(res_model, res_id, message, token='', _hash=False, pid=
         else:
             if not author_id:
                 raise NotFound()
-    # Signed Token Case: author_id is forced
-    elif _hash and pid:
-        author_id = pid
 
     email_from = None
     if author_id and 'email_from' not in kw:
@@ -102,7 +102,7 @@ def _message_post_helper(res_model, res_id, message, token='', _hash=False, pid=
 class PortalChatter(http.Controller):
 
     def _portal_post_filter_params(self):
-        return ['token', 'hash', 'pid']
+        return ['token', 'pid']
 
     def _portal_post_check_attachments(self, attachment_ids, attachment_tokens):
         if len(attachment_tokens) != len(attachment_ids):
@@ -142,6 +142,7 @@ class PortalChatter(http.Controller):
                 'attachment_ids': attachment_ids,
             }
             post_values.update((fname, kw.get(fname)) for fname in self._portal_post_filter_params())
+            post_values['_hash'] = kw.get('hash')
             message = _message_post_helper(**post_values)
 
         return request.redirect(url)

--- a/addons/test_mail_full/__manifest__.py
+++ b/addons/test_mail_full/__manifest__.py
@@ -16,7 +16,7 @@ real applications. """,
         'mail_bot',
         # 'snailmail',
         'mass_mailing',
-        'mass_mailing_sms',
+        'mass_mailing_sms',  # adds portal
         'phone_validation',
         'sms',
     ],

--- a/addons/test_mail_full/models/test_mail_models.py
+++ b/addons/test_mail_full/models/test_mail_models.py
@@ -4,6 +4,25 @@
 from odoo import api, fields, models
 
 
+class MailTestPortal(models.Model):
+    """ A model intheriting from mail.thread with some fields used for portal
+    sharing, like a partner, ..."""
+    _description = 'Chatter Model for Portal'
+    _name = 'mail.test.portal'
+    _inherit = [
+        'mail.thread',
+        'portal.mixin',
+    ]
+
+    name = fields.Char()
+    partner_id = fields.Many2one('res.partner', 'Customer')
+
+    def _compute_access_url(self):
+        self.access_url = False
+        for record in self.filtered('id'):
+            record.access_url = '/my/test_portal/%s' % self.id
+
+
 class MailTestSMS(models.Model):
     """ A model inheriting from mail.thread with some fields used for SMS
     gateway, like a partner, a specific mobile phone, ... """

--- a/addons/test_mail_full/security/ir.model.access.csv
+++ b/addons/test_mail_full/security/ir.model.access.csv
@@ -1,4 +1,6 @@
 id,name,model_id:id,group_id:id,perm_read,perm_write,perm_create,perm_unlink
+access_mail_test_portal_all,mail.test.portal.all,model_mail_test_portal,,1,0,0,0
+access_mail_test_portal_user,mail.test.portal.user,model_mail_test_portal,base.group_user,1,1,1,1
 access_mail_test_sms_all,mail.test.sms.all,model_mail_test_sms,,0,0,0,0
 access_mail_test_sms_user,mail.test.sms.user,model_mail_test_sms,base.group_user,1,1,1,1
 access_mail_test_sms_bl_all,mail.test.sms.bl.all,model_mail_test_sms_bl,,0,0,0,0

--- a/addons/test_mail_full/tests/__init__.py
+++ b/addons/test_mail_full/tests/__init__.py
@@ -2,6 +2,7 @@
 
 from . import common
 from . import test_phone_blacklist
+from . import test_portal
 from . import test_mass_sms
 from . import test_sms_composer
 from . import test_sms_management

--- a/addons/test_mail_full/tests/test_portal.py
+++ b/addons/test_mail_full/tests/test_portal.py
@@ -1,0 +1,76 @@
+# -*- coding: utf-8 -*-
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from odoo import http
+from odoo.addons.test_mail.tests.common import mail_new_test_user
+from odoo.tests import tagged, users
+from odoo.tests.common import HttpCase
+
+
+@tagged('portal')
+class TestPortal(HttpCase):
+
+    def setUp(self):
+        super(TestPortal, self).setUp()
+
+        self.user_employee = mail_new_test_user(
+            self.env,
+            groups='base.group_user',
+            login='employee',
+            name='Ernest Employee',
+            signature='--\nErnest',
+        )
+        self.partner_1, self.partner_2 = self.env['res.partner'].create([
+            {'name': 'Valid Lelitre',
+             'email': 'valid.lelitre@agrolait.com',
+             'country_id': self.env.ref('base.be').id,
+             'mobile': '0456001122'},
+            {'name': 'Valid Poilvache',
+             'email': 'valid.other@gmail.com',
+             'country_id': self.env.ref('base.be').id,
+             'mobile': '+32 456 22 11 00'}
+        ])
+
+        self.record_portal = self.env['mail.test.portal'].create({
+            'partner_id': self.partner_1.id,
+            'name': 'Test Portal Record',
+        })
+
+        self.record_portal._portal_ensure_token()
+
+    @users('employee')
+    def test_portal_mixin(self):
+        """ Test internals of portal mixin """
+        customer = self.partner_1.with_env(self.env)
+        record_portal = self.env['mail.test.portal'].create({
+            'partner_id': customer.id,
+            'name': 'Test Portal Record',
+        })
+
+        self.assertFalse(record_portal.access_token)
+        self.assertEqual(record_portal.access_url, '/my/test_portal/%s' % record_portal.id)
+
+        record_portal._portal_ensure_token()
+        self.assertTrue(record_portal.access_token)
+
+    def test_portal_share_comment(self):
+        """ Test posting through portal controller allowing to use a hash to
+        post wihtout access rights. """
+        post_url = "/mail/chatter_post"
+        post_data = {
+            'csrf_token': http.WebRequest.csrf_token(self),
+            'hash': self.record_portal._sign_token(self.partner_2.id),
+            'message': 'Test',
+            'pid': self.partner_2.id,
+            'redirect': '/',
+            'res_model': self.record_portal._name,
+            'res_id': self.record_portal.id,
+            'token': self.record_portal.access_token,
+        }
+
+        # test as not logged
+        self.url_open(url=post_url, data=post_data)
+        message = self.record_portal.message_ids[0]
+
+        self.assertIn('Test', message.body)
+        self.assertEqual(message.author_id, self.partner_2)


### PR DESCRIPTION
Steps to reproduce
------------------

1. Create two partners A and B.
2. Create a shareable record, e.g. a sales order, and set A as the customer.
3. Share the record with B.
4. Use the share link sent to B and comment on the record.
5. Your comments will be sent with A as the author.

Expected behavior
-----------------

Share links sent to a customer should make you comment as that customer.

Resolves #93377

Task-2883044