### PR TITLE
[FIX] better error catching during import based on database id

### DIFF
--- a/odoo/models.py
+++ b/odoo/models.py
@@ -1334,8 +1334,16 @@ class BaseModel(metaclass=MetaModel):
                 try:
                     dbid = int(record['.id'])
                 except ValueError:
-                    # in case of overridden id column
-                    dbid = record['.id']
+                    if self._fields["id"].type != "integer":
+                        # in case of overridden id column
+                        dbid = record['.id']
+                    else:
+                        log(dict(extras,
+                            type='error',
+                            record=stream.index,
+                            field='.id',
+                            message=_(u"Invalid database identifier '%s'") % dbid))
+
                 if not self.search([('id', '=', dbid)]):
                     log(dict(extras,
                         type='error',


### PR DESCRIPTION
Description of the issue/feature this PR addresses:

When having a custom module that reuse the load method (here is the project : https://github.com/shopinvader/pattern-import-export.

Current behavior before PR:
If you pass an invalid type of field for the database id (".id"), the error is not catched correctly and you have a pg traceback

Desired behavior after PR is merged:
If you pass an invalid type of field for the database id the error is catched correctly.



Reproduce it easily with odoo shell : 
- Install base module
- In odoo shell, run : `self.env['res.partner'].load(['.id', 'name'], [['wrong_db_id_type', 'test']])`

Without the fix, we get the pg traceback
With the fix, we got a clean error in the returned values.



--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
