### PR TITLE
[FIX] stock: allow “apply all” with grouped list

### DIFF
--- a/addons/stock/static/src/js/inventory_singleton_list_controller.js
+++ b/addons/stock/static/src/js/inventory_singleton_list_controller.js
@@ -3,6 +3,7 @@ odoo.define('stock.SingletonListController', function (require) {
 
 var core = require('web.core');
 var InventoryReportListController = require('stock.InventoryReportListController');
+var session = require('web.session');
 
 var _t = core._t;
 
@@ -120,11 +121,12 @@ var SingletonListController = InventoryReportListController.extend({
         }).guardedCatch(this._enableButtons.bind(this));
     },
 
-    _onApplyAll: function () {
+    _onApplyAll: async function () {
+        const resIds = await this._domainToResIds(this.renderer.state.getDomain(), session.active_ids_limit);
         this.do_action('stock.action_stock_inventory_adjustement_name', {
             additional_context: {
                 'active_model': 'ir.ui.view',
-                'active_ids': this.renderer.state.data.map(el => el['res_id']),
+                'active_ids': resIds,
             },
             on_close: this.reload,
         });


### PR DESCRIPTION
Steps to reproduce the bug:
- Go to inventory > reporting > inventory report
- Add any “group by”, for example: ‘product’
- Click on the “Apply All”  button

Problem:
A Missing record error is triggered.

When we click on the button, the `active_ids` key is added in the context, but it does not represent the ids of the `stock.quant` but rather the ids of the grouped records, "product" in our case:
https://github.com/odoo/odoo/blob/bec3c58df303df6ac508bdfbb9b317d5019b858a/addons/stock/static/src/js/inventory_singleton_list_controller.js#L127

Then, They are added in the context of the wizard with the key: `default_quant_ids`: https://github.com/odoo/odoo/blob/262b49d85a95bc445e954741224305ebaa7f545b/addons/stock/wizard/stock_inventory_adjustment_name.xml#L27-L28

So when we get the `stock.quant` records, we do a search with the ids of the products instead of the `stock.quant`
https://github.com/odoo/odoo/blob/8f12dbc00fdc96732fd2ec9104ed6bf057327ef4/addons/stock/wizard/stock_inventory_adjustment_name.py#L14

Therefore, if there is no `stock.quant` with the same id as the products, an error will be thrown

opw-2879590




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
