### PR TITLE
[FIX] #93564 sale_timesheet: profitable project report handle partial refund

### DIFF
--- a/addons/sale_timesheet/report/project_profitability_report_analysis.py
+++ b/addons/sale_timesheet/report/project_profitability_report_analysis.py
@@ -164,7 +164,7 @@ class ProfitabilityAnalysis(models.Model):
                                     AAL.so_line AS sale_line_id,
                                     0.0 AS timesheet_unit_amount,
                                     0.0 AS timesheet_cost,
-                                    AAL.amount AS other_revenues,
+                                    AAL.amount + COALESCE(AAL_RINV.amount, 0) AS other_revenues,
                                     0.0 AS expense_cost,
                                     0.0 AS expense_amount_untaxed_to_invoice,
                                     0.0 AS expense_amount_untaxed_invoiced,
@@ -191,10 +191,10 @@ class ProfitabilityAnalysis(models.Model):
                                                                   AND RINVL.parent_state = 'posted'
                                                                   AND RINVL.exclude_from_invoice_tab = 'f'
                                                                   AND RINVL.product_id = AML.product_id
+                                    LEFT JOIN account_analytic_line AAL_RINV ON RINVL.id = AAL_RINV.move_id
                                 WHERE AAL.amount > 0.0 AND AAL.project_id IS NULL AND P.active = 't'
                                     AND P.allow_timesheets = 't'
                                     AND BILLL.id IS NULL
-                                    AND RINVL.id IS NULL
                                     AND (SOL.id IS NULL
                                         OR (SOL.is_expense IS NOT TRUE AND SOL.is_downpayment IS NOT TRUE AND SOL.is_service IS NOT TRUE))
 
@@ -208,7 +208,7 @@ class ProfitabilityAnalysis(models.Model):
                                     0.0 AS timesheet_unit_amount,
                                     0.0 AS timesheet_cost,
                                     0.0 AS other_revenues,
-                                    AAL.amount AS expense_cost,
+                                    AAL.amount + COALESCE(AML_RBILLL.amount, 0) AS expense_cost,
                                     0.0 AS expense_amount_untaxed_to_invoice,
                                     0.0 AS expense_amount_untaxed_invoiced,
                                     0.0 AS amount_untaxed_to_invoice,
@@ -232,12 +232,12 @@ class ProfitabilityAnalysis(models.Model):
                                                                       AND RBILLL.parent_state = 'posted'
                                                                       AND RBILLL.exclude_from_invoice_tab = 'f'
                                                                       AND RBILLL.product_id = AML.product_id
+                                    LEFT JOIN account_analytic_line AML_RBILLL ON RBILLL.id = AML_RBILLL.move_id
                                     -- Check if the AAL is not related to a consumed downpayment (when the SOL is fully invoiced - with downpayment discounted.)
                                     LEFT JOIN sale_order_line_invoice_rel SOINVDOWN ON SOINVDOWN.invoice_line_id = AML.id
                                     LEFT JOIN sale_order_line SOLDOWN on SOINVDOWN.order_line_id = SOLDOWN.id AND SOLDOWN.is_downpayment = 't'
                                 WHERE AAL.amount < 0.0 AND AAL.project_id IS NULL
                                   AND INVL.id IS NULL
-                                  AND RBILLL.id IS NULL
                                   AND SOLDOWN.id IS NULL
                                   AND P.active = 't' AND P.allow_timesheets = 't'
 

--- a/addons/sale_timesheet/tests/test_reporting.py
+++ b/addons/sale_timesheet/tests/test_reporting.py
@@ -3,7 +3,7 @@
 from odoo.osv import expression
 from odoo.tools import float_is_zero, float_compare
 from odoo.addons.sale_timesheet.tests.common_reporting import TestCommonReporting
-from odoo.tests import tagged
+from odoo.tests import tagged, Form
 
 
 @tagged('-at_install', 'post_install')
@@ -936,4 +936,127 @@ class TestReporting(TestCommonReporting):
         self.assertAlmostEqual(project_stat['expense_amount_untaxed_to_invoice'], 0, msg="The expense cost to reinvoice of the project should be zero, after credit note.")
         self.assertAlmostEqual(project_stat['expense_amount_untaxed_invoiced'], 0, msg="The expense invoiced amount of the project should be zero, after credit note.")
         self.assertAlmostEqual(project_stat['expense_cost'], 0, msg="The expense costs (credit note) of the project should be zero (not taken into account), after credit note.")
+        self.assertAlmostEqual(project_stat['other_revenues'], 0, msg="The other revenues of the project should be zero, as it is balanced by credit note.")
+
+    def test_profitability_partial_refund_invoice(self):
+        ProjectProfitabilityReport = self.env['project.profitability.report']
+        analytic_account = self.project_global.analytic_account_id
+        product = self.env['product.product'].with_context(mail_notrack=True, mail_create_nolog=True).create({
+            'name': "Product",
+            'standard_price': 100.0,
+            'list_price': 100.0,
+            'taxes_id': False,
+        })
+        test_invoice = self.env['account.move'].create({
+            'move_type': 'out_invoice',
+            'currency_id': self.env.user.company_id.currency_id,
+            'partner_id': self.partner_a,
+            'invoice_date': '2021-01-01',
+            'invoice_line_ids': [(0, 0, {
+                'quantity': 2,
+                'product_id': product.id,
+                'price_unit': 100.0,
+                'analytic_account_id': analytic_account.id,
+            })]
+        })
+        test_invoice.action_post()
+        ProjectProfitabilityReport.flush()
+
+        project_stat= ProjectProfitabilityReport.read_group([('project_id', 'in', self.project_global.ids)], ['project_id', 'amount_untaxed_to_invoice', 'amount_untaxed_invoiced', 'timesheet_unit_amount', 'timesheet_cost', 'expense_cost', 'expense_amount_untaxed_to_invoice', 'expense_amount_untaxed_invoiced', 'other_revenues'], ['project_id'])[0]
+        self.assertAlmostEqual(project_stat['amount_untaxed_invoiced'], 0, msg="The invoiced amount of the project should be zero, before credit note.")
+        self.assertAlmostEqual(project_stat['amount_untaxed_to_invoice'], 0, msg="The amount to invoice of the project should be zero, before credit note.")
+        self.assertAlmostEqual(project_stat['timesheet_unit_amount'], 0, msg="The timesheet unit amount of the project should be zero, before credit note.")
+        self.assertAlmostEqual(project_stat['timesheet_cost'], 0, msg="The timesheet cost of the project should be zero, before credit note.")
+        self.assertAlmostEqual(project_stat['expense_amount_untaxed_to_invoice'], 0, msg="The expense cost to reinvoice of the project should be zero, before credit note.")
+        self.assertAlmostEqual(project_stat['expense_amount_untaxed_invoiced'], 0, msg="The expense invoiced amount of the project should be zero, before credit note.")
+        self.assertAlmostEqual(project_stat['expense_cost'], 0, msg="The expense cost of the project should be zero, before credit note.")
+        self.assertAlmostEqual(project_stat['other_revenues'], test_invoice.amount_total_signed, msg="The other revenues of the project should be equal to the the invoice line price, after credit note.")
+
+        refund_note_wizard = self.env['account.move.reversal'].with_context({
+            'active_model': 'account.move',
+            'active_ids': test_invoice.ids,
+            'active_id': test_invoice.id,
+        }).create({
+            'refund_method': 'refund',
+            'reason': 'no reason',
+        })
+        refund = self.env['account.move'].browse(refund_note_wizard.reverse_moves()["res_id"])
+
+        move_form = Form(refund)
+        with move_form.invoice_line_ids.edit(0) as line_form:
+            line_form.quantity = 1
+        refund = move_form.save()
+        refund.action_post()
+        ProjectProfitabilityReport.flush()
+
+        project_stat= ProjectProfitabilityReport.read_group([('project_id', 'in', self.project_global.ids)], ['project_id', 'amount_untaxed_to_invoice', 'amount_untaxed_invoiced', 'timesheet_unit_amount', 'timesheet_cost', 'expense_cost', 'expense_amount_untaxed_to_invoice', 'expense_amount_untaxed_invoiced', 'other_revenues'], ['project_id'])[0]
+        self.assertAlmostEqual(project_stat['amount_untaxed_invoiced'], 0, msg="The invoiced amount of the project should be zero, after credit note.")
+        self.assertAlmostEqual(project_stat['amount_untaxed_to_invoice'], 0, msg="The amount to invoice of the project should be zero, after credit note.")
+        self.assertAlmostEqual(project_stat['timesheet_unit_amount'], 0, msg="The timesheet unit amount of the project should be zero, after credit note.")
+        self.assertAlmostEqual(project_stat['timesheet_cost'], 0, msg="The timesheet cost of the project should be zero, after credit note.")
+        self.assertAlmostEqual(project_stat['expense_amount_untaxed_to_invoice'], 0, msg="The expense cost to reinvoice of the project should be zero, after credit note.")
+        self.assertAlmostEqual(project_stat['expense_amount_untaxed_invoiced'], 0, msg="The expense invoiced amount of the project should be zero, after credit note.")
+        self.assertAlmostEqual(project_stat['expense_cost'], 0, msg="The expense costs (credit note) of the project should be zero (not taken into account), after credit note.")
+        self.assertAlmostEqual(project_stat['other_revenues'], test_invoice.amount_total_signed + refund.amount_total_signed, msg="The other revenues of the project should be zero, as it is balanced by credit note.")
+
+
+    def test_profitability_partial_refund_vendor_bill(self):
+        ProjectProfitabilityReport = self.env['project.profitability.report']
+        analytic_account = self.project_global.analytic_account_id
+        product = self.env['product.product'].with_context(mail_notrack=True, mail_create_nolog=True).create({
+            'name': "Product",
+            'standard_price': 100.0,
+            'list_price': 100.0,
+            'taxes_id': False,
+        })
+        test_invoice = self.env['account.move'].create({
+            'move_type': 'in_invoice',
+            'currency_id': self.env.user.company_id.currency_id,
+            'partner_id': self.partner_a,
+            'invoice_date': '2021-01-01',
+            'invoice_line_ids': [(0, 0, {
+                'quantity': 2,
+                'product_id': product.id,
+                'price_unit': 100.0,
+                'analytic_account_id': analytic_account.id,
+            })]
+        })
+        test_invoice.action_post()
+        ProjectProfitabilityReport.flush()
+
+        project_stat= ProjectProfitabilityReport.read_group([('project_id', 'in', self.project_global.ids)], ['project_id', 'amount_untaxed_to_invoice', 'amount_untaxed_invoiced', 'timesheet_unit_amount', 'timesheet_cost', 'expense_cost', 'expense_amount_untaxed_to_invoice', 'expense_amount_untaxed_invoiced', 'other_revenues'], ['project_id'])[0]
+        self.assertAlmostEqual(project_stat['amount_untaxed_invoiced'], 0, msg="The invoiced amount of the project should be zero, before credit note.")
+        self.assertAlmostEqual(project_stat['amount_untaxed_to_invoice'], 0, msg="The amount to invoice of the project should be zero, before credit note.")
+        self.assertAlmostEqual(project_stat['timesheet_unit_amount'], 0, msg="The timesheet unit amount of the project should be zero, before credit note.")
+        self.assertAlmostEqual(project_stat['timesheet_cost'], 0, msg="The timesheet cost of the project should be zero, before credit note.")
+        self.assertAlmostEqual(project_stat['expense_amount_untaxed_to_invoice'], 0, msg="The expense cost to reinvoice of the project should be zero, before credit note.")
+        self.assertAlmostEqual(project_stat['expense_amount_untaxed_invoiced'], 0, msg="The expense invoiced amount of the project should be zero, before credit note.")
+        self.assertAlmostEqual(project_stat['expense_cost'], test_invoice.amount_total_signed, msg="The expense cost of the project should be zero, before credit note.")
+        self.assertAlmostEqual(project_stat['other_revenues'], 0, msg="The other revenues of the project should be equal to the the invoice line price, after credit note.")
+
+        refund_note_wizard = self.env['account.move.reversal'].with_context({
+            'active_model': 'account.move',
+            'active_ids': test_invoice.ids,
+            'active_id': test_invoice.id,
+        }).create({
+            'refund_method': 'refund',
+            'reason': 'no reason',
+        })
+        refund = self.env['account.move'].browse(refund_note_wizard.reverse_moves()["res_id"])
+
+        move_form = Form(refund)
+        with move_form.invoice_line_ids.edit(0) as line_form:
+            line_form.quantity = 1
+        refund = move_form.save()
+        refund.action_post()
+        ProjectProfitabilityReport.flush()
+
+        project_stat= ProjectProfitabilityReport.read_group([('project_id', 'in', self.project_global.ids)], ['project_id', 'amount_untaxed_to_invoice', 'amount_untaxed_invoiced', 'timesheet_unit_amount', 'timesheet_cost', 'expense_cost', 'expense_amount_untaxed_to_invoice', 'expense_amount_untaxed_invoiced', 'other_revenues'], ['project_id'])[0]
+        self.assertAlmostEqual(project_stat['amount_untaxed_invoiced'], 0, msg="The invoiced amount of the project should be zero, after credit note.")
+        self.assertAlmostEqual(project_stat['amount_untaxed_to_invoice'], 0, msg="The amount to invoice of the project should be zero, after credit note.")
+        self.assertAlmostEqual(project_stat['timesheet_unit_amount'], 0, msg="The timesheet unit amount of the project should be zero, after credit note.")
+        self.assertAlmostEqual(project_stat['timesheet_cost'], 0, msg="The timesheet cost of the project should be zero, after credit note.")
+        self.assertAlmostEqual(project_stat['expense_amount_untaxed_to_invoice'], 0, msg="The expense cost to reinvoice of the project should be zero, after credit note.")
+        self.assertAlmostEqual(project_stat['expense_amount_untaxed_invoiced'], 0, msg="The expense invoiced amount of the project should be zero, after credit note.")
+        self.assertAlmostEqual(project_stat['expense_cost'], test_invoice.amount_total_signed + refund.amount_total_signed, msg="The expense costs (credit note) of the project should be zero (not taken into account), after credit note.")
         self.assertAlmostEqual(project_stat['other_revenues'], 0, msg="The other revenues of the project should be zero, as it is balanced by credit note.")

--- a/doc/cla/individual/petrus-v.md
+++ b/doc/cla/individual/petrus-v.md
@@ -1,0 +1,11 @@
+France, 2021-03-22
+
+I hereby agree to the terms of the Odoo Individual Contributor License
+Agreement v1.0.
+
+I declare that I am authorized and able to make this agreement and sign this
+declaration.
+
+Signed,
+
+Pierre Verkest pierreverkest84@gmail.com https://github.com/petrus-v


### PR DESCRIPTION
This fix profitability total report while using partial refund on customer/vendor invoices.
    
To reproduce this issue:
    * enable Analytic Accounting
    * create a billable project
    * create an invoice and link to the analytic account and post it (ie: 33 items at $ 10/unit $ 330 HT)
    * generate a partial refund and change quantities (ie: from 33 to 3 units => $ 30HT)
    * check account analytic lines are correct (get 2 lines +330 - 30 => $ 300)
    * go to the project overview and check other revenues and Total Profitability
    
Before this commit total is $ 0
After this commit total is invoiced amount - refund amount ($ 300)

More details in the related issue: #93564


--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
