### PR TITLE
[FIX] website: Assets depend on debug mode

### DIFF
--- a/addons/website/views/website_templates.xml
+++ b/addons/website/views/website_templates.xml
@@ -53,7 +53,7 @@
     </xpath>
 
     <xpath expr="//head" position="attributes">
-        <attribute name="t-cache">main_object if main_object and main_object._name == 'website.page' and not (editable or translatable) else None</attribute>
+        <attribute name="t-cache">('assets' in request.session.debug, main_object) if main_object and main_object._name == 'website.page' and not (editable or translatable) else None</attribute>
     </xpath>
     <xpath expr="//head/*[1]" position="before">
         <t t-if="not title">


### PR DESCRIPTION
issue: The debug-assets didn't work anymore. The t-cache placed on the
header allowing not to redo this one for each rendering did not depend
on the debug mode.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
