### PR TITLE
[FIX] web_editor: fix attachment removal warning from media dialog

### DIFF
--- a/addons/web_editor/controllers/main.py
+++ b/addons/web_editor/controllers/main.py
@@ -205,14 +205,17 @@ class Web_Editor(http.Controller):
         removal_blocked_by = {}
 
         for attachment in Attachment.browse(ids):
-            # in-document URLs are html-escaped, a straight search will not
-            # find them
-            url = tools.html_escape(attachment.local_url)
-            views = Views.search([
-                "|",
-                ('arch_db', 'like', '"%s"' % url),
-                ('arch_db', 'like', "'%s'" % url)
-            ])
+            if attachment.image_src:
+                # in-document URLs are html-escaped, a straight search will not
+                # find them
+                url = tools.html_escape(attachment.image_src)
+                views = Views.search([
+                    "|",
+                    ('arch_db', 'like', '"%s"' % url),
+                    ('arch_db', 'like', "'%s'" % url)
+                ])
+            else:
+                views = Views.search([('arch_db', 'like', 'web/content/%s?' % attachment.id)])
 
             if views:
                 removal_blocked_by[attachment.id] = views.read(['name'])


### PR DESCRIPTION
Before this commit, the user could delete an attachment (image or
document) he previously uploaded in the media dialog, even if that
attachment was used in a view.

To fix that and block the removal of attachments that are still in use,
the /web_editor/attachment/remove controller is adapted to the url that
the media dialog is using when uploading an attachment
(attachment.image_src for an image and /web/content/attachment.id for a
document).

task-2687506

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
