### PR TITLE
[FIX] tools, test_assetsbundle: support trailing comma in named imports

### DIFF
--- a/odoo/addons/test_assetsbundle/tests/test_js_transpiler.py
+++ b/odoo/addons/test_assetsbundle/tests/test_js_transpiler.py
@@ -251,6 +251,9 @@ import  { Line10, Notification }  from 'test.Dialog2';
 import * as Line11 from "test.Dialog";
 import Default1, { Named1 } from "legacy.module";
 import Default1, { Named1 } from "@new_module/file";
+import Default1, {
+    Named1,
+} from "@new_module/file";
 import Default2, * as Star1 from "test.Dialog";
 import "test.Dialog";
 
@@ -286,7 +289,10 @@ const { Line10, Notification } = require('test.Dialog2');
 const Line11 = require("test.Dialog");
 const Default1 = require("legacy.module");
 const { Named1 } = Default1;
-const { Named1 , [Symbol.for("default")]: Default1 } = require("@new_module/file");
+const { [Symbol.for("default")]: Default1, Named1 } = require("@new_module/file");
+const { [Symbol.for("default")]: Default1,
+    Named1,
+} = require("@new_module/file");
 const Star1 = require("test.Dialog");
 const Default2 = Star1[Symbol.for("default")];
 require("test.Dialog");

--- a/odoo/tools/js_transpiler.py
+++ b/odoo/tools/js_transpiler.py
@@ -487,7 +487,7 @@ def convert_default_and_named_import(content):
         import something, { a } from "some/path";
         import somethingElse, { b } from "legacy.module";
         // after
-        const { a , [Symbol.for("default")]: something } = require("some/path");
+        const { [Symbol.for("default")]: something, a } = require("some/path");
         const somethingElse = require("legacy.module");
         const { b } = somethingElse;
     """
@@ -497,7 +497,7 @@ def convert_default_and_named_import(content):
         if is_legacy:
             return f"""{matchobj['space']}const {matchobj['default_export']} = require({matchobj['path']});
 {matchobj['space']}const {new_object} = {matchobj['default_export']}"""
-        new_object = f"""{new_object[:-1]}, [Symbol.for("default")]: {matchobj['default_export']} }}"""
+        new_object = f"""{{ [Symbol.for("default")]: {matchobj['default_export']},{new_object[1:]}"""
         return f"{matchobj['space']}const {new_object} = require({matchobj['path']})"
     return IMPORT_DEFAULT_AND_NAMED_RE.sub(repl, content)
 


### PR DESCRIPTION
Previously, when importing both the default export and named imports
with a trailing comma, we would transpile into an object where the first
keys were the named imports, including any trailing comma, and
concatenating with the default import with a leading comma, this means
that the trailing comma would transpile to two successive commas which
is not valid syntax.

This commit fixes that by putting the default import first, and adding
the named imports after, preserving the trailing comma if any, but
precluding the possibility that we get two commas back to back.
