### PR TITLE
[FIX] l10n_cl: documents domain in sales journal to prevent availabil…

### DIFF
--- a/addons/l10n_cl/models/account_move.py
+++ b/addons/l10n_cl/models/account_move.py
@@ -24,7 +24,7 @@ class AccountMove(models.Model):
             if self.move_type == 'out_refund':
                 internal_types_domain = ('internal_type', '=', 'credit_note')
             else:
-                internal_types_domain = ('internal_type', 'not in', ['invoice_in', 'credit_note'])
+                internal_types_domain = ('internal_type', 'in', ['invoice', 'debit_note'])
             domain = [('country_id.code', '=', 'CL'), internal_types_domain]
             if self.company_id.partner_id.l10n_cl_sii_taxpayer_type == '1':
                 domain += [('code', '!=', '71')]  # Companies with VAT Affected doesn't have "Boleta de honorarios Electrónica"


### PR DESCRIPTION
l10n_cl: fix document type domains in sales journal or in out_* documents

Description of the issue/feature this PR addresses:

Current behavior before PR:
Incorrect document types are shown as available in sales journals (Delivery guide for example, or other not invoiceable document types) if they are enabled.

Desired behavior after PR is merged:
only document types such as 'invoices' and 'debit_notes' are available.




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
