### PR TITLE
[IMP] stock: added group by warehouse in Inventory Report

### DIFF
--- a/addons/stock/models/stock_quant.py
+++ b/addons/stock/models/stock_quant.py
@@ -67,6 +67,7 @@ class StockQuant(models.Model):
         'stock.location', 'Location',
         domain=lambda self: self._domain_location_id(),
         auto_join=True, ondelete='restrict', required=True, index=True, check_company=True)
+    warehouse_id = fields.Many2one(related='location_id.warehouse_id', store=True)
     storage_category_id = fields.Many2one(related='location_id.storage_category_id', store=True)
     cyclic_inventory_frequency = fields.Integer(related='location_id.cyclic_inventory_frequency')
     lot_id = fields.Many2one(

--- a/addons/stock/views/stock_quant_views.xml
+++ b/addons/stock/views/stock_quant_views.xml
@@ -33,6 +33,7 @@
                     <filter name="my_count" string="My Counts" domain="[('user_id', '=', uid)]"/>
                 </group>
                 <group expand='0' string='Group by...'>
+                    <filter string='Warehouse' name="warehousegroup" domain="[]" context="{'group_by': 'warehouse_id'}"/>
                     <filter string='Product' name="productgroup" context="{'group_by': 'product_id'}"/>
                     <filter string='Location' name="locationgroup" domain="[]" context="{'group_by': 'location_id'}"/>
                     <filter string='Storage Category' name="storagecategorygroup" domain="[]" context="{'group_by': 'storage_category_id'}"/>
@@ -96,6 +97,7 @@
                 <field name="product_id" attrs="{'readonly': [('id', '!=', False)]}"
                        readonly="context.get('single_product', False)" force_save="1"
                        options="{'no_create': True}"/>
+                <field name="warehouse_id" optional="hide"/>
                 <field name="product_categ_id" optional="hide"/>
                 <field name="location_id" attrs="{'readonly': [('id', '!=', False)]}"
                        invisible="context.get('hide_location', False)"
@@ -172,6 +174,7 @@
         <field name="code">
             action = model.with_context(
                 search_default_internal_loc=1,
+                search_default_warehousegroup=1,
                 search_default_productgroup=1,
                 search_default_locationgroup=1,
             ).action_view_quants()
@@ -180,7 +183,7 @@
 
     <record model="ir.actions.act_window" id="dashboard_open_quants"> <!-- Used in dashboard -->
         <field name="name">Stock On Hand</field>
-        <field name="context">{'search_default_internal_loc': 1, 'search_default_productgroup':1, 'search_default_locationgroup':1}</field>
+        <field name="context">{'search_default_internal_loc': 1, 'search_default_warehousegroup':1, 'search_default_productgroup':1, 'search_default_locationgroup':1}</field>
         <field name="res_model">stock.quant</field>
     </record>
 


### PR DESCRIPTION
Currently, there is no group for the warehouse in Inventory Report If you have a
lot of warehouses and want to see stock levels for all products in this warehouse.

In this commit, I have added a group by the warehouse in Inventory Report and
also added the warehouse field in the list view with an optional hide.

TaskID - 2859532
PR - #93559