### PR TITLE
[FIX] purchase_stock: restrict recomputation of qty_received_method ...

### DIFF
--- a/addons/purchase_stock/models/purchase.py
+++ b/addons/purchase_stock/models/purchase.py
@@ -573,4 +573,4 @@ class PurchaseOrderLine(models.Model):
     @api.model
     def _update_qty_received_method(self):
         """Update qty_received_method for old PO before install this module."""
-        self.search([])._compute_qty_received_method()
+        self.search(['!', ('state', 'in', ['purchase', 'done'])])._compute_qty_received_method()


### PR DESCRIPTION
…to unconfirmed POs

This PR adds a search restriction on _compute_qty_received_method which will prevent the received method field from recomputing on orders that have already been finished.

Description of the issue/feature this PR addresses:
The _compute_qty_received_method function is only used when the purchase_stock module is installed. It is designed to recompute consumable product lines in purchase orders to have the standard inventory behavior. This method will recompute all consumable lines on every purchase order regardless of state. 

Current behavior before PR:
In cases where purchase orders were completed ahead of this module's installation, this method effectively undoes all received quantities and resets them to zero. In orders that were already confirmed and billed, this displays the order lines with zero received quantities. The standard behavior expects linked stock moves to update the received quantity but this will not be the case for purchase orders that were already completed. 

Desired behavior after PR is merged:
Confirmed purchase orders should not have their lines updated by this method. It should only update existing orders that are yet to be confirmed. This way, confirming the purchase order will create the stock moves needed to compute the received quantity fields.

opw-2854810

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
