### PR TITLE
[FIX] account: wrong currency separator in the tax field

### DIFF
--- a/addons/account/static/src/js/tax_totals.js
+++ b/addons/account/static/src/js/tax_totals.js
@@ -30,8 +30,12 @@ class TaxGroupComponent extends Component {
 
     patched() {
         if (this.state.value === 'edit') {
+            let newValue = this.props.taxGroup.tax_group_amount;
+            let currency = session.get_currency(this.props.record.data.currency_id.data.id);
+
+            newValue = fieldUtils.format.float(newValue, null, {digits: currency.digits});
             this.inputTax.el.focus(); // Focus the input
-            this.inputTax.el.value = this.props.taxGroup.tax_group_amount;
+            this.inputTax.el.value = newValue;
         }
     }
 


### PR DESCRIPTION
The issue:
1.) Switch to German language (or any language that uses , versus . as a point separator
2.) Create a vendor bill
3.) Add items
4.) Click on the pencil/edit icon next to the tax field (below subtotal)
5.) Separator used is . instead of ,

The fix:
the field will use the right separator depending on the currency.

opw-2824337