### PR TITLE
[FIX] pos_sale: hide sale orders that are not in POS currency

### DIFF
--- a/addons/pos_sale/static/src/js/OrderManagementScreen/SaleOrderFetcher.js
+++ b/addons/pos_sale/static/src/js/OrderManagementScreen/SaleOrderFetcher.js
@@ -79,10 +79,11 @@ odoo.define('pos_sale.SaleOrderFetcher', function (require) {
             return sale_orders;
         }
         async _getOrderIdsForCurrentPage(limit, offset) {
+            let domain = [['currency_id', '=', this.comp.env.pos.currency.id]].concat(this.searchDomain || []);
             return await this.rpc({
                 model: 'sale.order',
                 method: 'search_read',
-                args: [this.searchDomain ? this.searchDomain : [], ['name', 'partner_id', 'amount_total', 'date_order', 'state', 'user_id'], offset, limit],
+                args: [domain, ['name', 'partner_id', 'amount_total', 'date_order', 'state', 'user_id'], offset, limit],
                 context: this.comp.env.session.user_context,
             });
         }


### PR DESCRIPTION
Sale orders' amount in POS are displayed in the POS currency but they
can be in another currency making it possible to settle the wrong amount

Steps to reproduce:
1. Install Point of Sale and Sales
2. Go to Settings > Invoicing > Currencies and activate another
   currency (e.g. EUR)
3. Go to Settings > Sales > Pricing > Pricelists and create a new
   pricelist for the new currency
4. Create a new Sale Order with the EUR pricelist and any product and
   confirm it (do not invoice)
5. Open a new session in the POS Shop
6. Go to Quotation/Order
7. The new SO is displayed with the amount in EUR but the currency
   symbol is USD

Solution:
Add a filter on the POS currency to the domain of the rpc call
search_read on sale orders

Problem:
The field `amount_total` is used to display the price but this field can
be in any currency

opw-2865371