### PR TITLE
[IMP] base: adding `bank_id` to Bank Accounts in view `base.res_partner_view_form_private`.

### DIFF
--- a/odoo/addons/base/views/res_partner_views.xml
+++ b/odoo/addons/base/views/res_partner_views.xml
@@ -389,6 +389,7 @@
                         <group string="Bank Accounts">
                             <field name="bank_ids">
                                 <tree editable="bottom">
+                                    <field name="bank_id"/>
                                     <field name="acc_number"/>
                                     <field name="acc_holder_name" invisible="1"/>
                                 </tree>


### PR DESCRIPTION
Version: 15
Behavior:
Employee -> Private Infomation -> Address 


Description of the issue/feature this PR addresses:
Currently, when user setting data for accounting or payroll, the bank
had not set yet.
Therefore, they have to open Contacts to adding new bank, then back to
Employees to check if bank available.
Current behavior before PR: bank_id not show up on view 
Desired behavior after PR is merged: 
This PR will adding `bank_id` to improve UX, make fewer duplicate processes.

![Screenshot from 2022-06-15 17-07-55](https://user-images.githubusercontent.com/90305443/173802964-08a5cd73-37b7-48a7-9002-b366f0c1bded.png)




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
