### PR TITLE
[FIX] website_forum: display escaped warning message

### DIFF
--- a/addons/website_forum/static/src/js/website_forum.js
+++ b/addons/website_forum/static/src/js/website_forum.js
@@ -6,6 +6,7 @@ var core = require('web.core');
 var wysiwygLoader = require('web_editor.loader');
 var publicWidget = require('web.public.widget');
 var session = require('web.session');
+var { Markup } = require('web.utils');
 var qweb = core.qweb;
 
 var _t = core._t;
@@ -253,10 +254,9 @@ publicWidget.registry.websiteForum = publicWidget.Widget.extend({
             // translation, to fix in the appropriate version
             notifOptions.message = `${karma} ${_t("karma is required to perform this action. ")}`;
             if (forumID) {
-                notifOptions.messageIsHtml = true;
-                const linkLabel = _.escape(_t("Read the guidelines to know how to gain karma."));
-                notifOptions.message = `
-                    ${_.escape(notifOptions.message)}<br/>
+                const linkLabel = _t("Read the guidelines to know how to gain karma.");
+                notifOptions.message = Markup`
+                    ${notifOptions.message}<br/>
                     <a class="alert-link" href="/forum/${forumID}/faq">${linkLabel}</a>
                 `;
             }


### PR DESCRIPTION
Steps to reproduce:

  - Install `website_forum` module
  - Go to Users, select Joel Willis user and set his karma to 0
  - Go to Website homepage
  - Login as Portal user (Joel Willis)
  - Click on Forum and select any post
  - Upvote the answer.

Issue:

  Warning message is displayed but html content tags/syntax
  is not escaped.

Solution:

  Use `Markup` from `web.utils` to escape html in message.

opw-2878582