### PR TITLE
[FIX] When importing data with database id, search also the inactive records

### DIFF
--- a/odoo/models.py
+++ b/odoo/models.py
@@ -1336,7 +1336,7 @@ class BaseModel(metaclass=MetaModel):
                 except ValueError:
                     # in case of overridden id column
                     dbid = record['.id']
-                if not self.search([('id', '=', dbid)]):
+                if not self.with_context(active_test=False).search([("id", "=", dbid)]):
                     log(dict(extras,
                         type='error',
                         record=stream.index,


### PR DESCRIPTION
Description of the issue/feature this PR addresses:

When having a custom module that reuse the load method (here is the project : https://github.com/shopinvader/pattern-import-export.

Current behavior before PR:
If you update a record by import using its database id (".id"), and the record is unactive, it is not updated and an error is showned.

Desired behavior after PR is merged:
If you pass the database id of an unactive record, it gets updated.

Reproduce it easily with odoo shell : 
- Install contacts module
- In odoo shell, run the following script : 
```
demo_partner = self.env.ref("base.res_partner_12")
demo_partner_id = demo_partner.id
demo_partner.write({'active': False})
self.env['res.partner'].load(['.id', 'active'], [[demo_partner_id, '1']])
```

Without the fix, the demo partner become inactive and an error is showed in the return of the import (load)
With the fix, the demo partner become unactive and then is put back to active because the import find it.



--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
