### PR TITLE
FIX: serve the right company logo

### DIFF
--- a/addons/web/controllers/binary.py
+++ b/addons/web/controllers/binary.py
@@ -234,7 +234,7 @@ class Binary(http.Controller):
                         imgext = '.' + mimetype.split('/')[1]
                         if imgext == '.svg+xml':
                             imgext = '.svg'
-                        response = send_file(image_data, filename=imgname + imgext, mimetype=mimetype, mtime=row[1])
+                        response = http.send_file(image_data, filename=imgname + imgext, mimetype=mimetype, mtime=row[1])
                     else:
                         response = http.Stream.from_path(placeholder('nologo.png')).get_response()
             except Exception:


### PR DESCRIPTION
`odoo.tools._vendor.send_file` is called with the kwargs of `http.send_file`; it raises error and the `http.Stream.from_path` is always called instead.

Current behavior before PR:
It always shows the placeholder logo rather than the company logo

Desired behavior after PR is merged:
Show the company logo

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
