### PR TITLE
[IMP] point_of_sale: up-to-date due within open session

### DIFF
--- a/addons/point_of_sale/models/pos_payment.py
+++ b/addons/point_of_sale/models/pos_payment.py
@@ -22,7 +22,7 @@ class PosPayment(models.Model):
     payment_date = fields.Datetime(string='Date', required=True, readonly=True, default=lambda self: fields.Datetime.now())
     currency_id = fields.Many2one('res.currency', string='Currency', related='pos_order_id.currency_id')
     currency_rate = fields.Float(string='Conversion Rate', related='pos_order_id.currency_rate', help='Conversion rate from company currency to order currency.')
-    partner_id = fields.Many2one('res.partner', string='Customer', related='pos_order_id.partner_id')
+    partner_id = fields.Many2one('res.partner', string='Customer', related='pos_order_id.partner_id', store=True)
     session_id = fields.Many2one('pos.session', string='Session', related='pos_order_id.session_id', store=True, index=True)
     company_id = fields.Many2one('res.company', string='Company', related='pos_order_id.company_id', store=True)
     card_type = fields.Char('Type of card used')

--- a/addons/point_of_sale/static/src/js/models.js
+++ b/addons/point_of_sale/static/src/js/models.js
@@ -1005,7 +1005,7 @@ class PosGlobalState extends PosModel {
         const partnerWithUpdatedTotalDue = await this.env.services.rpc({
             model: 'res.partner',
             method: 'search_read',
-            fields: ['total_due'],
+            fields: ['forecasted_total_due'],
             domain: [['id', '=', partner.id]],
         });
         this.db.update_partners(partnerWithUpdatedTotalDue);


### PR DESCRIPTION
Need to make partner_id a stored field to allow faster computation of
forecasted_total_due.

Task-ID: 2809293

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
