### PR TITLE
[FIX] {test_}mail: auto-corrects custom values in alias

### DIFF
--- a/addons/mail/views/mail_alias_views.xml
+++ b/addons/mail/views/mail_alias_views.xml
@@ -8,6 +8,11 @@
             <field name="model">mail.alias</field>
             <field name="arch" type="xml">
                 <form string="Alias">
+                    <field name="alias_defaults_error" invisible="1"/>
+                    <div attrs="{'invisible':[('alias_defaults_error', '=', False)]}"
+                         class="alert alert-danger text-center" role="alert">
+                        Incorrect "Default Values": <field name="alias_defaults_error"/>
+                    </div>
                     <sheet>
                         <div class="oe_button_box" name="button_box">
                             <button name="open_document" string="Open Document"
@@ -43,7 +48,8 @@
                     <field name="alias_name"/>
                     <field name="alias_model_id"/>
                     <field name="alias_user_id"/>
-                    <field name="alias_defaults"/>
+                    <field name="alias_defaults_error" invisible="1"/>
+                    <field name="alias_defaults" decoration-danger="alias_defaults_error"/>
                     <field name="alias_contact"/>
                 </tree>
             </field>

--- a/addons/test_mail/models/test_mail_models.py
+++ b/addons/test_mail/models/test_mail_models.py
@@ -201,3 +201,5 @@ class MailTestDocument(models.Model):
     partner_id = fields.Many2one('res.partner')
     folder_id = fields.Many2one('mail.test.document.folder')
     tag_ids = fields.Many2many('mail.test.document.tag', 'mail_test_document_tag_rel')
+    parent_id = fields.Many2one('mail.test.document')
+    sub_document_ids = fields.One2many('mail.test.document', 'parent_id')

--- a/addons/test_mail/models/test_mail_models.py
+++ b/addons/test_mail/models/test_mail_models.py
@@ -165,3 +165,39 @@ class MailTestComposerMixin(models.Model):
 
     def _compute_render_model(self):
         self.render_model = self._name
+
+
+class MailTestDocumentTags(models.Model):
+    """ Model required for mail.test.document to define a many2many relation. """
+    _name = "mail.test.document.tag"
+    _description = "Tag"
+
+    name = fields.Char(required=True)
+    active = fields.Boolean(default=True, string="Active")
+
+
+class MailTestDocumentFolder(models.Model):
+    """ Model required for mail.test.document to define a many2one relation. """
+    _name = "mail.test.document.folder"
+    _description = "Folder"
+
+    name = fields.Char(required=True)
+    active = fields.Boolean(default=True, string="Active")
+
+
+class MailTestDocument(models.Model):
+    """ Model with all kind of relations and most field types to test with alias_defaults. """
+    _description = 'Document'
+    _name = 'mail.test.document'
+    _inherit = ['mail.thread.blacklist', 'mail.activity.mixin']
+    _primary_email = 'email_from'
+
+    name = fields.Char(required=True)
+    email_from = fields.Char()
+    type = fields.Selection([('url', 'URL'), ('binary', 'File'), ('empty', 'Request')])
+    is_todo = fields.Boolean()
+
+    company_id = fields.Many2one('res.company')
+    partner_id = fields.Many2one('res.partner')
+    folder_id = fields.Many2one('mail.test.document.folder')
+    tag_ids = fields.Many2many('mail.test.document.tag', 'mail_test_document_tag_rel')

--- a/addons/test_mail/security/ir.model.access.csv
+++ b/addons/test_mail/security/ir.model.access.csv
@@ -29,3 +29,6 @@ access_mail_test_track_compute,mail.test.track.compute,model_mail_test_track_com
 access_mail_test_track_monetary,mail.test.track.monetary,model_mail_test_track_monetary,base.group_user,1,1,1,1
 access_mail_test_track_selection_portal,mail.test.track.selection.portal,model_mail_test_track_selection,base.group_portal,0,0,0,0
 access_mail_test_track_selection_user,mail.test.track.selection.user,model_mail_test_track_selection,base.group_user,1,1,1,1
+access_mail_test_document,mail.test.document,model_mail_test_document,base.group_user,1,1,1,1
+access_mail_test_document_folder,mail.test.document.folder,model_mail_test_document_folder,base.group_user,1,1,1,1
+access_mail_test_document_tag,mail.test.document.tag,model_mail_test_document_tag,base.group_user,1,1,1,1


### PR DESCRIPTION
Alias custom default values that references archived or deleted records can
prevent the record to be created when receiving an email. This solves the
problem by removing dangling references, allowing the creation of the record
by skipping thoses references.

Task-2675209

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
