### PR TITLE
[FIX][14.0]hr_expense:fix constrains _check_payment_mode only applied on sheet

### DIFF
--- a/addons/hr_expense/models/hr_expense.py
+++ b/addons/hr_expense/models/hr_expense.py
@@ -208,6 +208,10 @@ class HrExpense(models.Model):
         self.analytic_account_id = self.analytic_account_id or rec.analytic_id.id
         self.analytic_tag_ids = self.analytic_tag_ids or rec.analytic_tag_ids.ids
 
+    @api.constrains('payment_mode')
+    def _check_payment_mode(self):
+        self.sheet_id._check_payment_mode()
+
     @api.constrains('product_id', 'product_uom_id')
     def _check_product_uom_category(self):
         if self.product_id and self.product_uom_id.category_id != self.product_id.uom_id.category_id:


### PR DESCRIPTION
- Currently, constraints _check_payment_mode only applied on expense sheet, we also need to check when changing payment_mode on dividual expense.

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
