### PR TITLE
[FIX] web_editor: copy paste from website

### DIFF
--- a/addons/web_editor/static/src/js/editor/rte.js
+++ b/addons/web_editor/static/src/js/editor/rte.js
@@ -332,8 +332,22 @@ var RTEWidget = Widget.extend({
         });
 
         // start element observation
+        let pastingData = false;
+        $(document).on('paste', function (ev) {
+            pastingData = [...self.editable()];
+            browser.setTimeout(function(){ pastingData = false; }, 0);
+        });
         $(document).on('content_changed', function (ev) {
             self.trigger_up('rte_change', {target: ev.target});
+
+            if (pastingData) {
+                const pastedDirtyEls = ev.target.querySelectorAll('[data-oe-id]');
+                _.difference([...pastedDirtyEls], pastingData).forEach(el => {
+                    const dirtyAttributes = el.getAttributeNames().filter(name => !name.indexOf("data-oe"));
+                    dirtyAttributes.forEach(name => el.removeAttribute(name));
+                })
+                pastingData = false;
+            }
 
             // Add the dirty flag to the element that changed by either adding
             // it on the highest editable ancestor or, if there is no editable


### PR DESCRIPTION
Pasting from the website to the website could for example copy
t-field="..." which then would easily add an error if e.g a field
is copied to an area where it is not available.

This fix strip the data-oe-... attributes of nodes added to the DOM
when pasting.

cherrypick of https://github.com/odoo/odoo/commit/e7e9eb987b654d3c49d5b62c055ccb8d3ddb8cd7
opw-2782639