### PR TITLE
[FIX] {purchase_,}stock: recompute orderpoints on SM's date change

### DIFF
--- a/addons/purchase_stock/tests/test_reordering_rule.py
+++ b/addons/purchase_stock/tests/test_reordering_rule.py
@@ -683,3 +683,34 @@ class TestReorderingRule(SavepointCase):
             {'product_id': self.product_01.id, 'qty_done': 1.0, 'state': 'done', 'location_dest_id': stock_location.id},
             {'product_id': self.product_01.id, 'qty_done': 2.0, 'state': 'done', 'location_dest_id': sub_location.id},
         ])
+
+    def test_change_of_scheduled_date(self):
+        """
+        A user creates a delivery, an orderpoint is created. Its forecast
+        quantity becomes -1 and the quantity to order is 1. Then the user
+        postpones the scheduled date of the delivery. The quantities of the
+        orderpoint should be reset to zero.
+        """
+        delivery_form = Form(self.env['stock.picking'])
+        delivery_form.partner_id = self.partner
+        delivery_form.picking_type_id = self.env.ref('stock.picking_type_out')
+        with delivery_form.move_ids_without_package.new() as move:
+            move.product_id = self.product_01
+            move.product_uom_qty = 1
+        delivery = delivery_form.save()
+        delivery.action_confirm()
+
+        self.env['report.stock.quantity'].flush()
+        self.env['stock.warehouse.orderpoint']._get_orderpoint_action()
+
+        orderpoint = self.env['stock.warehouse.orderpoint'].search([('product_id', '=', self.product_01.id)])
+        self.assertRecordValues(orderpoint, [
+            {'qty_forecast': -1, 'qty_to_order': 1},
+        ])
+
+        delivery.scheduled_date += td(days=7)
+        orderpoint.invalidate_cache(fnames=['qty_forecast', 'qty_to_order'], ids=orderpoint.ids)
+
+        self.assertRecordValues(orderpoint, [
+            {'qty_forecast': 0, 'qty_to_order': 0},
+        ])

--- a/addons/stock/models/stock_orderpoint.py
+++ b/addons/stock/models/stock_orderpoint.py
@@ -226,7 +226,8 @@ class StockWarehouseOrderpoint(models.Model):
         self.trigger = 'auto'
         return self.action_replenish()
 
-    @api.depends('product_id', 'location_id', 'product_id.stock_move_ids', 'product_id.stock_move_ids.state', 'product_id.stock_move_ids.product_uom_qty')
+    @api.depends('product_id', 'location_id', 'product_id.stock_move_ids', 'product_id.stock_move_ids.state',
+                 'product_id.stock_move_ids.date', 'product_id.stock_move_ids.product_uom_qty')
     def _compute_qty(self):
         orderpoints_contexts = defaultdict(lambda: self.env['stock.warehouse.orderpoint'])
         for orderpoint in self:


### PR DESCRIPTION
Updating the scheduled date of a delivery doesn't update the quantity to
order of an orderpoint

To reproduce the issue:
(Need purchase)
1. Create a storable product P with a seller
2. Create and confirm a planned delivery D with 1 x P
3. Open the replenishment page
    - There should be a line for P (Forecast: -1, To Order: 1)
4. Edit D and postpone the scheduled date
5. Go back to replenishment page

Error: The line is still present, its forecast qty is correct (0) but
the quantity to order is still 1 (instead of 0)

`qty_to_order` is a stored field, so when loading the replenishment
page, its compute method is not called. Moreover, even though
`qty_to_order` depends on `qty_forecast` and the compute method of
`qty_forecast` is called, it still won't trigger the compute:
when setting the value of `qty_forecast` from its compute method, it
will lead to:
https://github.com/odoo/odoo/blob/b54f78de307543efcea934206806f361eaac811a/odoo/fields.py#L1106-L1109
So, as shown and explained, we bypass the `write` of `BaseModel` and
skip the business logic and the recomputations

The compute of `qty_to_order` should actually be triggered earlier: when
we edit the scheduled date (step 4). That's the reason why this commit
adds a dependency to the compute of `qty_forecast`: it makes more sense
and becomes an implicit dependency of `qty_to_order` -> update the
scheduled date will trigger the compute of `qty_to_order`

OPW-2868167