### PR TITLE
[FIX] project: stringify the domain list before using Domain.and

### DIFF
--- a/addons/project/static/src/js/project_kanban.js
+++ b/addons/project/static/src/js/project_kanban.js
@@ -352,7 +352,7 @@ const ProjectTaskKanbanModel = KanbanModel.extend({
         if (groupedBy === 'personal_stage_type_ids') {
             list.domain = Domain.and([
                 [['user_ids', 'in', this.getSession().user_id[0]]],
-                list.domain
+                JSON.stringify(list.domain),
             ]).toList();
         }
         return this._super(...arguments);


### PR DESCRIPTION
Before this commit, when we use a domain list made by the old
implementation of the Domain in js and in this domain we have a date in
a right leaf then this date is an object of Date class. However, with
the new implementation of the Domain, the date will be converted into a
PyDate/PyDatetine object and so when we create a domain with the new
implementation by giving a list containing the result of the old
implementation. The date will be converted as a plain object instead of
a date formatted or instead of a date object.

This commit converts the list in string before using `Domain.and` with
the new implementation to having a date formatted as a string to avoid
the issue.

for instance, when the user choose a filter containing a date in the
right of a leaf in the domain. The old implementation of domain class
will return `[['date', '=', new Date(1970, 1, 1)]]`
```js
new Domain([['date', '=', new Date(1970, 1, 1)]]).toList()
// result: [['date', '=', {day: 1, month: 1, year: 1970}]]
```
if the list is converted as a string before passing the result will be:
```js
new Domain(JSON.stringify([['date', '=', new Date(1970, 1, 1)]])).toList()
// result: [['date', '=', '1970-01-01']]
```
