### PR TITLE
[FIX] hr_contract: fix access error when archiving employee

### DIFF
--- a/addons/hr/wizard/hr_departure_wizard.py
+++ b/addons/hr/wizard/hr_departure_wizard.py
@@ -35,4 +35,4 @@ class HrDepartureWizard(models.TransientModel):
             # ignore contact links to internal users
             private_address = employee.address_home_id
             if private_address and private_address.active and not self.env['res.users'].search([('partner_id', '=', private_address.id)]):
-                private_address.toggle_active()
+                private_address.sudo().toggle_active()

--- a/addons/hr_contract/wizard/hr_departure_wizard.py
+++ b/addons/hr_contract/wizard/hr_departure_wizard.py
@@ -8,13 +8,13 @@ from odoo.exceptions import UserError
 class HrDepartureWizard(models.TransientModel):
     _inherit = 'hr.departure.wizard'
 
-    set_date_end = fields.Boolean(string="Set Contract End Date", default=True,
+    set_date_end = fields.Boolean(string="Set Contract End Date", default=lambda self: self.env.user.user_has_groups('hr_contract.group_hr_contract_manager'),
         help="Set the end date on the current contract.")
 
     def action_register_departure(self):
         """If set_date_end is checked, set the departure date as the end date to current running contract,
         and cancel all draft contracts"""
-        current_contract = self.employee_id.contract_id
+        current_contract = self.sudo().employee_id.contract_id
         if current_contract and current_contract.date_start > self.departure_date:
             raise UserError(_("Departure date can't be earlier than the start date of current contract."))
 
@@ -22,4 +22,4 @@ class HrDepartureWizard(models.TransientModel):
         if self.set_date_end:
             self.employee_id.contract_ids.filtered(lambda c: c.state == 'draft').write({'state': 'cancel'})
             if current_contract:
-                self.employee_id.contract_id.write({'date_end': self.departure_date})
+                self.sudo().employee_id.contract_id.write({'date_end': self.departure_date})

--- a/addons/hr_fleet/wizard/hr_departure_wizard.py
+++ b/addons/hr_fleet/wizard/hr_departure_wizard.py
@@ -7,7 +7,7 @@ from odoo import api, fields, models
 class HrDepartureWizard(models.TransientModel):
     _inherit = 'hr.departure.wizard'
 
-    release_campany_car = fields.Boolean("Release Company Car", default=True,
+    release_campany_car = fields.Boolean("Release Company Car", default=lambda self: self.env.user.user_has_groups('fleet.fleet_group_user'),
         help="Release the company car.")
 
     def action_register_departure(self):


### PR DESCRIPTION
Scenario:
hr_contract is installed and employee/officer without rights on contract
tries to archive an employee.

Before the fix:
An employee/officer without rights on contract gets the following access error:
Due to security restrictions, you are not allowed to access 'Employee Contract' (hr.contract) records.
THis is because the action tries to access employee's contract and set
date_end on it.

After the fix an employee/officer without rights on contract can archive
an employee without access error.

task - 2811165


