### PR TITLE
[FIX] project: project duplication is done correctly

### DIFF
--- a/addons/project/models/project.py
+++ b/addons/project/models/project.py
@@ -488,7 +488,11 @@ class Project(models.Model):
             defaults = self._map_tasks_default_valeus(task, project)
             if task.parent_id:
                 # set the parent to the duplicated task
-                defaults['parent_id'] = old_to_new_tasks.get(task.parent_id.id, False)
+                parent_id = old_to_new_tasks.get(task.parent_id.id, False)
+                defaults['parent_id'] = parent_id
+                if not parent_id:
+                    defaults['project_id'] = project.id if task.display_project_id == self else False
+                    defaults['display_project_id'] = project.id if task.display_project_id == self else False
             elif task.display_project_id == self:
                 defaults['project_id'] = project.id
                 defaults['display_project_id'] = project.id

--- a/addons/project/tests/test_project_flow.py
+++ b/addons/project/tests/test_project_flow.py
@@ -36,9 +36,24 @@ Integrator at Agrolait"""
 class TestProjectFlow(TestProjectCommon, MockEmail):
 
     def test_project_process_project_manager_duplicate(self):
+        Task = self.env['project.task'].with_context({'tracking_disable': True})
         pigs = self.project_pigs.with_user(self.user_projectmanager)
+        root_task = self.task_1
+        sub_task = Task.create({
+            'name': 'Sub Task',
+            'parent_id': root_task.id,
+            'project_id': self.project_pigs.id,
+        })
+        Task.create({
+            'name': 'Sub Sub Task',
+            'parent_id': sub_task.id,
+            'project_id': self.project_pigs.id,
+        })
         dogs = pigs.copy()
-        self.assertEqual(len(dogs.tasks), 2, 'project: duplicating a project must duplicate its tasks')
+        self.assertEqual(len(dogs.tasks), 4, 'project: duplicating a project must duplicate its tasks')
+        self.assertEqual(dogs.task_count, 2, 'project: duplicating a project must not change the original project')
+        self.assertEqual(pigs.task_count, 2, 'project: duplicating a project must duplicate its displayed tasks')
+        self.assertEqual(dogs.task_count_with_subtasks, 4, 'project: duplicating a project must duplicate its subtasks')
 
     @mute_logger('odoo.addons.mail.mail_thread')
     def test_task_process_without_stage(self):


### PR DESCRIPTION
How to reproduce the bug ?

- install project app
- In the Project app, create a new project.
- Add a column and a new task in it.
- Edit this task and add a subtask to it.
- Edit the subtask and add a sub-subtask to it.
- Go to the project dashboard and edit the project to duplicate (you
need to click on the discard button to be able to duplicate it)
- Save the duplicate project.
- Go back to the dashboard (first bug: the number of task of the
duplicated project)
- Click on the first project.

What is the bug ?

When you duplicate a project, you will duplicate all the tasks that
belongs to it. The order of the task is not defined which means that you
might duplicate the sub-subtask before the subtask. In this case, the
field display_project_id will be set.

opw-2881127

Signed-off-by: Adrien Minet <admi@odoo.com>

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
