### PR TITLE
[FIX] crm: close_date not reset accoredint to the stage

### DIFF
--- a/addons/crm/views/crm_lead_views.xml
+++ b/addons/crm/views/crm_lead_views.xml
@@ -518,6 +518,7 @@
                     archivable="false" sample="1">
                     <field name="stage_id" options='{"group_by_tooltip": {"requirements": "Description"}}'/>
                     <field name="probability"/>
+                    <field name="automated_probability"/>
                     <field name="color"/>
                     <field name="priority"/>
                     <field name="expected_revenue"/>


### PR DESCRIPTION
Steps to reproduce the bug:

- Create a lead L and pass it to a won stage
- Pass L to a not won and not lost stage from the kanban view

Bug:

The close_date was not reset.
Making the same flow from the form view reset the close_date.
PS: automated_probability is needed to write the probability from function _compute_probabilities

opw:2877861