### PR TITLE
[FIX] web: tagline rendering box repport pdf vs preview

### DIFF
--- a/addons/web/static/src/legacy/scss/layout_boxed.scss
+++ b/addons/web/static/src/legacy/scss/layout_boxed.scss
@@ -7,10 +7,14 @@
     img {
         max-height: 100px;
     }
-    h4 {
+    /* "h4 + p" selector is necessary when P is ejected outside of H4 */
+    h4, h4 + p {
         color: #999999;
         font-weight: 700;
         text-transform: uppercase;
+    }
+    h4 + p {
+        font-size: 1.5rem;
     }
 }
 .o_boxed_footer {


### PR DESCRIPTION
Steps to reproduce:
	- Go into settings > Configure Document Layout
	- Choose layout boxed
	- set a company tagline
	- click "download PDF Preview"
Issue:
	The styling of the company tagline is not the same on the pdf and
	the preview
Cause:
	Module lxml from etree would not interpret the html the same way as
	the browser. In the browser, we would have a 'p' markup inside of the
	'h4' for the title. Effectively applying the style from the css
	sheet. In the pdf, the lxlm module place the 'p' markup after the
	'h4'. Therefore it would not receive the styling of the 'h4'.
	Reproduction:
```
	>>> from lxml import html
	>>> html.tostring(html.fromstring('<div><h4><p>hi</h4></div>'))
	b'<div><h4></h4><p>hi</p></div>'
```
Solution:
	Add an additional styling in the scss file to include the 'p' that
	would come directly after the 'h4'.

opw-2846247