### PR TITLE
[FIX] web_editor, website: update toolbar visibility in translate mode

### DIFF
--- a/addons/web_editor/static/src/js/editor/snippets.editor.js
+++ b/addons/web_editor/static/src/js/editor/snippets.editor.js
@@ -1323,6 +1323,8 @@ var SnippetsMenu = Widget.extend({
             this.$('.o_we_customize_snippet_btn').addClass('active').prop('disabled', false);
             this.$('o_we_ui_loading').addClass('d-none');
             $(this.customizePanel).removeClass('d-none');
+            this.$('#o_we_editor_toolbar_container').hide();
+            this.$('#o-we-editor-table-container').addClass('d-none');
             return Promise.all(defs);
         }
         this.invisibleDOMPanelEl = document.createElement('div');
@@ -3478,8 +3480,8 @@ var SnippetsMenu = Widget.extend({
         const range = selection && selection.rangeCount && selection.getRangeAt(0);
         if (!range ||
             !$(range.commonAncestorContainer).parents('#wrapwrap, .iframe-editor-wrapper .o_editable').length ||
-            $(selection.anchorNode).parent('[data-oe-model]:not([data-oe-type="html"]):not([data-oe-field="arch"])').length ||
-            $(selection.focusNode).parent('[data-oe-model]:not([data-oe-type="html"]):not([data-oe-field="arch"])').length ||
+            $(selection.anchorNode).parent('[data-oe-model]:not([data-oe-type="html"]):not([data-oe-field="arch"]):not([data-oe-translation-id])').length ||
+            $(selection.focusNode).parent('[data-oe-model]:not([data-oe-type="html"]):not([data-oe-field="arch"]):not([data-oe-translation-id])').length ||
             (e && $(e.target).closest('.fa, img').length ||
             this.options.wysiwyg.lastMediaClicked && $(this.options.wysiwyg.lastMediaClicked).is('.fa, img')) ||
             (this.options.wysiwyg.lastElement && !this.options.wysiwyg.lastElement.isContentEditable)

--- a/addons/website/static/src/js/menu/translate.js
+++ b/addons/website/static/src/js/menu/translate.js
@@ -310,13 +310,6 @@ var TranslatePageMenu = websiteNavbarData.WebsiteNavbarActionWidget.extend({
             var trans = self._getTranlationObject(this);
             trans.value = (trans.value ? trans.value : $node.html()).replace(/[ \t\n\r]+/, ' ');
         });
-        this._getEditableArea().prependEvent('click.translator', function (ev) {
-            if (ev.ctrlKey || !$(ev.target).is(':o_editable')) {
-                return;
-            }
-            ev.preventDefault();
-            ev.stopPropagation();
-        });
 
         // attributes
 


### PR DESCRIPTION
Before this commit, in translate mode, the toolbar and the
table-container were shown when initializing the SnippetsMenu (and
removed for a click on an element that was not a translation).
To reproduce:
-> Install another language on website 1,
-> Click on translate
-> Click on a button of the informative dialog
-> The toolbar was there, then was removed on the click on the dialog,
and won't reappear

(If the informative dialog is not shown, because it was permentantly
dismissed, click on an image, the toolbar is still there and won't be
removed).

To fix that, the clicks on translations elements  are not stopped from
the TranslatePageMenu and are taken into account in
_checkEditorToolbarVisibility to show/hide the toolbar.

task-2687506

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
