### PR TITLE
[FIX] mail, web: correct cid selected from the tab

### DIFF
--- a/addons/mail/static/src/components/file_uploader/file_uploader.js
+++ b/addons/mail/static/src/components/file_uploader/file_uploader.js
@@ -5,6 +5,8 @@ const useShouldUpdateBasedOnProps = require('mail/static/src/component_hooks/use
 
 const core = require('web.core');
 
+const utils = require('web.utils');
+
 const { Component } = owl;
 const { useRef } = owl.hooks;
 
@@ -121,6 +123,8 @@ class FileUploader extends Component {
                 continue;
             }
             try {
+                const hash = $.bbq.getState()
+                utils.set_cookie('cids', hash.cids);
                 const response = await this.env.browser.fetch('/web/binary/upload_attachment', {
                     method: 'POST',
                     body: this._createFormData(file),

--- a/addons/mail/static/src/components/file_uploader/file_uploader_tests.js
+++ b/addons/mail/static/src/components/file_uploader/file_uploader_tests.js
@@ -18,6 +18,7 @@ const {
         inputFiles,
     },
 } = require('web.test_utils');
+const utils = require('web.utils');
 
 QUnit.module('mail', {}, function () {
 QUnit.module('components', {}, function () {
@@ -84,6 +85,43 @@ QUnit.test('no conflicts between file uploaders', async function (assert) {
         this.env.models['mail.attachment'].all().length,
         2,
         'Uploaded file should be the only attachment added'
+    );
+});
+
+QUnit.test('no conflict multi-company multi-tab', async function (assert) {
+    assert.expect(1);
+
+    this.data['res.company'] = {
+        fields: {
+            id: { type: 'integer' },
+            name: { string: "Name", type: 'char' },
+        },
+        records: [
+            {id:1, name:'Company A'},
+            {id:2, name:'Company B'},
+        ]
+    };
+    /* We simulate a multi-tab env by selecting Company A in the window and by setting the cookie to Company B */
+    $.bbq.pushState({'cids': 1});
+    utils.set_cookie('cids', 2);
+
+    await this.start();
+    const fileUploader1 = await this.createFileUploaderComponent();
+    const file1 = await createFile({
+        name: 'text1.txt',
+        content: 'hello, world',
+        contentType: 'text/plain',
+    });
+    inputFiles(
+        fileUploader1.el.querySelector('.o_FileUploader_input'),
+        [file1]
+    );
+    await nextAnimationFrame(); // we can't use afterNextRender as fileInput are display:none
+    const cookie = utils.get_cookie('cids');
+    assert.strictEqual(
+        cookie,
+        '1',
+        'Company A should have been set in the cookie'
     );
 });
 

--- a/addons/web/controllers/main.py
+++ b/addons/web/controllers/main.py
@@ -1607,7 +1607,10 @@ class Binary(http.Controller):
             try:
                 cids = request.httprequest.cookies.get('cids', str(request.env.user.company_id.id))
                 allowed_company_ids = [int(cid) for cid in cids.split(',')]
-                attachment = Model.with_context(allowed_company_ids=allowed_company_ids).create({
+                main_cid = allowed_company_ids[0]
+                user_allowed_companies = Model.env.user.company_ids.ids
+                ordered_companies = sorted(user_allowed_companies, key=lambda c: c == main_cid, reverse=True)
+                attachment = Model.with_context(allowed_company_ids=ordered_companies).create({
                     'name': filename,
                     'datas': base64.encodebytes(ufile.read()),
                     'res_model': model,


### PR DESCRIPTION
Steps to reproduce:
- Set 2 companies
- Install Accounting and Purchase
- Open a tab with Company A and go to bills
- open a bills and upload a document
- open a new tab and select company B
- go to invoicing and upload a document
- go back to the first tab and try to umpoad a document

Issue:
Access error

Cause:
In the second tab, we selected the second company which overrided the company in the cookie.
And we used the information of the company from the cookie:
https://github.com/odoo/odoo/blob/40b5f52cf2bd135fde1c63bd122b106378dd6241/addons/web/controllers/main.py#L1608

Solution:
Set the cookie when calling uploade method

Note:
The problem is in 13.0 but I need to figure out how to set the cookie since file_uploader.js does not exist.

opw-2870469