### PR TITLE
[FIX] mail, web: correct cid selected from the tab

### DIFF
--- a/addons/mail/static/src/js/attachment_box.js
+++ b/addons/mail/static/src/js/attachment_box.js
@@ -9,6 +9,8 @@ var DocumentViewer = require('mail.DocumentViewer');
 var QWeb = core.qweb;
 var _t = core._t;
 
+const utils = require('web.utils');
+
 var AttachmentBox = Widget.extend({
     template: 'mail.chatter.AttachmentBox',
     events: {
@@ -110,6 +112,8 @@ var AttachmentBox = Widget.extend({
      * @param {MouseEvent} ev
      */
     _onUploadAttachments: function (ev) {
+        const hash = $.bbq.getState()
+        utils.set_cookie('cids', hash.cids);
         this.$('input.o_input_file').click();
     },
     /**

--- a/addons/web/controllers/main.py
+++ b/addons/web/controllers/main.py
@@ -1534,7 +1534,10 @@ class Binary(http.Controller):
             try:
                 cids = request.httprequest.cookies.get('cids', str(request.env.user.company_id.id))
                 allowed_company_ids = [int(cid) for cid in cids.split(',')]
-                attachment = Model.with_context(allowed_company_ids=allowed_company_ids).create({
+                main_cid = allowed_company_ids[0]
+                user_allowed_companies = Model.env.user.company_ids.ids
+                ordered_companies = sorted(user_allowed_companies, key=lambda c: c == main_cid, reverse=True)
+                attachment = Model.with_context(allowed_company_ids=ordered_companies).create({
                     'name': filename,
                     'datas': base64.encodebytes(ufile.read()),
                     'res_model': model,


### PR DESCRIPTION
Steps to reproduce:
- Set 2 companies
- Install Accounting and Purchase
- Open a tab with Company A and go to bills
- open a bills and upload a document
- open a new tab and select company B
- go to invoicing and upload a document
- go back to the first tab and try to umpoad a document

Issue:
Access error

Cause:
In the second tab, we selected the second company which overrided the company in the cookie.
And we used the information of the company from the cookie.

Solution:
Set the cookie when calling upload attachment method

opw-2870469