### PR TITLE
[FIX] mail: properly display the call systray menu

### DIFF
--- a/addons/mail/static/src/components/call_systray_menu_container/call_systray_menu_container.js
+++ b/addons/mail/static/src/components/call_systray_menu_container/call_systray_menu_container.js
@@ -17,6 +17,10 @@ export class CallSystrayMenuContainer extends Component {
         super.setup();
     }
 
+    get messaging() {
+        return this.env.services.messaging.modelManager.messaging;
+    }
+
 }
 
 Object.assign(CallSystrayMenuContainer, {


### PR DESCRIPTION
Before this commit, since the removal of the modelManager from the
scope of some components, the call systray menu would never show up
as messaging was never defined.
