### PR TITLE
[FIX] account: restore add_banner() method

### DIFF
--- a/addons/account/models/ir_actions_report.py
+++ b/addons/account/models/ir_actions_report.py
@@ -1,10 +1,10 @@
 # -*- coding: utf-8 -*-
 import io
-
 from collections import OrderedDict
 
 from odoo import models, _
 from odoo.exceptions import UserError
+from odoo.tools import pdf
 
 
 class IrActionsReport(models.Model):
@@ -25,10 +25,15 @@ class IrActionsReport(models.Model):
 
         collected_streams = OrderedDict()
         for invoice in invoices:
-            if invoice.message_main_attachment_id:
+            attachment = invoice.message_main_attachment_id
+            if attachment:
+                stream = io.BytesIO(attachment.raw)
+                if attachment.mimetype == 'application/pdf':
+                    record = self.env[attachment.res_model].browse(attachment.res_id)
+                    stream = pdf.add_banner(stream, record.name, logo=True)
                 collected_streams[invoice.id] = {
-                    'stream': io.BytesIO(invoice.message_main_attachment_id.raw),
-                    'attachment': invoice.message_main_attachment_id,
+                    'stream': stream,
+                    'attachment': attachment,
                 }
         return collected_streams
 


### PR DESCRIPTION
Since this commit : 7d69a28f0710ffc27979f6e977997f972bc129bb,
the add_banner() method is no longer executed,
which disables a recently added feature (see here : https://github.com/odoo/odoo/pull/84542).

The goal here is simply to restore it.

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
