### PR TITLE
[FIX] mail: apply SCSS of CallDemoView

### DIFF
--- a/addons/mail/static/src/components/call_demo_view/call_demo_view.scss
+++ b/addons/mail/static/src/components/call_demo_view/call_demo_view.scss
@@ -1,16 +1,16 @@
-.o_MediaPreview {
+.o_CallDemoView {
     max-width: max-content;
 }
 
-.o_MediaPreview_mediaDevicesStatus {
+.o_CallDemoView_mediaDevicesStatus {
     @include o-position-absolute($bottom: 50%);
 }
 
-.o_MediaPreview_buttonsContainer {
+.o_CallDemoView_buttonsContainer {
     @include o-position-absolute($bottom: 0);
 }
 
-.o_MediaPreview_button {
+.o_CallDemoView_button {
     height: 4rem;
     width: 4rem;
     font-size: 1.5em;


### PR DESCRIPTION
Follow-up of https://github.com/odoo/odoo/pull/93330

Commit above renamed "MediaPreview" to "CallDemoView".
However, it mistakenly did not rename the SCSS rules that
referred to `o_MediaPreview`.

As a result, some styles were no longer applied, like buttons
being an overlay on top of camera stream.
