### PR TITLE
[FIX] web_unsplash, website: fix deps between website and web_unsplash

### DIFF
--- a/addons/web_unsplash/models/res_users.py
+++ b/addons/web_unsplash/models/res_users.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
-from odoo import api, models
+from odoo import models
 
 
 class ResUsers(models.Model):
@@ -8,4 +8,8 @@ class ResUsers(models.Model):
 
     def _has_unsplash_key_rights(self):
         self.ensure_one()
-        return self.has_group('base.group_erp_manager')
+        # Website has no dependency to web_unsplash, we cannot warranty the order of the execution
+        # of the overwrite done in 5ef8300.
+        # So to avoid to create a new module bridge, with a lot of code, we prefer to make a check
+        # here for website's user.
+        return self.has_group('base.group_erp_manager') or self.has_group('website.group_website_designer')

--- a/addons/website/models/res_users.py
+++ b/addons/website/models/res_users.py
@@ -2,7 +2,7 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 import logging
 
-from odoo import api, fields, models, tools, _
+from odoo import api, fields, models, _
 from odoo.exceptions import ValidationError
 from odoo.http import request
 
@@ -18,12 +18,6 @@ class ResUsers(models.Model):
         # Partial constraint, complemented by a python constraint (see below).
         ('login_key', 'unique (login, website_id)', 'You can not have two users with the same login!'),
     ]
-
-    def _has_unsplash_key_rights(self):
-        self.ensure_one()
-        if self.has_group('website.group_website_designer'):
-            return True
-        return super(ResUsers, self)._has_unsplash_key_rights()
 
     @api.constrains('login', 'website_id')
     def _check_login(self):


### PR DESCRIPTION
Website has no dependency to web_unsplash, we cannot warranty the order
of the execution of the overwrite done in 5ef8300.
So to avoid to create a new module bridge, with a lot of code, we prefer
to make a check for website user directly in unsplash module.
It is 'safe' since if you don't have website, the group
`group_website_designer` doesn't exists and so it will do a `or False`.





--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
