### PR TITLE
[FIX] mrp: display only one spinning wheel when printing

### DIFF
--- a/addons/mrp/static/src/js/mrp_bom_report.js
+++ b/addons/mrp/static/src/js/mrp_bom_report.js
@@ -145,7 +145,7 @@ var MrpBomReport = stock_report_generic.extend({
         var childBomIDs = _.map(this.$el.find('.o_mrp_bom_foldable').closest('tr'), function (el) {
             return $(el).data('id');
         });
-        framework.blockUI();
+        this.searchModelConfig.env.services.ui.block();
         var reportname = 'mrp.report_bom_structure?docids=' + this.given_context.active_id +
                          '&report_type=' + this.given_context.report_type +
                          '&quantity=' + (this.given_context.searchQty || 1);
@@ -163,8 +163,8 @@ var MrpBomReport = stock_report_generic.extend({
             'report_name': reportname,
             'report_file': 'mrp.report_bom_structure',
         };
-        return this.do_action(action).then(function (){
-            framework.unblockUI();
+        return this.do_action(action).then(() => {
+            this.searchModelConfig.env.services.ui.unblock();
         });
     },
     _onChangeQty: function (ev) {


### PR DESCRIPTION
Steps to reproduce:

  - Install `mrp` module
  - Go to Manufacturing > Products > Bills of Materials
  - Choose any one
  - Click on `Structure & Cost` stat button
  - Click on `Print` button

Issue:

  Two spinning wheels appears while waiting for download.

Cause:

  The print button triggers an `ir.actions.report` that already block
  the ui but with a different block method (from `web.framework`).

Solution:

  Use block/unblock methods from `env.services.ui` who manage if
  multiple calls of block method are made.

opw-2881030