### PR TITLE
[IMP] stock: replenishment locations

### DIFF
--- a/addons/stock/models/stock_warehouse.py
+++ b/addons/stock/models/stock_warehouse.py
@@ -601,6 +601,7 @@ class Warehouse(models.Model):
                 'name': _('Stock'),
                 'active': True,
                 'usage': 'internal',
+                'replenish_location': True,
                 'barcode': self._valid_barcode(code + '-STOCK', company_id)
             },
             'wh_input_stock_loc_id': {

--- a/addons/stock/views/stock_location_views.xml
+++ b/addons/stock/views/stock_location_views.xml
@@ -39,6 +39,7 @@
                             <field name="company_id" groups="base.group_multi_company" options="{'no_create': True}"/>
                             <field name="scrap_location" attrs="{'invisible': [('usage', 'not in', ('inventory', 'internal'))]}"/>
                             <field name="return_location"/>
+                            <field name="replenish_location" attrs="{'invisible': [('usage', '!=', 'internal')]}"/>
                         </group>
                         <group string="Cyclic Counting" attrs="{'invisible': ['|', ('usage', 'not in', ('internal', 'transit')), ('company_id', '=', False)]}">
                             <field name="cyclic_inventory_frequency"/>

--- a/addons/stock/views/stock_orderpoint_views.xml
+++ b/addons/stock/views/stock_orderpoint_views.xml
@@ -92,6 +92,10 @@
                     <filter string="Product" name="groupby_product" domain="[]" context="{'group_by': 'product_id'}"/>
                     <filter string="Category" name="groupby_category" domain="[]" context="{'group_by': 'product_category_id'}"/>
                 </group>
+                <searchpanel>
+                    <field name="location_id" string="Locations" groups="stock.group_stock_multi_locations" enable_counters="1"/>
+                    <field name="trigger" string="Trigger" enable_counters="1"/>
+                </searchpanel>
             </search>
         </field>
     </record>
@@ -211,8 +215,8 @@
             action = model.with_context(
                 search_default_filter_to_reorder=True,
                 search_default_filter_not_snoozed=True,
-                search_default_filter_creation_trigger=True,
-                default_trigger='manual'
+                default_trigger='manual',
+                searchpanel_default_trigger='manual'
             ).action_open_orderpoints()
         </field>
     </record>


### PR DESCRIPTION
adds the abiltiy to replenish to any internal stock location,
marked as replenish location, instead of just the warehouse location

Current behavior before PR:
Replenish lines in stock are only created with warehouse stock location.

Desired behavior after PR is merged:
Replenish lines now target the replenish location for the warehouse chosen by the user

Task Id: 2796757

Upgrade PR: https://github.com/odoo/upgrade/pull/3626

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
