### PR TITLE
[FIX] keep invoice_date in sync with move.date

### DIFF
--- a/addons/account/wizard/account_move_reversal.py
+++ b/addons/account/wizard/account_move_reversal.py
@@ -101,7 +101,7 @@ class AccountMoveReversal(models.TransientModel):
                    if self.reason
                    else _('Reversal of: %s', move.name),
             'date': reverse_date,
-            'invoice_date': move.is_invoice(include_receipts=True) and (self.date or move.date) or False,
+            'invoice_date': move.is_invoice(include_receipts=True) and reverse_date or False,
             'journal_id': self.journal_id.id,
             'invoice_payment_term_id': None,
             'invoice_user_id': move.invoice_user_id.id,


### PR DESCRIPTION
Description of the issue/feature this PR addresses:

When reversing an invoice, the wizard has an option to set the reversed move at the same date as the original move.

This was done properly for the move date, however, the invoice date is not synchronised.

For invoice, the user mostly sees invoice_date in the GUI, thus being misled to believe that the move has been created with the current date rather than with the initial invoice date.


Current behavior before PR:

invoice_date was set to self.date (first in the 'or' test).

Desired behavior after PR is merged:

After merging, invoice_date is determined the same way as move.date, keeping the behaviour coherent.


--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
