### PR TITLE
[IMP] mrp: MO component qty changes reflected in pickings

### DIFF
--- a/addons/mrp/models/mrp_workorder.py
+++ b/addons/mrp/models/mrp_workorder.py
@@ -619,7 +619,7 @@ class MrpWorkorder(models.Model):
             })
         if self.state == 'progress':
             return True
-        start_date = datetime.now()
+        start_date = fields.Datetime.now()
         vals = {
             'state': 'progress',
             'date_start': start_date,

--- a/addons/mrp/wizard/mrp_production_backorder.py
+++ b/addons/mrp/wizard/mrp_production_backorder.py
@@ -31,7 +31,7 @@ class MrpProductionBackorder(models.TransientModel):
             wizard.show_backorder_lines = len(wizard.mrp_production_backorder_line_ids) > 1
 
     def action_close_mo(self):
-        return self.mrp_production_ids.with_context(skip_backorder=True).button_mark_done()
+        return self.mrp_production_ids.with_context(skip_backorder=True, no_procurement=True).button_mark_done()
 
     def action_backorder(self):
         ctx = dict(self.env.context)


### PR DESCRIPTION
When changing quantities of raw moves after MO confirm,
procurement is run to fulfill updated need.

Since procurement creates new moves, some fixes were also done to allow
moves to be merged with older ones, including:

1) `date_planned_start` of merged MO included microsecond which
blocked merging new moves created by procurement with orig moves.
Removed microseconds.

2) `_set_date_deadline` did not allow a simple date update to moves with
orig or dest moves. Added context to hard set all moves in self to specific
deadline.

3) `_update_candidate_moves_list` when merging moves, did not return candidates
from pickings that were merged to same MO. Usually just mattered when decreasing
quantity. Added explicit check for sibling pickings in MO

Task: 2859547


--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
