### PR TITLE
[FIX] sale_timesheet: fallback on task's company for analytic line

### DIFF
--- a/addons/sale_timesheet/models/account.py
+++ b/addons/sale_timesheet/models/account.py
@@ -94,7 +94,7 @@ class AccountAnalyticLine(models.Model):
             task = self.env['project.task'].browse(values.get('task_id'))
             if task.analytic_account_id:
                 values['account_id'] = task.analytic_account_id.id
-                values['company_id'] = task.analytic_account_id.company_id.id
+                values['company_id'] = task.analytic_account_id.company_id.id or task.company_id.id
         values = super(AccountAnalyticLine, self)._timesheet_preprocess(values)
         return values
 


### PR DESCRIPTION
An error is thrown when trying to create timesheet lines in a sale task
if the task's project has no company set for their analytic account

Steps to reproduce:
1. Install Project, Sales and Accounting
2. Go to Settings > Project > Time Management and enable Timesheets
3. Go to Settings > Accounting > Analytics and enable
Analytic Accounting
4. Create another company
5. Go to Project and create a new project 'Test' with Timesheets enabled
6. Edit the project's analytic account and remove the company it is
linked to
7. Go to Sales and create a SO for any customer with product 'Senior
Architect (Invoice on Timesheets)' and project 'Test' then confirm
8. Go to the created task and add a timesheet line
9. A validation error is thrown

Problem:
There is no company set for the project's analytic account so the
value that it tries to right on the analytic line is False which
violates the required constraint of the model's company_id

Solution:
Fallback on the task's company if the task's analytic account has no
company in `_timesheet_preprocess` of `sale_timesheet/account.py`

opw-2831100