### PR TITLE
[FIX] mrp: convert qty of subcontracted move

### DIFF
--- a/addons/mrp/models/mrp_abstract_workorder.py
+++ b/addons/mrp/models/mrp_abstract_workorder.py
@@ -271,9 +271,8 @@ class MrpAbstractWorkorder(models.AbstractModel):
                         'location_dest_id': location_dest_id,
                     })
             else:
-                rounding = production_move.product_uom.rounding
                 production_move._set_quantity_done(
-                    float_round(abstract_wo.qty_producing, precision_rounding=rounding)
+                    abstract_wo.product_uom_id._compute_quantity(abstract_wo.qty_producing, production_move.product_uom, rounding_method='HALF-UP')
                 )
         self.env['stock.move.line'].create(move_line_vals)
 


### PR DESCRIPTION
To reproduce the issue:
1. In Settings, enable:
    - Units of Measure
    - Storage Locations
2. Create two consumable products P1, P2:
    - P1:
        - UoM: g
        - Purchase UoM: g
3. Create a BoM:
    - Product: P1
    - Qty: 1 kg
    - Type: Subcontracting
    - Subcontractor: a partner PA
    - Component:
        - 1 x P2
4. Create a planned receipt R:
    - From: PA
    - With:
        - 10000 g x P1
5. Mark R as todo
6. In the detailed operations, add a new line:
    - To: WH/Stock
    - Done: 10
    - UoM: kg
7. Validate R
8. Open the product moves of P1

Error: The move from Production to Subcontacting Location contains 10 g,
which is incorrect.

In the detailed operations, we used an UoM different than the one of the
move. However, there isn't any conversion of the quantity

OPW-2859754