### PR TITLE
[FIX] account: Exclude to_check st_lines from accounting dashboard

### DIFF
--- a/addons/account/models/account_bank_statement.py
+++ b/addons/account/models/account_bank_statement.py
@@ -973,7 +973,7 @@ class AccountBankStatementLine(models.Model):
         return [
             # Base domain.
             ('display_type', 'not in', ('line_section', 'line_note')),
-            ('move_id.state', '=', 'posted'),
+            ('parent_state', '=', 'posted'),
             ('company_id', '=', self.company_id.id),
             # Reconciliation domain.
             ('reconciled', '=', False),

--- a/addons/account/models/account_journal_dashboard.py
+++ b/addons/account/models/account_journal_dashboard.py
@@ -282,6 +282,7 @@ class account_journal(models.Model):
                 WHERE st_line_move.journal_id IN %s
                 AND st.state = 'posted'
                 AND NOT st_line.is_reconciled
+                AND NOT st_line_move.to_check
             ''', [tuple(self.ids)])
             number_to_reconcile = self.env.cr.fetchone()[0]
 

--- a/addons/account/models/account_reconcile_model.py
+++ b/addons/account/models/account_reconcile_model.py
@@ -725,6 +725,7 @@ class AccountReconcileModel(models.Model):
                             )
                         ) AS token
                     FROM {tables}
+                    JOIN account_move account_move_line__move_id ON account_move_line__move_id.id = account_move_line.move_id
                     WHERE {where_clause} AND {table_alias}.{field} IS NOT NULL
                 ''')
 


### PR DESCRIPTION
The bank reconciliation widget is using the 'not matched' filter excluding the already reconciled statement lines and the lines marked as 'to_check'.
This commit aims to adapt the accounting dashboard to the same behavior.
This avoid having "RECONCILE 5 ITEMS" and display only 4 of them when opening the wizard.
This happens when a statement line is not reconciled but marked as 'to check'.

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
