### PR TITLE
[FIX] sale_crm: fix default value for team_id

### DIFF
--- a/addons/sale_crm/models/crm_lead.py
+++ b/addons/sale_crm/models/crm_lead.py
@@ -84,7 +84,7 @@ class CrmLead(models.Model):
             'default_tag_ids': [(6, 0, self.tag_ids.ids)]
         }
         if self.team_id:
-            quotation_context['default_team_id'] = self.team_id.id,
+            quotation_context['default_team_id'] = self.team_id.id
         if self.user_id:
             quotation_context['default_user_id'] = self.user_id.id
         return quotation_context


### PR DESCRIPTION
When create a sale order from a opportunity the default value
for the team_id was wrong and thus the team_id was not properly set

Solution
--------
Return the id of the team not a tuple that contains the id of the team





--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
