### PR TITLE
[14.0][auth_signup] Define 'disable_database_manager' for reset password template

### DIFF
--- a/addons/auth_signup/controllers/main.py
+++ b/addons/auth_signup/controllers/main.py
@@ -3,7 +3,7 @@
 import logging
 import werkzeug
 
-from odoo import http, _
+from odoo import http, tools, _
 from odoo.addons.auth_signup.models.res_users import SignupError
 from odoo.addons.web.controllers.main import ensure_db, Home, SIGN_UP_REQUEST_PARAMS
 from odoo.addons.base_setup.controllers.main import BaseSetup
@@ -95,6 +95,7 @@ class AuthSignupHome(Home):
 
         get_param = request.env['ir.config_parameter'].sudo().get_param
         return {
+            'disable_database_manager': not tools.config['list_db'],
             'signup_enabled': request.env['res.users']._get_signup_invitation_scope() == 'b2c',
             'reset_password_enabled': get_param('auth_signup.reset_password') == 'True',
         }


### PR DESCRIPTION
Linked to the issue https://github.com/odoo/odoo/issues/93678

To reproduce, open the web page "/web/reset_password" and show in the footer, you have the link "databases manager" either If you disable list_db config from Odoo configuration.

The expected behavior is to don't show "databases manager" if list_db has been deactivated.

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
