### PR TITLE
[FIX] web: fix scroll tests

### DIFF
--- a/addons/point_of_sale/static/tests/unit/test_ProductScreen.js
+++ b/addons/point_of_sale/static/tests/unit/test_ProductScreen.js
@@ -431,7 +431,7 @@ odoo.define('point_of_sale.tests.ProductScreen', function (require) {
         const product1el = parent.el.querySelector(
             'article.product[aria-labelledby="article_product_1"]'
         );
-        assert.ok(product1el.querySelector('.product-img img[alt="Water"]'));
+        assert.ok(product1el.querySelector('.product-img img[data-alt="Water"]'));
         assert.ok(product1el.querySelector('.product-img .price-tag').textContent.includes('$2'));
         await testUtils.dom.click(product1el);
         await testUtils.nextTick();

--- a/addons/web/static/tests/helpers/test_utils.js
+++ b/addons/web/static/tests/helpers/test_utils.js
@@ -27,6 +27,30 @@ odoo.define('web.test_utils', async function (require) {
     const testUtilsPivot = require('web.test_utils_pivot');
     const tools = require('web.tools');
 
+    QUnit.begin(() => {
+        // alt attribute causes issues with scroll tests. Indeed, alt is
+        // displayed between the time we scroll to the bottom of a thread
+        // and the time we assert for the scroll position. The src
+        // attribute is removed as well to make sure images won't
+        // trigger a GET request on the server.
+        function replaceAttr(attrName, prefix, element) {
+            const attrKey = `${prefix}${attrName}`;
+            const attrValue = element.getAttribute(attrKey);
+            element.removeAttribute(attrKey);
+            element.setAttribute(`${prefix}data-${attrName}`, attrValue);
+        }
+        const attrsToRemove = ['alt', 'src'];
+        const attrPrefixes = ['', 't-att-', 't-attf-'];
+        const templates = new DOMParser().parseFromString(session.owlTemplates, "text/xml");
+        for (const attrName of attrsToRemove) {
+            for (const prefix of attrPrefixes) {
+                for (const element of templates.querySelectorAll(`*[${prefix}${attrName}]`)) {
+                    replaceAttr(attrName, prefix, element);
+                }
+            }
+        }
+        session.owlTemplates = templates.documentElement.outerHTML;
+    });
 
     function deprecated(fn, type) {
         const msg = `Helper 'testUtils.${fn.name}' is deprecated. ` +


### PR DESCRIPTION
The alt of images can be displayed slightly after the programatic
scroll which means the scroll height we set and the one we assert
are slightly different (the client height have changed). In order
to solve this issue, all alt attributes are replaed by data-alt
during tests.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
