### PR TITLE
[IMP] hr_recruitment: applicant changes update related partner

### DIFF
--- a/addons/hr_recruitment/models/hr_recruitment.py
+++ b/addons/hr_recruitment/models/hr_recruitment.py
@@ -344,15 +344,15 @@ class Applicant(models.Model):
             applicant.email_from = applicant.partner_id.email
 
     def _inverse_partner_email(self):
-        for applicant in self.filtered(lambda a: a.partner_id and a.email_from and not a.partner_id.email):
+        for applicant in self.filtered(lambda a: a.partner_id and a.email_from):
             applicant.partner_id.email = applicant.email_from
 
     def _inverse_partner_phone(self):
-        for applicant in self.filtered(lambda a: a.partner_id and a.partner_phone and not a.partner_id.phone):
+        for applicant in self.filtered(lambda a: a.partner_id and a.partner_phone):
             applicant.partner_id.phone = applicant.partner_phone
 
     def _inverse_partner_mobile(self):
-        for applicant in self.filtered(lambda a: a.partner_id and a.partner_mobile and not a.partner_id.mobile):
+        for applicant in self.filtered(lambda a: a.partner_id and a.partner_mobile):
             applicant.partner_id.mobile = applicant.partner_mobile
 
     @api.depends('stage_id.hired_stage')


### PR DESCRIPTION
From the applicant page, there is no way to access the related partner's page.
If you made an error on the email address before creating the partner and you wish to update it,
it will not be updated on the partner's mail address, which is used to send the signature request.

taskID 2880904