### PR TITLE
[FIX] hr: non-HR users should not be able to access to HR

### DIFF
--- a/addons/hr/views/hr_views.xml
+++ b/addons/hr/views/hr_views.xml
@@ -5,7 +5,7 @@
         <menuitem
             id="menu_hr_root"
             name="Employees"
-            groups="group_hr_manager,group_hr_user,base.group_user"
+            groups="group_hr_manager,group_hr_user"
             web_icon="hr,static/description/icon.png"
             sequence="75"/>
 


### PR DESCRIPTION
**Description of the issue/feature this PR addresses:**

It doesn't makes sense to let every user access to HR menu. That's why group_hr_user exists.

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr