### PR TITLE
[FIX] mail: fix scroll tests

### DIFF
--- a/addons/mail/static/tests/helpers/test_utils.js
+++ b/addons/mail/static/tests/helpers/test_utils.js
@@ -23,6 +23,32 @@ const modelDefinitionsPromise = new Promise(resolve => {
     QUnit.begin(() => resolve(getModelDefinitions()));
 });
 
+QUnit.begin(() => {
+    // alt attribute causes issues with scroll tests. Indeed, alt is
+    // displayed between the time we scroll to the bottom of a thread
+    // and the time we assert for the scroll position. The src attribute
+    // can also cause issues: the mutationObserver is async and there is
+    // no guarantee that the src is already replaced when asserting
+    // during tests.
+    function replaceAttr(altKey, element) {
+        const attrValue = element.getAttribute(altKey);
+        const attrName = altKey.split('-').at(-1);
+        element.removeAttribute(altKey);
+        const altPosition = altKey.indexOf(attrName);
+        element.setAttribute(
+            `${altKey.substr(0, altPosition)}data-${attrName}`,
+            attrValue
+        );
+    }
+    const templates = window.__OWL_TEMPLATES__;
+    const attrToRemove = ['alt', 't-att-alt', 't-attf-alt', 'src', 't-att-src', 't-attf-src'];
+    for (const key of attrToRemove) {
+        for (const element of templates.querySelectorAll(`img[${key}]`)) {
+            replaceAttr(key, element);
+        }
+    }
+});
+
 //------------------------------------------------------------------------------
 // Private
 //------------------------------------------------------------------------------
@@ -575,6 +601,7 @@ async function start(param0 = {}) {
     } = param0;
     const advanceTime = hasTimeControl ? getAdvanceTime() : undefined;
     const target = param0['target'] || getFixture();
+    target.classList.add('o_web_client');
     param0['target'] = target;
     if (!['none', 'created', 'initialized'].includes(waitUntilMessagingCondition)) {
         throw Error(`Unknown parameter value ${waitUntilMessagingCondition} for 'waitUntilMessaging'.`);

--- a/addons/test_mail_full/static/tests/qunit_suite_tests/thread_needaction_preview_tests.js
+++ b/addons/test_mail_full/static/tests/qunit_suite_tests/thread_needaction_preview_tests.js
@@ -56,7 +56,7 @@ QUnit.test('rating value displayed on the thread needaction preview', async func
         "should contain the correct rating image"
     );
     assert.strictEqual(
-        $('.o_ThreadNeedactionPreview_ratingImage').attr('alt'),
+        $('.o_ThreadNeedactionPreview_ratingImage').attr('data-alt'),
         "top",
         "should contain the correct rating text"
     );

--- a/addons/test_mail_full/static/tests/qunit_suite_tests/thread_preview_tests.js
+++ b/addons/test_mail_full/static/tests/qunit_suite_tests/thread_preview_tests.js
@@ -47,7 +47,7 @@ QUnit.test('rating value displayed on the thread preview', async function (asser
         "should contain the correct rating image"
     );
     assert.strictEqual(
-        $('.o_ThreadPreview_ratingImage').attr('alt'),
+        $('.o_ThreadPreview_ratingImage').attr('data-alt'),
         "top",
         "should contain the correct rating text"
     );


### PR DESCRIPTION
The lack of the o_web_client CSS class during tests prevent
from testing discuss scroll behavior. Indeed, the message list
needs this class to be set to grow. Without it, we just have a
0px height messageList. Adding this class is problematic: when an
image can't be fetched, the alt is displayed. But it is displayed
slightly after the scroll is triggered. This means, the scroll height
we set programatically and the one we assert during test is slightly
different. In order to solve this problem, all alt attributes have
been replaced by a data-alt attribute.