### PR TITLE
[FIX] pos_restaurant: add table as search field in TicketScreen

### DIFF
--- a/addons/pos_restaurant/static/src/js/Screens/TicketScreen.js
+++ b/addons/pos_restaurant/static/src/js/Screens/TicketScreen.js
@@ -28,12 +28,17 @@ odoo.define('pos_restaurant.TicketScreen', function (require) {
             getTable(order) {
                 return `${order.table.floor.name} (${order.table.name})`;
             }
-            get _searchFields() {
+            //@override
+            _getSearchFields() {
                 if (!this.env.pos.config.iface_floorplan) {
-                    return super._searchFields;
+                    return super._getSearchFields();
                 }
-                return Object.assign({}, super._searchFields, {
-                    Table: (order) => `${order.table.floor.name} (${order.table.name})`,
+                return Object.assign({}, super._getSearchFields(), {
+                    TABLE: {
+                        repr: (order) => `${order.table.floor.name} (${order.table.name})`,
+                        displayName: this.env._t('Table'),
+                        modelField: 'table_id.name',
+                    }
                 });
             }
             _setOrder(order) {


### PR DESCRIPTION
The overridden method was not properly renamed and converted, with this fix we can now filter orders
based on their table.

