### PR TITLE
[FIX] web_editor: transform space to nbsp when deleterange

### DIFF
--- a/addons/web_editor/static/lib/odoo-editor/src/OdooEditor.js
+++ b/addons/web_editor/static/lib/odoo-editor/src/OdooEditor.js
@@ -49,6 +49,7 @@ import {
     unwrapContents,
     peek,
     rightPos,
+    rightLeafOnlyNotBlockPath,
 } from './utils/utils.js';
 import { editorCommands } from './commands/commands.js';
 import { Powerbox } from './powerbox/Powerbox.js';
@@ -1388,9 +1389,9 @@ export class OdooEditor extends EventTarget {
         fillEmpty(closestBlock(range.endContainer));
         // Ensure trailing space remains visible.
         const joinWith = range.endContainer;
-        const joinSibling = joinWith && joinWith.nextSibling;
         const oldText = joinWith.textContent;
-        const hasSpaceAfter = joinSibling && joinSibling.textContent.startsWith(' ');
+        const rightLeaf = rightLeafOnlyNotBlockPath(range.endContainer).next().value;
+        const hasSpaceAfter = !rightLeaf || rightLeaf.textContent.startsWith(' ');
         const shouldPreserveSpace = (doJoin || hasSpaceAfter) && joinWith && oldText.endsWith(' ');
         if (shouldPreserveSpace) {
             joinWith.textContent = oldText.replace(/ $/, '\u00A0');
@@ -1418,10 +1419,9 @@ export class OdooEditor extends EventTarget {
                 break;
             }
         }
-        next = joinWith && joinWith.nextSibling;
+        next = range.endContainer && rightLeafOnlyNotBlockPath(range.endContainer).next().value;
         if (
-            shouldPreserveSpace &&
-            !(next && next.nodeType === Node.TEXT_NODE && next.textContent.startsWith(' '))
+            shouldPreserveSpace && next && !(next && next.nodeType === Node.TEXT_NODE && next.textContent.startsWith(' '))
         ) {
             // Restore the text we modified in order to preserve trailing space.
             joinWith.textContent = oldText;

--- a/addons/web_editor/static/lib/odoo-editor/test/spec/editor.test.js
+++ b/addons/web_editor/static/lib/odoo-editor/test/spec/editor.test.js
@@ -2377,6 +2377,15 @@ X[]
                     <p>before[]after</p>`),
             });
         });
+        it('should transform the last space of a container to an &nbsp; after removing the last word through deleteRange', async () => {
+            await testEditor(BasicEditor, {
+                contentBefore: `<p>a [b]</p>`,
+                stepFunction: async editor => {
+                    await deleteBackward(editor);
+                },
+                contentAfter: `<p>a&nbsp;[]</p>`,
+            });
+        });
     });
 
     describe('insertParagraphBreak', () => {


### PR DESCRIPTION
Before this commit
When removing the last word of an html container, the last space was
not transformed into an `nbsp`. This caused google chrome to not
render the space.

Task-2809312





--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
