### PR TITLE
[FIX] web: use editable param in AbstractView.init()

### DIFF
--- a/addons/web/static/src/legacy/js/views/abstract_view.js
+++ b/addons/web/static/src/legacy/js/views/abstract_view.js
@@ -360,6 +360,7 @@ var AbstractView = Factory.extend({
      * @param {Object} [action.controlPanelFieldsView]
      * @param {string} [action.display_name]
      * @param {Array[]} [action.domain=[]]
+     * @param {boolean} [action.editable]
      * @param {string} [action.help]
      * @param {integer} [action.id]
      * @param {integer} [action.limit]
@@ -382,6 +383,7 @@ var AbstractView = Factory.extend({
             currentId: action.res_id ? action.res_id : undefined,  // load returns 0
             displayName: action.display_name || action.name,
             domain: action.domain || [],
+            editable: action.editable,
             limit: action.limit,
             modelName: action.res_model,
             noContentHelp: action.help,


### PR DESCRIPTION
Prior this fix,
in AbstractView.init(), we first set params to
this._extractParamsFromAction(params.action),
and later, we try to set
this.controllerParams.activeActions.edit = params.editable .

Yet, _extractParamsFromAction() does not take params.action.editable
into account, so its value is lost.

Fix :
Take it into account. If absent, params.editable will be undefined,
so we will fall back on this.arch.attrs.edit or else true.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
