### PR TITLE
[IMP] website, website_sale: make searchbar show count always visible

### DIFF
--- a/addons/website/views/website_templates.xml
+++ b/addons/website/views/website_templates.xml
@@ -2371,7 +2371,12 @@ Sitemap: <t t-esc="url_root"/>sitemap.xml
         <t t-set="search_placeholder">Search...</t>
         <input type="search" name="search" t-att-class="'search-query form-control oe_search_box %s' % _input_classes" t-att-placeholder="placeholder if placeholder else search_placeholder" t-att-value="search"/>
         <div class="input-group-append">
-            <button type="submit" t-att-class="'btn oe_search_button %s' % (_submit_classes or 'btn-primary')" aria-label="Search" title="Search"><i class="fa fa-search"/></button>
+            <button type="submit" t-att-class="'btn oe_search_button %s' % (_submit_classes or 'btn-primary')" aria-label="Search" title="Search">
+                <i class="fa fa-search"/>
+                <span t-if="search" class="oe_search_found">
+                    <small>(<t t-out="search_count or 0"/> found)</small>
+                </span>
+            </button>
         </div>
     </div>
 </template>

--- a/addons/website_sale/views/templates.xml
+++ b/addons/website_sale/views/templates.xml
@@ -154,12 +154,6 @@
         </t>
     </template>
 
-    <template id="search_count_box" inherit_id="website.website_search_box" active="False" customize_show="True" name="Show # found">
-        <xpath expr="//button[contains(@t-att-class, 'oe_search_button')]" position="inside">
-            <span t-if='search' class='oe_search_found'> <small>(<t t-esc="search_count or 0"/> found)</small></span>
-        </xpath>
-    </template>
-
     <template id="products_item" name="Products item">
         <form action="/shop/cart/update" method="post" class="oe_product_cart h-100 d-flex"
             t-att-data-publish="product.website_published and 'on' or 'off'"

--- a/addons/website_sale_loyalty/static/tests/tours/test_gift_card_tour.js
+++ b/addons/website_sale_loyalty/static/tests/tours/test_gift_card_tour.js
@@ -8,20 +8,6 @@ tour.register('shop_sale_gift_card', {
     url: '/shop?search=Small%20Drawer'
 },
     [
-        {
-            content: 'Open customize menu',
-            extra_trigger: '.oe_website_sale .o_wsale_products_searchbar_form',
-            trigger: '#customize-menu > a',
-        },
-        {
-            content: "Enable 'Show # found' if needed",
-            trigger: '#customize-menu label:contains(Show # found)',
-            run: function () {
-                if (!$('#customize-menu label:contains(Show # found) input').prop('checked')) {
-                    $('#customize-menu label:contains(Show # found)').click();
-                }
-            }
-        },
         // Add a small drawer to the order (50$)
         {
             content: 'select Small Drawer',

--- a/addons/website_sale_loyalty/static/tests/tours/test_promo_main_tour.js
+++ b/addons/website_sale_loyalty/static/tests/tours/test_promo_main_tour.js
@@ -9,20 +9,6 @@ tour.register('shop_sale_loyalty', {
     url: '/shop?search=Small%20Cabinet',
 },
     [
-        {
-            content: "open customize menu",
-            extra_trigger: '.oe_website_sale .o_wsale_products_searchbar_form',
-            trigger: '#customize-menu > a',
-        },
-        {
-            content: "enable 'Show # found' if needed",
-            trigger: "#customize-menu label:contains(Show # found)",
-            run: function () {
-                if (!$('#customize-menu label:contains(Show # found) input').prop('checked')) {
-                    $('#customize-menu label:contains(Show # found)').click();
-                }
-            }
-        },
         /* 1. Buy 1 Small Cabinet, enable coupon code & insert 10% code */
         {
             content: "select Small Cabinet",

--- a/addons/website_sale_loyalty/tests/test_shop_sale_coupon.py
+++ b/addons/website_sale_loyalty/tests/test_shop_sale_coupon.py
@@ -90,7 +90,6 @@ class TestUi(TestSaleProductAttributeValueCommon, HttpCase):
             })],
         })
 
-        self.env.ref("website_sale.search_count_box").write({"active": True})
         self.start_tour("/", 'shop_sale_loyalty', login="admin")
 
     def test_02_admin_shop_gift_card_tour(self):


### PR DESCRIPTION
After this commit, the "show # found" option of the search bar is no
longer available for users. The "show # found" is now always displayed.

It was actually a strange option in this first place as it was only
available when website_sale was installed but actually impacted all
other apps.

Related to task-2710582
