### PR TITLE
[IMP] {test_}mail: auto-corrects custom values in alias

### DIFF
--- a/addons/mail/models/mail_thread.py
+++ b/addons/mail/models/mail_thread.py
@@ -1330,7 +1330,7 @@ class MailThread(models.AbstractModel):
         try:
             # Internal transaction to be able to correct data if it fails because of incorrect data
             with self.env.cr.savepoint():
-                return self.create(data)
+                return self.create(self._get_safe_create_data(data))
         except IntegrityError:
             return self.create(self._get_safe_create_data(data, is_remove_missing_ref=True))
 

--- a/addons/test_mail/models/test_mail_models.py
+++ b/addons/test_mail/models/test_mail_models.py
@@ -206,3 +206,36 @@ class MailTestComposerMixin(models.Model):
 
     def _compute_render_model(self):
         self.render_model = self._name
+
+
+class MailTestDocumentTags(models.Model):
+    """ Model required for mail.test.document to define a many2many relation. """
+    _name = "mail.test.document.tag"
+    _description = "Tag"
+
+    name = fields.Char(required=True)
+    active = fields.Boolean(default=True, string="Active")
+
+
+class MailTestDocumentFolder(models.Model):
+    """ Model required for mail.test.document to define a many2one relation. """
+    _name = "mail.test.document.folder"
+    _description = "Folder"
+
+    name = fields.Char(required=True)
+    active = fields.Boolean(default=True, string="Active")
+
+
+class MailTestDocument(models.Model):
+    """ Model with all kind of relations and most field types to test with alias_defaults. """
+    _description = 'Document'
+    _name = 'mail.test.document'
+    _inherit = ['mail.thread']
+
+    name = fields.Char(required=True)
+    type = fields.Selection([('url', 'URL'), ('binary', 'File'), ('empty', 'Request')])
+    is_todo = fields.Boolean()
+    description = fields.Char()
+
+    folder_id = fields.Many2one('mail.test.document.folder')
+    tag_ids = fields.Many2many('mail.test.document.tag', 'mail_test_document_tag_rel')

--- a/addons/test_mail/models/test_mail_models.py
+++ b/addons/test_mail/models/test_mail_models.py
@@ -239,3 +239,5 @@ class MailTestDocument(models.Model):
 
     folder_id = fields.Many2one('mail.test.document.folder')
     tag_ids = fields.Many2many('mail.test.document.tag', 'mail_test_document_tag_rel')
+    parent_id = fields.Many2one('mail.test.document')
+    sub_document_ids = fields.One2many('mail.test.document', 'parent_id')

--- a/addons/test_mail/security/ir.model.access.csv
+++ b/addons/test_mail/security/ir.model.access.csv
@@ -32,3 +32,6 @@ access_mail_test_multi_company_portal,mail.test.multi.company.portal,model_mail_
 access_mail_test_track_compute,mail.test.track.compute,model_mail_test_track_compute,base.group_user,1,1,1,1
 access_mail_test_track_monetary,mail.test.track.monetary,model_mail_test_track_monetary,base.group_user,1,1,1,1
 access_mail_test_track_all,mail.test.track.all,model_mail_test_track_all,base.group_user,1,1,1,1
+access_mail_test_document,mail.test.document,model_mail_test_document,base.group_user,1,1,1,1
+access_mail_test_document_folder,mail.test.document.folder,model_mail_test_document_folder,base.group_user,1,1,1,1
+access_mail_test_document_tag,mail.test.document.tag,model_mail_test_document_tag,base.group_user,1,1,1,1


### PR DESCRIPTION
[IMP] {test_}mail: auto-corrects custom values in alias

Cleanup on the alias_defaults to prevent as possible creation failure or
unwanted side effects:
- remove any creation of sub-record
- remove any set to one2many field
- remove non-existing field
- remove any command different from link and set. For example, update cannot
be used.

Task-2675209

This commit will be merged in 15 but is necessary for the [IMP] commit:
[FIX] {test_}mail: auto-corrects custom values in alias

Alias custom default values that references archived or deleted records can
prevent the record to be created when receiving an email. This solves the
problem by removing dangling references, allowing the creation of the record
by skipping thoses references.

Task-2675209

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
