### PR TITLE
[REV] l10n_nl: set 'Cost of Revenue' in allowed account types for Ven…

### DIFF
--- a/addons/l10n_nl/models/account_journal.py
+++ b/addons/l10n_nl/models/account_journal.py
@@ -7,18 +7,6 @@ class AccountJournal(models.Model):
     _inherit = 'account.journal'
 
     @api.model
-    def _fill_missing_values(self, vals):
-        super()._fill_missing_values(vals)
-
-        if vals.get('type') != 'purchase':
-            return
-
-        company = self.env['res.company'].browse(vals['company_id']) if vals.get('company_id') else self.env.company
-        if company.country_id.code == "NL" and not vals.get('type_control_ids', [(6, 0, [])])[0][2]:
-            type_control_ids = self.env.ref('account.data_account_type_direct_costs').ids
-            vals['type_control_ids'] = [(6, 0, type_control_ids)]
-
-    @api.model
     def _prepare_liquidity_account_vals(self, company, code, vals):
         # OVERRIDE
         account_vals = super()._prepare_liquidity_account_vals(company, code, vals)


### PR DESCRIPTION
…dor Bills journal created for a l10n_nl chart of account

This reverts commit f4235243700d4a52117ca6750c44afb10142bf42.

This commit introduced an unwanted effect, by using the
`type_control_ids` to allow an account type on a journal.

But it was intended as a constraint, to limit the account types
allowed on the journal and exclude all the others.

In this case, by allowing the type of the account
`data_account_type_direct_costs`, it also excluded all other
account types on the Vendor Bill journal.

The `type_control_ids` feature was fixed here : 9278f1aceee53843e3c23d953db8c65e26c27460,
which brought up the current issue.

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
