### PR TITLE
[14.0][FIX] mail: clean context also on chatter model create

### DIFF
--- a/addons/mail/models/mail_thread.py
+++ b/addons/mail/models/mail_thread.py
@@ -2120,10 +2120,12 @@ class MailThread(models.AbstractModel):
             create_values['partner_ids'] = [(4, pid) for pid in create_values.get('partner_ids', [])]
             create_values['channel_ids'] = [(4, cid) for cid in create_values.get('channel_ids', [])]
             create_values_list.append(create_values)
-        if 'default_child_ids' in self._context:
-            ctx = {key: val for key, val in self._context.items() if key != 'default_child_ids'}
-            self = self.with_context(ctx)
-        return self.env['mail.message'].create(create_values_list)
+
+        # remove context, notably for default keys, as this thread method is not
+        # meant to propagate default values for messages, only for master records
+        return self.env['mail.message'].with_context(
+            clean_context(self.env.context)
+        ).create(create_values_list)
 
     # ------------------------------------------------------
     # NOTIFICATION API


### PR DESCRIPTION
_Description of the issue/feature this PR addresses:_

Default values in the context when creating a record of a model with chatter will be applied to the mail.message model, which is a problem if the same field exists on the mail.message model. Similar to https://github.com/odoo/odoo/pull/43405

_Current behavior before PR:_

Record creation halts on

```
psycopg2.errors.ForeignKeyViolation: insert or update on table "mail_message" violates foreign key constraint "mail_message_parent_id_fkey"
DETAIL:  Key (parent_id)=(2147483647) is not present in table "mail_message".
```

_Desired behavior after PR is merged:_

Record is created properly.

OPW-2888152


--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
