### PR TITLE
Saas 15.4 knowledge fix resequence faba

### DIFF
--- a/addons/knowledge/controllers/main.py
+++ b/addons/knowledge/controllers/main.py
@@ -95,8 +95,7 @@ class KnowledgeController(http.Controller):
 
     def _get_root_articles(self, limit=None):
         """ Meant to be overriden by website_knowledge to search in sudo with adapted domain."""
-        _order = 'sequence' if limit is not None else None
-        return request.env["knowledge.article"].search([("parent_id", "=", False)], limit=limit, order=_order)
+        return request.env["knowledge.article"].search([("parent_id", "=", False)], limit=limit, order='sequence, id')
 
     def _prepare_articles_tree_html(self, template, active_article, unfolded_articles=False):
         """ Prepares all the info needed to render the article tree view side panel

--- a/addons/knowledge/tests/test_knowledge_article_sequence.py
+++ b/addons/knowledge/tests/test_knowledge_article_sequence.py
@@ -145,6 +145,25 @@ class TestKnowledgeArticleSequence(KnowledgeCommon):
         self.assertSortedSequence(article_children[2] + article_children[3] + article_children[1] + article_children[0])
 
     @users('employee')
+    def test_resequence_with_move_noparent(self):
+        """ Test move resetting parent_id should also compute sequence """
+        article_private = self.article_private.with_env(self.env)
+        article_private_child = self.article_children[0].with_env(self.env)
+        article_private2 = self.article_private2.with_env(self.env)
+        article_root_noise = self.article_root_noise.with_env(self.env)
+
+        self.assertEqual(article_private_child.sequence, 0)
+        article_private_child.move_to(parent_id=False)
+        self.assertEqual(article_private_child.sequence, 6)
+        self.assertSortedSequence(article_root_noise + article_private + article_private2 + article_private_child)
+        article_private_child.move_to(
+            parent_id=False,
+            before_article_id=self.article_root_noise[0].id
+        )
+        self.assertEqual(article_private_child.sequence, 1)
+        self.assertSortedSequence(article_private_child + article_root_noise + article_private + article_private2)
+
+    @users('employee')
     def test_resequence_with_parent(self):
         """Checking the sequence of the articles"""
         existing_private = self.article_private.with_env(self.env)

--- a/addons/knowledge/tests/test_knowledge_performance.py
+++ b/addons/knowledge/tests/test_knowledge_performance.py
@@ -81,7 +81,7 @@ class KnowledgePerformanceCase(KnowledgeCommonWData):
     @users('employee')
     @warmup
     def test_article_invite_members(self):
-        with self.assertQueryCount(employee=86):  # knowledge only: 86
+        with self.assertQueryCount(employee=86):  # knowledge only: 85
             shared_article = self.shared_children.with_env(self.env)
             partners = (self.customer + self.partner_employee_manager + self.partner_employee2).with_env(self.env)
             shared_article.invite_members(partners, 'write')


### PR DESCRIPTION
Purpose
=======
Properly display and resequence articles based on sequence field.
Articles are currently not sorted based on sequence, and when moving
articles outside of a parent resequencing is not applied.

Task-2883368