### PR TITLE
[FIX] website: prevent sending the value of a file field if it is hidden

### DIFF
--- a/addons/website/static/src/snippets/s_website_form/000.js
+++ b/addons/website/static/src/snippets/s_website_form/000.js
@@ -257,7 +257,7 @@ odoo.define('website.s_website_form', function (require) {
 
             // Prepare form inputs
             this.form_fields = this.$target.serializeArray();
-            $.each(this.$target.find('input[type=file]'), function (outer_index, input) {
+            $.each(this.$target.find('input[type=file]:not([disabled])'), (outer_index, input) => {
                 $.each($(input).prop('files'), function (index, file) {
                     // Index field name as ajax won't accept arrays of files
                     // when aggregating multiple files into a single field value


### PR DESCRIPTION
When a field in a form has a conditional visibility, its potential value
is not sent once the form is submitted if the conditional visibility is
not met. Before this commit, that was not the case for file fields.

Steps to reproduce the bug fixed by this commit:
 - Drop a form or go to /contactus
 - Add a file field
 - Put a visibility condition on this field and save
 - Fill the form, respect the visibility condition you have introduced,
   add a file in the previously added field.
 - Before submitting the form, make sure the visibility condition is no
   longer met and then submit the form.

Your file is part of the submitted data by mistake. As it was hidden at
the time you submitted the form, it should not have been sent.

opw-2856054