### PR TITLE
[13.0][FIX] payment: malformed reference

### DIFF
--- a/addons/payment/models/payment_acquirer.py
+++ b/addons/payment/models/payment_acquirer.py
@@ -3,6 +3,7 @@ from collections import defaultdict
 import hashlib
 import hmac
 import logging
+import re
 from datetime import datetime
 from dateutil import relativedelta
 import pprint
@@ -928,14 +929,14 @@ class PaymentTransaction(models.Model):
                 FROM payment_transaction WHERE reference LIKE %s ORDER BY suffix
             ''', [prefix + '-%'])
         query_res = self._cr.fetchone()
+        suffix = ''
         if query_res:
             # Increment the last reference by one
             suffix = '%s' % (-query_res[0] + 1)
-        else:
+        elif not re.search(r"(-\d+)$", prefix):
             # Start a new indexing from 1
             suffix = '1'
-
-        return '%s-%s' % (prefix, suffix)
+        return suffix and '%s-%s' % (prefix, suffix) or prefix
 
     def action_view_invoices(self):
         action = {


### PR DESCRIPTION
Affected versions: 13.0 and 14.0 (in 15.0 is fixed after the payment refactor)

When generating a payment link for an invoice the `payment.transaction._compute_reference` method is called several times.
The first times the right payment reference is created, but the next ones the reference suffix is added to the previous ones. In the end, the reference payment ends being something like:

`INV/01999-1-1-1`

Instead of the expected:

`INV/01999-1`

This is an issue with some acquirers which character limits for these
reference can be quite restrictive causing problems to match the
transactions in the callback.

TT37489 cc @Tecnativa

Steps to reproduce:

![steps-to-reproduce](https://user-images.githubusercontent.com/5040182/173858766-d0045693-c523-467b-ac07-9d9b829e5680.gif)

ping @sergio-teruel 

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
