### PR TITLE
[FIX] web: registry: getAll and getEntries return shallow copies

### DIFF
--- a/addons/web/static/src/core/registry.js
+++ b/addons/web/static/src/core/registry.js
@@ -99,7 +99,7 @@ export class Registry extends EventBus {
             const content = Object.values(this.content).sort((el1, el2) => el1[0] - el2[0]);
             this.elements = content.map((elem) => elem[1]);
         }
-        return this.elements;
+        return this.elements.slice();
     }
 
     /**
@@ -112,7 +112,7 @@ export class Registry extends EventBus {
             const entries = Object.entries(this.content).sort((el1, el2) => el1[1][0] - el2[1][0]);
             this.entries = entries.map(([str, elem]) => [str, elem[1]]);
         }
-        return this.entries;
+        return this.entries.slice();
     }
 
     /**

--- a/addons/web/static/tests/core/registry_test.js
+++ b/addons/web/static/tests/core/registry_test.js
@@ -100,6 +100,29 @@ QUnit.test("can get ordered list of entries", function (assert) {
     ]);
 });
 
+QUnit.test("getAll and getEntries returns shallow copies", function (assert) {
+    const registry = new Registry();
+
+    registry.add("foo1", "foo1");
+
+    const all = registry.getAll();
+    const entries = registry.getEntries();
+
+    assert.deepEqual(all, ["foo1"]);
+    assert.deepEqual(entries, [["foo1", "foo1"]]);
+
+    all.push("foo2");
+    entries.push(["foo2", "foo2"]);
+
+    assert.deepEqual(all, ["foo1", "foo2"]);
+    assert.deepEqual(entries, [
+        ["foo1", "foo1"],
+        ["foo2", "foo2"],
+    ]);
+    assert.deepEqual(registry.getAll(), ["foo1"]);
+    assert.deepEqual(registry.getEntries(), [["foo1", "foo1"]]);
+});
+
 QUnit.test("can override element with sequence", function (assert) {
     const registry = new Registry();
 


### PR DESCRIPTION
The getAll and getEntries functions have a cache, i.e. the array
they return is lazy evaluated once, and then kept until the next
update of the registry. Before this commit, those functions
returned their own version of those arrays, not a copy. As a
consequence, someone that would modify those arrays would actually
modify the arrays in the cache, and every subsequent calls to those
functions would return those modified arrays, which would not
correspond to the actual state of the registry.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
