### PR TITLE
[FIX] mass_mailing: btn to select template not hidden in other languages

### DIFF
--- a/addons/mass_mailing/static/src/js/mass_mailing_widget.js
+++ b/addons/mass_mailing/static/src/js/mass_mailing_widget.js
@@ -347,7 +347,7 @@ var MassMailingFieldHtml = FieldHtml.extend({
         var $snippets_menu = $snippetsSideBar.find("#snippets_menu");
 
         for (const button of $snippets_menu.get(0).children) {
-            if (button.textContent === 'Select a template') {
+            if (!button.hasAttribute('tabindex') && !button.hasAttribute('accesskey')) {
                 button.style.display = 'none';
             }
         }


### PR DESCRIPTION
The button to select a template when using the editor was hidden on
a012019c because it was deemed useless. However, the way to determine
what button to hide relies on the button text, which doesn't work when
we're on a different language.

To solve the above, button is now identified by other attributes
(tabindex and accesskey).



--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
