### PR TITLE
[FIX] hr_skills_slides: Fix completion step

### DIFF
--- a/addons/hr_skills_slides/models/slide_channel.py
+++ b/addons/hr_skills_slides/models/slide_channel.py
@@ -9,19 +9,36 @@ class SlideChannelPartner(models.Model):
 
     def _recompute_completion(self):
         res = super(SlideChannelPartner, self)._recompute_completion()
-        partner_has_completed = {channel_partner.partner_id.id: channel_partner.channel_id for channel_partner in self}
-        employees = self.env['hr.employee'].sudo().search([('user_id.partner_id', 'in', list(partner_has_completed.keys()))])
-        for employee in employees:
+        partner_has_completed = {
+            channel_partner.partner_id.id: channel_partner.channel_id for channel_partner in self
+            if channel_partner.completed}
+        employees = self.env['hr.employee'].sudo().search(
+            [('user_id.partner_id', 'in', list(partner_has_completed.keys()))])
+
+        if employees:
+            HrResumeLine = self.env['hr.resume.line'].sudo()
             line_type = self.env.ref('hr_skills_slides.resume_type_training', raise_if_not_found=False)
-            channel = partner_has_completed[employee.user_id.partner_id.id]
-            self.env['hr.resume.line'].create({
-                'employee_id': employee.id,
-                'name': channel.name,
-                'date_start': fields.Date.today(),
-                'date_end': fields.Date.today(),
-                'description': channel.description,
-                'line_type_id': line_type and line_type.id,
-                'display_type': 'course',
-                'channel_id': channel.id
-            })
+            line_type_id = line_type and line_type.id
+
+            for employee in employees:
+                channel = partner_has_completed[employee.user_id.partner_id.id]
+
+                already_added = HrResumeLine.search([
+                    ("employee_id", "in", employees.ids),
+                    ("channel_id", "=", channel.id),
+                    ("line_type_id", "=", line_type_id),
+                    ("display_type", "=", "course")
+                ])
+
+                if not already_added:
+                    HrResumeLine.create({
+                        'employee_id': employee.id,
+                        'name': channel.name,
+                        'date_start': fields.Date.today(),
+                        'date_end': fields.Date.today(),
+                        'description': channel.description,
+                        'line_type_id': line_type_id,
+                        'display_type': 'course',
+                        'channel_id': channel.id
+                    })
         return res


### PR DESCRIPTION
This commit addresses several issues:

1. The overwrite of `_recompute_completion` was not properly filtering
the partners that had actually completed the course. meaning that
passing through this function could add a course/slide.channel as an
employee skill iven if they did not complete it. Now, we only act upon
employees that have actually finished the course.

2. The function would add the same skill over and over again, assuming
that we could only pass through it once but it is actually called every
time we publish or archive any slide of a course since 9920f20e.
This can lead to a bit of bloat on an employee resume  (See task
attachments). Now, we try to make the function idempotent and only add a
resumé line only once.

3. The addition of a resume line could not be achieved and would raise
an ACL when the current user was not an HR Officer (group `hr_user`).
Since it can be called by any eLearning(`slides`) manager, a sudo
privilege is necessary.

Related Task: 2830016

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
