### PR TITLE
[FIX] web_editor: restore finding attachment image info

### DIFF
--- a/addons/web_editor/controllers/main.py
+++ b/addons/web_editor/controllers/main.py
@@ -268,7 +268,7 @@ class Web_Editor(http.Controller):
                 _, args = request.env['ir.http']._match(src)
                 record = request.env['ir.binary']._find_record(
                     xmlid=args.get('xmlid'),
-                    res_model=args.get('model'),
+                    res_model=args.get('model', 'ir.attachment'),
                     res_id=args.get('id'),
                 )
                 if record._name == 'ir.attachment':

--- a/addons/web_editor/tests/test_controller.py
+++ b/addons/web_editor/tests/test_controller.py
@@ -84,3 +84,34 @@ class TestController(HttpCase):
         self.assertEqual(len(svg), len(response.content), 'Expect same length as original')
         self.assertTrue('ABCDEF' in str(response.content), 'Expect patched c1')
         self.assertTrue('3AADAA' not in str(response.content), 'Old c1 should not be there anymore')
+
+    def test_03_get_image_info(self):
+        gif_base64 = "R0lGODdhAQABAIAAAP///////ywAAAAAAQABAAACAkQBADs="
+        self.authenticate('admin', 'admin')
+        # Upload document.
+        response = self.url_open(
+            '/web_editor/attachment/add_data',
+            headers={'Content-Type': 'application/json'},
+            data=json_safe.dumps({'params': {
+                'name': 'test.gif',
+                'data': gif_base64,
+                'is_image': True,
+            }})
+        ).json()
+        self.assertFalse('error' in response, 'Upload failed: %s' % response.get('error', {}).get('message'))
+        attachment_id = response['result']['id']
+        image_src = response['result']['image_src']
+        mimetype = response['result']['mimetype']
+        self.assertEqual('image/gif', mimetype, "Wrong mimetype")
+        # Ensure image info can be retrieved.
+        response = self.url_open('/web_editor/get_image_info',
+            headers={'Content-Type': 'application/json'},
+            data=json_safe.dumps({
+                "params": {
+                    "src": image_src,
+                }
+            }),
+        ).json()
+        self.assertEqual(attachment_id, response['result']['original']['id'], "Wrong id")
+        self.assertEqual(image_src, response['result']['original']['image_src'], "Wrong image_src")
+        self.assertEqual(mimetype, response['result']['original']['mimetype'], "Wrong mimetype")


### PR DESCRIPTION
Since [1] the attachments are not found by `get_image_info` anymore
because the search based on the id only does not specify the model.
Because of this the mimetype of uploaded images is not put in the DOM
image's dataset. This lack of mimetype prevents the Shape, Filter, Width
and Quality image options from being used.

This commit defaults the model to `ir.attachment`.

Steps to reproduce:
- Drop a "Text - Image" snippet.
- Replace the image by uploading one.
=> The Shape, Filter, Width & Quality options did not appear anymore.

[1]: https://github.com/odoo/odoo/commit/da8def8e410de68256ba4ab09ebf7a8b699355ac

task-2883695

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
