### PR TITLE
[FIX] web: mock search_count returning 0

### DIFF
--- a/addons/web/static/tests/helpers/mock_server.js
+++ b/addons/web/static/tests/helpers/mock_server.js
@@ -111,7 +111,7 @@ export class MockServer {
         //   );
         //   return Promise.reject({ message: errorString, event });
         // }
-        const resultString = JSON.stringify(result || false);
+        const resultString = JSON.stringify(result !== undefined ? result : false);
         if (this.debug) {
             console.log(
                 "%c[rpc] response" + route,
@@ -1618,10 +1618,12 @@ export class MockServer {
      * @private
      * @param {string} model
      * @param {Array} args
-     * @returns {integer}
+     * @param {object} kwargs
+     * @param {object} [kwargs.context]
+     * @returns {number}
      */
-    mockSearchCount(model, args) {
-        return this.getRecords(model, args[0]).length;
+    mockSearchCount(model, args, kwargs = {}) {
+        return this.getRecords(model, args[0], kwargs.context).length;
     }
 
     mockSearchRead(modelName, args, kwargs) {

--- a/addons/web/static/tests/mock_server_tests.js
+++ b/addons/web/static/tests/mock_server_tests.js
@@ -288,6 +288,53 @@ QUnit.module("MockServer", (hooks) => {
         assert.deepEqual(result, [[null, ""]]);
     });
 
+    QUnit.test("performRPC: search_count", async function (assert) {
+        const server = new MockServer(data, {});
+        const result = await server.performRPC("", {
+            model: "partner",
+            method: "search_count",
+            args: [[]],
+            kwargs: {},
+        });
+        assert.deepEqual(result, 1);
+    });
+
+    QUnit.test("performRPC: search_count with domain", async function (assert) {
+        data.models.partner.records.push({ id: 4, name: "José" })
+        const server = new MockServer(data, {});
+        const result = await server.performRPC("", {
+            model: "partner",
+            method: "search_count",
+            args: [[["name", "=", "José"]]],
+            kwargs: {},
+        });
+        assert.deepEqual(result, 1);
+    });
+
+    QUnit.test("performRPC: search_count with domain matching no record", async function (assert) {
+        const server = new MockServer(data, {});
+        const result = await server.performRPC("", {
+            model: "partner",
+            method: "search_count",
+            args: [[[0, "=", 1]]],
+            kwargs: {},
+        });
+        assert.deepEqual(result, 0);
+    });
+
+    QUnit.test("performRPC: search_count with archived records", async function (assert) {
+        const server = new MockServer(data, {});
+        const result = await server.performRPC("", {
+            model: "partner",
+            method: "search_count",
+            args: [[]],
+            kwargs: {
+                context: { active_test: false },
+            },
+        });
+        assert.deepEqual(result, 2);
+    });
+
     QUnit.test("performRPC: read_group, group by char", async function (assert) {
         const server = new MockServer(data, {});
         const result = await server.performRPC("", {


### PR DESCRIPTION
The mock implementation of search_count returns `false` instead of 0 when the
domain doesn't match any records.

Also, writing some tests revealed the `active_test` context key was not taken
into account.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
