### PR TITLE
[FIX] website_blog: fix the wrong href on the top banner of /blog

### DIFF
--- a/addons/website_blog/controllers/main.py
+++ b/addons/website_blog/controllers/main.py
@@ -97,7 +97,7 @@ class WebsiteBlog(http.Controller):
         first_post = BlogPost
         if not blog:
             first_post = BlogPost.search(domain + [('website_published', '=', True)], order="post_date desc, id asc", limit=1)
-            if use_cover and not fullwidth_cover:
+            if use_cover and not fullwidth_cover and not tags and not date_begin and not date_end:
                 offset += 1
 
         posts = BlogPost.search(domain, offset=offset, limit=self._blog_post_per_page, order="is_published desc, post_date desc, id asc")

--- a/addons/website_blog/controllers/main.py
+++ b/addons/website_blog/controllers/main.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
-import json
+import re
 import werkzeug
 import itertools
 import pytz
@@ -149,6 +149,25 @@ class WebsiteBlog(http.Controller):
     ], type='http', auth="public", website=True)
     def blog(self, blog=None, tag=None, page=1, **opt):
         Blog = request.env['blog.blog']
+
+        # TODO adapt in master. This is a fix for templates wrongly using the
+        # 'blog_url' QueryURL which is defined below. Indeed, in the case where
+        # we are rendering a blog page where no specific blog is selected we
+        # define(d) that as `QueryURL('/blog', ['tag'], ...)` but then some
+        # parts of the template used it like this: `blog_url(blog=XXX)` thus
+        # generating an URL like "/blog?blog=blog.blog(2,)". Adding "blog" to
+        # the list of params would not be right as would create "/blog/blog/2"
+        # which is still wrong as we want "/blog/2". And of course the "/blog"
+        # prefix in the QueryURL definition is needed in case we only specify a
+        # tag via `blog_url(tab=X)` (we expect /blog/tag/X). Patching QueryURL
+        # or making blog_url a custom function instead of a QueryURL instance
+        # could be a solution but it was judged not stable enough. We'll do that
+        # in master. Here we only support "/blog?blog=blog.blog(2,)" URLs.
+        if isinstance(blog, str):
+            blog = Blog.browse(int(re.search(r'\d+', blog)[0]))
+            if not blog.exists():
+                raise werkzeug.exceptions.NotFound()
+
         if blog and not blog.can_access_from_current_website():
             raise werkzeug.exceptions.NotFound()
 


### PR DESCRIPTION
Before this commit, following these steps:
- Go to /blog
- Activate the option Customize > Top banner - Name / Latest Post
- Disable the option Customize > Full Width Cover

The URL to which we are redirected when we click on the category of the
post presented at the top of the page leads to an error. This commit
makes the controller understand this url.

During the bugfix I found another issue:

Before this commit, following these steps:
- Go to /blog
- Activate the option Customize > Top banner - Name / Latest Post
- Disable the option Customize > Full Width Cover
- Click on the "guides" tag of the "Buying A Telescope" blog

No blog is displayed.

opw-2882492
