### PR TITLE
[FIX] point_of_sale: adapt logo for multi companies customer display

### DIFF
--- a/addons/point_of_sale/models/pos_config.py
+++ b/addons/point_of_sale/models/pos_config.py
@@ -99,7 +99,7 @@ class PosConfig(models.Model):
 
     def _compute_customer_html(self):
         for config in self:
-            config.customer_facing_display_html = self.env['ir.qweb'].render('point_of_sale.customer_facing_display_html')
+            config.customer_facing_display_html = self.env['ir.qweb'].render('point_of_sale.customer_facing_display_html', {'company': self.company_id})
 
     name = fields.Char(string='Point of Sale', index=True, required=True, help="An internal identification of the point of sale.")
     is_installed_account_accountant = fields.Boolean(string="Is the Full Accounting Installed",

--- a/addons/point_of_sale/views/point_of_sale.xml
+++ b/addons/point_of_sale/views/point_of_sale.xml
@@ -66,7 +66,7 @@
                 </div>
 
                 <div class="pos-payment_info">
-                    <div class="pos-company_logo"/>
+                    <div class="pos-company_logo" t-attf-style="background-image:url(/logo?company=#{company.id})"/>
 
                     <div class="pos-payment_info_details">
                         <div class="pos-total">


### PR DESCRIPTION
Customer display does not show the appropriate logo when multi-company is
enabled. The logo shown is always the logo of the default company.

Step to reproduce the issue:
1) Install Point of Sale and set up a second company
2) Put a logo on both companies (different ones)
3) Create a POS session on the newest company (not the default one)
4) In this session, activate Customer Display
5) Launch the session and open the Customer Display
The logo shown is the logo of the default company.

Solution: The issue is that when fetching the logo, we don't include
information about the current company. Thus, we include the logo of the default
company (at url /logo). We can easily specifiy which logo we need via the url
/logo?company={company_id}. As dynamic information cannot be included into a
CSS, we include this into the XML as it is done with other images rendered.
In our case, we don't need to retrieve the logo and map it to base 64 (for
ressources requiring to be logged in) because the logo is a resource available
to anyone.

opw-2745014