### PR TITLE
[FIX] mail: guard MessageSeenIndicatorView/messageSeenIndicator

### DIFF
--- a/addons/mail/static/src/components/message_seen_indicator/message_seen_indicator.xml
+++ b/addons/mail/static/src/components/message_seen_indicator/message_seen_indicator.xml
@@ -2,7 +2,7 @@
 <templates xml:space="preserve">
 
     <t t-name="mail.MessageSeenIndicator" owl="1">
-        <t t-if="messageSeenIndicatorView">
+        <t t-if="messageSeenIndicatorView and messageSeenIndicatorView.messageSeenIndicator">
             <span class="o_MessageSeenIndicator position-relative d-flex opacity-75-hover opacity-50" t-att-class="{ 'o-all-seen text-odoo': messageSeenIndicatorView.messageSeenIndicator.hasEveryoneSeen }" t-attf-class="{{ className }}" t-att-title="messageSeenIndicatorView.messageSeenIndicator.text" t-ref="root">
                 <t t-if="!messageSeenIndicatorView.messageSeenIndicator.isMessagePreviousToLastCurrentPartnerMessageSeenByEveryone">
                     <t t-if="messageSeenIndicatorView.messageSeenIndicator.hasSomeoneFetched or messageSeenIndicatorView.messageSeenIndicator.hasSomeoneSeen">


### PR DESCRIPTION
Follow-up of https://github.com/odoo/odoo/pull/88950

Commit above introduced `MessageSeenIndicatorView`.

Conceptually, `MessageSeenIndicatorView/messageSeenIndicator`
is required. However, the current implementation make it
possible to have a view without the related pure logic record.

This commit simply guards the template to take this implementation
detail into account, as to not make it crash.

Note that future changes in modelling will enforce
`MessageSeenIndicatorView/messageSeenIndicator` being required, so
that we won't need to guard it in template. But this is a fix in
stable version, so it's safer to keep minimal code changes.
