### PR TITLE
[IMP] hr_timesheet, sale_timesheet: generic improvements for timesheet

### DIFF
--- a/addons/hr_timesheet/controllers/portal.py
+++ b/addons/hr_timesheet/controllers/portal.py
@@ -172,6 +172,7 @@ class TimesheetCustomerPortal(CustomerPortal):
             'searchbar_filters': OrderedDict(sorted(searchbar_filters.items())),
             'filterby': filterby,
             'is_uom_day': request.env['account.analytic.line']._is_timesheet_encode_uom_day(),
+            'access_project_ids': list(request.env['project.project']._search([])),
         })
         return request.render("hr_timesheet.portal_my_timesheets", values)
 

--- a/addons/hr_timesheet/models/hr_employee.py
+++ b/addons/hr_timesheet/models/hr_employee.py
@@ -10,3 +10,19 @@ class HrEmployee(models.Model):
     timesheet_cost = fields.Monetary('Cost', currency_field='currency_id',
     	groups="hr.group_hr_user", default=0.0)
     currency_id = fields.Many2one('res.currency', related='company_id.currency_id', readonly=True)
+
+    def name_get(self):
+        res = super().name_get()
+        if len(self.env.context.get('allowed_company_ids', [])) <= 1:
+            return res
+        name_mapping = dict(res)
+        employee_read_group = self.env['hr.employee'].sudo()._read_group(
+            [('user_id', 'in', self.user_id.ids)],
+            ['user_id'],
+            ['user_id'],
+        )
+        employees_count_per_user = {res['user_id'][0]: res['user_id_count'] for res in employee_read_group}
+        for employee in self:
+            if employees_count_per_user.get(employee.user_id.id, 0) > 1:
+                name_mapping[employee.id] = f'{name_mapping[employee.id]} - {employee.company_id.name}'
+        return list(name_mapping.items())

--- a/addons/hr_timesheet/views/hr_timesheet_portal_templates.xml
+++ b/addons/hr_timesheet/views/hr_timesheet_portal_templates.xml
@@ -118,8 +118,15 @@
                                 <tr>
                                     <td t-if="not groupby == 'date'"><span t-field="timesheet.date" t-options='{"widget": "date"}'/></td>
                                     <td t-if="not groupby == 'employee'"><span t-field="timesheet.employee_id" t-att-title="timesheet.employee_id.display_name" /></td>
-                                    <td t-if="not groupby == 'project'"><span t-field="timesheet.project_id" t-att-title="timesheet.project_id.display_name"/></td>
-                                    <td t-if="not groupby == 'task'"><span t-field="timesheet.task_id" t-att-title="timesheet.task_id.display_name"/></td>
+                                    <td t-if="not groupby == 'project'">
+                                        <a t-attf-href="#{timesheet.project_id.access_url}" t-out="timesheet.project_id.display_name"
+                                            t-att-title="timesheet.project_id.display_name" t-if="timesheet.project_id.id in access_project_ids"/>
+                                        <t t-else="" t-out="timesheet.project_id.display_name" t-att-title="timesheet.project_id.display_name"/>
+                                    </td>
+                                    <td t-if="not groupby == 'task'">
+                                        <a t-attf-href="#{timesheet.task_id.access_url}" t-out="timesheet.task_id.display_name"
+                                            t-att-title="timesheet.task_id.display_name"/>
+                                    </td>
                                     <td><span t-esc="timesheet.name" t-att-title="timesheet.name"/></td>
                                     <td class="text-end">
                                         <span t-if="is_uom_day" t-esc="timesheet._get_timesheet_time_day()" t-options='{"widget": "timesheet_uom"}'/>

--- a/addons/sale_timesheet/controllers/portal.py
+++ b/addons/sale_timesheet/controllers/portal.py
@@ -59,6 +59,11 @@ class PortalProjectAccount(PortalAccount, ProjectCustomerPortal):
 
 class SaleTimesheetCustomerPortal(TimesheetCustomerPortal):
 
+    def _prepare_portal_layout_values(self):
+        values = super()._prepare_portal_layout_values()
+        values['access_sale_order_ids'] = list(request.env['sale.order']._search([]))
+        return values
+
     def _get_searchbar_inputs(self):
         searchbar_inputs = super()._get_searchbar_inputs()
         searchbar_inputs.update(

--- a/addons/sale_timesheet/views/sale_timesheet_portal_templates.xml
+++ b/addons/sale_timesheet/views/sale_timesheet_portal_templates.xml
@@ -87,7 +87,11 @@
             <th t-if="not groupby == 'sol'">Sales Order Item</th>
         </xpath>
         <xpath expr="//tbody//td[hasclass('text-end')]" position="before">
-            <td t-if="not groupby == 'sol'"><span t-field="timesheet.so_line" t-att-title="timesheet.so_line.display_name"></span></td>
+            <td t-if="not groupby == 'sol'">
+                <a t-attf-href="#{timesheet.order_id.access_url}" t-out="timesheet.so_line.display_name"
+                    t-att-title="timesheet.so_line.display_name" t-if="timesheet.order_id.id in access_sale_order_ids"/>
+                <t t-else="" t-out="timesheet.so_line.display_name" t-att-title="timesheet.so_line.display_name"/>
+            </td>
         </xpath>
     </template>
 


### PR DESCRIPTION
The purpose of this commit is to make generic improvements in timesheets.

So in this commit following changes are made:

-Currently, when employees in different companies are related to same user,
the name of all those employees are same which can be confusing. So in timesheet,
name of the company is displayed next to employee name when a user is related
to multiple employees.

-In timesheets portal, the project, task and SOL fields are made clickable (if user has
access to the record) redirecting to the corresponding record in portal.

task-2813765
--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
