### PR TITLE
 [FIX] point_of_sale: Date at PRO FORMA bill incorrect printing behavior

### DIFF
--- a/addons/point_of_sale/static/src/js/models.js
+++ b/addons/point_of_sale/static/src/js/models.js
@@ -3144,6 +3144,9 @@ exports.Order = Backbone.Model.extend({
         } else {
             receipt.footer = this.pos.config.receipt_footer || '';
         }
+        if (!receipt.date.localestring && (!this.state || this.state == 'draft')){
+            receipt.date.localestring = field_utils.format.datetime(moment(new Date()), {}, {timezone: false});
+        }
 
         return receipt;
     },


### PR DESCRIPTION
Impacted versions:
- 15.0

Problem A) Date not showing at proforma at newly opened orders. [Picture 1, see below]

Steps to reproduce:

1) Enter Point of Sale module
2) Configure a PoS as a Bar/Restaurant with Bill Printing before payment (with or without Floor and Tables).
3) Start a new session in the configured PoS.
4) If Floors and Tables are configured, select a Table. Otherwise, skip
   this step.
5) Add some products to the order.
6) Push the Bill Button.
7) A bill ticket will appear on the screen.

Current behavior:
In the bottom part of the bill the date is not shown at its place
between Order Reference and PRO FORMA text.

Expected behavior:
The date should be shown after Order Reference on the PRO FORMA bill.

#########################################################

Problem B) Date showed at proforma with different timezone (more/less
hours). [Picture 2, see below]

Steps to reproduce:
Steps 1 to 5) Same steps as Problem A) but Floor and Tables configuration must be
active.
6) Push the top green button to return to the Tables screen (or wait one
   minute).
7) Return to the same Table with the recently created order.
8) Puss the Bill Button.
9) A bill ticket will appear on the screen.

Current behavior:
The date in the bottom part of the PRO FORMA ticket is showing a time
with a different timezone (with more or fewer hours). Besides, the time
printing corresponds to the time where the order was saved, not the
the current time of printing the bill.

Expected behavior:
The date must show the correct time accordingly to the actual timezone and
to the moment of printing the PRO FORMA bill.

Video/Screenshot link (optional):
https://youtu.be/-2Td-RjhR9U

Picture 1) 
![Missing_date](https://user-images.githubusercontent.com/95451988/174148604-ad6fb54e-e369-4d0e-887c-e8cf35a240df.jpeg)

Picture 2)
![Wrong_date_timezone](https://user-images.githubusercontent.com/95451988/174148613-633b1513-651c-4965-81e0-f56007c30063.jpeg)


SOLUTION:
The presented solution of this PR, allows deciding whether you want to keep the current behavior on Odoo or you want no make an inherited method that allows for correcting the printing date.

Such an inherited method that applies the change to PRO FORMA, just needs a condition about knowing that the ticket belongs to PROFORMA and then just getting a new Date, formatting it, and done! (such change can be applied int this PR too if desired)

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
