### PR TITLE
[FIX] crm: not recalculating date in dashboard

### DIFF
--- a/addons/crm/models/crm_lead.py
+++ b/addons/crm/models/crm_lead.py
@@ -684,6 +684,8 @@ class Lead(models.Model):
         if any(field in ['active', 'stage_id'] for field in vals):
             self._handle_won_lost(vals)
         if not stage_is_won:
+            if not ('active' in vals and not vals['active']):
+                vals['date_closed'] = False
             return super(Lead, self).write(vals)
 
         # stage change between two won stages: does not change the date_closed


### PR DESCRIPTION
Steps to reproduce the issue:

1. Create four leads
2. Move one lead to won stage
3. In dashboard view the closed % = 25%
4. Move lead back to "new"
5. the graph still says 25%

Error: the closed_date was not being reset after the stage changed from
`won` to any other stage

Solution: Set the closed_date to `None` whenever the stage was not `won`

opw-2877861
