### PR TITLE
[FIX] hr_holidays: fix traceback when changing duration of time off

### DIFF
--- a/addons/hr_holidays/static/src/js/form/allocation_leave_form.js
+++ b/addons/hr_holidays/static/src/js/form/allocation_leave_form.js
@@ -25,7 +25,9 @@ export const AllocationLeaveFormController = FormController.extend({
                 context: nameSearchContext,
                 limit: 1
             });
-            this.$el.find("div[name='holiday_status_id']").find('input')[0].value = nameSearch[0][1];
+            if (this.$el.find("div[name='holiday_status_id']").find('input')[0]) {
+                this.$el.find("div[name='holiday_status_id']").find('input')[0].value = nameSearch[0][1];
+            }
         }
         return result;
     }


### PR DESCRIPTION
When the duration of an approved time off is changed from the time off dashboard,
the holiday_status_id field is no longer editable in the form, only the duration of the leave.
This causes a traceback due to the custom form controller to update the name of the time off type
based on the allocations available.

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
