### PR TITLE
[FIX] mail: remove obsolete and invalid use of state

### DIFF
--- a/addons/mail/static/src/components/call_view/call_view.xml
+++ b/addons/mail/static/src/components/call_view/call_view.xml
@@ -27,7 +27,7 @@
                             'o-isSidebar': callView.hasSidebar and callView.mainParticipantCard,
                         }"
                         t-ref="tileContainer"
-                        t-attf-style="--height:{{state.tileHeight}}px; --width:{{state.tileWidth}}px;"
+                        t-attf-style="--height:{{callView.tileHeight}}px; --width:{{callView.tileWidth}}px;"
                     >
                         <t t-foreach="callView.tileParticipantCards" t-as="participantCard" t-key="'grid_tile_'+participantCard.localId">
                             <t t-if="!callView.filterVideoGrid or (participantCard.rtcSession and participantCard.rtcSession.videoStream)">


### PR DESCRIPTION
Change forgotten references to `state` to references to the record.

Fix crash introduced in https://github.com/odoo/odoo/pull/93330/